### PR TITLE
Move VM Template's Scheduling tab next to YAML tab

### DIFF
--- a/src/views/templates/details/hooks/useTemplateTabs.ts
+++ b/src/views/templates/details/hooks/useTemplateTabs.ts
@@ -19,14 +19,14 @@ export const useVirtualMachineTabs = () => {
         component: TemplateDetailsPage,
       },
       {
-        href: 'scheduling',
-        name: t('Scheduling'),
-        component: TemplateSchedulingTab,
-      },
-      {
         href: 'yaml',
         name: 'YAML',
         component: TemplateYAMLPage,
+      },
+      {
+        href: 'scheduling',
+        name: t('Scheduling'),
+        component: TemplateSchedulingTab,
       },
       {
         href: 'network-interfaces',


### PR DESCRIPTION
## 📝 Description
Place the tab in a correct place in the UI according to the design update.

**Before:**
![sch1](https://user-images.githubusercontent.com/13417815/165973158-9d8bb3cf-111d-4017-805b-c382d22042d2.png)
**After:**
![sch2](https://user-images.githubusercontent.com/13417815/165973166-62ec6505-50c5-4ae9-8db8-c5582341f5c5.png)

