### PR TITLE
Bug 2139257: cant edit root disk to use existing PVC

### DIFF
--- a/src/utils/components/CapacityInput/CapacityInput.tsx
+++ b/src/utils/components/CapacityInput/CapacityInput.tsx
@@ -24,7 +24,7 @@ type CapacityInputProps = {
 const CapacityInput: React.FC<CapacityInputProps> = ({ size, onChange, label }) => {
   const { t } = useKubevirtTranslation();
   const [selectOpen, toggleSelect] = useState<boolean>(false);
-  const [unitValue] = size?.match(/[a-zA-Z]+/g);
+  const [unitValue = ''] = size?.match(/[a-zA-Z]+/g) || [];
   const [sizeValue = 0] = size?.match(/[0-9]+/g) || [];
   const unit = !unitValue?.endsWith('B') ? `${unitValue}B` : unitValue;
   const value = Number(sizeValue);

--- a/src/utils/components/DiskModal/DiskFormFields/utils/constants.ts
+++ b/src/utils/components/DiskModal/DiskFormFields/utils/constants.ts
@@ -57,6 +57,7 @@ export const mapSourceTypeToVolumeType = {
   [volumeTypes.CONFIG_MAP]: OTHER,
   [volumeTypes.SECRET]: OTHER,
   [volumeTypes.SERVICE_ACCOUNT]: OTHER,
+  [volumeTypes.DATA_VOLUME]: volumeTypes.DATA_VOLUME,
   [OTHER]: OTHER,
 };
 


### PR DESCRIPTION
Signed-off-by: Matan Schatzman <mschatzm@redhat.com>

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When trying to edit root disk to use the existing PVC option getting this error message:

<img width="575" alt="image" src="https://user-images.githubusercontent.com/14824964/199740865-920069cf-60da-4ef3-ae21-0fa26786ec62.png">





