### PR TITLE
Bug 2177589: Sort Preferences in Add volume modal

### DIFF
--- a/src/views/bootablevolumes/list/BootableVolumesList.tsx
+++ b/src/views/bootablevolumes/list/BootableVolumesList.tsx
@@ -31,7 +31,7 @@ import './BootableVolumesList.scss';
 const BootableVolumesList: FC = () => {
   const { t } = useKubevirtTranslation();
   const [dataSources, loadedDataSources, loadErrorDataSources] = useBootableVolumes();
-  const { preferences, instanceTypes, loaded, loadError } = useInstanceTypesAndPreferences();
+  const { preferences, instanceTypes, loadError } = useInstanceTypesAndPreferences();
   const instanceTypesNames = (instanceTypes || []).map(getName).sort((a, b) => a.localeCompare(b));
   const [data, filteredData, onFilterChange] = useListPageFilter(
     getAvailableDataSources(dataSources),
@@ -55,7 +55,6 @@ const BootableVolumesList: FC = () => {
         <AddBootableVolumeButton
           preferencesNames={Object.keys(convertResourceArrayToMap(preferences))}
           instanceTypesNames={instanceTypesNames}
-          loaded={loaded}
           loadError={loadError}
           buttonVariant={ButtonVariant.primary}
         />

--- a/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
@@ -33,7 +33,7 @@ const CreateFromInstanceType: FC = () => {
   const [ns] = useActiveNamespace();
 
   const bootableVolumesResources = useBootableVolumes();
-  const { preferences, instanceTypes, loaded, loadError } = useInstanceTypesAndPreferences();
+  const { preferences, instanceTypes, loadError } = useInstanceTypesAndPreferences();
   const preferencesMap = useMemo(() => convertResourceArrayToMap(preferences), [preferences]);
   const instanceTypesMap = useMemo(() => convertResourceArrayToMap(instanceTypes), [instanceTypes]);
 
@@ -84,13 +84,8 @@ const CreateFromInstanceType: FC = () => {
                 sectionState={sectionState}
                 headerAction={
                   <AddBootableVolumeButton
-                    preferencesNames={Object.keys(preferencesMap).sort((a, b) =>
-                      a.localeCompare(b),
-                    )}
-                    instanceTypesNames={Object.keys(instanceTypesMap).sort((a, b) =>
-                      a.localeCompare(b),
-                    )}
-                    loaded={loaded}
+                    preferencesNames={Object.keys(preferencesMap)}
+                    instanceTypesNames={Object.keys(instanceTypesMap)}
                     loadError={loadError}
                   />
                 }

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeButton/AddBootableVolumeButton.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeButton/AddBootableVolumeButton.tsx
@@ -9,7 +9,6 @@ import AddBootableVolumeModal from '../AddBootableVolumeModal/AddBootableVolumeM
 export type AddBootableVolumeButtonProps = {
   preferencesNames: string[];
   instanceTypesNames: string[];
-  loaded: boolean;
   loadError?: any;
   buttonVariant?: ButtonVariant;
 };
@@ -17,12 +16,12 @@ export type AddBootableVolumeButtonProps = {
 const AddBootableVolumeButton: FC<AddBootableVolumeButtonProps> = ({
   preferencesNames,
   instanceTypesNames,
-  loaded,
   loadError,
   buttonVariant,
 }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
+
   return (
     <Button
       onClick={() =>

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -82,7 +82,7 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
   const isUploadForm = formSelection === RADIO_FORM_SELECTION.UPLOAD_IMAGE;
 
   const instanceTypesToSizesMap = useMemo(
-    () => getInstanceTypesToSizesMap(instanceTypesNames),
+    () => getInstanceTypesToSizesMap(instanceTypesNames.sort((a, b) => a.localeCompare(b))),
     [instanceTypesNames],
   );
   const instanceTypeAndSize = useMemo(
@@ -249,7 +249,7 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
           <FilterSelect
             selected={labels?.[DEFAULT_PREFERENCE_LABEL]}
             setSelected={setBootableVolumeField('labels', DEFAULT_PREFERENCE_LABEL)}
-            options={preferencesNames}
+            options={preferencesNames.sort((a, b) => a.localeCompare(b))}
             groupVersionKind={VirtualMachineClusterPreferenceModelGroupVersionKind}
             optionLabelText={t('preference')}
           />


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2177589

Sort the preferences names in _Preference_ field/drop down, in _Add volume to boot from_ modal alphabetically, no matter where the modal is accessible from.

Move sorting of InstanceTypes names alphabetically to the modal component, too.

Also remove forgotten `loaded` prop from the component `AddBootableVolumeButton` and from the places where the component is used.

## 🎥 Screenshots
**Before:**
Preferences names not sorted in the modal, in _Bootable volumes_ list:
![pref_before](https://user-images.githubusercontent.com/13417815/224779774-04dfbe6d-6e46-4a24-a39b-058824b1773e.png)

**After:**
Preferences names sorted alphabetically:
![pref_after](https://user-images.githubusercontent.com/13417815/224779791-44baa4f0-4f78-464b-b057-9b65e0bc7b67.png)

