### PR TITLE
Bug 2087701: [RFE] Missing a link to VMI from running VM details page

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -712,6 +712,7 @@
   "VirtualMachine Templates": "VirtualMachine Templates",
   "VirtualMachine updated successfully": "VirtualMachine updated successfully",
   "VirtualMachine will attempt to boot from disks by order of appearance in YAML file": "VirtualMachine will attempt to boot from disks by order of appearance in YAML file",
+  "VirtualMachineInstance": "VirtualMachineInstance",
   "VirtualMachineInstance details": "VirtualMachineInstance details",
   "VirtualMachineInstance Details": "VirtualMachineInstance Details",
   "VirtualMachineInstances": "VirtualMachineInstances",

--- a/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGridLayout.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGridLayout.tsx
@@ -65,6 +65,10 @@ const VirtualMachineDetailsRightGridLayout: React.FC<VirtualMachineDetailsRightG
           descriptionHeader={t('Pod')}
         />
         <VirtualMachineDescriptionItem
+          descriptionData={vmDetailsRightGridObj?.vmi}
+          descriptionHeader={t('VirtualMachineInstance')}
+        />
+        <VirtualMachineDescriptionItem
           descriptionData={<BootOrderSummary vm={vm} />}
           descriptionHeader={t('Boot Order')}
           isEdit

--- a/src/views/virtualmachines/details/tabs/details/utils/gridHelper.tsx
+++ b/src/views/virtualmachines/details/tabs/details/utils/gridHelper.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { TFunction } from 'i18next';
 
 import { NodeModel, PodModel } from '@kubevirt-ui/kubevirt-api/console';
+import { VirtualMachineInstanceModelRef } from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstanceModel';
 import {
   V1VirtualMachineInstance,
   V1VirtualMachineInstanceGuestAgentInfo,
@@ -18,6 +19,7 @@ import FirstItemListPopover from '../../../../list/components/FirstItemListPopov
 
 export type VirtualMachineDetailsRightGridLayoutPresentation = {
   pod: React.ReactNode;
+  vmi: React.ReactNode;
   ipAddress: React.ReactNode;
   hostname: React.ReactNode;
   timezone: React.ReactNode;
@@ -34,6 +36,7 @@ export const getStoppedVMRightGridPresentation = (
 
   return {
     pod: NotAvailable,
+    vmi: NotAvailable,
     ipAddress: VirtualMachineIsNotRunning,
     hostname: NotAvailable,
     timezone: VirtualMachineIsNotRunning,
@@ -65,6 +68,13 @@ export const getRunningVMRightGridPresentation = (
         kind={PodModel.kind}
         name={vmiPod?.metadata?.name}
         namespace={vmiPod?.metadata?.namespace}
+      />
+    ),
+    vmi: (
+      <ResourceLink
+        kind={VirtualMachineInstanceModelRef}
+        name={vmi?.metadata?.name}
+        namespace={vmi?.metadata?.namespace}
       />
     ),
     ipAddress: <FirstItemListPopover items={ipAddresses} headerContent={'IP Addresses'} />,


### PR DESCRIPTION
## 📝 Description

## 🎥 Demo

![VMI-link1](https://user-images.githubusercontent.com/67270715/169046831-cddce78b-a683-49fe-8d2b-60fcc3b0b624.png)
![VMI-link2](https://user-images.githubusercontent.com/67270715/169046839-3563875c-f052-4153-862d-b1ff83916bd8.png)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>