### PR TITLE
Bug 2096780: Add Sysprep in template Objects array

### DIFF
--- a/src/utils/components/SysprepModal/SysprepModal.tsx
+++ b/src/utils/components/SysprepModal/SysprepModal.tsx
@@ -12,8 +12,7 @@ export const SysprepModal: React.FC<{
   isOpen: boolean;
   autoUnattend: string;
   unattend: string;
-  onAutoUnattendChange?: (value: string) => void | Promise<void>;
-  onUnattendChange?: (value: string) => void | Promise<void>;
+  onSysprepCreation?: (unattended: string, autoUnattend: string) => void | Promise<void>;
   onClose: () => void;
   enableCreation?: boolean;
   onSysprepSelected?: (sysprepName: string) => void | Promise<void>;
@@ -23,8 +22,7 @@ export const SysprepModal: React.FC<{
   onClose,
   autoUnattend: initialAutoUnattend,
   unattend: initialUnattend,
-  onAutoUnattendChange,
-  onUnattendChange,
+  onSysprepCreation,
   enableCreation = true,
   onSysprepSelected,
   sysprepSelected,
@@ -37,8 +35,7 @@ export const SysprepModal: React.FC<{
 
   const submitHandler = async () => {
     if (enableCreation && creationSectionOpen) {
-      await onAutoUnattendChange(autoUnattend);
-      await onUnattendChange(unattend);
+      return await onSysprepCreation(unattend, autoUnattend);
     }
 
     if (onSysprepSelected) await onSysprepSelected(selectedSysprepName);

--- a/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
@@ -38,17 +38,6 @@ const WizardScriptsTab: WizardTab = ({ vm, updateVM, tabsData, updateTabsData })
   const autoUnattend = tabsData?.scripts?.sysprep?.autounattend;
   const selectedSysprep = tabsData?.scripts?.sysprep?.selectedSysprep;
 
-  const onUnattendChange = (value: string) =>
-    updateTabsData((tabsDraft) => {
-      ensurePath(tabsDraft, 'scripts.sysprep');
-      if (value) {
-        tabsDraft.scripts.sysprep.unattended = value;
-        delete tabsDraft.scripts.sysprep.selectedSysprep;
-      } else {
-        delete tabsDraft.scripts.sysprep.unattended;
-      }
-    });
-
   const onSysprepSelected = (newSysprep: string) =>
     updateTabsData((tabsDraft) => {
       ensurePath(tabsDraft, 'scripts.sysprep');
@@ -61,14 +50,14 @@ const WizardScriptsTab: WizardTab = ({ vm, updateVM, tabsData, updateTabsData })
       }
     });
 
-  const onAutoUnattendChange = (value: string) =>
+  const onSysprepCreation = (unattended: string, autounattend: string) =>
     updateTabsData((tabsDraft) => {
       ensurePath(tabsDraft, 'scripts.sysprep');
-      if (value) {
-        tabsDraft.scripts.sysprep.autounattend = value;
+      tabsDraft.scripts.sysprep.autounattend = autounattend;
+      tabsDraft.scripts.sysprep.unattended = unattended;
+
+      if (unattended || autounattend) {
         delete tabsDraft.scripts.sysprep.selectedSysprep;
-      } else {
-        delete tabsDraft.scripts.sysprep.autounattend;
       }
     });
 
@@ -167,8 +156,7 @@ const WizardScriptsTab: WizardTab = ({ vm, updateVM, tabsData, updateTabsData })
                     {...modalProps}
                     unattend={unattend}
                     autoUnattend={autoUnattend}
-                    onAutoUnattendChange={onAutoUnattendChange}
-                    onUnattendChange={onUnattendChange}
+                    onSysprepCreation={onSysprepCreation}
                     onSysprepSelected={onSysprepSelected}
                     sysprepSelected={selectedSysprep}
                   />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Currently, the template can only be attached to an existing Sysprep config in the same namespace.
Now we can add it to the template objects array.

Users can choose between creating a new one every time the template is used or attaching the template to an existing Sysprep config.


Same thing can be done for ssh keys and ssh services


## 🎥 Demo

![Screenshot from 2022-08-05 11-18-42](https://user-images.githubusercontent.com/29160323/183046161-32639da3-3acf-42dd-8895-3837b67f1088.png)
![Screenshot from 2022-08-05 11-18-35](https://user-images.githubusercontent.com/29160323/183046165-1b7a7630-4ee7-4b58-bedf-a5e11e9cda47.png)

