### PR TITLE
Bug 2114516: Open website after clicking on Fedora cloud image list link

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourceUrlInput.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourceUrlInput.tsx
@@ -16,7 +16,7 @@ const URLSourceHelperText: React.FC<{ os: OS_NAME_TYPES }> = ({ os }) => {
     <>
       {beforeLabelText}
       <strong>
-        <a href={OS_IMAGE_LINKS[os]} target="_blank" rel="noreferrer">
+        <a href={OS_IMAGE_LINKS[os || OS_NAME_TYPES.fedora]} target="_blank" rel="noreferrer">
           {label}
         </a>
       </strong>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2114516

Make the link in the "Example" for Fedora work, when editing template's disk and choosing "URL (creates PVC)" as _Source_ in the _Edit disk_ modal.

The core of the problem was missing some default value for the `os` (in some edge cases when it is `undefined`), comparing to what is returned for `getURLSourceHelpertText` function (used [in the affected component](https://github.com/kubevirt-ui/kubevirt-plugin/blob/main/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourceUrlInput.tsx#L14)): Fedora OS related helper text. So the same OS was used as the default one also in the affected `URLSourceHelperText` component.

## 🎥 Demo
_Before:_
Nothing happens after clicking on **_Fedora cloud image list_** link.
![fedora_before](https://user-images.githubusercontent.com/13417815/182480453-ba57d303-8da0-4d9f-9299-bbae48b544a9.png)
_After:_
The corresponding website is opened:
![fedora_after](https://user-images.githubusercontent.com/13417815/182480476-eb909217-2cfa-49ba-a1a5-5df2f97fad96.png)


