### PR TITLE
Bug 2084532: Console is crashed while detaching disk

### DIFF
--- a/src/views/virtualmachines/details/tabs/disk/tables/filesystem/FilesystemList.tsx
+++ b/src/views/virtualmachines/details/tabs/disk/tables/filesystem/FilesystemList.tsx
@@ -4,6 +4,7 @@ import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevir
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-utils/models';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { Bullseye } from '@patternfly/react-core';
 
 import { printableVMStatus } from '../../../../../utils';
 
@@ -21,15 +22,23 @@ const FilesystemList: React.FC<FilesystemListProps> = ({ vm }) => {
     name: vm?.metadata?.name,
     namespace: vm?.metadata?.namespace,
   });
+  const isVMRunning = vm?.status?.printableStatus === printableVMStatus.Running;
 
   const guestOS = vmi?.status?.guestOSInfo?.id;
-  let noDataEmptyMsg = undefined;
-  if (vm?.status?.printableStatus !== printableVMStatus.Running) {
-    noDataEmptyMsg = () => <>{t('VirtualMachine is not running')}</>;
-  } else if (!guestOS && vmi?.metadata) {
-    noDataEmptyMsg = () => <>{t('Guest agent is required')}</>;
-  }
-  return <FileSystemListLayout vmi={vmi} noDataEmptyMsg={noDataEmptyMsg} />;
+  const noDataEmptyMsg = React.useMemo(() => {
+    if (!isVMRunning) {
+      return t('VirtualMachine is not running');
+    } else if (!guestOS && isVMRunning) {
+      return t('Guest agent is required');
+    }
+  }, [guestOS, isVMRunning, t]);
+
+  return (
+    <FileSystemListLayout
+      vmi={isVMRunning ? vmi : null}
+      noDataEmptyMsg={() => <Bullseye>{noDataEmptyMsg}</Bullseye>}
+    />
+  );
 };
 
 export default FilesystemList;

--- a/src/views/virtualmachines/details/tabs/disk/tables/filesystem/FilesystemListLayout.tsx
+++ b/src/views/virtualmachines/details/tabs/disk/tables/filesystem/FilesystemListLayout.tsx
@@ -15,7 +15,7 @@ type FileSystemListLayoutProps = {
 };
 
 const FileSystemListLayout: React.FC<FileSystemListLayoutProps> = ({ vmi, noDataEmptyMsg }) => {
-  const [data, loaded, loadingError] = useGuestOS(vmi);
+  const [data, loaded] = useGuestOS(vmi);
   const columns = useFilesystemListColumns();
   const fileSystems = data?.fsInfo?.disks || [];
 
@@ -26,7 +26,7 @@ const FileSystemListLayout: React.FC<FileSystemListLayoutProps> = ({ vmi, noData
         data={fileSystems}
         unfilteredData={fileSystems}
         loaded={loaded}
-        loadError={loadingError}
+        loadError={null}
         columns={columns}
         Row={FilesystemRow}
         NoDataEmptyMsg={noDataEmptyMsg}


### PR DESCRIPTION
## 📝 Description

on the VM disks tab when switching from `Running` status to `Stopped` status, the watched VMI resource still exists even though the VM is at `Stopped` status and the VMI resource no longer exists in the cluster.
this causes to show incorrect data in the disk's and the filesystem's tables when deleting/creating disks.

to fix this we change the way to check for the VM status, now checking for the `status.printableStatus === "Running"` instead of checking the VMI resource existence.

this PR fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=2084532
https://bugzilla.redhat.com/show_bug.cgi?id=2087188

## 🎥 Demo

after:

https://user-images.githubusercontent.com/67270715/169028288-bd1c7a36-9f25-4ec9-9639-1a566baef8d4.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>