### PR TITLE
fix overview page crashing

### DIFF
--- a/src/views/clusteroverview/overview/components/details-card/SourceMissingStatus/SubscriptionStatus.tsx
+++ b/src/views/clusteroverview/overview/components/details-card/SourceMissingStatus/SubscriptionStatus.tsx
@@ -14,13 +14,13 @@ import UpgradeApprovalLink from './UpgradeApprovalLink';
 
 const upgradeRequiresApproval = (subscription: SubscriptionKind): boolean =>
   subscription?.status?.state === SubscriptionState.SubscriptionStateUpgradePending &&
-  (subscription.status?.conditions ?? []).filter(
+  (subscription?.status?.conditions ?? []).filter(
     ({ status, reason }) => status === 'True' && reason === 'RequiresApproval',
   ).length > 0;
 
 const SubscriptionStatus: React.FC<{ subscription: SubscriptionKind }> = ({ subscription }) => {
   const { t } = useKubevirtTranslation();
-  switch (subscription.status.state) {
+  switch (subscription?.status?.state) {
     case SubscriptionState.SubscriptionStateUpgradeAvailable:
       return (
         <span>
@@ -28,7 +28,7 @@ const SubscriptionStatus: React.FC<{ subscription: SubscriptionKind }> = ({ subs
         </span>
       );
     case SubscriptionState.SubscriptionStateUpgradePending:
-      return upgradeRequiresApproval(subscription) && subscription.status.installPlanRef ? (
+      return upgradeRequiresApproval(subscription) && subscription?.status?.installPlanRef ? (
         <UpgradeApprovalLink subscription={subscription} />
       ) : (
         <span>
@@ -43,8 +43,8 @@ const SubscriptionStatus: React.FC<{ subscription: SubscriptionKind }> = ({ subs
       );
     default:
       return (
-        <span className={isEmpty(subscription.status.state) ? 'text-muted' : ''}>
-          {subscription.status.state || t('Unknown failure')}
+        <span className={isEmpty(subscription?.status?.state) ? 'text-muted' : ''}>
+          {subscription?.status?.state || t('Unknown failure')}
         </span>
       );
   }


### PR DESCRIPTION
## 📝 Description

The Subscription CR is not available for non-privileged users, which causes the error for reaching an undefined property.
Adding optional chaining to the undefined property will prevent the crash.

## 🎥 Demo

before:

![overview-crash-before](https://user-images.githubusercontent.com/67270715/166209623-84341d64-9bcc-4667-bd23-74a1b78ea5e5.png)

after:

![overview-crash-after](https://user-images.githubusercontent.com/67270715/166209636-75042913-6ac8-40b7-a42b-1f1ed1d8b128.png)

