### PR TITLE
Remove extra buttons to create VM or MigrationPolicy

### DIFF
--- a/src/utils/components/ExternalLink/ExternalLink.tsx
+++ b/src/utils/components/ExternalLink/ExternalLink.tsx
@@ -1,31 +1,32 @@
-import * as React from 'react';
-import classNames from 'classnames';
+import React, { FC } from 'react';
+
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 type ExternalLinkProps = {
   href: string;
   text?: React.ReactNode;
-  additionalClassName?: string;
+  className?: string;
   dataTestID?: string;
   stopPropagation?: boolean;
 };
 
-const ExternalLink: React.FC<ExternalLinkProps> = ({
+const ExternalLink: FC<ExternalLinkProps> = ({
   children,
   href,
   text,
-  additionalClassName = '',
+  className = '',
   dataTestID,
   stopPropagation,
 }) => (
   <a
-    className={classNames('co-external-link', additionalClassName)}
+    className={className}
     href={href}
     target="_blank"
     rel="noopener noreferrer"
     data-test-id={dataTestID}
     {...(stopPropagation ? { onClick: (e) => e.stopPropagation() } : {})}
   >
-    {children || text}
+    {children || text} <ExternalLinkAltIcon />
   </a>
 );
 

--- a/src/views/bootablevolumes/actions/components/EditBootableVolumesModal.tsx
+++ b/src/views/bootablevolumes/actions/components/EditBootableVolumesModal.tsx
@@ -146,7 +146,7 @@ const EditBootableVolumesModal: FC<EditBootableVolumesModalProps> = ({
                   <>
                     {t(
                       'The preferred VirtualMachine attribute values required to run a given workload.',
-                    )}
+                    )}{' '}
                     <ExternalLink
                       href={
                         'https://kubevirt.io/user-guide/virtual_machines/instancetypes/#virtualmachinepreference'

--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/PreferenceSelect.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/PreferenceSelect.tsx
@@ -31,7 +31,7 @@ const PreferenceSelect: FC<PreferenceSelectProps> = ({
               <>
                 {t(
                   'The preferred VirtualMachine attribute values required to run a given workload.',
-                )}
+                )}{' '}
                 <ExternalLink
                   href={
                     'https://kubevirt.io/user-guide/virtual_machines/instancetypes/#virtualmachinepreference'

--- a/src/views/clusteroverview/OverviewTab/getting-started-card/utils/getting-started-content/GettingStartedLinkExtraContent.tsx
+++ b/src/views/clusteroverview/OverviewTab/getting-started-card/utils/getting-started-content/GettingStartedLinkExtraContent.tsx
@@ -21,7 +21,7 @@ const GettingStartedLinkExtraContent: React.FC<GettingStartedLinkExtraContentPro
       <ExternalLink
         href={link?.secondaryLinkHref}
         text={link?.secondaryLinkText}
-        additionalClassName="getting-started-link-extra-content__more-block--link"
+        className="getting-started-link-extra-content__more-block--link"
       />
     ) : (
       <Link to={link?.secondaryLinkHref}>{link?.secondaryLinkText}</Link>

--- a/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
+++ b/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom';
 
 import { MigrationPolicyModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import { V1alpha1MigrationPolicy } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   ListPageBody,
-  ListPageCreateDropdown,
   ListPageFilter,
   ListPageHeader,
   useK8sWatchResource,
@@ -14,10 +13,10 @@ import {
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 
+import MigrationPoliciesCreateButton from './components/MigrationPoliciesCreateButton/MigrationPoliciesCreateButton';
 import MigrationPoliciesEmptyState from './components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState';
 import MigrationPoliciesRow from './components/MigrationPoliciesRow/MigrationPoliciesRow';
 import useMigrationPoliciesListColumns from './hooks/useMigrationPoliciesListColumns';
-import { migrationPoliciesPageBaseURL } from './utils/constants';
 
 type MigrationPoliciesListProps = {
   kind: string;
@@ -25,7 +24,6 @@ type MigrationPoliciesListProps = {
 
 const MigrationPoliciesList: React.FC<MigrationPoliciesListProps> = ({ kind }) => {
   const { t } = useKubevirtTranslation();
-  const history = useHistory();
   const [mps, loaded, loadError] = useK8sWatchResource<V1alpha1MigrationPolicy[]>({
     kind,
     isList: true,
@@ -35,28 +33,12 @@ const MigrationPoliciesList: React.FC<MigrationPoliciesListProps> = ({ kind }) =
   const [columns, activeColumns] = useMigrationPoliciesListColumns();
   const [unfilteredData, data, onFilterChange] = useListPageFilter(mps);
 
-  const createItems = {
-    form: t('With form'),
-    yaml: t('With YAML'),
-  };
-
-  const onCreate = (type: string) => {
-    return type === 'form'
-      ? history.push(`${migrationPoliciesPageBaseURL}/form`)
-      : history.push(`${migrationPoliciesPageBaseURL}/~new`);
-  };
-
   return (
     <>
       <ListPageHeader title={t('MigrationPolicies')}>
-        <ListPageCreateDropdown
-          items={createItems}
-          onClick={onCreate}
-          createAccessReview={{ groupVersionKind: kind }}
-        >
-          {t('Create MigrationPolicy')}
-        </ListPageCreateDropdown>
+        {!isEmpty(mps) && <MigrationPoliciesCreateButton kind={kind} />}
       </ListPageHeader>
+
       <ListPageBody>
         <ListPageFilter
           data={unfilteredData}
@@ -80,7 +62,7 @@ const MigrationPoliciesList: React.FC<MigrationPoliciesListProps> = ({ kind }) =
           loadError={loadError}
           columns={activeColumns}
           Row={MigrationPoliciesRow}
-          EmptyMsg={() => <MigrationPoliciesEmptyState />}
+          EmptyMsg={() => <MigrationPoliciesEmptyState kind={kind} />}
         />
       </ListPageBody>
     </>

--- a/src/views/migrationpolicies/list/components/MigrationPoliciesCreateButton/MigrationPoliciesCreateButton.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPoliciesCreateButton/MigrationPoliciesCreateButton.tsx
@@ -1,0 +1,34 @@
+import React, { FC } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { ListPageCreateDropdown } from '@openshift-console/dynamic-plugin-sdk';
+
+import { createItems, migrationPoliciesPageBaseURL } from '../../utils/constants';
+
+type MigrationPoliciesCreateButtonProps = {
+  kind: string;
+};
+
+const MigrationPoliciesCreateButton: FC<MigrationPoliciesCreateButtonProps> = ({ kind }) => {
+  const { t } = useKubevirtTranslation();
+  const history = useHistory();
+
+  const onCreate = (type: string) => {
+    return type === 'form'
+      ? history.push(`${migrationPoliciesPageBaseURL}/form`)
+      : history.push(`${migrationPoliciesPageBaseURL}/~new`);
+  };
+
+  return (
+    <ListPageCreateDropdown
+      items={createItems}
+      onClick={onCreate}
+      createAccessReview={{ groupVersionKind: kind }}
+    >
+      {t('Create MigrationPolicy')}
+    </ListPageCreateDropdown>
+  );
+};
+
+export default MigrationPoliciesCreateButton;

--- a/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.tsx
@@ -1,12 +1,10 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { Trans } from 'react-i18next';
-import { Link } from 'react-router-dom';
 import migrationPoliciesEmptyState from 'images/migrationPoliciesEmptyState.svg';
 
+import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
-  Button,
-  ButtonVariant,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
@@ -15,13 +13,16 @@ import {
   EmptyStateVariant,
   Title,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import { migrationPoliciesPageBaseURL } from '../../utils/constants';
+import MigrationPoliciesCreateButton from '../MigrationPoliciesCreateButton/MigrationPoliciesCreateButton';
 
 import './MigrationPoliciesEmptyState.scss';
 
-const MigrationPoliciesEmptyState: React.FC = () => {
+type MigrationPoliciesEmptyStateProps = {
+  kind: string;
+};
+
+const MigrationPoliciesEmptyState: FC<MigrationPoliciesEmptyStateProps> = ({ kind }) => {
   const { t } = useKubevirtTranslation();
 
   return (
@@ -38,18 +39,15 @@ const MigrationPoliciesEmptyState: React.FC = () => {
         </Trans>
       </EmptyStateBody>
       <EmptyStatePrimary>
-        <Link to={`${migrationPoliciesPageBaseURL}/form`}>
-          <Button variant={ButtonVariant.primary}>{t('Create MigrationPolicy')}</Button>
-        </Link>
+        <MigrationPoliciesCreateButton kind={kind} />
       </EmptyStatePrimary>
       <EmptyStateSecondaryActions>
-        <a
-          href="https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/virtualization/live-migration#virt-configuring-live-migration-policies"
-          target="_blank"
-          rel="noreferrer"
-        >
-          {t('View documentation')} <ExternalLinkAltIcon />
-        </a>
+        <ExternalLink
+          href={
+            'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/virtualization/live-migration#virt-configuring-live-migration-policies'
+          }
+          text={t('View documentation')}
+        />
       </EmptyStateSecondaryActions>
     </EmptyState>
   );

--- a/src/views/migrationpolicies/list/utils/constants.ts
+++ b/src/views/migrationpolicies/list/utils/constants.ts
@@ -1,3 +1,9 @@
 import { MigrationPolicyModelRef } from '@kubevirt-ui/kubevirt-api/console';
+import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
 export const migrationPoliciesPageBaseURL = `/k8s/cluster/${MigrationPolicyModelRef}`;
+
+export const createItems = {
+  form: t('With form'),
+  yaml: t('With YAML'),
+};

--- a/src/views/virtualmachines/list/components/VirtualMachineEmptyState/VirtualMachineEmptyState.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineEmptyState/VirtualMachineEmptyState.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 import { Trans } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 
@@ -16,13 +16,17 @@ import {
 } from '@patternfly/react-core';
 import { RocketIcon, VirtualMachineIcon } from '@patternfly/react-icons';
 
+import VirtualMachinesCreateButton from '../VirtualMachinesCreateButton/VirtualMachinesCreateButton';
+
 type VirtualMachineEmptyStateProps = {
   catalogURL: string;
+  namespace: string;
 };
 
-const VirtualMachineEmptyState: React.FC<VirtualMachineEmptyStateProps> = ({ catalogURL }) => {
+const VirtualMachineEmptyState: FC<VirtualMachineEmptyStateProps> = ({ catalogURL, namespace }) => {
   const { t } = useKubevirtTranslation();
   const history = useHistory();
+
   return (
     <EmptyState variant={EmptyStateVariant.large}>
       <EmptyStateIcon icon={VirtualMachineIcon} />
@@ -39,9 +43,10 @@ const VirtualMachineEmptyState: React.FC<VirtualMachineEmptyStateProps> = ({ cat
         </Trans>
       </EmptyStateBody>
       <EmptyStatePrimary>
-        <Button variant={ButtonVariant.primary} onClick={() => history.push(catalogURL)}>
-          {t('Create VirtualMachine')}
-        </Button>
+        <VirtualMachinesCreateButton
+          namespace={namespace}
+          buttonText={t('Create VirtualMachine')}
+        />
       </EmptyStatePrimary>
       <EmptyStateSecondaryActions>
         <Button

--- a/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
@@ -1,0 +1,64 @@
+import React, { FC, useCallback, useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { VirtualMachineModelRef } from '@kubevirt-ui/kubevirt-api/console';
+import DeveloperPreviewLabel from '@kubevirt-utils/components/DeveloperPreviewLabel/DeveloperPreviewLabel';
+import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { ListPageCreateDropdown } from '@openshift-console/dynamic-plugin-sdk';
+
+type VirtualMachinesCreateButtonProps = {
+  namespace: string;
+  buttonText?: string;
+};
+
+const VirtualMachinesCreateButton: FC<VirtualMachinesCreateButtonProps> = ({
+  namespace,
+  buttonText,
+}) => {
+  const { t } = useKubevirtTranslation();
+  const history = useHistory();
+
+  const createItems = {
+    catalog: t('From template'),
+    volume: (
+      <>
+        {t('From volume')} <DeveloperPreviewLabel />
+      </>
+    ),
+    yaml: t('From YAML'),
+  };
+
+  const catalogURL = useMemo(
+    () => `/k8s/ns/${namespace || DEFAULT_NAMESPACE}/templatescatalog`,
+    [namespace],
+  );
+
+  const onCreate = useCallback(
+    (type: string) => {
+      switch (type) {
+        case 'catalog':
+          return history.push(catalogURL);
+        case 'volume':
+          return history.push(`${catalogURL}/instanceTypes`);
+        default:
+          return history.push(
+            `/k8s/ns/${namespace || DEFAULT_NAMESPACE}/${VirtualMachineModelRef}/~new`,
+          );
+      }
+    },
+    [catalogURL, history, namespace],
+  );
+
+  return (
+    <ListPageCreateDropdown
+      items={createItems}
+      onClick={onCreate}
+      createAccessReview={{ groupVersionKind: VirtualMachineModelRef, namespace }}
+    >
+      {buttonText || t('Create')}
+    </ListPageCreateDropdown>
+  );
+};
+
+export default VirtualMachinesCreateButton;


### PR DESCRIPTION
## 📝 Description

This is a followup PR for the comment:
https://github.com/kubevirt-ui/kubevirt-plugin/pull/1234#issuecomment-1496124398

Don't display the unnecessary buttons to create VirtualMachine or MigrationPolicy in the empty state pages (no resources present), as there is the button to create the appropriate resource present also in the center of the page, which is the default for Patternfly empty state. Make this change according to the UX suggestions.

Create new `MigrationPoliciesCreateButton` component to be used where needed.
Update `MigrationPoliciesEmptyState` component: use preferred `ExternalLink` component instead of `a` in there.

Also remove unnecessary pagination for VM's empty state page, as it doesn't make sense for this case.

## 🎥 Screenshots
**Before:**
MigrationPolicies empty state - 2 buttons to create the resource present in the page (and no options to create a policy from in the middle button):
![mm_before](https://user-images.githubusercontent.com/13417815/231774838-b5c244b5-d796-4284-80b4-5ad0e70bbd79.png)
VirtualMachines empty state - 2 buttons to create the resource present in the page (and no options to create a VM from in the middle button):
![vm_before](https://user-images.githubusercontent.com/13417815/231772213-030ca239-4130-4176-afaf-04cfff7ff2b2.png)

**After**:
MigrationPolicies empty state - only 1 button to create the resource present in the page (together w all the options to create a policy from):
![mig_after](https://user-images.githubusercontent.com/13417815/231753112-7194d048-e95b-4805-abb0-76b0f424f033.png)
VirtualMachines empty state - only 1 button to create the resource present in the page (plus options to create a VM from present in the middle button):
![vm-after](https://user-images.githubusercontent.com/13417815/231772356-3bad5f73-f1d5-4c58-875f-3ee5c22918ad.png)

---

TODO:

- [x] figure out what to do with the fact, that the button in the center of the page contains only one option to create the resource, comparing to the removed button from upper right of the page, ask the UX about that - done, missing options added to the buttons for empty states
- [x] remove unnecessary pagination for VM's empty state

