### PR TITLE
CNV-21086: Change Not migratable label to blue

### DIFF
--- a/src/views/virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel.scss
+++ b/src/views/virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel.scss
@@ -1,5 +1,5 @@
 .migratable-label {
     .pf-c-label__content {
-      color: var(--pf-global--palette--orange-500);
+      color: var(--pf-global--palette--blue-400);
     }
 }


### PR DESCRIPTION
## 📝 Description

This is another PR for the feature: https://issues.redhat.com/browse/CNV-21086

Change the label to Compact, Unfilled, Blue, according to the design changes and Patternfly styles.

More on Patternfly `Label` component:
https://www.patternfly.org/v4/components/label
https://www.patternfly.org/v4/components/label/design-guidelines#when-to-use-filled-or-unfilled-labels

## 🎥 Screenshots
**Before:**
VMs list:
![b1](https://user-images.githubusercontent.com/13417815/220130836-ee8c079e-ae86-47b2-8414-bda54bac3041.png)
VM _Overview_ tab:
![b2](https://user-images.githubusercontent.com/13417815/220130840-6eecdcec-b383-4ee5-8105-eba396194e58.png)
VM _Details_ tab:
![b3](https://user-images.githubusercontent.com/13417815/220130844-e2157361-28ba-4417-ae6e-82b7aee6d821.png)

**After:**
![blue1](https://user-images.githubusercontent.com/13417815/220130938-98aedcdd-75b2-4cf3-9fab-4abca333444f.png)
![blue2](https://user-images.githubusercontent.com/13417815/220130940-52eac2d5-bc1d-496d-ade9-3d6809c6f7fd.png)
![blue3](https://user-images.githubusercontent.com/13417815/220130947-a36a7418-19c2-459e-86bc-3aab578884e0.png)





