### PR TITLE
CNV-30667: Align VM name in catalog tabs - fix centos stream use case

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypeVMInitialStore.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypeVMInitialStore.ts
@@ -28,7 +28,7 @@ export const useInstanceTypeVMInitialStore = create<InstanceTypeVMStore>()((set,
           );
           instanceTypeVMState.selectedInstanceType = getInstanceTypeFromVolume(selectedVolume);
 
-          const osName = getLabel(selectedVolume, DEFAULT_PREFERENCE_LABEL).replace('.', '');
+          const osName = getLabel(selectedVolume, DEFAULT_PREFERENCE_LABEL).replaceAll('.', '-');
           instanceTypeVMState.vmName = getRandomVMName(osName);
         }),
       ),


### PR DESCRIPTION
## 📝 Description

centos stream preference has more than 1 '.' char in it's name so using replaceAll to fix to issue.

## 🎥 Demo

Before:
![vm_name-1](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/4db65b63-fb94-485d-9308-2d2b2862a6c0)

After:
![vm_name-1-after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/e5962c24-54bd-40b6-ab27-6a6cce2461d2)

