### PR TITLE
Bug 2168861: take namespace from vm instead of useParams

### DIFF
--- a/src/utils/components/SysprepModal/SelectSysprep.tsx
+++ b/src/utils/components/SysprepModal/SelectSysprep.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useParams } from 'react-router-dom';
 
 import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1Secret } from '@kubevirt-ui/kubevirt-api/kubernetes';
@@ -23,14 +22,15 @@ type SelectSysprepProps = {
   selectedSysprepName: string;
   onSelectSysprep: (secretName: string) => void;
   id?: string;
+  namespace: string;
 };
 
 const SelectSysprep: React.FC<SelectSysprepProps> = ({
   selectedSysprepName,
   onSelectSysprep,
   id,
+  namespace,
 }) => {
-  const { ns: namespace } = useParams<{ ns: string }>();
   const { t } = useKubevirtTranslation();
   const [isSecretSelectOpen, setSecretSelectOpen] = React.useState(false);
 

--- a/src/utils/components/SysprepModal/SysprepModal.tsx
+++ b/src/utils/components/SysprepModal/SysprepModal.tsx
@@ -17,6 +17,7 @@ export const SysprepModal: React.FC<{
   enableCreation?: boolean;
   onSysprepSelected?: (sysprepName: string) => void | Promise<void>;
   sysprepSelected?: string;
+  namespace: string;
 }> = ({
   isOpen,
   onClose,
@@ -26,6 +27,7 @@ export const SysprepModal: React.FC<{
   enableCreation = true,
   onSysprepSelected,
   sysprepSelected,
+  namespace,
 }) => {
   const { t } = useKubevirtTranslation();
   const [autoUnattend, setAutoUnattend] = React.useState(initialAutoUnattend);
@@ -54,6 +56,7 @@ export const SysprepModal: React.FC<{
             <SelectSysprep
               selectedSysprepName={selectedSysprepName}
               onSelectSysprep={setSelectedSysprepName}
+              namespace={namespace}
             />
           </FormGroup>
         </div>
@@ -94,6 +97,7 @@ export const SysprepModal: React.FC<{
           <SelectSysprep
             selectedSysprepName={selectedSysprepName}
             onSelectSysprep={setSelectedSysprepName}
+            namespace={namespace}
           />
         </ExpandableSection>
       </div>

--- a/src/views/catalog/wizard/tabs/scripts/components/Sysprep.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/components/Sysprep.tsx
@@ -96,6 +96,7 @@ const Sysprep: React.FC = () => {
         createModal((modalProps) => (
           <SysprepModal
             {...modalProps}
+            namespace={vm?.metadata?.namespace}
             unattend={unattend}
             autoUnattend={autoUnattend}
             onSysprepCreation={onSysprepCreation}

--- a/src/views/templates/details/tabs/scripts/components/SysPrepItem/SysPrepItem.tsx
+++ b/src/views/templates/details/tabs/scripts/components/SysPrepItem/SysPrepItem.tsx
@@ -102,6 +102,7 @@ const SysPrepItem: React.FC<SysPrepItemProps> = ({ template }) => {
                   createModal((modalProps) => (
                     <SysprepModal
                       {...modalProps}
+                      namespace={vm?.metadata?.namespace}
                       unattend={unattend}
                       autoUnattend={autoUnattend}
                       onSysprepSelected={onSysprepSelected}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Same thing as [this pr](https://github.com/kubevirt-ui/kubevirt-plugin/pull/1050) but for sysprep instead of auth ssh.

`useParams` take params from the nearest route. `HorizontalNav` in this case instead of the global route So there is no `ns` parameter
