### PR TITLE
Bug 2173563: Add titles to VM Environment and Scripts tabs

### DIFF
--- a/src/utils/components/EnvironmentEditor/EnvironmentForm.scss
+++ b/src/utils/components/EnvironmentEditor/EnvironmentForm.scss
@@ -1,0 +1,3 @@
+.environment-form__form {
+  margin-top: var(--pf-global--spacer--lg);
+}

--- a/src/utils/components/EnvironmentEditor/EnvironmentForm.tsx
+++ b/src/utils/components/EnvironmentEditor/EnvironmentForm.tsx
@@ -15,6 +15,8 @@ import EnvironmentFormTitle from './components/EnvironmentFormTitle';
 import useEnvironments from './hooks/useEnvironments';
 import useEnvironmentsResources from './hooks/useEnvironmentsResources';
 
+import './EnvironmentForm.scss';
+
 type EnvironmentFormProps = {
   vm: V1VirtualMachine;
   onEditChange?: (edited: boolean) => void;
@@ -59,8 +61,8 @@ const EnvironmentForm: FC<EnvironmentFormProps> = ({ vm, onEditChange, updateVM 
 
   return (
     <SidebarEditor<V1VirtualMachine> resource={temporaryVM} onChange={setTemporaryVM}>
-      <Form>
-        <EnvironmentFormTitle />
+      <EnvironmentFormTitle />
+      <Form className="environment-form__form">
         {environments.length !== 0 && (
           <div className="row pairs-list__heading">
             <div className="col-xs-5 text-secondary text-uppercase" id="environment-name-header">

--- a/src/utils/components/EnvironmentEditor/components/EnvironmentFormTitle.tsx
+++ b/src/utils/components/EnvironmentEditor/components/EnvironmentFormTitle.tsx
@@ -1,32 +1,29 @@
-import * as React from 'react';
+import React, { FC, memo } from 'react';
 
+import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Popover, Title } from '@patternfly/react-core';
-import { HelpIcon } from '@patternfly/react-icons';
+import { Flex, FlexItem, Title } from '@patternfly/react-core';
 
-const EnvironmentFormTitle: React.FC = React.memo(() => {
+const EnvironmentFormTitle: FC = memo(() => {
   const { t } = useKubevirtTranslation();
+
   return (
     <>
-      <SidebarEditorSwitch />
-      <Title headingLevel="h2" className="co-section-heading">
-        <span>
-          {t('Include all values from existing config maps, secrets or service accounts (as disk)')}{' '}
-          <Popover
-            aria-label={'Help'}
-            bodyContent={() => (
-              <div>
-                {t(
-                  'Add new values by referencing an existing config map, secret or service account. Using these values requires mounting them manually to the VM.',
-                )}
-              </div>
-            )}
-          >
-            <HelpIcon />
-          </Popover>
-        </span>
+      <Title headingLevel="h2">
+        <Flex>
+          <FlexItem>{t('Environment')}</FlexItem>
+          <FlexItem>
+            <SidebarEditorSwitch />
+          </FlexItem>
+        </Flex>
       </Title>
+      {t('Include all values from existing config maps, secrets or service accounts (as disk)')}{' '}
+      <HelpTextIcon
+        bodyContent={t(
+          'Add new values by referencing an existing config map, secret or service account. Using these values requires mounting them manually to the VM.',
+        )}
+      />
     </>
   );
 });

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSection/SchedulingSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSection/SchedulingSection.tsx
@@ -43,6 +43,7 @@ const SchedulingSection: React.FC<SchedulingSectionProps> = ({ vm, pathname }) =
   });
   const accessReview = asAccessReview(VirtualMachineModel, vm, 'update' as K8sVerb);
   const [canUpdateVM] = useAccessReview(accessReview || {});
+
   return (
     <div className="vm-scheduling-section">
       <a href={`${pathname}#scheduling`} className="link-icon">

--- a/src/views/virtualmachines/details/tabs/configuration/scripts/ScriptsTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scripts/ScriptsTab.tsx
@@ -23,10 +23,13 @@ import {
 import {
   DescriptionList,
   Divider,
+  Flex,
+  FlexItem,
   PageSection,
   Stack,
   Text,
   TextVariants,
+  Title,
 } from '@patternfly/react-core';
 
 import VirtualMachineDescriptionItem from '../../details/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
@@ -70,7 +73,15 @@ const ScriptsTab: React.FC<VirtualMachineScriptPageProps> = ({ obj: vm }) => {
       <SidebarEditor resource={vm} onResourceUpdate={onSubmit}>
         {(resource) => (
           <DescriptionList className="vm-scripts-tab">
-            <SidebarEditorSwitch />
+            <Title headingLevel="h2">
+              <Flex>
+                <FlexItem>{t('Scripts')}</FlexItem>
+                <FlexItem>
+                  <SidebarEditorSwitch />
+                </FlexItem>
+              </Flex>
+            </Title>
+
             <VirtualMachineDescriptionItem
               descriptionData={<CloudInitDescription vm={resource} />}
               descriptionHeader={t('Cloud-init')}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2173563

Add missing titles to VM _Environment_ and _Scripts_ tabs, place the _YAML_ switcher next to them.

Make the existing subtitle for Environment tab smaller, position its text properly:
_Include all values from existing config maps, secrets or service accounts (as disk)_

Make these changes to achieve consistency with the other tabs.

## 🎥 Screenshots
**Before:**
_Environment_ tab without the title, subtitle too big:
![env_before](https://user-images.githubusercontent.com/13417815/224832288-771dc7c4-f145-4a2e-9450-4c41ea9fdb18.png)
_Scripts_ tab without the title:
![scripts_before](https://user-images.githubusercontent.com/13417815/224832304-fdbae3e5-8d2a-4193-932f-20461ab02880.png)

**After:**
_Environment_ tab with the nice title and subtitle:
![env_after](https://user-images.githubusercontent.com/13417815/224832329-edc4020b-fbd7-4dd9-840f-96f7ef4ef36b.png)
_Scripts_ tab with the title:
![scripts_after](https://user-images.githubusercontent.com/13417815/224832344-16ab2e87-8e3d-4fda-8ac3-a6852f3f621a.png)








