### PR TITLE
CNV-33013: Sort the instanceType list by the size of CPU and memory

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/constants.ts
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/constants.ts
@@ -76,7 +76,17 @@ export const instanceTypeSeriesNameMapper: {
   },
   o1: {
     Icon: ModuleIcon,
-    possibleSizes: ['medium', 'large', 'xlarge', '2xlarge', '4xlarge', '8xlarge'],
+    possibleSizes: [
+      'nano',
+      'micro',
+      'small',
+      'medium',
+      'large',
+      'xlarge',
+      '2xlarge',
+      '4xlarge',
+      '8xlarge',
+    ],
     seriesLabel: t('O series'),
   },
   server: {
@@ -86,7 +96,17 @@ export const instanceTypeSeriesNameMapper: {
   },
   u1: {
     Icon: ServerGroupIcon,
-    possibleSizes: ['medium', 'large', 'xlarge', '2xlarge', '4xlarge', '8xlarge'],
+    possibleSizes: [
+      'nano',
+      'micro',
+      'small',
+      'medium',
+      'large',
+      'xlarge',
+      '2xlarge',
+      '4xlarge',
+      '8xlarge',
+    ],
     seriesLabel: t('U series'),
   },
 };

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/utils.ts
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/utils.ts
@@ -1,3 +1,5 @@
+import { parseSize } from 'xbytes';
+
 import { V1beta1VirtualMachineClusterInstancetype } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
 import { getAnnotation, getLabel, getName } from '@kubevirt-utils/resources/shared';
@@ -57,7 +59,7 @@ export const getInstanceTypeMenuItems = (
 ): InstanceTypesMenuItemsData => {
   if (isEmpty(instanceTypes)) return initialMenuItems;
 
-  return instanceTypes.reduce((acc, it) => {
+  const itemsData = instanceTypes.reduce((acc, it) => {
     if (!isRedHatInstanceType(it)) {
       !acc.userProvided.items.includes(getName(it)) && acc.userProvided.items.push(getName(it));
       return acc;
@@ -85,4 +87,11 @@ export const getInstanceTypeMenuItems = (
 
     return acc;
   }, initialMenuItems);
+
+  itemsData.redHatProvided.items = itemsData.redHatProvided.items.map((series) => ({
+    ...series,
+    sizes: series.sizes.sort((a, b) => parseSize(a?.memory) - parseSize(b?.memory)),
+  }));
+
+  return itemsData;
 };

--- a/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/utils/types.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/utils/types.ts
@@ -1,6 +1,15 @@
 import { MutableRefObject } from 'react';
 
-export type InstanceTypeSize = '2xlarge' | '4xlarge' | '8xlarge' | 'large' | 'medium' | 'xlarge';
+export type InstanceTypeSize =
+  | '2xlarge'
+  | '4xlarge'
+  | '8xlarge'
+  | 'large'
+  | 'medium'
+  | 'micro'
+  | 'nano'
+  | 'small'
+  | 'xlarge';
 
 export enum InstanceTypeCategory {
   ComputeIntensive = 'ComputeIntensive',


### PR DESCRIPTION
## 📝 Description

Sorting IT according to their CPUs and Memory

## 🎥 Demo

Before:
![it-sorted-b4-2](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/4e654246-a2bb-4b8e-ae7c-51a8563f0aec)
![it-sorted-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/016784c8-1c39-4202-b3b9-8eb0cd2ca40c)

After:
![it-sorted-2](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/8cc2d8a7-400c-4556-84d3-adad055890f9)
![it-sorted](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/78557b22-b775-4cb1-b3f6-9270f0f72d02)
