### PR TITLE
Make Tolerations and Affinity in Template's Scheduling tab editable

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1,5 +1,4 @@
 {
-  " 0 Toleration rules": " 0 Toleration rules",
   " Password: ": " Password: ",
   "--- Select {{ dsLabel }} name ---": "--- Select {{ dsLabel }} name ---",
   "--- Select {{dsLabel}} project ---": "--- Select {{dsLabel}} project ---",
@@ -19,6 +18,8 @@
   "{{count}} GPU devices_other": "{{count}} GPU devices",
   "{{count}} Host devices_one": "{{count}} Host devices",
   "{{count}} Host devices_other": "{{count}} Host devices",
+  "{{count}} Toleration rules_one": "{{count}} Toleration rules",
+  "{{count}} Toleration rules_other": "{{count}} Toleration rules",
   "{{count}} Tolerations rules_one": "{{count}} Tolerations rules",
   "{{count}} Tolerations rules_other": "{{count}} Tolerations rules",
   "{{cpu}} CPU | {{memory}} Memory": "{{cpu}} CPU | {{memory}} Memory",
@@ -32,7 +33,6 @@
   "{{qualifiedNodesCount}} matching nodes found": "{{qualifiedNodesCount}} matching nodes found",
   "{{qualifiedNodesCount}} matching Nodes found": "{{qualifiedNodesCount}} matching Nodes found",
   "{{qualifiedNodesCount}} nodes found": "{{qualifiedNodesCount}} nodes found",
-  "{{rulesCount}} Affinity rules": "{{rulesCount}} Affinity rules",
   "<0>Autounattend.xml</0><1>Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.</1><2><0>{t('Learn more')}</0></2>": "<0>Autounattend.xml</0><1>Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.</1><2><0>{t('Learn more')}</0></2>",
   "<0>Clicking &quot;Launch Remote Desktop&quot; will download an .rdp file and launch <2>Remote Desktop Viewer</2>.</0><1>Since the RDP is native Windows protocol, the best experience is achieved when used on Windows-based desktop.</1><2>For other operating systems, the <1>Remote Viewer</1> is recommended. If RDP needs to be accessed anyway, the <3>Remmina</3> client is available.</2>": "<0>Clicking &quot;Launch Remote Desktop&quot; will download an .rdp file and launch <2>Remote Desktop Viewer</2>.</0><1>Since the RDP is native Windows protocol, the best experience is achieved when used on Windows-based desktop.</1><2>For other operating systems, the <1>Remote Viewer</1> is recommended. If RDP needs to be accessed anyway, the <3>Remmina</3> client is available.</2>",
   "<0>Clicking &quot;Launch Remote Viewer&quot; will download a .vv file and launch <2>Remote Viewer</2></0><1><0>Remote Viewer</0> is available for most operating systems. To install it, search for it in GNOME Software or run the following:</1>": "<0>Clicking &quot;Launch Remote Viewer&quot; will download a .vv file and launch <2>Remote Viewer</2></0><1><0>Remote Viewer</0> is available for most operating systems. To install it, search for it in GNOME Software or run the following:</1>",

--- a/src/views/templates/details/tabs/scheduling/components/AffinityRules.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/AffinityRules.tsx
@@ -2,27 +2,49 @@ import React from 'react';
 import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
 import { getAffinity } from 'src/views/templates/utils/selectors';
 
+import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getAffinityRules } from '@kubevirt-utils/resources/vmi';
 import {
+  Button,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
   Text,
 } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
 
