### PR TITLE
Bug 2139479: virtualization overview crashes for non-priv user

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -205,12 +205,12 @@
   {
     "type": "console.navigation/href",
     "properties": {
+      "prefixNamespaced": true,
       "id": "overview",
       "section": "virtualization",
       "insertBefore": "virtualization-catalog",
       "name": "%plugin__kubevirt-plugin~Overview%",
-      "href": "/virtualization-overview",
-      "namespaced": true,
+      "href": "virtualization-overview",
       "dataAttributes": {
         "data-quickstart-id": "qs-nav-virtualization-overview",
         "data-test-id": "virtualization-overview-nav-item"
@@ -223,8 +223,7 @@
   {
     "type": "console.page/route",
     "properties": {
-      "exact": false,
-      "path": ["/virtualization-overview/ns/:ns", "/virtualization-overview/all-namespaces"],
+      "path": ["/k8s/ns/:ns/virtualization-overview", "/k8s/all-namespaces/virtualization-overview"],
       "component": {
         "$codeRef": "ClusterOverviewPage"
       }

--- a/src/views/clusteroverview/ClusterOverviewPage.tsx
+++ b/src/views/clusteroverview/ClusterOverviewPage.tsx
@@ -3,7 +3,7 @@ import { Helmet } from 'react-helmet';
 
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { HorizontalNav, NamespaceBar, NavPage } from '@openshift-console/dynamic-plugin-sdk';
+import { HorizontalNav, NavPage } from '@openshift-console/dynamic-plugin-sdk';
 
 import ClusterOverviewPageHeader from './Header/ClusterOverviewPageHeader';
 import MigrationsCard from './MonitoringTab/migrations-card/MigrationsCard';
@@ -40,7 +40,6 @@ const ClusterOverviewPage: React.FC = () => {
 
   return (
     <>
-      <NamespaceBar />
       <Helmet>
         <title>{t('Virtualization')}</title>
       </Helmet>


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

> NamespaceBar component is causing issues for non-priv users, removed NamespaceBar component and injected via console-extensions

## 🎥 Demo

### Before
![remove-namespace-bar-b4](https://user-images.githubusercontent.com/67270715/199548249-70fac865-c28f-4628-be61-e11fd5d841db.png)
### After
![remove-namespace-bar](https://user-images.githubusercontent.com/67270715/199548256-1458d82d-b585-450a-915a-3c9439d9361b.png)

