### PR TITLE
Bug 2083100: Something keeps loading in the 'node selector' modal

### DIFF
--- a/src/views/catalog/wizard/tabs/scheduling/WizardSchedulingTab.tsx
+++ b/src/views/catalog/wizard/tabs/scheduling/WizardSchedulingTab.tsx
@@ -51,6 +51,8 @@ const WizardSchedulingTab: WizardTab = ({ vm, updateVM }) => {
                     isOpen={isOpen}
                     onClose={onClose}
                     onSubmit={updateVM}
+                    nodes={nodes}
+                    nodesLoaded={nodesLoaded}
                   />
                 ))
               }


### PR DESCRIPTION
## 📝 Description

missing `nodes` and `nodesLoaded` props caused the loader to get stuck

## 🎥 Demo

before:

https://user-images.githubusercontent.com/67270715/167392852-bc74b4c0-2673-43f8-8122-d89c6758dba9.mp4

after:

https://user-images.githubusercontent.com/67270715/167392872-a1d9e535-a630-442a-9eca-0bcb29b381f8.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>