### PR TITLE
Bug 2177578: Set columns' width for volumes in Catalog > InstanceTypes

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
@@ -39,6 +39,7 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
   const bootVolumeName = bootableVolume?.metadata?.name;
   const pvcDiskSize = pvcSource?.spec?.resources?.requests?.storage;
   const sizeData = pvcDiskSize && humanizeBinaryBytes(pvcDiskSize);
+
   return (
     <Tr
       isHoverable
@@ -46,20 +47,20 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
       isRowSelected={bootableVolumeSelected?.metadata?.name === bootVolumeName}
       onClick={() => setBootSourceSelected(bootableVolume)}
     >
-      <TableData activeColumnIDs={activeColumnIDs} id="name">
+      <TableData activeColumnIDs={activeColumnIDs} id="name" width={20}>
         <img src={getOSIcon(preference)} alt="os-icon" className="vm-catalog-row-icon" />
         <Text component={TextVariants.small}>{bootVolumeName}</Text>
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} id="operating-system">
+      <TableData activeColumnIDs={activeColumnIDs} id="operating-system" width={20}>
         {preference?.metadata?.annotations?.[ANNOTATIONS.displayName] || NO_DATA_DASH}
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} id="storage-class">
+      <TableData activeColumnIDs={activeColumnIDs} id="storage-class" width={20}>
         {pvcSource?.spec?.storageClassName || NO_DATA_DASH}
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} id="size">
+      <TableData activeColumnIDs={activeColumnIDs} id="size" width={10}>
         {sizeData?.string || NO_DATA_DASH}
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} id={ANNOTATIONS.description}>
+      <TableData activeColumnIDs={activeColumnIDs} id={ANNOTATIONS.description} width={30}>
         {bootableVolume?.metadata?.annotations?.[ANNOTATIONS.description] || NO_DATA_DASH}
       </TableData>
     </Tr>

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/TableData.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/TableData.tsx
@@ -1,13 +1,18 @@
 import React, { FC } from 'react';
 
-import { Td } from '@patternfly/react-table';
+import { BaseCellProps, Td } from '@patternfly/react-table';
 
 type TableDataProps = {
   id: string;
   activeColumnIDs: string[];
+  width?: BaseCellProps['width'];
 };
 
-const TableData: FC<TableDataProps> = ({ children, id, activeColumnIDs }) =>
-  activeColumnIDs?.some((activeID) => activeID === id) ? <Td id={id}>{children}</Td> : null;
+const TableData: FC<TableDataProps> = ({ children, id, activeColumnIDs, width = 10 }) =>
+  activeColumnIDs?.some((activeID) => activeID === id) ? (
+    <Td id={id} width={width}>
+      {children}
+    </Td>
+  ) : null;
 
 export default TableData;


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2177578

Set the minimum width for each of the columns in the volumes list in _Catalog_ > _InstanceTypes_. To be able to do that, update `TableData` component to be able to get `width` as an optional prop, to get styled according to requirements.

## 🎥 Screenshots
**Before:**
Not enough space for the volume name, in case that the description is very long:
![row_before1](https://user-images.githubusercontent.com/13417815/226453441-df0e4c02-51ee-4e57-b5bf-19165a85bdb1.png)
If more columns displayed, same problem as for the volume name:
![row_before2](https://user-images.githubusercontent.com/13417815/226453443-e83c79c2-8761-41a1-afdc-562673c5c6d9.png)

**After:**
Enough space for the volume name, in case that the description is very long:
![a1](https://user-images.githubusercontent.com/13417815/226459875-d08dd1f0-ba0c-479a-b68f-89068726ebe0.png)
If more columns displayed, each column has an appropriate width suitable for its content:
![a2](https://user-images.githubusercontent.com/13417815/226459890-d4c0563a-fd54-41c9-8b6d-e6d925e500f6.png)




