### PR TITLE
Bug 2093866: Make VM creation from template from default yaml work

### DIFF
--- a/src/views/catalog/customize/components/CustomizeForms/useCustomizeFormSubmit.ts
+++ b/src/views/catalog/customize/components/CustomizeForms/useCustomizeFormSubmit.ts
@@ -59,7 +59,7 @@ export const useCustomizeFormSubmit = ({
   } = useWizardVMContext();
   const { upload, uploadData } = useCDIUpload();
 
-  const onSubmit = async (data, event: { target: HTMLFormElement }) => {
+  const onSubmit = async (data: { [x: string]: any }, event: { target: HTMLFormElement }) => {
     // upload only supported for diskSource
     const uploadFile = data?.['disk-boot-source-uploadFile'];
 
@@ -76,7 +76,7 @@ export const useCustomizeFormSubmit = ({
 
       const vmObj = getTemplateVirtualMachineObject(processedTemplate);
 
-      const dataVolumeTemplate = vmObj.spec.dataVolumeTemplates[0];
+      const dataVolumeTemplate = vmObj?.spec?.dataVolumeTemplates?.[0];
       const updatedVM = produce(vmObj, (vmDraft) => {
         vmDraft.metadata.namespace = ns || DEFAULT_NAMESPACE;
         vmDraft.metadata.labels[LABEL_USED_TEMPLATE_NAME] = processedTemplate.metadata.name;


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2093866

Make VM creation work, VM creation from the template, that was created from the default yaml
(without any changes; with _vm-template-example_ as the default VM template name).

## 🎥 Demo
**Before:**
Error, cannot create a VM:
![before](https://user-images.githubusercontent.com/13417815/172616466-e544e6a9-bb47-4d2d-a7bc-2ca895445930.png)
**After:**
![after1](https://user-images.githubusercontent.com/13417815/172616505-c8436257-8cb7-4bd8-b016-ff79f0661432.png)
VM created successfully:
![after2](https://user-images.githubusercontent.com/13417815/172616518-4bb69ba4-1458-4467-af45-40d830666e5f.png)




