### PR TITLE
Fix VM details action crash when vm not loaded yet

### DIFF
--- a/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
@@ -3,9 +3,12 @@ import { useHistory } from 'react-router-dom';
 
 import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import Loading from '@kubevirt-utils/components/Loading/Loading';
 import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
+import { getName } from '@kubevirt-utils/resources/shared';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Label, Split, SplitItem } from '@patternfly/react-core';
 import VirtualMachineActions from '@virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions';
@@ -64,9 +67,17 @@ const VirtualMachineNavPageTitle: FC<VirtualMachineNavPageTitleProps> = ({ name,
               <SidebarEditorSwitch />
             </SplitItem>
           )}
-          <SplitItem>
-            <VirtualMachineActions isSingleNodeCluster={isSingleNodeCluster} vm={vm} vmim={vmim} />
-          </SplitItem>
+          {!isEmpty(vm) ? (
+            <SplitItem id={getName(vm)}>
+              <VirtualMachineActions
+                isSingleNodeCluster={isSingleNodeCluster}
+                vm={vm}
+                vmim={vmim}
+              />
+            </SplitItem>
+          ) : (
+            <Loading />
+          )}
         </Split>
       </span>
       <VirtualMachinePendingChangesAlert vm={vm} vmi={vmi} />


### PR DESCRIPTION
## 📝 Description

When getting inside any VM and clicking on actions will crash as the VM is not loaded yet

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/9586fd45-b9ac-41ee-8981-8ec3d2123e0a

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/9040270a-ebb4-4b0b-bb26-e331827922db


