### PR TITLE
Bug 2095224: affinity rules list has stuck loader for non-privileged user

### DIFF
--- a/src/utils/components/AffinityModal/components/AffinityList/AffinityList.tsx
+++ b/src/utils/components/AffinityModal/components/AffinityList/AffinityList.tsx
@@ -52,7 +52,7 @@ const AffinityList: React.FC<AffinityListProps> = ({
         <AddAffinityRuleButton isLinkButton onAffinityClickAdd={onAffinityClickAdd} />
       </StackItem>
       <StackItem>
-        {affinities?.some((affinity) => affinity?.type === AffinityType.node) && (
+        {affinities?.some((affinity) => affinity?.type === AffinityType.node) && nodesLoaded && (
           <NodeCheckerAlert
             qualifiedNodes={qualifiedNodes}
             prefferedQualifiedNodes={prefferedQualifiedNodes}

--- a/src/views/templates/details/tabs/scheduling/components/AffinityRulesModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/AffinityRulesModal.tsx
@@ -136,6 +136,7 @@ const AffinityRulesModal: React.FC<AffinityModalProps> = ({
       onSubmit={onSubmit}
       headerText={t('Affinity rules')}
       modalVariant={ModalVariant.medium}
+      submitBtnText={t('Apply rules')}
     >
       {list}
     </TabModal>


### PR DESCRIPTION
## 📝 Description

when adding affinity rule as non-privileged user, below the rules list to be applied there is a stuck loader,

## 🎥 Demo
### before:

https://user-images.githubusercontent.com/67270715/172847605-ab869ab3-7170-4c54-ace6-6b43f2429abe.mp4

### after:

https://user-images.githubusercontent.com/67270715/172848624-24608eda-5692-4f2a-9e2f-fe4198a133cc.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>