### PR TITLE
Add missing namespace to ResourceLink in BootableVolumesRow

### DIFF
--- a/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
+++ b/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
@@ -32,6 +32,7 @@ const BootableVolumesRow: FC<
         <ResourceLink
           groupVersionKind={getBootableVolumeGroupVersionKind(obj)}
           name={obj?.metadata?.name}
+          namespace={obj?.metadata?.namespace}
           inline
         />
         {obj.kind === DataSourceModel.kind && isDataSourceCloning(obj as V1beta1DataSource) && (


### PR DESCRIPTION
## 📝 Description

_Related BZ:_
https://bugzilla.redhat.com/show_bug.cgi?id=2196161

_Related PR comment:_
https://github.com/kubevirt-ui/kubevirt-plugin/pull/1323#discussion_r1218273916

This is just a small improvement of the BZ fix. Add missing namespace prop to `ResourceLink` in `BootableVolumesRow` component, to avoid possible 404 error when clicking on the resource in _Bootable volumes_ list.

