### PR TITLE
Bug 2183491: Truncate PVC name in Add volume modal

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourcePVCSelectName.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourcePVCSelectName.tsx
@@ -7,7 +7,7 @@ import {
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
-import { FormGroup, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { FormGroup, Select, SelectOption, SelectVariant, Truncate } from '@patternfly/react-core';
 
 import { FilterPVCSelect } from '../../utils/Filters';
 
@@ -61,8 +61,9 @@ const DiskSourcePVCSelectName: React.FC<DiskSourcePVCSelectNameProps> = ({
               <ResourceLink
                 groupVersionKind={modelToGroupVersionKind(PersistentVolumeClaimModel)}
                 linkTo={false}
-                name={name}
-              />
+              >
+                <Truncate content={name} />
+              </ResourceLink>
             </SelectOption>
           ))}
         </Select>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2183491

Truncate the PVC name options for the _PVC name_ drop down in _Add volume_ modal (when selecting _Use existing volume_ radio button) in case when the name is too long according to the width of the modal. Display the whole name in the popover displayed on mouseover.

Note that the decision to make this change to fix the problem of not displaying the modal nicely when PVC name is too long, was made by the UX, of course.

## 🎥 Screenshots
**Before:**
![trun_before](https://user-images.githubusercontent.com/13417815/230170089-e2af27f4-abfd-459e-a83b-c3bc7903b8c6.png)

**After:**
![trun_after](https://user-images.githubusercontent.com/13417815/230170103-3e422f8d-0f8a-4d0a-a079-a93f33bb2d17.png)


