### PR TITLE
Bug 2186763 - The storageclass option is not respected in add volume modal for "Use existing volume"

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/AddBootableVolumeModal/utils/utils.ts
@@ -52,7 +52,7 @@ export const createDataSource =
     const bootableVolumeToCreate = produce(emptySourceDataVolume, (draftBootableVolume) => {
       draftBootableVolume.metadata.name = bootableVolumeName;
       draftBootableVolume.spec.storage.resources.requests.storage = size;
-      if (storageClassName && isUploadForm) {
+      if (storageClassName) {
         draftBootableVolume.spec.storage.storageClassName = storageClassName;
       }
 


### PR DESCRIPTION
## 📝 Description

Applying SC to created volume

## 🎥 Demo

After:


https://user-images.githubusercontent.com/67270715/232500258-e7b8fbdd-8106-4d53-84d8-2673c9e29350.mp4


