### PR TITLE
Bug 2090057: Make Help icon small in VM Environment, Disks tab

### DIFF
--- a/src/views/virtualmachines/details/tabs/disk/tables/disk/DiskListTitle.tsx
+++ b/src/views/virtualmachines/details/tabs/disk/tables/disk/DiskListTitle.tsx
@@ -11,16 +11,14 @@ const DiskListTitle = () => {
 
   return (
     <span>
-      <h3 className="HeaderWithIcon">{t('Disks')} </h3>
+      <h3 className="HeaderWithIcon">{t('Disks')}</h3>
       <Popover
-        bodyContent={
-          <div>
-            {t('The following information is provided by the OpenShift Virtualization operator.')}
-          </div>
-        }
+        bodyContent={t(
+          'The following information is provided by the OpenShift Virtualization operator.',
+        )}
         position={PopoverPosition.right}
       >
-        <HelpIcon />
+        <HelpIcon className="icon-size-small" />
       </Popover>
     </span>
   );

--- a/src/views/virtualmachines/details/tabs/disk/tables/filesystem/FilesystemListTitle.tsx
+++ b/src/views/virtualmachines/details/tabs/disk/tables/filesystem/FilesystemListTitle.tsx
@@ -9,18 +9,14 @@ const FilesystemListTitle = () => {
 
   return (
     <span>
-      <h3 className="HeaderWithIcon">{t('File System')} </h3>
+      <h3 className="HeaderWithIcon">{t('File System')}</h3>
       <Popover
-        bodyContent={
-          <div>
-            {t(
-              'The following information regarding how the disks are partitioned is provided by the guest agent.',
-            )}
-          </div>
-        }
+        bodyContent={t(
+          'The following information regarding how the disks are partitioned is provided by the guest agent.',
+        )}
         position={PopoverPosition.right}
       >
-        <HelpIcon />
+        <HelpIcon className="icon-size-small" />
       </Popover>
     </span>
   );

--- a/src/views/virtualmachines/details/tabs/disk/tables/tables.scss
+++ b/src/views/virtualmachines/details/tabs/disk/tables/tables.scss
@@ -1,4 +1,8 @@
 .HeaderWithIcon {
-    display: inline-block;
-    margin-right: var(--pf-global--spacer--sm);
+  display: inline-block;
+  margin-right: var(--pf-global--spacer--sm);
+}
+
+.icon-size-small {
+  font-size: var(--pf-global--FontSize--sm);
 }

--- a/src/views/virtualmachines/details/tabs/environment/components/VirtualMachineEnvironmentTabTitle.scss
+++ b/src/views/virtualmachines/details/tabs/environment/components/VirtualMachineEnvironmentTabTitle.scss
@@ -1,0 +1,7 @@
+.header-title-inline {
+  display: inline;
+}
+
+.icon-size-small {
+  font-size: var(--pf-global--FontSize--sm);
+}

--- a/src/views/virtualmachines/details/tabs/environment/components/VirtualMachineEnvironmentTabTitle.tsx
+++ b/src/views/virtualmachines/details/tabs/environment/components/VirtualMachineEnvironmentTabTitle.tsx
@@ -4,23 +4,23 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { Popover, Title } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
+import './VirtualMachineEnvironmentTabTitle.scss';
+
 const VirtualMachineEnvironmentTabTitle: React.FC = () => {
   const { t } = useKubevirtTranslation();
   return (
-    <Title headingLevel="h2" className="co-section-heading">
+    <Title headingLevel="h6" className="co-section-heading">
       <span>
-        {t('Include all values from existing config maps, secrets or service accounts (as Disk)')}{' '}
+        <h2 className="header-title-inline">
+          {t('Include all values from existing config maps, secrets or service accounts (as Disk)')}{' '}
+        </h2>
         <Popover
           aria-label={'Help'}
-          bodyContent={() => (
-            <div>
-              {t(
-                'Add new values by referencing an existing config map, secret or service account. Using these values requires mounting them manually to the VM.',
-              )}
-            </div>
+          bodyContent={t(
+            'Add new values by referencing an existing config map, secret or service account. Using these values requires mounting them manually to the VM.',
           )}
         >
-          <HelpIcon />
+          <HelpIcon className="icon-size-small" />
         </Popover>
       </span>
     </Title>


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2090057

Display the Patternfly `HelpIcon` in size `small`, according to the design recommendations, in the title VirtualMachine _Environment_ and _Disks_ tabs' titles.

_More about PF Icons:_
https://www.patternfly.org/v4/guidelines/icons

## Screenshots:
**Before:**
VM _Environment_ tab:
![icon_before](https://user-images.githubusercontent.com/13417815/171044246-2a30a748-8eca-439a-8fda-4cadf24b619b.png)
VM _Disks_ tab:
![icon_before2](https://user-images.githubusercontent.com/13417815/171044257-d2f04c10-ba22-49ba-ae66-bdad667cb5ec.png)
**After:**
![icon_after](https://user-images.githubusercontent.com/13417815/171044287-83cf986c-d635-4d85-b390-f5ada508162f.png)
![icon_after2](https://user-images.githubusercontent.com/13417815/171044289-a940819e-677e-4f18-bbb7-117403e04d6b.png)

