### PR TITLE
[release-4.13] CNV-30536: Display second-level VM Configuration tabs

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/virtual-machine-configuration-tab.scss
+++ b/src/views/virtualmachines/details/tabs/configuration/virtual-machine-configuration-tab.scss
@@ -1,6 +1,7 @@
 .VirtualMachineConfigurationTab {
   &--main {
     margin: var(--pf-global--spacer--sm);
+    overflow: visible;
   }
   &--tab-nav {
     height: 100%;


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-30536

Display second-level VM _Configuration_ tabs that have been truncated for small browser window.

## 🎥 Screenshots
**Before:**
Sub-tabs like _Scheduling_, _Environment_ etc are not visible for small browser window:
![sm_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/2ef5f4b1-ccff-4f52-9fa8-0cbf412bdb8e)

**After:**
![sm_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/52391028-db5d-45ca-9357-dc116c7e44cc)


