### PR TITLE
Bug 2086488: Cannot cancel vm migration

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -136,6 +136,7 @@
   "Can edit only when VM is stopped": "Can edit only when VM is stopped",
   "Cancel": "Cancel",
   "Cancel VirtualMachine migration": "Cancel VirtualMachine migration",
+  "Canceling ongoing migration": "Canceling ongoing migration",
   "Cannot edit resources that already created": "Cannot edit resources that already created",
   "Cannot update": "Cannot update",
   "Capability": "Capability",

--- a/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
@@ -117,10 +117,11 @@ export const VirtualMachineActionFactory = {
   ): Action => {
     return {
       id: 'vm-action-cancel-migrate',
-      disabled: vm?.status?.printableStatus !== Migrating,
+      disabled: !vmim || !!vmim?.metadata?.deletionTimestamp,
       label: t('Cancel VirtualMachine migration'),
       cta: () => cancelMigration(vmim),
       accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
+      description: !!vmim?.metadata?.deletionTimestamp && t('Canceling ongoing migration'),
     };
   },
   clone: (


### PR DESCRIPTION
## 📝 Description

`Cancel VirtualMachine migration` action was enabled only when `Migrating` status exists in `vm.status.printableStatus`. 
This behavior was changed to enable the `Cancel VirtualMachine migration` action when VirtualMachineInstanceMigration exists and a delete request to the VMIM resources hasn't made yet (checking `vmim.metadata.deleteionTimestamp` exists)
if `vmim.metadata.deleteionTimestamp` exists, a description text to the action will be added until the VMIM resource will be deleted 

## 🎥 Demo

### before:

https://user-images.githubusercontent.com/67270715/169856706-ec8ac959-d526-47b6-80c1-8ccd47126c23.mp4

### after:

https://user-images.githubusercontent.com/67270715/169856883-1082fa83-9e4c-4742-9085-45cd5d91faa5.mp4



Signed-off-by: Aviv Turgeman <aturgema@redhat.com>