### PR TITLE
Fix VM action font weight on VM details header

### DIFF
--- a/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Label, Title } from '@patternfly/react-core';
+import { Label } from '@patternfly/react-core';
 
 import VirtualMachineActions from '../list/components/VirtualMachineActions/VirtualMachineActions';
 import { getVMStatusIcon } from '../utils';
@@ -16,18 +16,16 @@ const VirtualMachineNavPageTitle: React.FC<VirtualMachineNavPageTitleProps> = ({
   const StatusIcon = getVMStatusIcon(vm?.status?.printableStatus);
   return (
     <div className="co-m-nav-title co-m-nav-title--detail">
-      <Title className="co-m-pane__heading" headingLevel="h1">
-        <span className="co-resource-item__resource-name">
+      <span className="co-m-pane__heading">
+        <h1 className="co-resource-item__resource-name">
           <span className="co-m-resource-icon co-m-resource-icon--lg">{t('VM')}</span>
-          <span className="co-resource-item__resource-name">
-            {vm?.metadata?.name}{' '}
-            <Label isCompact icon={<StatusIcon />}>
-              {vm?.status?.printableStatus}
-            </Label>
-          </span>
-        </span>
+          {vm?.metadata?.name}{' '}
+          <Label isCompact icon={<StatusIcon />}>
+            {vm?.status?.printableStatus}
+          </Label>
+        </h1>
         <VirtualMachineActions vm={vm} />
-      </Title>
+      </span>
     </div>
   );
 };


### PR DESCRIPTION
## 🎥 Demo

before:
![bold-font-weight](https://user-images.githubusercontent.com/67270715/164048032-34a3be8d-f422-4068-a602-37e2b5b75554.png)

after:
![normal-font-weight](https://user-images.githubusercontent.com/67270715/164048052-0dbc3b05-f076-4777-8a84-62c91db0e329.png)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>