### PR TITLE
CNV-31357: Remove unnecessary text from Disks tab when customizing VM

### DIFF
--- a/src/views/catalog/wizard/tabs/disks/WizardDisksTab.tsx
+++ b/src/views/catalog/wizard/tabs/disks/WizardDisksTab.tsx
@@ -40,9 +40,6 @@ const WizardDisksTab: WizardTab = ({ loaded, tabsData, updateTabsData, updateVM,
           pathsToHighlight={PATHS_TO_HIGHLIGHT.DISKS_TAB}
           resource={vm}
         >
-          <Flex className="wizard-disk-tab__flex">
-            {t('The following information is provided by the OpenShift Virtualization operator.')}
-          </Flex>
           <ListPageCreateButton
             onClick={() =>
               createModal(({ isOpen, onClose }) => (
@@ -67,7 +64,7 @@ const WizardDisksTab: WizardTab = ({ loaded, tabsData, updateTabsData, updateVM,
                 />
               ))
             }
-            className="wizard-disk-tab__list-page-create-button"
+            className="list-page-create-button-margin"
             isDisabled={!loaded}
           >
             {t('Add disk')}

--- a/src/views/catalog/wizard/tabs/disks/wizard-disk-tab.scss
+++ b/src/views/catalog/wizard/tabs/disks/wizard-disk-tab.scss
@@ -8,12 +8,4 @@
   .pf-c-sidebar__panel {
     padding-top: var(--pf-global--spacer--lg);
   }
-
-  &__list-page-create-button {
-    margin: 1rem 0 0.5rem 0;
-  }
-
-  &__flex {
-    margin: 1.5rem 0 0 0;
-  }
 }


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-31357

Remove "The following information is provided by the OpenShift Virtualization operator" text from _Customize and create VirtualMachine_ page - _Disks_ tab, as it is not necessary. Make this change according to the latest UX suggestion.

## 🎥 Screenshots
**Before:**
![cus_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/de883d7f-1927-4afe-9ef2-c7eb651ee8d8)

**After:**
![cus_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/64c1d38e-4358-47c6-8e2a-a98ca13762de)


