### PR TITLE
Bug 2188886: Pending loading on detach modal

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/disk/modal/DeleteDiskModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/disk/modal/DeleteDiskModal.tsx
@@ -32,8 +32,13 @@ const DeleteDiskModal: React.FC<DeleteDiskModalProps> = ({ vm, volume, isOpen, o
 
   const diskName = volume?.name;
 
-  const { volumeResource, loaded, volumeResourceName, volumeResourceModel } =
-    useVolumeOwnedResource(vm, volume);
+  const {
+    volumeResource,
+    loaded,
+    error: loadingError,
+    volumeResourceName,
+    volumeResourceModel,
+  } = useVolumeOwnedResource(vm, volume);
 
   const updatedVirtualMachine = React.useMemo(() => {
     const updatedDisks = (getDisks(vm) || [])?.filter(({ name }) => name !== diskName);
@@ -101,6 +106,7 @@ const DeleteDiskModal: React.FC<DeleteDiskModalProps> = ({ vm, volume, isOpen, o
       headerText={t('Detach disk?')}
       submitBtnText={t('Detach')}
       submitBtnVariant={ButtonVariant.danger}
+      modalError={loadingError}
     >
       <Stack hasGutter>
         <StackItem>
@@ -111,7 +117,7 @@ const DeleteDiskModal: React.FC<DeleteDiskModalProps> = ({ vm, volume, isOpen, o
             action="detach"
           />
         </StackItem>
-        {loaded ? (
+        {loaded && (
           <StackItem>
             {volumeResource && (
               <Checkbox
@@ -128,9 +134,9 @@ const DeleteDiskModal: React.FC<DeleteDiskModalProps> = ({ vm, volume, isOpen, o
               />
             )}
           </StackItem>
-        ) : (
-          <Loading />
         )}
+
+        {!loaded && !loadingError && <Loading />}
       </Stack>
     </TabModal>
   );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description


**Cause**
We transform volume in `persistentVolumeClaim` with `convertDataVolumeToPVC` even when the volume is not a DV.

**Solution** 
Do not transform the volume if it's not a datavolume.

To prevent further issues, let's show the fetch error to the user when something goes wrong.
If we fail to load the resource, we'll not be able to delete it or detach it
I've added a prop to the TabModal as in this component the error alert is already showed for API errors and can be useful for other modals that use tabmodal
 

