### PR TITLE
Bug 2094848: Add view details link to details card

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -750,6 +750,7 @@
   "view {{qualifiedNodesCount}} matching nodes": "view {{qualifiedNodesCount}} matching nodes",
   "View Alert": "View Alert",
   "View all quick starts": "View all quick starts",
+  "View details": "View details",
   "View documentation": "View documentation",
   "View events": "View events",
   "View matching {{matchingNodeText}}": "View matching {{matchingNodeText}}",

--- a/src/views/clusteroverview/overview/components/details-card/DetailsCard.tsx
+++ b/src/views/clusteroverview/overview/components/details-card/DetailsCard.tsx
@@ -1,14 +1,16 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { DetailsBody } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { OverviewDetailItem } from '@openshift-console/plugin-shared';
-import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import { Card, CardActions, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 
 import { useKubevirtCSVDetails } from './hooks/useKubevirtCSVDetails';
 import SourceMissingStatus from './SourceMissingStatus/SourceMissingStatus';
 import SubscriptionStatus from './SourceMissingStatus/SubscriptionStatus';
+import { OPENSHIFT_VIRT_PATH } from './utils/constants';
 
 const DetailsCard: React.FC = () => {
   const { t } = useKubevirtTranslation();
@@ -31,6 +33,9 @@ const DetailsCard: React.FC = () => {
       <Card data-test-id="kubevirt-overview-dashboard--details-card">
         <CardHeader>
           <CardTitle>{t('Details')}</CardTitle>
+          <CardActions className="co-overview-card__actions">
+            <Link to={OPENSHIFT_VIRT_PATH}>{t('View details')}</Link>
+          </CardActions>
         </CardHeader>
         <CardBody>
           <DetailsBody>

--- a/src/views/clusteroverview/overview/components/details-card/utils/constants.ts
+++ b/src/views/clusteroverview/overview/components/details-card/utils/constants.ts
@@ -1,0 +1,2 @@
+export const OPENSHIFT_VIRT_PATH =
+  'k8s/ns/openshift-cnv/operators.coreos.com~v1alpha1~ClusterServiceVersion/kubevirt-hyperconverged-operator.v4.11.0';


### PR DESCRIPTION
This PR adds the `View details` link to the details card on the cluster overview page. The link leads to the page for the operator.

### Screenshot

![Selection_113](https://user-images.githubusercontent.com/8544299/174107989-ef4956fd-7f32-4e14-a78a-bebe6bf58662.png)

