### PR TITLE
Use getTemplateVirtualMachineObject in template utils

### DIFF
--- a/src/views/templates/details/tabs/details/components/WorkloadProfileModal.tsx
+++ b/src/views/templates/details/tabs/details/components/WorkloadProfileModal.tsx
@@ -14,14 +14,14 @@ type WorkloadProfileModalProps = {
   obj: V1Template;
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (workload: WORKLOADS) => Promise<void | K8sResourceCommon>;
+  onSubmit: (workload: string) => Promise<void | K8sResourceCommon>;
 };
 
 const WorkloadProfileModal: React.FC<WorkloadProfileModalProps> = React.memo(
   ({ obj, isOpen, onClose, onSubmit }) => {
     const { t } = useKubevirtTranslation();
     const [isDropdownOpen, setIsDropdownOpen] = React.useState<boolean>(false);
-    const [workload, setWorkload] = React.useState<WORKLOADS>(
+    const [workload, setWorkload] = React.useState<string>(
       getTemplateWorkload(obj) || WORKLOADS.desktop,
     );
 

--- a/src/views/templates/utils/index.ts
+++ b/src/views/templates/utils/index.ts
@@ -1,6 +1,10 @@
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import KubeDeschedulerModel from '@kubevirt-ui/kubevirt-api/console/models/KubeDeschedulerModel';
-import { TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_LABEL } from '@kubevirt-utils/resources/template';
+import {
+  getTemplateVirtualMachineObject,
+  TEMPLATE_TYPE_BASE,
+  TEMPLATE_TYPE_LABEL,
+} from '@kubevirt-utils/resources/template';
 import { DESCHEDULER_EVICT_LABEL } from '@kubevirt-utils/resources/vmi';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -8,7 +12,8 @@ export const isCommonVMTemplate = (template: V1Template): boolean =>
   template?.metadata?.labels?.[TEMPLATE_TYPE_LABEL] === TEMPLATE_TYPE_BASE;
 
 export const isDedicatedCPUPlacement = (template: V1Template): boolean =>
-  template?.objects[0]?.spec?.template?.spec?.domain?.cpu?.dedicatedCpuPlacement;
+  getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.domain?.cpu
+    ?.dedicatedCpuPlacement;
 
 // check if the Descheduler is installed
 export const useDeschedulerInstalled = (): boolean => {
@@ -22,7 +27,9 @@ export const useDeschedulerInstalled = (): boolean => {
 // check if the descheduler is ON
 export const isDeschedulerOn = (template: V1Template): boolean =>
   // check for the descheduler.alpha.kubernetes.io/evict: 'true' annotation
-  template?.objects[0]?.spec?.template?.metadata?.annotations[DESCHEDULER_EVICT_LABEL] === 'true';
+  getTemplateVirtualMachineObject(template)?.spec?.template?.metadata?.annotations[
+    DESCHEDULER_EVICT_LABEL
+  ] === 'true';
 
 export const ensurePath = <T extends object>(data: T, paths: string | string[]) => {
   let current = data;

--- a/src/views/templates/utils/selectors.ts
+++ b/src/views/templates/utils/selectors.ts
@@ -1,29 +1,34 @@
 import { V1Template } from '@kubevirt-utils/models';
 import { getAnnotation } from '@kubevirt-utils/resources/shared';
 import { getLabel } from '@kubevirt-utils/resources/shared';
-import { WORKLOADS, WORKLOADS_LABELS } from '@kubevirt-utils/resources/template';
+import {
+  getTemplateVirtualMachineObject,
+  WORKLOADS_LABELS,
+} from '@kubevirt-utils/resources/template';
 import { VM_WORKLOAD_ANNOTATION } from '@kubevirt-utils/resources/vm/utils';
 
 import { ANNOTATIONS, LABELS } from './constants';
 
 export const getAffinity = (template: V1Template) =>
-  template?.objects[0]?.spec?.template?.spec?.affinity || {};
+  getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.affinity || {};
 
 export const getEvictionStrategy = (template: V1Template): string =>
-  template?.objects[0]?.spec?.template?.spec?.evictionStrategy;
+  getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.evictionStrategy;
 
 export const getNodeSelector = (template: V1Template) =>
-  template?.objects[0]?.spec?.template?.spec?.nodeSelector;
+  getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.nodeSelector;
 
 export const getTemplateProviderName = (template: V1Template): string =>
   getAnnotation(template, ANNOTATIONS.providerName, null) ||
   getAnnotation(template, ANNOTATIONS.providerDisplayName, null);
 
-export const getTemplateWorkload = (template: V1Template): WORKLOADS =>
-  template?.objects[0]?.spec?.template?.metadata?.annotations?.[VM_WORKLOAD_ANNOTATION];
+export const getTemplateWorkload = (template: V1Template): string =>
+  getTemplateVirtualMachineObject(template)?.spec?.template?.metadata?.annotations?.[
+    VM_WORKLOAD_ANNOTATION
+  ];
 
 export const getTolerations = (template: V1Template) =>
-  template?.objects[0]?.spec?.template?.spec?.tolerations;
+  getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.tolerations;
 
 // t('Other')
 export const getWorkloadProfile = (template: V1Template): string =>


### PR DESCRIPTION
## 📝 Description
This is a small refactoring PR related to:
using `getTemplateVirtualMachineObject` function to get the VM object where needed, instead of hardcoced `template.objects[0]`, in the template utils/selectors.

