### PR TITLE
Fix Template's URL at Virtualization overview inventory card

### DIFF
--- a/src/views/clusteroverview/overview/components/inventory-card/utils/ResourcesSection.tsx
+++ b/src/views/clusteroverview/overview/components/inventory-card/utils/ResourcesSection.tsx
@@ -38,7 +38,7 @@ const ResourcesSection: React.FC<ResourcesSectionProps> = ({ resources }) => {
           isLoading={resources?.vmCommonTemplates?.loaded === false}
           error={!!resources?.vmCommonTemplates?.loadError}
           dataTest="kv-inventory-card--vm-templates"
-          basePath={`/k8s/ns/${dataSourceNS}/virtualmachinetemplates`}
+          basePath={`/k8s/ns/${dataSourceNS}/templates`}
         />
       </StackItem>
       <StackItem key={NodeModel.kind}>


### PR DESCRIPTION
## 📝 Description

Fix Template's URL at Virtualization overview inventory card

## 🎥 Demo

before:

https://user-images.githubusercontent.com/67270715/165523908-eed0a42d-efc2-441f-b67c-bd84cd2c2c40.mp4

after:

https://user-images.githubusercontent.com/67270715/165523962-2935cc21-cbd5-4f28-b32b-3213031115fe.mp4


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>