### PR TITLE
Bug 2124558: Allow MigrationPolicy creation only to privileged user

### DIFF
--- a/src/views/migrationpolicies/details/tabs/details/components/MigrationPolicyDetailsSection/MigrationPolicyDetailsSection.tsx
+++ b/src/views/migrationpolicies/details/tabs/details/components/MigrationPolicyDetailsSection/MigrationPolicyDetailsSection.tsx
@@ -42,6 +42,7 @@ const MigrationPolicyDetailsSection: React.FC<MigrationPolicyDetailsSectionProps
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const hasOwnPropertySpec = (key: string) => key in (mp?.spec || {});
+
   return (
     <div>
       <a href={`${pathname}#details`} className="link-icon">

--- a/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
+++ b/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
@@ -49,7 +49,11 @@ const MigrationPoliciesList: React.FC<MigrationPoliciesListProps> = ({ kind }) =
   return (
     <>
       <ListPageHeader title={t('MigrationPolicies')}>
-        <ListPageCreateDropdown items={createItems} onClick={onCreate}>
+        <ListPageCreateDropdown
+          items={createItems}
+          onClick={onCreate}
+          createAccessReview={{ groupVersionKind: kind }}
+        >
           {t('Create MigrationPolicy')}
         </ListPageCreateDropdown>
       </ListPageHeader>

--- a/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.tsx
@@ -21,6 +21,7 @@ import { migrationPoliciesPageBaseURL } from '../../utils/constants';
 
 const MigrationPoliciesEmptyState: React.FC = () => {
   const { t } = useKubevirtTranslation();
+
   return (
     <EmptyState variant={EmptyStateVariant.xs}>
       <EmptyStateIcon icon={() => <img src={migrationPoliciesEmptyState} />} />


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2124558

Allow _MigrationPolicy_ creation only to privileged user by displaying _Create MigrationPolicy_ button only for such users.

## Screenshots
**Before**:
The unprivileged user can click on _Create MigrationPolicy_ button:
![beforee](https://user-images.githubusercontent.com/13417815/193931500-d4afde4a-8b98-4b67-a4c1-1bbd0bb9acb7.png)
**After**:
No any  _Create MigrationPolicy_ button present for unprivileged user:
![afterr](https://user-images.githubusercontent.com/13417815/193931550-e7975bd8-73e5-488d-8e07-fd1d61379383.png)



