### PR TITLE
CNV-31550: Add an alert to Add disk (hot plugged) modal

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1,5 +1,6 @@
 {
   " {{sockets}} sockets, {{threads}} threads, and {{cores}} cores.": " {{sockets}} sockets, {{threads}} threads, and {{cores}} cores.",
+  " Adding hot plugged disk": " Adding hot plugged disk",
   "--- Pick an Operating system ---": "--- Pick an Operating system ---",
   "--- Select {{ dsLabel }} name ---": "--- Select {{ dsLabel }} name ---",
   "--- Select {{dsLabel}} project ---": "--- Select {{dsLabel}} project ---",
@@ -104,6 +105,7 @@
   "Add tolerations to allow a VirtualMachine to schedule onto Nodes with matching taints.": "Add tolerations to allow a VirtualMachine to schedule onto Nodes with matching taints.",
   "Add volume": "Add volume",
   "Adding a bridged network interface to a running VirtualMachine is a Technology Preview feature that allows you to choose between live-migrating the VirtualMachine or restarting it to apply the changes. Enabling this feature requires cluster admin permissions.": "Adding a bridged network interface to a running VirtualMachine is a Technology Preview feature that allows you to choose between live-migrating the VirtualMachine or restarting it to apply the changes. Enabling this feature requires cluster admin permissions.",
+  "Additional disks types and interfaces are available when the VirtualMachine is stopped.": "Additional disks types and interfaces are available when the VirtualMachine is stopped.",
   "Additional resources": "Additional resources",
   "Additional statuses": "Additional statuses",
   "Address": "Address",

--- a/src/utils/components/DiskModal/DiskFormFields/DiskInterfaceSelect.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/DiskInterfaceSelect.tsx
@@ -52,44 +52,42 @@ const DiskInterfaceSelect: FC<DiskInterfaceSelectProps> = ({
       });
     }
   }, [diskInterface, dispatchDiskState, isCDROMType]);
+
   return (
-    <>
-      <FormGroup
-        fieldId="disk-interface"
-        helperText={t('Hot plug is enabled only for "SCSI" interface')}
-        isRequired
-        label={t('Interface')}
-      >
-        <div data-test-id="disk-interface-select">
-          <Select
-            direction="up"
-            isOpen={isOpen}
-            menuAppendTo="parent"
-            onSelect={onSelect}
-            onToggle={setIsOpen}
-            selections={diskInterface}
-            variant={SelectVariant.single}
-          >
-            {interfaceOptions.map(({ description, id, name }) => {
-              const isDisabled =
-                (isVMRunning && id !== interfaceTypes.SCSI) ||
-                (isCDROMType && id === interfaceTypes.VIRTIO);
-              return (
-                <SelectOption
-                  data-test-id={`disk-interface-select-${id}`}
-                  description={description}
-                  isDisabled={isDisabled}
-                  key={id}
-                  value={id}
-                >
-                  {name}
-                </SelectOption>
-              );
-            })}
-          </Select>
-        </div>
-      </FormGroup>
-    </>
+    <FormGroup
+      fieldId="disk-interface"
+      helperText={t('Hot plug is enabled only for "SCSI" interface')}
+      isRequired
+      label={t('Interface')}
+    >
+      <div data-test-id="disk-interface-select">
+        <Select
+          direction="up"
+          isDisabled={isVMRunning}
+          isOpen={isOpen}
+          menuAppendTo="parent"
+          onSelect={onSelect}
+          onToggle={setIsOpen}
+          selections={diskInterface}
+          variant={SelectVariant.single}
+        >
+          {interfaceOptions.map(({ description, id, name }) => {
+            const isDisabled = isCDROMType && id === interfaceTypes.VIRTIO;
+            return (
+              <SelectOption
+                data-test-id={`disk-interface-select-${id}`}
+                description={description}
+                isDisabled={isDisabled}
+                key={id}
+                value={id}
+              >
+                {name}
+              </SelectOption>
+            );
+          })}
+        </Select>
+      </div>
+    </FormGroup>
   );
 };
 

--- a/src/utils/components/DiskModal/DiskFormFields/DiskTypeSelect.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/DiskTypeSelect.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { Dispatch, FC, useCallback, useState } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { diskTypes, diskTypesLabels } from '@kubevirt-utils/resources/vm/utils/disk/constants';
@@ -8,27 +8,24 @@ import { diskReducerActions, DiskReducerActionType } from '../state/actions';
 
 type DiskTypeSelectProps = {
   diskType: string;
-  dispatchDiskState: React.Dispatch<DiskReducerActionType>;
+  dispatchDiskState: Dispatch<DiskReducerActionType>;
   isVMRunning?: boolean;
 };
 
