### PR TITLE
Bug 2091897: Cloud Init noCloud and ConfigDrive

### DIFF
--- a/src/utils/resources/vmi/utils/cloud-init.ts
+++ b/src/utils/resources/vmi/utils/cloud-init.ts
@@ -3,9 +3,14 @@ import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 export const getCloudInitCredentials = (
   vmi: V1VirtualMachineInstance,
 ): { user: string; password: string } => {
-  const cloudInitValuesStrings = vmi?.spec?.volumes
-    ?.find((volume) => volume?.cloudInitNoCloud)
-    ?.cloudInitNoCloud?.userData?.split('\n')
+  const cloudInitVolume = vmi?.spec?.volumes?.find(
+    (volume) => volume?.cloudInitNoCloud || volume?.cloudInitConfigDrive,
+  );
+
+  const cloudInit = cloudInitVolume?.cloudInitNoCloud || cloudInitVolume?.cloudInitConfigDrive;
+
+  const cloudInitValuesStrings = cloudInit?.userData
+    ?.split('\n')
     ?.filter((row) => !row?.includes('#cloud-config'));
 
   const password = cloudInitValuesStrings


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

**Bug cause**
When the ssh key is added, the `cloudInitNoCloud` property is converted to `cloudInitConfigDrive` to support `accessCredentials`.
To find user credentials, there is a function that search only for `cloudInitNoCloud` volume ignoring credentials defined in a `cloudInitConfigDrive` volume


**Solution**
Find user credentials on cloudInitNoCloud and/or cloudInitConfigDrive property

