### PR TITLE
CNV-23926:  Fixing the warning in the "Add Disk" modal

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/BootSourceCheckbox/BootSourceCheckbox.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/BootSourceCheckbox/BootSourceCheckbox.tsx
@@ -31,7 +31,7 @@ const BootSourceCheckbox: React.FC<BootSourceCheckboxProps> = ({
   isDisabled,
 }) => {
   const { t } = useKubevirtTranslation();
-  const showOverrideAlert = !isDisabled && isBootSource;
+  const showOverrideAlert = !isDisabled && isBootSource && initialBootDiskName;
 
   return (
     <FormGroup fieldId="enable-bootsource">


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
When we are in the process of creating a new VM and delete the existing disks, and want to add a new disk that will be used as a boot source, the warning is incorrect because there is no boot source before it and we don't need it.
## 🎥 Demo

> Please add a video or an image of the behavior/changes
Before:
![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/61961469/2b3f9def-c71a-4eb0-8b79-86dc53317f3e)

After:
![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/61961469/da7a818e-b8b9-4066-aaeb-900e0364cba6)
