### PR TITLE
Bug 2097586: fix storage profile settings checkbox

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/ApplyStorageProfileSettingsCheckbox.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/ApplyStorageProfileSettingsCheckbox.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import StorageProfileModel from '@kubevirt-ui/kubevirt-api/console/models/StorageProfileModel';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Checkbox, FormGroup } from '@patternfly/react-core';
 
@@ -38,24 +39,9 @@ const ApplyStorageProfileSettingsCheckbox: React.FC<ApplyStorageProfileSettingsC
   React.useEffect(() => {
     dispatchDiskState({
       type: diskReducerActions.SET_STORAGE_PROFILE_SETTINGS_CHECKBOX_DISABLED,
-      payload: !loaded || !claimPropertySets,
+      payload: !loaded || !claimPropertySets || isEmpty(claimPropertySets),
     });
-
-    // only if claimPropertySets is not empty and the user checked for the optimized settings checkbox
-    // we set the values from claimPropertySets
-    if (applyStorageProfileSettings && claimPropertySets?.length > 0) {
-      const firstCliamPropertySet = claimPropertySets?.[0];
-      dispatchDiskState({
-        type: diskReducerActions.SET_ACCESS_MODE,
-        payload: firstCliamPropertySet?.accessModes?.[0],
-      });
-      dispatchDiskState({
-        type: diskReducerActions.SET_VOLUME_MODE,
-        payload: firstCliamPropertySet?.volumeMode,
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [applyStorageProfileSettings, claimPropertySets, loaded]);
+  }, [claimPropertySets, dispatchDiskState, loaded]);
 
   return (
     <FormGroup

--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -136,8 +136,10 @@ export const getDataVolumeFromState = ({
   dataVolume.metadata.name = dvName;
   dataVolume.spec.storage.resources.requests.storage = diskState.diskSize;
   dataVolume.spec.storage.storageClassName = diskState.storageClass;
-  dataVolume.spec.storage.accessModes = [diskState.accessMode];
-  dataVolume.spec.storage.volumeMode = diskState.volumeMode;
+  if (!diskState.applyStorageProfileSettings) {
+    dataVolume.spec.storage.accessModes = [diskState.accessMode];
+    dataVolume.spec.storage.volumeMode = diskState.volumeMode;
+  }
   dataVolume.spec.preallocation = diskState.enablePreallocation;
   if (diskState.diskSource === sourceTypes.BLANK) {
     dataVolume.spec.source = {

--- a/src/views/catalog/wizard/tabs/disks/hooks/useEditDiskState.ts
+++ b/src/views/catalog/wizard/tabs/disks/hooks/useEditDiskState.ts
@@ -64,56 +64,60 @@ export const useEditDiskStates: UseEditDiskStates = (vm, diskName) => {
   const initialDiskSourceState = React.useMemo(() => ({ ...initialStateDiskSource }), []);
   const disk = getDisks(vm)?.find(({ name }) => name === diskName);
 
-  const { diskSource, diskSize, isBootDisk, accessMode, volumeMode } = React.useMemo(() => {
-    const dataVolumeTemplates = getDataVolumeTemplates(vm);
+  const { diskSource, diskSize, isBootDisk, accessMode, volumeMode, applyStorageProfileSettings } =
+    React.useMemo(() => {
+      const dataVolumeTemplates = getDataVolumeTemplates(vm);
 
-    const volumes = getVolumes(vm);
-    const volume = volumes?.find(({ name }) => name === diskName);
-    // volume consists of 2 keys:
-    // name and one of: containerDisk/cloudInitNoCloud
-    const volumeSource = Object.keys(volume).find((key) =>
-      [
-        volumeTypes.CONTAINER_DISK,
-        volumeTypes.DATA_VOLUME,
-        volumeTypes.PERSISTENT_VOLUME_CLAIM,
-      ].includes(key),
-    );
+      const volumes = getVolumes(vm);
+      const volume = volumes?.find(({ name }) => name === diskName);
+      // volume consists of 2 keys:
+      // name and one of: containerDisk/cloudInitNoCloud
+      const volumeSource = Object.keys(volume).find((key) =>
+        [
+          volumeTypes.CONTAINER_DISK,
+          volumeTypes.DATA_VOLUME,
+          volumeTypes.PERSISTENT_VOLUME_CLAIM,
+        ].includes(key),
+      );
 
-    if (volumeSource === sourceTypes.EPHEMERAL) {
-      initialDiskSourceState.ephemeralSource = volume.containerDisk?.image;
-      return { diskSource: sourceTypes.EPHEMERAL, diskSize: DYNAMIC };
-    }
+      if (volumeSource === sourceTypes.EPHEMERAL) {
+        initialDiskSourceState.ephemeralSource = volume.containerDisk?.image;
+        return { diskSource: sourceTypes.EPHEMERAL, diskSize: DYNAMIC };
+      }
 
-    if (volumeSource === volumeTypes.PERSISTENT_VOLUME_CLAIM) {
-      initialDiskSourceState.pvcSourceName = volume.persistentVolumeClaim?.claimName;
-      return {
-        diskSource: sourceTypes.PVC,
-      };
-    }
+      if (volumeSource === volumeTypes.PERSISTENT_VOLUME_CLAIM) {
+        initialDiskSourceState.pvcSourceName = volume.persistentVolumeClaim?.claimName;
+        return {
+          diskSource: sourceTypes.PVC,
+        };
+      }
 
-    const dataVolumeTemplate = dataVolumeTemplates?.find(
-      (dataVolume) => dataVolume.metadata.name === volume.dataVolume?.name,
-    );
+      const dataVolumeTemplate = dataVolumeTemplates?.find(
+        (dataVolume) => dataVolume.metadata.name === volume.dataVolume?.name,
+      );
 
-    if (
-      dataVolumeTemplate &&
-      (dataVolumeTemplate.spec?.source || dataVolumeTemplate.spec?.sourceRef)
-    ) {
-      setInitialStateFromDataVolume(dataVolumeTemplate, initialDiskSourceState);
-      return {
-        isBootDisk: getBootDisk(vm)?.name === diskName,
-        diskSource: getSourceFromDataVolume(dataVolumeTemplate),
-        diskSize:
-          dataVolumeTemplate.spec?.storage?.resources?.requests?.storage ||
-          dataVolumeTemplate.spec?.pvc?.resources?.requests?.storage ||
-          '',
-        accessMode: dataVolumeTemplate?.spec?.storage?.accessModes?.[0],
-        volumeMode: dataVolumeTemplate?.spec?.storage?.volumeMode,
-      };
-    }
+      if (
+        dataVolumeTemplate &&
+        (dataVolumeTemplate.spec?.source || dataVolumeTemplate.spec?.sourceRef)
+      ) {
+        setInitialStateFromDataVolume(dataVolumeTemplate, initialDiskSourceState);
+        return {
+          isBootDisk: getBootDisk(vm)?.name === diskName,
+          diskSource: getSourceFromDataVolume(dataVolumeTemplate),
+          diskSize:
+            dataVolumeTemplate.spec?.storage?.resources?.requests?.storage ||
+            dataVolumeTemplate.spec?.pvc?.resources?.requests?.storage ||
+            '',
+          accessMode: dataVolumeTemplate?.spec?.storage?.accessModes?.[0],
+          volumeMode: dataVolumeTemplate?.spec?.storage?.volumeMode,
+          applyStorageProfileSettings:
+            !dataVolumeTemplate?.spec?.storage?.accessModes &&
+            !dataVolumeTemplate?.spec?.storage?.volumeMode,
+        };
+      }
 
-    return { diskSource: OTHER, diskSize: null, isBootDisk: getBootDisk(vm)?.name === diskName };
-  }, [initialDiskSourceState, vm, diskName]);
+      return { diskSource: OTHER, diskSize: null, isBootDisk: getBootDisk(vm)?.name === diskName };
+    }, [initialDiskSourceState, vm, diskName]);
 
   const initialDiskState: DiskFormState = {
     diskName,
@@ -125,7 +129,7 @@ export const useEditDiskStates: UseEditDiskStates = (vm, diskName) => {
     volumeMode,
     accessMode,
     diskInterface: getDiskInterface(disk),
-    applyStorageProfileSettings: false,
+    applyStorageProfileSettings,
     storageClassProvisioner: null,
     storageProfileSettingsCheckboxDisabled: false,
     asBootSource: isBootDisk,


### PR DESCRIPTION
## 📝 Description

The "apply StorageProfile settings" checkbox in the disk modal / edit disk modal was not working correctly,
fixed to not have accessModes and volumeMode keys when checkbox is checked, and fixing edit modal showing if user marked this checkbox before creation or not.

## 🎥 Demo

### before:

https://user-images.githubusercontent.com/67270715/174799255-3ba20c18-4026-4f66-b1eb-be2eb2faf17b.mp4

### after:

https://user-images.githubusercontent.com/67270715/174799292-5a4aa1be-9e88-4705-bcfb-454d548c6ba8.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>