### PR TITLE
Bug 2138112: Unsupported S3 endpoint option in Add disk modal

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -416,7 +416,7 @@
   "Hot plug is enabled only for \"SCSI\" interface": "Hot plug is enabled only for \"SCSI\" interface",
   "Image URL": "Image URL",
   "Import content via container registry.": "Import content via container registry.",
-  "Import content via URL (HTTP or S3 endpoint).": "Import content via URL (HTTP or S3 endpoint).",
+  "Import content via URL (HTTP or HTTPS endpoint).": "Import content via URL (HTTP or HTTPS endpoint).",
   "In": "In",
   "Include all values from existing config maps, secrets or service accounts (as disk)": "Include all values from existing config maps, secrets or service accounts (as disk)",
   "Increment": "Increment",

--- a/src/utils/components/DiskModal/DiskFormFields/utils/helpers.ts
+++ b/src/utils/components/DiskModal/DiskFormFields/utils/helpers.ts
@@ -21,7 +21,7 @@ export const getSourceOptions = (t: TFunction) => ({
   http: {
     id: sourceTypes.HTTP,
     name: t('URL (creates PVC)'),
-    description: t('Import content via URL (HTTP or S3 endpoint).'),
+    description: t('Import content via URL (HTTP or HTTPS endpoint).'),
   },
   pvc: {
     id: sourceTypes.PVC,

--- a/src/views/catalog/customize/components/CustomizeSource/SelectSourceOption.tsx
+++ b/src/views/catalog/customize/components/CustomizeSource/SelectSourceOption.tsx
@@ -45,7 +45,7 @@ const getSourceOption = (source: SOURCE_OPTIONS_IDS, ns: string, t: TFunction) =
         <SelectOption
           value={HTTP_SOURCE_NAME}
           key={HTTP_SOURCE_NAME}
-          description={t('Import content via URL (HTTP or S3 endpoint).')}
+          description={t('Import content via URL (HTTP or HTTPS endpoint).')}
         >
           <span data-test-id={HTTP_SOURCE_NAME}>{t('URL (creates PVC)')}</span>
         </SelectOption>

--- a/src/views/templates/actions/components/SelectSourceOption.tsx
+++ b/src/views/templates/actions/components/SelectSourceOption.tsx
@@ -1,18 +1,13 @@
 import * as React from 'react';
-import { TFunction } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
-import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 
 import { SOURCE_OPTIONS_IDS, SOURCE_TYPES } from '../../utils/constants';
 
-const getSourceOption = (
-  source: SOURCE_OPTIONS_IDS,
-  ns: string,
-  t: TFunction<'plugin__kubevirt-plugin', undefined>,
-) => {
+const getSourceOption = (source: SOURCE_OPTIONS_IDS, ns: string) => {
   switch (source) {
     case SOURCE_TYPES.defaultSource:
       return (
@@ -38,7 +33,7 @@ const getSourceOption = (
       return (
         <SelectOption
           value={SOURCE_TYPES.httpSource}
-          description={t('Import content via URL (HTTP or S3 endpoint).')}
+          description={t('Import content via URL (HTTP or HTTPS endpoint).')}
         >
           <span data-test-id={SOURCE_TYPES.httpSource}>{t('URL (creates PVC)')}</span>
         </SelectOption>
@@ -66,6 +61,8 @@ const getSourceOption = (
           {t('Upload (Upload a new file to a PVC)')} <ExternalLinkAltIcon />
         </SelectOption>
       );
+    default:
+      return;
   }
 };
 
@@ -84,7 +81,6 @@ const SelectSourceOption: React.FC<SelectSourceOptionProps> = ({
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const { ns } = useParams<{ ns: string }>();
-  const { t } = useKubevirtTranslation();
 
   const onSelect = React.useCallback(
     (event, selection) => {
@@ -113,7 +109,7 @@ const SelectSourceOption: React.FC<SelectSourceOptionProps> = ({
         menuAppendTo="parent"
       >
         {<SelectOption key={0} value="Select a title" isPlaceholder /> &&
-          options.map((option) => getSourceOption(option, ns, t))}
+          options.map((option) => getSourceOption(option, ns))}
       </Select>
     </FormGroup>
   );


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

> Change URL disk source description to show support of HTTPS and not S3 URLs

## 🎥 Demo
### Before:
![s3-url-b4-3](https://user-images.githubusercontent.com/67270715/198296656-59c85df7-cec2-4bba-b5b8-6f51c49abe9e.png)
![s3-url-b4-4](https://user-images.githubusercontent.com/67270715/198296660-655b83e7-ee74-47b5-8700-11e2a1d49c2a.png)
![s3-url-b4-2](https://user-images.githubusercontent.com/67270715/198296662-a4d0f0ae-3a55-4754-afe8-eee6d786ac2c.png)
![s3-url-b4-1](https://user-images.githubusercontent.com/67270715/198296664-33546650-d629-4467-a057-720911d1f909.png)

### After:

https://user-images.githubusercontent.com/67270715/198296850-f125fe95-281e-4c98-a4b8-807427d9286a.mp4

