### PR TITLE
Bug 2091406: Fixing the namespace label when customize new vm

### DIFF
--- a/src/views/catalog/customize/components/CustomizeForms/useCustomizeFormSubmit.ts
+++ b/src/views/catalog/customize/components/CustomizeForms/useCustomizeFormSubmit.ts
@@ -80,8 +80,7 @@ export const useCustomizeFormSubmit = ({
       const updatedVM = produce(vmObj, (vmDraft) => {
         vmDraft.metadata.namespace = ns || DEFAULT_NAMESPACE;
         vmDraft.metadata.labels[LABEL_USED_TEMPLATE_NAME] = processedTemplate.metadata.name;
-        vmDraft.metadata.labels[LABEL_USED_TEMPLATE_NAMESPACE] =
-          processedTemplate.metadata.namespace;
+        vmDraft.metadata.labels[LABEL_USED_TEMPLATE_NAMESPACE] = template.metadata.namespace;
 
         // upload is required, we need to patch the volume and delete the data volume template (keep only cd dv template if available)
         if (uploadFile) {


### PR DESCRIPTION
Signed-off-by: Dana Orr <dorr@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
When creating a vm using customize wizard, default is referring to namespace of newly created vm instead of template namespace.
This fix will use the template namespace for openshift.

## 🎥 Demo
Before:
![image](https://user-images.githubusercontent.com/61961469/170870467-bed37021-b3d1-4ae0-baa5-4cadb27747f3.png)

After:
![image](https://user-images.githubusercontent.com/61961469/170870290-7a5998df-9ec8-42e2-b3af-ce4363c7a138.png)
