### PR TITLE
[release-4.13] CNV-30519: Prevent text to exceed the size of tab in Overview > Settings

### DIFF
--- a/src/views/clusteroverview/SettingsTab/settings-tab.scss
+++ b/src/views/clusteroverview/SettingsTab/settings-tab.scss
@@ -4,7 +4,6 @@
   }
 
   &__card {
-    height: 75%;
     flex-direction: row;
   }
 


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-30519

Prevent text to exceed the size of the tab in _Overview > Settings > General_, display size of the tab (represented by the PF `Tab` component, seen as the white background in the screenshots below) according to its content. Make it work in the actual Firefox, Chrome, Chromium browsers.

Note that the problem has occurred mainly for smaller browser windows, when size of the tab was set to 75% of the visible screen by the css `height` prop. This is also core of the problem, so removing unnecessary prop fixes the problem. Now the size of the tab is based on its content, nothing exceeds no matter the size of the browser window, no matter the browser used.

## 🎥 Screenshots
**Before:**
![h_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/84417a68-2c77-4def-a678-e1045c49a33e)

**After:**
![h_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/4be9e4a0-6a88-415f-8193-5cb722549c59)

