### PR TITLE
remove redundant @types/webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@types/node": "^16.11.12",
     "@types/react": "^17.0.37",
     "@types/react-router-dom": "5.x",
-    "@types/webpack-dev-server": "^4.5.0",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",
     "copy-webpack-plugin": "^6.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,15 +1265,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/bonjour@npm:*":
-  version: 3.5.9
-  resolution: "@types/bonjour@npm:3.5.9"
-  dependencies:
-    "@types/node": "*"
-  checksum: a04f2eb99ed3b3a8bfc2443dee9c7a7aa904f552e595e9c8459e6cf937ba03599b839197657ebb8ce6be9b93ce4b123092fa19c8bab1d2c84d58f1ef6ad9f571
-  languageName: node
-  linkType: hard
-
 "@types/bonjour@npm:^3.5.9":
   version: 3.5.10
   resolution: "@types/bonjour@npm:3.5.10"
@@ -1283,7 +1274,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/connect-history-api-fallback@npm:*, @types/connect-history-api-fallback@npm:^1.3.5":
+"@types/connect-history-api-fallback@npm:^1.3.5":
   version: 1.3.5
   resolution: "@types/connect-history-api-fallback@npm:1.3.5"
   dependencies:
@@ -1560,7 +1551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/serve-index@npm:*, @types/serve-index@npm:^1.9.1":
+"@types/serve-index@npm:^1.9.1":
   version: 1.9.1
   resolution: "@types/serve-index@npm:1.9.1"
   dependencies:
@@ -1622,34 +1613,6 @@ __metadata:
   dependencies:
     "@types/jest": "*"
   checksum: e08715a565cc189112a6611485d779a0f1ceb546a9d4601b21aacff7596d7acf8b7c702e4c5f825677431ff601df3e635887dc8a5735da1a263cc857eb7c3833
-  languageName: node
-  linkType: hard
-
-"@types/webpack-dev-middleware@npm:*":
-  version: 5.0.2
-  resolution: "@types/webpack-dev-middleware@npm:5.0.2"
-  dependencies:
-    "@types/connect": "*"
-    tapable: ^2.1.1
-    webpack: ^5.38.1
-  checksum: fd7ff7608362a1bd01ca7f89d1f3308d21519e4271a16f672e7801b087618c9fda10a102db61a8f5fda1253d580bfc227d574feb10ee0d87d24288f19bd846a9
-  languageName: node
-  linkType: hard
-
-"@types/webpack-dev-server@npm:^4.5.0":
-  version: 4.5.0
-  resolution: "@types/webpack-dev-server@npm:4.5.0"
-  dependencies:
-    "@types/bonjour": "*"
-    "@types/connect-history-api-fallback": "*"
-    "@types/express": "*"
-    "@types/serve-index": "*"
-    "@types/serve-static": "*"
-    "@types/webpack-dev-middleware": "*"
-    chokidar: ^3.5.1
-    http-proxy-middleware: ^2.0.0
-    webpack: "*"
-  checksum: 3d4c4efba232f077d998811bc56fa90567f0832980ef694a0bca19d61dd0a3aa35071376cc9418c669ec6c844efa1e68cdb692e87da7bf3844192eda098912dd
   languageName: node
   linkType: hard
 
@@ -3022,7 +2985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.4.2, chokidar@npm:^3.5.1":
+"chokidar@npm:^3.4.2":
   version: 3.5.2
   resolution: "chokidar@npm:3.5.2"
   dependencies:
@@ -7227,7 +7190,6 @@ __metadata:
     "@types/node": ^16.11.12
     "@types/react": ^17.0.37
     "@types/react-router-dom": 5.x
-    "@types/webpack-dev-server": ^4.5.0
     "@typescript-eslint/eslint-plugin": ^5.9.1
     "@typescript-eslint/parser": ^5.9.1
     copy-webpack-plugin: ^6.4.1


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

remove redundant @types/webpack-dev-server, types now come in `webpack-dev-server`