### PR TITLE
CNV-21086: Add 'Not migratable' badge to VM title

### DIFF
--- a/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
@@ -5,9 +5,10 @@ import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevir
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { Label } from '@patternfly/react-core';
+import { Label, Split, SplitItem } from '@patternfly/react-core';
 import VirtualMachineActions from '@virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions';
 import useVirtualMachineInstanceMigration from '@virtualmachines/actions/hooks/useVirtualMachineInstanceMigration';
+import VMNotMigratableBadge from '@virtualmachines/list/components/VMNotMigratableBadge/VMNotMigratableBadge';
 
 import VirtualMachineBreadcrumb from '../list/components/VirtualMachineBreadcrumb/VirtualMachineBreadcrumb';
 import { getVMStatusIcon } from '../utils';
@@ -34,16 +35,22 @@ const VirtualMachineNavPageTitle: React.FC<VirtualMachineNavPageTitleProps> = ({
   const [isSingleNodeCluster] = useSingleNodeCluster();
 
   const StatusIcon = getVMStatusIcon(vm?.status?.printableStatus);
+
   return (
     <div className="co-m-nav-title co-m-nav-title--detail">
       <VirtualMachineBreadcrumb />
       <span className="co-m-pane__heading">
         <h1 className="co-resource-item__resource-name">
-          <span className="co-m-resource-icon co-m-resource-icon--lg">{t('VM')}</span>
-          {name}{' '}
-          <Label isCompact icon={<StatusIcon />} className="vm-resource-label">
-            {vm?.status?.printableStatus}
-          </Label>
+          <Split hasGutter>
+            <SplitItem>
+              <span className="co-m-resource-icon co-m-resource-icon--lg">{t('VM')}</span>
+              {name}{' '}
+              <Label isCompact icon={<StatusIcon />} className="vm-resource-label">
+                {vm?.status?.printableStatus}
+              </Label>
+            </SplitItem>
+            <VMNotMigratableBadge vm={vm} />
+          </Split>
         </h1>
         <VirtualMachineActions vm={vm} vmim={vmim} isSingleNodeCluster={isSingleNodeCluster} />
       </span>


### PR DESCRIPTION
## 📝 Description

This is another (hopefully the last) PR for the feature: https://issues.redhat.com/browse/CNV-21086

Add 'Not migratable' badge next to the status in the VM title, to clearly mark the VM that isn't live migratable (only if it isn't, of course), according to the very recent design changes. 

## 🎥 Demo
**Before:**
Not so clearly and fast recognizable from the VM title, if the VM is/isn't live migratable:
![vv_before](https://user-images.githubusercontent.com/13417815/212066756-f6ad2e3c-79fc-4159-82e5-068a14d6e023.png)
**After:**
'Not migratable' badge present next to the status in the VM title, clearly marking the non live migratable VM: 
![vv_after](https://user-images.githubusercontent.com/13417815/212066762-aac36776-78b7-45f6-8e0b-a4e733d27e0d.png)



