### PR TITLE
Bug 2088355: disk modal shows all storage classes as default

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/utils/helpers.ts
+++ b/src/utils/components/DiskModal/DiskFormFields/utils/helpers.ts
@@ -135,7 +135,7 @@ export const getVolumeResourceName = (volume: V1Volume): string => {
 };
 
 export const isDefaultStorageClass = (storageClass: IoK8sApiStorageV1StorageClass): boolean =>
-  Boolean(storageClass?.metadata?.annotations?.['storageclass.kubernetes.io/is-default-class']);
+  storageClass?.metadata?.annotations?.['storageclass.kubernetes.io/is-default-class'] === 'true';
 
 export const getDefaultStorageClass = (
   storageClasses: IoK8sApiStorageV1StorageClass[],


### PR DESCRIPTION
## 📝 Description

for SC doing explicit  check `storageclass.kubernetes.io/is-default-class = 'true'` 

## 🎥 Demo

### before:

![Screenshot (43)](https://user-images.githubusercontent.com/67270715/169267331-0b566209-8c42-4444-9872-6ca91dd57a7b.png)

### after:

![Screenshot (48)](https://user-images.githubusercontent.com/67270715/169267384-946a083d-4fe6-40cc-8591-b70eb73f5f83.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>