### PR TITLE
Bug 2155409: PVC details page crashing

### DIFF
--- a/src/views/cdi-upload-provider/PVCAlertExtension.tsx
+++ b/src/views/cdi-upload-provider/PVCAlertExtension.tsx
@@ -21,18 +21,16 @@ const PVCAlertExtension: React.FC<PVCAlertExtension> = ({ pvc }) => {
       upl?.uploadStatus === UPLOAD_STATUS.UPLOADING,
   );
 
-  return (
-    isUploading && (
-      <Alert
-        className="co-m-form-row"
-        isInline
-        variant={AlertVariant.warning}
-        title={t("Please don't close this browser tab")}
-      >
-        {t('Closing it will cause the upload to fail. You may still navigate the console.')}
-      </Alert>
-    )
-  );
+  return isUploading ? (
+    <Alert
+      className="co-m-form-row"
+      isInline
+      variant={AlertVariant.warning}
+      title={t("Please don't close this browser tab")}
+    >
+      {t('Closing it will cause the upload to fail. You may still navigate the console.')}
+    </Alert>
+  ) : null;
 };
 
 export default PVCAlertExtension;


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

Changing to render null instead of undefined to avoid React minified error 152#

## 🎥 Demo

### Before

![pvc-details-crashes](https://user-images.githubusercontent.com/67270715/208852087-54932c0e-d4ea-4d88-9801-be5bff581345.png)

### After 

![pvc-details-crashes-after](https://user-images.githubusercontent.com/67270715/208852084-a8393218-8fd8-419a-b279-f2ec46f666b6.png)