### PR TITLE
Bug 2186462: Fix Add network interface modal for non-admin user

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect.tsx
@@ -14,7 +14,7 @@ import {
 import { interfaceTypeTypes } from '../utils/constants';
 import { networkNameStartWithPod, podNetworkExists } from '../utils/helpers';
 
-import useNadsData from './hooks/useNadsData';
+import useNADsData from './hooks/useNADsData';
 
 type NetworkInterfaceNetworkSelectProps = {
   vm: V1VirtualMachine;
@@ -39,7 +39,7 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState(false);
-  const { nads, loaded, loadError } = useNadsData(vm?.metadata?.namespace || namespace);
+  const { nads, loaded, loadError } = useNADsData(vm?.metadata?.namespace || namespace);
 
   const hasPodNetwork = useMemo(() => podNetworkExists(vm), [vm]);
   const hasNads = useMemo(() => nads && nads.length > 0, [nads]);

--- a/src/utils/components/NetworkInterfaceModal/components/hooks/useNADListPermissions.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/hooks/useNADListPermissions.ts
@@ -1,0 +1,37 @@
+import NetworkAttachmentDefinitionModel from '@kubevirt-ui/kubevirt-api/console/models/NetworkAttachmentDefinitionModel';
+import {
+  DEFAULT_NAMESPACE,
+  OPENSHIFT_MULTUS_NS,
+  OPENSHIFT_SRIOV_NETWORK_OPERATOR_NS,
+} from '@kubevirt-utils/constants/constants';
+import { K8sVerb, useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
+
+type UseNADListPermissions = () => boolean;
+
+const useNADListPermissions: UseNADListPermissions = () => {
+  const [canListDefaultNSNads] = useAccessReview({
+    namespace: DEFAULT_NAMESPACE,
+    verb: 'list' as K8sVerb,
+    resource: NetworkAttachmentDefinitionModel.plural,
+  });
+
+  const [canListOpenShiftSRIOVNetworkOperatorNamespaceNADs] = useAccessReview({
+    namespace: OPENSHIFT_SRIOV_NETWORK_OPERATOR_NS,
+    verb: 'list' as K8sVerb,
+    resource: NetworkAttachmentDefinitionModel.plural,
+  });
+
+  const [canListOpenShiftMultusNamespaceNADs] = useAccessReview({
+    namespace: OPENSHIFT_MULTUS_NS,
+    verb: 'list' as K8sVerb,
+    resource: NetworkAttachmentDefinitionModel.plural,
+  });
+
+  return [
+    canListDefaultNSNads,
+    canListOpenShiftSRIOVNetworkOperatorNamespaceNADs,
+    canListOpenShiftMultusNamespaceNADs,
+  ].every((permission) => permission);
+};
+
+export default useNADListPermissions;

--- a/src/utils/components/NetworkInterfaceModal/components/hooks/utils.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/hooks/utils.ts
@@ -1,0 +1,30 @@
+import { NetworkAttachmentDefinitionModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import {
+  DEFAULT_NAMESPACE,
+  OPENSHIFT_MULTUS_NS,
+  OPENSHIFT_SRIOV_NETWORK_OPERATOR_NS,
+} from '@kubevirt-utils/constants/constants';
+
+export const getOtherNADResources = (namespace: string, canListGlobalNSNADs: boolean) => {
+  if (!canListGlobalNSNADs) return {};
+  return {
+    //global namespace to get usable NADs
+    ...(namespace !== DEFAULT_NAMESPACE && {
+      default: {
+        groupVersionKind: NetworkAttachmentDefinitionModelGroupVersionKind,
+        isList: true,
+        namespace: DEFAULT_NAMESPACE,
+      },
+    }),
+    OPENSHIFT_SRIOV_NETWORK_OPERATOR_NS: {
+      groupVersionKind: NetworkAttachmentDefinitionModelGroupVersionKind,
+      isList: true,
+      namespace: OPENSHIFT_SRIOV_NETWORK_OPERATOR_NS,
+    },
+    OPENSHIFT_MULTUS_NS: {
+      groupVersionKind: NetworkAttachmentDefinitionModelGroupVersionKind,
+      isList: true,
+      namespace: OPENSHIFT_MULTUS_NS,
+    },
+  };
+};


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug that prevented non-admin users from being able to create a new network interface.

Cause: The code was attempting to pull network attachment definitions in namespaces inaccessible to non-admin users, which caused an error that prevented the form submit button from being enabled.
   
## 🎥 Screenshots
### Before
![Selection_266](https://user-images.githubusercontent.com/8544299/231879398-897300b6-4ca8-4733-802f-34cbc906e7b1.png)

### After
![Selection_265](https://user-images.githubusercontent.com/8544299/231879439-8772bc0c-2d0a-4fcf-985b-846eddd07e5d.png)
