### PR TITLE
CNV-29473: Change CPU unit from 's' to 'm' in single VM Overview

### DIFF
--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
@@ -51,10 +51,10 @@ const CPUUtil: FC<CPUUtilProps> = ({ pods, vmi }) => {
       <div className="util-upper">
         <div className="util-title">{t('CPU')}</div>
         <div className="util-summary" data-test-id="util-summary-cpu">
-          <div className="util-summary-value">{`${isReady ? cpuUsage?.toFixed(2) : 0}s`}</div>
+          <div className="util-summary-value">{`${isReady ? cpuUsage?.toFixed(2) : 0}m`}</div>
           <div className="util-summary-text text-muted">
             <div>{t('Requested of ')}</div>
-            <div>{`${isReady ? cpuRequested?.toFixed(2) : 0}s`}</div>
+            <div>{`${isReady ? cpuRequested?.toFixed(2) : 0}m`}</div>
           </div>
         </div>
       </div>
@@ -67,7 +67,7 @@ const CPUUtil: FC<CPUUtilProps> = ({ pods, vmi }) => {
             }}
             animate
             constrainToVisibleArea
-            labels={({ datum }) => (datum.x ? `${datum.x}: ${(cpuUsage || 0)?.toFixed(2)}s` : null)}
+            labels={({ datum }) => (datum.x ? `${datum.x}: ${(cpuUsage || 0)?.toFixed(2)}m` : null)}
             style={{ labels: { fontSize: 20 } }}
             subTitle={t('Used')}
             subTitleComponent={<ChartLabel y={135} />}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-29473

Change units from 's' to 'm' for CPU Utilization chart in VM's Overview page, including labels for the chart (black in the pictures below).

## 🎥 Screenshots
**Before:**
![m_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/3b9f825a-4067-44fe-9cc8-93a217b10c4e)

**After:**
![m_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/83f30bec-430e-4bee-a38d-ce40332e2eeb)

