### PR TITLE
Add global useModal

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -185,5 +185,12 @@
         "$codeRef": "ClusterOverviewPage"
       }
     }
+  },
+  {
+    "type": "console.context-provider",
+    "properties": {
+      "provider": { "$codeRef": "modalProvider.ModalProvider" },
+      "useValueHook": { "$codeRef": "modalProvider.useModalValue" }
+    }
   }
 ]

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "VirtualMachinesInstancesList": "./views/virtualmachinesinstance/list/VirtualMachinesInstancesList.tsx",
       "useVirtualMachineInstanceActionsProvider": "./views/virtualmachinesinstance/actions/hooks/useVirtualMachineInstanceActionsProvider.tsx",
       "ClusterOverviewPage": "./views/clusteroverview/overview/components/ClusterOverviewPage.tsx",
-      "VirtualMachineTemplatesList": "./views/templates/list/VirtualMachineTemplatesList.tsx"
+      "VirtualMachineTemplatesList": "./views/templates/list/VirtualMachineTemplatesList.tsx",
+      "modalProvider": "./utils/components/ModalProvider/ModalProvider.tsx"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/src/utils/components/ModalProvider/ModalProvider.tsx
+++ b/src/utils/components/ModalProvider/ModalProvider.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+
+export type ModalComponentProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  appendTo: () => HTMLElement;
+};
+export type ModalComponent = React.ComponentType<ModalComponentProps>;
+
+export type ModalContextType = {
+  /** the modal component to render */
+  modal?: ModalComponent;
+  /** whether the modal is open */
+  isOpen?: boolean;
+  /** callback to close the modal */
+  onClose?: () => void;
+  /** receives a modal component as an argument and injects it to the dom, the component callback will receive the following parameters,
+   * isOpen: open state of the modal
+   * onClose: callback to close the modal
+   * appendTo: callback to get the dom element to append the modal to
+   * @example
+   * const { createModal } = useModal();
+   *
+   * createModal(({ isOpen, onClose, appendTo }) => (
+   *  <ExampleModal isOpen={isOpen} onClose={onClose} appendTo={appendTo} />
+   * ))
+   *
+   */
+  createModal?: (modal: ModalComponent) => void;
+};
+
+export const ModalContext = React.createContext<ModalContextType>({});
+/**
+ * A hook that returns a global modal context. This context is used to inject a modal component to the dom.
+ * @example
+ * const { createModal } = useModal();
+ *
+ * createModal(({ isOpen, onClose, appendTo }) => (
+ *  <ExampleModal isOpen={isOpen} onClose={onClose} appendTo={appendTo} />
+ * ))
+ */
+export const useModal = () => React.useContext(ModalContext);
+
+export const useModalValue = (): ModalContextType => {
+  const [modal, setModal] = React.useState<ModalComponent>();
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const createModal = (modal: ModalComponent) => {
+    setIsOpen(true);
+    setModal(() => modal);
+  };
+
+  const onClose = () => {
+    setIsOpen(false);
+    setModal(undefined);
+  };
+
+  return { modal, isOpen, createModal, onClose };
+};
+
+export const ModalProvider: React.FC<{ value: ModalContextType }> = ({ value = {}, children }) => {
+  const { modal: Modal, isOpen, onClose } = value;
+
+  return (
+    <ModalContext.Provider value={value}>
+      {Modal && isOpen && (
+        <Modal
+          isOpen
+          onClose={onClose}
+          appendTo={() => document.querySelector('#modal-container')}
+        />
+      )}
+      {children}
+    </ModalContext.Provider>
+  );
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add global useModal. The hook can be used anywhere in the plugin.
This will help us open a modal programmatically without having to handle its state.

## 🎥 Demo

Example usage
```tsx
const { createModal } = useModal();

<Button
  onClick={() =>
    createModal(({ isOpen, onClose, appendTo }) => (
      <ExampleModal isOpen={isOpen} onClose={onClose} appendTo={appendTo} />
    ))
  }
/>
```
