### PR TITLE
Bug 2175641: Add volume from existing PVC not working

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/utils/constants.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/utils/constants.ts
@@ -6,6 +6,7 @@ import {
 } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { DEFAULT_DISK_SIZE } from '@kubevirt-utils/components/DiskModal/state/initialState';
 import { OPENSHIFT_OS_IMAGES_NS } from '@kubevirt-utils/constants/constants';
+import { CDI_BIND_REQUESTED_ANNOTATION } from '@kubevirt-utils/hooks/useCDIUpload/consts';
 
 export enum RADIO_FORM_SELECTION {
   UPLOAD_IMAGE = 'upload',
@@ -43,6 +44,9 @@ export const emptySourceDataVolume: V1beta1DataVolume = {
   metadata: {
     name: '',
     namespace: OPENSHIFT_OS_IMAGES_NS,
+    annotations: {
+      [CDI_BIND_REQUESTED_ANNOTATION]: 'true',
+    },
   },
   spec: {
     storage: {


### PR DESCRIPTION
## 📝 Description

creating a volume from the 'use existing PVC' in Add volume modal dialog is creating a non functional PVC due to missing annotation to bind CDI to the DV

## 🎥 Demo