-const AffinityRules: React.FC<TemplateSchedulingGridProps> = ({ template, editable }) => {
+import AffinityRulesModal from './AffinityRulesModal';
+
+const AffinityRules: React.FC<TemplateSchedulingGridProps> = ({ template, editable, onSubmit }) => {
+  const { createModal } = useModal();
   const { t } = useKubevirtTranslation();
+  const rulesCount = t('{{count}} Affinity rules', {
+    count: getAffinityRules(getAffinity(template))?.length ?? 0,
+  });
+
+  const onEditClick = () =>
+    createModal(({ isOpen, onClose }) => (
+      <AffinityRulesModal
+        template={template}
+        isOpen={isOpen}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />
+    ));
 
   return (
     <DescriptionListGroup>
       <DescriptionListTerm>{t('Affinity rules')}</DescriptionListTerm>
       <DescriptionListDescription>
-        <Text className={editable ? '' : 'text-muted'}>
-          {/* TODO edit rules */}
-          {t('{{rulesCount}} Affinity rules', {
-            rulesCount: getAffinity(template).length,
-          })}
-        </Text>
+        {editable ? (
+          <Button type="button" isInline onClick={onEditClick} variant="link">
+            {rulesCount}
+            <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+          </Button>
+        ) : (
+          <Text className="text-muted">{rulesCount}</Text>
+        )}
       </DescriptionListDescription>
     </DescriptionListGroup>
   );

--- a/src/views/templates/details/tabs/scheduling/components/AffinityRulesModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/AffinityRulesModal.tsx
@@ -1,0 +1,146 @@
+import * as React from 'react';
+import produce from 'immer';
+import { getAffinity } from 'src/views/templates/utils/selectors';
+
+import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import AffinityEditModal from '@kubevirt-utils/components/AffinityModal/components/AffinityEditModal/AffinityEditModal';
+import AffinityEmptyState from '@kubevirt-utils/components/AffinityModal/components/AffinityEmptyState';
+import AffinityList from '@kubevirt-utils/components/AffinityModal/components/AffinityList/AffinityList';
+import { useRequiredAndPrefferedQualifiedNodes } from '@kubevirt-utils/components/AffinityModal/hooks/useRequiredAndPrefferedQualifiedNodes';
+import { defaultNewAffinity } from '@kubevirt-utils/components/AffinityModal/utils/constants';
+import {
+  getAffinityFromRowsData,
+  getAvailableAffinityID,
+  getRowsDataFromAffinity,
+} from '@kubevirt-utils/components/AffinityModal/utils/helpers';
+import { AffinityRowData } from '@kubevirt-utils/components/AffinityModal/utils/types';
+import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
+import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { modelToGroupVersionKind, NodeModel, V1Template } from '@kubevirt-utils/models';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { ModalVariant } from '@patternfly/react-core';
+
+type AffinityModalProps = {
+  template: V1Template;
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (updatedTemplate: V1Template) => Promise<V1Template | void>;
+};
+
+const AffinityRulesModal: React.FC<AffinityModalProps> = ({
+  template,
+  isOpen,
+  onClose,
+  onSubmit,
+}) => {
+  const { t } = useKubevirtTranslation();
+  const [affinities, setAffinities] = React.useState<AffinityRowData[]>(
+    getRowsDataFromAffinity(getAffinity(template)),
+  );
+  const [focusedAffinity, setFocusedAffinity] = React.useState<AffinityRowData>(defaultNewAffinity);
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [isCreating, setIsCreating] = React.useState(false);
+  const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
+    groupVersionKind: modelToGroupVersionKind(NodeModel),
+    isList: true,
+  });
+  const [qualifiedRequiredNodes, qualifiedPreferredNodes] = useRequiredAndPrefferedQualifiedNodes(
+    nodes,
+    nodesLoaded,
+    affinities,
+  );
+
+  const onAffinityAdd = (affinity: AffinityRowData) => {
+    setAffinities((prevAffinities) => [...(prevAffinities || []), affinity]);
+    setIsEditing(false);
+    setIsCreating(false);
+  };
+
+  const onAffinityChange = (updatedAffinity: AffinityRowData) => {
+    setAffinities((prevAffinities) =>
+      prevAffinities.map((affinity) => {
+        if (affinity.id === updatedAffinity.id) return { ...affinity, ...updatedAffinity };
+        return affinity;
+      }),
+    );
+    setIsEditing(false);
+  };
+
+  const onAffinityClickAdd = () => {
+    setIsEditing(true);
+    setIsCreating(true);
+    setFocusedAffinity({ ...defaultNewAffinity, id: getAvailableAffinityID(affinities) });
+  };
+
+  const onAffinityClickEdit = (affinity: AffinityRowData) => {
+    setFocusedAffinity(affinity);
+    setIsEditing(true);
+  };
+
+  const onAffinityDelete = (affinity: AffinityRowData) =>
+    setAffinities((prevAffinities) => prevAffinities.filter(({ id }) => id !== affinity.id));
+
+  const onCancel = () => {
+    setIsEditing(false);
+    setIsCreating(false);
+  };
+
+  const onSaveAffinity = isCreating ? onAffinityAdd : onAffinityChange;
+
+  const updatedTemplate = React.useMemo(() => {
+    return produce<V1Template>(template, (templateDraft: V1Template) => {
+      if (!getAffinity(templateDraft)) {
+        templateDraft.objects[0].spec.template.spec.affinity = [];
+      }
+
+      const updatedAffinity = getAffinityFromRowsData(affinities);
+
+      if (!isEqualObject(getAffinity(templateDraft), updatedAffinity)) {
+        templateDraft.objects[0].spec.template.spec.affinity = updatedAffinity;
+      }
+    });
+  }, [affinities, template]);
+
+  const list = isEmpty(affinities) ? (
+    <AffinityEmptyState onAffinityClickAdd={onAffinityClickAdd} />
+  ) : (
+    <AffinityList
+      affinities={affinities}
+      onAffinityClickAdd={onAffinityClickAdd}
+      qualifiedNodes={qualifiedRequiredNodes}
+      prefferedQualifiedNodes={qualifiedPreferredNodes}
+      nodesLoaded={nodesLoaded}
+      onEdit={onAffinityClickEdit}
+      onDelete={onAffinityDelete}
+    />
+  );
+
+  return isEditing ? (
+    <AffinityEditModal
+      nodes={nodes}
+      nodesLoaded={nodesLoaded}
+      isOpen={isOpen}
+      onCancel={onCancel}
+      onSubmit={onSaveAffinity}
+      focusedAffinity={focusedAffinity}
+      setFocusedAffinity={setFocusedAffinity}
+      title={isCreating ? t('Add affinity rule') : t('Edit affinity rule')}
+    />
+  ) : (
+    <TabModal
+      isOpen={isOpen}
+      onClose={onClose}
+      obj={updatedTemplate}
+      onSubmit={onSubmit}
+      headerText={t('Affinity rules')}
+      submitBtnText={t('Save')}
+      modalVariant={ModalVariant.medium}
+    >
+      {list}
+    </TabModal>
+  );
+};
+
+export default AffinityRulesModal;

