### PR TITLE
Bug 2182172: Add alert for clound init and ssh auth keys

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -231,6 +231,7 @@
   "Cloning": "Cloning",
   "Closing it will cause the upload to fail. You may still navigate the console.": "Closing it will cause the upload to fail. You may still navigate the console.",
   "Cloud-init": "Cloud-init",
+  "Cloud-init and SSH key configurations will be applied to the VirtualMachine only at the first boot.": "Cloud-init and SSH key configurations will be applied to the VirtualMachine only at the first boot.",
   "Cluster scope migrations": "Cluster scope migrations",
   "Collapse": "Collapse",
   "Completion timeout": "Completion timeout",
@@ -1177,5 +1178,6 @@
   "You can select the boot source in the <2>Disks</2> tab.": "You can select the boot source in the <2>Disks</2> tab.",
   "You can upload a new volume or use an existing PersistentVolumeClaim (PVC)": "You can upload a new volume or use an existing PersistentVolumeClaim (PVC)",
   "You can use cloud-init to initialize the operating system with a specific configuration when the VirtualMachine is started.": "You can use cloud-init to initialize the operating system with a specific configuration when the VirtualMachine is started.",
+  "You must ensure that the configuration is correct before starting the VirtualMachine.": "You must ensure that the configuration is correct before starting the VirtualMachine.",
   "You're in view-only mode": "You're in view-only mode"
 }

--- a/src/utils/components/AlertScripts/AlertScripts.tsx
+++ b/src/utils/components/AlertScripts/AlertScripts.tsx
@@ -1,0 +1,22 @@
+import React, { FC } from 'react';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { Alert, AlertVariant } from '@patternfly/react-core';
+
+const AlertScripts: FC = () => {
+  const { t } = useKubevirtTranslation();
+  return (
+    <Alert
+      className="scripts-alert"
+      title={t(
+        'Cloud-init and SSH key configurations will be applied to the VirtualMachine only at the first boot.',
+      )}
+      isInline
+      variant={AlertVariant.warning}
+    >
+      {t('You must ensure that the configuration is correct before starting the VirtualMachine.')}
+    </Alert>
+  );
+};
+
+export default AlertScripts;

--- a/src/utils/components/AlertScripts/index.tsx
+++ b/src/utils/components/AlertScripts/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './AlertScripts';

--- a/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { WizardDescriptionItem } from '@catalog/wizard/components/WizardDescriptionItem';
 import { WizardTab } from '@catalog/wizard/tabs';
+import AlertScripts from '@kubevirt-utils/components/AlertScripts/AlertScripts';
 import { CloudInitDescription } from '@kubevirt-utils/components/CloudinitDescription/CloudInitDescription';
 import { CloudinitModal } from '@kubevirt-utils/components/CloudinitModal/CloudinitModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -9,7 +10,12 @@ import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEdito
 import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
-import { DescriptionList, Divider, PageSection } from '@patternfly/react-core';
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  Divider,
+  PageSection,
+} from '@patternfly/react-core';
 
 import SSHKey from './components/SSHKey';
 import Sysprep from './components/Sysprep';
@@ -29,6 +35,9 @@ const WizardScriptsTab: WizardTab = ({ vm, updateVM }) => {
       >
         <SidebarEditorSwitch />
         <DescriptionList className="wizard-scripts-tab__description-list">
+          <DescriptionListDescription>
+            <AlertScripts />
+          </DescriptionListDescription>
           <WizardDescriptionItem
             testId="wizard-cloudinit"
             title={t('Cloud-init')}

--- a/src/views/virtualmachines/details/tabs/configuration/scripts/ScriptsTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scripts/ScriptsTab.tsx
@@ -5,6 +5,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import AlertScripts from '@kubevirt-utils/components/AlertScripts/AlertScripts';
 import { CloudInitDescription } from '@kubevirt-utils/components/CloudinitDescription/CloudInitDescription';
 import { CloudinitModal } from '@kubevirt-utils/components/CloudinitModal/CloudinitModal';
 import LinuxLabel from '@kubevirt-utils/components/Labels/LinuxLabel';
@@ -22,6 +23,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
   DescriptionList,
+  DescriptionListDescription,
   Divider,
   PageSection,
   Stack,
@@ -74,6 +76,9 @@ const ScriptsTab: FC<VirtualMachineScriptPageProps> = ({ obj: vm }) => {
       >
         {(resource) => (
           <DescriptionList className="vm-scripts-tab">
+            <DescriptionListDescription>
+              <AlertScripts />
+            </DescriptionListDescription>
             <VirtualMachineDescriptionItem
               descriptionData={<CloudInitDescription vm={resource} />}
               descriptionHeader={t('Cloud-init')}


### PR DESCRIPTION
- Add lines and units to VM metric charts y-axis
- Bug 2182172: Add alert for clound init and ssh auth keys

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Cloud-init runs only the first time and editing this property alongside auth keys is useless for now.

Unfortunately, following the bug conversation, there is no good way to understand if was already executed and applied.
We could use the status.created of the VM to disable cloud init and ssh key editing but it's not accurate as the cloud-init could not be executed yet.

The good news: the backend is implementing a way to fix that and allow the user to change the configuration after the first tun.

## 🎥 Demo

![Screenshot from 2023-04-26 12-09-14](https://user-images.githubusercontent.com/29160323/234545037-e4664485-9d07-4420-aaf7-d1a773199798.png)

