### PR TITLE
Bug 2140627: Allow to select storageClass in Add disk modal

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/StorageClassSelect.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/StorageClassSelect.tsx
@@ -34,7 +34,7 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
 
   const onSelect = useCallback(
     (event: React.MouseEvent<Element, MouseEvent>, selection: string) => {
-      setShowSCAlert(selection !== defaultSC.metadata?.name);
+      setShowSCAlert(selection !== defaultSC?.metadata?.name);
       dispatchDiskState({ type: diskReducerActions.SET_STORAGE_CLASS, payload: selection });
       setIsOpen(false);
       const provisioner = storageClasses.find(


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2140627

Allow to select StorageClass when adding a new Disk to a VM if there is no default storageclass defined.

Note that if you want to reproduce this bug, you need to:
- set the annotation _storageclass.kubernetes.io/is-default-class_ to `'false'` for all storage classes
  (in _Storage_ > _StorageClasses_)

## 🎥 Screenshots
**Before:**
Not being able to select a different StorageClass than already selected (nothing happens when clicking on it):
![sc_before](https://user-images.githubusercontent.com/13417815/200370340-703f6096-f4ed-46ff-93b8-77e6553fa9f5.png)
Error in the browser console:
![sc_err](https://user-images.githubusercontent.com/13417815/200370352-117460fd-4113-4268-ad53-bf0932a9c5f8.png)
**After:**
Successfully selected a different StorageClass, incl. displaying the correct info:
![sc_after](https://user-images.githubusercontent.com/13417815/200370364-2026d43c-6376-4d92-8238-b8004629ef6f.png)