--- a/src/views/templates/details/tabs/scheduling/components/NodeSelector.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/NodeSelector.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
 import { getNodeSelector } from 'src/views/templates/utils/selectors';
 
-import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
   DescriptionListDescription,
@@ -20,7 +18,7 @@ import { PencilAltIcon } from '@patternfly/react-icons';
 
 import NodeSelectorModal from './NodeSelectorModal';
 
-const NodeSelector: React.FC<TemplateSchedulingGridProps> = ({ template, editable }) => {
+const NodeSelector: React.FC<TemplateSchedulingGridProps> = ({ template, editable, onSubmit }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const nodeSelector = getNodeSelector(template);
@@ -32,17 +30,6 @@ const NodeSelector: React.FC<TemplateSchedulingGridProps> = ({ template, editabl
     </LabelGroup>
   ) : (
     t('No selector')
-  );
-
-  const onSubmit = React.useCallback(
-    (updatedTemplate: V1Template) =>
-      k8sUpdate({
-        model: TemplateModel,
-        data: updatedTemplate,
-        ns: updatedTemplate?.metadata?.namespace,
-        name: updatedTemplate?.metadata?.name,
-      }),
-    [],
   );
 
   const onEditClick = () =>

--- a/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid.tsx
@@ -4,23 +4,36 @@ import Descheduler from 'src/views/templates/details/tabs/scheduling/components/
 import NodeSelector from 'src/views/templates/details/tabs/scheduling/components/NodeSelector';
 import Tolerations from 'src/views/templates/details/tabs/scheduling/components/Tolerations';
 
-import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList } from '@patternfly/react-core';
 
 export type TemplateSchedulingGridProps = {
   template: V1Template;
   editable: boolean;
+  onSubmit?: (updatedTemplate: V1Template) => Promise<V1Template | void>;
 };
 
 const TemplateSchedulingLeftGrid: React.FC<TemplateSchedulingGridProps> = ({
   template,
   editable,
 }) => {
+  const onSubmit = React.useCallback(
+    (updatedTemplate: V1Template) =>
+      k8sUpdate({
+        model: TemplateModel,
+        data: updatedTemplate,
+        ns: updatedTemplate?.metadata?.namespace,
+        name: updatedTemplate?.metadata?.name,
+      }),
+    [],
+  );
+
   return (
     <DescriptionList>
-      <NodeSelector template={template} editable={editable} />
-      <Tolerations template={template} editable={editable} />
-      <AffinityRules template={template} editable={editable} />
+      <NodeSelector template={template} editable={editable} onSubmit={onSubmit} />
+      <Tolerations template={template} editable={editable} onSubmit={onSubmit} />
+      <AffinityRules template={template} editable={editable} onSubmit={onSubmit} />
       <Descheduler template={template} />
     </DescriptionList>
   );

--- a/src/views/templates/details/tabs/scheduling/components/Tolerations.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/Tolerations.tsx
@@ -2,33 +2,42 @@ import React from 'react';
 import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
 import { getTolerations } from 'src/views/templates/utils/selectors';
 
+import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
+  Button,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
-  Label,
-  LabelGroup,
   Text,
 } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
 
-const Tolerations: React.FC<TemplateSchedulingGridProps> = ({ template, editable }) => {
+import TolerationsModal from './TolerationsModal';
+
+const Tolerations: React.FC<TemplateSchedulingGridProps> = ({ template, editable, onSubmit }) => {
+  const { createModal } = useModal();
   const { t } = useKubevirtTranslation();
-  const tolerations = getTolerations(template);
+  const tolerationsCount = t('{{count}} Toleration rules', {
+    count: getTolerations(template)?.length ?? 0,
+  });
+
+  const onEditClick = () =>
+    createModal(({ isOpen, onClose }) => (
+      <TolerationsModal template={template} isOpen={isOpen} onClose={onClose} onSubmit={onSubmit} />
+    ));
 
   return (
     <DescriptionListGroup>
       <DescriptionListTerm>{t('Tolerations')}</DescriptionListTerm>
       <DescriptionListDescription>
-        {/* TODO edit labels */}
-        {tolerations ? (
-          <LabelGroup defaultIsOpen>
-            {Object.entries(tolerations)?.map(([key, value]) => (
-              <Label key={key}>{`${key}=${value}`}</Label>
-            ))}
-          </LabelGroup>
+        {editable ? (
+          <Button type="button" isInline onClick={onEditClick} variant="link">
+            {tolerationsCount}
+            <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+          </Button>
         ) : (
-          <Text className={editable ? '' : 'text-muted'}>{t(' 0 Toleration rules')}</Text>
+          <Text className="text-muted">{tolerationsCount}</Text>
         )}
       </DescriptionListDescription>
     </DescriptionListGroup>

--- a/src/views/templates/details/tabs/scheduling/components/TolerationsModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/TolerationsModal.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import produce from 'immer';
+import { getTolerations } from 'src/views/templates/utils/selectors';
+
+import { modelToGroupVersionKind, NodeModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
+import { K8sIoApiCoreV1Toleration } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import LabelsList from '@kubevirt-utils/components/NodeSelectorModal/components/LabelList';
+import NodeCheckerAlert from '@kubevirt-utils/components/NodeSelectorModal/components/NodeCheckerAlert';
+import { useIDEntities } from '@kubevirt-utils/components/NodeSelectorModal/hooks/useIDEntities';
+import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
+import TolerationEditRow from '@kubevirt-utils/components/TolerationsModal/TolerationEditRow';
+import TolerationListHeaders from '@kubevirt-utils/components/TolerationsModal/TolerationListHeaders';
+import TolerationModalDescriptionText from '@kubevirt-utils/components/TolerationsModal/TolerationModalDescriptionText';
+import {
+  TolerationLabel,
+  TOLERATIONS_EFFECTS,
+} from '@kubevirt-utils/components/TolerationsModal/utils/constants';
+import { getNodeTaintQualifier } from '@kubevirt-utils/components/TolerationsModal/utils/helpers';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { Operator, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { Form, ModalVariant } from '@patternfly/react-core';
+
+type TolerationsModalProps = {
+  template: V1Template;
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (updatedTemplate: V1Template) => Promise<V1Template | void>;
+};
+
+const TolerationsModal: React.FC<TolerationsModalProps> = ({
+  template,
+  isOpen,
+  onClose,
+  onSubmit,
+}) => {
+  const { t } = useKubevirtTranslation();
+  const {
+    entities: tolerationsLabels,
+    onEntityAdd: onTolerationAdd,
+    onEntityChange: onTolerationChange,
+    onEntityDelete: onTolerationDelete,
+  } = useIDEntities<TolerationLabel>(
+    (getTolerations(template) || []).map((toleration, id) => ({ ...toleration, id })),
+  );
+  const tolerationLabelsEmpty = tolerationsLabels?.length === 0;
+  const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
+    groupVersionKind: modelToGroupVersionKind(NodeModel),
+    isList: true,
+  });
+  const qualifiedNodes = getNodeTaintQualifier(nodes, nodesLoaded, tolerationsLabels);
+
+  const onSelectorLabelAdd = () =>
+    onTolerationAdd({ id: null, key: '', value: '', effect: TOLERATIONS_EFFECTS[0] });
+
+  const updatedTemplate = React.useMemo(() => {
+    return produce<V1Template>(template, (templateDraft: V1Template) => {
+      const updatedTolerations: K8sIoApiCoreV1Toleration[] = (tolerationsLabels || []).map(
+        (toleration) => {
+          return {
+            ...toleration,
+            operator: toleration?.value ? 'Equal' : Operator.Exists,
+          };
+        },
+      );
+
+      templateDraft.objects[0].spec.template.spec.tolerations = updatedTolerations;
+    });
+  }, [template, tolerationsLabels]);
+
+  return (
+    <TabModal
+      obj={updatedTemplate}
+      isOpen={isOpen}
+      onClose={onClose}
+      onSubmit={onSubmit}
+      headerText={t('Tolerations')}
+      modalVariant={ModalVariant.medium}
+      submitBtnText={t('Save')}
+    >
+      <TolerationModalDescriptionText />
+      <Form>
+        <LabelsList
+          isEmpty={tolerationLabelsEmpty}
+          model={NodeModel}
+          onLabelAdd={onSelectorLabelAdd}
+          addRowText={t('Add toleration')}
+          emptyStateAddRowText={t('Add toleration to specify qualifying Nodes')}
+        >
+          {!tolerationLabelsEmpty && (
+            <>
+              <TolerationListHeaders />
+              {tolerationsLabels.map((label) => (
+                <TolerationEditRow
+                  key={label.id}
+                  label={label}
+                  onChange={onTolerationChange}
+                  onDelete={onTolerationDelete}
+                />
+              ))}
+            </>
+          )}
+        </LabelsList>
+        {!tolerationLabelsEmpty && nodesLoaded && (
+          <NodeCheckerAlert
+            qualifiedNodes={tolerationsLabels?.length === 0 ? nodes : qualifiedNodes}
+            nodesLoaded={nodesLoaded}
+          />
+        )}
+      </Form>
+    </TabModal>
+  );
+};
+
+export default TolerationsModal;

--- a/src/views/templates/utils/selectors.ts
+++ b/src/views/templates/utils/selectors.ts
@@ -6,7 +6,7 @@ import { VM_WORKLOAD_ANNOTATION } from '@kubevirt-utils/resources/vm/utils';
 import { ANNOTATIONS, LABELS } from './constants';
 
 export const getAffinity = (template: V1Template) =>
-  template?.objects[0]?.spec?.template?.spec?.affinity || [];
+  template?.objects[0]?.spec?.template?.spec?.affinity || {};
 
 export const getEvictionStrategy = (template: V1Template): string =>
   template?.objects[0]?.spec?.template?.spec?.evictionStrategy;


### PR DESCRIPTION
## 📝 Description
Make _Tolerations_ and _Affinity rules_ fields editable, in the VM Template's _Scheduling_ tab, if the template is not a common template.
Add the appropriate modals to edit the fields.

## 🎥 Demo
**Before:**
The number of tolerations/affinity rules displayed, but no ability to edit:
![-before](https://user-images.githubusercontent.com/13417815/168682499-c0df7681-926c-41a0-bf49-f65c7cc489cc.png)

**After:**
Tolerations/affinity rules editable:
![-after](https://user-images.githubusercontent.com/13417815/168682684-dabc6989-c278-4c75-8246-e5b5839a84ac.png)
Modal window to add/edit tolerations:
![-after2](https://user-images.githubusercontent.com/13417815/168682687-527fdb3f-e8dc-4a8f-b070-e914275085bf.png)
Modal window to add/edit affinity rules:
![-after3](https://user-images.githubusercontent.com/13417815/168682693-bf8c430b-fb20-4cb3-9d61-1c53cd834222.png)

