### PR TITLE
Bug 2168859: useParams under HorizontalNav does not give namespace

### DIFF
--- a/src/utils/components/AuthorizedSSHKeyModal/AuthorizedSSHKeyModal.tsx
+++ b/src/utils/components/AuthorizedSSHKeyModal/AuthorizedSSHKeyModal.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { validateSSHPublicKey } from '@kubevirt-utils/utils/utils';
@@ -20,14 +19,14 @@ import SelectSecret from './SelectSecret';
 import './auth-ssh-key-modal.scss';
 
 export const AuthorizedSSHKeyModal: React.FC<{
+  namespace: string;
   isOpen: boolean;
   onClose: () => void;
   sshKey?: string;
   vmSecretName: string;
   enableCreation?: boolean;
   onSubmit: (secretName: string, sshKey?: string) => Promise<void | any>;
-}> = ({ sshKey, vmSecretName, onSubmit, onClose, isOpen, enableCreation = true }) => {
-  const { ns: namespace } = useParams<{ ns: string }>();
+}> = ({ sshKey, vmSecretName, onSubmit, onClose, isOpen, namespace, enableCreation = true }) => {
   const { t } = useKubevirtTranslation();
   const [value, setValue] = React.useState(sshKey);
   const [createSecretOpen, setCreateSecretOpen] = React.useState(vmSecretName ? false : true);

--- a/src/utils/components/AuthorizedSSHKeyModal/SelectSecret.tsx
+++ b/src/utils/components/AuthorizedSSHKeyModal/SelectSecret.tsx
@@ -27,12 +27,16 @@ const SelectSecret: React.FC<SelectSecretProps> = ({
   const { t } = useKubevirtTranslation();
   const [isSecretSelectOpen, setSecretSelectOpen] = React.useState(false);
 
-  const [secrets, secretsLoaded, secretsError] = useK8sWatchResource<IoK8sApiCoreV1Secret[]>({
-    groupVersionKind: modelToGroupVersionKind(SecretModel),
-    namespaced: true,
-    isList: true,
-    namespace,
-  });
+  const [secrets, secretsLoaded, secretsError] = useK8sWatchResource<IoK8sApiCoreV1Secret[]>(
+    namespace
+      ? {
+          groupVersionKind: modelToGroupVersionKind(SecretModel),
+          namespaced: true,
+          isList: true,
+          namespace,
+        }
+      : null,
+  );
 
   const sshKeySecrets = secrets?.filter((secret) => validateSSHPublicKey(decodeSecret(secret)));
 

--- a/src/views/catalog/wizard/tabs/scripts/components/SSHKey.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/components/SSHKey.tsx
@@ -71,6 +71,7 @@ const SSHKey: React.FC = () => {
         createModal((modalProps) => (
           <AuthorizedSSHKeyModal
             {...modalProps}
+            namespace={vm?.metadata?.namespace}
             sshKey={secretKey}
             vmSecretName={!sshSecretObject && vmAttachedSecretName}
             onSubmit={onSSHChange}

--- a/src/views/templates/details/tabs/scripts/components/SSHKey/SSHKey.tsx
+++ b/src/views/templates/details/tabs/scripts/components/SSHKey/SSHKey.tsx
@@ -62,6 +62,7 @@ const SSHKey: React.FC<SSHKeyProps> = ({ template }) => {
                   createModal((modalProps) => (
                     <AuthorizedSSHKeyModal
                       {...modalProps}
+                      namespace={vm?.metadata?.namespace}
                       sshKey={secretKey}
                       vmSecretName={externalSecretName}
                       onSubmit={onSSHChange}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

namespace is undefined here and the `SSHServiceSelect` show all the secrets cluster-wide.
Should filter based on VM namespace as cannot attach secrets with a different namespace

Avoid fetching secrets cluster-wide because of permissions errors
