### PR TITLE
Bug 2172371: Disable "Restore template settings" for VM without template

### DIFF
--- a/src/utils/components/CPUMemoryModal/CpuMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CpuMemoryModal.tsx
@@ -3,6 +3,8 @@ import produce from 'immer';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getLabel } from '@kubevirt-utils/resources/shared';
+import { VM_TEMPLATE_ANNOTATION } from '@kubevirt-utils/resources/vm';
 import { toIECUnit } from '@kubevirt-utils/utils/units';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 import {
@@ -54,6 +56,8 @@ const CPUMemoryModal: React.FC<CPUMemoryModalProps> = ({ vm, isOpen, onClose, on
   const [cpuCores, setCpuCores] = React.useState<number>();
   const [memoryUnit, setMemoryUnit] = React.useState<string>();
   const [isDropdownOpen, setIsDropdownOpen] = React.useState<boolean>(false);
+
+  const templateName = getLabel(vm, VM_TEMPLATE_ANNOTATION);
 
   const updatedVirtualMachine = React.useMemo(() => {
     const updatedVM = produce<V1VirtualMachine>(vm, (vmDraft: V1VirtualMachine) => {
@@ -115,12 +119,13 @@ const CPUMemoryModal: React.FC<CPUMemoryModalProps> = ({ vm, isOpen, onClose, on
           key="default"
           variant={ButtonVariant.secondary}
           isDisabled={
+            !templateName ||
             !defaultsLoaded ||
             !templateDefaultsData?.defaultCpu ||
             !templateDefaultsData?.defaultMemory ||
             defaultLoadError
           }
-          isLoading={!defaultsLoaded}
+          isLoading={templateName && !defaultsLoaded}
           onClick={() => {
             setCpuCores(templateDefaultsData?.defaultCpu);
             setMemory(templateDefaultsData?.defaultMemory?.size);


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2172371

Disable _Restore template settings_ button in _Edit CPU | Memory_ modal in VM _Details_ tab, because it does not make sense if the VM has no base template specified (check _Template_ field in the same page in the UI).

## 🎥 Screenshots
**Before:**
_Restore template settings_ button was loaded and is now clickable even it makes no sense:
![none_before](https://user-images.githubusercontent.com/13417815/223181981-60e61727-6108-40ce-bc7f-6bea92a4a108.png)

**After:**
_Restore template settings_ disabled for the VM without base template:
![none_after](https://user-images.githubusercontent.com/13417815/223181996-1ecafc50-587d-4fbf-97b6-26fe6e894d44.png)
