### PR TITLE
CNV-30327: Add identity flag to ssh command

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -968,6 +968,7 @@
   "SSH key name": "SSH key name",
   "SSH over LoadBalancer": "SSH over LoadBalancer",
   "SSH over NodePort": "SSH over NodePort",
+  "SSH secret not configured": "SSH secret not configured",
   "SSH service type": "SSH service type",
   "SSH using virtctl": "SSH using virtctl",
   "Start": "Start",

--- a/src/utils/components/SSHAccess/SSHAccess.tsx
+++ b/src/utils/components/SSHAccess/SSHAccess.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
 import { DescriptionList } from '@patternfly/react-core';
 
 import ConsoleOverVirtctl from './components/ConsoleOverVirtctl';
@@ -16,16 +15,9 @@ type SSHAccessProps = {
 };
 
 const SSHAccess: React.FC<SSHAccessProps> = ({ sshService, sshServiceLoaded, vm, vmi }) => {
-  const userData = getCloudInitCredentials(vm);
-  const userName = userData?.users?.[0]?.name;
-
   return (
     <DescriptionList>
-      <ConsoleOverVirtctl
-        userName={userName}
-        vmName={vm?.metadata?.name}
-        vmNamespace={vm?.metadata?.namespace}
-      />
+      <ConsoleOverVirtctl vm={vm} />
       <SSHCommand sshService={sshService} sshServiceLoaded={sshServiceLoaded} vm={vm} vmi={vmi} />
     </DescriptionList>
   );

--- a/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.tsx
+++ b/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 
-import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
-  ClipboardCopy,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
@@ -10,19 +10,14 @@ import {
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
-import { getConsoleVirtctlCommand } from '../utils';
+import VirtctlSSHCommandClipboardCopy from './VirtctlSSHCommandClipboardCopy';
 
 type ConsoleOverVirtctlProps = {
-  userName?: string;
-  vmName: string;
-  vmNamespace: string;
+  vm: V1VirtualMachine;
 };
 
-const ConsoleOverVirtctl: React.FC<ConsoleOverVirtctlProps> = ({
-  userName,
-  vmName,
-  vmNamespace,
-}) => {
+const ConsoleOverVirtctl: FC<ConsoleOverVirtctlProps> = ({ vm }) => {
+  const { t } = useKubevirtTranslation();
   return (
     <DescriptionListGroup>
       <DescriptionListTerm className="pf-u-font-size-xs">
@@ -39,14 +34,7 @@ const ConsoleOverVirtctl: React.FC<ConsoleOverVirtctlProps> = ({
       </DescriptionListTerm>
 
       <DescriptionListDescription className="sshcommand-body">
-        <ClipboardCopy
-          clickTip={t('Copied')}
-          data-test="ssh-over-virtctl"
-          hoverTip={t('Copy to clipboard')}
-          isReadOnly
-        >
-          {getConsoleVirtctlCommand(userName, vmName, vmNamespace)}
-        </ClipboardCopy>
+        <VirtctlSSHCommandClipboardCopy vm={vm} />
       </DescriptionListDescription>
     </DescriptionListGroup>
   );

--- a/src/utils/components/SSHAccess/components/VirtctlSSHCommandClipboardCopy.tsx
+++ b/src/utils/components/SSHAccess/components/VirtctlSSHCommandClipboardCopy.tsx
@@ -1,0 +1,42 @@
+import React, { FC } from 'react';
+
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getVMSSHSecretName } from '@kubevirt-utils/resources/vm';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { ClipboardCopy, HelperText, HelperTextItem } from '@patternfly/react-core';
+
+import { exampleIdentityFilePath } from '../constants';
+import { getConsoleVirtctlCommand } from '../utils';
+
+type VirtctlSSHCommandClipboardCopyProps = {
+  vm: V1VirtualMachine;
+};
+
+const VirtctlSSHCommandClipboardCopy: FC<VirtctlSSHCommandClipboardCopyProps> = ({ vm }) => {
+  const { t } = useKubevirtTranslation();
+
+  if (isEmpty(getVMSSHSecretName(vm))) {
+    return <div className="pf-u-font-size-xs">{t('SSH secret not configured')}</div>;
+  }
+
+  return (
+    <>
+      <ClipboardCopy
+        clickTip={t('Copied')}
+        data-test="ssh-over-virtctl"
+        hoverTip={t('Copy to clipboard')}
+      >
+        {getConsoleVirtctlCommand(vm)}
+      </ClipboardCopy>
+      <HelperText className="pf-u-mt-sm">
+        <HelperTextItem variant="indeterminate">
+          {t('Example: ')}
+          {getConsoleVirtctlCommand(vm, exampleIdentityFilePath)}
+        </HelperTextItem>
+      </HelperText>
+    </>
+  );
+};
+
+export default VirtctlSSHCommandClipboardCopy;

--- a/src/utils/components/SSHAccess/constants.ts
+++ b/src/utils/components/SSHAccess/constants.ts
@@ -13,3 +13,5 @@ export enum SERVICE_TYPES {
 }
 
 export const METALLB_GROUP = 'metallb.io';
+
+export const exampleIdentityFilePath = '--identity-file=/home/jdoe/.ssh/id_rsa';

--- a/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
@@ -11,6 +11,8 @@ import { LabelsModal } from '@kubevirt-utils/components/LabelsModal/LabelsModal'
 import { ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { asAccessReview } from '@kubevirt-utils/resources/shared';
+import { getVMSSHSecretName } from '@kubevirt-utils/resources/vm';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Action, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 import { CopyIcon } from '@patternfly/react-icons';
 
@@ -78,6 +80,7 @@ export const VirtualMachineActionFactory = {
       accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
       cta: () => command && navigator.clipboard.writeText(command),
       description: t('SSH using virtctl'),
+      disabled: isEmpty(getVMSSHSecretName(vm)),
       icon: <CopyIcon />,
       id: 'vm-action-copy-ssh',
       label: t('Copy SSH command'),

--- a/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
+++ b/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
@@ -7,7 +7,6 @@ import {
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { getConsoleVirtctlCommand } from '@kubevirt-utils/components/SSHAccess/utils';
 import { VirtualMachineModelRef } from '@kubevirt-utils/models';
-import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
 import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
 import { Action, useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -26,12 +25,8 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (
   isSingleNodeCluster,
 ) => {
   const { createModal } = useModal();
-  const userName = getCloudInitCredentials(vm)?.users?.[0]?.name;
-  const virtctlCommand = getConsoleVirtctlCommand(
-    userName,
-    vm?.metadata?.name,
-    vm?.metadata?.namespace,
-  );
+
+  const virtctlCommand = getConsoleVirtctlCommand(vm);
 
   const [, inFlight] = useK8sModel(VirtualMachineModelRef);
   const actions: Action[] = React.useMemo(() => {

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsTitle.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsTitle.tsx
@@ -6,7 +6,8 @@ import { printableVMStatus } from 'src/views/virtualmachines/utils';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getConsoleVirtctlCommand } from '@kubevirt-utils/components/SSHAccess/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
+import { getVMSSHSecretName } from '@kubevirt-utils/resources/vm';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { CardTitle, Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import { CopyIcon } from '@patternfly/react-icons';
 
@@ -21,12 +22,7 @@ const VirtualMachinesOverviewTabDetailsTitle: FC<VirtualMachinesOverviewTabDetai
 }) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const { t } = useKubevirtTranslation();
-  const userName = getCloudInitCredentials(vm)?.users?.[0]?.name;
-  const virtctlCommand = getConsoleVirtctlCommand(
-    userName,
-    vm?.metadata?.name,
-    vm?.metadata?.namespace,
-  );
+  const virtctlCommand = getConsoleVirtctlCommand(vm);
 
   const isMachinePaused = vm?.status?.printableStatus === printableVMStatus.Paused;
   const isMachineStopped = vm?.status?.printableStatus === printableVMStatus.Stopped;
@@ -38,6 +34,7 @@ const VirtualMachinesOverviewTabDetailsTitle: FC<VirtualMachinesOverviewTabDetai
         dropdownItems={[
           <DropdownItem
             description={t('SSH using virtctl')}
+            isDisabled={isEmpty(getVMSSHSecretName(vm))}
             key="copy"
             onClick={() => virtctlCommand && navigator.clipboard.writeText(virtctlCommand)}
           >


### PR DESCRIPTION
## 📝 Description

This PR fixes:
- Allow editing the SSH command in the details tab to insert the identity file (ssh private key) path.
- Adding an example of how an SSH command should look like with virtctl.
- Disable the option to copy the SSH command if the VM is missing an SSH secret attached to it.

## 🎥 Demo

Before: 
actions enabled and VM does not have secret with ssh public key:
![copy-ssh-disabled-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/fd43506b-0810-444b-b9d7-90fa7a2432b8)
![copy-ssh-disabled-b4-2](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/1ea2c20b-ebe3-4f94-9931-728984c5d71e)

showing ssh command:
![ssh-command-available-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/bb0943ea-c5be-437c-a937-53bf6a1244d9)


After:
show ssh command only if ssh secret is available
![Screenshot - 2023-06-29T145932 871](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/21236778-0415-498d-9662-b6154a15298d)


ssh secret not configured:
![ssh-command-not-available](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/d823f359-fadb-4db2-bab1-2552153c6041)

action disabled only if vm missing ssh secret configured:
![copy-ssh-disabled](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/7a9e695b-16a0-4228-8ebb-96fbea7e30fe)
![copy-ssh-disabled-2](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/91240162-c442-410e-a5ed-f21752d051ba)

