### PR TITLE
CNV-33133: Make buttons in VMs and MigrationPolicies pages not blink

### DIFF
--- a/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
+++ b/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import { V1alpha1MigrationPolicy } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -21,7 +21,7 @@ type MigrationPoliciesListProps = {
   kind: string;
 };
 
-const MigrationPoliciesList: React.FC<MigrationPoliciesListProps> = ({ kind }) => {
+const MigrationPoliciesList: FC<MigrationPoliciesListProps> = ({ kind }) => {
   const { t } = useKubevirtTranslation();
   const [mps, loaded, loadError] = useK8sWatchResource<V1alpha1MigrationPolicy[]>({
     isList: true,
@@ -54,10 +54,11 @@ const MigrationPoliciesList: React.FC<MigrationPoliciesListProps> = ({ kind }) =
           loaded={loaded}
           onFilterChange={onFilterChange}
         />
+        {isEmpty(mps) && <MigrationPoliciesEmptyState kind={kind} />}
         <VirtualizedTable<V1alpha1MigrationPolicy>
           columns={activeColumns}
           data={data}
-          EmptyMsg={() => <MigrationPoliciesEmptyState kind={kind} />}
+          EmptyMsg={() => <></>}
           loaded={loaded}
           loadError={loadError}
           Row={MigrationPoliciesRow}

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -181,10 +181,8 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({ kind, namespace }) 
             />
           )}
         </div>
+        {isEmpty(vms) && <VirtualMachineEmptyState catalogURL={catalogURL} namespace={namespace} />}
         <VirtualizedTable<K8sResourceCommon>
-          NoDataEmptyMsg={() => (
-            <VirtualMachineEmptyState catalogURL={catalogURL} namespace={namespace} />
-          )}
           rowData={{
             getVmi: (ns: string, name: string) => vmiMapper?.mapper?.[ns]?.[name],
             getVmim: (ns: string, name: string) => vmimMapper?.[ns]?.[name],
@@ -195,6 +193,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({ kind, namespace }) 
           data={data}
           loaded={loaded && vmiLoaded && vmimsLoaded && isSingleNodeLoaded && !loadingFeatureProxy}
           loadError={loadError}
+          NoDataEmptyMsg={() => <></>}
           Row={VirtualMachineRow}
           unfilteredData={unfilteredData}
         />


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-33133

Make empty state related buttons for _VirtualMachines_ list and _MigrationPolicies_ list pages not blink, when entering those pages for the first time.

Note that the problem this PR is fixing, is not so easy to reproduce and not always reproducible, you must try couple of times to see the issue there.

## 🎥 Demo
**Before**:
_VirtualMachines_ list page (see how the buttons blink once or twice when entering the page):

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/4d96880e-117b-46d3-a5ed-aa6705c69085

_MigrationPolicies_ list page (see how the buttons blink once or twice when entering the page):

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/f4d9efa9-5d77-43fc-a5d4-3ae112635470

**After:**
_VirtualMachines_ list page (no any blinking anymore):

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/9a45583e-8f3c-4ac5-b9cf-006df422b375

_MigrationPolicies_ list page (no any blinking anymore):

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/8765fac1-63ad-41df-8110-439ed7d920c6

**Comparing the behavior of the two implementations of empty state screen (within the one screen):**
_VirtualMachines_ list page:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/cb9751ef-d824-49b4-9480-f9055b5f63f6

_MigrationPolicies_ list page:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/d04e01b6-43ba-4c60-b381-e2d330fbb3bc

