### PR TITLE
Bug 2095129: Display disk size units in Clone VM modal

### DIFF
--- a/src/utils/resources/vm/utils/disk/size.ts
+++ b/src/utils/resources/vm/utils/disk/size.ts
@@ -30,7 +30,7 @@ export const formatBytes = (rawSize: string, unit?: string): string => {
   }
   const size = hasNumber(rawSize);
   const sizeUnit = hasSizeUnit(rawSize) || unit;
-  const sizeUnits = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  const sizeUnits = ['', 'Ki', 'Mi', 'Gi', 'Ti'];
   let unitIndex = (sizeUnit && sizeUnits.findIndex((sUnit) => sUnit === sizeUnit)) || 0;
   let convertedSize = size;
   while (convertedSize >= 1024) {


### PR DESCRIPTION
## 📝 Description
**Fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=2095129

Display the units instead of 'undefined', in the _Clone VirtualMachine_ modal, for the _Disks_ field in the _Configuration_ section.

Related PR: https://github.com/kubevirt-ui/kubevirt-plugin/pull/558

## 🎥 Demo
**Before:**
![clone-before](https://user-images.githubusercontent.com/13417815/172914516-be635121-99c9-403f-ad8b-585d6d880482.png)
**After:**
![clone-after](https://user-images.githubusercontent.com/13417815/172914538-0f70dc6c-99ef-4288-938b-e9cd388ec917.png)

