### PR TITLE
Bug 2074337: Missing docker:// prefix in vm creation from registry

### DIFF
--- a/src/views/catalog/customize/components/CustomizeSource/SelectSource.tsx
+++ b/src/views/catalog/customize/components/CustomizeSource/SelectSource.tsx
@@ -16,7 +16,7 @@ import {
   SOURCE_OPTIONS_IDS,
 } from './constants';
 import SelectSourceOption from './SelectSourceOption';
-import { getGenericSourceCustomization, getPVCSource } from './utils';
+import { appendDockerPrefix, getGenericSourceCustomization, getPVCSource } from './utils';
 import { VolumeSize } from './VolumeSize';
 
 export type SelectSourceProps = {
@@ -72,7 +72,7 @@ export const SelectSource: React.FC<SelectSourceProps> = ({
         return onSourceChange(
           getGenericSourceCustomization(
             selectedSourceType,
-            containerImage,
+            appendDockerPrefix(containerImage),
             withSize ? volumeQuantity : null,
           ),
         );

--- a/src/views/catalog/customize/components/CustomizeSource/utils.ts
+++ b/src/views/catalog/customize/components/CustomizeSource/utils.ts
@@ -84,3 +84,5 @@ export const getRegistryHelperText = (template: V1Template, t: TFunction) => {
       containerDisk: containerDisks[0],
     });
 };
+
+export const appendDockerPrefix = (image: string) => 'docker://'.concat(image);

--- a/src/views/catalog/customize/tests/CustomizeSource.test.tsx
+++ b/src/views/catalog/customize/tests/CustomizeSource.test.tsx
@@ -146,7 +146,7 @@ describe('Test CustomizeSource', () => {
       },
       source: {
         registry: {
-          url: testContainer,
+          url: 'docker://'.concat(testContainer),
         },
       },
     });
@@ -163,7 +163,7 @@ describe('Test CustomizeSource', () => {
       },
       source: {
         registry: {
-          url: testContainer,
+          url: 'docker://'.concat(testContainer),
         },
       },
     });


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Missing docker:// prefix in image registry URL was causing VM creation to fail.
## 🎥 Demo

![image](https://user-images.githubusercontent.com/14824964/165514136-fcd6a2a6-3749-4605-851d-b5c848ba4bce.png)
