### PR TITLE
CNV-29306: Simplify VM Overview Utilization charts

### DIFF
--- a/src/utils/components/Charts/CPUUtil/CPUThresholdChart.tsx
+++ b/src/utils/components/Charts/CPUUtil/CPUThresholdChart.tsx
@@ -17,7 +17,6 @@ import {
   ChartThreshold,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
-import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
@@ -87,21 +86,10 @@ const CPUThresholdChart: FC<CPUThresholdChartProps> = ({ pods, vmi }) => {
               x: [currentTime - timespan, currentTime],
             }}
             height={height}
-            padding={{ bottom: 35, left: 70, right: 35, top: 35 }}
+            padding={35}
             scale={{ x: 'time', y: 'linear' }}
             width={width}
           >
-            <ChartAxis
-              style={{
-                grid: {
-                  stroke: chart_color_black_200.value,
-                },
-              }}
-              dependentAxis
-              tickCount={2}
-              tickFormat={(tick: number) => `${tick === 0 ? tick : tick?.toFixed(2)} s`}
-              tickValues={[0, thresholdData?.[0]?.y]}
-            />
             <ChartAxis
               style={{
                 tickLabels: { padding: 2 },

--- a/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
+++ b/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
@@ -14,7 +14,6 @@ import {
   ChartThreshold,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
-import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
@@ -22,13 +21,7 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
 import { getUtilizationQueries } from '../utils/queries';
-import {
-  formatMemoryYTick,
-  MILLISECONDS_MULTIPLIER,
-  queriesToLink,
-  tickFormat,
-  TICKS_COUNT,
-} from '../utils/utils';
+import { MILLISECONDS_MULTIPLIER, queriesToLink, tickFormat, TICKS_COUNT } from '../utils/utils';
 
 type MemoryThresholdChartProps = {
   vmi: V1VirtualMachineInstance;
@@ -87,21 +80,10 @@ const MemoryThresholdChart: FC<MemoryThresholdChartProps> = ({ vmi }) => {
               x: [currentTime - timespan, currentTime],
             }}
             height={height}
-            padding={{ bottom: 35, left: 55, right: 35, top: 35 }}
+            padding={35}
             scale={{ x: 'time', y: 'linear' }}
             width={width}
           >
-            <ChartAxis
-              style={{
-                grid: {
-                  stroke: chart_color_black_200.value,
-                },
-              }}
-              dependentAxis
-              tickCount={2}
-              tickFormat={formatMemoryYTick(thresholdLine?.[0]?.y, 0)}
-              tickValues={[0, thresholdLine?.[0]?.y]}
-            />
             <ChartAxis
               style={{
                 tickLabels: { padding: 2 },

--- a/src/utils/components/Charts/NetworkUtil/NetworkThresholdChart.tsx
+++ b/src/utils/components/Charts/NetworkUtil/NetworkThresholdChart.tsx
@@ -84,6 +84,7 @@ const NetworkThresholdChart: React.FC<NetworkThresholdChartProps> = ({ vmi }) =>
           >
             <ChartAxis
               style={{
+                tickLabels: { padding: 2 },
                 ticks: { stroke: 'transparent' },
               }}
               axisComponent={<></>}

--- a/src/utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart.tsx
@@ -11,10 +11,11 @@ import {
   ChartArea,
   ChartAxis,
   ChartGroup,
+  ChartThreshold,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
-import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
+import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
 import ComponentReady from '../ComponentReady/ComponentReady';
@@ -22,7 +23,6 @@ import useResponsiveCharts from '../hooks/useResponsiveCharts';
 import { getUtilizationQueries } from '../utils/queries';
 import {
   findMaxYValue,
-  formatMemoryYTick,
   MILLISECONDS_MULTIPLIER,
   queriesToLink,
   tickFormat,
@@ -60,6 +60,10 @@ const StorageTotalReadWriteThresholdChart: React.FC<StorageTotalReadWriteThresho
   });
   const yMax = findMaxYValue(chartData);
 
+  const thresholdData = storageWriteData?.map(([x]) => {
+    return { x: new Date(x * MILLISECONDS_MULTIPLIER), y: yMax };
+  });
+
   return (
     <ComponentReady isReady={!isEmpty(chartData)}>
       <div className="util-threshold-chart" ref={ref}>
@@ -80,20 +84,10 @@ const StorageTotalReadWriteThresholdChart: React.FC<StorageTotalReadWriteThresho
               y: [0, yMax],
             }}
             height={height}
-            padding={{ bottom: 35, left: 80, right: 35, top: 35 }}
+            padding={35}
             scale={{ x: 'time', y: 'linear' }}
             width={width}
           >
-            <ChartAxis
-              style={{
-                grid: {
-                  stroke: chart_color_black_200.value,
-                },
-              }}
-              dependentAxis
-              tickFormat={formatMemoryYTick(yMax, 2)}
-              tickValues={[0, yMax]}
-            />
             <ChartAxis
               style={{
                 tickLabels: { padding: 2 },
@@ -113,6 +107,15 @@ const StorageTotalReadWriteThresholdChart: React.FC<StorageTotalReadWriteThresho
                 data={chartData}
               />
             </ChartGroup>
+            <ChartThreshold
+              style={{
+                data: {
+                  stroke: chart_color_orange_300.value,
+                  strokeDasharray: 10,
+                },
+              }}
+              data={thresholdData}
+            />
           </Chart>
         </Link>
       </div>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/virtual-machines-overview-tab-utilization.scss
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/virtual-machines-overview-tab-utilization.scss
@@ -54,7 +54,6 @@
         display: flex;
         &__sum,
         &__title {
-          font-size: var(--pf-global--FontSize--lg);
           width: 50%;
         }
         &__title {


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-29306

Simplify VM _Overview_ _Utilization_ charts, especially _CPU, Memory_ and _Storage_ ones, remove unnecessary y axis, make the padding of the charts the same, so the distance between each other is the same, make charts look similar as Network transfer chart.

Additionally, update font size of _In_ and _Out_ to be the same as _Total_.

## 🎥 Screenshots
**Before:**
![beforee](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/7a3d43ed-5064-4e77-b413-f298ae9c06b7)
Showing the data of the last day:
![beforee2](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/91c1c65e-05cd-4c65-ab39-eee9dcb74316)

**After:**
![afterr](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/f8e4c8ed-0506-42b1-bf9b-34b72ae895d4)
Showing the data of the last day:
![afterr2](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/6793d31c-bc73-414a-b353-3b37705004c9)


