### PR TITLE
CNV-32266: The example of bootable volumes does not show in the list

### DIFF
--- a/src/templates/bootablevolume-yaml.ts
+++ b/src/templates/bootablevolume-yaml.ts
@@ -8,6 +8,8 @@ metadata:
   labels:
     instancetype.kubevirt.io/default-instancetype: u1.medium
     instancetype.kubevirt.io/default-preference: fedora
+  annotations:
+    cdi.kubevirt.io/storage.bind.immediate.requested: 'true'
 spec:
   source:
     registry:


### PR DESCRIPTION
## 📝 Description

add immediate bind annotation to allow image import

## 🎥 Demo
YAML edited:
![added-annotation](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/dab955b7-4ffe-482a-ba9b-9d92e2c88b06)

PVC bound: 
![bound-pvc](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/7ad9bd43-1e77-4d9b-8e5f-9bc2d43db17d)

