### PR TITLE
CNV-32665: Fix hot plug NIC not added to VMI after live migration

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateCatalogDrawer.scss
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateCatalogDrawer.scss
@@ -3,7 +3,8 @@
     padding: 0;
 
     .template-catalog-drawer-footer-section {
-      padding: var(--pf-c-modal-box__footer--PaddingTop) var(--pf-global--spacer--xl) var(--pf-global--spacer--xl);
+      padding: var(--pf-c-modal-box__footer--PaddingTop) var(--pf-global--spacer--xl)
+        var(--pf-global--spacer--xl);
       border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
     }
   }

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesNetworkInterfaceModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesNetworkInterfaceModal.tsx
@@ -17,6 +17,7 @@ import ModalPendingChangesAlert from '@kubevirt-utils/components/PendingChanges/
 import { BRIDGED_NIC_HOTPLUG_ENABLED } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
+import { interfacesTypes } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import { addInterface } from '@virtualmachines/actions/actions';
 
@@ -51,7 +52,7 @@ const VirtualMachinesNetworkInterfaceModal: FC<VirtualMachinesNetworkInterfaceMo
         const updatedInterfaces: V1Interface[] = [...(getInterfaces(vm) || []), resultInterface];
         const updatedVM = updateVMNetworkInterface(vm, updatedNetworks, updatedInterfaces);
 
-        if (nicHotPlugEnabled && interfaceType === 'bridge') {
+        if (nicHotPlugEnabled && interfaceType === interfacesTypes.bridge) {
           return addInterface(updatedVM, {
             name: nicName,
             networkAttachmentDefinitionName: networkName,


### PR DESCRIPTION
## 📝 Description

This fixes a bug wherein a secondary hot-plugged NIC is added to a VM, but it is not added to the VMI after live migration.

jira issue: https://issues.redhat.com/browse/CNV-32665

## 🎥 Screenshots

### Hot-plug NIC added - Before migration
![2023-09-16_15-41](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/3cdf52cc-7305-4f24-bb9f-7d65ea9db6c1)

### After migration
![2023-09-16_15-42](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/e3814c2d-66ea-48cb-9392-42fcf4bc5d39)

