### PR TITLE
Delete modal count

### DIFF
--- a/src/views/virtualmachines/actions/components/DeleteVMModal/components/DeleteOwnedResourcesMessage.tsx
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/components/DeleteOwnedResourcesMessage.tsx
@@ -7,6 +7,8 @@ import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Bullseye, Checkbox, StackItem } from '@patternfly/react-core';
 
+import { findPVCOwner } from '../utils/helpers';
+
 type DeleteOwnedResourcesMessageProps = {
   dataVolumes: V1beta1DataVolume[];
   deleteOwnedResource: boolean;
@@ -34,7 +36,9 @@ const DeleteOwnedResourcesMessage: React.FC<DeleteOwnedResourcesMessageProps> = 
     );
   }
 
-  const diskCount = dataVolumes?.length + pvcs?.length || 0;
+  const pvcsWithNoDataVolumes = pvcs?.filter((pvc) => !findPVCOwner(pvc, dataVolumes));
+
+  const diskCount = dataVolumes?.length + pvcsWithNoDataVolumes?.length || 0;
   const hasSnapshots = snapshots?.length > 0;
 
   return (

--- a/src/views/virtualmachines/actions/components/DeleteVMModal/utils/helpers.ts
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/utils/helpers.ts
@@ -1,7 +1,12 @@
 import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import { compareOwnerReferences } from '@kubevirt-utils/resources/shared';
-import { K8sModel, k8sPatch, OwnerReference } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  K8sModel,
+  k8sPatch,
+  K8sResourceCommon,
+  OwnerReference,
+} from '@openshift-console/dynamic-plugin-sdk';
 
 export const updateVolumeResources = (
   resources: IoK8sApiCoreV1PersistentVolumeClaim[] | V1beta1DataVolume[],
@@ -25,3 +30,11 @@ export const updateVolumeResources = (
     });
   });
 };
+
+export const findPVCOwner = (
+  pvc: IoK8sApiCoreV1PersistentVolumeClaim,
+  resources: K8sResourceCommon[],
+) =>
+  resources.find((resource) =>
+    pvc?.metadata?.ownerReferences.find((owner) => owner.uid === resource.metadata.uid),
+  );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When data volume garbage collector is disabled, we count two times the data volume disks. 
One as PVC and one as dv but they are actually the same disk.

Here: https://github.com/kubevirt-ui/kubevirt-plugin/blob/5c9a4131711ee885c01e297fd91bef19caa4b772/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useDataVolumeConvertedVolumeNames.ts

So, just filter the PVC already represented by the DV in the count. 

## 🎥 Demo

**Before**
![Screenshot from 2023-08-02 16-15-45](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/11ba3a41-9b2d-494a-8772-12d781e558ad)
![Screenshot from 2023-08-02 16-15-39](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/65b7699f-e482-48a3-b007-ad84326a437f)


**After**
![Screenshot from 2023-08-02 16-12-18](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/a2c2f0f3-f102-42de-9ad4-08c286028a88)
![Screenshot from 2023-08-02 16-12-10](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/db1c22fa-474c-4b93-81c4-c404e67f9b66)

