### PR TITLE
Bug 2119615: The unit field doesn't change if the size number is big enough in Disk modal

### DIFF
--- a/src/utils/components/CapacityInput/CapacityInput.tsx
+++ b/src/utils/components/CapacityInput/CapacityInput.tsx
@@ -27,10 +27,10 @@ const CapacityInput: React.FC<CapacityInputProps> = ({ size, onChange, label }) 
   const [unitValue] = size?.match(/[a-zA-Z]+/g);
   const [sizeValue = 0] = size?.match(/[0-9]+/g) || [];
   const unit = !unitValue?.endsWith('B') ? `${unitValue}B` : unitValue;
-  const value = +sizeValue;
+  const value = Number(sizeValue);
 
   const onFormatChange = (_, newUnit: CAPACITY_UNITS) => {
-    onChange(`${+value}${removeByteSuffix(newUnit)}`);
+    onChange(`${Number(value)}${removeByteSuffix(newUnit)}`);
     toggleSelect(false);
   };
   const unitOptions = Object.values(CAPACITY_UNITS);
@@ -52,11 +52,16 @@ const CapacityInput: React.FC<CapacityInputProps> = ({ size, onChange, label }) 
           <NumberInput
             min={1}
             value={value}
-            onMinus={() => onChange(`${+value - 1}${removeByteSuffix(unit)}`)}
+            max={Number.MAX_SAFE_INTEGER}
+            onMinus={() => onChange(`${Number(value) - 1}${removeByteSuffix(unit)}`)}
             onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-              event?.target?.value && onChange(`${+event.target.value}${removeByteSuffix(unit)}`)
+              Number(event?.target?.value) <= Number.MAX_SAFE_INTEGER &&
+              onChange(`${Number(event.target.value)}${removeByteSuffix(unit)}`)
             }
-            onPlus={() => onChange(`${+value + 1}${removeByteSuffix(unit)}`)}
+            onPlus={() =>
+              Number(value) < Number.MAX_SAFE_INTEGER &&
+              onChange(`${Number(value) + 1}${removeByteSuffix(unit)}`)
+            }
             minusBtnAriaLabel={t('Decrement')}
             plusBtnAriaLabel={t('Increment')}
           />


### PR DESCRIPTION
Signed-off-by: Dana Orr <dorr@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

## 🎥 Demo

Before:
![unitChangedBefore](https://user-images.githubusercontent.com/61961469/196411822-a24fa41e-d3e8-4b87-8fae-9816f02bbe19.gif)

After:
![unitChangedAfter](https://user-images.githubusercontent.com/61961469/196411062-815e0841-bd34-4262-84ad-794aa7d4d041.gif)
