### PR TITLE
Bug 2089979: adjust CPU|Memory pencil icon location

### DIFF
--- a/src/views/virtualmachines/details/tabs/details/components/CPUMemory/CPUMemory.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/CPUMemory/CPUMemory.tsx
@@ -18,9 +18,9 @@ const CPUMemory: React.FC<CPUMemoryProps> = ({ vm }) => {
   )?.memory;
 
   return (
-    <div data-test-id="virtual-machine-overview-details-cpu-memory">
+    <span data-test-id="virtual-machine-overview-details-cpu-memory">
       {t('{{cpu}} CPU | {{memory}} Memory', { cpu, memory })}
-    </div>
+    </span>
   );
 };
 


### PR DESCRIPTION
## 📝 Description

using span instead of div

## 🎥 Demo

### before:
![pencil-wrong-location](https://user-images.githubusercontent.com/67270715/171374569-f885560d-8a63-4c1e-a59a-af21efa01e79.png)

### after:
![pencil-wrong-location-after](https://user-images.githubusercontent.com/67270715/171374599-1bce7cdd-c0f6-4a00-960a-c3d04f843b11.png)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>