### PR TITLE
Bug 2174334: VM's disk is not deleted along with the VM if the VM is created from upload image

### DIFF
--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -131,7 +131,10 @@ export const getDataVolumeFromState = ({
   createOwnerReference?: boolean;
 }): V1beta1DataVolume => {
   const dataVolume = getEmptyVMDataVolumeResource(vm, createOwnerReference);
-  const dvName = resultVolume?.dataVolume?.name || `${vm?.metadata?.name}-${diskState.diskName}`;
+  const dvName =
+    resultVolume?.dataVolume?.name ||
+    resultVolume?.persistentVolumeClaim?.claimName ||
+    `${vm?.metadata?.name}-${diskState.diskName}`;
 
   dataVolume.metadata.name = dvName;
   dataVolume.spec.storage.resources.requests.storage = diskState.diskSize;
@@ -174,7 +177,6 @@ export const getDataVolumeFromState = ({
     dataVolume.spec.source = {
       upload: {},
     };
-    dataVolume.metadata.name = `uploaded-${diskState.diskName}`;
   }
   return dataVolume;
 };


### PR DESCRIPTION
## 📝 Description

DataVolumes are now garbage collected, so when trying to update ownerReference for the upload's DV, it will not find it.
updating owner reference on correlated PVC, so the PVC will be GC when deleting VM.
Also fixed an issue where the volume name and the PVC resource name didn't match which caused the VM to fail on start

## 🎥 Demo

Before:

https://user-images.githubusercontent.com/67270715/224706010-c431cc4a-5988-464d-b926-110028c347e5.mp4


https://user-images.githubusercontent.com/67270715/224706017-ff8d7f0f-ac84-4402-a473-feee5d709b48.mp4

After:

https://user-images.githubusercontent.com/67270715/224706060-eecad2db-a54b-473c-af4f-471e1ce60b83.mp4


https://user-images.githubusercontent.com/67270715/224706065-a9cb4f2f-ae54-442c-801e-7103d111c87e.mp4


