### PR TITLE
Bug 2151766: No boot source available for existing pvc

### DIFF
--- a/src/utils/resources/vm/utils/source.ts
+++ b/src/utils/resources/vm/utils/source.ts
@@ -65,6 +65,15 @@ export const getVMBootSourceType = (vm: V1VirtualMachine): TemplateBootSource =>
     };
   }
 
+  if (volume?.persistentVolumeClaim) {
+    return {
+      type: BOOT_SOURCE.PVC,
+      source: {
+        pvc: { name: volume?.persistentVolumeClaim.claimName, namespace: vm?.metadata?.namespace },
+      },
+    };
+  }
+
   return { type: BOOT_SOURCE.NONE, source: {} };
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When changing blank disk to existing PVC on wizard - wizard still showing modal of no available boot source.
This fix will not show this modal, as existing PVC is a available boot source.
https://bugzilla.redhat.com/show_bug.cgi?id=2151766
## 🎥 Demo

Before:
![existing-pvc-1](https://user-images.githubusercontent.com/14824964/220334761-de21df76-4f30-484c-b7e8-fb1a47ea23dc.gif)



After:
![existing-pvc](https://user-images.githubusercontent.com/14824964/220334784-44b6d859-a934-447e-99a0-c1b652e93b8b.gif)


