### PR TITLE
CNV-21029: Disable migration if its a single node cluster

### DIFF
--- a/src/utils/hooks/useSingleNodeCluster.ts
+++ b/src/utils/hooks/useSingleNodeCluster.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+
+import { InfrastructureModel, modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource';
+
+type UseSingleNodeCluster = () => [isSingleNodeCluster: boolean, loaded: boolean];
+const useSingleNodeCluster: UseSingleNodeCluster = () => {
+  const [infrastructure, loaded] = useKubevirtWatchResource({
+    groupVersionKind: modelToGroupVersionKind(InfrastructureModel),
+    namespaced: false,
+  });
+
+  const isSingleNodeCluster = useMemo(
+    () => infrastructure?.status?.infrastructureTopology === 'SingleReplica',
+    [infrastructure],
+  );
+
+  return [isSingleNodeCluster, loaded];
+};
+
+export default useSingleNodeCluster;

--- a/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
@@ -97,10 +97,11 @@ export const VirtualMachineActionFactory = {
       accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
     };
   },
-  migrate: (vm: V1VirtualMachine, t: TFunction): Action => {
+  migrate: (vm: V1VirtualMachine, isSingleNodeCluster: boolean, t: TFunction): Action => {
     return {
       id: 'vm-action-migrate',
       disabled:
+        isSingleNodeCluster ||
         vm?.status?.printableStatus !== Running ||
         !!vm?.status?.conditions?.find(
           ({ type, status }) => type === 'LiveMigratable' && status === 'False',
@@ -114,11 +115,12 @@ export const VirtualMachineActionFactory = {
   cancelMigration: (
     vm: V1VirtualMachine,
     vmim: V1VirtualMachineInstanceMigration,
+    isSingleNodeCluster: boolean,
     t: TFunction,
   ): Action => {
     return {
       id: 'vm-action-cancel-migrate',
-      disabled: !vmim || !!vmim?.metadata?.deletionTimestamp,
+      disabled: isSingleNodeCluster || !vmim || !!vmim?.metadata?.deletionTimestamp,
       label: t('Cancel migration'),
       cta: () => cancelMigration(vmim),
       accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),

--- a/src/views/virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions.tsx
@@ -17,16 +17,18 @@ import {
 } from '@patternfly/react-core';
 import useVirtualMachineActionsProvider from '@virtualmachines/actions/hooks/useVirtualMachineActionsProvider';
 
-type VirtualMachinesInsanceActionsProps = {
+type VirtualMachinesInstanceActionsProps = {
   vm: V1VirtualMachine;
   isKebabToggle?: boolean;
   vmim: V1VirtualMachineInstanceMigration;
+  isSingleNodeCluster: boolean;
 };
 
-const VirtualMachineActions: React.FC<VirtualMachinesInsanceActionsProps> = ({
+const VirtualMachineActions: React.FC<VirtualMachinesInstanceActionsProps> = ({
   vm,
   vmim,
   isKebabToggle,
+  isSingleNodeCluster,
 }) => {
   const { t } = useKubevirtTranslation();
   // TODO: use LazyActionMenu when fixed
@@ -38,7 +40,7 @@ const VirtualMachineActions: React.FC<VirtualMachinesInsanceActionsProps> = ({
   //   />
   // );
   const [isOpen, setIsOpen] = React.useState(false);
-  const [actions] = useVirtualMachineActionsProvider(vm, vmim);
+  const [actions] = useVirtualMachineActionsProvider(vm, vmim, isSingleNodeCluster);
 
   const handleClick = (action: Action) => {
     if (typeof action?.cta === 'function') {

--- a/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
+++ b/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
@@ -17,9 +17,14 @@ import { VirtualMachineActionFactory } from '../VirtualMachineActionFactory';
 type UseVirtualMachineActionsProvider = (
   vm: V1VirtualMachine,
   vmim?: V1VirtualMachineInstanceMigration,
+  isSingleNodeCluster?: boolean,
 ) => [Action[], boolean, any];
 
-const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, vmim) => {
+const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (
+  vm,
+  vmim,
+  isSingleNodeCluster,
+) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const virtctlCommand = getConsoleVirtctlCommand(vm?.metadata?.name, vm?.metadata?.namespace);
@@ -37,8 +42,8 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, 
     const migrateOrCancelMigration =
       printableStatus === Migrating ||
       (vmim && ![vmimStatuses.Failed, vmimStatuses.Succeeded].includes(vmim?.status?.phase))
-        ? VirtualMachineActionFactory.cancelMigration(vm, vmim, t)
-        : VirtualMachineActionFactory.migrate(vm, t);
+        ? VirtualMachineActionFactory.cancelMigration(vm, vmim, isSingleNodeCluster, t)
+        : VirtualMachineActionFactory.migrate(vm, isSingleNodeCluster, t);
 
     const pauseOrUnpause =
       printableStatus === Paused

--- a/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 import VirtualMachineActions from '@virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions';
@@ -30,6 +31,7 @@ const VirtualMachineNavPageTitle: React.FC<VirtualMachineNavPageTitleProps> = ({
     isList: false,
   });
   const vmim = useVirtualMachineInstanceMigration(vm);
+  const [isSingleNodeCluster] = useSingleNodeCluster();
 
   const StatusIcon = getVMStatusIcon(vm?.status?.printableStatus);
   return (
@@ -43,7 +45,7 @@ const VirtualMachineNavPageTitle: React.FC<VirtualMachineNavPageTitleProps> = ({
             {vm?.status?.printableStatus}
           </Label>
         </h1>
-        <VirtualMachineActions vm={vm} vmim={vmim} />
+        <VirtualMachineActions vm={vm} vmim={vmim} isSingleNodeCluster={isSingleNodeCluster} />
       </span>
       <VirtualMachinePendingChangesAlert vm={vm} vmi={vmi} />
     </div>

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -10,6 +10,7 @@ import {
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource';
+import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
 import {
   K8sResourceCommon,
   ListPageBody,
@@ -61,6 +62,8 @@ const VirtualMachinesList: React.FC<VirtualMachinesListProps> = ({ kind, namespa
     limit: OBJECTS_FETCHING_LIMIT,
   });
 
+  const [isSingleNodeCluster, isSingleNodeLoaded] = useSingleNodeCluster();
+
   const [vmims, vmimsLoaded] = useKubevirtWatchResource({
     groupVersionKind: VirtualMachineInstanceMigrationModelGroupVersionKind,
     isList: true,
@@ -109,7 +112,7 @@ const VirtualMachinesList: React.FC<VirtualMachinesListProps> = ({ kind, namespa
         <div className="VirtualMachineList--filters__main">
           <ListPageFilter
             data={unfilteredData}
-            loaded={loaded}
+            loaded={loaded && vmiLoaded && vmimsLoaded && isSingleNodeLoaded}
             rowFilters={filters}
             onFilterChange={(...args) => {
               onFilterChange(...args);
@@ -149,7 +152,7 @@ const VirtualMachinesList: React.FC<VirtualMachinesListProps> = ({ kind, namespa
         <VirtualizedTable<K8sResourceCommon>
           data={data}
           unfilteredData={unfilteredData}
-          loaded={loaded && vmiLoaded && vmimsLoaded}
+          loaded={loaded && vmiLoaded && vmimsLoaded && isSingleNodeLoaded}
           columns={activeColumns}
           loadError={loadError}
           Row={VirtualMachineRow}
@@ -157,6 +160,7 @@ const VirtualMachinesList: React.FC<VirtualMachinesListProps> = ({ kind, namespa
             kind,
             getVmi: (ns: string, name: string) => vmiMapper?.mapper?.[ns]?.[name],
             getVmim: (ns: string, name: string) => vmimMapper?.[ns]?.[name],
+            isSingleNodeCluster,
           }}
           NoDataEmptyMsg={() => <VirtualMachineEmptyState catalogURL={catalogURL} />}
         />

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRow.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRow.tsx
@@ -20,9 +20,10 @@ const VirtualMachineRow: React.FC<
       kind: string;
       getVmi: (namespace: string, name: string) => V1VirtualMachineInstance;
       getVmim: (ns: string, name: string) => V1VirtualMachineInstanceMigration;
+      isSingleNodeCluster: boolean;
     }
   >
-> = ({ obj, activeColumnIDs, rowData: { kind, getVmi, getVmim } }) => {
+> = ({ obj, activeColumnIDs, rowData: { kind, getVmi, getVmim, isSingleNodeCluster } }) => {
   return obj?.status?.printableStatus === printableVMStatus.Running ? (
     <VirtualMachineRunningRow
       obj={obj}
@@ -31,13 +32,14 @@ const VirtualMachineRow: React.FC<
         kind,
         vmi: getVmi(obj?.metadata?.namespace, obj?.metadata?.name),
         vmim: getVmim(obj?.metadata?.namespace, obj?.metadata?.name),
+        isSingleNodeCluster,
       }}
     />
   ) : (
     <VirtualMachineRowLayout
       obj={obj}
       activeColumnIDs={activeColumnIDs}
-      rowData={{ kind, node: NO_DATA_DASH, ips: NO_DATA_DASH, vmim: null }}
+      rowData={{ kind, node: NO_DATA_DASH, ips: NO_DATA_DASH, vmim: null, isSingleNodeCluster }}
     />
   );
 };

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
@@ -21,9 +21,10 @@ const VirtualMachineRowLayout: React.FC<
       node: React.ReactNode | string;
       ips: React.ReactNode | string;
       vmim: V1VirtualMachineInstanceMigration;
+      isSingleNodeCluster: boolean;
     }
   >
-> = ({ obj, activeColumnIDs, rowData: { kind, node, ips, vmim } }) => {
+> = ({ obj, activeColumnIDs, rowData: { kind, node, ips, vmim, isSingleNodeCluster } }) => {
   return (
     <>
       <TableData id="name" activeColumnIDs={activeColumnIDs} className="pf-m-width-15 vm-column">
@@ -64,7 +65,12 @@ const VirtualMachineRowLayout: React.FC<
         activeColumnIDs={activeColumnIDs}
         className="dropdown-kebab-pf pf-c-table__action"
       >
-        <VirtualMachineActions vm={obj} isKebabToggle vmim={vmim} />
+        <VirtualMachineActions
+          vm={obj}
+          isKebabToggle
+          vmim={vmim}
+          isSingleNodeCluster={isSingleNodeCluster}
+        />
       </TableData>
     </>
   );

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
@@ -16,9 +16,14 @@ import VirtualMachineRowLayout from './VirtualMachineRowLayout';
 const VirtualMachineRunningRow: React.FC<
   RowProps<
     V1VirtualMachine,
-    { kind: string; vmi: V1VirtualMachineInstance; vmim: V1VirtualMachineInstanceMigration }
+    {
+      kind: string;
+      vmi: V1VirtualMachineInstance;
+      vmim: V1VirtualMachineInstanceMigration;
+      isSingleNodeCluster: boolean;
+    }
   >
-> = ({ obj, activeColumnIDs, rowData: { kind, vmi, vmim } }) => {
+> = ({ obj, activeColumnIDs, rowData: { kind, vmi, vmim, isSingleNodeCluster } }) => {
   const { t } = useKubevirtTranslation();
 
   const ipAddressess = vmi && getVMIIPAddresses(vmi);
@@ -31,6 +36,7 @@ const VirtualMachineRunningRow: React.FC<
         node: <ResourceLink kind="Node" name={vmi?.status?.nodeName} />,
         ips: <FirstItemListPopover items={ipAddressess} headerContent={t('IP addresses')} />,
         vmim,
+        isSingleNodeCluster,
       }}
     />
   );


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When we have a single node cluster, we don't need to enable the option of migration as there are no different nodes to move the resource to. 

## 🎥 Demo

<img width="393" alt="image" src="https://user-images.githubusercontent.com/14824964/188465044-63b95860-c2ba-4b21-8d21-944c46a376fe.png">

