### PR TITLE
Update cypress tests

### DIFF
--- a/cypress/support/nav.ts
+++ b/cypress/support/nav.ts
@@ -23,7 +23,7 @@ Cypress.Commands.add('visitOverview', () => {
 
 Cypress.Commands.add('visitCatalog', () => {
   cy.clickVirtLink(catalogNav);
-  cy.contains('Create VirtualMachine from catalog').should('be.visible');
+  cy.contains('Create new VirtualMachine').should('be.visible');
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(1000);
 });

--- a/cypress/tests/catalog/filter.spec.ts
+++ b/cypress/tests/catalog/filter.spec.ts
@@ -4,14 +4,14 @@ import * as catalogView from '../../views/catalog';
 describe('Test VM catalog filter', () => {
   before(() => {
     cy.login();
-    cy.visit('/k8s/ns/default/templatescatalog');
+    cy.visitCatalog();
   });
 
   it('ID(CNV-8464) Filter VM catalog by OS name', () => {
     cy.get(catalogView.RHEL).find(catalogView.checkbox).check();
-    cy.get(catalogView.GRID).find('a').should('contain', TEMPLATE.RHEL8.name);
-    cy.get(catalogView.GRID).find('a').should('contain', TEMPLATE.RHEL7.name);
-    cy.get(catalogView.GRID).find('a').should('contain', TEMPLATE.RHEL6.name);
+    cy.get(catalogView.GRID).find('a').should('contain', TEMPLATE.RHEL9.metadataName);
+    cy.get(catalogView.GRID).find('a').should('contain', TEMPLATE.RHEL8.metadataName);
+    cy.get(catalogView.GRID).find('a').should('contain', TEMPLATE.RHEL7.metadataName);
     cy.get(catalogView.RHEL).find(catalogView.checkbox).uncheck();
 
     cy.get(catalogView.WINDOWS).find(catalogView.checkbox).check();
@@ -22,7 +22,7 @@ describe('Test VM catalog filter', () => {
     cy.get(catalogView.WINDOWS).find(catalogView.checkbox).uncheck();
 
     cy.get(catalogView.FEDORA).find(catalogView.checkbox).check();
-    cy.get(catalogView.GRID).find('a').should('have.length', 1);
+    cy.get(catalogView.GRID).find('a').should('contain', TEMPLATE.FEDORA.metadataName);
     cy.get(catalogView.FEDORA).find(catalogView.checkbox).uncheck();
   });
 

--- a/cypress/tests/check-tabs.spec.ts
+++ b/cypress/tests/check-tabs.spec.ts
@@ -5,17 +5,17 @@ import { vm } from '../views/vm';
 describe('Check all virtualization pages can be loaded', () => {
   before(() => {
     cy.login();
-    cy.deleteResource(K8S_KIND.VM, 'vm-example', 'default');
-    cy.deleteResource(K8S_KIND.TEMPLATE, 'vm-template-example', 'default');
+    cy.deleteResource(K8S_KIND.VM, 'example', 'default');
+    cy.deleteResource(K8S_KIND.TEMPLATE, 'example', 'default');
   });
 
   after(() => {
-    cy.deleteResource(K8S_KIND.VM, 'vm-example', 'default');
-    cy.deleteResource(K8S_KIND.TEMPLATE, 'vm-template-example', 'default');
+    cy.deleteResource(K8S_KIND.VM, 'example', 'default');
+    cy.deleteResource(K8S_KIND.TEMPLATE, 'example', 'default');
   });
 
   describe('Check VM list and tabs', () => {
-    it('create vm-example', () => {
+    it('create example VM', () => {
       cy.visitVMs();
       vm.createVMFromYAML();
       cy.contains('Hostname').should('be.visible');
@@ -67,7 +67,7 @@ describe('Check all virtualization pages can be loaded', () => {
       cy.contains('centos7-desktop-large').click();
 
       cy.contains('Display name').should('be.visible');
-      cy.contains('Templates provided by KubeVirt are not editable').should('be.visible');
+      cy.byTestID('common-template-alert').should('be.visible');
 
       tab.navigateToYAML();
       cy.contains('Download').should('be.visible');

--- a/src/views/templates/details/CommonTemplateAlert.tsx
+++ b/src/views/templates/details/CommonTemplateAlert.tsx
@@ -40,6 +40,7 @@ const CommonTemplateAlert: React.FC<CommonTemplateAlertProps> = ({ template }) =
       title={t('Templates provided by {{providerName}} are not editable.', {
         providerName,
       })}
+      data-test="common-template-alert"
     >
       <Trans ns="plugin__kubevirt-plugin">
         {{ osName }} VirtualMachine can not be edited because it is provided by OpenShift


### PR DESCRIPTION
## 📝 Description

Fixing cypress test:
- Aligning text to fit current text in the app.

- filter.spec.ts:
1. the visit function was flaky changed to the visitCatalog function.
2. changing rhel 6 to 9 and using metadata name instead of name as it didn't match anymore.
3. switch to check for fedora template instead of checking just count of templates (crashes locally when having more than one fedora template).

- check-tabs.spec.ts: 
1. creating vm/template from yaml gets a resource name `example` for both cases.
2. common template alert text didn't matched - getting by id instead of text.


