### PR TITLE
Use isRunning VM util

### DIFF
--- a/src/utils/components/CPUMemory/CPUMemory.tsx
+++ b/src/utils/components/CPUMemory/CPUMemory.tsx
@@ -10,7 +10,7 @@ import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Skeleton } from '@patternfly/react-core';
-import { isVMRunning } from '@virtualmachines/utils';
+import { isRunning } from '@virtualmachines/utils';
 
 type CPUMemoryProps = {
   vm: V1VirtualMachine;
@@ -20,13 +20,13 @@ const CPUMemory: FC<CPUMemoryProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
   const itMatcher: V1InstancetypeMatcher = vm?.spec?.instancetype;
   const { instanceType, instanceTypeLoaded, instanceTypeLoadError } = useInstanceType(itMatcher);
-  const isMachineRunning = isVMRunning(vm);
+  const isVMRunning = isRunning(vm);
   const { vmi, vmiLoadError } = useVMI(getName(vm), getNamespace(vm));
 
-  if ((isMachineRunning && vmiLoadError) || (!isEmpty(itMatcher) && instanceTypeLoadError))
+  if ((isVMRunning && vmiLoadError) || (!isEmpty(itMatcher) && instanceTypeLoadError))
     return <MutedTextSpan text={t('Not available')} />;
 
-  if ((isMachineRunning && !vmi) || !vm || !instanceTypeLoaded) return <Skeleton />;
+  if ((isVMRunning && !vmi) || !vm || !instanceTypeLoaded) return <Skeleton />;
 
   const cpu =
     vCPUCount(vmi?.spec?.domain?.cpu || vm?.spec?.template?.spec?.domain?.cpu) ||

--- a/src/utils/components/DiskModal/DiskModal.tsx
+++ b/src/utils/components/DiskModal/DiskModal.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback, useMemo, useReducer } from 'react';
-import { printableVMStatus } from 'src/views/virtualmachines/utils';
+import { isRunning } from 'src/views/virtualmachines/utils';
 
 import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -64,7 +64,7 @@ const DiskModal: FC<DiskModalProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
 