-const DiskTypeSelect: React.FC<DiskTypeSelectProps> = ({
-  diskType,
-  dispatchDiskState,
-  isVMRunning,
-}) => {
+const DiskTypeSelect: FC<DiskTypeSelectProps> = ({ diskType, dispatchDiskState, isVMRunning }) => {
   const { t } = useKubevirtTranslation();
-  const [isOpen, setIsOpen] = React.useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
   const typeOptions = Object.values(diskTypes).filter((type) => type !== diskTypes.floppy);
 
-  const onSelectDiskSource = React.useCallback(
-    (event: React.MouseEvent<Element, MouseEvent>, selection: string) => {
+  const onSelectDiskSource = useCallback(
+    (_event: React.MouseEvent<Element, MouseEvent>, selection: string) => {
       dispatchDiskState({ payload: selection, type: diskReducerActions.SET_DISK_TYPE });
       setIsOpen(false);
     },
     [dispatchDiskState],
   );
+
   return (
     <FormGroup
       fieldId="disk-source-type-select"
@@ -37,6 +34,7 @@ const DiskTypeSelect: React.FC<DiskTypeSelectProps> = ({
     >
       <div data-test-id="disk-type-select">
         <Select
+          isDisabled={isVMRunning}
           isOpen={isOpen}
           menuAppendTo="parent"
           onSelect={onSelectDiskSource}
@@ -45,12 +43,7 @@ const DiskTypeSelect: React.FC<DiskTypeSelectProps> = ({
           variant={SelectVariant.single}
         >
           {typeOptions.map((type) => (
-            <SelectOption
-              data-test-id={`disk-type-select-${type}`}
-              isDisabled={isVMRunning && type !== diskTypes.disk}
-              key={type}
-              value={type}
-            >
+            <SelectOption data-test-id={`disk-type-select-${type}`} key={type} value={type}>
               {diskTypesLabels[type]}
             </SelectOption>
           ))}

--- a/src/utils/components/DiskModal/DiskFormFields/StorageClassAndPreallocation.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/StorageClassAndPreallocation.tsx
@@ -1,0 +1,74 @@
+import React, { FC, useMemo } from 'react';
+
+import { diskReducerActions, DiskReducerActionType } from '../state/actions';
+import { DiskFormState } from '../state/initialState';
+import { requiresDataVolume } from '../utils/helpers';
+
+import useStorageProfileClaimPropertySets from './hooks/useStorageProfileClaimPropertySets';
+import AlertedStorageClassSelect from './StorageClass/AlertedStorageClassSelect';
+import { sourceTypes } from './utils/constants';
+import AccessMode from './AccessMode';
+import ApplyStorageProfileSettingsCheckbox from './ApplyStorageProfileSettingsCheckbox';
+import EnablePreallocationCheckbox from './EnablePreallocationCheckbox';
+import VolumeMode from './VolumeMode';
+
+type StorageClassAndPreallocationProps = {
+  diskState: DiskFormState;
+  dispatchDiskState: React.Dispatch<DiskReducerActionType>;
+};
+
+const StorageClassAndPreallocation: FC<StorageClassAndPreallocationProps> = ({
+  diskState,
+  dispatchDiskState,
+}) => {
+  const sourceRequiresDataVolume = useMemo(
+    () => requiresDataVolume(diskState.diskSource),
+    [diskState.diskSource],
+  );
+
+  const { claimPropertySets, loaded: storageProfileLoaded } = useStorageProfileClaimPropertySets(
+    diskState?.storageClass,
+  );
+
+  if (!sourceRequiresDataVolume && diskState.diskSource !== sourceTypes.UPLOAD) return null;
+
+  return (
+    <>
+      <AlertedStorageClassSelect
+        setStorageClassName={(scName) =>
+          dispatchDiskState({ payload: scName, type: diskReducerActions.SET_STORAGE_CLASS })
+        }
+        setStorageClassProvisioner={(scProvisioner: string) =>
+          dispatchDiskState({
+            payload: scProvisioner,
+            type: diskReducerActions.SET_STORAGE_CLASS_PROVISIONER,
+          })
+        }
+        storageClass={diskState.storageClass}
+      />
+      <ApplyStorageProfileSettingsCheckbox
+        claimPropertySets={claimPropertySets}
+        diskState={diskState}
+        dispatchDiskState={dispatchDiskState}
+        loaded={storageProfileLoaded}
+      />
+      <AccessMode
+        diskState={diskState}
+        dispatchDiskState={dispatchDiskState}
+        spAccessMode={claimPropertySets?.[0]?.accessModes?.[0]}
+      />
+      <VolumeMode
+        diskState={diskState}
+        dispatchDiskState={dispatchDiskState}
+        spVolumeMode={claimPropertySets?.[0]?.volumeMode}
+      />
+      <EnablePreallocationCheckbox
+        dispatchDiskState={dispatchDiskState}
+        enablePreallocation={diskState.enablePreallocation}
+        isDisabled={!sourceRequiresDataVolume}
+      />
+    </>
+  );
+};
+
+export default StorageClassAndPreallocation;

--- a/src/utils/components/DiskModal/EditDiskModal.tsx
+++ b/src/utils/components/DiskModal/EditDiskModal.tsx
@@ -13,20 +13,14 @@ import {
 } from '@kubevirt-utils/resources/vm';
 import { Form } from '@patternfly/react-core';
 
-import AccessMode from './DiskFormFields/AccessMode';
-import ApplyStorageProfileSettingsCheckbox from './DiskFormFields/ApplyStorageProfileSettingsCheckbox';
 import BootSourceCheckbox from './DiskFormFields/BootSourceCheckbox/BootSourceCheckbox';
 import DiskInterfaceSelect from './DiskFormFields/DiskInterfaceSelect';
 import DiskSourceSizeInput from './DiskFormFields/DiskSizeInput/DiskSizeInput';
 import DiskSourceFormSelect from './DiskFormFields/DiskSourceFormSelect/DiskSourceFormSelect';
 import DiskTypeSelect from './DiskFormFields/DiskTypeSelect';
-import EnablePreallocationCheckbox from './DiskFormFields/EnablePreallocationCheckbox';
-import useStorageProfileClaimPropertySets from './DiskFormFields/hooks/useStorageProfileClaimPropertySets';
 import NameFormField from './DiskFormFields/NameFormField';
-import AlertedStorageClassSelect from './DiskFormFields/StorageClass/AlertedStorageClassSelect';
+import StorageClassAndPreallocation from './DiskFormFields/StorageClassAndPreallocation';
 import { sourceTypes } from './DiskFormFields/utils/constants';
-import VolumeMode from './DiskFormFields/VolumeMode';
-import { diskReducerActions } from './state/actions';
 import { DiskFormState, DiskSourceState } from './state/initialState';
 import { diskReducer, diskSourceReducer } from './state/reducers';
 import {
@@ -77,10 +71,6 @@ const EditDiskModal: FC<DiskModalProps> = ({
   const sourceRequiresDataVolume = useMemo(
     () => requiresDataVolume(diskState.diskSource),
     [diskState.diskSource],
-  );
-
-  const { claimPropertySets, loaded: storageProfileLoaded } = useStorageProfileClaimPropertySets(
-    diskState?.storageClass,
   );
 
   const uploadPromise = useCallback(() => {
@@ -230,43 +220,7 @@ const EditDiskModal: FC<DiskModalProps> = ({
           dispatchDiskState={dispatchDiskState}
           isVMRunning={false}
         />
-        {(sourceRequiresDataVolume || diskState.diskSource === sourceTypes.UPLOAD) && (
-          <>
-            <AlertedStorageClassSelect
-              setStorageClassName={(scName) =>
-                dispatchDiskState({ payload: scName, type: diskReducerActions.SET_STORAGE_CLASS })
-              }
-              setStorageClassProvisioner={(scProvisioner: string) =>
-                dispatchDiskState({
-                  payload: scProvisioner,
-                  type: diskReducerActions.SET_STORAGE_CLASS_PROVISIONER,
-                })
-              }
-              storageClass={diskState.storageClass}
-            />
-            <ApplyStorageProfileSettingsCheckbox
-              claimPropertySets={claimPropertySets}
-              diskState={diskState}
-              dispatchDiskState={dispatchDiskState}
-              loaded={storageProfileLoaded}
-            />
-            <AccessMode
-              diskState={diskState}
-              dispatchDiskState={dispatchDiskState}
-              spAccessMode={claimPropertySets?.[0]?.accessModes?.[0]}
-            />
-            <VolumeMode
-              diskState={diskState}
-              dispatchDiskState={dispatchDiskState}
-              spVolumeMode={claimPropertySets?.[0]?.volumeMode}
-            />
-            <EnablePreallocationCheckbox
-              dispatchDiskState={dispatchDiskState}
-              enablePreallocation={diskState.enablePreallocation}
-              isDisabled={!sourceRequiresDataVolume}
-            />
-          </>
-        )}
+        <StorageClassAndPreallocation diskState={diskState} dispatchDiskState={dispatchDiskState} />
       </Form>
     </TabModal>
   );


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-31550

Add an info alert to "Add disk (hot plugged)" modal to inform the user that _Additional disks types and interfaces are available when the VirtualMachine is stopped._ for a running VM.

Also disable "Type" and "Interface" drop downs for a running VM.

Refactor `DiskModal` and `EditDiskModal` components, create new `StorageClassAndPreallocation` component to be used within `DiskModal` and `EditDiskModal` to prevent unnecessary repeating the same code in those components.

## 🎥 Screenshots
**Before:**
![disk_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/edbd27bc-7552-47a4-8ce5-7361e74bf099)

**After:**
![disk_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/2a52cf6d-f1d4-4c19-aef5-70813236b305)

