### PR TITLE
CNV-31327: Display Default templates in Catalog by default

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogFilters/TemplatesCatalogFilters.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogFilters/TemplatesCatalogFilters.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo } from 'react';
 
 import { CATALOG_FILTERS } from '@catalog/templatescatalog/utils/consts';
+import { hasNoDefaultUserAllFilters } from '@catalog/templatescatalog/utils/helpers';
 import { TemplateFilters } from '@catalog/templatescatalog/utils/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
@@ -31,14 +32,14 @@ export const TemplatesCatalogFilters: FC<{
 
       <VerticalTabs>
         <VerticalTabsTab
-          active={!filters?.onlyDefault && !filters?.onlyUser}
+          active={filters?.allItems}
           data-test-id="catalog-template-filter-all-items"
           id={'all-templates'}
-          onActivate={() => onFilterChange(CATALOG_FILTERS.ONLY_DEFAULT, false)}
+          onActivate={() => onFilterChange(CATALOG_FILTERS.ALL_ITEMS, true)}
           title={t('All items')}
         />
         <VerticalTabsTab
-          active={filters?.onlyDefault}
+          active={filters?.onlyDefault || hasNoDefaultUserAllFilters(filters)}
           data-test-id="catalog-template-filter-default-templates"
           id={'default-templates'}
           onActivate={() => onFilterChange(CATALOG_FILTERS.ONLY_DEFAULT, true)}

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogHeader.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogHeader.tsx
@@ -12,6 +12,7 @@ import {
 import { ListIcon, ThIcon } from '@patternfly/react-icons';
 
 import { CATALOG_FILTERS } from '../utils/consts';
+import { hasNoDefaultUserAllFilters } from '../utils/helpers';
 import { TemplateFilters } from '../utils/types';
 
 export const TemplatesCatalogHeader: FC<{
@@ -40,9 +41,9 @@ export const TemplatesCatalogHeader: FC<{
   return (
     <div className="co-catalog-page__header">
       <div className="co-catalog-page__heading text-capitalize">
-        {(filters?.onlyDefault && t('Default templates')) ||
-          (filters?.onlyUser && t('User templates')) ||
-          t('All items')}
+        {(filters?.onlyDefault || hasNoDefaultUserAllFilters(filters)) && t('Default templates')}
+        {filters?.onlyUser && t('User templates')}
+        {filters?.allItems && t('All items')}
       </div>
       <div className="co-catalog-page__filter">
         <div>

--- a/src/views/catalog/templatescatalog/tests/TemplatesCatalog.test.tsx
+++ b/src/views/catalog/templatescatalog/tests/TemplatesCatalog.test.tsx
@@ -67,7 +67,7 @@ test('TemplatesCatalog', async () => {
   expect(getByTestId('container-template')).toBeInTheDocument();
 
   // not default variant template, clicking on 'All items', should be in catalog
-  fireEvent.click(getByTestId('catalog-template-filter-all-items'));
+  fireEvent.click(getByText('All items'));
   expect(getByTestId('url-template')).toBeInTheDocument();
 
   // switching to user templates, url template should be in catalog as custom template

--- a/src/views/catalog/templatescatalog/utils/consts.ts
+++ b/src/views/catalog/templatescatalog/utils/consts.ts
@@ -1,4 +1,5 @@
 export enum CATALOG_FILTERS {
+  ALL_ITEMS = 'allItems',
   IS_LIST = 'isList',
   NAMESPACE = 'namespace',
   ONLY_AVAILABLE = 'onlyAvailable',

--- a/src/views/catalog/templatescatalog/utils/helpers.ts
+++ b/src/views/catalog/templatescatalog/utils/helpers.ts
@@ -26,7 +26,9 @@ export const filterTemplates = (templates: V1Template[], filters: TemplateFilter
         getTemplateName(tmp).toLowerCase().includes(textFilterLowerCase) ||
         tmp?.metadata?.name?.includes(textFilterLowerCase);
 
-      const defaultVariantFilter = !filters?.onlyDefault || isDefaultVariantTemplate(tmp);
+      const defaultVariantFilter =
+        (!filters?.onlyDefault && !hasNoDefaultUserAllFilters(filters)) ||
+        isDefaultVariantTemplate(tmp);
 
       const userFilter = !filters.onlyUser || !isDefaultVariantTemplate(tmp);
 
@@ -73,3 +75,6 @@ export const updateVMCPUMemory = (
     return updateVM(updatedVM);
   };
 };
+
+export const hasNoDefaultUserAllFilters = (filters: TemplateFilters): boolean =>
+  !filters?.allItems && !filters?.onlyDefault && !filters?.onlyUser; // none of the filters are set - when first time in

--- a/src/views/catalog/templatescatalog/utils/types.ts
+++ b/src/views/catalog/templatescatalog/utils/types.ts
@@ -1,6 +1,7 @@
 import { CATALOG_FILTERS } from './consts';
 
 export type TemplateFilters = {
+  [CATALOG_FILTERS.ALL_ITEMS]: boolean;
   [CATALOG_FILTERS.IS_LIST]: boolean;
   [CATALOG_FILTERS.NAMESPACE]: string;
   [CATALOG_FILTERS.ONLY_AVAILABLE]: boolean;


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-31327

Display "Default templates" in Catalog page by default, when first time in, not "All items" as previously.

TODO:
- [x] fix failing unit test

## 🎥 Demo
**Before:**
"All items" displayed when accessing Catalog:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/d29b1e0d-0c90-490d-a298-f17b0401a49e

**After:**
"Default templates" displayed when accessing Catalog:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/2897915d-9aab-4d98-bfb2-5b57e1ee68e1


