### PR TITLE
Update 'Developer preview' label colors

### DIFF
--- a/src/utils/components/DeveloperPreviewLabel/DeveloperPreviewLabel.scss
+++ b/src/utils/components/DeveloperPreviewLabel/DeveloperPreviewLabel.scss
@@ -1,0 +1,13 @@
+.dev-preview-label {
+  background-color: var(--pf-c-label--m-orange--BackgroundColor);
+
+  .pf-c-label__content {
+    color: var(--pf-global--palette--gold-700);
+  }
+
+  .pf-c-label__icon {
+    color: var(--pf-global--palette--orange-300);
+  }
+
+  --pf-c-label__content--before--BorderColor: var(--pf-global--palette--orange-100);
+}

--- a/src/utils/components/DeveloperPreviewLabel/DeveloperPreviewLabel.tsx
+++ b/src/utils/components/DeveloperPreviewLabel/DeveloperPreviewLabel.tsx
@@ -4,6 +4,8 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { Label, Popover } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 
+import './DeveloperPreviewLabel.scss';
+
 const DeveloperPreviewLabel: React.FC = () => {
   const { t } = useKubevirtTranslation();
 
@@ -13,7 +15,7 @@ const DeveloperPreviewLabel: React.FC = () => {
         'Developer preview features are not intended to be used in production environments. The clusters deployed with the developer preview features are considered to be development clusters and are not supported through the Red Hat Customer Portal case management system.',
       )}
     >
-      <Label isCompact variant="outline" color="orange" icon={<InfoCircleIcon />}>
+      <Label isCompact icon={<InfoCircleIcon />} className="dev-preview-label">
         {t('Developer preview')}
       </Label>
     </Popover>


### PR DESCRIPTION
## 📝 Description

Update colors of the label according to the design changes and Patternfly guidlines, for better visual experience.

The exact colors the label should have (I've got the info from our UX):
 - text: #3D2C00, equivalent to PF variable `--pf-global--palette--gold-700`
 - fill: #FFF6EC ... `--pf-c-label--m-orange--BackgroundColor`
 - border: #F4B678 ... `--pf-global--palette--orange-100`
 - icon: #EC7A08 ... `--pf-global--palette--orange-300`

_Some resources:_
https://www.patternfly.org/2022.11/components/label
https://www.patternfly.org/2022.11/guidelines/colors

_Note:_
I had to remove `variant="outline"` from the `Label` component, to be able to overwrite color of the border.

## 🎥 Demo
**Before:**
![dev_before](https://user-images.githubusercontent.com/13417815/217908001-2e6d9375-0c63-4ba9-9c51-5018f071ee12.png)

**After:**
![dev_after](https://user-images.githubusercontent.com/13417815/217908026-8b12d46c-f63b-45b8-a59e-952d2df57c4d.png)

