### PR TITLE
Bug 2180666: Display PVC size correctly in Add disk modal

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -742,7 +742,7 @@
   "Persistent Volume Claim creation": "Persistent Volume Claim creation",
   "Persistent Volume Claim has been created and your data source is now being uploaded to it. Once the uploading is completed the Persistent Volume Claim will become available": "Persistent Volume Claim has been created and your data source is now being uploaded to it. Once the uploading is completed the Persistent Volume Claim will become available",
   "Persistent Volume Claim Name": "Persistent Volume Claim Name",
-  "Persistent Volume Claim size": "Persistent Volume Claim size",
+  "PersistentVolumeClaim size": "PersistentVolumeClaim size",
   "pick an operating system": "pick an operating system",
   "Please <2>try again</2>.": "Please <2>try again</2>.",
   "Please do not close this window, you can keep navigating the app freely.": "Please do not close this window, you can keep navigating the app freely.",

--- a/src/utils/components/DiskModal/DiskFormFields/DiskSizeInput/DiskSizeInput.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/DiskSizeInput/DiskSizeInput.tsx
@@ -38,7 +38,7 @@ const DiskSizeInput: React.FC<DiskSizeInputProps> = ({ diskState, dispatchDiskSt
   }
 
   return (
-    <CapacityInput size={diskSize} onChange={onChange} label={t('Persistent Volume Claim size')} />
+    <CapacityInput size={diskSize} onChange={onChange} label={t('PersistentVolumeClaim size')} />
   );
 };
 

--- a/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourcePVCSelect.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourcePVCSelect.tsx
@@ -1,5 +1,7 @@
 import React, { FC, useCallback, useMemo } from 'react';
 
+import { bytesFromQuantity } from '@catalog/utils/quantity';
+
 import { useProjectsAndPVCs } from '../../hooks/useProjectsAndPVCs';
 
 import DiskSourcePVCSelectName from './DiskSourcePVCSelectName';
@@ -36,7 +38,7 @@ const DiskSourcePVCSelect: FC<DiskSourcePVCSelectProps> = ({
       selectPVCName(selection);
       const selectedPVC = pvcs?.find((pvc) => pvc?.metadata?.name === selection);
       const selectedPVCSize = selectedPVC?.spec?.resources?.requests?.storage;
-      setDiskSize && setDiskSize(selectedPVCSize);
+      setDiskSize && setDiskSize(bytesFromQuantity(selectedPVCSize)?.join(''));
     },
     [selectPVCName, pvcs, setDiskSize],
   );


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2180666

Display _Persistent Volume Claim size_ correctly, readable for a user, in _Add disk_ modal accessible from VM _Disks_ page, when choosing _PVC (creates PVC)_ for _Source_ field. Display the value in appropriate size and unit (for example _GiB_ instead of big number + _B_ as bytes unit).

## 🎥 Demo
The actual info about the selected PVC as an example of the expected size when selecting that PVC later in Add disk modal:
![pvc_info](https://user-images.githubusercontent.com/13417815/229152637-19642d53-5567-4d13-8df7-cdcf1c916ec0.png)

**Before:**
Not very user friendly PVC size (in bytes):
![pvc_before](https://user-images.githubusercontent.com/13417815/229152580-f6332252-dcb8-442f-a9a7-d37defc17109.png)

**After:**
Nice, readable size - smaller number with _GiB_ units instead of bytes:
![pvc_after](https://user-images.githubusercontent.com/13417815/229152601-5696734b-5c2e-403b-bfb8-1ec6fcc8a5c9.png)



