### PR TITLE
Bug 2176804: VM created with instanceType from UI cannot be started due to secret missing

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/SSHKeySection/SSHKeySection.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/SSHKeySection/SSHKeySection.tsx
@@ -31,7 +31,7 @@ const SSHKeySection: FC<SSHKeySectionProps> = ({
   const { t } = useKubevirtTranslation();
   const [namespace] = useActiveNamespace();
   const [newKeyValue, setNewKeyValue] = useState(sshSecretKey);
-  const [createSecretOpen, setCreateSecretOpen] = useState(!sshSecretName);
+  const [createSecretOpen, setCreateSecretOpen] = useState(false);
   const [selectedSecretName, setSelectedSecretName] = useState(sshSecretName);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isValidatedKey, setIsValidatedKey] = useState<boolean>(true);
@@ -42,6 +42,7 @@ const SSHKeySection: FC<SSHKeySectionProps> = ({
       : selectedSecretName;
     const secretKey = createSecretOpen ? newKeyValue : undefined;
     setSSHSecretCredentials({ sshSecretName: secretName, sshSecretKey: secretKey });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [newKeyValue, selectedSecretName, createSecretOpen]);
 
   return (


### PR DESCRIPTION
## 📝 Description

the ssh section component had an effect that generate a secret name as default, which causes the created VM to get stuck on Provisioning status

## 🎥 Demo

After:
https://user-images.githubusercontent.com/67270715/224018604-df8fc733-5e52-4384-8bb8-b4f51f865a8e.mp4


