### PR TITLE
Use getCPUcores selector in checkCPUMemoryChanged

### DIFF
--- a/src/utils/components/CPUMemoryModal/CpuMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CpuMemoryModal.tsx
@@ -6,7 +6,7 @@ import ModalPendingChangesAlert from '@kubevirt-utils/components/PendingChanges/
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getLabel } from '@kubevirt-utils/resources/shared';
-import { getMemory, VM_TEMPLATE_ANNOTATION } from '@kubevirt-utils/resources/vm';
+import { getCPUcores, getMemory, VM_TEMPLATE_ANNOTATION } from '@kubevirt-utils/resources/vm';
 import { toIECUnit } from '@kubevirt-utils/utils/units';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 import {
@@ -24,7 +24,7 @@ import {
 } from '@patternfly/react-core';
 
 import useTemplateDefaultCpuMemory from './hooks/useTemplateDefaultCpuMemory';
-import { getCPUcores, getMemorySize, memorySizesTypes } from './utils/CpuMemoryUtils';
+import { getMemorySize, memorySizesTypes } from './utils/CpuMemoryUtils';
 
 import './cpu-memory-modal.scss';
 

--- a/src/utils/components/CPUMemoryModal/utils/CpuMemoryUtils.ts
+++ b/src/utils/components/CPUMemoryModal/utils/CpuMemoryUtils.ts
@@ -1,8 +1,3 @@
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getCPU } from '@kubevirt-utils/resources/vm';
-
-export const getCPUcores = (vm: V1VirtualMachine): number => getCPU(vm)?.cores || 1;
-
 const GI = 'Gi';
 const MI = 'Mi';
 const TI = 'Ti';

--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -24,6 +24,7 @@ import {
 import {
   getAffinity,
   getCPU,
+  getCPUcores,
   getGPUDevices,
   getHostDevices,
   getInterfaces,
@@ -46,11 +47,10 @@ export const checkCPUMemoryChanged = (
     return false;
   }
   const vmMemory = getMemory(vm);
-  const vmCPU = getCPU(vm)?.cores || 0;
+  const vmCPU = getCPUcores(vm);
 
   const vmiMemory = getMemory(vmi) || '';
-
-  const vmiCPU = getCPU(vmi)?.cores || 0;
+  const vmiCPU = getCPUcores(vmi);
 
   return vmMemory !== vmiMemory || vmCPU !== vmiCPU;
 };

--- a/src/utils/resources/vm/utils/selectors.ts
+++ b/src/utils/resources/vm/utils/selectors.ts
@@ -185,3 +185,10 @@ export const getMemoryCPU = <T>(obj: T): { cpu: V1CPU; memory: string } => ({
   cpu: getCPU(obj),
   memory: getMemory(obj),
 });
+
+/**
+ * A selector that returns number of CPU cores of the resource
+ * @param {T} obj resource such as vm or vmi
+ * @returns {number} the number of CPU cores
+ */
+export const getCPUcores = <T>(obj: T): number => getCPU(obj)?.cores || 1;

--- a/src/utils/resources/vmi/utils/selectors.ts
+++ b/src/utils/resources/vmi/utils/selectors.ts
@@ -8,14 +8,14 @@ export const getVMIVolumes = (vmi: V1VirtualMachineInstance) => vmi?.spec?.volum
 
 /**
  * A selector for the virtual machine instance's networks
- * @param {V1VirtualMachineInstance} vmi the virtual machine
+ * @param {V1VirtualMachineInstance} vmi the virtual machine instance
  * @returns the virtual machine instance networks
  */
 export const getVMINetworks = (vmi: V1VirtualMachineInstance) => vmi?.spec?.networks;
 
 /**
  * A selector for the virtual machine instance's interfaces
- * @param {V1VirtualMachineInstance} vmi the virtual machine
+ * @param {V1VirtualMachineInstance} vmi the virtual machine instance
  * @returns the virtual machine instance interfaces
  */
 export const getVMIInterfaces = (vmi: V1VirtualMachineInstance) =>

--- a/src/views/templates/details/tabs/details/components/CPUMemoryModal.tsx
+++ b/src/views/templates/details/tabs/details/components/CPUMemoryModal.tsx
@@ -3,13 +3,12 @@ import produce from 'immer';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import {
-  getCPUcores,
   getMemorySize,
   memorySizesTypes,
 } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
-import { getMemory } from '@kubevirt-utils/resources/vm';
+import { getCPUcores, getMemory } from '@kubevirt-utils/resources/vm';
 import { toIECUnit } from '@kubevirt-utils/utils/units';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 import {


### PR DESCRIPTION
## 📝 Description

Use the existing `getCPUcores` selector in `checkCPUMemoryChanged` where possible, also add other minor improvements to the code like add missing "instance" to the description of some VMI related selectors, also move `getCPUcores` to VM selectors related file.

## 🎥 Demo

No any visual changes
