### PR TITLE
Bug 2093867: OS for template 'vm-template-example' should matching the version of the image

### DIFF
--- a/src/templates/vm-template-yaml.ts
+++ b/src/templates/vm-template-yaml.ts
@@ -7,10 +7,10 @@ metadata:
   name: vm-template-example
   labels:
     template.kubevirt.io/type: vm
-    os.template.kubevirt.io/fedora31: 'true'
+    os.template.kubevirt.io/fedora36: 'true'
     workload.template.kubevirt.io/server: 'true'
   annotations:
-    name.os.template.kubevirt.io/fedora31: Fedora 31
+    name.os.template.kubevirt.io/fedora36: Fedora 36
     description: VM template example
 objects:
   - apiVersion: kubevirt.io/v1


### PR DESCRIPTION
## 🎥 Demo
### before:
![Screenshot (56)](https://user-images.githubusercontent.com/67270715/172857227-99a8ed9c-d6db-4815-84f2-d37ca8cda954.png)

### after:
![Screenshot (57)](https://user-images.githubusercontent.com/67270715/172857259-282c448f-e5e2-41af-a358-6cef7c194fb8.png)

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>