### PR TITLE
Bug 2094646: data-test-id missing on Scheduling tab

### DIFF
--- a/src/views/catalog/wizard/tabs/scheduling/WizardSchedulingTab.tsx
+++ b/src/views/catalog/wizard/tabs/scheduling/WizardSchedulingTab.tsx
@@ -44,6 +44,7 @@ const WizardSchedulingTab: WizardTab = ({ vm, updateVM }) => {
               title={t('Node Selector')}
               description={<NodeSelector vm={vm} />}
               isEdit
+              testId="node-selector"
               onEditClick={() =>
                 createModal(({ isOpen, onClose }) => (
                   <NodeSelectorModal
@@ -62,6 +63,7 @@ const WizardSchedulingTab: WizardTab = ({ vm, updateVM }) => {
               description={<Tolerations vm={vm} />}
               title={t('Tolerations')}
               isEdit
+              testId="tolerations"
               onEditClick={() =>
                 createModal(({ isOpen, onClose }) => (
                   <TolerationsModal vm={vm} isOpen={isOpen} onClose={onClose} onSubmit={updateVM} />
@@ -72,6 +74,7 @@ const WizardSchedulingTab: WizardTab = ({ vm, updateVM }) => {
             <WizardDescriptionItem
               title={t('Affinity Rules')}
               description={<Affinity vm={vm} />}
+              testId="affinity-rules"
               isEdit
               onEditClick={() =>
                 createModal(({ isOpen, onClose }) => (
@@ -91,6 +94,7 @@ const WizardSchedulingTab: WizardTab = ({ vm, updateVM }) => {
               title={t('Descheduler')}
               description={<Descheduler vm={vm} />}
               isEdit
+              testId="descheduler"
               onEditClick={() =>
                 createModal(({ isOpen, onClose }) => (
                   <DeschedulerModal vm={vm} isOpen={isOpen} onClose={onClose} onSubmit={updateVM} />
@@ -106,6 +110,7 @@ const WizardSchedulingTab: WizardTab = ({ vm, updateVM }) => {
               title={t('Dedicated Resources')}
               description={<DedicatedResources vm={vm} />}
               isEdit
+              testId="dedicated-resources"
               onEditClick={() =>
                 createModal(({ isOpen, onClose }) => (
                   <DedicatedResourcesModal
@@ -123,6 +128,7 @@ const WizardSchedulingTab: WizardTab = ({ vm, updateVM }) => {
               title={t('Eviction Strategy')}
               description={<EvictionStrategy vm={vm} />}
               isEdit
+              testId="eviction-strategy"
               onEditClick={() =>
                 createModal(({ isOpen, onClose }) => (
                   <EvictionStrategyModal

--- a/src/views/virtualmachines/details/tabs/scheduling/components/VirtualMachineSchedulingLeftGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/scheduling/components/VirtualMachineSchedulingLeftGrid.tsx
@@ -55,6 +55,7 @@ const VirtualMachineSchedulingLeftGrid: React.FC<VirtualMachineSchedulingLeftGri
           descriptionData={<NodeSelector vm={vm} />}
           descriptionHeader={t('Node Selector')}
           isEdit={canUpdateVM}
+          data-test-id="node-selector"
           onEditClick={() =>
             createModal(({ isOpen, onClose }) => (
               <NodeSelectorModal
@@ -73,6 +74,7 @@ const VirtualMachineSchedulingLeftGrid: React.FC<VirtualMachineSchedulingLeftGri
           descriptionData={<Tolerations vm={vm} />}
           descriptionHeader={t('Tolerations')}
           isEdit={canUpdateVM}
+          data-test-id="tolerations"
           onEditClick={() =>
             createModal(({ isOpen, onClose }) => (
               <TolerationsModal
@@ -91,6 +93,7 @@ const VirtualMachineSchedulingLeftGrid: React.FC<VirtualMachineSchedulingLeftGri
           descriptionData={<Affinity vm={vm} />}
           descriptionHeader={t('Affinity Rules')}
           isEdit={canUpdateVM}
+          data-test-id="affinity-rules"
           onEditClick={() =>
             createModal(({ isOpen, onClose }) => (
               <AffinityModal
@@ -109,6 +112,7 @@ const VirtualMachineSchedulingLeftGrid: React.FC<VirtualMachineSchedulingLeftGri
           descriptionData={<Descheduler vm={vm} />}
           descriptionHeader={t('Descheduler')}
           isEdit={canUpdateVM}
+          data-test-id="descheduler"
           onEditClick={() =>
             createModal(({ isOpen, onClose }) => (
               <DeschedulerModal

--- a/src/views/virtualmachines/details/tabs/scheduling/components/VirtualMachineSchedulingRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/scheduling/components/VirtualMachineSchedulingRightGrid.tsx
@@ -46,6 +46,7 @@ const VirtualMachineSchedulingRightGrid: React.FC<VirtualMachineSchedulingRightG
           descriptionData={<DedicatedResources vm={vm} />}
           descriptionHeader={t('Dedicated Resources')}
           isEdit={canUpdateVM}
+          data-test-id="dedicated-resources"
           onEditClick={() =>
             createModal(({ isOpen, onClose }) => (
               <DedicatedResourcesModal
@@ -63,6 +64,7 @@ const VirtualMachineSchedulingRightGrid: React.FC<VirtualMachineSchedulingRightG
           descriptionData={<EvictionStrategy vm={vm} />}
           descriptionHeader={t('Eviction Strategy')}
           isEdit={canUpdateVM}
+          data-test-id="eviction-strategy"
           onEditClick={() =>
             createModal(({ isOpen, onClose }) => (
               <EvictionStrategyModal


### PR DESCRIPTION
Signed-off-by: Dana Orr <dorr@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
Adding data-test-id on the Scheduling tab when vm is created, and rename the data-test-id on Scheduling tab on the catalog review page.

## 🎥 Demo
Before:
![image](https://user-images.githubusercontent.com/61961469/172583666-5a97c4a2-c250-474e-9a9e-3716d788ada0.png)
After:
![image](https://user-images.githubusercontent.com/61961469/172583072-4833e7da-ffa2-4e1c-88b0-af4613558700.png)
