### PR TITLE
Bug 2087577: 'VMs per template' load time is a bit long

### DIFF
--- a/src/views/clusteroverview/overview/components/inventory-card/hooks/useProjectNames.ts
+++ b/src/views/clusteroverview/overview/components/inventory-card/hooks/useProjectNames.ts
@@ -1,0 +1,18 @@
+import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui/kubevirt-api/console';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+export const useProjectNames = (): string[] => {
+  const [projects] = useK8sWatchResource<K8sResourceCommon[]>({
+    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+    namespaced: false,
+    isList: true,
+  });
+  const projectNames = (projects || []).map((project) => project.metadata.name);
+
+  if (isEmpty(projectNames) || !projectNames?.includes('openshift')) {
+    projectNames.push('openshift');
+  }
+
+  return projectNames;
+};

--- a/src/views/clusteroverview/overview/components/inventory-card/hooks/useWatchedResourcesInventoryCard.ts
+++ b/src/views/clusteroverview/overview/components/inventory-card/hooks/useWatchedResourcesInventoryCard.ts
@@ -1,0 +1,71 @@
+import {
+  modelToGroupVersionKind,
+  NodeModel,
+  TemplateModel,
+} from '@kubevirt-ui/kubevirt-api/console';
+import NetworkAttachmentDefinitionModel, {
+  NetworkAttachmentDefinitionModelGroupVersionKind,
+} from '@kubevirt-ui/kubevirt-api/console/models/NetworkAttachmentDefinitionModel';
+import VirtualMachineModel, {
+  VirtualMachineModelGroupVersionKind,
+} from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
+import { TEMPLATE_TYPE_LABEL } from '@kubevirt-utils/resources/template';
+
+import { getAllowedResources, getAllowedTemplateResources } from '../../../utils/utils';
+
+import { useProjectNames } from './useProjectNames';
+
+const useNonAdminResourcesInventoryCard = () => {
+  const projectNames = useProjectNames();
+  const allowedVMResources = getAllowedResources(projectNames, VirtualMachineModel);
+  const allowedNADResources = getAllowedResources(projectNames, NetworkAttachmentDefinitionModel);
+  const allowedTemplateResources = getAllowedTemplateResources(projectNames);
+
+  const watchedResources = {
+    ...allowedVMResources,
+    ...allowedTemplateResources,
+    nodes: {
+      groupVersionKind: modelToGroupVersionKind(NodeModel),
+      namespaced: false,
+      isList: true,
+    },
+    ...allowedNADResources,
+  };
+  return watchedResources;
+};
+
+const useAdminResourcesInventoryCard = () => {
+  return {
+    vms: {
+      groupVersionKind: VirtualMachineModelGroupVersionKind,
+      namespaced: true,
+      isList: true,
+    },
+    vmTemplates: {
+      groupVersionKind: modelToGroupVersionKind(TemplateModel),
+      isList: true,
+      selector: {
+        matchExpressions: [
+          {
+            key: TEMPLATE_TYPE_LABEL,
+            operator: 'Exists',
+          },
+        ],
+      },
+    },
+    nodes: {
+      groupVersionKind: modelToGroupVersionKind(NodeModel),
+      namespaced: false,
+      isList: true,
+    },
+    nads: {
+      groupVersionKind: NetworkAttachmentDefinitionModelGroupVersionKind,
+      namespaced: false,
+      isList: true,
+    },
+  };
+};
+
+export const useWatchedResourcesHook = (isAdmin: boolean) => {
+  return isAdmin ? useAdminResourcesInventoryCard : useNonAdminResourcesInventoryCard;
+};

--- a/src/views/clusteroverview/overview/components/inventory-card/utils/ResourcesSection.tsx
+++ b/src/views/clusteroverview/overview/components/inventory-card/utils/ResourcesSection.tsx
@@ -15,20 +15,24 @@ export type ResourcesSectionProps = {
   resources?: WatchK8sResults<{
     [key: string]: K8sResourceCommon[];
   }>;
+  isAdmin?: boolean;
 };
 
