### PR TITLE
Fix i18n script

### DIFF
--- a/i18n-scripts/build-i18n.sh
+++ b/i18n-scripts/build-i18n.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -exuo pipefail
-
-FILE_PATTERN="{!(dist|node_modules)/**/*.{js,jsx,ts,tsx,json},*.{js,jsx,ts,tsx,json}}"
-
-i18next "${FILE_PATTERN}" [-oc] -c "./i18next-parser.config.js" -o "locales/\$LOCALE/\$NAMESPACE.json"

--- a/i18next-parser.config.js
+++ b/i18next-parser.config.js
@@ -2,7 +2,7 @@
 const { CustomJSONLexer } = require('./i18n-scripts/lexers');
 
 module.exports = {
-  input: ['src/**/*.{js,jsx,ts,tsx}'],
+  input: ['src/**/*.{js,jsx,ts,tsx,json}', './console-extensions.json'],
   sort: true,
   createOldCatalogs: false,
   keySeparator: false,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "start-console": "./start-console.sh",
     "i18n-to-po": "node ./i18n-scripts/i18n-to-po.js",
     "po-to-i18n": "node ./i18n-scripts/po-to-i18n.js",
-    "i18n": "./i18n-scripts/build-i18n.sh && node ./i18n-scripts/set-english-defaults.js",
+    "i18n": "i18next && node ./i18n-scripts/set-english-defaults.js",
     "export-pos": "./i18n-scripts/export-pos.sh",
     "memsource-upload": "./i18n-scripts/memsource-upload.sh",
     "memsource-download": "./i18n-scripts/memsource-download.sh"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

There was something wrong with translations. 
the script for no reason adds inexistence keys like.


```json
{
"showFailed": "showFailed",
"showSuccess": "showSuccess"
}
```

just use i18next which will load automatically our i18next configuration file and restrict the research to the `src` folder and the console-extensions.json file

