### PR TITLE
Bug 2180664: Console is almost frozen if scroll down and up in VM metrics tab

### DIFF
--- a/src/utils/components/Charts/utils/utils.ts
+++ b/src/utils/components/Charts/utils/utils.ts
@@ -81,7 +81,7 @@ export const findNetworkMaxYValue = (
       return Math.max(...dataArray?.map((data) => data?.y));
     });
   const maxY = Math.max(...(yValues || []));
-  return maxY;
+  return Number.isInteger(maxY) ? maxY : 0;
 };
 
 export const getNetworkTickValues = (Ymax: number) => {


### PR DESCRIPTION
## 📝 Description

We can get `-Infinity` value from Prometheus which which causes an infinite loop that causes the UI to get stuck as CPU is getting overload

NOTE: credits to @metalice the genius! :crown: 

## 🎥 Demo

Before:

https://user-images.githubusercontent.com/67270715/228532763-15944add-ccb1-4092-9bbf-423ae4b4b287.mp4

After:

https://user-images.githubusercontent.com/67270715/228532978-6d5cd88d-1a60-495d-8612-0c54c0112bda.mp4


