### PR TITLE
add getResourceUrl method

### DIFF
--- a/src/utils/resource.ts
+++ b/src/utils/resource.ts
@@ -1,0 +1,13 @@
+import { K8sModel, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+export const getResourceUrl = (model: K8sModel, resource: K8sResourceCommon): string => {
+  if (!model || !resource) return null;
+
+  const ref = `${model.apiGroup || 'core'}~${model.apiVersion}~${model.kind}`;
+
+  const namespace = resource?.metadata?.namespace
+    ? `ns/${resource.metadata.namespace}`
+    : 'all-namespaces';
+
+  return `/k8s/${namespace}/${ref}/${resource?.metadata?.name}`;
+};

--- a/src/utils/tests/resource.test.ts
+++ b/src/utils/tests/resource.test.ts
@@ -1,0 +1,17 @@
+import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
+import { getResourceUrl } from '@kubevirt-utils/resource';
+
+test('getResourceUrl', () => {
+  const resource = {
+    metadata: {
+      namespace: 'kube',
+      name: 'vm',
+    },
+  };
+
+  const url = getResourceUrl(VirtualMachineModel, resource);
+  expect(url).toBe('/k8s/ns/kube/kubevirt.io~v1~VirtualMachine/vm');
+
+  const nullUrl = getResourceUrl(VirtualMachineModel, null);
+  expect(nullUrl).toBe(null);
+});


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Retuns a URL Path for a Resource

## 🎥 Demo

```ts
  const vm = {
    metadata: {
      namespace: 'kube',
      name: 'vm',
    },
  };

  const url = getResourceUrl(VirtualMachineModel, vm);
  // returns  => /k8s/ns/kube/kubevirt.io~v1~VirtualMachine/vm


```
