### PR TITLE
CNV-31484: The example of preference has 'example' as OS

### DIFF
--- a/src/templates/clusterpreference-yaml.ts
+++ b/src/templates/clusterpreference-yaml.ts
@@ -5,6 +5,8 @@ apiVersion: ${VirtualMachineClusterPreferenceModel.apiGroup}/${VirtualMachineClu
 kind: ${VirtualMachineClusterPreferenceModel.kind}
 metadata:
   name: example
+  annotations:
+    openshift.io/display-name: Fedora
 spec: 
   devices:
     preferredDiskBus: virtio

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/utils/utils.ts
@@ -24,8 +24,9 @@ export const getOSFromDefaultPreference = (
   const defaultPreferenceDisplayName = getAnnotation(
     defaultPreference,
     PREFERENCE_DISPLAY_NAME_KEY,
+    '',
   );
-  return defaultPreferenceDisplayName || defaultPreferenceName;
+  return defaultPreferenceDisplayName;
 };
 
 export const getCPUAndMemoryFromDefaultInstanceType = (


### PR DESCRIPTION
## 📝 Description

Adding os display name annotation to the initial example yaml.
Fallback to empty OS instead of preference name.

## 🎥 Demo

![add-os-annotation](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/8be907d4-994a-4e08-bd01-0c10875f891c)

