### PR TITLE
Add Machine type field to Review and create VirtualMachine

### DIFF
--- a/src/views/catalog/wizard/tabs/overview/WizardOverviewTab.tsx
+++ b/src/views/catalog/wizard/tabs/overview/WizardOverviewTab.tsx
@@ -11,7 +11,7 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getAnnotation } from '@kubevirt-utils/resources/shared';
 import { getVmCPUMemory, WORKLOADS_LABELS } from '@kubevirt-utils/resources/template';
-import { getGPUDevices, getHostDevices } from '@kubevirt-utils/resources/vm';
+import { getGPUDevices, getHostDevices, getMachineType } from '@kubevirt-utils/resources/vm';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { DescriptionList, Grid, GridItem } from '@patternfly/react-core';
 
@@ -112,6 +112,13 @@ const WizardOverviewTab: WizardTab = ({ vm, tabsData, updateVM }) => {
                   {t('CPU')} {cpuCount} | {t('Memory')} {readableSizeUnit(memory)}
                 </>
               }
+            />
+
+            <WizardDescriptionItem
+              className="wizard-overview-description-left-column"
+              title={t('Machine type')}
+              testId="wizard-overview-machine-type"
+              description={getMachineType(vm)}
             />
 
             <WizardDescriptionItem


### PR DESCRIPTION
## 📝 Description

Display qemu 'Machine type' in the _Overview_ tab of the _Review and create VirtualMachine_ page. The field is not editable.

_Related upstream doc:_
https://kubevirt.io/user-guide/virtual_machines/virtual_hardware/#machine-type

_Issue:_
https://issues.redhat.com/browse/CNV-12598

## 🎥 Demo
![type2](https://user-images.githubusercontent.com/13417815/176914823-a7c6e8fa-80aa-4245-982d-46d857745868.png)
