### PR TITLE
Bug 2136425: Windows 11 is detected as Windows 10

### DIFF
--- a/src/utils/components/Timestamp/utils/datetime.ts
+++ b/src/utils/components/Timestamp/utils/datetime.ts
@@ -1,3 +1,5 @@
+import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
+
 import {
   DAY,
   HOUR,
@@ -113,7 +115,7 @@ export const fromNow = (dateTime: string | Date, now?: Date, options?) => {
 
 export const timestampFor = (mdate: Date, now: Date, omitSuffix: boolean) => {
   if (!isValid(mdate)) {
-    return '-';
+    return NO_DATA_DASH;
   }
 
   const timeDifference = now.getTime() - mdate.getTime();

--- a/src/utils/resources/vm/hooks/useVMIAndPodsForVM.ts
+++ b/src/utils/resources/vm/hooks/useVMIAndPodsForVM.ts
@@ -34,7 +34,7 @@ export const useVMIAndPodsForVM = (
   const error = vmiLoadError || podsLoadError;
 
   return {
-    vmi,
+    vmi: vmName === vmi?.metadata?.name && vmNamespace === vmi?.metadata?.namespace && vmi,
     pods,
     loaded,
     error,

--- a/src/utils/resources/vmi/utils/guest-agent.ts
+++ b/src/utils/resources/vmi/utils/guest-agent.ts
@@ -1,6 +1,16 @@
-import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1VirtualMachineInstance,
+  V1VirtualMachineInstanceGuestAgentInfo,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
 
 export const isGuestAgentConnected = (vmi: V1VirtualMachineInstance): boolean =>
   vmi?.status?.conditions?.some(
     (condition) => condition?.type === 'AgentConnected' && condition?.status === 'True',
   );
+
+export const getOsNameFromGuestAgent = (
+  guestAgentData: V1VirtualMachineInstanceGuestAgentInfo,
+): string =>
+  guestAgentData?.os?.name?.includes('Windows') && guestAgentData?.os?.version?.includes('Windows')
+    ? guestAgentData?.os?.version
+    : `${guestAgentData?.os?.name} ${guestAgentData?.os?.version}`;

--- a/src/views/virtualmachines/details/tabs/details/components/grid/leftGrid/VirtualMachineDetailsLeftGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/leftGrid/VirtualMachineDetailsLeftGrid.tsx
@@ -28,7 +28,8 @@ import {
   VM_TEMPLATE_ANNOTATION,
 } from '@kubevirt-utils/resources/vm';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
-import { useGuestOS } from '@kubevirt-utils/resources/vmi';
+import { getOsNameFromGuestAgent, useGuestOS } from '@kubevirt-utils/resources/vmi';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   k8sPatch,
   k8sUpdate,
@@ -55,7 +56,7 @@ const VirtualMachineDetailsLeftGrid: React.FC<VirtualMachineDetailsLeftGridProps
 
   const accessReview = asAccessReview(VirtualMachineModel, vm, 'update' as K8sVerb);
   const [canUpdateVM] = useAccessReview(accessReview || {});
-  const [guestAgentData] = useGuestOS(vmi);
+  const [guestAgentData, loadedGuestAgent] = useGuestOS(vmi);
   const firmwareBootloaderTitle = getBootloaderTitleFromVM(vm, t);
   const templateName = getLabel(vm, VM_TEMPLATE_ANNOTATION);
   const templateNamespace = getLabel(vm, LABEL_USED_TEMPLATE_NAMESPACE);
@@ -208,8 +209,9 @@ const VirtualMachineDetailsLeftGrid: React.FC<VirtualMachineDetailsLeftGridProps
         />
         <VirtualMachineDescriptionItem
           descriptionData={
-            guestAgentData?.os?.prettyName ||
-            guestAgentData?.os?.name || <GuestAgentIsRequiredText vmi={vmi} />
+            (loadedGuestAgent &&
+              !isEmpty(guestAgentData) &&
+              getOsNameFromGuestAgent(guestAgentData)) || <GuestAgentIsRequiredText vmi={vmi} />
           }
           isPopover
           // body-content text copied from:

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/StatusPopoverButton/StatusPopoverButton.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/StatusPopoverButton/StatusPopoverButton.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react';
+
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import { getVMStatusIcon } from '@virtualmachines/utils';
+
+type StatusPopoverButtonProps = {
+  vmPrintableStatus: string;
+};
+
+const StatusPopoverButton: FC<StatusPopoverButtonProps> = ({ vmPrintableStatus }) => {
+  if (!vmPrintableStatus) return null;
+
+  const Icon = getVMStatusIcon(vmPrintableStatus);
+
+  return (
+    <span>
+      <Icon />{' '}
+      <Button variant={ButtonVariant.link} isInline>
+        {vmPrintableStatus}
+      </Button>
+    </span>
+  );
+};
+
+export default StatusPopoverButton;

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachineOverviewStatus/VirtualMachineOverviewStatus.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachineOverviewStatus/VirtualMachineOverviewStatus.tsx
@@ -1,0 +1,34 @@
+import React, { FC } from 'react';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
+import { Popover, PopoverPosition } from '@patternfly/react-core';
+
+import StatusPopoverButton from '../StatusPopoverButton/StatusPopoverButton';
+
+type VirtualMachineOverviewStatusProps = {
+  vmPrintableStatus: string;
+};
+
+const VirtualMachineOverviewStatus: FC<VirtualMachineOverviewStatusProps> = ({
+  vmPrintableStatus,
+}) => {
+  const { t } = useKubevirtTranslation();
+  if (!vmPrintableStatus) return <>{NO_DATA_DASH}</>;
+
+  return (
+    <>
+      <Popover
+        headerContent={vmPrintableStatus}
+        bodyContent={t('VirtualMachine is currently {{status}}', {
+          status: vmPrintableStatus,
+        })}
+        position={PopoverPosition.right}
+      >
+        <StatusPopoverButton vmPrintableStatus={vmPrintableStatus} />
+      </Popover>
+    </>
+  );
+};
+
+export default VirtualMachineOverviewStatus;

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Details.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Details.tsx
@@ -47,7 +47,7 @@ type DetailsProps = {
 
 const Details: React.FC<DetailsProps> = ({ vmi, pathname }) => {
   const { t } = useKubevirtTranslation();
-  const [guestAgentData] = useGuestOS(vmi);
+  const [guestAgentData, loadedGuestAgent] = useGuestOS(vmi);
   const [vm] = useK8sWatchResource<V1VirtualMachine>({
     groupVersionKind: VirtualMachineModelGroupVersionKind,
     name: vmi?.metadata?.name,
@@ -82,7 +82,11 @@ const Details: React.FC<DetailsProps> = ({ vmi, pathname }) => {
               <Description vmi={vmi} />
             </DescriptionListGroup>
             <DescriptionListGroup>
-              <OperatingSystem vmi={vmi} />
+              <OperatingSystem
+                vmi={vmi}
+                guestAgentData={guestAgentData}
+                loadedGuestAgent={loadedGuestAgent}
+              />
             </DescriptionListGroup>
             <DescriptionListGroup>
               <DescriptionListTerm>{t('CPU | Memory')}</DescriptionListTerm>

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Details/OperatingSystem/OperatingSystem.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Details/OperatingSystem/OperatingSystem.tsx
@@ -1,24 +1,34 @@
 import * as React from 'react';
 
-import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
-  getOperatingSystem,
-  getOperatingSystemName,
-} from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
+  V1VirtualMachineInstance,
+  V1VirtualMachineInstanceGuestAgentInfo,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
+import GuestAgentIsRequiredText from '@kubevirt-utils/components/GuestAgentIsRequiredText/GuestAgentIsRequiredText';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getOsNameFromGuestAgent } from '@kubevirt-utils/resources/vmi';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { DescriptionListDescription, DescriptionListTerm } from '@patternfly/react-core';
 
 type OperatingSystemProps = {
   vmi: V1VirtualMachineInstance;
+  guestAgentData: V1VirtualMachineInstanceGuestAgentInfo;
+  loadedGuestAgent: boolean;
 };
 
-const OperatingSystem: React.FC<OperatingSystemProps> = ({ vmi }) => {
+const OperatingSystem: React.FC<OperatingSystemProps> = ({
+  vmi,
+  guestAgentData,
+  loadedGuestAgent,
+}) => {
   const { t } = useKubevirtTranslation();
   return (
     <>
       <DescriptionListTerm>{t('Operating system')}</DescriptionListTerm>
       <DescriptionListDescription>
-        {getOperatingSystemName(vmi) || getOperatingSystem(vmi)}
+        {(loadedGuestAgent &&
+          !isEmpty(guestAgentData) &&
+          getOsNameFromGuestAgent(guestAgentData)) || <GuestAgentIsRequiredText vmi={vmi} />}
       </DescriptionListDescription>
     </>
   );


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

- windows VMs have double labeling for the os name for the guest agent
- inconsistent os naming in vm overview, vm details and vmi details

## 🎥 Demo

### Before
VMI details
![wrong-os-vmi-details-win11](https://user-images.githubusercontent.com/67270715/203567601-8f168ef5-0691-48b4-992f-c24a1b56f3c5.png)
VM details
![wrong-os-vm-details-win11](https://user-images.githubusercontent.com/67270715/203567621-ac709eea-f859-4dec-9db5-c88816eebc06.png)
VM overview
![wrong-os-vm-ov-win11](https://user-images.githubusercontent.com/67270715/203567641-335eedff-c115-4f14-b86e-2f72a99f29eb.png)

### After
VMI details
![wrong-os-vmi-details-win11-after](https://user-images.githubusercontent.com/67270715/203567852-75865fbf-c41c-45b2-a8e8-6a7f17fe380e.png)
VM details

![wrong-os-vm-details-win11-after](https://user-images.githubusercontent.com/67270715/203567870-132ef15c-7fea-4d3b-88b1-da1992d98bd0.png)

VM overview
![wrong-os-vm-ov-win11-after](https://user-images.githubusercontent.com/67270715/203567890-0ce0377c-486f-43ca-b50a-b8c39c605fc9.png)