### PR TITLE
Disable VM actions for view only users

### DIFF
--- a/src/utils/components/ActionDropdownItem/ActionDropdownItem.tsx
+++ b/src/utils/components/ActionDropdownItem/ActionDropdownItem.tsx
@@ -1,0 +1,39 @@
+import React, { Dispatch, FC, SetStateAction } from 'react';
+
+import { Action, useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
+import { DropdownItem } from '@patternfly/react-core';
+
+type ActionDropdownItemProps = {
+  action: Action;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+const ActionDropdownItem: FC<ActionDropdownItemProps> = ({ action, setIsOpen }) => {
+  const [actionAllowed] = useAccessReview(action?.accessReview);
+
+  const handleClick = () => {
+    if (typeof action?.cta === 'function') {
+      action?.cta();
+      setIsOpen(false);
+    }
+  };
+  return (
+    <DropdownItem
+      data-test-id={`${action?.id}`}
+      key={action?.id}
+      onClick={handleClick}
+      isDisabled={action?.disabled || !actionAllowed}
+      description={action?.description}
+    >
+      {action?.label}
+      {action?.icon && (
+        <>
+          {' '}
+          <span className="text-muted">{action.icon}</span>
+        </>
+      )}
+    </DropdownItem>
+  );
+};
+
+export default ActionDropdownItem;

--- a/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { TFunction } from 'i18next';
 
+import VirtualMachineInstanceMigrationModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstanceMigrationModel';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import {
   V1VirtualMachine,
@@ -101,7 +102,12 @@ export const VirtualMachineActionFactory = {
       disabled: !isLiveMigratable(vm, isSingleNodeCluster),
       label: t('Migrate'),
       cta: () => migrateVM(vm),
-      accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
+      accessReview: {
+        resource: VirtualMachineInstanceMigrationModel.plural,
+        namespace: vm?.metadata?.namespace,
+        verb: 'create',
+        group: VirtualMachineInstanceMigrationModel.apiGroup,
+      },
       description: t('Migrate to a different Node'),
     };
   },
@@ -116,7 +122,12 @@ export const VirtualMachineActionFactory = {
       disabled: isSingleNodeCluster || !vmim || !!vmim?.metadata?.deletionTimestamp,
       label: t('Cancel migration'),
       cta: () => cancelMigration(vmim),
-      accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
+      accessReview: {
+        resource: VirtualMachineInstanceMigrationModel.plural,
+        namespace: vm?.metadata?.namespace,
+        verb: 'delete',
+        group: VirtualMachineInstanceMigrationModel.apiGroup,
+      },
       description: !!vmim?.metadata?.deletionTimestamp && t('Canceling ongoing migration'),
     };
   },
