### PR TITLE
Bug 2187242: Increase Utilization pie charts popovers font size

### DIFF
--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/VirtualMachinesOverviewTabUtilization.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/VirtualMachinesOverviewTabUtilization.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 import { Trans } from 'react-i18next';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -32,9 +32,9 @@ type VirtualMachinesOverviewTabUtilizationProps = {
   vm: V1VirtualMachine;
 };
 
-const VirtualMachinesOverviewTabUtilization: React.FC<
-  VirtualMachinesOverviewTabUtilizationProps
-> = ({ vm }) => {
+const VirtualMachinesOverviewTabUtilization: FC<VirtualMachinesOverviewTabUtilizationProps> = ({
+  vm,
+}) => {
   const { t } = useKubevirtTranslation();
   const { vmi, pods } = useVMIAndPodsForVM(vm?.metadata?.name, vm?.metadata?.namespace);
   const isVMRunning = vm?.status?.printableStatus === printableVMStatus.Running;

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC, useMemo } from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ComponentReady from '@kubevirt-utils/components/Charts/ComponentReady/ComponentReady';
@@ -18,11 +18,11 @@ type CPUUtilProps = {
   pods: K8sResourceCommon[];
 };
 
-const CPUUtil: React.FC<CPUUtilProps> = ({ vmi, pods }) => {
+const CPUUtil: FC<CPUUtilProps> = ({ vmi, pods }) => {
   const { t } = useKubevirtTranslation();
-  const vmiPod = React.useMemo(() => getVMIPod(vmi, pods), [pods, vmi]);
+  const vmiPod = useMemo(() => getVMIPod(vmi, pods), [pods, vmi]);
   const { currentTime, duration } = useDuration();
-  const queries = React.useMemo(
+  const queries = useMemo(
     () => getUtilizationQueries({ obj: vmi, duration, launcherPodName: vmiPod?.metadata?.name }),
     [vmi, vmiPod, duration],
   );
@@ -71,6 +71,7 @@ const CPUUtil: React.FC<CPUUtilProps> = ({ vmi, pods }) => {
             subTitle={t('Used')}
             subTitleComponent={<ChartLabel y={135} />}
             title={`${averageCPUUsage.toFixed(2) || 0}%`}
+            style={{ labels: { fontSize: 20 } }}
           />
         </ComponentReady>
       </div>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC, useMemo } from 'react';
 import xbytes from 'xbytes';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -15,13 +15,10 @@ type MemoryUtilProps = {
   vmi: V1VirtualMachineInstance;
 };
 
-const MemoryUtil: React.FC<MemoryUtilProps> = ({ vmi }) => {
+const MemoryUtil: FC<MemoryUtilProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
   const { currentTime, duration } = useDuration();
-  const queries = React.useMemo(
-    () => getUtilizationQueries({ obj: vmi, duration }),
-    [vmi, duration],
-  );
+  const queries = useMemo(() => getUtilizationQueries({ obj: vmi, duration }), [vmi, duration]);
 
   const requests = vmi?.spec?.domain?.resources?.requests as {
     [key: string]: string;
@@ -69,6 +66,7 @@ const MemoryUtil: React.FC<MemoryUtilProps> = ({ vmi }) => {
             subTitle={t('Used')}
             subTitleComponent={<ChartLabel y={135} />}
             title={`${Number(percentageMemoryUsed?.toFixed(2))}%`}
+            style={{ labels: { fontSize: 20 } }}
           />
         </ComponentReady>
       </div>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/StorageUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/StorageUtil.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import xbytes from 'xbytes';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -11,7 +11,7 @@ type StorageUtilProps = {
   vmi: V1VirtualMachineInstance;
 };
 
-const StorageUtil: React.FC<StorageUtilProps> = ({ vmi }) => {
+const StorageUtil: FC<StorageUtilProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
 
   const [guestAgentData, loaded] = useGuestOS(vmi);
@@ -59,6 +59,7 @@ const StorageUtil: React.FC<StorageUtilProps> = ({ vmi }) => {
             subTitle={t('Used')}
             subTitleComponent={<ChartLabel y={135} />}
             title={`${usedPercentage.toFixed(2) || 0}%`}
+            style={{ labels: { fontSize: 20 } }}
           />
         </ComponentReady>
       </div>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2187242

Increase pie charts popovers font size in the VM _Overview_ _Utilization_ card to be the same as in the line charts displayed below those pie charts, for better readability, as the original popovers font size was too small.

## 🎥 Screenshots
**Before:**
CPU chart popover font size too small to be easily readable (same for _Memory_ and _Storage_ charts):
![ut_before](https://user-images.githubusercontent.com/13417815/234673326-b0d1b0c6-32b7-44dc-952a-45d6d471508f.png)

**After:**
CPU chart popover font size bigger (same for _Memory_ and _Storage_ charts):
![ut_after](https://user-images.githubusercontent.com/13417815/234673334-1e33dc46-4093-45f0-9f76-9507de9298c5.png)


