### PR TITLE
CNV-21086: Remove Live migratable from VM Details

### DIFF
--- a/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGridLayout.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGridLayout.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import produce from 'immer';
-import { getBooleanText } from 'src/views/migrationpolicies/utils/utils';
 
 import { NodeModel } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
@@ -14,12 +13,10 @@ import SSHAccess from '@kubevirt-utils/components/SSHAccess/SSHAccess';
 import useSSHService from '@kubevirt-utils/components/SSHAccess/useSSHService';
 import WorkloadProfileModal from '@kubevirt-utils/components/WorkloadProfileModal/WorkloadProfileModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
 import { WORKLOADS, WORKLOADS_LABELS } from '@kubevirt-utils/resources/template';
 import { getWorkload, VM_WORKLOAD_ANNOTATION } from '@kubevirt-utils/resources/vm';
 import { k8sUpdate, K8sVerb, useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList, GridItem } from '@patternfly/react-core';
-import { isLiveMigratable } from '@virtualmachines/utils';
 
 import VirtualMachineStatus from '../../../../../../list/components/VirtualMachineStatus/VirtualMachineStatus';
 import { VirtualMachineDetailsRightGridLayoutPresentation } from '../../../utils/gridHelper';
@@ -38,8 +35,6 @@ const VirtualMachineDetailsRightGridLayout: React.FC<VirtualMachineDetailsRightG
   vmi,
 }) => {
   const [sshService, sshServiceLoaded] = useSSHService(vm);
-
-  const [isSingleNodeCluster] = useSingleNodeCluster();
 
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
@@ -89,11 +84,6 @@ const VirtualMachineDetailsRightGridLayout: React.FC<VirtualMachineDetailsRightG
           descriptionData={<VirtualMachineStatus vm={vm} />}
           descriptionHeader={t('Status')}
           data-test-id={`${vm?.metadata?.name}-status`}
-        />
-        <VirtualMachineDescriptionItem
-          descriptionData={getBooleanText(isLiveMigratable(vm, isSingleNodeCluster))}
-          descriptionHeader={t('Live migratable')}
-          data-test-id={`${vm?.metadata?.name}-migratable`}
         />
         <VirtualMachineDescriptionItem
           descriptionData={vmDetailsRightGridObj?.pod}


### PR DESCRIPTION
## 📝 Description

This is the last PR for the feature: https://issues.redhat.com/browse/CNV-21086

Remove forgotten unnecessary _Live migratable_ field from VM _Details_ page,
as this field was already replaced by the label, placed next to the _Status_ of the VM,
see: https://github.com/kubevirt-ui/kubevirt-plugin/pull/1008, https://github.com/kubevirt-ui/kubevirt-plugin/pull/1013, https://github.com/kubevirt-ui/kubevirt-plugin/pull/1018.

## 🎥 Screenshots
**Before:**
_Live migratable_ field together with the label containing the same info:
![live_before](https://user-images.githubusercontent.com/13417815/215230410-8f9fb16b-6174-42fd-bb52-b3820c7ef9bb.png)
**After:**
Only the label next to the _Status_:
![live_after](https://user-images.githubusercontent.com/13417815/215230416-b8c14848-69a2-4a66-a1f4-524d82b5665f.png)


