### PR TITLE
CNV-29485: Move YAML switcher out of Template tabs

### DIFF
--- a/src/views/templates/details/CommonTemplateAlert.tsx
+++ b/src/views/templates/details/CommonTemplateAlert.tsx
@@ -10,8 +10,6 @@ import { getTemplateProviderName } from '@kubevirt-utils/resources/template';
 import { getOperatingSystemName } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import { Alert, AlertVariant, Button, ButtonVariant } from '@patternfly/react-core';
 
-import './template-header-alert.scss';
-
 type CommonTemplateAlertProps = {
   template: V1Template;
 };

--- a/src/views/templates/details/NoPermissionTemplateAlert.tsx
+++ b/src/views/templates/details/NoPermissionTemplateAlert.tsx
@@ -3,8 +3,6 @@ import React, { FC } from 'react';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Alert, AlertVariant } from '@patternfly/react-core';
 
-import './template-header-alert.scss';
-
 const NoPermissionTemplateAlert: FC = () => {
   const { t } = useKubevirtTranslation();
   return (

--- a/src/views/templates/details/TemplateNavPage.scss
+++ b/src/views/templates/details/TemplateNavPage.scss
@@ -1,0 +1,17 @@
+.template-header-alert {
+  margin-bottom: 0;
+  
+  button.pf-c-button.pf-m-link {
+    padding-left: 0;
+  }
+} 
+
+.TemplatePageTitle {
+  .pf-c-title {
+    align-items: center;
+  }
+
+  .pf-c-switch {
+    padding-top: var(--pf-global--spacer--xs);
+  }
+}

--- a/src/views/templates/details/TemplateNavPage.tsx
+++ b/src/views/templates/details/TemplateNavPage.tsx
@@ -15,6 +15,8 @@ import useEditTemplateAccessReview from './hooks/useIsTemplateEditable';
 import { useVirtualMachineTabs } from './hooks/useTemplateTabs';
 import TemplatePageTitle from './TemplatePageTitle';
 
+import './TemplateNavPage.scss';
+
 export type TemplateNavPageProps = RouteComponentProps<{
   ns: string;
   name: string;

--- a/src/views/templates/details/TemplatePageTitle.tsx
+++ b/src/views/templates/details/TemplatePageTitle.tsx
@@ -2,10 +2,20 @@ import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
+import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useLastNamespacePath } from '@kubevirt-utils/hooks/useLastNamespacePath';
 import { isDeprecatedTemplate } from '@kubevirt-utils/resources/template';
-import { Breadcrumb, BreadcrumbItem, Button, Label, Title } from '@patternfly/react-core';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  Label,
+  Split,
+  SplitItem,
+  Title,
+} from '@patternfly/react-core';
 
 import useEditTemplateAccessReview from './hooks/useIsTemplateEditable';
 import CommonTemplateAlert from './CommonTemplateAlert';
@@ -22,8 +32,12 @@ const TemplatePageTitle: React.FC<TemplatePageTitleTitleProps> = ({ template }) 
   const lastNamespacePath = useLastNamespacePath();
   const { isCommonTemplate, hasEditPermission } = useEditTemplateAccessReview(template);
 
+  const isSidebarEditorDisplayed = !history.location.pathname.includes(
+    `/templates/${template?.metadata?.name}/${VirtualMachineDetailsTab.YAML}`,
+  );
+
   return (
-    <div className="pf-c-page__main-breadcrumb">
+    <div className="pf-c-page__main-breadcrumb TemplatePageTitle">
       <Breadcrumb>
         <BreadcrumbItem>
           <Button
@@ -45,7 +59,16 @@ const TemplatePageTitle: React.FC<TemplatePageTitleTitleProps> = ({ template }) 
             {isDeprecatedTemplate(template) && <Label isCompact>{t('Deprecated')}</Label>}
           </span>
         </span>
-        <TemplateActions template={template} />
+        <Split hasGutter>
+          {isSidebarEditorDisplayed && (
+            <SplitItem>
+              <SidebarEditorSwitch />
+            </SplitItem>
+          )}
+          <SplitItem>
+            <TemplateActions template={template} />
+          </SplitItem>
+        </Split>
       </Title>
       {isCommonTemplate && <CommonTemplateAlert template={template} />}
       {!isCommonTemplate && !hasEditPermission && <NoPermissionTemplateAlert />}

--- a/src/views/templates/details/tabs/details/TemplateDetailsPage.scss
+++ b/src/views/templates/details/tabs/details/TemplateDetailsPage.scss
@@ -11,9 +11,3 @@
   justify-content: space-between;
   flex: 1;
 }
-
-.template-details-page {
-  &__flex {
-    align-items: center;
-  }
-}

--- a/src/views/templates/details/tabs/details/TemplateDetailsPage.tsx
+++ b/src/views/templates/details/tabs/details/TemplateDetailsPage.tsx
@@ -3,10 +3,9 @@ import { RouteComponentProps } from 'react-router-dom';
 
 import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
-import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
-import { Flex, Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
+import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 
 import TemplateDetailsLeftGrid from './components/TemplateDetailsLeftGrid';
 import TemplateDetailsRightGrid from './components/TemplateDetailsRightGrid';
@@ -46,10 +45,7 @@ const TemplateDetailsPage: FC<TemplateDetailsPageProps> = ({ obj: template }) =>
       <SidebarEditor<V1Template> resource={template} onResourceUpdate={onSubmitTemplate}>
         {(resource) => (
           <>
-            <Flex className="template-details-page__flex">
-              <Title headingLevel="h2">{t('Template details')}</Title>
-              <SidebarEditorSwitch />
-            </Flex>
+            <Title headingLevel="h2">{t('Template details')}</Title>
             <Grid className="margin-top">
               <GridItem span={5}>
                 <TemplateDetailsLeftGrid template={resource} />

--- a/src/views/templates/details/tabs/disks/TemplateDisksPage.scss
+++ b/src/views/templates/details/tabs/disks/TemplateDisksPage.scss
@@ -6,19 +6,14 @@
   }
 
   .pf-c-sidebar__panel {
-    padding-top: var(--pf-global--spacer--md);
+    padding-top: var(--pf-global--spacer--lg);
   }
 
   &__button {
     margin: 0 0 0.5rem 0;
   }
 
-  .pf-l-flex {
-    align-items: center;
-  }
-
   .disk-list-title {
-    margin-right: 0;
-    margin-top: 0;
+    margin: 1.5rem 0 1rem 0;
   }
 }

--- a/src/views/templates/details/tabs/disks/TemplateDisksPage.tsx
+++ b/src/views/templates/details/tabs/disks/TemplateDisksPage.tsx
@@ -7,7 +7,6 @@ import DiskListTitle from '@kubevirt-utils/components/DiskListTitle/DiskListTitl
 import DiskModal from '@kubevirt-utils/components/DiskModal/DiskModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
-import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { replaceTemplateVM } from '@kubevirt-utils/resources/template';
 import {
@@ -17,7 +16,7 @@ import {
   useListPageFilter,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, Flex, FlexItem } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 
 import useEditTemplateAccessReview from '../../hooks/useIsTemplateEditable';
 
@@ -69,14 +68,7 @@ const TemplateDisksPage: FC<TemplateDisksPageProps> = ({ obj: template }) => {
     <div className="template-disks-page">
       <ListPageBody>
         <SidebarEditor<V1Template> resource={template} onResourceUpdate={onSubmitTemplate}>
-          <Flex className="list-page-create-button-margin">
-            <FlexItem>
-              <DiskListTitle />
-            </FlexItem>
-            <FlexItem>
-              <SidebarEditorSwitch />
-            </FlexItem>
-          </Flex>
+          <DiskListTitle />
 
           <Button
             className="template-disks-page__button"

--- a/src/views/templates/details/tabs/network/TemplateNetworkPage.tsx
+++ b/src/views/templates/details/tabs/network/TemplateNetworkPage.tsx
@@ -4,10 +4,9 @@ import { RouteComponentProps } from 'react-router-dom';
 import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
-import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { k8sUpdate, ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, Flex, FlexItem, Title } from '@patternfly/react-core';
+import { Button, Title } from '@patternfly/react-core';
 
 import useEditTemplateAccessReview from '../../hooks/useIsTemplateEditable';
 
@@ -45,14 +44,9 @@ const TemplateNetwork: FC<TemplateNetworkProps> = ({ obj: template }) => {
     <div className="template-network-tab">
       <ListPageBody>
         <SidebarEditor<V1Template> resource={template} onResourceUpdate={onSubmitTemplate}>
-          <Flex className="list-page-create-button-margin">
-            <FlexItem>
-              <Title headingLevel="h2">{t('Network interfaces')}</Title>
-            </FlexItem>
-            <FlexItem>
-              <SidebarEditorSwitch />
-            </FlexItem>
-          </Flex>
+          <Title headingLevel="h2" className="list-page-create-button-margin">
+            {t('Network interfaces')}
+          </Title>
 
           <Button
             className="template-network-tab__button"

--- a/src/views/templates/details/tabs/network/template-network-tab.scss
+++ b/src/views/templates/details/tabs/network/template-network-tab.scss
@@ -6,11 +6,7 @@
   }
 
   .pf-c-sidebar__panel {
-    padding-top: var(--pf-global--spacer--md);
-  }
-
-  .pf-l-flex {
-    align-items: center;
+    padding-top: var(--pf-global--spacer--lg);
   }
 
   &__button {

--- a/src/views/templates/details/tabs/parameters/TemplateParametersPage.tsx
+++ b/src/views/templates/details/tabs/parameters/TemplateParametersPage.tsx
@@ -5,7 +5,6 @@ import { useImmer } from 'use-immer';
 import { TemplateModel, TemplateParameter, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
-import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -14,7 +13,6 @@ import {
   AlertVariant,
   Button,
   Divider,
-  Flex,
   Form,
   PageSection,
   Title,
@@ -83,10 +81,8 @@ const TemplateParametersPage: FC<TemplateParametersPageProps> = ({ obj: template
         onChange={(newTemplate) => setEditableTemplate(newTemplate)}
       >
         <Form className="template-parameters-page__form">
-          <Flex className="template-parameters-page__flex">
-            <Title headingLevel="h2">{t('Parameters')}</Title>
-            <SidebarEditorSwitch />
-          </Flex>
+          <Title headingLevel="h2">{t('Parameters')}</Title>
+
           {parameters.map((parameter, index) => (
             <>
               <ParameterEditor

--- a/src/views/templates/details/tabs/parameters/template-parameters-page.scss
+++ b/src/views/templates/details/tabs/parameters/template-parameters-page.scss
@@ -8,10 +8,6 @@
     border-top: none;
   }
 
-  &__flex {
-    align-items: center;
-  }
-
   .pf-c-expandable-section__toggle-text {
     color: var(--pf-global--Color--100);
   }

--- a/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.scss
+++ b/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.scss
@@ -1,9 +1,3 @@
 .no-left-padding {
   padding-left: 0;
 }
-
-.template-scheduling-tab {
-  &__flex {
-    align-items: center;
-  }
-}

--- a/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.tsx
+++ b/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.tsx
@@ -3,10 +3,9 @@ import { RouteComponentProps } from 'react-router-dom';
 
 import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
-import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
-import { Flex, Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
+import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
 
 import useEditTemplateAccessReview from '../../hooks/useIsTemplateEditable';
 
@@ -42,10 +41,7 @@ const TemplateSchedulingTab: FC<TemplateSchedulingTabProps> = ({ obj: template }
       <SidebarEditor<V1Template> resource={template} onResourceUpdate={onSubmitTemplate}>
         {(resource) => (
           <>
-            <Flex className="template-scheduling-tab__flex">
-              <Title headingLevel="h2">{t('Scheduling and resource requirements')}</Title>
-              <SidebarEditorSwitch />
-            </Flex>
+            <Title headingLevel="h2">{t('Scheduling and resource requirements')}</Title>
             <Grid className="margin-top">
               <GridItem span={5}>
                 <TemplateSchedulingLeftGrid template={resource} editable={isTemplateEditable} />

--- a/src/views/templates/details/tabs/scripts/TemplateScriptsPage.tsx
+++ b/src/views/templates/details/tabs/scripts/TemplateScriptsPage.tsx
@@ -7,7 +7,6 @@ import { CloudInitDescription } from '@kubevirt-utils/components/CloudinitDescri
 import { CloudinitModal } from '@kubevirt-utils/components/CloudinitModal/CloudinitModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
-import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   getTemplateVirtualMachineObject,
@@ -99,9 +98,6 @@ const TemplateScriptsPage: FC<TemplateScriptsPageProps> = ({ obj: template }) =>
                       {t('Edit')}
                       <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
                     </Button>
-                  </FlexItem>
-                  <FlexItem>
-                    <SidebarEditorSwitch />
                   </FlexItem>
                 </Flex>
               </DescriptionListTermHelpText>

--- a/src/views/templates/details/template-header-alert.scss
+++ b/src/views/templates/details/template-header-alert.scss
@@ -1,7 +1,0 @@
-.template-header-alert {
-  margin-bottom: 0;
-
-  button.pf-c-button.pf-m-link {
-    padding-left: 0;
-  }
-}

--- a/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { useHistory } from 'react-router-dom';
 
 import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -24,6 +25,7 @@ type VirtualMachineNavPageTitleProps = {
 
 const VirtualMachineNavPageTitle: FC<VirtualMachineNavPageTitleProps> = ({ vm, name }) => {
   const { t } = useKubevirtTranslation();
+  const history = useHistory();
 
   const [vmi] = useK8sWatchResource<V1VirtualMachineInstance>({
     groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
@@ -37,7 +39,7 @@ const VirtualMachineNavPageTitle: FC<VirtualMachineNavPageTitleProps> = ({ vm, n
   const StatusIcon = getVMStatusIcon(vm?.status?.printableStatus);
 
   const isSidebarEditorDisplayed = vmTabsWithYAML.find((tab) =>
-    window.location.pathname.includes(`/${name}/${tab}`),
+    history.location.pathname.includes(`/${name}/${tab}`),
   );
 
   return (


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-29485

_Design doc:_
https://docs.google.com/document/d/1Y8TA1EeAZVCLkqUT-ZHzWKGkSEpVMq6jYdXwG1Uv2Gw/

Move the YAML switcher out of the Templates tabs/pages, display it to the left of _Actions_ menu and only for relevant pages, that contained the switcher also before this change. Make this change according to the recent design updates.

Make some css updates for some pages to achieve more consistent look: align sidebar editor properly in _Disks_ and _NICs_ tabs to be the same as in the other pages (`padding-top`).

## 🎥 Screenshots
The following screenshots are displayed as pairs - before and after, for better visual comparison:

_Details_ tab:
![details_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/43fe0574-703a-4a87-b4df-ea30ff0594e3)
![details_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/9831bb91-cb1c-4594-9fa2-3f31b756c183)

_Disks_ tab:
![disks_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/7c2fb2ec-1359-4b63-818c-8d85b4fb3746)
![disks_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/0ebcbe07-d87b-4eba-9eee-57eed0f8a7cb)

_Network interfaces_ (a.k.a NICs) tab:
![nics_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/68d9ff8b-fcc9-4ccf-ada0-92bceac633fb)
![nics_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/41661e92-2448-401b-b936-334b1582ab7e)

_Parameters_ tab:
![params_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/586a786c-4668-44b0-9832-a28a4e2bf054)
![params_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/aa92dbeb-8241-45be-b064-f5bffb9bb309)

_Scheduling_ tab:
![scheduling_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/36192b48-da3a-4ce1-a043-217fbe843d1a)
![scheduling_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/b4117152-9a8b-4cb1-ba23-410e33305717)

_Scripts_ tab:
![scripts_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/0d9dc9bb-6e0f-4811-aea2-6eafd835757c)
![scripts_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/aa0442c0-039d-4043-8c93-a68bb8e51eb6)






