### PR TITLE
Bug 2139651: non-priv user can click create when have no permissions

### DIFF
--- a/src/views/templates/list/VirtualMachineTemplatesList.tsx
+++ b/src/views/templates/list/VirtualMachineTemplatesList.tsx
@@ -48,7 +48,10 @@ const VirtualMachineTemplatesList: React.FC<RouteComponentProps<{ ns: string }>>
   return (
     <>
       <ListPageHeader title={t('VirtualMachine Templates')}>
-        <ListPageCreate groupVersionKind={modelToRef(TemplateModel)}>
+        <ListPageCreate
+          createAccessReview={{ groupVersionKind: modelToRef(TemplateModel), namespace }}
+          groupVersionKind={modelToRef(TemplateModel)}
+        >
           {t('Create Template')}
         </ListPageCreate>
       </ListPageHeader>

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -106,7 +106,11 @@ const VirtualMachinesList: React.FC<VirtualMachinesListProps> = ({ kind, namespa
   return (
     <>
       <ListPageHeader title={t('VirtualMachines')}>
-        <ListPageCreateDropdown items={createItems} onClick={onCreate}>
+        <ListPageCreateDropdown
+          items={createItems}
+          onClick={onCreate}
+          createAccessReview={{ groupVersionKind: VirtualMachineModelRef, namespace }}
+        >
           {t('Create')}
         </ListPageCreateDropdown>
       </ListPageHeader>


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

> Non-privileged user could click on create for both VirtualMachine and Templates views under namespace not allowed to `list` or `create` and eventually leads to a crash

## 🎥 Demo

### Before
![can-click-create-no-permissions-templates-b4](https://user-images.githubusercontent.com/67270715/199685669-045928ea-d6b0-4eda-9389-12ed6cd6f898.png)
![can-click-create-no-permissions-vm-b4](https://user-images.githubusercontent.com/67270715/199685677-ae2d377e-47ab-40cc-a6f3-ffca50479741.png)

### After
![can-click-create-no-permissions-vm](https://user-images.githubusercontent.com/67270715/199685748-bf4324e1-6fe0-4a56-bf11-f32621c8726c.png)
![can-click-create-no-permissions-templates](https://user-images.githubusercontent.com/67270715/199685755-d3d3f716-d713-42d2-8881-35e47e908a9a.png)
