### PR TITLE
Bug 2139293: Non-admin user cannot load VM list page

### DIFF
--- a/src/utils/hooks/useSingleNodeCluster.ts
+++ b/src/utils/hooks/useSingleNodeCluster.ts
@@ -3,8 +3,11 @@ import { useMemo } from 'react';
 import { InfrastructureModel, modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource';
 
+import { useIsAdmin } from './useIsAdmin';
+
 type UseSingleNodeCluster = () => [isSingleNodeCluster: boolean, loaded: boolean];
 const useSingleNodeCluster: UseSingleNodeCluster = () => {
+  const isAdmin = useIsAdmin();
   const [infrastructure, loaded] = useKubevirtWatchResource({
     groupVersionKind: modelToGroupVersionKind(InfrastructureModel),
     namespaced: false,
@@ -15,7 +18,7 @@ const useSingleNodeCluster: UseSingleNodeCluster = () => {
     [infrastructure],
   );
 
-  return [isSingleNodeCluster, loaded];
+  return isAdmin ? [isSingleNodeCluster, loaded] : [undefined, true];
 };
 
 export default useSingleNodeCluster;

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -68,6 +68,7 @@ const VirtualMachinesList: React.FC<VirtualMachinesListProps> = ({ kind, namespa
     groupVersionKind: VirtualMachineInstanceMigrationModelGroupVersionKind,
     isList: true,
     namespaced: true,
+    namespace,
     limit: OBJECTS_FETCHING_LIMIT,
   });
 


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

> The VM list was stuck as it tried to fetch the Infrastructure resource which a non-priv user is usually not allowed to list this resource at all, also missing the namespace prop for vmim resource list which also is not allowed on cluster scope for non-priv users, both caused the VM list page to stuck as it is still loading

## 🎥 Demo
### Before
![vm-list-stuck-non-priv-b4](https://user-images.githubusercontent.com/67270715/199488968-d174b774-b991-4603-85c2-7832a36c4b47.png)
### After
![vm-list-stuck-non-priv](https://user-images.githubusercontent.com/67270715/199488971-32f51cf1-9267-45d9-810e-071390c0d48d.png)

