### PR TITLE
Move StorageClass field to Destination details

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -43,7 +43,7 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
     initialBootableVolumeState,
   );
 
-  const { bootableVolumeName, labels } = bootableVolume || {};
+  const { labels } = bootableVolume || {};
 
   const isUploadForm = formSelection === RADIO_FORM_SELECTION.UPLOAD_IMAGE;
 
@@ -95,7 +95,8 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
         <FormGroup>{/* Spacer */}</FormGroup>
         <Title headingLevel="h5">{t('Destination details')}</Title>
         <VolumeDestination
-          bootableVolumeName={bootableVolumeName}
+          bootableVolume={bootableVolume}
+          setBootableVolumeField={setBootableVolumeField}
           setBootableVolumeName={setBootableVolumeField('bootableVolumeName')}
         />
         <FormGroup>{/* Spacer */}</FormGroup>

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeDestination/VolumeDestination.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeDestination/VolumeDestination.tsx
@@ -1,22 +1,55 @@
-import React, { Dispatch, FC, SetStateAction } from 'react';
+import React, { Dispatch, FC, SetStateAction, useState } from 'react';
 
+import CapacityInput from '@kubevirt-utils/components/CapacityInput/CapacityInput';
+import DefaultStorageClassAlert from '@kubevirt-utils/components/DiskModal/DiskFormFields/StorageClass/DefaultStorageClassAlert';
+import StorageClassSelect from '@kubevirt-utils/components/DiskModal/DiskFormFields/StorageClass/StorageClassSelect';
 import { KUBEVIRT_OS_IMAGES_NS, OPENSHIFT_OS_IMAGES_NS } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isUpstream } from '@kubevirt-utils/utils/utils';
