### PR TITLE
CNV-28248: Display CPU and memory from VMI on VM Details page

### DIFF
--- a/src/utils/resources/vm/hooks/useInstanceType.ts
+++ b/src/utils/resources/vm/hooks/useInstanceType.ts
@@ -1,0 +1,36 @@
+import {
+  VirtualMachineClusterInstancetypeModelGroupVersionKind,
+  VirtualMachineInstancetypeModelGroupVersionKind,
+} from '@kubevirt-ui/kubevirt-api/console';
+import {
+  V1beta1VirtualMachineInstancetype,
+  V1InstancetypeMatcher,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+type UseInstanceType = (instanceTypeMatcher: V1InstancetypeMatcher) => {
+  instanceType: V1beta1VirtualMachineInstancetype;
+  instanceTypeLoaded: boolean;
+  instanceTypeLoadError: Error;
+};
+
+const useInstanceType: UseInstanceType = (instanceTypeMatcher) => {
+  const [instanceType, instanceTypeLoaded, instanceTypeLoadError] =
+    useK8sWatchResource<V1beta1VirtualMachineInstancetype>(
+      !isEmpty(instanceTypeMatcher) && {
+        groupVersionKind: instanceTypeMatcher.kind.includes('cluster')
+          ? VirtualMachineClusterInstancetypeModelGroupVersionKind
+          : VirtualMachineInstancetypeModelGroupVersionKind,
+        name: instanceTypeMatcher.name,
+      },
+    );
+
+  return {
+    instanceType,
+    instanceTypeLoaded,
+    instanceTypeLoadError,
+  };
+};
+
+export default useInstanceType;

--- a/src/utils/resources/vm/hooks/useVMI.ts
+++ b/src/utils/resources/vm/hooks/useVMI.ts
@@ -1,0 +1,29 @@
+import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+type UseVMI = (
+  vmName: string,
+  vmNamespace: string,
+) => {
+  vmi: V1VirtualMachineInstance;
+  vmiLoaded: boolean;
+  vmiLoadError: Error;
+};
+
+const useVMI: UseVMI = (vmName, vmNamespace) => {
+  const [vmi, vmiLoaded, vmiLoadError] = useK8sWatchResource<V1VirtualMachineInstance>({
+    groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
+    isList: false,
+    name: vmName,
+    namespace: vmNamespace,
+  });
+
+  return {
+    vmi,
+    vmiLoaded,
+    vmiLoadError,
+  };
+};
+
+export default useVMI;

--- a/src/utils/resources/vm/hooks/useVMIAndPodsForVM.ts
+++ b/src/utils/resources/vm/hooks/useVMIAndPodsForVM.ts
@@ -1,9 +1,6 @@
-import {
-  modelToGroupVersionKind,
-  PodModel,
-  VirtualMachineInstanceModelGroupVersionKind,
-} from '@kubevirt-ui/kubevirt-api/console';
+import { modelToGroupVersionKind, PodModel } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
 import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 type UseVMIAndPodsForVMValues = {
@@ -17,12 +14,7 @@ export const useVMIAndPodsForVM = (
   vmName: string,
   vmNamespace: string,
 ): UseVMIAndPodsForVMValues => {
-  const [vmi, vmiLoaded, vmiLoadError] = useK8sWatchResource<V1VirtualMachineInstance>({
-    groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
-    isList: false,
-    name: vmName,
-    namespace: vmNamespace,
-  });
+  const { vmi, vmiLoaded, vmiLoadError } = useVMI(vmName, vmNamespace);
 
   const [pods, podsLoaded, podsLoadError] = useK8sWatchResource<K8sResourceCommon[]>({
     groupVersionKind: modelToGroupVersionKind(PodModel),


### PR DESCRIPTION
## 📝 Description

For VMs created from InstanceTypes the CPU and memory on the VM Details page is currently being read from the InstanceType, which leads to a mismatch on the VM Details page if the Instancetype is updated. The value circled on the graph shows the actual value.

## 🎥 Screenshots

The InstanceType used to create the VM starts off having 1 CPU and 4GiB of RAM. Between the "Before InstanceType update" and "After InstanceType update" screenshots, that InstanceType is edited to have 2 CPU and 2GiB of RAM.

### Before

#### Before InstanceType update
![Selection_251](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/6e4d2b15-b8d7-494a-a362-2a34154e2899)


#### After InstanceType update
![Selection_250](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/759213f0-ca1b-4b86-bc72-cdcbecb14a2d)

### After

#### Before InstanceType update
![Selection_252](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/b46b60fe-6eed-4edf-ab25-78f4e5538f4a)


#### After InstanceType update
![Selection_253](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/6b516c9e-67f0-49f3-8eb8-658d4f78a512)


