### PR TITLE
Bug 2093691: Add left padding to VM create drawer content

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
@@ -79,7 +79,7 @@ export const TemplatesCatalogDrawerPanel: React.FC<TemplatesCatalogDrawerPanelPr
     const hardwareDevicesCount = hostDevicesCount + gpusCount;
 
     return (
-      <div className="modal-body modal-body-border">
+      <div className="modal-body modal-body-border modal-body-content">
         <div className="modal-body-inner-shadow-covers">
           <div className="co-catalog-page__overlay-body">
             <Stack hasGutter className="template-catalog-drawer-info">


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2093691

When creating a VM, the drawer left padding in upper part disappeared. Fix the missing padding to display the content correctly.

## 🎥 Screenshots
**Before:**
![padding_before](https://user-images.githubusercontent.com/13417815/172239698-38c8b401-e454-46da-a6d0-2688103053e7.png)
**After:**
![padding_after](https://user-images.githubusercontent.com/13417815/172239686-c13339c2-3d4a-44b9-95d6-93ac487a7100.png)

---

_Note:_
When investigating the problem, the relevant component had the following variable set:
`--pf-c-modal-box__body--PaddingLeft: 0 !important;`
Because of this, we cannot use the Patternfly `--pf-c-modal-box__body--PaddingLeft`, nor even `--pf-c-modal-box--PaddingLeft` to achieve the expected result, because this is actually not working correctly, doesn't set the expected padding when used.

Related PF doc:
https://www.patternfly.org/2020.06/documentation/core/components/modalbox

