### PR TITLE
Changing in vmi page the console and event tabs location

### DIFF
--- a/src/views/virtualmachinesinstance/details/hooks/useVirtualMachinesInstanceTabs.ts
+++ b/src/views/virtualmachinesinstance/details/hooks/useVirtualMachinesInstanceTabs.ts
@@ -25,14 +25,14 @@ const useVirtualMachinesInstanceTabs = () => {
         component: VirtualMachinesInstancePageYAMLTab,
       },
       {
-        href: 'console',
-        name: t('Console'),
-        component: VirtualMachinesInstancePageConsoleTab,
-      },
-      {
         href: 'events',
         name: t('Events'),
         component: VirtualMachinesInstancePageEventsTab,
+      },
+      {
+        href: 'console',
+        name: t('Console'),
+        component: VirtualMachinesInstancePageConsoleTab,
       },
       {
         href: 'network',


### PR DESCRIPTION
Signed-off-by: Dana Orr <dorr@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
Changing in the vmi page the location of the tabs like in vm page, first the event tab and then the console tab.

## 🎥 Demo
Before:
<img width="1620" alt="image" src="https://user-images.githubusercontent.com/61961469/167295820-0034be37-3601-47fa-ac02-153292ec8d9c.png">

After:
<img width="1623" alt="image" src="https://user-images.githubusercontent.com/61961469/167295715-d3ba05d2-8f9e-42e9-a681-d6d87ae42a77.png">
