### PR TITLE
Bug 2175974: Show 8 rows in bootable volumes list

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/utils/constants.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/utils/constants.ts
@@ -1,8 +1,8 @@
 import { PerPageOptions } from '@patternfly/react-core';
 
 export const paginationDefaultValuesForm = [
-  { title: '5', value: 5 },
-  { title: '10', value: 10 },
+  { title: '8', value: 8 },
+  { title: '16', value: 16 },
 ];
 
 export const paginationDefaultValuesModal: PerPageOptions[] = [
@@ -20,14 +20,14 @@ export type PaginationState = {
 
 export const paginationInitialStateForm: PaginationState = {
   page: 1,
-  perPage: 5,
+  perPage: 8,
   startIndex: 0,
-  endIndex: 5,
+  endIndex: 8,
 };
 
 export const paginationInitialStateModal: PaginationState = {
   page: 1,
-  perPage: 15,
+  perPage: 16,
   startIndex: 0,
-  endIndex: 15,
+  endIndex: 16,
 };


### PR DESCRIPTION
## 📝 Description

Update the bootable volumes list to show 8 rows at a time.

## 🎥 Screenshot

### Before
![Selection_236](https://user-images.githubusercontent.com/8544299/226955814-108c2eda-88b8-4f23-843f-c5d9ddb45cbc.png)

### After
![Selection_235](https://user-images.githubusercontent.com/8544299/226955835-592f4ce2-a03c-490b-b5a2-1c0d39ca8b5f.png)

