### PR TITLE
Add missing title to Template Hardware devices field

### DIFF
--- a/src/views/templates/details/tabs/details/components/DescriptionItem.tsx
+++ b/src/views/templates/details/tabs/details/components/DescriptionItem.tsx
@@ -8,7 +8,7 @@ import {
 
 type DescriptionProps = {
   title: string;
-  content: string;
+  content: string | JSX.Element;
 };
 
 // a simple DescriptionList item component

--- a/src/views/templates/details/tabs/details/components/TemplateDetailsRightGrid.tsx
+++ b/src/views/templates/details/tabs/details/components/TemplateDetailsRightGrid.tsx
@@ -50,10 +50,15 @@ const TemplateDetailsRightGrid: React.FC<TemplateDetailsGridProps> = ({ template
         title={t('Support')}
         content={getTemplateSupportLevel(template) || NO_DATA_DASH}
       />
-      <HardwareDevices
-        vm={getTemplateVirtualMachineObject(template)}
-        canEdit={!isCommonTemplate(template)}
-        onSubmit={onSubmit}
+      <DescriptionItem
+        title={t('Hardware devices')}
+        content={
+          <HardwareDevices
+            vm={getTemplateVirtualMachineObject(template)}
+            canEdit={!isCommonTemplate(template)}
+            onSubmit={onSubmit}
+          />
+        }
       />
     </DescriptionList>
   );


### PR DESCRIPTION
## 📝 Description
Add missing 'Hardware devices' title to the appropriate field, in the VM Template _Details_ tab.

## 🎥 Demo
**Before:**
![dev_before](https://user-images.githubusercontent.com/13417815/171747103-98220d5d-ccc0-4072-9df4-f4e62187863b.png)
**After:**
![dev_after](https://user-images.githubusercontent.com/13417815/171747121-d5e1b450-fa62-4263-a718-edebb1ef611d.png)

