### PR TITLE
Bug 2177888: fix pending notification

### DIFF
--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -42,13 +42,18 @@ export const checkCPUMemoryChanged = (
   if (isEmpty(vm) || isEmpty(vmi)) {
     return false;
   }
-  const vmRequests = vm?.spec?.template?.spec?.domain?.resources?.requests || {};
+  const vmRequests = vm?.spec?.template?.spec?.domain?.resources?.requests;
   const vmCPU = vm?.spec?.template?.spec?.domain?.cpu?.cores || 0;
 
-  const vmiRequests = vmi?.spec?.domain?.resources?.requests || {};
+  const vmiRequests: { [key in string]?: string } = vmi?.spec?.domain?.resources?.requests || {};
+
   const vmiCPU = vmi?.spec?.domain?.cpu?.cores || 0;
 
-  return !isEqualObject(vmRequests, vmiRequests) || vmCPU !== vmiCPU;
+  const memoryChanged = vmRequests
+    ? !isEqualObject(vmRequests, vmiRequests)
+    : vmiRequests?.memory !== vm?.spec?.template?.spec?.domain?.memory?.guest;
+
+  return memoryChanged || vmCPU !== vmiCPU;
 };
 
 export const checkBootOrderChanged = (
@@ -110,6 +115,14 @@ export const getChangedEnvDisks = (
     ...(vmEnvDisksNames?.filter((disk) => !unchangedEnvDisks?.includes(disk)) || []),
     ...(vmiEnvDisksNames?.filter((disk) => !unchangedEnvDisks?.includes(disk)) || []),
   ];
+
+  if (
+    vmEnvDisksNames.length === 0 &&
+    vmiEnvDisksNames.length === 1 &&
+    vmiEnvDisksNames?.[0] === 'default'
+  )
+    return [];
+
   return changedEnvDisks;
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

**Cause**

pending change notification even if the user just created the VM.

**Reason**
VM has memory specified in the `spec.template.spec.domain.memory.guest` instead of the canonical `.spec.template.spec.domain.resources.requests`

VM has no network and the vmi gets the default one

**Result**
Use also `spec.template.spec.domain.memory.guest` to identify if the memory is changed

Add a special case condition for the situation: no network interfaces in the VM and one default network in the VMI
