### PR TITLE
Bug 2096492: No ownerReference in template

### DIFF
--- a/src/views/templates/details/tabs/disks/TemplateDisksPage.tsx
+++ b/src/views/templates/details/tabs/disks/TemplateDisksPage.tsx
@@ -69,6 +69,7 @@ const TemplateDisksPage: React.FC<TemplateDisksPageProps> = ({ obj: template }) 
                 onClose={onClose}
                 onSubmit={onUpdate}
                 headerText={t('Add disk')}
+                createOwnerReference={false}
               />
             ))
           }

--- a/src/views/templates/details/tabs/disks/components/DiskRowActions.tsx
+++ b/src/views/templates/details/tabs/disks/components/DiskRowActions.tsx
@@ -82,6 +82,7 @@ const DiskRowActions: React.FC<DiskRowActionsProps> = ({ diskName, vm, onUpdate,
         onSubmit={onUpdate}
         initialDiskState={initialDiskState}
         initialDiskSourceState={initialDiskSourceState}
+        createOwnerReference={false}
       />
     ));
   };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

https://bugzilla.redhat.com/show_bug.cgi?id=2096492

Don't create ownerReference in dataVolumeTemplate when creating/editing VM template's disks.
VM template does not have uuid as the VM was not created yet. 


