### PR TITLE
Bug 2177977: The volume in instanceTypes page should be selected automatically just after it's been added

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeButton/AddBootableVolumeButton.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeButton/AddBootableVolumeButton.tsx
@@ -1,8 +1,13 @@
 import React, { FC, useEffect, useState } from 'react';
 
+import DataSourceModel from '@kubevirt-ui/kubevirt-api/console/models/DataSourceModel';
+import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
+import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { KUBEVIRT_OS_IMAGES_NS, OPENSHIFT_OS_IMAGES_NS } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { isEmpty, isUpstream } from '@kubevirt-utils/utils/utils';
+import { K8sVerb, useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 
 import AddBootableVolumeModal from '../AddBootableVolumeModal/AddBootableVolumeModal';
@@ -11,16 +16,27 @@ export type AddBootableVolumeButtonProps = {
   preferencesNames: string[];
   loadError?: any;
   buttonVariant?: ButtonVariant;
+  onSelectCreatedVolume?: (
+    selectedVolume: V1beta1DataSource,
+    pvcSource: V1alpha1PersistentVolumeClaim,
+  ) => void;
 };
 
 const AddBootableVolumeButton: FC<AddBootableVolumeButtonProps> = ({
   preferencesNames,
   loadError,
   buttonVariant,
+  onSelectCreatedVolume,
 }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const [preferences, setPreferences] = useState<string[]>([]);
+  const [canCreateVolume] = useAccessReview({
+    resource: DataSourceModel.plural,
+    verb: 'create' as K8sVerb,
+    namespace: isUpstream ? KUBEVIRT_OS_IMAGES_NS : OPENSHIFT_OS_IMAGES_NS,
+    group: DataSourceModel.apiGroup,
+  });
 
   useEffect(() => {
     isEmpty(preferences) &&
@@ -38,11 +54,12 @@ const AddBootableVolumeButton: FC<AddBootableVolumeButtonProps> = ({
             isOpen={isOpen}
             onClose={onClose}
             preferencesNames={preferences}
+            onSelectCreatedVolume={onSelectCreatedVolume}
           />
         ))
       }
       variant={buttonVariant || ButtonVariant.secondary}
-      isDisabled={loadError}
+      isDisabled={loadError || !canCreateVolume}
     >
       {t('Add volume')}
     </Button>

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -30,6 +30,7 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
   isOpen,
   onClose,
   preferencesNames,
+  onSelectCreatedVolume,
 }) => {
   const { t } = useKubevirtTranslation();
   const [formSelection, setFormSelection] = useState<RADIO_FORM_SELECTION>(
@@ -60,7 +61,13 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
   return (
     <TabModal
       obj={emptyDataSource}
-      onSubmit={createDataSource(bootableVolume, uploadData, isUploadForm, cloneExistingPVC)}
+      onSubmit={createDataSource(
+        bootableVolume,
+        uploadData,
+        isUploadForm,
+        cloneExistingPVC,
+        onSelectCreatedVolume,
+      )}
       headerText={t('Add volume')}
       isOpen={isOpen}
       onClose={() => {

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeSource/VolumeSource.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeSource/VolumeSource.tsx
@@ -10,6 +10,7 @@ import StorageClassSelect from '@kubevirt-utils/components/DiskModal/DiskFormFie
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { DataUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { hasSizeUnit } from '@kubevirt-utils/resources/vm/utils/disk/size';
 import {
   Checkbox,
   Grid,
@@ -59,7 +60,9 @@ const VolumeSource: FC<VolumeSourceProps> = ({
             selectPVCNamespace={setBootableVolumeField('pvcNamespace')}
             setDiskSize={(newSize) =>
               setBootableVolumeField('size')(
-                removeByteSuffix(xbytes(Number(newSize), { iec: true, space: false })),
+                hasSizeUnit(newSize)
+                  ? newSize
+                  : removeByteSuffix(xbytes(Number(newSize), { iec: true, space: false })),
               )
             }
           />
@@ -81,6 +84,7 @@ const VolumeSource: FC<VolumeSourceProps> = ({
           </Split>
         </>
       )}
+
       <Grid hasGutter span={12}>
         <GridItem span={6}>
           <StorageClassSelect

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/utils/utils.ts
@@ -1,9 +1,20 @@
 import produce from 'immer';
 
+import {
+  DEFAULT_INSTANCETYPE_LABEL,
+  initialInstanceTypeState,
+  InstanceTypeState,
+} from '@catalog/CreateFromInstanceTypes/utils/constants';
+import { getInstanceTypeState } from '@catalog/CreateFromInstanceTypes/utils/utils';
 import DataSourceModel from '@kubevirt-ui/kubevirt-api/console/models/DataSourceModel';
 import DataVolumeModel from '@kubevirt-ui/kubevirt-api/console/models/DataVolumeModel';
-import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
+import {
+  V1beta1DataSource,
+  V1beta1DataVolumeSourcePVC,
+} from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
+import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { UploadDataProps } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
+import { getPVC } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import { AddBootableVolumeState, emptySourceDataVolume } from './constants';
@@ -14,8 +25,12 @@ export const createDataSource =
     uploadData: ({ file, dataVolume }: UploadDataProps) => Promise<void>,
     isUploadForm: boolean,
     cloneExistingPVC: boolean,
+    onSelectCreatedVolume: (
+      selectedVolume: V1beta1DataSource,
+      pvcSource: V1alpha1PersistentVolumeClaim,
+    ) => void,
   ) =>
-  (dataSource: V1beta1DataSource) => {
+  async (dataSource: V1beta1DataSource) => {
     const {
       bootableVolumeName,
       size,
@@ -51,21 +66,33 @@ export const createDataSource =
         : { pvc: { name: pvcName, namespace: pvcNamespace } };
     });
 
-    const promise = isUploadForm
-      ? uploadData({
+    isUploadForm
+      ? await uploadData({
           file: uploadFile as File,
           dataVolume: bootableVolumeToCreate,
         })
-      : k8sCreate({ model: DataVolumeModel, data: bootableVolumeToCreate });
+      : await k8sCreate({ model: DataVolumeModel, data: bootableVolumeToCreate });
 
+    const { name, namespace }: V1beta1DataVolumeSourcePVC = {
+      name: bootableVolumeToCreate.metadata.name,
+      namespace: bootableVolumeToCreate.metadata.namespace,
+    };
     const dataSourceToCreate = produce(updatedDataSource, (draftDS) => {
       draftDS.spec.source = {
-        pvc: {
-          name: bootableVolumeToCreate.metadata.name,
-          namespace: bootableVolumeToCreate.metadata.namespace,
-        },
+        pvc: { name, namespace },
       };
     });
 
-    return promise.then(() => k8sCreate({ model: DataSourceModel, data: dataSourceToCreate }));
+    const newDataSource = await k8sCreate({ model: DataSourceModel, data: dataSourceToCreate });
+
+    const pvcSource = await getPVC(name, namespace);
+
+    onSelectCreatedVolume?.(newDataSource, pvcSource);
   };
+
+export const getInstanceTypeFromVolume = (dataSource: V1beta1DataSource): InstanceTypeState => {
+  const defaultInstanceTypeName = dataSource?.metadata?.labels?.[DEFAULT_INSTANCETYPE_LABEL];
+  return defaultInstanceTypeName
+    ? getInstanceTypeState(defaultInstanceTypeName)
+    : initialInstanceTypeState;
+};

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
@@ -6,10 +6,12 @@ import {
   V1alpha1PersistentVolumeClaim,
   V1alpha2VirtualMachineClusterPreference,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ANNOTATIONS } from '@kubevirt-utils/resources/template';
+import { isDataSourceCloning } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
-import { humanizeBinaryBytes } from '@kubevirt-utils/utils/humanize.js';
-import { Text, TextVariants } from '@patternfly/react-core';
+import { formatBytes } from '@kubevirt-utils/resources/vm/utils/disk/size';
+import { Label, Text, TextVariants } from '@patternfly/react-core';
 import { TableText, Tr, WrapModifier } from '@patternfly/react-table';
 
 import TableData from './TableData';
@@ -36,9 +38,9 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
     pvcSource,
   },
 }) => {
+  const { t } = useKubevirtTranslation();
   const bootVolumeName = bootableVolume?.metadata?.name;
-  const pvcDiskSize = pvcSource?.spec?.resources?.requests?.storage;
-  const sizeData = pvcDiskSize && humanizeBinaryBytes(pvcDiskSize);
+  const sizeData = formatBytes(pvcSource?.spec?.resources?.requests?.storage);
 
   return (
     <Tr
@@ -50,6 +52,9 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
       <TableData activeColumnIDs={activeColumnIDs} id="name" width={20}>
         <img src={getOSIcon(preference)} alt="os-icon" className="vm-catalog-row-icon" />
         <Text component={TextVariants.small}>{bootVolumeName}</Text>
+        {isDataSourceCloning(bootableVolume) && (
+          <Label className="vm-catalog-row-label">{t('Clone in progress')}</Label>
+        )}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="operating-system" width={20}>
         {preference?.metadata?.annotations?.[ANNOTATIONS.displayName] || NO_DATA_DASH}
@@ -58,7 +63,7 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
         {pvcSource?.spec?.storageClassName || NO_DATA_DASH}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="size" width={10}>
-        {sizeData?.string || NO_DATA_DASH}
+        {sizeData || NO_DATA_DASH}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id={ANNOTATIONS.description} width={30}>
         <TableText wrapModifier={WrapModifier.truncate}>

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/VMDetailsBody/components/DetailsRightGrid.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/VMDetailsBody/components/DetailsRightGrid.tsx
@@ -3,10 +3,9 @@ import React from 'react';
 import { SSHSecretCredentials } from '@catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/SSHKeySection/utils/types';
 import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { formatBytes } from '@kubevirt-utils/resources/vm/utils/disk/size';
 import { DescriptionList } from '@patternfly/react-core';
 import VirtualMachineDescriptionItem from '@virtualmachines/details/tabs/details/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
-
-import { humanizeBinaryBytes } from '../../../../../../../../utils/utils/humanize';
 
 type DetailsRightGridProps = {
   pvcSource: V1alpha1PersistentVolumeClaim;
@@ -20,13 +19,13 @@ const DetailsRightGrid: React.FC<DetailsRightGridProps> = ({
   sshSecretCredentials,
 }) => {
   const pvcDiskSize = pvcSource?.spec?.resources?.requests?.storage;
-  const sizeData = humanizeBinaryBytes(pvcDiskSize);
+  const sizeData = formatBytes(pvcDiskSize);
 
   return (
     <DescriptionList isHorizontal>
       <VirtualMachineDescriptionItem descriptionData={namespace} descriptionHeader={t('Project')} />
       <VirtualMachineDescriptionItem
-        descriptionData={pvcDiskSize && sizeData?.string}
+        descriptionData={pvcDiskSize && sizeData}
         descriptionHeader={t('Boot disk size')}
       />
       <VirtualMachineDescriptionItem

--- a/src/views/catalog/CreateFromInstanceTypes/hooks/useBootableVolumes.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/hooks/useBootableVolumes.ts
@@ -1,13 +1,10 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { DataSourceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { KUBEVIRT_OS_IMAGES_NS, OPENSHIFT_OS_IMAGES_NS } from '@kubevirt-utils/constants/constants';
-import {
-  convertResourceArrayToMap,
-  getAvailableDataSources,
-} from '@kubevirt-utils/resources/shared';
+import { convertResourceArrayToMap } from '@kubevirt-utils/resources/shared';
 import { getPVC } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { isEmpty, isUpstream } from '@kubevirt-utils/utils/utils';
 import { Operator, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
@@ -39,20 +36,18 @@ const useBootableVolumes: UseBootableVolumes = () => {
 
   const [pvcSources, setPVCSources] = useState<V1alpha1PersistentVolumeClaim[]>([]);
 
-  const readyDataSources = useMemo(() => getAvailableDataSources(dataSources), [dataSources]);
-
   useEffect(() => {
-    if (loadedDataSources && !loadErrorDataSources && !isEmpty(readyDataSources)) {
-      const pvcSourcePromises = (readyDataSources || []).map((ds) =>
+    if (loadedDataSources && !loadErrorDataSources && !isEmpty(dataSources)) {
+      const pvcSourcePromises = (dataSources || []).map((ds) =>
         getPVC(ds?.spec?.source?.pvc?.name, ds?.spec?.source?.pvc?.namespace),
       );
 
       Promise.all(pvcSourcePromises).then((pvcs) => setPVCSources(pvcs));
     }
-  }, [readyDataSources, loadErrorDataSources, loadedDataSources, dataSources]);
+  }, [loadErrorDataSources, loadedDataSources, dataSources]);
 
   return {
-    bootableVolumes: loadErrorDataSources || isEmpty(readyDataSources) ? null : readyDataSources,
+    bootableVolumes: loadErrorDataSources || isEmpty(dataSources) ? null : dataSources,
     loaded: loadErrorDataSources ? true : loadedDataSources,
     loadError: loadErrorDataSources,
     pvcSources: convertResourceArrayToMap(pvcSources, true),

--- a/src/views/catalog/templatescatalog/TemplatesCatalog.scss
+++ b/src/views/catalog/templatescatalog/TemplatesCatalog.scss
@@ -17,6 +17,10 @@
     vertical-align: bottom;
   }
 
+  &-row-label {
+    margin-left: var(--pf-global--spacer--sm);
+  }
+
   &-grid {
     padding: var(--pf-global--spacer--lg);
 


### PR DESCRIPTION
## 📝 Description

This PR fixes:
- Selecting the volume from the `Add volume` modal + including a label for cloning in progress
- Getting correct size for volume that is cloned from another PVC instead of `0 B` (saw this regression a few days ago on another cluster)
- Disabling `Add volume` button if user is not allowed to create a DataSource object within the os images name (either kubevirt-os-images for US or openshift-virtualization-os-images for DS)

## 🎥 Demo

Before:

https://user-images.githubusercontent.com/67270715/227772536-3609ef18-86cf-43b5-9549-300190ca9836.mp4

After:

https://user-images.githubusercontent.com/67270715/227772389-ac51e3fc-c954-4e67-b36f-db5c3af9bdb8.mp4


