### PR TITLE
Expose qemu machine type read-only in VM Details tab

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -398,6 +398,7 @@
   "Local storage (LSO)": "Local storage (LSO)",
   "MAC address": "MAC address",
   "MAC Address": "MAC Address",
+  "Machine type": "Machine type",
   "Make sure to have clone permissions in the destination namespace. <2>Learn more <1></1></2>": "Make sure to have clone permissions in the destination namespace. <2>Learn more <1></1></2>",
   "Manual Connection": "Manual Connection",
   "Map of string keys and values that can be used to organize and categorize (scope and select) objects": "Map of string keys and values that can be used to organize and categorize (scope and select) objects",

--- a/src/utils/resources/vm/utils/selectors.ts
+++ b/src/utils/resources/vm/utils/selectors.ts
@@ -118,3 +118,11 @@ export const getBootDisk = (vm: V1VirtualMachine): V1Disk =>
     .reduce((acc, disk) => {
       return acc.bootOrder < disk.bootOrder ? acc : disk;
     }, getDisks(vm)?.[0]);
+
+/**
+ * A selector for the QEMU machine's type
+ * @param {V1VirtualMachine} vm the virtual machine
+ * @returns {string} the machine type
+ */
+export const getMachineType = (vm: V1VirtualMachine): string =>
+  vm?.spec?.template?.spec?.domain?.machine?.type;

--- a/src/views/templates/details/tabs/details/components/TemplateDetailsLeftGrid.tsx
+++ b/src/views/templates/details/tabs/details/components/TemplateDetailsLeftGrid.tsx
@@ -10,6 +10,9 @@ import Owner from 'src/views/templates/details/tabs/details/components/Owner';
 import { TemplateDetailsGridProps } from 'src/views/templates/details/tabs/details/TemplateDetailsPage';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
+import { getMachineType } from '@kubevirt-utils/resources/vm';
+import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { getOperatingSystemName } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import { DescriptionList } from '@patternfly/react-core';
 
@@ -21,6 +24,7 @@ import WorkloadProfile from './WorkloadProfile';
 
 const TemplateDetailsLeftGrid: React.FC<TemplateDetailsGridProps> = ({ template, editable }) => {
   const { t } = useKubevirtTranslation();
+  const machineType = getMachineType(getTemplateVirtualMachineObject(template)) || NO_DATA_DASH;
 
   return (
     <DescriptionList>
@@ -33,6 +37,7 @@ const TemplateDetailsLeftGrid: React.FC<TemplateDetailsGridProps> = ({ template,
       <DescriptionItem title={t('Operating system')} content={getOperatingSystemName(template)} />
       <WorkloadProfile template={template} editable={editable} />
       <CPUMemory template={template} />
+      <DescriptionItem title={t('Machine type')} content={machineType} />
       <BootMethod template={template} />
       <BaseTemplate template={template} />
       <CreatedAt template={template} />

--- a/src/views/virtualmachines/details/tabs/details/components/grid/leftGrid/VirtualMachineDetailsLeftGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/leftGrid/VirtualMachineDetailsLeftGrid.tsx
@@ -21,9 +21,11 @@ import { asAccessReview, getAnnotation, getLabel } from '@kubevirt-utils/resourc
 import { LABEL_USED_TEMPLATE_NAMESPACE } from '@kubevirt-utils/resources/template';
 import {
   DESCRIPTION_ANNOTATION,
+  getMachineType,
   useVMIAndPodsForVM,
   VM_TEMPLATE_ANNOTATION,
 } from '@kubevirt-utils/resources/vm';
+import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { useGuestOS } from '@kubevirt-utils/resources/vmi';
 import {
   k8sPatch,
@@ -226,6 +228,10 @@ const VirtualMachineDetailsLeftGrid: React.FC<VirtualMachineDetailsLeftGridProps
             ))
           }
           data-test-id={`${vm?.metadata?.name}-cpu-memory`}
+        />
+        <VirtualMachineDescriptionItem
+          descriptionData={getMachineType(vm) || NO_DATA_DASH}
+          descriptionHeader={t('Machine type')}
         />
         <VirtualMachineDescriptionItem
           descriptionData={


### PR DESCRIPTION
## 📝 Description

Display qemu machine type in the VM/Template _Details_ tab, the field is not editable. 

_Related doc:_
https://kubevirt.io/user-guide/virtual_machines/virtual_hardware/#machine-type

_Issue:_
https://issues.redhat.com/browse/CNV-12598

## 🎥 Demo
_Machine type_ field in the VM _Details_ tab:
![machine1](https://user-images.githubusercontent.com/13417815/175977280-acabb13d-b972-4d3a-b014-4b2a0d9839bd.png)
_Machine type_ field in the VM Template's _Details_ tab:
![machine2](https://user-images.githubusercontent.com/13417815/175977294-248a2173-ff2b-4b8d-8e4e-ed0b3879af44.png)


