### PR TITLE
Bug 2098135: Template replace workload label

### DIFF
--- a/src/utils/resources/template/utils/constants.ts
+++ b/src/utils/resources/template/utils/constants.ts
@@ -40,6 +40,9 @@ export enum WORKLOADS {
   highperformance = 'highperformance',
 }
 
+// t('Desktop')
+// t('Server')
+// t('High performance')
 export const WORKLOADS_LABELS = {
   [WORKLOADS.desktop]: 'Desktop',
   [WORKLOADS.server]: 'Server',

--- a/src/views/templates/details/tabs/details/components/WorkloadProfile.tsx
+++ b/src/views/templates/details/tabs/details/components/WorkloadProfile.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
-import { WorkloadProfileKeys } from 'src/views/templates/utils/constants';
 import { getWorkloadProfile } from 'src/views/templates/utils/selectors';
 
 import { TemplateModel } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import {
+  getTemplateWorkload,
+  TEMPLATE_WORKLOAD_LABEL,
+  WORKLOADS,
+} from '@kubevirt-utils/resources/template';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
@@ -24,7 +28,7 @@ const WorkloadProfile: React.FC<TemplateDetailsGridProps> = ({ template, editabl
   const { t } = useKubevirtTranslation();
   const workload = getWorkloadProfile(template);
 
-  const updateWorkload = (updatedWorkload: WorkloadProfileKeys) => {
+  const updateWorkload = (updatedWorkload: WORKLOADS) => {
     const vmObjectIndex = template?.objects.findIndex(
       (obj) => obj.kind === VirtualMachineModel.kind,
     );
@@ -42,6 +46,15 @@ const WorkloadProfile: React.FC<TemplateDetailsGridProps> = ({ template, editabl
           op: hasWorkload ? 'replace' : 'add',
           path: workloadPath,
           value: updatedWorkload,
+        },
+        {
+          op: 'remove',
+          path: `/metadata/labels/${TEMPLATE_WORKLOAD_LABEL}~1${getTemplateWorkload(template)}`,
+        },
+        {
+          op: 'add',
+          path: `/metadata/labels/${TEMPLATE_WORKLOAD_LABEL}~1${updatedWorkload}`,
+          value: 'true',
         },
       ],
     });

--- a/src/views/templates/details/tabs/details/components/WorkloadProfileModal.tsx
+++ b/src/views/templates/details/tabs/details/components/WorkloadProfileModal.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { WorkloadProfileKeys, workloadProfiles } from 'src/views/templates/utils/constants';
 import { getTemplateWorkload } from 'src/views/templates/utils/selectors';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { WORKLOADS, WORKLOADS_LABELS } from '@kubevirt-utils/resources/template';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { Form, FormGroup, Select, SelectOption } from '@patternfly/react-core';
 
@@ -14,21 +14,18 @@ type WorkloadProfileModalProps = {
   obj: V1Template;
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (workload: WorkloadProfileKeys) => Promise<void | K8sResourceCommon>;
+  onSubmit: (workload: WORKLOADS) => Promise<void | K8sResourceCommon>;
 };
 
 const WorkloadProfileModal: React.FC<WorkloadProfileModalProps> = React.memo(
   ({ obj, isOpen, onClose, onSubmit }) => {
     const { t } = useKubevirtTranslation();
     const [isDropdownOpen, setIsDropdownOpen] = React.useState<boolean>(false);
-    const [workload, setWorkload] = React.useState<WorkloadProfileKeys>(
-      getTemplateWorkload(obj) || 'desktop',
+    const [workload, setWorkload] = React.useState<WORKLOADS>(
+      getTemplateWorkload(obj) || WORKLOADS.desktop,
     );
 
-    const handleChange = (
-      event: React.ChangeEvent<HTMLSelectElement>,
-      value: WorkloadProfileKeys,
-    ) => {
+    const handleChange = (event: React.ChangeEvent<HTMLSelectElement>, value: WORKLOADS) => {
       event.preventDefault();
       setWorkload(value);
       setIsDropdownOpen(false);
@@ -51,7 +48,7 @@ const WorkloadProfileModal: React.FC<WorkloadProfileModalProps> = React.memo(
               onSelect={handleChange}
               selections={workload}
             >
-              {Object.entries(workloadProfiles).map(([key, value]) => (
+              {Object.entries(WORKLOADS_LABELS).map(([key, value]) => (
                 <SelectOption key={key} value={key}>
                   {t(value)}
                 </SelectOption>

--- a/src/views/templates/utils/constants.ts
+++ b/src/views/templates/utils/constants.ts
@@ -27,15 +27,3 @@ export type SOURCE_OPTIONS_IDS =
   | typeof SOURCE_TYPES.uploadSource;
 
 export const SUPPORT_URL = 'https://access.redhat.com/articles/4234591';
-
-// t('Desktop')
-// t('Server')
-// t('High performance')
-
-export const workloadProfiles = {
-  desktop: 'Desktop',
-  server: 'Server',
-  highperformance: 'High performance',
-};
-
-export type WorkloadProfileKeys = 'desktop' | 'server' | 'highperformance';

--- a/src/views/templates/utils/selectors.ts
+++ b/src/views/templates/utils/selectors.ts
@@ -1,9 +1,10 @@
 import { V1Template } from '@kubevirt-utils/models';
 import { getAnnotation } from '@kubevirt-utils/resources/shared';
 import { getLabel } from '@kubevirt-utils/resources/shared';
+import { WORKLOADS, WORKLOADS_LABELS } from '@kubevirt-utils/resources/template';
 import { VM_WORKLOAD_ANNOTATION } from '@kubevirt-utils/resources/vm/utils';
 
-import { ANNOTATIONS, LABELS, WorkloadProfileKeys, workloadProfiles } from './constants';
+import { ANNOTATIONS, LABELS } from './constants';
 
 export const getAffinity = (template: V1Template) =>
   template?.objects[0]?.spec?.template?.spec?.affinity || {};
@@ -18,16 +19,15 @@ export const getTemplateProviderName = (template: V1Template): string =>
   getAnnotation(template, ANNOTATIONS.providerName, null) ||
   getAnnotation(template, ANNOTATIONS.providerDisplayName, null);
 
-export const getTemplateWorkload = (template: V1Template): WorkloadProfileKeys =>
+export const getTemplateWorkload = (template: V1Template): WORKLOADS =>
   template?.objects[0]?.spec?.template?.metadata?.annotations?.[VM_WORKLOAD_ANNOTATION];
 
 export const getTolerations = (template: V1Template) =>
   template?.objects[0]?.spec?.template?.spec?.tolerations;
 
 // t('Other')
-
 export const getWorkloadProfile = (template: V1Template): string =>
-  workloadProfiles[getTemplateWorkload(template)] || 'Other';
+  WORKLOADS_LABELS[getTemplateWorkload(template)] || 'Other';
 
 export const getVMTemplateBaseName = (
   template: V1Template,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

**Cause**
Catalog get template workload info from the template label `workload.template.kubevirt.io/${TEMPLATE_WORLOAD} = 'true'` 
Template details instead get this info from VM label `vm.kubevirt.io/workload` as in VM details 

**Solution**
On template details when the user changes the workload, the code should change also the template-related label `workload.template.kubevirt.io/${TEMPLATE_WORLOAD} = 'true'` 


NOTE: I've replaced `WorkloadProfileKeys` and `workloadProfiles` in `/views/template/utils` in favor of `WORKLOADS` and `WORKLOADS_LABELS` in `/utils/resources/template`