### PR TITLE
Bug 2132746: Background is broken in Virtualization Settings page

### DIFF
--- a/src/views/clusteroverview/SettingsTab/settings-tab.scss
+++ b/src/views/clusteroverview/SettingsTab/settings-tab.scss
@@ -4,7 +4,7 @@
   }
 
   &__card {
-    height: 100%;
+    height: 75%;
     flex-direction: row;
   }
 


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

the card height was 100% and in addition to the alert's component height we got unwanted scrollbar which broke the background from the overview copmonent.

## 🎥 Demo
### Before:
![setting-bg-b4](https://user-images.githubusercontent.com/67270715/198227913-1272369d-66f8-4b05-b444-91d1716319f3.png)
### After:
![setting-bg](https://user-images.githubusercontent.com/67270715/198227917-489b6182-1c9d-4a05-a932-c2e54f6cae17.png)

