### PR TITLE
Bug 2100442: show ssh service even without running vm

### DIFF
--- a/src/utils/components/SSHAccess/SSHAccessModal.tsx
+++ b/src/utils/components/SSHAccess/SSHAccessModal.tsx
@@ -36,7 +36,7 @@ const SSHAccessModal: React.FC<SSHAccessModalProps> = ({
     if (initiallyEnabled === isEnabled) return;
 
     if (isEnabled) {
-      await createSSHService(vmi, vm);
+      await createSSHService(vm, vmi);
     } else {
       await k8sDelete({
         model: ServiceModel,

--- a/src/utils/components/SSHAccess/constants.ts
+++ b/src/utils/components/SSHAccess/constants.ts
@@ -4,4 +4,4 @@ export const NODE_PORTS_LINK =
 export const PORT = 22000;
 export const SSH_PORT = 22;
 
-export const VM_LABEL_AS_SSH_SERVICE_SELECTOR = 'kubevirt.io/domain';
+export const VMI_LABEL_AS_SSH_SERVICE_SELECTOR = 'kubevirt.io/domain';

--- a/src/utils/components/SSHAccess/utils.ts
+++ b/src/utils/components/SSHAccess/utils.ts
@@ -7,7 +7,7 @@ import { getRandomChars } from '@kubevirt-utils/utils/utils';
 import { k8sCreate, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
 import { buildOwnerReference } from './../../resources/shared';
-import { PORT, SSH_PORT, VM_LABEL_AS_SSH_SERVICE_SELECTOR } from './constants';
+import { PORT, SSH_PORT, VMI_LABEL_AS_SSH_SERVICE_SELECTOR } from './constants';
 
 const buildSSHServiceFromVM = (vm: V1VirtualMachine, sshLabel: string) => ({
   kind: ServiceModel.kind,
@@ -26,29 +26,25 @@ const buildSSHServiceFromVM = (vm: V1VirtualMachine, sshLabel: string) => ({
     ],
     type: IoK8sApiCoreV1ServiceSpecTypeEnum.NodePort,
     selector: {
-      [VM_LABEL_AS_SSH_SERVICE_SELECTOR]: sshLabel,
+      [VMI_LABEL_AS_SSH_SERVICE_SELECTOR]: sshLabel,
     },
   },
 });
 
-export const createSSHService = async (vmi: V1VirtualMachineInstance, vm: V1VirtualMachine) => {
-  const { namespace, labels, name } = vmi?.metadata;
-  const labelSelector = labels[VM_LABEL_AS_SSH_SERVICE_SELECTOR] || `${name}-${getRandomChars()}`;
+export const createSSHService = async (vm: V1VirtualMachine, vmi: V1VirtualMachineInstance) => {
+  const { namespace, name } = vm?.metadata || {};
+  const vmiLabels = vm?.spec?.template?.metadata?.labels;
+  const labelSelector =
+    vmiLabels[VMI_LABEL_AS_SSH_SERVICE_SELECTOR] || `${name}-${getRandomChars()}`;
 
-  if (!labels[VM_LABEL_AS_SSH_SERVICE_SELECTOR]) {
+  if (!vmiLabels[VMI_LABEL_AS_SSH_SERVICE_SELECTOR]) {
     await k8sPatch({
       model: VirtualMachineModel,
-      resource: {
-        kind: VirtualMachineModel.kind,
-        metadata: {
-          name: vmi?.metadata?.ownerReferences?.[0]?.name,
-          namespace: namespace,
-        },
-      },
+      resource: vm,
       data: [
         {
           op: 'add',
-          path: `/spec/template/metadata/labels/${VM_LABEL_AS_SSH_SERVICE_SELECTOR.replaceAll(
+          path: `/spec/template/metadata/labels/${VMI_LABEL_AS_SSH_SERVICE_SELECTOR.replaceAll(
             '/',
             '~1',
           )}`,
@@ -57,17 +53,18 @@ export const createSSHService = async (vmi: V1VirtualMachineInstance, vm: V1Virt
       ],
     });
 
-    await k8sPatch<V1VirtualMachineInstance>({
-      model: VirtualMachineInstanceModel,
-      resource: vmi,
-      data: [
-        {
-          op: 'add',
-          path: `/metadata/labels/${VM_LABEL_AS_SSH_SERVICE_SELECTOR.replaceAll('/', '~1')}`,
-          value: labelSelector,
-        },
-      ],
-    });
+    if (vmi)
+      await k8sPatch<V1VirtualMachineInstance>({
+        model: VirtualMachineInstanceModel,
+        resource: vmi,
+        data: [
+          {
+            op: 'add',
+            path: `/metadata/labels/${VMI_LABEL_AS_SSH_SERVICE_SELECTOR.replaceAll('/', '~1')}`,
+            value: labelSelector,
+          },
+        ],
+      });
   }
 
   const serviceResource = buildSSHServiceFromVM(vm, labelSelector);

--- a/src/utils/resources/vmi/utils/services.ts
+++ b/src/utils/resources/vmi/utils/services.ts
@@ -1,12 +1,11 @@
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
-import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
 export const getServicesForVmi = (
   services: IoK8sApiCoreV1Service[],
-  vmi: V1VirtualMachineInstance,
+  vmiLabels: {
+    [key: string]: string;
+  },
 ): IoK8sApiCoreV1Service[] => {
-  const vmiLabels = vmi?.metadata?.labels;
-
   if (!vmiLabels) return [];
 
   return (services || []).filter((service) => {

--- a/src/utils/resources/vmi/utils/tests/services.test.ts
+++ b/src/utils/resources/vmi/utils/tests/services.test.ts
@@ -16,7 +16,7 @@ describe('Test getServicesForVmi', () => {
     const services: IoK8sApiCoreV1Service[] = [];
     const vmi: V1VirtualMachineInstance = vmiMock;
 
-    const result = getServicesForVmi(services, vmi);
+    const result = getServicesForVmi(services, vmi?.metadata?.labels);
 
     expect(result).toEqual([]);
   });
@@ -25,7 +25,7 @@ describe('Test getServicesForVmi', () => {
     const services: IoK8sApiCoreV1Service[] = [serviceWithUndefinedSelectors];
     const vmi: V1VirtualMachineInstance = vmiMock;
 
-    const result = getServicesForVmi(services, vmi);
+    const result = getServicesForVmi(services, vmi?.metadata?.labels);
 
     expect(result).toEqual([]);
   });
@@ -34,7 +34,7 @@ describe('Test getServicesForVmi', () => {
     const services: IoK8sApiCoreV1Service[] = [serviceWithoutSelectors];
     const vmi: V1VirtualMachineInstance = vmiMock;
 
-    const result = getServicesForVmi(services, vmi);
+    const result = getServicesForVmi(services, vmi?.metadata?.labels);
 
     expect(result).toEqual([]);
   });
@@ -43,7 +43,7 @@ describe('Test getServicesForVmi', () => {
     const services: IoK8sApiCoreV1Service[] = [serviceWithoutMatchingSelectors];
     const vmi: V1VirtualMachineInstance = vmiMock;
 
-    const result = getServicesForVmi(services, vmi);
+    const result = getServicesForVmi(services, vmi?.metadata?.labels);
 
     expect(result).toEqual([]);
   });
@@ -52,7 +52,7 @@ describe('Test getServicesForVmi', () => {
     const services: IoK8sApiCoreV1Service[] = [serviceWithMatchingSelectors];
     const vmi: V1VirtualMachineInstance = vmiMock;
 
-    const result = getServicesForVmi(services, vmi);
+    const result = getServicesForVmi(services, vmi?.metadata?.labels);
 
     expect(result).toEqual([serviceWithMatchingSelectors]);
   });

--- a/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/RunningVirtualMachineDetailsRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/RunningVirtualMachineDetailsRightGrid.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import useSSHService from '@kubevirt-utils/components/SSHAccess/useSSHService';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm/hooks';
 import { useGuestOS } from '@kubevirt-utils/resources/vmi/hooks';
@@ -20,19 +19,11 @@ const RunningVirtualMachineDetailsRightGrid: React.FC<VirtualMachineDetailsRight
   const { t } = useKubevirtTranslation();
   const { vmi, pods } = useVMIAndPodsForVM(vm?.metadata?.name, vm?.metadata?.namespace);
   const [guestAgentData] = useGuestOS(vmi);
-  const watchSSHService = useSSHService(vmi);
 
   return (
     <VirtualMachineDetailsRightGridLayout
       vm={vm}
-      vmDetailsRightGridObj={getRunningVMRightGridPresentation(
-        t,
-        vmi,
-        pods,
-        guestAgentData,
-        watchSSHService,
-      )}
-      sshService={watchSSHService[0]}
+      vmDetailsRightGridObj={getRunningVMRightGridPresentation(t, vmi, pods, guestAgentData)}
       vmi={vmi}
     />
   );

--- a/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGridLayout.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGridLayout.tsx
@@ -3,13 +3,14 @@ import produce from 'immer';
 
 import { NodeModel } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
-import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { BootOrderModal } from '@kubevirt-utils/components/BootOrderModal/BootOrderModal';
 import HardwareDevices from '@kubevirt-utils/components/HardwareDevices/HardwareDevices';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
+import SSHAccess from '@kubevirt-utils/components/SSHAccess/SSHAccess';
 import SSHAccessModal from '@kubevirt-utils/components/SSHAccess/SSHAccessModal';
+import useSSHService from '@kubevirt-utils/components/SSHAccess/useSSHService';
 import WorkloadProfileModal from '@kubevirt-utils/components/WorkloadProfileModal/WorkloadProfileModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { WORKLOADS, WORKLOADS_LABELS } from '@kubevirt-utils/resources/template';
@@ -25,16 +26,16 @@ import VirtualMachineDescriptionItem from '../../VirtualMachineDescriptionItem/V
 type VirtualMachineDetailsRightGridLayout = {
   vm: V1VirtualMachine;
   vmDetailsRightGridObj: VirtualMachineDetailsRightGridLayoutPresentation;
-  sshService?: IoK8sApiCoreV1Service;
   vmi?: V1VirtualMachineInstance;
 };
 
 const VirtualMachineDetailsRightGridLayout: React.FC<VirtualMachineDetailsRightGridLayout> = ({
   vm,
-  sshService,
   vmDetailsRightGridObj,
   vmi,
 }) => {
+  const [sshService, sshServiceLoaded] = useSSHService(vm);
+
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
 
@@ -147,9 +148,11 @@ const VirtualMachineDetailsRightGridLayout: React.FC<VirtualMachineDetailsRightG
           data-test-id={`${vm?.metadata?.name}-workload-profile`}
         />
         <VirtualMachineDescriptionItem
-          descriptionData={vmDetailsRightGridObj?.sshAccess}
-          isEdit={!!vmi}
+          descriptionData={
+            <SSHAccess sshService={sshService} vmi={vmi} sshServiceLoaded={sshServiceLoaded} />
+          }
           showEditOnTitle
+          isEdit
           onEditClick={() =>
             createModal(({ isOpen, onClose }) => (
               <SSHAccessModal

--- a/src/views/virtualmachines/details/tabs/details/components/sections/ServicesSection.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/sections/ServicesSection.tsx
@@ -20,7 +20,10 @@ const ServicesSection = ({ vm, pathname }) => {
   });
   const { vmi } = useVMIAndPodsForVM(vm?.metadata?.name, vm?.metadata?.namespace);
 
-  const data = getServicesForVmi(services, vmi);
+  const data = getServicesForVmi(
+    services,
+    vmi?.metadata?.labels || vm?.spec?.template?.metadata?.labels,
+  );
 
   return (
     <div className="VirtualMachinesDetailsSection">

--- a/src/views/virtualmachines/details/tabs/details/utils/gridHelper.tsx
+++ b/src/views/virtualmachines/details/tabs/details/utils/gridHelper.tsx
@@ -8,8 +8,6 @@ import {
   V1VirtualMachineInstanceGuestAgentInfo,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
-import SSHAccess from '@kubevirt-utils/components/SSHAccess/SSHAccess';
-import { UseSSHServiceReturnType } from '@kubevirt-utils/components/SSHAccess/useSSHService';
 import { getVMIIPAddresses, getVMIPod } from '@kubevirt-utils/resources/vmi';
 import { K8sResourceCommon, ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -22,7 +20,6 @@ export type VirtualMachineDetailsRightGridLayoutPresentation = {
   hostname: React.ReactNode;
   timezone: React.ReactNode;
   node: React.ReactNode;
-  sshAccess: React.ReactNode;
 };
 
 export const getStoppedVMRightGridPresentation = (
@@ -38,7 +35,6 @@ export const getStoppedVMRightGridPresentation = (
     hostname: NotAvailable,
     timezone: VirtualMachineIsNotRunning,
     node: NotAvailable,
-    sshAccess: VirtualMachineIsNotRunning,
   };
 };
 
@@ -47,7 +43,6 @@ export const getRunningVMRightGridPresentation = (
   vmi: V1VirtualMachineInstance,
   pods: K8sResourceCommon[],
   guestAgentData?: V1VirtualMachineInstanceGuestAgentInfo,
-  watchSSHService?: UseSSHServiceReturnType,
 ): VirtualMachineDetailsRightGridLayoutPresentation => {
   const vmiPod = getVMIPod(vmi, pods);
   const ipAddresses = getVMIIPAddresses(vmi);
@@ -55,8 +50,6 @@ export const getRunningVMRightGridPresentation = (
   const guestAgentIsRequired = guestAgentData && Object.keys(guestAgentData)?.length === 0;
 
   const GuestAgentIsRequiredText = <MutedTextSpan text={t('Guest agent is required')} />;
-
-  const [sshService, sshServiceLoaded] = watchSSHService;
 
   return {
     pod: (
@@ -79,6 +72,5 @@ export const getRunningVMRightGridPresentation = (
       ? GuestAgentIsRequiredText
       : guestAgentData?.timezone?.split(',')[0],
     node: <ResourceLink kind={NodeModel.kind} name={nodeName} />,
-    sshAccess: <SSHAccess sshService={sshService} sshServiceLoaded={sshServiceLoaded} vmi={vmi} />,
   };
 };

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsTitle.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsTitle.tsx
@@ -23,7 +23,7 @@ const VirtualMachinesOverviewTabDetailsTitle: React.FC<
   const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
   const { t } = useKubevirtTranslation();
   const { vmi } = useVMIAndPodsForVM(vm?.metadata?.name, vm?.metadata?.namespace);
-  const [sshService] = useSSHService(vmi);
+  const [sshService] = useSSHService(vm);
   const { command } = useSSHCommand(vmi, sshService);
 
   const isMachinePaused = vm?.status?.printableStatus === printableVMStatus.Paused;

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Details.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Details.tsx
@@ -53,7 +53,7 @@ const Details: React.FC<DetailsProps> = ({ vmi, pathname }) => {
     name: vmi?.metadata?.name,
     namespace: vmi?.metadata?.namespace,
   });
-  const [sshService, sshServiceLoaded] = useSSHService(vmi);
+  const [sshService, sshServiceLoaded] = useSSHService(vm);
 
   return (
     <div>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Show services with stopped VM using `vm.spec.template.metadata.labels` instead of `vmi.metadata.labels` when vmi is not available (because vm not running)

Do you guys think we need both vm and vmi? Or we can just use `vm.spec.template.metadata.labels` ? 
## 🎥 Demo

![image](https://user-images.githubusercontent.com/29160323/178539597-434582f3-bd09-482a-b4b8-6f796b464eed.png)
