### PR TITLE
Bug 2182233: Enforcing ssh secret name to be 51 chars or less

### DIFF
--- a/src/views/catalog/wizard/tabs/scripts/components/sshkey-utils.ts
+++ b/src/views/catalog/wizard/tabs/scripts/components/sshkey-utils.ts
@@ -44,7 +44,8 @@ export const updateSSHKeyObject = (
   updateTabsData: WizardVMContextType['updateTabsData'],
   sshkey: string,
 ) => {
-  const sshSecretName = `${vm.metadata.name}-ssh-key-${getRandomChars()}`;
+  // secret name must be under 51 chars, or machine will fail starting. substring vm name to 37.
+  const sshSecretName = `${vm?.metadata?.name.substring(0, 37)}-sshkey-${getRandomChars()}`;
 
   updateTabsData((draftTabs) => {
     if (!draftTabs.additionalObjects) draftTabs.additionalObjects = [];

--- a/src/views/templates/details/tabs/scripts/components/SSHKey/sshkey-utils.ts
+++ b/src/views/templates/details/tabs/scripts/components/SSHKey/sshkey-utils.ts
@@ -43,8 +43,8 @@ export const updateSSHKeyObject = (
     sshKeySecretObject.data.key = sshKey;
   } else {
     const vm = getTemplateVirtualMachineObject(template);
-
-    const sshSecretName = `${vm?.metadata?.name}-sshkey-${getRandomChars()}`;
+    // secret name must be under 51 chars, or machine will fail starting. substring vm name to 37.
+    const sshSecretName = `${vm?.metadata?.name.substring(0, 37)}-sshkey-${getRandomChars()}`;
 
     updateSecretName(template, sshSecretName);
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The secret volume has a maximum of 63 chars. The BE adds more chars to the volume name extending our secret name, and this fix limits the chars to 51 to stay safe with the 63 volume limit.

## 🎥 Demo

> Please add a video or an image of the behavior/changes
