### PR TITLE
Bug 2086479: Use "Save" submit button text in all modals

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -593,7 +593,6 @@
   "Storage throughput": "Storage throughput",
   "Storage used": "Storage used",
   "StorageClass": "StorageClass",
-  "Submit": "Submit",
   "Success": "Success",
   "Support": "Support",
   "Supported by most operating systems including Windows out of the box. Offers lower performance compared to virtio.": "Supported by most operating systems including Windows out of the box. Offers lower performance compared to virtio.",

--- a/src/utils/components/AffinityModal/AffinityModal.tsx
+++ b/src/utils/components/AffinityModal/AffinityModal.tsx
@@ -139,7 +139,6 @@ const AffinityModal: React.FC<AffinityModalProps> = ({
       obj={updatedVirtualMachine}
       onSubmit={onSubmit}
       headerText={t('Affinity rules')}
-      submitBtnText={t('Save')}
       modalVariant={ModalVariant.medium}
     >
       {list}

--- a/src/utils/components/AuthorizedSSHKeyModal/AuthorizedSSHKeyModal.tsx
+++ b/src/utils/components/AuthorizedSSHKeyModal/AuthorizedSSHKeyModal.tsx
@@ -25,7 +25,6 @@ export const AuthorizedSSHKeyModal: React.FC<{
       onClose={onClose}
       onSubmit={submitHandler}
       headerText={t('Authorized SSH Key')}
-      submitBtnText={t('Save')}
     >
       <FileUpload
         id={'ssh-key-modal'}

--- a/src/utils/components/CloudinitModal/CloudinitModal.tsx
+++ b/src/utils/components/CloudinitModal/CloudinitModal.tsx
@@ -39,7 +39,6 @@ export const CloudinitModal: React.FC<{
       onClose={onClose}
       headerText={t('Cloud-init')}
       isDisabled={isSubmitDisabled}
-      submitBtnText={t('Save')}
     >
       <Stack hasGutter>
         <CloudInitInfoHelper />

--- a/src/utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal.tsx
+++ b/src/utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal.tsx
@@ -91,7 +91,6 @@ const FirmwareBootloaderModal: React.FC<FirmwareBootloaderModalProps> = ({
       onClose={onClose}
       headerText={t('VirtualMachine boot method')}
       obj={updatedVirtualMachine}
-      submitBtnText={t('Save')}
     >
       <Form>
         <FormGroup fieldId="firmware-bootloader" label={t('Bootloader method')}>

--- a/src/utils/components/SSHAccess/SSHAccessModal.tsx
+++ b/src/utils/components/SSHAccess/SSHAccessModal.tsx
@@ -50,7 +50,6 @@ const SSHAccessModal: React.FC<SSHAccessModalProps> = ({ vmi, isOpen, onClose, s
       onClose={onClose}
       onSubmit={onSubmit}
       headerText={t('SSH Access')}
-      submitBtnText={t('Save')}
       modalVariant={ModalVariant.medium}
     >
       <Stack hasGutter>

--- a/src/utils/components/SysprepModal/SysprepModal.tsx
+++ b/src/utils/components/SysprepModal/SysprepModal.tsx
@@ -38,7 +38,6 @@ export const SysprepModal: React.FC<{
       onClose={onClose}
       headerText={t('Sysprep')}
       modalVariant={ModalVariant.medium}
-      submitBtnText={t('Save')}
     >
       <Sysprep
         autoUnattend={autoUnattend}

--- a/src/utils/components/TabModal/TabModal.tsx
+++ b/src/utils/components/TabModal/TabModal.tsx
@@ -103,7 +103,7 @@ const TabModal: TabModalFC = React.memo(
                     isLoading={isSubmitting}
                     variant={submitBtnVariant ?? 'primary'}
                   >
-                    {submitBtnText || t('Submit')}
+                    {submitBtnText || t('Save')}
                   </Button>
                 </ActionListItem>
                 <ActionListItem>

--- a/src/utils/components/TolerationsModal/TolerationsModal.tsx
+++ b/src/utils/components/TolerationsModal/TolerationsModal.tsx
@@ -80,7 +80,6 @@ const TolerationsModal: React.FC<TolerationsModalProps> = ({
       onSubmit={onSubmit}
       headerText={t('Tolerations')}
       modalVariant={ModalVariant.medium}
-      submitBtnText={t('Save')}
     >
       <TolerationModalDescriptionText />
       <Form>

--- a/src/views/templates/actions/components/EditBootSourceModal.tsx
+++ b/src/views/templates/actions/components/EditBootSourceModal.tsx
@@ -6,7 +6,7 @@ import { V1beta1DataVolumeSpec } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import { ButtonVariant, Form, FormGroup, TextInput } from '@patternfly/react-core';
+import { Form, FormGroup, TextInput } from '@patternfly/react-core';
 
 import { SOURCE_TYPES } from '../../utils/constants';
 import { editBootSource } from '../editBootSource';
@@ -38,8 +38,6 @@ const EditBootSourceModal: React.FC<EditBootSourceModalProps> = ({ isOpen, obj, 
         onSubmit={onSubmit}
         isOpen={isOpen}
         onClose={onClose}
-        submitBtnText={t('Save')}
-        submitBtnVariant={ButtonVariant.primary}
       >
         <p className="margin-bottom-md">
           This data can be found in{' '}

--- a/src/views/templates/details/tabs/details/components/BootMethod/TemplateBootloaderModal.tsx
+++ b/src/views/templates/details/tabs/details/components/BootMethod/TemplateBootloaderModal.tsx
@@ -96,7 +96,6 @@ const TemplateBootloaderModal: React.FC<TemplateBootloaderModalProps> = ({
       onClose={onClose}
       headerText={t('VirtualMachine Template boot method')}
       obj={updatedTemplate}
-      submitBtnText={t('Save')}
     >
       <Form>
         <FormGroup fieldId="template-firmware-bootloader" label={t('Bootloader method')}>

--- a/src/views/templates/details/tabs/scheduling/components/AffinityRulesModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/AffinityRulesModal.tsx
@@ -135,7 +135,6 @@ const AffinityRulesModal: React.FC<AffinityModalProps> = ({
       obj={updatedTemplate}
       onSubmit={onSubmit}
       headerText={t('Affinity rules')}
-      submitBtnText={t('Save')}
       modalVariant={ModalVariant.medium}
     >
       {list}

--- a/src/views/templates/details/tabs/scheduling/components/TolerationsModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/TolerationsModal.tsx
@@ -76,7 +76,6 @@ const TolerationsModal: React.FC<TolerationsModalProps> = ({
       onSubmit={onSubmit}
       headerText={t('Tolerations')}
       modalVariant={ModalVariant.medium}
-      submitBtnText={t('Save')}
     >
       <TolerationModalDescriptionText />
       <Form>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2086479

Use "Save" string as the default submit button text for all of the modal windows we use, instead of "Submit", to achieve consistency in the UI.
Remove unnecessary optional `submitBtnText` prop when using `TabModal` component, as "Save" will be the default submit button text.

## 🎥 Screenshots
**Before:**
![btn_before](https://user-images.githubusercontent.com/13417815/168899381-3fd77167-30b8-4b85-b01e-4bfe502650dd.png)

**After:**
![btn_after](https://user-images.githubusercontent.com/13417815/168899405-6578c25b-e393-4470-92c1-6c4326d5bc62.png)

