### PR TITLE
Bug 2183979: Console page - disable only vnc console in headless mode

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -248,6 +248,7 @@
   "Connect with any viewer application for following protocols": "Connect with any viewer application for following protocols",
   "Connecting": "Connecting",
   "Console": "Console",
+  "Console is disabled": "Console is disabled",
   "Console is disabled in headless mode": "Console is disabled in headless mode",
   "Contact the image provider for more information.": "Contact the image provider for more information.",
   "Container": "Container",

--- a/src/utils/components/Consoles/Consoles.tsx
+++ b/src/utils/components/Consoles/Consoles.tsx
@@ -21,7 +21,7 @@ import {
 } from './components/utils/ConsoleConsts';
 import VncConsole from './components/vnc-console/VncConsole';
 import { INSECURE, SECURE } from './utils/constants';
-import { isConnectionEncrypted } from './utils/utils';
+import { isConnectionEncrypted, isHeadlessModeVMI } from './utils/utils';
 
 const Consoles: React.FC<ConsolesProps> = ({ vmi }) => {
   const isEncrypted = isConnectionEncrypted();
@@ -33,6 +33,7 @@ const Consoles: React.FC<ConsolesProps> = ({ vmi }) => {
     namespace: vmi?.metadata?.namespace,
   });
   const gpus = getGPUDevices(vm);
+  const isHeadlessMode = isHeadlessModeVMI(vmi);
 
   return !vmi?.metadata ? (
     <Bullseye>
@@ -52,6 +53,8 @@ const Consoles: React.FC<ConsolesProps> = ({ vmi }) => {
           <VncConsole
             type={VNC_CONSOLE_TYPE}
             encrypt={isEncrypted}
+            disabled={isHeadlessMode}
+            CustomDisabledComponent={t('Console is disabled in headless mode')}
             host={window.location.hostname}
             port={window.location.port || (isEncrypted ? SECURE : INSECURE)}
             path={`api/kubernetes/apis/subresources.kubevirt.io/v1/namespaces/${vmi?.metadata?.namespace}/virtualmachineinstances/${vmi?.metadata?.name}/vnc`}

--- a/src/utils/components/Consoles/components/vnc-console/utils/VncConsoleTypes.ts
+++ b/src/utils/components/Consoles/components/vnc-console/utils/VncConsoleTypes.ts
@@ -65,6 +65,8 @@ export type VncConsoleProps = React.HTMLProps<HTMLDivElement> & {
   autoConnect?: boolean;
   /** A custom component to replace th default connect button screen */
   CustomConnectComponent?: React.FC<{ connect: () => void }>;
+  /** A custom component to replace th default disabled component */
+  CustomDisabledComponent?: React.ReactNode;
   /** Should console render alt tabs */
   hasGPU?: boolean;
 };

--- a/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.tsx
+++ b/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.tsx
@@ -4,7 +4,6 @@ import { RouteComponentProps } from 'react-router-dom';
 import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Consoles from '@kubevirt-utils/components/Consoles/Consoles';
-import { isHeadlessModeVMI } from '@kubevirt-utils/components/Consoles/utils/utils';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
@@ -24,15 +23,12 @@ const VirtualMachineConsolePage: React.FC<VirtualMachineConsolePageProps> = ({ o
     namespace: vm?.metadata?.namespace,
     isList: false,
   });
-  const isHeadlessMode = isHeadlessModeVMI(vmi);
 
-  if (!vmi || vm?.status?.printableStatus === printableVMStatus.Stopped || isHeadlessMode) {
+  if (!vmi || vm?.status?.printableStatus === printableVMStatus.Stopped) {
     return (
       <EmptyState>
         <EmptyStateBody>
-          {!isHeadlessMode &&
-            t('This VirtualMachine is down. Please start it to access its console.')}
-          {isHeadlessMode && t('Console is disabled in headless mode')}
+          {t('This VirtualMachine is down. Please start it to access its console.')}
         </EmptyStateBody>
       </EmptyState>
     );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When VM headless mode is on, the console page is all disabled, but only vnc console page should be disabled as the serial console is available. 
## 🎥 Demo

After:
<img width="1659" alt="image" src="https://user-images.githubusercontent.com/14824964/229722526-c063d034-06f6-450d-96d2-7b62b10d93ba.png">

Before:
<img width="1556" alt="image" src="https://user-images.githubusercontent.com/14824964/229722645-cfd56e46-cda3-437c-b275-34f00a76e10f.png">
