### PR TITLE
CNV-21086: Change Not migratable label style

### DIFF
--- a/src/views/virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel.scss
+++ b/src/views/virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel.scss
@@ -1,0 +1,5 @@
+.migratable-label {
+    .pf-c-label__content {
+      color: var(--pf-global--palette--orange-500);
+    }
+}

--- a/src/views/virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel.tsx
+++ b/src/views/virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel.tsx
@@ -6,6 +6,8 @@ import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
 import { Label, SplitItem } from '@patternfly/react-core';
 import { isLiveMigratable } from '@virtualmachines/utils';
 
+import './VMNotMigratableLabel.scss';
+
 type VMNotMigratableLabelProps = {
   vm: V1VirtualMachine;
 };
@@ -17,7 +19,9 @@ const VMNotMigratableLabel: React.FC<VMNotMigratableLabelProps> = ({ vm }) => {
 
   return !isMigratable ? (
     <SplitItem>
-      <Label key="available-boot">{t('Not migratable')}</Label>
+      <Label isCompact variant="outline" key="not-migratable" className="migratable-label">
+        {t('Not migratable')}
+      </Label>
     </SplitItem>
   ) : null;
 };


### PR DESCRIPTION
## 📝 Description

This is another PR for the feature: https://issues.redhat.com/browse/CNV-21086

Change the label to Compact, Unfilled, Orange, according to the design changes and Patternfly styles.

More on Patternfly `Label` component:
https://www.patternfly.org/v4/components/label
https://www.patternfly.org/v4/components/label/design-guidelines#when-to-use-filled-or-unfilled-labels

## 🎥 Screenshots
**Before:**
VMs list:
![orange_before1](https://user-images.githubusercontent.com/13417815/216107898-a75cc744-19a2-4fd9-a682-dc339ffc609f.png)
VM _Overview_ tab:
![orange_before2](https://user-images.githubusercontent.com/13417815/216107904-7332cd1b-bfb2-4902-9047-a500030ce0fc.png)
VM _Details_ tab:
![orange_before3](https://user-images.githubusercontent.com/13417815/216107908-b31afaf3-67b5-4ac5-bfe6-71b916f906a0.png)

**After:**
![orange_after1](https://user-images.githubusercontent.com/13417815/216107962-f15e7940-2dea-4f74-adea-aca36c850570.png)
![orange_after2](https://user-images.githubusercontent.com/13417815/216107965-a7fe77b0-6407-4c5b-8a8b-47ed5c8ed639.png)
![orange_after3](https://user-images.githubusercontent.com/13417815/216107971-4f47e213-af75-46fc-a804-47cccbab6c6a.png)

