### PR TITLE
CNV-31249: Bootable volume list does not listen to namespace bar

### DIFF
--- a/src/views/bootablevolumes/list/BootableVolumesList.tsx
+++ b/src/views/bootablevolumes/list/BootableVolumesList.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { RouteComponentProps, useHistory } from 'react-router-dom';
 
 import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import AddBootableVolumeModal from '@kubevirt-utils/components/AddBootableVolumeModal/AddBootableVolumeModal';
@@ -34,11 +34,8 @@ import useBootableVolumesFilters from './hooks/useBootableVolumesFilters';
 
 import '@kubevirt-utils/styles/list-managment-group.scss';
 
-type BootableVolumesListProps = {
-  namespace: string;
-};
-
-const BootableVolumesList: FC<BootableVolumesListProps> = ({ namespace }) => {
+const BootableVolumesList: FC<RouteComponentProps<{ ns: string }>> = ({ match }) => {
+  const namespace = match.params.ns;
   const { t } = useKubevirtTranslation();
   const history = useHistory();
   const { createModal } = useModal();


### PR DESCRIPTION
## 📝 Description

Fix bootable volumes list to listen to the namespace bar

## 🎥 Demo

Before:
![volumes-list-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/c6b586f3-8fde-4952-99a6-e25e0a225707)

After:
![volumes-list](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/9cb7fa09-ce3e-4831-a4c0-bfa627080334)
