### PR TITLE
Add immutability to VM Context

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,13 +52,15 @@
     "byte-size": "^8.1.0",
     "date-fns": "^2.28.0",
     "global": "^4.4.0",
+    "immer": "^9.0.12",
     "mochawesome-report-generator": "^6.0.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-helmet": "^6.1.0",
     "react-i18next": "^11.14.3",
     "react-router-dom": "5.x",
-    "unique-names-generator": "^4.6.0"
+    "unique-names-generator": "^4.6.0",
+    "use-immer": "^0.6.0"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.11.0",

--- a/src/views/catalog/wizard/tabs/metadata/components/WizardAnnotationsModal/WizardAnnotationsModal.tsx
+++ b/src/views/catalog/wizard/tabs/metadata/components/WizardAnnotationsModal/WizardAnnotationsModal.tsx
@@ -6,6 +6,8 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { Button, Grid } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 
+import { ContextUpdateVM } from '../../../../../utils/WizardVMContext';
+
 import { WizardAnnotationsModalRow } from './WizardAnnotationsModalRow';
 
 import './WizardAnnotationsModal.scss';
@@ -15,7 +17,7 @@ const getIdAnnotations = (annotations: { [key: string]: string }) =>
 
 export const WizardAnnotationsModal: React.FC<{
   vm: V1VirtualMachine;
-  updateVM: (vm: V1VirtualMachine) => Promise<void>;
+  updateVM: ContextUpdateVM;
   isOpen: boolean;
   onClose: () => void;
 }> = ({ vm, isOpen, updateVM, onClose }) => {
@@ -40,7 +42,7 @@ export const WizardAnnotationsModal: React.FC<{
     });
   };
 
-  const onSubmit = (vmObj: V1VirtualMachine) => {
+  const onSubmit = () => {
     const uniqWith = (arr, fn) =>
       arr.filter((element, index) => arr.findIndex((step) => fn(element, step)) === index);
 
@@ -51,12 +53,13 @@ export const WizardAnnotationsModal: React.FC<{
       return Promise.reject({ message: t('Duplicate keys found') });
     }
 
-    const updatedVM = { ...vmObj };
-    updatedVM.metadata.annotations = Object.fromEntries(
+    const updatedAnnotations = Object.fromEntries(
       Object.entries(annotations).map(([, { key, value }]) => [key, value]),
     );
 
-    return updateVM(updatedVM);
+    return updateVM((vmDraft) => {
+      vmDraft.metadata.annotations = updatedAnnotations;
+    });
   };
 
   // reset annotations when modal is closed

--- a/yarn.lock
+++ b/yarn.lock
@@ -5781,6 +5781,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immer@npm:^9.0.12":
+  version: 9.0.12
+  resolution: "immer@npm:9.0.12"
+  checksum: bcbec6d76dac65e49068eb67ece4d407116e62b8cde3126aa89c801e408f5047763ba0aeb62f1938c1aa704bb6612f1d8302bb2a86fa1fc60fcc12d8b25dc895
+  languageName: node
+  linkType: hard
+
 "immutable@npm:^4.0.0":
   version: 4.0.0
   resolution: "immutable@npm:4.0.0"
@@ -7105,6 +7112,7 @@ __metadata:
     global: ^4.4.0
     i18next: ^21.6.0
     i18next-parser: 3.x
+    immer: ^9.0.12
     jest: ^27.4.5
     mocha: ^9.2.0
     mocha-junit-reporter: ^2.0.2
@@ -7127,6 +7135,7 @@ __metadata:
     tsconfig-paths-webpack-plugin: ^3.5.1
     typescript: ^4.5.5
     unique-names-generator: ^4.6.0
+    use-immer: ^0.6.0
     webpack: ^5.68.0
     webpack-cli: 4.9.x
     webpack-dev-server: ^4.7.4
@@ -10790,6 +10799,16 @@ __metadata:
     punycode: 1.3.2
     querystring: 0.2.0
   checksum: 50d100d3dd2d98b9fe3ada48cadb0b08aa6be6d3ac64112b867b56b19be4bfcba03c2a9a0d7922bfd7ac17d4834e88537749fe182430dfd9b68e520175900d90
+  languageName: node
+  linkType: hard
+
+"use-immer@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "use-immer@npm:0.6.0"
+  peerDependencies:
+    immer: ">=2.0.0"
+    react: ^16.8.0 || ^17.0.1
+  checksum: 5cb3e2f411cfaf0eeab8cce8919a83fdf82e10b3acfd2d4550d9c6a0afb105aace8c0406131126557a2eab6c4ef8aef87c24a82830b75140ec6b2cdffe818d76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add immutability to VM Context

- add `immer` and `useImmer` to the vm object in the context state
- This change makes the vm object immutable (read only)
- Updating a vm is now simplified and fail-safe, we pass a callback that receives a vm draft, editing only the needed part without worrying about cloning the object's untouched parts beforehand

e.g. 
before:

```ts
updateVM({
      ...vmObj,
      metadata: {
        ...vmObj.metadata,
        annotations: updatedAnnotations,
      },
    };
``` 

after:

```ts
updateVM((vmDraft) => {
   vmDraft.metadata.annotations = updatedAnnotations;
});
```


> Please add a video or an image of the behavior/changes
