### PR TITLE
Fix template's page to load templates for non-priv user

### DIFF
--- a/src/utils/resources/template/hooks/useVmTemplates.tsx
+++ b/src/utils/resources/template/hooks/useVmTemplates.tsx
@@ -17,8 +17,6 @@ import { Operator } from '@openshift-console/dynamic-plugin-sdk-internal/lib/api
 import { TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_LABEL, TEMPLATE_TYPE_VM } from '../utils/constants';
 
 const OPENSHIFT_NS = 'openshift';
-const KUBEVIRT_OS_IMAGES_NS = 'kubevirt-os-images';
-const OPENSHIFT_OS_IMAGES_NS = 'openshift-virtualization-os-images';
 
 /** A Hook that returns VM Templates from allowed namespaces
  * @param namespace - The namespace to filter the templates by
@@ -37,17 +35,11 @@ export const useVmTemplates = (namespace?: string): useVmTemplatesValues => {
     isList: true,
   });
 
-  // Bug fix: TODO open BZ for SSP oc get projects don't show on projects when non-priv users
+  // Bug fix: BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2081295
   const projectNames = projects?.map((proj) => proj?.metadata?.name);
   if (projectNames && !projectNames.includes(OPENSHIFT_NS)) {
     projectNames.push(OPENSHIFT_NS);
   }
-
-  // Bug fix: the project with the images can't access templates which cause
-  // the template list view to show error instead of existing templates
-  const filteredProjNames = projectNames?.filter(
-    (proj) => proj !== OPENSHIFT_OS_IMAGES_NS && proj !== KUBEVIRT_OS_IMAGES_NS,
-  );
 
   const [allTemplates, allTemplatesLoaded, allTemplatesError] = useK8sWatchResource<V1Template[]>({
     groupVersionKind: TemplateModelGroupVersionKind,
@@ -67,7 +59,7 @@ export const useVmTemplates = (namespace?: string): useVmTemplatesValues => {
   const allowedResources = useK8sWatchResources<{ [key: string]: V1Template[] }>(
     Object.fromEntries(
       loaded && !isAdmin
-        ? (filteredProjNames || []).map((name) => [
+        ? (projectNames || []).map((name) => [
             name,
             {
               groupVersionKind: TemplateModelGroupVersionKind,


### PR DESCRIPTION
## 📝 Description

when selecting a namespace as non-privileged user, and navigating to templates list, we get an error message for fetching templates if one of all namespaces that a user can list, has recieved an error.

## 🎥 Demo

before:

![templates-page-load-error](https://user-images.githubusercontent.com/67270715/167402647-04a71ffc-60bd-4cf4-961a-c7ca106baa31.png)


after:

https://user-images.githubusercontent.com/67270715/167402693-c4812c89-9732-4c6a-811c-8b3c9cf84497.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>