### PR TITLE
CNV-33531: Fix broken Diagnostics link in VM Overview Details card

### DIFF
--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachineOverviewStatus/VirtualMachineOverviewStatus.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachineOverviewStatus/VirtualMachineOverviewStatus.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { Popover, PopoverPosition, Text } from '@patternfly/react-core';
+import { createURL } from '@virtualmachines/details/tabs/overview/utils/utils';
 
 import StatusPopoverButton from '../StatusPopoverButton/StatusPopoverButton';
 
@@ -29,7 +30,7 @@ const VirtualMachineOverviewStatus: FC<VirtualMachineOverviewStatusProps> = ({
             </Text>
             <br />
             <Text>
-              <Link to={(location) => location?.pathname + '/diagnostics'}>
+              <Link to={(location) => createURL('diagnostics', location?.pathname)}>
                 {t('View diagnostic')}
               </Link>
             </Text>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-33531

Make _View diagnostic_ broken link, displayed in VM _Overview_ _Details_ card _Status_ popover, lead to _Diagnostics_ tab successfully, in case of some VM status error. Make the link work by using `createUrl` util to generate the url for the page correctly.

Note that when finding and then investigating this bug, I've found that all other links present in the VM _Overview_ tab were created by use of `createUrl`. It seems it was just forgotten to use it also for that broken link hidden in the popover of one field in that page.

Also note that you must click on _Overview_ tab to be able to always reproduce the bug. When accessing _Overview_ tab from VM list page and not clicking on the tab name explicitly, you won't be able to reproduce the bug, because the url string will be missing "/" at its end.

## 🎥 Demo
**Before:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/07d17f35-fece-4e3e-b532-10343ea5f409

**After:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/045293c8-6262-4aa8-a16f-2b9ca93f9a76

