### PR TITLE
CNV-32684: Fixing the dynamic ssh key injection

### DIFF
--- a/src/utils/resources/vm/utils/selectors.ts
+++ b/src/utils/resources/vm/utils/selectors.ts
@@ -1,5 +1,6 @@
 import { V1AccessCredential, V1Disk, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { DYNAMIC_CREDENTIALS_SUPPORT } from '@kubevirt-utils/components/DynamicSSHKeyInjection/constants/constants';
+import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { getAnnotation, getLabel } from '@kubevirt-utils/resources/shared';
 
 import { VM_WORKLOAD_ANNOTATION } from './annotations';
@@ -146,8 +147,11 @@ export const getWorkload = (vm: V1VirtualMachine): string =>
 export const getAccessCredentials = (vm: V1VirtualMachine): V1AccessCredential[] =>
   vm?.spec?.template?.spec?.accessCredentials;
 
-export const getIsDynamicSSHInjectionEnabled = (vm: V1VirtualMachine): boolean =>
-  getLabel(vm, DYNAMIC_CREDENTIALS_SUPPORT) === 'true' &&
+export const getIsDynamicSSHInjectionEnabled = (
+  vm: V1VirtualMachine,
+  bootableVolume?: BootableVolume,
+): boolean =>
+  getLabel(bootableVolume || vm, DYNAMIC_CREDENTIALS_SUPPORT) === 'true' &&
   Boolean(getAccessCredentials(vm)?.[0]?.sshPublicKey?.propagationMethod?.qemuGuestAgent);
 
 /**

--- a/src/views/catalog/wizard/tabs/scripts/components/DynamicSSHKeyInjectionWizard.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/components/DynamicSSHKeyInjectionWizard.tsx
@@ -32,6 +32,7 @@ const DynamicSSHKeyInjectionWizard = () => {
             cloudInitConfigDrive: getCloudInitConfigDrive(
               checked,
               cloudInitConfigDrive.cloudInitConfigDrive,
+              true,
             ),
             name: cloudInitConfigDrive.name,
           },

--- a/src/views/virtualmachines/details/tabs/configuration/scripts/hooks/useDynamicSSHInjection.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/scripts/hooks/useDynamicSSHInjection.ts
@@ -1,0 +1,14 @@
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import useBootableVolumes from '@kubevirt-utils/resources/bootableresources/hooks/useBootableVolumes';
+import { getName } from '@kubevirt-utils/resources/shared';
+import { getIsDynamicSSHInjectionEnabled } from '@kubevirt-utils/resources/vm';
+import { getPVCSourceOrSourceRef } from '@kubevirt-utils/resources/vm/utils/source';
+
+export const useDynamicSSHInjection = (vm: V1VirtualMachine) => {
+  const { name, namespace } = getPVCSourceOrSourceRef(vm);
+  const { bootableVolumes } = useBootableVolumes(namespace);
+  const bootableVolume = bootableVolumes?.find((bv) => getName(bv) === name);
+  const isDynamicSSHInjectionEnabled = getIsDynamicSSHInjectionEnabled(vm, bootableVolume);
+
+  return isDynamicSSHInjectionEnabled;
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
These changes involve adding the missing line - 'runcmd - [ setsebool, -P, virt_qemu_ga_manage_ssh, on ]` to the YAML in instanceTypes.
Also, I fixed the problem that after creating a VM, and the dynamic SSH key injection switch was turned on, we could not edit the ssh key. Now, we should be able to edit or remove the SSH key.
If the dynamic SSH key injection switch has not been activated, it will not be possible to edit the ssh key after creation and the option to edit will be disabled.

## 🎥 Demo
Template-
![templateCheckDynamic](https://github.com/kubevirt-ui/kubevirt-plugin/assets/61961469/3220e612-bff1-48ae-852c-8645e34b3a9d)
![templateUnCheckDynamic](https://github.com/kubevirt-ui/kubevirt-plugin/assets/61961469/bf3add2f-ca9e-4e5c-ae0b-f3c7ef13ca97)

InstanceType - 
![itCheckDynamic](https://github.com/kubevirt-ui/kubevirt-plugin/assets/61961469/2ef71eae-cdae-442a-b170-8858a195b838)
![itUnCheckDynamic](https://github.com/kubevirt-ui/kubevirt-plugin/assets/61961469/8cde8365-acb8-44b8-a9a1-105cd8818160)

