### PR TITLE
Bug 2176746: Distinguish templates with same display name

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplateRowAvailableSource/TemplateRowAvailableSource.scss
+++ b/src/views/catalog/templatescatalog/components/TemplateRowAvailableSource/TemplateRowAvailableSource.scss
@@ -1,5 +1,5 @@
 .template-row-available-source {
   &__source {
-    min-width: 22%;
+    width: 30%;
   }
 }

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogRow.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogRow.tsx
@@ -3,7 +3,9 @@ import * as React from 'react';
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getAnnotation, getName } from '@kubevirt-utils/resources/shared';
 import {
+  ANNOTATIONS,
   getTemplateFlavorData,
   getTemplateName,
   getTemplateWorkload,
@@ -12,8 +14,9 @@ import {
 import { getTemplateBootSourceType } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { getVMBootSourceLabel } from '@kubevirt-utils/resources/vm/utils/source';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
-import { Button } from '@patternfly/react-core';
+import { Button, Label } from '@patternfly/react-core';
 
 import { getTemplateOSIcon } from '../utils/os-icons';
 
@@ -45,10 +48,15 @@ export const TemplatesCatalogRow: React.FC<
 
     return (
       <>
-        <TableData id="name" activeColumnIDs={activeColumnIDs} className="pf-m-width-20">
+        <TableData id="name" activeColumnIDs={activeColumnIDs} className="pf-m-width-40">
           <img src={getTemplateOSIcon(obj)} alt="" className="vm-catalog-row-icon" />
           <Button variant="link" isInline onClick={() => onTemplateClick(obj)}>
-            {getTemplateName(obj)}
+            {getTemplateName(obj)}{' '}
+            {!isEmpty(getAnnotation(obj, ANNOTATIONS.displayName)) && (
+              <Label isCompact variant="outline">
+                {getName(obj)}
+              </Label>
+            )}
           </Button>
         </TableData>
         <TableData id="workload" activeColumnIDs={activeColumnIDs} className="pf-m-width-10">
@@ -60,7 +68,7 @@ export const TemplatesCatalogRow: React.FC<
             isBootSourceAvailable={availableTemplatesUID.has(obj.metadata.uid)}
           />
         </TableData>
-        <TableData id="cpu" activeColumnIDs={activeColumnIDs} className="pf-m-width-30">
+        <TableData id="cpu" activeColumnIDs={activeColumnIDs} className="pf-m-width-20">
           {t('CPU')} {cpuCount} | {t('Memory')} {readableSizeUnit(memory)}
         </TableData>
       </>

--- a/src/views/catalog/templatescatalog/hooks/useTemplatesCatalogColumns.ts
+++ b/src/views/catalog/templatescatalog/hooks/useTemplatesCatalogColumns.ts
@@ -11,7 +11,7 @@ const useTemplatesCatalogColumns = (): TableColumn<K8sResourceCommon>[] => {
       id: 'name',
       transforms: [sortable],
       sort: 'metadata.name',
-      props: { className: 'pf-m-width-20' },
+      props: { className: 'pf-m-width-40' },
     },
     {
       title: t('Workload'),
@@ -25,7 +25,7 @@ const useTemplatesCatalogColumns = (): TableColumn<K8sResourceCommon>[] => {
     {
       title: t('CPU | Memory'),
       id: 'cpu',
-      props: { className: 'pf-m-width-30' },
+      props: { className: 'pf-m-width-20' },
     },
   ];
 };


### PR DESCRIPTION
## 📝 Description

whenever a template has display name annotation, we want to show a label next to it with the template's name so we can differentiate between the templates

## 🎥 Demo
Before:
![232824455-b8f8f96c-fa38-463e-a439-23b2431821d2](https://user-images.githubusercontent.com/67270715/233129109-0707c09d-fa68-439b-aaec-2ece2f8735e3.png)

After:
![Screenshot - 2023-04-19T183213 098](https://user-images.githubusercontent.com/67270715/233129197-3b67283f-3242-4a86-808f-4d93fce265c7.png)

