### PR TITLE
Bug 2137736: The column name "MigrationPolicy name" can just be "Name"

### DIFF
--- a/src/views/migrationpolicies/list/hooks/useMigrationPoliciesListColumns.ts
+++ b/src/views/migrationpolicies/list/hooks/useMigrationPoliciesListColumns.ts
@@ -15,7 +15,7 @@ const useMigrationPoliciesListColumns = (): [
   const columns: TableColumn<V1alpha1MigrationPolicy>[] = React.useMemo(
     () => [
       {
-        title: t('MigrationPolicy name'),
+        title: t('Name'),
         id: 'name',
         transforms: [sortable],
         sort: 'metadata.name',


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 🎥 Demo
### Before:

![mp-name-column-b4](https://user-images.githubusercontent.com/67270715/197974647-c6bf79bc-d4a6-4e7d-ba8f-bc65712be492.png)

### After:

![mp-name-column](https://user-images.githubusercontent.com/67270715/197974638-499849d7-4d94-41a4-a8a5-c6b0f932e1aa.png)