### PR TITLE
Missing OS annotation on VMI

### DIFF
--- a/src/views/virtualmachinesinstance/list/utils/virtualMachinesInstancesRowFilter.ts
+++ b/src/views/virtualmachinesinstance/list/utils/virtualMachinesInstancesRowFilter.ts
@@ -13,8 +13,8 @@ const osTitles = {
 };
 
 const getOSName = (obj: V1VirtualMachineInstance): string | undefined => {
-  const osAnnotation = obj?.metadata?.annotations[VM_KUBEVIRT_OS_ANNOTATION];
-  const [osName] = osAnnotation?.split(/(\d.*)/);
+  const osAnnotation = obj?.metadata?.annotations?.[VM_KUBEVIRT_OS_ANNOTATION];
+  const [osName] = osAnnotation?.split(/(\d.*)/) || [];
   return osTitles[osName] ? osName : 'other';
 };
 

--- a/src/views/virtualmachinesinstance/list/utils/virtualMachinesInstancesStatuses.ts
+++ b/src/views/virtualmachinesinstance/list/utils/virtualMachinesInstancesStatuses.ts
@@ -20,7 +20,7 @@ export const vmiStatuses = {
   Failed: 'Failed',
 };
 
-export const osNames = ['centos', 'fedora', 'windows', 'opensuse', 'rhel', 'ubuntu'];
+export const osNames = ['centos', 'fedora', 'windows', 'rhel', 'other'];
 
 const iconHandler = {
   get: (mapper: typeof iconMapper, prop: string) => {


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> If VMI is missing OS annotation a blank screen appears in VMI list. this fix this.

## 🎥 Demo

> Please add a video or an image of the behavior/changes
