### PR TITLE
Bug 2175274: Display Edit CPU | Memory modal in VM Details

### DIFF
--- a/src/utils/components/CPUMemoryModal/CpuMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CpuMemoryModal.tsx
@@ -4,6 +4,7 @@ import produce from 'immer';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { toIECUnit } from '@kubevirt-utils/utils/units';
+import { ensurePath } from '@kubevirt-utils/utils/utils';
 import {
   Alert,
   Button,
@@ -56,6 +57,7 @@ const CPUMemoryModal: React.FC<CPUMemoryModalProps> = ({ vm, isOpen, onClose, on
 
   const updatedVirtualMachine = React.useMemo(() => {
     const updatedVM = produce<V1VirtualMachine>(vm, (vmDraft: V1VirtualMachine) => {
+      ensurePath(vmDraft, ['spec.template.spec.domain.resources', 'spec.template.spec.domain.cpu']);
       vmDraft.spec.template.spec.domain.resources.requests = {
         ...vm?.spec?.template?.spec?.domain?.resources?.requests,
         memory: `${memory}${memoryUnit}`,

--- a/src/utils/components/DedicatedResourcesModal/DedicatedResourcesModal.tsx
+++ b/src/utils/components/DedicatedResourcesModal/DedicatedResourcesModal.tsx
@@ -66,7 +66,7 @@ const DedicatedResourcesModal: React.FC<DedicatedResourcesModalProps> = ({
 
   const updatedVirtualMachine = React.useMemo(() => {
     const updatedVM = produce<V1VirtualMachine>(vm, (vmDraft: V1VirtualMachine) => {
-      ensurePath(vmDraft, ['vm.spec.template.spec.domain.cpu']);
+      ensurePath(vmDraft, ['spec.template.spec.domain.cpu']);
       vmDraft.spec.template.spec.domain.cpu.dedicatedCpuPlacement = checked;
     });
     return updatedVM;

--- a/src/views/templates/details/tabs/details/components/CPUMemoryModal.tsx
+++ b/src/views/templates/details/tabs/details/components/CPUMemoryModal.tsx
@@ -10,6 +10,7 @@ import {
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { toIECUnit } from '@kubevirt-utils/utils/units';
+import { ensurePath } from '@kubevirt-utils/utils/utils';
 import {
   Alert,
   Button,
@@ -53,6 +54,10 @@ const CPUMemoryModal: React.FC<CPUMemoryModalProps> = ({ template, isOpen, onClo
     () =>
       produce<V1Template>(template, (templateDraft: V1Template) => {
         const draftVM = getTemplateVirtualMachineObject(templateDraft);
+        ensurePath(draftVM, [
+          'spec.template.spec.domain.resources',
+          'spec.template.spec.domain.cpu',
+        ]);
         draftVM.spec.template.spec.domain.resources.requests = {
           ...vm?.spec?.template?.spec?.domain?.resources?.requests,
           memory: `${memory}${memoryUnit}`,

--- a/src/views/templates/details/tabs/scheduling/components/DedicatedResourcesModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/DedicatedResourcesModal.tsx
@@ -14,7 +14,7 @@ import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, NodeModel, V1Template } from '@kubevirt-utils/models';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { ensurePath, isEmpty } from '@kubevirt-utils/utils/utils';
 import { ResourceLink, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Alert,
@@ -59,9 +59,9 @@ const DedicatedResourcesModal: React.FC<DedicatedResourcesModalProps> = ({
 
   const updatedTemplate = React.useMemo(() => {
     return produce<V1Template>(template, (templateDraft: V1Template) => {
-      getTemplateVirtualMachineObject(
-        templateDraft,
-      ).spec.template.spec.domain.cpu.dedicatedCpuPlacement = checked;
+      const draftVM = getTemplateVirtualMachineObject(templateDraft);
+      ensurePath(draftVM, ['spec.template.spec.domain.cpu']);
+      draftVM.spec.template.spec.domain.cpu.dedicatedCpuPlacement = checked;
     });
   }, [checked, template]);
 


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2175274

Fix the error, prevent blank page to be displayed, after trying to edit CPU/Memory of a VM, created from a template without `spec.template.spec.domain.cpu` defined in its VM object (see the YAML of a VM or a Template).

Fix the error by making sure the path exists (using `ensurePath`), when editing the VM or Template object (the same problem occurs in more places).

## 🎥 Demo
**Before:**
![cpu_before](https://user-images.githubusercontent.com/13417815/222801018-4d502e23-1ef9-4388-ba27-da5db3122d25.png)

**After:**
![cpu_after](https://user-images.githubusercontent.com/13417815/222801022-d24e0f68-00fc-46f9-bfeb-aaa41ca9a20a.png)



