### PR TITLE
Bug 2096333: Align releated opertors icon

### DIFF
--- a/src/views/clusteroverview/overview/components/getting-started-card/related-operators-section/RelatedOperatorsSection.tsx
+++ b/src/views/clusteroverview/overview/components/getting-started-card/related-operators-section/RelatedOperatorsSection.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
-import { recommendedOperatorIcon } from '../../../utils/svg/icons';
 import GettingStartedSectionContents from '../utils/getting-started-content/GettingStartedSectionContents';
 import useMTVResources from '../utils/hooks/useMTVResources';
 import { GettingStartedLink } from '../utils/types';
@@ -47,10 +46,11 @@ const RelatedOperatorsSection: React.FC = () => {
     <GettingStartedSectionContents
       id="related-operators"
       icon={
-        <img
+        <i
+          className="fas fa-cubes"
+          color="var(--pf-global--primary-color--100)"
+          aria-hidden="true"
           id="kv-getting-started--related-operators-icon"
-          src={recommendedOperatorIcon}
-          alt={t('Related operators')}
         />
       }
       title={t('Related operators')}


### PR DESCRIPTION
Signed-off-by: yzamir <yzamir@redhat.com>

Align related operators icon

## 🎥 Demo

Before:
![align-icon-before](https://user-images.githubusercontent.com/2181522/173520454-41416a61-3a64-4454-ad5a-ef2be01b2bb9.png)

After:
![align-icon](https://user-images.githubusercontent.com/2181522/173520455-ec2e816f-5ac7-49f6-ad02-e2c54a9e1677.png)

