### PR TITLE
Bug 2089376: No exception on Virtual Machine Template without boot source 

### DIFF
--- a/src/utils/resources/template/hooks/useVmTemplateSource/utils.ts
+++ b/src/utils/resources/template/hooks/useVmTemplateSource/utils.ts
@@ -11,6 +11,7 @@ import {
   V1beta1DataVolumeSourcePVC,
   V1beta1DataVolumeSourceRef,
   V1beta1DataVolumeSourceRegistry,
+  V1ContainerDiskSource,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getVMBootSourceType } from '@kubevirt-utils/resources/vm/utils/source';
 import { k8sGet } from '@openshift-console/dynamic-plugin-sdk';
@@ -26,12 +27,14 @@ export type TemplateBootSource = {
     pvc?: V1beta1DataVolumeSourcePVC;
     http?: V1beta1DataVolumeSourceHTTP;
     registry?: V1beta1DataVolumeSourceRegistry;
+    containerDisk?: V1ContainerDiskSource;
   };
   sourceValue?: {
     sourceRef?: V1alpha1PersistentVolumeClaim;
     pvc?: V1alpha1PersistentVolumeClaim;
     http?: V1beta1DataVolumeSourceHTTP;
     registry?: V1beta1DataVolumeSourceRegistry;
+    containerDisk?: V1ContainerDiskSource;
   };
 };
 

--- a/src/utils/resources/template/utils/constants.ts
+++ b/src/utils/resources/template/utils/constants.ts
@@ -79,6 +79,8 @@ export enum BOOT_SOURCE {
   DATA_SOURCE_AUTO_UPLOAD = 'DATA_SOURCE_AUTO_UPLOAD',
   URL = 'URL',
   REGISTRY = 'REGISTRY',
+  CONTAINER_DISK = 'CONTAINER_DISK',
+  NONE = 'NONE',
 }
 
 export const BOOT_SOURCE_LABELS = {
@@ -87,6 +89,8 @@ export const BOOT_SOURCE_LABELS = {
   [BOOT_SOURCE.DATA_SOURCE_AUTO_UPLOAD]: 'PVC (auto upload)',
   [BOOT_SOURCE.URL]: 'URL',
   [BOOT_SOURCE.REGISTRY]: 'Registry',
+  [BOOT_SOURCE.CONTAINER_DISK]: 'Container Disk',
+  [BOOT_SOURCE.NONE]: 'No Boot Source',
 };
 
 export const OS_IMAGE_LINKS = {

--- a/src/utils/resources/vm/utils/source.ts
+++ b/src/utils/resources/vm/utils/source.ts
@@ -56,7 +56,16 @@ export const getVMBootSourceType = (vm: V1VirtualMachine): TemplateBootSource =>
     }
   }
 
-  return null;
+  if (volume.containerDisk) {
+    return {
+      type: BOOT_SOURCE.CONTAINER_DISK,
+      source: {
+        containerDisk: volume.containerDisk,
+      },
+    };
+  }
+
+  return { type: BOOT_SOURCE.NONE, source: {} };
 };
 
 /**

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogTile.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogTile.tsx
@@ -33,7 +33,7 @@ export const TemplateTile: React.FC<TemplateTileProps> = React.memo(
 
     const dataSource =
       availableDatasources[
-        `${bootSource?.source?.sourceRef.namespace}-${bootSource?.source?.sourceRef.name}`
+        `${bootSource?.source?.sourceRef?.namespace}-${bootSource?.source?.sourceRef?.name}`
       ];
     const { memory, cpuCount } = getTemplateFlavorData(template);
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- `getVMBootSourceType` return always something
- Added `containerDisk` as boot source
