### PR TITLE
CNV-32912: Fix duplicate pending changes messages

### DIFF
--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -163,9 +163,9 @@ export const nonHotPlugNICChangesExist = (
   pendingChanges: PendingChange[],
   nonHotPlugNICsExist: boolean,
 ) => {
-  const moreChangeTypesExist = pendingChanges?.every(
-    (change) => change?.tabLabel === VirtualMachineDetailsTabLabel.NetworkInterfaces,
-  );
+  const moreChangeTypesExist = pendingChanges
+    ?.filter((change) => change?.hasPendingChange)
+    ?.some((change) => change?.tabLabel !== VirtualMachineDetailsTabLabel.NetworkInterfaces);
   return moreChangeTypesExist || nonHotPlugNICsExist;
 };
 

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateCatalogDrawer.scss
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateCatalogDrawer.scss
@@ -3,7 +3,8 @@
     padding: 0;
 
     .template-catalog-drawer-footer-section {
-      padding: var(--pf-c-modal-box__footer--PaddingTop) var(--pf-global--spacer--xl) var(--pf-global--spacer--xl);
+      padding: var(--pf-c-modal-box__footer--PaddingTop) var(--pf-global--spacer--xl)
+        var(--pf-global--spacer--xl);
       border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
     }
   }

--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/LiveMigratePendingChanges.tsx
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/LiveMigratePendingChanges.tsx
@@ -1,10 +1,7 @@
 import React, { FC } from 'react';
 
 import PendingChangesBreadcrumb from '@kubevirt-utils/components/PendingChanges/PendingChangesBreadcrumb/PendingChangesBreadcrumb';
-import { hasPendingChange } from '@kubevirt-utils/components/PendingChanges/utils/helpers';
 import { PendingChange } from '@kubevirt-utils/components/PendingChanges/utils/types';
-import { BRIDGED_NIC_HOTPLUG_ENABLED } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { List } from '@patternfly/react-core';
 
