### PR TITLE
Add sorting Bootable volumes by Operating system

### DIFF
--- a/src/views/bootablevolumes/list/BootableVolumesList.tsx
+++ b/src/views/bootablevolumes/list/BootableVolumesList.tsx
@@ -38,7 +38,7 @@ const BootableVolumesList: FC = () => {
     useBootableVolumesFilters(),
   );
   const [pagination, setPagination] = useState(paginationInitialState);
-  const [columns, activeColumns] = useBootableVolumesColumns(pagination, filteredData);
+  const [columns, activeColumns] = useBootableVolumesColumns(pagination, filteredData, preferences);
 
   const onPageChange = ({ page, perPage, startIndex, endIndex }) => {
     setPagination(() => ({

--- a/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
+++ b/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
@@ -30,7 +30,7 @@ const BootableVolumesRow: FC<
         <ResourceLink groupVersionKind={groupVersionKind} name={obj?.metadata?.name} />
       </TableData>
       <TableData id="os" activeColumnIDs={activeColumnIDs} className="pf-m-width-15">
-        {getPreferenceReadableOS(obj, preferences) || NO_DATA_DASH}
+        {getPreferenceReadableOS(obj, preferences)}
       </TableData>
       <TableData id="description" activeColumnIDs={activeColumnIDs} className="pf-m-width-15">
         {obj?.metadata?.annotations?.description || NO_DATA_DASH}

--- a/src/views/bootablevolumes/utils/utils.ts
+++ b/src/views/bootablevolumes/utils/utils.ts
@@ -6,6 +6,7 @@ import DataSourceModel from '@kubevirt-ui/kubevirt-api/console/models/DataSource
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { V1alpha2VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { ANNOTATIONS, OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
+import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { k8sPatch, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 import { BootableVolumeMetadata, InstanceTypesToSizesMap } from './types';
@@ -15,7 +16,7 @@ export const getDataSourcePreferenceLabelValue = (
 ): string => obj?.metadata?.labels?.[DEFAULT_PREFERENCE_LABEL] || '';
 
 export const getPreferenceReadableOS = (
-  obj: V1beta1DataSource,
+  obj: V1beta1DataSource | K8sResourceCommon,
   preferences: V1alpha2VirtualMachineClusterPreference[],
 ): string => {
   const preferenceLabelValue = getDataSourcePreferenceLabelValue(obj); // preference name
@@ -23,7 +24,7 @@ export const getPreferenceReadableOS = (
     (preference) => preference?.metadata?.name === preferenceLabelValue,
   );
 
-  return preferenceObject?.metadata?.annotations?.[ANNOTATIONS.displayName];
+  return preferenceObject?.metadata?.annotations?.[ANNOTATIONS.displayName] || NO_DATA_DASH;
 };
 
 export const getPreferenceOSType = (obj: V1beta1DataSource): OS_NAME_TYPES => {


### PR DESCRIPTION
## 📝 Description

Add missing ability to sort Bootable volumes in _Bootable volumes_ list by OS name (_Operating system_ column).

## 🎥 Screenshots
**Before:**
Bootable volumes not sorted by OS, no ability to sort them:
![sort_before](https://user-images.githubusercontent.com/13417815/223191056-3a4e6489-1855-4545-8685-808da1c2dc83.png)

**After:**
Bootable volumes can be sorted by OS, ability to change the direction (ascending/descending):
![sort_after](https://user-images.githubusercontent.com/13417815/223191073-45c62092-27a6-49f6-99e4-922bd88ba405.png)


