### PR TITLE
Bug 2167226: Make sorting NICs by Type work correctly

### DIFF
--- a/src/utils/resources/vm/utils/network/utils.ts
+++ b/src/utils/resources/vm/utils/network/utils.ts
@@ -1,0 +1,14 @@
+import { NetworkPresentation } from './constants';
+import { getPrintableNetworkInterfaceType } from './selectors';
+
+export const nicsSorting = (nics: NetworkPresentation[], direction: string) =>
+  nics.sort((a: NetworkPresentation, b: NetworkPresentation) => {
+    const aUpdated = getPrintableNetworkInterfaceType(a.iface);
+    const bUpdated = getPrintableNetworkInterfaceType(b.iface);
+
+    if (aUpdated && bUpdated) {
+      return direction === 'asc'
+        ? aUpdated.localeCompare(bUpdated)
+        : bUpdated.localeCompare(aUpdated);
+    }
+  });

--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceList.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceList.tsx
@@ -26,7 +26,7 @@ const NetworkInterfaceList: React.FC<NetworkInterfaceListProps> = ({ vm }) => {
   const networkInterfacesData = getNetworkInterfaceRowData(networks, interfaces);
   const [data, filteredData, onFilterChange] = useListPageFilter(networkInterfacesData, filters);
 
-  const columns = useNetworkColumns();
+  const columns = useNetworkColumns(filteredData);
   return (
     <>
       <ListPageFilter data={data} loaded rowFilters={filters} onFilterChange={onFilterChange} />

--- a/src/views/catalog/wizard/tabs/network/hooks/useNetworkColumns.ts
+++ b/src/views/catalog/wizard/tabs/network/hooks/useNetworkColumns.ts
@@ -1,14 +1,17 @@
-import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { nicsSorting } from '@kubevirt-utils/resources/vm/utils/network/utils';
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 
-const useNetworkColumns = () => {
+const useNetworkColumns = (data: NetworkPresentation[]) => {
   const { t } = useKubevirtTranslation();
 
-  const columns: TableColumn<NetworkPresentation>[] = React.useMemo(
+  const sorting = useCallback((direction) => nicsSorting(data, direction), [data]);
+
+  const columns: TableColumn<NetworkPresentation>[] = useMemo(
     () => [
       {
         title: t('Name'),
@@ -32,7 +35,7 @@ const useNetworkColumns = () => {
         title: t('Type'),
         id: 'type',
         transforms: [sortable],
-        sort: 'iface.masquerade' || 'iface.bridge' || 'iface.sriov',
+        sort: (_, direction) => sorting(direction),
       },
       {
         title: t('MAC address'),
@@ -46,7 +49,7 @@ const useNetworkColumns = () => {
         props: { className: 'dropdown-kebab-pf pf-c-table__action' },
       },
     ],
-    [t],
+    [sorting, t],
   );
 
   return columns;

--- a/src/views/templates/details/tabs/network/components/list/NetworkInterfaceList.tsx
+++ b/src/views/templates/details/tabs/network/components/list/NetworkInterfaceList.tsx
@@ -28,7 +28,7 @@ const NetworkInterfaceList: React.FC<NetworkInterfaceListProps> = ({ template })
   const networkInterfacesData = getNetworkInterfaceRowData(networks, interfaces);
   const [data, filteredData, onFilterChange] = useListPageFilter(networkInterfacesData, filters);
 
-  const columns = useNetworkColumns();
+  const columns = useNetworkColumns(filteredData);
   return (
     <>
       <ListPageFilter data={data} loaded rowFilters={filters} onFilterChange={onFilterChange} />

--- a/src/views/templates/details/tabs/network/hooks/useNetworkColumns.ts
+++ b/src/views/templates/details/tabs/network/hooks/useNetworkColumns.ts
@@ -1,14 +1,17 @@
-import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { nicsSorting } from '@kubevirt-utils/resources/vm/utils/network/utils';
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 
-const useNetworkColumns = () => {
+const useNetworkColumns = (data: NetworkPresentation[]) => {
   const { t } = useKubevirtTranslation();
 
-  const columns: TableColumn<NetworkPresentation>[] = React.useMemo(
+  const sorting = useCallback((direction) => nicsSorting(data, direction), [data]);
+
+  const columns: TableColumn<NetworkPresentation>[] = useMemo(
     () => [
       {
         title: t('Name'),
@@ -32,7 +35,7 @@ const useNetworkColumns = () => {
         title: t('Type'),
         id: 'type',
         transforms: [sortable],
-        sort: 'iface.masquerade' || 'iface.bridge' || 'iface.sriov',
+        sort: (_, direction) => sorting(direction),
       },
       {
         title: t('MAC address'),
@@ -46,7 +49,7 @@ const useNetworkColumns = () => {
         props: { className: 'dropdown-kebab-pf pf-c-table__action' },
       },
     ],
-    [t],
+    [sorting, t],
   );
 
   return columns;

--- a/src/views/virtualmachines/details/tabs/configuration/network/copmonents/list/NetworkInterfaceList.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/copmonents/list/NetworkInterfaceList.tsx
@@ -26,7 +26,8 @@ const NetworkInterfaceList: React.FC<NetworkInterfaceTableProps> = ({ vm }) => {
   const networkInterfacesData = getNetworkInterfaceRowData(networks, interfaces);
   const [data, filteredData, onFilterChange] = useListPageFilter(networkInterfacesData, filters);
 
-  const columns = useNetworkColumns();
+  const columns = useNetworkColumns(filteredData);
+
   return (
     <>
       <ListPageFilter data={data} loaded rowFilters={filters} onFilterChange={onFilterChange} />

--- a/src/views/virtualmachines/details/tabs/configuration/network/hooks/useNetworkColumns.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/network/hooks/useNetworkColumns.ts
@@ -1,14 +1,17 @@
-import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { nicsSorting } from '@kubevirt-utils/resources/vm/utils/network/utils';
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 
-const useNetworkColumns = () => {
+const useNetworkColumns = (data: NetworkPresentation[]) => {
   const { t } = useKubevirtTranslation();
 
-  const columns: TableColumn<NetworkPresentation>[] = React.useMemo(
+  const sorting = useCallback((direction) => nicsSorting(data, direction), [data]);
+
+  const columns: TableColumn<NetworkPresentation>[] = useMemo(
     () => [
       {
         title: t('Name'),
@@ -32,7 +35,7 @@ const useNetworkColumns = () => {
         title: t('Type'),
         id: 'type',
         transforms: [sortable],
-        sort: 'iface.masquerade' || 'iface.bridge' || 'iface.sriov',
+        sort: (_, direction) => sorting(direction),
       },
       {
         title: t('MAC address'),
@@ -46,7 +49,7 @@ const useNetworkColumns = () => {
         props: { className: 'dropdown-kebab-pf pf-c-table__action' },
       },
     ],
-    [t],
+    [sorting, t],
   );
 
   return columns;


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2167226

Make sorting NICs by _Type_ work correctly (alphabetically), in VM _Network Interfaces_ tab,
also for VM _Templates_ and in _Catalog_ accordingly.

## 🎥 Screenshots
**Before:**
![sort_before](https://user-images.githubusercontent.com/13417815/222764664-8be375f2-4d96-43c6-85b2-4ae831d9a33e.png)

**After:**
![sort_after](https://user-images.githubusercontent.com/13417815/222764684-b8064fb5-78aa-4bab-bed3-3d4f756846c2.png)




