### PR TITLE
Remove extra space in VM Template Details tab

### DIFF
--- a/src/views/templates/details/tabs/details/TemplateDetailsPage.tsx
+++ b/src/views/templates/details/tabs/details/TemplateDetailsPage.tsx
@@ -33,8 +33,8 @@ const TemplateDetailsPage: React.FC<TemplateDetailsPageProps> = ({ obj: template
 
   return (
     <>
-      <ListPageBody>
-        {isCommonTemplate && (
+      {isCommonTemplate && (
+        <ListPageBody>
           <Alert
             className="alert-margin-top-bottom"
             isInline
@@ -57,8 +57,8 @@ const TemplateDetailsPage: React.FC<TemplateDetailsPageProps> = ({ obj: template
               </div>
             </Trans>
           </Alert>
-        )}
-      </ListPageBody>
+        </ListPageBody>
+      )}
       <ListPageHeader title={t('VM Template Details')}></ListPageHeader>
       <ListPageBody>
         <Grid>


### PR DESCRIPTION
## 📝 Description
Remove the extra space in VM Template's _Details_ tab above _VM Template Details_ section, that appears for uncommon Templates.

## 🎥 Demo
_Before:_
![before](https://user-images.githubusercontent.com/13417815/165650146-a46e537e-4744-4a1a-bd56-f15854b2ad03.png)
_After:_
![after](https://user-images.githubusercontent.com/13417815/165650206-b5d744dd-eff7-49c3-8778-1fdc29b35fa9.png)
