### PR TITLE
Bug 2127931: Change top consumer metrics default to 30 minutes

### DIFF
--- a/src/views/clusteroverview/MonitoringTab/top-consumers-card/TopConsumersCard.tsx
+++ b/src/views/clusteroverview/MonitoringTab/top-consumers-card/TopConsumersCard.tsx
@@ -35,7 +35,7 @@ const TopConsumersCard: React.FC = () => {
   );
   const [duration, setDuration] = useLocalStorage(
     TOP_CONSUMERS_DURATION_KEY,
-    DurationOption.FIVE_MIN.toString(),
+    DurationOption.THIRTY_MIN.toString(),
   );
 
   const onNumItemsSelect = (value) => setNumItemsToShow(value);


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Change top consumer metrics default time to 30mins, to match observe dashboard.

## 🎥 Demo

![image](https://user-images.githubusercontent.com/14824964/191028310-3cf7755a-bb33-4331-ac8f-4e8f698b7c95.png)

