### PR TITLE
Bug 2174744: Fix bootable volumes filter chips alignment

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.scss
+++ b/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.scss
@@ -1,5 +1,10 @@
 .create-vm-instance-type-section {
   padding: var(--pf-global--spacer--xl);
+  &__list {
+    li + li {
+      margin-top: 0;
+    }
+  }
   &__step {
     font-size: var(--pf-global--FontSize--xl);
     height: var(--pf-global--spacer--xl);

--- a/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
@@ -79,7 +79,7 @@ const CreateFromInstanceType: FC = () => {
       <Grid className="co-dashboard-body">
         <GridItem>
           <Card>
-            <List isPlain>
+            <List className="create-vm-instance-type-section__list" isPlain>
               <SectionListItem
                 headerText={t('Select volume to boot from')}
                 sectionKey={INSTANCE_TYPES_SECTIONS.SELECT_VOLUME}


### PR DESCRIPTION
## 📝 Description

This PR fixes the misalignment of the filter chips on the InstanceTypes page.

## 🎥 Screenshots

### Before
![Selection_241](https://user-images.githubusercontent.com/8544299/227536550-67ba4a85-68be-474e-8c39-4cf6671055ea.png)


### After
![Selection_240](https://user-images.githubusercontent.com/8544299/227536561-c97290a0-5132-499e-acaa-75b80c5e1320.png)

