### PR TITLE
Bug 2187664: vm with no namespace means default

### DIFF
--- a/src/views/templates/details/tabs/scripts/components/SSHKey/SSHKey.tsx
+++ b/src/views/templates/details/tabs/scripts/components/SSHKey/SSHKey.tsx
@@ -1,9 +1,10 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { AuthorizedSSHKeyModal } from '@kubevirt-utils/components/AuthorizedSSHKeyModal/AuthorizedSSHKeyModal';
 import LinuxLabel from '@kubevirt-utils/components/Labels/LinuxLabel';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -30,7 +31,7 @@ type SSHKeyProps = {
   template: V1Template;
 };
 
-const SSHKey: React.FC<SSHKeyProps> = ({ template }) => {
+const SSHKey: FC<SSHKeyProps> = ({ template }) => {
   const { t } = useKubevirtTranslation();
   const { isTemplateEditable } = useEditTemplateAccessReview(template);
   const vm = getTemplateVirtualMachineObject(template);
@@ -66,7 +67,7 @@ const SSHKey: React.FC<SSHKeyProps> = ({ template }) => {
                   createModal((modalProps) => (
                     <AuthorizedSSHKeyModal
                       {...modalProps}
-                      namespace={vm?.metadata?.namespace}
+                      namespace={vm?.metadata?.namespace || DEFAULT_NAMESPACE}
                       sshKey={secretKey}
                       vmSecretName={externalSecretName}
                       onSubmit={onSSHChange}

--- a/src/views/templates/details/tabs/scripts/components/SysPrepItem/SysPrepItem.tsx
+++ b/src/views/templates/details/tabs/scripts/components/SysPrepItem/SysPrepItem.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 import { useParams } from 'react-router-dom';
 
 import {
@@ -11,6 +11,7 @@ import WindowsLabel from '@kubevirt-utils/components/Labels/WindowsLabel';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { AUTOUNATTEND, UNATTEND } from '@kubevirt-utils/components/SysprepModal/sysprep-utils';
 import { SysprepModal } from '@kubevirt-utils/components/SysprepModal/SysprepModal';
+import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { getVolumes } from '@kubevirt-utils/resources/vm';
@@ -42,7 +43,7 @@ type SysPrepItemProps = {
   template: V1Template;
 };
 
-const SysPrepItem: React.FC<SysPrepItemProps> = ({ template }) => {
+const SysPrepItem: FC<SysPrepItemProps> = ({ template }) => {
   const { ns: namespace } = useParams<{ ns: string }>();
   const { isTemplateEditable } = useEditTemplateAccessReview(template);
   const vm = getTemplateVirtualMachineObject(template);
@@ -106,7 +107,7 @@ const SysPrepItem: React.FC<SysPrepItemProps> = ({ template }) => {
                   createModal((modalProps) => (
                     <SysprepModal
                       {...modalProps}
-                      namespace={vm?.metadata?.namespace}
+                      namespace={vm?.metadata?.namespace || DEFAULT_NAMESPACE}
                       unattend={unattend}
                       autoUnattend={autoUnattend}
                       onSysprepSelected={onSysprepSelected}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The namespace was not propagated to the `SelectSecret`. With no namespace, the select was not fetching any namespace. 
This is to prevent the `useK8sWatchResources` to fetch all secrets from all namespaces