### PR TITLE
Bug 2101423: Display user name on using ignition

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -890,6 +890,7 @@
   "User": "User",
   "User Name": "User Name",
   "User name: ": "User name: ",
+  "User name: _plural": "User name: ",
   "User permissions": "User permissions",
   "Utilization": "Utilization",
   "Value": "Value",

--- a/src/utils/components/Consoles/components/CloudInitCredentials/CloudInitCredentialsContent.tsx
+++ b/src/utils/components/Consoles/components/CloudInitCredentials/CloudInitCredentialsContent.tsx
@@ -4,9 +4,8 @@ import { Trans } from 'react-i18next';
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ClipboardCopy } from '@patternfly/react-core';
-
-import { CLOUD_INIT_MISSING_USERNAME } from '../../utils/constants';
 
 type CloudInitCredentialsContentProps = {
   vmi: V1VirtualMachineInstance;
@@ -14,9 +13,10 @@ type CloudInitCredentialsContentProps = {
 
 const CloudInitCredentialsContent: React.FC<CloudInitCredentialsContentProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
-  const { user, password } = getCloudInitCredentials(vmi);
+  const { users } = getCloudInitCredentials(vmi);
+  const usernameTitle = t('User name: ', { count: users?.length });
 
-  if (!user && !password) {
+  if (isEmpty(users)) {
     return <>{t('No credentials, see operating system documentation for the default username.')}</>;
   }
 
@@ -28,23 +28,28 @@ const CloudInitCredentialsContent: React.FC<CloudInitCredentialsContentProps> = 
         for more information.
       </Trans>
       <div>
-        <strong>{t('User name: ')}</strong>
-        {user || CLOUD_INIT_MISSING_USERNAME}
-
-        {password && (
+        <strong>{usernameTitle}</strong>
+        {users.map((user, index) => (
           <>
-            <strong>{t(' Password: ')} </strong>
+            {user?.name}
+            {index + 1 < users?.length ? ', ' : ''}
 
-            <ClipboardCopy
-              variant="inline-compact"
-              isCode
-              clickTip={t('Copied')}
-              hoverTip={t('Copy to clipboard')}
-            >
-              {password}
-            </ClipboardCopy>
+            {user?.password && (
+              <>
+                <strong>{t(' Password: ')} </strong>
+
+                <ClipboardCopy
+                  variant="inline-compact"
+                  isCode
+                  clickTip={t('Copied')}
+                  hoverTip={t('Copy to clipboard')}
+                >
+                  {user.password}
+                </ClipboardCopy>
+              </>
+            )}
           </>
-        )}
+        ))}
       </div>
     </>
   );

--- a/src/utils/components/UserCredentials/useSSHCommand.ts
+++ b/src/utils/components/UserCredentials/useSSHCommand.ts
@@ -15,7 +15,8 @@ const useSSHCommand = (
 ): useSSHCommandResult => {
   const consoleHostname = window.location.hostname; // fallback to console hostname
 
-  const { user } = getCloudInitCredentials(vmi);
+  const { users } = getCloudInitCredentials(vmi);
+  const user = users?.[0]?.name;
   const sshServicePort = getSSHNodePort(sshService);
 
   let command = 'ssh ';


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2101423

Display the user name correctly in the _Guest login credentials_ in the VM's _Console_ tab.

KubeVirt supports the cloud-init NoCloud and ConfigDrive data sources. The implementation for ConfigDrive data source was missing. The fix supports also displaying multiple usernames. Note that `users` (list of objects) is optional in the `passwd` object.

_Useful docs:_
https://coreos.github.io/ignition/configuration-v3_3/
https://kubevirt.io/user-guide/virtual_machines/startup_scripts/#cloud-init

Thanks to @DanaOrr for her suggestions on https://github.com/kubevirt-ui/kubevirt-plugin/pull/806.

## 🎥 Demo
**Before:**
Displaying "[" as the _User name_ not corresponding to the VM's yaml:
![before_user](https://user-images.githubusercontent.com/13417815/182472011-a3316356-dd47-4131-b805-6935dd6ba887.png)
**After:**
Displaying the _User name_ correctly:
![afterr](https://user-images.githubusercontent.com/13417815/182472056-a2d88ba4-dfcf-4ae9-ab15-75daa5b19664.png)
If more users specified:
![users](https://user-images.githubusercontent.com/13417815/182939976-fbab7dba-5054-4e05-9857-1c8ce68d0ab7.png)
If no any credentials specified:
![after_no_credentials](https://user-images.githubusercontent.com/13417815/182472378-87470604-d850-4728-9c81-ddb412c00f5d.png)
If both the user name and password specified (not using ignition):
![fedora_no_ignition](https://user-images.githubusercontent.com/13417815/182695768-7a3fa417-9f2c-442e-893b-ab4ed0395287.png)
If `username` or `name` missing (and other credentials present):
![no_username](https://user-images.githubusercontent.com/13417815/183517922-4bf4a4db-ae51-498c-bb55-4fc6261e4a4c.png)

