### PR TITLE
Bug 2176753: Remove dashed line from Configurations subtitle

### DIFF
--- a/src/views/migrationpolicies/details/tabs/details/components/MigrationPolicyDetailsSection/MigrationPolicyDetailsSection.tsx
+++ b/src/views/migrationpolicies/details/tabs/details/components/MigrationPolicyDetailsSection/MigrationPolicyDetailsSection.tsx
@@ -6,11 +6,13 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import {
+  Button,
+  ButtonVariant,
   DescriptionList,
   DescriptionListDescription,
+  DescriptionListTerm,
   DescriptionListTermHelpTextButton,
   Flex,
-  FlexItem,
   Grid,
   GridItem,
   Popover,
@@ -71,22 +73,23 @@ const MigrationPolicyDetailsSection: React.FC<MigrationPolicyDetailsSectionProps
               description={mp?.metadata?.annotations?.description}
             />
             <>
-              <DescriptionListTermHelpTextButton
-                onClick={() =>
-                  createModal(({ isOpen, onClose }) => (
-                    <MigrationPolicyEditModal isOpen={isOpen} onClose={onClose} mp={mp} />
-                  ))
-                }
-              >
-                <Flex spaceItems={{ default: 'spaceItemsNone' }}>
-                  <FlexItem>
+              <DescriptionListTerm>
+                <Button
+                  isInline
+                  onClick={() =>
+                    createModal(({ isOpen, onClose }) => (
+                      <MigrationPolicyEditModal isOpen={isOpen} onClose={onClose} mp={mp} />
+                    ))
+                  }
+                  variant={ButtonVariant.link}
+                >
+                  <Flex spaceItems={{ default: 'spaceItemsNone' }}>
                     <Title headingLevel="h2">{t('Configurations')}</Title>
-                  </FlexItem>
-                  <FlexItem>
-                    <PencilAltIcon className="kv-icon-space-l" />
-                  </FlexItem>
-                </Flex>
-              </DescriptionListTermHelpTextButton>
+                    <PencilAltIcon className="kv-icon-space-l pf-c-button-icon--plain" />
+                  </Flex>
+                </Button>
+              </DescriptionListTerm>
+
               <DescriptionListDescription>
                 <DescriptionList>
                   <MigrationPolicyDescriptionItem


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2176753

Remove the dashed line from the _Configurations_ subtitle in _MigrationPolicies_ _Details_ page, as there is no any helper text for the title, but the modal is opened instead, when clicking on it.

## 🎥 Screenshots
**Before:**
Misleading dashed line under _Configurations_, as there's no any popover/helper text when clicking on it:
![conf_before](https://user-images.githubusercontent.com/13417815/224078683-ed0b2231-2c75-4683-90b2-b081f2d1276c.png)

**After:**
Proper style for the link to edit Configurations (modal is opened after clicking on it):
![conf_after](https://user-images.githubusercontent.com/13417815/224078692-673a459b-0d24-478c-bd1a-c386b5a36768.png)
