### PR TITLE
Add Template's Boot order popover to edit in Disks tab

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -244,6 +244,7 @@
   "Disks": "Disks",
   "Disks included in this snapshot ({{count}})_one": "Disks included in this snapshot ({{count}})",
   "Disks included in this snapshot ({{count}})_other": "Disks included in this snapshot ({{count}})",
+  "Disks tab": "Disks tab",
   "Documentation": "Documentation",
   "Domain": "Domain",
   "Download the MSI from ": "Download the MSI from ",
@@ -748,6 +749,7 @@
   "YAML": "YAML",
   "You can click the Create VirtualMachine button to create your VirtualMachine or customize it by editing each of the tabs below. When done, click the Create VirtualMachine button.": "You can click the Create VirtualMachine button to create your VirtualMachine or customize it by editing each of the tabs below. When done, click the Create VirtualMachine button.",
   "You can customize the Templates storage by overriding the original parameters": "You can customize the Templates storage by overriding the original parameters",
+  "You can edit the boot order in the <1>{t('Disks tab')}</1>": "You can edit the boot order in the <1>{t('Disks tab')}</1>",
   "You can select the boot source in the <2>Disks</2> tab.": "You can select the boot source in the <2>Disks</2> tab.",
   "You can use Cloudinit for post installation configuration of the guest operating system.": "You can use Cloudinit for post installation configuration of the guest operating system."
 }

--- a/src/views/templates/details/tabs/details/components/BootOrderItem.tsx
+++ b/src/views/templates/details/tabs/details/components/BootOrderItem.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Trans } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import BootOrder from 'src/views/virtualmachinesinstance/details/tabs/details/components/Details/BootOrder/BootOrder';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
@@ -7,7 +9,9 @@ import { getTemplateDisks, getTemplateInterfaces } from '@kubevirt-utils/resourc
 import {
   DescriptionListDescription,
   DescriptionListGroup,
-  DescriptionListTerm,
+  DescriptionListTermHelpText,
+  DescriptionListTermHelpTextButton,
+  Popover,
 } from '@patternfly/react-core';
 
 type BootOrderProps = {
@@ -18,10 +22,25 @@ const BootOrderItem: React.FC<BootOrderProps> = ({ template }) => {
   const { t } = useKubevirtTranslation();
   const disks = getTemplateDisks(template);
   const interfaces = getTemplateInterfaces(template);
+  const disksTabLink = `/k8s/ns/${template.metadata.namespace}/templates/${template.metadata.name}/disks`;
 
   return (
     <DescriptionListGroup>
-      <DescriptionListTerm>{t('Boot order')}</DescriptionListTerm>
+      <DescriptionListTermHelpText>
+        <Popover
+          hasAutoWidth
+          maxWidth="15rem"
+          position="right"
+          bodyContent={
+            <Trans ns="plugin__kubevirt-plugin">
+              You can edit the boot order in the <Link to={disksTabLink}>{t('Disks tab')}</Link>
+            </Trans>
+          }
+        >
+          <DescriptionListTermHelpTextButton>{t('Boot order')}</DescriptionListTermHelpTextButton>
+        </Popover>
+      </DescriptionListTermHelpText>
+
       <DescriptionListDescription>
         <BootOrder disks={disks} interfaces={interfaces} />
       </DescriptionListDescription>


### PR DESCRIPTION
## 📝 Description
Add missing popover to _Boot order_ field in the Template's _Details_ tab to inform the user to edit the order in the Template's _Disks_ tab (if editable), according to the design.

## 🎥 Demo
**Before:**
![boot-before](https://user-images.githubusercontent.com/13417815/169886124-7ccc0ece-3482-4f42-af5e-f6e27228e96e.png)
**After**:
![boot-after](https://user-images.githubusercontent.com/13417815/169886135-ccab1917-146e-4f8e-b4d2-f6c4cb640157.png)




