### PR TITLE
Fix memory metric query

### DIFF
--- a/src/utils/components/Charts/utils/queries.ts
+++ b/src/utils/components/Charts/utils/queries.ts
@@ -40,7 +40,7 @@ export const getUtilizationQueries: GetUtilizationQueries = ({
   return {
     [VMQueries.CPU_USAGE]: `sum(rate(container_cpu_usage_seconds_total{pod='${launcherPodName}',namespace='${namespace}',container="compute"}[${duration}])) BY (pod, namespace)`,
     [VMQueries.CPU_REQUESTED]: `sum(kube_pod_resource_request{resource='cpu',pod='${launcherPodName}',namespace='${namespace}'}) BY (name, namespace)`,
-    [VMQueries.MEMORY_USAGE]: `sum(kubevirt_vmi_memory_used_bytes{name='${name}',namespace='${namespace}'}) BY (name)`,
+    [VMQueries.MEMORY_USAGE]: `sum(rate(kubevirt_vmi_memory_used_bytes{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
     [VMQueries.NETWORK_IN_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
     [VMQueries.NETWORK_OUT_USAGE]: `sum(rate(kubevirt_vmi_network_transmit_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
     [VMQueries.NETWORK_IN_BY_INTERFACE_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace, interface)`,


### PR DESCRIPTION
## 📝 Description

Fixing the memory query to show proper values.

gauge queries should have the pattern of: `sum(rate(<metric_query>[duration]))`

## 🎥 Demo

### Before:
[Screencast from 05-29-2023 11:14:51 AM.webm](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/8cd58b55-9d3a-4e7a-b199-26b95840a8ac)

### After:
[Screencast from 05-29-2023 11:15:14 AM.webm](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/3f10ea5b-9904-4b21-b23d-57af1b9eec29)

