### PR TITLE
Bug 2096263: Display correct units for Disks size/Memory field

### DIFF
--- a/src/utils/components/CPUMemoryModal/CpuMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CpuMemoryModal.tsx
@@ -3,6 +3,7 @@ import produce from 'immer';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { toIECUnit } from '@kubevirt-utils/utils/units';
 import {
   Alert,
   Button,
@@ -170,19 +171,19 @@ const CPUMemoryModal: React.FC<CPUMemoryModalProps> = ({ vm, isOpen, onClose, on
           <Dropdown
             className="input-memory--dropdown"
             onSelect={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setMemoryUnit(e?.target?.innerText);
+              setMemoryUnit(e?.target?.value);
               setIsDropdownOpen(false);
             }}
             toggle={
               <DropdownToggle onToggle={(toggeld) => setIsDropdownOpen(toggeld)}>
-                {memoryUnit}
+                {toIECUnit(memoryUnit)}
               </DropdownToggle>
             }
             isOpen={isDropdownOpen}
             dropdownItems={memorySizesTypes.map((value) => {
               return (
-                <DropdownItem key={value} component="button">
-                  {value}
+                <DropdownItem key={value} value={value} component="button">
+                  {toIECUnit(value)}
                 </DropdownItem>
               );
             })}

--- a/src/utils/resources/vm/utils/disk/size.ts
+++ b/src/utils/resources/vm/utils/disk/size.ts
@@ -1,3 +1,5 @@
+import { toIECUnit } from '@kubevirt-utils/utils/units';
+
 /**
  * function that checks if rawSize has number
  * @param {string} rawSize raw size
@@ -38,6 +40,6 @@ export const formatBytes = (rawSize: string, unit?: string): string => {
     ++unitIndex;
   }
 
-  const formattedSize = convertedSize.toFixed(2).concat(' ', sizeUnits[unitIndex]);
+  const formattedSize = convertedSize.toFixed(2).concat(' ', toIECUnit(sizeUnits[unitIndex]));
   return formattedSize;
 };

--- a/src/utils/utils/units.ts
+++ b/src/utils/utils/units.ts
@@ -1,0 +1,31 @@
+enum BinaryUnit {
+  B = 'B',
+  Ki = 'Ki',
+  Mi = 'Mi',
+  Gi = 'Gi',
+  Ti = 'Ti',
+}
+
+/**
+ * A function to return unit for disk size/memory with 'B' suffix.
+ * @param {BinaryUnit | string} unit - unit
+ * @returns {string}
+ */
+export const toIECUnit = (unit: BinaryUnit | string): string =>
+  !unit || unit.endsWith('B') ? unit : `${unit}B`;
+
+/**
+ * A function to return the string for displaying more readable disk size/memory info
+ * @param {string} combinedStr - string containing both the value and the unit
+ * @returns {string} string for displaying the value and the unit with 'B' suffix, with the space between them
+ */
+export const readableSizeUnit = (combinedStr: string): string => {
+  const combinedString = combinedStr?.replace(/\s/g, ''); // remove empty spaces if there are any, to split the value and unit correctly
+  const index = combinedString?.search(/([a-zA-Z]+)/g);
+  const [value, unit] =
+    index === -1
+      ? [combinedString, '']
+      : [combinedString?.slice(0, index), combinedString?.slice(index)];
+
+  return `${value} ${toIECUnit(unit)}`;
+};

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
@@ -19,6 +19,7 @@ import {
   isDefaultVariantTemplate,
 } from '@kubevirt-utils/resources/template/utils/selectors';
 import { getGPUDevices, getHostDevices } from '@kubevirt-utils/resources/vm';
+import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import {
   Button,
   DescriptionList,
@@ -136,7 +137,10 @@ export const TemplatesCatalogDrawerPanel: React.FC<TemplatesCatalogDrawerPanelPr
                       <DescriptionListGroup>
                         <DescriptionListTerm>{t('CPU | Memory')}</DescriptionListTerm>
                         <DescriptionListDescription>
-                          {t('{{cpuCount}} CPU | {{memory}} Memory', { cpuCount, memory })}
+                          {t('{{cpuCount}} CPU | {{memory}} Memory', {
+                            cpuCount,
+                            memory: readableSizeUnit(memory),
+                          })}
                         </DescriptionListDescription>
                       </DescriptionListGroup>
                       <DescriptionListGroup>

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogRow.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogRow.tsx
@@ -11,6 +11,7 @@ import {
 } from '@kubevirt-utils/resources/template';
 import { getTemplateBootSourceType } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { getVMBootSourceLabel } from '@kubevirt-utils/resources/vm/utils/source';
+import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 import { Button } from '@patternfly/react-core';
 
@@ -60,7 +61,7 @@ export const TemplatesCatalogRow: React.FC<
           />
         </TableData>
         <TableData id="cpu" activeColumnIDs={activeColumnIDs} className="pf-m-width-30">
-          {t('CPU')} {cpuCount} | {t('Memory')} {memory}
+          {t('CPU')} {cpuCount} | {t('Memory')} {readableSizeUnit(memory)}
         </TableData>
       </>
     );

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogTile.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogTile.tsx
@@ -10,6 +10,7 @@ import {
   getTemplateWorkload,
 } from '@kubevirt-utils/resources/template/utils/selectors';
 import { getVMBootSourceLabel } from '@kubevirt-utils/resources/vm/utils/source';
+import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { CatalogTile } from '@patternfly/react-catalog-view-extension';
 import { Badge, Skeleton, Stack, StackItem } from '@patternfly/react-core';
 
@@ -80,7 +81,7 @@ export const TemplateTile: React.FC<TemplateTileProps> = React.memo(
                 <b>{t('Workload')}</b> {WORKLOADS_LABELS?.[workload] ?? t('Other')}
               </StackItem>
               <StackItem>
-                <b>{t('CPU')}</b> {cpuCount} | <b>{t('Memory')}</b> {memory}
+                <b>{t('CPU')}</b> {cpuCount} | <b>{t('Memory')}</b> {readableSizeUnit(memory)}
               </StackItem>
             </Stack>
           </StackItem>

--- a/src/views/catalog/wizard/tabs/disks/components/DiskRow.tsx
+++ b/src/views/catalog/wizard/tabs/disks/components/DiskRow.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { PersistentVolumeClaimModel } from '@kubevirt-utils/models';
 import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
+import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 import { Label, Split, SplitItem } from '@patternfly/react-core';
 
@@ -35,7 +36,7 @@ const DiskRow: React.FC<RowProps<DiskRowDataLayout>> = ({ obj, activeColumnIDs }
         )}
       </TableData>
       <TableData id="size" activeColumnIDs={activeColumnIDs}>
-        {obj?.size}
+        {readableSizeUnit(obj?.size)}
       </TableData>
       <TableData id="drive" activeColumnIDs={activeColumnIDs}>
         {obj?.drive}

--- a/src/views/catalog/wizard/tabs/overview/WizardOverviewTab.tsx
+++ b/src/views/catalog/wizard/tabs/overview/WizardOverviewTab.tsx
@@ -12,6 +12,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { getAnnotation } from '@kubevirt-utils/resources/shared';
 import { getVmCPUMemory, WORKLOADS_LABELS } from '@kubevirt-utils/resources/template';
 import { getGPUDevices, getHostDevices } from '@kubevirt-utils/resources/vm';
+import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { DescriptionList, Grid, GridItem } from '@patternfly/react-core';
 
 import { WizardDescriptionItem } from '../../components/WizardDescriptionItem';
@@ -27,7 +28,7 @@ const WizardOverviewTab: WizardTab = ({ vm, tabsData, updateVM }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
 
-  const flavor = getVmCPUMemory(vm);
+  const { cpuCount, memory } = getVmCPUMemory(vm);
   const description = getAnnotation(vm, 'description');
   const workloadAnnotation = vm?.spec?.template?.metadata?.annotations?.['vm.kubevirt.io/workload'];
   const networks = vm?.spec?.template?.spec?.networks;
@@ -108,7 +109,7 @@ const WizardOverviewTab: WizardTab = ({ vm, tabsData, updateVM }) => {
               }
               description={
                 <>
-                  {t('CPU')} {flavor?.cpuCount} | {t('Memory')} {flavor?.memory}
+                  {t('CPU')} {cpuCount} | {t('Memory')} {readableSizeUnit(memory)}
                 </>
               }
             />

--- a/src/views/catalog/wizard/tabs/overview/components/WizardOverviewDisksTable/WizardOverviewDisksTable.tsx
+++ b/src/views/catalog/wizard/tabs/overview/components/WizardOverviewDisksTable/WizardOverviewDisksTable.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import useWizardDisksTableData from '@catalog/wizard/tabs/disks/hooks/useWizardDisksTableData';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import {
   DescriptionList,
   DescriptionListDescription,
@@ -46,7 +47,7 @@ export const WizardOverviewDisksTable: React.FC<{
         <DescriptionListDescription>
           <Stack>
             {disks.map((disk) => (
-              <StackItem key={disk.name}>{disk.size}</StackItem>
+              <StackItem key={disk.name}>{readableSizeUnit(disk.size)}</StackItem>
             ))}
           </Stack>
         </DescriptionListDescription>

--- a/src/views/templates/details/tabs/details/components/CPUMemoryModal.tsx
+++ b/src/views/templates/details/tabs/details/components/CPUMemoryModal.tsx
@@ -10,6 +10,7 @@ import {
 } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
+import { toIECUnit } from '@kubevirt-utils/utils/units';
 import {
   Alert,
   Button,
@@ -142,21 +143,22 @@ const CPUMemoryModal: React.FC<CPUMemoryModalProps> = ({ template, isOpen, onClo
           />
 
           <Dropdown
+            selected
             className="input-memory--dropdown"
             onSelect={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setMemoryUnit(e?.target?.innerText);
+              setMemoryUnit(e?.target?.value);
               setIsDropdownOpen(false);
             }}
             toggle={
               <DropdownToggle onToggle={(toggeld) => setIsDropdownOpen(toggeld)}>
-                {memoryUnit}
+                {toIECUnit(memoryUnit)}
               </DropdownToggle>
             }
             isOpen={isDropdownOpen}
             dropdownItems={memorySizesTypes.map((value) => {
               return (
-                <DropdownItem key={value} component="button">
-                  {value}
+                <DropdownItem key={value} value={value} component="button">
+                  {toIECUnit(value)}
                 </DropdownItem>
               );
             })}

--- a/src/views/templates/details/tabs/disks/components/DiskRow.tsx
+++ b/src/views/templates/details/tabs/disks/components/DiskRow.tsx
@@ -5,6 +5,7 @@ import TemplateValue from '@kubevirt-utils/components/TemplateValue/TemplateValu
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { PersistentVolumeClaimModel } from '@kubevirt-utils/models';
 import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
+import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 import { Label, Split, SplitItem } from '@patternfly/react-core';
 
@@ -25,6 +26,7 @@ const DiskRow: React.FC<RowProps<DiskRowDataLayout, AdditionalRowData>> = ({
   const isPVCSource = !['URL', 'PVC (auto upload)', 'Container (Ephemeral)', 'Other'].includes(
     obj?.source,
   );
+
   return (
     <>
       <TableData id="name" activeColumnIDs={activeColumnIDs}>
@@ -49,7 +51,7 @@ const DiskRow: React.FC<RowProps<DiskRowDataLayout, AdditionalRowData>> = ({
         )}
       </TableData>
       <TableData id="size" activeColumnIDs={activeColumnIDs}>
-        <TemplateValue value={obj?.size} />
+        <TemplateValue value={readableSizeUnit(obj?.size)} />
       </TableData>
       <TableData id="drive" activeColumnIDs={activeColumnIDs}>
         <TemplateValue value={obj?.drive} />

--- a/src/views/templates/list/hooks/useVirtualMachineTemplatesCPUMemory.tsx
+++ b/src/views/templates/list/hooks/useVirtualMachineTemplatesCPUMemory.tsx
@@ -3,40 +3,10 @@ import * as React from 'react';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { V1Template } from '@kubevirt-utils/models';
 import { getFlavorData, getTemplateVirtualMachineCPU } from '@kubevirt-utils/resources/template';
+import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { isTemplateParameter } from '@kubevirt-utils/utils/utils';
 import { Popover, PopoverPosition } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
-
-enum BinaryUnit {
-  B = 'B',
-  Ki = 'Ki',
-  Mi = 'Mi',
-  Gi = 'Gi',
-  Ti = 'Ti',
-}
-
-const toIECUnit = (unit: BinaryUnit | string): string => {
-  if (!unit || unit.endsWith('B')) {
-    return unit;
-  }
-
-  return `${unit}B`;
-};
-
-const stringValueUnitSplit = (combinedVal: string): [value: string, unit: string] => {
-  const index = combinedVal?.search(/([a-zA-Z]+)/g);
-  let value = '';
-  let unit = '';
-
-  if (index === -1) {
-    value = combinedVal;
-  } else {
-    value = combinedVal?.slice(0, index);
-    unit = combinedVal?.slice(index);
-  }
-
-  return [value, toIECUnit(unit)];
-};
 
 export const useVirtualMachineTemplatesCPUMemory = (
   template: V1Template,
@@ -73,7 +43,6 @@ export const useVirtualMachineTemplatesCPUMemory = (
       </>
     );
   } else {
-    const [value, readableUnit] = stringValueUnitSplit(memory);
-    return `CPU ${cpu?.cores} | ${t('Memory')} ${value} ${readableUnit}`;
+    return `CPU ${cpu?.cores} | ${t('Memory')} ${readableSizeUnit(memory)}`;
   }
 };

--- a/src/views/virtualmachines/details/tabs/details/components/CPUMemory/CPUMemory.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/CPUMemory/CPUMemory.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getCPUCount } from '@kubevirt-utils/resources/vmi';
+import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 
 type CPUMemoryProps = {
   vm: V1VirtualMachine;
@@ -13,9 +14,9 @@ const CPUMemory: React.FC<CPUMemoryProps> = ({ vm }) => {
 
   const cpu = getCPUCount(vm?.spec?.template?.spec?.domain?.cpu);
 
-  const memory = (
-    vm?.spec?.template?.spec?.domain?.resources?.requests as { [key: string]: string }
-  )?.memory;
+  const memory = readableSizeUnit(
+    (vm?.spec?.template?.spec?.domain?.resources?.requests as { [key: string]: string })?.memory,
+  );
 
   return (
     <span data-test-id="virtual-machine-overview-details-cpu-memory">

--- a/src/views/virtualmachines/details/tabs/disk/tables/disk/DiskRow.tsx
+++ b/src/views/virtualmachines/details/tabs/disk/tables/disk/DiskRow.tsx
@@ -8,6 +8,7 @@ import {
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { PersistentVolumeClaimModel } from '@kubevirt-utils/models';
 import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
+import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 import { Label, Split, SplitItem } from '@patternfly/react-core';
 
@@ -45,7 +46,7 @@ const DiskRow: React.FC<
         )}
       </TableData>
       <TableData id="size" activeColumnIDs={activeColumnIDs}>
-        {obj?.size}
+        {readableSizeUnit(obj?.size)}
       </TableData>
       <TableData id="drive" activeColumnIDs={activeColumnIDs}>
         {obj?.drive}

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDisks/VirtualMachinesOverviewTabDisksRow.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDisks/VirtualMachinesOverviewTabDisksRow.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
+import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { TableData } from '@openshift-console/dynamic-plugin-sdk';
 
 const VirtualMachinesOverviewTabDisksRow = ({ obj, activeColumnIDs }) => {
@@ -13,7 +14,7 @@ const VirtualMachinesOverviewTabDisksRow = ({ obj, activeColumnIDs }) => {
         <div data-test-id={`disk-${obj?.drive}`}>{obj?.drive || NO_DATA_DASH}</div>
       </TableData>
       <TableData id="size" activeColumnIDs={activeColumnIDs}>
-        <div data-test-id={`disk-${obj?.size}`}>{obj?.size || NO_DATA_DASH}</div>
+        <div data-test-id={`disk-${obj?.size}`}>{readableSizeUnit(obj?.size) || NO_DATA_DASH}</div>
       </TableData>
     </>
   );


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2096263

Display the units for _Disks_ size/_Memory_ fields in various places across the UI correctly - by adding 'B' suffix to the unit and space between the numeric value and the unit. Display _Mi**B**/Gi**B**/Ti**B**_ units instead of _Mi/Gi/Ti_, and so improve the readability of this info in the UI.

## 🎥 Demo
**Before:** Example of a place with the problematic format of the units displayed in the table:
![bytes_before](https://user-images.githubusercontent.com/13417815/173907320-7fe92a7c-b394-4d60-a4e6-2c09336b553a.png)
**After:**
![bytes_after](https://user-images.githubusercontent.com/13417815/173907337-f116e218-4fda-4957-a6d2-58bf8a4d5d7c.png)


