### PR TITLE
Adding support to run more plugin along side kubevirt

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,6 +184,7 @@
     "postinstall": "cp node_modules/@openshift-console/dynamic-plugin-sdk/docs/console-extensions.md .",
     "prepare": "husky install",
     "start-console": "./start-console.sh",
+    "start-console-with-monitoring": "./start-console.sh monitoring-plugin",
     "test": "jest",
     "test-cov": "jest --coverage",
     "test-cypress": "cd cypress && $(npm bin)/cypress open --config-file ./cypress.json --env openshift=true",

--- a/start-console.sh
+++ b/start-console.sh
@@ -1,10 +1,41 @@
 #!/usr/bin/env bash
-
+#Please run this script under bash 4+
 set -euo pipefail
 
-npm_package_consolePlugin_name="kubevirt-plugin"
+#Cloning, pulling and running other plugins starting from port 9002
+# to add more plugin simply add more properites to dic. [name-of-plugin]={git-repo-url}
+declare -A plugins=(["monitoring-plugin"]="https://github.com/openshift/monitoring-plugin.git")
+declare -A runningPlugins=(["podman-linux"]="kubevirt-plugin=http://localhost:9001", ["podman"]="kubevirt-plugin=http://host.containers.internal:9001", ["docker"]="kubevirt-plugin=http://host.docker.internal:9001")
 
-CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console:latest"}
+INITIAL_PORT=9002
+for arg in $@; do
+
+    if [ ! -d "../$arg" ]; then
+        echo "Creating a folder $arg ..."
+        cd ../
+        echo "Cloning "${plugins[$arg]}" ..."
+        git clone ${plugins[$arg]}
+        cd $arg
+    else
+        cd ../$arg
+    fi
+
+    git pull
+    yarn
+
+    if [ "$(lsof -t -i:$INITIAL_PORT)" != "" ]; then
+        kill -9 $(lsof -t -i:$INITIAL_PORT)
+    fi
+
+    yarn start --port=$INITIAL_PORT &
+
+    runningPlugins["podman-linux"]+=",${arg}=http://localhost:${INITIAL_PORT}"
+    runningPlugins["podman"]+=",${arg}=http://host.containers.internal:${INITIAL_PORT}"
+    runningPlugins["docker"]+=",${arg}=http://host.docker.internal:${INITIAL_PORT}"
+    INITIAL_PORT=$(($INITIAL_PORT + 1))
+done
+
+CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console"}
 CONSOLE_PORT=${CONSOLE_PORT:=9000}
 
 echo "Starting local OpenShift console..."
@@ -20,23 +51,21 @@ BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
 BRIDGE_USER_SETTINGS_LOCATION="localstorage"
 BRIDGE_I18N_NAMESPACES="plugin__kubevirt-plugin"
 
-BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.docker.internal:9001"
-
 echo "API Server: $BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT"
 echo "Console Image: $CONSOLE_IMAGE"
 echo "Console URL: http://localhost:${CONSOLE_PORT}"
 
-# Prefer podman if installed. Otherwise, fall back to docker.
+#Prefer podman if installed. Otherwise, fall back to docker.
 if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
-        BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://localhost:9001"
+        BRIDGE_PLUGINS="${runningPlugins["podman-linux"]}"
         podman run --pull=always --rm --network=host --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
     else
-        BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.containers.internal:9001"
+        BRIDGE_PLUGINS="${runningPlugins["podman"]}"
         podman run --pull=always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
     fi
 else
-    BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.docker.internal:9001"
+    BRIDGE_PLUGINS="${runningPlugins["docker"]}"
     docker run --pull=always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
 fi


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Adding the option to run more plugin along side kubevirt from a single terminal
just neeed to run yarn start-console-with-monitoring
## 🎥 Demo


