### PR TITLE
Bug 2175977: Disable Create VM button if not everything selected

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
@@ -1,8 +1,9 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import produce from 'immer';
 
 import { SSHSecretCredentials } from '@catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/SSHKeySection/utils/types';
+import { DEFAULT_INSTANCETYPE_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -53,6 +54,14 @@ const CreateVMFooter: FC<CreateVMFooterProps> = ({
     namespace: vm?.metadata?.namespace,
     group: VirtualMachineModel.apiGroup,
   });
+
+  const hasNameAndInstanceType = useMemo(
+    () =>
+      !isEmpty(vm?.metadata?.name) &&
+      (!isEmpty(selectedBootableVolume?.metadata?.labels?.[DEFAULT_INSTANCETYPE_LABEL]) ||
+        !isEmpty(vm?.spec?.instancetype?.name)),
+    [selectedBootableVolume, vm],
+  );
 
   const handleSubmit = async () => {
     setIsSubmitting(true);
@@ -110,6 +119,7 @@ const CreateVMFooter: FC<CreateVMFooterProps> = ({
       .catch(setError)
       .finally(() => setIsSubmitting(false));
   };
+
   return (
     <footer className="create-vm-instance-type-footer">
       <Stack hasGutter>
@@ -142,7 +152,12 @@ const CreateVMFooter: FC<CreateVMFooterProps> = ({
             <SplitItem>
               <Button
                 isLoading={isSubmitting}
-                isDisabled={isSubmitting || isEmpty(selectedBootableVolume) || !canCreateVM}
+                isDisabled={
+                  isSubmitting ||
+                  isEmpty(selectedBootableVolume) ||
+                  !canCreateVM ||
+                  !hasNameAndInstanceType
+                }
                 onClick={handleSubmit}
                 variant={ButtonVariant.primary}
               >


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2175977

Disable _Create VirtualMachine_ button when creating a VM from InstanceType, if not everything needed is selected, for example when a VM name is missing or InstanceType selection (in case that a chosen volume is missing label with InstanceType name).

## 🎥 Screenshots
**Before**:
Name and InstanceType missing but _Create VirtualMachine_ button still enabled: 
![no_before](https://user-images.githubusercontent.com/13417815/225955280-08f44e98-dc60-43e6-8073-55791a10485b.png)

**After:**
Name and InstanceType missing and _Create VirtualMachine_ button disabled, as expected: 
![no_after](https://user-images.githubusercontent.com/13417815/225955296-f7d578cd-faf1-463d-99f3-297dc54cd005.png)