-  const isVMRunning = vm?.status?.printableStatus === printableVMStatus.Running;
+  const isVMRunning = isRunning(vm);
   const { upload, uploadData } = useCDIUpload();
   const [diskState, dispatchDiskState] = useReducer(diskReducer, initialStateDiskForm);
   const [diskSourceState, dispatchDiskSourceState] = useReducer(

--- a/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
+++ b/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import { printableVMStatus } from 'src/views/virtualmachines/utils';
+import { useMemo } from 'react';
+import { isRunning } from 'src/views/virtualmachines/utils';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import {
@@ -34,15 +34,15 @@ const useDisksTableData: UseDisksTableDisks = (vm: V1VirtualMachine) => {
     name: vm?.metadata?.name,
     namespace: vm?.metadata?.namespace,
   });
-  const isVMRunning = vm?.status?.printableStatus === printableVMStatus.Running;
-  const vmDisks = React.useMemo(
+  const isVMRunning = isRunning(vm);
+  const vmDisks = useMemo(
     () =>
       !isVMRunning
         ? getDisks(vm)
         : [...(getDisks(vm) || []), ...getRunningVMMissingDisksFromVMI(getDisks(vm) || [], vmi)],
     [vm, vmi, isVMRunning],
   );
-  const vmVolumes = React.useMemo(
+  const vmVolumes = useMemo(
     () =>
       !isVMRunning
         ? getVolumes(vm)
@@ -60,7 +60,7 @@ const useDisksTableData: UseDisksTableDisks = (vm: V1VirtualMachine) => {
     namespaced: true,
   });
 
-  const disks = React.useMemo(() => {
+  const disks = useMemo(() => {
     const diskDevices: DiskRawData[] = (vmVolumes || []).map((volume) => {
       const disk = vmDisks?.find(({ name }) => name === volume?.name);
       const pvc = pvcs?.find(

--- a/src/views/virtualmachines/actions/components/CloneVMModal/CloneVMModal.tsx
+++ b/src/views/virtualmachines/actions/components/CloneVMModal/CloneVMModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import VirtualMachineModel, {
@@ -14,8 +14,8 @@ import {
 } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 import { Form } from '@patternfly/react-core';
+import { isRunning } from '@virtualmachines/utils';
 
-import { printableVMStatus } from '../../../utils';
 import { stopVM } from '../../actions';
 
 import CloneRunningVMAlert from './components/CloneRunningVMAlert';
@@ -39,19 +39,19 @@ type CloneVMModalProps = {
   vm: V1VirtualMachine;
 };
 
-const CloneVMModal: React.FC<CloneVMModalProps> = ({ isOpen, onClose, vm }) => {
+const CloneVMModal: FC<CloneVMModalProps> = ({ isOpen, onClose, vm }) => {
   const { t } = useKubevirtTranslation();
 
   const history = useHistory();
 
-  const [cloneName, setCloneName] = React.useState(`${vm?.metadata?.name}-clone`);
-  const [cloneDescription, setCloneDescription] = React.useState(
+  const [cloneName, setCloneName] = useState(`${vm?.metadata?.name}-clone`);
+  const [cloneDescription, setCloneDescription] = useState(
     vm?.metadata?.annotations?.[DESCRIPTION_ANNOTATION],
   );
-  const [cloneProject, setCloneProject] = React.useState(vm?.metadata?.namespace);
-  const [startCloneVM, setStartCloneVM] = React.useState(false);
+  const [cloneProject, setCloneProject] = useState(vm?.metadata?.namespace);
+  const [startCloneVM, setStartCloneVM] = useState(false);
 
-  const isVMRunning = vm?.status?.printableStatus === printableVMStatus.Running;
+  const isVMRunning = isRunning(vm);
 
   const { loaded, projectNames, pvcs } = useCloneVMResources(vm);
 

--- a/src/views/virtualmachines/details/tabs/configuration/disk/tables/disk/DiskRowActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/disk/tables/disk/DiskRowActions.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC, useMemo, useState } from 'react';
 
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -9,7 +9,7 @@ import { getVolumes } from '@kubevirt-utils/resources/vm';
 import { getContentScrollableElement } from '@kubevirt-utils/utils/utils';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import { Dropdown, DropdownItem, DropdownPosition, KebabToggle } from '@patternfly/react-core';
-import { printableVMStatus } from '@virtualmachines/utils';
+import { isRunning } from '@virtualmachines/utils';
 
 import DeleteDiskModal from '../../modal/DeleteDiskModal';
 import MakePersistentModal from '../../modal/MakePersistentModal';
@@ -24,17 +24,12 @@ type DiskRowActionsProps = {
   vmi?: V1VirtualMachineInstance;
 };
 
-const DiskRowActions: React.FC<DiskRowActionsProps> = ({
-  diskName,
-  pvcResourceExists,
-  vm,
-  vmi,
-}) => {
+const DiskRowActions: FC<DiskRowActionsProps> = ({ diskName, pvcResourceExists, vm, vmi }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
-  const [isDropdownOpen, setIsDropdownOpen] = React.useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-  const isVMRunning = vm?.status?.printableStatus !== printableVMStatus.Stopped;
+  const isVMRunning = isRunning(vm);
   const isHotplug = isHotplugVolume(vm, diskName, vmi);
   const isEditDisabled = isVMRunning || pvcResourceExists;
 
@@ -47,7 +42,7 @@ const DiskRowActions: React.FC<DiskRowActionsProps> = ({
   const deleteBtnText = t('Detach');
   const removeHotplugBtnText = t('Make persistent');
 
-  const disabledEditText = React.useMemo(() => {
+  const disabledEditText = useMemo(() => {
     if (isVMRunning) {
       return t('Can edit only when VirtualMachine is stopped');
     }
@@ -127,17 +122,15 @@ const DiskRowActions: React.FC<DiskRowActionsProps> = ({
     );
   }
   return (
-    <>
-      <Dropdown
-        dropdownItems={items}
-        isOpen={isDropdownOpen}
-        isPlain
-        menuAppendTo={getContentScrollableElement}
-        onSelect={() => setIsDropdownOpen(false)}
-        position={DropdownPosition.right}
-        toggle={<KebabToggle id="toggle-id-6" onToggle={setIsDropdownOpen} />}
-      />
-    </>
+    <Dropdown
+      dropdownItems={items}
+      isOpen={isDropdownOpen}
+      isPlain
+      menuAppendTo={getContentScrollableElement}
+      onSelect={() => setIsDropdownOpen(false)}
+      position={DropdownPosition.right}
+      toggle={<KebabToggle id="toggle-id-6" onToggle={setIsDropdownOpen} />}
+    />
   );
 };
 

--- a/src/views/virtualmachines/details/tabs/configuration/disk/tables/filesystem/FilesystemList.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/disk/tables/filesystem/FilesystemList.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import React, { FC, useMemo } from 'react';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-utils/models';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Bullseye } from '@patternfly/react-core';
-import { printableVMStatus } from '@virtualmachines/utils';
+import { isRunning } from '@virtualmachines/utils';
 
 import FileSystemListLayout from './FilesystemListLayout';
 
@@ -13,7 +13,7 @@ export type FilesystemListProps = {
   vm: V1VirtualMachine;
 };
 
-const FilesystemList: React.FC<FilesystemListProps> = ({ vm }) => {
+const FilesystemList: FC<FilesystemListProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
   const [vmi] = useK8sWatchResource<V1VirtualMachineInstance>({
     groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
@@ -21,10 +21,10 @@ const FilesystemList: React.FC<FilesystemListProps> = ({ vm }) => {
     name: vm?.metadata?.name,
     namespace: vm?.metadata?.namespace,
   });
-  const isVMRunning = vm?.status?.printableStatus === printableVMStatus.Running;
+  const isVMRunning = isRunning(vm);
 
   const guestOS = vmi?.status?.guestOSInfo?.id;
-  const noDataEmptyMsg = React.useMemo(() => {
+  const noDataEmptyMsg = useMemo(() => {
     if (!isVMRunning) {
       return t('VirtualMachine is not running');
     } else if (!guestOS && isVMRunning) {

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceActions.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { FC, useMemo, useState } from 'react';
 
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
@@ -23,7 +23,7 @@ import {
   KebabToggle,
 } from '@patternfly/react-core';
 import { removeInterface } from '@virtualmachines/actions/actions';
-import { isVMRunning } from '@virtualmachines/utils';
+import { isRunning } from '@virtualmachines/utils';
 
 import VirtualMachinesEditNetworkInterfaceModal from '../modal/VirtualMachinesEditNetworkInterfaceModal';
 
@@ -88,7 +88,7 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
         submitBtnVariant={ButtonVariant.danger}
       >
         <span>
-          {isVMRunning(vm) && (
+          {isRunning(vm) && (
             <Alert
               title={t(
                 'Deleting a network interface is supported only on VirtualMachines that were created in versions greater than 4.13 or for network interfaces that were added to the VirtualMachine in these versions.',

--- a/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/details/components/grid/rightGrid/VirtualMachineDetailsRightGrid.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import { printableVMStatus } from 'src/views/virtualmachines/utils';
+import React, { FC } from 'react';
+import { isRunning } from 'src/views/virtualmachines/utils';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -12,11 +12,10 @@ type VirtualMachineDetailsRightGridProps = {
   vm?: V1VirtualMachine;
 };
 
-const VirtualMachineDetailsRightGrid: React.FC<VirtualMachineDetailsRightGridProps> = ({ vm }) => {
+const VirtualMachineDetailsRightGrid: FC<VirtualMachineDetailsRightGridProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
-  const isVMRunning = vm?.status?.printableStatus !== printableVMStatus.Stopped;
 
-  return isVMRunning ? (
+  return isRunning(vm) ? (
     <RunningVirtualMachineDetailsRightGrid vm={vm} />
   ) : (
     <VirtualMachineDetailsRightGridLayout

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { VNC_CONSOLE_TYPE } from '@kubevirt-utils/components/Consoles/components/utils/ConsoleConsts';
@@ -20,7 +20,7 @@ type VirtualMachinesOverviewTabDetailsConsoleProps = {
   vmi: V1VirtualMachineInstance;
 };
 
-const VirtualMachinesOverviewTabDetailsConsole: React.FC<
+const VirtualMachinesOverviewTabDetailsConsole: FC<
   VirtualMachinesOverviewTabDetailsConsoleProps
 > = ({ vmi }) => {
   const { t } = useKubevirtTranslation();

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/VirtualMachinesOverviewTabUtilization.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/VirtualMachinesOverviewTabUtilization.tsx
@@ -17,8 +17,7 @@ import {
   Popover,
   PopoverPosition,
 } from '@patternfly/react-core';
-
-import { printableVMStatus } from '../../../../../utils';
+import { isRunning } from '@virtualmachines/utils';
 
 import CPUUtil from './components/CPUUtil/CPUUtil';
 import MemoryUtil from './components/MemoryUtil/MemoryUtil';
@@ -37,7 +36,6 @@ const VirtualMachinesOverviewTabUtilization: FC<VirtualMachinesOverviewTabUtiliz
 }) => {
   const { t } = useKubevirtTranslation();
   const { pods, vmi } = useVMIAndPodsForVM(vm?.metadata?.name, vm?.metadata?.namespace);
-  const isVMRunning = vm?.status?.printableStatus === printableVMStatus.Running;
 
   return (
     <Card className="VirtualMachinesOverviewTabUtilization--main">
@@ -62,7 +60,7 @@ const VirtualMachinesOverviewTabUtilization: FC<VirtualMachinesOverviewTabUtiliz
       </div>
       <Divider />
       <CardBody isFilled>
-        <ComponentReady isReady={isVMRunning} text={t('VirtualMachine is not running')}>
+        <ComponentReady isReady={isRunning(vm)} text={t('VirtualMachine is not running')}>
           <Grid>
             <GridItem span={3}>
               <CPUUtil pods={pods} vmi={vmi} />

--- a/src/views/virtualmachines/utils/utils.ts
+++ b/src/views/virtualmachines/utils/utils.ts
@@ -9,5 +9,5 @@ export const isLiveMigratable = (vm: V1VirtualMachine, isSingleNodeCluster: bool
     ({ status, type }) => type === 'LiveMigratable' && status === 'True',
   );
 
-export const isVMRunning = (vm: V1VirtualMachine): boolean =>
+export const isRunning = (vm: V1VirtualMachine): boolean =>
   vm?.status?.printableStatus === printableVMStatus.Running;


### PR DESCRIPTION
## 📝 Description

Use recently implemented `isVMRunning` util instead of repeatedly defining the same variable across the codebase, rename it to `isRunning`, which is shorter and still self explaining enough, and it also prevents potential bugs that could be created while unnecessary renaming `isVMRunning` variable already used in many components.

## 🎥 Demo

No any visual changes
