### PR TITLE
CNV-31946: VM cannot be started if the secret name does not match the k8s conventions

### DIFF
--- a/src/utils/components/SSHSecretSection/SSHSecretModal.tsx
+++ b/src/utils/components/SSHSecretSection/SSHSecretModal.tsx
@@ -6,7 +6,8 @@ import MutedTextSpan from '../MutedTextSpan/MutedTextSpan';
 import TabModal from '../TabModal/TabModal';
 
 import useSecretsData from './hooks/useSecretsData';
-import { SSHSecretDetails } from './utils/types';
+import { SecretSelectionOption, SSHSecretDetails } from './utils/types';
+import { createSSHSecret } from './utils/utils';
 import SSHSecretSection from './SSHSecretSection';
 
 type SSHSecretModalProps = {
@@ -40,11 +41,18 @@ const SSHSecretModal: FC<SSHSecretModalProps> = ({
 
   return (
     <TabModal
+      onSubmit={async () => {
+        const { secretOption, sshPubKey, sshSecretName } = sshDetails;
+        if (secretOption === SecretSelectionOption.addNew) {
+          await createSSHSecret(sshPubKey, sshSecretName, namespace, true);
+        }
+
+        return onSubmit(sshDetails);
+      }}
       headerText={t('Authorized SSH key')}
       isDisabled={isDisabled}
       isOpen={isOpen}
       onClose={onClose}
-      onSubmit={() => onSubmit(sshDetails)}
     >
       <MutedTextSpan text={t('SSH key is saved in the project as a secret')} />
       <SSHSecretSection

--- a/src/utils/components/SSHSecretSection/utils/utils.ts
+++ b/src/utils/components/SSHSecretSection/utils/utils.ts
@@ -118,7 +118,12 @@ export const getCloudInitConfigDrive = (
     : { ...cloudInitVolumeData, userData: userDataClean };
 };
 
-export const createSSHSecret = (sshKey: string, secretName: string, secretNamespace: string) =>
+export const createSSHSecret = (
+  sshKey: string,
+  secretName: string,
+  secretNamespace: string,
+  dryRun = false,
+) =>
   k8sCreate<K8sResourceCommon & { data?: { [key: string]: string } }>({
     data: {
       apiVersion: SecretModel.apiVersion,
@@ -130,4 +135,5 @@ export const createSSHSecret = (sshKey: string, secretName: string, secretNamesp
       },
     },
     model: SecretModel,
+    ...(dryRun && { queryParams: { dryRun: 'All' } }),
   });

--- a/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings.ts
@@ -110,27 +110,28 @@ const useKubevirtUserSettings: UseKubevirtUserSettings = (key) => {
 
   const updateUserSetting = (val: any) => {
     setUserSettings((prevUserSettings) => {
+      const updateResource = async (data: { [key: string]: any }) => {
+        try {
+          await k8sPatch({
+            data: [
+              {
+                op: 'replace',
+                path: `/data/${userName}`,
+                value: JSON.stringify(data),
+              },
+            ],
+            model: ConfigMapModel,
+            resource: userConfigMap,
+          });
+        } catch (e) {
+          setError(e);
+        }
+      };
+
       const data = key ? { ...prevUserSettings, [key]: val } : val;
       updateResource(data);
       return data;
     });
-    const updateResource = async (data: { [key: string]: any }) => {
-      try {
-        await k8sPatch({
-          data: [
-            {
-              op: 'replace',
-              path: `/data/${userName}`,
-              value: JSON.stringify(data),
-            },
-          ],
-          model: ConfigMapModel,
-          resource: userConfigMap,
-        });
-      } catch (e) {
-        setError(e);
-      }
-    };
   };
 
   return [


### PR DESCRIPTION

## 📝 Description

The UI has a few specific input validations, but we should also validate against the BE validation.
Processing the secret with the `dryRun` param will apply an error to the modal dialog if the request is not proper.

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/a091aae2-040c-4734-9c12-3589ebc8eee5

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/c2f831d4-d9ac-4bf3-b4fe-1c0f9ccf8149


