### PR TITLE
' Bug 2143498:  Could not load template while creating VM from catalog'

### DIFF
--- a/src/utils/resources/template/hooks/useProcessedTemplate.ts
+++ b/src/utils/resources/template/hooks/useProcessedTemplate.ts
@@ -25,7 +25,7 @@ export const useProcessedTemplate = (
     if (template) {
       k8sCreate<V1Template>({
         model: ProcessedTemplatesModel,
-        data: template,
+        data: { ...template, metadata: { ...template?.metadata, namespace } },
         ns: namespace,
         queryParams: {
           dryRun: 'All',

--- a/src/utils/resources/template/hooks/useVMTemplateGeneratedParams.ts
+++ b/src/utils/resources/template/hooks/useVMTemplateGeneratedParams.ts
@@ -26,7 +26,11 @@ export default (template: V1Template): [template: V1Template, error: Error] => {
 
     k8sCreate<V1Template>({
       model: ProcessedTemplatesModel,
-      data: { ...template, parameters: parametersToGenerate },
+      data: {
+        ...template,
+        parameters: parametersToGenerate,
+        metadata: { ...template?.metadata, namespace },
+      },
       ns: namespace,
       queryParams: {
         dryRun: 'All',

--- a/src/views/catalog/customize/utils.ts
+++ b/src/views/catalog/customize/utils.ts
@@ -118,7 +118,7 @@ export const processTemplate = async ({
 
   return await k8sCreate<V1Template>({
     model: ProcessedTemplatesModel,
-    data: templateToProcess,
+    data: { ...templateToProcess, metadata: { ...template?.metadata, namespace } },
     queryParams: {
       dryRun: 'All',
     },

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/utils.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/utils.ts
@@ -10,7 +10,7 @@ export const getVMName = async (template: V1Template, namespace: string): Promis
 
   return await k8sCreate<V1Template>({
     model: ProcessedTemplatesModel,
-    data: templateToProcess,
+    data: { ...templateToProcess, metadata: { ...template?.metadata, namespace } },
     ns: namespace,
     queryParams: {
       dryRun: 'All',

--- a/src/views/catalog/utils/quick-create-vm.ts
+++ b/src/views/catalog/utils/quick-create-vm.ts
@@ -30,7 +30,7 @@ export const quickCreateVM: QuickCreateVMType = async ({
 }) => {
   const processedTemplate = await k8sCreate<V1Template>({
     model: ProcessedTemplatesModel,
-    data: template,
+    data: { ...template, metadata: { ...template?.metadata, namespace } },
     ns: namespace,
     queryParams: {
       dryRun: 'All',


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

workaround to failing proccessTemplate request as namespace of request call e.g. the active namespace is not the same as the namespace of the proccessed Template (regression from v4.12.0-151)

## 🎥 Demo

### Before

https://user-images.githubusercontent.com/67270715/202486230-9501c27f-e151-4367-ad3e-b553d3b458c2.mp4


### After

https://user-images.githubusercontent.com/67270715/202485898-0c4ae87b-42e2-44a1-88ff-319cdcd4024b.mp4


