### PR TITLE
Bug 2211168: Display VM Scripts tab correctly

### DIFF
--- a/src/utils/components/CloudinitDescription/CloudInitDescription.tsx
+++ b/src/utils/components/CloudinitDescription/CloudInitDescription.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import {
@@ -18,7 +18,7 @@ import {
 
 import CloudInitInfoHelper from './CloudinitInfoHelper';
 
-export const CloudInitDescription: React.FC<{ vm: V1VirtualMachine }> = ({ vm }) => {
+export const CloudInitDescription: FC<{ vm: V1VirtualMachine }> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
   const cloudInitData = getCloudInitData(getCloudInitVolume(vm));
   const userData = convertYAMLUserDataObject(cloudInitData?.userData);
@@ -37,7 +37,7 @@ export const CloudInitDescription: React.FC<{ vm: V1VirtualMachine }> = ({ vm })
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Password')}</DescriptionListTerm>
             <DescriptionListDescription>
-              {userData?.password?.replace(/./g, '*') || '-'}
+              {userData?.password?.toString().replace(/./g, '*') || '-'}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2211168

_Jira issue:_
https://issues.redhat.com/browse/CNV-29295

Display VM _Scripts_ tab correctly, fix the error in the page, for VMs with specific cloud init data.

## 🎥 Screenshots
**Before:**
Error in the page, unable to display _Scripts_ tab correctly:
![dyn_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/e1df90eb-b553-4295-ada0-7afb8f0aed94)

**After:**
_Scripts_ tab displayed as expected:
![dyn_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/80409b61-08db-4668-925a-e8bc2b11048b)


