### PR TITLE
Bug 2137349: Prevent "Manage source" action from loading infinitely

### DIFF
--- a/src/views/datasources/dataimportcron/hooks/useDataImportCronActions.tsx
+++ b/src/views/datasources/dataimportcron/hooks/useDataImportCronActions.tsx
@@ -31,7 +31,7 @@ export const useDataImportCronActionsProvider: UseDataImportCronActionsProvider 
 ) => {
   const dataSourceName = dataImportCron?.spec?.managedDataSource;
   const [dataSource, setDataSource] = React.useState<V1beta1DataSource>();
-  const [isLoading, setIsLoading] = React.useState<boolean>(true);
+  const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const history = useHistory();


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2137349

Prevent _Manage source_ action from loading infinitely, in the _Actions_ menu on _DataImportCron Details_ page.

## 🎥 Screenshots
**Before:**
![cron_before](https://user-images.githubusercontent.com/13417815/197581790-89bd465a-2a95-400e-ace5-6482ddc4d719.png)
**After:**
![cron_after](https://user-images.githubusercontent.com/13417815/197581809-ecb9f72a-14ab-49a7-a61d-9c079c83eba9.png)


