### PR TITLE
update yarn.lock

### DIFF
--- a/src/utils/components/AffinityModal/utils/helpers.ts
+++ b/src/utils/components/AffinityModal/utils/helpers.ts
@@ -136,7 +136,6 @@ export const getAffinityFromRowsData = (affinityRows: AffinityRowData[]) => {
     return null;
   }
 
-  debugger;
   const pickRows = (rowType, rowCondition, mapper) =>
     affinityRows
       .filter(({ type, condition }) => type === rowType && condition === rowCondition)

--- a/src/views/clusteroverview/overview/components/status-card/StatusCard.tsx
+++ b/src/views/clusteroverview/overview/components/status-card/StatusCard.tsx
@@ -2,13 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import {
-  DashboardsOverviewHealthSubsystem as DynamicDashboardsOverviewHealthSubsystem,
-  isDashboardsOverviewHealthSubsystem as isDynamicDashboardsOverviewHealthSubsystem,
-  isResolvedDashboardsOverviewHealthURLSubsystem,
-  K8sResourceCommon,
-  useK8sWatchResource,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { HealthBody } from '@openshift-console/dynamic-plugin-sdk-internal';
 import {
   Card,
@@ -19,20 +13,14 @@ import {
   GalleryItem,
 } from '@patternfly/react-core';
 
-import { VIRTUALIZATION } from './utils/constants';
-import useDashboardSubsystems from './utils/hooks/useDashboardSubsystems';
 import NetworkingHealthItem from './utils/NetworkingHealthItem';
 import StorageHealthItem from './utils/storage-health-item/StorageHealthItem';
 import { VirtStatusItems } from './utils/types';
-import URLHealthItem from './utils/URLHealthItem';
 import { getClusterNAC, NetworkAddonsConfigResource } from './utils/utils';
 import VirtualizationAlerts from './utils/VirtualizationAlerts';
 
 const StatusCard = () => {
   const { t } = useKubevirtTranslation();
-  const subsystems = useDashboardSubsystems<DynamicDashboardsOverviewHealthSubsystem>(
-    isDynamicDashboardsOverviewHealthSubsystem,
-  );
 
   const [networkAddonsConfigList] = useK8sWatchResource<K8sResourceCommon[]>(
     NetworkAddonsConfigResource,
@@ -40,17 +28,6 @@ const StatusCard = () => {
   const clusterNAC = getClusterNAC(networkAddonsConfigList);
 
   const virtStatusItems: VirtStatusItems = [];
-  subsystems?.forEach((subsystem) => {
-    if (
-      isResolvedDashboardsOverviewHealthURLSubsystem(subsystem) &&
-      subsystem?.properties?.title === VIRTUALIZATION
-    ) {
-      virtStatusItems.push({
-        title: t('Virtualization'),
-        Component: <URLHealthItem subsystem={subsystem.properties} />,
-      });
-    }
-  });
 
   virtStatusItems.push({
     title: t('Networking'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -874,6 +874,11 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
+"@patternfly/react-icons@^4.53.16", "@patternfly/react-icons@^4.72.3":
+  version "4.72.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.72.3.tgz#5886755a2b516d49d97ed3bdc88609d9b3c4fc2a"
+  integrity sha512-bZCPsOsxtFXTmZQqDKNebkBywud3E0ID3446AWI1RO5Ypufdc0FTkehSzBPANfJPYjjK9/EYaIy8rF0yiJdFPQ==
+
 "@patternfly/react-icons@^4.57.2":
   version "4.57.2"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.57.2.tgz#233db7d497c48ab8442687970bbe5d11036ea88f"
@@ -884,15 +889,15 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.65.1.tgz#bc31f349577e416c8211b68da4dfb5e46e8039d7"
   integrity sha512-CUYFRPztFkR7qrXq/0UAhLjeHd8FdjLe4jBjj8tfKc7OXwxDeZczqNFyRMATZpPaduTH7BU2r3OUjQrgAbquWg==
 
-"@patternfly/react-icons@^4.72.3":
-  version "4.72.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.72.3.tgz#5886755a2b516d49d97ed3bdc88609d9b3c4fc2a"
-  integrity sha512-bZCPsOsxtFXTmZQqDKNebkBywud3E0ID3446AWI1RO5Ypufdc0FTkehSzBPANfJPYjjK9/EYaIy8rF0yiJdFPQ==
-
 "@patternfly/react-styles@^4.11.4":
   version "4.52.16"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.52.16.tgz#7925013717eb5246529935d965d1ecdaf6240b60"
   integrity sha512-i/xj+r0qVlhSoxrFOePxXoC8BudDPsEma0qwP+3Ry4hSZhN6XhSRSqjA5xmaLkgbfWCAiT/+mR9ilCaguxoLTA==
+
+"@patternfly/react-styles@^4.52.16", "@patternfly/react-styles@^4.71.3":
+  version "4.71.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.71.3.tgz#4f1cf4624a675751f035dc3bfa4cb3c6ca48e43b"
+  integrity sha512-JpMBIrJfco3JwK9KbJvjr+tKZidVhbkGrQT7GyWbYAwZ2bOmCmeCPJYc0xhAWcvNumn9a7AhYzAWPJVlQQue3g==
 
 "@patternfly/react-styles@^4.56.2":
   version "4.56.2"
@@ -903,11 +908,6 @@
   version "4.64.1"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.64.1.tgz#a4e973b9153b269c821226ddf72fb92ff90c5a06"
   integrity sha512-+GxULkP2o5Vpr9w+J4NiGOGzhTfNniYzdPGEF/yC+oDoAXB6Q1HJyQnEj+kJH31xNvwmw3G3VFtwRLX4ZWr0oA==
-
-"@patternfly/react-styles@^4.71.3":
-  version "4.71.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.71.3.tgz#4f1cf4624a675751f035dc3bfa4cb3c6ca48e43b"
-  integrity sha512-JpMBIrJfco3JwK9KbJvjr+tKZidVhbkGrQT7GyWbYAwZ2bOmCmeCPJYc0xhAWcvNumn9a7AhYzAWPJVlQQue3g==
 
 "@patternfly/react-table@4.83.1":
   version "4.83.1"
@@ -933,7 +933,7 @@
     lodash "^4.17.19"
     tslib "^2.0.0"
 
-"@patternfly/react-tokens@^4.58.2", "@patternfly/react-tokens@^4.66.1", "@patternfly/react-tokens@^4.73.3":
+"@patternfly/react-tokens@^4.54.16", "@patternfly/react-tokens@^4.58.2", "@patternfly/react-tokens@^4.66.1", "@patternfly/react-tokens@^4.73.3":
   version "4.73.3"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.73.3.tgz#dae690220c25c242d2c45ec571e46d8cdcc7de13"
   integrity sha512-WyEcV9jiMZzscQMBhlDkypHw9qg0wbX7r/fe8HcWws+jnYWGVjwUdnr18ktI9aw/h/oQS46sirf8xbNTlIiQFg==


### PR DESCRIPTION
`useURLPoll` was intruduced to internal SDK in [1] after it doesn't not work with console 4.11
This PR removes it from the plugin for console 4.11

[1] https://github.com/openshift/console/pull/11708