### PR TITLE
[WIP] Bug 2092796: Display CPU | Memory field consistently in the UI

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -20,7 +20,6 @@
   "{{count}} Tolerations rules": "{{count}} Tolerations rules",
   "{{count}} Tolerations rules_plural": "{{count}} Tolerations rules",
   "{{cpu}} CPU | {{memory}} Memory": "{{cpu}} CPU | {{memory}} Memory",
-  "{{cpuCount}} CPU | {{memory}} Memory": "{{cpuCount}} CPU | {{memory}} Memory",
   "{{dsLabel}} name": "{{dsLabel}} name",
   "{{dsLabel}} project": "{{dsLabel}} project",
   "{{matchingNodeText}} matching": "{{matchingNodeText}} matching",

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalog.scss
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalog.scss
@@ -1,0 +1,3 @@
+.cpu-memory-divider {
+  color: var(--pf-global--disabled-color--100);
+}

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateCatalogDrawer.scss
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateCatalogDrawer.scss
@@ -27,3 +27,7 @@
 .template-catalog-drawer-description {
   max-width: 300px;
 }
+
+.cpu-memory-divider {
+  color: var(--pf-global--disabled-color--100);
+}

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
@@ -34,6 +34,8 @@ import {
 } from '@patternfly/react-core';
 import ExternalLinkSquareAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-square-alt-icon';
 
+import './TemplateCatalogDrawer.scss';
+
 type TemplatesCatalogDrawerPanelProps = {
   template: V1Template;
 };
@@ -136,7 +138,9 @@ export const TemplatesCatalogDrawerPanel: React.FC<TemplatesCatalogDrawerPanelPr
                       <DescriptionListGroup>
                         <DescriptionListTerm>{t('CPU | Memory')}</DescriptionListTerm>
                         <DescriptionListDescription>
-                          {t('{{cpuCount}} CPU | {{memory}} Memory', { cpuCount, memory })}
+                          {t('CPU')} {cpuCount}
+                          <span className="cpu-memory-divider"> | </span>
+                          {t('Memory')} {memory}
                         </DescriptionListDescription>
                       </DescriptionListGroup>
                       <DescriptionListGroup>

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogRow.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogRow.tsx
@@ -18,6 +18,8 @@ import { getTemplateOSIcon } from '../utils/os-icons';
 
 import TemplateRowAvailableSource from './TemplateRowAvailableSource';
 
+import './TemplatesCatalog.scss';
+
 export const TemplatesCatalogRow: React.FC<
   RowProps<
     V1Template,
@@ -60,7 +62,9 @@ export const TemplatesCatalogRow: React.FC<
           />
         </TableData>
         <TableData id="cpu" activeColumnIDs={activeColumnIDs} className="pf-m-width-30">
-          {t('CPU')} {cpuCount} | {t('Memory')} {memory}
+          {t('CPU')} {cpuCount}
+          <span className="cpu-memory-divider"> | </span>
+          {t('Memory')} {memory}
         </TableData>
       </>
     );

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogTile.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogTile.tsx
@@ -15,6 +15,8 @@ import { Badge, Skeleton, Stack, StackItem } from '@patternfly/react-core';
 
 import { getTemplateOSIcon } from '../utils/os-icons';
 
+import './TemplatesCatalog.scss';
+
 export type TemplateTileProps = {
   template: V1Template;
   availableTemplatesUID: Set<string>;
@@ -80,7 +82,9 @@ export const TemplateTile: React.FC<TemplateTileProps> = React.memo(
                 <b>{t('Workload')}</b> {WORKLOADS_LABELS?.[workload] ?? t('Other')}
               </StackItem>
               <StackItem>
-                <b>{t('CPU')}</b> {cpuCount} | <b>{t('Memory')}</b> {memory}
+                <b>{t('CPU')}</b> {cpuCount}
+                <span className="cpu-memory-divider"> | </span>
+                <b>{t('Memory')}</b> {memory}
               </StackItem>
             </Stack>
           </StackItem>

--- a/src/views/templates/list/hooks/useVirtualMachineTemplatesCPUMemory.scss
+++ b/src/views/templates/list/hooks/useVirtualMachineTemplatesCPUMemory.scss
@@ -1,0 +1,3 @@
+.cpu-memory-divider {
+  color: var(--pf-global--disabled-color--100);
+}

--- a/src/views/templates/list/hooks/useVirtualMachineTemplatesCPUMemory.tsx
+++ b/src/views/templates/list/hooks/useVirtualMachineTemplatesCPUMemory.tsx
@@ -7,6 +7,8 @@ import { isTemplateParameter } from '@kubevirt-utils/utils/utils';
 import { Popover, PopoverPosition } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
+import './useVirtualMachineTemplatesCPUMemory.scss';
+
 enum BinaryUnit {
   B = 'B',
   Ki = 'Ki',
@@ -74,6 +76,12 @@ export const useVirtualMachineTemplatesCPUMemory = (
     );
   } else {
     const [value, readableUnit] = stringValueUnitSplit(memory);
-    return `CPU ${cpu?.cores} | ${t('Memory')} ${value} ${readableUnit}`;
+    return (
+      <>
+        CPU {cpu?.cores}
+        <span className="cpu-memory-divider"> | </span>
+        {t('Memory')} {value} {readableUnit}
+      </>
+    );
   }
 };

--- a/src/views/virtualmachines/details/tabs/details/components/CPUMemory/CPUMemory.scss
+++ b/src/views/virtualmachines/details/tabs/details/components/CPUMemory/CPUMemory.scss
@@ -1,0 +1,3 @@
+.cpu-memory-divider {
+  color: var(--pf-global--disabled-color--100);
+}

--- a/src/views/virtualmachines/details/tabs/details/components/CPUMemory/CPUMemory.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/CPUMemory/CPUMemory.tsx
@@ -4,6 +4,8 @@ import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getCPUCount } from '@kubevirt-utils/resources/vmi';
 
+import './CPUMemory.scss';
+
 type CPUMemoryProps = {
   vm: V1VirtualMachine;
 };
@@ -19,7 +21,9 @@ const CPUMemory: React.FC<CPUMemoryProps> = ({ vm }) => {
 
   return (
     <span data-test-id="virtual-machine-overview-details-cpu-memory">
-      {t('{{cpu}} CPU | {{memory}} Memory', { cpu, memory })}
+      {t('CPU')} {cpu}
+      <span className="cpu-memory-divider"> | </span>
+      {t('Memory')} {memory}
     </span>
   );
 };


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2092796

Display _CPU | Memory_ field in the template card same as in the template drawer.
Display it the same also in other places like VM Templates list/_Details_ tab, VirtualMachines _Overview_/_Details_ tab.
Display the vertical divider line in the grey color.
Also display the values after "CPU" or "Memory" string and the units after the CPU value.

## 🎥 Demo
**Before:**
![cpu-before](https://user-images.githubusercontent.com/13417815/171868160-ade59779-8dcd-416e-bf1a-e6eaf92012a0.png)

**After:**
![cpu-after](https://user-images.githubusercontent.com/13417815/171868196-f8ed9b4f-c4c8-4b37-88a3-031f8ae29ed8.png)

---

TODO:
- [ ] refactor/unify the code, use one component in all the places
- [ ] check displaying the units with the UX: which ones to use? Gi vs. Gi**B**
