### PR TITLE
CNV-32168: Fix links in VMs per resource chart on the Virtualization Overview page

### DIFF
--- a/src/views/clusteroverview/OverviewTab/vms-per-resource-card/RunningVMsChartLegendLabel.tsx
+++ b/src/views/clusteroverview/OverviewTab/vms-per-resource-card/RunningVMsChartLegendLabel.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import { VirtualMachineModelRef } from '@kubevirt-ui/kubevirt-api/console';
+import { ALL_NAMESPACES } from '@kubevirt-utils/hooks/constants';
 import { getInstanceTypePrefix } from '@kubevirt-utils/resources/bootableresources/helpers';
+import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk-internal';
+
+import { isAllNamespaces } from '../vm-statuses-card/utils/utils';
 
 import { getInstanceTypeSeriesLabel } from './utils/utils';
 
@@ -23,9 +27,11 @@ type RunningVMsChartLegendLabelProps = {
 };
 
 const RunningVMsChartLegendLabel: React.FC<RunningVMsChartLegendLabelProps> = ({ item }) => {
+  const [activeNamespace] = useActiveNamespace();
+  const namespace = isAllNamespaces(activeNamespace) ? ALL_NAMESPACES : `ns/${activeNamespace}`;
   const iconStyle = { color: item.color };
   const filterKey = item.isInstanceType ? 'instanceType' : 'template';
-  const linkPath = `/k8s/all-namespaces/${VirtualMachineModelRef}?rowFilter-${filterKey}=${getInstanceTypePrefix(
+  const linkPath = `/k8s/${namespace}/${VirtualMachineModelRef}?rowFilter-${filterKey}=${getInstanceTypePrefix(
     item.name,
   )}`;
 


### PR DESCRIPTION
## 📝 Description

Links for individual resource types in the VirtualMachines per Resource chart on the Virtualization Overview were all hardcoded to use 'all-namespaces'. This PR makes the links namespaced to the active namespace.

Issue link: https://issues.redhat.com/browse/CNV-32168
