### PR TITLE
Bug 2081182: change to use node IP in ssh command

### DIFF
--- a/src/utils/components/UserCredentials/useSSHCommand.ts
+++ b/src/utils/components/UserCredentials/useSSHCommand.ts
@@ -1,9 +1,7 @@
-import { InfrastructureModel, modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
 import { getSSHNodePort } from '@kubevirt-utils/utils/utils';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 export type useSSHCommandResult = {
   command: string;
@@ -15,26 +13,12 @@ const useSSHCommand = (
   vmi: V1VirtualMachineInstance,
   sshService: IoK8sApiCoreV1Service,
 ): useSSHCommandResult => {
-  const [infrastructure, infrastructureLoaded, infrastructureError] = useK8sWatchResource<any>({
-    groupVersionKind: modelToGroupVersionKind(InfrastructureModel),
-    namespace: vmi?.metadata?.namespace,
-    name: 'cluster',
-    isList: false,
-  });
-
-  const infrastuctureApiUrl =
-    infrastructureLoaded && !infrastructureError && infrastructure?.status?.apiServerURL;
-  const apiHostname = infrastuctureApiUrl && new URL(infrastuctureApiUrl).hostname;
   const consoleHostname = window.location.hostname; // fallback to console hostname
 
   const { user } = getCloudInitCredentials(vmi);
   const sshServicePort = getSSHNodePort(sshService);
 
-  let command = 'ssh ';
-
-  if (user) command += `${user}@`;
-
-  command += `${apiHostname || consoleHostname} -p ${sshServicePort}`;
+  const command = `ssh ${user && `${user}@`}${consoleHostname} -p ${sshServicePort}`;
 
   return {
     command,


### PR DESCRIPTION
## 📝 Description

changing the hook that creates the string for SSH access command to follow doc [1] and using the VM's node IP address

[1] https://docs.openshift.com/container-platform/4.10/virt/virtual_machines/virt-accessing-vm-consoles.html#virt-accessing-vm-yaml-ssh_virt-accessing-vm-consoles

## 🎥 Demo

### after:
![ssh-command-before](https://user-images.githubusercontent.com/67270715/170235615-272cb08f-74d8-44d1-a459-54a88acda2ed.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>