### PR TITLE
Bug 2177977: Move pagination to created/selected volume from modals

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/ShowAllBootableVolumesButton/ShowAllBootableVolumesButton.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/ShowAllBootableVolumesButton/ShowAllBootableVolumesButton.tsx
@@ -9,7 +9,7 @@ import BootableVolumeListModal from '../BootableVolumeListModal/BootableVolumeLi
 
 export type ShowAllBootableVolumesButtonProps = BootableVolumeListProps;
 
-const ShowAllBootableVolumesButton: FC<BootableVolumeListProps> = (props) => {
+const ShowAllBootableVolumesButton: FC<ShowAllBootableVolumesButtonProps> = (props) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   return (

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/utils/utils.ts
@@ -1,7 +1,10 @@
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
+import { PaginationState } from '@virtualmachines/utils';
 
 import { DEFAULT_PREFERENCE_LABEL } from '../../../utils/constants';
+
+import { paginationInitialStateForm } from './constants';
 
 export const getBootVolumeOS = (bootVolume: V1beta1DataSource): OS_NAME_TYPES => {
   const bootVolumePreference = bootVolume?.metadata?.labels?.[DEFAULT_PREFERENCE_LABEL];
@@ -10,3 +13,23 @@ export const getBootVolumeOS = (bootVolume: V1beta1DataSource): OS_NAME_TYPES =>
     OS_NAME_TYPES.other
   );
 };
+
+export const getPaginationFromVolumeIndex =
+  (volumeIndex: number) =>
+  (prevPagination: PaginationState): PaginationState => {
+    if (volumeIndex <= 0 || volumeIndex / prevPagination.perPage < 1) {
+      return paginationInitialStateForm;
+    }
+
+    const perPage = prevPagination.perPage;
+    const page = Math.floor(volumeIndex / perPage) + 1;
+    const startIndex = (page - 1) * perPage;
+    const endIndex = page * perPage;
+
+    return {
+      page,
+      perPage,
+      startIndex,
+      endIndex,
+    };
+  };


### PR DESCRIPTION
## 📝 Description

When Creating a new volume from the "Add volume" modal dialog or selecting a volume from the "Show all" modal dialog, the volume is selected but the pagination is not moving to the proper page to show the created/selected volume.

## 🎥 Demo

Before:

select volume:

https://user-images.githubusercontent.com/67270715/232485885-357eae98-4735-4bcc-a864-840bdb2da1da.mp4

create volume:

https://user-images.githubusercontent.com/67270715/232486028-4925c48e-3e30-4e5f-89cf-d6fcdea20357.mp4

After:

select volume:

https://user-images.githubusercontent.com/67270715/232486226-b0a12f47-c0e0-47bb-b3f6-cd5489c8c86d.mp4

create volume:

https://user-images.githubusercontent.com/67270715/232486294-52e82a86-cf6e-4f03-9e96-2ad29ff8a229.mp4

