### PR TITLE
Fix InstanceType tab loading state

### DIFF
--- a/src/utils/hooks/useFeatures/types.ts
+++ b/src/utils/hooks/useFeatures/types.ts
@@ -1,0 +1,9 @@
+import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
+
+export type UseFeaturesValues = {
+  canEdit: boolean;
+  error: Error;
+  featureEnabled: boolean;
+  loading: boolean;
+  toggleFeature: (val: boolean) => Promise<IoK8sApiCoreV1ConfigMap>;
+};

--- a/src/utils/hooks/useFeatures/useFeatures.ts
+++ b/src/utils/hooks/useFeatures/useFeatures.ts
@@ -24,14 +24,9 @@ import {
   featuresRole,
   featuresRoleBinding,
 } from './constants';
+import { UseFeaturesValues } from './types';
 
-type UseFeatures = (featureName: string) => {
-  canEdit: boolean;
-  error: Error;
-  featureEnabled: boolean;
-  loading: boolean;
-  toggleFeature: (val: boolean) => Promise<IoK8sApiCoreV1ConfigMap>;
-};
+type UseFeatures = (featureName: string) => UseFeaturesValues;
 
 export const useFeatures: UseFeatures = (featureName) => {
   const isAdmin = useIsAdmin();

--- a/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.scss
+++ b/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.scss
@@ -44,4 +44,7 @@
   &__HelpTextIcon {
     max-width: 480px;
   }
+  &__page-loader {
+    height: 50vh;
+  }
 }

--- a/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
@@ -3,26 +3,59 @@ import { Trans } from 'react-i18next';
 
 import SelectInstanceTypeSection from '@catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/SelectInstanceTypeSection';
 import VMDetailsSection from '@catalog/CreateFromInstanceTypes/components/VMDetailsSection/VMDetailsSection';
+import EnableInstanceTypeTechPreviewModal from '@catalog/EnableInstanceTypeTechPreviewModal/EnableInstanceTypeTechPreviewModal';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
+import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Card, Divider, Grid, GridItem, List, PopoverPosition } from '@patternfly/react-core';
+import {
+  Bullseye,
+  Card,
+  Divider,
+  Grid,
+  GridItem,
+  List,
+  PopoverPosition,
+} from '@patternfly/react-core';
 
 import AddBootableVolumeButton from './components/AddBootableVolumeButton/AddBootableVolumeButton';
 import BootableVolumeList from './components/BootableVolumeList/BootableVolumeList';
 import CreateVMFooter from './components/CreateVMFooter/CreateVMFooter';
 import SectionListItem from './components/SectionListItem/SectionListItem';
+import useEnableInstanceTypeModal from './hooks/useEnableInstanceTypeModal';
 import { useInstanceTypeVMStore } from './state/useInstanceTypeVMStore';
 import { INSTANCE_TYPES_SECTIONS } from './utils/constants';
 
 import './CreateFromInstanceType.scss';
 
