### PR TITLE
CNV-32467: Disk modal crash if open too fast

### DIFF
--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -66,16 +66,18 @@ export const produceVMDisks = (
   updateDisks: (vmDraft: WritableDraft<V1VirtualMachine>) => void,
 ) => {
   return produce(vm, (draftVM) => {
-    ensurePath(draftVM, ['spec.template.spec.domain.devices']);
+    if (draftVM) {
+      ensurePath(draftVM, ['spec.template.spec.domain.devices']);
 
-    if (!draftVM.spec.template.spec.domain.devices.disks)
-      draftVM.spec.template.spec.domain.devices.disks = [];
+      if (!draftVM.spec.template.spec.domain.devices.disks)
+        draftVM.spec.template.spec.domain.devices.disks = [];
 
-    if (!draftVM.spec.template.spec.volumes) draftVM.spec.template.spec.volumes = [];
+      if (!draftVM.spec.template.spec.volumes) draftVM.spec.template.spec.volumes = [];
 
-    if (!draftVM.spec.dataVolumeTemplates) draftVM.spec.dataVolumeTemplates = [];
+      if (!draftVM.spec.dataVolumeTemplates) draftVM.spec.dataVolumeTemplates = [];
 
-    updateDisks(draftVM);
+      updateDisks(draftVM);
+    }
   });
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Disk modal crash if open too fast, this cause by missing VM obj so also draftvm is nullush value. 
## 🎥 Demo

> Please add a video or an image of the behavior/changes
