### PR TITLE
Bug 2184058: Display 'Add network interface' button only once

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/network/copmonents/list/AutoAttachedNetworkEmptyState.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/copmonents/list/AutoAttachedNetworkEmptyState.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Bullseye,
@@ -11,18 +10,15 @@ import {
 } from '@patternfly/react-core';
 import { NetworkIcon } from '@patternfly/react-icons';
 
-import AddNetworkInterfaceButton from '../AddNetworkInterfaceButton';
-
 type AutoAttachedNetworkEmptyStateProps = {
-  vm: V1VirtualMachine;
   isAutoAttached: boolean;
 };
 
 const AutoAttachedNetworkEmptyState: FC<AutoAttachedNetworkEmptyStateProps> = ({
-  vm,
   isAutoAttached,
 }) => {
   const { t } = useKubevirtTranslation();
+
   return (
     <Bullseye>
       <EmptyState variant={EmptyStateVariant.small}>
@@ -36,7 +32,6 @@ const AutoAttachedNetworkEmptyState: FC<AutoAttachedNetworkEmptyStateProps> = ({
                 'No network interface definitions found. Click the "Add network interface" to define one.',
               )}
         </EmptyStateBody>
-        <AddNetworkInterfaceButton vm={vm} />
       </EmptyState>
     </Bullseye>
   );

--- a/src/views/virtualmachines/details/tabs/configuration/network/copmonents/list/NetworkInterfaceList.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/copmonents/list/NetworkInterfaceList.tsx
@@ -43,9 +43,7 @@ const NetworkInterfaceList: FC<NetworkInterfaceTableProps> = ({ vm }) => {
         columns={columns}
         Row={NetworkInterfaceRow}
         rowData={{ vm }}
-        EmptyMsg={() => (
-          <AutoAttachedNetworkEmptyState vm={vm} isAutoAttached={autoattachPodInterface} />
-        )}
+        EmptyMsg={() => <AutoAttachedNetworkEmptyState isAutoAttached={autoattachPodInterface} />}
       />
     </>
   );


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2184058

Remove _Add network interface_ button from VM's _Network interfaces_ tab in case there are no any NICs present, according to the UX suggestions. Display the button only once - in the left up, next to the YAML switcher.

_Notes:_
Note that the solution is not 100% consistent with "empty state" but it’s more important that all the buttons in the VM details page are aligned (discussed that with the UX).

Also note that within the BZ https://bugzilla.redhat.com/show_bug.cgi?id=2176797, the title of the page _Network interfaces_ will be added and then the button will be positioned under that title.

## 🎥 Screenshots
**Before:**
_Add network interface_ button  displayed twice:
![nic_before](https://user-images.githubusercontent.com/13417815/229586030-b7be3c7a-f4d4-4f2b-b7ee-7f0e04e39df4.png)

**After:**
_Add network interface_ button  displayed once - position of the button same as in other VM's tabs:
![nic_after](https://user-images.githubusercontent.com/13417815/229586047-a6ecaef5-f75f-42ab-b67b-34484923b05a.png)
