### PR TITLE
CNV-32392: Fix error in catalog drawer for All Projects namespace

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
@@ -16,6 +16,7 @@ import CPUMemoryModal from '@kubevirt-utils/components/CPUMemoryModal/CpuMemoryM
 import HardwareDevices from '@kubevirt-utils/components/HardwareDevices/HardwareDevices';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
+import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { WORKLOADS_LABELS } from '@kubevirt-utils/resources/template/utils/constants';
 import {
@@ -59,6 +60,7 @@ export const TemplatesCatalogDrawerPanel: FC<TemplatesCatalogDrawerPanelProps> =
     const { createModal } = useModal();
     const { updateVM } = useWizardVMContext();
     const { ns } = useParams<{ ns: string }>();
+    const vmNamespace = ns || DEFAULT_NAMESPACE;
 
     const notAvailable = t('N/A');
     const vmObject = getTemplateVirtualMachineObject(template);
@@ -81,7 +83,7 @@ export const TemplatesCatalogDrawerPanel: FC<TemplatesCatalogDrawerPanelProps> =
       setError(undefined);
 
       const updatedTemplate = produce<V1Template>(template, (draftTemplate) => {
-        draftTemplate.metadata.namespace = ns;
+        draftTemplate.metadata.namespace = vmNamespace;
       });
 
       k8sCreate<V1Template>({
@@ -93,7 +95,7 @@ export const TemplatesCatalogDrawerPanel: FC<TemplatesCatalogDrawerPanelProps> =
       })
         .then((processedTemplate) => {
           updateVMCPUMemory(
-            ns,
+            vmNamespace,
             updateVM,
             setUpdatedVM,
           )(getTemplateVirtualMachineObject(processedTemplate)).catch((err) => {
@@ -103,8 +105,7 @@ export const TemplatesCatalogDrawerPanel: FC<TemplatesCatalogDrawerPanelProps> =
         .catch((err) => {
           setError(err);
         });
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [ns, template]);
+    }, [vmNamespace, template]);
 
     return (
       <div className="modal-body modal-body-border modal-body-content">
@@ -174,7 +175,7 @@ export const TemplatesCatalogDrawerPanel: FC<TemplatesCatalogDrawerPanelProps> =
                             <CPUMemoryModal
                               isOpen={isOpen}
                               onClose={onClose}
-                              onSubmit={updateVMCPUMemory(ns, updateVM, setUpdatedVM)}
+                              onSubmit={updateVMCPUMemory(vmNamespace, updateVM, setUpdatedVM)}
                               templateNamespace={template?.metadata?.namespace}
                               vm={updatedVM}
                             />


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug where an error alert was displayed in the catalog drawer.

Cause: Using the All Projects namespace session key in a `k8sCreate` call.

Issue: https://issues.redhat.com/browse/CNV-32392

## 🎥 Screenshots

### Before
![2023-08-30_08-50_1](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/123ee766-1249-4116-8bd9-520e43cc7270)


### After
![2023-08-30_08-47](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/6af99eec-c4c5-43de-930a-fb9cba300d8f)

