### PR TITLE
Message VM is down when vm is down or on stop state

### DIFF
--- a/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.tsx
+++ b/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.tsx
@@ -7,7 +7,7 @@ import Consoles from '@kubevirt-utils/components/Consoles/Consoles';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { Bullseye, PageSection } from '@patternfly/react-core';
+import { Bullseye, EmptyState, EmptyStateBody, PageSection } from '@patternfly/react-core';
 
 import { printableVMStatus } from '../../../utils';
 
@@ -24,11 +24,13 @@ const VirtualMachineConsolePage: React.FC<VirtualMachineConsolePageProps> = ({ o
     isList: false,
   });
 
-  if (!vmi && vm?.status?.printableStatus === printableVMStatus.Stopped) {
+  if (!vmi || vm?.status?.printableStatus === printableVMStatus.Stopped) {
     return (
-      <PageSection>
-        {t('This VirtualMachine is down. Please start it to access its console.')}
-      </PageSection>
+      <EmptyState>
+        <EmptyStateBody>
+          {t('This VirtualMachine is down. Please start it to access its console.')}
+        </EmptyStateBody>
+      </EmptyState>
     );
   }
 


### PR DESCRIPTION
## 📝 Description

When VM is stopped or VMI is missing, don't show a VNC connect button 

## 🎥 Demo
Before
![stopped-vm-before](https://user-images.githubusercontent.com/2181522/174570482-950f07af-7c90-4fa0-a9bb-4f097897a17a.png)
After
![stopped-vm-after](https://user-images.githubusercontent.com/2181522/174570487-4d37f8ba-d2dc-4171-b7a6-9dacc295d98a.png)

