### PR TITLE
Fix handling of undefined template annotations

### DIFF
--- a/src/utils/resources/template/utils/selectors.ts
+++ b/src/utils/resources/template/utils/selectors.ts
@@ -36,14 +36,26 @@ export const isDefaultVariantTemplate = (template: V1Template): boolean =>
  * @param {V1Template} template - template
  */
 export const getTemplateOSLabelName = (template: V1Template): string =>
-  getLabel(template, ANNOTATIONS.osTemplate, template?.metadata?.name);
+  getLabel(getTemplateVirtualMachineObject(template), ANNOTATIONS.osTemplate);
+
+/**
+ * A selector that returns the os label of a given template
+ * @param {V1Template} template - template
+ */
+export const getTemplateOS = (template: V1Template): OS_NAME_TYPES => {
+  return (
+    Object.values(OS_NAME_TYPES).find((osName) =>
+      getTemplateOSLabelName(template)?.includes(osName),
+    ) ?? OS_NAME_TYPES.other
+  );
+};
 
 /**
  * A selector that returns the template provider name of a given template
  * @param {V1Template} template - template
  */
 export const getTemplateProviderName = (template: V1Template): string =>
-  getAnnotation(template, ANNOTATIONS.providerDisplayName, template?.metadata?.name);
+  getAnnotation(template, ANNOTATIONS.providerDisplayName);
 
 /**
  * A selector that returns the support level of a given template
@@ -90,18 +102,6 @@ export const getTemplateWorkload = (template: V1Template): string => {
     getLabel(template, `${TEMPLATE_WORKLOAD_LABEL}/${workload}`) === 'true';
 
   return Object.values(WORKLOADS).find((flavor) => isWorkloadExist(flavor)) ?? 'unknown';
-};
-
-/**
- * A selector that returns the os label of a given template
- * @param {V1Template} template - template
- */
-export const getTemplateOS = (template: V1Template): OS_NAME_TYPES => {
-  return (
-    Object.values(OS_NAME_TYPES).find((osName) =>
-      getTemplateOSLabelName(template).includes(osName),
-    ) ?? OS_NAME_TYPES.other
-  );
 };
 
 /**

--- a/src/views/catalog/customize/components/CustomizeForms/useCustomizeFormSubmit.ts
+++ b/src/views/catalog/customize/components/CustomizeForms/useCustomizeFormSubmit.ts
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { getAnnotation } from '@kubevirt-utils/resources/shared';
+import { ANNOTATIONS } from '@kubevirt-utils/resources/template';
 import {
-  getTemplateName,
   getTemplateOS,
   getTemplateVirtualMachineObject,
 } from '@kubevirt-utils/resources/template/utils/selectors';
@@ -44,8 +45,11 @@ export const useCustomizeFormSubmit = (
         ensurePath(tabsDataDraft, 'overview.templateMetadata');
         tabsDataDraft.overview.templateMetadata.name = template.metadata.name;
         tabsDataDraft.overview.templateMetadata.namespace = template.metadata.namespace;
-        tabsDataDraft.overview.templateMetadata.displayName = getTemplateName(template);
         tabsDataDraft.overview.templateMetadata.osType = getTemplateOS(template);
+        tabsDataDraft.overview.templateMetadata.displayName = getAnnotation(
+          template,
+          ANNOTATIONS.displayName,
+        );
       });
       await updateVM(vm);
       history.push(`/k8s/ns/${ns || 'default'}/templatescatalog/review`);

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
@@ -67,7 +67,7 @@ export const TemplatesCatalogDrawerPanel: React.FC<TemplatesCatalogDrawerPanelPr
     const vmObject = getTemplateVirtualMachineObject(template);
     const displayName = getTemplateName(template);
     const description = getTemplateDescription(template) || notAvailable;
-    const documentationUrl = getTemplateDocumentationURL(template) || notAvailable;
+    const documentationUrl = getTemplateDocumentationURL(template);
     const workload = getTemplateWorkload(template);
     const networks = getTemplateNetworks(template);
     const interfaces = getTemplateInterfaces(template);
@@ -113,17 +113,25 @@ export const TemplatesCatalogDrawerPanel: React.FC<TemplatesCatalogDrawerPanelPr
                         <DescriptionListGroup>
                           <DescriptionListTerm>{t('Documentation')}</DescriptionListTerm>
                           <DescriptionListDescription>
-                            <Button
-                              isSmall
-                              isInline
-                              variant="link"
-                              icon={<ExternalLinkSquareAltIcon />}
-                              iconPosition="right"
-                            >
-                              <a href={documentationUrl} target="_blank" rel="noopener noreferrer">
-                                {t('Refer to documentation')}
-                              </a>
-                            </Button>
+                            {documentationUrl ? (
+                              <Button
+                                isSmall
+                                isInline
+                                variant="link"
+                                icon={<ExternalLinkSquareAltIcon />}
+                                iconPosition="right"
+                              >
+                                <a
+                                  href={documentationUrl}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                >
+                                  {t('Refer to documentation')}
+                                </a>
+                              </Button>
+                            ) : (
+                              notAvailable
+                            )}
                           </DescriptionListDescription>
                         </DescriptionListGroup>
                       </DescriptionList>

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogTile.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogTile.tsx
@@ -10,7 +10,6 @@ import {
 import { getTemplateBootSourceType } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import {
   getTemplateName,
-  getTemplateProviderName,
   getTemplateWorkload,
 } from '@kubevirt-utils/resources/template/utils/selectors';
 import { CatalogTile } from '@patternfly/react-catalog-view-extension';
@@ -27,7 +26,6 @@ export type TemplateTileProps = {
 export const TemplateTile: React.FC<TemplateTileProps> = React.memo(({ template, onClick }) => {
   const { t } = useKubevirtTranslation();
 
-  const provider = getTemplateProviderName(template);
   const workload = getTemplateWorkload(template);
   const displayName = getTemplateName(template);
   const bootSourceType = getTemplateBootSourceType(template)?.type;
@@ -43,7 +41,7 @@ export const TemplateTile: React.FC<TemplateTileProps> = React.memo(({ template,
           <StackItem>
             <b>{displayName}</b>
           </StackItem>
-          {provider && <StackItem className="text-secondary">{template.metadata.name}</StackItem>}
+          <StackItem className="text-secondary">{template.metadata.name}</StackItem>
         </Stack>
       }
       onClick={() => onClick(template)}
@@ -58,7 +56,7 @@ export const TemplateTile: React.FC<TemplateTileProps> = React.memo(({ template,
               <b>{t('Boot source')}</b> {BOOT_SOURCE_LABELS?.[bootSourceType] || 'N/A'}
             </StackItem>
             <StackItem>
-              <b>{t('Workload')}</b> {WORKLOADS_LABELS?.[workload]}
+              <b>{t('Workload')}</b> {WORKLOADS_LABELS?.[workload] ?? t('Other')}
             </StackItem>
             <StackItem>
               <b>{t('CPU')}</b> {cpuCount} | <b>{t('Memory')}</b> {memory}

--- a/src/views/catalog/templatescatalog/tests/mocks.ts
+++ b/src/views/catalog/templatescatalog/tests/mocks.ts
@@ -13,6 +13,7 @@ export const containerTemplateMock = {
       'template.kubevirt.io/default-os-variant': 'true',
     },
     annotations: {
+      'openshift.io/documentation-url': 'https://kubevirt.io/',
       description:
         'Template for Red Hat Enterprise Linux 9 VM or newer. A PVC with the RHEL disk image must be available. Red Hat Enterprise Linux Beta releases are made available only for testing purposes. Red Hat provides these Beta releases and revisions as a courtesy to facilitate early testing by users prior to a Generally Availability (GA) release, and to solicit feedback from users on the Beta functionality. Red Hat does not support the usage of RHEL Beta releases in production use cases. NOTE: Beta cases are handled as Severity 4. Upgrading to or from any RHEL Beta release is not an upgrade path that is supported by Red Hat. Red Hat Enterprise Linux Beta deployments cannot be directly updated to a non-beta Red Hat Enterprise Linux release, or vice-versa.',
       'name.os.template.kubevirt.io/fedora29': 'Fedora 29',

--- a/src/views/catalog/wizard/tabs/overview/WizardOverviewTab.tsx
+++ b/src/views/catalog/wizard/tabs/overview/WizardOverviewTab.tsx
@@ -106,7 +106,7 @@ const WizardOverviewTab: WizardTab = ({ vm, tabsData, updateVM }) => {
             <WizardDescriptionItem
               className="wizard-overview-description-left-column"
               title={t('Workload profile')}
-              description={WORKLOADS_LABELS?.[workloadAnnotation]}
+              description={WORKLOADS_LABELS?.[workloadAnnotation] ?? t('Other')}
             />
           </DescriptionList>
         </GridItem>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- Documentation link will now show `N/A` if link is not available
- Catalog Template will show `Other` if workload is not available
- Wizard Overview Tab - Operating system will show `Not available` if os is not available instead of template's name
