### PR TITLE
CNV19691: Add table column management to VM list

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -915,6 +915,7 @@
   "Virtual Machines": "Virtual Machines",
   "Virtualization": "Virtualization",
   "Virtualization dashboard": "Virtualization dashboard",
+  "VirtualMachine": "VirtualMachine",
   "VirtualMachine boot order": "VirtualMachine boot order",
   "VirtualMachine details": "VirtualMachine details",
   "VirtualMachine Details": "VirtualMachine Details",

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -69,7 +69,8 @@ const VirtualMachinesList: React.FC<VirtualMachinesListProps> = ({ kind, namespa
       ? history.push(catalogURL)
       : history.push(`/k8s/ns/${namespace || 'default'}/${VirtualMachineModelRef}/~new`);
 
-  const columns = useVirtualMachineColumns(namespace);
+  const [columns, activeColumns] = useVirtualMachineColumns(namespace);
+
   return (
     <>
       <ListPageHeader title={t('VirtualMachines')}>
@@ -83,12 +84,22 @@ const VirtualMachinesList: React.FC<VirtualMachinesListProps> = ({ kind, namespa
           loaded={loaded}
           rowFilters={filters}
           onFilterChange={onFilterChange}
+          columnLayout={{
+            columns: columns?.map(({ id, title, additional }) => ({
+              id,
+              title,
+              additional,
+            })),
+            id: VirtualMachineModelRef,
+            selectedColumns: new Set(activeColumns?.map((col) => col?.id)),
+            type: t('VirtualMachine'),
+          }}
         />
         <VirtualizedTable<K8sResourceCommon>
           data={data}
           unfilteredData={unfilteredData}
           loaded={loaded}
-          columns={columns}
+          columns={activeColumns}
           loadError={loadError}
           Row={VirtualMachineRow}
           rowData={{ kind, vmis }}

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
@@ -52,7 +52,7 @@ const VirtualMachineRowLayout: React.FC<
         {ips}
       </TableData>
       <TableData
-        id="actions"
+        id=""
         activeColumnIDs={activeColumnIDs}
         className="dropdown-kebab-pf pf-c-table__action"
       >

--- a/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
+++ b/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { NodeModel } from '@kubevirt-ui/kubevirt-api/console';
+import { NodeModel, VirtualMachineModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   K8sResourceCommon,
@@ -11,7 +11,9 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 
-const useVirtualMachineColumns = (namespace: string) => {
+const useVirtualMachineColumns = (
+  namespace: string,
+): [TableColumn<K8sResourceCommon>[], TableColumn<K8sResourceCommon>[]] => {
   const { t } = useKubevirtTranslation();
 
   const [canGetNode] = useAccessReview({
@@ -57,6 +59,7 @@ const useVirtualMachineColumns = (namespace: string) => {
         title: t('Created'),
         id: 'created',
         transforms: [sortable],
+        additional: true,
         sort: 'metadata.creationTimestamp',
         props: { className: 'pf-m-width-15' },
       },
@@ -67,7 +70,7 @@ const useVirtualMachineColumns = (namespace: string) => {
       },
       {
         title: '',
-        id: 'actions',
+        id: '',
         props: { className: 'dropdown-kebab-pf pf-c-table__action' },
       },
     ],
@@ -77,10 +80,10 @@ const useVirtualMachineColumns = (namespace: string) => {
   const [activeColumns] = useActiveColumns<K8sResourceCommon>({
     columns: canGetNode ? columns : columns.filter((column) => column.id !== 'node'),
     showNamespaceOverride: false,
-    columnManagementID: '',
+    columnManagementID: VirtualMachineModelRef,
   });
 
-  return activeColumns;
+  return [columns, activeColumns];
 };
 
 export default useVirtualMachineColumns;


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

Adding column management to VM list view
NOTES: 
- The kebab actions columns have no title and it appears as empty in the column management component, we should consider giving this column the `Actions` title so it will look better.
- When moving to a specific namespace and using the management column, check and uncheck to the namespace column will not make any effect, we should consider removing that column when user is under any namespace scope and not the `all-projects` scope.

@metalice @vojtechszocs @hstastna @pcbailey @upalatucci please review
## 🎥 Demo


https://user-images.githubusercontent.com/67270715/187917424-dcbbcf4a-ff3f-4408-b7f0-c99032ae832e.mp4


