### PR TITLE
Bug 2151237: "404: Not Found" appears before the VMIM details is loaded

### DIFF
--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/MigrationsRow.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/MigrationsRow.tsx
@@ -74,6 +74,7 @@ const MigrationsRow: React.FC<RowProps<MigrationTableDataLayout>> = ({ obj, acti
         <ResourceLink
           groupVersionKind={VirtualMachineInstanceMigrationModelGroupVersionKind}
           name={obj?.vmim?.metadata?.name}
+          namespace={obj?.vmim?.metadata?.namespace}
         />
       </TableData>
       <TableData id="created" activeColumnIDs={activeColumnIDs}>


### PR DESCRIPTION
## 📝 Description

The missing namespace prop is causing the VMIM details page to reach 404

## 🎥 Demo

Before:

https://user-images.githubusercontent.com/67270715/232819594-15d4d415-e793-4c77-9a67-42962a4e213c.mp4

After:

https://user-images.githubusercontent.com/67270715/232819688-58f75408-c815-44c9-9b8b-5a8f40ec614d.mp4


