### PR TITLE
Bug 2117813: Display 'Not available' for a stopped VM

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -395,7 +395,6 @@
   "Go to catalog": "Go to catalog",
   "GPU devices": "GPU devices",
   "GPU devices ({{gpusCount}})": "GPU devices ({{gpusCount}})",
-  "Guest agend is required": "Guest agend is required",
   "Guest agent is not installed on VirtualMachine": "Guest agent is not installed on VirtualMachine",
   "Guest agent is required": "Guest agent is required",
   "Guest login credentials": "Guest login credentials",

--- a/src/utils/components/GuestAgentIsRequiredText/GuestAgentIsRequiredText.tsx
+++ b/src/utils/components/GuestAgentIsRequiredText/GuestAgentIsRequiredText.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+
+import MutedTextSpan from '../MutedTextSpan/MutedTextSpan';
+
+type GuestAgentIsRequiredTextProps = {
+  vmi: V1VirtualMachineInstance;
+};
+
+const GuestAgentIsRequiredText: React.FC<GuestAgentIsRequiredTextProps> = ({ vmi }) => {
+  const { t } = useKubevirtTranslation();
+
+  return <MutedTextSpan text={vmi ? t('Guest agent is required') : t('Not available')} />;
+};
+
+export default GuestAgentIsRequiredText;

--- a/src/views/virtualmachines/actions/components/CloneVMModal/components/ConfigurationSummary.tsx
+++ b/src/views/virtualmachines/actions/components/CloneVMModal/components/ConfigurationSummary.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import GuestAgentIsRequiredText from '@kubevirt-utils/components/GuestAgentIsRequiredText/GuestAgentIsRequiredText';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getAnnotation } from '@kubevirt-utils/resources/shared';
@@ -30,7 +31,7 @@ const ConfigurationSummary: React.FC<ConfigurationSummaryProps> = ({ vm, pvcs })
   const { vmi } = useVMIAndPodsForVM(vm?.metadata?.name, vm?.metadata?.namespace);
   const [guestAgentData] = useGuestOS(vmi);
   const osName = (guestAgentData?.os?.prettyName || guestAgentData?.os?.name) ?? (
-    <MutedTextSpan text={t('Guest agent is required')} />
+    <GuestAgentIsRequiredText vmi={vmi} />
   );
 
   return (

--- a/src/views/virtualmachines/details/tabs/details/components/grid/leftGrid/VirtualMachineDetailsLeftGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/leftGrid/VirtualMachineDetailsLeftGrid.tsx
@@ -11,6 +11,7 @@ import CPUMemoryModal from '@kubevirt-utils/components/CPUMemoryModal/CpuMemoryM
 import { DescriptionModal } from '@kubevirt-utils/components/DescriptionModal/DescriptionModal';
 import FirmwareBootloaderModal from '@kubevirt-utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal';
 import { getBootloaderTitleFromVM } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/utils';
+import GuestAgentIsRequiredText from '@kubevirt-utils/components/GuestAgentIsRequiredText/GuestAgentIsRequiredText';
 import { LabelsModal } from '@kubevirt-utils/components/LabelsModal/LabelsModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
@@ -91,7 +92,7 @@ const VirtualMachineDetailsLeftGrid: React.FC<VirtualMachineDetailsLeftGridProps
   };
 
   const None = <MutedTextSpan text={t('None')} />;
