### PR TITLE
CNV-31327: Filter User templates in Catalog correctly

### DIFF
--- a/src/utils/resources/template/utils/helpers.ts
+++ b/src/utils/resources/template/utils/helpers.ts
@@ -7,7 +7,11 @@ import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getAnnotation } from '@kubevirt-utils/resources/shared';
 
 import { ANNOTATIONS } from './annotations';
-import { GENERATE_VM_PRETTY_NAME_ANNOTATION } from './constants';
+import {
+  GENERATE_VM_PRETTY_NAME_ANNOTATION,
+  TEMPLATE_TYPE_BASE,
+  TEMPLATE_TYPE_LABEL,
+} from './constants';
 import { getTemplatePVCName } from './selectors';
 
 // Only used for replacing parameters in the template, do not use for anything else
@@ -25,6 +29,9 @@ export const poorManProcess = (template: V1Template): V1Template => {
 
   return JSON.parse(templateString);
 };
+
+export const isCommonTemplate = (template: V1Template): boolean =>
+  template?.metadata?.labels?.[TEMPLATE_TYPE_LABEL] === TEMPLATE_TYPE_BASE;
 
 export const isDeprecatedTemplate = (template: V1Template): boolean =>
   getAnnotation(template, ANNOTATIONS.deprecated) === 'true';

--- a/src/views/catalog/templatescatalog/utils/helpers.ts
+++ b/src/views/catalog/templatescatalog/utils/helpers.ts
@@ -4,7 +4,7 @@ import { UpdateValidatedVM } from '@catalog/utils/WizardVMContext';
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
-import { OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
+import { isCommonTemplate, OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
 import {
   getTemplateName,
   getTemplateOS,
@@ -14,6 +14,9 @@ import {
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 
 import { TemplateFilters } from './types';
+
+const isUserTemplate = (template: V1Template): boolean =>
+  !isDefaultVariantTemplate(template) && !isCommonTemplate(template);
 
 export const filterTemplates = (templates: V1Template[], filters: TemplateFilters): V1Template[] =>
   templates
@@ -30,7 +33,7 @@ export const filterTemplates = (templates: V1Template[], filters: TemplateFilter
         (!filters?.onlyDefault && !hasNoDefaultUserAllFilters(filters)) ||
         isDefaultVariantTemplate(tmp);
 
-      const userFilter = !filters.onlyUser || !isDefaultVariantTemplate(tmp);
+      const userFilter = !filters.onlyUser || isUserTemplate(tmp);
 
       const workloadFilter = filters?.workload?.size <= 0 || filters.workload.has(workload);
 

--- a/src/views/clusteroverview/OverviewTab/inventory-card/utils/constants.ts
+++ b/src/views/clusteroverview/OverviewTab/inventory-card/utils/constants.ts
@@ -1,3 +1,2 @@
 export const TEMPLATE_CUSTOMIZED_ANNOTATION = 'template.kubevirt.ui/customized-template';
 export const DEFAULT_OS_VARIANT = 'template.kubevirt.io/default-os-variant';
-export const TEMPLATE_DEPRECATED_ANNOTATION = 'template.kubevirt.io/deprecated';

--- a/src/views/clusteroverview/OverviewTab/inventory-card/utils/flattenTemplates.ts
+++ b/src/views/clusteroverview/OverviewTab/inventory-card/utils/flattenTemplates.ts
@@ -1,10 +1,9 @@
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getAnnotation } from '@kubevirt-utils/resources/shared';
 import {
   getTemplateName,
-  TEMPLATE_TYPE_BASE,
-  TEMPLATE_TYPE_LABEL,
+  isCommonTemplate,
+  isDeprecatedTemplate,
   TEMPLATE_WORKLOAD_LABEL,
 } from '@kubevirt-utils/resources/template';
 import { findKeySuffixValue } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
@@ -13,11 +12,7 @@ import { WatchK8sResultsObject } from '@openshift-console/dynamic-plugin-sdk';
 
 import { K8sResourceKind } from '../../../utils/types';
 
-import {
-  DEFAULT_OS_VARIANT,
-  TEMPLATE_CUSTOMIZED_ANNOTATION,
-  TEMPLATE_DEPRECATED_ANNOTATION,
-} from './constants';
+import { DEFAULT_OS_VARIANT, TEMPLATE_CUSTOMIZED_ANNOTATION } from './constants';
 import {
   Flatten,
   TemplateItem,
@@ -32,12 +27,6 @@ export const getLoadedData = <T extends K8sResourceKind | K8sResourceKind[] = K8
   result: WatchK8sResultsObject<T>,
   defaultValue = null,
 ): T => (result && result.loaded && !result.loadError ? result.data : defaultValue);
-
-export const isCommonTemplate = (template: V1Template): boolean =>
-  template?.metadata?.labels?.[TEMPLATE_TYPE_LABEL] === TEMPLATE_TYPE_BASE;
-
-export const isDeprecatedTemplate = (template: V1Template): boolean =>
-  getAnnotation(template, TEMPLATE_DEPRECATED_ANNOTATION) === 'true';
 
 export const getWorkloadProfile = (vm: VMGenericLikeEntityKind) =>
   findKeySuffixValue(getLabels(vm), TEMPLATE_WORKLOAD_LABEL);


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-31327

This is hopefully the last PR that belongs to the feature (see the link above).

Display really only user created templates in _Catalog_ page when clicking on _User templates_. Filter out common templates from templates previously displayed in the page as user created templates.

Additionally, remove `isDeprecatedTemplate` from _src/views/clusteroverview/OverviewTab/inventory-card/utils/flattenTemplates.ts_ because the same function is already defined in _src/utils/resources/template/utils/helpers.ts_ (same definition). It's better if you DRY.

## 🎥 Screenshots
**Before:**
Common templates present in the page when clicking on "User templates":
![u_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/b735631a-d88b-4aff-86f5-3b53b0a4a0c4)

**After:**
Only user created templates displayed:
![u_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/dfa349d3-82db-4b6e-abf2-42fe227583ed)

