### PR TITLE
Empty state flickering in VM list

### DIFF
--- a/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
+++ b/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
@@ -54,7 +54,7 @@ const MigrationPoliciesList: FC<MigrationPoliciesListProps> = ({ kind }) => {
           loaded={loaded}
           onFilterChange={onFilterChange}
         />
-        {isEmpty(mps) && <MigrationPoliciesEmptyState kind={kind} />}
+        {loaded && isEmpty(mps) && <MigrationPoliciesEmptyState kind={kind} />}
         <VirtualizedTable<V1alpha1MigrationPolicy>
           columns={activeColumns}
           data={data}


### PR DESCRIPTION
## 📝 Description

In the VM and MP list pages we get a couple of flickering situations:
1. When we switch from any route to the VMs list page we load then we get an empty state then load again then the real list. (Same thing for MP list)
2. When we switch NS inside the VM list page, the empty state remains on the screen even though the data is currently loading. 

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/45f01fde-80b6-456c-8745-bb36dc49b9cc


https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/f575229a-bf7f-4250-a51e-c73fe6941391


https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/4c78c629-97cc-403d-8f8f-0d6d175f5f26


After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/f42ce2d8-3616-4fed-a03a-cf1d5fe04dd7


https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/f1ca629f-b6b1-489a-93d6-c3829a10b4db

