### PR TITLE
Bug 2091765: Prevent Edit boot source keeping in load

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -122,7 +122,7 @@
   "Boot Order": "Boot Order",
   "Boot source": "Boot source",
   "Boot source available": "Boot source available",
-  "Boot source cannot be edited for Red Hat templates": "Boot source cannot be edited for Red Hat templates",
+  "Boot source cannot be edited": "Boot source cannot be edited",
   "Boot source provider": "Boot source provider",
   "Boot source type": "Boot source type",
   "bootable": "bootable",

--- a/src/views/templates/actions/VirtualMachineTemplatesActions.tsx
+++ b/src/views/templates/actions/VirtualMachineTemplatesActions.tsx
@@ -11,8 +11,7 @@ type VirtualMachineTemplatesActionsProps = { template: V1Template };
 const VirtualMachineTemplatesActions: React.FC<VirtualMachineTemplatesActionsProps> = ({
   template,
 }) => {
-  // const { t } = useKubevirtTranslation();
-  const [actions, onLazsyActions] = useVirtualMachineTemplatesActions(template);
+  const [actions, onLazyActions] = useVirtualMachineTemplatesActions(template);
   const [isOpen, setIsOpen] = React.useState(false);
 
   const handleClick = (action: Action) => {
@@ -24,7 +23,7 @@ const VirtualMachineTemplatesActions: React.FC<VirtualMachineTemplatesActionsPro
 
   const onDropDownToggle = (value: boolean) => {
     setIsOpen(value);
-    if (value) onLazsyActions();
+    if (value) onLazyActions();
   };
 
   return (

--- a/src/views/templates/actions/hooks/useVirtualMachineTemplatesActions.tsx
+++ b/src/views/templates/actions/hooks/useVirtualMachineTemplatesActions.tsx
@@ -86,7 +86,7 @@ const useVirtualMachineTemplatesActions: useVirtualMachineTemplatesActionsProps 
           {t('Edit boot source')} {editableBootSource === null && <Loading />}
         </>
       ),
-      description: !editableBootSource && t('Boot source cannot be edited for Red Hat templates'),
+      description: !editableBootSource && t('Boot source cannot be edited'),
       disabled: !editableBootSource,
       cta: () =>
         createModal(({ isOpen, onClose }) => (

--- a/src/views/templates/details/TemplateActions.tsx
+++ b/src/views/templates/details/TemplateActions.tsx
@@ -17,7 +17,7 @@ const TemplateActions: React.FC<TemplateActionsProps> = ({ template }) => {
   const { t } = useKubevirtTranslation();
   const [isDropDownOpen, setDropdownOpen] = React.useState(false);
 
-  const [actions] = useVirtualMachineTemplatesActions(template);
+  const [actions, onLazyActions] = useVirtualMachineTemplatesActions(template);
 
   const filteredActions = actions.filter((action) => action.id !== EDIT_TEMPLATE_ID);
 
@@ -28,11 +28,16 @@ const TemplateActions: React.FC<TemplateActionsProps> = ({ template }) => {
     }
   };
 
+  const onDropDownToggle = (value: boolean) => {
+    setDropdownOpen(value);
+    if (value) onLazyActions();
+  };
+
   return (
     <Dropdown
       isOpen={isDropDownOpen}
       position={DropdownPosition.right}
-      toggle={<DropdownToggle onToggle={setDropdownOpen}>{t('Actions')}</DropdownToggle>}
+      toggle={<DropdownToggle onToggle={onDropDownToggle}>{t('Actions')}</DropdownToggle>}
       dropdownItems={filteredActions?.map((action) => (
         <DropdownItem
           key={action?.id}


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2091765

Prevent "Edit boot source" dropdown action keeping in load, in the Template _Details_ tab.

Update the message for not editable boot source, as it was not 100% appropriate, because it showed "Boot cannot be edited for Red Hat templates" also for other than the Red Hat/common templates - that was misleading. Boot source editability check is a bit more complicated than just checking if the template is a common template.

## 🎥 Demo
**Before:**
![b_before](https://user-images.githubusercontent.com/13417815/171408454-de1a6131-eaba-4b73-b8cd-8ae23745cddc.png)
**After:**
![b_after](https://user-images.githubusercontent.com/13417815/171408470-920f88d3-7e6b-41af-bdf8-3fc14b92e332.png)

