### PR TITLE
Bug 2094440: Memory Utilization chart VM overview memory change

### DIFF
--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
@@ -30,7 +30,7 @@ const MemoryUtil: React.FC<MemoryUtilProps> = ({ duration, vmi, vm }) => {
   const queries = React.useMemo(() => getUtilizationQueries({ vmName: vm?.metadata?.name }), [vm]);
   const timespan = React.useMemo(() => adjustDuration(duration), [adjustDuration, duration]);
 
-  const requests = vm?.spec?.template?.spec?.domain?.resources?.requests as {
+  const requests = vmi?.spec?.domain?.resources?.requests as {
     [key: string]: string;
   };
   const memory = getMemorySize(requests?.memory);


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When changing memory size on VM, the utilization charts reflect new memory before restarting.
Now instead of looking at VM resources, it will look at VMI resources.

## 🎥 Demo

![memory-change](https://user-images.githubusercontent.com/14824964/172558844-aa57c183-b999-438f-a161-8b04cb781eff.gif)

