### PR TITLE
Bug 2131165: Fixed in virtual machine statuses card the dark mode and removing icons

### DIFF
--- a/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusesCard.scss
+++ b/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusesCard.scss
@@ -52,7 +52,6 @@
       &:active {
         background-color: transparent;
       }
-      color: #151515;
     }
   }
 }

--- a/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusesCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusesCard.tsx
@@ -36,7 +36,7 @@ const VMStatusesCard: React.FC = () => {
   const { t } = useKubevirtTranslation();
   const [vms] = useK8sWatchResource<V1VirtualMachine[]>({
     groupVersionKind: VirtualMachineModelGroupVersionKind,
-    namespaced: !!namespace,
+    namespaced: Boolean(namespace),
     namespace: namespace,
     isList: true,
   });

--- a/src/views/clusteroverview/OverviewTab/vm-statuses-card/utils/utils.ts
+++ b/src/views/clusteroverview/OverviewTab/vm-statuses-card/utils/utils.ts
@@ -1,3 +1,5 @@
+import { Fragment } from 'react';
+
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getVMStatus } from '@kubevirt-utils/resources/shared';
 import { VM_STATUS } from '@kubevirt-utils/resources/vm/utils/vmStatus';
@@ -23,13 +25,13 @@ const ERROR_STATUSES = [
 export const vmStatusIcon = {
   Running: SyncAltIcon,
   Paused: PausedIcon,
-  Stopped: InProgressIcon,
+  Stopped: Fragment,
   Migrating: InProgressIcon,
-  Starting: InProgressIcon,
-  Stopping: InProgressIcon,
-  Deleting: InProgressIcon,
-  Provisioning: InProgressIcon,
-  Terminating: InProgressIcon,
+  Starting: Fragment,
+  Stopping: Fragment,
+  Deleting: Fragment,
+  Provisioning: Fragment,
+  Terminating: Fragment,
   Error: RedExclamationCircleIcon,
 };
 
@@ -53,9 +55,9 @@ export const getVMStatuses = (vms: V1VirtualMachine[]): StatusCounts => {
   });
 
   statusCounts[ERROR] = ERROR_STATUSES.reduce((acc, state) => {
-    acc += statusCounts?.[state] || 0;
+    const count = acc + (statusCounts?.[state] || 0);
     delete statusCounts[state];
-    return acc;
+    return count;
   }, 0);
 
   const primaryStatuses = PRIMARY_STATUSES.reduce((acc, state) => {


### PR DESCRIPTION
Signed-off-by: Dana Orr <dorr@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
In dark mode the additional status in the virtual machine statuses card was not visible enough.
And I removed the icons in the additional status because they are the same. 
## 🎥 Demo

Before:
<img width="838" alt="image" src="https://user-images.githubusercontent.com/61961469/196376923-831ba412-7009-4ae3-a0d5-bcd292ce4632.png">
<img width="844" alt="image" src="https://user-images.githubusercontent.com/61961469/196376750-06a610b8-9c25-449f-8a3e-eef67cf96ef3.png">

After: 
<img width="845" alt="image" src="https://user-images.githubusercontent.com/61961469/196377125-53c89faf-d841-481e-be63-ba223a494275.png">
<img width="863" alt="image" src="https://user-images.githubusercontent.com/61961469/196376563-2ef3d1ec-09e3-41b5-9949-8b1bae6671c1.png">

