### PR TITLE
Bug 2175990: Improve Default InstanceType field in Edit modal

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -891,7 +891,6 @@
   "Show top 5": "Show top 5",
   "Show virtualization health alerts": "Show virtualization health alerts",
   "Single user (RWO)": "Single user (RWO)",
-  "size": "size",
   "Size": "Size",
   "Size cannot be {{errorValue}}": "Size cannot be {{errorValue}}",
   "Small scale consumption, recommended for using the graphical console": "Small scale consumption, recommended for using the graphical console",

--- a/src/views/bootablevolumes/actions/BootableVolumesActions.tsx
+++ b/src/views/bootablevolumes/actions/BootableVolumesActions.tsx
@@ -11,15 +11,10 @@ import useBootableVolumesActions from './hooks/useBootableVolumesActions';
 type BootableVolumesActionsProps = {
   dataSource: V1beta1DataSource;
   preferences: V1alpha2VirtualMachineClusterPreference[];
-  instanceTypesNames: string[];
 };
 
-const BootableVolumesActions: FC<BootableVolumesActionsProps> = ({
-  dataSource,
-  preferences,
-  instanceTypesNames,
-}) => {
-  const [actions] = useBootableVolumesActions(dataSource, preferences, instanceTypesNames);
+const BootableVolumesActions: FC<BootableVolumesActionsProps> = ({ dataSource, preferences }) => {
+  const [actions] = useBootableVolumesActions(dataSource, preferences);
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const handleClick = (action: Action) => {

--- a/src/views/bootablevolumes/actions/components/EditBootableVolumesModal.tsx
+++ b/src/views/bootablevolumes/actions/components/EditBootableVolumesModal.tsx
@@ -1,14 +1,16 @@
-import React, { FC, useCallback, useMemo, useState } from 'react';
+import React, { ChangeEvent, FC, useCallback, useMemo, useState } from 'react';
 
 import FilterSelect from '@catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/FilterSelect/FilterSelect';
+import {
+  CategoryDetails,
+  InstanceTypeCategory,
+} from '@catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/utils/types';
+import { categoryDetailsMap } from '@catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/utils/utils';
 import {
   DEFAULT_INSTANCETYPE_LABEL,
   DEFAULT_PREFERENCE_LABEL,
 } from '@catalog/CreateFromInstanceTypes/utils/constants';
-import {
-  VirtualMachineClusterInstancetypeModelGroupVersionKind,
-  VirtualMachineClusterPreferenceModelGroupVersionKind,
-} from '@kubevirt-ui/kubevirt-api/console';
+import { VirtualMachineClusterPreferenceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { V1alpha2VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
@@ -17,18 +19,28 @@ import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { convertResourceArrayToMap } from '@kubevirt-utils/resources/shared';
 import { ANNOTATIONS } from '@kubevirt-utils/resources/template';
+import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import { Form, FormGroup, Grid, GridItem, PopoverPosition, TextArea } from '@patternfly/react-core';
+import {
+  Form,
+  FormGroup,
+  Grid,
+  GridItem,
+  PopoverPosition,
+  Select,
+  SelectOption,
+  SelectVariant,
+  TextArea,
+} from '@patternfly/react-core';
 
 import { BootableVolumeMetadata } from '../../utils/types';
-import { changeBootableVolumeMetadata, getInstanceTypesToSizesMap } from '../../utils/utils';
+import { changeBootableVolumeMetadata } from '../../utils/utils';
 
 type EditBootableVolumesModalProps = {
   dataSource: V1beta1DataSource;
   isOpen: boolean;
   onClose: () => void;
   preferences: V1alpha2VirtualMachineClusterPreference[];
-  instanceTypesNames: string[];
 };
 
 const EditBootableVolumesModal: FC<EditBootableVolumesModalProps> = ({
@@ -36,54 +48,67 @@ const EditBootableVolumesModal: FC<EditBootableVolumesModalProps> = ({
   isOpen,
   onClose,
   preferences,
-  instanceTypesNames,
 }) => {
   const { t } = useKubevirtTranslation();
+
   const preferencesNames = useMemo(
     () => Object.keys(convertResourceArrayToMap(preferences)).sort((a, b) => a.localeCompare(b)),
     [preferences],
   );
 
-  const instanceTypesToSizesMap = useMemo(
-    () => getInstanceTypesToSizesMap(instanceTypesNames),
-    [instanceTypesNames],
-  );
-
   const initialParams = useMemo(() => {
     const instanceTypeLabel =
       dataSource?.metadata?.labels?.[DEFAULT_INSTANCETYPE_LABEL]?.split('.');
+    const initialCategory = Object.entries(categoryDetailsMap).find(
+      (category) => category[1].prefix === instanceTypeLabel?.[0],
+    );
 
     return {
       preference: dataSource?.metadata?.labels?.[DEFAULT_PREFERENCE_LABEL],
-      instanceType: instanceTypeLabel?.[0],
-      size: instanceTypeLabel?.[1],
+      instanceType: initialCategory,
+      size: initialCategory && instanceTypeLabel?.[1],
       description: dataSource?.metadata?.annotations?.[ANNOTATIONS.description],
     };
   }, [dataSource]);
 
   const [preference, setPreference] = useState<string>(initialParams.preference);
-  const [instanceType, setInstanceType] = useState<string>(initialParams.instanceType);
+  const [isInstanceTypeOpen, setIsInstanceTypeOpen] = useState(false);
+  const [instanceType, setInstanceType] = useState<string>(initialParams.instanceType?.[0]);
+  const [isSizeOpen, setIsSizeOpen] = useState(false);
   const [size, setSize] = useState<string>(initialParams.size);
   const [description, setDescription] = useState<string>(initialParams.description);
 
-  const sizeOptions = useMemo(
-    () => instanceTypesToSizesMap[instanceType] || [],
-    [instanceType, instanceTypesToSizesMap],
+  // update options for 'Size' dropdown according to chosen 'instanceType' in 'Default InstanceType' dropdown
+  const { instanceTypes }: CategoryDetails = useMemo(
+    () => (instanceType ? categoryDetailsMap[instanceType] : {}),
+    [instanceType],
   );
 
-  const onInstanceTypeChange = useCallback(
-    (instanceTypeName: string) => {
-      setInstanceType(instanceTypeName);
-      setSize(instanceTypesToSizesMap[instanceTypeName][0]);
-    },
-    [instanceTypesToSizesMap],
-  );
+  const onInstanceTypeSelect = (
+    _event: ChangeEvent<HTMLSelectElement>,
+    newInstanceType: string,
+  ) => {
+    setInstanceType(newInstanceType);
+    setIsInstanceTypeOpen(false);
 
-  const onChangeVolumeParams = useCallback(() => {
+    const newCategoryObject = categoryDetailsMap[newInstanceType];
+    const newCategorySize = newCategoryObject.instanceTypes[0].label;
+    setSize(newCategorySize);
+  };
+
+  const onSizeSelect = (_event: ChangeEvent<HTMLSelectElement>, newSize: string) => {
+    setSize(newSize);
+    setIsSizeOpen(false);
+  };
+
+  const onSubmitVolumeParams = useCallback(() => {
     const preferenceLabel = preference && { [DEFAULT_PREFERENCE_LABEL]: preference };
+
+    const categoryObject = categoryDetailsMap[instanceType];
     const instanceLabel = instanceType && {
-      [DEFAULT_INSTANCETYPE_LABEL]: `${instanceType}.${size}`,
+      [DEFAULT_INSTANCETYPE_LABEL]: `${categoryObject.prefix}.${size}`,
     };
+
     const descriptionAnnotation = description?.trim()
       ? { [ANNOTATIONS.description]: description.trim() }
       : { [ANNOTATIONS.description]: undefined }; // we do want undefined here to get the annotation removed from the resource, if description not provided
@@ -109,7 +134,7 @@ const EditBootableVolumesModal: FC<EditBootableVolumesModalProps> = ({
       isOpen={isOpen}
       onClose={onClose}
       headerText={t('Edit volume metadata')}
-      onSubmit={onChangeVolumeParams()}
+      onSubmit={onSubmitVolumeParams()}
     >
       <Form>
         <FormGroup
@@ -157,24 +182,55 @@ const EditBootableVolumesModal: FC<EditBootableVolumesModalProps> = ({
                 </>
               }
             >
-              <FilterSelect
-                selected={instanceType}
-                setSelected={onInstanceTypeChange}
-                options={Object.keys(instanceTypesToSizesMap) || []}
-                groupVersionKind={VirtualMachineClusterInstancetypeModelGroupVersionKind}
-                optionLabelText={t('InstanceType')}
-              />
+              <Select
+                menuAppendTo="parent"
+                isOpen={isInstanceTypeOpen}
+                onToggle={setIsInstanceTypeOpen}
+                onSelect={onInstanceTypeSelect}
+                variant={SelectVariant.single}
+                placeholderText={t('Select InstanceType')}
+                selections={instanceType}
+              >
+                {Object.keys(InstanceTypeCategory)?.map((instanceTypeCategory) => {
+                  const { seriesLabel, title }: CategoryDetails =
+                    categoryDetailsMap[instanceTypeCategory];
+                  return (
+                    <SelectOption
+                      key={instanceTypeCategory}
+                      value={instanceTypeCategory}
+                      description={title}
+                    >
+                      {seriesLabel}
+                    </SelectOption>
+                  );
+                })}
+              </Select>
             </FormGroup>
           </GridItem>
           <GridItem span={6}>
             <FormGroup label={t('Size')}>
-              <FilterSelect
-                selected={size}
-                setSelected={setSize}
-                options={sizeOptions}
-                groupVersionKind={VirtualMachineClusterInstancetypeModelGroupVersionKind}
-                optionLabelText={t('size')}
-              />
+              <Select
+                menuAppendTo="parent"
+                isOpen={isSizeOpen}
+                onToggle={setIsSizeOpen}
+                onSelect={onSizeSelect}
+                variant={SelectVariant.single}
+                placeholderText={t('Select size')}
+                selections={size}
+              >
+                {instanceTypes?.map(({ label, cpus, memory }) => (
+                  <SelectOption
+                    key={label}
+                    value={label}
+                    description={t('{{cpus}} CPUs, {{memory}} Memory', {
+                      cpus,
+                      memory: readableSizeUnit(memory),
+                    })}
+                  >
+                    {label}
+                  </SelectOption>
+                ))}
+              </Select>
             </FormGroup>
           </GridItem>
         </Grid>

--- a/src/views/bootablevolumes/actions/hooks/useBootableVolumesActions.tsx
+++ b/src/views/bootablevolumes/actions/hooks/useBootableVolumesActions.tsx
@@ -14,14 +14,9 @@ import EditBootableVolumesModal from '../components/EditBootableVolumesModal';
 type BootableVolumesActionsProps = (
   dataSource: V1beta1DataSource,
   preferences: V1alpha2VirtualMachineClusterPreference[],
-  instanceTypesNames: string[],
 ) => [actions: Action[]];
 
-const useBootableVolumesActions: BootableVolumesActionsProps = (
-  dataSource,
-  preferences,
-  instanceTypesNames,
-) => {
+const useBootableVolumesActions: BootableVolumesActionsProps = (dataSource, preferences) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
 
@@ -42,7 +37,6 @@ const useBootableVolumesActions: BootableVolumesActionsProps = (
             isOpen={isOpen}
             onClose={onClose}
             preferences={preferences}
-            instanceTypesNames={instanceTypesNames}
           />
         )),
     },

--- a/src/views/bootablevolumes/list/BootableVolumesList.tsx
+++ b/src/views/bootablevolumes/list/BootableVolumesList.tsx
@@ -8,7 +8,6 @@ import { DataSourceModelGroupVersionKind, DataSourceModelRef } from '@kubevirt-u
 import {
   convertResourceArrayToMap,
   getAvailableOrCloningDataSources,
-  getName,
 } from '@kubevirt-utils/resources/shared';
 import {
   K8sResourceCommon,
@@ -31,8 +30,7 @@ import './BootableVolumesList.scss';
 const BootableVolumesList: FC = () => {
   const { t } = useKubevirtTranslation();
   const [dataSources, loadedDataSources, loadErrorDataSources] = useBootableVolumes();
-  const { preferences, instanceTypes, loadError } = useInstanceTypesAndPreferences();
-  const instanceTypesNames = (instanceTypes || []).map(getName).sort((a, b) => a.localeCompare(b));
+  const { preferences, loadError } = useInstanceTypesAndPreferences();
   const [data, filteredData, onFilterChange] = useListPageFilter(
     getAvailableOrCloningDataSources(dataSources),
     useBootableVolumesFilters(),
@@ -114,7 +112,6 @@ const BootableVolumesList: FC = () => {
             rowData={{
               groupVersionKind: DataSourceModelGroupVersionKind,
               preferences,
-              instanceTypesNames,
             }}
           />
         </Stack>

--- a/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
+++ b/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
@@ -25,10 +25,9 @@ const BootableVolumesRow: FC<
     {
       groupVersionKind: K8sGroupVersionKind;
       preferences: V1alpha2VirtualMachineClusterPreference[];
-      instanceTypesNames: string[];
     }
   >
-> = ({ obj, activeColumnIDs, rowData: { groupVersionKind, preferences, instanceTypesNames } }) => {
+> = ({ obj, activeColumnIDs, rowData: { groupVersionKind, preferences } }) => {
   const { t } = useKubevirtTranslation();
 
   return (
@@ -67,11 +66,7 @@ const BootableVolumesRow: FC<
         activeColumnIDs={activeColumnIDs}
         className="dropdown-kebab-pf pf-c-table__action"
       >
-        <BootableVolumesActions
-          dataSource={obj}
-          preferences={preferences}
-          instanceTypesNames={instanceTypesNames}
-        />
+        <BootableVolumesActions dataSource={obj} preferences={preferences} />
       </TableData>
     </>
   );

--- a/src/views/bootablevolumes/utils/types.ts
+++ b/src/views/bootablevolumes/utils/types.ts
@@ -2,7 +2,3 @@ export type BootableVolumeMetadata = {
   labels: { [key: string]: string };
   annotations: { [key: string]: string };
 };
-
-export type InstanceTypesToSizesMap = {
-  [key: string]: string[];
-};

--- a/src/views/bootablevolumes/utils/utils.ts
+++ b/src/views/bootablevolumes/utils/utils.ts
@@ -9,7 +9,7 @@ import { ANNOTATIONS, OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { k8sPatch, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
-import { BootableVolumeMetadata, InstanceTypesToSizesMap } from './types';
+import { BootableVolumeMetadata } from './types';
 
 export const getDataSourcePreferenceLabelValue = (
   obj: V1beta1DataSource | K8sResourceCommon,
@@ -99,15 +99,3 @@ export const changeBootableVolumeMetadata =
         ],
       }));
   };
-
-export const getInstanceTypesToSizesMap = (
-  instanceTypesNames: string[] = [],
-): InstanceTypesToSizesMap =>
-  instanceTypesNames.reduce((instanceTypesAndSizes, instanceType) => {
-    const [instanceTypePart, sizePart] = instanceType.split('.');
-
-    instanceTypesAndSizes[instanceTypePart] ??= [];
-    instanceTypesAndSizes[instanceTypePart].push(sizePart);
-
-    return instanceTypesAndSizes;
-  }, {});

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeSelect/InstanceTypeSelect.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeSelect/InstanceTypeSelect.tsx
@@ -36,7 +36,7 @@ const InstanceTypeSelect: FC<InstanceTypeSelectProps> = ({ setBootableVolumeFiel
     [category],
   );
 
-  const onCategorySelect = (event: ChangeEvent<HTMLSelectElement>, newCategory: string) => {
+  const onCategorySelect = (_event: ChangeEvent<HTMLSelectElement>, newCategory: string) => {
     setCategory(newCategory);
     setIsCategoryOpen(false);
 
@@ -50,11 +50,15 @@ const InstanceTypeSelect: FC<InstanceTypeSelectProps> = ({ setBootableVolumeFiel
     )(`${newCategoryObject.prefix}.${newCategorySize}`);
   };
 
-  const onCategorySizeSelect = (event: ChangeEvent<HTMLSelectElement>, newCategorySize: string) => {
+  const onCategorySizeSelect = (
+    _event: ChangeEvent<HTMLSelectElement>,
+    newCategorySize: string,
+  ) => {
     setCategorySize(newCategorySize);
     setIsCategorySizeOpen(false);
     setBootableVolumeField('labels', DEFAULT_INSTANCETYPE_LABEL)(`${prefix}.${newCategorySize}`);
   };
+
   return (
     <Grid hasGutter span={12}>
       <GridItem span={6}>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2175990

Improve _Default InstanceType_ field/dropdown in _Edit volume metadata_ modal, accessible in _Bootable volumes_ list, according to the design update: add descriptive text to each one, omit "highperformance" and "server" options from the dropdown.

Improve also related 'Size' dropdown to display items with more info about number of CPUs and Memory size, sorted according to the size and not alpabetically, as expected.

_See more for Default InstanceType and Size drop downs design here:_
https://docs.google.com/document/d/1HTF6_H2WDXwlVy7RnrHH28dzFlhNIa15Hhpeoyg2R0Q/edit

## 🎥 Screenshots
**Before:**
Not much info about options for _Default InstanceType_, also the selected option not marked as selected in the dropdown:
![cx1_before](https://user-images.githubusercontent.com/13417815/229220150-a87c351c-c0d8-412e-95d6-915eb6a76e84.png)
Sizes sorted alphabetically:
![cx2_before](https://user-images.githubusercontent.com/13417815/229220186-c9bc086e-a4fc-4adf-81f5-6d0be21a1233.png)

**After:**
![cx1_after](https://user-images.githubusercontent.com/13417815/229220165-9a949ea8-3674-4c55-8a64-c389029bc242.png)
![cx2_after](https://user-images.githubusercontent.com/13417815/229220206-ff982702-6a38-48e9-83b4-c6ea0214b636.png)







