### PR TITLE
Bug 2203187: Make adding disk by cloning PVC work

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourcePVCSelect.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourcePVCSelect.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useCallback, useMemo } from 'react';
 
-import { bytesFromQuantity } from '@catalog/utils/quantity';
+import { bytesToDiskSize } from '@catalog/utils/quantity';
 
 import { useProjectsAndPVCs } from '../../hooks/useProjectsAndPVCs';
 
@@ -38,7 +38,7 @@ const DiskSourcePVCSelect: FC<DiskSourcePVCSelectProps> = ({
       selectPVCName(selection);
       const selectedPVC = pvcs?.find((pvc) => pvc?.metadata?.name === selection);
       const selectedPVCSize = selectedPVC?.spec?.resources?.requests?.storage;
-      setDiskSize && setDiskSize(bytesFromQuantity(selectedPVCSize)?.join(''));
+      setDiskSize && setDiskSize(bytesToDiskSize(selectedPVCSize));
     },
     [selectPVCName, pvcs, setDiskSize],
   );

--- a/src/utils/utils/units.ts
+++ b/src/utils/utils/units.ts
@@ -33,6 +33,16 @@ export const customUnits = {
   ],
 };
 
+export const binaryUnits = {
+  IS: [
+    { from: 0, to: multipliers.Ki, unit: 'B' },
+    { from: multipliers.Ki, to: multipliers.Mi, unit: 'Ki', long: 'thousand' },
+    { from: multipliers.Mi, to: multipliers.Gi, unit: 'Mi', long: 'million' },
+    { from: multipliers.Gi, to: multipliers.Ti, unit: 'Gi', long: 'billion' },
+    { from: multipliers.Ti, unit: 'Ti', long: 'billion' },
+  ],
+};
+
 /**
  * A function to return unit for disk size/memory with 'B' suffix.
  * @param {BinaryUnit | string} unit - unit

--- a/src/views/catalog/utils/quantity.ts
+++ b/src/views/catalog/utils/quantity.ts
@@ -1,13 +1,22 @@
 import byteSize, { ByteSizeResult } from 'byte-size';
 
-import { customUnits, multipliers, toIECUnit } from '@kubevirt-utils/utils/units';
+import { binaryUnits, customUnits, multipliers, toIECUnit } from '@kubevirt-utils/utils/units';
 
-export const bytesToIECBytes = (bytes: number, precision: number): ByteSizeResult => {
+export const bytesToIECBytes = (
+  bytes: number,
+  precision: number,
+  customizedUnits = customUnits,
+): ByteSizeResult => {
   return byteSize(bytes, {
     precision,
-    customUnits,
+    customUnits: customizedUnits,
     units: 'IS',
   });
+};
+
+export const bytesToDiskSize = (size: string) => {
+  const bytesizeresult = bytesToIECBytes(parseFloat(size), 0, binaryUnits);
+  return [bytesizeresult.value, bytesizeresult.unit].join('');
 };
 
 export const bytesFromQuantity = (


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2203187

Make adding disk in _Add disk_ modal when choosing _PVC (creates PVC)_ as a source work. Make it work by setting the PVC size unit correctly for this option.

_Details:_
The problem was that when setting disk size for _PVC (creates PVC)_ source (`setDiskSize`), the disk size unit was set to one of the following: MiB, GiB, TiB. The disk was not able to be created when using these units (that we prefer when displaying size in the UI). The problem was presence of "B" at the end of the unit (a.k.a. IEC units) when using `bytesFromQuantity` to get the correct size and unit.
Originally, `bytesFromQuantity` was used to prevent getting the size in bytes in some situations (for example when deleting the size number in the appropriate field in the modal). Now it was replaced by a new function `bytesToDiskSize` that works brilliant, provides units without unnecessary "B" at the end of the unit string, and so it provides the expected result.

## 🎥 Screenshots
**Before:**
Adding disk to an existing VM fails when choosing _PVC (creates PVC)_ for _Source_ field:
![disk_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/bebdf8b0-a6b7-46c9-8fba-6c7cfa5ef594)

**After:**
Disk added successfully:
![disk_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/62caa754-630f-4aec-a0ae-299129e9a0e7)

