### PR TITLE
Bug 2114636: Change "File system" title to plural in VM Disks tab

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -367,7 +367,6 @@
   "Feature highlights": "Feature highlights",
   "Fedora cloud image list ": "Fedora cloud image list ",
   "Field selectors let you select Nodes based on the value of one or more resource fields.": "Field selectors let you select Nodes based on the value of one or more resource fields.",
-  "File system": "File system",
   "File system type": "File system type",
   "File systems": "File systems",
   "Filesystem": "Filesystem",

--- a/src/views/virtualmachines/details/tabs/disk/tables/filesystem/FilesystemListTitle.tsx
+++ b/src/views/virtualmachines/details/tabs/disk/tables/filesystem/FilesystemListTitle.tsx
@@ -9,7 +9,7 @@ const FilesystemListTitle = () => {
 
   return (
     <span>
-      <h3 className="HeaderWithIcon">{t('File system')}</h3>
+      <h3 className="HeaderWithIcon">{t('File systems')}</h3>
       <Popover
         bodyContent={t(
           'The following information regarding how the disks are partitioned is provided by the guest agent.',


### PR DESCRIPTION
## 📝 Description

This is a small nitpick, a forgotten little change, that should have been [here](https://github.com/kubevirt-ui/kubevirt-plugin/pull/823/files#diff-9f0ec7188a61121e7080447079f9c5959569cbe8defb33218027a30125aa465eR12).

## 🎥 Demo
**Before:**
![file_before](https://user-images.githubusercontent.com/13417815/183709442-70182288-4f36-4945-8e9d-9261e0c40be7.png)
**After:**
![file_after](https://user-images.githubusercontent.com/13417815/183709464-c1fcec37-76b3-49a6-82dd-d6147d419a7f.png)




