### PR TITLE
Bug 2182000: Display VM Metrics graphs with Y-Axis

### DIFF
--- a/src/utils/components/Charts/CPUUtil/CPUThresholdChart.tsx
+++ b/src/utils/components/Charts/CPUUtil/CPUThresholdChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -32,11 +32,11 @@ type CPUThresholdChartProps = {
   pods: K8sResourceCommon[];
 };
 
-const CPUThresholdChart: React.FC<CPUThresholdChartProps> = ({ vmi, pods }) => {
-  const vmiPod = React.useMemo(() => getVMIPod(vmi, pods), [pods, vmi]);
+const CPUThresholdChart: FC<CPUThresholdChartProps> = ({ vmi, pods }) => {
+  const vmiPod = useMemo(() => getVMIPod(vmi, pods), [pods, vmi]);
   const { currentTime, duration, timespan } = useDuration();
   const { ref, width, height } = useResponsiveCharts();
-  const queries = React.useMemo(
+  const queries = useMemo(
     () => getUtilizationQueries({ obj: vmi, duration, launcherPodName: vmiPod?.metadata?.name }),
     [vmi, vmiPod, duration],
   );
@@ -97,17 +97,10 @@ const CPUThresholdChart: React.FC<CPUThresholdChartProps> = ({ vmi, pods }) => {
               tickValues={[0, thresholdData?.[0]?.y]}
               tickFormat={(tick: number) => `${tick === 0 ? tick : tick?.toFixed(2)} s`}
               style={{
-                ticks: {
-                  stroke: 'transparent',
-                },
-                tickLabels: {
-                  padding: 20,
-                },
                 grid: {
                   stroke: chart_color_black_200.value,
                 },
               }}
-              axisComponent={<></>}
             />
             <ChartAxis
               tickFormat={tickFormat(duration, currentTime)}

--- a/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
+++ b/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import xbytes from 'xbytes';
 
@@ -34,12 +34,9 @@ type MemoryThresholdChartProps = {
   vmi: V1VirtualMachineInstance;
 };
 
-const MemoryThresholdChart: React.FC<MemoryThresholdChartProps> = ({ vmi }) => {
+const MemoryThresholdChart: FC<MemoryThresholdChartProps> = ({ vmi }) => {
   const { currentTime, duration, timespan } = useDuration();
-  const queries = React.useMemo(
-    () => getUtilizationQueries({ obj: vmi, duration }),
-    [vmi, duration],
-  );
+  const queries = useMemo(() => getUtilizationQueries({ obj: vmi, duration }), [vmi, duration]);
   const { ref, width, height } = useResponsiveCharts();
 
   const requests = vmi?.spec?.domain?.resources?.requests as {
@@ -100,14 +97,10 @@ const MemoryThresholdChart: React.FC<MemoryThresholdChartProps> = ({ vmi }) => {
               tickValues={[0, thresholdLine?.[0]?.y]}
               tickFormat={formatMemoryYTick(thresholdLine?.[0]?.y, 0)}
               style={{
-                ticks: {
-                  stroke: 'transparent',
-                },
                 grid: {
                   stroke: chart_color_black_200.value,
                 },
               }}
-              axisComponent={<></>}
             />
             <ChartAxis
               tickFormat={tickFormat(duration, currentTime)}

--- a/src/utils/components/Charts/NetworkUtil/NetworkThresholdChartSingleSource.tsx
+++ b/src/utils/components/Charts/NetworkUtil/NetworkThresholdChartSingleSource.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { Link } from 'react-router-dom';
 import xbytes from 'xbytes';
 
@@ -26,12 +26,13 @@ import {
   tickFormat,
   TICKS_COUNT,
 } from '../utils/utils';
+
 type NetworkThresholdSingleSourceChartProps = {
   data: PrometheusResult[];
   link: string;
 };
 
-const NetworkThresholdSingleSourceChart: React.FC<NetworkThresholdSingleSourceChartProps> = ({
+const NetworkThresholdSingleSourceChart: FC<NetworkThresholdSingleSourceChartProps> = ({
   data,
   link,
 }) => {
@@ -58,6 +59,7 @@ const NetworkThresholdSingleSourceChart: React.FC<NetworkThresholdSingleSourceCh
     chartData?.map((newChartdata, index) => {
       return { childName: newChartdata?.[index]?.name, name: newChartdata?.[index]?.name };
     });
+
   return (
     <ComponentReady isReady={isReady}>
       <div className="util-threshold-chart" ref={ref}>
@@ -99,14 +101,10 @@ const NetworkThresholdSingleSourceChart: React.FC<NetworkThresholdSingleSourceCh
               tickFormat={formatNetworkYTick}
               tickValues={getNetworkTickValues(Ymax)}
               style={{
-                ticks: {
-                  stroke: 'transparent',
-                },
                 grid: {
                   stroke: chart_color_black_200.value,
                 },
               }}
-              axisComponent={<></>}
             />
             <ChartAxis
               tickFormat={tickFormat(duration, currentTime)}

--- a/src/views/virtualmachines/details/tabs/metrics/NetworkCharts/NetworkCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/NetworkCharts/NetworkCharts.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { FC, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -11,11 +11,12 @@ import useQuery from './hook/useQuery';
 import NetworkChartsByNIC from './NetworkChartsByNIC';
 
 import '../virtual-machine-metrics-tab.scss';
+
 type NetworkChartsProps = {
   vmi: V1VirtualMachineInstance;
 };
 
-const NetworkCharts: React.FC<NetworkChartsProps> = ({ vmi }) => {
+const NetworkCharts: FC<NetworkChartsProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
   const history = useHistory();
 
@@ -26,8 +27,8 @@ const NetworkCharts: React.FC<NetworkChartsProps> = ({ vmi }) => {
   }, [vmi]);
 
   const query = useQuery();
-  const [isDropdownOpen, setIsDropdownOpen] = React.useState<boolean>(false);
-  const [selectedNetwork, setSelectedNetwork] = React.useState<string>(
+  const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
+  const [selectedNetwork, setSelectedNetwork] = useState<string>(
     query?.get('network') || ALL_NETWORKS,
   );
 

--- a/src/views/virtualmachines/details/tabs/metrics/NetworkCharts/NetworkChartsByNIC.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/NetworkCharts/NetworkChartsByNIC.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import NetworkThresholdSingleSourceChart from '@kubevirt-utils/components/Charts/NetworkUtil/NetworkThresholdChartSingleSource';
@@ -12,7 +12,7 @@ type NetworkChartsByNICProps = {
   nic: string;
 };
 
-const NetworkChartsByNIC: React.FC<NetworkChartsByNICProps> = ({ vmi, nic }) => {
+const NetworkChartsByNIC: FC<NetworkChartsByNICProps> = ({ vmi, nic }) => {
   const { t } = useKubevirtTranslation();
   const { data, links } = useNetworkData(vmi, nic);
 

--- a/src/views/virtualmachines/details/tabs/metrics/UtilizationCharts/UtilizationCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/UtilizationCharts/UtilizationCharts.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import CPUThresholdChart from '@kubevirt-utils/components/Charts/CPUUtil/CPUThresholdChart';
@@ -12,7 +12,7 @@ type UtilizationChartsProps = {
   pods: K8sResourceCommon[];
 };
 
-const UtilizationCharts: React.FC<UtilizationChartsProps> = ({ vmi, pods }) => {
+const UtilizationCharts: FC<UtilizationChartsProps> = ({ vmi, pods }) => {
   const { t } = useKubevirtTranslation();
 
   return (

--- a/src/views/virtualmachines/details/tabs/metrics/VirtualMachineMetricsTab.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/VirtualMachineMetricsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -21,10 +21,7 @@ type VirtualMachineMetricsTabProps = RouteComponentProps & {
   obj: V1VirtualMachine;
 };
 
-const VirtualMachineMetricsTab: React.FC<VirtualMachineMetricsTabProps> = ({
-  obj: vm,
-  location,
-}) => {
+const VirtualMachineMetricsTab: FC<VirtualMachineMetricsTabProps> = ({ obj: vm, location }) => {
   const { t } = useKubevirtTranslation();
   const { vmi, pods, loaded } = useVMIAndPodsForVM(vm?.metadata?.name, vm?.metadata?.namespace);
 


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2182000

Display Memory, CPU and Network graphs consistently with Storage graphs, in VM _Metrics_ tab:
show missing y-axis for those graphs.

## 🎥 Screenshots
**Before:**
No y-axis for Memory, CPU and Network graphs :
![before](https://user-images.githubusercontent.com/13417815/232052316-2ae6a0c2-8b2a-4cb6-9195-16ce2202f6cd.png)

**After:**
Y-axis present in Memory, CPU and Network graphs, same as in Storage graphs:
![after](https://user-images.githubusercontent.com/13417815/232052328-ffe617b1-0f06-42ca-9503-f65507f28c5e.png)

