### PR TITLE
Bug 2175054: Delete bootable volume modal crash the page

### DIFF
--- a/src/views/bootablevolumes/utils/utils.ts
+++ b/src/views/bootablevolumes/utils/utils.ts
@@ -46,7 +46,7 @@ export const deleteBootableVolumeMetadata = (obj: V1beta1DataSource) => {
       });
     }, {});
 
-  const annotationsWithoutDescription = Object.keys(obj?.metadata?.annotations)
+  const annotationsWithoutDescription = Object.keys(obj?.metadata?.annotations || {})
     .filter((key) => key !== 'description')
     .reduce((acc, key) => {
       return Object.assign(acc, {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Delete bootable volume modal crash the page as obj don't have annotations. This will fix it.

