### PR TITLE
Display Tooltip when VM Template Descheduler not installed

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -640,6 +640,7 @@
   "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
   "Time of login": "Time of login",
   "Time Zone": "Time Zone",
+  "To enable the descheduler, you must install the Kube Descheduler Operator from OperatorHub and enable one or more descheduler profiles.": "To enable the descheduler, you must install the Kube Descheduler Operator from OperatorHub and enable one or more descheduler profiles.",
   "To see the vCPU metric, you must set the schedstats=enable kernel argument in the MachineConfig object.": "To see the vCPU metric, you must set the schedstats=enable kernel argument in the MachineConfig object.",
   "To take a snapshot you can either edit an existing disk to add a snapshot-supported storage class or add a new disk with a compatible storage class defined. For further details, please contact your cluster admin.": "To take a snapshot you can either edit an existing disk to add a snapshot-supported storage class or add a new disk with a compatible storage class defined. For further details, please contact your cluster admin.",
   "Tolerations": "Tolerations",

--- a/src/views/templates/details/tabs/scheduling/components/Descheduler.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/Descheduler.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
-import { useDeschedulerInstalled, useDeschedulerOn } from 'src/views/templates/utils';
+import { isDeschedulerOn, useDeschedulerInstalled } from 'src/views/templates/utils';
 import { DESCHEDULER_URL } from 'src/views/templates/utils/constants';
 
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { V1Template } from '@kubevirt-utils/models';
 import {
   Button,
   DescriptionListDescription,
@@ -12,6 +12,7 @@ import {
   DescriptionListTermHelpText,
   DescriptionListTermHelpTextButton,
   Popover,
+  Tooltip,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, PencilAltIcon } from '@patternfly/react-icons';
 
@@ -19,10 +20,13 @@ import DeschedulerModal from './DeschedulerModal';
 
 import 'src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.scss';
 
-const Descheduler: React.FC<TemplateSchedulingGridProps> = ({ template }) => {
+type DeschedulerProps = {
+  template: V1Template;
+};
+
+const Descheduler: React.FC<DeschedulerProps> = ({ template }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
-  const isDeschedulerOn = useDeschedulerOn(template);
   const isDeschedulerInstalled = useDeschedulerInstalled();
 
   return (
@@ -58,22 +62,34 @@ const Descheduler: React.FC<TemplateSchedulingGridProps> = ({ template }) => {
       </DescriptionListTermHelpText>
 
       <DescriptionListDescription>
-        {useDeschedulerInstalled && (
-          <Button
-            isInline
-            isDisabled={!isDeschedulerInstalled}
-            onClick={() =>
-              createModal(({ isOpen, onClose }) => (
-                <DeschedulerModal template={template} isOpen={isOpen} onClose={onClose} />
-              ))
-            }
-            variant="link"
-            iconPosition={'right'}
-          >
-            {isDeschedulerOn ? t('ON') : t('OFF')}
-            <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
-          </Button>
-        )}
+        <Tooltip
+          content={
+            !isDeschedulerInstalled &&
+            t(
+              'To enable the descheduler, you must install the Kube Descheduler Operator from OperatorHub and enable one or more descheduler profiles.',
+            )
+          }
+          position="right"
+        >
+          <span>
+            <Button
+              isInline
+              isDisabled={!isDeschedulerInstalled}
+              onClick={() =>
+                createModal(({ isOpen, onClose }) => (
+                  <DeschedulerModal template={template} isOpen={isOpen} onClose={onClose} />
+                ))
+              }
+              variant="link"
+              iconPosition={'right'}
+            >
+              {isDeschedulerInstalled && isDeschedulerOn(template) ? t('ON') : t('OFF')}
+              {isDeschedulerInstalled && (
+                <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+              )}
+            </Button>
+          </span>
+        </Tooltip>
       </DescriptionListDescription>
     </DescriptionListGroup>
   );

--- a/src/views/templates/details/tabs/scheduling/components/DeschedulerModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/DeschedulerModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import produce from 'immer';
-import { useDeschedulerOn } from 'src/views/templates/utils';
+import { isDeschedulerOn } from 'src/views/templates/utils';
 
 import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
@@ -32,7 +32,7 @@ type DeschedulerModalProps = {
 
 const DeschedulerModal: React.FC<DeschedulerModalProps> = ({ template, isOpen, onClose }) => {
   const { t } = useKubevirtTranslation();
-  const [isOn, setOn] = React.useState<boolean>(useDeschedulerOn(template)); // the default is OFF, the admin has to opt-in this feature
+  const [isOn, setOn] = React.useState<boolean>(isDeschedulerOn(template)); // the default is OFF, the admin has to opt-in this feature
 
   const onSubmit = React.useCallback(
     (updatedTemplate: V1Template) =>

--- a/src/views/templates/utils/index.ts
+++ b/src/views/templates/utils/index.ts
@@ -20,7 +20,6 @@ export const useDeschedulerInstalled = (): boolean => {
 };
 
 // check if the descheduler is ON
-export const useDeschedulerOn = (template: V1Template): boolean =>
-  // check for the descheduler.alpha.kubernetes.io/evict: 'true' annotation, also the descheduler has to be installed
-  useDeschedulerInstalled &&
+export const isDeschedulerOn = (template: V1Template): boolean =>
+  // check for the descheduler.alpha.kubernetes.io/evict: 'true' annotation
   template?.objects[0]?.spec?.template?.metadata?.annotations[DESCHEDULER_EVICT_LABEL] === 'true';


### PR DESCRIPTION
## 📝 Description
Add the tooltip to the _Descheduler_ to inform the user that:
```
"To enable the descheduler, you must install the Kube Descheduler Operator from OperatorHub and enable one
or more descheduler profiles.", 
```
if the Descheduler is not installed, according to the new design.

Include some minor changes/fixes, regarding Descheduler:

 - Remove the unnecessary check [here](https://github.com/kubevirt-ui/kubevirt-plugin/compare/main...hstastna:Template_Descheduler_tooltip?expand=1#diff-162e38124fe78686c5785f0692a79308cbd1f8218295b61c53ea4551428de71eL61), as this check was already present as the prop for the `Button` component [here](https://github.com/kubevirt-ui/kubevirt-plugin/compare/main...hstastna:Template_Descheduler_tooltip?expand=1#diff-162e38124fe78686c5785f0692a79308cbd1f8218295b61c53ea4551428de71eL64).

 - Update the Descheduler component's props: use the `DeschedulerProps` instead of `TemplateSchedulingGridProps`.

 - Change the `useDeschedulerOn` to `isDeschedulerOn`, and check **only** the appropriate annotation.

 - Update displaying the Pencil icon (`PencilAltIcon` PF component) the way that if the field is not editable (operator not installed), the icon is not displayed - according to the design updates.

Related PR: https://github.com/kubevirt-ui/kubevirt-plugin/pull/348

## 🎥 Demo
_Before:_
![desch_before](https://user-images.githubusercontent.com/13417815/166296221-b2a25df4-bcc4-4324-ade8-5369886bcb54.png)

_After:_
Tooltip with the useful info and no any Pencil icon in case that the operator is not installed:
![afterr_d](https://user-images.githubusercontent.com/13417815/167461132-5f4a6a20-6a1c-4f85-86ca-6e776c2f4554.png)


