### PR TITLE
Bug 2176746: Distinguish templates with same display name

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogRow.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogRow.tsx
@@ -13,7 +13,7 @@ import { getTemplateBootSourceType } from '@kubevirt-utils/resources/template/ho
 import { getVMBootSourceLabel } from '@kubevirt-utils/resources/vm/utils/source';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
-import { Button } from '@patternfly/react-core';
+import { Button, Label } from '@patternfly/react-core';
 
 import { getTemplateOSIcon } from '../utils/os-icons';
 
@@ -45,11 +45,12 @@ export const TemplatesCatalogRow: React.FC<
 
     return (
       <>
-        <TableData id="name" activeColumnIDs={activeColumnIDs} className="pf-m-width-20">
+        <TableData id="name" activeColumnIDs={activeColumnIDs} className="pf-m-width-30">
           <img src={getTemplateOSIcon(obj)} alt="" className="vm-catalog-row-icon" />
           <Button variant="link" isInline onClick={() => onTemplateClick(obj)}>
             {getTemplateName(obj)}
-          </Button>
+          </Button>{' '}
+          <Label>{obj?.metadata?.name}</Label>
         </TableData>
         <TableData id="workload" activeColumnIDs={activeColumnIDs} className="pf-m-width-10">
           {WORKLOADS_LABELS?.[workload]}

--- a/src/views/catalog/templatescatalog/hooks/useTemplatesCatalogColumns.ts
+++ b/src/views/catalog/templatescatalog/hooks/useTemplatesCatalogColumns.ts
@@ -11,7 +11,7 @@ const useTemplatesCatalogColumns = (): TableColumn<K8sResourceCommon>[] => {
       id: 'name',
       transforms: [sortable],
       sort: 'metadata.name',
-      props: { className: 'pf-m-width-20' },
+      props: { className: 'pf-m-width-30' },
     },
     {
       title: t('Workload'),


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add `template.metadata.name` after the display name annotation for the templates with the same display name.

## 🎥 Demo

**Before**
![image](https://user-images.githubusercontent.com/29160323/232824455-b8f8f96c-fa38-463e-a439-23b2431821d2.png)



**After**
![Screenshot from 2023-04-19 17-21-44](https://user-images.githubusercontent.com/29160323/233123624-cc064291-76b6-468e-9638-eaeb60da9d54.png)

