### PR TITLE
Bug 2091754: making scheduling tab editable while VM is running- part 1

### DIFF
--- a/src/utils/components/DedicatedResourcesModal/DedicatedResourcesModal.tsx
+++ b/src/utils/components/DedicatedResourcesModal/DedicatedResourcesModal.tsx
@@ -4,7 +4,7 @@ import produce from 'immer';
 
 import { ensurePath } from '@catalog/utils/WizardVMContext';
 import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -21,6 +21,9 @@ import {
   Popover,
 } from '@patternfly/react-core';
 
+import { ModalPendingChangesAlert } from '../PendingChanges/ModalPendingChangesAlert/ModalPendingChangesAlert';
+import { getChangedDedicatedResources } from '../PendingChanges/utils/helpers';
+
 import { cpuManagerLabel, cpuManagerLabelKey, cpuManagerLabelValue } from './utils/constants';
 
 type DedicatedResourcesModalProps = {
@@ -29,6 +32,7 @@ type DedicatedResourcesModalProps = {
   onClose: () => void;
   onSubmit: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine | void>;
   headerText: string;
+  vmi?: V1VirtualMachineInstance;
 };
 
 const DedicatedResourcesModal: React.FC<DedicatedResourcesModalProps> = ({
@@ -37,6 +41,7 @@ const DedicatedResourcesModal: React.FC<DedicatedResourcesModalProps> = ({
   onClose,
   onSubmit,
   headerText,
+  vmi,
 }) => {
   const { t } = useKubevirtTranslation();
   const [checked, setChecked] = React.useState<boolean>(
@@ -75,6 +80,11 @@ const DedicatedResourcesModal: React.FC<DedicatedResourcesModalProps> = ({
       isDisabled={!loaded}
     >
       <Form>
+        {vmi && (
+          <ModalPendingChangesAlert
+            isChanged={getChangedDedicatedResources(updatedVirtualMachine, vmi, checked)}
+          />
+        )}
         <FormGroup fieldId="dedicated-resources" isInline>
           <Checkbox
             id="dedicated-resources"

--- a/src/utils/components/EvictionStrategyModal/EvictionStrategyModal.tsx
+++ b/src/utils/components/EvictionStrategyModal/EvictionStrategyModal.tsx
@@ -2,10 +2,13 @@ import * as React from 'react';
 import produce from 'immer';
 
 import { ensurePath } from '@catalog/utils/WizardVMContext';
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Checkbox, Form, FormGroup } from '@patternfly/react-core';
+
+import { ModalPendingChangesAlert } from '../PendingChanges/ModalPendingChangesAlert/ModalPendingChangesAlert';
+import { getChangedEvictionStrategy } from '../PendingChanges/utils/helpers';
 
 type EvictionStrategyModalProps = {
   vm: V1VirtualMachine;
@@ -13,6 +16,7 @@ type EvictionStrategyModalProps = {
   onClose: () => void;
   onSubmit: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine | void>;
   headerText: string;
+  vmi?: V1VirtualMachineInstance;
 };
 
 const EvictionStrategyModal: React.FC<EvictionStrategyModalProps> = ({
@@ -21,6 +25,7 @@ const EvictionStrategyModal: React.FC<EvictionStrategyModalProps> = ({
   onClose,
   onSubmit,
   headerText,
+  vmi,
 }) => {
   const { t } = useKubevirtTranslation();
   const [checked, setChecked] = React.useState<boolean>(
@@ -47,6 +52,11 @@ const EvictionStrategyModal: React.FC<EvictionStrategyModalProps> = ({
       headerText={headerText}
     >
       <Form>
+        {vmi && (
+          <ModalPendingChangesAlert
+            isChanged={getChangedEvictionStrategy(updatedVirtualMachine, vmi, checked)}
+          />
+        )}
         <FormGroup
           fieldId="eviction-strategy"
           helperText={t(

--- a/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
+++ b/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
@@ -5,6 +5,8 @@ import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/Virtua
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { BootOrderModal } from '@kubevirt-utils/components/BootOrderModal/BootOrderModal';
 import CPUMemoryModal from '@kubevirt-utils/components/CPUMemoryModal/CpuMemoryModal';
+import DedicatedResourcesModal from '@kubevirt-utils/components/DedicatedResourcesModal/DedicatedResourcesModal';
+import EvictionStrategyModal from '@kubevirt-utils/components/EvictionStrategyModal/EvictionStrategyModal';
 import FirmwareBootloaderModal from '@kubevirt-utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal';
 import HardwareDevicesModal from '@kubevirt-utils/components/HardwareDevices/HardwareDevicesModal';
 import { HARDWARE_DEVICE_TYPE } from '@kubevirt-utils/components/HardwareDevices/utils/constants';
@@ -19,7 +21,9 @@ import {
   checkBootModeChanged,
   checkBootOrderChanged,
   checkCPUMemoryChanged,
+  getChangedDedicatedResources,
   getChangedEnvDisks,
+  getChangedEvictionStrategy,
   getChangedGPUDevices,
   getChangedHostDevices,
   getChangedNics,
@@ -38,6 +42,16 @@ export const usePendingChanges = (
   const cpuMemoryChanged = checkCPUMemoryChanged(vm, vmi);
   const bootOrderChanged = checkBootOrderChanged(vm, vmi);
   const bootModeChanged = checkBootModeChanged(vm, vmi);
+  const dedicatedResourcesChanged = getChangedDedicatedResources(
+    vm,
+    vmi,
+    vm?.spec?.template?.spec?.domain?.cpu?.dedicatedCpuPlacement || false,
+  );
+  const evictionStrategyChanged = getChangedEvictionStrategy(
+    vm,
+    vmi,
+    !!vm?.spec?.template?.spec?.evictionStrategy,
+  );
 
   const modifiedEnvDisks = getChangedEnvDisks(vm, vmi);
   const modifiedNics = getChangedNics(vm, vmi);
@@ -157,6 +171,42 @@ export const usePendingChanges = (
             initialDevices={getHostDevices(vm)}
             btnText={t('Add Host device')}
             type={HARDWARE_DEVICE_TYPE.HOST_DEVICES}
+            vmi={vmi}
+          />
+        ));
+      },
+    },
+    {
+      hasPendingChange: dedicatedResourcesChanged,
+      tabLabel: VirtualMachineDetailsTabLabel.Scheduling,
+      label: t('Dedicated resources'),
+      handleAction: () => {
+        history.push(getTabURL(vm, VirtualMachineDetailsTab.Scheduling));
+        createModal(({ isOpen, onClose }) => (
+          <DedicatedResourcesModal
+            vm={vm}
+            isOpen={isOpen}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            headerText={t('Dedicated Resources')}
+            vmi={vmi}
+          />
+        ));
+      },
+    },
+    {
+      hasPendingChange: evictionStrategyChanged,
+      tabLabel: VirtualMachineDetailsTabLabel.Scheduling,
+      label: t('Eviction strategy'),
+      handleAction: () => {
+        history.push(getTabURL(vm, VirtualMachineDetailsTab.Scheduling));
+        createModal(({ isOpen, onClose }) => (
+          <EvictionStrategyModal
+            vm={vm}
+            isOpen={isOpen}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            headerText={t('Eviction Strategy')}
             vmi={vmi}
           />
         ));

--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -165,6 +165,36 @@ export const getChangedHostDevices = (
   return changedHostDevices;
 };
 
+export const getChangedDedicatedResources = (
+  vm: V1VirtualMachine,
+  vmi: V1VirtualMachineInstance,
+  currentSelection: boolean,
+): boolean => {
+  if (isEmpty(vm) || isEmpty(vmi)) {
+    return false;
+  }
+  const vmDedicatedResources =
+    vm?.spec?.template?.spec?.domain?.cpu?.dedicatedCpuPlacement || false;
+  const vmiDedicatedResources = vmi?.spec?.domain?.cpu?.dedicatedCpuPlacement || false;
+
+  return (
+    vmDedicatedResources !== vmiDedicatedResources || currentSelection !== vmiDedicatedResources
+  );
+};
+
+export const getChangedEvictionStrategy = (
+  vm: V1VirtualMachine,
+  vmi: V1VirtualMachineInstance,
+  currentSelection: boolean,
+): boolean => {
+  if (isEmpty(vm) || isEmpty(vmi)) {
+    return false;
+  }
+  const vmEvictionStrategy = !!vm?.spec?.template?.spec?.evictionStrategy;
+  const vmiEvictionStrategy = !!vmi?.spec?.evictionStrategy;
+  return vmEvictionStrategy !== vmiEvictionStrategy || currentSelection !== vmiEvictionStrategy;
+};
+
 export const getTabURL = (vm: V1VirtualMachine, tab: string) =>
   `/k8s/ns/${vm?.metadata?.namespace}/${VirtualMachineModelRef}/${vm?.metadata?.name}/${tab}`;
 
@@ -172,6 +202,10 @@ export const getPendingChangesByTab = (pendingChanges: PendingChange[]) => {
   const pendingChangesDetailsTab = pendingChanges?.filter(
     (change) =>
       change?.tabLabel === VirtualMachineDetailsTabLabel.Details && change?.hasPendingChange,
+  );
+  const pendingChangesSchedulingTab = pendingChanges?.filter(
+    (change) =>
+      change?.tabLabel === VirtualMachineDetailsTabLabel.Scheduling && change?.hasPendingChange,
   );
   const pendingChangesEnvTab = pendingChanges?.filter(
     (change) =>
@@ -185,6 +219,7 @@ export const getPendingChangesByTab = (pendingChanges: PendingChange[]) => {
 
   return {
     pendingChangesDetailsTab,
+    pendingChangesSchedulingTab,
     pendingChangesEnvTab,
     pendingChangesNICsTab,
   };

--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert.tsx
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert.tsx
@@ -22,8 +22,12 @@ const VirtualMachinePendingChangesAlert: React.FC<VirtualMachinePendingChangesAl
   const { t } = useKubevirtTranslation();
   const pendingChanges = usePendingChanges(vm, vmi);
 
-  const { pendingChangesDetailsTab, pendingChangesEnvTab, pendingChangesNICsTab } =
-    getPendingChangesByTab(pendingChanges);
+  const {
+    pendingChangesDetailsTab,
+    pendingChangesSchedulingTab,
+    pendingChangesEnvTab,
+    pendingChangesNICsTab,
+  } = getPendingChangesByTab(pendingChanges);
 
   const hasPendingChanges = pendingChanges?.some((change) => change?.hasPendingChange);
 
@@ -38,6 +42,7 @@ const VirtualMachinePendingChangesAlert: React.FC<VirtualMachinePendingChangesAl
       )}
       <List>
         <PendingChangesBreadcrumb pendingChanges={pendingChangesDetailsTab} />
+        <PendingChangesBreadcrumb pendingChanges={pendingChangesSchedulingTab} />
         <PendingChangesBreadcrumb pendingChanges={pendingChangesEnvTab} />
         <PendingChangesBreadcrumb pendingChanges={pendingChangesNICsTab} />
       </List>

--- a/src/views/virtualmachines/details/tabs/scheduling/components/SchedulingSection/SchedulingSection.tsx
+++ b/src/views/virtualmachines/details/tabs/scheduling/components/SchedulingSection/SchedulingSection.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 
-import { modelToGroupVersionKind, NodeModel } from '@kubevirt-ui/kubevirt-api/console';
+import {
+  modelToGroupVersionKind,
+  NodeModel,
+  VirtualMachineInstanceModelGroupVersionKind,
+} from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { asAccessReview } from '@kubevirt-utils/resources/shared';
 import {
@@ -26,6 +30,12 @@ type SchedulingSectionProps = {
 
 const SchedulingSection: React.FC<SchedulingSectionProps> = ({ vm, pathname }) => {
   const { t } = useKubevirtTranslation();
+  const [vmi] = useK8sWatchResource<V1VirtualMachineInstance>({
+    groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
+    name: vm?.metadata?.name,
+    namespace: vm?.metadata?.namespace,
+    isList: false,
+  });
   const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
     groupVersionKind: modelToGroupVersionKind(NodeModel),
     isList: true,
@@ -48,7 +58,7 @@ const SchedulingSection: React.FC<SchedulingSectionProps> = ({ vm, pathname }) =
           canUpdateVM={canUpdateVM}
         />
         <GridItem span={1}>{/* Spacer */}</GridItem>
-        <VirtualMachineSchedulingRightGrid vm={vm} canUpdateVM={canUpdateVM} />
+        <VirtualMachineSchedulingRightGrid vm={vm} canUpdateVM={canUpdateVM} vmi={vmi} />
       </Grid>
     </div>
   );

--- a/src/views/virtualmachines/details/tabs/scheduling/components/VirtualMachineSchedulingRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/scheduling/components/VirtualMachineSchedulingRightGrid.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { printableVMStatus } from 'src/views/virtualmachines/utils';
 
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import DedicatedResourcesModal from '@kubevirt-utils/components/DedicatedResourcesModal/DedicatedResourcesModal';
 import EvictionStrategyModal from '@kubevirt-utils/components/EvictionStrategyModal/EvictionStrategyModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -18,16 +17,16 @@ import EvictionStrategy from './EvictionStrategy';
 type VirtualMachineSchedulingRightGridProps = {
   vm: V1VirtualMachine;
   canUpdateVM: boolean;
+  vmi?: V1VirtualMachineInstance;
 };
 
 const VirtualMachineSchedulingRightGrid: React.FC<VirtualMachineSchedulingRightGridProps> = ({
   vm,
   canUpdateVM,
+  vmi,
 }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
-  const canUpdateStoppedVM =
-    canUpdateVM && vm?.status?.printableStatus === printableVMStatus.Stopped;
 
   const onSubmit = React.useCallback(
     (updatedVM: V1VirtualMachine) =>
@@ -46,7 +45,7 @@ const VirtualMachineSchedulingRightGrid: React.FC<VirtualMachineSchedulingRightG
         <VirtualMachineDescriptionItem
           descriptionData={<DedicatedResources vm={vm} />}
           descriptionHeader={t('Dedicated Resources')}
-          isEdit={canUpdateStoppedVM}
+          isEdit={canUpdateVM}
           onEditClick={() =>
             createModal(({ isOpen, onClose }) => (
               <DedicatedResourcesModal
@@ -55,6 +54,7 @@ const VirtualMachineSchedulingRightGrid: React.FC<VirtualMachineSchedulingRightG
                 onClose={onClose}
                 onSubmit={onSubmit}
                 headerText={t('Dedicated Resources')}
+                vmi={vmi}
               />
             ))
           }
@@ -62,7 +62,7 @@ const VirtualMachineSchedulingRightGrid: React.FC<VirtualMachineSchedulingRightG
         <VirtualMachineDescriptionItem
           descriptionData={<EvictionStrategy vm={vm} />}
           descriptionHeader={t('Eviction Strategy')}
-          isEdit={canUpdateStoppedVM}
+          isEdit={canUpdateVM}
           onEditClick={() =>
             createModal(({ isOpen, onClose }) => (
               <EvictionStrategyModal
@@ -71,6 +71,7 @@ const VirtualMachineSchedulingRightGrid: React.FC<VirtualMachineSchedulingRightG
                 onClose={onClose}
                 onSubmit={onSubmit}
                 headerText={t('Eviction Strategy')}
+                vmi={vmi}
               />
             ))
           }


### PR DESCRIPTION
## 📝 Description

Making dedicated resources & eviction strategy modals editable when VM is running and including them as pending changes to VM.

## 🎥 Demo

### before:

![scheduling-not-editable-before](https://user-images.githubusercontent.com/67270715/171652571-867fd363-2150-465f-9486-bcc2531e8c0e.png)

### after:

https://user-images.githubusercontent.com/67270715/171652626-1f5c853a-5f7f-4296-ae8e-d9d5ba8c7b5d.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>