### PR TITLE
Bug 2144580: Make Help icon small in VM Template's Disks tab

### DIFF
--- a/src/views/templates/details/tabs/disks/components/DiskListTitle.tsx
+++ b/src/views/templates/details/tabs/disks/components/DiskListTitle.tsx
@@ -12,14 +12,12 @@ const DiskListTitle = () => {
       <h3 className="HeaderWithIcon">
         {t('Disks')}{' '}
         <Popover
-          bodyContent={
-            <div>
-              {t('The following information is provided by the OpenShift Virtualization operator.')}
-            </div>
-          }
+          bodyContent={t(
+            'The following information is provided by the OpenShift Virtualization operator.',
+          )}
           position={PopoverPosition.right}
         >
-          <HelpIcon />
+          <HelpIcon className="icon-size-small" />
         </Popover>{' '}
       </h3>
     </div>

--- a/src/views/templates/details/tabs/disks/template-disk-tab.scss
+++ b/src/views/templates/details/tabs/disks/template-disk-tab.scss
@@ -9,3 +9,7 @@
         padding-top: var(--pf-global--spacer--md);
     }
 }
+
+.icon-size-small {
+  font-size: var(--pf-global--FontSize--sm);
+}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2144580

Display the Patternfly _HelpIcon_ in size small, according to the design recommendations and for consistency reasons, in the _Disks_ tab's page title.

_Note:_
There is an older BZ for the same problem but for VMs:
https://bugzilla.redhat.com/show_bug.cgi?id=2090057

## 🎥 Screenshots
**Before**:
![icon_before](https://user-images.githubusercontent.com/13417815/203139427-dd4340d3-00ce-41ee-9ee0-3b3599d9c7b7.png)
**After:**
![icon_after](https://user-images.githubusercontent.com/13417815/203139447-3aca79a8-9698-422f-8fba-216e3c373472.png)

