### PR TITLE
Fix error with undefined sourceRef value when accessing Catalog

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogTile.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogTile.tsx
@@ -33,7 +33,7 @@ export const TemplateTile: React.FC<TemplateTileProps> = React.memo(
 
     const dataSource =
       availableDatasources[
-        `${bootSource?.source?.sourceRef.namespace}-${bootSource?.source?.sourceRef.name}`
+        `${bootSource?.source?.sourceRef?.namespace}-${bootSource?.source?.sourceRef?.name}`
       ];
     const { memory, cpuCount } = getTemplateFlavorData(template);
 


### PR DESCRIPTION
## 📝 Description
Fix the error occurred after accessing _Catalog_ or creating a VM, display _Catalog_ with the templates correctly.

## 🎥 Screenshots
**Before**: 
Blank screen, no Catalog displayed, error:
![err](https://user-images.githubusercontent.com/13417815/169879820-6e3f60b8-dde1-41e9-a6f0-43c9dda73b3d.png)
**After**:
Catalog displayed correctly, no error present:
![err_after](https://user-images.githubusercontent.com/13417815/169879965-a75c3d75-896e-4627-8c38-817dbd7a67ca.png)

