### PR TITLE
CNV-33137: Fix hot plug NIC not added to VMI after live migration

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateCatalogDrawer.scss
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateCatalogDrawer.scss
@@ -3,10 +3,8 @@
     padding: 0;
 
     .template-catalog-drawer-footer-section {
-      padding-top: var(--pf-c-modal-box__footer--PaddingTop);
-      padding-right: var(--pf-c-modal-box__footer--PaddingRight);
-      padding-bottom: var(--pf-c-modal-box__footer--PaddingBottom);
-      padding-left: var(--pf-c-modal-box__footer--PaddingLeft);
+      padding: var(--pf-c-modal-box__footer--PaddingTop) var(--pf-global--spacer--xl)
+        var(--pf-global--spacer--xl);
       border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--300);
     }
   }

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesNetworkInterfaceModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesNetworkInterfaceModal.tsx
@@ -17,6 +17,7 @@ import ModalPendingChangesAlert from '@kubevirt-utils/components/PendingChanges/
 import { BRIDGED_NIC_HOTPLUG_ENABLED } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
+import { interfacesTypes } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import { addInterface } from '@virtualmachines/actions/actions';
 
@@ -51,7 +52,7 @@ const VirtualMachinesNetworkInterfaceModal: FC<VirtualMachinesNetworkInterfaceMo
         const updatedInterfaces: V1Interface[] = [...(getInterfaces(vm) || []), resultInterface];
         const updatedVM = updateVMNetworkInterface(vm, updatedNetworks, updatedInterfaces);
 
-        if (nicHotPlugEnabled && interfaceType === 'bridge') {
+        if (nicHotPlugEnabled && interfaceType === interfacesTypes.bridge) {
           return addInterface(updatedVM, {
             name: nicName,
             networkAttachmentDefinitionName: networkName,


### PR DESCRIPTION
Backport of https://github.com/kubevirt-ui/kubevirt-plugin/pull/1535

jira issue: https://issues.redhat.com/browse/CNV-33137

## Screenshot:
![2023-09-20_07-26](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/bd20b132-367c-455d-91e9-e3e768fff830)
