### PR TITLE
CNV-32995: Align volume name 'rootdisk' convention

### DIFF
--- a/src/utils/components/CloneTemplateModal/utils.ts
+++ b/src/utils/components/CloneTemplateModal/utils.ts
@@ -5,13 +5,14 @@ import {
   V1beta1DataVolumeSourcePVC,
   V1beta1DataVolumeSpec,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { ROOTDISK } from '@kubevirt-utils/constants/constants';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { getDataVolumeTemplates, getVolumes } from '@kubevirt-utils/resources/vm';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 const getBootSourceDataVolumeTemplate = (template: V1Template) => {
   const vm = getTemplateVirtualMachineObject(template);
-  const rootVolume = getVolumes(vm)?.find((volume) => volume.name === 'rootdisk');
+  const rootVolume = getVolumes(vm)?.find((volume) => volume.name === ROOTDISK);
 
   if (rootVolume?.dataVolume?.name)
     return getDataVolumeTemplates(vm)?.find(

--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -8,3 +8,5 @@ export const OPENSHIFT_SRIOV_NETWORK_OPERATOR_NS = 'openshift-sriov-network-oper
 export const OPENSHIFT_MULTUS_NS = 'openshift-multus';
 
 export const VENDOR_LABEL = 'instancetype.kubevirt.io/vendor';
+
+export const ROOTDISK = 'rootdisk';

--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -7,6 +7,7 @@ import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { convertUserDataObjectToYAML } from '@kubevirt-utils/components/CloudinitModal/utils/cloudinit-utils';
 import { ACTIVATION_KEY } from '@kubevirt-utils/components/CloudinitModal/utils/consts';
 import { addSecretToVM } from '@kubevirt-utils/components/SSHSecretSection/utils/utils';
+import { ROOTDISK } from '@kubevirt-utils/constants/constants';
 import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
 import { isBootableVolumePVCKind } from '@kubevirt-utils/resources/bootableresources/helpers';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
@@ -122,7 +123,7 @@ export const generateVM = (
                   disk: {
                     bus: 'virtio',
                   },
-                  name: `${virtualmachineName}-disk`,
+                  name: ROOTDISK,
                 },
                 {
                   disk: {
@@ -136,7 +137,7 @@ export const generateVM = (
           volumes: [
             {
               dataVolume: { name: `${virtualmachineName}-volume` },
-              name: `${virtualmachineName}-disk`,
+              name: ROOTDISK,
             },
             {
               cloudInitConfigDrive: {

--- a/src/views/catalog/templatescatalog/tests/mocks.ts
+++ b/src/views/catalog/templatescatalog/tests/mocks.ts
@@ -1,3 +1,5 @@
+import { ROOTDISK } from '@kubevirt-utils/constants/constants';
+
 export const containerTemplateMock = {
   apiVersion: 'template.openshift.io/v1',
   kind: 'Template',
@@ -43,7 +45,7 @@ export const containerTemplateMock = {
                     disk: {
                       bus: 'virtio',
                     },
-                    name: 'rootdisk',
+                    name: ROOTDISK,
                   },
                 ],
                 interfaces: [
@@ -72,7 +74,7 @@ export const containerTemplateMock = {
                 containerDisk: {
                   image: 'fooContainer',
                 },
-                name: 'rootdisk',
+                name: ROOTDISK,
               },
             ],
           },
@@ -130,7 +132,7 @@ export const urlTemplateMock = {
                     disk: {
                       bus: 'virtio',
                     },
-                    name: 'rootdisk',
+                    name: ROOTDISK,
                   },
                 ],
                 interfaces: [
@@ -160,7 +162,7 @@ export const urlTemplateMock = {
                   // eslint-disable-next-line no-template-curly-in-string
                   name: 'url-template-rootdisk',
                 },
-                name: 'rootdisk',
+                name: ROOTDISK,
               },
             ],
           },

--- a/src/views/templates/actions/editBootSource.ts
+++ b/src/views/templates/actions/editBootSource.ts
@@ -12,7 +12,7 @@ import {
   V1beta1DataVolumeSpec,
   V1DataVolumeTemplateSpec,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import { DEFAULT_NAMESPACE, ROOTDISK } from '@kubevirt-utils/constants/constants';
 import {
   getTemplateVirtualMachineObject,
   poorManProcess,
@@ -64,7 +64,7 @@ const getRootDiskDataVolumeTemplate = (
 ): undefined | V1DataVolumeTemplateSpec => {
   const vm = getTemplateVirtualMachineObject(template);
 
-  const rootVolume = getVolumes(vm)?.find((volume) => volume.name === 'rootdisk');
+  const rootVolume = getVolumes(vm)?.find((volume) => volume.name === ROOTDISK);
 
   return vm?.spec?.dataVolumeTemplates?.find(
     (dataVolumeTemplate) => rootVolume?.dataVolume?.name === dataVolumeTemplate?.metadata?.name,


### PR DESCRIPTION
## 📝 Description

Align the name of the bootable volume to `rootdisk`

## 🎥 Demo

Before:
![rootdisk-name-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/9ea3a4d0-5269-4ed8-aa71-389271968354)

After:
![rootdisk-name](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/af1cd4a0-b0cf-49a9-8b49-a9483b1da599)

