### PR TITLE
CNV19599: Rename overview performance tab to monitoring

### DIFF
--- a/src/views/clusteroverview/overview/components/ClusterOverviewPage.tsx
+++ b/src/views/clusteroverview/overview/components/ClusterOverviewPage.tsx
@@ -9,8 +9,8 @@ import SettingsTab from './SettingsTab/SettingsTab';
 import { KUBEVIRT_QUICK_START_USER_SETTINGS_KEY } from './utils/constants';
 import PageHeader from './utils/PageHeader';
 import RestoreGettingStartedButton from './utils/RestoreGettingStartedButton';
+import MonitoringTab from './MonitoringTab';
 import OverviewTab from './OverviewTab';
-import TopConsumersTab from './TopConsumersTab';
 
 const overviewTabs: NavPage[] = [
   {
@@ -19,9 +19,9 @@ const overviewTabs: NavPage[] = [
     component: OverviewTab,
   },
   {
-    href: 'performance',
-    name: 'Performance',
-    component: TopConsumersTab,
+    href: 'monitoring',
+    name: 'Monitoring',
+    component: MonitoringTab,
   },
   {
     href: 'settings',

--- a/src/views/clusteroverview/overview/components/MonitoringTab.tsx
+++ b/src/views/clusteroverview/overview/components/MonitoringTab.tsx
@@ -4,10 +4,10 @@ import { Overview } from '@openshift-console/dynamic-plugin-sdk';
 
 import TopConsumersCard from './top-consumers-card/TopConsumersCard';
 
-const TopConsumersTab: React.FC = () => (
+const MonitoringTab: React.FC = () => (
   <Overview>
     <TopConsumersCard />
   </Overview>
 );
 
-export default TopConsumersTab;
+export default MonitoringTab;

--- a/src/views/clusteroverview/overview/components/top-consumers-card/TopConsumersCard.scss
+++ b/src/views/clusteroverview/overview/components/top-consumers-card/TopConsumersCard.scss
@@ -1,9 +1,5 @@
 @import '~@patternfly/patternfly/sass-utilities/colors';
 
-.kv-top-consumers-card {
-  padding-top: 1rem;
-}
-
 .kv-top-consumers-card__header {
   border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
 }

--- a/src/views/clusteroverview/overview/components/top-consumers-card/TopConsumersCard.tsx
+++ b/src/views/clusteroverview/overview/components/top-consumers-card/TopConsumersCard.tsx
@@ -30,34 +30,32 @@ const TopConsumersCard: React.FC = () => {
   const onTopAmountSelect = (value) => setNumItemsToShow(value);
 
   return (
-    <div className="kv-top-consumers-card">
-      <Card data-test="kv-top-consumers-card">
-        <CardHeader className="kv-top-consumers-card__header">
-          <CardTitle>{t('Top consumers')} </CardTitle>
-          <CardActions className="co-overview-card__actions">
-            <Link to="/monitoring/dashboards/grafana-dashboard-kubevirt-top-consumers?period=4h">
-              {t('View virtualization dashboard')}
-            </Link>
-            <div className="kv-top-consumers-card__dropdown">
-              <FormPFSelect
-                toggleId="kv-top-consumers-card-amount-select"
-                variant={SelectVariant.single}
-                selections={numItemsToShow}
-                onSelect={(e, value) => onTopAmountSelect(value)}
-              >
-                {topAmountSelectOptions(t).map((opt) => (
-                  <SelectOption key={opt.key} value={opt.value} />
-                ))}
-              </FormPFSelect>
-            </div>
-          </CardActions>
-        </CardHeader>
-        <CardBody className="kv-top-consumers-card__body">
-          <TopConsumersGridRow rowNumber={1} topGrid />
-          <TopConsumersGridRow rowNumber={2} />
-        </CardBody>
-      </Card>
-    </div>
+    <Card data-test="kv-top-consumers-card">
+      <CardHeader className="kv-top-consumers-card__header">
+        <CardTitle>{t('Top consumers')} </CardTitle>
+        <CardActions className="co-overview-card__actions">
+          <Link to="/monitoring/dashboards/grafana-dashboard-kubevirt-top-consumers?period=4h">
+            {t('View virtualization dashboard')}
+          </Link>
+          <div className="kv-top-consumers-card__dropdown">
+            <FormPFSelect
+              toggleId="kv-top-consumers-card-amount-select"
+              variant={SelectVariant.single}
+              selections={numItemsToShow}
+              onSelect={(e, value) => onTopAmountSelect(value)}
+            >
+              {topAmountSelectOptions(t).map((opt) => (
+                <SelectOption key={opt.key} value={opt.value} />
+              ))}
+            </FormPFSelect>
+          </div>
+        </CardActions>
+      </CardHeader>
+      <CardBody className="kv-top-consumers-card__body">
+        <TopConsumersGridRow rowNumber={1} topGrid />
+        <TopConsumersGridRow rowNumber={2} />
+      </CardBody>
+    </Card>
   );
 };
 


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

This PR is renaming the `Performance` tab to `Monitoring` and removing redundant padding
For more info about this issue:
sub-task: https://issues.redhat.com/browse/CNV-19599
issue: https://issues.redhat.com/browse/CNV-18220

## 🎥 Demo

### before:

![rename-performeance-to-monitoring-before](https://user-images.githubusercontent.com/67270715/177191391-2e810675-18a6-4ac1-a607-edc10d5dfa5b.png)

### after:

![rename-performeance-to-monitoring](https://user-images.githubusercontent.com/67270715/177191384-bcad1fa4-5484-4681-b510-b8a52b503a71.png)