### PR TITLE
Bug 2094405: missing env resource from disks list

### DIFF
--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -11,6 +11,7 @@ import {
   V1Disk,
   V1RemoveVolumeOptions,
   V1VirtualMachine,
+  V1VirtualMachineInstance,
   V1Volume,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { buildOwnerReference } from '@kubevirt-utils/resources/shared';
@@ -225,4 +226,26 @@ export const getRemoveHotplugPromise = (vm: V1VirtualMachine, diskName: string) 
     name: diskName,
   };
   return removeVolume(vm, bodyRequestRemoveVolume);
+};
+
+export const getRunningVMMissingDisksFromVMI = (
+  vmDisks: V1Disk[],
+  vmi: V1VirtualMachineInstance,
+): V1Disk[] => {
+  const vmDiskNames = vmDisks?.map((disk) => disk?.name);
+  const missingDisksFromVMI = (vmi?.spec?.domain?.devices?.disks || [])?.filter(
+    (disk) => !vmDiskNames?.includes(disk?.name),
+  );
+  return missingDisksFromVMI || [];
+};
+
+export const getRunningVMMissingVolumesFromVMI = (
+  vmVolumes: V1Volume[],
+  vmi: V1VirtualMachineInstance,
+): V1Volume[] => {
+  const vmVolumeNames = vmVolumes?.map((vol) => vol?.name);
+  const missingVolumesFromVMI = (vmi?.spec?.volumes || [])?.filter(
+    (vol) => !vmVolumeNames?.includes(vol?.name),
+  );
+  return missingVolumesFromVMI || [];
 };

--- a/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
+++ b/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
@@ -2,6 +2,10 @@ import * as React from 'react';
 import { printableVMStatus } from 'src/views/virtualmachines/utils';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  getRunningVMMissingDisksFromVMI,
+  getRunningVMMissingVolumesFromVMI,
+} from '@kubevirt-utils/components/DiskModal/utils/helpers';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   PersistentVolumeClaimModel,
@@ -32,11 +36,20 @@ const useDisksTableData: UseDisksTableDisks = (vm: V1VirtualMachine) => {
   });
   const isVMRunning = vm?.status?.printableStatus === printableVMStatus.Running;
   const vmDisks = React.useMemo(
-    () => (!isVMRunning ? getDisks(vm) : vmi?.spec?.domain?.devices?.disks),
+    () =>
+      !isVMRunning
+        ? getDisks(vm)
+        : [...(getDisks(vm) || []), ...getRunningVMMissingDisksFromVMI(getDisks(vm) || [], vmi)],
     [vm, vmi, isVMRunning],
   );
   const vmVolumes = React.useMemo(
-    () => (!isVMRunning ? getVolumes(vm) : vmi?.spec?.volumes),
+    () =>
+      !isVMRunning
+        ? getVolumes(vm)
+        : [
+            ...(getVolumes(vm) || []),
+            ...getRunningVMMissingVolumesFromVMI(getVolumes(vm) || [], vmi),
+          ],
     [vm, vmi, isVMRunning],
   );
 


### PR DESCRIPTION
## 📝 Description

when adding a resource from the environment tab when VM is running the resource is not shown on the disks list

## 🎥 Demo

### before:
![env-resource-missing](https://user-images.githubusercontent.com/67270715/172402018-1bfc7ea2-0633-43a7-ac52-246433e31de2.png)


### after:
![env-resource-missing-after](https://user-images.githubusercontent.com/67270715/172401931-2175c63b-a5e5-4ffa-b571-84975606a7e0.png)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>