### PR TITLE
Add message alerting users to scope of the settings tab

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -89,6 +89,7 @@
   "Affinity rules": "Affinity rules",
   "Alerts ({{alertsQuantity}})": "Alerts ({{alertsQuantity}})",
   "All Items": "All Items",
+  "All settings are effective across the entire cluster.": "All settings are effective across the entire cluster.",
   "All snapshots of this VirtualMachine will be deleted as well.": "All snapshots of this VirtualMachine will be deleted as well.",
   "All sources selected": "All sources selected",
   "Allocating resources, please wait for upload to start.": "Allocating resources, please wait for upload to start.",

--- a/src/views/clusteroverview/SettingsTab/SettingsTab.tsx
+++ b/src/views/clusteroverview/SettingsTab/SettingsTab.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Overview } from '@openshift-console/dynamic-plugin-sdk';
-import { Card, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
+import { Alert, Card, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 
 import GeneralTab from './GeneralTab/GeneralTab';
 import LiveMigrationTab from './LiveMigrationTab/LiveMigrationTab';
@@ -16,6 +16,12 @@ const SettingsTab: React.FC = () => {
   const [activeTab, setActiveTab] = React.useState<number>(0);
   return (
     <Overview>
+      <Alert
+        variant="info"
+        isInline
+        className="settings-tab__scope-message"
+        title={t('All settings are effective across the entire cluster.')}
+      />
       <Card className="settings-tab__card">
         <Tabs
           activeKey={activeTab}

--- a/src/views/clusteroverview/SettingsTab/settings-tab.scss
+++ b/src/views/clusteroverview/SettingsTab/settings-tab.scss
@@ -1,4 +1,8 @@
 .settings-tab {
+  &__scope-message {
+    margin-bottom: var(--pf-global--spacer--md);
+  }
+
   &__card {
     height: 100%;
     flex-direction: row;


### PR DESCRIPTION
## 📝 Description

The namespace bar has been added to the entire overview page, which could cause users to think that settings are only effective for the selected namespace. This PR adds an alert to the settings tab that informs users that settings are effective cluster-wide.

## 🎥 Demo
![Selection_162](https://user-images.githubusercontent.com/8544299/192274951-38007c6c-613f-4783-8ccb-e57d0ddd048a.png)

