### PR TITLE
Bug 2094807: fix hw dropdown

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -444,6 +444,7 @@
   "No default value": "No default value",
   "No display name": "No display name",
   "No eviction strategy": "No eviction strategy",
+  "No host devices exists": "No host devices exists",
   "No IP address is reported for network interface": "No IP address is reported for network interface",
   "No matching nodes found for the {{cpuManagerLabel}} label": "No matching nodes found for the {{cpuManagerLabel}} label",
   "No matching Nodes found for the labels": "No matching Nodes found for the labels",

--- a/src/utils/components/HardwareDevices/form/DeviceNameSelect.tsx
+++ b/src/utils/components/HardwareDevices/form/DeviceNameSelect.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { V1PermittedHostDevices } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   FormGroup,
   GridItem,
@@ -42,20 +43,36 @@ const DeviceNameSelect: React.FC<DeviceNameSelectProps> = ({
           variant={SelectVariant.single}
           selections={deviceName}
         >
-          <SelectGroup label={t('Mediated devices')} key="mediated">
+          <SelectGroup
+            hidden={isEmpty(permittedHostDevices?.mediatedDevices)}
+            label={t('Mediated devices')}
+            key="mediated"
+          >
             {permittedHostDevices?.mediatedDevices?.map(({ resourceName }) => (
               <SelectOption key={resourceName} value={resourceName}>
                 {resourceName}
               </SelectOption>
             ))}
           </SelectGroup>
-          <SelectGroup label={t('PCI host devices')} key="pciHost">
+          <SelectGroup
+            hidden={isEmpty(permittedHostDevices?.pciHostDevices)}
+            label={t('PCI host devices')}
+            key="pciHost"
+          >
             {permittedHostDevices?.pciHostDevices?.map(({ resourceName }) => (
               <SelectOption key={resourceName} value={resourceName}>
                 {resourceName}
               </SelectOption>
             ))}
           </SelectGroup>
+          <SelectGroup
+            hidden={
+              !isEmpty(permittedHostDevices?.mediatedDevices) ||
+              !isEmpty(permittedHostDevices?.pciHostDevices)
+            }
+            label={t('No host devices exists')}
+            key="noDevices"
+          />
         </Select>
       </FormGroup>
     </GridItem>


### PR DESCRIPTION
## 📝 Description

when trying to add HW device, and no devices are configured to the cluster, the dropwdown still shows the group headers

## 🎥 Demo

### before:
#### no devices:
![no_hw_exists_before_2](https://user-images.githubusercontent.com/67270715/172597364-fc9bf2de-f5ee-41af-916e-5db5eaf7cb86.png)
#### only mediated devices:
![no_hw_exists_before_1](https://user-images.githubusercontent.com/67270715/172597366-3c5c46a4-ce86-4664-8be2-c02661444f95.png)

### after:
#### no devices:
![no_hw_exists_after_1](https://user-images.githubusercontent.com/67270715/172597424-e5f1436b-d0d7-4a6d-b939-8eb450d04044.png)
#### only mediated devices:
![no_hw_exists_after_2](https://user-images.githubusercontent.com/67270715/172597417-193d7716-77c7-422d-a6dd-972d486d4240.png)
#### both PCI host and mediated devices:
![no_hw_exists_after_3](https://user-images.githubusercontent.com/67270715/172597421-2417f692-cfd1-4ed2-a896-a432a5c002d2.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>