### PR TITLE
Bug 2091766: confirm dialog pops up from templates breadcrumb

### DIFF
--- a/src/views/templates/details/TemplatePageTitle.tsx
+++ b/src/views/templates/details/TemplatePageTitle.tsx
@@ -20,9 +20,6 @@ const TemplatePageTitle: React.FC<TemplatePageTitleTitleProps> = ({ template }) 
 
   const namespacePath = lastNamespace === ALL_NAMESPACES ? lastNamespace : `ns/${lastNamespace}`;
 
-  const onBreadcrumbClick = (url: string) =>
-    confirm(t('Are you sure you want to leave this page?')) && history.push(url);
-
   return (
     <div className="pf-c-page__main-breadcrumb">
       <Breadcrumb>
@@ -30,7 +27,7 @@ const TemplatePageTitle: React.FC<TemplatePageTitleTitleProps> = ({ template }) 
           <Button
             variant="link"
             isInline
-            onClick={() => onBreadcrumbClick(`/k8s/${namespacePath}/templates`)}
+            onClick={() => history.push(`/k8s/${namespacePath}/templates`)}
           >
             {t('Templates')}
           </Button>


### PR DESCRIPTION
## 📝 Description

On Template's details page, when we click on templates, a confirm dialog pops up, and it shouldn't

## 🎥 Demo

### before:

https://user-images.githubusercontent.com/67270715/171177498-5c356838-e2c8-42da-bf8b-d689d481b758.mp4

### after:

https://user-images.githubusercontent.com/67270715/171177529-c11df1b1-cda9-49c8-ac92-68d462149bd5.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>