### PR TITLE
CNV-32531: Fix error in Catalog drawer for "All Projects"

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
@@ -16,6 +16,7 @@ import CPUMemoryModal from '@kubevirt-utils/components/CPUMemoryModal/CpuMemoryM
 import HardwareDevices from '@kubevirt-utils/components/HardwareDevices/HardwareDevices';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
+import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { WORKLOADS_LABELS } from '@kubevirt-utils/resources/template/utils/constants';
 import {
@@ -77,11 +78,13 @@ export const TemplatesCatalogDrawerPanel: FC<TemplatesCatalogDrawerPanelProps> =
     const [updatedVM, setUpdatedVM] = useState<V1VirtualMachine>(undefined);
     const [error, setError] = useState(undefined);
 
+    const vmNamespace = ns || DEFAULT_NAMESPACE;
+
     useEffect(() => {
       setError(undefined);
 
       const updatedTemplate = produce<V1Template>(template, (draftTemplate) => {
-        draftTemplate.metadata.namespace = ns;
+        draftTemplate.metadata.namespace = vmNamespace;
       });
 
       k8sCreate<V1Template>({
@@ -93,7 +96,7 @@ export const TemplatesCatalogDrawerPanel: FC<TemplatesCatalogDrawerPanelProps> =
       })
         .then((processedTemplate) => {
           updateVMCPUMemory(
-            ns,
+            vmNamespace,
             updateVM,
             setUpdatedVM,
           )(getTemplateVirtualMachineObject(processedTemplate)).catch((err) => {
@@ -104,7 +107,7 @@ export const TemplatesCatalogDrawerPanel: FC<TemplatesCatalogDrawerPanelProps> =
           setError(err);
         });
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [ns, template]);
+    }, [template, vmNamespace]);
 
     return (
       <div className="modal-body modal-body-border modal-body-content">


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-32531

"Error: the server could not find the requested resource" appeared in _Catalog_ drawer for "All Projects" _Project_. This PR fixes the error by properly setting the namespace for the template object that needs to be processed before moving forward in VM creation.

The root cause of the problem was that the namespace in the code for "All Projects" was "undefined", so the correct template object couldn't be created and then processing such an incorrect template object failed and lead to the mentioned error.

This problem was introduced in https://github.com/kubevirt-ui/kubevirt-plugin/pull/1472

## 🎥 Screenshots
**Before:**
![error_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/63952b5a-fa6f-4acf-87de-c138eb4beb01)

**After:**
![error_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/14435af8-fd4d-4a3c-8d83-17e5f6e9f6e6)
