### PR TITLE
Bug 2181920: Disable Secure Boot for UEFI Boot mode

### DIFF
--- a/src/utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal.tsx
+++ b/src/utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal.tsx
@@ -74,7 +74,7 @@ const FirmwareBootloaderModal: React.FC<FirmwareBootloaderModalProps> = ({
       switch (selectedFirmwareBootloader) {
         case 'uefi':
           vmDraft.spec.template.spec.domain.firmware.bootloader = {
-            efi: {},
+            efi: { secureBoot: false },
           };
           break;
         case 'uefiSecure':


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2181920

Disable secure boot when choosing "UEFI" option in the VM _Details_ page for "Boot mode" field. Fix the yaml when choosing this option in the UI.

_How to reproduce the bug:_
1. choose/create some VM with Fedora OS (or any other OS, but easier to reproduce with Fedora, because it has _bootctl_ already installed - to easily get the status for secure boot)
2. go to VM's _Details_ page and check _Boot mode_ field:
- if there is "UEFI" already chosen, continue to the next step
- if there is something else, choose "UEFI" in the modal and restart the VM to apply the change
3. go to VM's console:
  click on _Open web console_ in VM _Overview_ tab or also you can go to VM Console tab
5. log in to (running!) VM, open _Guest login credentials_ up left in the page to get the credentials
   (or you also can look to the VM's _Scripts_ tab -  _Cloud-init_ section, where you also can change the password if you are allowed to do so)
6. after logging to the VM, check secure boot status, in the VM console:
`sudo bootctl status | grep "Secure Boot"`
=> it was enabled even if it shouldn't be!

## 🎥 Screenshots
Choosing "UEFI" option in the VM _Details_ page for "Boot mode" field:
![uefi](https://user-images.githubusercontent.com/13417815/230123487-da7c4178-669a-4519-902e-a1b6f7d28332.png)

**Before:**
Secure boot enabled, when checking the status after logging to the VM:
![uefi_before](https://user-images.githubusercontent.com/13417815/230123400-fb32a944-5470-4323-911e-7835d8b3d787.png)
VM's yaml:
![uefi_before2](https://user-images.githubusercontent.com/13417815/230123405-f3d1c70c-5d49-464a-9c23-52ebaadd6785.png)

**After:**
Secure boot disabled as expected, when checking the status after logging to the VM:
![uefi_after](https://user-images.githubusercontent.com/13417815/230123455-32b155d7-a9e7-4257-9ed5-a2ecdf7bf8bf.png)
VM's yaml:
![uefi_after2](https://user-images.githubusercontent.com/13417815/230123457-ffe023a1-3677-4316-bf8c-291566ff17cd.png)


