### PR TITLE
[WIP] CNV-23832: Apply StorageClass from Template's boot source

### DIFF
--- a/src/utils/resources/template/hooks/useVmTemplateSource/useVmTemplateSource.ts
+++ b/src/utils/resources/template/hooks/useVmTemplateSource/useVmTemplateSource.ts
@@ -65,6 +65,11 @@ export const useVmTemplateSource = (template: V1Template): useVmTemplateSourceVa
         setTemplateBootSource({
           source: {
             pvc: dataSource?.spec?.source?.pvc,
+            sourceRef: {
+              kind: dataSource?.kind,
+              name,
+              namespace,
+            },
           },
           storageClassName: pvc?.spec?.storageClassName,
           type: BOOT_SOURCE.DATA_SOURCE,

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerFooter.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerFooter.tsx
@@ -43,7 +43,12 @@ export const TemplatesCatalogDrawerFooter: FC<TemplateCatalogDrawerFooterProps> 
   template,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { isBootSourceAvailable, loaded: bootSourceLoaded } = useVmTemplateSource(template);
+  const {
+    isBootSourceAvailable,
+    loaded: bootSourceLoaded,
+    templateBootSource,
+  } = useVmTemplateSource(template);
+
   const [authorizedSSHKeys, updateAuthorizedSSHKeys, userSettingsLoaded] =
     useKubevirtUserSettings('ssh');
   const { loaded: loadedRHELSubscription, subscriptionData } = useRHELAutomaticSubscription();
@@ -109,6 +114,7 @@ export const TemplatesCatalogDrawerFooter: FC<TemplateCatalogDrawerFooterProps> 
             onCancel={onCancel}
             subscriptionData={subscriptionData}
             template={template}
+            templateBootSource={templateBootSource}
           />
         </Stack>
       </div>

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/utils/helpers.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/utils/helpers.ts
@@ -1,0 +1,54 @@
+import {
+  ProcessedTemplatesModel,
+  StorageClassModel,
+  V1Template,
+} from '@kubevirt-ui/kubevirt-api/console';
+import { IoK8sApiStorageV1StorageClassList } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { isDefaultStorageClass } from '@kubevirt-utils/components/DiskModal/DiskFormFields/utils/helpers';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import {
+  LABEL_USED_TEMPLATE_NAME,
+  LABEL_USED_TEMPLATE_NAMESPACE,
+} from '@kubevirt-utils/resources/template';
+import { getDataVolumeTemplates, getMemoryCPU } from '@kubevirt-utils/resources/vm';
+import { ensurePath, isEmpty } from '@kubevirt-utils/utils/utils';
+import { k8sCreate, k8sGet } from '@openshift-console/dynamic-plugin-sdk';
+
+export const shouldApplyInitialStorageClass = async (vm: V1VirtualMachine): Promise<string> => {
+  const vmSCExists = getDataVolumeTemplates(vm)?.some(
+    (dvt) => !!dvt?.spec?.storage?.storageClassName,
+  );
+  if (vmSCExists) return null;
+
+  const storageClasses = await k8sGet<IoK8sApiStorageV1StorageClassList>({
+    model: StorageClassModel,
+  });
+
+  const defaultSC = storageClasses?.items?.find((item) => isDefaultStorageClass(item));
+
+  return isEmpty(defaultSC) ? getName(storageClasses?.items[0]) : null;
+};
+
+export const applyCPUMemory = (draftVM: V1VirtualMachine, contextVM: V1VirtualMachine) => {
+  ensurePath(draftVM, ['spec.template.spec.domain.cpu', 'spec.template.spec.domain.memory.guest']);
+
+  const { cpu, memory } = getMemoryCPU(contextVM);
+  draftVM.spec.template.spec.domain.cpu.cores = cpu?.cores;
+  draftVM.spec.template.spec.domain.memory.guest = memory;
+};
+
+export const applyTemplateMetadataToVM = (draftVM: V1VirtualMachine, template: V1Template) => {
+  draftVM.metadata.labels[LABEL_USED_TEMPLATE_NAME] = getName(template);
+  draftVM.metadata.labels[LABEL_USED_TEMPLATE_NAMESPACE] = getNamespace(template);
+};
+
+export const processTemplate = (template: V1Template, namespace: string) =>
+  k8sCreate<V1Template>({
+    data: { ...template, metadata: { ...template?.metadata, namespace } },
+    model: ProcessedTemplatesModel,
+    ns: namespace,
+    queryParams: {
+      dryRun: 'All',
+    },
+  });

--- a/src/views/catalog/utils/quick-create-vm.ts
+++ b/src/views/catalog/utils/quick-create-vm.ts
@@ -1,75 +1,22 @@
-import produce from 'immer';
-
-import { ProcessedTemplatesModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { updateCloudInitRHELSubscription } from '@kubevirt-utils/components/CloudinitModal/utils/cloudinit-utils';
-import { applyCloudDriveCloudInitVolume } from '@kubevirt-utils/components/SSHSecretSection/utils/utils';
-import { addSecretToVM } from '@kubevirt-utils/components/SSHSecretSection/utils/utils';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
-import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
-import {
-  LABEL_USED_TEMPLATE_NAME,
-  LABEL_USED_TEMPLATE_NAMESPACE,
-  replaceTemplateVM,
-} from '@kubevirt-utils/resources/template';
-import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template/utils/selectors';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { k8sCreate, K8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { replaceTemplateVM } from '@kubevirt-utils/resources/template';
+import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
-import { createMultipleResources, isRHELTemplate } from './utils';
+import { createMultipleResources } from './utils';
 
 type QuickCreateVMType = (inputs: {
   models: { [key: string]: K8sModel };
-  overrides: {
-    authorizedSSHKey: string;
-    name: string;
-    namespace: string;
-    startVM: boolean;
-    subscriptionData: RHELAutomaticSubscriptionData;
-  };
-  template: V1Template;
+  processedTemplate: V1Template;
+  vm: V1VirtualMachine;
 }) => Promise<V1VirtualMachine>;
 
-export const quickCreateVM: QuickCreateVMType = async ({
-  models,
-  overrides: { authorizedSSHKey, name, namespace = DEFAULT_NAMESPACE, startVM, subscriptionData },
-  template,
-}) => {
-  const processedTemplate = await k8sCreate<V1Template>({
-    data: { ...template, metadata: { ...template?.metadata, namespace } },
-    model: ProcessedTemplatesModel,
-    ns: namespace,
-    queryParams: {
-      dryRun: 'All',
-    },
-  });
+export const quickCreateVM: QuickCreateVMType = async ({ models, processedTemplate, vm }) => {
+  const { objects } = replaceTemplateVM(processedTemplate, vm);
 
-  const vm = getTemplateVirtualMachineObject(processedTemplate);
-
-  const overridedVM = produce(vm, (draftVM) => {
-    draftVM.metadata.namespace = namespace;
-    draftVM.metadata.name = name;
-
-    draftVM.metadata.labels[LABEL_USED_TEMPLATE_NAME] = processedTemplate.metadata.name;
-    draftVM.metadata.labels[LABEL_USED_TEMPLATE_NAMESPACE] = template.metadata.namespace;
-    if (startVM) {
-      draftVM.spec.running = true;
-    }
-
-    const updatedVolumes = applyCloudDriveCloudInitVolume(vm);
-    draftVM.spec.template.spec.volumes = isRHELTemplate(processedTemplate)
-      ? updateCloudInitRHELSubscription(updatedVolumes, subscriptionData)
-      : updatedVolumes;
-  });
-
-  const vmToCreate = !isEmpty(authorizedSSHKey)
-    ? addSecretToVM(overridedVM, authorizedSSHKey)
-    : overridedVM;
-
-  const { objects } = replaceTemplateVM(processedTemplate, vmToCreate);
-
-  const createdObjects = await createMultipleResources(objects, models, namespace);
+  const createdObjects = await createMultipleResources(objects, models, getNamespace(vm));
 
   const createdVM = createdObjects.find(
     (object) => object.kind === VirtualMachineModel.kind,


### PR DESCRIPTION
## 📝 Description

When there's no StorageClass defined in the template or default StorageClass in the cluster, the CDI clone process can't determine which StorageClass to use and the DataVolume does not create its PersistentVolumeClaim.
If a template has an available boot source, we should apply the boot source's StorageClass if exist to allow VM to be created.

Note: This applies to the quick create flow for now, as we some issue with customize flow: 

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/3b0a0828-8e1e-4349-9178-cb532fd047d6

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/f25b3270-165f-4a73-9ed2-27885ef72d06


