### PR TITLE
Bug 2085322: Not able to stop/restart VM if the VM is staying in "Starting"

### DIFF
--- a/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
@@ -59,7 +59,7 @@ export const VirtualMachineActionFactory = {
   stop: (vm: V1VirtualMachine, t: TFunction): Action => {
     return {
       id: 'vm-action-stop',
-      disabled: [Starting, Stopping, Terminating, Stopped, Paused, Unknown].includes(
+      disabled: [Stopping, Terminating, Stopped, Paused, Unknown].includes(
         vm?.status?.printableStatus,
       ),
       label: t('Stop'),
@@ -70,15 +70,9 @@ export const VirtualMachineActionFactory = {
   restart: (vm: V1VirtualMachine, t: TFunction): Action => {
     return {
       id: 'vm-action-restart',
-      disabled: [
-        Starting,
-        Stopping,
-        Terminating,
-        Provisioning,
-        Migrating,
-        Stopped,
-        Unknown,
-      ].includes(vm?.status?.printableStatus),
+      disabled: [Stopping, Terminating, Provisioning, Migrating, Stopped, Unknown].includes(
+        vm?.status?.printableStatus,
+      ),
       label: t('Restart'),
       cta: () => restartVM(vm),
       accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),


### PR DESCRIPTION
## 📝 Description

Enabling `Stop` and `Restart` actions when VM is on `Starting` status

## 🎥 Demo

before:

![starting-vm-cant-stop-or-restart](https://user-images.githubusercontent.com/67270715/168467135-84306cf4-98cd-411b-b61a-0d12156ae66b.png)

after:

![starting-vm-cant-stop-or-restart-fix](https://user-images.githubusercontent.com/67270715/168467142-8ee52bad-3688-4e15-bdbb-d1fd07db4030.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>