### PR TITLE
CNV-31532: Cannot add environment disk to instanceType VM

### DIFF
--- a/src/utils/components/EnvironmentEditor/hooks/useEnvironments.ts
+++ b/src/utils/components/EnvironmentEditor/hooks/useEnvironments.ts
@@ -63,7 +63,7 @@ const useEnvironments = (
 
       const diskName = `environment-disk-${getRandomChars()}`;
       getDisks(draftVM).push({
-        disk: { bus: 'sata' },
+        disk: {},
         name: diskName,
         serial: getRandomSerial().toUpperCase(),
       });


### PR DESCRIPTION
## 📝 Description

When adding an env disk we add bus: sata property which is not a must according to kubevirt docs: https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#as-a-disk

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/600041d5-0ceb-4e65-959a-28c8ab1c973d

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/dd110234-9ca8-4f18-be80-81dccc7a06f2


