### PR TITLE
Bug 2089745: When removing all disk from VM customized wizard is crashing

### DIFF
--- a/src/utils/resources/vm/utils/source.ts
+++ b/src/utils/resources/vm/utils/source.ts
@@ -56,11 +56,11 @@ export const getVMBootSourceType = (vm: V1VirtualMachine): TemplateBootSource =>
     }
   }
 
-  if (volume.containerDisk) {
+  if (volume?.containerDisk) {
     return {
       type: BOOT_SOURCE.CONTAINER_DISK,
       source: {
-        containerDisk: volume.containerDisk,
+        containerDisk: volume?.containerDisk,
       },
     };
   }


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When removing all disks from VM customized wizard is crashing.

## 🎥 Demo

After:
![disk-remove-crash-after](https://user-images.githubusercontent.com/14824964/170019247-9cb29d1c-fc1a-4a0e-ade7-805da298e11c.gif)


Before:
![disk-remove-crash-before](https://user-images.githubusercontent.com/14824964/170019594-df665b2f-af82-40af-9937-fbb94f1d6ad6.gif)


