### PR TITLE
Fix crash for 'Add volume' modal dialog

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/StorageClassSelect.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/StorageClassSelect.tsx
@@ -48,7 +48,7 @@ const StorageClassSelect: React.FC<StorageClassSelectProps> = ({
   useEffect(() => {
     if (!storageClass && loaded) {
       setStorageClassName(defaultSC?.metadata?.name);
-      setStorageClassProvisioner(defaultSC?.provisioner);
+      setStorageClassProvisioner?.(defaultSC?.provisioner);
     }
   }, [defaultSC, setStorageClassName, setStorageClassProvisioner, storageClass, loaded]);
 


### PR DESCRIPTION
## 📝 Description

missing optional chaining operator causing the 'Add volume' modal dialog to crash 

## 🎥 Demo

> Please add a video or an image of the behavior/changes
