### PR TITLE
CNV-20469: Apply activation key and organiztion ID to QuickCreate VM - part2

### DIFF
--- a/src/utils/components/CloudinitModal/utils/cloudinit-utils.ts
+++ b/src/utils/components/CloudinitModal/utils/cloudinit-utils.ts
@@ -1,13 +1,16 @@
-import { dump, load } from 'js-yaml';
+import produce from 'immer';
+import { dump, load, LoadOptions } from 'js-yaml';
 
 import {
   V1CloudInitConfigDriveSource,
   V1VirtualMachine,
   V1Volume,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
 import { getVolumes } from '@kubevirt-utils/resources/vm';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 
-import { CLOUD_CONFIG_HEADER } from './consts';
+import { ACTIVATION_KEY, CLOUD_CONFIG_HEADER } from './consts';
 
 export const deleteObjBlankValues = (obj: object) =>
   Object.fromEntries(Object.entries(obj).filter(([, v]) => !!v));
@@ -20,9 +23,12 @@ export const getCloudInitData = (cloudInitVolume: V1Volume): V1CloudInitConfigDr
   return cloudInitVolume?.cloudInitConfigDrive || cloudInitVolume?.cloudInitNoCloud;
 };
 
-export const convertYAMLUserDataObject = (userData: string): CloudInitUserData => {
+export const convertYAMLUserDataObject = (
+  userData: string,
+  opts?: LoadOptions,
+): CloudInitUserData => {
   try {
-    return load(userData) as CloudInitUserData;
+    return load(userData, opts) as CloudInitUserData;
   } catch (e) {
     return undefined;
   }
@@ -100,10 +106,56 @@ export const createDefaultCloudInitYAML = () =>
     true,
   );
 
+export const updateVMRHELSubscription = (
+  vm: V1VirtualMachine,
+  subscriptionData: RHELAutomaticSubscriptionData,
+): V1VirtualMachine => {
+  const { activationKey, organizationID } = subscriptionData || {};
+
+  if (isEmpty(organizationID) || isEmpty(activationKey)) {
+    return vm;
+  }
+
+  const cloudInitVol = getCloudInitVolume(vm);
+  const restVolumes = getVolumes(vm).filter((vol) => vol?.name !== cloudInitVol?.name);
+  const cloudInitVolData = getCloudInitData(cloudInitVol);
+
+  const userDataObject = convertYAMLUserDataObject(cloudInitVolData?.userData);
+
+  const updatedUserDataObject = produce(userDataObject, (draftUserDataObject) => {
+    draftUserDataObject.rh_subscription = {
+      [ACTIVATION_KEY]: activationKey,
+      org: organizationID,
+    };
+  });
+
+  const updatedCloudInitVolumeData = produce(cloudInitVolData, (draftCloudInitVolumeData) => {
+    draftCloudInitVolumeData.userData = convertUserDataObjectToYAML(updatedUserDataObject, true);
+  });
+
+  const updatedCloudInitVolume = produce(cloudInitVol, (draftCloudInitVolume) => {
+    if (cloudInitVol?.cloudInitConfigDrive) {
+      draftCloudInitVolume.cloudInitConfigDrive = updatedCloudInitVolumeData;
+      return;
+    }
+    draftCloudInitVolume.cloudInitNoCloud = updatedCloudInitVolumeData;
+  });
+
+  const updatedVM = produce(vm, (draftVM) => {
+    draftVM.spec.template.spec.volumes = [...restVolumes, updatedCloudInitVolume];
+  });
+
+  return updatedVM;
+};
+
 export type CloudInitUserData = {
   chpasswd?: { expire?: boolean };
   hostname: string;
   password: string;
+  rh_subscription?: {
+    [ACTIVATION_KEY]: string;
+    org: string;
+  };
   user: string;
 };
 

--- a/src/utils/components/CloudinitModal/utils/consts.ts
+++ b/src/utils/components/CloudinitModal/utils/consts.ts
@@ -1,2 +1,5 @@
 export const CLOUD = 'cloud';
 export const CLOUD_CONFIG_HEADER = '#cloud-config';
+export const ACTIVATION_KEY = 'activation-key';
+export const ORG_KEY = 'org';
+export const RH_SUBSCRIPTION_KEY = 'rh_subscription';

--- a/src/utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription.ts
+++ b/src/utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription.ts
@@ -10,19 +10,18 @@ import useFeaturesConfigMap from '@kubevirt-utils/hooks/useFeatures/useFeaturesC
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 
-type UseSubscriptionData = () => {
-  isAdmin: boolean;
+import { RHELAutomaticSubscriptionData } from './utils/types';
+
+type UseRHELAutomaticSubscription = () => {
+  canEdit: boolean;
   loaded: boolean;
   loadError: Error;
   loading: boolean;
-  subscriptionData: {
-    activationKey: string;
-    organizationID: string;
-  };
+  subscriptionData: RHELAutomaticSubscriptionData;
   updateSubscription: (activationKey: string, organizationID: string) => void;
 };
 
-const useSubscriptionData: UseSubscriptionData = () => {
+const useRHELAutomaticSubscription: UseRHELAutomaticSubscription = () => {
   const {
     featuresConfigMapData: [featureConfigMap, loaded, loadError],
     isAdmin,
@@ -45,7 +44,7 @@ const useSubscriptionData: UseSubscriptionData = () => {
   };
 
   return {
-    isAdmin,
+    canEdit: isAdmin,
     loaded,
     loadError,
     loading,
@@ -57,4 +56,4 @@ const useSubscriptionData: UseSubscriptionData = () => {
   };
 };
 
-export default useSubscriptionData;
+export default useRHELAutomaticSubscription;

--- a/src/utils/hooks/useRHELAutomaticSubscription/utils/types.ts
+++ b/src/utils/hooks/useRHELAutomaticSubscription/utils/types.ts
@@ -1,0 +1,4 @@
+export type RHELAutomaticSubscriptionData = {
+  activationKey: string;
+  organizationID: string;
+};

--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -114,7 +114,7 @@ export const generateVM = (
               name: `${virtualmachineName}-disk`,
             },
             {
-              cloudInitNoCloud: {
+              cloudInitConfigDrive: {
                 userData: `#cloud-config\nuser: ${getCloudInitUserNameByOS(
                   selectedPreference,
                 )}\npassword: ${generateCloudInitPassword()}\nchpasswd: { expire: False }`,

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -15,6 +15,7 @@ import {
 } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { ensurePath, isEmpty } from '@kubevirt-utils/utils/utils';
@@ -46,6 +47,7 @@ type TemplatesCatalogDrawerCreateFormProps = {
   isBootSourceAvailable: boolean;
   namespace: string;
   onCancel: () => void;
+  subscriptionData: RHELAutomaticSubscriptionData;
   template: V1Template;
 };
 
@@ -57,6 +59,7 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
     isBootSourceAvailable,
     namespace,
     onCancel,
+    subscriptionData,
     template,
   }) => {
     const history = useHistory();
@@ -106,7 +109,7 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
 
       quickCreateVM({
         models,
-        overrides: { authorizedSSHKey, name: vmName, namespace, startVM },
+        overrides: { authorizedSSHKey, name: vmName, namespace, startVM, subscriptionData },
         template: templateToProcess,
       })
         .then((quickCreatedVM) => {

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerFooter.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerFooter.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import useRHELAutomaticSubscription from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription';
 import {
   generateVMName,
   getTemplateVirtualMachineObject,
@@ -39,10 +40,12 @@ export const TemplatesCatalogDrawerFooter: React.FC<TemplateCatalogDrawerFooterP
   const { t } = useKubevirtTranslation();
   const { isBootSourceAvailable, loaded: bootSourceLoaded } = useVmTemplateSource(template);
   const [authorizedSSHKeys, , userSettingsLoaded] = useKubevirtUserSettings('ssh');
+  const { loaded: loadedRHELSubscription, subscriptionData } = useRHELAutomaticSubscription();
   const [processedTemplate, processedTemplateLoaded] = useProcessedTemplate(template, namespace);
 
   const canQuickCreate = Boolean(processedTemplate) && isBootSourceAvailable;
-  const loaded = bootSourceLoaded && processedTemplateLoaded && userSettingsLoaded;
+  const loaded =
+    bootSourceLoaded && processedTemplateLoaded && userSettingsLoaded && loadedRHELSubscription;
 
   if (!loaded) {
     return <TemplatesCatalogDrawerFooterSkeleton />;
@@ -83,6 +86,7 @@ export const TemplatesCatalogDrawerFooter: React.FC<TemplateCatalogDrawerFooterP
             isBootSourceAvailable={isBootSourceAvailable}
             namespace={namespace}
             onCancel={onCancel}
+            subscriptionData={subscriptionData}
             template={template}
           />
         </Stack>

--- a/src/views/catalog/templatescatalog/tests/TemplatesCatalogDrawer.test.tsx
+++ b/src/views/catalog/templatescatalog/tests/TemplatesCatalogDrawer.test.tsx
@@ -66,6 +66,10 @@ jest.mock('@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings
   return jest.fn().mockReturnValue([{}, jest.fn(), true, null]);
 });
 
+jest.mock('@kubevirt-utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription', () => {
+  return jest.fn().mockReturnValue({ loaded: true, subscriptionData: {} });
+});
+
 afterEach(cleanup);
 
 const renderWithWizardContext = ({ children }) => (

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/AutomaticSubscriptionRHELGuests/components/AutomaticSubscriptionForm/AutomaticSubscriptionForm.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/AutomaticSubscriptionRHELGuests/components/AutomaticSubscriptionForm/AutomaticSubscriptionForm.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useState } from 'react';
 
 import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useSubscriptionData from '@kubevirt-utils/hooks/useSubscriptionData/useSubscriptionData';
+import useRHELAutomaticSubscription from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   ActionGroup,
@@ -24,7 +24,8 @@ import './AutomaticSubscriptionForm.scss';
 
 const AutomaticSubscriptionForm: FC = () => {
   const { t } = useKubevirtTranslation();
-  const { isAdmin, loaded, loading, subscriptionData, updateSubscription } = useSubscriptionData();
+  const { canEdit, loaded, loading, subscriptionData, updateSubscription } =
+    useRHELAutomaticSubscription();
 
   const [activationKey, setActivationKey] = useState<string>(null);
   const [organizationID, setOrganizationID] = useState<string>(null);
@@ -39,7 +40,7 @@ const AutomaticSubscriptionForm: FC = () => {
   if (!loaded) return <Skeleton />;
 
   const isDisabled =
-    !isAdmin ||
+    !canEdit ||
     isEqualObject(subscriptionData, { activationKey, organizationID }) ||
     (!isEmpty(organizationID) && isEmpty(activationKey)) ||
     (isEmpty(organizationID) && !isEmpty(activationKey));


### PR DESCRIPTION
## 📝 Description

Apply activation key and organization ID to cloud-init config when creating RHEL VM with Quick Create VM flow.
Also Changing the cloud-init volume to Cloud Drive

## 🎥 Demo

![rhel-subscribed-vm](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/88e7ede2-0bd6-40d4-82ca-cfa5e8b46200)

upgrade successful:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/37c29be1-1017-4337-9712-0c5e55f5e47c

