### PR TITLE
CNV-29788: Remove titles from Environment, Disks tab for customizing VM

### DIFF
--- a/src/utils/components/EnvironmentEditor/components/EnvironmentFormTitle.tsx
+++ b/src/utils/components/EnvironmentEditor/components/EnvironmentFormTitle.tsx
@@ -1,4 +1,5 @@
 import React, { FC, memo } from 'react';
+import { useHistory } from 'react-router-dom';
 
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -6,13 +7,14 @@ import { Title } from '@patternfly/react-core';
 
 const EnvironmentFormTitle: FC = memo(() => {
   const { t } = useKubevirtTranslation();
+  const history = useHistory();
 
   return (
     <>
-      <Title headingLevel="h2">{t('Environment')}</Title>
-      {t(
-        'Include all values from existing config maps, secrets or service accounts (as disk)',
-      )}{' '}
+      {!history.location.pathname.includes('/review/environment') && (
+        <Title headingLevel="h2">{t('Environment')}</Title>
+      )}
+      {t('Include all values from existing config maps, secrets or service accounts (as disk)')}{' '}
       <HelpTextIcon
         bodyContent={t(
           'Add new values by referencing an existing config map, secret or service account. Using these values requires mounting them manually to the VM.',

--- a/src/views/catalog/wizard/tabs/disks/WizardDisksTab.tsx
+++ b/src/views/catalog/wizard/tabs/disks/WizardDisksTab.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 
 import { WizardTab } from '@catalog/wizard/tabs';
-import DiskListTitle from '@kubevirt-utils/components/DiskListTitle/DiskListTitle';
 import DiskModal from '@kubevirt-utils/components/DiskModal/DiskModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
@@ -41,8 +40,9 @@ const WizardDisksTab: WizardTab = ({ loaded, tabsData, updateTabsData, updateVM,
           pathsToHighlight={PATHS_TO_HIGHLIGHT.DISKS_TAB}
           resource={vm}
         >
-          <DiskListTitle />
-
+          <Flex className="wizard-disk-tab__flex">
+            {t('The following information is provided by the OpenShift Virtualization operator.')}
+          </Flex>
           <ListPageCreateButton
             onClick={() =>
               createModal(({ isOpen, onClose }) => (

--- a/src/views/catalog/wizard/tabs/disks/wizard-disk-tab.scss
+++ b/src/views/catalog/wizard/tabs/disks/wizard-disk-tab.scss
@@ -12,4 +12,8 @@
   &__list-page-create-button {
     margin: 1rem 0 0.5rem 0;
   }
+
+  &__flex {
+    margin: 1.5rem 0 0 0;
+  }
 }


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-29788

Remove titles from _Environment_ and _Disks_ tabs in _Review and create VirtualMachine_ page to make the tabs more consistent with each other. 

Add _The following information is provided by the OpenShift Virtualization operator._ text to _Disks_ tab instead of help text icon displaying the popover containing this text, similarly as it is already done in the _Environment_ tab, to keep the original information available to the user.

## 🎥 Screenshots
**Before**:
![disk_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/b8d831df-efe9-481f-9188-71152028860d)
![en_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/956e6df2-4b18-41e5-a9a0-2890268c51c0)

**After:**
_Disks_ title removed, text of the original popover added:
![disk_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/5cda063b-048b-4fdc-b000-b5cb6af2e831)
_Environment_ title removed:
![en_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/051bac06-4524-43ce-994b-571ca6bc5278)

