### PR TITLE
Bug 2180931: Truncate long text in Description column for boot volumes

### DIFF
--- a/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
+++ b/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { V1alpha2VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { ANNOTATIONS } from '@kubevirt-utils/resources/template';
 import { isDataSourceCloning } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import {
@@ -13,6 +14,7 @@ import {
   Timestamp,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { Label, Split, SplitItem } from '@patternfly/react-core';
+import { TableText, WrapModifier } from '@patternfly/react-table';
 
 import BootableVolumesActions from '../../actions/BootableVolumesActions';
 import { getDataSourcePreferenceLabelValue, getPreferenceReadableOS } from '../../utils/utils';
@@ -47,7 +49,9 @@ const BootableVolumesRow: FC<
         {getPreferenceReadableOS(obj, preferences)}
       </TableData>
       <TableData id="description" activeColumnIDs={activeColumnIDs} className="pf-m-width-15">
-        {obj?.metadata?.annotations?.description || NO_DATA_DASH}
+        <TableText wrapModifier={WrapModifier.truncate}>
+          {obj?.metadata?.annotations?.[ANNOTATIONS.description] || NO_DATA_DASH}
+        </TableText>
       </TableData>
       <TableData id="preference" activeColumnIDs={activeColumnIDs} className="pf-m-width-15">
         {getDataSourcePreferenceLabelValue(obj)}

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
@@ -10,7 +10,7 @@ import { ANNOTATIONS } from '@kubevirt-utils/resources/template';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { humanizeBinaryBytes } from '@kubevirt-utils/utils/humanize.js';
 import { Text, TextVariants } from '@patternfly/react-core';
-import { Tr } from '@patternfly/react-table';
+import { TableText, Tr, WrapModifier } from '@patternfly/react-table';
 
 import TableData from './TableData';
 
@@ -61,7 +61,9 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
         {sizeData?.string || NO_DATA_DASH}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id={ANNOTATIONS.description} width={30}>
-        {bootableVolume?.metadata?.annotations?.[ANNOTATIONS.description] || NO_DATA_DASH}
+        <TableText wrapModifier={WrapModifier.truncate}>
+          {bootableVolume?.metadata?.annotations?.[ANNOTATIONS.description] || NO_DATA_DASH}
+        </TableText>
       </TableData>
     </Tr>
   );


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2180931

Use wrap modifier "truncate" to shorten long description text displayed in _Description_ column in _Bootable volumes_ list and in volumes list in _Catalog > InstanceTypes_ page.

Display the whole text in the popover when the mouse pointer moves over the description text.

More about used modifier of the Patternfly `TableText` component:
https://www.patternfly.org/2022.05/components/table

## 🎥 Demo
**Before:**
Description column in _Bootable volumes_ list:
![desc_before](https://user-images.githubusercontent.com/13417815/227599850-cbc47274-e794-40b0-bb65-a7f6251af24b.png)
Description in volumes list in _Catalog > InstanceTypes_ page:
![desc2_before](https://user-images.githubusercontent.com/13417815/227599863-af696519-1ae9-4ae6-a6d7-0cfc2d4c3644.png)

**After:**
Description column in _Bootable volumes_ list:
![desc_after](https://user-images.githubusercontent.com/13417815/227599784-1a8fd395-be1c-4efc-a33f-ecb8385ed85e.png)
Description in volumes list in _Catalog > InstanceTypes_ page:
![desc2_after](https://user-images.githubusercontent.com/13417815/227600014-251d015a-b67b-45bb-ac1e-05d298769f68.png)
