### PR TITLE
Add VM Context HOC for Tabs

### DIFF
--- a/src/views/catalog/utils/WizardVMContext.tsx
+++ b/src/views/catalog/utils/WizardVMContext.tsx
@@ -25,7 +25,7 @@ export const clearSessionStorageVM = () => {
   } catch (e) {}
 };
 
-type WizardVMContextType = {
+export type WizardVMContextType = {
   /** the vm used for the wizard */
   vm?: V1VirtualMachine;
   /**

--- a/src/views/catalog/wizard/Wizard.scss
+++ b/src/views/catalog/wizard/Wizard.scss
@@ -1,3 +1,9 @@
+.vm-wizard-body {
+  .co-m-page__body {
+    height: 100%;
+  }
+}
+
 .vm-wizard-footer {
   padding: var(--pf-global--spacer--lg);
   border-top: 1px solid var(--pf-chart-color-black-200);

--- a/src/views/catalog/wizard/Wizard.tsx
+++ b/src/views/catalog/wizard/Wizard.tsx
@@ -22,7 +22,7 @@ const Wizard: React.FC = () => {
   return (
     <Stack hasGutter>
       <WizardHeader />
-      <StackItem isFilled>
+      <StackItem className="vm-wizard-body" isFilled>
         <HorizontalNav pages={wizardNavPages} />
       </StackItem>
       <WizardFooter namespace={ns} />

--- a/src/views/catalog/wizard/tabs.tsx
+++ b/src/views/catalog/wizard/tabs.tsx
@@ -1,4 +1,10 @@
+import * as React from 'react';
+
+import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { NavPage } from '@openshift-console/dynamic-plugin-sdk';
+import { Bullseye } from '@patternfly/react-core';
+
+import { useWizardVMContext, WizardVMContextType } from '../utils/WizardVMContext';
 
 import WizardAdvancedTab from './tabs/advanced/WizardAdvancedTab';
 import WizardDisksTab from './tabs/disks/WizardDisksTab';
@@ -9,45 +15,59 @@ import WizardSchedulingTab from './tabs/scheduling/WizardSchedulingTab';
 import WizardScriptsTab from './tabs/scripts/WizardScriptsTab';
 import WizardYAMLTab from './tabs/yaml/WizardYAMLTab';
 
+const withVmContext = (Page: React.FC<WizardVMContextType>) => (props) => {
+  const { vm, updateVM, loaded, error } = useWizardVMContext();
+
+  if (!vm && !loaded) {
+    return (
+      <Bullseye>
+        <Loading />
+      </Bullseye>
+    );
+  }
+
+  return <Page vm={vm} loaded={loaded} updateVM={updateVM} error={error} {...props} />;
+};
+
 export const wizardNavPages: NavPage[] = [
   {
     href: '',
     name: 'Overview',
-    component: WizardOverviewTab,
+    component: withVmContext(WizardOverviewTab),
   },
   {
     href: 'yaml',
     name: 'YAML',
-    component: WizardYAMLTab,
+    component: withVmContext(WizardYAMLTab),
   },
   {
     href: 'scheduling',
     name: 'Scheduling',
-    component: WizardSchedulingTab,
+    component: withVmContext(WizardSchedulingTab),
   },
   {
     href: 'enviornment',
     name: 'Enviornment',
-    component: WizardEnvironmentTab,
+    component: withVmContext(WizardEnvironmentTab),
   },
   {
     href: 'network-interfaces',
     name: 'Network Interfaces',
-    component: WizardNetworkTab,
+    component: withVmContext(WizardNetworkTab),
   },
   {
     href: 'disks',
     name: 'Disks',
-    component: WizardDisksTab,
+    component: withVmContext(WizardDisksTab),
   },
   {
     href: 'scripts',
     name: 'Scripts',
-    component: WizardScriptsTab,
+    component: withVmContext(WizardScriptsTab),
   },
   {
     href: 'advanced',
     name: 'Advanced',
-    component: WizardAdvancedTab,
+    component: withVmContext(WizardAdvancedTab),
   },
 ];

--- a/src/views/catalog/wizard/tabs/advanced/WizardAdvancedTab.tsx
+++ b/src/views/catalog/wizard/tabs/advanced/WizardAdvancedTab.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-// import { useWizardVMContext } from '../../../utils/WizardVMContext';
+import { WizardVMContextType } from '../../../utils/WizardVMContext';
 
-const WizardAdvancedTab = () => {
-  // const { vm, updateVM, loaded, error } = useWizardVMContext();
+const WizardAdvancedTab: React.FC<WizardVMContextType> = ({ vm, updateVM, loaded, error }) => {
+  console.log(vm, updateVM, loaded, error);
 
   return <div>WizardAdvancedTab</div>;
 };

--- a/src/views/catalog/wizard/tabs/disks/WizardDisksTab.tsx
+++ b/src/views/catalog/wizard/tabs/disks/WizardDisksTab.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-// import { useWizardVMContext } from '../../../utils/WizardVMContext';
+import { WizardVMContextType } from '../../../utils/WizardVMContext';
 
-const WizardDisksTab = () => {
-  // const { vm, updateVM, loaded, error } = useWizardVMContext();
+const WizardDisksTab: React.FC<WizardVMContextType> = ({ vm, updateVM, loaded, error }) => {
+  console.log(vm, updateVM, loaded, error);
 
   return <div>WizardDisksTab</div>;
 };

--- a/src/views/catalog/wizard/tabs/environment/WizardEnvironmentTab.tsx
+++ b/src/views/catalog/wizard/tabs/environment/WizardEnvironmentTab.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-// import { useWizardVMContext } from '../../../utils/WizardVMContext';
+import { WizardVMContextType } from '../../../utils/WizardVMContext';
 
-const WizardEnvironmentTab = () => {
-  // const { vm, updateVM, loaded, error } = useWizardVMContext();
+const WizardEnvironmentTab: React.FC<WizardVMContextType> = ({ vm, updateVM, loaded, error }) => {
+  console.log(vm, updateVM, loaded, error);
 
   return <div>WizardEnvironmentTab</div>;
 };

--- a/src/views/catalog/wizard/tabs/network/WizardNetworkTab.tsx
+++ b/src/views/catalog/wizard/tabs/network/WizardNetworkTab.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-// import { useWizardVMContext } from '../../../utils/WizardVMContext';
+import { WizardVMContextType } from '../../../utils/WizardVMContext';
 
-const WizardNetworkTab = () => {
-  // const { vm, updateVM, loaded, error } = useWizardVMContext();
+const WizardNetworkTab: React.FC<WizardVMContextType> = ({ vm, updateVM, loaded, error }) => {
+  console.log(vm, updateVM, loaded, error);
 
   return <div>WizardNetworkTab</div>;
 };

--- a/src/views/catalog/wizard/tabs/overview/WizardOverviewTab.tsx
+++ b/src/views/catalog/wizard/tabs/overview/WizardOverviewTab.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-// import { useWizardVMContext } from '../../../utils/WizardVMContext';
+import { WizardVMContextType } from '../../../utils/WizardVMContext';
 
-const WizardOverviewTab = () => {
-  // const { vm, updateVM, loaded, error } = useWizardVMContext();
+const WizardOverviewTab: React.FC<WizardVMContextType> = ({ vm, updateVM, loaded, error }) => {
+  console.log(vm, updateVM, loaded, error);
 
   return <div>WizardOverviewTab</div>;
 };

--- a/src/views/catalog/wizard/tabs/scheduling/WizardSchedulingTab.tsx
+++ b/src/views/catalog/wizard/tabs/scheduling/WizardSchedulingTab.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-// import { useWizardVMContext } from '../../../utils/WizardVMContext';
+import { WizardVMContextType } from '../../../utils/WizardVMContext';
 
-const WizardSchedulingTab = () => {
-  // const { vm, updateVM, loaded, error } = useWizardVMContext();
+const WizardSchedulingTab: React.FC<WizardVMContextType> = ({ vm, updateVM, loaded, error }) => {
+  console.log(vm, updateVM, loaded, error);
 
   return <div>WizardSchedulingTab</div>;
 };

--- a/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-// import { useWizardVMContext } from '../../../utils/WizardVMContext';
+import { WizardVMContextType } from '../../../utils/WizardVMContext';
 
-const WizardScriptsTab = () => {
-  // const { vm, updateVM, loaded, error } = useWizardVMContext();
+const WizardScriptsTab: React.FC<WizardVMContextType> = ({ vm, updateVM, loaded, error }) => {
+  console.log(vm, updateVM, loaded, error);
 
   return <div>WizardScriptsTab</div>;
 };

--- a/src/views/catalog/wizard/tabs/yaml/WizardYAMLTab.tsx
+++ b/src/views/catalog/wizard/tabs/yaml/WizardYAMLTab.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-// import { useWizardVMContext } from '../../../utils/WizardVMContext';
+import { WizardVMContextType } from '../../../utils/WizardVMContext';
 
-const WizardYAMLTab = () => {
-  // const { vm, updateVM, loaded, error } = useWizardVMContext();
+const WizardYAMLTab: React.FC<WizardVMContextType> = ({ vm, updateVM, loaded, error }) => {
+  console.log(vm, updateVM, loaded, error);
 
   return <div>WizardYAMLTab</div>;
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add VM Context HOC for Tabs
This decouples the Tabs from the VM Context.
It also allows to render a loading state before the VM is ready for review.

## 🎥 Demo

Here is a loading VM
<img width="933" alt="Screen Shot 2022-03-06 at 13 01 44 1" src="https://user-images.githubusercontent.com/24938324/156920299-0b24387c-6627-4a2c-a8c7-599b844d7cb4.png">

