### PR TITLE
Make Template's Description field editable

### DIFF
--- a/src/views/templates/details/tabs/details/TemplateDetailsPage.tsx
+++ b/src/views/templates/details/tabs/details/TemplateDetailsPage.tsx
@@ -14,6 +14,7 @@ import './TemplateDetailsPage.scss';
 
 export type TemplateDetailsGridProps = {
   template: V1Template;
+  editable?: boolean;
 };
 
 type TemplateDetailsPageProps = RouteComponentProps<{
@@ -33,7 +34,7 @@ const TemplateDetailsPage: React.FC<TemplateDetailsPageProps> = ({ obj: template
         <ListPageBody>
           <Grid>
             <GridItem span={5} className="margin-top-grid-item">
-              <TemplateDetailsLeftGrid template={template} />
+              <TemplateDetailsLeftGrid template={template} editable={!isCommonTemplate} />
             </GridItem>
             <GridItem span={1}></GridItem>
             <GridItem span={5} className="margin-top-grid-item">

--- a/src/views/templates/details/tabs/details/components/Description.tsx
+++ b/src/views/templates/details/tabs/details/components/Description.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import produce from 'immer';
+
+import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { DescriptionModal } from '@kubevirt-utils/components/DescriptionModal/DescriptionModal';
+import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  Button,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
+
+type DescriptionProps = {
+  template: V1Template;
+  editable: boolean;
+};
+
+const Description: React.FC<DescriptionProps> = ({ template, editable }) => {
+  const { createModal } = useModal();
+  const { t } = useKubevirtTranslation();
+  const templateDescription = template?.metadata?.annotations?.description || (
+    <MutedTextSpan text={t('None')} />
+  );
+
+  const updateDescription = (updatedDescription: string) => {
+    const updatedTemplate = produce<V1Template>(template, (templateDraft: V1Template) => {
+      if (!templateDraft.metadata.annotations) templateDraft.metadata.annotations = {};
+
+      if (updatedDescription) {
+        templateDraft.metadata.annotations.description = updatedDescription;
+      } else {
+        delete templateDraft.metadata.annotations.description;
+      }
+      return templateDraft;
+    });
+
+    return k8sUpdate({
+      model: TemplateModel,
+      data: updatedTemplate,
+      ns: updatedTemplate?.metadata?.namespace,
+      name: updatedTemplate?.metadata?.name,
+    });
+  };
+
+  const onEditClick = () =>
+    createModal(({ isOpen, onClose }) => (
+      <DescriptionModal
+        obj={template}
+        isOpen={isOpen}
+        onClose={onClose}
+        onSubmit={updateDescription}
+      />
+    ));
+
+  return (
+    <DescriptionListGroup>
+      <DescriptionListTerm>{t('Description')}</DescriptionListTerm>
+      <DescriptionListDescription>
+        {templateDescription}
+        {editable && (
+          <Button type="button" isInline onClick={onEditClick} variant="link">
+            <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+          </Button>
+        )}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
+  );
+};
+
+export default Description;

--- a/src/views/templates/details/tabs/details/components/TemplateDetailsLeftGrid.tsx
+++ b/src/views/templates/details/tabs/details/components/TemplateDetailsLeftGrid.tsx
@@ -11,14 +11,14 @@ import { TemplateDetailsGridProps } from 'src/views/templates/details/tabs/detai
 import useWorkloadProfile from 'src/views/templates/list/hooks/useWorkloadProfile';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { getOperatingSystemName } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import { DescriptionList } from '@patternfly/react-core';
 
 import BootMethod from './BootMethod/BootMethod';
 import CPUMemory from './CPUMemory';
+import Description from './Description';
 
-const TemplateDetailsLeftGrid: React.FC<TemplateDetailsGridProps> = ({ template }) => {
+const TemplateDetailsLeftGrid: React.FC<TemplateDetailsGridProps> = ({ template, editable }) => {
   const { t } = useKubevirtTranslation();
 
   return (
@@ -27,10 +27,7 @@ const TemplateDetailsLeftGrid: React.FC<TemplateDetailsGridProps> = ({ template 
       <Namespace namespace={template?.metadata?.namespace} />
       <Labels labels={template?.metadata?.labels} />
       <Annotations count={Object.keys(template?.metadata?.annotations || {}).length} />
-      <DescriptionItem
-        title={t('Description')}
-        content={template?.metadata?.annotations?.description || NO_DATA_DASH}
-      />
+      <Description template={template} editable={editable} />
       <DescriptionItem title={t('Operating system')} content={getOperatingSystemName(template)} />
       <DescriptionItem title={t('Workload profile')} content={useWorkloadProfile(template)} />
       <CPUMemory template={template} />


### PR DESCRIPTION
## 📝 Description
Make _Description_ field editable, in VM Template's _Details_ tab.
Add using the appropriate modal to edit the description - in case that the VM Template is not a common template.

## 🎥 Demo
**Before:**
Dash displayed in case there was no any description + no editability:
![desc_before](https://user-images.githubusercontent.com/13417815/168885610-d35b79de-1bde-4b41-9303-9831d4b35faa.png)

**After:**
"None" string displayed in case there is no any description + editability present (only the pencil icon clickable): 
![d_1](https://user-images.githubusercontent.com/13417815/169038333-f6b34113-498d-41b8-a8de-714b565617cf.png)
Modal window to add/edit the description, after clicking on "None" or pencil icon:
![desc_after2](https://user-images.githubusercontent.com/13417815/168885660-e84c60a2-838a-499f-8932-cba485927a92.png)
Description updated after changes in the modal saved (only the pencil icon clickable):
![d_2](https://user-images.githubusercontent.com/13417815/169038380-041cd925-73e7-4182-8549-e0dae69d2ad3.png)



