### PR TITLE
CNV-32920: Disable Stop button for VM being provisioned

### DIFF
--- a/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
@@ -240,7 +240,9 @@ export const VirtualMachineActionFactory = {
     return {
       accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
       cta: () => stopVM(vm),
-      disabled: [Stopped, Stopping, Terminating, Unknown].includes(vm?.status?.printableStatus),
+      disabled: [Provisioning, Stopped, Stopping, Terminating, Unknown].includes(
+        vm?.status?.printableStatus,
+      ),
       id: 'vm-action-stop',
       label: t('Stop'),
     };


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-32920

Disable _Stop_ button in _Actions_ drop down for a VM that is being provisioned, as clicking on that button at this stage does not have any meaning, it should not be active.

## 🎥 Screenshots
**Before:**
Possible to click on _Stop_ button, which is unnecessary for a VM with _Provisioning_ status:
![prov_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/c3f12e5c-fc56-4e0e-8b54-e4b7b1b3c6da)

**After:**
_Stop_ button disabled:
![prov_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/60907c91-bee2-409d-a2a4-9d81cdcc1ad6)
