### PR TITLE
CNV-30901: Make "Start this VirtualMachine after creation" checkbox work

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
@@ -114,7 +114,7 @@ const CreateVMFooter: FC<CreateVMFooterProps> = ({ isDisabled }) => {
         )}
         <StackItem>
           <Checkbox
-            id="start-after-create-checkbox"
+            id="start-after-creation-checkbox"
             isChecked={startVM}
             label={t('Start this VirtualMachine after creation')}
             onChange={setStartVM}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2222607

_Jira:_
https://issues.redhat.com/browse/CNV-30901

Make the checkbox responsive/change its value in the catalog drawer when clicking on the label of the checkbox.

In general, it is not a good practice to have same elements with the same id in the same page. Having it so can lead to unexpected behavior. In this PR, one of such checkbox ids is changed to fix the problem.

## 🎥 Demo
**Before:**
The checkbox in the catalog drawer does not work as expected, when clicking on its label:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/0a855a5d-960f-4f89-83d3-1a3eb1fc7fb1

**After:**
All the checkboxes to allow starting VM after its creation work as expected:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/91c22a70-5e01-4960-95e4-a15121a1105d




