### PR TITLE
Bug 2092781: Hide the details card for non-admins

### DIFF
--- a/src/views/clusteroverview/overview/components/details-card/DetailsCard.tsx
+++ b/src/views/clusteroverview/overview/components/details-card/DetailsCard.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { DetailsBody } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { OverviewDetailItem } from '@openshift-console/plugin-shared';
@@ -11,6 +12,7 @@ import SubscriptionStatus from './SourceMissingStatus/SubscriptionStatus';
 
 const DetailsCard: React.FC = () => {
   const { t } = useKubevirtTranslation();
+  const isAdmin = useIsAdmin();
   const kvCsvDetails = useKubevirtCSVDetails();
   const {
     name,
@@ -25,34 +27,36 @@ const DetailsCard: React.FC = () => {
   const isLoading = !loaded && !loadError && !kubevirtSub;
 
   return (
-    <Card data-test-id="kubevirt-overview-dashboard--details-card">
-      <CardHeader>
-        <CardTitle>{t('Details')}</CardTitle>
-      </CardHeader>
-      <CardBody>
-        <DetailsBody>
-          <OverviewDetailItem isLoading={isLoading} title={t('Service name')}>
-            {name}
-          </OverviewDetailItem>
-          <OverviewDetailItem isLoading={isLoading} title={t('Provider')}>
-            {provider}
-          </OverviewDetailItem>
-          <OverviewDetailItem isLoading={isLoading} title={t('OpenShift Virtualization version')}>
-            {version}
-            <div>
-              {catalogSourceMissing ? (
-                <SourceMissingStatus />
-              ) : (
-                <SubscriptionStatus subscription={kubevirtSub} />
-              )}
-            </div>
-          </OverviewDetailItem>
-          <OverviewDetailItem isLoading={isLoading} title={t('Update Channel')}>
-            {updateChannel}
-          </OverviewDetailItem>
-        </DetailsBody>
-      </CardBody>
-    </Card>
+    isAdmin && (
+      <Card data-test-id="kubevirt-overview-dashboard--details-card">
+        <CardHeader>
+          <CardTitle>{t('Details')}</CardTitle>
+        </CardHeader>
+        <CardBody>
+          <DetailsBody>
+            <OverviewDetailItem isLoading={isLoading} title={t('Service name')}>
+              {name}
+            </OverviewDetailItem>
+            <OverviewDetailItem isLoading={isLoading} title={t('Provider')}>
+              {provider}
+            </OverviewDetailItem>
+            <OverviewDetailItem isLoading={isLoading} title={t('OpenShift Virtualization version')}>
+              {version}
+              <div>
+                {catalogSourceMissing ? (
+                  <SourceMissingStatus />
+                ) : (
+                  <SubscriptionStatus subscription={kubevirtSub} />
+                )}
+              </div>
+            </OverviewDetailItem>
+            <OverviewDetailItem isLoading={isLoading} title={t('Update Channel')}>
+              {updateChannel}
+            </OverviewDetailItem>
+          </DetailsBody>
+        </CardBody>
+      </Card>
+    )
   );
 };
 


### PR DESCRIPTION
This PR hides the details card in the cluster overview page for non-admins.

## Screenshots:

### Admin:
![Selection_112](https://user-images.githubusercontent.com/8544299/174099363-bfa2a823-7ed6-4945-8ef6-4717b5ec938c.png)

### Non-admin:
![Selection_111](https://user-images.githubusercontent.com/8544299/174099383-4f370b3e-1257-4e9d-9489-4cf002adf9e9.png)


