### PR TITLE
Bug 2176706: Fix inner tabs routing

### DIFF
--- a/src/utils/components/PendingChanges/utils/constants.ts
+++ b/src/utils/components/PendingChanges/utils/constants.ts
@@ -15,6 +15,14 @@ export enum VirtualMachineDetailsTab {
   Configurations = 'configurations',
 }
 
+export const VirtualMachineConfigurationTabInner = {
+  [VirtualMachineDetailsTab.Scripts]: VirtualMachineDetailsTab.Scripts,
+  [VirtualMachineDetailsTab.Disks]: VirtualMachineDetailsTab.Disks,
+  [VirtualMachineDetailsTab.Scheduling]: VirtualMachineDetailsTab.Scheduling,
+  [VirtualMachineDetailsTab.NetworkInterfaces]: VirtualMachineDetailsTab.NetworkInterfaces,
+  [VirtualMachineDetailsTab.Environment]: VirtualMachineDetailsTab.Environment,
+};
+
 export enum VirtualMachineDetailsTabLabel {
   // t('Overview')
   Overview = 'Overview',

--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -28,7 +28,11 @@ import { DESCHEDULER_EVICT_LABEL } from '@kubevirt-utils/resources/vmi';
 import { getVMIVolumes } from '@kubevirt-utils/resources/vmi/utils/selectors';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
-import { VirtualMachineDetailsTabLabel } from './constants';
+import {
+  VirtualMachineConfigurationTabInner,
+  VirtualMachineDetailsTab,
+  VirtualMachineDetailsTabLabel,
+} from './constants';
 import { PendingChange } from './types';
 
 export const checkCPUMemoryChanged = (
@@ -352,8 +356,12 @@ export const getChangedHeadlessMode = (
   );
 };
 
-export const getTabURL = (vm: V1VirtualMachine, tab: string) =>
-  `/k8s/ns/${vm?.metadata?.namespace}/${VirtualMachineModelRef}/${vm?.metadata?.name}/${tab}`;
+export const getTabURL = (vm: V1VirtualMachine, tab: string) => {
+  const tabPath = VirtualMachineConfigurationTabInner[tab]
+    ? `${VirtualMachineDetailsTab.Configurations}/${tab}`
+    : tab;
+  return `/k8s/ns/${vm?.metadata?.namespace}/${VirtualMachineModelRef}/${vm?.metadata?.name}/${tabPath}`;
+};
 
 export const getPendingChangesByTab = (pendingChanges: PendingChange[]) => {
   const pendingChangesDetailsTab = pendingChanges?.filter(

--- a/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
@@ -11,6 +11,7 @@ export type VirtualMachineDetailsPageProps = {
   namespace: string;
   kind: string;
 };
+import './virtual-machine-page.scss';
 
 const VirtualMachineNavPage: React.FC<VirtualMachineDetailsPageProps> = ({
   name,

--- a/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
@@ -15,8 +15,6 @@ import { getVMStatusIcon } from '../utils';
 
 import VirtualMachinePendingChangesAlert from './VirtualMachinePendingChangesAlert';
 
-import './virtual-machine-page-title.scss';
-
 type VirtualMachineNavPageTitleProps = {
   vm: V1VirtualMachine;
   name: string;

--- a/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
+++ b/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
@@ -3,6 +3,7 @@ import {
   VirtualMachineDetailsTabLabel,
 } from '@kubevirt-utils/components/PendingChanges/utils/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { NETWORK } from '@virtualmachines/utils';
 
 import VirtualMachineConfigurationTab from '../tabs/configuration/VirtualMachineConfigurationTab';
 import VirtualMachineConsolePage from '../tabs/console/VirtualMachineConsolePage';
@@ -41,6 +42,31 @@ export const useVirtualMachineTabs = () => {
     {
       href: VirtualMachineDetailsTab.Configurations,
       name: t(VirtualMachineDetailsTabLabel.Configuration),
+      component: VirtualMachineConfigurationTab,
+    },
+    {
+      href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Disks}`,
+      name: 'hide',
+      component: VirtualMachineConfigurationTab,
+    },
+    {
+      href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Environment}`,
+      name: 'hide',
+      component: VirtualMachineConfigurationTab,
+    },
+    {
+      href: `${VirtualMachineDetailsTab.Configurations}/${NETWORK}`,
+      name: 'hide',
+      component: VirtualMachineConfigurationTab,
+    },
+    {
+      href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Scheduling}`,
+      name: 'hide',
+      component: VirtualMachineConfigurationTab,
+    },
+    {
+      href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Scripts}`,
+      name: 'hide',
       component: VirtualMachineConfigurationTab,
     },
     {

--- a/src/views/virtualmachines/details/tabs/configuration/disk/modal/MakePersistentModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/disk/modal/MakePersistentModal.tsx
@@ -22,7 +22,7 @@ const MakePersistentModal: FC<MakePersistentModalProps> = ({ vm, volume, isOpen,
 
   const updatedVirtualMachine = useMemo(() => {
     return produce(vm, (draftVM) => {
-      const volumes = [...getVolumes(vm)].map((machineVolume) => {
+      const volumes = [...getVolumes(draftVM)].map((machineVolume) => {
         if (machineVolume?.name === volume?.name) {
           if (machineVolume?.dataVolume?.hotpluggable)
             delete machineVolume?.dataVolume?.hotpluggable;

--- a/src/views/virtualmachines/details/tabs/configuration/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/utils/utils.ts
@@ -1,4 +1,8 @@
-import { VirtualMachineDetailsTabLabel } from '@kubevirt-utils/components/PendingChanges/utils/constants';
+import {
+  VirtualMachineDetailsTab,
+  VirtualMachineDetailsTabLabel,
+} from '@kubevirt-utils/components/PendingChanges/utils/constants';
+import { NETWORK } from '@virtualmachines/utils';
 
 import DiskListPage from '../disk/DiskListPage';
 import VirtualMachineEnvironmentPage from '../environment/VirtualMachineEnvironmentPage';
@@ -7,9 +11,40 @@ import VirtualMachineSchedulingPage from '../scheduling/VirtualMachineScheduling
 import ScriptsTab from '../scripts/ScriptsTab';
 
 export const tabs = [
-  { title: VirtualMachineDetailsTabLabel.Scheduling, Component: VirtualMachineSchedulingPage },
-  { title: VirtualMachineDetailsTabLabel.Environment, Component: VirtualMachineEnvironmentPage },
-  { title: VirtualMachineDetailsTabLabel.NetworkInterfaces, Component: NetworkInterfaceListPage },
-  { title: VirtualMachineDetailsTabLabel.Disks, Component: DiskListPage },
-  { title: VirtualMachineDetailsTabLabel.Scripts, Component: ScriptsTab },
+  {
+    title: VirtualMachineDetailsTabLabel.Scheduling,
+    Component: VirtualMachineSchedulingPage,
+    name: VirtualMachineDetailsTab.Scheduling,
+  },
+  {
+    title: VirtualMachineDetailsTabLabel.Environment,
+    Component: VirtualMachineEnvironmentPage,
+    name: VirtualMachineDetailsTab.Environment,
+  },
+  {
+    title: VirtualMachineDetailsTabLabel.NetworkInterfaces,
+    Component: NetworkInterfaceListPage,
+    name: NETWORK,
+  },
+  {
+    title: VirtualMachineDetailsTabLabel.Disks,
+    Component: DiskListPage,
+    name: VirtualMachineDetailsTab.Disks,
+  },
+  {
+    title: VirtualMachineDetailsTabLabel.Scripts,
+    Component: ScriptsTab,
+    name: VirtualMachineDetailsTab.Scripts,
+  },
 ];
+
+export const innerTabs: { [key: string]: string } = tabs.reduce((acc, { name }) => {
+  acc[name] = name;
+  return acc;
+}, {});
+
+export const getInnerTabFromPath = (path: string) =>
+  innerTabs[path.slice(path.lastIndexOf('/') + 1)];
+
+export const includesConfigurationPath = (path: string): boolean =>
+  path.includes(`${VirtualMachineDetailsTab.Configurations}/`);

--- a/src/views/virtualmachines/details/virtual-machine-page-title.scss
+++ b/src/views/virtualmachines/details/virtual-machine-page-title.scss
@@ -1,3 +1,0 @@
-.vm-resource-label {
-    vertical-align: middle;
-}

--- a/src/views/virtualmachines/details/virtual-machine-page.scss
+++ b/src/views/virtualmachines/details/virtual-machine-page.scss
@@ -1,0 +1,8 @@
+.vm-resource-label {
+  vertical-align: middle;
+}
+li.co-m-horizontal-nav__menu-item {
+  a[data-test-id='horizontal-link-hide'] {
+    display: none;
+  }
+}

--- a/src/views/virtualmachines/utils/constants.ts
+++ b/src/views/virtualmachines/utils/constants.ts
@@ -25,3 +25,5 @@ export const booleanTextIds = {
   yes: 'yes',
   no: 'no',
 };
+
+export const NETWORK = 'netwrok';


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Configuration inner tabs were missing routing, this is a small hack to add routing as we don't have support from SDK tabs, nor can we add Route from react-router-dom as the tabs from patternfly are nested into Tabs which causes the Switch not to work.

## 🎥 Demo

After:
![routes](https://user-images.githubusercontent.com/14824964/224985983-c66cd225-8962-41fa-8000-e8e8060f5747.gif)
