### PR TITLE
CNV-29502: Move YAML switcher out of tabs in Review and create VM

### DIFF
--- a/src/utils/components/EnvironmentEditor/EnvironmentForm.tsx
+++ b/src/utils/components/EnvironmentEditor/EnvironmentForm.tsx
@@ -22,15 +22,9 @@ type EnvironmentFormProps = {
   vm: V1VirtualMachine;
   onEditChange?: (edited: boolean) => void;
   updateVM: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine | void>;
-  displayYAMLSwitcher?: boolean;
 };
 
-const EnvironmentForm: FC<EnvironmentFormProps> = ({
-  vm,
-  onEditChange,
-  updateVM,
-  displayYAMLSwitcher,
-}) => {
+const EnvironmentForm: FC<EnvironmentFormProps> = ({ vm, onEditChange, updateVM }) => {
   const [temporaryVM, setTemporaryVM] = useImmer(vm);
 
   const { t } = useKubevirtTranslation();
@@ -64,7 +58,7 @@ const EnvironmentForm: FC<EnvironmentFormProps> = ({
     [environments],
   );
 
-  if (!loaded) return <EnvironmentFormSkeleton displayYAMLSwitcher={displayYAMLSwitcher} />;
+  if (!loaded) return <EnvironmentFormSkeleton />;
 
   return (
     <SidebarEditor<V1VirtualMachine>
@@ -72,7 +66,7 @@ const EnvironmentForm: FC<EnvironmentFormProps> = ({
       onChange={setTemporaryVM}
       pathsToHighlight={PATHS_TO_HIGHLIGHT.ENV_TAB}
     >
-      <EnvironmentFormTitle displayYAMLSwitcher={displayYAMLSwitcher} />
+      <EnvironmentFormTitle />
       <Form className="environment-form__form">
         {environments.length !== 0 && (
           <div className="row pairs-list__heading">

--- a/src/utils/components/EnvironmentEditor/components/EnvironmentFormSkeleton.tsx
+++ b/src/utils/components/EnvironmentEditor/components/EnvironmentFormSkeleton.tsx
@@ -4,22 +4,14 @@ import { Skeleton, Stack, StackItem } from '@patternfly/react-core';
 
 import EnvironmentFormTitle from './EnvironmentFormTitle';
 
-type EnvironmentFormSkeletonProps = {
-  displayYAMLSwitcher?: boolean;
-};
-
-const EnvironmentFormSkeleton: FC<EnvironmentFormSkeletonProps> = memo(
-  ({ displayYAMLSwitcher }) => (
-    <>
-      <Stack hasGutter>
-        <EnvironmentFormTitle displayYAMLSwitcher={displayYAMLSwitcher} />
-        <StackItem />
-        <Skeleton width="80%" height="40px" />
-        <Skeleton width="40%" height="30px" />
-      </Stack>
-    </>
-  ),
-);
+const EnvironmentFormSkeleton: FC = memo(() => (
+  <Stack hasGutter>
+    <EnvironmentFormTitle />
+    <StackItem />
+    <Skeleton width="80%" height="40px" />
+    <Skeleton width="40%" height="30px" />
+  </Stack>
+));
 EnvironmentFormSkeleton.displayName = 'EnvironmentFormSkeleton';
 
 export default EnvironmentFormSkeleton;

--- a/src/utils/components/EnvironmentEditor/components/EnvironmentFormTitle.tsx
+++ b/src/utils/components/EnvironmentEditor/components/EnvironmentFormTitle.tsx
@@ -1,40 +1,26 @@
 import React, { FC, memo } from 'react';
 
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
-import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Flex, FlexItem, Title } from '@patternfly/react-core';
+import { Title } from '@patternfly/react-core';
 
-type EnvironmentFormTitleProps = {
-  displayYAMLSwitcher?: boolean;
-};
+const EnvironmentFormTitle: FC = memo(() => {
+  const { t } = useKubevirtTranslation();
 
-const EnvironmentFormTitle: FC<EnvironmentFormTitleProps> = memo(
-  ({ displayYAMLSwitcher = false }) => {
-    const { t } = useKubevirtTranslation();
-
-    return (
-      <>
-        <Title headingLevel="h2">
-          <Flex>
-            <FlexItem>{t('Environment')}</FlexItem>
-            {displayYAMLSwitcher && (
-              <FlexItem>
-                <SidebarEditorSwitch />
-              </FlexItem>
-            )}
-          </Flex>
-        </Title>
-        {t('Include all values from existing config maps, secrets or service accounts (as disk)')}{' '}
-        <HelpTextIcon
-          bodyContent={t(
-            'Add new values by referencing an existing config map, secret or service account. Using these values requires mounting them manually to the VM.',
-          )}
-        />
-      </>
-    );
-  },
-);
+  return (
+    <>
+      <Title headingLevel="h2">{t('Environment')}</Title>
+      {t(
+        'Include all values from existing config maps, secrets or service accounts (as disk)',
+      )}{' '}
+      <HelpTextIcon
+        bodyContent={t(
+          'Add new values by referencing an existing config map, secret or service account. Using these values requires mounting them manually to the VM.',
+        )}
+      />
+    </>
+  );
+});
 EnvironmentFormTitle.displayName = 'EnvironmentFormTitle';
 
 export default EnvironmentFormTitle;

--- a/src/views/catalog/wizard/Wizard.scss
+++ b/src/views/catalog/wizard/Wizard.scss
@@ -31,3 +31,9 @@
   background: var(--pf-c-page__main-section--m-light--BackgroundColor);
   z-index: 1000;
 }
+
+.wizard-header {
+  .pf-l-split {
+    justify-content: space-between;
+  }
+}

--- a/src/views/catalog/wizard/components/WizardHeader.tsx
+++ b/src/views/catalog/wizard/components/WizardHeader.tsx
@@ -2,12 +2,15 @@ import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { useWizardVMContext } from '@catalog/utils/WizardVMContext';
+import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Breadcrumb,
   BreadcrumbItem,
   Button,
+  Split,
   Text,
   TextVariants,
   Title,
@@ -25,8 +28,12 @@ export const WizardHeader: React.FC<{ namespace: string }> = React.memo(({ names
   const onBreadcrumbClick = (url: string) =>
     confirm(t('Are you sure you want to leave this page?')) && history.push(url);
 
+  const isSidebarEditorDisplayed = !history.location.pathname.includes(
+    `/templatescatalog/review/${VirtualMachineDetailsTab.YAML}`,
+  );
+
   return (
-    <div className="pf-c-page__main-breadcrumb">
+    <div className="pf-c-page__main-breadcrumb wizard-header">
       <Breadcrumb className="pf-c-breadcrumb co-breadcrumb">
         <BreadcrumbItem>
           <Button
@@ -56,7 +63,10 @@ export const WizardHeader: React.FC<{ namespace: string }> = React.memo(({ names
         </BreadcrumbItem>
         <BreadcrumbItem>{t('Review')}</BreadcrumbItem>
       </Breadcrumb>
-      <Title headingLevel="h1">{t('Review and create VirtualMachine')}</Title>
+      <Split hasGutter>
+        <Title headingLevel="h1">{t('Review and create VirtualMachine')}</Title>
+        {isSidebarEditorDisplayed && <SidebarEditorSwitch />}
+      </Split>
       <Text component={TextVariants.small} data-test="wizard title help">
         {t('Template: {{templateDisplayName}}', { templateDisplayName })}
       </Text>

--- a/src/views/catalog/wizard/tabs/disks/WizardDisksTab.tsx
+++ b/src/views/catalog/wizard/tabs/disks/WizardDisksTab.tsx
@@ -5,7 +5,6 @@ import DiskListTitle from '@kubevirt-utils/components/DiskListTitle/DiskListTitl
 import DiskModal from '@kubevirt-utils/components/DiskModal/DiskModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
-import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import WindowsDrivers from '@kubevirt-utils/components/WindowsDrivers/WindowsDrivers';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
@@ -42,14 +41,7 @@ const WizardDisksTab: WizardTab = ({ vm, loaded, updateVM, tabsData, updateTabsD
           onResourceUpdate={(newVM) => updateVM(newVM)}
           pathsToHighlight={PATHS_TO_HIGHLIGHT.DISKS_TAB}
         >
-          <Flex>
-            <FlexItem>
-              <DiskListTitle />
-            </FlexItem>
-            <FlexItem>
-              <SidebarEditorSwitch />
-            </FlexItem>
-          </Flex>
+          <DiskListTitle />
 
           <ListPageCreateButton
             className="wizard-disk-tab__list-page-create-button"

--- a/src/views/catalog/wizard/tabs/disks/wizard-disk-tab.scss
+++ b/src/views/catalog/wizard/tabs/disks/wizard-disk-tab.scss
@@ -6,7 +6,7 @@
   }
 
   .pf-c-sidebar__panel {
-    padding-top: var(--pf-global--spacer--md);
+    padding-top: var(--pf-global--spacer--lg);
   }
 
   &__list-page-create-button {

--- a/src/views/catalog/wizard/tabs/environment/WizardEnvironmentTab.tsx
+++ b/src/views/catalog/wizard/tabs/environment/WizardEnvironmentTab.tsx
@@ -17,12 +17,7 @@ const WizardEnvironmentTab: WizardTab = ({ vm, updateVM, setDisableVmCreate }) =
 
   return (
     <PageSection className="wizard-environment-tab">
-      <EnvironmentForm
-        vm={vm}
-        onEditChange={setDisableVmCreate}
-        updateVM={updateVM}
-        displayYAMLSwitcher
-      />
+      <EnvironmentForm vm={vm} onEditChange={setDisableVmCreate} updateVM={updateVM} />
     </PageSection>
   );
 };

--- a/src/views/catalog/wizard/tabs/metadata/WizardMetadataTab.tsx
+++ b/src/views/catalog/wizard/tabs/metadata/WizardMetadataTab.tsx
@@ -5,7 +5,6 @@ import { AnnotationsModal } from '@kubevirt-utils/components/AnnotationsModal/An
 import { LabelsModal } from '@kubevirt-utils/components/LabelsModal/LabelsModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
-import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
 import { DescriptionList, PageSection, pluralize } from '@patternfly/react-core';
@@ -29,7 +28,6 @@ const WizardMetadataTab: WizardTab = ({ vm, updateVM, loaded }) => {
       >
         {(resource) => (
           <>
-            <SidebarEditorSwitch />
             <DescriptionList className="wizard-metadata-tab__description-list">
               <WizardDescriptionItem
                 title={t('Labels')}

--- a/src/views/catalog/wizard/tabs/metadata/wizard-metadata-tab.scss
+++ b/src/views/catalog/wizard/tabs/metadata/wizard-metadata-tab.scss
@@ -1,13 +1,12 @@
 .wizard-metadata-tab {
 
-    .wizard-description-item__title {
-        justify-content: space-between;
-        flex: 1;
-      }
+  .wizard-description-item__title {
+    justify-content: space-between;
+    flex: 1;
+  }
 
-    &__description-list {
-        max-width: 700px;
-        margin-top: var(--pf-global--spacer--md);
-    }
-      
+  &__description-list {
+    max-width: 700px;
+    margin-top: var(--pf-global--spacer--md);
+  }    
 }

--- a/src/views/catalog/wizard/tabs/network/WizardNetworkTab.tsx
+++ b/src/views/catalog/wizard/tabs/network/WizardNetworkTab.tsx
@@ -3,11 +3,9 @@ import * as React from 'react';
 import { WizardTab } from '@catalog/wizard/tabs';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
-import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
 import { ListPageBody, ListPageCreateButton } from '@openshift-console/dynamic-plugin-sdk';
-import { Flex, FlexItem } from '@patternfly/react-core';
 
 import NetworkInterfaceList from './components/list/NetworkInterfaceList';
 import WizardNetworkInterfaceModal from './components/modal/WizardNetworkInterfaceModal';
@@ -20,6 +18,7 @@ const WizardNetworkTab: WizardTab = ({ vm, updateVM }) => {
   const { createModal } = useModal();
 
   const actionText = t('Add network interface');
+
   return (
     <div className="wizard-network-tab">
       <ListPageBody>
@@ -28,29 +27,23 @@ const WizardNetworkTab: WizardTab = ({ vm, updateVM }) => {
           onResourceUpdate={(newVM) => updateVM(newVM)}
           pathsToHighlight={PATHS_TO_HIGHLIGHT.NETWORK_TAB}
         >
-          <Flex>
-            <FlexItem>
-              <ListPageCreateButton
-                className="list-page-create-button-margin"
-                onClick={() =>
-                  createModal(({ isOpen, onClose }) => (
-                    <WizardNetworkInterfaceModal
-                      isOpen={isOpen}
-                      onClose={onClose}
-                      headerText={actionText}
-                      vm={vm}
-                      updateVM={updateVM}
-                    />
-                  ))
-                }
-              >
-                {actionText}
-              </ListPageCreateButton>
-            </FlexItem>
-            <FlexItem>
-              <SidebarEditorSwitch />
-            </FlexItem>
-          </Flex>
+          <ListPageCreateButton
+            className="list-page-create-button-margin"
+            onClick={() =>
+              createModal(({ isOpen, onClose }) => (
+                <WizardNetworkInterfaceModal
+                  isOpen={isOpen}
+                  onClose={onClose}
+                  headerText={actionText}
+                  vm={vm}
+                  updateVM={updateVM}
+                />
+              ))
+            }
+          >
+            {actionText}
+          </ListPageCreateButton>
+
           <NetworkInterfaceList vm={vm} />
         </SidebarEditor>
       </ListPageBody>

--- a/src/views/catalog/wizard/tabs/network/wizard-network-tab.scss
+++ b/src/views/catalog/wizard/tabs/network/wizard-network-tab.scss
@@ -1,12 +1,11 @@
 .wizard-network-tab {
+  height: 100%;
+
+  .co-m-pane__body {
     height: 100%;
+  }
 
-    .co-m-pane__body {
-        height: 100%;
-    }
-
-
-    .pf-c-sidebar__panel {
-        padding-top: var(--pf-global--spacer--md);
-    }
+  .pf-c-sidebar__panel {
+    padding-top: var(--pf-global--spacer--lg);
+  }
 }

--- a/src/views/catalog/wizard/tabs/overview/WizardOverviewTab.tsx
+++ b/src/views/catalog/wizard/tabs/overview/WizardOverviewTab.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { WizardTab } from '@catalog/wizard/tabs';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
-import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
 import { PageSection } from '@patternfly/react-core';
 
@@ -17,12 +16,7 @@ const WizardOverviewTab: WizardTab = ({ vm, tabsData, updateVM }) => (
       onResourceUpdate={(newVM) => updateVM(newVM)}
       pathsToHighlight={PATHS_TO_HIGHLIGHT.DETAILS_TAB}
     >
-      {(resource) => (
-        <>
-          <SidebarEditorSwitch />
-          <WizardOverviewGrid vm={resource} tabsData={tabsData} updateVM={updateVM} />
-        </>
-      )}
+      {(resource) => <WizardOverviewGrid vm={resource} tabsData={tabsData} updateVM={updateVM} />}
     </SidebarEditor>
   </PageSection>
 );

--- a/src/views/catalog/wizard/tabs/scheduling/WizardSchedulingTab.tsx
+++ b/src/views/catalog/wizard/tabs/scheduling/WizardSchedulingTab.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { WizardTab } from '@catalog/wizard/tabs';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
-import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
 import { PageSection } from '@patternfly/react-core';
 
@@ -19,12 +18,7 @@ const WizardSchedulingTab: WizardTab = ({ vm, updateVM }) => {
         onResourceUpdate={updateVM}
         pathsToHighlight={PATHS_TO_HIGHLIGHT.SCHEDULING_TAB}
       >
-        {(resource) => (
-          <>
-            <SidebarEditorSwitch />
-            <WizardSchedulingGrid vm={resource} updateVM={updateVM} />
-          </>
-        )}
+        {(resource) => <WizardSchedulingGrid vm={resource} updateVM={updateVM} />}
       </SidebarEditor>
     </PageSection>
   );

--- a/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
@@ -7,7 +7,6 @@ import { CloudInitDescription } from '@kubevirt-utils/components/CloudinitDescri
 import { CloudinitModal } from '@kubevirt-utils/components/CloudinitModal/CloudinitModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
-import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
 import {
@@ -33,7 +32,6 @@ const WizardScriptsTab: WizardTab = ({ vm, updateVM }) => {
         onResourceUpdate={(newVM) => updateVM(newVM)}
         pathsToHighlight={PATHS_TO_HIGHLIGHT.SCRIPTS_TAB}
       >
-        <SidebarEditorSwitch />
         <DescriptionList className="wizard-scripts-tab__description-list">
           <DescriptionListDescription>
             <AlertScripts />


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-29502

**Design:**
https://docs.google.com/document/d/1j5SeV-4ZxJnOvJAhnVn6pjF7A-5TJgx4UQD-6brTn64/

Move the YAML switcher out of the tabs in _Review and create VirtualMachine_ page to the new place in the right - above the tabs, same as it is for VM or Template tabs, for consistency reasons. Display the switcher only for relevant pages that contained the switcher also before this change (all tabs in the page except _YAML_ one). Make this change according to the recent design updates.

Make also some minor css updates for some pages to achieve more consistent look:
align sidebar editor properly in _Disks_ and _NICs_ tabs to be the same as in the other pages (`padding-top`).

## 🎥 Screenshots
The following screenshots are displayed as pairs - before and after, for better visual comparison:

_Overview_ tab:
![over_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/8dd5e5e0-6ce0-4166-aec4-edcc3caffcb2)
![over_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/91c13fe9-5be3-42bd-af89-fa9ba1d8f7d4)

_Scheduling_ tab:
![sched_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/9f82274f-9034-47d0-aaf0-c24d18f47ec9)
![sched_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/c16c09ef-265a-4c66-abea-43fc86a16bf3)

_Environment_ tab:
![env_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/df283b46-a6dd-4b20-8740-b5af18dd05fc)
![env_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/701422a0-00a0-4f1f-a40a-07c937816196)

_Network interfaces_ (a.k.a NICs) tab:
![nic_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/c65de4a8-071d-4dfd-af47-328f56c11d90)
![nic_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/bc2869a2-3036-4693-9ee1-824e81cffd8a)

_Disks_ tab:
![d_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/66c64a30-b4c8-4491-8dad-35491ed95e67)
![d_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/b0cd8baa-e280-461c-80bd-66b7c848a689)

_Scripts_ tab:
![s_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/72e18dd6-62a7-4572-b074-2f4f8ed17b62)
![s_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/0095c9b5-443e-4d1e-bbd5-a595f686889e)

_Metadata_ tab:
![meta_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/3eda146f-9a7e-43a1-bedd-ba481cfbec3f)
![meta_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/f5d9a0c7-b50d-4f18-b34d-f2f91fbd22d3)


