### PR TITLE
CNV-21086: Add 'Not migratable' badge to VM Overview tab

### DIFF
--- a/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGridLayout.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGridLayout.tsx
@@ -82,18 +82,11 @@ const VirtualMachineDetailsRightGridLayout: React.FC<VirtualMachineDetailsRightG
     });
   };
 
-  const isMigratable = isLiveMigratable(vm, isSingleNodeCluster);
-
   return (
     <GridItem span={5}>
       <DescriptionList>
         <VirtualMachineDescriptionItem
-          descriptionData={
-            <VirtualMachineStatus
-              printableStatus={vm?.status?.printableStatus}
-              isMigratable={isMigratable}
-            />
-          }
+          descriptionData={<VirtualMachineStatus vm={vm} />}
           descriptionHeader={t('Status')}
           data-test-id={`${vm?.metadata?.name}-status`}
         />

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useMemo } from 'react';
-import { getBooleanText } from 'src/views/migrationpolicies/utils/utils';
 
 import { modelToGroupVersionKind, TemplateModel } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -7,7 +6,6 @@ import GuestAgentIsRequiredText from '@kubevirt-utils/components/GuestAgentIsReq
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { timestampFor } from '@kubevirt-utils/components/Timestamp/utils/datetime';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
 import { getLabel } from '@kubevirt-utils/resources/shared';
 import { LABEL_USED_TEMPLATE_NAMESPACE } from '@kubevirt-utils/resources/template';
 import { useVMIAndPodsForVM, VM_TEMPLATE_ANNOTATION } from '@kubevirt-utils/resources/vm';
@@ -27,9 +25,12 @@ import {
   GridItem,
   pluralize,
   Skeleton,
+  Split,
+  SplitItem,
 } from '@patternfly/react-core';
+import VMNotMigratableBadge from '@virtualmachines/list/components/VMNotMigratableBadge/VMNotMigratableBadge';
 
-import { isLiveMigratable, printableVMStatus } from '../../../../../utils';
+import { printableVMStatus } from '../../../../../utils';
 import CPUMemory from '../../../details/components/CPUMemory/CPUMemory';
 
 import MigrationProgressPopover from './components/MigrationProgressPopover/MigrationProgressPopover';
@@ -77,8 +78,6 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
 
   const vmPrintableStatus = vm?.status?.printableStatus;
 
-  const [isSingleNodeCluster] = useSingleNodeCluster();
-
   return (
     <div className="VirtualMachinesOverviewTabDetails--details">
       <Card>
@@ -98,20 +97,18 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('Status')}</DescriptionListTerm>
                   <DescriptionListDescription data-test-id="virtual-machine-overview-details-status">
-                    {vmPrintableStatus !== printableVMStatus.Migrating ? (
-                      <VirtualMachineOverviewStatus vmPrintableStatus={vmPrintableStatus} />
-                    ) : (
-                      <MigrationProgressPopover vmi={vmi}>
-                        <StatusPopoverButton vmPrintableStatus={vmPrintableStatus} />
-                      </MigrationProgressPopover>
-                    )}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-
-                <DescriptionListGroup>
-                  <DescriptionListTerm>{t('Live migratable')}</DescriptionListTerm>
-                  <DescriptionListDescription data-test-id="virtual-machine-overview-details-migratable">
-                    {getBooleanText(isLiveMigratable(vm, isSingleNodeCluster))}
+                    <Split hasGutter>
+                      <SplitItem>
+                        {vmPrintableStatus !== printableVMStatus.Migrating ? (
+                          <VirtualMachineOverviewStatus vmPrintableStatus={vmPrintableStatus} />
+                        ) : (
+                          <MigrationProgressPopover vmi={vmi}>
+                            <StatusPopoverButton vmPrintableStatus={vmPrintableStatus} />
+                          </MigrationProgressPopover>
+                        )}
+                      </SplitItem>
+                      <VMNotMigratableBadge vm={vm} />
+                    </Split>
                   </DescriptionListDescription>
                 </DescriptionListGroup>
 

