### PR TITLE
Bug 2111328: kubevirt plugin console crashed after visit vmi page

### DIFF
--- a/src/utils/hooks/useKubevirtWatchResource.ts
+++ b/src/utils/hooks/useKubevirtWatchResource.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+import { useK8sWatchResource, WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
+
+const useKubevirtWatchResource = (watchOptions: WatchK8sResource) => {
+  const [data, setData] = useState([]);
+  const [resource, loaded, loadError] = useK8sWatchResource<any>(watchOptions);
+
+  useEffect(() => {
+    if (resource && loaded) {
+      const isList = typeof resource?.[0] === 'string';
+      setData((isList && resource?.[1]) || resource?.items || resource);
+    }
+  }, [resource, loaded]);
+  return [data, loaded, loadError];
+};
+
+export default useKubevirtWatchResource;

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -3,17 +3,17 @@ import { useHistory } from 'react-router-dom';
 
 import {
   VirtualMachineInstanceModelGroupVersionKind,
+  VirtualMachineModelGroupVersionKind,
   VirtualMachineModelRef,
 } from '@kubevirt-ui/kubevirt-api/console';
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource';
 import {
   K8sResourceCommon,
   ListPageBody,
   ListPageCreateDropdown,
   ListPageFilter,
   ListPageHeader,
-  useK8sWatchResource,
   useListPageFilter,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
@@ -37,14 +37,14 @@ const VirtualMachinesList: React.FC<VirtualMachinesListProps> = ({ kind, namespa
 
   const catalogURL = `/k8s/ns/${namespace || 'default'}/templatescatalog`;
 
-  const [vms, loaded, loadError] = useK8sWatchResource<V1VirtualMachine[]>({
-    kind,
+  const [vms, loaded] = useKubevirtWatchResource({
+    groupVersionKind: VirtualMachineModelGroupVersionKind,
     isList: true,
     namespaced: true,
     namespace,
   });
 
-  const [vmis] = useK8sWatchResource<V1VirtualMachineInstance[]>({
+  const [vmis] = useKubevirtWatchResource({
     groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
     isList: true,
     namespaced: true,
@@ -88,11 +88,11 @@ const VirtualMachinesList: React.FC<VirtualMachinesListProps> = ({ kind, namespa
           data={data}
           unfilteredData={unfilteredData}
           loaded={loaded}
-          loadError={loadError}
           columns={columns}
+          loadError={null}
           Row={VirtualMachineRow}
           rowData={{ kind, vmis }}
-          EmptyMsg={() => <VirtualMachineEmptyState catalogURL={catalogURL} />}
+          NoDataEmptyMsg={() => <VirtualMachineEmptyState catalogURL={catalogURL} />}
         />
       </ListPageBody>
     </>


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

the `useK8sWatchResource` from SDK returns in-consistent data (especially when argument `isList: true` is set)
We get sometimes (not 100% reproducible) an object of `V1VirtualMachineList` instead of `V1VirtualMachine[]` which causing the VM list page to crash.

The solution is to wrap the `useK8sWatchResource` hook with extra logic to guarantee we get the list of resources as needed for the VirtualizedTable component.
Also changed the table to receive null as `loadError` prop since we're getting an error whenever the `useK8sWatchResource` return a non-expected result

NOTE: `loadError` variable contains the following error message:
```
TypeError: e.get(...).get is not a function
    at main-chunk-38cf75c9479113bc6a73.min.js:1
    at Set.forEach (<anonymous>)
    at main-chunk-38cf75c9479113bc6a73.min.js:1
    at Te.withMutations (vendors~main-chunk-060a38a3a92bb93b24f1.min.js:6429)
    at main-chunk-38cf75c9479113bc6a73.min.js:1
    at t.a (main-chunk-38cf75c9479113bc6a73.min.js:1)
    at vendors~main-chunk-060a38a3a92bb93b24f1.min.js:27529
    at m (vendors~main-chunk-060a38a3a92bb93b24f1.min.js:27529)
    at vendors~main-chunk-060a38a3a92bb93b24f1.min.js:53893
    at dispatch (vendors~main-chunk-060a38a3a92bb93b24f1.min.js:27529)
```

This PR is a workaround to get the VM list not crashing and we should fix the hook at SDK as soon as possible since it will probably cause more issues accross the plugin

cc: @tnisan @gouyang @vojtechszocs 

## 🎥 Demo

### Before:

https://user-images.githubusercontent.com/67270715/181528653-3fbf86a5-5607-421f-a637-6a1d1cd82fab.mp4

### After:

https://user-images.githubusercontent.com/67270715/181528990-5234093e-d6a4-40b6-ab84-7c2a8bd96576.mp4


