### PR TITLE
Bug 2095125: Display OS name in the Clone VM modal

### DIFF
--- a/src/utils/resources/vm/utils/operation-system/operationSystem.ts
+++ b/src/utils/resources/vm/utils/operation-system/operationSystem.ts
@@ -73,7 +73,7 @@ export const getOperatingSystem = (obj: K8sResourceCommon): string =>
  * @param {K8sResourceCommon} obj - object to search
  * @returns {string}
  */
-export const getOperatingSystemName = (obj: K8sResourceCommon) =>
+export const getOperatingSystemName = (obj: K8sResourceCommon): string =>
   getValueByPrefix(
     obj?.metadata?.annotations,
     `${NAME_OS_TEMPLATE_ANNOTATION}/${getOperatingSystem(obj)}`,

--- a/src/views/virtualmachines/actions/components/CloneVMModal/components/ConfigurationSummary.tsx
+++ b/src/views/virtualmachines/actions/components/CloneVMModal/components/ConfigurationSummary.tsx
@@ -6,11 +6,16 @@ import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getAnnotation } from '@kubevirt-utils/resources/shared';
-import { getInterfaces, VM_WORKLOAD_ANNOTATION } from '@kubevirt-utils/resources/vm';
+import {
+  getInterfaces,
+  useVMIAndPodsForVM,
+  VM_WORKLOAD_ANNOTATION,
+} from '@kubevirt-utils/resources/vm';
 import {
   getOperatingSystem,
   getOperatingSystemName,
 } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
+import { useGuestOS } from '@kubevirt-utils/resources/vmi';
 import { FormGroup, TextListItem, TextListItemVariants } from '@patternfly/react-core';
 
 import CPUMemory from '../../../../details/tabs/details/components/CPUMemory/CPUMemory';
@@ -24,13 +29,19 @@ type ConfigurationSummaryProps = {
 
 const ConfigurationSummary: React.FC<ConfigurationSummaryProps> = ({ vm, pvcs, dataVolumes }) => {
   const { t } = useKubevirtTranslation();
+  const { vmi } = useVMIAndPodsForVM(vm?.metadata?.name, vm?.metadata?.namespace);
+  const [guestAgentData] = useGuestOS(vmi);
+  const osName = (guestAgentData?.os?.prettyName || guestAgentData?.os?.name) ?? (
+    <MutedTextSpan text={t('Guest agent is required')} />
+  );
+
   return (
     <FormGroup hasNoPaddingTop label={t('Configuration')} fieldId="configuration">
       <TextListItem className="text-muted" component={TextListItemVariants.dt}>
-        {t('Operating System')}
+        {t('Operating system')}
       </TextListItem>
       <TextListItem component={TextListItemVariants.dd}>
-        {getOperatingSystemName(vm) || getOperatingSystem(vm)}
+        {getOperatingSystemName(vm) || getOperatingSystem(vm) || osName}
       </TextListItem>
       <TextListItem className="text-muted" component={TextListItemVariants.dt}>
         {t('Flavor')}
@@ -39,7 +50,7 @@ const ConfigurationSummary: React.FC<ConfigurationSummaryProps> = ({ vm, pvcs, d
         <CPUMemory vm={vm} />
       </TextListItem>
       <TextListItem className="text-muted" component={TextListItemVariants.dt}>
-        {t('Workload Profile')}
+        {t('Workload profile')}
       </TextListItem>
       <TextListItem component={TextListItemVariants.dd}>
         {getAnnotation(vm?.spec?.template, VM_WORKLOAD_ANNOTATION) || (


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2095125

Display missing operating system name in the _Clone VirtualMachine_ modal.
Also add little improvements in the related files, such as renaming 'Operating **S**ystem' to 'Operating system' and 'Workload **P**rofile' to 'Workload profile', and adding a missing returning value type `string` to `getOperatingSystemName` function.

## 🎥 Demo
**Before:**
No any OS name, in the _Clone VirtualMachine_ modal:
![os_before](https://user-images.githubusercontent.com/13417815/172868137-4d773e66-cd45-469b-ba3a-5d825ca10183.png)
**After:**
![os_after](https://user-images.githubusercontent.com/13417815/172868144-37ceb18f-2ba9-45ad-8cc1-917317f071fb.png)

