### PR TITLE
CNV-28335: Connecting top consumer cards to persistent user settings

### DIFF
--- a/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTopConsumerCards.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTopConsumerCards.ts
@@ -1,0 +1,67 @@
+import { useEffect, useMemo, useRef } from 'react';
+
+import DurationOption from '@kubevirt-utils/components/DurationOption/DurationOption';
+import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
+
+import useLocalStorage from '../useLocalStorage';
+
+import {
+  SHOW_TOP_5_ITEMS,
+  TOP_CONSUMERS_DURATION_KEY,
+  TOP_CONSUMERS_NUM_ITEMS_KEY,
+} from './../../../views/clusteroverview/TopConsumersTab/utils/constants';
+import { initialTopConsumerCardSettings } from './../../../views/clusteroverview/TopConsumersTab/utils/utils';
+import { TOP_CONSUMERS_CARD } from './utils/const';
+import { TopConsumersData, UseKubevirtUserSettingsTopConsumerCards } from './utils/types';
+import useKubevirtUserSettings from './useKubevirtUserSettings';
+
+const useKubevirtUserSettingsTopConsumerCards: UseKubevirtUserSettingsTopConsumerCards = () => {
+  const updateOnceFromUserSetting = useRef(null);
+  const [cards, setCards, loaded] = useKubevirtUserSettings('cards');
+  const [topConsumerSettingsLocalStorage, setTopConsumerSettingsLocalStorage] =
+    useLocalStorage<TopConsumersData>(TOP_CONSUMERS_CARD);
+
+  useEffect(() => {
+    if (!updateOnceFromUserSetting.current && loaded) {
+      if (cards?.[TOP_CONSUMERS_CARD]) {
+        setTopConsumerSettingsLocalStorage({
+          ...cards?.[TOP_CONSUMERS_CARD],
+        });
+      }
+      if (!cards?.[TOP_CONSUMERS_CARD]) {
+        setTopConsumerSettingsLocalStorage(
+          JSON.stringify({
+            [TOP_CONSUMERS_NUM_ITEMS_KEY]: SHOW_TOP_5_ITEMS,
+            [TOP_CONSUMERS_DURATION_KEY]: DurationOption.THIRTY_MIN.toString(),
+            ...initialTopConsumerCardSettings,
+          }),
+        );
+      }
+      updateOnceFromUserSetting.current = true;
+      return;
+    }
+
+    if (!isEqualObject(topConsumerSettingsLocalStorage, cards?.[TOP_CONSUMERS_CARD])) {
+      setCards?.({ [TOP_CONSUMERS_CARD]: topConsumerSettingsLocalStorage });
+    }
+  }, [
+    cards,
+    topConsumerSettingsLocalStorage,
+    setCards,
+    setTopConsumerSettingsLocalStorage,
+    loaded,
+  ]);
+
+  const setLocalStorageData = useMemo(
+    () =>
+      <T>(field: string, value: T): void =>
+        setTopConsumerSettingsLocalStorage(
+          JSON.stringify({ ...topConsumerSettingsLocalStorage, [field]: value }),
+        ),
+    [setTopConsumerSettingsLocalStorage, topConsumerSettingsLocalStorage],
+  );
+
+  return [topConsumerSettingsLocalStorage, setLocalStorageData];
+};
+
+export default useKubevirtUserSettingsTopConsumerCards;

--- a/src/utils/hooks/useKubevirtUserSettings/utils/const.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/utils/const.ts
@@ -1,0 +1,1 @@
+export const TOP_CONSUMERS_CARD = 'topConsumersCard';

--- a/src/utils/hooks/useKubevirtUserSettings/utils/types.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/utils/types.ts
@@ -1,0 +1,5 @@
+export type TopConsumersData = { [key: string]: any };
+
+export type SetTopConsumerData = <T>(field: string, value: T) => void;
+
+export type UseKubevirtUserSettingsTopConsumerCards = () => [TopConsumersData, SetTopConsumerData];

--- a/src/utils/hooks/useKubevirtUserSettings/utils/utils.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/utils/utils.ts
@@ -1,0 +1,10 @@
+export const parseNestedJSON = <T>(str: string): T => {
+  try {
+    return JSON.parse(str, (_, val) => {
+      if (typeof val === 'string') return parseNestedJSON(val);
+      return val;
+    });
+  } catch (exc) {
+    return (<unknown>str) as T;
+  }
+};

