### PR TITLE
Bug 2128949: Cannot create MigrationPolicy from example YAML

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -303,6 +303,23 @@
     }
   },
   {
+    "type": "console.yaml-template",
+    "properties": {
+      "name": "default",
+      "model": {
+        "group": "migrations.kubevirt.io",
+        "kind": "MigrationPolicy",
+        "version": "v1alpha1"
+      },
+      "template": {
+        "$codeRef": "yamlTemplates.defaultMigrationPolicyYamlTemplate"
+      }
+    },
+    "flags": {
+      "required": ["KUBEVIRT"]
+    }
+  },
+  {
     "type": "console.navigation/separator",
     "properties": {
       "perspective": "admin",

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,3 +1,4 @@
 export * from './datasource-yaml';
+export * from './migrationpolicy-yaml';
 export * from './vm-template-yaml';
 export * from './vm-yaml';

--- a/src/templates/migrationpolicy-yaml.ts
+++ b/src/templates/migrationpolicy-yaml.ts
@@ -1,0 +1,10 @@
+import MigrationPolicyModel from '@kubevirt-ui/kubevirt-api/console/models/MigrationPolicyModel';
+
+export const defaultMigrationPolicyYamlTemplate = `
+apiVersion: ${MigrationPolicyModel.apiGroup}/${MigrationPolicyModel.apiVersion}
+kind: ${MigrationPolicyModel.kind}
+metadata:
+  name: example
+spec: 
+  selectors: {}
+`;


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

adding missing property for YAML example to allow creation

## 🎥 Demo

### Before:

https://user-images.githubusercontent.com/67270715/192751898-e89fc296-4e4f-4da5-86cb-8ed8849e668f.mp4

### After:

https://user-images.githubusercontent.com/67270715/192751934-2000824f-3af1-46b8-90df-7e40aa54124a.mp4


