### PR TITLE
Bug 2132746: Background is broken in Virtualization Monitoring page

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -519,7 +519,6 @@
   "Missing guest agent": "Missing guest agent",
   "Missing required fields": "Missing required fields",
   "Model": "Model",
-  "Monitoring": "Monitoring",
   "More info": "More info",
   "More info: ": "More info: ",
   "Mount point": "Mount point",

--- a/src/views/clusteroverview/ClusterOverviewPage.tsx
+++ b/src/views/clusteroverview/ClusterOverviewPage.tsx
@@ -6,7 +6,8 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { HorizontalNav, NamespaceBar, NavPage } from '@openshift-console/dynamic-plugin-sdk';
 
 import ClusterOverviewPageHeader from './Header/ClusterOverviewPageHeader';
-import MonitoringTab from './MonitoringTab/MonitoringTab';
+import MigrationsCard from './MonitoringTab/migrations-card/MigrationsCard';
+import TopConsumersCard from './MonitoringTab/top-consumers-card/TopConsumersCard';
 import OverviewTab from './OverviewTab/OverviewTab';
 import SettingsTab from './SettingsTab/SettingsTab';
 
@@ -21,9 +22,14 @@ const ClusterOverviewPage: React.FC = () => {
       component: OverviewTab,
     },
     {
-      href: 'monitoring',
-      name: t('Monitoring'),
-      component: MonitoringTab,
+      href: 'top-consumers',
+      name: t('Top consumers'),
+      component: TopConsumersCard,
+    },
+    {
+      href: 'migrations',
+      name: t('Migrations'),
+      component: MigrationsCard,
     },
     {
       href: 'settings',


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

> Removing the monitoring tab and moving the top consumers and migration cards to main navigation

## 🎥 Demo

### before:
![sub-tabs-4](https://user-images.githubusercontent.com/67270715/196721550-3a249521-803a-4faa-9b50-28e0ad616988.png)
![sub-tabs-1](https://user-images.githubusercontent.com/67270715/196721554-7da9af17-5680-40c8-bfca-bad65bbcc9a2.png)

### after:
![sub-tabs-3](https://user-images.githubusercontent.com/67270715/196721618-044cf877-85ba-4e9d-b1a0-3c5f6ff4ea6f.png)
![sub-tabs-2](https://user-images.githubusercontent.com/67270715/196721622-c08063be-d3c4-42d5-904c-b6adedde0e01.png)

