### PR TITLE
CNV-21086: Replace 'Not migratable' badge with label

### DIFF
--- a/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
@@ -8,7 +8,7 @@ import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Label, Split, SplitItem } from '@patternfly/react-core';
 import VirtualMachineActions from '@virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions';
 import useVirtualMachineInstanceMigration from '@virtualmachines/actions/hooks/useVirtualMachineInstanceMigration';
-import VMNotMigratableBadge from '@virtualmachines/list/components/VMNotMigratableBadge/VMNotMigratableBadge';
+import VMNotMigratableLabel from '@virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel';
 
 import VirtualMachineBreadcrumb from '../list/components/VirtualMachineBreadcrumb/VirtualMachineBreadcrumb';
 import { getVMStatusIcon } from '../utils';
@@ -49,7 +49,7 @@ const VirtualMachineNavPageTitle: React.FC<VirtualMachineNavPageTitleProps> = ({
                 {vm?.status?.printableStatus}
               </Label>
             </SplitItem>
-            <VMNotMigratableBadge vm={vm} />
+            <VMNotMigratableLabel vm={vm} />
           </Split>
         </h1>
         <VirtualMachineActions vm={vm} vmim={vmim} isSingleNodeCluster={isSingleNodeCluster} />

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
@@ -28,7 +28,7 @@ import {
   Split,
   SplitItem,
 } from '@patternfly/react-core';
-import VMNotMigratableBadge from '@virtualmachines/list/components/VMNotMigratableBadge/VMNotMigratableBadge';
+import VMNotMigratableLabel from '@virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel';
 
 import { printableVMStatus } from '../../../../../utils';
 import CPUMemory from '../../../details/components/CPUMemory/CPUMemory';
@@ -107,7 +107,7 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
                           </MigrationProgressPopover>
                         )}
                       </SplitItem>
-                      <VMNotMigratableBadge vm={vm} />
+                      <VMNotMigratableLabel vm={vm} />
                     </Split>
                   </DescriptionListDescription>
                 </DescriptionListGroup>

--- a/src/views/virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel.tsx
+++ b/src/views/virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel.tsx
@@ -3,23 +3,23 @@ import * as React from 'react';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
-import { Badge, SplitItem } from '@patternfly/react-core';
+import { Label, SplitItem } from '@patternfly/react-core';
 import { isLiveMigratable } from '@virtualmachines/utils';
 
-type VMNotMigratableBadgeProps = {
+type VMNotMigratableLabelProps = {
   vm: V1VirtualMachine;
 };
 
-const VMNotMigratableBadge: React.FC<VMNotMigratableBadgeProps> = ({ vm }) => {
+const VMNotMigratableLabel: React.FC<VMNotMigratableLabelProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
   const [isSingleNodeCluster] = useSingleNodeCluster();
   const isMigratable = isLiveMigratable(vm, isSingleNodeCluster);
 
   return !isMigratable ? (
     <SplitItem>
-      <Badge key="available-boot">{t('Not migratable')}</Badge>
+      <Label key="available-boot">{t('Not migratable')}</Label>
     </SplitItem>
   ) : null;
 };
 
-export default VMNotMigratableBadge;
+export default VMNotMigratableLabel;

--- a/src/views/virtualmachines/list/components/VirtualMachineStatus/VirtualMachineStatus.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineStatus/VirtualMachineStatus.tsx
@@ -4,7 +4,7 @@ import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { HelperText, HelperTextItem, Split, SplitItem } from '@patternfly/react-core';
 
 import { getVMStatusIcon } from '../../../utils';
-import VMNotMigratableBadge from '../VMNotMigratableBadge/VMNotMigratableBadge';
+import VMNotMigratableLabel from '../VMNotMigratableLabel/VMNotMigratableLabel';
 
 type VirtualMachinesPageStatusProps = {
   vm: V1VirtualMachine;
@@ -21,7 +21,7 @@ const VirtualMachineStatus: React.FC<VirtualMachinesPageStatusProps> = ({ vm }) 
           <HelperTextItem icon={<Icon />}>{printableStatus}</HelperTextItem>
         </HelperText>
       </SplitItem>
-      <VMNotMigratableBadge vm={vm} />
+      <VMNotMigratableLabel vm={vm} />
     </Split>
   );
 };


### PR DESCRIPTION
## 📝 Description

This is another (hopefully the last) PR for the feature: https://issues.redhat.com/browse/CNV-21086

Replace 'Not migratable' badge, for clearly marking the VM that isn't live migratable, with the label, to be less contrasting to the badge to not to get all the user’s attention to it, according to yesterday's design changes.

## 🎥 Demo
**Before:**
VMs list:
![before_1](https://user-images.githubusercontent.com/13417815/212713398-ff8ff0bb-5f39-432d-b7ab-417e6d3e83ed.png)
VM _Details_ tab (see also the VM title):
![before_2](https://user-images.githubusercontent.com/13417815/212713408-ec7e0af9-cec1-4ec6-ac0a-7e35a001dffc.png)
VM _Overview_ tab (see also the VM title):
![before_3](https://user-images.githubusercontent.com/13417815/212713415-a53fe005-f5c6-4118-ac7b-66d289a2416d.png)
**After:**
![1](https://user-images.githubusercontent.com/13417815/212713424-d09a0a0d-4154-4683-a8dc-01d69453dc7c.png)
![2](https://user-images.githubusercontent.com/13417815/212713433-7bb7aa49-9482-4f07-a152-9ebfdf454d46.png)
![3](https://user-images.githubusercontent.com/13417815/212713445-7bcac8ca-091c-4bca-9976-70e3288e6e0d.png)




