### PR TITLE
Bug 2221939: Add help icon with text to SSH key field in  M Sctips tab

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -985,6 +985,7 @@
   "Start this VirtualMachine in pause mode": "Start this VirtualMachine in pause mode",
   "Start VirtualMachine": "Start VirtualMachine",
   "Start VirtualMachine on clone": "Start VirtualMachine on clone",
+  "Static SSH keys can be added on <2>Overview > Settings > User > Manage SSH keys</2>.": "Static SSH keys can be added on <2>Overview > Settings > User > Manage SSH keys</2>.",
   "Status": "Status",
   "Status conditions": "Status conditions",
   "Stop": "Stop",

--- a/src/utils/components/DescriptionItem/DescriptionItemHeader.tsx
+++ b/src/utils/components/DescriptionItem/DescriptionItemHeader.tsx
@@ -15,6 +15,7 @@ type DescriptionItemHeaderProps = {
   bodyContent: ReactNode;
   breadcrumb?: string;
   descriptionHeader: string;
+  iconContent?: ReactNode;
   isPopover: boolean;
   label?: ReactNode;
   maxWidth?: string;
@@ -25,6 +26,7 @@ export const DescriptionItemHeader: FC<DescriptionItemHeaderProps> = ({
   bodyContent,
   breadcrumb,
   descriptionHeader,
+  iconContent,
   isPopover,
   label,
   maxWidth,
@@ -66,7 +68,7 @@ export const DescriptionItemHeader: FC<DescriptionItemHeaderProps> = ({
 
   return (
     <DescriptionListTerm>
-      {descriptionHeader} {label}
+      {descriptionHeader} {iconContent} {label}
     </DescriptionListTerm>
   );
 };

--- a/src/utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
+++ b/src/utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
@@ -24,6 +24,7 @@ type VirtualMachineDescriptionItemProps = {
   descriptionData: any;
   descriptionHeader?: string;
   editOnTitleJustify?: boolean;
+  iconContent?: ReactNode;
   isDisabled?: boolean;
   isEdit?: boolean;
   isPopover?: boolean;
@@ -41,6 +42,7 @@ const VirtualMachineDescriptionItem: FC<VirtualMachineDescriptionItemProps> = ({
   descriptionData,
   descriptionHeader,
   editOnTitleJustify = false,
+  iconContent,
   isDisabled,
   isEdit,
   isPopover,
@@ -78,6 +80,7 @@ const VirtualMachineDescriptionItem: FC<VirtualMachineDescriptionItemProps> = ({
               bodyContent={bodyContent}
               breadcrumb={breadcrumb}
               descriptionHeader={descriptionHeader}
+              iconContent={iconContent}
               isPopover={isPopover}
               label={label}
               moreInfoURL={moreInfoURL}

--- a/src/views/virtualmachines/details/tabs/configuration/scripts/ScriptsTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scripts/ScriptsTab.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useCallback, useMemo } from 'react';
+import { Trans } from 'react-i18next';
 import { RouteComponentProps } from 'react-router-dom';
 
 import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
@@ -7,6 +8,7 @@ import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevir
 import AlertScripts from '@kubevirt-utils/components/AlertScripts/AlertScripts';
 import { CloudInitDescription } from '@kubevirt-utils/components/CloudinitDescription/CloudInitDescription';
 import { CloudinitModal } from '@kubevirt-utils/components/CloudinitModal/CloudinitModal';
+import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import LinuxLabel from '@kubevirt-utils/components/Labels/LinuxLabel';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
@@ -29,6 +31,7 @@ import {
   DescriptionListDescription,
   Divider,
   PageSection,
+  PopoverPosition,
   Stack,
 } from '@patternfly/react-core';
 
@@ -112,6 +115,21 @@ const ScriptsTab: FC<VirtualMachineScriptPageProps> = ({ obj: vm }) => {
                   </div>
                   <SecretNameLabel secretName={secretName} />
                 </Stack>
+              }
+              iconContent={
+                <HelpTextIcon
+                  bodyContent={
+                    <Trans ns="plugin__kubevirt-plugin" t={t}>
+                      Static SSH keys can be added on{' '}
+                      <i>
+                        Overview {'>'} Settings {'>'} User {'>'} Manage SSH keys
+                      </i>
+                      .
+                    </Trans>
+                  }
+                  helpIconClassName="title-help-text-icon"
+                  position={PopoverPosition.right}
+                />
               }
               onEditClick={() =>
                 createModal((modalProps) => (


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2221939

_Jira:_
https://issues.redhat.com/browse/CNV-30864

Add "?" help icon with the popover containing the following text to help the user find where to add static public SSH key:
_"Static SSH keys can be added on Overview > Settings > User > Manage SSH keys."_

Add it to "Authorized SSH key" field/section in VM _Configuration > Scripts_ tab, according to the suggestions from the doc team and UX.

## 🎥 Screenshots
**Before:**
![ss_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/17ec8221-2e2e-4bfd-b57e-2a2f37ec3adf)

**After:**
![ss_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/650bbb80-0fee-4cb7-9e33-26d98ac5ca89)

