### PR TITLE
CNV-29220: Remove VM's access credentials if ssh is not configured

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -133,9 +133,7 @@ export const generateVM = (
     },
   };
 
-  const vmToCreate = addSecretToVM(emptyVM, sshSecretName);
-
-  return vmToCreate;
+  return sshSecretName ? addSecretToVM(emptyVM, sshSecretName) : emptyVM;
 };
 
 export const isBootableVolumePVCKind = (bootableVolume: BootableVolume): boolean =>


### PR DESCRIPTION
## 📝 Description

VM created from instanceTypes cannot be scheduled because secret not found

## 🎥 Demo

### Before: 
![instancetype_ssh](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/95c42f71-3f4a-4ef9-bc42-3c99c5ac65c7)

### After:
![instancetype_ssh-after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/83d83561-640e-48fc-ae90-f661524b4104)
