### PR TITLE
Bug 2159975: Remove the "docker://" prefix while editing the rootdisk (registry)

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/DiskSourceFormSelect.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/DiskSourceFormSelect.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { removeDockerPrefix } from '@catalog/customize/components/CustomizeSource/utils';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { DataUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -131,7 +132,7 @@ const DiskSourceFormSelect: React.FC<DiskSourceFormSelectProps> = ({
       )}
       {diskSource === sourceTypes.REGISTRY && (
         <DiskSourceContainer
-          url={registrySource}
+          url={removeDockerPrefix(registrySource)}
           onChange={(value) =>
             dispatchDiskSourceState({
               type: diskSourceReducerActions.SET_REGISTRY_SOURCE,

--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -155,7 +155,7 @@ export const getDataVolumeFromState = ({
   } else if (diskState.diskSource === sourceTypes.REGISTRY) {
     dataVolume.spec.source = {
       [diskState.diskSource]: {
-        url: `docker://${diskSourceState.registrySource}`,
+        url: `${diskSourceState.registrySource}`,
       },
     };
   } else if (diskState.diskSource === sourceTypes.HTTP) {

--- a/src/views/catalog/customize/components/CustomizeSource/utils.ts
+++ b/src/views/catalog/customize/components/CustomizeSource/utils.ts
@@ -91,4 +91,9 @@ export const getRegistryHelperText = (template: V1Template, t: TFunction) => {
     });
 };
 
-export const appendDockerPrefix = (image: string) => 'docker://'.concat(image);
+const DOCKER_PREFIX = 'docker://';
+
+export const appendDockerPrefix = (image: string) => {
+  return image?.startsWith(DOCKER_PREFIX) ? image : DOCKER_PREFIX.concat(image);
+};
+export const removeDockerPrefix = (image: string) => image.replace(DOCKER_PREFIX, '');


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Add a brief description

## 🎥 Demo
Before: 
![RemoveDockerPrefixBefore](https://user-images.githubusercontent.com/61961469/220883209-dae7f030-52cb-4b8e-ac24-5d3a23e03fff.gif)

After:
![RemoveDockerPrefixAfter](https://user-images.githubusercontent.com/61961469/220882560-d69ac9e1-a0e8-4da2-9002-3c4fe5c0f2f7.gif)
