### PR TITLE
Bug 2071491: Fix storage throughput value in Top Consumers card

### DIFF
--- a/src/views/clusteroverview/MonitoringTab/top-consumers-card/utils/utils.ts
+++ b/src/views/clusteroverview/MonitoringTab/top-consumers-card/utils/utils.ts
@@ -3,7 +3,6 @@ import { TFunction } from 'i18next';
 import {
   humanizeBinaryBytes,
   humanizeDecimalBytes,
-  humanizeDecimalBytesPerSec,
   humanizeSeconds,
 } from '../../../../../utils/utils/humanize';
 
@@ -29,7 +28,7 @@ export const humanizeTopConsumerMetric = (value: number, metric: TopConsumerMetr
       humanizedValue = humanizeSeconds(value, 's', 'ms');
       break;
     case TopConsumerMetric.STORAGE_THROUGHPUT:
-      humanizedValue = humanizeDecimalBytesPerSec(value, 'MBps');
+      humanizedValue = humanizeDecimalBytes(value);
       break;
     case TopConsumerMetric.STORAGE_IOPS:
       humanizedValue = { value: value.toFixed(2), unit: STORAGE_IOPS_UNIT };


### PR DESCRIPTION
## 📝 Description

The values for storage throughput in the top consumers card were being reported incorrectly when compared with the same metric in the top consumers dashboard in Observe > Dashboards. This PR fixes the issue by using the correct function to convert from the bytes returned from Prometheus to the unit to be displayed.

## 🎥 Screenshot
Before:
![Selection_169](https://user-images.githubusercontent.com/8544299/195349011-da409459-4f30-4767-8afc-d4d896b35b83.png)

After:
![Selection_167](https://user-images.githubusercontent.com/8544299/194632501-b3c72b90-e112-4e53-afb3-a5394c6ecb03.png)
