### PR TITLE
Bug 2175256: Display Catalog page correctly, fix TypeError when accessing Catalog

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
@@ -32,7 +32,7 @@ const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
     return [
       getName(bootableVolume),
       getName(preferences[bootableVolume?.metadata?.labels?.[DEFAULT_PREFERENCE_LABEL]]),
-      bootableVolume.metadata.annotations[DESCRIPTION_ANNOTATION],
+      bootableVolume?.metadata?.annotations?.[DESCRIPTION_ANNOTATION],
     ];
   };
 


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2175256

Fix the error of `bootableVolume.metadata.annotations` that was `undefined`, when accessing the _Catalog_ page.

## 🎥 Screenshots
**Before:**
Right after accessing _Catalog_ (_Virtualization > Catalog_), TypeError occurs:
![catalog_error](https://user-images.githubusercontent.com/13417815/222780663-8bd09690-f326-433a-8f91-6c4ea56d1905.png)

**After:**
_Catalog_ page displayed correctly:
![catalog_after](https://user-images.githubusercontent.com/13417815/222780678-6f76f0ba-8ea5-440b-b8b2-265f9aac3211.png)

