### PR TITLE
[release-4.12] Bug 2236112: Fix disk table crash after memory dump

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/utils/helpers.ts
+++ b/src/utils/components/DiskModal/DiskFormFields/utils/helpers.ts
@@ -111,7 +111,8 @@ export const getInterfaceOptions = (t: TFunction) => ({
 });
 
 export const getVolumeType = (volume: V1Volume): string => {
-  const volumeType = Object.keys(volume)?.find((key) => Object.values(volumeTypes).includes(key));
+  const volumeType =
+    volume && Object.keys(volume)?.find((key) => Object.values(volumeTypes).includes(key));
   return volumeType;
 };
 

--- a/src/views/catalog/wizard/tabs/disks/hooks/useEditDiskState.ts
+++ b/src/views/catalog/wizard/tabs/disks/hooks/useEditDiskState.ts
@@ -78,13 +78,15 @@ export const useEditDiskStates: UseEditDiskStates = (vm, diskName) => {
     const volume = volumes?.find(({ name }) => name === diskName);
     // volume consists of 2 keys:
     // name and one of: containerDisk/cloudInitNoCloud
-    const volumeSource = Object.keys(volume).find((key) =>
-      [
-        volumeTypes.CONTAINER_DISK,
-        volumeTypes.DATA_VOLUME,
-        volumeTypes.PERSISTENT_VOLUME_CLAIM,
-      ].includes(key),
-    );
+    const volumeSource =
+      volume &&
+      Object.keys(volume)?.find((key) =>
+        [
+          volumeTypes.CONTAINER_DISK,
+          volumeTypes.DATA_VOLUME,
+          volumeTypes.PERSISTENT_VOLUME_CLAIM,
+        ].includes(key),
+      );
 
     const isBootDisk = getBootDisk(vm)?.name === diskName;
 

--- a/src/views/virtualmachines/details/tabs/disk/tables/disk/hooks/useEditDiskStates.ts
+++ b/src/views/virtualmachines/details/tabs/disk/tables/disk/hooks/useEditDiskStates.ts
@@ -50,13 +50,15 @@ export const useEditDiskStates: UseEditDiskStates = (vm, diskName, vmi) => {
     const volume = volumes?.find(({ name }) => name === diskName);
     // volume consists of 2 keys:
     // name and one of: containerDisk/cloudInitNoCloud
-    const volumeSource = Object.keys(volume).find((key) =>
-      [
-        volumeTypes.CONTAINER_DISK,
-        volumeTypes.DATA_VOLUME,
-        volumeTypes.PERSISTENT_VOLUME_CLAIM,
-      ].includes(key),
-    );
+    const volumeSource =
+      volume &&
+      Object.keys(volume)?.find((key) =>
+        [
+          volumeTypes.CONTAINER_DISK,
+          volumeTypes.DATA_VOLUME,
+          volumeTypes.PERSISTENT_VOLUME_CLAIM,
+        ].includes(key),
+      );
 
     const isBootDisk = diskName === getBootDisk(vm)?.name;
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

VM Disk table crashed after doing a memory dump
## 🎥 Demo

After:
![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/14824964/d4da0e1f-094e-4346-bbc1-83f4a3052810)

Before:
![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/14824964/ea03cdb4-50c0-42b3-b424-32452306f45c)
