### PR TITLE
Bug 2189312: Add missing titles to Templates tabs

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -970,6 +970,7 @@
   "Template": "Template",
   "Template catalog": "Template catalog",
   "Template default": "Template default",
+  "Template details": "Template details",
   "Template display name": "Template display name",
   "Template does not use boot source reference": "Template does not use boot source reference",
   "Template info": "Template info",

--- a/src/views/templates/details/tabs/details/TemplateDetailsPage.scss
+++ b/src/views/templates/details/tabs/details/TemplateDetailsPage.scss
@@ -11,3 +11,9 @@
   justify-content: space-between;
   flex: 1;
 }
+
+.template-details-page {
+  &__flex {
+    align-items: center;
+  }
+}

--- a/src/views/templates/details/tabs/details/TemplateDetailsPage.tsx
+++ b/src/views/templates/details/tabs/details/TemplateDetailsPage.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
+import React, { FC, useCallback } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 
 import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
 import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
-import { Grid, GridItem, PageSection } from '@patternfly/react-core';
+import { Flex, Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 
 import TemplateDetailsLeftGrid from './components/TemplateDetailsLeftGrid';
 import TemplateDetailsRightGrid from './components/TemplateDetailsRightGrid';
@@ -26,8 +27,10 @@ type TemplateDetailsPageProps = RouteComponentProps<{
   obj?: V1Template;
 };
 
-const TemplateDetailsPage: React.FC<TemplateDetailsPageProps> = ({ obj: template }) => {
-  const onSubmitTemplate = React.useCallback(
+const TemplateDetailsPage: FC<TemplateDetailsPageProps> = ({ obj: template }) => {
+  const { t } = useKubevirtTranslation();
+
+  const onSubmitTemplate = useCallback(
     (updatedTemplate: V1Template) =>
       k8sUpdate({
         model: TemplateModel,
@@ -43,13 +46,16 @@ const TemplateDetailsPage: React.FC<TemplateDetailsPageProps> = ({ obj: template
       <SidebarEditor<V1Template> resource={template} onResourceUpdate={onSubmitTemplate}>
         {(resource) => (
           <>
-            <SidebarEditorSwitch />
+            <Flex className="template-details-page__flex">
+              <Title headingLevel="h2">{t('Template details')}</Title>
+              <SidebarEditorSwitch />
+            </Flex>
             <Grid className="margin-top">
-              <GridItem span={5} className="margin-top-grid-item">
+              <GridItem span={5}>
                 <TemplateDetailsLeftGrid template={resource} />
               </GridItem>
               <GridItem lg={1}></GridItem>
-              <GridItem span={5} className="margin-top-grid-item">
+              <GridItem span={5}>
                 <TemplateDetailsRightGrid template={resource} />
               </GridItem>
             </Grid>

--- a/src/views/templates/details/tabs/disks/TemplateDisksPage.scss
+++ b/src/views/templates/details/tabs/disks/TemplateDisksPage.scss
@@ -10,6 +10,15 @@
   }
 
   &__button {
-    margin: 1rem 0 0.5rem 0;
+    margin: 0 0 0.5rem 0;
+  }
+
+  .pf-l-flex {
+    align-items: center;
+  }
+
+  .disk-list-title {
+    margin-right: 0;
+    margin-top: 0;
   }
 }

--- a/src/views/templates/details/tabs/disks/TemplateDisksPage.tsx
+++ b/src/views/templates/details/tabs/disks/TemplateDisksPage.tsx
@@ -69,7 +69,7 @@ const TemplateDisksPage: FC<TemplateDisksPageProps> = ({ obj: template }) => {
     <div className="template-disks-page">
       <ListPageBody>
         <SidebarEditor<V1Template> resource={template} onResourceUpdate={onSubmitTemplate}>
-          <Flex>
+          <Flex className="list-page-create-button-margin">
             <FlexItem>
               <DiskListTitle />
             </FlexItem>

--- a/src/views/templates/details/tabs/network/TemplateNetworkPage.tsx
+++ b/src/views/templates/details/tabs/network/TemplateNetworkPage.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC, useCallback } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 
 import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
@@ -7,7 +7,7 @@ import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEdito
 import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { k8sUpdate, ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, Flex, FlexItem } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Title } from '@patternfly/react-core';
 
 import useEditTemplateAccessReview from '../../hooks/useIsTemplateEditable';
 
@@ -24,13 +24,13 @@ type TemplateNetworkProps = RouteComponentProps<{
   obj: V1Template;
 };
 
-const TemplateNetwork: React.FC<TemplateNetworkProps> = ({ obj: template }) => {
+const TemplateNetwork: FC<TemplateNetworkProps> = ({ obj: template }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const { isTemplateEditable } = useEditTemplateAccessReview(template);
   const actionText = t('Add network interface');
 
-  const onSubmitTemplate = React.useCallback(
+  const onSubmitTemplate = useCallback(
     (updatedTemplate: V1Template) =>
       k8sUpdate({
         model: TemplateModel,
@@ -47,26 +47,30 @@ const TemplateNetwork: React.FC<TemplateNetworkProps> = ({ obj: template }) => {
         <SidebarEditor<V1Template> resource={template} onResourceUpdate={onSubmitTemplate}>
           <Flex className="list-page-create-button-margin">
             <FlexItem>
-              <Button
-                isDisabled={!isTemplateEditable}
-                onClick={() =>
-                  createModal(({ isOpen, onClose }) => (
-                    <TemplatesNetworkInterfaceModal
-                      isOpen={isOpen}
-                      onClose={onClose}
-                      headerText={actionText}
-                      template={template}
-                    />
-                  ))
-                }
-              >
-                {actionText}
-              </Button>
+              <Title headingLevel="h2">{t('Network interfaces')}</Title>
             </FlexItem>
             <FlexItem>
               <SidebarEditorSwitch />
             </FlexItem>
           </Flex>
+
+          <Button
+            className="template-network-tab__button"
+            isDisabled={!isTemplateEditable}
+            onClick={() =>
+              createModal(({ isOpen, onClose }) => (
+                <TemplatesNetworkInterfaceModal
+                  isOpen={isOpen}
+                  onClose={onClose}
+                  headerText={actionText}
+                  template={template}
+                />
+              ))
+            }
+          >
+            {actionText}
+          </Button>
+
           <NetworkInterfaceList template={template} />
         </SidebarEditor>
       </ListPageBody>

--- a/src/views/templates/details/tabs/network/template-network-tab.scss
+++ b/src/views/templates/details/tabs/network/template-network-tab.scss
@@ -1,11 +1,19 @@
 .template-network-tab {
+  height: 100%;
+
+  .co-m-pane__body {
     height: 100%;
+  }
 
-    .co-m-pane__body {
-      height: 100%;
-    }
+  .pf-c-sidebar__panel {
+    padding-top: var(--pf-global--spacer--md);
+  }
 
-    .pf-c-sidebar__panel {
-        padding-top: var(--pf-global--spacer--md);
-    }
+  .pf-l-flex {
+    align-items: center;
+  }
+
+  &__button {
+    margin-bottom: 0.5rem ;
+  }
 }

--- a/src/views/templates/details/tabs/parameters/TemplateParametersPage.tsx
+++ b/src/views/templates/details/tabs/parameters/TemplateParametersPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { FC, MouseEventHandler, useCallback, useEffect, useState } from 'react';
 import { RouteComponentProps, useHistory } from 'react-router-dom';
 import { useImmer } from 'use-immer';
 
@@ -14,8 +14,10 @@ import {
   AlertVariant,
   Button,
   Divider,
+  Flex,
   Form,
   PageSection,
+  Title,
 } from '@patternfly/react-core';
 
 import useEditTemplateAccessReview from '../../hooks/useIsTemplateEditable';
@@ -31,7 +33,7 @@ type TemplateParametersPageProps = RouteComponentProps<{
   obj?: V1Template;
 };
 
-const TemplateParametersPage: React.FC<TemplateParametersPageProps> = ({ obj: template }) => {
+const TemplateParametersPage: FC<TemplateParametersPageProps> = ({ obj: template }) => {
   const [editableTemplate, setEditableTemplate] = useImmer(template);
 
   useEffect(() => setEditableTemplate(template), [setEditableTemplate, template]);
@@ -39,9 +41,9 @@ const TemplateParametersPage: React.FC<TemplateParametersPageProps> = ({ obj: te
   const { t } = useKubevirtTranslation();
   const { isTemplateEditable } = useEditTemplateAccessReview(template);
   const history = useHistory();
-  const [error, setError] = React.useState();
-  const [success, setSuccess] = React.useState(false);
-  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = useState();
+  const [success, setSuccess] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const onParameterChange = (parameter: TemplateParameter) => {
     setEditableTemplate(({ parameters: draftParameters }) => {
@@ -54,11 +56,11 @@ const TemplateParametersPage: React.FC<TemplateParametersPageProps> = ({ obj: te
 
   const isSaveDisabled = isEqualObject(template.parameters, parameters);
 
-  const goBack = React.useCallback(() => {
+  const goBack = useCallback(() => {
     history.goBack();
   }, [history]);
 
-  const onSave: React.MouseEventHandler<HTMLButtonElement> = async (event) => {
+  const onSave: MouseEventHandler<HTMLButtonElement> = async (event) => {
     event.preventDefault();
     setLoading(true);
     try {
@@ -81,7 +83,10 @@ const TemplateParametersPage: React.FC<TemplateParametersPageProps> = ({ obj: te
         onChange={(newTemplate) => setEditableTemplate(newTemplate)}
       >
         <Form className="template-parameters-page__form">
-          <SidebarEditorSwitch />
+          <Flex className="template-parameters-page__flex">
+            <Title headingLevel="h2">{t('Parameters')}</Title>
+            <SidebarEditorSwitch />
+          </Flex>
           {parameters.map((parameter, index) => (
             <>
               <ParameterEditor

--- a/src/views/templates/details/tabs/parameters/template-parameters-page.scss
+++ b/src/views/templates/details/tabs/parameters/template-parameters-page.scss
@@ -8,6 +8,10 @@
     border-top: none;
   }
 
+  &__flex {
+    align-items: center;
+  }
+
   .pf-c-expandable-section__toggle-text {
     color: var(--pf-global--Color--100);
   }

--- a/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.scss
+++ b/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.scss
@@ -1,3 +1,9 @@
 .no-left-padding {
   padding-left: 0;
 }
+
+.template-scheduling-tab {
+  &__flex {
+    align-items: center;
+  }
+}

--- a/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.tsx
+++ b/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.tsx
@@ -1,11 +1,12 @@
-import * as React from 'react';
+import React, { FC, useCallback } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 
 import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
 import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
-import { Grid, GridItem, PageSection } from '@patternfly/react-core';
+import { Flex, Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 
 import useEditTemplateAccessReview from '../../hooks/useIsTemplateEditable';
 
@@ -21,10 +22,11 @@ type TemplateSchedulingTabProps = RouteComponentProps<{
   obj?: V1Template;
 };
 
-const TemplateSchedulingTab: React.FC<TemplateSchedulingTabProps> = ({ obj: template }) => {
+const TemplateSchedulingTab: FC<TemplateSchedulingTabProps> = ({ obj: template }) => {
   const { isTemplateEditable } = useEditTemplateAccessReview(template);
+  const { t } = useKubevirtTranslation();
 
-  const onSubmitTemplate = React.useCallback(
+  const onSubmitTemplate = useCallback(
     (updatedTemplate: V1Template) =>
       k8sUpdate({
         model: TemplateModel,
@@ -40,13 +42,16 @@ const TemplateSchedulingTab: React.FC<TemplateSchedulingTabProps> = ({ obj: temp
       <SidebarEditor<V1Template> resource={template} onResourceUpdate={onSubmitTemplate}>
         {(resource) => (
           <>
-            <SidebarEditorSwitch />
+            <Flex className="template-scheduling-tab__flex">
+              <Title headingLevel="h2">{t('Scheduling and resource requirements')}</Title>
+              <SidebarEditorSwitch />
+            </Flex>
             <Grid className="margin-top">
-              <GridItem span={5} className="margin-top-grid-item">
+              <GridItem span={5}>
                 <TemplateSchedulingLeftGrid template={resource} editable={isTemplateEditable} />
               </GridItem>
               <GridItem lg={1}></GridItem>
-              <GridItem span={5} className="margin-top-grid-item">
+              <GridItem span={5}>
                 <TemplateSchedulingRightGrid template={resource} editable={isTemplateEditable} />
               </GridItem>
             </Grid>

--- a/src/views/templates/details/tabs/scripts/TemplateScriptsPage.tsx
+++ b/src/views/templates/details/tabs/scripts/TemplateScriptsPage.tsx
@@ -25,6 +25,7 @@ import {
   Flex,
   FlexItem,
   PageSection,
+  Title,
 } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
@@ -70,13 +71,14 @@ const TemplateScriptsPage: FC<TemplateScriptsPageProps> = ({ obj: template }) =>
   return (
     <PageSection>
       <SidebarEditor<V1Template> resource={template} onResourceUpdate={onSubmitTemplate}>
-        <SidebarEditorSwitch />
-        <DescriptionList className="template-scripts-tab__description-list margin-top">
+        <DescriptionList className="template-scripts-tab__description-list">
           <DescriptionListGroup>
             <DescriptionListTerm>
               <DescriptionListTermHelpText>
                 <Flex className="vm-description-item__title">
-                  <FlexItem>{t('Cloud-init')}</FlexItem>
+                  <FlexItem>
+                    <Title headingLevel="h2">{t('Cloud-init')}</Title>
+                  </FlexItem>
                   <FlexItem>
                     <Button
                       type="button"
@@ -97,6 +99,9 @@ const TemplateScriptsPage: FC<TemplateScriptsPageProps> = ({ obj: template }) =>
                       {t('Edit')}
                       <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
                     </Button>
+                  </FlexItem>
+                  <FlexItem>
+                    <SidebarEditorSwitch />
                   </FlexItem>
                 </Flex>
               </DescriptionListTermHelpText>

--- a/src/views/templates/details/tabs/scripts/components/SSHKey/SSHKey.tsx
+++ b/src/views/templates/details/tabs/scripts/components/SSHKey/SSHKey.tsx
@@ -30,6 +30,7 @@ import {
   Stack,
   Text,
   TextVariants,
+  Title,
 } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
@@ -117,8 +118,9 @@ const SSHKey: FC<SSHKeyProps> = ({ template }) => {
         <DescriptionListTermHelpText>
           <Flex className="vm-description-item__title">
             <FlexItem>
-              {t('Authorized SSH key')}
-              {<LinuxLabel />}
+              <Title headingLevel="h2">
+                {t('Authorized SSH key')} {<LinuxLabel />}
+              </Title>
             </FlexItem>
             <FlexItem>
               <Button

--- a/src/views/templates/details/tabs/scripts/components/SysPrepItem/SysPrepItem.tsx
+++ b/src/views/templates/details/tabs/scripts/components/SysPrepItem/SysPrepItem.tsx
@@ -25,6 +25,7 @@ import {
   DescriptionListTermHelpText,
   Flex,
   FlexItem,
+  Title,
 } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
@@ -95,8 +96,9 @@ const SysPrepItem: FC<SysPrepItemProps> = ({ template }) => {
         <DescriptionListTermHelpText>
           <Flex className="vm-description-item__title">
             <FlexItem>
-              {t('Sysprep')}
-              {<WindowsLabel />}
+              <Title headingLevel="h2">
+                {t('Sysprep')} {<WindowsLabel />}
+              </Title>
             </FlexItem>
             <FlexItem>
               <Button

--- a/src/views/templates/details/tabs/scripts/template-scripts-tab.scss
+++ b/src/views/templates/details/tabs/scripts/template-scripts-tab.scss
@@ -1,3 +1,7 @@
 .template-scripts-tab__description-list {
-    max-width: 700px;
+  max-width: 700px;
+
+  .pf-l-flex {
+    align-items: center;
+  }
 }


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2189312

Add missing titles to the following _Templates_ tabs:
- _Details_
- _Scheduling_
- _Network interfaces_
- _Parameters_

Update _Disks_ tab title to be better aligned with YAML switcher, for better look.

Make titles in _Scripts_ tab bigger, same as in other tabs, for consistency reasons.

_Design doc:_
https://docs.google.com/document/d/1Y8TA1EeAZVCLkqUT-ZHzWKGkSEpVMq6jYdXwG1Uv2Gw/

_Notes:_
Note that in the design doc, YAML switcher is not displayed. This is not because it should be removed, no.
It is just a bug of the doc. And there is a plan to move the YAML switcher to another location, as mentioned in the design doc at it's top. This will be done by another PR once the design doc will be updated.

Note that picture for _Scripts_ tab in the design doc is kinda buggy, too, because it shows **VM** _Scripts_ tab, not templates' one.

Also note that dimensions of dividers in these pages will be solved separately, within a different task/PR, as more pages, not only Templates ones are involved in this inconsistency, and more code changes will be needed to do in case we do not want to use negative values for dividers in related css files to hack their parameters. And of course, it requires some more discussion with UX to make sure about the expected look of the dividers.

## 🎥 Screenshots
The following screenshots are displayed as pairs - **before** and **after**, for better visual comparison:

_Details_ tab:
![details_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/587c99ec-8c3d-4dc4-bd6a-61ac9806de8d)
![details_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/da4a6c5c-c86d-436b-97d4-8333cb436475)

_Disks_ tab:
![disks_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/0b6f2b0d-b044-4c3b-ab35-576fcbaedbed)
![disks_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/8d20e9e3-8594-420f-b12d-2bbafdde91d7)

_Network interfaces_ (a.k.a NICs) tab:
![network_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/3769b8a6-7e3f-4a72-a7a9-b7616a036fd6)
![network_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/b254767a-5168-46ec-bd66-0194ba3add8b)

_Parameters_ tab:
![params_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/5ae25ef1-03ae-4705-aaae-768092990a2b)
![params_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/37b0fb6b-2110-4634-a390-e636c9c57d54)

_Scheduling_ tab:
![scheduling_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/37487479-c192-4f50-bf70-3f9ff9f686fe)
![scheduling-after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/9bfeaf66-1093-4964-ad80-3ff9d4c11a07)

_Scripts_ tab:
![scripts_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/65e7708e-9a9c-4d77-b1b8-01a4051fa057)
![scripts_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/07c0346b-accc-4dcc-ba2f-c9dc6be18011)





