### PR TITLE
Bug 2184098: Fix size in add volume modal

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -100,7 +100,6 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
         <VolumeDestination
           bootableVolume={bootableVolume}
           setBootableVolumeField={setBootableVolumeField}
-          setBootableVolumeName={setBootableVolumeField('bootableVolumeName')}
         />
         <FormGroup>{/* Spacer */}</FormGroup>
         <Title headingLevel="h5">

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeDestination/VolumeDestination.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeDestination/VolumeDestination.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FC, SetStateAction, useState } from 'react';
+import React, { FC, useState } from 'react';
 
 import CapacityInput from '@kubevirt-utils/components/CapacityInput/CapacityInput';
 import DefaultStorageClassAlert from '@kubevirt-utils/components/DiskModal/DiskFormFields/StorageClass/DefaultStorageClassAlert';
@@ -13,13 +13,11 @@ import { AddBootableVolumeState } from '../../utils/constants';
 type VolumeDestinationProps = {
   bootableVolume: AddBootableVolumeState;
   setBootableVolumeField: (key: string, fieldKey?: string) => (value: string) => void;
-  setBootableVolumeName: Dispatch<SetStateAction<string>>;
 };
 
 const VolumeDestination: FC<VolumeDestinationProps> = ({
   bootableVolume,
   setBootableVolumeField,
-  setBootableVolumeName,
 }) => {
   const { t } = useKubevirtTranslation();
   const [showSCAlert, setShowSCAlert] = useState(false);
@@ -55,7 +53,7 @@ const VolumeDestination: FC<VolumeDestinationProps> = ({
           id="name"
           type="text"
           value={bootableVolumeName}
-          onChange={setBootableVolumeName}
+          onChange={setBootableVolumeField('bootableVolumeName')}
         />
       </FormGroup>
       <FormGroup label={t('Destination project')}>

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeSource/VolumeSource.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeSource/VolumeSource.tsx
@@ -47,7 +47,7 @@ const VolumeSource: FC<VolumeSourceProps> = ({
         setDiskSize={(newSize) =>
           setBootableVolumeField('size')(
             hasSizeUnit(newSize)
-              ? newSize
+              ? removeByteSuffix(newSize)
               : removeByteSuffix(xbytes(Number(newSize), { iec: true, space: false })),
           )
         }


### PR DESCRIPTION
## 📝 Description

when getting a size from the pvc we need to remove the `B` suffix more info on: https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/


## 🎥 Demo

After:

https://user-images.githubusercontent.com/67270715/229574555-2f907a8f-6258-4d92-a182-817d60f306ee.mp4