-const ResourcesSection: React.FC<ResourcesSectionProps> = ({ resources }) => {
+const ResourcesSection: React.FC<ResourcesSectionProps> = ({ resources, isAdmin }) => {
   const templates = React.useMemo(
-    () => getAllowedResourceData(resources, TemplateModel),
-    [resources],
+    () => (isAdmin ? resources?.vmTemplates : getAllowedResourceData(resources, TemplateModel)),
+    [resources, isAdmin],
   );
   const vms = React.useMemo(
-    () => getAllowedResourceData(resources, VirtualMachineModel),
-    [resources],
+    () => (isAdmin ? resources?.vms : getAllowedResourceData(resources, VirtualMachineModel)),
+    [resources, isAdmin],
   );
   const nads = React.useMemo(
-    () => getAllowedResourceData(resources, NetworkAttachmentDefinitionModel),
-    [resources],
+    () =>
+      isAdmin
+        ? resources?.nads
+        : getAllowedResourceData(resources, NetworkAttachmentDefinitionModel),
+    [resources, isAdmin],
   );
 
   return (

--- a/src/views/clusteroverview/overview/components/inventory-card/utils/flattenTemplates.ts
+++ b/src/views/clusteroverview/overview/components/inventory-card/utils/flattenTemplates.ts
@@ -96,11 +96,10 @@ export const filterTemplates = (templates: V1Template[]): TemplateItem[] => {
 };
 
 export const flattenTemplates: Flatten<
-  { vmTemplates: V1Template[]; vmCommonTemplates: V1Template[]; vms: V1VirtualMachine[] },
+  { vmTemplates: V1Template[]; vms: V1VirtualMachine[] },
   VirtualMachineTemplateBundle[]
-> = ({ vmTemplates, vmCommonTemplates, vms }) => {
-  const user = getLoadedData<V1Template[]>(vmTemplates, []);
-  const common = getLoadedData<V1Template[]>(vmCommonTemplates, []);
+> = ({ vmTemplates, vms }) => {
+  const templates = getLoadedData<V1Template[]>(vmTemplates, []);
   return [
     ...getLoadedData<V1VirtualMachine[]>(vms, []).map((vm) => {
       let template: V1Template;
@@ -117,7 +116,7 @@ export const flattenTemplates: Flatten<
         metadata: vm.metadata,
       };
     }),
-    ...filterTemplates([...user, ...common]).map((template) => ({
+    ...filterTemplates([...templates]).map((template) => ({
       template,
       metadata: template.variants[0].metadata,
     })),

--- a/src/views/clusteroverview/overview/components/inventory-card/utils/types.ts
+++ b/src/views/clusteroverview/overview/components/inventory-card/utils/types.ts
@@ -21,7 +21,6 @@ export type NetworkAttachmentDefinitionKind = {
 export type InventoryCardResources = {
   vms: V1VirtualMachine[];
   vmTemplates: V1Template[];
-  vmCommonTemplates: V1Template[];
   nodes: IoK8sApiCoreV1Node[];
   nads: NetworkAttachmentDefinitionKind[];
 };

--- a/src/views/clusteroverview/overview/components/inventory-card/utils/utils.ts
+++ b/src/views/clusteroverview/overview/components/inventory-card/utils/utils.ts
@@ -20,9 +20,8 @@ export const getOSImagesNS = (): string =>
 
 export const getTemplates = (resources) => {
   const vmTemplates = resources?.vmTemplates as WatchK8sResultsObject<V1Template[]>;
-  const vmCommonTemplates = resources?.vmCommonTemplates as WatchK8sResultsObject<V1Template[]>;
   const vms = resources?.vms as WatchK8sResultsObject<V1VirtualMachine[]>;
-  return flattenTemplates({ vmTemplates, vmCommonTemplates, vms }) || [];
+  return flattenTemplates({ vmTemplates, vms }) || [];
 };
 
 export const getVMStatusCounts = (vms) => {

--- a/src/views/clusteroverview/overview/components/running-vms-per-template-card/RunningVMsPerTemplateCard.tsx
+++ b/src/views/clusteroverview/overview/components/running-vms-per-template-card/RunningVMsPerTemplateCard.tsx
@@ -15,7 +15,7 @@ import {
   TitleSizes,
 } from '@patternfly/react-core';
 
-import { useRunningVMsPerTemplateResourcesHook } from './hooks/useRunningVMsPerTemplateResources';
+import { useRunningVMsPerTemplatesHook } from './hooks/useRunningVMsPerTemplateResources';
 import EmptyStateNoVMs from './utils/EmptyStateNoVMs';
 import RunningVMsChartLegend from './utils/RunningVMsChartLegend';
 import { getChartData, getLegendItems, getTemplateToVMCountMap } from './utils/utils';
@@ -24,7 +24,8 @@ import './RunningVMsPerTemplateCard.scss';
 
 const RunningVMsPerTemplateCard = () => {
   const { t } = useKubevirtTranslation();
-  const { loaded, vms, templates } = useRunningVMsPerTemplateResourcesHook();
+  const useRunningVMsPerTemplatesResources = useRunningVMsPerTemplatesHook();
+  const { loaded, vms, templates } = useRunningVMsPerTemplatesResources();
   const templateToVMCountMap = React.useMemo(
     () => getTemplateToVMCountMap(loaded, vms, templates),
     [loaded, vms, templates],

--- a/src/views/clusteroverview/overview/utils/utils.ts
+++ b/src/views/clusteroverview/overview/utils/utils.ts
@@ -1,6 +1,6 @@
 import { modelToGroupVersionKind, TemplateModel } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_LABEL } from '@kubevirt-utils/resources/template';
+import { TEMPLATE_TYPE_LABEL } from '@kubevirt-utils/resources/template';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   K8sModel,
@@ -33,11 +33,7 @@ export const getAllowedResourceData = (
 ) => {
   const resourcesArray = Object.entries(resources)
     .map(([key, { data, loaded, loadError }]) => {
-      if (
-        loaded &&
-        (key?.includes(model.plural) || (model === TemplateModel && key === 'vmCommonTemplates')) &&
-        !isEmpty(data)
-      ) {
+      if (loaded && key?.includes(model.plural) && !isEmpty(data)) {
         return { data, loaded, loadError };
       }
     })
@@ -56,7 +52,7 @@ export const getAllowedResourceData = (
 
 export const getAllowedTemplateResources = (projectNames: string[]) => {
   const TemplateModelGroupVersionKind = modelToGroupVersionKind(TemplateModel);
-  const allowedTemplateResources = Object.fromEntries(
+  return Object.fromEntries(
     (projectNames || []).map((projName) => [
       `${projName}/${TemplateModel.plural}`,
       {
@@ -74,15 +70,4 @@ export const getAllowedTemplateResources = (projectNames: string[]) => {
       },
     ]),
   );
-  return {
-    ...allowedTemplateResources,
-    vmCommonTemplates: {
-      groupVersionKind: TemplateModelGroupVersionKind,
-      isList: true,
-      namespace: 'openshift',
-      selector: {
-        matchLabels: { [TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_BASE },
-      },
-    },
-  };
 };


### PR DESCRIPTION
## 📝 Description

changing the way we fetch resources for overview, if admin user - simply fetch all needed resources from all namespaces,
when non-admin (non-privileged) user is logged, we first list the namespaces and then fetch needed resources per namesapce.
this will fix the loading time when admin is logged (has access to all namespace so listing them one by one is taking more time for admin)

## 🎥 Demo

### before: (loading takes over 15 seconds and template count is incorrect):

https://user-images.githubusercontent.com/67270715/169866451-1cb303c5-34a5-41f9-8c18-e7027398f96d.mp4

### after: (loading time ~3 seconds and fixed templates count):

https://user-images.githubusercontent.com/67270715/169866536-1993f999-0504-4cf1-9466-a65fcdd8225c.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>