### PR TITLE
Bug 2183082: Adding margin left to diagnostic tab content

### DIFF
--- a/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineDiagnosticTab.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineDiagnosticTab.tsx
@@ -17,7 +17,7 @@ const VirtualMachineDiagnosticTab: FC<VirtualMachineDiagnosticTabProps> = ({ obj
   const { conditions, volumeSnapshotStatuses } = useDiagnosticData(vm);
 
   return (
-    <div className="co-m-pane__body--no-top-margin">
+    <div className="co-m-pane__body--no-top-margin VirtualMachineDiagnosticTab--main">
       <>
         <VirtualMachineDiagnosticTabConditions conditions={conditions} />
         <VirtualMachineDiagnosticTabVolumeStatus volumeSnapshotStatuses={volumeSnapshotStatuses} />

--- a/src/views/virtualmachines/details/tabs/diagnostic/virtual-machine-diagnostic-tab.scss
+++ b/src/views/virtualmachines/details/tabs/diagnostic/virtual-machine-diagnostic-tab.scss
@@ -1,6 +1,25 @@
-.VirtualMachineDiagnosticTab--filters__main {
-  display: flex;
-  justify-content: space-between;
+.VirtualMachineDiagnosticTab {
+  &--main {
+    margin-left: var(--pf-global--spacer--sm);
+  }
+  &--filters__main {
+    display: flex;
+    justify-content: space-between;
+  }
+  &--header {
+    display: flex;
+    justify-content: space-between;
+    &.extra-margin {
+      margin-top: var(--pf-global--spacer--lg);
+    }
+    .co-m-nav-title.co-m-nav-title--row {
+      align-items: baseline;
+      .co-operator-details__actions {
+        margin-left: var(--pf-global--spacer--sm);
+        cursor: pointer;
+      }
+    }
+  }
 }
 
 .VirtualMachineDiagnosticTabRow--expanded {
@@ -14,19 +33,5 @@
 .pf-c-table {
   tr.VirtualMachineDiagnosticTabRow--row {
     border-bottom: none;
-  }
-}
-.VirtualMachineDiagnosticTab--header {
-  display: flex;
-  justify-content: space-between;
-  &.extra-margin {
-    margin-top: var(--pf-global--spacer--lg);
-  }
-  .co-m-nav-title.co-m-nav-title--row {
-    align-items: baseline;
-    .co-operator-details__actions {
-      margin-left: var(--pf-global--spacer--sm);
-      cursor: pointer;
-    }
   }
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Adding margin left to diagnostic tab content so blue line of expend content will be more visible.
## 🎥 Demo

After:
<img width="621" alt="image" src="https://user-images.githubusercontent.com/14824964/228820515-39dd7c19-4910-4498-8610-6f6b73159a02.png">

Before:
<img width="881" alt="image" src="https://user-images.githubusercontent.com/14824964/228820626-12d44eb1-2849-4e84-b9c7-13df78496369.png">
