### PR TITLE
Bug 2101144: VM filter has two 'Other' checkboxes which are triggered together

### DIFF
--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -27,7 +27,7 @@ import {
   paginationInitialState,
 } from '@virtualmachines/utils';
 
-import { useGetVMListFilters } from '../utils';
+import { useVMListFilters } from '../utils';
 
 import VirtualMachineEmptyState from './components/VirtualMachineEmptyState/VirtualMachineEmptyState';
 import VirtualMachineRow from './components/VirtualMachineRow/VirtualMachineRow';
@@ -71,7 +71,7 @@ const VirtualMachinesList: React.FC<VirtualMachinesListProps> = ({ kind, namespa
     limit: OBJECTS_FETCHING_LIMIT,
   });
 
-  const { vmiMapper, vmimMapper, filters } = useGetVMListFilters(vmis, vms, vmims);
+  const { vmiMapper, vmimMapper, filters } = useVMListFilters(vmis, vms, vmims);
 
   const [pagination, setPagination] = useState(paginationInitialState);
 
@@ -94,10 +94,11 @@ const VirtualMachinesList: React.FC<VirtualMachinesListProps> = ({ kind, namespa
     }));
   };
 
-  const onCreate = (type: string) =>
-    type === 'catalog'
+  const onCreate = (type: string) => {
+    return type === 'catalog'
       ? history.push(catalogURL)
       : history.push(`/k8s/ns/${namespace || 'default'}/${VirtualMachineModelRef}/~new`);
+  };
 
   const [columns, activeColumns] = useVirtualMachineColumns(namespace, pagination, data);
 

--- a/src/views/virtualmachines/utils/virtualMachineRowFilter.ts
+++ b/src/views/virtualmachines/utils/virtualMachineRowFilter.ts
@@ -37,7 +37,7 @@ const statusFilterItems = [
   FailedStatus,
 ];
 
-const useGetStatusFilter = (): RowFilter => ({
+const useStatusFilter = (): RowFilter => ({
   filterGroupName: t('Status'),
   type: 'status',
   isMatch: (obj, filterStatus) => {
@@ -55,27 +55,27 @@ const useGetStatusFilter = (): RowFilter => ({
   items: statusFilterItems,
 });
 
-const useGetTemplatesFilter = (vms: V1VirtualMachine[]): RowFilter => {
-  const other = t('Other');
+const useTemplatesFilter = (vms: V1VirtualMachine[]): RowFilter => {
+  const noTemplate = t('None');
   const templates = useMemo(
     () =>
       [
         ...new Set(
           (vms || []).map((vm) => {
             const templateName = vm.metadata?.labels?.[LABEL_USED_TEMPLATE_NAME];
-            return templateName ?? other;
+            return templateName ?? noTemplate;
           }),
         ),
       ].map((template) => ({ id: template, title: template })),
-    [vms, other],
+    [vms, noTemplate],
   );
 
   return {
     filterGroupName: t('Template'),
     type: 'template',
-    reducer: (obj) => obj?.metadata?.labels?.[LABEL_USED_TEMPLATE_NAME] ?? other,
+    reducer: (obj) => obj?.metadata?.labels?.[LABEL_USED_TEMPLATE_NAME] ?? noTemplate,
     filter: (selectedTemplates, obj) => {
-      const templateName = obj?.metadata?.labels?.[LABEL_USED_TEMPLATE_NAME] ?? other;
+      const templateName = obj?.metadata?.labels?.[LABEL_USED_TEMPLATE_NAME] ?? noTemplate;
       return (
         selectedTemplates.selected?.length === 0 ||
         selectedTemplates.selected?.includes(templateName)
@@ -85,7 +85,7 @@ const useGetTemplatesFilter = (vms: V1VirtualMachine[]): RowFilter => {
   };
 };
 
-const useGetOSFilter = (): RowFilter => {
+const useOSFilter = (): RowFilter => {
   const getOSName = useCallback((obj) => {
     const osAnnotation = getAnnotation(obj?.spec?.template, ANNOTATIONS.os);
     const osLabel = getOperatingSystemName(obj) || getOperatingSystem(obj);
@@ -109,7 +109,7 @@ const useGetOSFilter = (): RowFilter => {
     })),
   };
 };
-const useGetNodesFilter = (vmiMapper: VmiMapper): RowFilter => {
+const useNodesFilter = (vmiMapper: VmiMapper): RowFilter => {
   const sortedNodeNamesItems = useMemo(() => {
     return Object.values(vmiMapper?.nodeNames).sort((a, b) =>
       a?.id?.localeCompare(b?.id, undefined, {
@@ -133,7 +133,7 @@ const useGetNodesFilter = (vmiMapper: VmiMapper): RowFilter => {
   };
 };
 
-export const useGetVMListFilters = (
+export const useVMListFilters = (
   vmis: V1VirtualMachineInstance[],
   vms: V1VirtualMachine[],
   vmims: V1VirtualMachineInstanceMigration[],
@@ -174,10 +174,10 @@ export const useGetVMListFilters = (
     }, {});
   }, [vmims]);
 
-  const statusFilter = useGetStatusFilter();
-  const templatesFilter = useGetTemplatesFilter(vms);
-  const osFilters = useGetOSFilter();
-  const nodesFilter = useGetNodesFilter(vmiMapper);
+  const statusFilter = useStatusFilter();
+  const templatesFilter = useTemplatesFilter(vms);
+  const osFilters = useOSFilter();
+  const nodesFilter = useNodesFilter(vmiMapper);
 
   return {
     filters: [statusFilter, templatesFilter, osFilters, nodesFilter],


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

Changing the `Other` opt to `None` for template filter to avoid conflicts on different filters and to have better terminology for not having a template label in the VM.

## 🎥 Demo

### Before:
![Screenshot - 2022-10-03T125044 744](https://user-images.githubusercontent.com/67270715/193549110-dcf3375c-1f4a-47df-9073-3d9e355ba6c7.png)

### After:
![Screenshot - 2022-10-03T124105 080](https://user-images.githubusercontent.com/67270715/193548948-34a780bf-b6c3-4b42-a386-b56be429ecce.png)

