### PR TITLE
CNV-32618: Fix pending badge showing on migrating VMs

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceList.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceList.tsx
@@ -18,7 +18,7 @@ import {
   useListPageFilter,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { printableVMStatus } from '@virtualmachines/utils';
+import { isRunning } from '@virtualmachines/utils';
 
 import useNetworkColumns from '../../hooks/useNetworkColumns';
 import useNetworkRowFilters from '../../hooks/useNetworkRowFilters';
@@ -33,9 +33,8 @@ type NetworkInterfaceTableProps = {
 const NetworkInterfaceList: FC<NetworkInterfaceTableProps> = ({ vm }) => {
   const filters = useNetworkRowFilters();
 
-  const vmiExists = printableVMStatus.Stopped !== vm?.status?.printableStatus;
   const [vmi] = useK8sWatchResource<V1VirtualMachineInstance>(
-    vmiExists && {
+    isRunning(vm) && {
       groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
       isList: false,
       name: getName(vm),
@@ -52,8 +51,8 @@ const NetworkInterfaceList: FC<NetworkInterfaceTableProps> = ({ vm }) => {
 
   const autoattachPodInterface = getAutoAttachPodInterface(vm) !== false;
 
-  const isPending = (network: V1Network) =>
-    getVMINetworks(vmi)?.some((ntwork) => ntwork?.name !== network.name);
+  const isPending = (network: V1Network): boolean =>
+    isRunning(vm) && !getVMINetworks(vmi)?.some((ntwork) => ntwork?.name === network.name);
 
   return (
     <>


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug wherein the Pending badge still shows on a hot plug NIC even after the VM has migrated and the NIC has been added to the VMI.

jira issue: https://issues.redhat.com/browse/CNV-32618

## 🎥 Screenshots

### Before

#### Before migration
![2023-09-08_15-28](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/19ddc698-51c6-49eb-87ca-0cd6dbbd67d8)


### After migration
![2023-09-08_15-29](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/d3bf70e7-2767-47fe-9b3a-2af02a0bd3df)


### After

#### Before migration
![2023-09-08_14-21](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/5ad1e9dd-f1a0-4d41-86b5-8afc130ac439)


### After migration
![2023-09-08_14-24](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/16c84a37-95a4-4bf7-8fab-f7cb7bfa9f73)

