### PR TITLE
added 'plugin__kubevirt-plugin' as default namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,11 @@ OC_PASS=<password>
 ## i18n
 
 The plugin uses the following
-`plugin__kubevirt-plugin` namespace. You should use the `useTranslation` hook
-with this namespace as follows:
+`plugin__kubevirt-plugin` namespace as default. You should use the `useTranslation` hook:
 
 ```tsx
 conster Header: React.FC = () => {
-  const { t } = useTranslation('plugin__kubevirt-plugin');
+  const { t } = useTranslation();
   return <h1>{t('Hello, World!')}</h1>;
 };
 ```

--- a/i18next-parser.config.js
+++ b/i18next-parser.config.js
@@ -4,5 +4,6 @@ module.exports = {
   locales: ['en'],
   namespaceSeparator: '~',
   reactNamespace: false,
+  defaultNamespace: 'plugin__kubevirt-plugin',
   useKeysAsDefaultValue: true,
 };

--- a/src/views/catalog/templatescatalog/TemplatesCatalog.tsx
+++ b/src/views/catalog/templatescatalog/TemplatesCatalog.tsx
@@ -15,7 +15,7 @@ import { filterTemplates } from './utils/helpers';
 import './TemplatesCatalog.scss';
 
 const TemplatesCatalog: React.FC = () => {
-  const { t } = useTranslation('plugin__kubevirt-plugin');
+  const { t } = useTranslation();
   const [isAdmin, isAdminLoaded] = useIsAdmin();
 
   const { templates, loaded: templatedLoaded } = useVmTemplates();

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogFilters/CatalogTemplateFilters.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogFilters/CatalogTemplateFilters.tsx
@@ -21,7 +21,7 @@ export const CatalogTemplateFilters: React.FC<{
   filters: TemplateFilters;
   onFilterChange: (type: string, value: string | boolean) => void;
 }> = React.memo(({ filters, onFilterChange }) => {
-  const { t } = useTranslation('plugin__kubevirt-plugin');
+  const { t } = useTranslation();
 
   return (
     <div className="co-catalog-page__tabs">

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogHeader.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogHeader.tsx
@@ -11,7 +11,7 @@ export const TemplatesCatalogHeader: React.FC<{
   onFilterChange: (type: string, value: string | boolean) => void;
   itemCount: number;
 }> = React.memo(({ filters, onFilterChange, itemCount }) => {
-  const { t } = useTranslation('plugin__kubevirt-plugin');
+  const { t } = useTranslation();
   const { inputRef } = useInputDebounce({
     delay: 150,
     updateURLParam: 'query',

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogTile.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogTile.tsx
@@ -21,7 +21,7 @@ export type TemplateTileProps = {
 };
 
 export const TemplateTile: React.FC<TemplateTileProps> = React.memo(({ template, onClick }) => {
-  const { t } = useTranslation('plugin__kubevirt-plugin');
+  const { t } = useTranslation();
 
   const provider = getTemplateProviderName(template);
   const workload = getTemplateWorkload(template);

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -91,7 +91,7 @@ type VMTableProps = {
 };
 
 const VMTable: React.FC<VMTableProps> = ({ data, unfilteredData, loaded, loadError, kind }) => {
-  const { t } = useTranslation('plugin__kubevirt-plugin');
+  const { t } = useTranslation();
 
   return (
     <VirtualizedTable<K8sResourceCommon>
@@ -127,7 +127,7 @@ export const filters: RowFilter[] = [
 ];
 
 const VirtualMachinesList = ({ kind }: { kind: string }) => {
-  const { t } = useTranslation('plugin__kubevirt-plugin');
+  const { t } = useTranslation();
 
   const [vms, loaded, loadError] = useK8sWatchResource<V1VirtualMachine[]>({
     kind,


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

## 📝 Description

I18n will now use 'plugin__kubevirt-plugin' as default namespace. no need to do useTranslation('plugin__kubevirt-plugin') anymore , useTranslation() is good.


