### PR TITLE
Bug 2138119: Rename "Review and create VirtualMachine" to "Next"

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -544,6 +544,7 @@
   "Networking": "Networking",
   "Networks": "Networks",
   "Networks misconfigured": "Networks misconfigured",
+  "Next": "Next",
   "NICs": "NICs",
   "No": "No",
   "No active users": "No active users",

--- a/src/views/catalog/customize/components/FormActionGroup.tsx
+++ b/src/views/catalog/customize/components/FormActionGroup.tsx
@@ -36,7 +36,7 @@ export const FormActionGroup: React.FC<FormActionGroupProps> = ({ loading, onCan
         isLoading={loading}
         data-test-id="customize-vm-submit-button"
       >
-        {t('Review and create VirtualMachine')}
+        {t('Next')}
       </Button>
       <Button variant="link" onClick={handleCancel}>
         {t('Cancel')}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2138119

Rename "Review and create VirtualMachine" button on the Edit Template Parameters modal to "Next", to make the process of VM creation more clear to the user.

## 🎥 Screenshots
**Before:**
![next_before](https://user-images.githubusercontent.com/13417815/200362347-43984cdb-87aa-4675-b2d4-4ede54d1d086.png)
**After:**
![next_after](https://user-images.githubusercontent.com/13417815/200362361-d27207ce-6a9f-4aa7-be8a-b8d76bb6623b.png)
