### PR TITLE
CNV-21086: Display "Not migratable" only for running VMs

### DIFF
--- a/src/views/virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel.tsx
+++ b/src/views/virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel.tsx
@@ -4,7 +4,7 @@ import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
 import { Label, SplitItem } from '@patternfly/react-core';
-import { isLiveMigratable } from '@virtualmachines/utils';
+import { isLiveMigratable, printableVMStatus } from '@virtualmachines/utils';
 
 import './VMNotMigratableLabel.scss';
 
@@ -16,8 +16,9 @@ const VMNotMigratableLabel: React.FC<VMNotMigratableLabelProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
   const [isSingleNodeCluster] = useSingleNodeCluster();
   const isMigratable = isLiveMigratable(vm, isSingleNodeCluster);
+  const isVMrunning = vm?.status?.printableStatus === printableVMStatus.Running;
 
-  return !isMigratable ? (
+  return isVMrunning && !isMigratable ? (
     <SplitItem>
       <Label isCompact variant="outline" key="not-migratable" className="migratable-label">
         {t('Not migratable')}


### PR DESCRIPTION
## 📝 Description

This is another PR for the feature: https://issues.redhat.com/browse/CNV-21086

Display "Not migratable" label only for the VMs that are running.

The purpose of this change is to limit the amount of labels and to display the labels only when necessary.

## 🎥 Demo
**Before:**
![live_before](https://user-images.githubusercontent.com/13417815/219351122-a5f7d585-4346-4c58-bb26-9fc6329550f5.png)

**After:**
![live_after](https://user-images.githubusercontent.com/13417815/219351140-d41facb2-1506-46c7-94c5-d5069cb41276.png)



