### PR TITLE
Bug 2100682: Delete only the appropriate HW device in the modal

### DIFF
--- a/src/utils/components/HardwareDevices/HardwareDevicesModal.tsx
+++ b/src/utils/components/HardwareDevices/HardwareDevicesModal.tsx
@@ -63,7 +63,7 @@ const HardwareDevicesModal: React.FC<HardwareDevicesModalProps> = ({
   };
 
   const onRemoveDevice = (device: V1GPU | V1HostDevice) => {
-    setDevices((prevDevices) => prevDevices?.filter((d) => d.name !== device.name));
+    setDevices((prevDevices) => prevDevices?.filter((d) => d !== device));
   };
 
   const onCancel = () => {


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2100682

Delete only the appropriate hardware device (GPU device/Host device)
from the devices list, when clicking on the icon to delete
on the right in the modal.

## 🎥 Demo
Having 2 devices with the same _Name_ leading to the buggy scenario:
![delete-a](https://user-images.githubusercontent.com/13417815/177193318-dca4304f-4f42-4272-8486-5d4f36e4d930.png)
**Before:**
Deletion of the one of the devices caused deletion of all the devices with the same _Name_:
![a_before](https://user-images.githubusercontent.com/13417815/177193295-6db94fed-3b28-4aeb-8fcf-80081be26e04.png)
**After:**
Only the appropriate device deleted:
![a_after](https://user-images.githubusercontent.com/13417815/177193303-08683a3b-72ee-44e9-b5a6-1beb676744a6.png)

