### PR TITLE
Move CPU | Memory to VM Details tab

### DIFF
--- a/src/views/virtualmachines/details/tabs/scheduling/components/VirtualMachineSchedulingRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/scheduling/components/VirtualMachineSchedulingRightGrid.tsx
@@ -3,33 +3,29 @@ import { printableVMStatus } from 'src/views/virtualmachines/utils';
 
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import CPUMemoryModal from '@kubevirt-utils/components/CPUMemoryModal/CpuMemoryModal';
 import DedicatedResourcesModal from '@kubevirt-utils/components/DedicatedResourcesModal/DedicatedResourcesModal';
 import EvictionStrategyModal from '@kubevirt-utils/components/EvictionStrategyModal/EvictionStrategyModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList, GridItem } from '@patternfly/react-core';
 
-import CPUMemory from '../../details/components/CPUMemory/CPUMemory';
 import VirtualMachineDescriptionItem from '../../details/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 
 import DedicatedResources from './DedicatedResources';
 import EvictionStrategy from './EvictionStrategy';
 
-type VirtualMachineSchedulingLeftGridProps = {
+type VirtualMachineSchedulingRightGridProps = {
   vm: V1VirtualMachine;
   canUpdateVM: boolean;
 };
 
-const VirtualMachineSchedulingLeftGrid: React.FC<VirtualMachineSchedulingLeftGridProps> = ({
+const VirtualMachineSchedulingRightGrid: React.FC<VirtualMachineSchedulingRightGridProps> = ({
   vm,
   canUpdateVM,
 }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
-  const { vmi } = useVMIAndPodsForVM(vm?.metadata?.name, vm?.metadata?.namespace);
   const canUpdateStoppedVM =
     canUpdateVM && vm?.status?.printableStatus === printableVMStatus.Stopped;
 
@@ -47,22 +43,6 @@ const VirtualMachineSchedulingLeftGrid: React.FC<VirtualMachineSchedulingLeftGri
   return (
     <GridItem span={5}>
       <DescriptionList>
-        <VirtualMachineDescriptionItem
-          descriptionData={<CPUMemory vm={vm} />}
-          descriptionHeader={t('CPU | Memory')}
-          isEdit={canUpdateVM}
-          onEditClick={() =>
-            createModal(({ isOpen, onClose }) => (
-              <CPUMemoryModal
-                vm={vm}
-                isOpen={isOpen}
-                onClose={onClose}
-                onSubmit={onSubmit}
-                vmi={vmi}
-              />
-            ))
-          }
-        />
         <VirtualMachineDescriptionItem
           descriptionData={<DedicatedResources vm={vm} />}
           descriptionHeader={t('Dedicated Resources')}
@@ -100,4 +80,4 @@ const VirtualMachineSchedulingLeftGrid: React.FC<VirtualMachineSchedulingLeftGri
   );
 };
 
-export default VirtualMachineSchedulingLeftGrid;
+export default VirtualMachineSchedulingRightGrid;


### PR DESCRIPTION
## 📝 Description
Move _CPU | Memory_ info from VM _Scheduling_ tab to _Details_ tab, under the _Operating System_ info in _Virtual Machine Details_ section, according to the design update.

Also make a small fix: rename the component `VirtualMachineSchedulingLeftGrid` to `VirtualMachineSchedulingRightGrid`, in _VirtualMachineSchedulingRightGrid.tsx_ file.

## 🎥 Demo
_Before:_
No _CPU | Memory_ in the VM _Details_ tab:
![before2](https://user-images.githubusercontent.com/13417815/166683660-709d5812-313f-43e4-88cc-6714ed88d60d.png)
_CPU | Memory_ present in VM _Scheduling_ tab:
![before1](https://user-images.githubusercontent.com/13417815/166683668-6d9148dd-a1d7-40d2-8ab7-da609cc7839e.png)

_After:_
![after2](https://user-images.githubusercontent.com/13417815/166683684-46475cdc-98c3-4431-9fd8-5b1aa3363be6.png)
![after1](https://user-images.githubusercontent.com/13417815/166683691-0263e6dd-a23c-4cbc-a237-7b0124db7a3c.png)

