### PR TITLE
Bug 2181323: Select 'Size' automatically if 'Default InstanceType' chosen

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeSelect/InstanceTypeSelect.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeSelect/InstanceTypeSelect.tsx
@@ -30,6 +30,7 @@ const InstanceTypeSelect: FC<InstanceTypeSelectProps> = ({ setBootableVolumeFiel
   const [category, setCategory] = useState<string>();
   const [categorySize, setCategorySize] = useState<string>();
 
+  // update options for 'Size' dropdown according to chosen 'category' in 'Default InstanceType' dropdown
   const { instanceTypes, prefix }: CategoryDetails = useMemo(
     () => (category ? categoryDetailsMap[category] : {}),
     [category],
@@ -38,6 +39,15 @@ const InstanceTypeSelect: FC<InstanceTypeSelectProps> = ({ setBootableVolumeFiel
   const onCategorySelect = (event: ChangeEvent<HTMLSelectElement>, newCategory: string) => {
     setCategory(newCategory);
     setIsCategoryOpen(false);
+
+    // when setting category, we need to set also some default categorySize, because the instanceType label on a bootable volume cannot be without that
+    const newCategoryObject = categoryDetailsMap[newCategory];
+    const newCategorySize = newCategoryObject.instanceTypes[0].label;
+    setCategorySize(newCategorySize);
+    setBootableVolumeField(
+      'labels',
+      DEFAULT_INSTANCETYPE_LABEL,
+    )(`${newCategoryObject.prefix}.${newCategorySize}`);
   };
 
   const onCategorySizeSelect = (event: ChangeEvent<HTMLSelectElement>, newCategorySize: string) => {


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2181323

Select the 1st of the options in _Size_ dropdown if already some _Default InstanceType_ was chosen. Prevent missing 'instancetype.kubevirt.io/default-instancetype' label in the created bootable volume's yaml in case of not choosing _Size_ in _Add volume_ modal, because the correctly set instanceType label requires both parts defined. It does not make sense to only choose _Default InstanceType_ without size. 

With this change, also align with the actual behavior in _Edit_ modal accessible in _Bootable_ _volumes_ list. Save one user's click when automatically selecting the 1st option from sizes, if they already choose something from _Default InstanceType_ dropdown. They still can choose some other option if they want.

## 🎥 Demo
**Before:**
it's possible to add a bootable volume with only _Default InstanceType_ chosen, without _Size_ => label missing:

https://user-images.githubusercontent.com/13417815/228647283-92f62f18-fc9f-4524-b006-46cc709e35a1.mp4

**After:**
'Size' automatically set if 'Default InstanceType' chosen by the user => label correctly set:

https://user-images.githubusercontent.com/13417815/228647292-db2be1ab-f980-404a-9d0f-1b6d3863eef5.mp4