--- a/src/utils/hooks/useLocalStorage.ts
+++ b/src/utils/hooks/useLocalStorage.ts
@@ -1,18 +1,19 @@
-import React from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
+import { parseNestedJSON } from './useKubevirtUserSettings/utils/utils';
 import { EVENT_LOCALSTORAGE } from './constants';
 
-type UseLocalStorage = (
+type UseLocalStorage = <T = string>(
   key: string,
   initialValue?: string,
-) => [value: string, setLocalStorageValue: (newValue: any) => void, removeItem: () => void];
+) => [value: T, setLocalStorageValue: (newValue: any) => void, removeItem: () => void];
 
 const event = new Event(EVENT_LOCALSTORAGE);
-const useLocalStorage: UseLocalStorage = (key, initialValue) => {
-  const [value, setValue] = React.useState(localStorage.getItem(key));
+const useLocalStorage: UseLocalStorage = <T = string>(key, initialValue) => {
+  const [value, setValue] = useState<T>(parseNestedJSON(localStorage.getItem(key)));
 
   const setLocalStorageValue = (val: any) => {
-    localStorage.setItem(key, val.toString());
+    localStorage.setItem(key, JSON.stringify(val));
     document.dispatchEvent(event);
   };
 
@@ -25,10 +26,11 @@ const useLocalStorage: UseLocalStorage = (key, initialValue) => {
     document.dispatchEvent(event);
   };
 
-  const localStorageSetHandler = React.useCallback(() => {
-    setValue(localStorage.getItem(key));
+  const localStorageSetHandler = useCallback(() => {
+    setValue(parseNestedJSON(localStorage.getItem(key)));
   }, [key]);
-  React.useEffect(() => {
+
+  useEffect(() => {
     document.addEventListener(EVENT_LOCALSTORAGE, localStorageSetHandler, false);
     return () => {
       document.removeEventListener(EVENT_LOCALSTORAGE, localStorageSetHandler, false);

--- a/src/views/clusteroverview/TopConsumersTab/TopConsumersTab.tsx
+++ b/src/views/clusteroverview/TopConsumersTab/TopConsumersTab.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 import { Link } from 'react-router-dom';
 
 import DurationDropdown from '@kubevirt-utils/components/DurationOption/DurationDropdown';
 import DurationOption from '@kubevirt-utils/components/DurationOption/DurationOption';
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useLocalStorage from '@kubevirt-utils/hooks/useLocalStorage';
+import useKubevirtUserSettingsTopConsumerCards from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTopConsumerCards';
 import { Overview } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Card,
@@ -17,30 +17,22 @@ import {
   SelectVariant,
 } from '@patternfly/react-core';
 
-import {
-  SHOW_TOP_5_ITEMS,
-  TOP_CONSUMERS_DURATION_KEY,
-  TOP_CONSUMERS_NUM_ITEMS_KEY,
-} from './utils/constants';
+import { TOP_CONSUMERS_DURATION_KEY, TOP_CONSUMERS_NUM_ITEMS_KEY } from './utils/constants';
 import TopConsumersGridRow from './utils/TopConsumersGridRow';
 import { topAmountSelectOptions } from './utils/utils';
 
 import './TopConsumersTab.scss';
 
-const TopConsumersTab: React.FC = () => {
+const TopConsumersTab: FC = () => {
   const { t } = useKubevirtTranslation();
-  const [numItemsToShow, setNumItemsToShow] = useLocalStorage(
-    TOP_CONSUMERS_NUM_ITEMS_KEY,
-    SHOW_TOP_5_ITEMS,
-  );
-  const [duration, setDuration] = useLocalStorage(
-    TOP_CONSUMERS_DURATION_KEY,
-    DurationOption.THIRTY_MIN.toString(),
-  );
 
-  const onNumItemsSelect = (value) => setNumItemsToShow(value);
+  const [localStorageData, setLocalStorageData] = useKubevirtUserSettingsTopConsumerCards();
+  const onNumItemsSelect = (value) => setLocalStorageData(TOP_CONSUMERS_NUM_ITEMS_KEY, value);
   const onDurationSelect = (value: string) =>
-    setDuration(DurationOption.fromDropdownLabel(value).toString());
+    setLocalStorageData(
+      TOP_CONSUMERS_DURATION_KEY,
+      DurationOption.fromDropdownLabel(value).toString(),
+    );
 
   return (
     <Overview>
@@ -52,13 +44,16 @@ const TopConsumersTab: React.FC = () => {
               {t('View virtualization dashboard')}
             </Link>
             <div className="kv-top-consumers-card__dropdown--duration">
-              <DurationDropdown selectedDuration={duration} selectHandler={onDurationSelect} />
+              <DurationDropdown
+                selectedDuration={localStorageData?.[TOP_CONSUMERS_DURATION_KEY]}
+                selectHandler={onDurationSelect}
+              />
             </div>
             <div className="kv-top-consumers-card__dropdown--num-items">
               <FormPFSelect
                 toggleId="kv-top-consumers-card-amount-select"
                 variant={SelectVariant.single}
-                selections={numItemsToShow}
+                selections={localStorageData?.[TOP_CONSUMERS_NUM_ITEMS_KEY]}
                 onSelect={(e, value) => onNumItemsSelect(value)}
               >
                 {topAmountSelectOptions(t).map((opt) => (
@@ -69,8 +64,17 @@ const TopConsumersTab: React.FC = () => {
           </CardActions>
         </CardHeader>
         <CardBody className="kv-top-consumers-card__body">
-          <TopConsumersGridRow rowNumber={1} topGrid />
-          <TopConsumersGridRow rowNumber={2} />
+          <TopConsumersGridRow
+            rowNumber={1}
+            topGrid
+            localStorageData={localStorageData}
+            setLocalStorageData={setLocalStorageData}
+          />
+          <TopConsumersGridRow
+            rowNumber={2}
+            localStorageData={localStorageData}
+            setLocalStorageData={setLocalStorageData}
+          />
         </CardBody>
       </Card>
     </Overview>

--- a/src/views/clusteroverview/TopConsumersTab/utils/TopConsumerCard.tsx
+++ b/src/views/clusteroverview/TopConsumersTab/utils/TopConsumerCard.tsx
@@ -1,38 +1,59 @@
-import * as React from 'react';
+import React, { FC, useMemo } from 'react';
 
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useLocalStorage from '@kubevirt-utils/hooks/useLocalStorage';
+import {
+  SetTopConsumerData,
+  TopConsumersData,
+} from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
 import { Card, SelectOption, SelectVariant } from '@patternfly/react-core';
 
 import { TopConsumerMetric } from './topConsumerMetric';
 import { TopConsumersChartList } from './TopConsumersChartList';
 import { TopConsumerScope } from './topConsumerScope';
-import { initialTopConsumerCardSettings } from './utils';
 
 import './TopConsumerCard.scss';
 
 type TopConsumersMetricCard = {
   cardID: string;
+  localStorageData: TopConsumersData;
+  setLocalStorageData: SetTopConsumerData;
 };
 
-const TopConsumerCard: React.FC<TopConsumersMetricCard> = ({ cardID }) => {
+const TopConsumerCard: FC<TopConsumersMetricCard> = ({
+  cardID,
+  localStorageData,
+  setLocalStorageData,
+}) => {
   const { t } = useKubevirtTranslation();
 
-  const [metricKey, setMetricKey] = useLocalStorage(
-    `${cardID}-metric-value`,
-    initialTopConsumerCardSettings[cardID]?.metric.toString(),
+  const metricKey = useMemo(
+    () => localStorageData?.[cardID]?.metric?.value,
+    [cardID, localStorageData],
   );
-  const [scopeKey, setScopeKey] = useLocalStorage(
-    `${cardID}-scope-value`,
-    initialTopConsumerCardSettings[cardID]?.scope.toString(),
+
+  const scopeKey = useMemo(
+    () => localStorageData?.[cardID]?.scope?.value,
+    [cardID, localStorageData],
   );
 
   const onMetricSelect = (value) => {
-    setMetricKey(TopConsumerMetric.fromDropdownLabel(value).toString());
+    setLocalStorageData(cardID, {
+      ...localStorageData?.[cardID],
+      metric: {
+        ...localStorageData?.[cardID]?.metric,
+        value: TopConsumerMetric.fromDropdownLabel(value).toString(),
+      },
+    });
   };
   const onScopeSelect = (value) => {
-    setScopeKey(TopConsumerScope.fromDropdownLabel(value).toString());
+    setLocalStorageData(cardID, {
+      ...localStorageData?.[cardID],
+      scope: {
+        ...localStorageData?.[cardID]?.scope,
+        value: TopConsumerScope.fromDropdownLabel(value).toString(),
+      },
+    });
   };
 
   return (
@@ -72,6 +93,7 @@ const TopConsumerCard: React.FC<TopConsumersMetricCard> = ({ cardID }) => {
       <TopConsumersChartList
         metric={TopConsumerMetric.fromString(metricKey)}
         scope={TopConsumerScope.fromString(scopeKey)}
+        localStorageData={localStorageData}
       />
     </Card>
   );

--- a/src/views/clusteroverview/TopConsumersTab/utils/TopConsumersChartList.tsx
+++ b/src/views/clusteroverview/TopConsumersTab/utils/TopConsumersChartList.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import React, { FC, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useLocalStorage from '@kubevirt-utils/hooks/useLocalStorage';
+import { TopConsumersData } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
 import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
 import { CardBody } from '@patternfly/react-core';
 
@@ -22,13 +22,24 @@ import './TopConsumersChartList.scss';
 type TopConsumersChartListProps = {
   metric: TopConsumerMetric;
   scope: TopConsumerScope;
+  localStorageData: TopConsumersData;
 };
 
-export const TopConsumersChartList: React.FC<TopConsumersChartListProps> = ({ metric, scope }) => {
+export const TopConsumersChartList: FC<TopConsumersChartListProps> = ({
+  metric,
+  scope,
+  localStorageData,
+}) => {
   const { t } = useKubevirtTranslation();
-  const [duration] = useLocalStorage(TOP_CONSUMERS_DURATION_KEY);
-  const [numItemsLabel] = useLocalStorage(TOP_CONSUMERS_NUM_ITEMS_KEY);
-  const numItemsToShow = React.useMemo(
+  const duration = useMemo(
+    () => localStorageData?.[TOP_CONSUMERS_DURATION_KEY],
+    [localStorageData],
+  );
+  const numItemsLabel = useMemo(
+    () => localStorageData?.[TOP_CONSUMERS_NUM_ITEMS_KEY],
+    [localStorageData],
+  );
+  const numItemsToShow = useMemo(
     () => (numItemsLabel === SHOW_TOP_5_ITEMS ? 5 : 10),
     [numItemsLabel],
   );

--- a/src/views/clusteroverview/TopConsumersTab/utils/TopConsumersGridRow.tsx
+++ b/src/views/clusteroverview/TopConsumersTab/utils/TopConsumersGridRow.tsx
@@ -1,6 +1,10 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 import classNames from 'classnames';
 
+import {
+  SetTopConsumerData,
+  TopConsumersData,
+} from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
 import { Grid, GridItem } from '@patternfly/react-core';
 
 import TopConsumerCard from './TopConsumerCard';
@@ -11,11 +15,15 @@ import './TopConsumersGridRow.scss';
 type TopConsumersGridRowProps = {
   rowNumber: number;
   topGrid?: boolean;
+  localStorageData: TopConsumersData;
+  setLocalStorageData: SetTopConsumerData;
 };
 
-const TopConsumersGridRow: React.FC<TopConsumersGridRowProps> = ({
+const TopConsumersGridRow: FC<TopConsumersGridRowProps> = ({
   rowNumber,
   topGrid = false,
+  localStorageData,
+  setLocalStorageData,
 }) => {
   const classes = classNames('kv-top-consumers-card__grid', {
     'kv-top-consumers-card__top-grid': topGrid,
@@ -23,15 +31,18 @@ const TopConsumersGridRow: React.FC<TopConsumersGridRowProps> = ({
 
   return (
     <Grid className={classes}>
-      <GridItem span={4} className="kv-top-consumers-card__card-grid-item">
-        <TopConsumerCard cardID={getTopConsumerCardID(rowNumber, 1)} />
-      </GridItem>
-      <GridItem span={4} className="kv-top-consumers-card__card-grid-item">
-        <TopConsumerCard cardID={getTopConsumerCardID(rowNumber, 2)} />
-      </GridItem>
-      <GridItem span={4} className="kv-top-consumers-card__card-grid-item">
-        <TopConsumerCard cardID={getTopConsumerCardID(rowNumber, 3)} />
-      </GridItem>
+      {Array.from({ length: 3 }, (_, i) => {
+        const cardID = getTopConsumerCardID(rowNumber, i + 1);
+        return (
+          <GridItem span={4} key={cardID} className="kv-top-consumers-card__card-grid-item">
+            <TopConsumerCard
+              localStorageData={localStorageData}
+              setLocalStorageData={setLocalStorageData}
+              cardID={cardID}
+            />
+          </GridItem>
+        );
+      })}
     </Grid>
   );
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

connection overview -> top consumers

All charts settings are now connecting to kubevirt user settings and will be persistent between logins in different sessions and not only over sessions.



## 🎥 Demo

> Please add a video or an image of the behavior/changes
