### PR TITLE
CNV-32775: Change breadcrumbs to redirect back to Bootable volumes

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -330,7 +330,6 @@
   "DataImportCrons": "DataImportCrons",
   "DataSource": "DataSource",
   "DataSource details": "DataSource details",
-  "DataSource Details": "DataSource Details",
   "DataSources": "DataSources",
   "Deadline": "Deadline",
   "Deadline must be a number": "Deadline must be a number",

--- a/src/views/datasources/details/DataSourcePage.tsx
+++ b/src/views/datasources/details/DataSourcePage.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC, useMemo } from 'react';
 
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
@@ -16,7 +16,7 @@ type DataSourcePageProps = {
   namespace: string;
 };
 
-const DataSourceNavPage: React.FC<DataSourcePageProps> = ({ kind, name, namespace }) => {
+const DataSourceNavPage: FC<DataSourcePageProps> = ({ kind, name, namespace }) => {
   const { t } = useKubevirtTranslation();
   const [dataSource, loaded] = useK8sWatchResource<V1beta1DataSource>({
     kind,
@@ -24,7 +24,7 @@ const DataSourceNavPage: React.FC<DataSourcePageProps> = ({ kind, name, namespac
     namespace,
   });
 
-  const pages = React.useMemo(
+  const pages = useMemo(
     () => [
       {
         component: DataSourceDetailsPage,
@@ -42,7 +42,7 @@ const DataSourceNavPage: React.FC<DataSourcePageProps> = ({ kind, name, namespac
 
   return (
     <>
-      <DataSourcePageTitle dataSource={dataSource} name={name} namespace={namespace} />
+      <DataSourcePageTitle dataSource={dataSource} name={name} />
       {loaded ? (
         <HorizontalNav pages={pages} resource={dataSource} />
       ) : (

--- a/src/views/datasources/details/DataSourcePageTitle.tsx
+++ b/src/views/datasources/details/DataSourcePageTitle.tsx
@@ -1,10 +1,9 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 import { Link } from 'react-router-dom';
 
-import { DataSourceModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { useLastNamespacePath } from '@kubevirt-utils/hooks/useLastNamespacePath';
 import { Breadcrumb, BreadcrumbItem, Label } from '@patternfly/react-core';
 
 import DataSourceActions from '../actions/DataSourceActions';
@@ -13,26 +12,20 @@ import { isDataSourceReady } from '../utils';
 type DataSourcePageTitleProps = {
   dataSource: V1beta1DataSource;
   name: string;
-  namespace: string;
 };
 
-const DataSourcePageTitle: React.FC<DataSourcePageTitleProps> = ({
-  dataSource,
-  name,
-  namespace,
-}) => {
+const DataSourcePageTitle: FC<DataSourcePageTitleProps> = ({ dataSource, name }) => {
   const { t } = useKubevirtTranslation();
+  const lastNamespacePath = useLastNamespacePath();
 
   return (
     <>
       <div className="pf-c-page__main-breadcrumb">
         <Breadcrumb className="pf-c-breadcrumb co-breadcrumb">
           <BreadcrumbItem>
-            <Link to={`/k8s/ns/${namespace || DEFAULT_NAMESPACE}/${DataSourceModelRef}`}>
-              {t('DataSources')}
-            </Link>
+            <Link to={`/k8s/${lastNamespacePath}/bootablevolumes`}>{t('Bootable volumes')}</Link>
           </BreadcrumbItem>
-          <BreadcrumbItem>{t('DataSource Details')}</BreadcrumbItem>
+          <BreadcrumbItem>{t('DataSource details')}</BreadcrumbItem>
         </Breadcrumb>
       </div>
       <div className="co-m-nav-title co-m-nav-title--detail co-m-nav-title--breadcrumbs">


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-32775

Change _DataSources > DataSource Details_ breadcrumbs to _Bootable volumes > DataSource details_, present in the page rendered after clicking on some DataSource in _Bootable volumes_ list.

## 🎥 Demo
**Before:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/25f3cfcb-ad8f-48d4-b3df-a08f66113ded

**After:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/8efed613-351f-4952-9b66-9c8f7a6c0e50

