### PR TITLE
[release-4.12] CNV-27485: Unavailable data and wrong data during VM live migration

### DIFF
--- a/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGrid.tsx
@@ -14,7 +14,7 @@ type VirtualMachineDetailsRightGridProps = {
 
 const VirtualMachineDetailsRightGrid: React.FC<VirtualMachineDetailsRightGridProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
-  const isVMRunning = vm?.status?.printableStatus === printableVMStatus.Running;
+  const isVMRunning = vm?.status?.printableStatus !== printableVMStatus.Stopped;
 
   return isVMRunning ? (
     <RunningVirtualMachineDetailsRightGrid vm={vm} />


### PR DESCRIPTION
## 📝 Description

Change the condition to start watching VMI and pod if VM status is not `Stopped`

## 🎥 Demo

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/db668cb9-b24d-4d84-b0ff-f7dd26c1984f


