### PR TITLE
Bug 2132793: Load and show boot source reference

### DIFF
--- a/src/views/templates/actions/components/EditBootSourceModal.scss
+++ b/src/views/templates/actions/components/EditBootSourceModal.scss
@@ -2,6 +2,7 @@
   margin-bottom: var(--pf-global--spacer--md);
 }
 
-.select-source-option {
+.select-source-option,
+.disk-source-form-group {
   margin-bottom: var(--pf-global--spacer--md);
 }

--- a/src/views/templates/actions/components/PersistentVolumeClaimSelect/PersistentVolumeClaimSelect.tsx
+++ b/src/views/templates/actions/components/PersistentVolumeClaimSelect/PersistentVolumeClaimSelect.tsx
@@ -10,34 +10,32 @@ import './PersistentVolumeClaimSelect.scss';
 type PersistentVolumeClaimSelectProps = {
   pvcNameSelected: string;
   projectSelected: string;
-  selectNamespace: (namespace: string) => void;
-  selectPVCName: (pvcName: string) => void;
+  selectPVC: (pvcNamespace: string, pvcName?: string) => void;
 };
 
 export const PersistentVolumeClaimSelect: React.FC<PersistentVolumeClaimSelectProps> = ({
   pvcNameSelected,
   projectSelected,
-  selectPVCName,
-  selectNamespace,
+  selectPVC,
 }) => {
-  const { projectsNames, filteredPVCNames, loaded } = useProjectsAndPVCs(projectSelected);
+  const { projectsNames, filteredPVCNames, projectsLoaded, pvcsLoaded } =
+    useProjectsAndPVCs(projectSelected);
 
   const onSelectProject = React.useCallback(
     (newProject) => {
-      selectNamespace(newProject);
-      selectPVCName(undefined);
+      selectPVC(newProject);
     },
-    [selectNamespace, selectPVCName],
+    [selectPVC],
   );
 
   const onPVCSelected = React.useCallback(
     (selection) => {
-      selectPVCName(selection);
+      selectPVC(projectSelected, selection);
     },
-    [selectPVCName],
+    [selectPVC, projectSelected],
   );
 
-  if (!loaded) return <PersistentVolumeClainSelectSkeleton />;
+  if (!projectsLoaded) return <PersistentVolumeClainSelectSkeleton />;
 
   return (
     <div>
@@ -51,6 +49,7 @@ export const PersistentVolumeClaimSelect: React.FC<PersistentVolumeClaimSelectPr
         pvcNameSelected={pvcNameSelected}
         pvcNames={filteredPVCNames}
         isDisabled={!projectSelected}
+        isLoading={!pvcsLoaded}
       />
     </div>
   );

--- a/src/views/templates/actions/components/PersistentVolumeClaimSelect/PersistentVolumeSelectName.tsx
+++ b/src/views/templates/actions/components/PersistentVolumeClaimSelect/PersistentVolumeSelectName.tsx
@@ -6,6 +6,7 @@ import {
   Select,
   SelectOption,
   SelectVariant,
+  Skeleton,
   ValidatedOptions,
 } from '@patternfly/react-core';
 
@@ -16,6 +17,7 @@ type PersistentVolumeSelectNameProps = {
   pvcNameSelected: string;
   pvcNames: string[];
   onChange: (newPVCName: string) => void;
+  isLoading?: boolean;
 };
 
 export const PersistentVolumeSelectName: React.FC<PersistentVolumeSelectNameProps> = ({
@@ -23,6 +25,7 @@ export const PersistentVolumeSelectName: React.FC<PersistentVolumeSelectNameProp
   pvcNameSelected,
   pvcNames,
   onChange,
+  isLoading,
 }) => {
   const { t } = useKubevirtTranslation();
   const [isOpen, setSelectOpen] = React.useState(false);
@@ -36,6 +39,16 @@ export const PersistentVolumeSelectName: React.FC<PersistentVolumeSelectNameProp
   );
 
   const fieldId = 'pvc-name-select';
+
+  if (isLoading) {
+    return (
+      <>
+        <br />
+        <Skeleton fontSize="lg" className="pvc-selection-formgroup" />
+        <br />
+      </>
+    );
+  }
 
   return (
     <FormGroup

--- a/src/views/templates/actions/components/SelectSourceSkeleton.tsx
+++ b/src/views/templates/actions/components/SelectSourceSkeleton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { Skeleton } from '@patternfly/react-core';
+
+const SelectSourceSkeleton: React.FC = () => (
+  <>
+    <br />
+    <Skeleton fontSize="lg" className="select-source-option" />
+    <br />
+    <Skeleton fontSize="lg" className="select-source-option" />
+    <br />
+    <Skeleton fontSize="lg" width="50%" className="select-source-option" />
+  </>
+);
+
+export default SelectSourceSkeleton;

--- a/src/views/templates/actions/components/utils.ts
+++ b/src/views/templates/actions/components/utils.ts
@@ -1,0 +1,79 @@
+import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
+import { V1beta1DataVolumeSpec } from '@kubevirt-ui/kubevirt-api/kubevirt';
+
+import { SOURCE_OPTIONS_IDS, SOURCE_TYPES } from '../../utils/constants';
+import { getDataSourceDataVolume } from '../editBootSource';
+
+export const getDataVolumeSpec = async (
+  dataSource: V1beta1DataSource,
+): Promise<V1beta1DataVolumeSpec> => {
+  const dataSourcePVCName = dataSource?.spec?.source?.pvc?.name;
+  const dataSourcePVCNamespace = dataSource?.spec?.source?.pvc?.namespace;
+
+  const dataVolume = await getDataSourceDataVolume(dataSourcePVCName, dataSourcePVCNamespace);
+
+  return dataVolume?.spec;
+};
+
+export const getSourceTypeFromDataVolumeSpec = (dataVolumeSpec: V1beta1DataVolumeSpec) => {
+  if (dataVolumeSpec?.source?.pvc) return SOURCE_TYPES.pvcSource;
+
+  if (dataVolumeSpec?.source?.http) return SOURCE_TYPES.httpSource;
+
+  if (dataVolumeSpec?.source?.registry) return SOURCE_TYPES.registrySource;
+};
+
+export const getGenericSourceCustomization = (
+  diskSourceId: SOURCE_OPTIONS_IDS,
+  url?: string,
+  storage?: string,
+): V1beta1DataVolumeSpec => {
+  const dataVolumeSpec: V1beta1DataVolumeSpec = {
+    source: {
+      [diskSourceId]: {},
+    },
+    storage: {
+      resources: {
+        requests: {
+          storage: storage ?? '30Gi',
+        },
+      },
+    },
+  };
+
+  if (url) dataVolumeSpec.source[diskSourceId].url = url;
+
+  return dataVolumeSpec;
+};
+
+export const getPVCSource = (
+  pvcName: string,
+  pvcNamespace: string,
+  storage?: string,
+): V1beta1DataVolumeSpec => {
+  const dataVolumeSpec: V1beta1DataVolumeSpec = {
+    source: {
+      pvc: {
+        name: pvcName,
+        namespace: pvcNamespace,
+      },
+    },
+  };
+
+  if (storage)
+    dataVolumeSpec.storage = {
+      resources: {
+        requests: {
+          storage,
+        },
+      },
+    };
+
+  return dataVolumeSpec;
+};
+
+const DOCKER_PREFIX = 'docker://';
+
+export const appendDockerPrefix = (image: string) => {
+  return image?.startsWith(DOCKER_PREFIX) ? image : DOCKER_PREFIX.concat(image);
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

**Cause**
The EditBootSourceModal does not fetch the dataVolume and does not show the dataVolume source.

**Solution**
Fetch DV from DataSource and get from it the specs. Populate the form with specs data and be able to edit them. On submission, edit the DV


Most of the changes were made in the [SelectSource](https://github.com/kubevirt-ui/kubevirt-plugin/pull/913/files#diff-67651d5ff71151c93431684b8f429ba4985aef31fb688bbb6ee994ebb0b09daf).
The previous select source was not accepting a state or an initial state so was impossible to solve the bug without touching it.
Also in the component, there were a giant `useEffect` runner at every update. 
Now the SelectSource accepts a state (data volume spec) and all the component states were transformed into constants dependent on that state. There is just one callback when the volume or source type change
 
## 🎥 Demo


[Screencast from 11-10-2022 10:46:52.webm](https://user-images.githubusercontent.com/29160323/195043359-5096aedd-c821-45ac-93e6-e3e96d320f42.webm)

