### PR TITLE
Bug 2154257: 'Quick create VirtualMachine' does no show up when upgrade OCP 4.11 to OCP 4.12

### DIFF
--- a/src/utils/resources/template/hooks/useProcessedTemplate.ts
+++ b/src/utils/resources/template/hooks/useProcessedTemplate.ts
@@ -25,7 +25,7 @@ export const useProcessedTemplate = (
     if (template) {
       k8sCreate<V1Template>({
         model: ProcessedTemplatesModel,
-        data: template,
+        data: { ...template, metadata: { ...template?.metadata, namespace } },
         ns: namespace,
         queryParams: {
           dryRun: 'All',

--- a/src/views/catalog/customize/utils.ts
+++ b/src/views/catalog/customize/utils.ts
@@ -116,7 +116,7 @@ export const processTemplate = async ({
 
   const processedTemplate = await k8sCreate<V1Template>({
     model: ProcessedTemplatesModel,
-    data: templateToProcess,
+    data: { ...templateToProcess, metadata: { ...template?.metadata, namespace } },
     queryParams: {
       dryRun: 'All',
     },

--- a/src/views/catalog/utils/quick-create-vm.ts
+++ b/src/views/catalog/utils/quick-create-vm.ts
@@ -25,7 +25,7 @@ export const quickCreateVM = (
 ) =>
   k8sCreate<V1Template>({
     model: ProcessedTemplatesModel,
-    data: template,
+    data: { ...template, metadata: { ...template?.metadata, namespace } },
     ns: namespace,
     queryParams: {
       dryRun: 'All',


### PR DESCRIPTION
## 📝 Description

manual backport for https://github.com/kubevirt-ui/kubevirt-plugin/pull/974

## :movie_camera: Demo

### Before
https://user-images.githubusercontent.com/67270715/209650035-198ce3df-5d86-4453-8b1a-daa2757b61c3.mp4

### After
https://user-images.githubusercontent.com/67270715/209649415-de02dc63-f62d-4084-9904-40c1ea5cba45.mp4

