### PR TITLE
Use lowercase autounattend and unattend file names

### DIFF
--- a/src/utils/components/SysprepModal/sysprep-utils.ts
+++ b/src/utils/components/SysprepModal/sysprep-utils.ts
@@ -6,8 +6,8 @@ import { getDisks, getVolumes } from '@kubevirt-utils/resources/vm';
 import { getRandomChars } from '@kubevirt-utils/utils/utils';
 
 export const SYSPREP = 'sysprep';
-export const AUTOUNATTEND = 'Autounattend.xml';
-export const UNATTEND = 'Unattend.xml';
+export const AUTOUNATTEND = 'autounattend.xml';
+export const UNATTEND = 'unattend.xml';
 export const WINDOWS = 'windows';
 
 export type SysprepData = { autounattend?: string; unattended?: string };


### PR DESCRIPTION

## 📝 Description

The const variables AUTOUNATTEND and UNATTEND are using Autounattend.xml and Unattend.xml instead lowercase names.

Creating a VM and attach a sysprep is not possible, as in most of the cases the name are lowercase in the configmap.

