### PR TITLE
Bug 2176725: Carry over "Start this VirtualMachine after creation" value

### DIFF
--- a/src/views/catalog/customize/utils.ts
+++ b/src/views/catalog/customize/utils.ts
@@ -40,7 +40,7 @@ export const overrideVirtualMachineDataVolumeSpec = (
 };
 
 export const setTemplateParameters = (template: V1Template, formData: FormData): V1Template => {
-  template.parameters = template.parameters.map((parameter) => {
+  template.parameters = template?.parameters?.map((parameter) => {
     const formParameter = formData.get(parameter.name) as string;
     if (formParameter.length > 0) parameter.value = formParameter;
 

--- a/src/views/catalog/utils/WizardVMContext/utils/tabs-data.ts
+++ b/src/views/catalog/utils/WizardVMContext/utils/tabs-data.ts
@@ -14,4 +14,5 @@ export type TabsData = {
   disks?: {
     dataVolumesToAddOwnerRef?: V1beta1DataVolume[];
   };
+  startVM?: boolean;
 };


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2176725

Carry over "Start this VirtualMachine after creation" checkbox value to the last step of creating VM when customizing VM.

Notes:
For achieving the expected behavior `useWizardVMContext` hook was used.
Also note that changes in _src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx_ look a bit wild, but that's just because indentation was updated a bit, due to importing `memo` from `'react'`, and only [this](https://github.com/kubevirt-ui/kubevirt-plugin/compare/main...hstastna:BZ_Start_this_VirtualMachine_after_creation_not_carried_over?expand=1#diff-fcad411937b404f59f942a70de7a8de426f001e371ff8bdaef5151d8409569baR48) and  [this piece of code](https://github.com/kubevirt-ui/kubevirt-plugin/compare/main...hstastna:BZ_Start_this_VirtualMachine_after_creation_not_carried_over?expand=1#diff-fcad411937b404f59f942a70de7a8de426f001e371ff8bdaef5151d8409569baR99-R103) was added.

## 🎥 Screenshots
Unchecking the checkbox, when creating a VM from the chosen template in Catalog:
![unchecking](https://user-images.githubusercontent.com/13417815/224398764-a6628522-4db9-4c6c-9a2d-dc66063595c0.png)

**Before:**
The checkbox is checked no matter we un-checked it in the catalog drawer earlier:
![ch_before](https://user-images.githubusercontent.com/13417815/224398037-2a0cb9fa-7924-42b7-8835-18bce84d7881.png)

**After:**
The checkbox is unchecked as expected :
![ch_after](https://user-images.githubusercontent.com/13417815/224398046-5aed4cce-a285-44e1-b41c-323fc264f1a6.png)
