### PR TITLE
CNV-32498: Main menu remove instancetype entries for non admin users

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -445,6 +445,9 @@
     "type": "console.page/resource/list"
   },
   {
+    "flags": {
+      "required": ["CAN_LIST_NS"]
+    },
     "properties": {
       "dataAttributes": {
         "data-quickstart-id": "qs-nav-virtualmachineclusterinstancetypes",
@@ -473,6 +476,9 @@
     "type": "console.page/resource/list"
   },
   {
+    "flags": {
+      "required": ["CAN_LIST_NS"]
+    },
     "properties": {
       "dataAttributes": {
         "data-quickstart-id": "qs-nav-virtualmachineclusterpreferences",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Non admin users cannot list instancetypes and preferences in main menu

## 🎥 Demo

Admin user:
<img width="373" alt="image" src="https://github.com/kubevirt-ui/kubevirt-plugin/assets/14824964/31f333d2-ff6f-4798-90d9-e5e063e38e1f">

Non admin user:
<img width="394" alt="image" src="https://github.com/kubevirt-ui/kubevirt-plugin/assets/14824964/cdf3abd6-6dae-45f4-8e2e-a322c936e670">

