### PR TITLE
CNV-23381: Make necessary changes to VM details tabs

### DIFF
--- a/src/utils/resources/vm/utils/disk/rowData.ts
+++ b/src/utils/resources/vm/utils/disk/rowData.ts
@@ -13,6 +13,7 @@ import {
   getPrintableDiskInterface,
 } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
 import { formatBytes } from '@kubevirt-utils/resources/vm/utils/disk/size';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import { NO_DATA_DASH } from '../constants';
 
@@ -33,10 +34,10 @@ export const getDiskRowDataLayout = (
     const volumeSource = Object.keys(device?.volume).find((key) => key !== 'name');
 
     const diskRowDataObject: DiskRowDataLayout = {
-      name: device?.disk?.name,
-      interface: getPrintableDiskInterface(device?.disk),
-      drive: getPrintableDiskDrive(device?.disk),
-      metadata: { name: device?.disk?.name },
+      name: device?.volume?.name,
+      interface: isEmpty(device?.disk) ? NO_DATA_DASH : getPrintableDiskInterface(device?.disk),
+      drive: isEmpty(device?.disk) ? NO_DATA_DASH : getPrintableDiskDrive(device?.disk),
+      metadata: { name: device?.volume?.name },
       namespace: device?.pvc?.metadata?.namespace,
       source: t(OTHER),
       size: NO_DATA_DASH,

--- a/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { SidebarEditorProvider } from '@kubevirt-utils/components/SidebarEditor/SidebarEditorContext';

--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert.tsx
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert.tsx
@@ -6,6 +6,7 @@ import { PendingChangesAlert } from '@kubevirt-utils/components/PendingChanges/P
 import PendingChangesBreadcrumb from '@kubevirt-utils/components/PendingChanges/PendingChangesBreadcrumb/PendingChangesBreadcrumb';
 import { getPendingChangesByTab } from '@kubevirt-utils/components/PendingChanges/utils/helpers';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { List } from '@patternfly/react-core';
 
 import { printableVMStatus } from '../utils';
@@ -32,7 +33,14 @@ const VirtualMachinePendingChangesAlert: React.FC<VirtualMachinePendingChangesAl
 
   const hasPendingChanges = pendingChanges?.some((change) => change?.hasPendingChange);
 
-  if (!vmi || vm?.status?.printableStatus === printableVMStatus.Stopped || !hasPendingChanges) {
+  const isInstanceTypeVM = !isEmpty(vm?.spec?.instancetype) || !isEmpty(vm?.spec?.preference);
+
+  if (
+    !vmi ||
+    vm?.status?.printableStatus === printableVMStatus.Stopped ||
+    !hasPendingChanges ||
+    isInstanceTypeVM
+  ) {
     return null;
   }
 

--- a/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGrid.tsx
@@ -14,7 +14,7 @@ type VirtualMachineDetailsRightGridProps = {
 
 const VirtualMachineDetailsRightGrid: React.FC<VirtualMachineDetailsRightGridProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
-  const isVMRunning = vm?.status?.printableStatus === printableVMStatus.Running;
+  const isVMRunning = vm?.status?.printableStatus !== printableVMStatus.Stopped;
 
   return isVMRunning ? (
     <RunningVirtualMachineDetailsRightGrid vm={vm} />


### PR DESCRIPTION
Signed-off-by: Aviv Turgeman <aturgema@redhat.com>
## 📝 Description

> This PR focuses on making sure the VM details tabs view is still functional and nothing crashes

** Fixing a crash of VM disks tab, and cancelling the pending changes for VMs with instancetype or preference section included in the VM YAML

## 🎥 Demo

> https://user-images.githubusercontent.com/67270715/214373191-b4cef08b-e4ac-4f78-98ed-0b9ae9a4a5b9.mp4