### PR TITLE
CNV-22802: Warning "Selected StorageClass is different from the default StorageClass" should be improved

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -932,7 +932,7 @@
   "Select StorageClass": "Select StorageClass",
   "Select volume to boot from": "Select volume to boot from",
   "Select workloads that must have all the following expressions.": "Select workloads that must have all the following expressions.",
-  "Selected StorageClass is different from StorageClass of the template's boot source": "Selected StorageClass is different from StorageClass of the template's boot source",
+  "Selected StorageClass is different from StorageClass of the source": "Selected StorageClass is different from StorageClass of the source",
   "Selected sysprep": "Selected sysprep",
   "selector key": "selector key",
   "selector value": "selector value",

--- a/src/utils/components/DiskModal/DiskFormFields/StorageClass/AlertedStorageClassSelect.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/StorageClass/AlertedStorageClassSelect.tsx
@@ -4,6 +4,7 @@ import DefaultStorageClassAlert from './DefaultStorageClassAlert';
 import StorageClassSelect from './StorageClassSelect';
 
 export type AlertedStorageClassSelectProps = {
+  checkSC?: (selectedSC: string) => boolean;
   setStorageClassName: (value: string) => void;
   setStorageClassProvisioner?: Dispatch<SetStateAction<string>>;
   storageClass: string;

--- a/src/utils/components/DiskModal/DiskFormFields/StorageClass/DefaultStorageClassAlert.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/StorageClass/DefaultStorageClassAlert.tsx
@@ -6,7 +6,7 @@ import { Alert, AlertVariant } from '@patternfly/react-core';
 const DefaultStorageClassAlert: FC = () => (
   <Alert
     isInline
-    title={t("Selected StorageClass is different from StorageClass of the template's boot source")}
+    title={t('Selected StorageClass is different from StorageClass of the source')}
     variant={AlertVariant.info}
   >
     {t('It may take several minutes until the clone is done and the VirtualMachine is ready.')}

--- a/src/utils/components/DiskModal/DiskFormFields/StorageClass/StorageClassSelect.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/StorageClass/StorageClassSelect.tsx
@@ -26,6 +26,7 @@ type StorageClassSelectProps = {
 } & AlertedStorageClassSelectProps;
 
 const StorageClassSelect: FC<StorageClassSelectProps> = ({
+  checkSC,
   setShowSCAlert,
   setStorageClassName,
   setStorageClassProvisioner,
@@ -43,7 +44,7 @@ const StorageClassSelect: FC<StorageClassSelectProps> = ({
 
   const onSelect = useCallback(
     (event: ChangeEvent<Element>, selection: string) => {
-      setShowSCAlert(selection !== defaultSC?.metadata?.name);
+      setShowSCAlert(checkSC ? checkSC(selection) : false);
       setStorageClassName(selection);
       setIsOpen(false);
       setStorageClassProvisioner?.(

--- a/src/utils/components/DiskModal/DiskFormFields/StorageClassAndPreallocation.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/StorageClassAndPreallocation.tsx
@@ -13,11 +13,13 @@ import EnablePreallocationCheckbox from './EnablePreallocationCheckbox';
 import VolumeMode from './VolumeMode';
 
 type StorageClassAndPreallocationProps = {
+  checkSC?: (selectedStorageClass: string) => boolean;
   diskState: DiskFormState;
   dispatchDiskState: React.Dispatch<DiskReducerActionType>;
 };
 
 const StorageClassAndPreallocation: FC<StorageClassAndPreallocationProps> = ({
+  checkSC,
   diskState,
   dispatchDiskState,
 }) => {
@@ -44,6 +46,7 @@ const StorageClassAndPreallocation: FC<StorageClassAndPreallocationProps> = ({
             type: diskReducerActions.SET_STORAGE_CLASS_PROVISIONER,
           })
         }
+        checkSC={checkSC}
         storageClass={diskState.storageClass}
       />
       <ApplyStorageProfileSettingsCheckbox

--- a/src/utils/components/DiskModal/DiskModal.tsx
+++ b/src/utils/components/DiskModal/DiskModal.tsx
@@ -29,6 +29,7 @@ import { sourceTypes } from './DiskFormFields/utils/constants';
 import { initialStateDiskForm, initialStateDiskSource } from './state/initialState';
 import { diskReducer, diskSourceReducer } from './state/reducers';
 import {
+  checkDifferentStorageClassFromBootPVC,
   getDataVolumeFromState,
   getDataVolumeHotplugPromise,
   getDataVolumeTemplate,
@@ -224,7 +225,13 @@ const DiskModal: FC<DiskModalProps> = ({
           dispatchDiskState={dispatchDiskState}
           isVMRunning={isVMRunning}
         />
-        <StorageClassAndPreallocation diskState={diskState} dispatchDiskState={dispatchDiskState} />
+        <StorageClassAndPreallocation
+          checkSC={(selectedStorageClass) =>
+            checkDifferentStorageClassFromBootPVC(vm, selectedStorageClass)
+          }
+          diskState={diskState}
+          dispatchDiskState={dispatchDiskState}
+        />
       </Form>
     </TabModal>
   );


### PR DESCRIPTION
## 📝 Description

Currently the alert is shown whenever a SC is selected which is not the same as the cluster's default which is wrong.
Changing the alert to show when VM is created with DS or cloned PVC as boot disk, and the selected SC of newly created disk is not the same.
Note: If VM was booted from URL/upload/registry, the alert should not show at all.

## 🎥 Demo

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/f0c695cd-5d79-468d-a043-4c8ecd44d823


