### PR TITLE
CNV-30667: Align VM name in catalog tabs

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypeVMInitialStore.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypeVMInitialStore.ts
@@ -2,8 +2,10 @@ import produce from 'immer';
 import { create } from 'zustand';
 
 import { getInstanceTypeFromVolume } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/utils';
+import { DEFAULT_PREFERENCE_LABEL } from '@kubevirt-utils/resources/bootableresources/constants';
 import { getBootableVolumePVCSource } from '@kubevirt-utils/resources/bootableresources/helpers';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { getLabel } from '@kubevirt-utils/resources/shared';
 
 import { instanceTypeVMStoreInitialState } from '../utils/state';
 import {
@@ -25,16 +27,12 @@ export const useInstanceTypeVMInitialStore = create<InstanceTypeVMStore>()((set,
             get().bootableVolumesData.pvcSources,
           );
           instanceTypeVMState.selectedInstanceType = getInstanceTypeFromVolume(selectedVolume);
+
+          const osName = getLabel(selectedVolume, DEFAULT_PREFERENCE_LABEL).replace('.', '');
+          instanceTypeVMState.vmName = getRandomVMName(osName);
         }),
       ),
-    resetInstanceTypeVMState: () =>
-      set({
-        ...instanceTypeVMStoreInitialState,
-        instanceTypeVMState: {
-          ...instanceTypeVMStoreInitialState.instanceTypeVMState,
-          vmName: getRandomVMName(),
-        },
-      }),
+    resetInstanceTypeVMState: () => set(instanceTypeVMStoreInitialState),
     setActiveNamespace: (namespace: string) => set({ activeNamespace: namespace }),
     setBootableVolumesData: (data: UseBootableVolumesValues) => set({ bootableVolumesData: data }),
     setInstanceTypesAndPreferencesData: (data: UseInstanceTypeAndPreferencesValues) =>

--- a/src/views/catalog/CreateFromInstanceTypes/state/utils/state.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/utils/state.ts
@@ -6,7 +6,6 @@ import {
   UseBootableVolumesValues,
   UseInstanceTypeAndPreferencesValues,
 } from './types';
-import { getRandomVMName } from './utils';
 
 const instanceTypeVMInitialState: InstanceTypeVMState = {
   isDynamicSSHInjection: false,
@@ -14,7 +13,7 @@ const instanceTypeVMInitialState: InstanceTypeVMState = {
   selectedBootableVolume: null,
   selectedInstanceType: '',
   sshSecretCredentials: initialSSHCredentials,
-  vmName: getRandomVMName(),
+  vmName: '',
 };
 
 export const instanceTypeVMStoreInitialState: InstanceTypeVMStoreState = {

--- a/src/views/catalog/CreateFromInstanceTypes/state/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/utils/utils.ts
@@ -1,7 +1,7 @@
 import { adjectives, animals, uniqueNamesGenerator } from 'unique-names-generator';
 
-export const getRandomVMName = () =>
-  uniqueNamesGenerator({
+export const getRandomVMName = (osName: string) =>
+  `${osName}-${uniqueNamesGenerator({
     dictionaries: [adjectives, animals],
     separator: '-',
-  });
+  })}`;


### PR DESCRIPTION
## 📝 Description

Creating a VM with IT is missing the os prefix as we do in the catalog.
To fix that we must select a volume first, and than we base the VM name on that volume's OS

## 🎥 Demo

Before:
![random-name](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/3445aa0b-1503-4613-941d-e098123a775d)


After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/5be0f2fb-5b78-4a93-90c8-1f06b00cff87


