### PR TITLE
Bug 2184063: Display titles in VM Diagnostic tab smaller

### DIFF
--- a/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabConditions.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabConditions.tsx
@@ -7,10 +7,9 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   ListPageBody,
   ListPageFilter,
-  ListPageHeader,
   useListPageFilter,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { Pagination } from '@patternfly/react-core';
+import { Flex, FlexItem, Pagination, Title } from '@patternfly/react-core';
 import { TableComposable, Th, Thead, Tr } from '@patternfly/react-table';
 import { columnSorting } from '@virtualmachines/list/hooks/utils/utils';
 import { paginationDefaultValues } from '@virtualmachines/utils';
@@ -55,58 +54,64 @@ const VirtualMachineDiagnosticTabConditions: FC<VirtualMachineDiagnosticTabCondi
 
   return (
     <>
-      <div className="VirtualMachineDiagnosticTab--header">
-        <ListPageHeader title={t('Status conditions')}>
+      <ListPageBody>
+        <Title headingLevel="h2" className="VirtualMachineDiagnosticTab--header">
+          {t('Status conditions')}{' '}
           <HelpTextIcon
             bodyContent={t(
               'Conditions provide a standard mechanism for status reporting. Conditions are reported for all aspects of a VM.',
             )}
+            helpIconClassName="title-help-text-icon"
           />
-        </ListPageHeader>
-      </div>
-      <ListPageBody>
-        <div className="VirtualMachineDiagnosticTab--filters__main">
-          <ListPageFilter
-            data={unfilteredData}
-            loaded={!isEmpty(unfilteredData)}
-            rowFilters={filters}
-            nameFilterPlaceholder={t('Search by reason...')}
-            hideLabelFilter
-            onFilterChange={(...args) => {
-              onFilterChange(...args);
-              onPaginationChange({
-                page: 1,
-                startIndex: 0,
-                endIndex: pagination?.perPage,
-                perPage: pagination?.perPage,
-              });
-            }}
-            columnLayout={{
-              columns: columns?.map(({ id, title }) => ({
-                id,
-                title,
-              })),
-              id: 'diagnostic-tab-status',
-              selectedColumns: new Set(activeColumns?.map((col) => col?.id)),
+        </Title>
 
-              type: t('VirtualMachine'),
-            }}
-          />
-          <Pagination
-            itemCount={filteredData?.length}
-            page={pagination?.page}
-            perPage={pagination?.perPage}
-            defaultToFullPage
-            onSetPage={(_e, page, perPage, startIndex, endIndex) =>
-              onPaginationChange({ page, perPage, startIndex, endIndex })
-            }
-            onPerPageSelect={(_e, perPage, page, startIndex, endIndex) =>
-              onPaginationChange({ page, perPage, startIndex, endIndex })
-            }
-            perPageOptions={paginationDefaultValues}
-          />
-        </div>
+        <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+          <FlexItem>
+            <ListPageFilter
+              data={unfilteredData}
+              loaded={!isEmpty(unfilteredData)}
+              rowFilters={filters}
+              nameFilterPlaceholder={t('Search by reason...')}
+              hideLabelFilter
+              onFilterChange={(...args) => {
+                onFilterChange(...args);
+                onPaginationChange({
+                  page: 1,
+                  startIndex: 0,
+                  endIndex: pagination?.perPage,
+                  perPage: pagination?.perPage,
+                });
+              }}
+              columnLayout={{
+                columns: columns?.map(({ id, title }) => ({
+                  id,
+                  title,
+                })),
+                id: 'diagnostic-tab-status',
+                selectedColumns: new Set(activeColumns?.map((col) => col?.id)),
+
+                type: t('VirtualMachine'),
+              }}
+            />
+          </FlexItem>
+          <FlexItem>
+            <Pagination
+              itemCount={filteredData?.length}
+              page={pagination?.page}
+              perPage={pagination?.perPage}
+              defaultToFullPage
+              onSetPage={(_e, page, perPage, startIndex, endIndex) =>
+                onPaginationChange({ page, perPage, startIndex, endIndex })
+              }
+              onPerPageSelect={(_e, perPage, page, startIndex, endIndex) =>
+                onPaginationChange({ page, perPage, startIndex, endIndex })
+              }
+              perPageOptions={paginationDefaultValues}
+            />
+          </FlexItem>
+        </Flex>
       </ListPageBody>
+
       <TableComposable isExpandable>
         <Thead>
           <Tr>

--- a/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabVolumeStatus.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabVolumeStatus.tsx
@@ -3,8 +3,8 @@ import React, { FC, useEffect, useMemo, useState } from 'react';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import usePagination from '@kubevirt-utils/hooks/usePagination';
-import { ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
-import { Pagination } from '@patternfly/react-core';
+import { ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
+import { Flex, FlexItem, Pagination, Title } from '@patternfly/react-core';
 import { TableComposable, Th, Thead, Tr } from '@patternfly/react-table';
 import { columnSorting } from '@virtualmachines/list/hooks/utils/utils';
 import { paginationDefaultValues } from '@virtualmachines/utils';
@@ -45,30 +45,37 @@ const VirtualMachineDiagnosticTabVolumeStatus: FC<VirtualMachineDiagnosticTabVol
 
   return (
     <>
-      <div className="VirtualMachineDiagnosticTab--header extra-margin">
-        <ListPageHeader title={t('Volume snapshot status')}>
-          <HelpTextIcon
-            bodyContent={t(
-              'Volume Snapshot Status is a mechanism for reporting if a volume can be snapshotted or not.',
-            )}
-          />
-        </ListPageHeader>
-        <div className="VirtualMachineDiagnosticTab--filters__main">
-          <Pagination
-            itemCount={sortedData?.length}
-            page={pagination?.page}
-            perPage={pagination?.perPage}
-            defaultToFullPage
-            onSetPage={(_e, page, perPage, startIndex, endIndex) =>
-              onPaginationChange({ page, perPage, startIndex, endIndex })
-            }
-            onPerPageSelect={(_e, perPage, page, startIndex, endIndex) =>
-              onPaginationChange({ page, perPage, startIndex, endIndex })
-            }
-            perPageOptions={paginationDefaultValues}
-          />
-        </div>
-      </div>
+      <ListPageBody>
+        <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+          <FlexItem>
+            <Title headingLevel="h2" className="VirtualMachineDiagnosticTab--header">
+              {t('Volume snapshot status')}{' '}
+              <HelpTextIcon
+                bodyContent={t(
+                  'Volume Snapshot Status is a mechanism for reporting if a volume can be snapshotted or not.',
+                )}
+                helpIconClassName="title-help-text-icon"
+              />
+            </Title>
+          </FlexItem>
+          <FlexItem>
+            <Pagination
+              itemCount={sortedData?.length}
+              page={pagination?.page}
+              perPage={pagination?.perPage}
+              defaultToFullPage
+              onSetPage={(_e, page, perPage, startIndex, endIndex) =>
+                onPaginationChange({ page, perPage, startIndex, endIndex })
+              }
+              onPerPageSelect={(_e, perPage, page, startIndex, endIndex) =>
+                onPaginationChange({ page, perPage, startIndex, endIndex })
+              }
+              perPageOptions={paginationDefaultValues}
+            />
+          </FlexItem>
+        </Flex>
+      </ListPageBody>
+
       <TableComposable isExpandable>
         <Thead>
           <Tr>

--- a/src/views/virtualmachines/details/tabs/diagnostic/virtual-machine-diagnostic-tab.scss
+++ b/src/views/virtualmachines/details/tabs/diagnostic/virtual-machine-diagnostic-tab.scss
@@ -2,23 +2,8 @@
   &--main {
     margin-left: var(--pf-global--spacer--sm);
   }
-  &--filters__main {
-    display: flex;
-    justify-content: space-between;
-  }
   &--header {
-    display: flex;
-    justify-content: space-between;
-    &.extra-margin {
-      margin-top: var(--pf-global--spacer--lg);
-    }
-    .co-m-nav-title.co-m-nav-title--row {
-      align-items: baseline;
-      .co-operator-details__actions {
-        margin-left: var(--pf-global--spacer--sm);
-        cursor: pointer;
-      }
-    }
+    margin-top: var(--pf-global--spacer--lg);
   }
 }
 


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2184063

Display "Status conditions" and "Volume snapshot status" sub-titles in VM _Diagnostic_ tab smaller, more aligned with such titles in other VM tabs.

Use Patternfly `Flex`, `FlexItem` components for that, simplify the related css file.

_Used PF `Flex` component:_
https://pf4.patternfly.org/layouts/flex/

## 🎥 Screenshots
**Before:**
Titles too big, also aligning of pagination not perfect:
![diag_before](https://user-images.githubusercontent.com/13417815/231507522-c7ace6ef-a761-43f2-83b4-eef36380affd.png)

**After:**
Titles smaller, aligning of pagination perfect:
![diag_after](https://user-images.githubusercontent.com/13417815/231507542-5cc3de7a-037b-4f05-b219-2dba51c478cb.png)


