### PR TITLE
CNV-32609: Keep the CPU value from Catalog drawer for customizing page

### DIFF
--- a/src/views/catalog/customize/components/CustomizeForms/useCustomizeFormSubmit.ts
+++ b/src/views/catalog/customize/components/CustomizeForms/useCustomizeFormSubmit.ts
@@ -100,7 +100,7 @@ export const useCustomizeFormSubmit = ({
           ...vmDraft?.spec?.template?.spec?.domain?.resources?.requests,
           memory: `${vm.spec.template.spec.domain.resources.requests['memory']}`,
         };
-        vmDraft.spec.template.spec.domain.cpu.cores = vmObj.spec.template.spec.domain.cpu.cores;
+        vmDraft.spec.template.spec.domain.cpu.cores = vm.spec.template.spec.domain.cpu.cores;
 
         const updatedVolumes = applyCloudDriveCloudInitVolume(vmObj);
         vmDraft.spec.template.spec.volumes = isRHELTemplate(processedTemplate)

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -135,6 +135,7 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
 
     const onCustomize = (e: MouseEvent) => {
       e.preventDefault();
+
       if (isEmpty(template?.parameters)) {
         return k8sCreate<V1Template>({
           data: { ...template, metadata: { ...template?.metadata, namespace } },
@@ -159,8 +160,7 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
               ...vmDraft?.spec?.template?.spec?.domain?.resources?.requests,
               memory: `${vm.spec.template.spec.domain.resources.requests['memory']}`,
             };
-            vmDraft.spec.template.spec.domain.cpu.cores =
-              vmObject.spec.template.spec.domain.cpu.cores;
+            vmDraft.spec.template.spec.domain.cpu.cores = vm.spec.template.spec.domain.cpu.cores;
 
             const updatedVolumes = applyCloudDriveCloudInitVolume(vmObject);
             vmDraft.spec.template.spec.volumes = isRHELTemplate(processedTemplate)


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-32609

Save correctly the CPU value from _Catalog_ drawer, especially if the user has edited this value in the drawer, so it can be displayed in _Customize and create VirtualMachine_ page correctly, same as it was set when the user has left the drawer.

_Note:_
This PR can be merged now, but it is kinda problematic to reproduce the bug without https://github.com/kubevirt-ui/kubevirt-plugin/pull/1514 being merged. 

## 🎥 Demo
**Before:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/310234ff-65d8-4c75-9b71-aabc870826c0

**After:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/d72aaff2-e7e7-4696-8e77-76aa6ae94dfb


