### PR TITLE
Bug 2101454: cant load PVCs for non-priv user

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -705,6 +705,7 @@
   "This field is required": "This field is required",
   "This Template requires some additional parameters. Click the Customize VirtualMachine button to complete the creation flow.": "This Template requires some additional parameters. Click the Customize VirtualMachine button to complete the creation flow.",
   "This Template supports quick create VirtualMachine": "This Template supports quick create VirtualMachine",
+  "This user is not allowed to edit this boot source": "This user is not allowed to edit this boot source",
   "This VirtualMachine is down. Please start it to access its console.": "This VirtualMachine is down. Please start it to access its console.",
   "This VirtualMachine is subject to the Descheduler profiles configured for eviction.": "This VirtualMachine is subject to the Descheduler profiles configured for eviction.",
   "Threads": "Threads",

--- a/src/views/templates/actions/components/PersistentVolumeClaimSelect/utils.tsx
+++ b/src/views/templates/actions/components/PersistentVolumeClaimSelect/utils.tsx
@@ -1,12 +1,19 @@
 import * as React from 'react';
+import {
+  getAllowedResourceData,
+  getAllowedResources,
+} from 'src/views/clusteroverview/overview/utils/utils';
 
 import {
   modelToGroupVersionKind,
   PersistentVolumeClaimModel,
   ProjectModel,
 } from '@kubevirt-ui/kubevirt-api/console';
-import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  K8sResourceCommon,
+  useK8sWatchResource,
+  useK8sWatchResources,
+} from '@openshift-console/dynamic-plugin-sdk';
 import { SelectOption } from '@patternfly/react-core';
 
 export const filter = (options: string[]) => {
@@ -40,11 +47,13 @@ export const useProjectsAndPVCs = (projectSelected: string): useProjectsAndPVCsR
 
   const projectsNames = projects.map((project) => project.metadata.name);
 
-  const [pvcs, pvcsLoaded, pvcsErrors] = useK8sWatchResource<V1alpha1PersistentVolumeClaim[]>({
-    groupVersionKind: modelToGroupVersionKind(PersistentVolumeClaimModel),
-    namespaced: false,
-    isList: true,
-  });
+  const watchedResources = getAllowedResources(projectsNames, PersistentVolumeClaimModel);
+  const resources = useK8sWatchResources<{ [key: string]: K8sResourceCommon[] }>(watchedResources);
+  const {
+    data: pvcs,
+    loaded: pvcsLoaded,
+    loadError: pvcsErrors,
+  } = getAllowedResourceData(resources, PersistentVolumeClaimModel);
 
   const pvcNamesFilteredByProjects = pvcs
     .filter((pvc) => pvc.metadata.namespace === projectSelected)

--- a/src/views/templates/actions/editBootSource.ts
+++ b/src/views/templates/actions/editBootSource.ts
@@ -35,7 +35,7 @@ const DATA_VOLUME: V1beta1DataVolume = {
   spec: {},
 };
 
-const createDataVolume = (
+export const createDataVolume = (
   name: string,
   namespace: string,
   bootSource: V1beta1DataVolumeSpec,
@@ -80,7 +80,7 @@ export const getBootDataSource = async (
 };
 
 export const hasEditableBootSource = (dataSource: V1beta1DataSource): boolean => {
-  return dataSource && !dataSource.metadata.labels['cdi.kubevirt.io/dataImportCron'];
+  return dataSource && !dataSource.metadata.labels?.['cdi.kubevirt.io/dataImportCron'];
 };
 
 const waitPVCGetDeleted = (name: string, namespace: string): Promise<void> => {
@@ -131,7 +131,12 @@ export const editBootSource = async (
   });
 };
 
-export const getEditBootSourceRefDescription = (t: TFunction, dataSource: V1beta1DataSource) => {
+export const getEditBootSourceRefDescription = (
+  t: TFunction,
+  dataSource: V1beta1DataSource,
+  canEditBootSource: boolean,
+) => {
+  if (!canEditBootSource) return t('This user is not allowed to edit this boot source');
   if (!dataSource) return t('Template does not use boot source reference');
   if (!hasEditableBootSource(dataSource)) return t('Boot source reference cannot be edited');
 };


### PR DESCRIPTION
## 📝 Description

this fix includes:

- fetching the PVCs data from each namespace instead of fetching for 'all-namespaces'
- When a non priv user is trying to change a boot source reference for a DataSource that points to a PVC in a namespace where the user has no permissions to re-create the PVC, it will fail, so disabled this action in case the user can not re-create the PVC in the same namespace the older PVC was

## 🎥 Demo

### before:
![edit-boot-source-ref-before-pvc-stuck](https://user-images.githubusercontent.com/67270715/176730542-33acf950-0746-4f45-8aee-aa2f2ade74f6.png)

### after:

https://user-images.githubusercontent.com/67270715/176730575-2ce1bf0d-56b9-4e5b-8db5-4b81e97cf518.mp4

Signed-off-by: Aviv Turgeman <aturgema@redhat.com>