### PR TITLE
Bug 2089967: Adding network and model to VM overview network interfaces cards - popover

### DIFF
--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/VirtualMachinesOverviewTabNetworkInterfacesRow.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/VirtualMachinesOverviewTabNetworkInterfacesRow.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import FirstItemListPopover from 'src/views/virtualmachines/list/components/FirstItemListPopover/FirstItemListPopover';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { getPrintableNetworkInterfaceType } from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { TableData } from '@openshift-console/dynamic-plugin-sdk';
 import { Popover, PopoverPosition } from '@patternfly/react-core';
@@ -17,7 +18,12 @@ const VirtualMachinesOverviewTabInterfacesRow: React.FC<
   VirtualMachinesOverviewTabNetworkInterfacesProps
 > = ({ obj, activeColumnIDs }) => {
   const { t } = useKubevirtTranslation();
-
+  const popoverFields = {
+    [t('Name')]: obj?.network?.name,
+    [t('Model')]: obj?.iface?.model,
+    [t('Network')]: obj?.network?.multus?.networkName || t('Pod networking'),
+    [t('Type')]: getPrintableNetworkInterfaceType(obj?.iface),
+  };
   return (
     <>
       <TableData id="name" activeColumnIDs={activeColumnIDs}>
@@ -25,16 +31,12 @@ const VirtualMachinesOverviewTabInterfacesRow: React.FC<
           <Popover
             hasAutoWidth
             position={PopoverPosition.left}
-            bodyContent={
+            bodyContent={Object.entries(popoverFields).map(([key, value]) => (
               <>
-                <div className="interface-row--title">{t('Network')}</div>
-                <div className="interface-row--value">{obj?.network?.name}</div>
-                <div className="interface-row--title">{t('Type')}</div>
-                <div className="interface-row--value">
-                  {getPrintableNetworkInterfaceType(obj?.iface)}
-                </div>
+                <div className="interface-row--title">{key}</div>
+                <div className="interface-row--value">{value || NO_DATA_DASH}</div>
               </>
-            }
+            ))}
           >
             <div className="pf-c-description-list__text pf-m-help-text help">
               {obj?.iface?.name}

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/virtual-machines-overview-tab-interfaces.scss
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/virtual-machines-overview-tab-interfaces.scss
@@ -23,6 +23,5 @@
   }
   .interface-row--value {
     margin-bottom: var(--pf-global--spacer--sm);
-    margin-top: var(--pf-global--spacer--xs);
   }
 }


### PR DESCRIPTION

Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Popover of network interfaces card at VM overview was missing some fields.

## 🎥 Demo

After:
![image](https://user-images.githubusercontent.com/14824964/171112235-2caac9e6-634a-4c33-8613-4820fad2fb2c.png)


Before:
![image](https://user-images.githubusercontent.com/14824964/171112086-96e0de6f-4ffb-4413-875d-b042d49c0a5c.png)

