### PR TITLE
Disable console vm overview auto connect

### DIFF
--- a/src/utils/components/Consoles/components/vnc-console/VncConsole.tsx
+++ b/src/utils/components/Consoles/components/vnc-console/VncConsole.tsx
@@ -50,6 +50,7 @@ export const VncConsole: React.FC<VncConsoleProps> = ({
   textDisconnect,
   textSendShortcut,
   textCtrlAltDel,
+  autoConnect = true,
 }) => {
   const { t } = useKubevirtTranslation();
   const [rfb, setRfb] = React.useState<any>();
@@ -135,7 +136,7 @@ export const VncConsole: React.FC<VncConsoleProps> = ({
     if (!rfb && status === disconnected) {
       try {
         initLogging(vncLogging);
-        connect();
+        autoConnect && connect();
       } catch (e) {
         onInitFailed && onInitFailed(e);
       }
@@ -146,7 +147,7 @@ export const VncConsole: React.FC<VncConsoleProps> = ({
         rfb?.disconnect();
       }
     };
-  }, [connect, onInitFailed, vncLogging, rfb, status]);
+  }, [connect, onInitFailed, vncLogging, rfb, status, autoConnect]);
 
   return (
     <>

--- a/src/utils/components/Consoles/components/vnc-console/utils/VncConsoleTypes.ts
+++ b/src/utils/components/Consoles/components/vnc-console/utils/VncConsoleTypes.ts
@@ -59,4 +59,6 @@ export type VncConsoleProps = React.HTMLProps<HTMLDivElement> & {
   textSendShortcut?: string;
   /** Text content rendered inside the Ctrl-Alt-Delete dropdown entry */
   textCtrlAltDel?: string;
+  /** Should console try to connect once rendering */
+  autoConnect?: boolean;
 };

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
@@ -34,6 +34,7 @@ const VirtualMachinesOverviewTabDetailsConsole: React.FC<
             path={`api/kubernetes/apis/subresources.kubevirt.io/v1/namespaces/${vmi?.metadata?.namespace}/virtualmachineinstances/${vmi?.metadata?.name}/vnc`}
             scaleViewport
             showAccessControls={false}
+            autoConnect={false}
           />
           <div className="link">
             <Button


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

VM overview page console is auto-connecting while rendering, no it will connect only on a button click
## 🎥 Demo

> Please add a video or an image of the behavior/changes
