### PR TITLE
Bug 2168486: Enable Restore template settings by fixing templates link

### DIFF
--- a/src/views/catalog/utils/quick-create-vm.ts
+++ b/src/views/catalog/utils/quick-create-vm.ts
@@ -45,7 +45,7 @@ export const quickCreateVM: QuickCreateVMType = async ({
     draftVM.metadata.name = name;
 
     draftVM.metadata.labels[LABEL_USED_TEMPLATE_NAME] = processedTemplate.metadata.name;
-    draftVM.metadata.labels[LABEL_USED_TEMPLATE_NAMESPACE] = processedTemplate.metadata.namespace;
+    draftVM.metadata.labels[LABEL_USED_TEMPLATE_NAMESPACE] = template.metadata.namespace;
     if (startVM) {
       draftVM.spec.running = true;
     }


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2168486

Make "Restore template settings" enabled, when editing VM's CPU/Memory, by fixing incorrect link to the original Template the VM was created from. Fix the incorrect namespace in the link, which was set to the namespace of the VM when creating a VM, not the original Template's one.

## 🎥 Demo
**Before:**
Incorrect link to the base template:
![url_before1](https://user-images.githubusercontent.com/13417815/222825540-e22d7dd7-ca2b-4b21-b6eb-c1a387c03897.png)
After clicking on the template:
![url_before2](https://user-images.githubusercontent.com/13417815/222825554-d521e8f6-8503-426f-98aa-be2a65e07acc.png)
"Restore template settings" disabled, when editing VM's CPU/Memory:
![edit_disabled](https://user-images.githubusercontent.com/13417815/222827294-09cc52c6-8c54-4599-8c44-e25aacdace25.png)

**After:**
Correct link to the base template:
![url_after](https://user-images.githubusercontent.com/13417815/222825753-05f67be6-c6f1-42a0-9ec4-12996d2c9ff9.png)
After clicking on the template:
![url_after2](https://user-images.githubusercontent.com/13417815/222825761-14b033d6-f74a-4fef-b225-12c77a3d19b5.png)
"Restore template settings" enabled as expected:
![edit_enabled](https://user-images.githubusercontent.com/13417815/222827386-b6dc6f18-ef62-4e68-9979-d9117d314948.png)

