### PR TITLE
Fix user setting for non admin users

### DIFF
--- a/src/utils/hooks/useKubevirtUserSettings/utils/const.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/utils/const.ts
@@ -1,1 +1,48 @@
+import { ConfigMapModel, GroupModel, RoleModel } from '@kubevirt-ui/kubevirt-api/console';
+import {
+  IoK8sApiRbacV1Role,
+  IoK8sApiRbacV1RoleBinding,
+} from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+
 export const TOP_CONSUMERS_CARD = 'topConsumersCard';
+
+export const KUBEVIRT_USER_SETTINGS_CONFIG_MAP_NAME = 'kubevirt-user-settings';
+
+const KUBEVIRT_USER_SETTINGS_ROLE_NAME = 'kubevirt-user-settings-reader';
+
+const KUBEVIRT_USER_SETTINGS_ROLE_BINDING_NAME = 'kubevirt-user-settings-reader-binding';
+
+export const userSettingsRole: IoK8sApiRbacV1Role = {
+  metadata: {
+    name: KUBEVIRT_USER_SETTINGS_ROLE_NAME,
+    namespace: DEFAULT_NAMESPACE,
+  },
+  rules: [
+    {
+      apiGroups: [''],
+      resourceNames: [KUBEVIRT_USER_SETTINGS_CONFIG_MAP_NAME],
+      resources: [ConfigMapModel.plural],
+      verbs: ['list', 'get', 'update', 'patch'],
+    },
+  ],
+};
+
+export const userSettingsRoleBinding: IoK8sApiRbacV1RoleBinding = {
+  metadata: {
+    name: KUBEVIRT_USER_SETTINGS_ROLE_BINDING_NAME,
+    namespace: DEFAULT_NAMESPACE,
+  },
+  roleRef: {
+    apiGroup: RoleModel.apiGroup,
+    kind: RoleModel.kind,
+    name: KUBEVIRT_USER_SETTINGS_ROLE_NAME,
+  },
+  subjects: [
+    {
+      apiGroup: RoleModel.apiGroup,
+      kind: GroupModel.kind,
+      name: 'system:authenticated',
+    },
+  ],
+};


### PR DESCRIPTION
## 📝 Description

This PR includes these changes to user settings mechanism:
- We create one CM for all users instead of one per user, named `kubevirt-user-settings` on `default` namespace, and the CMs data is looking like: `username: userSettings`
- We create a Role and RoleBinding CRs to allow all users `get` / `list` / `update` / `patch` actions only on the `kubevirt-user-settings` CM.

Current issues: 
- In some edge cases a user is logging into a cluster before any cluster admin is, this  feature won't work, an initial cluster-admin login is required. (We should push to get this CM on Kubevirt deployment from BE on the next version to avoid this issue).
- It is possible for any user to edit this CM manually (not directly through the UI) which can impact other users settings. 

## 🎥 Demo

After:
![user-settings-CM](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/cff036d3-e290-4bb6-9d61-d7fd406ba81b)

