### PR TITLE
Bug 2139296: Non-admin cannot load MigrationPolicies page

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -384,6 +384,9 @@
         "data-quickstart-id": "qs-nav-migrationpolicies",
         "data-test-id": "migrationpolicies-nav-item"
       }
+    },
+    "flags": {
+      "required": ["CAN_LIST_NS"]
     }
   },
   {


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

> requiring `CAN_LIST_NS` flag for MigrationPolicies page to show this page only for privileged users
## 🎥 Demo

### Before
![mp-page-error](https://user-images.githubusercontent.com/67270715/199502006-0848b7b4-ed0e-406a-a35d-4c2827ba6f96.png)

### After
![mp-page-error-after](https://user-images.githubusercontent.com/67270715/199501997-7d698026-8d39-4d9e-8fee-618514ff70ed.png)

