### PR TITLE
Fix storage throughput value in top consumers card

### DIFF
--- a/src/views/clusteroverview/overview/components/top-consumers-card/utils/utils.ts
+++ b/src/views/clusteroverview/overview/components/top-consumers-card/utils/utils.ts
@@ -3,7 +3,6 @@ import { TFunction } from 'i18next';
 import {
   humanizeBinaryBytes,
   humanizeDecimalBytes,
-  humanizeDecimalBytesPerSec,
   humanizeSeconds,
 } from '../../../../../../utils/utils/humanize';
 
@@ -29,7 +28,7 @@ export const humanizeTopConsumerMetric = (value: number, metric: TopConsumerMetr
       humanizedValue = humanizeSeconds(value, 's', 'ms');
       break;
     case TopConsumerMetric.STORAGE_THROUGHPUT:
-      humanizedValue = humanizeDecimalBytesPerSec(value, 'MBps');
+      humanizedValue = humanizeDecimalBytes(value);
       break;
     case TopConsumerMetric.STORAGE_IOPS:
       humanizedValue = { value: value.toFixed(2), unit: STORAGE_IOPS_UNIT };


### PR DESCRIPTION
## 📝 Description

The values for storage throughput in the top consumers card were being reported incorrectly when compared with the same metric in the top consumers dashboard in Observe > Dashboards. This PR fixes the issue by using the correct function to convert from the bytes returned from Prometheus to the unit to be displayed.