### PR TITLE
Bug 2221921: Change page title to "Bootable volumes"

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -191,7 +191,6 @@
   "Boot source reference cannot be edited": "Boot source reference cannot be edited",
   "Boot source type": "Boot source type",
   "bootable": "bootable",
-  "Bootable resources": "Bootable resources",
   "Bootable volumes": "Bootable volumes",
   "Breakdown by network": "Breakdown by network",
   "Bridge": "Bridge",

--- a/src/views/bootablevolumes/list/BootableVolumesList.tsx
+++ b/src/views/bootablevolumes/list/BootableVolumesList.tsx
@@ -80,7 +80,7 @@ const BootableVolumesList: FC<BootableVolumesListProps> = ({ namespace }) => {
 
   return (
     <>
-      <ListPageHeader title={t('Bootable resources')}>
+      <ListPageHeader title={t('Bootable volumes')}>
         {(canCreateDS || canCreatePVC) && (
           <ListPageCreateDropdown items={createItems} onClick={onCreate}>
             {t('Add volume')}


### PR DESCRIPTION
## 📝 Description

Fixes:
https://bugzilla.redhat.com/show_bug.cgi?id=2221921

_Jira:_
https://issues.redhat.com/browse/CNV-30859

Change page title from _Bootable resources_ to _Bootable volumes_ to match the menu item in `Virtualization` section. Make this change according to the UX suggestions.

## 🎥 Screenshots
**Before:**
 _Bootable resources_ page title vs _Bootable volumes_ in `Virtualization` section:
![boo_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/791f12d2-56ea-4b7d-9f3e-89871cf6535f)

**After:**
![boo_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/4f562bf6-fdd9-469d-ac7f-590eab196f16)


