### PR TITLE
CNV-31190: PVCs from default namespace present in catalog instanceType list page

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { getOSImagesNS } from 'src/views/clusteroverview/OverviewTab/inventory-card/utils/utils';
 
 import { SecretModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1Secret } from '@kubevirt-ui/kubevirt-api/kubernetes';
@@ -21,7 +22,7 @@ import { instanceTypeActionType } from './utils/types';
 export const useInstanceTypeVMStore = () => {
   const store = useInstanceTypeVMInitialStore();
 
-  const bootableVolumesData = useBootableVolumes();
+  const bootableVolumesData = useBootableVolumes(getOSImagesNS());
   const instanceTypesAndPreferencesData = useInstanceTypesAndPreferences();
   const [activeNamespace] = useActiveNamespace();
   const [authorizedSSHKeys, , loaded] = useKubevirtUserSettings('ssh');


### PR DESCRIPTION
## 📝 Description

The list was getting PVC and DS from all namespaces instead of just from the OS images namespace.

## 🎥 Demo

Before:
![volumes-list-create-vm-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/672c4162-6d04-40f9-95c0-fb681d5d5849)

After:
![volumes-list-create-vm](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/6a2513d5-5611-4862-af2e-cbc6077602c3)

