### PR TITLE
Bug 2086293: [Dark mode] Titles in Parameters tab are not visible enough 

### DIFF
--- a/src/views/templates/details/tabs/parameters/template-parameters-page.scss
+++ b/src/views/templates/details/tabs/parameters/template-parameters-page.scss
@@ -4,7 +4,7 @@
   }
 
   .pf-c-expandable-section__toggle-text {
-    color: black;
+    color: var(--pf-global--Color--100);
   }
 
   .pf-c-form__group {


### PR DESCRIPTION
Signed-off-by: Dana Orr <dorr@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
The titles in the accordion in Parameters tab didn't visible enough on dark mode, I corrected by changing the style.

## 🎥 Demo
Before:
![image](https://user-images.githubusercontent.com/61961469/172560930-2bb09b96-e099-4082-b20c-d013150f9320.png)

After:
![image](https://user-images.githubusercontent.com/61961469/172559202-0105f94b-78b3-427c-8349-3cc322ca3f1d.png)
