### PR TITLE
Bug 2060499: Quick create - template with multiple objects

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -27,6 +27,9 @@ const config: Config.InitialOptions = {
     ...pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/' }),
   },
   globals: {
+    SERVER_FLAGS: {
+      basePath: 'http://localhost:9000/',
+    },
     'ts-jest': {
       isolatedModules: true,
       diagnostics: {

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -12,6 +12,7 @@ import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/Virtua
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
 import { generateVMName } from '@kubevirt-utils/resources/template';
+import { useK8sModels } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Alert,
   Button,
@@ -45,6 +46,7 @@ export const TemplatesCatalogDrawerCreateForm: React.FC<TemplatesCatalogDrawerCr
     const [startVM, setStartVM] = React.useState(true);
     const [isQuickCreating, setIsQuickCreating] = React.useState(false);
     const [quickCreateError, setQuickCreateError] = React.useState(undefined);
+    const [models, modelsLoading] = useK8sModels();
 
     const onQuickCreate = () => {
       setIsQuickCreating(true);
@@ -55,7 +57,11 @@ export const TemplatesCatalogDrawerCreateForm: React.FC<TemplatesCatalogDrawerCr
         replaceTemplateParameterValue(draftTemplate, parameterForName, vmName);
       });
 
-      quickCreateVM(templateToProcess, { name: vmName, namespace, startVM })
+      quickCreateVM({
+        template: templateToProcess,
+        models,
+        overrides: { name: vmName, namespace, startVM },
+      })
         .then((vm) => {
           setIsQuickCreating(false);
           history.push(getResourceUrl(VirtualMachineModel, vm));
@@ -134,8 +140,10 @@ export const TemplatesCatalogDrawerCreateForm: React.FC<TemplatesCatalogDrawerCr
                     data-test-id="quick-create-vm-btn"
                     type="submit"
                     form="quick-create-form"
-                    isLoading={isQuickCreating}
-                    isDisabled={!isBootSourceAvailable || isQuickCreating || !vmName}
+                    isLoading={isQuickCreating || modelsLoading}
+                    isDisabled={
+                      !isBootSourceAvailable || isQuickCreating || !vmName || modelsLoading
+                    }
                     onClick={(e) => {
                       e.preventDefault();
                       onQuickCreate();

--- a/src/views/catalog/templatescatalog/tests/TemplatesCatalogDrawer.test.tsx
+++ b/src/views/catalog/templatescatalog/tests/TemplatesCatalogDrawer.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { BOOT_SOURCE } from '@kubevirt-utils/resources/template';
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -11,6 +12,13 @@ import { containerTemplateMock } from './mocks';
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   k8sCreate: jest.fn().mockResolvedValue({}),
   useK8sWatchResource: jest.fn(() => [[], true]),
+  useK8sModels: jest.fn(() => [
+    {
+      [`${VirtualMachineModel.apiGroup}~${VirtualMachineModel.apiVersion}~${VirtualMachineModel.kind}`]:
+        VirtualMachineModel,
+    },
+    true,
+  ]),
 }));
 
 jest.mock('@kubevirt-utils/resources/template/hooks/useVmTemplateSource', () => ({


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

In a follow-up pr, I'll solve this bug also in the wizard using the same function `createAllTemplateObjects`   


In this solution, I use `Promise.all`. This means that if any object creation request fails, it will follow the fail-fast behavior and throw an exception without waiting for the other promise's resolution.

What to do if one object fail?
Maybe some objects have been created and at least one failed. What can we do? We can try to delete the created objects? WDYT?  I can do it in a separate pr 