### PR TITLE
Bug 2172375: Error on deleting secret

### DIFF
--- a/src/utils/components/TabModal/TabModal.tsx
+++ b/src/utils/components/TabModal/TabModal.tsx
@@ -69,7 +69,10 @@ const TabModal: TabModalFC = React.memo(
 
       onSubmit(obj)
         .then(onClose)
-        .catch(setError)
+        .catch((submitError) => {
+          setError(submitError);
+          console.error(submitError);
+        })
         .finally(() => setIsSubmitting(false));
     };
 

--- a/src/utils/components/VMAuthorizedSSHKeyModal/utils.ts
+++ b/src/utils/components/VMAuthorizedSSHKeyModal/utils.ts
@@ -8,7 +8,6 @@ import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import {
   addSecretToVM,
   createVmSSHSecret,
-  removeSecretToVM,
 } from '@kubevirt-utils/components/CloudinitModal/utils/cloudinit-utils';
 import { getRandomChars } from '@kubevirt-utils/utils/utils';
 import { k8sDelete, k8sPatch, k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
@@ -55,11 +54,9 @@ export const changeVMSecret = async (
     });
 
     return await createVmSSHSecret(vm, newSSHKey, sshSecretName);
-  } else {
+  } else if (!!vm?.spec?.template?.spec?.accessCredentials) {
     await produceAndUpdate(vm, (vmDraft) => {
-      const produced = removeSecretToVM(vm);
-      vmDraft.spec = produced.spec;
-
+      delete vmDraft.spec.template.spec.accessCredentials;
       return vmDraft;
     });
   }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

**Cause**
`produce` inside another `produce` cause some issues with `immer` apparently.

**Solution**
Anyways, the function `removeSecretToVM` was a little bit useless as its just one line so i copied it without the additional `produce`
If the VM does not have other accessCredentials, just don't try to remove it another time.


Why that change in TabModal?
This bug would be more easily solved if the TabModal would throw the error in the submit catch.
Even to just log that something bad happened. 
 

