### PR TITLE
Bug 2102740: Rename Save button to Clone in Clone VM modal

### DIFF
--- a/src/views/virtualmachines/actions/components/CloneVMModal/CloneVMModal.tsx
+++ b/src/views/virtualmachines/actions/components/CloneVMModal/CloneVMModal.tsx
@@ -103,6 +103,7 @@ const CloneVMModal: React.FC<CloneVMModalProps> = ({ vm, isOpen, onClose }) => {
       onClose={onClose}
       onSubmit={onClone}
       obj={clonedVirtualMachine}
+      submitBtnText={t('Clone')}
     >
       <Form isHorizontal>
         <NameInput name={cloneName} setName={setCloneName} />


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2102740

Specify the submit button text for the _Clone VirtualMachine_ modal to be consistent with the appropriate action and with the button for _Clone template_ modal.

## 🎥 Demo
**Before:**
![btn_before](https://user-images.githubusercontent.com/13417815/177780050-8a7704dc-d25f-4eb0-9e84-07b15d35b5c8.png)
**After:**
![btn_after](https://user-images.githubusercontent.com/13417815/177780080-98b5a69f-6471-47fd-87fc-b264447836b2.png)




