### PR TITLE
Bug 2140730: Make links to resources on Overview page work correctly

### DIFF
--- a/src/utils/resources/shared.ts
+++ b/src/utils/resources/shared.ts
@@ -1,5 +1,6 @@
 import { modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1alpha1Condition, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { TemplateModel } from '@kubevirt-utils/models';
 import {
   AccessReviewResourceAttributes,
@@ -41,20 +42,27 @@ export const getLabel = (entity: K8sResourceCommon, label: string, defaultValue?
  * function for getting a resource URL
  * @param {k8sModel} model - model to get the URL from
  * @param {K8sResourceCommon} resource - resource to get the URL from
+ * @param {string} activeNamespace - name of the actual project (the active namespace)
+
  * @returns the URL for the resource
  */
-export const getResourceUrl = (model: K8sModel, resource?: K8sResourceCommon): string => {
+export const getResourceUrl = (
+  model: K8sModel,
+  resource?: K8sResourceCommon,
+  activeNamespace?: string,
+): string => {
   if (!model) return null;
   const { crd, namespaced, plural } = model;
 
-  const namespace = resource?.metadata?.namespace
-    ? `ns/${resource.metadata.namespace}`
-    : 'all-namespaces';
+  const namespace =
+    resource?.metadata?.namespace ||
+    (activeNamespace !== ALL_NAMESPACES_SESSION_KEY && activeNamespace);
+  const namespaceUrl = namespace ? `ns/${namespace}` : 'all-namespaces';
 
   const ref = crd ? `${model.apiGroup || 'core'}~${model.apiVersion}~${model.kind}` : plural || '';
   const name = resource?.metadata?.name || '';
 
-  return `/k8s/${namespaced ? namespace : 'cluster'}/${ref}/${name}`;
+  return `/k8s/${namespaced ? namespaceUrl : 'cluster'}/${ref}/${name}`;
 };
 
 /**

--- a/src/views/clusteroverview/OverviewTab/resources-inventory-card/ResourcesInventoryCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/resources-inventory-card/ResourcesInventoryCard.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { NodeModel } from '@kubevirt-ui/kubevirt-api/console';
+import { NodeModel, TemplateModel } from '@kubevirt-ui/kubevirt-api/console';
 import NetworkAttachmentDefinitionModel from '@kubevirt-ui/kubevirt-api/console/models/NetworkAttachmentDefinitionModel';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
+import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { Card, Grid, GridItem } from '@patternfly/react-core';
 
 import useResourcesQuantities from './hooks/useResourcesQuantities';
@@ -17,6 +18,7 @@ const ResourcesInventoryCard: React.FC = () => {
   const { t } = useKubevirtTranslation();
   const isAdmin = useIsAdmin();
   const { networks, nodes, vms, vmTemplates } = useResourcesQuantities();
+  const [activeNamespace] = useActiveNamespace();
 
   return (
     <div data-test-id="resources-inventory-card" className="resources-inventory-card">
@@ -26,7 +28,7 @@ const ResourcesInventoryCard: React.FC = () => {
             <ResourceInventoryItem
               quantity={vms}
               label={t('VirtualMachines')}
-              path={getResourceUrl(VirtualMachineModel)}
+              path={getResourceUrl(VirtualMachineModel, undefined, activeNamespace)}
             />
           </Card>
         </GridItem>
@@ -35,7 +37,7 @@ const ResourcesInventoryCard: React.FC = () => {
             <ResourceInventoryItem
               quantity={vmTemplates}
               label={t('Templates')}
-              path="/k8s/all-namespaces/templates"
+              path={getResourceUrl(TemplateModel, undefined, activeNamespace)}
             />
           </Card>
         </GridItem>
@@ -55,7 +57,7 @@ const ResourcesInventoryCard: React.FC = () => {
             <ResourceInventoryItem
               quantity={networks}
               label={t('Networks')}
-              path={getResourceUrl(NetworkAttachmentDefinitionModel)}
+              path={getResourceUrl(NetworkAttachmentDefinitionModel, undefined, activeNamespace)}
             />
           </Card>
         </GridItem>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2140730

Make links to the lists of VMs, Templates, Networks work correctly - to lead to the correct list of the resources with the correct project/namespace name.

## 🎥 Screenshots
**Before:** 
After clicking on the number of _VirtualMachines_ in the _Virtualization > Overview_ page, VMs for _All Projects_ are displayed, all the VMs incl. those that don't belong to the namespace or project originally set in the _Overview_ page (same for the Templates, Networks):
![proj_before](https://user-images.githubusercontent.com/13417815/200829582-e36368d5-436d-4aef-9c6e-3bf8128a53fd.png)
**After:**
![proj_after](https://user-images.githubusercontent.com/13417815/200829594-e2cd7fb0-ee1a-4ac3-ac6f-2aff5c42c6cd.png)

