### PR TITLE
Bug 2102475: Template example like fedora

### DIFF
--- a/src/templates/vm-template-yaml.ts
+++ b/src/templates/vm-template-yaml.ts
@@ -12,6 +12,8 @@ metadata:
   annotations:
     name.os.template.kubevirt.io/fedora36: Fedora 36
     description: VM template example
+    openshift.io/display-name: "Fedora VM"
+    iconClass: icon-fedora
 objects:
   - apiVersion: kubevirt.io/v1
     kind: VirtualMachine

--- a/src/utils/resources/template/utils/selectors.ts
+++ b/src/utils/resources/template/utils/selectors.ts
@@ -45,17 +45,17 @@ export const isCustomTemplate = (template: V1Template): boolean =>
  * @param {V1Template} template - template
  */
 export const getTemplateOSLabelName = (template: V1Template): string =>
-  getLabel(getTemplateVirtualMachineObject(template), ANNOTATIONS.osTemplate);
+  getAnnotation(getTemplateVirtualMachineObject(template)?.spec?.template, ANNOTATIONS.os);
 
 /**
  * A selector that returns the os label of a given template
  * @param {V1Template} template - template
  */
 export const getTemplateOS = (template: V1Template): OS_NAME_TYPES => {
+  const templateOS = getTemplateOSLabelName(template);
   return (
-    Object.values(OS_NAME_TYPES).find((osName) =>
-      getTemplateOSLabelName(template)?.includes(osName),
-    ) ?? OS_NAME_TYPES.other
+    Object.values(OS_NAME_TYPES).find((osName) => templateOS?.includes(osName)) ??
+    OS_NAME_TYPES.other
   );
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Make sure the Template example is shown like a fedora template. 

- fedora icon for template example
- OS like other fedora distributions
- filtered as a fedora template

 Getting the OS key:
 Before: getting the os distro key from the VM metadata `vm.kubevirt.io/template` annotation (indicate the template name used to create the VM like fedora-desktop-small). 
 After: use the proper annotation from VM -> spec -> template -> metadata -> annotation `vm.kubevirt.io/os` (annotation used to indicate the actual os key). 

## 🎥 Demo

![Screenshot from 2022-07-01 12-06-22](https://user-images.githubusercontent.com/29160323/176874206-8de4cc18-a825-4bfa-8a3c-6b4f6fa1f91d.png)


![Screenshot from 2022-07-01 12-06-15](https://user-images.githubusercontent.com/29160323/176874211-cc7458b1-4bef-45b3-9dd4-bc7fa05b3866.png)
