### PR TITLE
Bug 2085320: Tolerations rules is not adding correctly

### DIFF
--- a/src/utils/components/TolerationsModal/TolerationsModal.tsx
+++ b/src/utils/components/TolerationsModal/TolerationsModal.tsx
@@ -62,7 +62,7 @@ const TolerationsModal: React.FC<TolerationsModalProps> = ({
         (toleration) => {
           return {
             ...toleration,
-            operator: toleration?.value ? Operator.Equals : Operator.Exists,
+            operator: toleration?.value ? 'Equal' : Operator.Exists,
           };
         },
       );


### PR DESCRIPTION
## 📝 Description

when adding a toleration rule to a VM with a value input, the operator used is `Equals` which returned a pod error,
using `Equal` as an operator resolves this issue 

## 🎥 Demo

before:

https://user-images.githubusercontent.com/67270715/168466547-fe167244-b25e-4317-a31a-baf46242f3e1.mp4

after:

https://user-images.githubusercontent.com/67270715/168466563-b1459aca-a880-463c-b54a-e68fc4245d5a.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>