### PR TITLE
display default templates for non priv user

### DIFF
--- a/src/views/catalog/templatescatalog/hooks/useVmTemplatesFilters.ts
+++ b/src/views/catalog/templatescatalog/hooks/useVmTemplatesFilters.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useURLParams } from '@kubevirt-utils/hooks/useURLParams';
 
 import { CATALOG_FILTERS } from '../utils/consts';
@@ -20,12 +19,11 @@ export const useTemplatesFilters = (): [
   (type: CATALOG_FILTERS, value: string | boolean) => void,
   () => void,
 ] => {
-  const isAdmin = useIsAdmin();
   const { params, appendParam, setParam, deleteParam } = useURLParams();
   const onlyDefaultParam = params.get(CATALOG_FILTERS.ONLY_DEFAULT);
 
   const [filters, setFilters] = React.useState<TemplateFilters>({
-    [CATALOG_FILTERS.ONLY_DEFAULT]: isAdmin,
+    [CATALOG_FILTERS.ONLY_DEFAULT]: true,
     [CATALOG_FILTERS.ONLY_AVAILABLE]: params.get(CATALOG_FILTERS.ONLY_AVAILABLE) === 'true',
     [CATALOG_FILTERS.IS_LIST]: params.get(CATALOG_FILTERS.IS_LIST) === 'true',
     [CATALOG_FILTERS.QUERY]: params.get(CATALOG_FILTERS.QUERY) || '',
@@ -73,7 +71,7 @@ export const useTemplatesFilters = (): [
 
   const clearAll = () => {
     setFilters({
-      [CATALOG_FILTERS.ONLY_DEFAULT]: isAdmin,
+      [CATALOG_FILTERS.ONLY_DEFAULT]: true,
       [CATALOG_FILTERS.ONLY_AVAILABLE]: false,
       [CATALOG_FILTERS.IS_LIST]: filters.isList,
       [CATALOG_FILTERS.QUERY]: '',
@@ -90,10 +88,10 @@ export const useTemplatesFilters = (): [
     if (onlyDefaultParam) {
       updateFilter(CATALOG_FILTERS.ONLY_DEFAULT, onlyDefaultParam === 'true');
     } else {
-      updateFilter(CATALOG_FILTERS.ONLY_DEFAULT, isAdmin);
+      updateFilter(CATALOG_FILTERS.ONLY_DEFAULT, true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAdmin, onlyDefaultParam]);
+  }, [onlyDefaultParam]);
 
   return [filters, onFilterChange, clearAll];
 };

--- a/src/views/catalog/templatescatalog/tests/TemplatesCatalog.test.tsx
+++ b/src/views/catalog/templatescatalog/tests/TemplatesCatalog.test.tsx
@@ -64,11 +64,12 @@ test('TemplatesCatalog', async () => {
     />,
   );
 
-  // non admin user, should see all templates by default
+  // non admin user, should see default templates by default
   // default variant template, should be in catalog
   expect(getByTestId('container-template')).toBeInTheDocument();
 
   // not default variant template, should be in catalog
+  fireEvent.click(getByText('All Items'));
   expect(getByTestId('url-template')).toBeInTheDocument();
 
   // switching to default templates, url template should not be in catalog


### PR DESCRIPTION
## 📝 Description

when navigating to Virtualization -> Catalog as non-privileged user we are displaied with all template items instead of default templates 

## 🎥 Demo

before:

https://user-images.githubusercontent.com/67270715/168478328-2c3dd5e0-408e-4a98-93d8-c3235b322bb8.mp4

after:

https://user-images.githubusercontent.com/67270715/168478344-771a5984-3ec4-4dc4-a9ff-c8efb633c7a5.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>