### PR TITLE
Bug 2086272: Changing the colors of the titles in Overview for the dark mode

### DIFF
--- a/src/views/clusteroverview/overview/components/getting-started-card/feature-highlights-section/FeatureHighlightsSection.tsx
+++ b/src/views/clusteroverview/overview/components/getting-started-card/feature-highlights-section/FeatureHighlightsSection.tsx
@@ -55,7 +55,7 @@ const FeatureHighlightsSection: React.FC = () => {
         />
       }
       title={t('Feature highlights')}
-      titleColor={'var(--pf-global--palette--blue-600)'}
+      titleColor={'var(--co-global--palette--blue-400)'}
       description={t(
         'Read about the latest information and key virtualization features on the Virtualization highlights.',
       )}

--- a/src/views/clusteroverview/overview/components/getting-started-card/related-operators-section/RelatedOperatorsSection.tsx
+++ b/src/views/clusteroverview/overview/components/getting-started-card/related-operators-section/RelatedOperatorsSection.tsx
@@ -54,7 +54,7 @@ const RelatedOperatorsSection: React.FC = () => {
         />
       }
       title={t('Related operators')}
-      titleColor={'var(--pf-global--palette--blue-600)'}
+      titleColor={'var(--co-global--palette--orange-400)'}
       description={t('Ease operational complexity with virtualization by using Operators.')}
       links={links}
       moreLink={moreLink}


### PR DESCRIPTION
Signed-off-by: Dana Orr <dorr@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
Changing the colors of the titles in the first card in Overview because in the dark mode there are not visible enough.

## 🎥 Demo
Before:
![image](https://user-images.githubusercontent.com/61961469/170056972-372a70cf-6a1b-46df-89fc-b2725e5f6c88.png)

After:
![image](https://user-images.githubusercontent.com/61961469/170056153-af802645-aae2-4234-9c34-5b7eb66058a3.png)
