### PR TITLE
Bug 2091758: Rename OS to Operating system in filtering

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogFilters/TemplatesCatalogFilters.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogFilters/TemplatesCatalogFilters.tsx
@@ -56,7 +56,7 @@ export const TemplatesCatalogFilters: React.FC<{
         />
         <TemplatesCatalogFiltersGroup
           groupKey="osName"
-          groupLabel={t('OS')}
+          groupLabel={t('Operating system')}
           pickedFilters={filters.osName}
           onFilterClick={onFilterChange}
           filters={Object.values(OS_NAME_TYPES).map((v) => ({

--- a/src/views/templates/list/hooks/useVirtualMachineTemplatesFilters.ts
+++ b/src/views/templates/list/hooks/useVirtualMachineTemplatesFilters.ts
@@ -94,7 +94,7 @@ const useVirtualMachineTemplatesFilters = (
       items: providers,
     },
     {
-      filterGroupName: t('OS'),
+      filterGroupName: t('Operating system'),
       type: 'osName',
       reducer: (obj) => getItemNameWithOther(getTemplateOS(obj), osNames),
       filter: (availableOsNames, obj) =>

--- a/src/views/virtualmachines/utils/virtualMachineRowFilter.ts
+++ b/src/views/virtualmachines/utils/virtualMachineRowFilter.ts
@@ -94,7 +94,7 @@ export const getNodesFilter = (vmis: V1VirtualMachineInstance[], t: TFunction): 
 export const getOSFilter = (vms: V1VirtualMachine[], t: TFunction): RowFilter[] => {
   return [
     {
-      filterGroupName: t('OS'),
+      filterGroupName: t('Operating system'),
       type: 'os',
       reducer: (obj) => {
         const osAnnotation = getAnnotation(obj?.spec?.template, ANNOTATIONS.os);


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2091758

Change the "OS" string to correct "Operating system", in the VM Template list filtering.
Change it the same way also in the Catalog and VirtualMachine list filtering, for consistency reasons.

## 🎥 Demo
**Before:**
![os_before3](https://user-images.githubusercontent.com/13417815/171397332-1ca879c5-bea5-4eff-b14e-b538a4f4ae0d.png)
![os_before1](https://user-images.githubusercontent.com/13417815/171397356-8f0a5a2c-5f8f-4498-81d2-c36599a576c9.png)
![os_before2](https://user-images.githubusercontent.com/13417815/171397373-4f995ff7-48f8-46db-9002-a78fd6c920e0.png)
**After:**
![os_after3](https://user-images.githubusercontent.com/13417815/171397408-1fd91940-934e-443a-9ad9-86ed900ac032.png)
![os_after1](https://user-images.githubusercontent.com/13417815/171397424-8bad6b7e-45cd-4458-ac5d-b655cc35c3f2.png)
![os_after2](https://user-images.githubusercontent.com/13417815/171397451-c8563eda-907b-44d0-a126-6da1520067f3.png)



