### PR TITLE
Bug 2096620: Update boot source reference modal title

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -274,7 +274,6 @@
   "Edit Annotations": "Edit Annotations",
   "Edit boot source": "Edit boot source",
   "Edit boot source reference": "Edit boot source reference",
-  "Edit boot source to template": "Edit boot source to template",
   "Edit CPU | Memory": "Edit CPU | Memory",
   "Edit disk": "Edit disk",
   "Edit Display name": "Edit Display name",

--- a/src/views/templates/actions/components/EditBootSourceModal.tsx
+++ b/src/views/templates/actions/components/EditBootSourceModal.tsx
@@ -49,7 +49,7 @@ const EditBootSourceModal: React.FC<EditBootSourceModalProps> = ({
     <>
       <TabModal<K8sResourceCommon>
         obj={obj}
-        headerText={t('Edit boot source to template')}
+        headerText={t('Edit boot source reference')}
         onSubmit={onSubmit}
         isOpen={isOpen}
         onClose={onClose}
@@ -87,7 +87,6 @@ const EditBootSourceModal: React.FC<EditBootSourceModalProps> = ({
                 SOURCE_TYPES.pvcSource,
                 SOURCE_TYPES.registrySource,
                 SOURCE_TYPES.httpSource,
-                SOURCE_TYPES.uploadSource,
               ]}
               withSize
               initialVolumeQuantity={getTemplateStorageQuantity(obj)}


### PR DESCRIPTION
Signed-off-by: yzamir <yzamir@redhat.com>

## 📝 Description

Update boot source reference modal title

a. The action "Edit boot source reference" now opens a modal with the same name
b. Opening a new tab for upload is deprecated and should be replaced with inline upload, removed the deprecated options to upload using a different tab.

## 🎥 Demo

Before:
![boot-reference-modal-before](https://user-images.githubusercontent.com/2181522/173528502-284bd24f-84dc-4bbc-acc0-5135c68ce330.gif)

After:
![boot-reference-modal](https://user-images.githubusercontent.com/2181522/173528507-19f85d10-ec77-4929-a18b-4d7bb8c41495.gif)

