### PR TITLE
Display Template Descheduler ON according to annotation

### DIFF
--- a/src/views/templates/details/tabs/scheduling/components/Descheduler.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/Descheduler.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { isDeschedulerOn, useDeschedulerInstalled } from 'src/views/templates/utils';
 import { DESCHEDULER_URL } from 'src/views/templates/utils/constants';
 
-import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { V1Template } from '@kubevirt-utils/models';
 import {
@@ -14,9 +15,9 @@ import {
   Popover,
   Tooltip,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon, PencilAltIcon } from '@patternfly/react-icons';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import DeschedulerModal from './DeschedulerModal';
+import DeschedulerModalButton from './DeschedulerModalButton';
 
 import 'src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.scss';
 
@@ -26,8 +27,9 @@ type DeschedulerProps = {
 
 const Descheduler: React.FC<DeschedulerProps> = ({ template }) => {
   const { t } = useKubevirtTranslation();
-  const { createModal } = useModal();
   const isDeschedulerInstalled = useDeschedulerInstalled();
+  const isAdmin = useIsAdmin();
+  const isEditable = isAdmin && isDeschedulerInstalled;
 
   return (
     <DescriptionListGroup>
@@ -62,34 +64,18 @@ const Descheduler: React.FC<DeschedulerProps> = ({ template }) => {
       </DescriptionListTermHelpText>
 
       <DescriptionListDescription>
-        <Tooltip
-          content={
-            !isDeschedulerInstalled &&
-            t(
+        {isAdmin && !isDeschedulerInstalled ? (
+          <Tooltip
+            content={t(
               'To enable the descheduler, you must install the Kube Descheduler Operator from OperatorHub and enable one or more descheduler profiles.',
-            )
-          }
-          position="right"
-        >
-          <span>
-            <Button
-              isInline
-              isDisabled={!isDeschedulerInstalled}
-              onClick={() =>
-                createModal(({ isOpen, onClose }) => (
-                  <DeschedulerModal template={template} isOpen={isOpen} onClose={onClose} />
-                ))
-              }
-              variant="link"
-              iconPosition={'right'}
-            >
-              {isDeschedulerInstalled && isDeschedulerOn(template) ? t('ON') : t('OFF')}
-              {isDeschedulerInstalled && (
-                <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
-              )}
-            </Button>
-          </span>
-        </Tooltip>
+            )}
+            position="right"
+          >
+            <MutedTextSpan text={isDeschedulerOn(template) ? t('ON') : t('OFF')} />
+          </Tooltip>
+        ) : (
+          <DeschedulerModalButton template={template} editable={isEditable} />
+        )}
       </DescriptionListDescription>
     </DescriptionListGroup>
   );

--- a/src/views/templates/details/tabs/scheduling/components/DeschedulerModalButton.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/DeschedulerModalButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { isDeschedulerOn } from 'src/views/templates/utils';
+
+import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { Button } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
+
+import DeschedulerModal from './DeschedulerModal';
+
+type DeschedulerModalButtonProps = {
+  template: V1Template;
+  editable: boolean;
+};
+
+const DeschedulerModalButton: React.FC<DeschedulerModalButtonProps> = ({ template, editable }) => {
+  const { createModal } = useModal();
+  const { t } = useKubevirtTranslation();
+
+  return (
+    <Button
+      isInline
+      isDisabled={!editable}
+      onClick={() =>
+        createModal(({ isOpen, onClose }) => (
+          <DeschedulerModal template={template} isOpen={isOpen} onClose={onClose} />
+        ))
+      }
+      variant="link"
+      iconPosition={'right'}
+    >
+      {isDeschedulerOn(template) ? t('ON') : t('OFF')}
+      {editable && <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />}
+    </Button>
+  );
+};
+export default DeschedulerModalButton;

--- a/src/views/templates/utils/index.ts
+++ b/src/views/templates/utils/index.ts
@@ -10,8 +10,8 @@ export const isCommonVMTemplate = (template: V1Template): boolean =>
 export const isDedicatedCPUPlacement = (template: V1Template): boolean =>
   template?.objects[0]?.spec?.template?.spec?.domain?.cpu?.dedicatedCpuPlacement;
 
+// check if the Descheduler is installed
 export const useDeschedulerInstalled = (): boolean => {
-  // check if the Descheduler is installed
   const [resourceList] = useK8sWatchResource<any>({
     kind: KubeDeschedulerModel.kind,
     isList: true,


### PR DESCRIPTION
## 📝 Description
Display Template Descheduler's value "ON"/"OFF" according to annotation, no matter the operator installed or not, according to the design.
Only display the value for non admin user (cannot edit no matter the operator installed or not).

## 🎥 Demo
Before: Descheduler operator not installed but the annotation present:
![off](https://user-images.githubusercontent.com/13417815/167850929-e16e9164-5697-4fb1-950d-67cd0623ac3d.png)
After: The operator not installed but the annotation present:
![on](https://user-images.githubusercontent.com/13417815/167850977-64e705fd-d43d-41a1-acca-9f82bb0022b0.png)
Non admin can only see the value: (annotation not present)
![off_non_admin](https://user-images.githubusercontent.com/13417815/167851084-ad5a8bbf-c788-4c2d-b40a-10d15ef6d0c4.png)
