### PR TITLE
CNV-25217: Fixing the wrong values in Bandwidth Consumption chart

### DIFF
--- a/src/views/clusteroverview/MonitoringTab/migrations-card/components/BandwidthConsumptionChart/BandwidthConsumptionChart.tsx
+++ b/src/views/clusteroverview/MonitoringTab/migrations-card/components/BandwidthConsumptionChart/BandwidthConsumptionChart.tsx
@@ -20,7 +20,7 @@ import {
 } from '@patternfly/react-charts';
 import { Bullseye, HelperText, HelperTextItem } from '@patternfly/react-core';
 
-import { roundToNearest512MiB } from './utils';
+import { getDomainY, getTickValuesAxisY } from './utils';
 
 type ChartDataObject = {
   x: Date;
@@ -88,7 +88,7 @@ const BandwidthConsumptionChart: React.FC<BandwidthConsumptionChartProps> = ({ d
           width={width}
           domain={{
             x: [currentTime - timespan, currentTime],
-            y: [0, Math.max(...bandwidthConsumed.map((o) => o.y)) * 1.5],
+            y: getDomainY(Math.max(...bandwidthConsumed.map((o) => o.y))),
           }}
           padding={{ top: 25, bottom: 55, left: 85, right: 55 }}
           scale={{ x: 'time', y: 'linear' }}
@@ -125,7 +125,8 @@ const BandwidthConsumptionChart: React.FC<BandwidthConsumptionChartProps> = ({ d
           />
           <ChartAxis
             dependentAxis
-            tickFormat={(y) => xbytes(roundToNearest512MiB(y), { iec: true, fixed: 1 })}
+            tickValues={getTickValuesAxisY(Math.max(...bandwidthConsumed.map((o) => o.y)))}
+            tickFormat={(y) => xbytes(y, { fixed: 0, iec: true, prefixIndex: 3 })}
             style={{ tickLabels: fontSize }}
           />
           <ChartLine data={bandwidthConsumed} />

--- a/src/views/clusteroverview/MonitoringTab/migrations-card/components/BandwidthConsumptionChart/utils.ts
+++ b/src/views/clusteroverview/MonitoringTab/migrations-card/components/BandwidthConsumptionChart/utils.ts
@@ -1,6 +1,20 @@
 import { multipliers } from '@kubevirt-utils/utils/units';
 
-export const roundToNearest512MiB = (size: number): number => {
-  const mib512 = multipliers.Mi * 512;
-  return Math.round(size / mib512) * mib512 ?? mib512;
+const GRID_LINES = 2;
+
+export const getTickValuesAxisY = (maxValue: number, normalize = multipliers.Gi) => {
+  const tickValues = [];
+
+  const normalizedMaxValue = Math.ceil(maxValue / normalize);
+  const gridLineSpacer = Math.ceil(normalizedMaxValue / GRID_LINES) || 1;
+  for (let i = 0; i <= gridLineSpacer * GRID_LINES; i += gridLineSpacer) {
+    tickValues.push(i * normalize);
+  }
+
+  return tickValues;
+};
+
+export const getDomainY = (maxValue: number, normalize = multipliers.Gi): [number, number] => {
+  const tickValues = getTickValuesAxisY(maxValue, normalize);
+  return [tickValues?.[0], tickValues?.[GRID_LINES]];
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
https://issues.redhat.com/browse/CNV-25217
Fixing the wrong values in Bandwidth consumption chart on the Migration tab on the Overview page. 

## 🎥 Demo
Before:
<img width="1452" alt="wrongValuesBefore" src="https://github.com/kubevirt-ui/kubevirt-plugin/assets/61961469/ddcedccb-07fb-448f-91e3-fd939dc632b0">

After: 
<img width="1455" alt="wrongValuesAfter" src="https://github.com/kubevirt-ui/kubevirt-plugin/assets/61961469/3e755ec0-e40a-43e5-9eed-1e0d89e8093b">
