### PR TITLE
Bug 2196765: Sort project names in Clone VM modal

### DIFF
--- a/src/views/virtualmachines/actions/components/CloneVMModal/CloneVMModal.tsx
+++ b/src/views/virtualmachines/actions/components/CloneVMModal/CloneVMModal.tsx
@@ -54,12 +54,7 @@ const CloneVMModal: React.FC<CloneVMModalProps> = ({ vm, isOpen, onClose }) => {
 
   const isVMRunning = vm?.status?.printableStatus === printableVMStatus.Running;
 
-  const { projects, pvcs, loaded } = useCloneVMResources(vm);
-
-  const projectNames = React.useMemo(
-    () => (projects || [])?.map((project) => project.metadata.name),
-    [projects],
-  );
+  const { projectNames, pvcs, loaded } = useCloneVMResources(vm);
 
   const clonedVirtualMachine = React.useMemo(() => {
     const clonedVM = produceCleanClonedVM(vm, (draftVM) => {

--- a/src/views/virtualmachines/actions/components/CloneVMModal/hooks/useCloneVMResources.tsx
+++ b/src/views/virtualmachines/actions/components/CloneVMModal/hooks/useCloneVMResources.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import {
   modelToGroupVersionKind,
   PersistentVolumeClaimModel,
@@ -5,17 +7,21 @@ import {
 } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { getName } from '@kubevirt-utils/resources/shared';
 import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 type UseCloneVMResources = (vm: V1VirtualMachine) => {
   projects: K8sResourceCommon[];
+  projectNames: string[];
   pvcs: IoK8sApiCoreV1PersistentVolumeClaim[];
   loaded: boolean;
   error: any;
 };
 
 const useCloneVMResources: UseCloneVMResources = (vm: V1VirtualMachine) => {
-  const [projects, projectsLoaded, projectsLoadError] = useK8sWatchResource<K8sResourceCommon[]>({
+  const [projects = [], projectsLoaded, projectsLoadError] = useK8sWatchResource<
+    K8sResourceCommon[]
+  >({
     isList: true,
     groupVersionKind: modelToGroupVersionKind(ProjectModel),
   });
@@ -29,8 +35,14 @@ const useCloneVMResources: UseCloneVMResources = (vm: V1VirtualMachine) => {
     namespace: vm?.metadata?.namespace,
   });
 
+  const projectNames = useMemo(
+    () => projects.map(getName).sort((a, b) => a.localeCompare(b)),
+    [projects],
+  );
+
   return {
     projects,
+    projectNames,
     pvcs,
     loaded: projectsLoaded && pvcsLoaded,
     error: projectsLoadError || pvcsLoadError,


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2196765

Sort the namespaces/project names for "Namespace" field/drop down in "Clone VirtualMachine" modal alphabetically to make searching easier.

## 🎥 Screenshots
**Before:**
Namespaces not sorted alphabetically, harder to find the specific one:
![cv_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/23239976-f4f1-4820-921d-ffb8472ea1a5)

**After:**
Namespaces sorted as expected:
![cv_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/c651328b-0d29-4dd8-9323-6474b804f314)

