### PR TITLE
Bug 2089700: Removing double disk type from VM overview disk section

### DIFF
--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDisks/VirtualMachinesOverviewTabDisksRow.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDisks/VirtualMachinesOverviewTabDisksRow.tsx
@@ -10,10 +10,7 @@ const VirtualMachinesOverviewTabDisksRow = ({ obj, activeColumnIDs }) => {
         <div data-test-id={`disk-${obj?.name}`}>{obj?.name}</div>
       </TableData>
       <TableData id="drive" activeColumnIDs={activeColumnIDs}>
-        <div data-test-id={`disk-${obj?.drive}`}>
-          {obj?.drive}
-          {obj?.drive || NO_DATA_DASH}
-        </div>
+        <div data-test-id={`disk-${obj?.drive}`}>{obj?.drive || NO_DATA_DASH}</div>
       </TableData>
       <TableData id="size" activeColumnIDs={activeColumnIDs}>
         <div data-test-id={`disk-${obj?.size}`}>{obj?.size || NO_DATA_DASH}</div>


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Removed double disk type from VM overview -disk section

## 🎥 Demo

After:
![image](https://user-images.githubusercontent.com/14824964/170010369-165ecfc4-9e4e-4510-8ac6-e04d0ce27a36.png)

Before:
![image](https://user-images.githubusercontent.com/14824964/170010506-38badfc7-44dc-4a2b-a4a5-76bc75ffcde8.png)

