### PR TITLE
add YAML editor and Console to VM details tabs

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -370,6 +370,7 @@
   "The following information is provided by the OpenShift Virtualization operator.": "The following information is provided by the OpenShift Virtualization operator.",
   "The following information regarding how the disks are partitioned is provided by the guest agent.": "The following information regarding how the disks are partitioned is provided by the guest agent.",
   "The guest OS needs to have the Cloudinit service running.": "The guest OS needs to have the Cloudinit service running.",
+  "This Virtual Machine is down. Please start it to access its console.": "This Virtual Machine is down. Please start it to access its console.",
   "This disk's source is not editable": "This disk's source is not editable",
   "This field is required": "This field is required",
   "This template requires some additional parameters. Click the Customize Virtual machine button to complete the creation flow.": "This template requires some additional parameters. Click the Customize Virtual machine button to complete the creation flow.",

--- a/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
+++ b/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
@@ -8,6 +8,7 @@ import VirtualMachineEnvironmentPage from '../tabs/environment/VirtualMachineEnv
 import NetworkInterfaceListPage from '../tabs/network/NetworkInterfaceListPage';
 import VirtualMachinesOverviewTab from '../tabs/overview/VirtualMachinesOverviewTab';
 import SnapshotListPage from '../tabs/snapshots/SnapshotListPage';
+import VirtualMachineYAMLPage from '../tabs/yaml/VirtualMachineYAMLPage';
 
 export const useVirtualMachineTabs = () => {
   const { t } = useKubevirtTranslation();
@@ -27,7 +28,7 @@ export const useVirtualMachineTabs = () => {
       {
         href: 'yaml',
         name: 'YAML',
-        component: React.Fragment,
+        component: VirtualMachineYAMLPage,
       },
       {
         href: 'environment',

--- a/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
+++ b/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
+import VirtualMachineConsolePage from '../tabs/console/VirtualMachineConsolePage';
 import VirtualMachineDetailsPage from '../tabs/details/VirtualMachineDetailsPage';
 import DiskListPage from '../tabs/disk/tables/disk/DiskListPage';
 import VirtualMachineEnvironmentPage from '../tabs/environment/VirtualMachineEnvironmentPage';
@@ -43,7 +44,7 @@ export const useVirtualMachineTabs = () => {
       {
         href: 'console',
         name: t('Console'),
-        component: React.Fragment,
+        component: VirtualMachineConsolePage,
       },
       {
         href: 'network-interfaces',

--- a/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.tsx
+++ b/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+
+import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import Consoles from '@kubevirt-utils/components/Consoles/Consoles';
+import Loading from '@kubevirt-utils/components/Loading/Loading';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { Bullseye } from '@patternfly/react-core';
+
+import { printableVMStatus } from '../../../utils';
+
+type VirtualMachineConsolePageProps = RouteComponentProps & {
+  obj: V1VirtualMachine;
+};
+
+const VirtualMachineConsolePage: React.FC<VirtualMachineConsolePageProps> = ({ obj: vm }) => {
+  const { t } = useKubevirtTranslation();
+  const [vmi, vmiLoaded] = useK8sWatchResource<V1VirtualMachineInstance>({
+    groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
+    name: vm?.metadata?.name,
+    namespace: vm?.metadata?.namespace,
+    isList: false,
+  });
+
+  if (!vmi && vm?.status?.printableStatus === printableVMStatus.Stopped) {
+    return (
+      <div className="co-m-pane__body">
+        {t('This Virtual Machine is down. Please start it to access its console.')}
+      </div>
+    );
+  }
+
+  if (!vmiLoaded) {
+    return (
+      <Bullseye>
+        <Loading />
+      </Bullseye>
+    );
+  }
+
+  return (
+    <div className="co-m-pane__body">
+      <Consoles vmi={vmi} />
+    </div>
+  );
+};
+
+export default VirtualMachineConsolePage;

--- a/src/views/virtualmachines/details/tabs/yaml/VirtualMachineYAMLPage.tsx
+++ b/src/views/virtualmachines/details/tabs/yaml/VirtualMachineYAMLPage.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router';
+
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import Loading from '@kubevirt-utils/components/Loading/Loading';
+import { ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
+import { Bullseye } from '@patternfly/react-core';
+
+type VirtualMachineYAMLPageProps = RouteComponentProps<{
+  ns: string;
+  name: string;
+}> & {
+  obj?: V1VirtualMachine;
+};
+
+const VirtualMachineYAMLPage: React.FC<VirtualMachineYAMLPageProps> = ({ obj: vm }) => {
+  return (
+    <React.Suspense
+      fallback={
+        <Bullseye>
+          <Loading />
+        </Bullseye>
+      }
+    >
+      <ResourceYAMLEditor initialResource={vm} />
+    </React.Suspense>
+  );
+};
+
+export default VirtualMachineYAMLPage;


### PR DESCRIPTION
## :pencil2: Description

adding console and yaml tabs to VM details navigation

## 🎥 Demo

consoles:
https://user-images.githubusercontent.com/67270715/162694116-1612e86f-dae7-4def-aea6-d2a74ff412c4.mp4

yaml editor:
https://user-images.githubusercontent.com/67270715/162688339-af881f26-94ea-4bc8-b940-d5dfbc812f85.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>