### PR TITLE
Bug 2221939: Remove help icon for SSH key field in VM Sctips tab

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -990,7 +990,6 @@
   "Start this VirtualMachine in pause mode": "Start this VirtualMachine in pause mode",
   "Start VirtualMachine": "Start VirtualMachine",
   "Start VirtualMachine on clone": "Start VirtualMachine on clone",
-  "Static SSH keys can be added on <2>Overview > Settings > User > Manage SSH keys</2>.": "Static SSH keys can be added on <2>Overview > Settings > User > Manage SSH keys</2>.",
   "Status": "Status",
   "Status conditions": "Status conditions",
   "Stop": "Stop",

--- a/src/utils/components/DescriptionItem/DescriptionItemHeader.tsx
+++ b/src/utils/components/DescriptionItem/DescriptionItemHeader.tsx
@@ -15,7 +15,6 @@ type DescriptionItemHeaderProps = {
   bodyContent: ReactNode;
   breadcrumb?: string;
   descriptionHeader: string;
-  iconContent?: ReactNode;
   isPopover: boolean;
   label?: ReactNode;
   maxWidth?: string;
@@ -26,7 +25,6 @@ export const DescriptionItemHeader: FC<DescriptionItemHeaderProps> = ({
   bodyContent,
   breadcrumb,
   descriptionHeader,
-  iconContent,
   isPopover,
   label,
   maxWidth,
@@ -68,7 +66,7 @@ export const DescriptionItemHeader: FC<DescriptionItemHeaderProps> = ({
 
   return (
     <DescriptionListTerm>
-      {descriptionHeader} {iconContent} {label}
+      {descriptionHeader} {label}
     </DescriptionListTerm>
   );
 };

--- a/src/utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
+++ b/src/utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
@@ -24,7 +24,6 @@ type VirtualMachineDescriptionItemProps = {
   descriptionData: any;
   descriptionHeader?: string;
   editOnTitleJustify?: boolean;
-  iconContent?: ReactNode;
   isDisabled?: boolean;
   isEdit?: boolean;
   isPopover?: boolean;
@@ -42,7 +41,6 @@ const VirtualMachineDescriptionItem: FC<VirtualMachineDescriptionItemProps> = ({
   descriptionData,
   descriptionHeader,
   editOnTitleJustify = false,
-  iconContent,
   isDisabled,
   isEdit,
   isPopover,
@@ -80,7 +78,6 @@ const VirtualMachineDescriptionItem: FC<VirtualMachineDescriptionItemProps> = ({
               bodyContent={bodyContent}
               breadcrumb={breadcrumb}
               descriptionHeader={descriptionHeader}
-              iconContent={iconContent}
               isPopover={isPopover}
               label={label}
               moreInfoURL={moreInfoURL}

--- a/src/views/virtualmachines/details/tabs/configuration/scripts/ScriptsTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scripts/ScriptsTab.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useCallback, useMemo } from 'react';
-import { Trans } from 'react-i18next';
 import { RouteComponentProps } from 'react-router-dom';
 
 import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
@@ -8,7 +7,6 @@ import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevir
 import AlertScripts from '@kubevirt-utils/components/AlertScripts/AlertScripts';
 import { CloudInitDescription } from '@kubevirt-utils/components/CloudinitDescription/CloudInitDescription';
 import { CloudinitModal } from '@kubevirt-utils/components/CloudinitModal/CloudinitModal';
-import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import LinuxLabel from '@kubevirt-utils/components/Labels/LinuxLabel';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
@@ -31,7 +29,6 @@ import {
   DescriptionListDescription,
   Divider,
   PageSection,
-  PopoverPosition,
   Stack,
 } from '@patternfly/react-core';
 
@@ -115,21 +112,6 @@ const ScriptsTab: FC<VirtualMachineScriptPageProps> = ({ obj: vm }) => {
                   </div>
                   <SecretNameLabel secretName={secretName} />
                 </Stack>
-              }
-              iconContent={
-                <HelpTextIcon
-                  bodyContent={
-                    <Trans ns="plugin__kubevirt-plugin" t={t}>
-                      Static SSH keys can be added on{' '}
-                      <i>
-                        Overview {'>'} Settings {'>'} User {'>'} Manage SSH keys
-                      </i>
-                      .
-                    </Trans>
-                  }
-                  helpIconClassName="title-help-text-icon"
-                  position={PopoverPosition.right}
-                />
               }
               onEditClick={() =>
                 createModal((modalProps) => (


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://bugzilla.redhat.com/show_bug.cgi?id=2221939
see the comment: https://bugzilla.redhat.com/show_bug.cgi?id=2221939#c14

_Jira:_
https://issues.redhat.com/browse/CNV-30864

_Related PR that added the popover originally:_
https://github.com/kubevirt-ui/kubevirt-plugin/pull/1395

Remove "?" help icon with the popover containing the following text that was originally added to help the user find where to add static public SSH key:

_"Static SSH keys can be added on Overview > Settings > User > Manage SSH keys."_

Remove it from "Authorized SSH key" field/section in VM _Configuration_ > _Scripts_ tab, according to the suggestions from the doc team and UX.

## 🎥 Screenshots
**Before:**
"?" icon with popover present next to the _Authorized SSH key_:
![aut_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/bdd5d985-99a4-4518-969d-02fa83292bbd)

**After:**
No any "?" icon with popover present next to the _Authorized SSH key_:
![aut_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/e342d64c-37f0-4440-82ce-0cc54a4a157b)
