### PR TITLE
Bug 2180279: VM cannot be started while creating from a template which has 2nd disk added

### DIFF
--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -183,7 +183,7 @@ export const getDataVolumeFromState = ({
 
 export const getDataVolumeTemplate = (dataVolume: V1beta1DataVolume): V1DataVolumeTemplateSpec => {
   const dataVolumeTemplate: V1DataVolumeTemplateSpec = { metadata: {}, spec: {} };
-  dataVolumeTemplate.metadata = { ...dataVolume.metadata };
+  dataVolumeTemplate.metadata = { name: dataVolume.metadata.name };
   dataVolumeTemplate.spec = { ...dataVolume.spec };
   return dataVolumeTemplate;
 };


### PR DESCRIPTION
## 📝 Description

Adding the namespace to the DataVolumeTemplate object causes issues and is not really necessary

## 🎥 Demo
After:


https://user-images.githubusercontent.com/67270715/226923973-38367565-8f98-4345-85c4-f7230bf5bb1d.mp4






