### PR TITLE
Bug 2097586: AccessMode should stay on ReadWriteOnce

### DIFF
--- a/src/views/catalog/wizard/tabs/disks/hooks/useEditDiskState.ts
+++ b/src/views/catalog/wizard/tabs/disks/hooks/useEditDiskState.ts
@@ -64,7 +64,7 @@ export const useEditDiskStates: UseEditDiskStates = (vm, diskName) => {
   const initialDiskSourceState = React.useMemo(() => ({ ...initialStateDiskSource }), []);
   const disk = getDisks(vm)?.find(({ name }) => name === diskName);
 
-  const { diskSource, diskSize, isBootDisk } = React.useMemo(() => {
+  const { diskSource, diskSize, isBootDisk, accessMode, volumeMode } = React.useMemo(() => {
     const dataVolumeTemplates = getDataVolumeTemplates(vm);
 
     const volumes = getVolumes(vm);
@@ -107,6 +107,8 @@ export const useEditDiskStates: UseEditDiskStates = (vm, diskName) => {
           dataVolumeTemplate.spec?.storage?.resources?.requests?.storage ||
           dataVolumeTemplate.spec?.pvc?.resources?.requests?.storage ||
           '',
+        accessMode: dataVolumeTemplate?.spec?.storage?.accessModes?.[0],
+        volumeMode: dataVolumeTemplate?.spec?.storage?.volumeMode,
       };
     }
 
@@ -120,8 +122,8 @@ export const useEditDiskStates: UseEditDiskStates = (vm, diskName) => {
     diskSource,
     enablePreallocation: false,
     storageClass: null,
-    volumeMode: null,
-    accessMode: null,
+    volumeMode,
+    accessMode,
     diskInterface: getDiskInterface(disk),
     applyStorageProfileSettings: false,
     storageClassProvisioner: null,

--- a/src/views/templates/details/tabs/disks/hooks/useEditDiskState.ts
+++ b/src/views/templates/details/tabs/disks/hooks/useEditDiskState.ts
@@ -64,7 +64,7 @@ export const useEditDiskStates: UseEditDiskStates = (vm, diskName) => {
   const initialDiskSourceState = React.useMemo(() => ({ ...initialStateDiskSource }), []);
   const disk = getDisks(vm)?.find(({ name }) => name === diskName);
 
-  const { diskSource, diskSize, isBootDisk } = React.useMemo(() => {
+  const { diskSource, diskSize, isBootDisk, accessMode, volumeMode } = React.useMemo(() => {
     const dataVolumeTemplates = getDataVolumeTemplates(vm);
 
     const volumes = getVolumes(vm);
@@ -106,6 +106,8 @@ export const useEditDiskStates: UseEditDiskStates = (vm, diskName) => {
         diskSize:
           dataVolumeTemplate.spec?.storage?.resources?.requests?.storage ||
           dataVolumeTemplate.spec?.pvc?.resources?.requests?.storage,
+        accessMode: dataVolumeTemplate?.spec?.storage?.accessModes?.[0],
+        volumeMode: dataVolumeTemplate?.spec?.storage?.volumeMode,
       };
     }
 
@@ -119,8 +121,8 @@ export const useEditDiskStates: UseEditDiskStates = (vm, diskName) => {
     diskSource,
     enablePreallocation: false,
     storageClass: null,
-    volumeMode: null,
-    accessMode: null,
+    volumeMode,
+    accessMode,
     diskInterface: getDiskInterface(disk),
     applyStorageProfileSettings: false,
     storageClassProvisioner: null,


### PR DESCRIPTION
## 📝 Description

editing a data volume disk is not giving the data volume's initial data for access mode and volume mode

## 🎥 Demo

### before:

https://user-images.githubusercontent.com/67270715/174075749-a7443b7b-06cf-40ae-bfe1-4813f5ff5470.mp4

### after:

https://user-images.githubusercontent.com/67270715/174075783-8a1d304f-4f7d-41b2-8b46-5bb1b0978f47.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
