### PR TITLE
CNV-32369: Display proper CPU | Memory values in Catalog drawer

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerPanel.tsx
@@ -166,7 +166,7 @@ export const TemplatesCatalogDrawerPanel: FC<TemplatesCatalogDrawerPanelProps> =
                       <VirtualMachineDescriptionItem
                         bodyContent={
                           <CPUDescription
-                            cpu={vmObject?.spec?.template?.spec?.domain?.cpu}
+                            cpu={updatedVM?.spec?.template?.spec?.domain?.cpu}
                             helperTextResource={CpuMemHelperTextResources.FutureVM}
                           />
                         }

--- a/src/views/catalog/wizard/components/WizardHeader.tsx
+++ b/src/views/catalog/wizard/components/WizardHeader.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC, memo } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { CUSTOMIZE_TEMPLATE_TITLE } from '@catalog/customize/constants';
@@ -17,7 +17,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 
-export const WizardHeader: React.FC<{ namespace: string }> = React.memo(({ namespace }) => {
+export const WizardHeader: FC<{ namespace: string }> = memo(({ namespace }) => {
   const { t } = useKubevirtTranslation();
   const { tabsData } = useWizardVMContext();
   const history = useHistory();


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-32369

Display the CPU and Memory values for "CPU | Memory" field in the Catalog drawer, instead of showing "Not available". Make them editable again. 

Also display the values correctly, reflect the latest actual values after editing (this was also not correct) in the drawer.

The root cause of the problem was that to the related CPU/Memory code - to `CPUMemory` component was VMI related logic added without any considering that this code is common for existing VMs/VMIs and also for Catalog drawer and VMs that don't exist yet (so those cannot run yet, obviously). This also caused incorrect CPU value in the drawer (once "Not available" issue was solved by adding necessary conditions to `vmi` checks in the same component).

_Note:_
There is another bug in _Catalog_ drawer, but was hidden by the bug this PR is fixing: once editing _CPU | Memory_ field will work, the expected CPU/Mem values will appear for the newly created VM when quick creating VM, but when customizing VMs, will not. This is fixed separately, within [this](https://github.com/kubevirt-ui/kubevirt-plugin/pull/1515) PR, as this issue is related to the different code.

## 🎥 Screenshots
**Before:**
![cpu_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/39a9af49-93f9-4ec3-8d25-2fc848efa60f)

**After:**
![cpu_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/693a2deb-6cfb-4b37-a92f-1db8c829a801)
