### PR TITLE
CNV-29082: Make "View alert" on Overview > Alerts card work

### DIFF
--- a/src/utils/hooks/useAlerts/utils/utils.ts
+++ b/src/utils/hooks/useAlerts/utils/utils.ts
@@ -1,6 +1,3 @@
-import { murmur3 } from 'murmurhash-js';
-
-import { MONITORING_SALT } from '@kubevirt-utils/constants/prometheus';
 import { Group, PrometheusRulesResponse } from '@kubevirt-utils/types/prometheus';
 import { generateAlertId } from '@kubevirt-utils/utils/prometheus';
 import {
@@ -15,8 +12,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 
 export const addAlertIdToRule = (group: Group, rule: PrometheusRule): Rule => {
-  const key = generateAlertId(group, rule);
-  return { ...rule, id: String(murmur3(key, MONITORING_SALT)) };
+  return { ...rule, id: generateAlertId(group, rule) };
 };
 
 export const getAlertsAndRules = (


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-29082

Make clicking on _View alert_ link to a specific alert work, accessible on _Virtualization > Overview > Alerts_ card > _Warnings_.

_How to reproduce a bug/test this PR:_
You need to clone the monitoring repo: https://github.com/openshift/monitoring-plugin
Then you just need to add it as the plugin and run that together with this repo, so that _Observe_ appears in the main menu in the UI. If you need help/more details, feel free to ask me. 

## 🎥 Demo
**Before:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/71a86c22-caf4-4ce3-bd2d-45709ac97679

**After:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/dfc998a7-36a0-4f95-ac6c-c7286321295e



