### PR TITLE
Bug 2103807: Name PVC source same as VM name when creating VM quickly

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
+import produce from 'immer';
 
+import {
+  extractParameterNameFromMetadataName,
+  replaceTemplateParameterValue,
+} from '@catalog/customize/utils';
 import { quickCreateVM } from '@catalog/utils/quick-create-vm';
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
@@ -45,7 +50,12 @@ export const TemplatesCatalogDrawerCreateForm: React.FC<TemplatesCatalogDrawerCr
       setIsQuickCreating(true);
       setQuickCreateError(undefined);
 
-      quickCreateVM(template, { name: vmName, namespace, startVM })
+      const parameterForName = extractParameterNameFromMetadataName(template);
+      const templateToProcess = produce(template, (draftTemplate) => {
+        replaceTemplateParameterValue(draftTemplate, parameterForName, vmName);
+      });
+
+      quickCreateVM(templateToProcess, { name: vmName, namespace, startVM })
         .then((vm) => {
           setIsQuickCreating(false);
           history.push(getResourceUrl(VirtualMachineModel, vm));


### PR DESCRIPTION
## 📝 Description

Name the PVC source name the same as the VM name, according to the parameter NAME in the yaml used also for the PVC source name.

The problem was that the part of the processing template was omitted, when quick creating VM, comparing creating VM with the customization process. The parameter NAME was not properly set when quick creating VM.

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2103807

## 🎥 Demo
**Before:**
![quick_before](https://user-images.githubusercontent.com/13417815/179255667-0bd3c563-202e-4db8-a174-84f53c86a905.png)
**After:**
![quick_after](https://user-images.githubusercontent.com/13417815/179255698-a754724e-eda2-4b07-9df1-bcc172ce277e.png)

