### PR TITLE
Bug 2187971: guard for template parameter on disk moda

### DIFF
--- a/src/utils/components/DiskModal/DiskModal.tsx
+++ b/src/utils/components/DiskModal/DiskModal.tsx
@@ -12,6 +12,7 @@ import {
   getDisks,
   getVolumes,
 } from '@kubevirt-utils/resources/vm';
+import { getRandomChars } from '@kubevirt-utils/utils/utils';
 import { Form } from '@patternfly/react-core';
 
 import AccessMode from './DiskFormFields/AccessMode';
@@ -37,6 +38,7 @@ import {
   getDiskFromState,
   getPersistentVolumeClaimHotplugPromise,
   getVolumeFromState,
+  nameWithoutParameter,
   produceVMDisks,
   requiresDataVolume,
 } from './utils/helpers';
@@ -87,11 +89,11 @@ const DiskModal: React.FC<DiskModalProps> = ({
         );
       }
       if (diskState.diskSource === sourceTypes.UPLOAD) {
-        return getPersistentVolumeClaimHotplugPromise(
-          vmObj,
+        const pvcName = nameWithoutParameter(
           `${vm?.metadata?.name}-${diskState.diskName}`,
-          resultDisk,
+          `${diskState.diskName}-${getRandomChars()}`,
         );
+        return getPersistentVolumeClaimHotplugPromise(vmObj, pvcName, resultDisk);
       }
       const resultDataVolume = getDataVolumeFromState({
         vm: vmObj,
@@ -106,7 +108,10 @@ const DiskModal: React.FC<DiskModalProps> = ({
 
   const updatedVirtualMachine: V1VirtualMachine = React.useMemo(() => {
     const updatedVM = produceVMDisks(vm, (vmDraft) => {
-      const dvName = `${vmDraft?.metadata?.name}-${diskState.diskName}`;
+      const dvName = nameWithoutParameter(
+        `${vmDraft?.metadata?.name}-${diskState.diskName}`,
+        `${diskState.diskName}-${getRandomChars()}`,
+      );
 
       const resultDisk = getDiskFromState(diskState);
       const resultVolume = getVolumeFromState(vm, diskState, diskSourceState, dvName);

--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -14,7 +14,8 @@ import {
   V1Volume,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { buildOwnerReference } from '@kubevirt-utils/resources/shared';
-import { ensurePath } from '@kubevirt-utils/utils/utils';
+import { hasTemplateParameter } from '@kubevirt-utils/resources/template';
+import { ensurePath, getRandomChars } from '@kubevirt-utils/utils/utils';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import {
@@ -23,6 +24,13 @@ import {
 } from '../../../../views/virtualmachines/actions/actions';
 import { sourceTypes } from '../DiskFormFields/utils/constants';
 import { DiskFormState, DiskSourceState } from '../state/initialState';
+
+export const nameWithoutParameter = (name: string, defaultValue?) => {
+  if (hasTemplateParameter(name)) {
+    return defaultValue;
+  }
+  return name;
+};
 
 export const getEmptyVMDataVolumeResource = (
   vm: V1VirtualMachine,
@@ -136,7 +144,11 @@ export const getDataVolumeFromState = ({
     resultVolume?.persistentVolumeClaim?.claimName ||
     `${vm?.metadata?.name}-${diskState.diskName}`;
 
-  dataVolume.metadata.name = dvName;
+  dataVolume.metadata.name = nameWithoutParameter(
+    dvName,
+    `${diskState.diskName}-${getRandomChars()}`,
+  );
+
   dataVolume.spec.storage.resources.requests.storage = diskState.diskSize;
   dataVolume.spec.storage.storageClassName = diskState.storageClass;
   if (!diskState.applyStorageProfileSettings) {

--- a/src/utils/resources/template/utils/helpers.ts
+++ b/src/utils/resources/template/utils/helpers.ts
@@ -66,3 +66,5 @@ export const generateParamsWithPrettyName = (template: V1Template) => {
   }
   return [];
 };
+
+export const hasTemplateParameter = (stringToTest: string) => /[${}]/.test(stringToTest);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

No UI diff.

Do not use `vm.metadata.name` if contains a parameter to create the DV NAME. Like ${NAME}
Disk name is provided by the user so no need to guard on that.