### PR TITLE
Add Scheduling tab to VM Template details page

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1,4 +1,5 @@
 {
+  " 0 Toleration rules": " 0 Toleration rules",
   " Password: ": " Password: ",
   "(default)": "(default)",
   "(default) | ": "(default) | ",
@@ -157,6 +158,7 @@
   "Deadline must be greater than 0": "Deadline must be greater than 0",
   "Decrement": "Decrement",
   "Dedicated Resources": "Dedicated Resources",
+  "Dedicated resources": "Dedicated resources",
   "Default": "Default",
   "Default Templates": "Default Templates",
   "Define an affinity rule. This rule will be added to the list of affinity rules applied to this workload.": "Define an affinity rule. This rule will be added to the list of affinity rules applied to this workload.",
@@ -220,6 +222,7 @@
   "Error Loading Template: the server could not find the requested resource": "Error Loading Template: the server could not find the requested resource",
   "Events": "Events",
   "Eviction Strategy": "Eviction Strategy",
+  "Eviction strategy": "Eviction strategy",
   "EvictionStrategy can be set to \"LiveMigrate\" if the VirtualMachineInstance should be migrated instead of shut-off in case of a node drain.": "EvictionStrategy can be set to \"LiveMigrate\" if the VirtualMachineInstance should be migrated instead of shut-off in case of a node drain.",
   "Example: ": "Example: ",
   "Example: For CentOS, visit the ": "Example: For CentOS, visit the ",
@@ -367,6 +370,7 @@
   "Node fields": "Node fields",
   "Node labels": "Node labels",
   "Node port": "Node port",
+  "Node selector": "Node selector",
   "None": "None",
   "Not available": "Not available",
   "Note that for Node field expressions, entering a full path is required in the \"Key\" field (e.g. \"metadata.name: value\").": "Note that for Node field expressions, entering a full path is required in the \"Key\" field (e.g. \"metadata.name: value\").",
@@ -469,6 +473,7 @@
   "Save": "Save",
   "Save affinity rule": "Save affinity rule",
   "Schedule this workload with dedicated resources (guaranteed policy)": "Schedule this workload with dedicated resources (guaranteed policy)",
+  "Scheduling": "Scheduling",
   "Scheduling and resources requirements": "Scheduling and resources requirements",
   "Scheduling will not be possible at this state": "Scheduling will not be possible at this state",
   "Search": "Search",
@@ -696,5 +701,6 @@
   "{{matchingNodeText}} matching": "{{matchingNodeText}} matching",
   "{{qualifiedNodesCount}} matching Nodes found": "{{qualifiedNodesCount}} matching Nodes found",
   "{{qualifiedNodesCount}} matching nodes found": "{{qualifiedNodesCount}} matching nodes found",
-  "{{qualifiedNodesCount}} nodes found": "{{qualifiedNodesCount}} nodes found"
+  "{{qualifiedNodesCount}} nodes found": "{{qualifiedNodesCount}} nodes found",
+  "{{rulesCount}} Affinity rules": "{{rulesCount}} Affinity rules"
 }

--- a/src/views/templates/details/hooks/useTemplateTabs.ts
+++ b/src/views/templates/details/hooks/useTemplateTabs.ts
@@ -5,6 +5,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import TemplateDetailsPage from '../tabs/details/TemplateDetailsPage';
 import TemplateDisksPage from '../tabs/disks/TemplateDisksPage';
 import TemplateNetworkPage from '../tabs/network/TemplateNetworkPage';
