### PR TITLE
Change text 'boot method' to 'boot mode'

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -129,7 +129,6 @@
   "Boot disk": "Boot disk",
   "Boot from CD": "Boot from CD",
   "Boot from CD requires an image file i.e. ISO, qcow, etc. that will be mounted to the VirtualMachine as a CD": "Boot from CD requires an image file i.e. ISO, qcow, etc. that will be mounted to the VirtualMachine as a CD",
-  "Boot method": "Boot method",
   "Boot mode": "Boot mode",
   "Boot order": "Boot order",
   "Boot Order": "Boot Order",

--- a/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
+++ b/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
@@ -121,7 +121,7 @@ export const usePendingChanges = (
     {
       hasPendingChange: bootModeChanged,
       tabLabel: VirtualMachineDetailsTabLabel.Details,
-      label: t('Boot method'),
+      label: t('Boot mode'),
       handleAction: () => {
         history.push(getTabURL(vm, VirtualMachineDetailsTab.Details));
         createModal(({ isOpen, onClose }) => (


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

changing the `boot method` text to `Boot mode` as a follow up fix to https://github.com/kubevirt-ui/kubevirt-plugin/pull/422#discussion_r915674592