### PR TITLE
Remove alerts with health impact of none from health status popup chart

### DIFF
--- a/src/utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts.ts
+++ b/src/utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts.ts
@@ -4,7 +4,7 @@ import useAlerts from '@kubevirt-utils/hooks/useAlerts';
 import {
   getNumberOfAlerts,
   isFiringAlert,
-  isInfrastructureAlert,
+  isImportantInfrastructureAlert,
   sortAlertsByHealthImpact,
 } from '@kubevirt-utils/hooks/useInfrastructureAlerts/utils/utils';
 import { isKubeVirtAlert } from '@kubevirt-utils/hooks/useKubevirtAlerts';
@@ -24,7 +24,8 @@ const useInfrastructureAlerts: UseInfrastructureAlerts = () => {
 
   const alertsByHealthImpact = useMemo(() => {
     const filteredAlerts = alerts?.filter(
-      (alert) => isKubeVirtAlert(alert) && isFiringAlert(alert) && isInfrastructureAlert(alert),
+      (alert) =>
+        isKubeVirtAlert(alert) && isFiringAlert(alert) && isImportantInfrastructureAlert(alert),
     );
 
     return sortAlertsByHealthImpact(filteredAlerts);

--- a/src/utils/hooks/useInfrastructureAlerts/utils/utils.ts
+++ b/src/utils/hooks/useInfrastructureAlerts/utils/utils.ts
@@ -5,11 +5,19 @@ import {
 } from '@kubevirt-utils/hooks/useInfrastructureAlerts/utils/constants';
 import { Alert } from '@openshift-console/dynamic-plugin-sdk-internal/lib/api/common-types';
 
+import { HealthImpactLevel } from '../../../../views/dashboard-extensions/KubevirtHealthPopup/utils/types';
+
 export const isFiringAlert = (alert: Alert) => alert?.state === FIRING;
 
 const getHealthImpact = (alert: Alert) => alert?.labels?.[OPERATOR_HEALTH_IMPACT_LABEL];
 
-export const isInfrastructureAlert = (alert: Alert) => Boolean(getHealthImpact(alert));
+export const isImportantInfrastructureAlert = (alert: Alert) => {
+  const healthImpact = getHealthImpact(alert);
+  return (
+    healthImpact &&
+    (healthImpact === HealthImpactLevel.warning || healthImpact === HealthImpactLevel.critical)
+  );
+};
 
 export const sortAlertsByHealthImpact = (alerts: Alert[]) =>
   alerts?.reduce(


### PR DESCRIPTION
## 📝 Description

This PR removes alerts whose value for the label `operator_health_impact` is `none` from the chart shown in the "OpenShift Virtualization" health status popup.