@@ -150,13 +161,14 @@ export const VirtualMachineActionFactory = {
   //       ),
   //   };
   // },
-  copySSHCommand: (command: string, t: TFunction): Action => {
+  copySSHCommand: (vm: V1VirtualMachine, command: string, t: TFunction): Action => {
     return {
       id: 'vm-action-copy-ssh',
       label: t('Copy SSH command'),
       icon: <CopyIcon />,
       description: t('SSH using virtctl'),
       cta: () => command && navigator.clipboard.writeText(command),
+      accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
     };
   },
   editLabels: (
@@ -168,6 +180,7 @@ export const VirtualMachineActionFactory = {
       id: 'vm-action-edit-labels',
       disabled: false,
       label: t('Edit labels'),
+      accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
       cta: () =>
         createModal(({ isOpen, onClose }) => (
           <LabelsModal
@@ -200,6 +213,7 @@ export const VirtualMachineActionFactory = {
       id: 'vm-action-edit-annotations',
       disabled: false,
       label: t('Edit annotations'),
+      accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
       cta: () =>
         createModal(({ isOpen, onClose }) => (
           <AnnotationsModal

--- a/src/views/virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions.tsx
@@ -1,20 +1,14 @@
-import * as React from 'react';
+import React, { useState } from 'react';
 
 import {
   V1VirtualMachine,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import ActionDropdownItem from '@kubevirt-utils/components/ActionDropdownItem/ActionDropdownItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getContentScrollableElement } from '@kubevirt-utils/utils/utils';
-import { Action } from '@openshift-console/dynamic-plugin-sdk';
 // import { LazyActionMenu } from '@openshift-console/dynamic-plugin-sdk-internal';
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownPosition,
-  DropdownToggle,
-  KebabToggle,
-} from '@patternfly/react-core';
+import { Dropdown, DropdownPosition, DropdownToggle, KebabToggle } from '@patternfly/react-core';
 import useVirtualMachineActionsProvider from '@virtualmachines/actions/hooks/useVirtualMachineActionsProvider';
 
 type VirtualMachinesInstanceActionsProps = {
@@ -39,15 +33,8 @@ const VirtualMachineActions: React.FC<VirtualMachinesInstanceActionsProps> = ({
   //     context={{ [VirtualMachineModelRef]: vm }}
   //   />
   // );
-  const [isOpen, setIsOpen] = React.useState(false);
+  const [isOpen, setIsOpen] = useState(false);
   const [actions] = useVirtualMachineActionsProvider(vm, vmim, isSingleNodeCluster);
-
-  const handleClick = (action: Action) => {
-    if (typeof action?.cta === 'function') {
-      action?.cta();
-      setIsOpen(false);
-    }
-  };
 
   return (
     <Dropdown
@@ -64,21 +51,7 @@ const VirtualMachineActions: React.FC<VirtualMachinesInstanceActionsProps> = ({
         )
       }
       dropdownItems={actions?.map((action) => (
-        <DropdownItem
-          data-test-id={`${action.id}`}
-          key={action?.id}
-          onClick={() => handleClick(action)}
-          isDisabled={action?.disabled}
-          description={action?.description}
-        >
-          {action?.label}
-          {action?.icon && (
-            <>
-              {' '}
-              <span className="text-muted">{action.icon}</span>
-            </>
-          )}
-        </DropdownItem>
+        <ActionDropdownItem key={action?.id} action={action} setIsOpen={setIsOpen} />
       ))}
     />
   );

--- a/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
+++ b/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
@@ -57,7 +57,7 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (
       VirtualMachineActionFactory.clone(vm, createModal, t),
       migrateOrCancelMigration,
       // VirtualMachineActionFactory.openConsole(vm),
-      VirtualMachineActionFactory.copySSHCommand(virtctlCommand, t),
+      VirtualMachineActionFactory.copySSHCommand(vm, virtctlCommand, t),
       VirtualMachineActionFactory.editLabels(vm, createModal, t),
       VirtualMachineActionFactory.editAnnotations(vm, createModal, t),
       VirtualMachineActionFactory.delete(vm, createModal, t),


### PR DESCRIPTION
## 📝 Description

Introducing a new component called ActionDropdownItem, which his single purpose is to load the RBAC access for each action, and disable the action in case the user does not hold permissions for that action

## 🎥 Demo

Before:

Enabled for view-only permission on VM list:
![disable-actions-by-RBAC-b4](https://user-images.githubusercontent.com/67270715/227962265-cfc8f514-79f8-420c-aecd-e941593f678c.png)


After:

disabled for view-only permission on VM list:
![disable-actions-by-RBAC-2](https://user-images.githubusercontent.com/67270715/227961576-05e144e8-59c1-4104-8c66-e53a3f9eec85.png)

disabled for view-only permission on single VM overview:
![disable-actions-by-RBAC-3](https://user-images.githubusercontent.com/67270715/227961588-69044613-84bf-4f43-a124-d1d969479f02.png)

Enabled for project-admin:
![disable-actions-by-RBAC](https://user-images.githubusercontent.com/67270715/227961593-a7b934c3-cd2e-4c09-a410-4864ffaa2614.png)

