### PR TITLE
Bug 2100290: Fix when creating a new vm the error doesn't dismissed

### DIFF
--- a/src/views/catalog/customize/components/CustomizeSource/SelectSource.tsx
+++ b/src/views/catalog/customize/components/CustomizeSource/SelectSource.tsx
@@ -199,6 +199,7 @@ export const SelectSource: React.FC<SelectSourceProps> = ({
                 <Controller
                   name={`${testId}-uploadFile`}
                   control={control}
+                  shouldUnregister
                   rules={{ required: true }}
                   render={({ field: { value: fileValue, onChange }, fieldState: { error } }) => (
                     <FileUpload


### PR DESCRIPTION
Signed-off-by: Dana Orr <dorr@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
Fix when we click the "Review and create VirtualMachine" button, the error will not pop up and we can create a new vm with the new option selected.

## 🎥 Demo
Before:
![ErrorNotDismissedBefore](https://user-images.githubusercontent.com/61961469/185790586-5fc3b026-da15-41e3-8094-9d4dd454e842.gif)

After:
![ErrorNotDismissed](https://user-images.githubusercontent.com/61961469/185790405-db5d5d54-83f4-43a3-9726-24eff3ee0549.gif)
