### PR TITLE
Bug 2175571: Sort Catalog templates in grid view

### DIFF
--- a/src/views/catalog/templatescatalog/TemplatesCatalog.tsx
+++ b/src/views/catalog/templatescatalog/TemplatesCatalog.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC, useMemo, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
@@ -17,12 +17,12 @@ import { filterTemplates } from './utils/helpers';
 
 import './TemplatesCatalog.scss';
 
-const TemplatesCatalog: React.FC<RouteComponentProps<{ ns: string }>> = ({
+const TemplatesCatalog: FC<RouteComponentProps<{ ns: string }>> = ({
   match: {
     params: { ns: namespace },
   },
 }) => {
-  const [selectedTemplate, setSelectedTemplate] = React.useState<V1Template | undefined>(undefined);
+  const [selectedTemplate, setSelectedTemplate] = useState<V1Template | undefined>(undefined);
 
   const [filters, onFilterChange, clearAll] = useTemplatesFilters();
   const { templates, availableTemplatesUID, loaded, bootSourcesLoaded, availableDatasources } =
@@ -32,7 +32,7 @@ const TemplatesCatalog: React.FC<RouteComponentProps<{ ns: string }>> = ({
       onlyDefault: filters.onlyDefault,
     });
 
-  const filteredTemplates = React.useMemo(
+  const filteredTemplates = useMemo(
     () => filterTemplates(templates, filters),
     [templates, filters],
   );

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogItems.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogItems.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useMemo, VFC } from 'react';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
@@ -21,7 +21,7 @@ type TemplatesCatalogItemsProps = {
   loaded: boolean;
 };
 
-export const TemplatesCatalogItems: React.VFC<TemplatesCatalogItemsProps> = ({
+export const TemplatesCatalogItems: VFC<TemplatesCatalogItemsProps> = ({
   templates,
   availableTemplatesUID,
   availableDatasources,
@@ -31,6 +31,14 @@ export const TemplatesCatalogItems: React.VFC<TemplatesCatalogItemsProps> = ({
   loaded,
 }) => {
   const columns = useTemplatesCatalogColumns();
+
+  const sortedTemplates = useMemo(
+    () =>
+      templates.sort((a: V1Template, b: V1Template) =>
+        a?.metadata?.name?.localeCompare(b?.metadata?.name),
+      ),
+    [templates],
+  );
 
   return filters?.isList ? (
     <div className="vm-catalog-table-container">
@@ -47,7 +55,7 @@ export const TemplatesCatalogItems: React.VFC<TemplatesCatalogItemsProps> = ({
   ) : (
     <StackItem className="co-catalog-page__grid vm-catalog-grid-container">
       <Gallery hasGutter className="vm-catalog-grid" id="vm-catalog-grid">
-        {templates.map((template) => (
+        {sortedTemplates.map((template) => (
           <TemplateTile
             key={template?.metadata?.uid}
             template={template}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2175571

Sort the VM Templates in _Catalog_ alphabetically (by name), when displayed in the grid view.

## 🎥 Demo
**Before:**
Templates not sorted, beginning with "rhel...":
![sort_before](https://user-images.githubusercontent.com/13417815/224042336-638c14ec-1a15-4f3b-839b-c4272a92fd7a.png)

**After:**
Templates sorted by their names (ascending):
![sort_after](https://user-images.githubusercontent.com/13417815/224042365-e671c2d0-9810-4ac8-b59f-f5e705c2dc51.png)