--- a/src/views/virtualmachines/list/components/VMNotMigratableBadge/VMNotMigratableBadge.tsx
+++ b/src/views/virtualmachines/list/components/VMNotMigratableBadge/VMNotMigratableBadge.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
+import { Badge, SplitItem } from '@patternfly/react-core';
+import { isLiveMigratable } from '@virtualmachines/utils';
+
+type VMNotMigratableBadgeProps = {
+  vm: V1VirtualMachine;
+};
+
+const VMNotMigratableBadge: React.FC<VMNotMigratableBadgeProps> = ({ vm }) => {
+  const { t } = useKubevirtTranslation();
+  const [isSingleNodeCluster] = useSingleNodeCluster();
+  const isMigratable = isLiveMigratable(vm, isSingleNodeCluster);
+
+  return !isMigratable ? (
+    <SplitItem>
+      <Badge key="available-boot">{t('Not migratable')}</Badge>
+    </SplitItem>
+  ) : null;
+};
+
+export default VMNotMigratableBadge;

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
@@ -7,7 +7,6 @@ import {
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 import VirtualMachineActions from '@virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions';
-import { isLiveMigratable } from '@virtualmachines/utils';
 
 import VirtualMachineStatus from '../VirtualMachineStatus/VirtualMachineStatus';
 import { VMStatusConditionLabelList } from '../VMStatusConditionLabel';
@@ -26,8 +25,6 @@ const VirtualMachineRowLayout: React.FC<
     }
   >
 > = ({ obj, activeColumnIDs, rowData: { kind, node, ips, vmim, isSingleNodeCluster } }) => {
-  const isMigratable = isLiveMigratable(obj, isSingleNodeCluster);
-
   return (
     <>
       <TableData id="name" activeColumnIDs={activeColumnIDs} className="pf-m-width-15 vm-column">
@@ -41,10 +38,7 @@ const VirtualMachineRowLayout: React.FC<
         <ResourceLink kind="Namespace" name={obj.metadata.namespace} />
       </TableData>
       <TableData id="status" activeColumnIDs={activeColumnIDs} className="pf-m-width-15 vm-column">
-        <VirtualMachineStatus
-          printableStatus={obj?.status?.printableStatus}
-          isMigratable={isMigratable}
-        />
+        <VirtualMachineStatus vm={obj} />
       </TableData>
       <TableData
         id="conditions"

--- a/src/views/virtualmachines/list/components/VirtualMachineStatus/VirtualMachineStatus.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineStatus/VirtualMachineStatus.tsx
@@ -1,15 +1,17 @@
 import * as React from 'react';
 
-import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Badge, HelperText, HelperTextItem, Split, SplitItem } from '@patternfly/react-core';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { HelperText, HelperTextItem, Split, SplitItem } from '@patternfly/react-core';
 
 import { getVMStatusIcon } from '../../../utils';
+import VMNotMigratableBadge from '../VMNotMigratableBadge/VMNotMigratableBadge';
 
-const VirtualMachineStatus: React.FC<VirtualMachinesPageStatusProps> = ({
-  printableStatus,
-  isMigratable,
-}) => {
-  const { t } = useKubevirtTranslation();
+type VirtualMachinesPageStatusProps = {
+  vm: V1VirtualMachine;
+};
+
+const VirtualMachineStatus: React.FC<VirtualMachinesPageStatusProps> = ({ vm }) => {
+  const printableStatus = vm?.status?.printableStatus;
   const Icon = getVMStatusIcon(printableStatus);
 
   return (
@@ -19,18 +21,9 @@ const VirtualMachineStatus: React.FC<VirtualMachinesPageStatusProps> = ({
           <HelperTextItem icon={<Icon />}>{printableStatus}</HelperTextItem>
         </HelperText>
       </SplitItem>
-      {!isMigratable && (
-        <SplitItem>
-          <Badge key="available-boot">{t('Not migratable')}</Badge>
-        </SplitItem>
-      )}
+      <VMNotMigratableBadge vm={vm} />
     </Split>
   );
-};
-
-type VirtualMachinesPageStatusProps = {
-  printableStatus: string;
-  isMigratable: boolean;
 };
 
 export default VirtualMachineStatus;


### PR DESCRIPTION
## 📝 Description

This is another PR for the feature: https://issues.redhat.com/browse/CNV-21086

Add 'Not migratable' badge to _Status_ in the _Details_ card of the VM _Overview_ tab, instead of 'Live migratable' field (removed in this PR), to clearly mark the VM that isn't live migratable (only if it isn't, of course).

This change follows the very recent design changes. With this change, we achieve the UI to be more "airy" and the non live migratable VM is very easily recognized, and we also save some space in the UI.

## 🎥 Demo
**Before:**
_Live migratable_ field always present in the VM _Overview_:
![over_before](https://user-images.githubusercontent.com/13417815/211861759-470cd418-da19-429a-8745-2922463ebfe9.png)
**After:**
'Not migratable' badge displayed only if the VM is not live migratable:
![over_after](https://user-images.githubusercontent.com/13417815/211861835-3ae1e741-1ada-4295-a256-d8f8dbb08678.png)



