### PR TITLE
Fix OS display name

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/utils/utils.ts
@@ -3,11 +3,16 @@ import {
   PREFERENCE_DISPLAY_NAME_KEY,
 } from '@catalog/CreateFromInstanceTypes/utils/constants';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
-import { getLabel } from '@kubevirt-utils/resources/shared';
+import { getAnnotation, getLabel } from '@kubevirt-utils/resources/shared';
 
 export const getOSFromDefaultPreference = (bootSource: V1beta1DataSource, preferencesMap) => {
   const defaultPreferenceName = getLabel(bootSource, DEFAULT_PREFERENCE_LABEL);
-  const defaultPreferenceDisplayName =
-    preferencesMap?.[defaultPreferenceName]?.[PREFERENCE_DISPLAY_NAME_KEY];
+
+  const defaultPreference = preferencesMap?.[defaultPreferenceName];
+
+  const defaultPreferenceDisplayName = getAnnotation(
+    defaultPreference,
+    PREFERENCE_DISPLAY_NAME_KEY,
+  );
   return defaultPreferenceDisplayName || defaultPreferenceName;
 };


### PR DESCRIPTION
## 📝 Description

Fixing OS name in the VM details section in VM create with Instance type flow

## 🎥 Demo

Before:
![os-display-name-b4](https://user-images.githubusercontent.com/67270715/222187558-aebd783f-ccbb-4d04-ad5f-02dfc16548f5.png)

After:
![os-display-name](https://user-images.githubusercontent.com/67270715/222187551-033f0deb-8dad-4e43-a236-faac12104aab.png)


