### PR TITLE
hosts.yml file not a directory

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - ..:/workspace:cached
       - ~/.bash_history:/root/.bash_history
       - ~/.zsh_history:/root/.zsh_history
-      - ~/.config/gh/hosts.yml:/root/.config/gh/hosts.yml
+      - ~/.config/gh:/root/.config/gh
     volumes_from:
       - x11-bridge:rw
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The devcontainer environment has created a directory called `hosts.yaml` which caused some issues with the Github cli.

`hosts.yaml` is a github file and volumes can be only directories.

