### PR TITLE
Bug 2115258: Quick create -default storage class name

### DIFF
--- a/src/utils/hooks/useDefaultStorage/constants.ts
+++ b/src/utils/hooks/useDefaultStorage/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_STORAGE_CLASS_ANNOTATION = 'storageclass.kubernetes.io/is-default-class';

--- a/src/utils/hooks/useDefaultStorage/useDefaultStorageClass.ts
+++ b/src/utils/hooks/useDefaultStorage/useDefaultStorageClass.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react';
+
+import { modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
+import { StorageClassModel } from '@kubevirt-utils/models';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+import { isEmpty } from '../../utils/utils';
+
+import { DEFAULT_STORAGE_CLASS_ANNOTATION } from './constants';
+
+type UseDefaultStorageClass = () => [IoK8sApiStorageV1StorageClass, boolean];
+
+const useDefaultStorageClass: UseDefaultStorageClass = () => {
+  const [storageClasses, loaded] = useK8sWatchResource<IoK8sApiStorageV1StorageClass[]>({
+    groupVersionKind: modelToGroupVersionKind(StorageClassModel),
+    isList: true,
+  });
+
+  const defaultStorageClass = useMemo(() => {
+    if (!loaded || isEmpty(storageClasses)) return null;
+
+    return storageClasses?.find(
+      ({ metadata }) => metadata?.annotations?.[DEFAULT_STORAGE_CLASS_ANNOTATION] === 'true',
+    );
+  }, [storageClasses, loaded]);
+  return [defaultStorageClass, loaded];
+};
+
+export default useDefaultStorageClass;

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -9,6 +9,7 @@ import {
 import { quickCreateVM } from '@catalog/utils/quick-create-vm';
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
+import useDefaultStorageClass from '@kubevirt-utils/hooks/useDefaultStorage/useDefaultStorageClass';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
 import { generateVMName } from '@kubevirt-utils/resources/template';
@@ -47,6 +48,7 @@ export const TemplatesCatalogDrawerCreateForm: React.FC<TemplatesCatalogDrawerCr
     const [isQuickCreating, setIsQuickCreating] = React.useState(false);
     const [quickCreateError, setQuickCreateError] = React.useState(undefined);
     const [models, modelsLoading] = useK8sModels();
+    const [defaultStorageClass, defaultStorageClassLoaded] = useDefaultStorageClass();
 
     const onQuickCreate = () => {
       setIsQuickCreating(true);
@@ -60,7 +62,7 @@ export const TemplatesCatalogDrawerCreateForm: React.FC<TemplatesCatalogDrawerCr
       quickCreateVM({
         template: templateToProcess,
         models,
-        overrides: { name: vmName, namespace, startVM },
+        overrides: { name: vmName, namespace, startVM, defaultStorageClass },
       })
         .then((vm) => {
           setIsQuickCreating(false);
@@ -140,7 +142,7 @@ export const TemplatesCatalogDrawerCreateForm: React.FC<TemplatesCatalogDrawerCr
                     data-test-id="quick-create-vm-btn"
                     type="submit"
                     form="quick-create-form"
-                    isLoading={isQuickCreating || modelsLoading}
+                    isLoading={isQuickCreating || modelsLoading || !defaultStorageClassLoaded}
                     isDisabled={
                       !isBootSourceAvailable || isQuickCreating || !vmName || modelsLoading
                     }

--- a/src/views/catalog/utils/quick-create-vm.ts
+++ b/src/views/catalog/utils/quick-create-vm.ts
@@ -2,6 +2,7 @@ import produce from 'immer';
 
 import { ProcessedTemplatesModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
+import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import {
   LABEL_USED_TEMPLATE_NAME,
@@ -16,13 +17,18 @@ import { createMultipleResources } from './utils';
 type QuickCreateVMType = (inputs: {
   template: V1Template;
   models: { [key: string]: K8sModel };
-  overrides: { namespace: string; name: string; startVM: boolean };
+  overrides: {
+    namespace: string;
+    name: string;
+    startVM: boolean;
+    defaultStorageClass: IoK8sApiStorageV1StorageClass;
+  };
 }) => Promise<V1VirtualMachine>;
 
 export const quickCreateVM: QuickCreateVMType = async ({
   template,
   models,
-  overrides: { namespace, name, startVM },
+  overrides: { namespace, name, startVM, defaultStorageClass },
 }) => {
   const processedTemplate = await k8sCreate<V1Template>({
     model: ProcessedTemplatesModel,
@@ -41,7 +47,15 @@ export const quickCreateVM: QuickCreateVMType = async ({
 
     draftVM.metadata.labels[LABEL_USED_TEMPLATE_NAME] = processedTemplate.metadata.name;
     draftVM.metadata.labels[LABEL_USED_TEMPLATE_NAMESPACE] = processedTemplate.metadata.namespace;
-
+    if (defaultStorageClass) {
+      draftVM.spec.dataVolumeTemplates = draftVM?.spec?.dataVolumeTemplates?.map((dv) => {
+        const storage = dv?.spec?.storage;
+        if (storage && storage?.storageClassName !== defaultStorageClass?.metadata?.name) {
+          storage.storageClassName = defaultStorageClass?.metadata?.name;
+        }
+        return dv;
+      });
+    }
     if (startVM) {
       draftVM.spec.running = true;
     }


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Quick create option from the catalog would have not to use the default storage class but will use the storage class from the template.
Wizard is using the default storage class.
The behavior will now be the same as the wizard, and quick create will use of the default storage class.

## 🎥 Demo

> Please add a video or an image of the behavior/changes