+import TemplateSchedulingTab from '../tabs/scheduling/TemplateSchedulingTab';
 import TemplateYAMLPage from '../tabs/yaml/TemplateYAMLPage';
 
 export const useVirtualMachineTabs = () => {
@@ -16,6 +17,11 @@ export const useVirtualMachineTabs = () => {
         href: '',
         name: t('Details'),
         component: TemplateDetailsPage,
+      },
+      {
+        href: 'scheduling',
+        name: t('Scheduling'),
+        component: TemplateSchedulingTab,
       },
       {
         href: 'yaml',

--- a/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.tsx
+++ b/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import TemplateSchedulingLeftGrid from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
+import TemplateSchedulingRightGrid from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingRightGrid';
+
+import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { ListPageBody, ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
+import { Grid, GridItem } from '@patternfly/react-core';
+
+type TemplateSchedulingTabProps = RouteComponentProps<{
+  ns: string;
+  name: string;
+}> & {
+  obj?: V1Template;
+};
+
+const TemplateSchedulingTab: React.FC<TemplateSchedulingTabProps> = ({ obj: template }) => {
+  const { t } = useKubevirtTranslation();
+
+  return (
+    <>
+      <ListPageHeader title={t('Scheduling and resources requirements')}></ListPageHeader>
+      <ListPageBody>
+        <Grid>
+          <GridItem span={5}>
+            <TemplateSchedulingLeftGrid template={template} />
+          </GridItem>
+          <GridItem span={1}></GridItem>
+          <GridItem span={5}>
+            <TemplateSchedulingRightGrid template={template} />
+          </GridItem>
+        </Grid>
+      </ListPageBody>
+    </>
+  );
+};
+
+export default TemplateSchedulingTab;

--- a/src/views/templates/details/tabs/scheduling/components/AffinityRules.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/AffinityRules.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
+import { getAffinity } from 'src/views/templates/utils/selectors';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import {
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Text,
+} from '@patternfly/react-core';
+
+const AffinityRules: React.FC<TemplateSchedulingGridProps> = ({ template, editable }) => {
+  const { t } = useKubevirtTranslation();
+
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>{t('Affinity rules')}</DescriptionListTerm>
+      <DescriptionListDescription>
+        <Text className={editable ? '' : 'text-muted'}>
+          {/* TODO edit rules */}
+          {t('{{rulesCount}} Affinity rules', {
+            rulesCount: getAffinity(template).length,
+          })}
+        </Text>
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+export default AffinityRules;

--- a/src/views/templates/details/tabs/scheduling/components/DedicatedResources.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/DedicatedResources.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
+import { isDedicatedCPUPlacement } from 'src/views/templates/utils';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import {
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Text,
+} from '@patternfly/react-core';
+
+const DedicatedResources: React.FC<TemplateSchedulingGridProps> = ({ template, editable }) => {
+  const { t } = useKubevirtTranslation();
+
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>{t('Dedicated resources')}</DescriptionListTerm>
+      {/* TODO edit */}
+      <DescriptionListDescription>
+        <Text className={editable ? '' : 'text-muted'}>
+          {isDedicatedCPUPlacement(template)
+            ? t('Workload scheduled with dedicated resources (guaranteed policy)')
+            : t('No Dedicated resources applied')}
+        </Text>
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+export default DedicatedResources;

--- a/src/views/templates/details/tabs/scheduling/components/EvictionStrategy.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/EvictionStrategy.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
+import { getEvictionStrategy } from 'src/views/templates/utils/selectors';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import {
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Text,
+} from '@patternfly/react-core';
+
+const EvictionStrategy: React.FC<TemplateSchedulingGridProps> = ({ template, editable }) => {
+  const { t } = useKubevirtTranslation();
+  const strategy = getEvictionStrategy(template);
+
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>{t('Eviction strategy')}</DescriptionListTerm>
+      {/* TODO  edit */}
+      <DescriptionListDescription>
+        <Text className={editable ? '' : 'text-muted'}>
+          {strategy || t('No eviction strategy')}
+        </Text>
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+export default EvictionStrategy;

--- a/src/views/templates/details/tabs/scheduling/components/NodeSelector.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/NodeSelector.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
+import { getNodeSelector } from 'src/views/templates/utils/selectors';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import {
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Label,
+  LabelGroup,
+  Text,
+} from '@patternfly/react-core';
+
+const NodeSelector: React.FC<TemplateSchedulingGridProps> = ({ template, editable }) => {
+  const { t } = useKubevirtTranslation();
+  const nodeSelector = getNodeSelector(template);
+
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>{t('Node selector')}</DescriptionListTerm>
+      <DescriptionListDescription>
+        {/* TODO edit labels */}
+        {nodeSelector ? (
+          <LabelGroup defaultIsOpen>
+            {Object.entries(nodeSelector)?.map(([key, value]) => (
+              <Label key={key}>{`${key}=${value}`}</Label>
+            ))}
+          </LabelGroup>
+        ) : (
+          <Text className={editable ? '' : 'text-muted'}>{t('No selector')}</Text>
+        )}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+export default NodeSelector;

--- a/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { TemplateDetailsGridProps } from 'src/views/templates/details/tabs/details/TemplateDetailsPage';
+import AffinityRules from 'src/views/templates/details/tabs/scheduling/components/AffinityRules';
+import NodeSelector from 'src/views/templates/details/tabs/scheduling/components/NodeSelector';
+import Tolerations from 'src/views/templates/details/tabs/scheduling/components/Tolerations';
+import { isCommonVMTemplate } from 'src/views/templates/utils';
+
+import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { DescriptionList } from '@patternfly/react-core';
+
+export type TemplateSchedulingGridProps = {
+  template: V1Template;
+  editable: boolean;
+};
+
+const TemplateSchedulingLeftGrid: React.FC<TemplateDetailsGridProps> = ({ template }) => {
+  const isTemplateEditable = !isCommonVMTemplate(template);
+
+  return (
+    <DescriptionList>
+      <NodeSelector template={template} editable={isTemplateEditable} />
+      <Tolerations template={template} editable={isTemplateEditable} />
+      <AffinityRules template={template} editable={isTemplateEditable} />
+      {/* TODO Descheduler */}
+    </DescriptionList>
+  );
+};
+
+export default TemplateSchedulingLeftGrid;

--- a/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingRightGrid.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingRightGrid.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { TemplateDetailsGridProps } from 'src/views/templates/details/tabs/details/TemplateDetailsPage';
+import DedicatedResources from 'src/views/templates/details/tabs/scheduling/components//DedicatedResources';
+import EvictionStrategy from 'src/views/templates/details/tabs/scheduling/components//EvictionStrategy';
+import { isCommonVMTemplate } from 'src/views/templates/utils';
+
+import { DescriptionList } from '@patternfly/react-core';
+
+const TemplateSchedulingRightGrid: React.FC<TemplateDetailsGridProps> = ({ template }) => {
+  const isTemplateEditable = !isCommonVMTemplate(template);
+
+  return (
+    <DescriptionList>
+      <DedicatedResources template={template} editable={isTemplateEditable} />
+      <EvictionStrategy template={template} editable={isTemplateEditable} />
+    </DescriptionList>
+  );
+};
+export default TemplateSchedulingRightGrid;

--- a/src/views/templates/details/tabs/scheduling/components/Tolerations.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/Tolerations.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
+import { getTolerations } from 'src/views/templates/utils/selectors';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import {
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Label,
+  LabelGroup,
+  Text,
+} from '@patternfly/react-core';
+
+const Tolerations: React.FC<TemplateSchedulingGridProps> = ({ template, editable }) => {
+  const { t } = useKubevirtTranslation();
+  const tolerations = getTolerations(template);
+
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>{t('Tolerations')}</DescriptionListTerm>
+      <DescriptionListDescription>
+        {/* TODO edit labels */}
+        {tolerations ? (
+          <LabelGroup defaultIsOpen>
+            {Object.entries(tolerations)?.map(([key, value]) => (
+              <Label key={key}>{`${key}=${value}`}</Label>
+            ))}
+          </LabelGroup>
+        ) : (
+          <Text className={editable ? '' : 'text-muted'}>{t(' 0 Toleration rules')}</Text>
+        )}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+export default Tolerations;

--- a/src/views/templates/utils/index.ts
+++ b/src/views/templates/utils/index.ts
@@ -3,3 +3,6 @@ import { TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_LABEL } from '@kubevirt-utils/resourc
 
 export const isCommonVMTemplate = (template: V1Template): boolean =>
   template?.metadata?.labels?.[TEMPLATE_TYPE_LABEL] === TEMPLATE_TYPE_BASE;
+
+export const isDedicatedCPUPlacement = (template: V1Template): boolean =>
+  template?.objects[0]?.spec?.template?.spec?.domain?.cpu?.dedicatedCpuPlacement;

--- a/src/views/templates/utils/selectors.ts
+++ b/src/views/templates/utils/selectors.ts
@@ -5,12 +5,24 @@ import { VM_WORKLOAD_ANNOTATION } from '@kubevirt-utils/resources/vm/utils';
 
 import { ANNOTATIONS, LABELS } from './constants';
 
+export const getAffinity = (template: V1Template) =>
+  template?.objects[0]?.spec?.template?.spec?.affinity || [];
+
+export const getEvictionStrategy = (template: V1Template): string =>
+  template?.objects[0]?.spec?.template?.spec?.evictionStrategy;
+
+export const getNodeSelector = (template: V1Template) =>
+  template?.objects[0]?.spec?.template?.spec?.nodeSelector;
+
 export const getTemplateProviderName = (template: V1Template): string =>
   getAnnotation(template, ANNOTATIONS.providerName, null) ||
   getAnnotation(template, ANNOTATIONS.providerDisplayName, template?.metadata?.name);
 
 export const getTemplateWorkload = (template: V1Template): string =>
   template?.objects[0]?.spec?.template?.metadata?.annotations?.[VM_WORKLOAD_ANNOTATION];
+
+export const getTolerations = (template: V1Template) =>
+  template?.objects[0]?.spec?.template?.spec?.tolerations;
 
 export const getVMTemplateBaseName = (
   template: V1Template,


### PR DESCRIPTION
## 📝 Description
Add _Scheduling_ tab and its content.
Add _Scheduling and resources requirements_ section, that contains the info about:
```
- Node selector    - Dedicated resources
- Tolerations      - Eviction strategy
- Affinity rules
```

_Note:_
Descheduler info will be added to Scheduling tab in a followup PR.

## 🎥 Demo
![scheduling](https://user-images.githubusercontent.com/13417815/165648218-cb5ec3ca-d0ff-4275-a165-c236b7d9421b.png)


