### PR TITLE
CNV-29219: Hide namespace related info in Manage columns modal

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeColumns.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeColumns.ts
@@ -50,6 +50,7 @@ const useBootVolumeColumns: UseBootVolumesColumns = (isModal) => {
     })),
     id: DataSourceModelRef,
     selectedColumns: new Set(activeColumns?.map((col) => col?.id)),
+    showNamespaceOverride: true,
     type: t('Bootable volumes'),
   };
 


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-29219

Hide unnecessary namespace related info text displayed usually in _Manage columns_ modal, part of `ListPageFilter` component, for list of bootable resources when creating VM from InstanceTypes, as namespace is not relevant for this page. Specifically, hide the following in the modal:

_The namespace column is only shown when in "All projects"_

## 🎥 Screenshots
**Before:**
![col_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/606a33df-b8cf-4d41-a226-652664d70c1e)

**After:**
![col_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/77688c27-266b-4295-a96a-f73d1adda304)


