### PR TITLE
Bug 2071488: "Migrate Node to Node" is confusing.

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -307,7 +307,7 @@
   "Memory swap": "Memory swap",
   "Memory used": "Memory used",
   "Metrics are collected by the OpenShift Monitoring Operator.": "Metrics are collected by the OpenShift Monitoring Operator.",
-  "Migrate node to node": "Migrate node to node",
+  "Migrate VirtualMachine to Node": "Migrate VirtualMachine to Node",
   "Migration Toolkit for Virtualization": "Migration Toolkit for Virtualization",
   "Missing Guest Agent": "Missing Guest Agent",
   "Missing fields in Node fields": "Missing fields in Node fields",

--- a/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
@@ -109,7 +109,7 @@ export const VirtualMachineActionFactory = {
         !!vm?.status?.conditions?.find(
           ({ type, status }) => type === 'LiveMigratable' && status === 'False',
         ),
-      label: t('Migrate node to node'),
+      label: t('Migrate VirtualMachine to Node'),
       cta: () => migrateVM(vm),
       //   accessReview: {},
     };


### PR DESCRIPTION
## 📝 Description

fix migare button text

## 🎥 Demo

before:

![Screenshot (23)](https://user-images.githubusercontent.com/67270715/165493321-36e2b316-acfa-4cba-9d85-db9ecac1eee8.png)

after:

![Screenshot (22)](https://user-images.githubusercontent.com/67270715/165493310-12195acc-28fa-41aa-a137-71f9ca94dac2.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>