### PR TITLE
CNV-32925: Display correct units for Network transfer statistics

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -686,7 +686,7 @@
   "Network interfaces ({{count}})": "Network interfaces ({{count}})",
   "Network interfaces ({{count}})_plural": "Network interfaces ({{count}})",
   "Network out": "Network out",
-  "Network Transfer": "Network Transfer",
+  "Network transfer": "Network transfer",
   "Network transfer breakdown": "Network transfer breakdown",
   "Networking": "Networking",
   "Networks": "Networks",

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/NetworkUtil/NetworkUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/NetworkUtil/NetworkUtil.tsx
@@ -58,7 +58,7 @@ const NetworkUtil: React.FC<NetworkUtilProps> = ({ vmi }) => {
     <div className="util network">
       <div className="util-upper">
         <div className="util-title">
-          {t('Network Transfer')}
+          {t('Network transfer')}
           <Popover
             bodyContent={
               <div>
@@ -110,7 +110,7 @@ const NetworkUtil: React.FC<NetworkUtilProps> = ({ vmi }) => {
         </div>
 
         <div className="util-summary" data-test-id="util-summary-network-transfer">
-          <div className="util-summary-value">{`${totalTransferred}s`}</div>
+          <div className="util-summary-value">{`${totalTransferred}ps`}</div>
           <div className="util-summary-text text-muted network-value">
             <div>{t('Total')}</div>
           </div>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-32925

Display 'Bps' units instead of 'Bs' for _Network transfer_ statistics displayed in the VM _Overview_ tab of a running VM. Also change "Network Transfer" title to "Network transfer" to use sentence case to align with the rest of the UI.

## 🎥 Screenshots
**Before:**
![bs_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/a0699331-216e-47ab-ba2c-827c1251a792)

**After:**
![bs_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/0cecdb6f-6b22-400d-a2a4-999b9955f436)
