### PR TITLE
Bug 2124565: Deleted datasource reappear in the ui

### DIFF
--- a/src/views/datasources/hooks/useDataSourceActions.tsx
+++ b/src/views/datasources/hooks/useDataSourceActions.tsx
@@ -109,12 +109,21 @@ export const useDataSourceActionsProvider: UseDataSourceActionsProvider = (dataS
               isOpen={isOpen}
               onClose={onClose}
               headerText={t('Delete DataSource?')}
-              onDeleteSubmit={() =>
-                k8sDelete({
-                  model: DataSourceModel,
-                  resource: dataSource,
-                })
-              }
+              onDeleteSubmit={async () => {
+                try {
+                  await k8sDelete({
+                    model: DataImportCronModel,
+                    resource: dataImportCron,
+                  });
+                } catch (e) {
+                  console.log(e?.message);
+                } finally {
+                  await k8sDelete({
+                    model: DataSourceModel,
+                    resource: dataSource,
+                  });
+                }
+              }}
             />
           )),
         accessReview: asAccessReview(DataSourceModel, dataSource, 'delete'),


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When deleting Datasource, dataimportcron is deleted, but after, so it causes the datasource to reappear in the UI.
The change now will delete first the dataimportcron and then the datasource

## 🎥 Demo

> Please add a video or an image of the behavior/changes
