### PR TITLE
Bug 2177973: Display cloning bootable volumes, add "Clone in progress"

### DIFF
--- a/src/utils/resources/shared.ts
+++ b/src/utils/resources/shared.ts
@@ -16,6 +16,7 @@ import {
 import { isDataSourceReady } from '../../views/datasources/utils';
 
 import { isEmpty } from './../utils/utils';
+import { isDataSourceCloning } from './template/hooks/useVmTemplateSource/utils';
 import { TEMPLATE_TYPE_LABEL } from './template';
 
 /**
@@ -315,3 +316,16 @@ export const convertResourceArrayToMap = <A extends K8sResourceCommon = K8sResou
  */
 export const getAvailableDataSources = (dataSources: V1beta1DataSource[]): V1beta1DataSource[] =>
   dataSources?.filter((dataSource) => isDataSourceReady(dataSource));
+
+/**
+ * function to get all V1beta1DataSource objects with condition type 'Ready'and status 'True'
+ * and/or also those with 'False' status but only 'CloneScheduled' or 'CloneInProgress' reason (cloning of the DS in progress)
+ * @param {V1beta1DataSource[]} dataSources list of DataSources to be filtered
+ * @returns list of available/ready/cloning DataSources
+ */
+export const getAvailableOrCloningDataSources = (
+  dataSources: V1beta1DataSource[],
+): V1beta1DataSource[] =>
+  dataSources?.filter(
+    (dataSource) => isDataSourceReady(dataSource) || isDataSourceCloning(dataSource),
+  );

--- a/src/views/bootablevolumes/list/BootableVolumesList.tsx
+++ b/src/views/bootablevolumes/list/BootableVolumesList.tsx
@@ -7,7 +7,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { DataSourceModelGroupVersionKind, DataSourceModelRef } from '@kubevirt-utils/models';
 import {
   convertResourceArrayToMap,
-  getAvailableDataSources,
+  getAvailableOrCloningDataSources,
   getName,
 } from '@kubevirt-utils/resources/shared';
 import {
@@ -34,7 +34,7 @@ const BootableVolumesList: FC = () => {
   const { preferences, instanceTypes, loadError } = useInstanceTypesAndPreferences();
   const instanceTypesNames = (instanceTypes || []).map(getName).sort((a, b) => a.localeCompare(b));
   const [data, filteredData, onFilterChange] = useListPageFilter(
-    getAvailableDataSources(dataSources),
+    getAvailableOrCloningDataSources(dataSources),
     useBootableVolumesFilters(),
   );
   const [pagination, setPagination] = useState(paginationInitialState);

--- a/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
+++ b/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
@@ -2,6 +2,8 @@ import React, { FC } from 'react';
 
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { V1alpha2VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isDataSourceCloning } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import {
   K8sGroupVersionKind,
@@ -10,6 +12,7 @@ import {
   TableData,
   Timestamp,
 } from '@openshift-console/dynamic-plugin-sdk';
+import { Label, Split, SplitItem } from '@patternfly/react-core';
 
 import BootableVolumesActions from '../../actions/BootableVolumesActions';
 import { getDataSourcePreferenceLabelValue, getPreferenceReadableOS } from '../../utils/utils';
@@ -24,10 +27,21 @@ const BootableVolumesRow: FC<
     }
   >
 > = ({ obj, activeColumnIDs, rowData: { groupVersionKind, preferences, instanceTypesNames } }) => {
+  const { t } = useKubevirtTranslation();
+
   return (
     <>
       <TableData id="name" activeColumnIDs={activeColumnIDs} className="pf-m-width-15">
-        <ResourceLink groupVersionKind={groupVersionKind} name={obj?.metadata?.name} />
+        <Split hasGutter>
+          <SplitItem>
+            <ResourceLink groupVersionKind={groupVersionKind} name={obj?.metadata?.name} />
+          </SplitItem>
+          {isDataSourceCloning(obj) && (
+            <SplitItem>
+              <Label>{t('Clone in progress')}</Label>
+            </SplitItem>
+          )}
+        </Split>
       </TableData>
       <TableData id="os" activeColumnIDs={activeColumnIDs} className="pf-m-width-15">
         {getPreferenceReadableOS(obj, preferences)}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2177973

Display volumes that are boing cloned in _Bootable volumes_ list, also display _Clone in progress_ label in _Name_ column for such bootable volumes in the list, so the user can see a volume immediately in the list, right after they add it (via Add volume to boot from modal), so they know what is going on.

## 🎥 Screenshots
**Before:**
After adding a new bootable volume, nothing has appeared in the list, user has to wait and wondering what's going on:
![clone_before](https://user-images.githubusercontent.com/13417815/225679469-9915a4ea-d38c-4de5-846e-3b22cb9f3acd.png)

**After:**
After adding a new bootable volume, the volume did appear in the list immediately, together with the label:
![clone_after](https://user-images.githubusercontent.com/13417815/225679486-72028798-740d-4b1f-82b4-e426a57fb840.png)

