### PR TITLE
Bug 2093772: add env resource changes boot order pending alert

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -115,6 +115,7 @@
   "Blank": "Blank",
   "Blank (creates PVC)": "Blank (creates PVC)",
   "Block": "Block",
+  "Boot disk": "Boot disk",
   "Boot from CD": "Boot from CD",
   "Boot from CD requires an image file i.e. ISO, qcow, etc. that will be mounted to the VirtualMachine as a CD": "Boot from CD requires an image file i.e. ISO, qcow, etc. that will be mounted to the VirtualMachine as a CD",
   "Boot method": "Boot method",

--- a/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
+++ b/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
@@ -104,7 +104,7 @@ export const usePendingChanges = (
     {
       hasPendingChange: bootOrderChanged,
       tabLabel: VirtualMachineDetailsTabLabel.Details,
-      label: t('Boot order'),
+      label: t('Boot disk'),
       handleAction: () => {
         history.push(getTabURL(vm, VirtualMachineDetailsTab.Details));
         createModal(({ isOpen, onClose }) => (


### PR DESCRIPTION
## 📝 Description

the pending alert is linked to the entire bootorder of all disks but we want to know only about the bootdisk when is changed

## 🎥 Demo

### before:
![boot-order-changed](https://user-images.githubusercontent.com/67270715/172419817-063c7659-ded6-4657-9764-15785d135ee1.png)

### after:
![boot-order-changed-after](https://user-images.githubusercontent.com/67270715/172419872-c86d4465-bc81-44e9-bab6-736d29d04a66.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>