### PR TITLE
CNV-28485: Move IT feature from dev preview to tech preview

### DIFF
--- a/src/views/bootablevolumes/list/BootableVolumesList.tsx
+++ b/src/views/bootablevolumes/list/BootableVolumesList.tsx
@@ -3,7 +3,6 @@ import { useHistory } from 'react-router-dom';
 
 import { V1alpha2VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import AddBootableVolumeModal from '@kubevirt-utils/components/AddBootableVolumeModal/AddBootableVolumeModal';
-import DeveloperPreviewLabel from '@kubevirt-utils/components/DeveloperPreviewLabel/DeveloperPreviewLabel';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -78,7 +77,7 @@ const BootableVolumesList: FC<BootableVolumesListProps> = ({ namespace }) => {
 
   return (
     <>
-      <ListPageHeader title={t('Bootable resources')} badge={<DeveloperPreviewLabel />}>
+      <ListPageHeader title={t('Bootable resources')}>
         <ListPageCreateDropdown items={createItems} onClick={onCreate}>
           {t('Add bootable resource')}
         </ListPageCreateDropdown>

--- a/src/views/catalog/CreateVMHorizontalNav/CreateVMHorizontalNav.tsx
+++ b/src/views/catalog/CreateVMHorizontalNav/CreateVMHorizontalNav.tsx
@@ -56,7 +56,7 @@ const CreateVMHorizontalNav: FC<RouteComponentProps<{ ns: string }>> = ({
         </Tab>
         <Tab
           eventKey={CREATE_VM_TAB.INSTANCE_TYPES}
-          title={<CreateVMTabTitle Icon={ImageIcon} titleText={t('InstanceTypes')} badge />}
+          title={<CreateVMTabTitle Icon={ImageIcon} titleText={t('InstanceTypes')} />}
         >
           <CreateFromInstanceType />
         </Tab>

--- a/src/views/catalog/CreateVMHorizontalNav/components/CreateVMTabTitle/CreateVMTabTitle.tsx
+++ b/src/views/catalog/CreateVMHorizontalNav/components/CreateVMTabTitle/CreateVMTabTitle.tsx
@@ -1,12 +1,11 @@
-import React, { ComponentClass, FC } from 'react';
+import React, { ComponentClass, FC, ReactNode } from 'react';
 
-import DeveloperPreviewLabel from '@kubevirt-utils/components/DeveloperPreviewLabel/DeveloperPreviewLabel';
 import { TabTitleIcon, TabTitleText } from '@patternfly/react-core';
 
 type CreateVMTabTitleProps = {
   titleText: string;
   Icon: ComponentClass;
-  badge?: boolean;
+  badge?: ReactNode;
 };
 
 const CreateVMTabTitle: FC<CreateVMTabTitleProps> = ({ Icon, titleText, badge }) => (
@@ -15,7 +14,7 @@ const CreateVMTabTitle: FC<CreateVMTabTitleProps> = ({ Icon, titleText, badge })
       <Icon />
     </TabTitleIcon>
     <TabTitleText>{titleText}</TabTitleText>
-    {badge && <DeveloperPreviewLabel />}
+    {badge}
   </>
 );
 

--- a/src/views/instancetypes/list/ClusterInstancetypeList.tsx
+++ b/src/views/instancetypes/list/ClusterInstancetypeList.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 
 import { V1alpha2VirtualMachineClusterInstancetype } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import DeveloperPreviewLabel from '@kubevirt-utils/components/DeveloperPreviewLabel/DeveloperPreviewLabel';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import usePagination from '@kubevirt-utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@kubevirt-utils/hooks/usePagination/utils/constants';
@@ -42,10 +41,7 @@ const ClusterInstancetypeList: FC<ClusterInstancetypeListProps> = ({ kind }) => 
 
   return (
     <>
-      <ListPageHeader
-        title={t('VirtualMachineClusterInstancetypes')}
-        badge={<DeveloperPreviewLabel />}
-      >
+      <ListPageHeader title={t('VirtualMachineClusterInstancetypes')}>
         <ListPageCreate createAccessReview={{ groupVersionKind: kind }} groupVersionKind={kind}>
           {t('Create')}
         </ListPageCreate>

--- a/src/views/preferences/list/ClusterPreferenceList.tsx
+++ b/src/views/preferences/list/ClusterPreferenceList.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 
 import { V1alpha2VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import DeveloperPreviewLabel from '@kubevirt-utils/components/DeveloperPreviewLabel/DeveloperPreviewLabel';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import usePagination from '@kubevirt-utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@kubevirt-utils/hooks/usePagination/utils/constants';
@@ -42,10 +41,7 @@ const ClusterPreferenceList: FC<ClusterPreferenceListProps> = ({ kind }) => {
 
   return (
     <>
-      <ListPageHeader
-        title={t('VirtualMachineClusterPreferences')}
-        badge={<DeveloperPreviewLabel />}
-      >
+      <ListPageHeader title={t('VirtualMachineClusterPreferences')}>
         <ListPageCreate createAccessReview={{ groupVersionKind: kind }} groupVersionKind={kind}>
           {t('Create')}
         </ListPageCreate>

--- a/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
@@ -2,7 +2,6 @@ import React, { FC, useCallback, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { VirtualMachineModelRef } from '@kubevirt-ui/kubevirt-api/console';
-import DeveloperPreviewLabel from '@kubevirt-utils/components/DeveloperPreviewLabel/DeveloperPreviewLabel';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ListPageCreateDropdown } from '@openshift-console/dynamic-plugin-sdk';
@@ -21,11 +20,7 @@ const VirtualMachinesCreateButton: FC<VirtualMachinesCreateButtonProps> = ({
 
   const createItems = {
     catalog: t('From template'),
-    volume: (
-      <>
-        {t('From volume')} <DeveloperPreviewLabel />
-      </>
-    ),
+    volume: t('From volume'),
     yaml: t('From YAML'),
   };
 


### PR DESCRIPTION
## 📝 Description

After discussion with UX, to move from dev preview to tech preview we need to just remove the dev preview labels.

## 🎥 Demo

### Before:
![dev-prev-5-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/539f2e51-0403-4e1b-8087-d5d0de1fdb37)
![dev-prev-4-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/0b99b283-c1a6-4be0-9e17-8de9cf20435f)
![dev-prev-3-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/2cc7f1e3-d322-4ab6-8c87-fb7f58fbed61)
![dev-prev-2-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/c0e2cb36-09ee-4e97-956f-a697a56b61ef)
![dev-prev-1-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/93fb26b9-8ff4-4fa5-802c-ba11bf52d3d8)

### After:
![dev-prev-5](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/848ec5e3-4c50-4e07-9984-686a4713aa50)
![dev-prev-4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/9ec3f616-d86a-4f6b-886b-420273e3770c)
![dev-prev-3](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/20ebc314-b878-4351-afde-e2a329b1e9eb)
![dev-prev-2](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/b559f6db-1b4f-41f0-a36b-238e05e3fde3)
![dev-prev-1](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/4169c3a0-7513-422a-a4ba-df946488379e)

