### PR TITLE
Bug 2150832: Fix vCPU query in cluster overview metrics card

### DIFF
--- a/src/views/clusteroverview/OverviewTab/metric-charts-card/utils/metricQueries.ts
+++ b/src/views/clusteroverview/OverviewTab/metric-charts-card/utils/metricQueries.ts
@@ -5,7 +5,8 @@ import { METRICS } from './constants';
 const metricQueriesForNamespace = {
   [METRICS.VM]: (namespace) =>
     `sum by (namespace)(count by (name,namespace)(kubevirt_vm_error_status_last_transition_timestamp_seconds{namespace="${namespace}"} + kubevirt_vm_migrating_status_last_transition_timestamp_seconds{namespace="${namespace}"} + kubevirt_vm_non_running_status_last_transition_timestamp_seconds{namespace="${namespace}"} + kubevirt_vm_running_status_last_transition_timestamp_seconds{namespace="${namespace}"} + kubevirt_vm_starting_status_last_transition_timestamp_seconds{namespace="${namespace}"}))`,
-  [METRICS.VCPU_USAGE]: (namespace) => `sum(kubevirt_vmi_vcpu_seconds) by (${namespace})`,
+  [METRICS.VCPU_USAGE]: (namespace) =>
+    `count(kubevirt_vmi_vcpu_wait_seconds{namespace="${namespace}"})`,
   [METRICS.MEMORY]: (namespace) =>
     `sum(kubevirt_vmi_memory_available_bytes - kubevirt_vmi_memory_usable_bytes) by (${namespace})`,
   [METRICS.STORAGE]: (namespace) => `sum(kubevirt_vmi_filesystem_used_bytes) by (${namespace})`,
@@ -14,7 +15,7 @@ const metricQueriesForNamespace = {
 const metricQueriesForAllNamespaces = {
   [METRICS.VM]: () =>
     `sum(count by (name,namespace)(kubevirt_vm_error_status_last_transition_timestamp_seconds + kubevirt_vm_migrating_status_last_transition_timestamp_seconds + kubevirt_vm_non_running_status_last_transition_timestamp_seconds + kubevirt_vm_running_status_last_transition_timestamp_seconds + kubevirt_vm_starting_status_last_transition_timestamp_seconds))`,
-  [METRICS.VCPU_USAGE]: () => `sum(kubevirt_vmi_vcpu_seconds)`,
+  [METRICS.VCPU_USAGE]: () => `count(kubevirt_vmi_vcpu_wait_seconds)`,
   [METRICS.MEMORY]: () =>
     `sum(kubevirt_vmi_memory_available_bytes - kubevirt_vmi_memory_usable_bytes)`,
   [METRICS.STORAGE]: () => `sum(kubevirt_vmi_filesystem_used_bytes)`,


### PR DESCRIPTION
## 📝 Description

This PR corrects the vCPU query in the cluster over metric charts to use `count` instead of `sum` and to use `kubevirt_vmi_vcpu_wait_seconds` instead of `kubevirt_vmi_vcpu_seconds`.

## 🎥 Screenshot

![Selection_216](https://user-images.githubusercontent.com/8544299/215101388-8920949a-55d8-445f-beaf-c1d2a3682dda.png)
