### PR TITLE
Bug 2158079: Align Storage expandable section with HelpIcon

### DIFF
--- a/src/utils/components/HelpTextIcon/HelpTextIcon.scss
+++ b/src/utils/components/HelpTextIcon/HelpTextIcon.scss
@@ -1,5 +1,5 @@
 .help-text-icon__popover {
-    font-size: var(--pf-global--FontSize--sm);
+  font-size: var(--pf-global--FontSize--sm);
 }
 
 .help-icon__cursor {

--- a/src/views/catalog/customize/components/CustomizeSource/ExpandableCustomizeSourceSection.scss
+++ b/src/views/catalog/customize/components/CustomizeSource/ExpandableCustomizeSourceSection.scss
@@ -1,0 +1,9 @@
+.expandable-customize-source-section__stack-item-storage {
+  .pf-l-flex {
+    --pf-l-flex--AlignItems: center;
+  }
+
+  .pf-c-expandable-section__toggle {
+    padding-right: var(--pf-c-expandable-section__toggle--PaddingTop);
+  }
+}

--- a/src/views/catalog/customize/components/CustomizeSource/ExpandableCustomizeSourceSection.tsx
+++ b/src/views/catalog/customize/components/CustomizeSource/ExpandableCustomizeSourceSection.tsx
@@ -1,21 +1,21 @@
-import * as React from 'react';
+import React, { FC, useState } from 'react';
 
+import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   ExpandableSection,
   ExpandableSectionToggle,
   Flex,
   FlexItem,
-  Popover,
-  PopoverPosition,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import { HelpIcon } from '@patternfly/react-icons';
 
 import { CustomizeSource, CustomizeSourceProps } from './CustomizeSource';
 
-export const ExpandableCustomizeSourceSection: React.FC<CustomizeSourceProps> = ({
+import './ExpandableCustomizeSourceSection.scss';
+
+export const ExpandableCustomizeSourceSection: FC<CustomizeSourceProps> = ({
   diskSource,
   setDiskSource,
   template,
@@ -28,13 +28,13 @@ export const ExpandableCustomizeSourceSection: React.FC<CustomizeSourceProps> = 
   isBootSourceAvailable,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [storageFieldsExpanded, setStorageFieldsExpanded] = React.useState<boolean>(
+  const [storageFieldsExpanded, setStorageFieldsExpanded] = useState<boolean>(
     !isBootSourceAvailable,
   );
 
   return (
     <Stack hasGutter>
-      <StackItem>
+      <StackItem className="expandable-customize-source-section__stack-item-storage">
         <Flex>
           <FlexItem spacer={{ default: 'spacerNone' }}>
             <ExpandableSectionToggle
@@ -46,19 +46,11 @@ export const ExpandableCustomizeSourceSection: React.FC<CustomizeSourceProps> = 
             </ExpandableSectionToggle>
           </FlexItem>
           <FlexItem>
-            <Popover
-              position={PopoverPosition.top}
-              aria-label="Condition Popover"
-              bodyContent={() => (
-                <div>
-                  {t(
-                    'You can customize the Templates storage by overriding the original parameters',
-                  )}
-                </div>
+            <HelpTextIcon
+              bodyContent={t(
+                'You can customize the Templates storage by overriding the original parameters',
               )}
-            >
-              <HelpIcon />
-            </Popover>
+            />
           </FlexItem>
         </Flex>
       </StackItem>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2158079

Align _Storage_ expandable section with its `HelpIcon` "?", in _Customize Template parameters_ when creating a VM.

## 🎥 Screenshots
**Before:**
Storage and "?" not aligned nicely, "?" too far from Storage:
![align_before](https://user-images.githubusercontent.com/13417815/224360612-26fffe32-a549-4521-b3eb-6e39b1b6dd81.png)

**After:**
Storage and "?" aligned properly:
![align_after](https://user-images.githubusercontent.com/13417815/224360628-0b291e5d-362f-4009-b450-abb0aacd504a.png)



