### PR TITLE
Bug 2137731: Overview links for VM status not working

### DIFF
--- a/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusItem.tsx
+++ b/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusItem.tsx
@@ -5,8 +5,7 @@ import { VirtualMachineModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import { ALL_NAMESPACES } from '@kubevirt-utils/hooks/constants';
 import { GridItem } from '@patternfly/react-core';
 
-import { ERROR } from './utils/constants';
-import { vmStatusIcon } from './utils/utils';
+import { isAllNamespaces, vmStatusIcon } from './utils/utils';
 
 import './VMStatusesCard.scss';
 
@@ -18,8 +17,8 @@ type VMStatusItemProps = {
 
 const VMStatusItem: React.FC<VMStatusItemProps> = ({ status, count, namespace }) => {
   const Icon = vmStatusIcon[status];
-  const path = `/k8s/ns/${
-    namespace || ALL_NAMESPACES
+  const path = `/k8s/${
+    isAllNamespaces(namespace) ? ALL_NAMESPACES : `ns/${namespace}`
   }/${VirtualMachineModelRef}?rowFilter-status=${status}`;
 
   return (
@@ -30,7 +29,7 @@ const VMStatusItem: React.FC<VMStatusItemProps> = ({ status, count, namespace })
             <Icon />
           </span>
           <span className="vm-statuses-card__status-item--value">
-            {status !== ERROR ? <Link to={path}>{count.toString()}</Link> : count.toString()}
+            <Link to={path}>{count.toString()}</Link>
           </span>
         </div>
         <div className="vm-statuses-card__status-item--status">{status}</div>

--- a/src/views/clusteroverview/OverviewTab/vm-statuses-card/utils/utils.ts
+++ b/src/views/clusteroverview/OverviewTab/vm-statuses-card/utils/utils.ts
@@ -1,6 +1,7 @@
 import { Fragment } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { ALL_NAMESPACES, ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { getVMStatus } from '@kubevirt-utils/resources/shared';
 import { VM_STATUS } from '@kubevirt-utils/resources/vm/utils/vmStatus';
 import { RedExclamationCircleIcon } from '@openshift-console/dynamic-plugin-sdk';
@@ -68,3 +69,6 @@ export const getVMStatuses = (vms: V1VirtualMachine[]): StatusCounts => {
 
   return { primaryStatuses, additionalStatuses: statusCounts };
 };
+
+export const isAllNamespaces = (namespace: string) =>
+  !namespace || namespace === ALL_NAMESPACES || namespace === ALL_NAMESPACES_SESSION_KEY;

--- a/src/views/virtualmachines/utils/virtualMachineRowFilter.ts
+++ b/src/views/virtualmachines/utils/virtualMachineRowFilter.ts
@@ -18,7 +18,7 @@ import {
 } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 
-import { isFailedPrintableStatus, printableVMStatus } from './virtualMachineStatuses';
+import { isErrorPrintableStatus, printableVMStatus } from './virtualMachineStatuses';
 
 type VmiMapper = {
   mapper: { [key: string]: { [key: string]: V1VirtualMachineInstance } };
@@ -27,14 +27,14 @@ type VmiMapper = {
 
 type VmimMapper = { [key: string]: { [key: string]: V1VirtualMachineInstance } };
 
-const FailedStatus = { id: 'Failed', title: 'Failed' };
+const ErrorStatus = { id: 'Error', title: 'Error' };
 
 const statusFilterItems = [
   ...Object.keys(printableVMStatus).map((status) => ({
     id: status,
     title: status,
   })),
-  FailedStatus,
+  ErrorStatus,
 ];
 
 const useStatusFilter = (): RowFilter => ({
@@ -43,14 +43,14 @@ const useStatusFilter = (): RowFilter => ({
   isMatch: (obj, filterStatus) => {
     return (
       filterStatus === obj?.status?.printableStatus ||
-      (filterStatus === FailedStatus.id && isFailedPrintableStatus(obj?.status?.printableStatus))
+      (filterStatus === ErrorStatus.id && isErrorPrintableStatus(obj?.status?.printableStatus))
     );
   },
   filter: (statuses, obj) => {
     const status = obj?.status?.printableStatus;
-    const isFailed = statuses.selected.includes(FailedStatus.id) && isFailedPrintableStatus(status);
+    const isError = statuses.selected.includes(ErrorStatus.id) && isErrorPrintableStatus(status);
 
-    return statuses.selected?.length === 0 || statuses.selected?.includes(status) || isFailed;
+    return statuses.selected?.length === 0 || statuses.selected?.includes(status) || isError;
   },
   items: statusFilterItems,
 });

--- a/src/views/virtualmachines/utils/virtualMachineStatuses.ts
+++ b/src/views/virtualmachines/utils/virtualMachineStatuses.ts
@@ -35,7 +35,7 @@ export const errorPrintableVMStatus = {
   DataVolumeError: 'DataVolumeError',
 };
 
-export const isFailedPrintableStatus = (printableStatus: string) =>
+export const isErrorPrintableStatus = (printableStatus: string) =>
   Object.values(errorPrintableVMStatus).includes(printableStatus);
 
 export const getVMStatusIcon = (status: string): React.ComponentClass | React.FC => {
@@ -55,9 +55,9 @@ export const getVMStatusIcon = (status: string): React.ComponentClass | React.FC
       return PausedIcon;
     case printableVMStatus.Migrating:
       return MigrationIcon;
+    case errorPrintableVMStatus[status]:
+      return ExclamationCircleIcon;
+    default:
+      return UnknownIcon;
   }
-
-  if (isFailedPrintableStatus(status)) return ExclamationCircleIcon;
-
-  return UnknownIcon;
 };


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description
issues:
- Error status on overview has no link to VM Failed status - link was added and VM Failed status changed to Error for consistency
- VM status link in the overview where broken - namespace prop was having a value of `#ALL-NS#` instead of being empty made a check to verify if namespace value indicates on `all-namespace` or a specific namespace

## 🎥 Demo

### Before:

https://user-images.githubusercontent.com/67270715/197972342-93f0bf22-8787-460d-85b4-a1e20819b50a.mp4

### After:

https://user-images.githubusercontent.com/67270715/197972376-da862572-3e59-48f1-865f-a2b814008f62.mp4

NOTE: this PR also solves https://bugzilla.redhat.com/show_bug.cgi?id=2137731 as they are strongly related and to avoid PR conflicts