### PR TITLE
Combine Catalog routes to one Switch

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -100,16 +100,6 @@
   {
     "type": "console.page/route",
     "properties": {
-      "path": ["/k8s/ns/:ns/templatescatalog/customize", "/k8s/all-namespaces/templatescatalog/customize"],
-      "component": {
-        "$codeRef": "CustomizeVirtualMachine"
-      }
-    }
-  },
-  {
-    "type": "console.page/route",
-    "properties": {
-      "exact": true,
       "path": ["/k8s/ns/:ns/templatescatalog", "/k8s/all-namespaces/templatescatalog"],
       "component": {
         "$codeRef": "TemplatesCatalog"
@@ -136,15 +126,6 @@
         "version": "v1"
       },
       "component": { "$codeRef": "VirtualMachinesInstancePage" }
-    }
-  },
-  {
-    "type": "console.page/route",
-    "properties": {
-      "path": ["/k8s/ns/:ns/templatescatalog/review", "/k8s/all-namespaces/templatescatalog/review"],
-      "component": {
-        "$codeRef": "Wizard"
-      }
     }
   },
   {

--- a/package.json
+++ b/package.json
@@ -27,11 +27,9 @@
     "displayName": "Kubevirt Plugin",
     "exposedModules": {
       "VirtualMachinesList": "./views/virtualmachines/list/VirtualMachinesList.tsx",
-      "TemplatesCatalog": "./views/catalog/templatescatalog/TemplatesCatalog.tsx",
-      "CustomizeVirtualMachine": "./views/catalog/customize/CustomizeVirtualMachine.tsx",
+      "TemplatesCatalog": "./views/catalog/Catalog.tsx",
       "VirtualMachineNavPage": "./views/virtualmachines/details/VirtualMachineNavPage.tsx",
       "VirtualMachinesInstancePage": "./views/virtualmachinesinstance/details/VirtualMachinesInstancePage.tsx",
-      "Wizard": "./views/catalog/wizard/Wizard.tsx",
       "useVirtualMachineActionsProvider": "./views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts",
       "VirtualMachinesInstancesList": "./views/virtualmachinesinstance/list/VirtualMachinesInstancesList.tsx"
     },

--- a/src/views/catalog/Catalog.tsx
+++ b/src/views/catalog/Catalog.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { Route, Switch } from 'react-router-dom';
+
+import CustomizeVirtualMachine from './customize/CustomizeVirtualMachine';
+import TemplatesCatalog from './templatescatalog/TemplatesCatalog';
+import Wizard from './wizard/Wizard';
+
+const Catalog: React.FC = () => {
+  return (
+    <Switch>
+      <Route
+        path={[
+          '/k8s/ns/:ns/templatescatalog/customize',
+          '/k8s/all-namespaces/templatescatalog/customize',
+        ]}
+        component={CustomizeVirtualMachine}
+      />
+      <Route
+        path={[
+          '/k8s/ns/:ns/templatescatalog/review',
+          '/k8s/all-namespaces/templatescatalog/review',
+        ]}
+        component={Wizard}
+      />
+      <Route component={TemplatesCatalog} />
+    </Switch>
+  );
+};
+export default Catalog;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Combine Catalog routes into a single component with a nested Switch.
This will help us share state between these routes in a more efficient and isolated way.
Next step is to wrap the new Switch with a custom Context Provider