-import { FormGroup, TextInput } from '@patternfly/react-core';
+import { FormGroup, Grid, GridItem, TextInput } from '@patternfly/react-core';
+
+import { AddBootableVolumeState } from '../../utils/constants';
 
 type VolumeDestinationProps = {
-  bootableVolumeName: string;
+  bootableVolume: AddBootableVolumeState;
+  setBootableVolumeField: (key: string, fieldKey?: string) => (value: string) => void;
   setBootableVolumeName: Dispatch<SetStateAction<string>>;
 };
 
 const VolumeDestination: FC<VolumeDestinationProps> = ({
-  bootableVolumeName,
+  bootableVolume,
+  setBootableVolumeField,
   setBootableVolumeName,
 }) => {
   const { t } = useKubevirtTranslation();
+  const [showSCAlert, setShowSCAlert] = useState(false);
+
+  const { bootableVolumeName, size, storageClassName } = bootableVolume || {};
+
   return (
     <>
+      <Grid hasGutter span={12}>
+        <GridItem span={6}>
+          <StorageClassSelect
+            storageClass={storageClassName}
+            setStorageClassName={setBootableVolumeField('storageClassName')}
+            setShowSCAlert={setShowSCAlert}
+          />
+        </GridItem>
+        <GridItem span={6}>
+          <CapacityInput
+            size={size}
+            onChange={setBootableVolumeField('size')}
+            label={t('Disk size')}
+          />
+        </GridItem>
+        {showSCAlert && (
+          <GridItem span={12}>
+            <DefaultStorageClassAlert />
+          </GridItem>
+        )}
+      </Grid>
+
       <FormGroup label={t('Volume name')} isRequired>
         <TextInput
           id="name"

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeSource/VolumeSource.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeSource/VolumeSource.tsx
@@ -1,24 +1,14 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 import xbytes from 'xbytes';
 
-import CapacityInput from '@kubevirt-utils/components/CapacityInput/CapacityInput';
 import { removeByteSuffix } from '@kubevirt-utils/components/CapacityInput/utils';
 import DiskSourcePVCSelect from '@kubevirt-utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourcePVCSelect';
 import DiskSourceUploadPVC from '@kubevirt-utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourceUploadPVC';
-import DefaultStorageClassAlert from '@kubevirt-utils/components/DiskModal/DiskFormFields/StorageClass/DefaultStorageClassAlert';
-import StorageClassSelect from '@kubevirt-utils/components/DiskModal/DiskFormFields/StorageClass/StorageClassSelect';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { DataUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { hasSizeUnit } from '@kubevirt-utils/resources/vm/utils/disk/size';
-import {
-  Checkbox,
-  Grid,
-  GridItem,
-  PopoverPosition,
-  Split,
-  SplitItem,
-} from '@patternfly/react-core';
+import { Checkbox, PopoverPosition, Split, SplitItem } from '@patternfly/react-core';
 
 import { AddBootableVolumeState } from '../../utils/constants';
 
@@ -36,76 +26,43 @@ const VolumeSource: FC<VolumeSourceProps> = ({
   isUploadForm,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [showSCAlert, setShowSCAlert] = useState(false);
-  const { uploadFile, uploadFilename, pvcName, pvcNamespace, size, storageClassName } =
-    bootableVolume || {};
+  const { uploadFile, uploadFilename, pvcName, pvcNamespace } = bootableVolume || {};
 
-  return (
+  return isUploadForm ? (
+    <DiskSourceUploadPVC
+      relevantUpload={upload}
+      uploadFile={uploadFile}
+      uploadFileName={uploadFilename}
+      setUploadFile={setBootableVolumeField('uploadFile')}
+      setUploadFileName={setBootableVolumeField('uploadFilename')}
+      label={t('Upload PVC image')}
+    />
+  ) : (
     <>
-      {isUploadForm ? (
-        <DiskSourceUploadPVC
-          relevantUpload={upload}
-          uploadFile={uploadFile}
-          uploadFileName={uploadFilename}
-          setUploadFile={setBootableVolumeField('uploadFile')}
-          setUploadFileName={setBootableVolumeField('uploadFilename')}
-          label={t('Upload PVC image')}
-        />
-      ) : (
-        <>
-          <DiskSourcePVCSelect
-            pvcNameSelected={pvcName}
-            pvcNamespaceSelected={pvcNamespace}
-            selectPVCName={setBootableVolumeField('pvcName')}
-            selectPVCNamespace={setBootableVolumeField('pvcNamespace')}
-            setDiskSize={(newSize) =>
-              setBootableVolumeField('size')(
-                hasSizeUnit(newSize)
-                  ? newSize
-                  : removeByteSuffix(xbytes(Number(newSize), { iec: true, space: false })),
-              )
-            }
+      <DiskSourcePVCSelect
+        pvcNameSelected={pvcName}
+        pvcNamespaceSelected={pvcNamespace}
+        selectPVCName={setBootableVolumeField('pvcName')}
+        selectPVCNamespace={setBootableVolumeField('pvcNamespace')}
+        setDiskSize={(newSize) =>
+          setBootableVolumeField('size')(
+            hasSizeUnit(newSize)
+              ? newSize
+              : removeByteSuffix(xbytes(Number(newSize), { iec: true, space: false })),
+          )
+        }
+      />
+      <Split hasGutter>
+        <SplitItem>
+          <Checkbox id="clone-pvc-checkbox" isChecked isDisabled label={t('Clone existing PVC')} />
+        </SplitItem>
+        <SplitItem>
+          <HelpTextIcon
+            bodyContent={t('This creates a cloned copy of the PVC in the destination project.')}
+            position={PopoverPosition.right}
           />
-          <Split hasGutter>
-            <SplitItem>
-              <Checkbox
-                id="clone-pvc-checkbox"
-                isChecked
-                isDisabled
-                label={t('Clone existing PVC')}
-              />
-            </SplitItem>
-            <SplitItem>
-              <HelpTextIcon
-                bodyContent={t('This creates a cloned copy of the PVC in the destination project.')}
-                position={PopoverPosition.right}
-              />
-            </SplitItem>
-          </Split>
-        </>
-      )}
-
-      <Grid hasGutter span={12}>
-        <GridItem span={6}>
-          <StorageClassSelect
-            storageClass={storageClassName}
-            setStorageClassName={setBootableVolumeField('storageClassName')}
-            setShowSCAlert={setShowSCAlert}
-          />
-        </GridItem>
-        <GridItem span={6}>
-          <CapacityInput
-            size={size}
-            onChange={setBootableVolumeField('size')}
-            label={t('Disk size')}
-          />
-        </GridItem>
-        {showSCAlert && (
-          <GridItem span={12}>
-            <DefaultStorageClassAlert />
-          </GridItem>
-        )}
-      </Grid>
+        </SplitItem>
+      </Split>
     </>
   );
 };


### PR DESCRIPTION
## 📝 Description

Move _StorageClass_ field together with _Disk size_ to _Destination details_ section from _Source details_ one, in _Add volume_ modal, according to the design doc.

_Design doc:_
https://docs.google.com/document/d/1HTF6_H2WDXwlVy7RnrHH28dzFlhNIa15Hhpeoyg2R0Q/edit#heading=h.xt31tt3xq1x

## 🎥 Screenshots
**Before:**
Add volume modal and selecting "Upload volume" radio button:
![add1_before](https://user-images.githubusercontent.com/13417815/228318385-00e38d71-c4b1-495f-ab17-4901cf6c2df9.png)
Add volume modal and selecting "Use existing volume" radio button:
![add2_before](https://user-images.githubusercontent.com/13417815/228318405-6d7587f4-6294-44fc-ada6-d3cb0b1f19f1.png)

**After:**
Add volume modal and selecting "Upload volume" radio button:
![add1_after](https://user-images.githubusercontent.com/13417815/228318397-f937a299-96e6-4722-8cd6-5daa72b2de92.png)
Add volume modal and selecting "Use existing volume" radio button:
![add2_after](https://user-images.githubusercontent.com/13417815/228318410-56dffbf3-b56d-4c1e-aff2-4bfd641be7b3.png)

