### PR TITLE
Bug 2140998: Display correct number of Nodes and NADs in the Overview

### DIFF
--- a/src/views/clusteroverview/OverviewTab/resources-inventory-card/ResourcesInventoryCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/resources-inventory-card/ResourcesInventoryCard.tsx
@@ -17,7 +17,7 @@ import './ResourcesInventoryCard.scss';
 const ResourcesInventoryCard: React.FC = () => {
   const { t } = useKubevirtTranslation();
   const isAdmin = useIsAdmin();
-  const { networks, nodes, vms, vmTemplates } = useResourcesQuantities();
+  const { nads, nodes, vms, vmTemplates } = useResourcesQuantities();
   const [activeNamespace] = useActiveNamespace();
 
   return (
@@ -55,7 +55,7 @@ const ResourcesInventoryCard: React.FC = () => {
         <GridItem>
           <Card className="resources-inventory-card__grid-item">
             <ResourceInventoryItem
-              quantity={networks}
+              quantity={nads}
               label={t('Networks')}
               path={getResourceUrl(NetworkAttachmentDefinitionModel, undefined, activeNamespace)}
             />

--- a/src/views/clusteroverview/OverviewTab/resources-inventory-card/hooks/useResourcesQuantities.ts
+++ b/src/views/clusteroverview/OverviewTab/resources-inventory-card/hooks/useResourcesQuantities.ts
@@ -14,7 +14,7 @@ import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk-intern
 
 type UseResourcesQuantities = () => {
   loaded: boolean;
-  networks: number;
+  nads: number;
   nodes: number;
   vms: number;
   vmTemplates: number;
@@ -50,8 +50,7 @@ const useResourcesQuantities: UseResourcesQuantities = () => {
     },
     nodes: {
       groupVersionKind: modelToGroupVersionKind(NodeModel),
-      namespaced: !!namespace,
-      namespace,
+      namespaced: false,
       isList: true,
     },
     nads: {
@@ -71,7 +70,7 @@ const useResourcesQuantities: UseResourcesQuantities = () => {
         acc.loaded = acc.loaded && value?.loaded;
         return acc;
       },
-      { loaded: false as boolean, networks: 0, nodes: 0, vms: 0, vmTemplates: 0 },
+      { loaded: false as boolean, nads: 0, nodes: 0, vms: 0, vmTemplates: 0 },
     );
   }, [resources]);
 };


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2140998

Display the correct number of Nodes and NADs/Networks in the Virtualization Overview page.

_Cause:_
The number of Nodes wasn't fetched correctly (`namespace` was unnecessary). 
Regarding NADs, there was a mismatch between "nads" and "networks" in the code.

_Note:_
When testing/reproducing this bug, make sure the project name/namespace in the _Overview_ page is the same - for "before" and "after" scenarios.

## 🎥 Screenshots
**Before:**
Incorrect numbers in the Nodes and Networks cards (after clicking on the number, the correct list is displayed):
![nad_before](https://user-images.githubusercontent.com/13417815/200860744-e095a80f-fcd1-47cd-ba15-7b35f52879e8.png)
**After**:
![nad_after](https://user-images.githubusercontent.com/13417815/200860759-0a61ff99-5a8d-4256-a5f8-fcb381311e49.png)


