### PR TITLE
Add size and StorageClass columns to bootable volumes list

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/TableData.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/TableData.tsx
@@ -1,0 +1,13 @@
+import React, { FC } from 'react';
+
+import { Td } from '@patternfly/react-table';
+
+type TableDataProps = {
+  id: string;
+  activeColumnIDs: string[];
+};
+
+const TableData: FC<TableDataProps> = ({ children, id, activeColumnIDs }) =>
+  activeColumnIDs?.some((activeID) => activeID === id) ? <Td id={id}>{children}</Td> : null;
+
+export default TableData;

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeColumns.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeColumns.ts
@@ -1,17 +1,34 @@
+import { DataSourceModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
+import { TableColumn, useActiveColumns } from '@openshift-console/dynamic-plugin-sdk';
+import { ColumnLayout } from '@openshift-console/dynamic-plugin-sdk-internal/lib/extensions/console-types';
 
-const useBootVolumeColumns = () => {
+type UseBootVolumesColumns = (isModal: boolean) => {
+  columns: TableColumn<V1beta1DataSource>[];
+  activeColumns: TableColumn<V1beta1DataSource>[];
+  columnLayout: ColumnLayout | null;
+};
+
+const useBootVolumeColumns: UseBootVolumesColumns = (isModal) => {
   const { t } = useKubevirtTranslation();
+
   const columns: TableColumn<V1beta1DataSource>[] = [
     {
       title: t('Volume name'),
-      id: 'volume-name',
+      id: 'name',
     },
     {
       title: t('Operating system'),
       id: 'operating-system',
+    },
+    {
+      title: t('Storage class'),
+      id: 'storage-class',
+    },
+    {
+      title: t('Size'),
+      id: 'size',
     },
     {
       title: t('Description'),
@@ -19,7 +36,24 @@ const useBootVolumeColumns = () => {
     },
   ];
 
-  return columns;
+  const [activeColumns] = useActiveColumns<V1beta1DataSource>({
+    columns,
+    showNamespaceOverride: false,
+    columnManagementID: DataSourceModelRef,
+  });
+
+  const columnLayout: ColumnLayout = {
+    columns: columns?.map(({ id, title, additional }) => ({
+      id,
+      title,
+      additional,
+    })),
+    id: DataSourceModelRef,
+    selectedColumns: new Set(activeColumns?.map((col) => col?.id)),
+    type: t('Bootable volumes'),
+  };
+
+  return { columns, activeColumns, columnLayout: isModal ? null : columnLayout };
 };
 
 export default useBootVolumeColumns;

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
@@ -2,7 +2,10 @@ import { useState } from 'react';
 
 import { DEFAULT_PREFERENCE_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
-import { V1alpha2VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1alpha1PersistentVolumeClaim,
+  V1alpha2VirtualMachineClusterPreference,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { DESCRIPTION_ANNOTATION } from '@kubevirt-utils/resources/vm';
 import { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base';
@@ -14,6 +17,9 @@ type UseBootVolumeSortColumns = (
   preferences: {
     [resourceKeyName: string]: V1alpha2VirtualMachineClusterPreference;
   },
+  pvcSources: {
+    [resourceKeyName: string]: V1alpha1PersistentVolumeClaim;
+  },
   pagination: PaginationState,
 ) => {
   sortedData: V1beta1DataSource[];
@@ -23,15 +29,22 @@ type UseBootVolumeSortColumns = (
 const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
   unsortedData,
   preferences,
+  pvcSources,
   pagination,
 ) => {
   const [activeSortIndex, setActiveSortIndex] = useState<number | null>(null);
   const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc' | null>(null);
 
   const getSortableRowValues = (bootableVolume: V1beta1DataSource): string[] => {
+    const pvcSource =
+      pvcSources?.[bootableVolume?.spec?.source?.pvc?.namespace]?.[
+        bootableVolume?.spec?.source?.pvc?.name
+      ];
     return [
       getName(bootableVolume),
       getName(preferences[bootableVolume?.metadata?.labels?.[DEFAULT_PREFERENCE_LABEL]]),
+      pvcSource?.spec?.storageClassName,
+      pvcSource?.spec?.resources?.requests?.storage,
       bootableVolume?.metadata?.annotations?.[DESCRIPTION_ANNOTATION],
     ];
   };

--- a/src/views/catalog/CreateFromInstanceTypes/hooks/useBootableVolumes.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/hooks/useBootableVolumes.ts
@@ -1,6 +1,15 @@
+import { useEffect, useState } from 'react';
+
 import { DataSourceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { KUBEVIRT_OS_IMAGES_NS, OPENSHIFT_OS_IMAGES_NS } from '@kubevirt-utils/constants/constants';
+import {
+  convertResourceArrayToMap,
+  getAvailableDataSources,
+} from '@kubevirt-utils/resources/shared';
+import { getPVC } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
+import { isEmpty, isUpstream } from '@kubevirt-utils/utils/utils';
 import { Operator, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 import { DEFAULT_PREFERENCE_LABEL } from '../utils/constants';
@@ -9,6 +18,9 @@ type UseBootableVolumes = () => {
   bootableVolumes: V1beta1DataSource[];
   loaded: boolean;
   loadError: any;
+  pvcSources: {
+    [resourceKeyName: string]: V1alpha1PersistentVolumeClaim;
+  };
 };
 
 const useBootableVolumes: UseBootableVolumes = () => {
@@ -17,15 +29,31 @@ const useBootableVolumes: UseBootableVolumes = () => {
   >({
     groupVersionKind: DataSourceModelGroupVersionKind,
     isList: true,
+    namespace: isUpstream ? KUBEVIRT_OS_IMAGES_NS : OPENSHIFT_OS_IMAGES_NS,
     selector: {
       matchExpressions: [{ key: DEFAULT_PREFERENCE_LABEL, operator: Operator.Exists }],
     },
   });
 
+  const [pvcSources, setPVCSources] = useState<V1alpha1PersistentVolumeClaim[]>([]);
+
+  const readyDataSources = getAvailableDataSources(dataSources);
+
+  useEffect(() => {
+    if (loadedDataSources && !loadErrorDataSources && !isEmpty(readyDataSources)) {
+      const pvcSourcePromises = (readyDataSources || []).map((ds) =>
+        getPVC(ds?.spec?.source?.pvc?.name, ds?.spec?.source?.pvc?.namespace),
+      );
+
+      Promise.all(pvcSourcePromises).then((pvcs) => setPVCSources(pvcs));
+    }
+  }, [readyDataSources, loadErrorDataSources, loadedDataSources, dataSources]);
+
   return {
-    bootableVolumes: loadErrorDataSources || isEmpty(dataSources) ? null : dataSources,
+    bootableVolumes: loadErrorDataSources || isEmpty(readyDataSources) ? null : readyDataSources,
     loaded: loadErrorDataSources ? true : loadedDataSources,
     loadError: loadErrorDataSources,
+    pvcSources: convertResourceArrayToMap(pvcSources, true),
   };
 };
 


### PR DESCRIPTION
## 📝 Description

Adding Size and StorageClass columns to boot volumes list, also adding column management 
NOTE: No col manage inside the show all modal since we can't show modal in modal as PF won't allow it

## 🎥 Demo

https://user-images.githubusercontent.com/67270715/223338508-ca8016ab-ad06-44a9-8abe-792912cdf636.mp4


