### PR TITLE
Bug 2094665: dedicated resources modal stuck loading for non priv user

### DIFF
--- a/src/utils/components/DedicatedResourcesModal/DedicatedResourcesModal.tsx
+++ b/src/utils/components/DedicatedResourcesModal/DedicatedResourcesModal.tsx
@@ -9,6 +9,7 @@ import Loading from '@kubevirt-utils/components/Loading/Loading';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, NodeModel } from '@kubevirt-utils/models';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ResourceLink, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Alert,
@@ -48,7 +49,7 @@ const DedicatedResourcesModal: React.FC<DedicatedResourcesModalProps> = ({
     !!vm?.spec?.template?.spec?.domain?.cpu?.dedicatedCpuPlacement,
   );
 
-  const [nodes, loaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
+  const [nodes, loaded, loadError] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
     groupVersionKind: modelToGroupVersionKind(NodeModel),
     isList: true,
   });
@@ -77,7 +78,6 @@ const DedicatedResourcesModal: React.FC<DedicatedResourcesModalProps> = ({
       onClose={onClose}
       onSubmit={onSubmit}
       headerText={headerText}
-      isDisabled={!loaded}
     >
       <Form>
         {vmi && (
@@ -95,19 +95,23 @@ const DedicatedResourcesModal: React.FC<DedicatedResourcesModalProps> = ({
               <>
                 {t('Available only on Nodes with labels')}{' '}
                 <Label variant="filled" color="purple">
-                  <Link
-                    to={`/search?kind=${NodeModel.kind}&q=${encodeURIComponent(cpuManagerLabel)}`}
-                    target="_blank"
-                  >
-                    {cpuManagerLabel}
-                  </Link>
+                  {!isEmpty(nodes) ? (
+                    <Link
+                      to={`/search?kind=${NodeModel.kind}&q=${encodeURIComponent(cpuManagerLabel)}`}
+                      target="_blank"
+                    >
+                      {cpuManagerLabel}
+                    </Link>
+                  ) : (
+                    cpuManagerLabel
+                  )}
                 </Label>
               </>
             }
           />
         </FormGroup>
         <FormGroup fieldId="dedicated-resources-node">
-          {loaded ? (
+          {!isEmpty(nodes) ? (
             <Alert
               title={
                 hasNodes
@@ -149,7 +153,7 @@ const DedicatedResourcesModal: React.FC<DedicatedResourcesModalProps> = ({
               )}
             </Alert>
           ) : (
-            <Loading />
+            !loaded && !loadError && <Loading />
           )}
         </FormGroup>
       </Form>

--- a/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
+++ b/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
@@ -217,7 +217,7 @@ export const usePendingChanges = (
             isOpen={isOpen}
             onClose={onClose}
             onSubmit={onSubmit}
-            headerText={t('Dedicated Resources')}
+            headerText={t('Dedicated resources')}
             vmi={vmi}
           />
         ));

--- a/src/views/catalog/wizard/tabs/scheduling/WizardSchedulingTab.tsx
+++ b/src/views/catalog/wizard/tabs/scheduling/WizardSchedulingTab.tsx
@@ -118,7 +118,7 @@ const WizardSchedulingTab: WizardTab = ({ vm, updateVM }) => {
                     isOpen={isOpen}
                     onClose={onClose}
                     onSubmit={updateVM}
-                    headerText={t('Dedicated Resources')}
+                    headerText={t('Dedicated resources')}
                   />
                 ))
               }

--- a/src/views/templates/details/tabs/scheduling/components/DedicatedResourcesModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/DedicatedResourcesModal.tsx
@@ -13,6 +13,7 @@ import Loading from '@kubevirt-utils/components/Loading/Loading';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, NodeModel, V1Template } from '@kubevirt-utils/models';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ResourceLink, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Alert,
@@ -40,7 +41,7 @@ const DedicatedResourcesModal: React.FC<DedicatedResourcesModalProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const [checked, setChecked] = React.useState<boolean>(isDedicatedCPUPlacement(template));
-  const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
+  const [nodes, nodesLoaded, loadError] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
     groupVersionKind: modelToGroupVersionKind(NodeModel),
     isList: true,
   });
@@ -68,7 +69,6 @@ const DedicatedResourcesModal: React.FC<DedicatedResourcesModalProps> = ({
       onClose={onClose}
       onSubmit={onSubmit}
       headerText={t('Dedicated resources')}
-      isDisabled={!nodesLoaded}
     >
       <Form>
         <FormGroup fieldId="dedicated-resources" isInline>
@@ -81,19 +81,23 @@ const DedicatedResourcesModal: React.FC<DedicatedResourcesModalProps> = ({
               <>
                 {t('Available only on Nodes with labels')}{' '}
                 <Label variant="filled" color="purple">
-                  <Link
-                    to={`/search?kind=${NodeModel.kind}&q=${encodeURIComponent(cpuManagerLabel)}`}
-                    target="_blank"
-                  >
-                    {cpuManagerLabel}
-                  </Link>
+                  {!isEmpty(nodes) ? (
+                    <Link
+                      to={`/search?kind=${NodeModel.kind}&q=${encodeURIComponent(cpuManagerLabel)}`}
+                      target="_blank"
+                    >
+                      {cpuManagerLabel}
+                    </Link>
+                  ) : (
+                    cpuManagerLabel
+                  )}
                 </Label>
               </>
             }
           />
         </FormGroup>
         <FormGroup fieldId="dedicated-resources-node">
-          {nodesLoaded ? (
+          {!isEmpty(nodes) ? (
             <Alert
               title={
                 hasNodes
@@ -135,7 +139,7 @@ const DedicatedResourcesModal: React.FC<DedicatedResourcesModalProps> = ({
               )}
             </Alert>
           ) : (
-            <Loading />
+            !loadError && !nodesLoaded && <Loading />
           )}
         </FormGroup>
       </Form>

--- a/src/views/virtualmachines/details/tabs/scheduling/components/VirtualMachineSchedulingRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/scheduling/components/VirtualMachineSchedulingRightGrid.tsx
@@ -54,7 +54,7 @@ const VirtualMachineSchedulingRightGrid: React.FC<VirtualMachineSchedulingRightG
                 isOpen={isOpen}
                 onClose={onClose}
                 onSubmit={onSubmit}
-                headerText={t('Dedicated Resources')}
+                headerText={t('Dedicated resources')}
                 vmi={vmi}
               />
             ))


### PR DESCRIPTION
## 📝 Description

this PR include fixes for:
- non-privileged users cant list nodes, so we do not show any info about the qualified nodes for a non-privileged user.
- disable the link to search for nodes as it will lead to an error.
- fixing title from `Dedicated Resources` to `Dedicated resources`

## 🎥 Demo

### before:
![dedicated-before](https://user-images.githubusercontent.com/67270715/172800273-1a254c61-5080-4d03-8ce3-d2102c1496dc.png)

### after:
#### non-privileged user view:
![dedicated-after](https://user-images.githubusercontent.com/67270715/172820516-5e268a62-c95c-4f28-8572-bd3a0b8eeac6.png)

#### admin view:
![dedicated-after-admin](https://user-images.githubusercontent.com/67270715/172822371-86ad2a14-870c-48fe-9c66-ca43b34559e0.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>