### PR TITLE
CNV-29304: Make more space for VirtualMachine details in step 3

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/VMDetailsSection.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/VMDetailsSection.tsx
@@ -11,11 +11,11 @@ const VMDetailsSection: FC = () => {
   return (
     <div className="instancetypes-vm-details-section instancetypes-vm-details-body">
       <Grid hasGutter>
-        <GridItem span={3}>
+        <GridItem span={5}>
           <DetailsLeftGrid />
         </GridItem>
         <GridItem span={1}>{/* Spacer */}</GridItem>
-        <GridItem span={3}>
+        <GridItem span={5}>
           <DetailsRightGrid />
         </GridItem>
       </Grid>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-29304

Make more space for "VirtualMachine details" - step 3 of VM creation from InstanceTypes (_Catalog > InstanceTypes_ tab), especially for a long VM name and small screens.

## 🎥 Screenshots
**Before:**
![vm_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/0e681633-0d5e-427c-9ed6-41d5ce175043)

**After:**
![vm_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/d74b9323-8a25-4008-b3aa-fd3a2dc08f6d)