@@ -16,10 +13,6 @@ const LiveMigratePendingChanges: FC<LiveMigratePendingChangesProps> = ({
   nicHotPlugPendingChanges,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { featureEnabled: nicHotPlugEnabled } = useFeatures(BRIDGED_NIC_HOTPLUG_ENABLED);
-
-  const showLiveMigrateSection = nicHotPlugEnabled && hasPendingChange(nicHotPlugPendingChanges);
-  if (!showLiveMigrateSection) return null;
 
   return (
     <>

--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/LiveMigratePendingChanges.tsx
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/LiveMigratePendingChanges.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import PendingChangesBreadcrumb from '@kubevirt-utils/components/PendingChanges/PendingChangesBreadcrumb/PendingChangesBreadcrumb';
 import { hasPendingChange } from '@kubevirt-utils/components/PendingChanges/utils/helpers';
@@ -12,7 +12,7 @@ type LiveMigratePendingChangesProps = {
   nicHotPlugPendingChanges: PendingChange[];
 };
 
-const LiveMigratePendingChanges: React.FC<LiveMigratePendingChangesProps> = ({
+const LiveMigratePendingChanges: FC<LiveMigratePendingChangesProps> = ({
   nicHotPlugPendingChanges,
 }) => {
   const { t } = useKubevirtTranslation();

--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/RestartPendingChanges.tsx
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/RestartPendingChanges.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import PendingChangesBreadcrumb from '@kubevirt-utils/components/PendingChanges/PendingChangesBreadcrumb/PendingChangesBreadcrumb';
 import {
@@ -17,7 +17,7 @@ type RestartPendingChangesProps = {
   pendingChanges: PendingChange[];
 };
 
-const RestartPendingChanges: React.FC<RestartPendingChangesProps> = ({
+const RestartPendingChanges: FC<RestartPendingChangesProps> = ({
   nonHotPlugPendingChanges,
   pendingChanges,
 }) => {
@@ -34,8 +34,7 @@ const RestartPendingChanges: React.FC<RestartPendingChangesProps> = ({
   } = pendingChangesTabs;
   const showRestartSection =
     !nicHotPlugEnabled ||
-    nonHotPlugNICChangesExist(pendingChanges, hasPendingChange(nonHotPlugPendingChanges)) ||
-    Object.values(pendingChangesTabs).some((changes) => changes.length > 0);
+    nonHotPlugNICChangesExist(pendingChanges, hasPendingChange(nonHotPlugPendingChanges));
   if (!showRestartSection) return null;
 
   return (

--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/RestartPendingChanges.tsx
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/RestartPendingChanges.tsx
@@ -4,25 +4,24 @@ import PendingChangesBreadcrumb from '@kubevirt-utils/components/PendingChanges/
 import {
   getPendingChangesByTab,
   hasPendingChange,
-  nonHotPlugNICChangesExist,
 } from '@kubevirt-utils/components/PendingChanges/utils/helpers';
 import { PendingChange } from '@kubevirt-utils/components/PendingChanges/utils/types';
-import { BRIDGED_NIC_HOTPLUG_ENABLED } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { List } from '@patternfly/react-core';
 
 type RestartPendingChangesProps = {
+  nicHotPlugEnabled: boolean;
   nonHotPlugPendingChanges: PendingChange[];
   pendingChanges: PendingChange[];
 };
 
 const RestartPendingChanges: FC<RestartPendingChangesProps> = ({
+  nicHotPlugEnabled,
   nonHotPlugPendingChanges,
   pendingChanges,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { featureEnabled: nicHotPlugEnabled } = useFeatures(BRIDGED_NIC_HOTPLUG_ENABLED);
+
   const pendingChangesTabs = getPendingChangesByTab(pendingChanges);
   const {
     pendingChangesDetailsTab,
@@ -32,10 +31,6 @@ const RestartPendingChanges: FC<RestartPendingChangesProps> = ({
     pendingChangesSchedulingTab,
     pendingChangesScriptsTab,
   } = pendingChangesTabs;
-  const showRestartSection =
-    !nicHotPlugEnabled ||
-    nonHotPlugNICChangesExist(pendingChanges, hasPendingChange(nonHotPlugPendingChanges));
-  if (!showRestartSection) return null;
 
   return (
     <span>

--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/VirtualMachinePendingChangesAlert.tsx
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/VirtualMachinePendingChangesAlert.tsx
@@ -5,11 +5,15 @@ import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevir
 import { usePendingChanges } from '@kubevirt-utils/components/PendingChanges/hooks/usePendingChanges';
 import { PendingChangesAlert } from '@kubevirt-utils/components/PendingChanges/PendingChangesAlert/PendingChangesAlert';
 import { getSortedNICPendingChanges } from '@kubevirt-utils/components/PendingChanges/utils/helpers';
+import { BRIDGED_NIC_HOTPLUG_ENABLED } from '@kubevirt-utils/hooks/useFeatures/constants';
+import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Stack, StackItem } from '@patternfly/react-core';
 import LiveMigratePendingChanges from '@virtualmachines/details/VirtualMachinePendingChangesAlert/LiveMigratePendingChanges';
 import RestartPendingChanges from '@virtualmachines/details/VirtualMachinePendingChangesAlert/RestartPendingChanges';
 import { isRunning } from '@virtualmachines/utils';
+
+import { showPendingChangesSections } from '../utils/utils';
 
 type VirtualMachinePendingChangesAlertProps = {
   vm: V1VirtualMachine;
@@ -22,6 +26,7 @@ const VirtualMachinePendingChangesAlert: FC<VirtualMachinePendingChangesAlertPro
 }) => {
   const history = useHistory();
   const pendingChanges = usePendingChanges(vm, vmi);
+  const { featureEnabled: nicHotPlugEnabled } = useFeatures(BRIDGED_NIC_HOTPLUG_ENABLED);
 
   const hasPendingChanges = pendingChanges?.some((change) => change?.hasPendingChange);
   const isInstanceTypeVM = !isEmpty(vm?.spec?.instancetype) || !isEmpty(vm?.spec?.preference);
@@ -31,21 +36,31 @@ const VirtualMachinePendingChangesAlert: FC<VirtualMachinePendingChangesAlertPro
   }
 
   const sortedNICHotPlugPendingChanges = getSortedNICPendingChanges(vm, vmi, history);
+  const { showLiveMigrateSection, showRestartSection } = showPendingChangesSections(
+    nicHotPlugEnabled,
+    pendingChanges,
+    sortedNICHotPlugPendingChanges,
+  );
 
   return (
     <PendingChangesAlert isWarning>
       <Stack hasGutter>
-        <StackItem>
-          <LiveMigratePendingChanges
-            nicHotPlugPendingChanges={sortedNICHotPlugPendingChanges?.nicHotPlugPendingChanges}
-          />
-        </StackItem>
-        <StackItem>
-          <RestartPendingChanges
-            nonHotPlugPendingChanges={sortedNICHotPlugPendingChanges?.nicNonHotPlugPendingChanges}
-            pendingChanges={pendingChanges}
-          />
-        </StackItem>
+        {showLiveMigrateSection && (
+          <StackItem>
+            <LiveMigratePendingChanges
+              nicHotPlugPendingChanges={sortedNICHotPlugPendingChanges?.nicHotPlugPendingChanges}
+            />
+          </StackItem>
+        )}
+        {showRestartSection && (
+          <StackItem>
+            <RestartPendingChanges
+              nicHotPlugEnabled={nicHotPlugEnabled}
+              nonHotPlugPendingChanges={sortedNICHotPlugPendingChanges?.nicNonHotPlugPendingChanges}
+              pendingChanges={pendingChanges}
+            />
+          </StackItem>
+        )}
       </Stack>
     </PendingChangesAlert>
   );

--- a/src/views/virtualmachines/details/utils/utils.ts
+++ b/src/views/virtualmachines/details/utils/utils.ts
@@ -7,16 +7,17 @@ import {
   PendingChange,
 } from '@kubevirt-utils/components/PendingChanges/utils/types';
 
-export const showLiveMigrateAndRestartSections = (
-  bridgeNICHotPlugEnabled: boolean,
+export const showPendingChangesSections = (
+  nicHotPlugEnabled: boolean,
   pendingChanges: PendingChange[],
   sortedNICHotPlugPendingChanges: NICHotPlugPendingChanges,
-) => {
+): { showLiveMigrateSection: boolean; showRestartSection: boolean } => {
   const { nicHotPlugPendingChanges, nicNonHotPlugPendingChanges } = sortedNICHotPlugPendingChanges;
-  const showLiveMigrateSection =
-    bridgeNICHotPlugEnabled && hasPendingChange(nicHotPlugPendingChanges);
-  const showRestartSection =
-    !bridgeNICHotPlugEnabled ||
-    nonHotPlugNICChangesExist(pendingChanges, hasPendingChange(nicNonHotPlugPendingChanges));
-  return showLiveMigrateSection && showRestartSection;
+
+  return {
+    showLiveMigrateSection: nicHotPlugEnabled && hasPendingChange(nicHotPlugPendingChanges),
+    showRestartSection:
+      !nicHotPlugEnabled ||
+      nonHotPlugNICChangesExist(pendingChanges, hasPendingChange(nicNonHotPlugPendingChanges)),
+  };
 };


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug wherein the restart section of the pending changes alert is shown after adding a hot-plug NIC when there are no pending changes for that section.

jira issue: https://issues.redhat.com/browse/CNV-32912

## 🎥 Screenshots

### Before
![2023-09-13_10-34](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/2fc78067-f846-4a19-bbac-55870bce2d1e)

### After
![2023-09-13_10-24](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/2740a046-e7d5-4650-a680-f3b84805372d)

