### PR TITLE
Bug 2174636: Visit Virtualization -> Overview -> Migrations crashes the app

### DIFF
--- a/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/utils.ts
+++ b/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/utils.ts
@@ -55,7 +55,7 @@ export const getTickValuesAxisY = (maxValue: number, normalize = multipliers.Gi)
   const tickValues = [];
 
   const normalizedMaxValue = Math.ceil(maxValue / normalize);
-  const gridLineSpacer = Math.ceil(normalizedMaxValue / GRID_LINES);
+  const gridLineSpacer = Math.ceil(normalizedMaxValue / GRID_LINES) || 1;
   for (let i = 0; i <= gridLineSpacer * GRID_LINES; i += gridLineSpacer) {
     tickValues.push(i * normalize);
   }


### PR DESCRIPTION
## 📝 Description

when gridLineSpacer is 0 the for loop will run endlessly which will crash the script 

## 🎥 Demo

After:
![Screenshot - 2023-03-02T132609 135](https://user-images.githubusercontent.com/67270715/222415745-373dba94-305d-4922-bd84-894aaf84f8b3.png)
