### PR TITLE
Bug 2139820: cant reach vm details

### DIFF
--- a/src/utils/hooks/useLastNamespacePath.ts
+++ b/src/utils/hooks/useLastNamespacePath.ts
@@ -1,20 +1,14 @@
-import { useLastNamespace } from '@openshift-console/dynamic-plugin-sdk-internal';
-
 import {
   ALL_NAMESPACES,
   ALL_NAMESPACES_SESSION_KEY as ALL_NAMESPACES_ACTIVE_KEY,
 } from './constants';
 
-type UseActiveNamespacePathType = () => [
-  lastNamespace: string | undefined,
-  changeLastNamespace: (namespace: string) => void,
-];
+type UseActiveNamespacePathType = () => string;
 
 export const useLastNamespacePath: UseActiveNamespacePathType = () => {
-  const [lastNamespace, setLastNamespace] = useLastNamespace();
-
-  return [
-    lastNamespace === ALL_NAMESPACES_ACTIVE_KEY ? ALL_NAMESPACES : `ns/${lastNamespace}`,
-    setLastNamespace,
+  const lastNamespace = JSON.parse(localStorage.getItem('console-user-settings'))?.[
+    'console.lastNamespace'
   ];
+
+  return lastNamespace === ALL_NAMESPACES_ACTIVE_KEY ? ALL_NAMESPACES : `ns/${lastNamespace}`;
 };

--- a/src/views/templates/actions/hooks/useVirtualMachineTemplatesActions.tsx
+++ b/src/views/templates/actions/hooks/useVirtualMachineTemplatesActions.tsx
@@ -44,7 +44,7 @@ const useVirtualMachineTemplatesActions: useVirtualMachineTemplatesActionsProps 
   const [bootDataSource, setBootDataSource] = React.useState<V1beta1DataSource>();
   const [loadingBootSource, setLoadingBootSource] = React.useState(true);
   const editableBootSource = hasEditableBootSource(bootDataSource);
-  const [lastNamespacePath] = useLastNamespacePath();
+  const lastNamespacePath = useLastNamespacePath();
 
   const [canWriteToDataSourceNs] = useAccessReview(
     asAccessReview(

--- a/src/views/templates/details/TemplatePageTitle.tsx
+++ b/src/views/templates/details/TemplatePageTitle.tsx
@@ -19,7 +19,7 @@ type TemplatePageTitleTitleProps = {
 const TemplatePageTitle: React.FC<TemplatePageTitleTitleProps> = ({ template }) => {
   const { t } = useKubevirtTranslation();
   const history = useHistory();
-  const [lastNamespacePath] = useLastNamespacePath();
+  const lastNamespacePath = useLastNamespacePath();
   const isEditDisabled = isCommonVMTemplate(template);
 
   return (

--- a/src/views/virtualmachines/actions/components/DeleteVMModal/DeleteVMModal.tsx
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/DeleteVMModal.tsx
@@ -29,7 +29,7 @@ const DeleteVMModal: React.FC<DeleteVMModalProps> = ({ vm, isOpen, onClose }) =>
   const history = useHistory();
   const [deleteOwnedResource, setDeleteOwnedResource] = React.useState(true);
   const { dataVolumes, pvcs, snapshots, loaded } = useDeleteVMResources(vm);
-  const [lastNamespacePath] = useLastNamespacePath();
+  const lastNamespacePath = useLastNamespacePath();
 
   const onDelete = async (updatedVM: V1VirtualMachine) => {
     if (!deleteOwnedResource) {

--- a/src/views/virtualmachines/list/components/VirtualMachineBreadcrumb/VirtualMachineBreadcrumb.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineBreadcrumb/VirtualMachineBreadcrumb.tsx
@@ -7,7 +7,7 @@ import { useLastNamespacePath } from '@kubevirt-utils/hooks/useLastNamespacePath
 import { Breadcrumb, BreadcrumbItem, Button } from '@patternfly/react-core';
 
 export const VirtualMachineBreadcrumb: React.FC = React.memo(() => {
-  const [namespacePath] = useLastNamespacePath();
+  const namespacePath = useLastNamespacePath();
 
   const { t } = useKubevirtTranslation();
   const history = useHistory();

--- a/src/views/virtualmachinesinstance/list/components/VirtualMachineInstanceBreadcrumb/VirtualMachineInstanceBreadcrumb.tsx
+++ b/src/views/virtualmachinesinstance/list/components/VirtualMachineInstanceBreadcrumb/VirtualMachineInstanceBreadcrumb.tsx
@@ -9,7 +9,7 @@ import { Breadcrumb, BreadcrumbItem, Button } from '@patternfly/react-core';
 const VirtualMachineInstanceBreadcrumb: React.FC = React.memo(() => {
   const { t } = useKubevirtTranslation();
   const history = useHistory();
-  const [lastNamespacePath] = useLastNamespacePath();
+  const lastNamespacePath = useLastNamespacePath();
 
   return (
     <div>


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

> getting error about useLastNamespace hook from SDK when trying to reach VM details page (also affecting VM delete modal, vmi details page, template details page, and templates list page).
to get the actual last namespace property we can access it through the local storage (as done by console)
currently no option to reset it but only view it

## 🎥 Demo

### Before

https://user-images.githubusercontent.com/67270715/199743562-57d7f3f6-2ca6-4cc8-ab92-c950ea1d45c1.mp4

### After 

https://user-images.githubusercontent.com/67270715/199743610-f8256217-ebdb-409a-8d98-515541f7477b.mp4


