### PR TITLE
Bug 2176843 - 'No bootable device' shows in VM console if it's created with instanceType

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -48,6 +48,12 @@ export const generateVM = (
                   disk: {
                     bus: 'virtio',
                   },
+                  name: `${virtualmachineName}-disk`,
+                },
+                {
+                  disk: {
+                    bus: 'virtio',
+                  },
                   name: 'cloudinitdisk',
                 },
               ],


### PR DESCRIPTION
## 📝 Description

missing disk on vm creation causes the VM to boot from cloud-init instead of booting from PVC

## 🎥 Demo

Before:
https://bugzilla.redhat.com/attachment.cgi?id=1949350

After:

https://user-images.githubusercontent.com/67270715/224098950-f029af42-22b2-4e8a-a703-3ed3779b05a6.mp4


