### PR TITLE
Bug 2099535: Adding target blank to error message href links

### DIFF
--- a/src/utils/components/TabModal/TabModal.tsx
+++ b/src/utils/components/TabModal/TabModal.tsx
@@ -97,7 +97,9 @@ const TabModal: TabModalFC = React.memo(
                     <StackItem>{error.message}</StackItem>
                     {error?.href && (
                       <StackItem>
-                        <a href={error.href}>{error.href}</a>
+                        <a href={error.href} target="_blank" rel="noreferrer">
+                          {error.href}
+                        </a>
                       </StackItem>
                     )}
                   </Stack>

--- a/src/views/catalog/customize/components/FormError.tsx
+++ b/src/views/catalog/customize/components/FormError.tsx
@@ -21,7 +21,7 @@ export const FormError: React.FC<FormErrorProps> = ({ error }) => {
           <StackItem>{error.message}</StackItem>
           {error?.href && (
             <StackItem>
-              <a href={error.href} target="blank">
+              <a href={error.href} target="_blank" rel="noreferrer">
                 {error.href}
               </a>
             </StackItem>


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add target blank to open links of error in new tabs.

## 🎥 Demo

> Please add a video or an image of the behavior/changes
