### PR TITLE
CNV-31863: Stay on Bootable volumes list after DS deletion

### DIFF
--- a/src/utils/components/DeleteModal/DeleteModal.tsx
+++ b/src/utils/components/DeleteModal/DeleteModal.tsx
@@ -35,10 +35,9 @@ const DeleteModal: FC<DeleteModalProps> = memo(
 
     return (
       <TabModal<K8sResourceCommon>
-        onSubmit={() => {
-          return onDeleteSubmit().then(() => {
-            history.push(url);
-          });
+        onSubmit={async () => {
+          await onDeleteSubmit();
+          history.push(url);
         }}
         headerText={headerText || t('Delete Resource?')}
         isOpen={isOpen}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-31863

Fix incorrect redirection after deleting a DataSource in _Bootable volumes_ list page, stay in the same page, not redirect to _DataSources_ list page. Fix the bug by adding missing `redirectUrl` prop to `DeleteModal`, with the appropriate value. 

## 🎥 Demo
**Before**:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/548b4af8-1cb8-4ac4-acc9-863d7eb68054

**After**:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/17c3da8e-adb2-45a5-a58c-c93f80836d7c

