### PR TITLE
Bug 2214120: Show Feature highlights in CNV 4.13 instead of 4.10

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -752,7 +752,7 @@
   "OpenShift Data Foundation (ODF)": "OpenShift Data Foundation (ODF)",
   "OpenShift Data Foundation (recommended for full functionality) or another persistent storage service is required for OpenShift Virtualization": "OpenShift Data Foundation (recommended for full functionality) or another persistent storage service is required for OpenShift Virtualization",
   "OpenShift Virtualization": "OpenShift Virtualization",
-  "OpenShift Virtualization 4.10 Highlights": "OpenShift Virtualization 4.10 Highlights",
+  "OpenShift Virtualization 4.13 Highlights": "OpenShift Virtualization 4.13 Highlights",
   "Operating system": "Operating system",
   "Operating System": "Operating System",
   "Operating system source already defined": "Operating system source already defined",

--- a/src/views/clusteroverview/OverviewTab/getting-started-card/feature-highlights-section/FeatureHighlightsSection.tsx
+++ b/src/views/clusteroverview/OverviewTab/getting-started-card/feature-highlights-section/FeatureHighlightsSection.tsx
@@ -33,12 +33,12 @@ const FeatureHighlightsSection: React.FC = () => {
     },
     {
       external: true,
-      href: 'https://www.openshift.com/blog/whats-new-in-openshift-virtualization-4.10',
+      href: 'https://docs.openshift.com/container-platform/4.13/virt/virt-4-13-release-notes.html#virt-4-13-new',
       id: 'item2',
       title: (
         <FeatureHighlightsTitle
           readTime={t('5 min')}
-          title={t('OpenShift Virtualization 4.10 Highlights')}
+          title={t('OpenShift Virtualization 4.13 Highlights')}
         />
       ),
     },


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2214120

_Jira:_
https://issues.redhat.com/browse/CNV-29725

Change text "OpenShift Virtualization 4.10 Highlights" to "OpenShift Virtualization 4.13 Highlights",
update the link to https://docs.openshift.com/container-platform/4.13/virt/virt-4-13-release-notes.html#virt-4-13-new
(as it was suggested by me and approved by our PM).

## 🎥 Screenshots
**Before:**
![virt_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/2101c236-32d3-4145-ad32-88109e2ecde6)

**After:**
![virt_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/57b8aa4e-fcb6-4655-b229-89b9c0fd4f91)
