### PR TITLE
Bug 2090068: Lowering the label of the Name column in vm disks tab

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawer.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawer.tsx
@@ -34,6 +34,7 @@ export const TemplatesCatalogDrawer: React.FC<TemplatesCatalogDrawerProps> = ({
       className="ocs-modal co-catalog-page__overlay co-catalog-page__overlay--right template-catalog-drawer"
       isOpen={isOpen}
       onClose={onClose}
+      disableFocusTrap
       header={
         <CatalogItemHeader
           className="co-catalog-page__overlay-header"

--- a/src/views/virtualmachines/details/tabs/disk/tables/disk/DiskRow.tsx
+++ b/src/views/virtualmachines/details/tabs/disk/tables/disk/DiskRow.tsx
@@ -10,7 +10,7 @@ import { PersistentVolumeClaimModel } from '@kubevirt-utils/models';
 import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
-import { Label, Split, SplitItem } from '@patternfly/react-core';
+import { Label, SplitItem, Stack } from '@patternfly/react-core';
 
 import DiskRowActions from './DiskRowActions';
 import { HotplugLabel } from './HotplugLabel';
@@ -24,7 +24,7 @@ const DiskRow: React.FC<
   return (
     <>
       <TableData id="name" activeColumnIDs={activeColumnIDs}>
-        <Split className="disk-row-split">
+        <Stack>
           <SplitItem>
             {obj?.name} <HotplugLabel vm={vm} diskName={obj?.name} vmi={vmi} />
           </SplitItem>
@@ -42,7 +42,7 @@ const DiskRow: React.FC<
               </Label>
             </SplitItem>
           )}
-        </Split>
+        </Stack>
       </TableData>
 
       <TableData id="source" activeColumnIDs={activeColumnIDs}>

--- a/src/views/virtualmachines/details/tabs/disk/tables/disk/DiskRow.tsx
+++ b/src/views/virtualmachines/details/tabs/disk/tables/disk/DiskRow.tsx
@@ -10,7 +10,7 @@ import { PersistentVolumeClaimModel } from '@kubevirt-utils/models';
 import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
-import { Label, SplitItem, Stack } from '@patternfly/react-core';
+import { Label, Stack, StackItem } from '@patternfly/react-core';
 
 import DiskRowActions from './DiskRowActions';
 import { HotplugLabel } from './HotplugLabel';
@@ -25,22 +25,22 @@ const DiskRow: React.FC<
     <>
       <TableData id="name" activeColumnIDs={activeColumnIDs}>
         <Stack>
-          <SplitItem>
+          <StackItem>
             {obj?.name} <HotplugLabel vm={vm} diskName={obj?.name} vmi={vmi} />
-          </SplitItem>
+          </StackItem>
           {obj?.isBootDisk && (
-            <SplitItem>
+            <StackItem>
               <Label variant="filled" color="blue" className="icon-size-small">
                 {t('bootable')}
               </Label>
-            </SplitItem>
+            </StackItem>
           )}
           {obj?.isEnvDisk && (
-            <SplitItem>
+            <StackItem>
               <Label variant="filled" color="blue">
                 {t('environment disk')}
               </Label>
-            </SplitItem>
+            </StackItem>
           )}
         </Stack>
       </TableData>

--- a/src/views/virtualmachines/details/tabs/disk/tables/disk/DiskRow.tsx
+++ b/src/views/virtualmachines/details/tabs/disk/tables/disk/DiskRow.tsx
@@ -24,13 +24,13 @@ const DiskRow: React.FC<
   return (
     <>
       <TableData id="name" activeColumnIDs={activeColumnIDs}>
-        <Split hasGutter>
+        <Split className="disk-row-split">
           <SplitItem>
             {obj?.name} <HotplugLabel vm={vm} diskName={obj?.name} vmi={vmi} />
           </SplitItem>
           {obj?.isBootDisk && (
             <SplitItem>
-              <Label variant="filled" color="blue">
+              <Label variant="filled" color="blue" className="icon-size-small">
                 {t('bootable')}
               </Label>
             </SplitItem>

--- a/src/views/virtualmachines/details/tabs/disk/tables/tables.scss
+++ b/src/views/virtualmachines/details/tabs/disk/tables/tables.scss
@@ -6,4 +6,3 @@
 .icon-size-small {
   font-size: var(--pf-global--FontSize--sm);
 }
-

--- a/src/views/virtualmachines/details/tabs/disk/tables/tables.scss
+++ b/src/views/virtualmachines/details/tabs/disk/tables/tables.scss
@@ -7,7 +7,3 @@
   font-size: var(--pf-global--FontSize--sm);
 }
 
-.disk-row-split.pf-l-split {
-    display: block;
-  }
-

--- a/src/views/virtualmachines/details/tabs/disk/tables/tables.scss
+++ b/src/views/virtualmachines/details/tabs/disk/tables/tables.scss
@@ -6,3 +6,8 @@
 .icon-size-small {
   font-size: var(--pf-global--FontSize--sm);
 }
+
+.disk-row-split.pf-l-split {
+    display: block;
+  }
+


### PR DESCRIPTION
Signed-off-by: Dana Orr <dorr@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
The labels overlap each other as the page shrinks, so I fixed by lowering the label of the name.

## 🎥 Demo
Before:
<img width="1239" alt="image" src="https://user-images.githubusercontent.com/61961469/172136524-f6972e49-d69b-42cc-b358-5225e5051f18.png">

After:
<img width="1220" alt="image" src="https://user-images.githubusercontent.com/61961469/172134697-ab01bd80-9369-43b8-b91e-b959bfdf41f7.png">
