### PR TITLE
Fix namespace column management

### DIFF
--- a/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
+++ b/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
@@ -41,13 +41,17 @@ const useVirtualMachineColumns = (
         sort: (_, direction) => sorting(direction, 'metadata.name'),
         props: { className: 'pf-m-width-15' },
       },
-      {
-        title: t('Namespace'),
-        id: 'namespace',
-        transforms: [sortable],
-        sort: (_, direction) => sorting(direction, 'metadata.namespace'),
-        props: { className: 'pf-m-width-10' },
-      },
+      ...(!namespace
+        ? [
+            {
+              title: t('Namespace'),
+              id: 'namespace',
+              transforms: [sortable],
+              sort: (_, direction) => sorting(direction, 'metadata.namespace'),
+              props: { className: 'pf-m-width-10' },
+            },
+          ]
+        : []),
       {
         title: t('Status'),
         id: 'status',
@@ -84,7 +88,7 @@ const useVirtualMachineColumns = (
         props: { className: 'dropdown-kebab-pf pf-c-table__action' },
       },
     ],
-    [t, sorting],
+    [t, sorting, namespace],
   );
 
   const [activeColumns] = useActiveColumns<K8sResourceCommon>({


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

Checking the namespace in the column management component when inside any project was not having any effect.
the fix includes hiding the namespace column since it's not manageable, and can't be disabled.

## 🎥 Demo

### Before:

https://user-images.githubusercontent.com/67270715/188448590-ae095ea5-f705-4fd0-b264-fbeb96b6aa0e.mp4

### After:
![manage-namespace-after](https://user-images.githubusercontent.com/67270715/188448681-941d2c2d-f92a-4500-bfbf-c2db0f388a77.png)
![manage-namespace-after2](https://user-images.githubusercontent.com/67270715/188448670-8d760c92-8975-4991-bf01-e93930d369db.png)
![manage-namespace-after3](https://user-images.githubusercontent.com/67270715/188448684-eb26899e-d659-4938-a588-aa08b2c577df.png)

