### PR TITLE
Bug 2168749: disable network renaming on already created vm

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/NetworkInterfaceModal.tsx
+++ b/src/utils/components/NetworkInterfaceModal/NetworkInterfaceModal.tsx
@@ -37,6 +37,7 @@ type NetworkInterfaceModalProps = {
   headerText: string;
   namespace?: string;
   nicPresentation?: NetworkPresentation;
+  fixedName?: boolean;
   onSubmit: (
     args: NetworkInterfaceModalOnSubmit,
   ) => (
@@ -53,6 +54,7 @@ const NetworkInterfaceModal: FC<NetworkInterfaceModalProps> = ({
   headerText,
   namespace,
   nicPresentation = { network: null, iface: null },
+  fixedName = false,
 }) => {
   const { network = null, iface = null } = nicPresentation;
   const [nicName, setNicName] = useState(network?.name || generateNicName());
@@ -83,7 +85,7 @@ const NetworkInterfaceModal: FC<NetworkInterfaceModalProps> = ({
     >
       <Form>
         {Header}
-        <NameFormField objName={nicName} setObjName={setNicName} />
+        <NameFormField objName={nicName} setObjName={setNicName} isDisabled={fixedName} />
         <NetworkInterfaceModelSelect
           interfaceModel={interfaceModel}
           setInterfaceModel={setInterfaceModel}

--- a/src/utils/components/NetworkInterfaceModal/components/NameFormField.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NameFormField.tsx
@@ -6,14 +6,21 @@ import { FormGroup, TextInput } from '@patternfly/react-core';
 type NameFormFieldProps = {
   objName: string;
   setObjName: Dispatch<SetStateAction<string>>;
+  isDisabled?: boolean;
 };
 
-const NameFormField: FC<NameFormFieldProps> = ({ objName, setObjName }) => {
+const NameFormField: FC<NameFormFieldProps> = ({ objName, setObjName, isDisabled }) => {
   const { t } = useKubevirtTranslation();
 
   return (
     <FormGroup label={t('Name')} fieldId="name" isRequired>
-      <TextInput type="text" value={objName} onChange={setObjName} id="name" />
+      <TextInput
+        type="text"
+        value={objName}
+        onChange={setObjName}
+        id="name"
+        isDisabled={isDisabled}
+      />
     </FormGroup>
   );
 };

--- a/src/views/virtualmachines/details/tabs/configuration/network/copmonents/modal/VirtualMachinesEditNetworkInterfaceModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/copmonents/modal/VirtualMachinesEditNetworkInterfaceModal.tsx
@@ -65,6 +65,7 @@ const VirtualMachinesEditNetworkInterfaceModal: FC<
       nicPresentation={nicPresentation}
       isOpen={isOpen}
       onClose={onClose}
+      fixedName
     />
   );
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Renaming the networks interfaces is not supported by the backend for already created VM 



## 🎥 Demo


![image](https://user-images.githubusercontent.com/29160323/227173498-d02a1fa4-be7a-4469-8cfc-ae5fb755c32f.png)

