### PR TITLE
CNV-31483: Add pending NICs to list in VM Details page

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -788,6 +788,7 @@
   "Pause VirtualMachine": "Pause VirtualMachine",
   "PCI host devices": "PCI host devices",
   "PCI Host devices": "PCI Host devices",
+  "Pending": "Pending",
   "Pending changes": "Pending changes",
   "Permissions": "Permissions",
   "Persistent Hotplug": "Persistent Hotplug",

--- a/src/utils/components/PendingBadge/PendingBadge.scss
+++ b/src/utils/components/PendingBadge/PendingBadge.scss
@@ -1,0 +1,3 @@
+.pending-badge {
+  margin-left: var(--pf-global--spacer--sm);
+}

--- a/src/utils/components/PendingBadge/PendingBadge.tsx
+++ b/src/utils/components/PendingBadge/PendingBadge.tsx
@@ -1,0 +1,17 @@
+import React, { FC } from 'react';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { Label } from '@patternfly/react-core';
+
+import './PendingBadge.scss';
+
+const PendingBadge: FC = () => {
+  const { t } = useKubevirtTranslation();
+  return (
+    <Label className="pending-badge" color="orange">
+      {t('Pending')}
+    </Label>
+  );
+};
+
+export default PendingBadge;

--- a/src/utils/resources/vm/utils/network/utils.ts
+++ b/src/utils/resources/vm/utils/network/utils.ts
@@ -1,7 +1,12 @@
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
+import { getVMIInterfaces, getVMINetworks } from '@kubevirt-utils/resources/vmi/utils/selectors';
+import { removeDuplicatesByName } from '@kubevirt-utils/utils/utils';
+
 import { NetworkPresentation } from './constants';
 import { getPrintableNetworkInterfaceType } from './selectors';
 
-export const nicsSorting = (nics: NetworkPresentation[], direction: string) =>
+export const sortNICs = (nics: NetworkPresentation[], direction: string) =>
   nics.sort((a: NetworkPresentation, b: NetworkPresentation) => {
     const aUpdated = getPrintableNetworkInterfaceType(a.iface);
     const bUpdated = getPrintableNetworkInterfaceType(b.iface);
@@ -12,3 +17,19 @@ export const nicsSorting = (nics: NetworkPresentation[], direction: string) =>
         : bUpdated.localeCompare(aUpdated);
     }
   });
+
+export const getInterfacesAndNetworks = (vm: V1VirtualMachine, vmi: V1VirtualMachineInstance) => {
+  const vmNetworks = getNetworks(vm) || [];
+  const vmInterfaces = getInterfaces(vm) || [];
+
+  const vmiInterfaces = getVMIInterfaces(vmi) || [];
+  const vmiNetworks = getVMINetworks(vmi) || [];
+
+  const networks = removeDuplicatesByName([...vmNetworks, ...vmiNetworks]);
+  const interfaces = removeDuplicatesByName([...vmInterfaces, ...vmiInterfaces]);
+
+  return {
+    interfaces,
+    networks,
+  };
+};

--- a/src/utils/resources/vm/utils/selectors.ts
+++ b/src/utils/resources/vm/utils/selectors.ts
@@ -158,3 +158,11 @@ export const getIsDynamicSSHInjectionEnabled = (vm: V1VirtualMachine): boolean =
 export const getVMSSHSecretName = (vm: V1VirtualMachine): string =>
   getAccessCredentials(vm)?.find((ac) => ac?.sshPublicKey?.source?.secret?.secretName)?.sshPublicKey
     ?.source?.secret?.secretName;
+
+/**
+ * A selector that returns the autoAttachPodInterface of the VM
+ * @param {V1VirtualMachine} vm the virtual machine
+ * @returns {boolean} the autoAttachPodInterface
+ */
+export const getAutoAttachPodInterface = (vm: V1VirtualMachine): boolean =>
+  vm?.spec?.template?.spec?.domain?.devices?.autoattachPodInterface;

