### PR TITLE
CNV-32040: “vm is undefined“ shows when creating VM from template with regular user

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
@@ -1,5 +1,6 @@
 import React, { FC, memo, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import produce from 'immer';
 
 import { updateVMCPUMemory } from '@catalog/templatescatalog/utils/helpers';
 import { useWizardVMContext } from '@catalog/utils/WizardVMContext';
@@ -79,8 +80,12 @@ export const TemplatesCatalogDrawerPanel: FC<TemplatesCatalogDrawerPanelProps> =
     useEffect(() => {
       setError(undefined);
 
+      const updatedTemplate = produce<V1Template>(template, (draftTemplate) => {
+        draftTemplate.metadata.namespace = ns;
+      });
+
       k8sCreate<V1Template>({
-        data: template,
+        data: updatedTemplate,
         model: ProcessedTemplatesModel,
         queryParams: {
           dryRun: 'All',


### PR DESCRIPTION
## 📝 Description

when customizing we try to process the template as is, and it should be processed in the scope of the current namespace

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/9c561122-c6e6-4274-9e92-741580fd0ad7

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/240d0ad0-6e46-4e91-8406-db30f48485be

