### PR TITLE
Move DeleteResourceMessege to separate file

### DIFF
--- a/src/utils/components/DeleteModal/DeleteModal.tsx
+++ b/src/utils/components/DeleteModal/DeleteModal.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 
-import TabModal, { DeleteResourceMessege } from '@kubevirt-utils/components/TabModal/TabModal';
+import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { ButtonVariant } from '@patternfly/react-core';
+import DeleteResourceMessage from '../DeleteResourceMessage/DeleteResourceMessage';
 
 type DeleteModalProps = {
   isOpen: boolean;
@@ -29,7 +30,7 @@ const DeleteModal: React.FC<DeleteModalProps> = React.memo(
         submitBtnVariant={ButtonVariant.danger}
         titleIconVariant={'warning'}
       >
-        <DeleteResourceMessege obj={obj} />
+        <DeleteResourceMessage obj={obj} />
       </TabModal>
     );
   },

--- a/src/utils/components/DeleteResourceMessage/DeleteResourceMessage.tsx
+++ b/src/utils/components/DeleteResourceMessage/DeleteResourceMessage.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { Trans } from 'react-i18next';
+import { useKubevirtTranslation } from "@kubevirt-utils/hooks/useKubevirtTranslation";
+
+const DeleteResourceMessage: React.FC<{ obj: K8sResourceCommon }> = ({ obj }) => {
+  const { t } = useKubevirtTranslation();
+  return (
+    <Trans t={t}>
+      Are you sure you want to delete <strong>{obj.metadata.name} </strong>in namespace{' '}
+      <strong>{obj.metadata.namespace}?</strong>
+    </Trans>
+  );
+};
+
+export default DeleteResourceMessage;

--- a/src/utils/components/TabModal/TabModal.tsx
+++ b/src/utils/components/TabModal/TabModal.tsx
@@ -12,18 +12,7 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import { Trans } from 'react-i18next';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-
-export const DeleteResourceMessege: React.FC<{ obj: K8sResourceCommon }> = ({ obj }) => {
-  const { t } = useKubevirtTranslation();
-  return (
-    <Trans t={t}>
-      Are you sure you want to delete <strong>{obj.metadata.name} </strong>from namespace{' '}
-      <strong>{obj.metadata.namespace}?</strong>
-    </Trans>
-  );
-};
 
 type TabModalProps<T extends K8sResourceCommon = K8sResourceCommon> = {
   isOpen: boolean;

--- a/src/views/virtualmachines/details/tabs/network/copmonents/list/NetworkInterfaceActions.tsx
+++ b/src/views/virtualmachines/details/tabs/network/copmonents/list/NetworkInterfaceActions.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import DeleteResourceMessage from '@kubevirt-utils/components/DeleteResourceMessage/DeleteResourceMessage';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import TabModal, { DeleteResourceMessege } from '@kubevirt-utils/components/TabModal/TabModal';
+import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
@@ -74,7 +75,9 @@ const NetworkInterfaceActions: React.FC<NetworkInterfaceActionsProps> = ({
         submitBtnText={deleteBtnText}
         submitBtnVariant={ButtonVariant.danger}
       >
-        <DeleteResourceMessege obj={{ metadata: { name: nicName } }} />
+        <DeleteResourceMessage
+          obj={{ metadata: { name: nicName, namespace: vm?.metadata?.namespace } }}
+        />
       </TabModal>
     ));
     setIsDropdownOpen(false);

--- a/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotActionsMenu.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotActionsMenu.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 
 import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
 import { V1alpha1VirtualMachineSnapshot } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import DeleteResourceMessage from '@kubevirt-utils/components/DeleteResourceMessage/DeleteResourceMessage';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import TabModal, { DeleteResourceMessege } from '@kubevirt-utils/components/TabModal/TabModal';
+import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { k8sDelete } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -44,7 +45,7 @@ const SnapshotActionsMenu: React.FC<SnapshotActionsMenuProps> = ({ snapshot }) =
         submitBtnText={t('Delete')}
         submitBtnVariant={ButtonVariant.danger}
       >
-        <DeleteResourceMessege obj={snapshot} />
+        <DeleteResourceMessage obj={snapshot} />
       </TabModal>
     ));
     setIsDropdownOpen(false);


### PR DESCRIPTION
In this PR I:
- move the component to a separate file under _src/utils/components_.
- rename the component name to `DeleteResourceMessage`, 
- update the related code, where the component is used
- change the message from "... **from** namespace..." to "... **in** namespace...", according to the design updates
- add the missing `namespace` prop of the component, for deletion of VM NICs

**Screenshots**:
_Before:_
![nic_before](https://user-images.githubusercontent.com/13417815/161617293-1e6775b0-7ed5-4667-aef6-de3d90ecb296.png)

_After:_
![namespace](https://user-images.githubusercontent.com/13417815/161753582-942acbec-3398-42c8-9c3a-88ce5a62e1c6.png)

