### PR TITLE
Bug 2173527: Add help text to Machine type field

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -967,6 +967,7 @@
   "The following information is provided by the OpenShift Virtualization operator.": "The following information is provided by the OpenShift Virtualization operator.",
   "The following information regarding how the disks are partitioned is provided by the guest agent.": "The following information regarding how the disks are partitioned is provided by the guest agent.",
   "The following resources will be deleted along with this VirtualMachine. Unchecked items will not be deleted.": "The following resources will be deleted along with this VirtualMachine. Unchecked items will not be deleted.",
+  "The machine type defines the virtual hardware configuration while the operating system name and version refer to the hypervisor.": "The machine type defines the virtual hardware configuration while the operating system name and version refer to the hypervisor.",
   "The virtctl client is a supplemental command-line utility for managing virtualization resources from the command line.": "The virtctl client is a supplemental command-line utility for managing virtualization resources from the command line.",
   "The VirtualMachine {{vmName}} is still running. It will be powered off while cloning.": "The VirtualMachine {{vmName}} is still running. It will be powered off while cloning.",
   "The VirtualMachine will be bridged to the selected network, ideal for L2 devices": "The VirtualMachine will be bridged to the selected network, ideal for L2 devices",

--- a/src/views/catalog/wizard/tabs/overview/components/WizardOverviewGrid.tsx
+++ b/src/views/catalog/wizard/tabs/overview/components/WizardOverviewGrid.tsx
@@ -149,6 +149,12 @@ const WizardOverviewGrid: React.FC<WizardOverviewGridProps> = ({ vm, tabsData, u
             title={t('Machine type')}
             testId="wizard-overview-machine-type"
             description={getMachineType(vm)}
+            helperPopover={{
+              header: t('Machine type'),
+              content: t(
+                'The machine type defines the virtual hardware configuration while the operating system name and version refer to the hypervisor.',
+              ),
+            }}
           />
 
           <WizardDescriptionItem

--- a/src/views/templates/details/tabs/details/components/DescriptionItem.tsx
+++ b/src/views/templates/details/tabs/details/components/DescriptionItem.tsx
@@ -4,17 +4,29 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  DescriptionListTermHelpText,
+  DescriptionListTermHelpTextButton,
+  Popover,
 } from '@patternfly/react-core';
 
 type DescriptionProps = {
   title: string;
   content: string | JSX.Element;
+  popoverContent?: string | JSX.Element;
 };
 
-// a simple DescriptionList item component
-const DescriptionItem: React.FC<DescriptionProps> = ({ title, content }) => (
+const DescriptionItem: React.FC<DescriptionProps> = ({ title, content, popoverContent }) => (
   <DescriptionListGroup>
-    <DescriptionListTerm>{title}</DescriptionListTerm>
+    {popoverContent ? (
+      <DescriptionListTermHelpText>
+        <Popover hasAutoWidth maxWidth="30rem" headerContent={title} bodyContent={popoverContent}>
+          <DescriptionListTermHelpTextButton>{title}</DescriptionListTermHelpTextButton>
+        </Popover>
+      </DescriptionListTermHelpText>
+    ) : (
+      <DescriptionListTerm>{title}</DescriptionListTerm>
+    )}
+
     <DescriptionListDescription>{content}</DescriptionListDescription>
   </DescriptionListGroup>
 );

--- a/src/views/templates/details/tabs/details/components/TemplateDetailsLeftGrid.tsx
+++ b/src/views/templates/details/tabs/details/components/TemplateDetailsLeftGrid.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import Annotations from 'src/views/templates/details/tabs/details/components/Annotations';
 import BaseTemplate from 'src/views/templates/details/tabs/details/components/BaseTemplate';
 import CreatedAt from 'src/views/templates/details/tabs/details/components/CreatedAt';
@@ -24,7 +24,7 @@ import Description from './Description';
 import DisplayName from './DisplayName';
 import WorkloadProfile from './WorkloadProfile';
 
-const TemplateDetailsLeftGrid: React.FC<TemplateDetailsGridProps> = ({ template }) => {
+const TemplateDetailsLeftGrid: FC<TemplateDetailsGridProps> = ({ template }) => {
   const { t } = useKubevirtTranslation();
   const machineType = getMachineType(getTemplateVirtualMachineObject(template)) || NO_DATA_DASH;
   const { isTemplateEditable } = useEditTemplateAccessReview(template);
@@ -40,7 +40,13 @@ const TemplateDetailsLeftGrid: React.FC<TemplateDetailsGridProps> = ({ template 
       <DescriptionItem title={t('Operating system')} content={getOperatingSystemName(template)} />
       <WorkloadProfile template={template} editable={isTemplateEditable} />
       <CPUMemory template={template} />
-      <DescriptionItem title={t('Machine type')} content={machineType} />
+      <DescriptionItem
+        title={t('Machine type')}
+        content={machineType}
+        popoverContent={t(
+          'The machine type defines the virtual hardware configuration while the operating system name and version refer to the hypervisor.',
+        )}
+      />
       <BootMethod template={template} />
       <BaseTemplate template={template} />
       <CreatedAt template={template} />

--- a/src/views/virtualmachines/details/tabs/details/components/grid/leftGrid/VirtualMachineDetailsLeftGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/leftGrid/VirtualMachineDetailsLeftGrid.tsx
@@ -240,6 +240,10 @@ const VirtualMachineDetailsLeftGrid: React.FC<VirtualMachineDetailsLeftGridProps
         <VirtualMachineDescriptionItem
           descriptionData={getMachineType(vm) || NO_DATA_DASH}
           descriptionHeader={t('Machine type')}
+          isPopover
+          bodyContent={t(
+            'The machine type defines the virtual hardware configuration while the operating system name and version refer to the hypervisor.',
+          )}
         />
         <VirtualMachineDescriptionItem
           descriptionData={

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Details.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Details.tsx
@@ -12,8 +12,11 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  DescriptionListTermHelpText,
+  DescriptionListTermHelpTextButton,
   Grid,
   GridItem,
+  Popover,
   Title,
 } from '@patternfly/react-core';
 import { LinkIcon } from '@patternfly/react-icons';
@@ -92,7 +95,20 @@ const Details: React.FC<DetailsProps> = ({ vmi, pathname }) => {
               <CPUMemory vmi={vmi} />
             </DescriptionListGroup>
             <DescriptionListGroup>
-              <DescriptionListTerm>{t('Machine type')}</DescriptionListTerm>
+              <DescriptionListTermHelpText>
+                <Popover
+                  hasAutoWidth
+                  maxWidth="30rem"
+                  headerContent={t('Machine type')}
+                  bodyContent={t(
+                    'The machine type defines the virtual hardware configuration while the operating system name and version refer to the hypervisor.',
+                  )}
+                >
+                  <DescriptionListTermHelpTextButton>
+                    {t('Machine type')}
+                  </DescriptionListTermHelpTextButton>
+                </Popover>
+              </DescriptionListTermHelpText>
               <DescriptionListDescription>
                 {getMachineType(vm) || NO_DATA_DASH}
               </DescriptionListDescription>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2173527

Add help text/popover with more info to _Machine type_ field, present in the following places:
- VM Details tab
- VMI Details tab
- VM Template Details tab
- Customize VM flow (VM creation)

Display the following info in the popover, when clicking on the dashed title of the field:
_"The machine type defines the virtual hardware configuration while the operating system name and version refer to the hypervisor."_

## 🎥 Screenshots
**Before:**
No way to get some info about the _Machine type (VM _Details_ page/tab):
![machine_before](https://user-images.githubusercontent.com/13417815/222501221-832979a9-73b3-4ffc-b9d6-d17428c256d9.png)

**After:**
Clicking on the title of the _Machine type_ field shows us more (VM _Details_ page/tab):
![machine_after](https://user-images.githubusercontent.com/13417815/222501239-7d5e9f25-e110-4fe2-93d0-9732ca432461.png)

Note that in other places, the result of adding the popover looks the same.
