### PR TITLE
Bug 2160298: Simplify YAML Switcher text to "YAML"

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1077,8 +1077,6 @@
   "Workload type": "Workload type",
   "XML structure is not valid": "XML structure is not valid",
   "YAML": "YAML",
-  "YAML: OFF": "YAML: OFF",
-  "YAML: ON": "YAML: ON",
   "Yes": "Yes",
   "You can always bring these getting started resources back into view by clicking Show getting started resources in the page heading.": "You can always bring these getting started resources back into view by clicking Show getting started resources in the page heading.",
   "You can customize the Templates storage by overriding the original parameters": "You can customize the Templates storage by overriding the original parameters",

--- a/src/utils/components/SidebarEditor/SidebarEditorSwitch.tsx
+++ b/src/utils/components/SidebarEditor/SidebarEditorSwitch.tsx
@@ -14,10 +14,10 @@ const SidebarEditorSwitch: FC = memo(() => {
   return (
     <Switch
       id="sidebar-editor-switch"
-      label={t('YAML: ON')}
-      labelOff={t('YAML: OFF')}
+      label={t('YAML')}
       isChecked={showEditor}
       onChange={setEditorVisible}
+      className="regular-font-weight"
     />
   );
 });

--- a/src/utils/components/SidebarEditor/sidebar-editor.scss
+++ b/src/utils/components/SidebarEditor/sidebar-editor.scss
@@ -19,3 +19,6 @@
   }
 }
 
+.regular-font-weight {
+  font-weight: normal;
+}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2160298

Simplify the text and use the regular font weight, not the **bold** one, according to the design changes.

## 🎥 Screenshots
**Before:**
When the switcher is off:
![yaml_before1](https://user-images.githubusercontent.com/13417815/212738485-dde15ee2-2370-44c1-9dfb-eeeb80cd4314.png)
When the switcher is on:
![yaml_before2](https://user-images.githubusercontent.com/13417815/212738487-42bf81a6-46ec-48e6-a2ca-b4ed7f58b3a3.png)
**After:**
![yaml_after1](https://user-images.githubusercontent.com/13417815/212738505-cd1278e7-a8c7-40e4-b755-aeff29f8e751.png)
![yaml_after2](https://user-images.githubusercontent.com/13417815/212738513-5dc0f098-e95d-4acb-9a1f-6900aaa0a1c6.png)


