### PR TITLE
CNV-32959: Move InstanceTypes and Preferences under Templates in menu

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -124,6 +124,68 @@
     "type": "console.page/resource/list"
   },
   {
+    "flags": {
+      "required": ["CAN_LIST_NS"]
+    },
+    "properties": {
+      "dataAttributes": {
+        "data-quickstart-id": "qs-nav-virtualmachineclusterinstancetypes",
+        "data-test-id": "virtualmachineclusterinstancetypes-nav-item"
+      },
+      "id": "virtualmachineclusterinstancetypes",
+      "model": {
+        "group": "instancetype.kubevirt.io",
+        "kind": "VirtualMachineClusterInstancetype",
+        "version": "v1alpha2"
+      },
+      "name": "%plugin__kubevirt-plugin~InstanceTypes%",
+      "section": "virtualization"
+    },
+    "type": "console.navigation/resource-cluster"
+  },
+  {
+    "properties": {
+      "component": { "$codeRef": "ClusterInstancetypeList" },
+      "model": {
+        "group": "instancetype.kubevirt.io",
+        "kind": "VirtualMachineClusterInstancetype",
+        "version": "v1alpha2"
+      }
+    },
+    "type": "console.page/resource/list"
+  },
+  {
+    "flags": {
+      "required": ["CAN_LIST_NS"]
+    },
+    "properties": {
+      "dataAttributes": {
+        "data-quickstart-id": "qs-nav-virtualmachineclusterpreferences",
+        "data-test-id": "virtualmachineclusterpreferences-nav-item"
+      },
+      "id": "virtualmachineclusterpreferences",
+      "model": {
+        "group": "instancetype.kubevirt.io",
+        "kind": "VirtualMachineClusterPreference",
+        "version": "v1alpha2"
+      },
+      "name": "%plugin__kubevirt-plugin~Preferences%",
+      "section": "virtualization"
+    },
+    "type": "console.navigation/resource-cluster"
+  },
+  {
+    "properties": {
+      "component": { "$codeRef": "ClusterPreferenceList" },
+      "model": {
+        "group": "instancetype.kubevirt.io",
+        "kind": "VirtualMachineClusterPreference",
+        "version": "v1alpha2"
+      }
+    },
+    "type": "console.page/resource/list"
+  },
+  {
     "properties": {
       "component": {
         "$codeRef": "TemplatesCatalog"
@@ -360,8 +422,8 @@
   {
     "properties": {
       "id": "VirtualizationSeparator",
-      "insertAfter": "templates",
-      "insertBefore": "bootablevolumes",
+      "insertAfter": "virtualmachineclusterpreferences",
+      "insertBefore": "virtualization-bootablevolumes",
       "perspective": "admin",
       "section": "virtualization",
       "testID": "VirtualizationSeparator"
@@ -440,68 +502,6 @@
         "group": "migrations.kubevirt.io",
         "kind": "MigrationPolicy",
         "version": "v1alpha1"
-      }
-    },
-    "type": "console.page/resource/list"
-  },
-  {
-    "flags": {
-      "required": ["CAN_LIST_NS"]
-    },
-    "properties": {
-      "dataAttributes": {
-        "data-quickstart-id": "qs-nav-virtualmachineclusterinstancetypes",
-        "data-test-id": "virtualmachineclusterinstancetypes-nav-item"
-      },
-      "id": "virtualmachineclusterinstancetypes",
-      "model": {
-        "group": "instancetype.kubevirt.io",
-        "kind": "VirtualMachineClusterInstancetype",
-        "version": "v1alpha2"
-      },
-      "name": "%plugin__kubevirt-plugin~InstanceTypes%",
-      "section": "virtualization"
-    },
-    "type": "console.navigation/resource-cluster"
-  },
-  {
-    "properties": {
-      "component": { "$codeRef": "ClusterInstancetypeList" },
-      "model": {
-        "group": "instancetype.kubevirt.io",
-        "kind": "VirtualMachineClusterInstancetype",
-        "version": "v1alpha2"
-      }
-    },
-    "type": "console.page/resource/list"
-  },
-  {
-    "flags": {
-      "required": ["CAN_LIST_NS"]
-    },
-    "properties": {
-      "dataAttributes": {
-        "data-quickstart-id": "qs-nav-virtualmachineclusterpreferences",
-        "data-test-id": "virtualmachineclusterpreferences-nav-item"
-      },
-      "id": "virtualmachineclusterpreferences",
-      "model": {
-        "group": "instancetype.kubevirt.io",
-        "kind": "VirtualMachineClusterPreference",
-        "version": "v1alpha2"
-      },
-      "name": "%plugin__kubevirt-plugin~Preferences%",
-      "section": "virtualization"
-    },
-    "type": "console.navigation/resource-cluster"
-  },
-  {
-    "properties": {
-      "component": { "$codeRef": "ClusterPreferenceList" },
-      "model": {
-        "group": "instancetype.kubevirt.io",
-        "kind": "VirtualMachineClusterPreference",
-        "version": "v1alpha2"
       }
     },
     "type": "console.page/resource/list"


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-32959

Move _InstanceTypes_ and _Preferences_ menu items under _Templates_ in the _Virtualization_ menu, as those are just other resources related to VM creation.

## 🎥 Screenshots
**Before:**
_InstanceTypes_ and _Preferences_ menu items placed under _MigrationPolicies_:
![menu_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/fb166855-a622-49e5-af1f-767bb157743b)

**After:**
_InstanceTypes_ and _Preferences_ menu items placed under _Templates_:
![menu_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/ec9a834c-7238-405d-b195-5ae0f15b143d)

