### PR TITLE
remove vm error from disks tab table

### DIFF
--- a/src/views/catalog/wizard/tabs/disks/WizardDisksTab.tsx
+++ b/src/views/catalog/wizard/tabs/disks/WizardDisksTab.tsx
@@ -19,7 +19,7 @@ import useDiskColumns from './hooks/useDiskColumns';
 import useDisksFilters from './hooks/useDisksFilters';
 import useWizardDisksTableData from './hooks/useWizardDisksTableData';
 
-const WizardDisksTab: React.FC<WizardVMContextType> = ({ vm, loaded, updateVM, error }) => {
+const WizardDisksTab: React.FC<WizardVMContextType> = ({ vm, loaded, updateVM }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const columns = useDiskColumns();
@@ -59,7 +59,7 @@ const WizardDisksTab: React.FC<WizardVMContextType> = ({ vm, loaded, updateVM, e
           data={filteredData}
           unfilteredData={data}
           loaded={loaded}
-          loadError={error}
+          loadError={undefined}
           columns={columns}
           Row={DiskRow}
         />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The Disks table will show an error even if it's not related to the Disks tab.
The `loadError` prop is meant for resource fetch errors, the wizard's vm is not fetched, so we should remove it from the Disks tab table.