### PR TITLE
Bug 2207468: Clone vm without CR

### DIFF
--- a/src/views/virtualmachines/actions/components/CloneVMModal/utils/helpers.tsx
+++ b/src/views/virtualmachines/actions/components/CloneVMModal/utils/helpers.tsx
@@ -199,7 +199,9 @@ export const cloneControllerRevision = async (
   revisionName: string,
   destinationNamespace: string,
   originNamespace: string,
-) => {
+): Promise<IoK8sApiAppsV1ControllerRevision | null> => {
+  if (!revisionName) return null;
+
   const destNamespaceCR = await getControllerIfExist(revisionName, destinationNamespace);
 
   if (destNamespaceCR) return destNamespaceCR;
@@ -227,7 +229,9 @@ export const cloneControllerRevision = async (
 export const updateControllerRevisionOwnerReference = (
   controllerRevision: IoK8sApiAppsV1ControllerRevision,
   vm: V1VirtualMachine,
-): Promise<IoK8sApiAppsV1ControllerRevision> => {
+): Promise<IoK8sApiAppsV1ControllerRevision | null> => {
+  if (!controllerRevision) return Promise.resolve(null);
+
   const controllerRevisionWithOwner = produce(controllerRevision, (draftController) => {
     if (!draftController.metadata.ownerReferences) draftController.metadata.ownerReferences = [];
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2207468
The main issue was that the `k8sGet` method return a CR even if gets called with `undefined` name.
We should not clone the CR if the VM has no instancetype or preference.
So guard on this situation and make the CRs requests in parallel as they are not related to each other.