### PR TITLE
Bug 2177977: The volume in instanceTypes page should be selected automatically just after it's been added

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1047,6 +1047,7 @@
   "Upload data to Persistent Volume Claim": "Upload data to Persistent Volume Claim",
   "Upload error": "Upload error",
   "Upload finished": "Upload finished",
+  "Upload in progress": "Upload in progress",
   "Upload new file using the \"Upload data to Persistent Volume Claim\" page": "Upload new file using the \"Upload data to Persistent Volume Claim\" page",
   "Upload PVC image": "Upload PVC image",
   "Upload volume": "Upload volume",

--- a/src/utils/resources/shared.ts
+++ b/src/utils/resources/shared.ts
@@ -16,7 +16,10 @@ import {
 import { isDataSourceReady } from '../../views/datasources/utils';
 
 import { isEmpty } from './../utils/utils';
-import { isDataSourceCloning } from './template/hooks/useVmTemplateSource/utils';
+import {
+  isDataSourceCloning,
+  isDataSourceUploading,
+} from './template/hooks/useVmTemplateSource/utils';
 import { TEMPLATE_TYPE_LABEL } from './template';
 
 /**
@@ -328,4 +331,14 @@ export const getAvailableOrCloningDataSources = (
 ): V1beta1DataSource[] =>
   dataSources?.filter(
     (dataSource) => isDataSourceReady(dataSource) || isDataSourceCloning(dataSource),
+  );
+
+export const getReadyOrCloningOrUploadingDataSources = (
+  dataSources: V1beta1DataSource[],
+): V1beta1DataSource[] =>
+  dataSources?.filter(
+    (dataSource) =>
+      isDataSourceReady(dataSource) ||
+      isDataSourceCloning(dataSource) ||
+      isDataSourceUploading(dataSource),
   );

--- a/src/utils/resources/template/hooks/useVmTemplateSource/utils.ts
+++ b/src/utils/resources/template/hooks/useVmTemplateSource/utils.ts
@@ -118,7 +118,18 @@ export const isDataSourceCloning = (dataSource: V1beta1DataSource): boolean =>
     (c) =>
       c.type === 'Ready' &&
       c.status === 'False' &&
-      ['CloneScheduled', 'CloneInProgress'].includes(c?.reason),
+      [
+        'CloneScheduled',
+        'CloneInProgress',
+        'SnapshotForSmartCloneInProgress',
+        'Pending',
+        'PVCBound',
+      ].includes(c?.reason),
+  );
+
+export const isDataSourceUploading = (dataSource: V1beta1DataSource): boolean =>
+  dataSource?.status?.conditions?.some(
+    (c) => c.type === 'Ready' && c.status === 'False' && c?.reason === 'UploadScheduled',
   );
 
 /**

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeButton/AddBootableVolumeButton.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeButton/AddBootableVolumeButton.tsx
@@ -2,7 +2,6 @@ import React, { FC, useEffect, useState } from 'react';
 
 import DataSourceModel from '@kubevirt-ui/kubevirt-api/console/models/DataSourceModel';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
-import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { KUBEVIRT_OS_IMAGES_NS, OPENSHIFT_OS_IMAGES_NS } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -16,17 +15,14 @@ export type AddBootableVolumeButtonProps = {
   preferencesNames: string[];
   loadError?: any;
   buttonVariant?: ButtonVariant;
-  onSelectCreatedVolume?: (
-    selectedVolume: V1beta1DataSource,
-    pvcSource: V1alpha1PersistentVolumeClaim,
-  ) => void;
+  onSelectVolume?: (selectedVolume: V1beta1DataSource) => void;
 };
 
 const AddBootableVolumeButton: FC<AddBootableVolumeButtonProps> = ({
   preferencesNames,
   loadError,
   buttonVariant,
-  onSelectCreatedVolume,
+  onSelectVolume,
 }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
@@ -54,7 +50,7 @@ const AddBootableVolumeButton: FC<AddBootableVolumeButtonProps> = ({
             isOpen={isOpen}
             onClose={onClose}
             preferencesNames={preferences}
-            onSelectCreatedVolume={onSelectCreatedVolume}
+            onSelectVolume={onSelectVolume}
           />
         ))
       }

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -33,7 +33,7 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
   isOpen,
   onClose,
   preferencesNames,
-  onSelectCreatedVolume,
+  onSelectVolume,
 }) => {
   const { t } = useKubevirtTranslation();
   const [formSelection, setFormSelection] = useState<RADIO_FORM_SELECTION>(
@@ -69,7 +69,7 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
         uploadData,
         isUploadForm,
         cloneExistingPVC,
-        onSelectCreatedVolume,
+        onSelectVolume,
       )}
       headerText={t('Add volume')}
       isOpen={isOpen}

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/utils/utils.ts
@@ -12,9 +12,7 @@ import {
   V1beta1DataSource,
   V1beta1DataVolumeSourcePVC,
 } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
-import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { UploadDataProps } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
-import { getPVC } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import { AddBootableVolumeState, emptySourceDataVolume } from './constants';
@@ -25,10 +23,7 @@ export const createDataSource =
     uploadData: ({ file, dataVolume }: UploadDataProps) => Promise<void>,
     isUploadForm: boolean,
     cloneExistingPVC: boolean,
-    onSelectCreatedVolume: (
-      selectedVolume: V1beta1DataSource,
-      pvcSource: V1alpha1PersistentVolumeClaim,
-    ) => void,
+    onSelectVolume: (selectedVolume: V1beta1DataSource) => void,
   ) =>
   async (dataSource: V1beta1DataSource) => {
     const {
@@ -85,9 +80,7 @@ export const createDataSource =
 
     const newDataSource = await k8sCreate({ model: DataSourceModel, data: dataSourceToCreate });
 
-    const pvcSource = await getPVC(name, namespace);
-
-    onSelectCreatedVolume?.(newDataSource, pvcSource);
+    onSelectVolume?.(newDataSource);
   };
 
 export const getInstanceTypeFromVolume = (dataSource: V1beta1DataSource): InstanceTypeState => {

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
@@ -8,7 +8,10 @@ import {
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ANNOTATIONS } from '@kubevirt-utils/resources/template';
-import { isDataSourceCloning } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
+import {
+  isDataSourceCloning,
+  isDataSourceUploading,
+} from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { formatBytes } from '@kubevirt-utils/resources/vm/utils/disk/size';
 import { Label, Text, TextVariants } from '@patternfly/react-core';
@@ -54,6 +57,9 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
         <Text component={TextVariants.small}>{bootVolumeName}</Text>
         {isDataSourceCloning(bootableVolume) && (
           <Label className="vm-catalog-row-label">{t('Clone in progress')}</Label>
+        )}
+        {isDataSourceUploading(bootableVolume) && (
+          <Label className="vm-catalog-row-label">{t('Upload in progress')}</Label>
         )}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="operating-system" width={20}>

--- a/src/views/catalog/CreateFromInstanceTypes/hooks/useBootableVolumes.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/hooks/useBootableVolumes.ts
@@ -1,10 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { DataSourceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { KUBEVIRT_OS_IMAGES_NS, OPENSHIFT_OS_IMAGES_NS } from '@kubevirt-utils/constants/constants';
-import { convertResourceArrayToMap } from '@kubevirt-utils/resources/shared';
+import {
+  convertResourceArrayToMap,
+  getReadyOrCloningOrUploadingDataSources,
+} from '@kubevirt-utils/resources/shared';
 import { getPVC } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { isEmpty, isUpstream } from '@kubevirt-utils/utils/utils';
 import { Operator, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
@@ -36,18 +39,23 @@ const useBootableVolumes: UseBootableVolumes = () => {
 
   const [pvcSources, setPVCSources] = useState<V1alpha1PersistentVolumeClaim[]>([]);
 
+  const readyDS = useMemo(
+    () => getReadyOrCloningOrUploadingDataSources(dataSources),
+    [dataSources],
+  );
+
   useEffect(() => {
-    if (loadedDataSources && !loadErrorDataSources && !isEmpty(dataSources)) {
-      const pvcSourcePromises = (dataSources || []).map((ds) =>
+    if (loadedDataSources && !loadErrorDataSources && !isEmpty(readyDS)) {
+      const pvcSourcePromises = (readyDS || []).map((ds) =>
         getPVC(ds?.spec?.source?.pvc?.name, ds?.spec?.source?.pvc?.namespace),
       );
 
       Promise.all(pvcSourcePromises).then((pvcs) => setPVCSources(pvcs));
     }
-  }, [loadErrorDataSources, loadedDataSources, dataSources]);
+  }, [loadErrorDataSources, loadedDataSources, readyDS]);
 
   return {
-    bootableVolumes: loadErrorDataSources || isEmpty(dataSources) ? null : dataSources,
+    bootableVolumes: loadErrorDataSources || isEmpty(readyDS) ? null : readyDS,
     loaded: loadErrorDataSources ? true : loadedDataSources,
     loadError: loadErrorDataSources,
     pvcSources: convertResourceArrayToMap(pvcSources, true),


### PR DESCRIPTION
## 📝 Description

When adding a volume from existing PVC, the submit function tried to find a PVC that yet to be created, so changing it so the PVC gets selected only after being created.
also updating more possible statuses for cloning DS and creating a check to see if the DS is uploading a PVC
Also fixing list of bootable volumes to show only ready DS or DS in the upload/clone process

## 🎥 Demo

Before:

https://user-images.githubusercontent.com/67270715/228803353-6f0a3ff7-c0b8-4a4e-a4a3-53f10053f9e0.mp4

After:

https://user-images.githubusercontent.com/67270715/228803388-480d3baf-f7ba-4fab-9a12-6cf7ac2d704f.mp4


