### PR TITLE
CNV-30719: Hide Cancel button for ResourceYAMLEditor for VM Cloud-init

### DIFF
--- a/src/utils/components/CloudinitModal/CloudInitEditor/CloudInitEditor.scss
+++ b/src/utils/components/CloudinitModal/CloudInitEditor/CloudInitEditor.scss
@@ -7,6 +7,10 @@
     padding-top: 0;
     margin-left: 0;
     margin-right: 0;
+
+    button#cancel.pf-c-button.pf-m-secondary {
+      display: none;
+    }
   }
 
   @import '../../../styles/secondary-editor';


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-30719

Hide unnecessary _Cancel_ button that is part of the `ResourceYAMLEditor` component, displayed in _Cloud-init_ modal accessible in VM's _Configuration > Scripts_ tab.

## 🎥 Screenshots
**Before:**
Two _Cancel_ buttons present in the modal and clicking on the 1st one redirects to the incorrect page:
![but_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/c52a2abf-f714-4068-a430-8d44f82e59b8)

**After:**
Only one Cancel button present in the modal (and clicking on it does not redirect us anywhere as expected):
![but_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/22c8f754-2328-4128-ae09-5fdcdd4c5d13)




