### PR TITLE
CNV-31856: Prevent displaying "Pending changes" for stopped VM

### DIFF
--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/VirtualMachinePendingChangesAlert.tsx
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/VirtualMachinePendingChangesAlert.tsx
@@ -9,7 +9,7 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Stack, StackItem } from '@patternfly/react-core';
 import LiveMigratePendingChanges from '@virtualmachines/details/VirtualMachinePendingChangesAlert/LiveMigratePendingChanges';
 import RestartPendingChanges from '@virtualmachines/details/VirtualMachinePendingChangesAlert/RestartPendingChanges';
-import { printableVMStatus } from '@virtualmachines/utils';
+import { isRunning } from '@virtualmachines/utils';
 
 type VirtualMachinePendingChangesAlertProps = {
   vm: V1VirtualMachine;
@@ -26,12 +26,7 @@ const VirtualMachinePendingChangesAlert: FC<VirtualMachinePendingChangesAlertPro
   const hasPendingChanges = pendingChanges?.some((change) => change?.hasPendingChange);
   const isInstanceTypeVM = !isEmpty(vm?.spec?.instancetype) || !isEmpty(vm?.spec?.preference);
 
-  if (
-    !vmi ||
-    vm?.status?.printableStatus === printableVMStatus.Stopped ||
-    !hasPendingChanges ||
-    isInstanceTypeVM
-  ) {
+  if (!vmi || !isRunning(vm) || !hasPendingChanges || isInstanceTypeVM) {
     return null;
   }
 


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-31856

Prevent displaying "Pending changes" warning in _Configuration > Disks_ page of a stopped VM if non-bootdisk was added to the VM.

_Note:_
The bug this PR is fixing is reproducible only just a very short time after a VM was stopped, later you won't be able to reproduce.

## 🎥 Demo
**Before:** Pending changes warning appears for a while:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/a5ac3f04-fde3-4923-8841-93882627f931

**After:** Pending changes warning doesn't appear (as expected for a stopped VM):

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/73d7e8f4-4e6c-46ba-bd40-2999cb22bd92


