### PR TITLE
Bug 2099608: Display Dynamic instead of DynamicB for dynamic disk size

### DIFF
--- a/src/utils/utils/units.ts
+++ b/src/utils/utils/units.ts
@@ -27,5 +27,6 @@ export const readableSizeUnit = (combinedStr: string): string => {
       ? [combinedString, '']
       : [combinedString?.slice(0, index), combinedString?.slice(index)];
 
-  return `${value} ${toIECUnit(unit)}`;
+  // if there isn't any specific value/size present, return the original string, for example for the dynamic disk size
+  return !value ? combinedStr : `${value} ${toIECUnit(unit)}`;
 };


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2099608

Display 'Dynamic', not 'DynamicB' string in the VM _Disks_ card or VM _Disks_ tab - for the disk's _Size_ info,
in cases when the disk size is provided dynamically.

## 🎥 Demo
**Before:**
'DynamicB' in the VM _Overview_ _Disks_ card, _Size_ column:
![d_before1](https://user-images.githubusercontent.com/13417815/174853681-b648d794-0670-4c99-865e-0e123c2e0ea2.png)
'DynamicB' in the VM _Disks_ tab:
![d_before2](https://user-images.githubusercontent.com/13417815/174853692-37c898d5-30ff-4d98-be7c-33bd8094a906.png)
**After:**
![d_after1](https://user-images.githubusercontent.com/13417815/174853727-df192ff7-9348-4587-98a4-d0988464c4a7.png)
![d_after2](https://user-images.githubusercontent.com/13417815/174853736-e0231eb8-2278-4d1a-b1b3-e1e1f128b6b6.png)

