### PR TITLE
Bug 2142647: Delete modal lead to wrong URL

### DIFF
--- a/src/utils/components/DeleteModal/DeleteModal.tsx
+++ b/src/utils/components/DeleteModal/DeleteModal.tsx
@@ -3,7 +3,13 @@ import { useHistory } from 'react-router-dom';
 
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { getResourceUrl } from '@kubevirt-utils/resources/shared';
+import {
+  getGroupVersionKindForResource,
+  K8sResourceCommon,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/utils/k8s/hooks/useK8sModel';
+import { useLastNamespace } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { ButtonVariant } from '@patternfly/react-core';
 
 import ConfirmActionMessage from '../ConfirmActionMessage/ConfirmActionMessage';
@@ -21,15 +27,16 @@ const DeleteModal: React.FC<DeleteModalProps> = React.memo(
     const { t } = useKubevirtTranslation();
     const history = useHistory();
 
+    const [model] = useK8sModel(getGroupVersionKindForResource(obj));
+    const [lastNamespace] = useLastNamespace();
+    const url = getResourceUrl({ model, activeNamespace: lastNamespace });
     return (
       <TabModal<K8sResourceCommon>
         obj={obj}
         headerText={headerText || t('Delete Resource?')}
         onSubmit={() => {
           return onDeleteSubmit().then(() => {
-            const pathname = history?.location?.pathname;
-            const url = pathname.slice(0, pathname.indexOf(obj?.metadata?.name));
-            pathname?.includes(obj?.metadata?.name) && history.push(url);
+            history.push(url);
           });
         }}
         isOpen={isOpen}


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

> Delete modal was building the return URL in the wrong way which caused to 404 error when deleting a resource with a short name like `a`
basing now the return URL on the deleted resource's model to create the URL

## 🎥 Demo

### Before

https://user-images.githubusercontent.com/67270715/201921035-2b98ac3d-3cf0-49ed-a201-995e75766750.mp4

### After

https://user-images.githubusercontent.com/67270715/201921026-5ffb0076-3679-4dc8-a900-6e79c2fb66c6.mp4




