### PR TITLE
Bug 2236393: Not able to select StorageClass if there is no default StorageClass defined in the cluster

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/StorageClass/StorageClassSelect.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/StorageClass/StorageClassSelect.tsx
@@ -13,6 +13,7 @@ import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui/kubevirt-api/kuberne
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, StorageClassModel } from '@kubevirt-utils/models';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { FormGroup, Select, SelectVariant } from '@patternfly/react-core';
 
@@ -56,7 +57,7 @@ const StorageClassSelect: FC<StorageClassSelectProps> = ({
   );
 
   useEffect(() => {
-    if (!storageClass && loaded) {
+    if (!storageClass && loaded && !isEmpty(defaultSC)) {
       setStorageClassName(defaultSC?.metadata?.name);
       setStorageClassProvisioner?.(defaultSC?.provisioner);
     }


### PR DESCRIPTION
## 📝 Description

Improve check to useEffect hook on StorageClassSelect component, to allow selection when no default SC exists

## 🎥 Demo

> Please add a video or an image of the behavior/changes
