### PR TITLE
Bug 2151427: Virtualization -> Overview is crashed when creating VM in other browser session

### DIFF
--- a/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusItem.tsx
+++ b/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusItem.tsx
@@ -25,9 +25,7 @@ const VMStatusItem: React.FC<VMStatusItemProps> = ({ status, count, namespace })
     <GridItem span={3} className="vm-statuses-card__grid-item">
       <div className="vm-statuses-card__status-item">
         <div className="vm-statuses-card__status-item--count">
-          <span className="vm-statuses-card__status-item--icon">
-            <Icon />
-          </span>
+          <span className="vm-statuses-card__status-item--icon">{Icon && <Icon />}</span>
           <span className="vm-statuses-card__status-item--value">
             <Link to={path}>{count.toString()}</Link>
           </span>


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

> trying to render an undefined component (the status icon is undefined for about a second), which causes react to crash
> adding safety to render Icon only if defined would cause react to avoid this crash and will still render the icons properly

## 🎥 Demo

### Before
https://user-images.githubusercontent.com/67270715/206159052-9e8e698d-89d0-49f4-b16c-5722ca204531.mp4

### After
https://user-images.githubusercontent.com/67270715/206159081-82763e91-397b-4e79-a385-fbc4b6745bc0.mp4


