### PR TITLE
Bug 2096780: Wizard with ssh key in additionalResources

### DIFF
--- a/src/views/catalog/utils/WizardVMContext/utils/tabs-data.ts
+++ b/src/views/catalog/utils/WizardVMContext/utils/tabs-data.ts
@@ -14,9 +14,4 @@ export type TabsData = {
   disks?: {
     dataVolumesToAddOwnerRef?: V1beta1DataVolume[];
   };
-  scripts?: {
-    cloudInit: {
-      sshKey?: string;
-    };
-  };
 };

--- a/src/views/catalog/utils/WizardVMContext/utils/vm-produce.ts
+++ b/src/views/catalog/utils/WizardVMContext/utils/vm-produce.ts
@@ -85,7 +85,7 @@ export const produceVMSysprep = (vm: V1VirtualMachine, sysprepName?: string) => 
   });
 };
 
-export const produceVMSSHKey = (vm: V1VirtualMachine) => {
+export const produceVMSSHKey = (vm: V1VirtualMachine, secretName?: string) => {
   return produce(vm, (vmDraft) => {
     const cloudInitNoCloudVolume = vmDraft.spec.template.spec.volumes.find(
       (v) => v.cloudInitNoCloud,
@@ -105,7 +105,7 @@ export const produceVMSSHKey = (vm: V1VirtualMachine) => {
         sshPublicKey: {
           source: {
             secret: {
-              secretName: `${vmDraft.metadata.name}-ssh-key`,
+              secretName: secretName || `${vmDraft.metadata.name}-ssh-key`,
             },
           },
           propagationMethod: {

--- a/src/views/catalog/utils/useWizardVmCreate.ts
+++ b/src/views/catalog/utils/useWizardVmCreate.ts
@@ -3,7 +3,6 @@ import produce from 'immer';
 
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { createVmSSHSecret } from '@kubevirt-utils/components/CloudinitModal/utils/cloudinit-utils';
 import { addUploadDataVolumeOwnerReference } from '@kubevirt-utils/hooks/useCDIUpload/utils';
 import { k8sCreate, k8sDelete, useK8sModels } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -48,11 +47,6 @@ export const useWizardVmCreate = (): UseWizardVmCreateValues => {
           models,
           newVM.metadata.namespace,
         );
-      }
-
-      // ssh key
-      if (tabsData?.scripts?.cloudInit?.sshKey) {
-        await createVmSSHSecret(newVM, tabsData?.scripts?.cloudInit?.sshKey);
       }
 
       // add missing ownerReferences to upload data volumes

--- a/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
@@ -1,64 +1,21 @@
 import * as React from 'react';
-import { Trans } from 'react-i18next';
 
-import { ensurePath, produceVMSSHKey } from '@catalog/utils/WizardVMContext';
 import { WizardDescriptionItem } from '@catalog/wizard/components/WizardDescriptionItem';
 import { WizardTab } from '@catalog/wizard/tabs';
-import { AuthorizedSSHKeyModal } from '@kubevirt-utils/components/AuthorizedSSHKeyModal/AuthorizedSSHKeyModal';
 import { CloudInitDescription } from '@kubevirt-utils/components/CloudinitDescription/CloudInitDescription';
 import { CloudinitModal } from '@kubevirt-utils/components/CloudinitModal/CloudinitModal';
-import { addSecretToVM } from '@kubevirt-utils/components/CloudinitModal/utils/cloudinit-utils';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import {
-  DescriptionList,
-  Divider,
-  Grid,
-  GridItem,
-  Stack,
-  Text,
-  TextVariants,
-} from '@patternfly/react-core';
+import { DescriptionList, Divider, Grid, GridItem } from '@patternfly/react-core';
 
+import SSHKey from './components/SSHKey';
 import Sysprep from './components/Sysprep';
 
 import './WizardScriptsTab.scss';
 
-const WizardScriptsTab: WizardTab = ({ vm, updateVM, tabsData, updateTabsData }) => {
+const WizardScriptsTab: WizardTab = ({ vm, updateVM }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
-
-  const sshKey = tabsData?.scripts?.cloudInit?.sshKey;
-  const vmAttachedSecretName = vm?.spec?.template?.spec?.accessCredentials?.find(
-    (ac) => ac?.sshPublicKey?.source?.secret?.secretName,
-  )?.sshPublicKey?.source?.secret?.secretName;
-
-  const onSSHChange = (secretName: string, value?: string) => {
-    updateTabsData((tabsDraft) => {
-      ensurePath(tabsDraft, 'scripts.cloudInit');
-
-      if (value) {
-        tabsDraft.scripts.cloudInit.sshKey = value;
-      } else {
-        delete tabsDraft.scripts.cloudInit.sshKey;
-      }
-    });
-
-    if (value) {
-      return updateVM((vmDraft) => {
-        const produced = produceVMSSHKey(vmDraft);
-        vmDraft.spec = produced.spec;
-      });
-    } else if (secretName) {
-      return updateVM((vmDraft) => {
-        return addSecretToVM(vmDraft, secretName);
-      });
-    } else {
-      return updateVM((vmDraft) => {
-        vmDraft.spec.template.spec.accessCredentials = null;
-      });
-    }
-  };
 
   return (
     <div className="co-m-pane__body">
@@ -78,37 +35,7 @@ const WizardScriptsTab: WizardTab = ({ vm, updateVM, tabsData, updateTabsData })
               }
             />
             <Divider />
-            <WizardDescriptionItem
-              testId="wizard-sshkey"
-              title={t('Authorized SSH Key')}
-              isEdit
-              showEditOnTitle
-              description={
-                <Stack hasGutter>
-                  <div data-test="ssh-popover">
-                    <Trans t={t} ns="plugin__kubevirt-plugin">
-                      <Text component={TextVariants.p}>Store the key in a project secret.</Text>
-                      <Text component={TextVariants.p}>
-                        The key will be stored after the machine is created
-                      </Text>
-                    </Trans>
-                  </div>
-                  <span>
-                    {sshKey || vmAttachedSecretName ? t('Available') : t('Not available')}
-                  </span>
-                </Stack>
-              }
-              onEditClick={() =>
-                createModal((modalProps) => (
-                  <AuthorizedSSHKeyModal
-                    {...modalProps}
-                    sshKey={sshKey}
-                    vmSecretName={vmAttachedSecretName}
-                    onSubmit={onSSHChange}
-                  />
-                ))
-              }
-            />
+            <SSHKey />
             <Divider />
             <Sysprep />
           </DescriptionList>

--- a/src/views/catalog/wizard/tabs/scripts/components/SSHKey.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/components/SSHKey.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { Trans } from 'react-i18next';
+
+import { useWizardVMContext } from '@catalog/utils/WizardVMContext';
+import { WizardDescriptionItem } from '@catalog/wizard/components/WizardDescriptionItem';
+import { SecretModel } from '@kubevirt-ui/kubevirt-api/console';
+import { AuthorizedSSHKeyModal } from '@kubevirt-utils/components/AuthorizedSSHKeyModal/AuthorizedSSHKeyModal';
+import { addSecretToVM } from '@kubevirt-utils/components/CloudinitModal/utils/cloudinit-utils';
+import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { Stack, Text, TextVariants } from '@patternfly/react-core';
+
+import { changeSecretKey, removeSSHKeyObject, updateSSHKeyObject } from './sshkey-utils';
+
+const SSHKey: React.FC = () => {
+  const { vm, updateVM, tabsData, updateTabsData } = useWizardVMContext();
+  const { t } = useKubevirtTranslation();
+  const { createModal } = useModal();
+
+  const vmAttachedSecretName = vm?.spec?.template?.spec?.accessCredentials?.find(
+    (ac) => ac?.sshPublicKey?.source?.secret?.secretName,
+  )?.sshPublicKey?.source?.secret?.secretName;
+
+  const sshSecretObject = tabsData?.additionalObjects?.find(
+    (object) =>
+      object?.kind === SecretModel.kind && object?.metadata?.name === vmAttachedSecretName,
+  );
+  const secretKey = sshSecretObject?.data?.key && atob(sshSecretObject?.data?.key);
+
+  const onSSHChange = (secretName: string, sshKey?: string) => {
+    if (!sshKey && !secretName) {
+      return updateVM((vmDraft) => {
+        vmDraft.spec.template.spec.accessCredentials = null;
+      });
+    }
+
+    if (secretName) {
+      removeSSHKeyObject(updateTabsData, vmAttachedSecretName);
+      return updateVM((vmDraft) => {
+        return addSecretToVM(vmDraft, secretName);
+      });
+    }
+
+    if (sshKey) {
+      return sshSecretObject
+        ? Promise.resolve(changeSecretKey(updateTabsData, sshKey, vmAttachedSecretName))
+        : updateSSHKeyObject(vm, updateVM, updateTabsData, sshKey);
+    }
+  };
+
+  return (
+    <WizardDescriptionItem
+      testId="wizard-sshkey"
+      title={t('Authorized SSH Key')}
+      isEdit
+      showEditOnTitle
+      description={
+        <Stack hasGutter>
+          <div data-test="ssh-popover">
+            <Trans t={t} ns="plugin__kubevirt-plugin">
+              <Text component={TextVariants.p}>Store the key in a project secret.</Text>
+              <Text component={TextVariants.p}>
+                The key will be stored after the machine is created
+              </Text>
+            </Trans>
+          </div>
+          <span>{vmAttachedSecretName ? t('Available') : t('Not available')}</span>
+        </Stack>
+      }
+      onEditClick={() =>
+        createModal((modalProps) => (
+          <AuthorizedSSHKeyModal
+            {...modalProps}
+            sshKey={secretKey}
+            vmSecretName={!sshSecretObject && vmAttachedSecretName}
+            onSubmit={onSSHChange}
+          />
+        ))
+      }
+    />
+  );
+};
+
+export default SSHKey;

--- a/src/views/catalog/wizard/tabs/scripts/components/sshkey-utils.ts
+++ b/src/views/catalog/wizard/tabs/scripts/components/sshkey-utils.ts
@@ -1,0 +1,61 @@
+import { produceVMSSHKey, WizardVMContextType } from '@catalog/utils/WizardVMContext';
+import { SecretModel } from '@kubevirt-ui/kubevirt-api/console';
+import { IoK8sApiCoreV1Secret } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { getRandomChars } from '@kubevirt-utils/utils/utils';
+
+export const generateSSHKeySecret = (secretName: string, namespace: string, sshKey: string) => ({
+  kind: SecretModel.kind,
+  apiVersion: SecretModel.apiVersion,
+  metadata: {
+    name: secretName,
+    namespace: namespace,
+  },
+  data: { key: btoa(sshKey) },
+});
+
+export const removeSSHKeyObject = (
+  updateTabsData: WizardVMContextType['updateTabsData'],
+  oldSSHServiceName: string,
+) =>
+  updateTabsData((tabsDraft) => {
+    tabsDraft.additionalObjects = (tabsDraft?.additionalObjects || []).filter(
+      (object) =>
+        !(object?.kind === SecretModel.kind && object?.metadata?.name === oldSSHServiceName),
+    );
+  });
+
+export const changeSecretKey = (
+  updateTabsData: WizardVMContextType['updateTabsData'],
+  sshkey: string,
+  oldSSHServiceName: string,
+) =>
+  updateTabsData((draftTabs) => {
+    const secretObject = draftTabs?.additionalObjects?.find(
+      (object) => object?.kind === SecretModel.kind && object?.metadata?.name === oldSSHServiceName,
+    ) as IoK8sApiCoreV1Secret;
+
+    secretObject.data.key = btoa(sshkey);
+  });
+
+export const updateSSHKeyObject = (
+  vm: V1VirtualMachine,
+  updateVM: WizardVMContextType['updateVM'],
+  updateTabsData: WizardVMContextType['updateTabsData'],
+  sshkey: string,
+) => {
+  const sshSecretName = `${vm.metadata.name}-ssh-key-${getRandomChars()}`;
+
+  updateTabsData((draftTabs) => {
+    if (!draftTabs.additionalObjects) draftTabs.additionalObjects = [];
+
+    draftTabs.additionalObjects.push(
+      generateSSHKeySecret(sshSecretName, vm?.metadata?.namespace, sshkey),
+    );
+  });
+
+  return updateVM((vmDraft) => {
+    const produced = produceVMSSHKey(vmDraft, sshSecretName);
+    vmDraft.spec = produced.spec;
+  });
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Have the wizard play nice with multiple object templates.

SSH auth key section in scripts tab now will add and change secret in the `additionalResources` tabsData. 

Why this pr? 
The template can have in the objects array an already configured secret. With this pr will be detected in the wizard. 

