### PR TITLE
Bug 2180719: Provide username in "Copy SSH command" of a VM

### DIFF
--- a/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.tsx
+++ b/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.tsx
@@ -45,7 +45,7 @@ const ConsoleOverVirtctl: React.FC<ConsoleOverVirtctlProps> = ({
           clickTip={t('Copied')}
           hoverTip={t('Copy to clipboard')}
         >
-          {getConsoleVirtctlCommand(vmName, vmNamespace, userName)}
+          {getConsoleVirtctlCommand(userName, vmName, vmNamespace)}
         </ClipboardCopy>
       </DescriptionListDescription>
     </DescriptionListGroup>

--- a/src/utils/components/SSHAccess/utils.ts
+++ b/src/utils/components/SSHAccess/utils.ts
@@ -106,5 +106,5 @@ export const createSSHService = async (
   });
 };
 
-export const getConsoleVirtctlCommand = (vmName: string, vmNamespace?: string, userName?: string) =>
+export const getConsoleVirtctlCommand = (userName: string, vmName: string, vmNamespace?: string) =>
   `virtctl ${vmNamespace ? `-n ${vmNamespace}` : ''} ssh ${userName}@${vmName}`;

--- a/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
+++ b/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
@@ -8,6 +8,7 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import { getConsoleVirtctlCommand } from '@kubevirt-utils/components/SSHAccess/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VirtualMachineModelRef } from '@kubevirt-utils/models';
+import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
 import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
 import { Action, useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -27,7 +28,12 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (
 ) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
-  const virtctlCommand = getConsoleVirtctlCommand(vm?.metadata?.name, vm?.metadata?.namespace);
+  const userName = getCloudInitCredentials(vm)?.users?.[0]?.name;
+  const virtctlCommand = getConsoleVirtctlCommand(
+    userName,
+    vm?.metadata?.name,
+    vm?.metadata?.namespace,
+  );
 
   const [, inFlight] = useK8sModel(VirtualMachineModelRef);
   const actions: Action[] = React.useMemo(() => {

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsTitle.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsTitle.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getConsoleVirtctlCommand } from '@kubevirt-utils/components/SSHAccess/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
 import { CardTitle, Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import { CopyIcon } from '@patternfly/react-icons';
 
@@ -20,7 +21,12 @@ const VirtualMachinesOverviewTabDetailsTitle: React.FC<
 > = ({ vm }) => {
   const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
   const { t } = useKubevirtTranslation();
-  const virtctlCommand = getConsoleVirtctlCommand(vm?.metadata?.name, vm?.metadata?.namespace);
+  const userName = getCloudInitCredentials(vm)?.users?.[0]?.name;
+  const virtctlCommand = getConsoleVirtctlCommand(
+    userName,
+    vm?.metadata?.name,
+    vm?.metadata?.namespace,
+  );
 
   const isMachinePaused = vm?.status?.printableStatus === printableVMStatus.Paused;
   const isMachineStopped = vm?.status?.printableStatus === printableVMStatus.Stopped;


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2180719

Provide correct username in the copied command for "Copy SSH command" action in VM _Overview_ tab - _Details_ card, instead of username being `undefined`.

Make `userName` not optional param anymore, in `getConsoleVirtctlCommand` util, as we do need it to properly generate the command.

## 🎥 Demo
**Before:**
After VM creation, `undefined` user present in the ssh command, copied by "Copy SSH command" in VM _Overview_:

https://user-images.githubusercontent.com/13417815/228270885-65ba32c3-4171-403a-a0ae-b216c2fae47a.mp4

**After:**
Correct username present in the ssh command:

https://user-images.githubusercontent.com/13417815/228270913-be8f8bc6-8fc2-4711-96e7-0fb4176afa4b.mp4

