### PR TITLE
Bug 2104424: Check Descheduler Operator and enable/disable on pages

### DIFF
--- a/src/utils/hooks/useDeschedulerInstalled.ts
+++ b/src/utils/hooks/useDeschedulerInstalled.ts
@@ -1,0 +1,18 @@
+import { KubeDeschedulerModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+/**
+ * A Hook that checks if Kube Descheduler operator is installed.
+ * @returns {boolean} boolean value
+ */
+
+// check if the Descheduler is installed
+export const useDeschedulerInstalled = (): boolean => {
+  const [resourceList] = useK8sWatchResource<any>({
+    groupVersionKind: KubeDeschedulerModelGroupVersionKind,
+    isList: false,
+  });
+
+  return !isEmpty(resourceList);
+};

--- a/src/views/catalog/wizard/tabs/scheduling/WizardSchedulingTab.tsx
+++ b/src/views/catalog/wizard/tabs/scheduling/WizardSchedulingTab.tsx
@@ -10,9 +10,11 @@ import EvictionStrategyModal from '@kubevirt-utils/components/EvictionStrategyMo
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import NodeSelectorModal from '@kubevirt-utils/components/NodeSelectorModal/NodeSelectorModal';
 import TolerationsModal from '@kubevirt-utils/components/TolerationsModal/TolerationsModal';
+import { useDeschedulerInstalled } from '@kubevirt-utils/hooks/useDeschedulerInstalled';
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { DescriptionList, Grid, GridItem, Title } from '@patternfly/react-core';
+import { DescriptionList, Grid, GridItem } from '@patternfly/react-core';
 
 import { WizardDescriptionItem } from '../../components/WizardDescriptionItem';
 
@@ -32,11 +34,12 @@ const WizardSchedulingTab: WizardTab = ({ vm, updateVM }) => {
     isList: true,
   });
 
