### PR TITLE
Bug 2176932: Add title to Virtualization status in OCP dashboard

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -426,6 +426,7 @@
     "properties": {
       "name": "%plugin__kubevirt-plugin~Virtualization%",
       "url": "apis/subresources.kubevirt.io/v1/healthz",
+      "title": "%plugin__kubevirt-plugin~Virtualization%",
       "healthHandler": {
         "$codeRef": "dashboardExtensions.getKubevirtHealthState"
       }


### PR DESCRIPTION
## 📝 Description

This PR adds the "Virtualization" label to the Virtualization status item in the OCP dashboard.

This bug does not exist in 4.13 onward as the Virtualization status item has been replaced with a more robust solution.

## 🎥 Demo

### Before
![Selection_247](https://user-images.githubusercontent.com/8544299/230919437-f05eb2aa-d4ea-4b5f-864e-f4aa07f7eb68.png)

### After
![Selection_246](https://user-images.githubusercontent.com/8544299/230919330-20c622ce-8199-48f3-9060-2d9a0c274172.png)

