### PR TITLE
Bug 2097370: Display titles in Optional parameters accordion in wizard customization page

### DIFF
--- a/src/views/catalog/customize/components/FieldGroup.tsx
+++ b/src/views/catalog/customize/components/FieldGroup.tsx
@@ -22,7 +22,7 @@ export const FieldGroup: React.FC<FieldGroupProps> = ({ field, showError, classN
 
   return (
     <FormGroup
-      label={displayName}
+      label={displayName || name}
       fieldId={fieldId}
       isRequired={required}
       helperText={description}


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2097370

Display missing titles for optional parameters in wizard customization page.

## 🎥 Demo
**Before:**
![param_before](https://user-images.githubusercontent.com/13417815/173922007-ed91403b-f4ef-4d09-abc1-bcf5169ede26.png)
**After:**
![param_after](https://user-images.githubusercontent.com/13417815/173922019-0be7b25b-d151-4fd3-91cf-b3a150fdb208.png)


