### PR TITLE
CNV-32401: Change "SSH key name" field to "Authorized SSH key"

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -983,7 +983,6 @@
   "SSH access using the virtctl command is possible only when the API server is reachable.": "SSH access using the virtctl command is possible only when the API server is reachable.",
   "SSH key is invalid": "SSH key is invalid",
   "SSH key is saved in the project as a secret": "SSH key is saved in the project as a secret",
-  "SSH key name": "SSH key name",
   "SSH over LoadBalancer": "SSH over LoadBalancer",
   "SSH secret not configured": "SSH secret not configured",
   "SSH service type": "SSH service type",

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsRightGrid.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsRightGrid.tsx
@@ -64,7 +64,7 @@ const DetailsRightGrid: FC = () => {
             />
           ))
         }
-        descriptionHeader={t('SSH key name')}
+        descriptionHeader={t('Authorized SSH key')}
         isEdit={!isChangingNamespace}
       />
       <DynamicSSHKeyInjectionIntanceType />


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-32401

Change _SSH key name_ field name to _Authorized SSH key_ in _InstanceTypes_ tab when creating VM from InstanceTypes, section 3 - _VirtualMachine details_, to align it more with the _Authorized SSH key_ modal and with _VM -> Configuration -> Scripts_ tab.

## 🎥 Screenshots
**Before:**
![key_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/f8914270-773d-4526-9585-44d37785bef7)

**After:**
![key_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/82e50acf-8253-4d84-871f-3d7be046424b)
