### PR TITLE
Bug 2101167: Fix the clickable area for Edit buttons in VM pages

### DIFF
--- a/src/utils/components/HardwareDevices/HardwareDeviceTitle.tsx
+++ b/src/utils/components/HardwareDevices/HardwareDeviceTitle.tsx
@@ -16,14 +16,14 @@ const HardwareDeviceTitle: React.FC<HardwareDeviceTitleProps> = ({ title, canEdi
   if (!canEdit) return <DescriptionListTerm>{title}</DescriptionListTerm>;
   else
     return (
-      <Button isInline variant="link" onClick={onClick} className="pf-m-link--align-left">
-        <DescriptionListTerm>
+      <DescriptionListTerm>
+        <Button isInline variant="link" onClick={onClick} className="pf-m-link--align-left" isLarge>
           {title}
           {canEdit && (
-            <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain " alt={t('Edit')} />
+            <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" alt={t('Edit')} />
           )}
-        </DescriptionListTerm>
-      </Button>
+        </Button>
+      </DescriptionListTerm>
     );
 };
 

--- a/src/views/catalog/wizard/components/WizardDescriptionItem/WizardDescriptionItem.tsx
+++ b/src/views/catalog/wizard/components/WizardDescriptionItem/WizardDescriptionItem.tsx
@@ -102,17 +102,19 @@ export const WizardDescriptionItem: React.FC<WizardDescriptionItemProps> = React
           </Flex>
         </DescriptionListTermHelpText>
         {isEdit && !showEditOnTitle ? (
-          <Button
-            data-test-id={`${testId}-edit`}
-            type="button"
-            isInline
-            isDisabled={isDisabled}
-            onClick={onEditClick}
-            variant="link"
-          >
-            {description ?? <span className="text-muted">{t('Not available')}</span>}
-            <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
-          </Button>
+          <DescriptionListDescription>
+            <Button
+              data-test-id={`${testId}-edit`}
+              type="button"
+              isInline
+              isDisabled={isDisabled}
+              onClick={onEditClick}
+              variant="link"
+            >
+              {description ?? <span className="text-muted">{t('Not available')}</span>}
+              <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+            </Button>
+          </DescriptionListDescription>
         ) : (
           <div data-test-id={testId}>
             <DescriptionListDescription>

--- a/src/views/virtualmachines/details/tabs/details/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
@@ -125,13 +125,10 @@ const VirtualMachineDescriptionItem: React.FC<VirtualMachineDescriptionItemProps
           )}
         </Flex>
       </DescriptionListTermHelpText>
-      {isEdit && !showEditOnTitle ? (
-        description
-      ) : (
-        <DescriptionListDescription data-test-id={testId}>
-          {descriptionData}
-        </DescriptionListDescription>
-      )}
+
+      <DescriptionListDescription data-test-id={testId}>
+        {isEdit && !showEditOnTitle ? description : descriptionData}
+      </DescriptionListDescription>
     </DescriptionListGroup>
   );
 };


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2101167

Fix the area of Edit buttons in the VM _Details_ and _Scheduling_ tabs, also in the _Details_, _Scheduling_ and _Metadata_ tabs/pages of VM creation flow. Limit the clickable area only to the text and not the whole line, so clicking on the empty space is not possible anymore.

## 🎥 Demo
**Before:**
![before1](https://user-images.githubusercontent.com/13417815/177757226-24312dd8-a8e4-43a9-af0b-0b541e553af8.png)
![before2](https://user-images.githubusercontent.com/13417815/177757241-0f8f2346-964a-4924-9e06-c4f6816d5397.png)
**After:**
![after1](https://user-images.githubusercontent.com/13417815/177757268-4c884c75-aeb6-45ca-9b8c-2e6ae1c1a5a8.png)
![after2](https://user-images.githubusercontent.com/13417815/177757277-a644cf51-bcf7-4fb4-ab23-b34a151f8ccd.png)

