### PR TITLE
Bug 2095573: Add label for env disk

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -293,6 +293,7 @@
   "Enter URL to download (for example: {{importUrl}})": "Enter URL to download (for example: {{importUrl}})",
   "Enter value": "Enter value",
   "Environment": "Environment",
+  "environment disk": "environment disk",
   "Error": "Error",
   "Error Loading Template: the server could not find the requested resource": "Error Loading Template: the server could not find the requested resource",
   "Ethernet name": "Ethernet name",

--- a/src/utils/resources/vm/utils/disk/constants.ts
+++ b/src/utils/resources/vm/utils/disk/constants.ts
@@ -22,6 +22,7 @@ export type DiskRowDataLayout = {
   metadata: { name: string };
   namespace?: string;
   isBootDisk: boolean;
+  isEnvDisk: boolean;
 };
 
 export const diskTypes = {

--- a/src/utils/resources/vm/utils/disk/rowData.ts
+++ b/src/utils/resources/vm/utils/disk/rowData.ts
@@ -42,6 +42,8 @@ export const getDiskRowDataLayout = (
       size: NO_DATA_DASH,
       storageClass: NO_DATA_DASH,
       isBootDisk: device?.disk?.name === bootDisk?.name,
+      isEnvDisk:
+        !!device?.volume?.configMap || !!device?.volume?.secret || !!device?.volume?.serviceAccount,
     };
 
     if (device?.pvc) {

--- a/src/views/catalog/wizard/tabs/disks/components/DiskRow.tsx
+++ b/src/views/catalog/wizard/tabs/disks/components/DiskRow.tsx
@@ -25,6 +25,13 @@ const DiskRow: React.FC<RowProps<DiskRowDataLayout>> = ({ obj, activeColumnIDs }
               </Label>
             </SplitItem>
           )}
+          {obj?.isEnvDisk && (
+            <SplitItem>
+              <Label variant="filled" color="blue">
+                {t('environment disk')}
+              </Label>
+            </SplitItem>
+          )}
         </Split>
       </TableData>
       <TableData id="source" activeColumnIDs={activeColumnIDs}>

--- a/src/views/catalog/wizard/tabs/disks/hooks/useWizardDisksTableData.ts
+++ b/src/views/catalog/wizard/tabs/disks/hooks/useWizardDisksTableData.ts
@@ -86,6 +86,10 @@ const useWizardDisksTableData: UseDisksTableDisks = (vm: V1VirtualMachine) => {
         metadata: { name: device?.disk?.name },
         namespace: device?.pvc?.metadata?.namespace,
         isBootDisk: device?.disk?.name === getBootDisk(vm)?.name,
+        isEnvDisk:
+          !!device?.volume?.configMap ||
+          !!device?.volume?.secret ||
+          !!device?.volume?.serviceAccount,
       };
     });
   }, [pvcs, t, vm, vmDataVolumeTemplates, vmDisks, vmVolumes]);

--- a/src/views/templates/details/tabs/disks/components/DiskRow.tsx
+++ b/src/views/templates/details/tabs/disks/components/DiskRow.tsx
@@ -38,6 +38,13 @@ const DiskRow: React.FC<RowProps<DiskRowDataLayout, AdditionalRowData>> = ({
                 </Label>
               </SplitItem>
             )}
+            {obj?.isEnvDisk && (
+              <SplitItem>
+                <Label variant="filled" color="blue">
+                  {t('environment disk')}
+                </Label>
+              </SplitItem>
+            )}
           </Split>
         </TemplateValue>
       </TableData>

--- a/src/views/templates/details/tabs/disks/hooks/useTemplateDisksTableData.ts
+++ b/src/views/templates/details/tabs/disks/hooks/useTemplateDisksTableData.ts
@@ -35,7 +35,7 @@ const useTemplateDisksTableData: UseDisksTableDisks = (template: V1Template) => 
     kind: PersistentVolumeClaimModel.kind,
     isList: true,
     namespaced: true,
-    namespace: vm?.metadata?.namespace,
+    namespace: template?.metadata?.namespace,
   });
 
   const disks = React.useMemo(() => {
@@ -87,6 +87,10 @@ const useTemplateDisksTableData: UseDisksTableDisks = (template: V1Template) => 
         metadata: { name: device?.disk?.name },
         namespace: device?.pvc?.metadata?.namespace,
         isBootDisk: device?.disk?.name === getBootDisk(vm)?.name,
+        isEnvDisk:
+          !!device?.volume?.configMap ||
+          !!device?.volume?.secret ||
+          !!device?.volume?.serviceAccount,
       };
     });
   }, [pvcs, t, vm, vmDataVolumeTemplates, vmDisks, vmVolumes]);

--- a/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
+++ b/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
@@ -8,7 +8,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 
 import VirtualMachineConsolePage from '../tabs/console/VirtualMachineConsolePage';
 import VirtualMachineDetailsPage from '../tabs/details/VirtualMachineDetailsPage';
-import DiskListPage from '../tabs/disk/tables/disk/DiskListPage';
+import DiskListPage from '../tabs/disk/DiskListPage';
 import VirtualMachineEnvironmentPage from '../tabs/environment/VirtualMachineEnvironmentPage';
 import VirtualMachinePageEventsTab from '../tabs/events/VirtualMachinePageEvents';
 import NetworkInterfaceListPage from '../tabs/network/NetworkInterfaceListPage';

--- a/src/views/virtualmachines/details/tabs/disk/DiskListPage.tsx
+++ b/src/views/virtualmachines/details/tabs/disk/DiskListPage.tsx
@@ -3,9 +3,8 @@ import { RouteComponentProps } from 'react-router';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
-import FilesystemList from '../filesystem/FilesystemList';
-
-import DiskList from './DiskList';
+import DiskList from './tables/disk/DiskList';
+import FilesystemList from './tables/filesystem/FilesystemList';
 
 type DiskListPageProps = RouteComponentProps<{
   ns: string;

--- a/src/views/virtualmachines/details/tabs/disk/tables/disk/DiskRow.tsx
+++ b/src/views/virtualmachines/details/tabs/disk/tables/disk/DiskRow.tsx
@@ -34,6 +34,13 @@ const DiskRow: React.FC<
               </Label>
             </SplitItem>
           )}
+          {obj?.isEnvDisk && (
+            <SplitItem>
+              <Label variant="filled" color="blue">
+                {t('environment disk')}
+              </Label>
+            </SplitItem>
+          )}
         </Split>
       </TableData>
 


### PR DESCRIPTION
## 📝 Description

Adding a label to identify environment disks to DiskRow component

## 🎥 Demo

### Before:
![env-disk-label-before](https://user-images.githubusercontent.com/67270715/173863348-fb3b76cc-bedd-4bfb-8b77-079f56b5978d.png)

### After:
![env-disk-label](https://user-images.githubusercontent.com/67270715/173862666-ff16f324-7d53-4795-8743-6e223b8fcc93.png)
![env-disk-label-wizard](https://user-images.githubusercontent.com/67270715/173862670-2780294e-00db-490a-b726-ebfaad9703e6.png)
![env-disk-label-template](https://user-images.githubusercontent.com/67270715/173863762-b1b10213-efec-48e9-9a4d-98c7c73e812d.png)


Signed-off-by: Aviv Turgeman <aturgema@redhat.com>