-const CreateFromInstanceType: FC = () => {
+type CreateFromInstanceTypeProps = {
+  isInstanceTypeTab: boolean;
+  navigateToCatalog: () => void;
+};
+
+const CreateFromInstanceType: FC<CreateFromInstanceTypeProps> = ({
+  isInstanceTypeTab,
+  navigateToCatalog,
+}) => {
   const { t } = useKubevirtTranslation();
   const sectionState = useState<INSTANCE_TYPES_SECTIONS>(INSTANCE_TYPES_SECTIONS.SELECT_VOLUME);
 
-  const { resetInstanceTypeVMState } = useInstanceTypeVMStore();
+  const { bootableVolumesData, instanceTypesAndPreferencesData, resetInstanceTypeVMState } =
+    useInstanceTypeVMStore();
+
+  const { loading, ...enableITModalProps } = useEnableInstanceTypeModal(
+    isInstanceTypeTab,
+    navigateToCatalog,
+  );
 
   useEffect(() => resetInstanceTypeVMState(), [resetInstanceTypeVMState]);
+
+  if (loading || !bootableVolumesData?.loaded || !instanceTypesAndPreferencesData?.loaded) {
+    return (
+      <Bullseye className="create-vm-instance-type-section__page-loader">
+        <Loading />
+      </Bullseye>
+    );
+  }
 
   return (
     <>
@@ -81,7 +114,8 @@ const CreateFromInstanceType: FC = () => {
           </Card>
         </GridItem>
       </Grid>
-      <CreateVMFooter />
+      <CreateVMFooter isDisabled={enableITModalProps?.isOpen} />
+      <EnableInstanceTypeTechPreviewModal {...enableITModalProps} />
     </>
   );
 };

--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
@@ -29,7 +29,11 @@ import YamlAndCLIViewerModal from './components/YamlAndCLIViewerModal/YamlAndCLI
 
 import './CreateVMFooter.scss';
 
-const CreateVMFooter: FC = () => {
+type CreateVMFooterProps = {
+  isDisabled: boolean;
+};
+
+const CreateVMFooter: FC<CreateVMFooterProps> = ({ isDisabled }) => {
   const { t } = useKubevirtTranslation();
   const history = useHistory();
   const [startVM, setStartVM] = useState(true);
@@ -121,6 +125,7 @@ const CreateVMFooter: FC = () => {
             <SplitItem>
               <Button
                 isDisabled={
+                  isDisabled ||
                   isSubmitting ||
                   isEmpty(selectedBootableVolume) ||
                   !canCreateVM ||

--- a/src/views/catalog/CreateFromInstanceTypes/hooks/useEnableInstanceTypeModal.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/hooks/useEnableInstanceTypeModal.ts
@@ -1,0 +1,39 @@
+import { INSTANCE_TYPE_ENABLED } from '@kubevirt-utils/hooks/useFeatures/constants';
+import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+
+type UseEnableInstanceTypeModalValues = {
+  canEdit: boolean;
+  isOpen: boolean;
+  loading: boolean;
+  onClose: () => void;
+  onEnableInstanceTypeFeature: () => void;
+};
+
+type UseEnableInstanceTypeModal = (
+  isInstanceTypeTab: boolean,
+  navigateToCatalog: () => void,
+) => UseEnableInstanceTypeModalValues;
+
+const useEnableInstanceTypeModal: UseEnableInstanceTypeModal = (
+  isInstanceTypeTab,
+  navigateToCatalog,
+) => {
+  const { canEdit, featureEnabled, loading, toggleFeature } = useFeatures(INSTANCE_TYPE_ENABLED);
+
+  const onClose = () => {
+    navigateToCatalog();
+  };
+
+  const onEnableInstanceTypeFeature = () => {
+    toggleFeature(true);
+  };
+  return {
+    canEdit,
+    isOpen: isInstanceTypeTab && !featureEnabled,
+    loading,
+    onClose,
+    onEnableInstanceTypeFeature,
+  };
+};
+
+export default useEnableInstanceTypeModal;

--- a/src/views/catalog/CreateVMHorizontalNav/CreateVMHorizontalNav.tsx
+++ b/src/views/catalog/CreateVMHorizontalNav/CreateVMHorizontalNav.tsx
@@ -2,7 +2,6 @@ import React, { FC, useMemo, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 
 import CreateFromInstanceType from '@catalog/CreateFromInstanceTypes/CreateFromInstanceType';
-import EnableInstanceTypeTechPreviewModal from '@catalog/EnableInstanceTypeTechPreviewModal/EnableInstanceTypeTechPreviewModal';
 import TemplatesCatalog from '@catalog/templatescatalog/TemplatesCatalog';
 import { ALL_NAMESPACES } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -61,15 +60,13 @@ const CreateVMHorizontalNav: FC<RouteComponentProps<{ ns: string }>> = ({
           eventKey={CREATE_VM_TAB.INSTANCE_TYPES}
           title={<CreateVMTabTitle Icon={ImageIcon} titleText={t('InstanceTypes')} />}
         >
-          <CreateFromInstanceType />
-          {currentTab === CREATE_VM_TAB.INSTANCE_TYPES && (
-            <EnableInstanceTypeTechPreviewModal
-              navigateToCatalog={() => {
-                setCurrentTab(CREATE_VM_TAB.CATALOG);
-                history.push(catalogURL);
-              }}
-            />
-          )}
+          <CreateFromInstanceType
+            navigateToCatalog={() => {
+              setCurrentTab(CREATE_VM_TAB.CATALOG);
+              history.push(catalogURL);
+            }}
+            isInstanceTypeTab={currentTab === CREATE_VM_TAB.INSTANCE_TYPES}
+          />
         </Tab>
       </Tabs>
     </div>

--- a/src/views/catalog/EnableInstanceTypeTechPreviewModal/EnableInstanceTypeTechPreviewModal.tsx
+++ b/src/views/catalog/EnableInstanceTypeTechPreviewModal/EnableInstanceTypeTechPreviewModal.tsx
@@ -1,10 +1,7 @@
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { FC } from 'react';
 import instanceTypeTechPreviewModalImage from 'images/instance-type-tech-preview-modal-img.svg';
 
-import { INSTANCE_TYPE_ENABLED } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   Button,
   ButtonVariant,
@@ -21,38 +18,19 @@ import EnableInstanceTypeContent from './components/EnableInstanceTypeContent';
 import LinksList from './components/LinksList';
 
 type EnableInstanceTypeTechPreviewModalProps = {
-  navigateToCatalog: () => void;
+  canEdit: boolean;
+  isOpen: boolean;
+  onClose: () => void;
+  onEnableInstanceTypeFeature: () => void;
 };
 
 const EnableInstanceTypeTechPreviewModal: FC<EnableInstanceTypeTechPreviewModalProps> = ({
-  navigateToCatalog,
+  canEdit,
+  isOpen,
+  onClose,
+  onEnableInstanceTypeFeature,
 }) => {
   const { t } = useKubevirtTranslation();
-
-  const {
-    canEdit,
-    error,
-    featureEnabled: instanceTypesEnabled,
-    loading,
-    toggleFeature: toggleInstanceTypesFeature,
-  } = useFeatures(INSTANCE_TYPE_ENABLED);
-
-  const [isOpen, setIsOpen] = useState(false);
-
-  useEffect(() => {
-    if (!isEmpty(error)) {
-      setIsOpen(true);
-      return;
-    }
-    if (!loading) {
-      setIsOpen(!instanceTypesEnabled);
-    }
-  }, [loading, instanceTypesEnabled, error]);
-
-  const onClose = useCallback(() => {
-    setIsOpen(false);
-    navigateToCatalog();
-  }, [navigateToCatalog]);
 
   return (
     <Modal
@@ -73,12 +51,7 @@ const EnableInstanceTypeTechPreviewModal: FC<EnableInstanceTypeTechPreviewModalP
             <StackItem>
               <Split hasGutter>
                 {canEdit && (
-                  <Button
-                    onClick={() => {
-                      toggleInstanceTypesFeature(true);
-                    }}
-                    variant={ButtonVariant.primary}
-                  >
+                  <Button onClick={onEnableInstanceTypeFeature} variant={ButtonVariant.primary}>
                     {t('Enable')}
                   </Button>
                 )}


### PR DESCRIPTION
## 📝 Description

This Pr fixes:
- loading state of InstanceType tab under the catalog - instead of sections load one by one and modal to pop, I add a loading spinner to make the page loading look better
- By getting inside dev tools it was possible to remove the enable IT modal and create a VM, so adding another defense to disable the create button if the feature is disabled.

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/397e684a-bc24-422c-aba5-5c5fea09d07d

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/6df48245-d00e-4163-96be-276f1d5d738c


