### PR TITLE
Bug 2088034: Add optional chaining to getTemplateToVMCountMap

### DIFF
--- a/src/views/clusteroverview/overview/components/running-vms-per-template-card/utils/utils.ts
+++ b/src/views/clusteroverview/overview/components/running-vms-per-template-card/utils/utils.ts
@@ -60,7 +60,7 @@ export const getTemplateToVMCountMap = (loaded, vms, templates) => {
 
   if (loaded) {
     vms.forEach((vm) => {
-      const template = vm?.metadata?.labels[LABEL_USED_TEMPLATE_NAME];
+      const template = vm?.metadata?.labels?.[LABEL_USED_TEMPLATE_NAME];
       if (template) {
         const value = templateToVMCountMap.has(template)
           ? templateToVMCountMap.get(template).vmCount + 1


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

According to https://bugzilla.redhat.com/show_bug.cgi?id=2088034 , the overview screen was crashing when VM didn't have any labels. this fix will promise no crash if VM has no labels.

## 🎥 Demo


