### PR TITLE
CNV-32957: Add cloud-init basic info to instancetype cli command

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/components/YamlAndCLIViewerModal/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/components/YamlAndCLIViewerModal/utils/utils.ts
@@ -17,8 +17,10 @@ export const getCreateVMVirtctlCommand = (
     ? '--volume-clone-pvc='
     : '--volume-datasource=src:';
 
-  const encodedSSHCloudInitUserData =
-    sshPubKey && `--cloud-init-user-data ${encodeKeyForVirtctlCommand(sshPubKey)}`;
+  const encodedSSHCloudInitUserData = `--cloud-init-user-data ${encodeKeyForVirtctlCommand(
+    vm,
+    sshPubKey,
+  )}`;
 
   return `virtctl create vm \\
   --name=${getName(vm)} \\


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The current cli command in the catalog instancetype was with sshkey but without any other user data that belongs to cloud int.
## 🎥 Demo

> Please add a video or an image of the behavior/changes
