### PR TITLE
CNV-30574: Improve Manage SSH keys section for user settings

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -81,7 +81,6 @@
   "Active users": "Active users",
   "Activity": "Activity",
   "Add affinity rule": "Add affinity rule",
-  "Add authorized SSH key to project": "Add authorized SSH key to project",
   "Add Config Map, Secret or Service Account": "Add Config Map, Secret or Service Account",
   "Add configuration": "Add configuration",
   "Add disk": "Add disk",

--- a/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/ProjectSSHKeysList/ProjectSSHKeysList.tsx
+++ b/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/ProjectSSHKeysList/ProjectSSHKeysList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, useCallback, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -39,15 +39,50 @@ const ProjectSSHKeysList: FC = () => {
 
   const loaded = useMemo(() => settingsLoaded && projectsLoaded, [settingsLoaded, projectsLoaded]);
 
-  if (!loaded) return <Skeleton />;
-
-  const addSSHKey = () => {
+  const addSSHKey = useCallback(() => {
     setSSHSecretKeys((prev) => ({ ...prev, '': '' }));
     setIsAddingKey(true);
-  };
+  }, [setIsAddingKey, setSSHSecretKeys]);
+
+  if (!loaded) return <Skeleton />;
 
   return (
     <>
+      <Panel isScrollable>
+        <PanelMain maxHeight="12.25rem">
+          <Grid>
+            <GridItem span={5}>
+              <Text component={TextVariants.h6}>{t('Project')}</Text>
+            </GridItem>
+            <GridItem span={1} />
+            <GridItem span={5}>
+              <Text component={TextVariants.h6}>{t('Authorized SSH key')}</Text>
+            </GridItem>
+          </Grid>
+          {projectsWithSSHKey.map((projectName) => (
+            <ProjectSSHKeysRow
+              handleChangeKeys={(val: any) => {
+                updateAuthorizedSSHKeys(val);
+                setSSHSecretKeys(val);
+                setIsAddingKey(false);
+              }}
+              handleRemoveKey={() => {
+                if (isAddingKey) {
+                  setIsAddingKey(false);
+                  const updatedKeys = { ...sshSecretKeys };
+                  delete updatedKeys?.[''];
+                  setSSHSecretKeys(updatedKeys);
+                }
+              }}
+              authorizedSSHKeys={authorizedSSHKeys}
+              key={projectName}
+              projectsWithoutSSHKey={projectsWithoutSSHKey}
+              secretProject={projectName}
+            />
+          ))}
+        </PanelMain>
+      </Panel>
+
       <Button
         icon={<PlusCircleIcon />}
         isDisabled={isAddingKey || isEmpty(projectsWithoutSSHKey)}
@@ -55,44 +90,8 @@ const ProjectSSHKeysList: FC = () => {
         onClick={addSSHKey}
         variant="link"
       >
-        {t('Add authorized SSH key to project')}
+        {t('Add more')}
       </Button>
-      {!isEmpty(projectsWithSSHKey) && (
-        <Panel isScrollable>
-          <PanelMain maxHeight="12.25rem">
-            <Grid>
-              <GridItem span={5}>
-                <Text component={TextVariants.h6}>{t('Project')}</Text>
-              </GridItem>
-              <GridItem span={1} />
-              <GridItem span={5}>
-                <Text component={TextVariants.h6}>{t('Authorized SSH key')}</Text>
-              </GridItem>
-            </Grid>
-            {projectsWithSSHKey.map((projectName) => (
-              <ProjectSSHKeysRow
-                handleChangeKeys={(val: any) => {
-                  updateAuthorizedSSHKeys(val);
-                  setSSHSecretKeys(val);
-                  setIsAddingKey(false);
-                }}
-                handleRemoveKey={() => {
-                  if (isAddingKey) {
-                    setIsAddingKey(false);
-                    const updatedKeys = { ...sshSecretKeys };
-                    delete updatedKeys?.[''];
-                    setSSHSecretKeys(updatedKeys);
-                  }
-                }}
-                authorizedSSHKeys={authorizedSSHKeys}
-                key={projectName}
-                projectsWithoutSSHKey={projectsWithoutSSHKey}
-                secretProject={projectName}
-              />
-            ))}
-          </PanelMain>
-        </Panel>
-      )}
     </>
   );
 };

--- a/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/ProjectSSHKeysList/hooks/useAuthorizedSSHKeys.ts
+++ b/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/ProjectSSHKeysList/hooks/useAuthorizedSSHKeys.ts
@@ -20,12 +20,15 @@ const useAuthorizedSSHKeys: UseAuthorizedSSHKeys = () => {
   const [authorizedSSHKeys = {}, updateAuthorizedSSHKeys, loaded, error] =
     useKubevirtUserSettings('ssh');
 
-  const [sshSecretKeys, setSSHSecretKeys] = useState<ProjectSSHSecretMap>({});
+  const [sshSecretKeys, setSSHSecretKeys] = useState<ProjectSSHSecretMap>({ '': '' });
 
-  const [isAddingKey, setIsAddingKey] = useState(false);
+  const [isAddingKey, setIsAddingKey] = useState(true);
 
   useEffect(() => {
-    if (loaded && !isEmpty(authorizedSSHKeys)) setSSHSecretKeys(authorizedSSHKeys);
+    if (loaded && !isEmpty(authorizedSSHKeys)) {
+      setSSHSecretKeys(authorizedSSHKeys);
+      setIsAddingKey(false);
+    }
   }, [loaded, authorizedSSHKeys]);
 
   return {


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-30574

Improve _Manage SSH keys_ section in user settings:
display _Project_ and _Authorized SSH key" fields immediately when entering the section.

Also display _Add more_ button (to add more keys) under the fields, not above them, as it was originally.

Make these changes according to the newest UX suggestions.

## 🎥 Demo
**Before:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/8672f5c3-d9c9-41a8-bdad-5cd2af50092f

**After:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/39f09623-81d4-4975-b0de-4577029dc3a1

