### PR TITLE
CNV-21086: Add 'Live migratable' field to the VM Overview tab

### DIFF
--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useMemo } from 'react';
+import { getBooleanText } from 'src/views/migrationpolicies/utils/utils';
 
 import { modelToGroupVersionKind, TemplateModel } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -6,6 +7,7 @@ import GuestAgentIsRequiredText from '@kubevirt-utils/components/GuestAgentIsReq
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { timestampFor } from '@kubevirt-utils/components/Timestamp/utils/datetime';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
 import { getLabel } from '@kubevirt-utils/resources/shared';
 import { LABEL_USED_TEMPLATE_NAMESPACE } from '@kubevirt-utils/resources/template';
 import { useVMIAndPodsForVM, VM_TEMPLATE_ANNOTATION } from '@kubevirt-utils/resources/vm';
@@ -27,7 +29,7 @@ import {
   Skeleton,
 } from '@patternfly/react-core';
 
-import { printableVMStatus } from '../../../../../utils';
+import { isLiveMigratable, printableVMStatus } from '../../../../../utils';
 import CPUMemory from '../../../details/components/CPUMemory/CPUMemory';
 
 import MigrationProgressPopover from './components/MigrationProgressPopover/MigrationProgressPopover';
@@ -75,6 +77,8 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
 
   const vmPrintableStatus = vm?.status?.printableStatus;
 
+  const [isSingleNodeCluster] = useSingleNodeCluster();
+
   return (
     <div className="VirtualMachinesOverviewTabDetails--details">
       <Card>
@@ -87,10 +91,10 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('Name')}</DescriptionListTerm>
                   <DescriptionListDescription data-test-id="virtual-machine-overview-details-name">
-                    {' '}
                     {vm?.metadata?.name || NO_DATA_DASH}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
+
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('Status')}</DescriptionListTerm>
                   <DescriptionListDescription data-test-id="virtual-machine-overview-details-status">
@@ -103,6 +107,14 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
                     )}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
+
+                <DescriptionListGroup>
+                  <DescriptionListTerm>{t('Live migratable')}</DescriptionListTerm>
+                  <DescriptionListDescription data-test-id="virtual-machine-overview-details-migratable">
+                    {getBooleanText(isLiveMigratable(vm, isSingleNodeCluster))}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('Created')}</DescriptionListTerm>
                   <DescriptionListDescription data-test-id="virtual-machine-overview-details-created">
@@ -111,24 +123,28 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
                       : NO_DATA_DASH}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
+
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('Operating system')}</DescriptionListTerm>
                   <DescriptionListDescription data-test-id="virtual-machine-overview-details-os">
                     {osName ?? fallback}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
+
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('CPU | Memory')}</DescriptionListTerm>
                   <DescriptionListDescription>
                     <CPUMemory vm={vm} />
                   </DescriptionListDescription>
                 </DescriptionListGroup>
+
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('Hostname')}</DescriptionListTerm>
                   <DescriptionListDescription data-test-id="virtual-machine-overview-details-host">
                     {hostname ?? fallback}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
+
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('Template')}</DescriptionListTerm>
                   <DescriptionListDescription data-test-id="virtual-machine-overview-details-template">


### PR DESCRIPTION
## 📝 Description

This is the 2nd PR for the feature: https://issues.redhat.com/browse/CNV-21086

Add 'Live migratable' field to the _Details_ card in the VM _Overview_ tab.

## 🎥 Demo
**Before:**
![live_before](https://user-images.githubusercontent.com/13417815/210236029-d807701f-83b8-4873-a076-d45efbd92737.png)
**After:**
![live_after](https://user-images.githubusercontent.com/13417815/210236035-47a5df12-ef24-4619-9fac-ebad02be9d67.png)




