### PR TITLE
Add yarn dependency for cachito to cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
     "typescript": "^4.5.5",
     "webpack": "^5.68.0",
     "webpack-cli": "4.9.x",
-    "webpack-dev-server": "^4.7.4"
+    "webpack-dev-server": "^4.7.4",
+    "yarn": "^1.22.18"
   },
   "resolutions": {
     "webpack": "^5.68.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8679,6 +8679,11 @@ yargs@^17.2.1:
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
 
+yarn@^1.22.18:
+  version "1.22.18"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.18.tgz#05b822ade8c672987bab8858635145da0850f78a"
+  integrity sha512-oFffv6Jp2+BTUBItzx1Z0dpikTX+raRdqupfqzeMKnoh7WD6RuPAxcqDkMUy9vafJkrB0YaV708znpuMhEBKGQ==
+
 yauzl@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"


### PR DESCRIPTION
Signed-off-by: yaacov <kobi.zamir@gmail.com>

## 📝 Description

Red Hat build system does not allow to install npm packages not defined in the yarn lockfile, including yarn, adding yarn to the lock file will allow to install yarn on the build system.