### PR TITLE
CNV-30370: Clone modal crashes if VM has only pvcs

### DIFF
--- a/src/utils/resources/vm/utils/selectors.ts
+++ b/src/utils/resources/vm/utils/selectors.ts
@@ -62,7 +62,7 @@ export const getVolumeSnapshotStatuses = (vm: V1VirtualMachine) =>
  * @param {V1VirtualMachine} vm the virtual machine
  * @returns the virtual machine host devices
  */
-export const getDataVolumeTemplates = (vm: V1VirtualMachine) => vm?.spec?.dataVolumeTemplates;
+export const getDataVolumeTemplates = (vm: V1VirtualMachine) => vm?.spec?.dataVolumeTemplates || [];
 
 /**
  * A selector for the virtual machine's config maps


### PR DESCRIPTION
## 📝 Description

VM that has only pvc was crashing because of trying to loop on dataVolumeTemplate section of the VM assuming it's populated. Adding a protection to avoid looping on undefined as solved this issue.

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/f66790c3-f5eb-46b2-9299-c344d01b662a

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/8e844a81-6ab0-4493-8ab2-d250cb477828


