### PR TITLE
Disk tab table - amend for windows machines

### DIFF
--- a/src/views/virtualmachinesinstance/details/tabs/disks/hooks/useFileSystemTableGuestOS.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/disks/hooks/useFileSystemTableGuestOS.tsx
@@ -19,7 +19,8 @@ const useFileSystemTableGuestOS: UseFileSystemTableGuestOS = (vmi) => {
   React.useEffect(() => {
     const guestOS = vmi?.status?.guestOSInfo?.id;
 
-    if (guestOS && !loaded) {
+    setError(null);
+    if (guestOS) {
       (async () => {
         const response = await consoleFetch(
           `api/kubernetes/apis/subresources.${VirtualMachineInstanceModel.apiGroup}/${VirtualMachineInstanceModel.apiVersion}/namespaces/${vmi?.metadata?.namespace}/${VirtualMachineInstanceModel.plural}/${vmi?.metadata?.name}/guestosinfo`,
@@ -27,8 +28,12 @@ const useFileSystemTableGuestOS: UseFileSystemTableGuestOS = (vmi) => {
         const jsonData = await response.json();
         setData(jsonData);
         setLoaded(true);
-      })().catch((err) => setError(err));
+      })().catch((err) => {
+        setError(err);
+        setLoaded(true);
+      });
     }
+    !guestOS && vmi?.metadata && setLoaded(true);
   }, [loaded, vmi]);
 
   return [data, loaded, error];

--- a/src/views/virtualmachinesinstance/details/tabs/disks/table/disks/DisksTableRow.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/disks/table/disks/DisksTableRow.tsx
@@ -15,7 +15,8 @@ type DiskTableRowProps = {
 
 const DisksTableRow: React.FC<DiskTableRowProps> = ({ obj, activeColumnIDs }) => {
   const convertedSize = convertBytes(Number(obj?.size));
-  const size = obj?.size ? `${convertedSize.value} ${convertedSize.unit}` : '-';
+  const size = obj?.size && convertedSize?.unit && `${convertedSize.value} ${convertedSize.unit}`;
+  const defaultSize = obj?.size || '-';
   return (
     <>
       <TableData id="name" activeColumnIDs={activeColumnIDs}>
@@ -33,7 +34,7 @@ const DisksTableRow: React.FC<DiskTableRowProps> = ({ obj, activeColumnIDs }) =>
         )}
       </TableData>
       <TableData id="size" activeColumnIDs={activeColumnIDs}>
-        {size}
+        {size || defaultSize}
       </TableData>
       <TableData id="drive" activeColumnIDs={activeColumnIDs}>
         {obj?.drive}


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Windows machines storage size isn't in bytes but a size which don't need to be converted.
> Windows machines has (currently unknown filesystems so now it will stop loading

## 🎥 Demo

> Please add a video or an image of the behavior/changes
