### PR TITLE
Bug 2136425: Windows 11 is detected as Windows 10

### DIFF
--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
@@ -8,9 +8,9 @@ import { timestampFor } from '@kubevirt-utils/components/Timestamp/utils/datetim
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getLabel } from '@kubevirt-utils/resources/shared';
 import { LABEL_USED_TEMPLATE_NAMESPACE } from '@kubevirt-utils/resources/template';
-import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
-import { VM_TEMPLATE_ANNOTATION } from '@kubevirt-utils/resources/vm';
+import { useVMIAndPodsForVM, VM_TEMPLATE_ANNOTATION } from '@kubevirt-utils/resources/vm';
 import { useGuestOS } from '@kubevirt-utils/resources/vmi';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
@@ -64,7 +64,9 @@ const VirtualMachinesOverviewTabDetails: React.FC<VirtualMachinesOverviewTabDeta
   const guestAgentIsRequired = <GuestAgentIsRequiredText vmi={vmi} />;
 
   const osName =
-    (guestAgentData?.os?.prettyName || guestAgentData?.os?.name) ?? guestAgentIsRequired;
+    loaded && !isEmpty(guestAgentData)
+      ? `${guestAgentData?.os?.name} ${guestAgentData?.os?.version}`
+      : guestAgentIsRequired;
 
   const hostname = guestAgentData?.hostname ?? guestAgentIsRequired;
 


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>

## 📝 Description

> Guest agent is showing wrong pretty name data for win 11 so we change the way we evaluate the OS for the single VM overview details card  

