### PR TITLE
[WIP] Make a link to the VM Template's details tabs

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -89,6 +89,15 @@
     }
   },
   {
+    "type": "console.page/resource/details",
+    "properties": {
+      "path": ["/k8s/ns/:ns/templates/:name"],
+      "component": {
+        "$codeRef": "VirtualMachineTemplatesDetailsPage"
+      }
+    }
+  },
+  {
     "type": "console.page/resource/list",
     "properties": {
       "model": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
       "useVirtualMachineInstanceActionsProvider": "./views/virtualmachinesinstance/actions/hooks/useVirtualMachineInstanceActionsProvider.tsx",
       "ClusterOverviewPage": "./views/clusteroverview/overview/components/ClusterOverviewPage.tsx",
       "VirtualMachineTemplatesList": "./views/templates/list/VirtualMachineTemplatesList.tsx",
-      "modalProvider": "./utils/components/ModalProvider/ModalProvider.tsx"
+      "modalProvider": "./utils/components/ModalProvider/ModalProvider.tsx",
+      "VirtualMachineTemplatesDetailsPage": "./views/templates/details/VirtualMachineTemplatesDetailsPage.tsx"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/src/views/templates/details/VirtualMachineTemplatesDetailsPage.tsx
+++ b/src/views/templates/details/VirtualMachineTemplatesDetailsPage.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+
+import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { ListPageBody, ListPageHeader, ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+import { Grid, GridItem } from '@patternfly/react-core';
+
+type VirtualMachineTemplatesDetailsPageProps = RouteComponentProps<{
+  ns: string;
+  name: string;
+}> & {
+  obj?: V1Template;
+};
+
+const VirtualMachineTemplatesDetailsPage: React.FC<VirtualMachineTemplatesDetailsPageProps> = ({
+  obj: template,
+}) => {
+  const { t } = useKubevirtTranslation();
+
+  return (
+    <>
+      <ListPageHeader title={t('')}>
+        <ResourceLink
+          kind={TemplateModel.kind}
+          name={template.metadata.name}
+          namespace={template.metadata.namespace}
+        />
+      </ListPageHeader>
+      <Grid hasGutter>
+        <GridItem span={1}>{/* Spacer */}</GridItem>
+      </Grid>
+      <ListPageBody></ListPageBody>
+    </>
+  );
+};
+
+export default VirtualMachineTemplatesDetailsPage;


### PR DESCRIPTION
## 📝 Description
Add `VirtualMachineTemplatesDetailsPage` to the console extensions, create the component for displaying the appropriate tabs, such as Details, YAML, NICs, Disks (followup PRs).

## 🎥 Demo
