### PR TITLE
Bug 2173593: Display 'No data available' helper text correctly

### DIFF
--- a/src/utils/components/HelpTextIcon/HelpTextIcon.tsx
+++ b/src/utils/components/HelpTextIcon/HelpTextIcon.tsx
@@ -13,12 +13,12 @@ type HelpTextIconProps = {
   helpIconClassName?: string;
 };
 
-const HelpTextIcon: FC<HelpTextIconProps> = (
+const HelpTextIcon: FC<HelpTextIconProps> = ({
   bodyContent,
-  position = 'top',
+  position = PopoverPosition.top,
   className = 'help-text-icon__popover',
   helpIconClassName = '',
-) => (
+}) => (
   <Popover aria-label={'Help'} bodyContent={bodyContent} className={className} position={position}>
     <HelpIcon className={helpIconClassName} />
   </Popover>


### PR DESCRIPTION
## 📝 Description

**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=2173593

Display _No data available_ helper text correctly to prevent _Top consumers_ page/tab crash in _Virtualization > Overview_. Display the helper texts in _Add volume to boot from_ and _Edit volume parameters_ modals correctly, too, to prevent crashing the UI when accessing those modals, as all those places have the common root cause.

## 🎥 Screenshots
**Before:**
_Top consumers_ page broken:
![top_before](https://user-images.githubusercontent.com/13417815/221602529-53294389-2d20-4ebf-944b-740870d4fd9f.png)
Blank page after accessing _Add volume to boot from_ or _Edit volume parameters_ modal + same error in the browser console as in the picture above:
![pf_before](https://user-images.githubusercontent.com/13417815/221602755-6170377b-2757-496b-85a7-3f6af3580b66.png)

**After:**
_Top consumers_ page rendered correctly, incl. the helper text (+ no errors):
![top_afterr](https://user-images.githubusercontent.com/13417815/221603294-d9038601-83fe-4e90-b796-886a70e0f768.png)
_Add volume to boot from_ (or _Edit volume parameters_) modal rendered as expected:
![pf_after](https://user-images.githubusercontent.com/13417815/221603384-4cee2c00-437e-4f40-a549-f19abf58eb4c.png)

