### PR TITLE
Bug 2124555: View documentation link on MigrationPolicies page doesn't work

### DIFF
--- a/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.tsx
@@ -38,14 +38,13 @@ const MigrationPoliciesEmptyState: React.FC = () => {
         </Link>
       </EmptyStatePrimary>
       <EmptyStateSecondaryActions>
-        <Button
-          variant={ButtonVariant.link}
-          // onClick={() => history.push(MigrationPolicyDocURL)} waiting to get URL from docs team
-          icon={<ExternalLinkAltIcon />}
-          iconPosition="right"
+        <a
+          href="https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/virtualization/live-migration#virt-configuring-live-migration-policies"
+          target="_blank"
+          rel="noreferrer"
         >
-          {t('View documentation')}
-        </Button>
+          {t('View documentation')} <ExternalLinkAltIcon />
+        </a>
       </EmptyStateSecondaryActions>
     </EmptyState>
   );


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

Adding link to 4.11 doc for migration policies (given by doc team)
