### PR TITLE
CNV-28827: Remove upload option from template add/edit disk modal

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/DiskInterfaceSelect.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/DiskInterfaceSelect.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { ChangeEvent, Dispatch, FC, useEffect, useMemo, useState } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { diskTypes } from '@kubevirt-utils/resources/vm/utils/disk/constants';
@@ -12,11 +12,11 @@ import { getInterfaceOptions } from './utils/helpers';
 
 type DiskInterfaceSelectProps = {
   diskState: DiskFormState;
-  dispatchDiskState: React.Dispatch<DiskReducerActionType>;
+  dispatchDiskState: Dispatch<DiskReducerActionType>;
   isVMRunning: boolean;
 };
 
-const DiskInterfaceSelect: React.FC<DiskInterfaceSelectProps> = ({
+const DiskInterfaceSelect: FC<DiskInterfaceSelectProps> = ({
   diskState,
   dispatchDiskState,
   isVMRunning,
@@ -24,16 +24,16 @@ const DiskInterfaceSelect: React.FC<DiskInterfaceSelectProps> = ({
   const { t } = useKubevirtTranslation();
   const { diskInterface, diskType } = diskState || {};
   const isCDROMType = diskType === diskTypes.cdrom;
-  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  const interfaceOptions = React.useMemo(() => Object.values(getInterfaceOptions(t)), [t]);
+  const interfaceOptions = useMemo(() => getInterfaceOptions(), []);
 
-  const onSelect = (event: React.ChangeEvent<HTMLSelectElement>, value: string) => {
+  const onSelect = (event: ChangeEvent<HTMLSelectElement>, value: string) => {
     setIsOpen(false);
     dispatchDiskState({ payload: value, type: diskReducerActions.SET_DISK_INTERFACE });
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     // only SCSI is supported for hotplug
     if (isVMRunning && diskInterface !== interfaceTypes.SCSI) {
       dispatchDiskState({
@@ -43,7 +43,7 @@ const DiskInterfaceSelect: React.FC<DiskInterfaceSelectProps> = ({
     }
   }, [dispatchDiskState, isVMRunning, diskInterface]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // virtio is not supported for CDROM
     if (isCDROMType && diskInterface === interfaceTypes.VIRTIO) {
       dispatchDiskState({

--- a/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourceUrlInput.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/DiskSourceFormSelect/components/DiskSourceUrlInput.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { OS_IMAGE_LINKS, OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
@@ -9,9 +9,8 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { getURLSourceHelpertText } from '../../utils/helpers';
 import { HTTP_URL_PREFIX, HTTPS_URL_PREFIX } from '../utils/constants';
 
-const URLSourceHelperText: React.FC<{ os: OS_NAME_TYPES }> = ({ os }) => {
-  const { t } = useKubevirtTranslation();
-  const { afterLabelText, beforeLabelText, label } = getURLSourceHelpertText(t, os);
+const URLSourceHelperText: FC<{ os: OS_NAME_TYPES }> = ({ os }) => {
+  const { afterLabelText, beforeLabelText, label } = getURLSourceHelpertText(os);
   return (
     <>
       {beforeLabelText}
@@ -31,10 +30,10 @@ type DiskSourceUrlInputProps = {
   url: string;
 };
 
-const DiskSourceUrlInput: React.FC<DiskSourceUrlInputProps> = ({ onChange, os, url }) => {
+const DiskSourceUrlInput: FC<DiskSourceUrlInputProps> = ({ onChange, os, url }) => {
   const { t } = useKubevirtTranslation();
 
-  const isValidURL = React.useMemo(() => {
+  const isValidURL = useMemo(() => {
     if (!url) {
       return true;
     } else {

--- a/src/utils/components/DiskModal/DiskFormFields/utils/helpers.ts
+++ b/src/utils/components/DiskModal/DiskFormFields/utils/helpers.ts
@@ -1,60 +1,70 @@
-import { TFunction } from 'i18next';
 import { adjectives, animals, uniqueNamesGenerator } from 'unique-names-generator';
 
 import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import { V1DataVolumeTemplateSpec, V1Volume } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
 
 import { interfaceTypes, sourceTypes, volumeTypes } from './constants';
 
-export const getSourceOptions = (t: TFunction) => ({
-  blank: {
+type DropdownOptionProps = {
+  description: string;
+  id: string;
+  name: string;
+};
+
+export const getSourceOptions = (isTemplate: boolean): DropdownOptionProps[] => [
+  {
     description: t('Create an empty disk.'),
     id: sourceTypes.BLANK,
     name: t('Blank (creates PVC)'),
   },
-  clonePvc: {
+  {
     description: t(
       'Select an existing persistent volume claim already available on the cluster and clone it.',
     ),
     id: sourceTypes.CLONE_PVC,
     name: t('PVC (creates PVC)'),
   },
-  container: {
+  {
     description: t(
       'Upload content from a container located in a registry accessible from the cluster. The container disk is meant to be used only for read-only filesystems such as CD-ROMs or for small short-lived throw-away VMs.',
     ),
     id: sourceTypes.EPHEMERAL,
     name: t('Container (ephemeral)'),
   },
-  dataSource: {
+  {
     description: t('Select DataSource to use for automatic image upload.'),
     id: sourceTypes.DATA_SOURCE,
     name: t('PVC auto import (use DataSource)'),
   },
-  http: {
+  {
     description: t('Import content via URL (HTTP or HTTPS endpoint).'),
     id: sourceTypes.HTTP,
     name: t('URL (creates PVC)'),
   },
-  pvc: {
+  {
     description: t('Use a persistent volume claim (PVC) already available on the cluster.'),
     id: sourceTypes.PVC,
     name: t('Use an existing PVC'),
   },
-  registry: {
+  {
     description: t('Import content via container registry.'),
     id: sourceTypes.REGISTRY,
     name: t('Registry (creates PVC)'),
   },
-  upload: {
-    description: t('Upload a new file to PVC. a new PVC will be created.'),
-    id: sourceTypes.UPLOAD,
-    name: t('Upload (Upload a new file to PVC)'),
-  },
-});
+  ...(!isTemplate
+    ? [
+        {
+          description: t('Upload a new file to PVC. a new PVC will be created.'),
+          id: sourceTypes.UPLOAD,
+          name: t('Upload (Upload a new file to PVC)'),
+        },
+      ]
+    : []),
+];
 
-export const getURLSourceHelpertText = (t: TFunction, os: OS_NAME_TYPES) => {
+export const getURLSourceHelpertText = (os: OS_NAME_TYPES) => {
   switch (os) {
     case OS_NAME_TYPES.rhel:
       return {
@@ -86,29 +96,29 @@ export const getURLSourceHelpertText = (t: TFunction, os: OS_NAME_TYPES) => {
   }
 };
 
-export const getInterfaceOptions = (t: TFunction) => ({
-  sata: {
+export const getInterfaceOptions = (): DropdownOptionProps[] => [
+  {
     description: t(
       'Supported by most operating systems including Windows out of the box. Offers lower performance compared to virtio. Consider using it for CD-ROM devices.',
     ),
     id: interfaceTypes.SATA,
     name: t('SATA'),
   },
-  scsi: {
+  {
     description: t(
       'Paravirtualized iSCSI HDD driver offers similar functionality to the virtio-block device, with some additional enhancements. In particular, this driver supports adding hundreds of devices, and names devices using the standard SCSI device naming scheme.',
     ),
     id: interfaceTypes.SCSI,
     name: t('SCSI'),
   },
-  virtio: {
+  {
     description: t(
       'Optimized for best performance. Supported by most Linux distributions. Windows requires additional drivers to use this model.',
     ),
     id: interfaceTypes.VIRTIO,
     name: t('VirtIO'),
   },
-});
+];
 
 export const getVolumeType = (volume: V1Volume): string => {
   const volumeType = Object.keys(volume)?.find((key) => Object.values(volumeTypes).includes(key));

--- a/src/utils/components/DiskModal/EditDiskModal.tsx
+++ b/src/utils/components/DiskModal/EditDiskModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC, useCallback, useMemo, useReducer } from 'react';
 
 import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -49,30 +49,32 @@ type DiskModalProps = {
   initialDiskSourceState: DiskSourceState;
   initialDiskState: DiskFormState;
   isOpen: boolean;
+  isTemplate?: boolean;
   onClose: () => void;
   onSubmit: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine | void>;
   onUploadedDataVolume?: (dataVolume: V1beta1DataVolume) => void;
   vm: V1VirtualMachine;
 };
 
-const EditDiskModal: React.FC<DiskModalProps> = ({
+const EditDiskModal: FC<DiskModalProps> = ({
   createOwnerReference = true,
   headerText,
   initialDiskSourceState,
   initialDiskState,
   isOpen,
+  isTemplate = false,
   onClose,
   onSubmit,
   onUploadedDataVolume,
   vm,
 }) => {
   const { upload, uploadData } = useCDIUpload();
-  const [diskState, dispatchDiskState] = React.useReducer(diskReducer, initialDiskState);
-  const [diskSourceState, dispatchDiskSourceState] = React.useReducer(
+  const [diskState, dispatchDiskState] = useReducer(diskReducer, initialDiskState);
+  const [diskSourceState, dispatchDiskSourceState] = useReducer(
     diskSourceReducer,
     initialDiskSourceState,
   );
-  const sourceRequiresDataVolume = React.useMemo(
+  const sourceRequiresDataVolume = useMemo(
     () => requiresDataVolume(diskState.diskSource),
     [diskState.diskSource],
   );
@@ -81,7 +83,7 @@ const EditDiskModal: React.FC<DiskModalProps> = ({
     diskState?.storageClass,
   );
 
-  const uploadPromise = React.useCallback(() => {
+  const uploadPromise = useCallback(() => {
     const currentVmVolumes = getVolumes(vm);
 
     const volumeToUpdate = currentVmVolumes.find(
@@ -115,7 +117,7 @@ const EditDiskModal: React.FC<DiskModalProps> = ({
     uploadData,
   ]);
 
-  const updatedVirtualMachine: V1VirtualMachine = React.useMemo(() => {
+  const updatedVirtualMachine: V1VirtualMachine = useMemo(() => {
     const currentVmVolumes = getVolumes(vm);
 
     const volumeToUpdate = currentVmVolumes.find(
@@ -176,7 +178,7 @@ const EditDiskModal: React.FC<DiskModalProps> = ({
     initialDiskState.diskSource,
   ]);
 
-  const handleSubmit = React.useCallback(
+  const handleSubmit = useCallback(
     async (updatedVM: V1VirtualMachine) => {
       if (diskState.diskSource === sourceTypes.UPLOAD) {
         await uploadPromise();
@@ -212,6 +214,7 @@ const EditDiskModal: React.FC<DiskModalProps> = ({
           diskState={diskState}
           dispatchDiskSourceState={dispatchDiskSourceState}
           dispatchDiskState={dispatchDiskState}
+          isTemplate={isTemplate}
           isVMRunning={false}
           relevantUpload={upload}
           vm={vm}

--- a/src/views/templates/details/tabs/disks/TemplateDisksPage.tsx
+++ b/src/views/templates/details/tabs/disks/TemplateDisksPage.tsx
@@ -77,6 +77,7 @@ const TemplateDisksPage: FC<TemplateDisksPageProps> = ({ obj: template }) => {
                   createOwnerReference={false}
                   headerText={t('Add disk')}
                   isOpen={isOpen}
+                  isTemplate
                   onClose={onClose}
                   onSubmit={onUpdate}
                   vm={vm}

--- a/src/views/templates/details/tabs/disks/components/DiskRowActions.tsx
+++ b/src/views/templates/details/tabs/disks/components/DiskRowActions.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC, useCallback, useState } from 'react';
 
 import { produceVMDisks } from '@catalog/utils/WizardVMContext';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -25,15 +25,15 @@ type DiskRowActionsProps = {
   vm: V1VirtualMachine;
 };
 
-const DiskRowActions: React.FC<DiskRowActionsProps> = ({ diskName, isDisabled, onUpdate, vm }) => {
+const DiskRowActions: FC<DiskRowActionsProps> = ({ diskName, isDisabled, onUpdate, vm }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
-  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const deleteBtnText = t('Detach');
 
   const { initialDiskSourceState, initialDiskState } = useEditDiskStates(vm, diskName);
 
-  const onDelete = React.useCallback(() => {
+  const onDelete = useCallback(() => {
     const vmWithDeletedDisk = produceVMDisks(vm, (draftVM) => {
       const volumeToDelete = draftVM.spec.template.spec.volumes.find(
         (volume) => volume.name === diskName,
@@ -82,6 +82,7 @@ const DiskRowActions: React.FC<DiskRowActionsProps> = ({ diskName, isDisabled, o
         initialDiskSourceState={initialDiskSourceState}
         initialDiskState={initialDiskState}
         isOpen={isOpen}
+        isTemplate
         onClose={onClose}
         onSubmit={onUpdate}
         vm={vm}


### PR DESCRIPTION
## 📝 Description

Since upload is occurring instantly to a PVC, we can't save an upload to a template to be created.
Removing the upload option from the add disk / edit disk flow for Templates view

## 🎥 Demo

Before:
![remove-upload-from-template-edit-disk-modal-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/af105275-990c-4055-9484-a42e297bd495)
![remove-upload-from-template-disk-modal-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/99eb2e3f-d2cb-4938-84c1-b8efec9c166f)

After:
![remove-upload-from-template-edit-disk-modal](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/04785b94-8b7d-4d88-97b7-472f705f53b5)
![remove-upload-from-template-disk-modal](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/b19ba57a-56a0-4cd4-a23b-f7a7c5547ecd)

