### PR TITLE
CNV-29237: Enable Restore template settings" in Catalog CPU modal

### DIFF
--- a/src/utils/components/CPUMemoryModal/CpuMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CpuMemoryModal.tsx
@@ -2,6 +2,7 @@ import React, { ChangeEvent, FC, useEffect, useMemo, useState } from 'react';
 import produce from 'immer';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getLabel } from '@kubevirt-utils/resources/shared';
 import { VM_TEMPLATE_ANNOTATION } from '@kubevirt-utils/resources/vm';
@@ -26,7 +27,6 @@ import { checkCPUMemoryChanged } from '../PendingChanges/utils/helpers';
 
 import useTemplateDefaultCpuMemory from './hooks/useTemplateDefaultCpuMemory';
 import { getCPUcores, getMemorySize, memorySizesTypes } from './utils/CpuMemoryUtils';
-import { COMMON_TEMPLATE_DEFAULT_NAMESPACE } from './constants';
 
 import './cpu-memory-modal.scss';
 
@@ -36,9 +36,17 @@ type CPUMemoryModalProps = {
   onClose: () => void;
   onSubmit: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine | void>;
   vmi?: V1VirtualMachineInstance;
+  templateNamespace?: string;
 };
 
-const CPUMemoryModal: FC<CPUMemoryModalProps> = ({ vm, isOpen, onClose, onSubmit, vmi }) => {
+const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
+  vm,
+  isOpen,
+  onClose,
+  onSubmit,
+  vmi,
+  templateNamespace = DEFAULT_NAMESPACE,
+}) => {
   const { t } = useKubevirtTranslation();
   const {
     data: templateDefaultsData,
@@ -46,8 +54,7 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({ vm, isOpen, onClose, onSubmit
     error: defaultLoadError,
   } = useTemplateDefaultCpuMemory(
     vm?.metadata?.labels?.['vm.kubevirt.io/template'],
-    vm?.metadata?.labels?.['vm.kubevirt.io/template.namespace'] ||
-      COMMON_TEMPLATE_DEFAULT_NAMESPACE,
+    vm?.metadata?.labels?.['vm.kubevirt.io/template.namespace'] || templateNamespace,
   );
   const [updateInProcess, setUpdateInProcess] = useState<boolean>(false);
   const [updateError, setUpdateError] = useState<string>();

--- a/src/utils/components/CPUMemoryModal/constants.ts
+++ b/src/utils/components/CPUMemoryModal/constants.ts
@@ -1,1 +1,0 @@
-export const COMMON_TEMPLATE_DEFAULT_NAMESPACE = 'openshift';

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
@@ -175,6 +175,7 @@ export const TemplatesCatalogDrawerPanel: FC<TemplatesCatalogDrawerPanelProps> =
                               isOpen={isOpen}
                               onClose={onClose}
                               onSubmit={updateVMCPUMemory(ns, updateVM, setUpdatedVM)}
+                              templateNamespace={template?.metadata?.namespace}
                             />
                           ))
                         }


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-29237

Enable _Restore template settings_ button displayed in _Edit CPU | Modal_ accessible in _Catalog_ drawer and make it work correctly, by providing a correct template namespace to get the original CPU/Memory data, needed for restoring template CPU/Memory values.

_Notes:_
_src/utils/components/CPUMemoryModal/constants.ts_ file was deleted as it has no use anymore. It contained only one constant used in only [one place](https://github.com/kubevirt-ui/kubevirt-plugin/compare/main...hstastna:kubevirt-plugin:BZ_Restore_template_settings_is_disabled_catalog?expand=1#diff-604e7268a1183adcb2fe6c4ae607baf9b22253a3a0856c27675fd94317aa803fL50). We have some other constant with the same string if needed in future. No need to define more constants containing `'openshift'`.

Also note that `COMMON_TEMPLATE_DEFAULT_NAMESPACE` was replaced by `DEFAULT_NAMESPACE` because if the namespace is not provided at all, usually `'default'` one is the correct one, not `'openshift'`. However this approach was not possible to use in _Catalog_ drawer and the template namespace had to be provided explicitly. We could avoid providing the template namespace explicitly but we would have to do some other (more expensive) operations in Catalog drawer instead, like processing template again or already creating VM, which I consider unnecessary.

## 🎥 Screenshots
**Before:**
The button is disabled, not possible to restore the values to the original template's ones:
![edit_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/0ef940a6-d033-4668-b761-a8e66ff6e87c)

**After:**
The button is enabled and clicking on it changes the values to the original ones (displayed in the drawer - orange arrow):
![edit_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/fe6f2e7f-577e-4cef-89af-42a69bb67d9b)


