### PR TITLE
Bug 2141711: Node column selector is redundant for non-priv user

### DIFF
--- a/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
+++ b/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
@@ -64,11 +64,15 @@ const useVirtualMachineColumns = (
         id: 'conditions',
         props: { className: 'pf-m-width-20' },
       },
-      {
-        title: t('Node'),
-        id: 'node',
-        props: { className: 'pf-m-width-15' },
-      },
+      ...(canGetNode
+        ? [
+            {
+              title: t('Node'),
+              id: 'node',
+              props: { className: 'pf-m-width-15' },
+            },
+          ]
+        : []),
       {
         title: t('Created'),
         id: 'created',
@@ -88,7 +92,7 @@ const useVirtualMachineColumns = (
         props: { className: 'dropdown-kebab-pf pf-c-table__action' },
       },
     ],
-    [t, sorting, namespace],
+    [t, sorting, namespace, canGetNode],
   );
 
   const [activeColumns] = useActiveColumns<K8sResourceCommon>({


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

> hiding the node column in case a user is non-privileged that can't list nodes

## 🎥 Demo

### After
![remove-node-manage-cols](https://user-images.githubusercontent.com/67270715/201183744-75a835a7-3f10-4d96-b45c-e50997da3409.png)

