### PR TITLE
Bug 2102561: Use link to the downstream doc for Sysprep info

### DIFF
--- a/src/utils/components/SysprepModal/consts.ts
+++ b/src/utils/components/SysprepModal/consts.ts
@@ -1,3 +1,3 @@
 export const SYSPREP = 'sysprep';
 export const SYSPREP_DOC_URL =
-  'https://kubevirt.io/user-guide/virtual_machines/startup_scripts/#sysprep';
+  'https://docs.openshift.com/container-platform/4.10/virt/virtual_machines/virt-automating-windows-sysprep.html';


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2102561

Use the link to the downstream sysprep info instead of the related kubevirt doc. Redirect to the downstream doc when clicking on _Learn more_, when customizing VM sysprep.

## 🎥 Demo
Clicking on _Learn more_ in the _Review and create VirtualMachine_ page:
![learn_more](https://user-images.githubusercontent.com/13417815/176504626-1ab8b752-81bf-42c1-ab22-5daa523052b6.png)
**Before:**
Redirecting to the kubevirt doc:
![doc_before](https://user-images.githubusercontent.com/13417815/176504598-2eb7b514-73c7-46db-aaff-8c1822ec6a43.png)
**After:**
Redirecting to the new, downstream doc:
![doc_after](https://user-images.githubusercontent.com/13417815/176504615-a4f1cbfe-3187-4278-8b66-3625f3480bc9.png)

