### PR TITLE
Bug 2196161: Display Bootable volumes Name column correctly

### DIFF
--- a/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
+++ b/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
@@ -9,7 +9,7 @@ import { ANNOTATIONS } from '@kubevirt-utils/resources/template';
 import { isDataSourceCloning } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
-import { Label, Split, SplitItem } from '@patternfly/react-core';
+import { Label } from '@patternfly/react-core';
 import { TableText, WrapModifier } from '@patternfly/react-table';
 
 import BootableVolumesActions from '../../actions/BootableVolumesActions';
@@ -29,19 +29,14 @@ const BootableVolumesRow: FC<
   return (
     <>
       <TableData id="name" activeColumnIDs={activeColumnIDs} className="pf-m-width-20">
-        <Split hasGutter>
-          <SplitItem>
-            <ResourceLink
-              groupVersionKind={getBootableVolumeGroupVersionKind(obj)}
-              name={obj?.metadata?.name}
-            />
-          </SplitItem>
-          {obj.kind === DataSourceModel.kind && isDataSourceCloning(obj as V1beta1DataSource) && (
-            <SplitItem>
-              <Label>{t('Clone in progress')}</Label>
-            </SplitItem>
-          )}
-        </Split>
+        <ResourceLink
+          groupVersionKind={getBootableVolumeGroupVersionKind(obj)}
+          name={obj?.metadata?.name}
+          inline
+        />
+        {obj.kind === DataSourceModel.kind && isDataSourceCloning(obj as V1beta1DataSource) && (
+          <Label>{t('Clone in progress')}</Label>
+        )}
       </TableData>
       <TableData id="namespace" activeColumnIDs={activeColumnIDs} className="pf-m-width-20">
         <ResourceLink kind="Namespace" name={obj?.metadata?.namespace} />


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2196161

Display the _Name_ column correctly in case when the "Clone in progress" label is present next to the name while the browser window is very small.

_Solution:_
Using `inline` prop with `ResourceLink` instead of `Split` and `SplitItem` components for achieving displaying name with the label at the same line of the row solved the problem.
Additionally, the name with the label are more nicely aligned, when browser window has its normal/common size.

## 🎥 Screenshots
**Before:**
![before2](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/8132e7ea-fa3d-4260-acf7-8e535e77f3a2)
Name with the label not nicely aligned, when browser window has its normal/common size:
![before1](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/bacb7dd3-a4fd-4b91-9512-e9e832fa7690)

**After:**
![after2](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/b41dadce-38b1-48a1-b54f-535019f08458)
Name with the label both nicely aligned to the center of the row:
![after1](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/1933e4ad-8d85-43c8-9a68-ece132c8c8fb)







