### PR TITLE
Show running networks when VMI exists

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceList.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceList.tsx
@@ -1,13 +1,17 @@
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
 import { getNetworkInterfaceRowData } from '@kubevirt-utils/resources/vm/utils/network/rowData';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   ListPageFilter,
+  useK8sWatchResource,
   useListPageFilter,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
+import { printableVMStatus } from '@virtualmachines/utils';
 
 import useNetworkColumns from '../../hooks/useNetworkColumns';
 import useNetworkRowFilters from '../../hooks/useNetworkRowFilters';
@@ -20,8 +24,25 @@ type NetworkInterfaceTableProps = {
 };
 
 const NetworkInterfaceList: FC<NetworkInterfaceTableProps> = ({ vm }) => {
-  const networks = getNetworks(vm);
-  const interfaces = getInterfaces(vm);
+  const vmiExists = printableVMStatus.Stopped !== vm?.status?.printableStatus;
+
+  const [vmi] = useK8sWatchResource<V1VirtualMachineInstance>(
+    vmiExists && {
+      groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
+      isList: false,
+      name: vm?.metadata?.name,
+      namespace: vm?.metadata?.namespace,
+    },
+  );
+
+  const [networks, interfaces] = useMemo(
+    () =>
+      vmiExists
+        ? [vmi?.spec?.networks, vmi?.spec?.domain?.devices?.interfaces]
+        : [getNetworks(vm), getInterfaces(vm)],
+    [vm, vmi, vmiExists],
+  );
+
   const filters = useNetworkRowFilters();
 
   const networkInterfacesData = getNetworkInterfaceRowData(networks, interfaces);
@@ -38,7 +59,7 @@ const NetworkInterfaceList: FC<NetworkInterfaceTableProps> = ({ vm }) => {
       <VirtualizedTable
         data={filteredData}
         unfilteredData={data}
-        loaded
+        loaded={!isEmpty(vm)}
         loadError={false}
         columns={columns}
         Row={NetworkInterfaceRow}


### PR DESCRIPTION
## 📝 Description

Showing the VMI networks and interfaces in case the VM is running.

## 🎥 Demo

### Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/952537e0-79f9-4590-8c34-5d3a8d9e9854

### After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/8f11db94-480a-4ea3-8e59-4b2afe84c814



