### PR TITLE
Bug 2091940: Persistent label over vmi restarts

### DIFF
--- a/src/utils/components/SSHAccess/constants.ts
+++ b/src/utils/components/SSHAccess/constants.ts
@@ -4,4 +4,4 @@ export const NODE_PORTS_LINK =
 export const PORT = 22000;
 export const SSH_PORT = 22;
 
-export const TEMPLATE_VM_NAME_LABEL = 'vm.kubevirt.io/name';
+export const VM_LABEL_AS_SSH_SERVICE_SELECTOR = 'kubevirt.io/domain';

--- a/src/utils/components/SSHAccess/utils.ts
+++ b/src/utils/components/SSHAccess/utils.ts
@@ -1,12 +1,18 @@
 import { ServiceModel } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineInstanceModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstanceModel';
+import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { IoK8sApiCoreV1ServiceSpecTypeEnum } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { getRandomChars } from '@kubevirt-utils/utils/utils';
 import { k8sCreate, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
-import { PORT, SSH_PORT, TEMPLATE_VM_NAME_LABEL } from './constants';
+import { PORT, SSH_PORT, VM_LABEL_AS_SSH_SERVICE_SELECTOR } from './constants';
 
-const buildSSHServiceFromVM = (name: string, namespace: string) => ({
+const buildSSHServiceFromVM = (
+  name: string,
+  namespace: string,
+  selectors: { [key: string]: string },
+) => ({
   kind: ServiceModel.kind,
   apiVersion: ServiceModel.apiVersion,
   metadata: {
@@ -22,33 +28,53 @@ const buildSSHServiceFromVM = (name: string, namespace: string) => ({
     ],
     type: IoK8sApiCoreV1ServiceSpecTypeEnum.NodePort,
     selector: {
-      [TEMPLATE_VM_NAME_LABEL]: name,
+      ...selectors,
     },
   },
 });
 
 export const createSSHService = async (vmi: V1VirtualMachineInstance) => {
-  const { namespace, labels } = vmi?.metadata;
+  const { namespace, labels, name } = vmi?.metadata;
+  const labelSelector = labels[VM_LABEL_AS_SSH_SERVICE_SELECTOR] || `${name}-${getRandomChars()}`;
 
-  let vmiWithVMLabel = vmi;
-  if (!labels[TEMPLATE_VM_NAME_LABEL]) {
-    vmiWithVMLabel = await k8sPatch<V1VirtualMachineInstance>({
+  if (!labels[VM_LABEL_AS_SSH_SERVICE_SELECTOR]) {
+    await k8sPatch({
+      model: VirtualMachineModel,
+      resource: {
+        kind: VirtualMachineModel.kind,
+        metadata: {
+          name: vmi?.metadata?.ownerReferences?.[0]?.name,
+          namespace: namespace,
+        },
+      },
+      data: [
+        {
+          op: 'add',
+          path: `/spec/template/metadata/labels/${VM_LABEL_AS_SSH_SERVICE_SELECTOR.replaceAll(
+            '/',
+            '~1',
+          )}`,
+          value: labelSelector,
+        },
+      ],
+    });
+
+    await k8sPatch<V1VirtualMachineInstance>({
       model: VirtualMachineInstanceModel,
       resource: vmi,
       data: [
         {
           op: 'add',
-          path: `/metadata/labels/${TEMPLATE_VM_NAME_LABEL.replaceAll('/', '~1')}`,
-          value: vmi?.metadata?.name,
+          path: `/metadata/labels/${VM_LABEL_AS_SSH_SERVICE_SELECTOR.replaceAll('/', '~1')}`,
+          value: labelSelector,
         },
       ],
     });
   }
 
-  const serviceResource = buildSSHServiceFromVM(
-    vmiWithVMLabel?.metadata?.name,
-    vmiWithVMLabel?.metadata?.namespace,
-  );
+  const serviceResource = buildSSHServiceFromVM(name, namespace, {
+    [VM_LABEL_AS_SSH_SERVICE_SELECTOR]: labelSelector,
+  });
 
   await k8sCreate({
     model: ServiceModel,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

https://bugzilla.redhat.com/show_bug.cgi?id=2091940

**Bug cause**
During the ssh service creation process, the plugin adds to the vmi (if there isn't) a particular label used in the service as a selector. But when the VM gets restarted, another vmi gets created without this label.

**Solution:**
Add the label also in the VM /spec/template/metadata/labels so that in the next restart will be created a vmi with it

