### PR TITLE
Bug 2168480: Correct the link for Virtualization dashboard

### DIFF
--- a/src/views/virtualmachines/details/tabs/metrics/TimeRange/TimeRange.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/TimeRange/TimeRange.tsx
@@ -20,7 +20,9 @@ const TimeRange: React.FC = () => {
         <DurationDropdown selectedDuration={duration} selectHandler={onDurationSelect} />
       </span>
 
-      <Link to={'/overview'}>{t('Virtualization dashboard')}</Link>
+      <Link to={'/monitoring/dashboards/grafana-dashboard-kubevirt-top-consumers'}>
+        {t('Virtualization dashboard')}
+      </Link>
     </div>
   );
 };


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2168480

Correct the link for _Virtualization dashboard_ present in VM's _Metrics_ tab, so it redirects to _Observe -> Dashboards_
with "KubeVirt / Infrastructure Resources / Top Consumers" selected in the _Dashboard_ drop down.

## 🎥 Screenshots
When clicking on _Virtualization dashboard_:
![virt_dash](https://user-images.githubusercontent.com/13417815/225421125-2f9f1400-1767-422b-88b2-7045ef7e5bf7.png)

**Before:**
Clicking on _Virtualization dashboard_ leads to the following unexpected page:
![link_before](https://user-images.githubusercontent.com/13417815/225420318-fe3aba9c-5a5a-426b-a870-4952dc6f29e5.png)

**After:**
Clicking on _Virtualization dashboard_ leads us to the correct page:
![link_after](https://user-images.githubusercontent.com/13417815/225420343-4fc3cd07-9207-474e-9242-974e2d72debc.png)


