### PR TITLE
Add hook that checks if Template supports QuickCreate

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,7 +15,9 @@ const config: Config.InitialOptions = {
   testURL: 'http://localhost/',
   testRegex: '.*\\.test\\.(ts|tsx|js|jsx)$',
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/dist/'],
-  transformIgnorePatterns: ['<rootDir>/node_modules/(?!(@patternfly|@openshift-console\\S*?)/.*)'],
+  transformIgnorePatterns: [
+    '<rootDir>/node_modules/(?!(@kubevirt-ui/kubevirt-api|@patternfly|@openshift-console\\S*?)/.*)',
+  ],
   setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
   moduleNameMapper: {
     '\\.(css|less|scss|svg)$': '<rootDir>/__mocks__/dummy.ts',

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.11.0",
-    "@kubevirt-ui/kubevirt-api": "^0.0.34",
+    "@kubevirt-ui/kubevirt-api": "^0.0.35",
     "@openshift-console/dynamic-plugin-sdk": "0.0.5",
     "@openshift-console/dynamic-plugin-sdk-internal": "^0.0.4",
     "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.4",

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawer.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawer.tsx
@@ -5,6 +5,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { CatalogItemHeader } from '@patternfly/react-catalog-view-extension';
 import { Modal, Split, SplitItem } from '@patternfly/react-core';
 
+import { useProcessedTemplate } from '../../hooks/useProcessedTemplate';
 import {
   getTemplateName,
   getTemplateProviderName,
@@ -31,10 +32,13 @@ export const TemplatesCatalogDrawer: React.FC<TemplatesCatalogDrawerProps> = ({
   onClose,
 }) => {
   const { t } = useKubevirtTranslation();
+  const [processedTemplate, processedTemplateLoaded] = useProcessedTemplate(template);
+
   const provider = getTemplateProviderName(template);
   const support = getTemplateSupportLevel(template);
   const templateName = getTemplateName(template);
   const osIcon = getTemplateOSIcon(template);
+  const canQuickCreate = !!processedTemplate;
 
   return (
     <Modal
@@ -55,10 +59,14 @@ export const TemplatesCatalogDrawer: React.FC<TemplatesCatalogDrawerProps> = ({
               <SplitItem>
                 <strong>{t('Support level: ')}</strong> {support || 'N/A'}
               </SplitItem>
-              <SplitItem> | </SplitItem>
-              <SplitItem>
-                <strong>{t('Supports quick create VM')}</strong>
-              </SplitItem>
+              {canQuickCreate && (
+                <>
+                  <SplitItem> | </SplitItem>
+                  <SplitItem>
+                    <strong>{t('Supports quick create VM')}</strong>
+                  </SplitItem>
+                </>
+              )}
             </Split>
           }
           iconImg={osIcon}
@@ -70,6 +78,8 @@ export const TemplatesCatalogDrawer: React.FC<TemplatesCatalogDrawerProps> = ({
           template={template}
           onCreate={(tmp) => console.log(tmp)}
           onCancel={onClose}
+          canQuickCreate={canQuickCreate}
+          canQuickCreateLoaded={processedTemplateLoaded}
         />
       }
     >

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerFooter.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerFooter.tsx
@@ -10,6 +10,7 @@ import {
   DescriptionListGroup,
   DescriptionListTerm,
   FormGroup,
+  Skeleton,
   Split,
   SplitItem,
   Stack,
@@ -26,6 +27,8 @@ import { generateVMName } from '../../utils/helpers';
 type TemplateCatalogDrawerFooterProps = {
   namespace: string;
   template: V1Template | undefined;
+  canQuickCreate: boolean;
+  canQuickCreateLoaded: boolean;
   onCreate: (template: V1Template) => void;
   onCancel: () => void;
 };
@@ -33,14 +36,15 @@ type TemplateCatalogDrawerFooterProps = {
 export const TemplatesCatalogDrawerFooter: React.FC<TemplateCatalogDrawerFooterProps> = ({
   namespace,
   template,
+  canQuickCreate,
+  canQuickCreateLoaded,
   onCreate,
   onCancel,
 }) => {
   const { t } = useKubevirtTranslation();
   const [vmName, setVmName] = React.useState(generateVMName(template));
-  const canQuickCreate = true;
 
-  return (
+  return canQuickCreateLoaded ? (
     <Stack className="template-catalog-drawer-info">
       <StackItem className="template-catalog-drawer-footer-section">
         <Split hasGutter>
@@ -134,6 +138,25 @@ export const TemplatesCatalogDrawerFooter: React.FC<TemplateCatalogDrawerFooterP
           </Stack>
         </div>
       )}
+    </Stack>
+  ) : (
+    <Stack className="template-catalog-drawer-info" hasGutter>
+      <StackItem className="template-catalog-drawer-footer-section">
+        <Skeleton height="50px" width="30%" />
+      </StackItem>
+      <StackItem className="template-catalog-drawer-footer-section">
+        <Stack hasGutter>
+          <StackItem>
+            <Skeleton height="40px" width="40%" />
+          </StackItem>
+          <StackItem>
+            <Skeleton height="30px" width="40%" />
+          </StackItem>
+          <StackItem>
+            <Skeleton height="35px" width="40%" />
+          </StackItem>
+        </Stack>
+      </StackItem>
     </Stack>
   );
 };

--- a/src/views/catalog/templatescatalog/hooks/useProcessedTemplate.ts
+++ b/src/views/catalog/templatescatalog/hooks/useProcessedTemplate.ts
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+import { ProcessedTemplatesModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
+
+export const useProcessedTemplate = (template: V1Template): [V1Template, boolean, any] => {
+  const [processedTemplate, setProcessedTemplate] = React.useState<V1Template | undefined>(
+    undefined,
+  );
+  const [loaded, setLoaded] = React.useState(false);
+  const [error, setError] = React.useState<any>();
+
+  React.useEffect(() => {
+    setLoaded(false);
+
+    if (template) {
+      k8sCreate<V1Template>({
+        model: ProcessedTemplatesModel,
+        data: template,
+        queryParams: {
+          dryRun: 'All',
+        },
+      })
+        .then((temp: any) => {
+          setProcessedTemplate(temp);
+          setLoaded(true);
+        })
+        .catch((err) => {
+          setProcessedTemplate(undefined);
+          setLoaded(true);
+          setError(err);
+        });
+    }
+  }, [template]);
+
+  return [processedTemplate, loaded, error];
+};

--- a/src/views/catalog/templatescatalog/tests/TemplatesCatalog.test.tsx
+++ b/src/views/catalog/templatescatalog/tests/TemplatesCatalog.test.tsx
@@ -15,6 +15,11 @@ jest.mock('../hooks/useVmTemplates', () => ({
   useVmTemplates: () => ({ templates: [urlTemplateMock, containerTemplateMock], loaded: true }),
 }));
 
+// render template drawer without quick create
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sCreate: jest.fn().mockRejectedValue({}),
+}));
+
 afterEach(cleanup);
 
 test('TemplatesCatalog', async () => {

--- a/src/views/catalog/templatescatalog/tests/TemplatesCatalogDrawer.test.tsx
+++ b/src/views/catalog/templatescatalog/tests/TemplatesCatalogDrawer.test.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
 
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { TemplatesCatalogDrawer } from '../components/TemplatesCatalogDrawer/TemplatesCatalogDrawer';
 
 import { containerTemplateMock } from './mocks';
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sCreate: jest.fn().mockResolvedValue({}),
+}));
 
 afterEach(cleanup);
 
@@ -27,6 +31,11 @@ test('TemplatesCatalogDrawer', async () => {
 
   // test doc btn
   fireEvent.click(getByText('Refer to documentation'));
+
+  // wait for mocked useIsTemplateSupportsQuickCreate to return true and render the quick create form
+  await waitFor(() => {
+    expect(getByTestId('vm-name-input')).toBeInTheDocument();
+  });
 
   // change vm name
   userEvent.clear(getByTestId('vm-name-input'));

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -57,7 +57,7 @@ const config: Configuration = {
     rules: [
       {
         test: /\.(jsx?|tsx?)$/,
-        exclude: /node_modules/,
+        exclude: /node_modules\/(?!(@kubevirt-ui)\/kubevirt-api).*/,
         use: [
           {
             loader: 'ts-loader',

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,10 +800,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kubevirt-ui/kubevirt-api@npm:^0.0.34":
-  version: 0.0.34
-  resolution: "@kubevirt-ui/kubevirt-api@npm:0.0.34"
-  checksum: 001fdcf512259425890661a9a9ad5ac2033e98b596f40a1e8dec3c3ef8dd235143d3d88843b46003ed15f0be7c5ff6282166d32ee3a9f5e876221eb9f6ce5537
+"@kubevirt-ui/kubevirt-api@npm:^0.0.35":
+  version: 0.0.35
+  resolution: "@kubevirt-ui/kubevirt-api@npm:0.0.35"
+  checksum: eb6427e372bc736b0c177aacfbbd32108e0e4ea8eb64f5abf07f5e85330ff5571adc4e088afb0ae26cf2fb00ab01bd6209966d253471cd528dfaa81306ba7412
   languageName: node
   linkType: hard
 
@@ -7125,7 +7125,7 @@ __metadata:
   resolution: "kubevirt-plugin@workspace:."
   dependencies:
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@kubevirt-ui/kubevirt-api": ^0.0.34
+    "@kubevirt-ui/kubevirt-api": ^0.0.35
     "@openshift-console/dynamic-plugin-sdk": 0.0.5
     "@openshift-console/dynamic-plugin-sdk-internal": ^0.0.4
     "@openshift-console/dynamic-plugin-sdk-webpack": 0.0.4


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Added `useIsTemplateSupportsQuickCreate` that detects if QuickCreate is supported by a given template.
The Drawer will show a skeleton until the hook detection completes

## 🎥 Demo
Here is a Demo with Network Throttled to demonstrate the loading experience

https://user-images.githubusercontent.com/24938324/154291800-e38f7d6c-22c1-4db2-8b20-60464f853b98.mov


