### PR TITLE
CNV-32823: Update the example of VM and template YAML

### DIFF
--- a/src/templates/vm-template-yaml.ts
+++ b/src/templates/vm-template-yaml.ts
@@ -65,9 +65,8 @@ objects:
                 efi: {}
             machine:
               type: q35
-            resources:
-              requests:
-                memory: 2Gi
+            memory:
+              guest: 2Gi
           hostname: '\${NAME}'
           networks:
             - name: default

--- a/src/templates/vm-yaml.ts
+++ b/src/templates/vm-yaml.ts
@@ -50,9 +50,8 @@ spec:
             efi: {}
         machine:
           type: q35
-        resources:
-          requests:
-            memory: 2Gi
+        memory:
+          guest: 2Gi
       hostname: example
       networks:
         - name: default


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-32823

Update the "example" YAML of both VM and template used in the UI. Replace `vm.spec.template.spec.domain.resources.requests.memory` with `vm.spec.template.spec.domain.memory.guest` in the VM object, so the memory value gets saved correctly, according to the recent backend change introduced in
https://github.com/kubevirt/common-templates/pull/543.

Note that the bug this PR is fixing, fortunately didn't prevent VM to be created successfully and ran. 

Also note that VM creation from "example" template works as expected, too, with this PR, so its YAML is created and updated correctly.

## 🎥 Demo
**Before:**
"example" template creation - template created successfully, but incorrect YAML represetation regarding memory:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/f9d17d2b-90a3-4416-9d56-31e8927a94a5

VM creation "With YAML" - VM created successfully, but incorrect YAML represetation regarding memory:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/922103d3-ec12-4225-a4be-417fd0752f93

**After:**
"example" template creation - correct YAML:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/fe121a1e-8ea6-4a34-98f2-96d74e728911

VM creation "With YAML" - correct YAML:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/b44038c2-f90c-4c6e-89ce-11618a641415


