### PR TITLE
Bug 2091764: Clone a template should lead to the template details

### DIFF
--- a/src/views/templates/actions/hooks/useVirtualMachineTemplatesActions.tsx
+++ b/src/views/templates/actions/hooks/useVirtualMachineTemplatesActions.tsx
@@ -29,6 +29,15 @@ const useVirtualMachineTemplatesActions: useVirtualMachineTemplatesActionsProps 
   const history = useHistory();
   const [editableBootSource, setEditableBootSource] = React.useState<boolean>(null);
 
+  const goToTemplatePage = React.useCallback(
+    (clonedTemplate: V1Template) => {
+      history.push(
+        `/k8s/ns/${clonedTemplate.metadata.namespace}/templates/${clonedTemplate.metadata.name}`,
+      );
+    },
+    [history],
+  );
+
   const onLazyActions = React.useCallback(async () => {
     if (editableBootSource === null) {
       const editable = await hasEditableBootSource(template);
@@ -49,7 +58,12 @@ const useVirtualMachineTemplatesActions: useVirtualMachineTemplatesActionsProps 
       label: t('Clone Template'),
       cta: () =>
         createModal(({ isOpen, onClose }) => (
-          <CloneTemplateModal obj={template} isOpen={isOpen} onClose={onClose} />
+          <CloneTemplateModal
+            obj={template}
+            isOpen={isOpen}
+            onClose={onClose}
+            onTemplateCloned={goToTemplatePage}
+          />
         )),
     },
     {


### PR DESCRIPTION
## 📝 Description

after clone template, we want to route to cloned template details page

## 🎥 Demo

### before:

https://user-images.githubusercontent.com/67270715/171157625-bca21980-c976-4a3c-8aba-a99966e1f7b5.mp4

### after:

https://user-images.githubusercontent.com/67270715/171157665-2b309b9f-7197-4c1e-8c2a-74a10656690f.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>