### PR TITLE
Bug 2181515: spec.firmware.bootloader is not copied while cloning a UEFI VM

### DIFF
--- a/src/views/virtualmachines/actions/components/CloneVMModal/utils/helpers.tsx
+++ b/src/views/virtualmachines/actions/components/CloneVMModal/utils/helpers.tsx
@@ -63,10 +63,6 @@ export const produceCleanClonedVM = (
       delete draftVM?.metadata?.generation;
     }
 
-    if (draftVM?.spec?.template?.spec?.domain) {
-      delete draftVM?.spec?.template?.spec?.domain?.firmware;
-    }
-
     delete draftVM?.status;
     draftVM.spec.dataVolumeTemplates = [];
 


### PR DESCRIPTION
## 📝 Description

carrying the firmware from source VM to cloned VM

## 🎥 Demo

Before:

https://user-images.githubusercontent.com/67270715/228194307-76a83c26-2afd-4dcc-aa54-9abbd12b8f4e.mp4

After:

https://user-images.githubusercontent.com/67270715/228194360-75b5fff0-58ac-4f4e-a347-6249308bf60d.mp4

