### PR TITLE
Bug 2094486: save affinity ruly button is too small

### DIFF
--- a/src/utils/components/AffinityModal/components/AffinityEditModal/AffinityEditModal.tsx
+++ b/src/utils/components/AffinityModal/components/AffinityEditModal/AffinityEditModal.tsx
@@ -52,7 +52,6 @@ const AffinityEditModal: React.FC<AffinityEditModalProps> = ({
       footer={
         <ActionGroup>
           <Button
-            isSmall
             isDisabled={isDisabled}
             onClick={() =>
               onSubmit({


### PR DESCRIPTION
## 📝 Description

the "Save affinity rule" button is smaller than other modal primary button

## 🎥 Demo

### before:
![save-affinity-rule-small-before](https://user-images.githubusercontent.com/67270715/172604696-3b519f59-3528-45c1-a38b-5a966f931628.png)

### after:
![save-affinity-rule-small-after](https://user-images.githubusercontent.com/67270715/172604717-73ac2894-d7cf-4301-b657-99d911b7e653.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>