### PR TITLE
Bug 2089327: When trying to add network using network modal when no network found …

### DIFF
--- a/src/views/virtualmachines/details/tabs/network/copmonents/modal/NetworkInterfaceModal.tsx
+++ b/src/views/virtualmachines/details/tabs/network/copmonents/modal/NetworkInterfaceModal.tsx
@@ -63,7 +63,7 @@ const NetworkInterfaceModal: React.FC<NetworkInterfaceModalProps> = ({
       resultNetwork.pod = {};
     }
 
-    const updatedNetworks: V1Network[] = [...getNetworks(vm), resultNetwork];
+    const updatedNetworks: V1Network[] = [...(getNetworks(vm) || []), resultNetwork];
 
     const resultInterface: V1Interface = {
       name: nicName,
@@ -79,7 +79,7 @@ const NetworkInterfaceModal: React.FC<NetworkInterfaceModalProps> = ({
       resultInterface.sriov = {};
     }
 
-    const updatedInterfaces: V1Interface[] = [...getInterfaces(vm), resultInterface];
+    const updatedInterfaces: V1Interface[] = [...(getInterfaces(vm) || []), resultInterface];
 
     return updateVMNetworkInterface(vm, updatedNetworks, updatedInterfaces);
   }, [interfaceMACAddress, interfaceModel, interfaceType, networkName, nicName, vm]);


### PR DESCRIPTION
…is crashing

Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When removing all networks from VM and then trying to add a new network is causing the app to crash. It caused as trying to spread undefined. 

## 🎥 Demo

After:

![network-crash-after](https://user-images.githubusercontent.com/14824964/169996332-ebd27ba9-d963-4961-95df-4d297f66d38a.gif)


Before:

![network-crash-before](https://user-images.githubusercontent.com/14824964/169996381-eed45f5e-b740-4207-8830-21ec09bbea9d.gif)
