### PR TITLE
reinforcing negative values inputs for migration per cluster and node

### DIFF
--- a/src/views/clusteroverview/SettingsTab/LiveMigrationTab/Limits/Limits.tsx
+++ b/src/views/clusteroverview/SettingsTab/LiveMigrationTab/Limits/Limits.tsx
@@ -37,14 +37,15 @@ const Limits = ({ hyperConverge }) => {
           <Title headingLevel="h6" size="md">
             {t('Max. Migration per cluster')}
           </Title>
-          {migrationPerCluster ? (
+          {!isNaN(migrationPerCluster) ? (
             <NumberInput
               value={migrationPerCluster}
               onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                setMigrationPerCluster(() => {
-                  updateValuesCluster(hyperConverge, +event.target.value, MIGRATION_PER_CLUSTER);
-                  return +event.target.value;
-                });
+                +event.target.value >= 0 &&
+                  setMigrationPerCluster(() => {
+                    updateValuesCluster(hyperConverge, +event.target.value, MIGRATION_PER_CLUSTER);
+                    return +event.target.value;
+                  });
               }}
               min={0}
               onMinus={() =>
@@ -78,10 +79,11 @@ const Limits = ({ hyperConverge }) => {
           <Title headingLevel="h6" size="md">
             {t('Max. Migration per node')}
           </Title>
-          {migrationPerNode ? (
+          {!isNaN(migrationPerNode) ? (
             <NumberInput
               value={migrationPerNode}
               onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                +event.target.value >= 0 &&
                 setMigrationPerNode(() => {
                   updateValuesNode(hyperConverge, +event.target.value, MIGRATION_PER_NODE);
                   return +event.target.value;


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

In virtualization -> setting tab -> live migration tab - if a user types a negative value, it will fail the call and set a zero number instead of not changing the value. This fix will now check for positive/zero values before sending.

## 🎥 Demo

> Please add a video or an image of the behavior/changes
