### PR TITLE
Bug 2090059: Failed to add configmap in environment tab

### DIFF
--- a/src/views/virtualmachines/details/tabs/environment/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/environment/utils/utils.ts
@@ -95,7 +95,8 @@ export const addEnvironmentsToVM = (
     let newSourcesDisks: V1Disk[] = [];
     let newSourcesVolumes: V1Volume[] = [];
     environments.forEach((environment) => {
-      const diskName = environment.name + '-disk';
+      const dotRegex = /\./g;
+      const diskName = environment.name.replaceAll(dotRegex, '-') + '-disk';
 
       const newDisk: V1Disk = {
         serial: environment.serial,


### PR DESCRIPTION
## 📝 Description

when adding `kube-root-ca.crt` SC as environment variable we try to add the the disk name as `kube-root-ca.crt-disk`
when doing that, the backend fails to add the disk since it allows disks with names that consist only with alphanumeric chars and the dash char (`-`) and the disks must start and end with alphanumeric char like `disk-1` or `123-disk`

when changing the dot to a dash, the disk addition works.

## 🎥 Demo

### before:
![sc_env_before](https://user-images.githubusercontent.com/67270715/171059825-840706d6-ad2b-4d73-bb3d-3c230622c894.png)

### after:
![sc_env_after-2](https://user-images.githubusercontent.com/67270715/171059829-c19ac0d0-5cea-4027-80ea-1d8f7a5eebad.png)
![sc_env_after-1](https://user-images.githubusercontent.com/67270715/171059831-3f5d785f-0034-4ba9-b63e-b983ff121f69.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>