### PR TITLE
Bug 2174324: Rename Add to Add volume button for Bootable volumes

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -72,7 +72,6 @@
   "Active Descheduler": "Active Descheduler",
   "Active users": "Active users",
   "Activity": "Activity",
-  "Add": "Add",
   "Add affinity rule": "Add affinity rule",
   "Add Config Map, Secret or Service Account": "Add Config Map, Secret or Service Account",
   "Add configuration": "Add configuration",

--- a/src/views/bootablevolumes/list/BootableVolumesList.tsx
+++ b/src/views/bootablevolumes/list/BootableVolumesList.tsx
@@ -58,7 +58,6 @@ const BootableVolumesList: FC = () => {
           loaded={loaded}
           loadError={loadError}
           buttonVariant={ButtonVariant.primary}
-          buttonTitle={t('Add')}
         />
       </ListPageHeader>
 

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeButton/AddBootableVolumeButton.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeButton/AddBootableVolumeButton.tsx
@@ -12,7 +12,6 @@ export type AddBootableVolumeButtonProps = {
   loaded: boolean;
   loadError?: any;
   buttonVariant?: ButtonVariant;
-  buttonTitle?: string;
 };
 
 const AddBootableVolumeButton: FC<AddBootableVolumeButtonProps> = ({
@@ -21,7 +20,6 @@ const AddBootableVolumeButton: FC<AddBootableVolumeButtonProps> = ({
   loaded,
   loadError,
   buttonVariant,
-  buttonTitle,
 }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
@@ -41,7 +39,7 @@ const AddBootableVolumeButton: FC<AddBootableVolumeButtonProps> = ({
       isLoading={!loaded}
       isDisabled={!loaded || loadError}
     >
-      {buttonTitle || t('Add volume')}
+      {t('Add volume')}
     </Button>
   );
 };


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2174324

Rename the button from "Add" to "Add volume", in the _Bootable volumes_ list.

This change makes the list looking more consistent with the bootable volumes list under the _InstanceTypes_ tab when creating a VM, where _Add volume_ button already exists, with the same functionality.

## 🎥 Screenshots
**Before:**
![Add_before](https://user-images.githubusercontent.com/13417815/222237968-d49a7f60-7fc6-480f-83f7-934af7c05e81.png)

**After:**
![Add_after](https://user-images.githubusercontent.com/13417815/222237978-4113b11a-c291-4531-bcdb-2b38b82b72b5.png)






