### PR TITLE
Fix type issue in getVirtualMachineNameField util

### DIFF
--- a/src/views/catalog/customize/utils.tsx
+++ b/src/views/catalog/customize/utils.tsx
@@ -79,7 +79,7 @@ export const processTemplate = async (
 
 export const getVirtualMachineNameField = (
   template: V1Template,
-  t: TFunction,
+  t: TFunction<'plugin__kubevirt-plugin', undefined>,
 ): TemplateParameter => {
   return {
     required: true,


### PR DESCRIPTION
Fix the type issue of the t-function for translations, in the `getVirtualMachineNameField` util, used in `CustomizeForm`
and `CustomizeFormWithDisk` components.

Before:
![issuee](https://user-images.githubusercontent.com/13417815/159057228-bdadea17-5fff-4ae7-bd40-dfcaa66c4855.png)

