### PR TITLE
Bug 2093715: Display Optional parameters correctly

### DIFF
--- a/src/views/catalog/customize/components/ExpandableOptionalFields.tsx
+++ b/src/views/catalog/customize/components/ExpandableOptionalFields.tsx
@@ -6,6 +6,8 @@ import { ExpandableSection } from '@patternfly/react-core';
 
 import { FieldGroup } from './FieldGroup';
 
+import './ExpandableOptionsFields.scss';
+
 type ExpandableOptionsFieldsProps = {
   optionalFields: TemplateParameter[];
 };
@@ -26,7 +28,11 @@ export const ExpandableOptionsFields: React.FC<ExpandableOptionsFieldsProps> = (
         isIndented
       >
         {optionalFields?.map((field) => (
-          <FieldGroup key={field.name} field={field} />
+          <FieldGroup
+            key={field.name}
+            field={field}
+            className="expandable-section-content-margin-top"
+          />
         ))}
       </ExpandableSection>
     );

--- a/src/views/catalog/customize/components/ExpandableOptionsFields.scss
+++ b/src/views/catalog/customize/components/ExpandableOptionsFields.scss
@@ -1,0 +1,3 @@
+.expandable-section-content-margin-top {
+  margin-top: var(--pf-c-expandable-section__content--MarginTop);
+}

--- a/src/views/catalog/customize/components/FieldGroup.tsx
+++ b/src/views/catalog/customize/components/FieldGroup.tsx
@@ -8,9 +8,10 @@ import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
 type FieldGroupProps = {
   field: TemplateParameter;
   showError?: boolean;
+  className?: string;
 };
 
-export const FieldGroup: React.FC<FieldGroupProps> = ({ field, showError }) => {
+export const FieldGroup: React.FC<FieldGroupProps> = ({ field, showError, className }) => {
   const { t } = useKubevirtTranslation();
   const { name, description, displayName, required, value: initialValue } = field;
   const [value, setValue] = React.useState(initialValue || '');
@@ -28,6 +29,7 @@ export const FieldGroup: React.FC<FieldGroupProps> = ({ field, showError }) => {
       helperTextInvalid={t('This field is required')}
       helperTextInvalidIcon={<RedExclamationCircleIcon title="Error" />}
       validated={validated}
+      className={className}
     >
       <TextInput
         data-test-id={fieldId}


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2093715

Display the expandable section _Optional parameters_, when customizing VM, correctly - with the correct bottom margin that was missing (except the last parameter). Add the missing Patternfly `Form` React component to achieve the expected look.

## 🎥 Demo
**Before:**
![option_before](https://user-images.githubusercontent.com/13417815/172876627-baed64ab-4e35-4cf2-b35a-b76006a6d52f.png)
**After:**
![aafter](https://user-images.githubusercontent.com/13417815/173809561-67e0f220-b50b-4020-a683-df4fe939e83e.png)

