### PR TITLE
Bug 2092783: Hide the top consumers card for non-admins

### DIFF
--- a/src/views/clusteroverview/overview/components/top-consumers-card/TopConsumersCard.tsx
+++ b/src/views/clusteroverview/overview/components/top-consumers-card/TopConsumersCard.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { TFunction } from 'i18next';
 
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Card,
@@ -41,6 +42,7 @@ const topAmountSelectOptions = (t: TFunction) => [
 
 const TopConsumersCard: React.FC = () => {
   const { t } = useKubevirtTranslation();
+  const isAdmin = useIsAdmin();
   const [numItemsToShow, setNumItemsToShow] = React.useState<string>('Show top 5');
   const numItemsOptionSelected = React.useMemo(
     () => (numItemsToShow === 'Show top 5' ? 5 : 10),
@@ -50,41 +52,43 @@ const TopConsumersCard: React.FC = () => {
   const onTopAmountSelect = (value) => setNumItemsToShow(value);
 
   return (
-    <div className="kv-top-consumers-card">
-      <Card data-test="kv-top-consumers-card">
-        <CardHeader className="kv-top-consumers-card__header">
-          <CardTitle>{t('Top consumers')} </CardTitle>
-          <CardActions className="co-overview-card__actions">
-            <Link to="/monitoring/dashboards/grafana-dashboard-kubevirt-top-consumers?period=4h">
-              {t('View virtualization dashboard')}
-            </Link>
-            <div className="kv-top-consumers-card__dropdown">
-              <FormPFSelect
-                toggleId="kv-top-consumers-card-amount-select"
-                variant={SelectVariant.single}
-                selections={numItemsToShow}
-                onSelect={(e, value) => onTopAmountSelect(value)}
-              >
-                {topAmountSelectOptions(t).map((opt) => (
-                  <SelectOption key={opt.key} value={opt.value} />
-                ))}
-              </FormPFSelect>
-            </div>
-          </CardActions>
-        </CardHeader>
-        <CardBody className="kv-top-consumers-card__body">
-          <TopConsumersGridRow
-            topGrid
-            numItemsToShow={numItemsOptionSelected}
-            initialMetrics={initialMetrics.slice(0, 3)}
-          />
-          <TopConsumersGridRow
-            numItemsToShow={numItemsOptionSelected}
-            initialMetrics={initialMetrics.slice(3)}
-          />
-        </CardBody>
-      </Card>
-    </div>
+    isAdmin && (
+      <div className="kv-top-consumers-card">
+        <Card data-test="kv-top-consumers-card">
+          <CardHeader className="kv-top-consumers-card__header">
+            <CardTitle>{t('Top consumers')} </CardTitle>
+            <CardActions className="co-overview-card__actions">
+              <Link to="/monitoring/dashboards/grafana-dashboard-kubevirt-top-consumers?period=4h">
+                {t('View virtualization dashboard')}
+              </Link>
+              <div className="kv-top-consumers-card__dropdown">
+                <FormPFSelect
+                  toggleId="kv-top-consumers-card-amount-select"
+                  variant={SelectVariant.single}
+                  selections={numItemsToShow}
+                  onSelect={(e, value) => onTopAmountSelect(value)}
+                >
+                  {topAmountSelectOptions(t).map((opt) => (
+                    <SelectOption key={opt.key} value={opt.value} />
+                  ))}
+                </FormPFSelect>
+              </div>
+            </CardActions>
+          </CardHeader>
+          <CardBody className="kv-top-consumers-card__body">
+            <TopConsumersGridRow
+              topGrid
+              numItemsToShow={numItemsOptionSelected}
+              initialMetrics={initialMetrics.slice(0, 3)}
+            />
+            <TopConsumersGridRow
+              numItemsToShow={numItemsOptionSelected}
+              initialMetrics={initialMetrics.slice(3)}
+            />
+          </CardBody>
+        </Card>
+      </div>
+    )
   );
 };
 


### PR DESCRIPTION
This PR hides the top consumers card in the cluster overview page for non-admins.

## Screenshots:

### Admin:
![Selection_109](https://user-images.githubusercontent.com/8544299/174097710-95f9a0a7-5fa3-449b-b62e-d4dd71a8506c.png)

### Non-admin:
![Selection_110](https://user-images.githubusercontent.com/8544299/174097740-f3fb5ad5-8ea3-4276-ab8c-e89cfcda90e8.png)

