### PR TITLE
Improve getResourceUrl to accept an object instead of separate args

### DIFF
--- a/src/utils/resources/shared.ts
+++ b/src/utils/resources/shared.ts
@@ -38,19 +38,20 @@ export const getAnnotation = (
 export const getLabel = (entity: K8sResourceCommon, label: string, defaultValue?: string): string =>
   entity?.metadata?.labels?.[label] ?? defaultValue;
 
+type ResourceUrlProps = {
+  model: K8sModel;
+  resource?: K8sResourceCommon;
+  activeNamespace?: string;
+};
+
 /**
  * function for getting a resource URL
- * @param {k8sModel} model - model to get the URL from
- * @param {K8sResourceCommon} resource - resource to get the URL from
- * @param {string} activeNamespace - name of the actual project (the active namespace)
-
- * @returns the URL for the resource
+ * @param {ResourceUrlProps} urlProps - object with model, resource to get the URL from (optional) and active namespace/project name (optional)
+ * @returns {string} the URL for the resource
  */
-export const getResourceUrl = (
-  model: K8sModel,
-  resource?: K8sResourceCommon,
-  activeNamespace?: string,
-): string => {
+export const getResourceUrl = (urlProps: ResourceUrlProps): string => {
+  const { model, resource, activeNamespace } = urlProps;
+
   if (!model) return null;
   const { crd, namespaced, plural } = model;
 

--- a/src/utils/tests/resource.test.ts
+++ b/src/utils/tests/resource.test.ts
@@ -12,13 +12,17 @@ test('getResourceUrl', () => {
       name: 'vm',
     },
   };
+  const activeNamespace = 'default';
 
-  const url = getResourceUrl(VirtualMachineModel, resource);
+  const url = getResourceUrl({ model: VirtualMachineModel, resource });
   expect(url).toBe('/k8s/ns/kube/kubevirt.io~v1~VirtualMachine/vm');
 
-  const generalResourceURL = getResourceUrl(VirtualMachineModel, null);
+  const generalResourceURL = getResourceUrl({ model: VirtualMachineModel });
   expect(generalResourceURL).toBe('/k8s/all-namespaces/kubevirt.io~v1~VirtualMachine/');
 
-  const nullUrl = getResourceUrl(null, resource);
+  const nullUrl = getResourceUrl({ model: null, resource });
   expect(nullUrl).toBe(null);
+
+  const urlWithNamespace = getResourceUrl({ model: VirtualMachineModel, activeNamespace });
+  expect(urlWithNamespace).toBe(`/k8s/ns/${activeNamespace}/kubevirt.io~v1~VirtualMachine/`);
 });

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -78,7 +78,7 @@ export const TemplatesCatalogDrawerCreateForm: React.FC<TemplatesCatalogDrawerCr
       })
         .then((vm) => {
           setIsQuickCreating(false);
-          history.push(getResourceUrl(VirtualMachineModel, vm));
+          history.push(getResourceUrl({ model: VirtualMachineModel, resource: vm }));
         })
         .catch((err) => {
           setIsQuickCreating(false);

--- a/src/views/catalog/wizard/components/WizardFooter.tsx
+++ b/src/views/catalog/wizard/components/WizardFooter.tsx
@@ -36,7 +36,7 @@ export const WizardFooter: React.FC<{ namespace: string }> = ({ namespace }) => 
       startVM,
       onFullfilled: (createdVM) => {
         clearSessionStorageVM();
-        history.push(getResourceUrl(VirtualMachineModel, createdVM));
+        history.push(getResourceUrl({ model: VirtualMachineModel, resource: createdVM }));
       },
     });
 

--- a/src/views/clusteroverview/OverviewTab/resources-inventory-card/ResourcesInventoryCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/resources-inventory-card/ResourcesInventoryCard.tsx
@@ -28,7 +28,7 @@ const ResourcesInventoryCard: React.FC = () => {
             <ResourceInventoryItem
               quantity={vms}
               label={t('VirtualMachines')}
-              path={getResourceUrl(VirtualMachineModel, undefined, activeNamespace)}
+              path={getResourceUrl({ model: VirtualMachineModel, activeNamespace })}
             />
           </Card>
         </GridItem>
@@ -37,7 +37,7 @@ const ResourcesInventoryCard: React.FC = () => {
             <ResourceInventoryItem
               quantity={vmTemplates}
               label={t('Templates')}
-              path={getResourceUrl(TemplateModel, undefined, activeNamespace)}
+              path={getResourceUrl({ model: TemplateModel, activeNamespace })}
             />
           </Card>
         </GridItem>
@@ -47,7 +47,7 @@ const ResourcesInventoryCard: React.FC = () => {
               <ResourceInventoryItem
                 quantity={nodes}
                 label={t('Nodes')}
-                path={getResourceUrl(NodeModel)}
+                path={getResourceUrl({ model: NodeModel })}
               />
             </Card>
           </GridItem>
@@ -57,7 +57,7 @@ const ResourcesInventoryCard: React.FC = () => {
             <ResourceInventoryItem
               quantity={networks}
               label={t('Networks')}
-              path={getResourceUrl(NetworkAttachmentDefinitionModel, undefined, activeNamespace)}
+              path={getResourceUrl({ model: NetworkAttachmentDefinitionModel, activeNamespace })}
             />
           </Card>
         </GridItem>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/MigrationProgressPopover/MigrationProgressPopover.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/MigrationProgressPopover/MigrationProgressPopover.tsx
@@ -84,7 +84,12 @@ const MigrationProgressPopover: React.FC<MigrationProgressPopoverProps> = ({ vmi
             </Trans>
           </StackItem>
           <StackItem>
-            <Link to={`${getResourceUrl(VirtualMachineModel, vmi)}/metrics?migration`}>
+            <Link
+              to={`${getResourceUrl({
+                model: VirtualMachineModel,
+                resource: vmi,
+              })}/metrics?migration`}
+            >
               {t('Migration metrics')}
             </Link>
           </StackItem>


### PR DESCRIPTION
## 📝 Description

Improve `getResourceUrl` function to accept an object instead of separate arguments. 
See: https://github.com/kubevirt-ui/kubevirt-plugin/pull/958#discussion_r1018068575