### PR TITLE
Bug 2086303: non-priv user can't create VM when namespace is not selected

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -189,6 +189,7 @@
   "Create VirtualMachine": "Create VirtualMachine",
   "Create VirtualMachine error": "Create VirtualMachine error",
   "Create VirtualMachine from template": "Create VirtualMachine from template",
+  "Create VirtualMachine is forbidden at cluster scope. Please select a Project": "Create VirtualMachine is forbidden at cluster scope. Please select a Project",
   "Create with no available boot source": "Create with no available boot source",
   "Created": "Created",
   "Created at": "Created at",

--- a/src/utils/resources/template/hooks/useProcessedTemplate.ts
+++ b/src/utils/resources/template/hooks/useProcessedTemplate.ts
@@ -6,9 +6,13 @@ import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 /**
  * A Hook that processes a given template and returns the processed template.
  * @param {V1Template} template V1Template to process
+ * @param {string} namespace Namespace to process the template in
  * @returns the processed template.
  */
-export const useProcessedTemplate = (template: V1Template): [V1Template, boolean, any] => {
+export const useProcessedTemplate = (
+  template: V1Template,
+  namespace: string,
+): [V1Template, boolean, any] => {
   const [processedTemplate, setProcessedTemplate] = React.useState<V1Template | undefined>(
     undefined,
   );
@@ -22,6 +26,7 @@ export const useProcessedTemplate = (template: V1Template): [V1Template, boolean
       k8sCreate<V1Template>({
         model: ProcessedTemplatesModel,
         data: template,
+        ns: namespace,
         queryParams: {
           dryRun: 'All',
         },
@@ -36,7 +41,7 @@ export const useProcessedTemplate = (template: V1Template): [V1Template, boolean
           setError(err);
         });
     }
-  }, [template]);
+  }, [template, namespace]);
 
   return [processedTemplate, loaded, error];
 };

--- a/src/views/catalog/templatescatalog/TemplatesCatalog.tsx
+++ b/src/views/catalog/templatescatalog/TemplatesCatalog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { Stack, Toolbar, ToolbarContent } from '@patternfly/react-core';
 
 import { TemplatesCatalogDrawer } from './components/TemplatesCatalogDrawer/TemplatesCatalogDrawer';
@@ -24,6 +25,8 @@ const TemplatesCatalog: React.FC<RouteComponentProps<{ ns: string }>> = ({
 }) => {
   const [selectedTemplate, setSelectedTemplate] = React.useState<V1Template | undefined>(undefined);
 
+  const isAdmin = useIsAdmin();
+  const disableDrawer = !namespace && !isAdmin;
   const [filters, onFilterChange, clearAll] = useTemplatesFilters();
   const { templates, availableTemplatesUID, loaded, bootSourcesLoaded, error } =
     useTemplatesWithAvailableSource({
@@ -39,7 +42,7 @@ const TemplatesCatalog: React.FC<RouteComponentProps<{ ns: string }>> = ({
 
   return (
     <Stack hasGutter className="vm-catalog">
-      <TemplatesCatalogPageHeader namespace={namespace} />
+      <TemplatesCatalogPageHeader namespace={namespace} isAdmin={isAdmin} />
       {loaded ? (
         <div className="co-catalog-page co-catalog-page--with-sidebar">
           <TemplatesCatalogFilters filters={filters} onFilterChange={onFilterChange} />
@@ -59,7 +62,7 @@ const TemplatesCatalog: React.FC<RouteComponentProps<{ ns: string }>> = ({
                 availableTemplatesUID={availableTemplatesUID}
                 bootSourcesLoaded={bootSourcesLoaded}
                 filters={filters}
-                onTemplateClick={setSelectedTemplate}
+                onTemplateClick={!disableDrawer && setSelectedTemplate}
                 loaded={loaded}
                 error={error}
               />

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerFooter.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerFooter.tsx
@@ -33,7 +33,7 @@ export const TemplatesCatalogDrawerFooter: React.FC<TemplateCatalogDrawerFooterP
 }) => {
   const { t } = useKubevirtTranslation();
   const { isBootSourceAvailable, loaded: bootSourceLoaded } = useVmTemplateSource(template);
-  const [processedTemplate, processedTemplateLoaded] = useProcessedTemplate(template);
+  const [processedTemplate, processedTemplateLoaded] = useProcessedTemplate(template, namespace);
 
   const canQuickCreate = !!processedTemplate && isBootSourceAvailable;
   const loaded = bootSourceLoaded && processedTemplateLoaded;

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogPageHeader.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogPageHeader.tsx
@@ -4,6 +4,7 @@ import { useHistory } from 'react-router-dom';
 import { VirtualMachineModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
+  Alert,
   Breadcrumb,
   BreadcrumbItem,
   Button,
@@ -12,8 +13,8 @@ import {
   Title,
 } from '@patternfly/react-core';
 
-export const TemplatesCatalogPageHeader: React.FC<{ namespace: string }> = React.memo(
-  ({ namespace }) => {
+export const TemplatesCatalogPageHeader: React.FC<{ namespace: string; isAdmin: boolean }> =
+  React.memo(({ namespace, isAdmin }) => {
     const { t } = useKubevirtTranslation();
     const history = useHistory();
 
@@ -33,14 +34,20 @@ export const TemplatesCatalogPageHeader: React.FC<{ namespace: string }> = React
           </BreadcrumbItem>
           <BreadcrumbItem>{t('Catalog')}</BreadcrumbItem>
         </Breadcrumb>
-        <Stack>
+        <Stack hasGutter>
           <StackItem className="co-m-pane__heading">
             <Title headingLevel="h1">{t('Create new VirtualMachine from catalog')}</Title>
           </StackItem>
+          {!namespace && !isAdmin && (
+            <StackItem>
+              <Alert variant="danger" title={t('Error')} isInline>
+                {t('Create VirtualMachine is forbidden at cluster scope. Please select a Project')}
+              </Alert>
+            </StackItem>
+          )}
           <StackItem>{t('Select an option to create a VirtualMachine')}</StackItem>
         </Stack>
       </div>
     );
-  },
-);
+  });
 TemplatesCatalogPageHeader.displayName = 'TemplatesCatalogPageHeader';

--- a/src/views/catalog/utils/quick-create-vm.ts
+++ b/src/views/catalog/utils/quick-create-vm.ts
@@ -11,6 +11,7 @@ export const quickCreateVM = (
   k8sCreate<V1Template>({
     model: ProcessedTemplatesModel,
     data: template,
+    ns: namespace,
     queryParams: {
       dryRun: 'All',
     },


### PR DESCRIPTION
## 📝 Description

non-privileged user can not quick create VM (or customize create) when namespace is not selected and has no 'create' access to `default` project.

fix includes:

- disabling the templates drawer when namespace is not selected
- adding an alert that specify that a namespace needs to be selected
- fixing useProcessTemplate hook to use the current namespace if exists

## 🎥 Demo

before:

![Screenshot (38)](https://user-images.githubusercontent.com/67270715/168477638-6c5e6c64-75c3-46ca-a6d0-5086bb04a961.png)

after:

https://user-images.githubusercontent.com/67270715/168477867-e87efd22-7ff6-4c3a-b969-81ef857920ee.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
