### PR TITLE
Add VM Template Source utils and hook

### DIFF
--- a/src/views/catalog/templatescatalog/utils/flavor.ts
+++ b/src/views/catalog/templatescatalog/utils/flavor.ts
@@ -1,7 +1,9 @@
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { V1CPU } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
-import { getTemplateFlavor, getTemplateVirtualMachineObject } from './helpers';
+import { getTemplateVirtualMachineObject } from '../../utils/vm-template-source/utils';
+
+import { getTemplateFlavor } from './helpers';
 
 export const parseCPU = (cpu: V1CPU): V1CPU => {
   return {

--- a/src/views/catalog/templatescatalog/utils/helpers.ts
+++ b/src/views/catalog/templatescatalog/utils/helpers.ts
@@ -1,9 +1,10 @@
 import { adjectives, animals, uniqueNamesGenerator } from 'unique-names-generator';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
-import { V1Disk, V1Network, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1Disk, V1Network } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getAnnotation, getLabel } from '@kubevirt-utils/selectors';
 
+import { getTemplateVirtualMachineObject } from '../../utils/vm-template-source/utils';
 import { TemplateFilters } from '../hooks/useVmTemplatesFilters';
 
 import { ANNOTATIONS } from './annotations';
@@ -68,9 +69,6 @@ export const getTemplateOS = (template: V1Template): string => {
 export const getTemplateParameterValue = (template: V1Template, parameter): string => {
   return template?.parameters?.find((param) => param.name === parameter)?.value ?? '';
 };
-
-export const getTemplateVirtualMachineObject = (template: V1Template): V1VirtualMachine =>
-  template?.objects?.find((obj) => obj.kind === 'VirtualMachine');
 
 export const getTemplateNetworkInterfaces = (template: V1Template): V1Network[] => {
   return getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.networks ?? [];

--- a/src/views/catalog/utils/vm-template-source/useVmTemplateSource.ts
+++ b/src/views/catalog/utils/vm-template-source/useVmTemplateSource.ts
@@ -1,0 +1,110 @@
+import * as React from 'react';
+
+import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import DataSourceModel from '@kubevirt-ui/kubevirt-api/console/models/DataSourceModel';
+import {
+  V1beta1DataVolumeSourcePVC,
+  V1beta1DataVolumeSourceRef,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
+
+import {
+  BOOT_SOURCE,
+  getDataSourcePVC,
+  getPVC,
+  getTemplateBootSourceType,
+  TemplateBootSource,
+} from './utils';
+
+export const useVmTemplateSource = (template: V1Template): useVmTemplateSourceValue => {
+  const [templateBootSource, setTemplateBootSource] = React.useState<TemplateBootSource>(undefined);
+  const [loaded, setLoaded] = React.useState<boolean>(true);
+  const [error, setError] = React.useState<any>();
+
+  const bootSource = React.useMemo(() => getTemplateBootSourceType(template), [template]);
+
+  const getPVCSource = (pvc: V1beta1DataVolumeSourcePVC) => {
+    setLoaded(false);
+    return getPVC(pvc?.name, pvc?.namespace)
+      .then((foundPvc: any) => {
+        setTemplateBootSource({
+          type: BOOT_SOURCE.PVC,
+          source: {
+            pvc,
+          },
+          sourceValue: { pvc: foundPvc },
+        });
+      })
+      .catch((e) => {
+        setError(e);
+      })
+      .finally(() => setLoaded(true));
+  };
+
+  const getDataSourcePVCSource = (dataSource: V1beta1DataVolumeSourceRef) => {
+    setLoaded(false);
+    return getDataSourcePVC(dataSource.name, dataSource.namespace)
+      .then((pvc: any) => {
+        setTemplateBootSource({
+          type: BOOT_SOURCE.PVC_AUTO_UPLOAD,
+          source: {
+            sourceRef: {
+              kind: DataSourceModel.kind,
+              name: bootSource?.source?.sourceRef?.name,
+              namespace: bootSource?.source?.sourceRef?.namespace,
+            },
+          },
+          sourceValue: { pvc },
+        });
+      })
+      .catch((e) => {
+        setError(e);
+      })
+      .finally(() => setLoaded(true));
+  };
+
+  React.useEffect(() => {
+    setError(undefined);
+    setTemplateBootSource(undefined);
+
+    switch (bootSource?.type) {
+      case BOOT_SOURCE.PVC:
+        getPVCSource(bootSource?.source?.pvc);
+        break;
+
+      case BOOT_SOURCE.PVC_AUTO_UPLOAD:
+        getDataSourcePVCSource(bootSource?.source?.sourceRef);
+        break;
+
+      case BOOT_SOURCE.URL:
+        {
+          setTemplateBootSource({
+            type: bootSource.type,
+            source: bootSource.source,
+          });
+        }
+        break;
+
+      case BOOT_SOURCE.REGISTRY:
+        {
+          setTemplateBootSource({
+            type: bootSource.type,
+            source: bootSource.source,
+          });
+        }
+        break;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bootSource]);
+
+  return {
+    templateBootSource,
+    loaded,
+    error,
+  };
+};
+
+type useVmTemplateSourceValue = {
+  templateBootSource: TemplateBootSource;
+  loaded: boolean;
+  error: any;
+};

--- a/src/views/catalog/utils/vm-template-source/utils.ts
+++ b/src/views/catalog/utils/vm-template-source/utils.ts
@@ -1,0 +1,125 @@
+import { PersistentVolumeClaimModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import DataSourceModel from '@kubevirt-ui/kubevirt-api/console/models/DataSourceModel';
+import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
+import {
+  V1alpha1PersistentVolumeClaim,
+  V1beta1DataVolumeSourceHTTP,
+  V1beta1DataVolumeSourcePVC,
+  V1beta1DataVolumeSourceRef,
+  V1beta1DataVolumeSourceRegistry,
+  V1VirtualMachine,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { k8sGet } from '@openshift-console/dynamic-plugin-sdk';
+
+export enum BOOT_SOURCE {
+  PVC = 'PVC',
+  PVC_AUTO_UPLOAD = 'PVC_AUTO_UPLOAD',
+  URL = 'URL',
+  REGISTRY = 'REGISTRY',
+}
+
+export const BOOT_SOURCE_LABELS = {
+  [BOOT_SOURCE.PVC]: 'PVC',
+  [BOOT_SOURCE.PVC_AUTO_UPLOAD]: 'PVC (auto upload)',
+  [BOOT_SOURCE.URL]: 'URL',
+  [BOOT_SOURCE.REGISTRY]: 'Registry',
+};
+
+export type TemplateBootSource = {
+  type: BOOT_SOURCE;
+  source: {
+    sourceRef?: V1beta1DataVolumeSourceRef;
+    pvc?: V1beta1DataVolumeSourcePVC;
+    http?: V1beta1DataVolumeSourceHTTP;
+    registry?: V1beta1DataVolumeSourceRegistry;
+  };
+  sourceValue?: {
+    sourceRef?: V1alpha1PersistentVolumeClaim;
+    pvc?: V1alpha1PersistentVolumeClaim;
+    http?: V1beta1DataVolumeSourceHTTP;
+    registry?: V1beta1DataVolumeSourceRegistry;
+  };
+};
+
+export const TEMPLATE_ROOTDISK_VOLUME_NAME = '${NAME}';
+
+export const getTemplateVirtualMachineObject = (template: V1Template): V1VirtualMachine =>
+  template?.objects?.find((obj) => obj.kind === VirtualMachineModel.kind);
+
+// Only used for replacing parameters in the template, do not use for anything else
+const poorManProcess = (template: V1Template): V1Template => {
+  if (!template) return null;
+
+  let templateString = JSON.stringify(template);
+
+  template.parameters
+    .filter((p) => p.value)
+    .forEach((p) => {
+      templateString = templateString.replaceAll(`\${${p.name}}`, p.value);
+    });
+
+  return JSON.parse(templateString);
+};
+
+export const getTemplateBootSourceType = (template: V1Template): TemplateBootSource => {
+  const vmObject = getTemplateVirtualMachineObject(poorManProcess(template));
+
+  const rootVolume = vmObject?.spec?.template?.spec?.volumes?.find(
+    (v) => v.name === TEMPLATE_ROOTDISK_VOLUME_NAME,
+  );
+  const rootDataVolumeTemplate = vmObject?.spec?.dataVolumeTemplates?.find(
+    (dv) => dv.metadata?.name === rootVolume?.name,
+  );
+
+  if (rootDataVolumeTemplate?.spec?.sourceRef) {
+    const sourceRef = rootDataVolumeTemplate?.spec?.sourceRef;
+
+    if (sourceRef?.kind === DataSourceModel.kind) {
+      return {
+        type: BOOT_SOURCE.PVC_AUTO_UPLOAD,
+        source: { sourceRef },
+      };
+    }
+  }
+
+  if (rootDataVolumeTemplate?.spec?.source) {
+    const source = rootDataVolumeTemplate?.spec?.source;
+
+    if (source?.http) {
+      return {
+        type: BOOT_SOURCE.URL,
+        source: { http: source?.http },
+      };
+    }
+    if (source?.registry) {
+      return {
+        type: BOOT_SOURCE.REGISTRY,
+        source: { registry: source?.registry },
+      };
+    }
+    if (source?.pvc) {
+      return {
+        type: BOOT_SOURCE.PVC,
+        source: { pvc: source?.pvc },
+      };
+    }
+  }
+
+  return null;
+};
+
+export const getPVC = (name: string, ns: string) =>
+  k8sGet({
+    model: PersistentVolumeClaimModel,
+    name,
+    ns,
+  });
+
+export const getDataSourcePVC = (name: string, ns: string) =>
+  k8sGet({
+    model: DataSourceModel,
+    name,
+    ns,
+  })
+    .then((data: any) => data?.spec?.source?.pvc)
+    .then((pvc) => getPVC(pvc.name, pvc.namespace));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "node",
     "outDir": "dist",
     "target": "es2016",
-    "lib": ["es2016", "es2019", "es2020.promise", "dom", "dom.iterable"],
+    "lib": ["es2016", "es2019", "es2020.promise", "dom", "dom.iterable", "ES2021.String"],
     "jsx": "react",
     "allowJs": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Added `getTemplateBootSourceType` function and `useVmTemplateSource` hook.
`getTemplateBootSourceType` returns a `TemplateBootSource`

```ts
export enum BOOT_SOURCE {
  PVC = 'PVC',
  PVC_AUTO_UPLOAD = 'PVC_AUTO_UPLOAD',
  URL = 'URL',
  REGISTRY = 'REGISTRY',
}

export type TemplateBootSource = {
  type: BOOT_SOURCE;
  source: {
    sourceRef?: V1beta1DataVolumeSourceRef;
    pvc?: V1beta1DataVolumeSourcePVC;
    http?: V1beta1DataVolumeSourceHTTP;
    registry?: V1beta1DataVolumeSourceRegistry;
  };
  sourceValue?: {
    sourceRef?: V1alpha1PersistentVolumeClaim;
    pvc?: V1alpha1PersistentVolumeClaim;
    http?: V1beta1DataVolumeSourceHTTP;
    registry?: V1beta1DataVolumeSourceRegistry;
  };
};
```
`useVmTemplateSource` fetches the boot source and checks for its availability if possible.
as of now availability check is for `PVC` and `PVC_AUTO_UPLOAD (DataSource)`

`useVmTemplateSource` returns 

```ts
type useVmTemplateSourceValue = {
  templateBootSource: TemplateBootSource;
  loaded: boolean;
  error: any;
};
```

## 🎥 Demo

<img width="553" alt="Screen Shot 2022-02-20 at 9 01 08" src="https://user-images.githubusercontent.com/24938324/154834008-2f104840-6b42-41c5-b905-e82acc429d65.png">

