### PR TITLE
CNV-32173: Missing size input when creating disk from "Template default" disk source

### DIFF
--- a/src/views/catalog/customize/components/CustomizeSource/SelectSource.tsx
+++ b/src/views/catalog/customize/components/CustomizeSource/SelectSource.tsx
@@ -81,7 +81,6 @@ export const SelectSource: React.FC<SelectSourceProps> = ({
   React.useEffect(() => {
     switch (selectedSourceType) {
       case DEFAULT_SOURCE:
-        return onSourceChange(undefined);
       case BLANK_SOURCE_NAME:
       case UPLOAD_SOURCE_NAME:
         return onSourceChange(
@@ -255,7 +254,7 @@ export const SelectSource: React.FC<SelectSourceProps> = ({
         </FormGroup>
       )}
 
-      {showSizeInput && selectedSourceType !== DEFAULT_SOURCE && (
+      {showSizeInput && selectedSourceType !== CONTAINER_DISK_SOURCE_NAME && (
         <CapacityInput label={t('Disk size')} onChange={setVolumeQuantity} size={volumeQuantity} />
       )}
     </>


### PR DESCRIPTION
## 📝 Description

Exposing the size input for "Template default" option in customize template's parameters section.

## 🎥 Demo

Before:
Missing size input:
![missing-size-input](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/0de2b2c8-1858-4249-aade-5804644aa98b)

After:
Added size input:
![missing-size-input-after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/ffbf8acc-46e5-485d-bc37-5e10e8ff2298)

Make sure change is accepted:
![missing-size-input-after2](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/cfe7620c-3d0c-4a4f-ae2f-e49c05904dff)

