### PR TITLE
Bug 2101628: DataSource selection with parameter

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourceDataSourceSelect.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourceDataSourceSelect.tsx
@@ -21,6 +21,8 @@ const DiskSourceDataSourceSelect: React.FC<DiskSourceDataSourceSelectProps> = ({
   const { projectsNames, dataSources, projectsLoaded, dataSourcesLoaded } =
     useDataSourcesTypeResources(dataSourceNamespaceSelected);
 
+  const isTemplateParameter = /\$\{(.*?)\}/.test(dataSourceNamespaceSelected);
+
   const onSelectProject = React.useCallback(
     (newProject) => {
       selectDataSourceNamespace(newProject);
@@ -46,7 +48,7 @@ const DiskSourceDataSourceSelect: React.FC<DiskSourceDataSourceSelectProps> = ({
         onChange={selectDataSourceName}
         dataSourceNameSelected={dataSourceNameSelected}
         dataSourceNames={dataSourceNames}
-        isDisabled={!dataSourceNamespaceSelected}
+        isDisabled={!dataSourceNamespaceSelected || isTemplateParameter}
         dataSourcesLoaded={dataSourcesLoaded}
       />
     </>

--- a/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourceDataSourceSelectName.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourceDataSourceSelectName.tsx
@@ -38,7 +38,7 @@ const DiskSourcePVCSelectName: React.FC<DiskSourcePVCSelectNameProps> = ({
 
   return (
     <FormGroup label={t('{{dsLabel}} name', { dsLabel })} fieldId={fieldId} id={fieldId} isRequired>
-      {dataSourcesLoaded ? (
+      {dataSourcesLoaded || isDisabled ? (
         <Select
           menuAppendTo="parent"
           aria-labelledby={fieldId}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

**Cause**
Data source project value is a parameter so cannot load data sources

**Solution**
Disable the data source selection when the project is a parameter and display the data source select when is disabled without waiting to load other data sources.

## 🎥 Demo

![Screenshot from 2022-06-29 13-28-33](https://user-images.githubusercontent.com/29160323/176426663-efb25276-679b-4724-b9e9-a50d0232d6f0.png)

