### PR TITLE
Bug 2137241: Checkbox about delete vm disks is not loaded while deleting VM

### DIFF
--- a/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useDataVolumeConvertedVolumeNames.ts
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useDataVolumeConvertedVolumeNames.ts
@@ -1,0 +1,35 @@
+import { CDIConfigModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { V1beta1CDIConfig } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
+import { V1Volume } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+type UseDataVolumeConvertedVolumeNames = (vmVolumes: V1Volume[]) => {
+  dvVolumesNames: string[];
+  pvcVolumesNames: string[];
+};
+
+const useDataVolumeConvertedVolumeNames: UseDataVolumeConvertedVolumeNames = (vmVolumes) => {
+  const [cdiConfig] = useK8sWatchResource<V1beta1CDIConfig>({
+    groupVersionKind: CDIConfigModelGroupVersionKind,
+    namespaced: false,
+    isList: false,
+  });
+
+  const isDataVolumeGarbageCollector = cdiConfig?.spec?.dataVolumeTTLSeconds !== -1;
+
+  const dvVolumesNames = (vmVolumes || [])
+    .filter((volume) => volume?.dataVolume)
+    ?.map((volume) => volume?.dataVolume?.name);
+
+  const pvcVolumesNames = (vmVolumes || [])
+    .filter((volume) => volume?.persistentVolumeClaim)
+    ?.map((volume) => volume?.persistentVolumeClaim?.claimName);
+  return {
+    dvVolumesNames,
+    pvcVolumesNames: isDataVolumeGarbageCollector
+      ? pvcVolumesNames.concat(dvVolumesNames)
+      : pvcVolumesNames,
+  };
+};
+
+export default useDataVolumeConvertedVolumeNames;

--- a/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useDeleteVMResources.ts
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useDeleteVMResources.ts
@@ -13,6 +13,8 @@ import {
 import { getVolumes } from '@kubevirt-utils/resources/vm';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
+import useDataVolumeConvertedVolumeNames from './useDataVolumeConvertedVolumeNames';
+
 type UseDeleteVMResources = (vm: V1VirtualMachine) => {
   dataVolumes: V1beta1DataVolume[];
   pvcs: IoK8sApiCoreV1PersistentVolumeClaim[];
@@ -22,14 +24,7 @@ type UseDeleteVMResources = (vm: V1VirtualMachine) => {
 };
 
 const useDeleteVMResources: UseDeleteVMResources = (vm) => {
-  const dvVolumesNames = (getVolumes(vm) || [])
-    .filter((volume) => volume?.dataVolume)
-    ?.map((volume) => volume?.dataVolume?.name);
-
-  const pvcVolumesNames = (getVolumes(vm) || [])
-    .filter((volume) => volume?.persistentVolumeClaim)
-    ?.map((volume) => volume?.persistentVolumeClaim?.claimName);
-
+  const { dvVolumesNames, pvcVolumesNames } = useDataVolumeConvertedVolumeNames(getVolumes(vm));
   const namespace = vm?.metadata?.namespace;
   const [dataVolumes, dataVolumesLoaded, dataVolumesLoadError] = useK8sWatchResource<
     V1beta1DataVolume[]

--- a/src/views/virtualmachines/details/tabs/disk/modal/hooks/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/disk/modal/hooks/utils/utils.ts
@@ -3,7 +3,7 @@ import { V1Volume } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { volumeTypes } from '@kubevirt-utils/components/DiskModal/DiskFormFields/utils/constants';
 
 export const convertDataVolumeToPVC = (volume: V1Volume, cdiConfig: V1beta1CDIConfig): V1Volume => {
-  const isDataVolumeGarbageCollector = cdiConfig?.spec?.dataVolumeTTLSeconds >= 0;
+  const isDataVolumeGarbageCollector = cdiConfig?.spec?.dataVolumeTTLSeconds !== -1;
   const transformedDataVolumeToPVC = {
     [volumeTypes.PERSISTENT_VOLUME_CLAIM]: volume.dataVolume,
     name: volume.name,


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

> DataVolume is now garbage collected after creating the PVC, when trying to delete the DataVolume it no longer exists which causes it to not find the proper resource to delete.

## 🎥 Demo

### Before:
![missing-checkbox-b4](https://user-images.githubusercontent.com/67270715/197502534-13b07e4e-746a-41f6-a970-0d0767efc75d.png)


### After:
![missing-checkbox](https://user-images.githubusercontent.com/67270715/197502495-a3545f02-d3e3-46b6-a087-ec44bfd770b8.png)