+  const isDeschedulerInstalled = useDeschedulerInstalled();
+  const isAdmin = useIsAdmin();
+  const isDeschedulerEditable = isAdmin && isDeschedulerInstalled;
+
   return (
     <div className="co-m-pane__body">
-      <Title headingLevel="h2" className="co-section-heading">
-        {t('Scheduling and resources requirements')}
-      </Title>
       <Grid hasGutter>
         <GridItem span={6} rowSpan={4}>
           <DescriptionList>
@@ -100,7 +103,7 @@ const WizardSchedulingTab: WizardTab = ({ vm, updateVM }) => {
             <WizardDescriptionItem
               title={t('Descheduler')}
               description={<Descheduler vm={vm} />}
-              isEdit
+              isEdit={isDeschedulerEditable}
               testId="descheduler"
               onEditClick={() =>
                 createModal(({ isOpen, onClose }) => (

--- a/src/views/templates/actions/hooks/useVirtualMachineTemplatesActions.tsx
+++ b/src/views/templates/actions/hooks/useVirtualMachineTemplatesActions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
-import { isCommonVMTemplate } from 'src/views/templates/utils';
+import { isCommonVMTemplate } from 'src/views/templates/utils/utils';
 
 import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import DataVolumeModel from '@kubevirt-ui/kubevirt-api/console/models/DataVolumeModel';

--- a/src/views/templates/details/TemplatePageTitle.tsx
+++ b/src/views/templates/details/TemplatePageTitle.tsx
@@ -7,7 +7,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { isDeprecatedTemplate } from '@kubevirt-utils/resources/template';
 import { Breadcrumb, BreadcrumbItem, Button, Label, Title } from '@patternfly/react-core';
 
-import { isCommonVMTemplate } from '../utils';
+import { isCommonVMTemplate } from '../utils/utils';
 
 import NoEditableTemplateAlert from './NoEditableTemplateAlert';
 import TemplateActions from './TemplateActions';

--- a/src/views/templates/details/tabs/details/TemplateDetailsPage.tsx
+++ b/src/views/templates/details/tabs/details/TemplateDetailsPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import TemplateDetailsLeftGrid from 'src/views/templates/details/tabs/details/components/TemplateDetailsLeftGrid';
 import TemplateDetailsRightGrid from 'src/views/templates/details/tabs/details/components/TemplateDetailsRightGrid';
-import { isCommonVMTemplate } from 'src/views/templates/utils';
+import { isCommonVMTemplate } from 'src/views/templates/utils/utils';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { ListPageBody } from '@openshift-console/dynamic-plugin-sdk';

--- a/src/views/templates/details/tabs/details/components/BootMethod/BootMethod.tsx
+++ b/src/views/templates/details/tabs/details/components/BootMethod/BootMethod.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { isCommonVMTemplate } from 'src/views/templates/utils';
+import { isCommonVMTemplate } from 'src/views/templates/utils/utils';
 
 import { getBootloaderTitleFromVM } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/utils';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';

--- a/src/views/templates/details/tabs/details/components/CPUMemory.tsx
+++ b/src/views/templates/details/tabs/details/components/CPUMemory.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useVirtualMachineTemplatesCPUMemory } from 'src/views/templates/list/hooks/useVirtualMachineTemplatesCPUMemory';
-import { isCommonVMTemplate } from 'src/views/templates/utils';
+import { isCommonVMTemplate } from 'src/views/templates/utils/utils';
 
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';

--- a/src/views/templates/details/tabs/details/components/CPUMemoryModal.tsx
+++ b/src/views/templates/details/tabs/details/components/CPUMemoryModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import produce from 'immer';
-import { isCommonVMTemplate } from 'src/views/templates/utils';
+import { isCommonVMTemplate } from 'src/views/templates/utils/utils';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import {

--- a/src/views/templates/details/tabs/details/components/DisplayName.tsx
+++ b/src/views/templates/details/tabs/details/components/DisplayName.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import produce from 'immer';
-import { ensurePath } from 'src/views/templates/utils';
 import { ANNOTATIONS } from 'src/views/templates/utils/constants';
+import { ensurePath } from 'src/views/templates/utils/utils';
 
 import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';

--- a/src/views/templates/details/tabs/details/components/TemplateDetailsRightGrid.tsx
+++ b/src/views/templates/details/tabs/details/components/TemplateDetailsRightGrid.tsx
@@ -19,7 +19,7 @@ import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList } from '@patternfly/react-core';
 
-import { isCommonVMTemplate } from '../../../../utils';
+import { isCommonVMTemplate } from '../../../../utils/utils';
 
 const TemplateDetailsRightGrid: React.FC<TemplateDetailsGridProps> = ({ template }) => {
   const { t } = useKubevirtTranslation();

--- a/src/views/templates/details/tabs/disks/TemplateDisksPage.tsx
+++ b/src/views/templates/details/tabs/disks/TemplateDisksPage.tsx
@@ -17,7 +17,7 @@ import {
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 
-import { isCommonVMTemplate } from '../../../utils';
+import { isCommonVMTemplate } from '../../../utils/utils';
 
 import DiskListTitle from './components/DiskListTitle';
 import DiskRow from './components/DiskRow';

--- a/src/views/templates/details/tabs/network/TemplateNetworkPage.tsx
+++ b/src/views/templates/details/tabs/network/TemplateNetworkPage.tsx
@@ -6,7 +6,7 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ListPageBody, ListPageCreateButton } from '@openshift-console/dynamic-plugin-sdk';
 
-import { isCommonVMTemplate } from '../../../utils';
+import { isCommonVMTemplate } from '../../../utils/utils';
 
 import NetworkInterfaceList from './components/list/NetworkInterfaceList';
 import NetworkInterfaceModal from './components/modal/NetworkInterfaceModal';

--- a/src/views/templates/details/tabs/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/templates/details/tabs/network/components/list/NetworkInterfaceActions.tsx
@@ -18,7 +18,7 @@ import {
   KebabToggle,
 } from '@patternfly/react-core';
 
-import { isCommonVMTemplate } from '../../../../../utils';
+import { isCommonVMTemplate } from '../../../../../utils/utils';
 import EditNetworkInterfaceModal from '../modal/EditNetworkInterfaceModal';
 
 type NetworkInterfaceActionsProps = {

--- a/src/views/templates/details/tabs/parameters/TemplateParametersPage.tsx
+++ b/src/views/templates/details/tabs/parameters/TemplateParametersPage.tsx
@@ -7,7 +7,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 import { ActionGroup, Alert, AlertVariant, Button, Divider } from '@patternfly/react-core';
 
-import { isCommonVMTemplate } from '../../../utils';
+import { isCommonVMTemplate } from '../../../utils/utils';
 
 import ParameterEditor from './ParameterEditor';
 

--- a/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.tsx
+++ b/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.tsx
@@ -7,7 +7,7 @@ import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
 import { Grid, GridItem } from '@patternfly/react-core';
 
-import { isCommonVMTemplate } from '../../../utils';
+import { isCommonVMTemplate } from '../../../utils/utils';
 
 import './TemplateSchedulingTab.scss';
 

--- a/src/views/templates/details/tabs/scheduling/components/DedicatedResources.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/DedicatedResources.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
-import { isDedicatedCPUPlacement } from 'src/views/templates/utils';
+import { isDedicatedCPUPlacement } from 'src/views/templates/utils/utils';
 
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';

--- a/src/views/templates/details/tabs/scheduling/components/DedicatedResourcesModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/DedicatedResourcesModal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import produce from 'immer';
-import { isDedicatedCPUPlacement } from 'src/views/templates/utils';
+import { isDedicatedCPUPlacement } from 'src/views/templates/utils/utils';
 
 import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import {

--- a/src/views/templates/details/tabs/scheduling/components/Descheduler.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/Descheduler.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { isDeschedulerOn, useDeschedulerInstalled } from 'src/views/templates/utils';
 import { DESCHEDULER_URL } from 'src/views/templates/utils/constants';
+import { isDeschedulerOn } from 'src/views/templates/utils/utils';
 
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
+import { useDeschedulerInstalled } from '@kubevirt-utils/hooks/useDeschedulerInstalled';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { V1Template } from '@kubevirt-utils/models';

--- a/src/views/templates/details/tabs/scheduling/components/DeschedulerModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/DeschedulerModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import produce from 'immer';
-import { isDeschedulerOn } from 'src/views/templates/utils';
+import { isDeschedulerOn } from 'src/views/templates/utils/utils';
 
 import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';

--- a/src/views/templates/details/tabs/scheduling/components/DeschedulerModalButton.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/DeschedulerModalButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isDeschedulerOn } from 'src/views/templates/utils';
+import { isDeschedulerOn } from 'src/views/templates/utils/utils';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';

--- a/src/views/templates/details/tabs/scripts/SysPrepItem.tsx
+++ b/src/views/templates/details/tabs/scripts/SysPrepItem.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
-import { isCommonVMTemplate } from 'src/views/templates/utils';
+import { isCommonVMTemplate } from 'src/views/templates/utils/utils';
 
 import {
   ConfigMapModel,

--- a/src/views/templates/details/tabs/scripts/TemplateScriptsPage.tsx
+++ b/src/views/templates/details/tabs/scripts/TemplateScriptsPage.tsx
@@ -34,7 +34,7 @@ import {
 } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
-import { isCommonVMTemplate } from '../../../utils';
+import { isCommonVMTemplate } from '../../../utils/utils';
 
 import SysPrepItem from './SysPrepItem';
 

--- a/src/views/templates/utils/utils.ts
+++ b/src/views/templates/utils/utils.ts
@@ -1,12 +1,10 @@
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
-import KubeDeschedulerModel from '@kubevirt-ui/kubevirt-api/console/models/KubeDeschedulerModel';
 import {
   getTemplateVirtualMachineObject,
   TEMPLATE_TYPE_BASE,
   TEMPLATE_TYPE_LABEL,
 } from '@kubevirt-utils/resources/template';
 import { DESCHEDULER_EVICT_LABEL } from '@kubevirt-utils/resources/vmi';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 export const isCommonVMTemplate = (template: V1Template): boolean =>
   template?.metadata?.labels?.[TEMPLATE_TYPE_LABEL] === TEMPLATE_TYPE_BASE;
@@ -14,15 +12,6 @@ export const isCommonVMTemplate = (template: V1Template): boolean =>
 export const isDedicatedCPUPlacement = (template: V1Template): boolean =>
   getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.domain?.cpu
     ?.dedicatedCpuPlacement;
-
-// check if the Descheduler is installed
-export const useDeschedulerInstalled = (): boolean => {
-  const [resourceList] = useK8sWatchResource<any>({
-    kind: KubeDeschedulerModel.kind,
-    isList: true,
-  });
-  return resourceList.length > 0;
-};
 
 // check if the descheduler is ON
 export const isDeschedulerOn = (template: V1Template): boolean =>

--- a/src/views/virtualmachines/details/tabs/scheduling/components/VirtualMachineSchedulingLeftGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/scheduling/components/VirtualMachineSchedulingLeftGrid.tsx
@@ -10,6 +10,8 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import NodeSelectorModal from '@kubevirt-utils/components/NodeSelectorModal/NodeSelectorModal';
 import Tolerations from '@kubevirt-utils/components/Tolerations/Tolerations';
 import TolerationsModal from '@kubevirt-utils/components/TolerationsModal/TolerationsModal';
+import { useDeschedulerInstalled } from '@kubevirt-utils/hooks/useDeschedulerInstalled';
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList, GridItem } from '@patternfly/react-core';
@@ -41,6 +43,10 @@ const VirtualMachineSchedulingLeftGrid: React.FC<VirtualMachineSchedulingLeftGri
   const isMachineNotLiveMirgation = !!vm?.status?.conditions?.find(
     ({ type, status }) => type === 'LiveMigratable' && status === 'False',
   );
+
+  const isDeschedulerInstalled = useDeschedulerInstalled();
+  const isAdmin = useIsAdmin();
+  const isDeschedulerEditable = isAdmin && isDeschedulerInstalled && !isMachineNotLiveMirgation;
 
   const onSubmit = React.useCallback(
     (updatedVM: V1VirtualMachine) =>
@@ -116,7 +122,7 @@ const VirtualMachineSchedulingLeftGrid: React.FC<VirtualMachineSchedulingLeftGri
         <VirtualMachineDescriptionItem
           descriptionData={<Descheduler vm={vm} />}
           descriptionHeader={t('Descheduler')}
-          isEdit={!isMachineNotLiveMirgation}
+          isEdit={isDeschedulerEditable}
           data-test-id="descheduler"
           isPopover
           bodyContent={

--- a/src/views/virtualmachinesinstance/details/tabs/scheduling/Descheduler/Descheduler.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/scheduling/Descheduler/Descheduler.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 
-import KubeDeschedulerModel from '@kubevirt-ui/kubevirt-api/console/models/KubeDeschedulerModel';
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { DESCHEDULER_EVICT_LABEL } from '@kubevirt-utils/resources/vmi';
-import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 type DeschedulerProps = {
   vmi: V1VirtualMachineInstance;
@@ -13,14 +11,8 @@ type DeschedulerProps = {
 const Descheduler: React.FC<DeschedulerProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
   const deschedulerLabel = Boolean(vmi?.metadata?.annotations[DESCHEDULER_EVICT_LABEL]);
-  const [resourceList] = useK8sWatchResource<K8sResourceCommon[]>({
-    kind: KubeDeschedulerModel.kind,
-    isList: true,
-  });
 
-  const isVMdeschedulerOn = resourceList?.length > 0 && deschedulerLabel;
-
-  return isVMdeschedulerOn ? t('ON') : t('OFF');
+  return deschedulerLabel ? t('ON') : t('OFF');
 };
 
 export default Descheduler;


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2104424

Check correctly if the Kube Descheduler Operator is installed and enable/disable _Descheduler_ field appropriately on VMs/Templates _Scheduling_ tabs, also in the _Review and create VirtualMachine_ page - _Scheduling_ tab.
Additionaly, remove unnecessary title from the _Review and create VirtualMachine_ page - _Scheduling_ tab for UI consistency reasons.

## 🎥 Demo
**Before:**
Templates _Scheduling_ tab and _Descheduler_ field disabled even when the operator is installed:
![sched_before](https://user-images.githubusercontent.com/13417815/181041687-8ac91190-909e-463b-8e55-0f7d26384b05.png)
_Review and create VirtualMachine_ page - _Scheduling_ tab with the unnecessary title, also _Descheduler_ field always editable no matter the operator installed:
![wizard_sched_before](https://user-images.githubusercontent.com/13417815/181041764-fa535f21-988a-48d2-9d91-cb6b10d0cc89.png)
**After:**
![sched_after](https://user-images.githubusercontent.com/13417815/181041723-71abdac0-f694-4216-8611-43572dbab58d.png)
![wizard_sched_after](https://user-images.githubusercontent.com/13417815/181041806-22438dc3-a81f-4b13-90fa-55b87d96075c.png)


