### PR TITLE
Bug 2158362: filtering PVCs that are in terminate state

### DIFF
--- a/src/views/catalog/customize/components/PersistentVolumeClaimSelect/utils.tsx
+++ b/src/views/catalog/customize/components/PersistentVolumeClaimSelect/utils.tsx
@@ -5,7 +5,7 @@ import {
   PersistentVolumeClaimModel,
   ProjectModel,
 } from '@kubevirt-ui/kubevirt-api/console';
-import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { SelectOption } from '@patternfly/react-core';
 
@@ -51,10 +51,15 @@ export const useProjectsAndPVCs = (projectSelected: string): useProjectsAndPVCsR
     : null;
 
   const [pvcs, pvcsLoaded, pvcsErrors] =
-    useK8sWatchResource<V1alpha1PersistentVolumeClaim[]>(pvcWatchResource);
+    useK8sWatchResource<IoK8sApiCoreV1PersistentVolumeClaim[]>(pvcWatchResource);
 
   const pvcNamesFilteredByProjects = (pvcs || [])
-    .filter((pvc) => pvc.metadata.namespace === projectSelected)
+    .filter(
+      (pvc) =>
+        pvc.metadata.namespace === projectSelected &&
+        !pvc?.metadata?.deletionTimestamp &&
+        pvc?.status?.phase === 'Bound',
+    )
     .map((pvc) => pvc.metadata.name);
 
   return {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When cloning or using a PVC in a terminate state, VM wont be able to run or schedule.
This will filter the PVC in the wizard and won't present unworking PVC to select.

## 🎥 Demo

> Please add a video or an image of the behavior/changes
