### PR TITLE
Bug 2167660: Fix overview trend charts for All Projects namespace

### DIFF
--- a/src/views/clusteroverview/OverviewTab/metric-charts-card/utils/hooks/useMetricChartData.ts
+++ b/src/views/clusteroverview/OverviewTab/metric-charts-card/utils/hooks/useMetricChartData.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { getPrometheusData } from '@kubevirt-utils/components/Charts/utils/utils';
 import DurationOption from '@kubevirt-utils/components/DurationOption/DurationOption';
+import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk-internal';
 
@@ -35,7 +36,7 @@ const useMetricChartData: UseMetricChartData = (metric) => {
   const [queryData] = usePrometheusPoll({
     endpoint: PrometheusEndpoint.QUERY_RANGE,
     query: getMetricQuery(metric, activeNamespace),
-    namespace: activeNamespace,
+    namespace: activeNamespace === ALL_NAMESPACES_SESSION_KEY ? null : activeNamespace,
     endTime: currentTime,
     timespan,
   });


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug that caused the trend charts on the overview page to display no data. This bug does not present when the UI is run in the local context. The fix is to remove the `namespace` property in the `usePrometheusPoll` call when the active namespace is the all projects key `#ALL_NS#`. There appears to be a difference in how Prometheus handles the call based on whether the UI is in the local or cluster context.

## 🎥 Screenshot

### Before:
![Selection_245](https://user-images.githubusercontent.com/8544299/228893525-b38462f4-27e9-4411-8a51-e3b0a7b51ab5.png)


### After:
![Selection_244](https://user-images.githubusercontent.com/8544299/228892532-0b15da29-9869-4e10-b6d0-6623fac7d91e.png)