-  const GuestAgentIsRequired = <MutedTextSpan text={t('Guest agend is required')} />;
+
   return (
     <GridItem span={5}>
       <DescriptionList>
@@ -207,7 +208,8 @@ const VirtualMachineDetailsLeftGrid: React.FC<VirtualMachineDetailsLeftGridProps
         />
         <VirtualMachineDescriptionItem
           descriptionData={
-            guestAgentData?.os?.prettyName || guestAgentData?.os?.name || GuestAgentIsRequired
+            guestAgentData?.os?.prettyName ||
+            guestAgentData?.os?.name || <GuestAgentIsRequiredText vmi={vmi} />
           }
           isPopover
           // body-content text copied from:

--- a/src/views/virtualmachines/details/tabs/details/utils/gridHelper.tsx
+++ b/src/views/virtualmachines/details/tabs/details/utils/gridHelper.tsx
@@ -7,6 +7,7 @@ import {
   V1VirtualMachineInstance,
   V1VirtualMachineInstanceGuestAgentInfo,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import GuestAgentIsRequiredText from '@kubevirt-utils/components/GuestAgentIsRequiredText/GuestAgentIsRequiredText';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { getVMIIPAddresses, getVMIPod } from '@kubevirt-utils/resources/vmi';
 import { K8sResourceCommon, ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
@@ -49,7 +50,7 @@ export const getRunningVMRightGridPresentation = (
   const nodeName = vmi?.status?.nodeName;
   const guestAgentIsRequired = guestAgentData && Object.keys(guestAgentData)?.length === 0;
 
-  const GuestAgentIsRequiredText = <MutedTextSpan text={t('Guest agent is required')} />;
+  const guestAgentIsRequiredText = <GuestAgentIsRequiredText vmi={vmi} />;
 
   return {
     pod: (
@@ -67,9 +68,9 @@ export const getRunningVMRightGridPresentation = (
       />
     ),
     ipAddress: <FirstItemListPopover items={ipAddresses} headerContent={'IP addresses'} />,
-    hostname: guestAgentIsRequired ? GuestAgentIsRequiredText : guestAgentData?.hostname,
+    hostname: guestAgentIsRequired ? guestAgentIsRequiredText : guestAgentData?.hostname,
     timezone: guestAgentIsRequired
-      ? GuestAgentIsRequiredText
+      ? guestAgentIsRequiredText
       : guestAgentData?.timezone?.split(',')[0],
     node: <ResourceLink kind={NodeModel.kind} name={nodeName} />,
   };

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { modelToGroupVersionKind, TemplateModel } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import GuestAgentIsRequiredText from '@kubevirt-utils/components/GuestAgentIsRequiredText/GuestAgentIsRequiredText';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { timestampFor } from '@kubevirt-utils/components/Timestamp/utils/datetime';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -60,7 +61,7 @@ const VirtualMachinesOverviewTabDetails: React.FC<VirtualMachinesOverviewTabDeta
   );
   const timestampPluralized = pluralize(timestamp['value'], timestamp['time']);
 
-  const guestAgentIsRequired = <MutedTextSpan text={t('Guest agent is required')} />;
+  const guestAgentIsRequired = <GuestAgentIsRequiredText vmi={vmi} />;
 
   const osName =
     (guestAgentData?.os?.prettyName || guestAgentData?.os?.name) ?? guestAgentIsRequired;


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2117813

Unify the text displayed in the VM _Overview_ and _Details_ tabs: Display 'Not available' for a stopped VM in both tabs.
Display 'Guest agent is required' only when the VM is running and guest agent missing.

## 🎥 Demo
**Before:**
![3_before](https://user-images.githubusercontent.com/13417815/188692334-3061807d-3ab2-47e3-afd2-4d1986079d52.png)
![4_before](https://user-images.githubusercontent.com/13417815/188692440-a5372256-d783-4ccd-8f53-cd11f4fb1a92.png)
**After:**
![3_after](https://user-images.githubusercontent.com/13417815/188692519-b74a481e-7a1c-412c-9a01-366954ff19d1.png)
![4_after](https://user-images.githubusercontent.com/13417815/188692544-9ef43a11-7de8-4096-a69b-c34f0c80be28.png)
When the VM is running and guest agent missing, display 'Guest agent is required' text, same as before:
![running_vm](https://user-images.githubusercontent.com/13417815/188692590-f5b24615-5d34-4820-846b-3a026c50c190.png)

