### PR TITLE
Make Node selector field in VM Template's Scheduling tab editable

### DIFF
--- a/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.tsx
+++ b/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.tsx
@@ -29,11 +29,11 @@ const TemplateSchedulingTab: React.FC<TemplateSchedulingTabProps> = ({ obj: temp
         <ListPageBody>
           <Grid>
             <GridItem span={5} className="margin-top-grid-item">
-              <TemplateSchedulingLeftGrid template={template} />
+              <TemplateSchedulingLeftGrid template={template} editable={!isEditDisabled} />
             </GridItem>
             <GridItem span={1}></GridItem>
             <GridItem span={5} className="margin-top-grid-item">
-              <TemplateSchedulingRightGrid template={template} />
+              <TemplateSchedulingRightGrid template={template} editable={!isEditDisabled} />
             </GridItem>
           </Grid>
         </ListPageBody>

--- a/src/views/templates/details/tabs/scheduling/components/NodeSelector.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/NodeSelector.tsx
@@ -2,8 +2,13 @@ import React from 'react';
 import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
 import { getNodeSelector } from 'src/views/templates/utils/selectors';
 
+import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import {
+  Button,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
@@ -11,24 +16,56 @@ import {
   LabelGroup,
   Text,
 } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
+
+import NodeSelectorModal from './NodeSelectorModal';
 
 const NodeSelector: React.FC<TemplateSchedulingGridProps> = ({ template, editable }) => {
   const { t } = useKubevirtTranslation();
+  const { createModal } = useModal();
   const nodeSelector = getNodeSelector(template);
+  const nodeSelectorLabels = !isEmpty(nodeSelector) ? (
+    <LabelGroup defaultIsOpen>
+      {Object.entries(nodeSelector)?.map(([key, value]) => (
+        <Label key={key}>{`${key}=${value}`}</Label>
+      ))}
+    </LabelGroup>
+  ) : (
+    t('No selector')
+  );
+
+  const onSubmit = React.useCallback(
+    (updatedTemplate: V1Template) =>
+      k8sUpdate({
+        model: TemplateModel,
+        data: updatedTemplate,
+        ns: updatedTemplate?.metadata?.namespace,
+        name: updatedTemplate?.metadata?.name,
+      }),
+    [],
+  );
+
+  const onEditClick = () =>
+    createModal(({ isOpen, onClose }) => (
+      <NodeSelectorModal
+        template={template}
+        isOpen={isOpen}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />
+    ));
 
   return (
     <DescriptionListGroup>
       <DescriptionListTerm>{t('Node selector')}</DescriptionListTerm>
       <DescriptionListDescription>
-        {/* TODO edit labels */}
-        {nodeSelector ? (
-          <LabelGroup defaultIsOpen>
-            {Object.entries(nodeSelector)?.map(([key, value]) => (
-              <Label key={key}>{`${key}=${value}`}</Label>
-            ))}
-          </LabelGroup>
+        {editable ? (
+          <Button type="button" isInline onClick={onEditClick} variant="link">
+            {nodeSelectorLabels}
+            <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+          </Button>
         ) : (
-          <Text className={editable ? '' : 'text-muted'}>{t('No selector')}</Text>
+          <Text className="text-muted">{nodeSelectorLabels}</Text>
         )}
       </DescriptionListDescription>
     </DescriptionListGroup>

--- a/src/views/templates/details/tabs/scheduling/components/NodeSelectorModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/NodeSelectorModal.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import produce from 'immer';
+import { getNodeSelector } from 'src/views/templates/utils/selectors';
+
+import { modelToGroupVersionKind, NodeModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
+import LabelsList from '@kubevirt-utils/components/NodeSelectorModal/components/LabelList';
+import LabelRow from '@kubevirt-utils/components/NodeSelectorModal/components/LabelRow';
+import NodeCheckerAlert from '@kubevirt-utils/components/NodeSelectorModal/components/NodeCheckerAlert';
+import { useIDEntities } from '@kubevirt-utils/components/NodeSelectorModal/hooks/useIDEntities';
+import { useNodeLabelQualifier } from '@kubevirt-utils/components/NodeSelectorModal/hooks/useNodeLabelQualifier';
+import {
+  isEqualObject,
+  nodeSelectorToIDLabels,
+} from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
+import { IDLabel } from '@kubevirt-utils/components/NodeSelectorModal/utils/types';
+import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { Form } from '@patternfly/react-core';
+
+type NodeSelectorModalProps = {
+  template: V1Template;
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (updatedTemplate: V1Template) => Promise<V1Template | void>;
+};
+
+const NodeSelectorModal: React.FC<NodeSelectorModalProps> = ({
+  template,
+  isOpen,
+  onClose,
+  onSubmit,
+}) => {
+  const { t } = useKubevirtTranslation();
+  const {
+    entities: selectorLabels,
+    onEntityAdd: onLabelAdd,
+    onEntityChange: onLabelChange,
+    onEntityDelete: onLabelDelete,
+  } = useIDEntities<IDLabel>(nodeSelectorToIDLabels(getNodeSelector(template)));
+
+  const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
+    groupVersionKind: modelToGroupVersionKind(NodeModel),
+    isList: true,
+  });
+
+  const qualifiedNodes = useNodeLabelQualifier(nodes, nodesLoaded, selectorLabels);
+
+  const onSelectorLabelAdd = () => onLabelAdd({ id: null, key: '', value: '' });
+
+  const updatedTemplate = React.useMemo(() => {
+    const updatedVMTemplate = produce<V1Template>(template, (templateDraft: V1Template) => {
+      if (!getNodeSelector(templateDraft)) {
+        templateDraft.objects[0].spec.template.spec.nodeSelector = {};
+      }
+
+      const k8sSelector: { [key: string]: string } = selectorLabels.reduce(
+        (acc, { key, value }) => {
+          acc[key] = value;
+          return acc;
+        },
+        {},
+      );
+
+      if (!isEqualObject(getNodeSelector(templateDraft), k8sSelector)) {
+        templateDraft.objects[0].spec.template.spec.nodeSelector = k8sSelector;
+      }
+    });
+    return updatedVMTemplate;
+  }, [template, selectorLabels]);
+
+  return (
+    <TabModal
+      obj={updatedTemplate}
+      isOpen={isOpen}
+      onClose={onClose}
+      onSubmit={onSubmit}
+      headerText={t('Node Selector')}
+    >
+      <Form>
+        <LabelsList
+          isEmpty={selectorLabels?.length === 0}
+          model={NodeModel}
+          onLabelAdd={onSelectorLabelAdd}
+        >
+          {selectorLabels.length > 0 && (
+            <>
+              {selectorLabels.map((label) => (
+                <LabelRow
+                  key={label.id}
+                  label={label}
+                  onChange={onLabelChange}
+                  onDelete={onLabelDelete}
+                />
+              ))}
+            </>
+          )}
+        </LabelsList>
+        <NodeCheckerAlert
+          qualifiedNodes={selectorLabels?.length === 0 ? nodes : qualifiedNodes}
+          nodesLoaded={nodesLoaded}
+        />
+      </Form>
+    </TabModal>
+  );
+};
+
+export default NodeSelectorModal;

--- a/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid.tsx
@@ -1,27 +1,26 @@
 import React from 'react';
-import { TemplateDetailsGridProps } from 'src/views/templates/details/tabs/details/TemplateDetailsPage';
 import AffinityRules from 'src/views/templates/details/tabs/scheduling/components/AffinityRules';
 import Descheduler from 'src/views/templates/details/tabs/scheduling/components/Descheduler';
 import NodeSelector from 'src/views/templates/details/tabs/scheduling/components/NodeSelector';
 import Tolerations from 'src/views/templates/details/tabs/scheduling/components/Tolerations';
-import { isCommonVMTemplate } from 'src/views/templates/utils';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { DescriptionList } from '@patternfly/react-core';
 
 export type TemplateSchedulingGridProps = {
   template: V1Template;
-  editable?: boolean;
+  editable: boolean;
 };
 
-const TemplateSchedulingLeftGrid: React.FC<TemplateDetailsGridProps> = ({ template }) => {
-  const isTemplateEditable = !isCommonVMTemplate(template);
-
+const TemplateSchedulingLeftGrid: React.FC<TemplateSchedulingGridProps> = ({
+  template,
+  editable,
+}) => {
   return (
     <DescriptionList>
-      <NodeSelector template={template} editable={isTemplateEditable} />
-      <Tolerations template={template} editable={isTemplateEditable} />
-      <AffinityRules template={template} editable={isTemplateEditable} />
+      <NodeSelector template={template} editable={editable} />
+      <Tolerations template={template} editable={editable} />
+      <AffinityRules template={template} editable={editable} />
       <Descheduler template={template} />
     </DescriptionList>
   );

--- a/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingRightGrid.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingRightGrid.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
-import { TemplateDetailsGridProps } from 'src/views/templates/details/tabs/details/TemplateDetailsPage';
 import DedicatedResources from 'src/views/templates/details/tabs/scheduling/components//DedicatedResources';
 import EvictionStrategy from 'src/views/templates/details/tabs/scheduling/components//EvictionStrategy';
-import { isCommonVMTemplate } from 'src/views/templates/utils';
 
 import { DescriptionList } from '@patternfly/react-core';
 
-const TemplateSchedulingRightGrid: React.FC<TemplateDetailsGridProps> = ({ template }) => {
-  const isTemplateEditable = !isCommonVMTemplate(template);
+import { TemplateSchedulingGridProps } from './TemplateSchedulingLeftGrid';
 
+const TemplateSchedulingRightGrid: React.FC<TemplateSchedulingGridProps> = ({
+  template,
+  editable,
+}) => {
   return (
     <DescriptionList>
-      <DedicatedResources template={template} editable={isTemplateEditable} />
-      <EvictionStrategy template={template} editable={isTemplateEditable} />
+      <DedicatedResources template={template} editable={editable} />
+      <EvictionStrategy template={template} editable={editable} />
     </DescriptionList>
   );
 };


### PR DESCRIPTION
## 📝 Description
Make _Node selector_ field in Template's _Scheduling_ tab editable. Enable editing the labels if the template is not a common template.
Add the modal to edit the labels.

## 🎥 Demo
**Before:**
![before](https://user-images.githubusercontent.com/13417815/168639235-c0de6eb0-edad-4109-b584-f573387d9e7d.png)
**After:**
![after1](https://user-images.githubusercontent.com/13417815/168639251-cc5dcf3f-95f7-460d-9914-2b5f7d3e4876.png)
![after2](https://user-images.githubusercontent.com/13417815/168639264-93454fc6-5c34-4905-9c82-e9627b7e4b67.png)


