### PR TITLE
CNV-31902: "Automatically apply" is checked when adding a new ssh key while there is a key configured in settings

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/state/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/utils/utils.ts
@@ -30,7 +30,7 @@ export const getSSHCredentials = (
   })
     .then((secret) => ({
       appliedDefaultKey: true,
-      applyKeyToProject: true,
+      applyKeyToProject: false,
       secretOption: SecretSelectionOption.useExisting,
       sshPubKey: decodeSecret(secret),
       sshSecretName: sshSecretName,

--- a/src/views/catalog/utils/WizardVMContext/utils/tabs-data.ts
+++ b/src/views/catalog/utils/WizardVMContext/utils/tabs-data.ts
@@ -4,6 +4,7 @@ import { OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
 
 export type TabsData = {
   additionalObjects?: any[];
+  applySSHToSettings?: boolean;
   authorizedSSHKey?: string;
   disks?: {
     dataVolumesToAddOwnerRef?: V1beta1DataVolume[];

--- a/src/views/catalog/utils/useWizardVmCreate.ts
+++ b/src/views/catalog/utils/useWizardVmCreate.ts
@@ -3,6 +3,7 @@ import produce from 'immer';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { addUploadDataVolumeOwnerReference } from '@kubevirt-utils/hooks/useCDIUpload/utils';
+import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
 import { K8sResourceCommon, useK8sModels } from '@openshift-console/dynamic-plugin-sdk';
 
 import { createMultipleResources } from './utils';
@@ -22,6 +23,8 @@ type UseWizardVmCreateValues = {
 export const useWizardVmCreate = (): UseWizardVmCreateValues => {
   const { tabsData, vm } = useWizardVMContext();
   const [models] = useK8sModels();
+  const [authorizedSSHKeys, updateAuthorizedSSHKeys] = useKubevirtUserSettings('ssh');
+
   const [loaded, setLoaded] = useState<boolean>(true);
   const [error, setError] = useState<any>();
 
@@ -49,6 +52,13 @@ export const useWizardVmCreate = (): UseWizardVmCreateValues => {
             addUploadDataVolumeOwnerReference(newVM, dv),
           ),
         );
+      }
+
+      if (tabsData.authorizedSSHKey && tabsData.applySSHToSettings) {
+        updateAuthorizedSSHKeys({
+          ...authorizedSSHKeys,
+          [newVM.metadata.namespace]: tabsData.authorizedSSHKey,
+        });
       }
 
       setLoaded(true);


### PR DESCRIPTION
## 📝 Description

The checkbox in the SSH modal dialog was checked when you open it if the key was applied from the user settings.
Changing that behavior to just show the key name (checkbox is not unchecked on initial load if the key is applied from user settings).
Also changing the behavior of changing the key in the create VM flow to change the key in the settings only after VM creation and not everytime we edit the SSH key (on VM submit instead of SSH modal submit)

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/1a4f39cb-a0be-4058-b18a-3bfb4695a1d1

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/0fd9e001-6d57-482b-a1fd-cc65fd3fe3f5


