### PR TITLE
CNV-32787: Adjust length of VM name field in Catalog drawer

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateCatalogDrawer.scss
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateCatalogDrawer.scss
@@ -3,10 +3,7 @@
     padding: 0;
 
     .template-catalog-drawer-footer-section {
-      padding-top: var(--pf-c-modal-box__footer--PaddingTop);
-      padding-right: var(--pf-c-modal-box__footer--PaddingRight);
-      padding-bottom: var(--pf-c-modal-box__footer--PaddingBottom);
-      padding-left: var(--pf-c-modal-box__footer--PaddingLeft);
+      padding: var(--pf-c-modal-box__footer--PaddingTop) var(--pf-global--spacer--xl) var(--pf-global--spacer--xl);
       border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
     }
   }
@@ -21,7 +18,7 @@
 }
 
 .template-catalog-drawer-form-name {
-  width: 250px;
+  max-width: 49%;
 }
 
 .template-catalog-drawer-description {

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -229,13 +229,8 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
             <>
               <StackItem>
                 <Split hasGutter>
-                  <SplitItem>
-                    <FormGroup
-                      className="template-catalog-drawer-form-name"
-                      fieldId="vm-name-field"
-                      isRequired
-                      label={t('VirtualMachine name')}
-                    >
+                  <SplitItem className="template-catalog-drawer-form-name" isFilled>
+                    <FormGroup fieldId="vm-name-field" isRequired label={t('VirtualMachine name')}>
                       <TextInput
                         aria-label="virtualmachine name"
                         data-test-id="template-catalog-vm-name-input"


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-32787

Sometimes, the generated VM name is a bit longer, so the VM name field cannot hold it completely. This commit makes it a bit longer to hold the long name, as there's enough space in the line of the _Catalog_ drawer.

Additionally, edit the padding of the related part of the drawer the way that the whole content of the drawer is nicely aligned.

## 🎥 Screenshots
**Before:**
![width_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/4c0b9777-34b7-4eea-9313-283ae1846fba)

**After:**
![width_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/b59af713-5c28-4a03-97ba-4839e44049a3)

