### PR TITLE
Bug 2181920: Display "UEFI" for Boot mode for "efi: {}" in yaml

### DIFF
--- a/cypress/utils/const/index.ts
+++ b/cypress/utils/const/index.ts
@@ -11,7 +11,6 @@ export const adminOnlyDescribe = Cypress.env('NON_PRIV') ? xdescribe : describe;
 
 export const TEST_NS = 'auto-test-ns';
 
-// VM Status
 export enum VM_STATUS {
   Starting = 'Starting',
   Running = 'Running',

--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1026,7 +1026,6 @@
   "Total bytes": "Total bytes",
   "Type": "Type",
   "UEFI": "UEFI",
-  "UEFI ": "UEFI ",
   "UEFI (secure)": "UEFI (secure)",
   "Unattend.xml answer file": "Unattend.xml answer file",
   "Unavailable": "Unavailable",

--- a/src/utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal.tsx
+++ b/src/utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal.tsx
@@ -1,17 +1,16 @@
-import * as React from 'react';
-import produce from 'immer';
+import React, { ChangeEvent, FC, useMemo, useState } from 'react';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { ensurePath } from '@kubevirt-utils/utils/utils';
 import { Form, FormGroup, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 
 import { ModalPendingChangesAlert } from '../PendingChanges/ModalPendingChangesAlert/ModalPendingChangesAlert';
 import { checkBootModeChanged } from '../PendingChanges/utils/helpers';
 
-import { BootloaderLabel, BootloaderOptionValue } from './utils/constants';
-import { getBootloaderFromVM } from './utils/utils';
+import { bootloaderOptions } from './utils/constants';
+import { BootloaderOptionValue } from './utils/types';
+import { getBootloaderFromVM, updatedVMBootMode } from './utils/utils';
 
 type FirmwareBootloaderModalProps = {
   vm: V1VirtualMachine;
@@ -21,7 +20,7 @@ type FirmwareBootloaderModalProps = {
   vmi?: V1VirtualMachineInstance;
 };
 
-const FirmwareBootloaderModal: React.FC<FirmwareBootloaderModalProps> = ({
+const FirmwareBootloaderModal: FC<FirmwareBootloaderModalProps> = ({
   vm,
   isOpen,
   onClose,
@@ -29,65 +28,20 @@ const FirmwareBootloaderModal: React.FC<FirmwareBootloaderModalProps> = ({
   vmi,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [selectedFirmwareBootloader, setSelectedFirmwareBootloader] =
-    React.useState<BootloaderOptionValue>(getBootloaderFromVM(vm));
+    useState<BootloaderOptionValue>(getBootloaderFromVM(vm));
 
-  const bootloaderOptions: BootloaderLabel[] = [
-    {
-      value: 'bios',
-      title: t('BIOS'),
-      description: t('Use BIOS when bootloading the guest OS (Default)'),
-    },
-    {
-      value: 'uefi',
-      title: t('UEFI'),
-      description: t(
-        'Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true',
-      ),
-    },
-    {
-      value: 'uefiSecure',
-      title: t('UEFI (secure)'),
-      description: t(
-        'Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true',
-      ),
-    },
-  ];
-
-  const handleChange = (
-    event: React.ChangeEvent<HTMLSelectElement>,
-    value: BootloaderOptionValue,
-  ) => {
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>, value: BootloaderOptionValue) => {
     event.preventDefault();
     setSelectedFirmwareBootloader(value);
     setIsDropdownOpen(false);
   };
 
-  const updatedVirtualMachine = React.useMemo(() => {
-    const updatedVM = produce<V1VirtualMachine>(vm, (vmDraft: V1VirtualMachine) => {
-      ensurePath(vmDraft, 'spec.template.spec.domain.firmware.bootloader');
-
-      ensurePath(vmDraft, 'spec.template.spec.domain.features.smm');
-      vmDraft.spec.template.spec.domain.features.smm = { enabled: true };
-
-      switch (selectedFirmwareBootloader) {
-        case 'uefi':
-          vmDraft.spec.template.spec.domain.firmware.bootloader = {
-            efi: { secureBoot: false },
-          };
-          break;
-        case 'uefiSecure':
-          vmDraft.spec.template.spec.domain.firmware.bootloader = {
-            efi: { secureBoot: true },
-          };
-          break;
-        default: // 'bios'
-          vmDraft.spec.template.spec.domain.firmware.bootloader = { bios: {} };
-      }
-    });
-    return updatedVM;
-  }, [vm, selectedFirmwareBootloader]);
+  const updatedVirtualMachine = useMemo(
+    () => updatedVMBootMode(vm, selectedFirmwareBootloader),
+    [vm, selectedFirmwareBootloader],
+  );
 
   return (
     <TabModal

--- a/src/utils/components/FirmwareBootloaderModal/utils/constants.ts
+++ b/src/utils/components/FirmwareBootloaderModal/utils/constants.ts
@@ -1,3 +1,37 @@
-export type BootloaderLabel = { value: string; title: string; description: string };
+import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
-export type BootloaderOptionValue = 'bios' | 'uefi' | 'uefiSecure';
+import { BootloaderLabel } from './types';
+
+export enum BootMode {
+  uefi = 'uefi',
+  uefiSecure = 'uefiSecure',
+  bios = 'bios',
+}
+
+export const BootModeTitles = {
+  [BootMode.uefiSecure]: t('UEFI (secure)'),
+  [BootMode.uefi]: t('UEFI'),
+  [BootMode.bios]: t('BIOS'),
+};
+
+export const bootloaderOptions: BootloaderLabel[] = [
+  {
+    value: BootMode.bios,
+    title: BootModeTitles[BootMode.bios],
+    description: t('Use BIOS when bootloading the guest OS (Default)'),
+  },
+  {
+    value: BootMode.uefi,
+    title: BootModeTitles[BootMode.uefi],
+    description: t(
+      'Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true',
+    ),
+  },
+  {
+    value: BootMode.uefiSecure,
+    title: BootModeTitles[BootMode.uefiSecure],
+    description: t(
+      'Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true',
+    ),
+  },
+];

--- a/src/utils/components/FirmwareBootloaderModal/utils/types.ts
+++ b/src/utils/components/FirmwareBootloaderModal/utils/types.ts
@@ -1,0 +1,5 @@
+import { BootMode } from './constants';
+
+export type BootloaderLabel = { value: string; title: string; description: string };
+
+export type BootloaderOptionValue = BootMode.uefi | BootMode.uefiSecure | BootMode.bios;

--- a/src/utils/components/FirmwareBootloaderModal/utils/utils.ts
+++ b/src/utils/components/FirmwareBootloaderModal/utils/utils.ts
@@ -1,26 +1,58 @@
-import { TFunction } from 'i18next';
+import produce from 'immer';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { ensurePath, isEmpty } from '@kubevirt-utils/utils/utils';
 
-import { BootloaderOptionValue } from './constants';
+import { BootMode, BootModeTitles } from './constants';
+import { BootloaderOptionValue } from './types';
+
+export const isObjectEmpty = (obj: object): boolean => obj && isEmpty(obj);
 
 export const getBootloaderFromVM = (vm: V1VirtualMachine): BootloaderOptionValue => {
-  if (vm?.spec?.template?.spec?.domain?.firmware?.bootloader?.efi?.secureBoot) {
-    return 'uefiSecure';
+  const secureBoot = vm?.spec?.template?.spec?.domain?.firmware?.bootloader?.efi;
+
+  if (secureBoot?.secureBoot === true || isObjectEmpty(secureBoot)) {
+    return BootMode.uefiSecure;
   }
-  if (vm?.spec?.template?.spec?.domain?.firmware?.bootloader?.efi) {
-    return `uefi`;
+  if (secureBoot?.secureBoot === false) {
+    return BootMode.uefi;
   }
-  return 'bios';
+  return BootMode.bios;
 };
 
-export const getBootloaderTitleFromVM = (vm: V1VirtualMachine, t: TFunction): string => {
+export const getBootloaderTitleFromVM = (vm: V1VirtualMachine): string => {
   const bootloader = getBootloaderFromVM(vm);
-  const titles = {
-    uefiSecure: t('UEFI (secure)'),
-    uefi: t('UEFI '),
-    bios: t('BIOS'),
-  };
 
-  return titles[bootloader];
+  return BootModeTitles[bootloader];
 };
+
+/**
+ * A function to return the VirtualMachine object updated with a given boot mode
+ * @param {V1VirtualMachine} vm - VirtualMachine object
+ * @param {BootloaderOptionValue} firmwareBootloader - selected boot mode
+ * @returns {V1VirtualMachine} updated VirtualMachine object
+ */
+export const updatedVMBootMode = (
+  vm: V1VirtualMachine,
+  firmwareBootloader: BootloaderOptionValue,
+) =>
+  produce<V1VirtualMachine>(vm as V1VirtualMachine, (vmDraft: V1VirtualMachine) => {
+    ensurePath(vmDraft, 'spec.template.spec.domain.firmware.bootloader');
+    ensurePath(vmDraft, 'spec.template.spec.domain.features.smm');
+    vmDraft.spec.template.spec.domain.features.smm = { enabled: true };
+
+    switch (firmwareBootloader) {
+      case BootMode.uefi:
+        vmDraft.spec.template.spec.domain.firmware.bootloader = {
+          efi: { secureBoot: false },
+        };
+        break;
+      case BootMode.uefiSecure:
+        vmDraft.spec.template.spec.domain.firmware.bootloader = {
+          efi: { secureBoot: true },
+        };
+        break;
+      default:
+        vmDraft.spec.template.spec.domain.firmware.bootloader = { bios: {} };
+    }
+  });

--- a/src/views/catalog/wizard/tabs/overview/components/WizardOverviewGrid.tsx
+++ b/src/views/catalog/wizard/tabs/overview/components/WizardOverviewGrid.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 
 import { UpdateValidatedVM } from '@catalog/utils/WizardVMContext';
@@ -38,7 +38,7 @@ type WizardOverviewGridProps = {
   updateVM: UpdateValidatedVM;
 };
 
-const WizardOverviewGrid: React.FC<WizardOverviewGridProps> = ({ vm, tabsData, updateVM }) => {
+const WizardOverviewGrid: FC<WizardOverviewGridProps> = ({ vm, tabsData, updateVM }) => {
   const history = useHistory();
   const { ns } = useParams<{ ns: string }>();
   const { t } = useKubevirtTranslation();
@@ -171,7 +171,7 @@ const WizardOverviewGrid: React.FC<WizardOverviewGridProps> = ({ vm, tabsData, u
                 />
               ))
             }
-            description={getBootloaderTitleFromVM(vm, t)}
+            description={getBootloaderTitleFromVM(vm)}
           />
 
           <WizardDescriptionItem

--- a/src/views/templates/details/tabs/details/components/BootMethod/BootMethod.tsx
+++ b/src/views/templates/details/tabs/details/components/BootMethod/BootMethod.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC, useCallback } from 'react';
 
 import { getBootloaderTitleFromVM } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/utils';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -22,15 +22,14 @@ type BootMethodProps = {
   template: V1Template;
 };
 
-const BootMethod: React.FC<BootMethodProps> = ({ template }) => {
+const BootMethod: FC<BootMethodProps> = ({ template }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const { isTemplateEditable } = useEditTemplateAccessReview(template);
   const firmwareBootloaderTitle = getBootloaderTitleFromVM(
     getTemplateVirtualMachineObject(template),
-    t,
   );
-  const onSubmit = React.useCallback(
+  const onSubmit = useCallback(
     (updatedTemplate: V1Template) =>
       k8sUpdate({
         model: TemplateModel,

--- a/src/views/templates/details/tabs/details/components/BootMethod/TemplateBootloaderModal.tsx
+++ b/src/views/templates/details/tabs/details/components/BootMethod/TemplateBootloaderModal.tsx
@@ -1,16 +1,16 @@
-import * as React from 'react';
+import React, { ChangeEvent, FC, useMemo, useState } from 'react';
 import produce from 'immer';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { bootloaderOptions } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/constants';
+import { BootloaderOptionValue } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/types';
 import {
-  BootloaderLabel,
-  BootloaderOptionValue,
-} from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/constants';
-import { getBootloaderFromVM } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/utils';
+  getBootloaderFromVM,
+  updatedVMBootMode,
+} from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/utils';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
-import { ensurePath } from '@kubevirt-utils/utils/utils';
 import { Form, FormGroup, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 
 type TemplateBootloaderModalProps = {
@@ -20,74 +20,31 @@ type TemplateBootloaderModalProps = {
   onSubmit: (updatedVM: V1Template) => Promise<V1Template | void>;
 };
 
-const TemplateBootloaderModal: React.FC<TemplateBootloaderModalProps> = ({
+const TemplateBootloaderModal: FC<TemplateBootloaderModalProps> = ({
   template,
   isOpen,
   onClose,
   onSubmit,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [selectedFirmwareBootloader, setSelectedFirmwareBootloader] =
-    React.useState<BootloaderOptionValue>(
-      getBootloaderFromVM(getTemplateVirtualMachineObject(template)),
-    );
+    useState<BootloaderOptionValue>(getBootloaderFromVM(getTemplateVirtualMachineObject(template)));
 
-  const bootloaderOptions: BootloaderLabel[] = [
-    {
-      value: 'bios',
-      title: t('BIOS'),
-      description: t('Use BIOS when bootloading the guest OS (Default)'),
-    },
-    {
-      value: 'uefi',
-      title: t('UEFI'),
-      description: t(
-        'Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true',
-      ),
-    },
-    {
-      value: 'uefiSecure',
-      title: t('UEFI (secure)'),
-      description: t(
-        'Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true',
-      ),
-    },
-  ];
-
-  const handleChange = (
-    event: React.ChangeEvent<HTMLSelectElement>,
-    value: BootloaderOptionValue,
-  ) => {
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>, value: BootloaderOptionValue) => {
     event.preventDefault();
     setSelectedFirmwareBootloader(value);
     setIsDropdownOpen(false);
   };
 
-  const updatedTemplate = React.useMemo(() => {
+  const updatedTemplate = useMemo(() => {
     return produce<V1Template>(template, (templateDraft: V1Template) => {
       const vmDraft = getTemplateVirtualMachineObject(templateDraft);
-      ensurePath(vmDraft, 'spec.template.spec.domain.firmware.bootloader');
+      const updatedVM = updatedVMBootMode(vmDraft, selectedFirmwareBootloader);
 
-      ensurePath(vmDraft, 'spec.template.spec.domain.features.smm');
-      vmDraft.spec.template.spec.domain.features.smm = { enabled: true };
-
-      switch (selectedFirmwareBootloader) {
-        case 'uefi':
-          vmDraft.spec.template.spec.domain.firmware.bootloader = {
-            efi: {},
-          };
-          break;
-        case 'uefiSecure':
-          vmDraft.spec.template.spec.domain.firmware.bootloader = {
-            efi: { secureBoot: true },
-          };
-          break;
-        default: // 'bios'
-          vmDraft.spec.template.spec.domain.firmware.bootloader = { bios: {} };
-      }
+      vmDraft.spec.template.spec.domain = updatedVM.spec.template.spec.domain;
     });
-  }, [template, selectedFirmwareBootloader]);
+  }, [selectedFirmwareBootloader, template]);
 
   return (
     <TabModal

--- a/src/views/virtualmachines/details/tabs/details/components/grid/leftGrid/VirtualMachineDetailsLeftGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/leftGrid/VirtualMachineDetailsLeftGrid.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import produce from 'immer';
 
@@ -48,7 +48,7 @@ type VirtualMachineDetailsLeftGridProps = {
   vm?: V1VirtualMachine;
 };
 
-const VirtualMachineDetailsLeftGrid: React.FC<VirtualMachineDetailsLeftGridProps> = ({ vm }) => {
+const VirtualMachineDetailsLeftGrid: FC<VirtualMachineDetailsLeftGridProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
   const history = useHistory();
   const { createModal } = useModal();
@@ -57,11 +57,11 @@ const VirtualMachineDetailsLeftGrid: React.FC<VirtualMachineDetailsLeftGridProps
   const accessReview = asAccessReview(VirtualMachineModel, vm, 'update' as K8sVerb);
   const [canUpdateVM] = useAccessReview(accessReview || {});
   const [guestAgentData, loadedGuestAgent] = useGuestOS(vmi);
-  const firmwareBootloaderTitle = getBootloaderTitleFromVM(vm, t);
+  const firmwareBootloaderTitle = getBootloaderTitleFromVM(vm);
   const templateName = getLabel(vm, VM_TEMPLATE_ANNOTATION);
   const templateNamespace = getLabel(vm, LABEL_USED_TEMPLATE_NAMESPACE);
 
-  const onSubmit = React.useCallback(
+  const onSubmit = useCallback(
     (updatedVM: V1VirtualMachine) =>
       k8sUpdate({
         model: VirtualMachineModel,


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2181920

This is a followup of https://github.com/kubevirt-ui/kubevirt-plugin/pull/1236 introducing the change that `efi: { secureBoot: false }` was written to VM's yaml when changing _Boot mode_ field value to "UEFI", because that was correct representation of "UEFI" boot mode (secure boot disabled).

**In this PR, the following remaining issues are fixed:**
- for existing VM:
  - it shows "UEFI" for _Boot mode_ field in _Details_ for `efi: {}` in the yaml's bootloader section
- in Create VM wizard:
  - it shows "UEFI" for _Boot mode_ in _Review and create VirtualMachine_ screen for `efi: {}` in the yaml's bootloader section
- for existing template:
  - it shows "UEFI" for _Boot mode_ in _Details_ for `efi: {}` in the yaml's bootloader section
  - after changing _Boot mode_ value to "UEFI", `efi: {}` occurs in the yaml (this doesn't happen for existing VMs or when creating a VM)

Part of this PR is also a bit of refactoring - removing duplicated code for updating the VM with selected boot mode data.
The result of refactoring is new `updatedVMBootMode` function that returns the updated VM object.

**Expected results:**
The correct value in the yaml after selecting UEFI should be `efi: { secureBoot: false }`. Also for `efi: {}`  in the YAML (as many default templates come with this), secure boot is enabled and "UEFI (secure)" should be displayed in _Boot mode_ field in the UI.

_Notes about the moot modes:_
Both `efi: {}` and `efi: { secureBoot: true }` in the yaml are equivalent (at least now, maybe this will change) and refer to secure boot enabled displayed as "UEFI (secure)" option in the UI. If no `efi` present, then "BIOS" is displayed as a boot mode, in the Details tab. This was the original implementation at least. I was not dealing with this third option too much, the main problem was the secure boot option, that was enabled while the UI showed just "UEFI".

_How to reproduce the bug:_
https://github.com/kubevirt-ui/kubevirt-plugin/pull/1236#issue-1655828779

_Note:_
It is possible this issue will be fixed by backend eventually, probably the way that `efi: {}` in the yaml won't represent secure boot anymore (but it's possible they will come up with something else). But till then, we need this PR to make this work as expected.

## 🎥 Screenshots
Example of a VM yaml:
![vm_yaml](https://user-images.githubusercontent.com/13417815/235733255-97ad0ee3-40e6-4413-9d3d-ab55e057bbee.png)

**Before:**
"UEFI" is displayed for _Boot mode_ field in VM _Details_ for `efi: {}` (see the yaml example above):
![vm_before](https://user-images.githubusercontent.com/13417815/235733199-8aca9182-4f4b-4f28-944e-899c0df42eb0.png)
After changing _Boot mode_ value to "UEFI", `efi: {}` occurs in the VM Template's yaml:
![template_before](https://user-images.githubusercontent.com/13417815/235733694-9ddd92da-e865-43f8-82ef-6d0157b753e6.png)

**After:**
"UEFI (secure)" is displayed for _Boot mode_ field in VM _Details_ for `efi: {}` as expected:
![vm_after](https://user-images.githubusercontent.com/13417815/235733209-522949de-0af8-47e4-b661-658b690cb2df.png)
After changing _Boot mode_ value to "UEFI", `efi: { secureBoot: false }` occurs in the VM Template's yaml:
![template_after](https://user-images.githubusercontent.com/13417815/235733716-29de40b6-56d9-4654-86e1-601c384a32c6.png)

