### PR TITLE
CNV-18014: Rename Upload to Save in Add volume modal

### DIFF
--- a/src/views/bootablevolumes/actions/components/EditBootableVolumesModal.tsx
+++ b/src/views/bootablevolumes/actions/components/EditBootableVolumesModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo, useState } from 'react';
+import React, { FC, useCallback, useMemo, useState } from 'react';
 
 import FilterSelect from '@catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/FilterSelect/FilterSelect';
 import {
@@ -69,12 +69,15 @@ const EditBootableVolumesModal: FC<EditBootableVolumesModalProps> = ({
     [instanceType, instanceTypesToSizesMap],
   );
 
-  const onInstanceTypeChange = (instanceTypeName: string) => {
-    setInstanceType(instanceTypeName);
-    setSize(instanceTypesToSizesMap[instanceTypeName][0]);
-  };
+  const onInstanceTypeChange = useCallback(
+    (instanceTypeName: string) => {
+      setInstanceType(instanceTypeName);
+      setSize(instanceTypesToSizesMap[instanceTypeName][0]);
+    },
+    [instanceTypesToSizesMap],
+  );
 
-  const onChangeVolumeParams = () => {
+  const onChangeVolumeParams = useCallback(() => {
     const preferenceLabel = preference && { [DEFAULT_PREFERENCE_LABEL]: preference };
     const instanceLabel = instanceType && {
       [DEFAULT_INSTANCETYPE_LABEL]: `${instanceType}.${size}`,
@@ -94,7 +97,7 @@ const EditBootableVolumesModal: FC<EditBootableVolumesModalProps> = ({
     };
 
     return changeBootableVolumeMetadata(dataSource, metadata);
-  };
+  }, [dataSource, description, instanceType, preference, size]);
 
   return (
     <TabModal<K8sResourceCommon>

--- a/src/views/bootablevolumes/utils/utils.ts
+++ b/src/views/bootablevolumes/utils/utils.ts
@@ -105,9 +105,8 @@ export const getInstanceTypesToSizesMap = (
   instanceTypesNames.reduce((instanceTypesAndSizes, instanceType) => {
     const [instanceTypePart, sizePart] = instanceType.split('.');
 
-    instanceTypesAndSizes[instanceTypePart] !== undefined
-      ? instanceTypesAndSizes[instanceTypePart].push(sizePart)
-      : (instanceTypesAndSizes[instanceTypePart] = [sizePart]);
+    instanceTypesAndSizes[instanceTypePart] ??= [];
+    instanceTypesAndSizes[instanceTypePart].push(sizePart);
 
     return instanceTypesAndSizes;
   }, {});

--- a/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.scss
+++ b/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.scss
@@ -1,5 +1,5 @@
 .create-vm-instance-type-section {
-  padding: var(--pf-global--spacer--md);
+  padding: var(--pf-global--spacer--xl);
   &__step {
     font-size: var(--pf-global--FontSize--xl);
     height: var(--pf-global--spacer--xl);
@@ -26,5 +26,9 @@
   }
   &__add-volume-btn {
     padding-right: var(--pf-global--spacer--sm);
+  }
+  &__divider {
+    --pf-c-divider--BorderWidth--base: var(--pf-global--spacer--form-element);
+    --pf-c-divider--after--BackgroundColor: var(--pf-global--palette--black-200);
   }
 }

--- a/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
@@ -76,7 +76,9 @@ const CreateFromInstanceType: FC = () => {
                   displayShowAllButton
                 />
               </SectionListItem>
-              <Divider inset={{ default: 'insetLg' }} />
+
+              <Divider className="create-vm-instance-type-section__divider" />
+
               <SectionListItem
                 headerText={t('Select InstanceType')}
                 sectionKey={INSTANCE_TYPES_SECTIONS.SELECT_INSTANCE_TYPE}
@@ -87,7 +89,9 @@ const CreateFromInstanceType: FC = () => {
                   setSelectedInstanceType={setSelectedInstanceType}
                 />
               </SectionListItem>
-              <Divider inset={{ default: 'insetLg' }} />
+
+              <Divider className="create-vm-instance-type-section__divider" />
+
               <SectionListItem
                 headerText={t('VirtualMachine details')}
                 sectionKey={INSTANCE_TYPES_SECTIONS.VM_DETAILS}

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -177,7 +177,7 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
         }
         onClose();
       }}
-      submitBtnText={t('Upload')}
+      submitBtnText={t('Save')}
       isDisabled={!labels?.[DEFAULT_PREFERENCE_LABEL]}
     >
       {t('You can upload a new volume or use an existing PersistentVolumeClaim (PVC)')}


### PR DESCRIPTION
## 📝 Description

Rename the _Upload_ button to _Save_, in _Add volume to boot from_ modal, also update the style of dividers of the sections in _Create new VirtualMachine_ page when creating a VM from volume (_InstanceTypes_ tab).

_More on used Patternfly variables:_
https://www.patternfly.org/2021.16/components/divider/
https://pf4.patternfly.org/developer-resources/global-css-variables

_This PR is related to both features:_
https://issues.redhat.com/browse/CNV-18014
https://issues.redhat.com/browse/CNV-15501

## 🎥 Screenshots
**Before:**
_Upload_ button (as a bit misleading term, especially when using existing PVC - 2nd radio button in the modal):
![upload](https://user-images.githubusercontent.com/13417815/220719961-a15c57b8-6d02-4328-ace5-c9cb29130b65.png)
Dividers not properly aligned, not clearly divided sections:
![divider_before](https://user-images.githubusercontent.com/13417815/220720307-d0936d3a-444f-4755-a511-38076e1925c5.png)

**After:**
_Save_ button (more general, less misleading):
![save](https://user-images.githubusercontent.com/13417815/220720053-c4839e5b-3ab7-4563-bfc1-66fe665d301f.png)
![save2](https://user-images.githubusercontent.com/13417815/220720061-63770f94-d5cc-4eb7-8bad-ce1b5b45c139.png)
Clear and nice dividers, more space around (increased padding), clearly divided sections:
![divider_after](https://user-images.githubusercontent.com/13417815/220720609-1e7d6edc-0b15-44c8-a70a-803090e3ff37.png)

