### PR TITLE
[release-4.12] Bug 2144839: Display correct number of Alerts on Overview page

### DIFF
--- a/src/utils/components/AlertsCard/AlertsCard.tsx
+++ b/src/utils/components/AlertsCard/AlertsCard.tsx
@@ -46,7 +46,7 @@ const AlertsCard: React.FC<AlertsCardProps> = ({
   const isAdmin = useIsAdmin();
   const [alertScope, setAlertScope] = useLocalStorage(
     ALERTS_SCOPE_KEY,
-    isAdmin ? VIRTUALIZATION_ONLY_ALERTS : ALL_ALERTS,
+    isAdmin ? VIRTUALIZATION_ONLY_ALERTS : ALL_ALERTS, // for admins show the number of virtualization health alerts by default
   );
 
   const alerts = React.useMemo(() => {
@@ -55,8 +55,9 @@ const AlertsCard: React.FC<AlertsCardProps> = ({
       : removeVMAlerts(sortedAlerts);
   }, [alertScope, isAdmin, isOverviewPage, sortedAlerts]);
 
+  // number of alerts according to the selected scope: Virtualization health only or all alerts
   const alertsQuantity =
-    Object.values(sortedAlerts)?.reduce((acc, category) => acc + category?.length, 0) || 0;
+    Object.values(alerts)?.reduce((acc, category) => acc + category?.length, 0) || 0;
 
   return (
     <Card className={classNames('alerts-card', className)}>

--- a/src/utils/hooks/useKubevirtAlerts.ts
+++ b/src/utils/hooks/useKubevirtAlerts.ts
@@ -10,9 +10,10 @@ import { Alert } from '@openshift-console/dynamic-plugin-sdk-internal/lib/api/co
 
 import { OPERATOR_LABEL_KEY } from '../../views/clusteroverview/OverviewTab/status-card/utils/constants';
 
-const isKubeVirtAlert = (alert): boolean => alert?.labels?.[OPERATOR_LABEL_KEY] === KUBEVIRT;
+const isKubeVirtAlert = (alert: Alert): boolean => alert?.labels?.[OPERATOR_LABEL_KEY] === KUBEVIRT;
 
-const inNamespace = (namespace, alert): boolean => alert?.labels?.namespace === namespace;
+const inNamespace = (namespace: string, alert: Alert): boolean =>
+  alert?.labels?.namespace === namespace;
 
 export type UseKubevirtAlerts = () => [Alert[], boolean, Error];
 
@@ -28,7 +29,7 @@ const useKubevirtAlerts: UseKubevirtAlerts = () => {
     }
 
     return alerts?.filter((alert) => isKubeVirtAlert(alert));
-  }, [activeNamespace, alerts, isKubeVirtAlert]);
+  }, [activeNamespace, alerts]);
 
   return [filteredAlerts, loaded, loadError];
 };


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2144839

Display the correct total number of Alerts on Virtualization _Overview_ page - _Alerts_ card, according to the selected scope:
- Virtualization health only or
- All alerts.

## 🎥 Screenshots
**Before:**
Number of all alerts displayed in the brackets, when "Show virtualization health alerts" selected:
![virt_before](https://user-images.githubusercontent.com/13417815/202782874-042fec7f-1981-4632-a6de-769a2d2142c0.png)
**After:**
Only the number of virtualization health alerts displayed:
![virt_after](https://user-images.githubusercontent.com/13417815/202782891-9def0082-4017-4cb2-9b80-13783d9bec19.png)




