### PR TITLE
Bug 2188010: Rename VM "Diagnostic" tab to "Diagnostics"

### DIFF
--- a/cypress/tests/check-tabs.spec.ts
+++ b/cypress/tests/check-tabs.spec.ts
@@ -55,7 +55,7 @@ describe('Check all virtualization pages can be loaded', () => {
       tab.navigateToSnapshots();
       cy.contains('Take snapshot').should('be.visible');
 
-      tab.navigateToDiagnostic();
+      tab.navigateToDiagnostics();
       cy.contains('Message').should('be.visible');
     });
   });

--- a/cypress/views/tab.ts
+++ b/cypress/views/tab.ts
@@ -15,7 +15,7 @@ export enum tabs {
   Scripts = 'horizontal-link-Scripts',
   Snapshots = 'horizontal-link-Snapshots',
   Parameters = 'horizontal-link-Parameters',
-  Diagnostic = 'horizontal-link-Diagnostic',
+  Diagnostics = 'horizontal-link-Diagnostics',
 }
 
 export const navigateToTab = (tab: string) => {
@@ -71,8 +71,8 @@ export const tab = {
   navigateToParameters: () => {
     navigateToTab(tabs.Parameters);
   },
-  navigateToDiagnostic: () => {
-    navigateToTab(tabs.Diagnostic);
+  navigateToDiagnostics: () => {
+    navigateToTab(tabs.Diagnostics);
   },
   // navigate template's tabs
   navigateToTScheduling: () => {

--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -364,7 +364,7 @@
   "Developer preview": "Developer preview",
   "Developer preview features are not intended to use in production environments. The clusters deployed with the developer preview features are developmental clusters and are not currently supported by Red Hat.": "Developer preview features are not intended to use in production environments. The clusters deployed with the developer preview features are developmental clusters and are not currently supported by Red Hat.",
   "Device name": "Device name",
-  "Diagnostic": "Diagnostic",
+  "Diagnostics": "Diagnostics",
   "DIC": "DIC",
   "Disconnect": "Disconnect",
   "Disk size": "Disk size",

--- a/src/utils/constants/tabs-constants.ts
+++ b/src/utils/constants/tabs-constants.ts
@@ -13,7 +13,7 @@ export enum VirtualMachineDetailsTab {
   Disks = 'disks',
   Snapshots = 'snapshots',
   Scripts = 'scripts',
-  Diagnostic = 'diagnostic',
+  Diagnostics = 'diagnostics',
   Configurations = 'configurations',
 }
 
@@ -50,8 +50,8 @@ export enum VirtualMachineDetailsTabLabel {
   Snapshots = 'Snapshots',
   // t('Scripts')
   Scripts = 'Scripts',
-  // t('Diagnostic')
-  Diagnostic = 'Diagnostic',
+  // t('Diagnostics')
+  Diagnostics = 'Diagnostics',
   // t('Configuration')
   Configuration = 'Configuration',
 }

--- a/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
+++ b/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
@@ -85,8 +85,8 @@ export const useVirtualMachineTabs = () => {
       component: SnapshotListPage,
     },
     {
-      href: VirtualMachineDetailsTab.Diagnostic,
-      name: t(VirtualMachineDetailsTabLabel.Diagnostic),
+      href: VirtualMachineDetailsTab.Diagnostics,
+      name: t(VirtualMachineDetailsTabLabel.Diagnostics),
       component: VirtualMachineDiagnosticTab,
     },
   ];


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2188010

Display the proper name of the VM tab for diagnostics.

## 🎥 Screenshots
**Before:**
![diag_before](https://user-images.githubusercontent.com/13417815/233706356-011d283d-ba26-466d-a8f6-92d7470415ed.png)

**After:**
![diag_after](https://user-images.githubusercontent.com/13417815/233706363-442b4d45-985c-4806-b880-3907270ea352.png)



