### PR TITLE
Add CPU | Memory to VM Template Details tab

### DIFF
--- a/src/utils/components/CPUMemoryModal/hooks/useTemplateDefaultCpuMemory.ts
+++ b/src/utils/components/CPUMemoryModal/hooks/useTemplateDefaultCpuMemory.ts
@@ -6,7 +6,7 @@ import {
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
-import { getCPUCount, getMemorySize } from '../utils/CpuMemoryUtils';
+import { getCPUcores, getMemorySize } from '../utils/CpuMemoryUtils';
 
 type UseTemplateDefaultCpuMemory = (vm: V1VirtualMachine) => {
   data: {
@@ -39,7 +39,7 @@ const useTemplateDefaultCpuMemory: UseTemplateDefaultCpuMemory = (vm) => {
   const defaultMemory = getMemorySize(
     template?.objects?.[0]?.spec?.template?.spec?.domain?.resources?.requests?.memory,
   );
-  const defaultCpu = getCPUCount(template?.objects?.[0]?.spec?.template?.spec?.domain?.cpu);
+  const defaultCpu = getCPUcores(template?.objects?.[0]);
 
   return {
     data: {

--- a/src/utils/components/CPUMemoryModal/utils/CpuMemoryUtils.ts
+++ b/src/utils/components/CPUMemoryModal/utils/CpuMemoryUtils.ts
@@ -1,8 +1,7 @@
-import { V1CPU } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
-export const getCPUCount = (sourceCPU: V1CPU): number => {
-  return sourceCPU?.cores || 1;
-};
+export const getCPUcores = (vm: V1VirtualMachine): number =>
+  vm?.spec?.template?.spec?.domain?.cpu?.cores || 1;
 
 const GI = 'Gi';
 const MI = 'Mi';

--- a/src/views/templates/details/tabs/details/components/CPUMemory.tsx
+++ b/src/views/templates/details/tabs/details/components/CPUMemory.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { useVirtualMachineTemplatesCPUMemory } from 'src/views/templates/list/hooks/useVirtualMachineTemplatesCPUMemory';
+import { isCommonVMTemplate } from 'src/views/templates/utils';
+
+import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { TemplateModel, V1Template } from '@kubevirt-utils/models';
+import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  Button,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
+
+import CPUMemoryModal from './CPUMemoryModal';
+
+type CPUMemoryProps = {
+  template: V1Template;
+};
+
+const CPUMemory: React.FC<CPUMemoryProps> = ({ template }) => {
+  const { t } = useKubevirtTranslation();
+  const CPUMemData = useVirtualMachineTemplatesCPUMemory(template);
+  const { createModal } = useModal();
+  const isCommonTemplate = isCommonVMTemplate(template);
+
+  const onSubmitCPU = React.useCallback(
+    (updatedTemplate: V1Template) =>
+      k8sUpdate({
+        model: TemplateModel,
+        data: updatedTemplate,
+        ns: updatedTemplate?.metadata?.namespace,
+        name: updatedTemplate?.metadata?.name,
+      }),
+    [],
+  );
+
+  const onEditClick = () =>
+    createModal(({ isOpen, onClose }) => (
+      <CPUMemoryModal
+        template={template}
+        isOpen={isOpen}
+        onClose={onClose}
+        onSubmit={onSubmitCPU}
+      />
+    ));
+
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>{t('CPU | Memory')}</DescriptionListTerm>
+      <DescriptionListDescription>
+        {!isCommonTemplate ? (
+          <Button type="button" isInline onClick={onEditClick} variant="link">
+            {CPUMemData}
+            <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+          </Button>
+        ) : (
+          CPUMemData
+        )}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+export default CPUMemory;

--- a/src/views/templates/details/tabs/details/components/TemplateDetailsLeftGrid.tsx
+++ b/src/views/templates/details/tabs/details/components/TemplateDetailsLeftGrid.tsx
@@ -15,6 +15,8 @@ import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { getOperatingSystemName } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import { DescriptionList } from '@patternfly/react-core';
 
+import CPUMemory from './CPUMemory';
+
 const TemplateDetailsLeftGrid: React.FC<TemplateDetailsGridProps> = ({ template }) => {
   const { t } = useKubevirtTranslation();
 
@@ -30,6 +32,7 @@ const TemplateDetailsLeftGrid: React.FC<TemplateDetailsGridProps> = ({ template 
       />
       <DescriptionItem title={t('Operating system')} content={getOperatingSystemName(template)} />
       <DescriptionItem title={t('Workload profile')} content={useWorkloadProfile(template)} />
+      <CPUMemory template={template} />
       <BaseTemplate template={template} />
       <CreatedAt template={template} />
       <Owner template={template} />

--- a/src/views/templates/details/tabs/details/components/cpu-memory-modal.scss
+++ b/src/views/templates/details/tabs/details/components/cpu-memory-modal.scss
@@ -1,0 +1,18 @@
+.cpu-memory-modal {
+  .pf-c-modal-box__body {
+    display: table;
+  }
+  .inputs {
+    display: flex;
+    margin-top: var(--pf-global--spacer--xl);
+    margin-bottom: var(--pf-global--spacer--2xl);
+    .input-memory {
+      &--dropdown {
+        margin-left: var(--pf-global--spacer--md);
+      }
+    }
+    .input-cpu {
+      margin-right: var(--pf-global--spacer--xl);
+    }
+  }
+}

--- a/src/views/templates/list/hooks/useVirtualMachineTemplatesCPUMemory.tsx
+++ b/src/views/templates/list/hooks/useVirtualMachineTemplatesCPUMemory.tsx
@@ -42,11 +42,10 @@ export const useVirtualMachineTemplatesCPUMemory = (
   template: V1Template,
 ): string | React.ReactNode => {
   const { t } = useKubevirtTranslation();
-  const { cpuCount, memory } = getFlavorData(template);
+  const cpu = getTemplateVirtualMachineCPU(template);
+  const { memory } = getFlavorData(template);
 
-  if (!cpuCount || isTemplateParameter(memory)) {
-    const cpu = getTemplateVirtualMachineCPU(template);
-
+  if (isTemplateParameter(memory)) {
     return (
       <>
         {t('CPU | Memory depend on parameters')}{' '}
@@ -75,6 +74,6 @@ export const useVirtualMachineTemplatesCPUMemory = (
     );
   } else {
     const [value, readableUnit] = stringValueUnitSplit(memory);
-    return `CPU ${cpuCount} | ${t('Memory')} ${value} ${readableUnit}`;
+    return `CPU ${cpu.cores} | ${t('Memory')} ${value} ${readableUnit}`;
   }
 };


### PR DESCRIPTION
## 📝 Description
Add missing _CPU | Memory_ option to the tab, to _VM Template Details_ section, according to the design update.
Add the modal to be opened when editing the values (**cpu cores** + memory), check if the fields are editable, let the changes to be saved.
Rename and update _getCPUCount_ function appropriately.

## 🎥 Demo
Edit _CPU | Memory:
![cpu_after1](https://user-images.githubusercontent.com/13417815/167216319-7c870e22-7a99-4454-8147-30d8936e2f76.png)
Modal opened for editing the values:
![cpu_after2](https://user-images.githubusercontent.com/13417815/167216334-f616f586-5885-4798-aba2-394707bf2d6b.png)
Common templates are not editable:
![common_templates_not_editable](https://user-images.githubusercontent.com/13417815/167489203-18aae46c-d1bf-411b-bbb4-e62b16501920.png)

