### PR TITLE
CNV-32596: Display Memory value correctly in the UI

### DIFF
--- a/src/utils/components/CPUMemory/CPUMemory.tsx
+++ b/src/utils/components/CPUMemory/CPUMemory.tsx
@@ -35,7 +35,7 @@ const CPUMemory: FC<CPUMemoryProps> = ({ vm }) => {
   const memory = readableSizeUnit(
     vmi?.spec?.domain?.memory?.guest ||
       instanceType?.spec?.memory?.guest ||
-      (vm?.spec?.template?.spec?.domain?.resources?.requests as { [key: string]: string })?.memory,
+      vm?.spec?.template?.spec?.domain?.memory?.guest,
   );
 
   return (

--- a/src/utils/components/CPUMemoryModal/CpuMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CpuMemoryModal.tsx
@@ -66,22 +66,21 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
 
   const updatedVirtualMachine = useMemo(() => {
     const updatedVM = produce<V1VirtualMachine>(vm, (vmDraft: V1VirtualMachine) => {
-      ensurePath(vmDraft, ['spec.template.spec.domain.resources', 'spec.template.spec.domain.cpu']);
-      vmDraft.spec.template.spec.domain.resources.requests = {
-        ...vm?.spec?.template?.spec?.domain?.resources?.requests,
-        memory: `${memory}${memoryUnit}`,
-      };
+      ensurePath(vmDraft, [
+        'spec.template.spec.domain.cpu',
+        'spec.template.spec.domain.memory.guest',
+      ]);
+
       vmDraft.spec.template.spec.domain.cpu.cores = cpuCores;
+      vmDraft.spec.template.spec.domain.memory.guest = `${memory}${memoryUnit}`;
     });
+
     return updatedVM;
   }, [vm, memory, cpuCores, memoryUnit]);
 
   useEffect(() => {
     if (vm?.metadata) {
-      const requests = vm?.spec?.template?.spec?.domain?.resources?.requests as {
-        [key: string]: string;
-      };
-      const { size, unit } = getMemorySize(requests?.memory);
+      const { size, unit } = getMemorySize(vm?.spec?.template?.spec?.domain?.memory?.guest);
       setMemoryUnit(unit);
       setMemory(size);
       setCpuCores(getCPUcores(vm));

--- a/src/utils/components/CPUMemoryModal/hooks/useTemplateDefaultCpuMemory.ts
+++ b/src/utils/components/CPUMemoryModal/hooks/useTemplateDefaultCpuMemory.ts
@@ -39,7 +39,7 @@ const useTemplateDefaultCpuMemory: UseTemplateDefaultCpuMemory = (
   }, [templateName, templateNamespace]);
 
   const defaultMemory = getMemorySize(
-    template?.objects?.[0]?.spec?.template?.spec?.domain?.resources?.requests?.memory,
+    template?.objects?.[0]?.spec?.template?.spec?.domain?.memory?.guest,
   );
   const defaultCpu = getCPUcores(template?.objects?.[0]);
 

--- a/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
+++ b/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
@@ -32,10 +32,7 @@ const MemoryThresholdChart: FC<MemoryThresholdChartProps> = ({ vmi }) => {
   const queries = useMemo(() => getUtilizationQueries({ duration, obj: vmi }), [vmi, duration]);
   const { height, ref, width } = useResponsiveCharts();
 
-  const requests = vmi?.spec?.domain?.resources?.requests as {
-    [key: string]: string;
-  };
-  const memory = getMemorySize(requests?.memory);
+  const memory = getMemorySize(vmi?.spec?.domain?.memory?.guest);
 
   const [data] = usePrometheusPoll({
     endpoint: PrometheusEndpoint?.QUERY_RANGE,

--- a/src/utils/components/EnvironmentEditor/tests/mocks.ts
+++ b/src/utils/components/EnvironmentEditor/tests/mocks.ts
@@ -10,7 +10,7 @@ export const exampleVirtualMachineWithEnvironments: V1VirtualMachine = {
       'vm.kubevirt.io/validations': `[
           {    
             "name": "minimal-required-memory",    
-            "path": "jsonpath::.spec.domain.resources.requests.memory",    
+            "path": "jsonpath::.spec.domain.memory.guest",
             "rule": "integer",    
             "message": "This VM requires more memory.",    
             "min": 1610612736  

--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -43,18 +43,14 @@ export const checkCPUMemoryChanged = (
   if (isEmpty(vm) || isEmpty(vmi)) {
     return false;
   }
-  const vmRequests = vm?.spec?.template?.spec?.domain?.resources?.requests;
+  const vmMemory = vm?.spec?.template?.spec?.domain?.memory?.guest;
   const vmCPU = vm?.spec?.template?.spec?.domain?.cpu?.cores || 0;
 
-  const vmiRequests: { [key in string]?: string } = vmi?.spec?.domain?.resources?.requests || {};
+  const vmiMemory = vmi?.spec?.domain?.memory?.guest || '';
 
   const vmiCPU = vmi?.spec?.domain?.cpu?.cores || 0;
 
-  const memoryChanged = vmRequests
-    ? !isEqualObject(vmRequests, vmiRequests)
-    : vmiRequests?.memory !== vm?.spec?.template?.spec?.domain?.memory?.guest;
-
-  return memoryChanged || vmCPU !== vmiCPU;
+  return vmMemory !== vmiMemory || vmCPU !== vmiCPU;
 };
 
 export const checkBootOrderChanged = (

--- a/src/utils/resources/template/utils/flavor.ts
+++ b/src/utils/resources/template/utils/flavor.ts
@@ -40,10 +40,8 @@ export const getFlavorData = (
   memory: string;
 } => {
   const cpu = getTemplateVirtualMachineCPU(template);
-  const memory = (
-    getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.domain?.resources
-      ?.requests as { memory: string }
-  )?.memory;
+  const memory =
+    getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.domain?.memory?.guest;
 
   const cpuCount = vCPUCount(cpu);
   const flavor = getTemplateFlavor(template);
@@ -66,8 +64,7 @@ export const getVmCPUMemory = (
   memory: string;
 } => {
   const cpu = vm?.spec?.template?.spec?.domain?.cpu;
-  const memory = (vm?.spec?.template?.spec?.domain?.resources?.requests as { memory: string })
-    ?.memory;
+  const memory = vm?.spec?.template?.spec?.domain?.memory?.guest;
 
   const cpuCount = vCPUCount(cpu);
 

--- a/src/utils/resources/vm/utils/constants.ts
+++ b/src/utils/resources/vm/utils/constants.ts
@@ -8,7 +8,7 @@ export const PATHS_TO_HIGHLIGHT = {
     'spec.template.metadata.annotations',
     'spec.template.metadata.labels',
     'spec.template.spec.domain.cpu',
-    'spec.template.spec.domain.resources.requests',
+    'spec.template.spec.domain.memory.guest',
     'metadata.labels',
     'metadata.annotations',
   ],

--- a/src/views/catalog/customize/components/CustomizeForms/useCustomizeFormSubmit.ts
+++ b/src/views/catalog/customize/components/CustomizeForms/useCustomizeFormSubmit.ts
@@ -89,18 +89,16 @@ export const useCustomizeFormSubmit = ({
 
       const updatedVM = produce(vmObj, (vmDraft) => {
         ensurePath(vmDraft, [
-          'spec.template.spec.domain.resources',
           'spec.template.spec.domain.cpu',
+          'spec.template.spec.domain.memory.guest',
         ]);
 
         vmDraft.metadata.namespace = ns || DEFAULT_NAMESPACE;
         vmDraft.metadata.labels[LABEL_USED_TEMPLATE_NAME] = processedTemplate.metadata.name;
         vmDraft.metadata.labels[LABEL_USED_TEMPLATE_NAMESPACE] = template.metadata.namespace;
-        vmDraft.spec.template.spec.domain.resources.requests = {
-          ...vmDraft?.spec?.template?.spec?.domain?.resources?.requests,
-          memory: `${vm.spec.template.spec.domain.resources.requests['memory']}`,
-        };
+
         vmDraft.spec.template.spec.domain.cpu.cores = vm.spec.template.spec.domain.cpu.cores;
+        vmDraft.spec.template.spec.domain.memory.guest = vm.spec.template.spec.domain.memory.guest;
 
         const updatedVolumes = applyCloudDriveCloudInitVolume(vmObj);
         vmDraft.spec.template.spec.volumes = isRHELTemplate(processedTemplate)

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -107,14 +107,13 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
 
         if (vm?.spec?.template) {
           ensurePath(vmObject, [
-            'spec.template.spec.domain.resources',
             'spec.template.spec.domain.cpu',
+            'spec.template.spec.domain.memory.guest',
           ]);
-          vmObject.spec.template.spec.domain.resources.requests = {
-            ...vmObject?.spec?.template?.spec?.domain?.resources?.requests,
-            memory: `${vm.spec.template.spec.domain.resources.requests['memory']}`,
-          };
+
           vmObject.spec.template.spec.domain.cpu.cores = vm.spec.template.spec.domain.cpu.cores;
+          vmObject.spec.template.spec.domain.memory.guest =
+            vm.spec.template.spec.domain.memory.guest;
         }
       });
 
@@ -149,18 +148,17 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
 
           const updatedVM = produce(vmObject, (vmDraft) => {
             ensurePath(vmDraft, [
-              'spec.template.spec.domain.resources',
               'spec.template.spec.domain.cpu',
+              'spec.template.spec.domain.memory.guest',
             ]);
 
             vmDraft.metadata.namespace = namespace;
             vmDraft.metadata.labels[LABEL_USED_TEMPLATE_NAME] = template.metadata.name;
             vmDraft.metadata.labels[LABEL_USED_TEMPLATE_NAMESPACE] = template.metadata.namespace;
-            vmDraft.spec.template.spec.domain.resources.requests = {
-              ...vmDraft?.spec?.template?.spec?.domain?.resources?.requests,
-              memory: `${vm.spec.template.spec.domain.resources.requests['memory']}`,
-            };
+
             vmDraft.spec.template.spec.domain.cpu.cores = vm.spec.template.spec.domain.cpu.cores;
+            vmDraft.spec.template.spec.domain.memory.guest =
+              vm.spec.template.spec.domain.memory.guest;
 
             const updatedVolumes = applyCloudDriveCloudInitVolume(vmObject);
             vmDraft.spec.template.spec.volumes = isRHELTemplate(processedTemplate)

--- a/src/views/catalog/templatescatalog/utils/helpers.ts
+++ b/src/views/catalog/templatescatalog/utils/helpers.ts
@@ -63,14 +63,15 @@ export const updateVMCPUMemory = (
 ) => {
   return (vm: V1VirtualMachine) => {
     const updatedVM = produce<V1VirtualMachine>(vm, (vmDraft: V1VirtualMachine) => {
-      ensurePath(vmDraft, ['spec.template.spec.domain.resources', 'spec.template.spec.domain.cpu']);
+      ensurePath(vmDraft, [
+        'spec.template.spec.domain.cpu',
+        'spec.template.spec.domain.memory.guest',
+      ]);
 
       vmDraft.metadata.namespace = ns || DEFAULT_NAMESPACE;
-      vmDraft.spec.template.spec.domain.resources.requests = {
-        ...vmDraft?.spec?.template?.spec?.domain?.resources?.requests,
-        memory: `${vm.spec.template.spec.domain.resources.requests['memory']}`,
-      };
+
       vmDraft.spec.template.spec.domain.cpu.cores = vm.spec.template.spec.domain.cpu.cores;
+      vmDraft.spec.template.spec.domain.memory.guest = vm.spec.template.spec.domain.memory.guest;
     });
 
     setUpdatedVM(updatedVM);

--- a/src/views/templates/details/tabs/details/components/CPUMemoryModal.tsx
+++ b/src/views/templates/details/tabs/details/components/CPUMemoryModal.tsx
@@ -54,25 +54,21 @@ const CPUMemoryModal: React.FC<CPUMemoryModalProps> = ({ isOpen, onClose, onSubm
     () =>
       produce<V1Template>(template, (templateDraft: V1Template) => {
         const draftVM = getTemplateVirtualMachineObject(templateDraft);
+
         ensurePath(draftVM, [
-          'spec.template.spec.domain.resources',
           'spec.template.spec.domain.cpu',
+          'spec.template.spec.domain.memory.guest',
         ]);
-        draftVM.spec.template.spec.domain.resources.requests = {
-          ...vm?.spec?.template?.spec?.domain?.resources?.requests,
-          memory: `${memory}${memoryUnit}`,
-        };
+
         draftVM.spec.template.spec.domain.cpu.cores = cpuCores;
+        draftVM.spec.template.spec.domain.memory.guest = `${memory}${memoryUnit}`;
       }),
-    [vm, memory, cpuCores, memoryUnit, template],
+    [memory, cpuCores, memoryUnit, template],
   );
 
   React.useEffect(() => {
     if (vm?.metadata) {
-      const requests = vm?.spec?.template?.spec?.domain?.resources?.requests as {
-        [key: string]: string;
-      };
-      const { size, unit } = getMemorySize(requests?.memory);
+      const { size, unit } = getMemorySize(vm?.spec?.template?.spec?.domain?.memory?.guest);
       setMemoryUnit(unit);
       setMemory(size);
       setCpuCores(getCPUcores(vm));

--- a/src/views/virtualmachines/actions/tests/mocks.ts
+++ b/src/views/virtualmachines/actions/tests/mocks.ts
@@ -8,7 +8,7 @@ export const exampleRunningVirtualMachine: V1VirtualMachine = {
       description: 'VM example',
       'name.os.template.kubevirt.io/rhel8.5': 'Red Hat Enterprise Linux 8.0 or higher',
       'vm.kubevirt.io/validations':
-        '[\n  {\n    "name": "minimal-required-memory",\n    "path": "jsonpath::.spec.domain.resources.requests.memory",\n    "rule": "integer",\n    "message": "This VM requires more memory.",\n    "min": 1610612736\n  }\n]\n',
+        '[\n  {\n    "name": "minimal-required-memory",\n    "path": "jsonpath::.spec.domain.memory.guest",\n    "rule": "integer",\n    "message": "This VM requires more memory.",\n    "min": 1610612736\n  }\n]\n',
     },
     labels: {
       app: 'vm-example',

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
@@ -20,10 +20,7 @@ const MemoryUtil: FC<MemoryUtilProps> = ({ vmi }) => {
   const { currentTime, duration } = useDuration();
   const queries = useMemo(() => getUtilizationQueries({ duration, obj: vmi }), [vmi, duration]);
 
-  const requests = vmi?.spec?.domain?.resources?.requests as {
-    [key: string]: string;
-  };
-  const memory = getMemorySize(requests?.memory);
+  const memory = getMemorySize(vmi?.spec?.domain?.memory?.guest);
 
   const [data] = usePrometheusPoll({
     endpoint: PrometheusEndpoint?.QUERY,

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Details/CPUMemory/CPUMemory.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Details/CPUMemory/CPUMemory.tsx
@@ -20,9 +20,7 @@ const CPUMemory: FC<TolerationsProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
   const cpu = vCPUCount(vmi?.spec?.domain?.cpu);
 
-  const memory = readableSizeUnit(
-    (vmi?.spec?.domain?.resources?.requests as { [key: string]: string })?.memory,
-  );
+  const memory = readableSizeUnit(vmi?.spec?.domain?.memory?.guest);
 
   return (
     <>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-32596

The recent backend change in https://github.com/kubevirt/common-templates/pull/543 broke displaying memory value in the whole UI. This PR updates our UI codebase to reflect this new change. From now the memory value is read from:

`vm.spec.template.spec.domain.memory.guest`

## 🎥 Screenshots
**Before:**
Catalog drawer, error right after opening the drawer, no values for CPU and Memory:
![drawer_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/24cb6c40-8ba2-4332-90e1-e6214fb895a8)
Template details page - no value for memory:
![templates_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/5bf5212f-8159-4cea-965e-4f51c9945774)

**After:**
![drawer_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/30c689aa-a578-47f9-b8bb-2c0c92fe2359)
![templates_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/7bf2e454-1ab9-42e6-af26-f2a01bfd1b01)

