### PR TITLE
Bug 2117803: Display correct command with username for SSH

### DIFF
--- a/src/utils/components/Consoles/Consoles.tsx
+++ b/src/utils/components/Consoles/Consoles.tsx
@@ -40,7 +40,7 @@ const Consoles: React.FC<ConsolesProps> = ({ vmi }) => {
     </Bullseye>
   ) : (
     <Stack hasGutter>
-      <StackItem>{!isWindowsMachine && <CloudInitCredentials vmi={vmi} />}</StackItem>
+      <StackItem>{!isWindowsMachine && <CloudInitCredentials vm={vm} />}</StackItem>
       <StackItem>
         <AccessConsoles
           preselectedType={VNC_CONSOLE_TYPE}

--- a/src/utils/components/Consoles/components/CloudInitCredentials/CloudInitCredentials.tsx
+++ b/src/utils/components/Consoles/components/CloudInitCredentials/CloudInitCredentials.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Accordion,
@@ -14,10 +14,10 @@ import CloudInitCredentialsContent from './CloudInitCredentialsContent';
 import './cloud-init-credentials.scss';
 
 type CloudInitCredentialsProps = {
-  vmi: V1VirtualMachineInstance;
+  vm: V1VirtualMachine;
 };
 
-const CloudInitCredentials: React.FC<CloudInitCredentialsProps> = ({ vmi }) => {
+const CloudInitCredentials: React.FC<CloudInitCredentialsProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
   const [showCredentials, setShowCredentials] = React.useState<boolean>(false);
 
@@ -32,7 +32,7 @@ const CloudInitCredentials: React.FC<CloudInitCredentialsProps> = ({ vmi }) => {
           {t('Guest login credentials')}
         </AccordionToggle>
         <AccordionContent isHidden={!showCredentials}>
-          <CloudInitCredentialsContent vmi={vmi} />
+          <CloudInitCredentialsContent vm={vm} />
         </AccordionContent>
       </AccordionItem>
     </Accordion>

--- a/src/utils/components/Consoles/components/CloudInitCredentials/CloudInitCredentialsContent.tsx
+++ b/src/utils/components/Consoles/components/CloudInitCredentials/CloudInitCredentialsContent.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import { Trans } from 'react-i18next';
 
-import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ClipboardCopy } from '@patternfly/react-core';
 
 type CloudInitCredentialsContentProps = {
-  vmi: V1VirtualMachineInstance;
+  vm: V1VirtualMachine;
 };
 
-const CloudInitCredentialsContent: React.FC<CloudInitCredentialsContentProps> = ({ vmi }) => {
+const CloudInitCredentialsContent: React.FC<CloudInitCredentialsContentProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
-  const { users } = getCloudInitCredentials(vmi);
+  const { users } = getCloudInitCredentials(vm);
   const usernameTitle = t('User name: ', { count: users?.length });
 
   if (isEmpty(users)) {

--- a/src/utils/components/SSHAccess/components/SSHCommand.tsx
+++ b/src/utils/components/SSHAccess/components/SSHCommand.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { CLOUD_INIT_MISSING_USERNAME } from '@kubevirt-utils/components/Consoles/utils/constants';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
@@ -14,6 +15,7 @@ import {
   Popover,
   Stack,
   StackItem,
+  Tooltip,
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
@@ -37,7 +39,7 @@ const SSHCommand: React.FC<SSHCommandProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const [sshService, setSSHService] = useState<IoK8sApiCoreV1Service>();
-  const { command, sshServiceRunning } = useSSHCommand(vmi, sshService);
+  const { command, user, sshServiceRunning } = useSSHCommand(vm, sshService);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error>();
 
@@ -50,6 +52,8 @@ const SSHCommand: React.FC<SSHCommandProps> = ({
 
     request.catch(setError).finally(() => setLoading(false));
   };
+
+  const hasNoUsername = user === CLOUD_INIT_MISSING_USERNAME;
 
   useEffect(() => {
     setSSHService(initialSSHService);
@@ -85,11 +89,13 @@ const SSHCommand: React.FC<SSHCommandProps> = ({
       <DescriptionListDescription>
         <Stack hasGutter>
           <StackItem>
-            <SSHCheckbox
-              sshServiceRunning={Boolean(sshService)}
-              setSSHServiceRunning={onSSHChange}
-              isDisabled={loading}
-            />
+            <Tooltip content={CLOUD_INIT_MISSING_USERNAME} isVisible={hasNoUsername}>
+              <SSHCheckbox
+                sshServiceRunning={Boolean(sshService)}
+                setSSHServiceRunning={onSSHChange}
+                isDisabled={loading || hasNoUsername}
+              />
+            </Tooltip>
           </StackItem>
           {sshServiceLoaded && !loading ? (
             sshServiceRunning && (

--- a/src/utils/components/SSHAccess/useSSHCommand.ts
+++ b/src/utils/components/SSHAccess/useSSHCommand.ts
@@ -1,5 +1,5 @@
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
 import { getSSHNodePort } from '@kubevirt-utils/utils/utils';
 
@@ -11,12 +11,12 @@ export type useSSHCommandResult = {
 
 // SSH over NodePort
 const useSSHCommand = (
-  vmi: V1VirtualMachineInstance,
+  vm: V1VirtualMachine,
   sshService: IoK8sApiCoreV1Service,
 ): useSSHCommandResult => {
   const consoleHostname = window.location.hostname; // fallback to console hostname
 
-  const { users } = getCloudInitCredentials(vmi);
+  const { users } = getCloudInitCredentials(vm);
   const user = users?.[0]?.name;
   const sshServicePort = getSSHNodePort(sshService);
 
@@ -29,7 +29,7 @@ const useSSHCommand = (
   return {
     command,
     user,
-    sshServiceRunning: !!sshService,
+    sshServiceRunning: Boolean(sshService),
   };
 };
 

--- a/src/utils/resources/vmi/utils/cloud-init.ts
+++ b/src/utils/resources/vmi/utils/cloud-init.ts
@@ -1,6 +1,6 @@
 import { load } from 'js-yaml';
 
-import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { CLOUD_INIT_MISSING_USERNAME } from '@kubevirt-utils/components/Consoles/utils/constants';
 
 type CloudinitUserDataObject = {
@@ -10,9 +10,9 @@ type CloudinitUserDataObject = {
 };
 
 export const getCloudInitCredentials = (
-  vmi: V1VirtualMachineInstance,
+  vm: V1VirtualMachine,
 ): { users: { name?: string; password?: string }[] } => {
-  const cloudInitVolume = vmi?.spec?.volumes?.find(
+  const cloudInitVolume = vm?.spec?.template?.spec?.volumes?.find(
     (volume) => volume?.cloudInitNoCloud || volume?.cloudInitConfigDrive,
   );
   const cloudInitDataSource =

--- a/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGrid.tsx
@@ -15,6 +15,7 @@ type VirtualMachineDetailsRightGridProps = {
 const VirtualMachineDetailsRightGrid: React.FC<VirtualMachineDetailsRightGridProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
   const isVMRunning = vm?.status?.printableStatus === printableVMStatus.Running;
+
   return isVMRunning ? (
     <RunningVirtualMachineDetailsRightGrid vm={vm} />
   ) : (


### PR DESCRIPTION
## 📝 Description
**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2117803#c7

Get the correct cloud-init credentials even when the VM is stopped and generate the ssh command properly (_SSH over NodePort_).
Disable the SSH over NodePort related checkbox and show the tooltip on hover to inform the user in case that there is no username set.

## 🎥 Demo
**Before:**
The username missing in the command:
![before1](https://user-images.githubusercontent.com/13417815/197216461-1e0cab23-b9a7-46e8-8752-8826e110bd09.png)
**After:**
The username present in the command:
![after1](https://user-images.githubusercontent.com/13417815/197216474-be25aa25-e5d2-4fb8-80bf-4ffe9093bcf7.png)
If there is no username set, it doesn't make sense to display the command:
![after2](https://user-images.githubusercontent.com/13417815/197216508-ba83d381-1ffe-4ca2-ba22-a65931a2c81d.png)


