### PR TITLE
CNV-32923: Fix clicking enter after copy console

### DIFF
--- a/src/utils/components/Consoles/components/vnc-console/VncConsole.tsx
+++ b/src/utils/components/Consoles/components/vnc-console/VncConsole.tsx
@@ -1,4 +1,13 @@
-import React, { FC, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  FC,
+  MouseEvent,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import cn from 'classnames';
 
 import LoadingEmptyState from '@kubevirt-utils/components/LoadingEmptyState/LoadingEmptyState';
@@ -201,9 +210,13 @@ export const VncConsole: FC<VncConsoleProps> = ({
               text: 'Ctrl + Alt + 2',
             },
           ]}
+          onInjectTextFromClipboard={(e: MouseEvent<HTMLButtonElement>) => {
+            e.currentTarget.blur();
+            e.preventDefault();
+            rfb?.sendPasteCMD();
+          }}
           additionalButtons={additionalButtons}
           onDisconnect={() => rfb?.disconnect()}
-          onInjectTextFromClipboard={() => rfb?.sendPasteCMD()}
           textDisconnect={textDisconnect}
           textSendShortcut={textSendShortcut}
         />

--- a/src/utils/components/Consoles/components/vnc-console/utils/VncConsoleTypes.ts
+++ b/src/utils/components/Consoles/components/vnc-console/utils/VncConsoleTypes.ts
@@ -1,31 +1,33 @@
+import { FC, HTMLProps, MouseEventHandler, ReactNode } from 'react';
+
 export type VncConsoleActionsProps = {
   /** VNC console additional action elements */
-  additionalButtons?: React.ReactNode[];
+  additionalButtons?: ReactNode[];
   /** VNC console additional send keys elements */
   customButtons?: { onClick: () => void; text: string }[];
-  onDisconnect: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  onDisconnect: MouseEventHandler<HTMLButtonElement>;
   /** Injext text to VNC console from copied clipboard text */
-  onInjectTextFromClipboard?: () => void;
+  onInjectTextFromClipboard?: MouseEventHandler<HTMLButtonElement>;
   textDisconnect?: string;
   textSendShortcut?: string;
 };
 
-export type VncConsoleProps = React.HTMLProps<HTMLDivElement> & {
-  additionalButtons?: React.ReactNode[];
+export type VncConsoleProps = HTMLProps<HTMLDivElement> & {
+  additionalButtons?: ReactNode[];
 
   /** Should console try to connect once rendering */
   autoConnect?: boolean;
   /** Children nodes */
-  children?: React.ReactNode;
+  children?: ReactNode;
   consoleContainerId?: string;
   /** An Object specifying the credentials to provide to the server when authenticating
    * { username: '' password: '' target: ''}
    */
   credentials?: object;
   /** A custom component to replace th default connect button screen */
-  CustomConnectComponent?: React.FC<{ connect: () => void }>;
+  CustomConnectComponent?: FC<{ connect: () => void }>;
   /** A custom component to replace th default disabled component */
-  CustomDisabledComponent?: React.ReactNode;
+  CustomDisabledComponent?: ReactNode;
   encrypt?: boolean;
   /** Should console render alt tabs */
   hasGPU?: boolean;
@@ -56,7 +58,7 @@ export type VncConsoleProps = React.HTMLProps<HTMLDivElement> & {
   /* Text content rendered inside the EmptyState in the "Connect' button for when console is disconnnected */
   textConnect?: string;
   /* Text content rendered inside the EmptyState for when console is connecting */
-  textConnecting?: React.ReactNode | string;
+  textConnecting?: ReactNode | string;
   /** Text content rendered inside the Ctrl-Alt-Delete dropdown entry */
   textCtrlAltDel?: string;
   /** Text content rendered inside the Disconnect button */


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When clicking paste in the console screen the button stays in focus and when clicking enter it pastes again.
the fix is those 2 lines of code:
e.currentTarget.blur();
e.preventDefault();

the rest is to remove React.* 
## 🎥 Demo

> Please add a video or an image of the behavior/changes