--- a/src/utils/resources/vmi/utils/selectors.ts
+++ b/src/utils/resources/vmi/utils/selectors.ts
@@ -7,6 +7,13 @@ import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 export const getVMIVolumes = (vmi: V1VirtualMachineInstance) => vmi?.spec?.volumes;
 
 /**
+ * A selector for the virtual machine instance's networks
+ * @param {V1VirtualMachineInstance} vmi the virtual machine
+ * @returns the virtual machine instance networks
+ */
+export const getVMINetworks = (vmi: V1VirtualMachineInstance) => vmi?.spec?.networks;
+
+/**
  * A selector for the virtual machine instance's interfaces
  * @param {V1VirtualMachineInstance} vmi the virtual machine
  * @returns the virtual machine instance interfaces

--- a/src/utils/utils/utils.ts
+++ b/src/utils/utils/utils.ts
@@ -111,3 +111,9 @@ export const columnSorting = <T>(
   };
   return data?.sort(predicate)?.slice(startIndex, endIndex);
 };
+
+export const removeDuplicatesByName = (array: any[]) =>
+  array?.reduce((acc, curr) => {
+    if (!acc.find((item) => item?.name === curr?.name)) acc.push(curr);
+    return acc;
+  }, []);

--- a/src/views/catalog/wizard/tabs/network/hooks/useNetworkColumns.ts
+++ b/src/views/catalog/wizard/tabs/network/hooks/useNetworkColumns.ts
@@ -2,14 +2,14 @@ import { useCallback, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
-import { nicsSorting } from '@kubevirt-utils/resources/vm/utils/network/utils';
+import { sortNICs } from '@kubevirt-utils/resources/vm/utils/network/utils';
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 
 const useNetworkColumns = (data: NetworkPresentation[]) => {
   const { t } = useKubevirtTranslation();
 
-  const sorting = useCallback((direction) => nicsSorting(data, direction), [data]);
+  const sorting = useCallback((direction) => sortNICs(data, direction), [data]);
 
   const columns: TableColumn<NetworkPresentation>[] = useMemo(
     () => [

--- a/src/views/templates/details/tabs/network/hooks/useNetworkColumns.ts
+++ b/src/views/templates/details/tabs/network/hooks/useNetworkColumns.ts
@@ -2,14 +2,14 @@ import { useCallback, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
-import { nicsSorting } from '@kubevirt-utils/resources/vm/utils/network/utils';
+import { sortNICs } from '@kubevirt-utils/resources/vm/utils/network/utils';
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 
 const useNetworkColumns = (data: NetworkPresentation[]) => {
   const { t } = useKubevirtTranslation();
 
-  const sorting = useCallback((direction) => nicsSorting(data, direction), [data]);
+  const sorting = useCallback((direction) => sortNICs(data, direction), [data]);
 
   const columns: TableColumn<NetworkPresentation>[] = useMemo(
     () => [

--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/VirtualMachinePendingChangesAlert.tsx
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/VirtualMachinePendingChangesAlert.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -16,7 +16,7 @@ type VirtualMachinePendingChangesAlertProps = {
   vmi: V1VirtualMachineInstance;
 };
 
-const VirtualMachinePendingChangesAlert: React.FC<VirtualMachinePendingChangesAlertProps> = ({
+const VirtualMachinePendingChangesAlert: FC<VirtualMachinePendingChangesAlertProps> = ({
   vm,
   vmi,
 }) => {

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceRow.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceRow.tsx
@@ -1,6 +1,7 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1Network, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import PendingBadge from '@kubevirt-utils/components/PendingBadge/PendingBadge';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
@@ -13,16 +14,19 @@ export type NetworkInterfaceRowProps = {
   obj: NetworkPresentation;
 };
 
-const NetworkInterfaceRow: React.FC<RowProps<NetworkPresentation, { vm: V1VirtualMachine }>> = ({
-  activeColumnIDs,
-  obj: { iface, network },
-  rowData: { vm },
-}) => {
+const NetworkInterfaceRow: FC<
+  RowProps<
+    NetworkPresentation,
+    { isPending: (network: V1Network) => boolean; vm: V1VirtualMachine }
+  >
+> = ({ activeColumnIDs, obj: { iface, network }, rowData: { isPending, vm } }) => {
   const { t } = useKubevirtTranslation();
+
   return (
     <>
       <TableData activeColumnIDs={activeColumnIDs} id="name">
         {network.name}
+        {isPending(network) && <PendingBadge />}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="model">
         {iface.model || NO_DATA_DASH}

--- a/src/views/virtualmachines/details/tabs/configuration/network/hooks/useNetworkColumns.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/network/hooks/useNetworkColumns.ts
@@ -2,14 +2,14 @@ import { useCallback, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
-import { nicsSorting } from '@kubevirt-utils/resources/vm/utils/network/utils';
+import { sortNICs } from '@kubevirt-utils/resources/vm/utils/network/utils';
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 
 const useNetworkColumns = (data: NetworkPresentation[]) => {
   const { t } = useKubevirtTranslation();
 
-  const sorting = useCallback((direction) => nicsSorting(data, direction), [data]);
+  const sorting = useCallback((direction) => sortNICs(data, direction), [data]);
 
   const columns: TableColumn<NetworkPresentation>[] = useMemo(
     () => [


### PR DESCRIPTION
## 📝 Description

Newly added NICs are not present in the NICs list on the VM Details page. This PR adds the NICs to the list and marks them as pending.

## 🎥 Screenshots

### Before
![Selection_256](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/5e991f4a-e4f1-42e9-abaa-6151af9fc96c)

### After
![Selection_255](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/0864cf76-374f-4620-a2bc-8f78228c95a3)

