### PR TITLE
CNV-33502: Fix add/remove hot-plug NIC behavior

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/utils/helpers.ts
+++ b/src/utils/components/NetworkInterfaceModal/utils/helpers.ts
@@ -3,8 +3,10 @@ import { adjectives, animals, uniqueNamesGenerator } from 'unique-names-generato
 
 import { V1Interface, V1Network, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getInterfaces } from '@kubevirt-utils/resources/vm';
 import { interfacesTypes } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
+import { ABSENT } from '@virtualmachines/details/tabs/configuration/network/utils/constants';
 
 import { NetworkAttachmentDefinition } from '../components/hooks/types';
 
@@ -28,7 +30,7 @@ export const getNetworkName = (network: V1Network): string => {
   return null;
 };
 
-export const updateVMNetworkInterface = (
+export const updateVMNetworkInterfaces = (
   vm: V1VirtualMachine,
   updatedNetworks: V1Network[],
   updatedInterfaces: V1Interface[],
@@ -38,6 +40,39 @@ export const updateVMNetworkInterface = (
     vmDraft.spec.template.spec.domain.devices.interfaces = updatedInterfaces;
   });
   return updatedVM;
+};
+
+const getInterface = (interfaces: V1Interface[], nicName: string) =>
+  interfaces.find((iface) => iface?.name === nicName);
+
+/**
+ * To delete a hot plug NIC the state of the interface is set to 'absent'. The
+ * NIC will then be removed when the VM is live migrated or restarted.
+ * @param interfaces {V1Interface[]}
+ * @param nicName {string}
+ * @return the virtual machine's interfaces with the hot plug NIC's state set to 'absent;
+ */
+export const markInterfaceAbsent = (interfaces: V1Interface[], nicName: string) => {
+  if (!getInterface(interfaces, nicName)) return null;
+
+  const updatedInterfaces = produce<V1Interface[]>(interfaces, (draftInterfaces: V1Interface[]) => {
+    const ifaceToDelete = getInterface(draftInterfaces, nicName);
+    ifaceToDelete.state = ABSENT;
+  });
+  return updatedInterfaces;
+};
+
+const removeInterfaceToBeDeleted = (nicName: string, vm: V1VirtualMachine) =>
+  getInterfaces(vm)?.filter(({ name }) => name !== nicName);
+
+export const updateInterfacesForDeletion = (
+  isHotPlug: boolean,
+  nicName: string,
+  vm: V1VirtualMachine,
+): V1Interface[] => {
+  return isHotPlug
+    ? markInterfaceAbsent(getInterfaces(vm), nicName)
+    : removeInterfaceToBeDeleted(nicName, vm);
 };
 
 export const createNetwork = (nicName: string, networkName: string): V1Network => {

--- a/src/views/virtualmachines/actions/actions.ts
+++ b/src/views/virtualmachines/actions/actions.ts
@@ -2,9 +2,7 @@ import VirtualMachineInstanceMigrationModel from '@kubevirt-ui/kubevirt-api/cons
 import VirtualMachineInstanceModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstanceModel';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import {
-  V1AddInterfaceOptions,
   V1AddVolumeOptions,
-  V1RemoveInterfaceOptions,
   V1RemoveVolumeOptions,
   V1StopOptions,
   V1VirtualMachine,
@@ -21,10 +19,8 @@ import {
 const generateRandomString = () => Math.random().toString(36).substring(2, 7);
 
 export enum VMActionType {
-  AddInterface = 'addinterface',
   AddVolume = 'addvolume',
   Pause = 'pause',
-  RemoveInterface = 'removeinterface',
   RemoveVolume = 'removevolume',
   Restart = 'restart',
   Start = 'start',
@@ -36,12 +32,7 @@ export const VMActionRequest = async (
   vm: V1VirtualMachine,
   action: VMActionType,
   model: K8sModel,
-  body?:
-    | V1AddInterfaceOptions
-    | V1AddVolumeOptions
-    | V1RemoveInterfaceOptions
-    | V1RemoveVolumeOptions
-    | V1StopOptions,
+  body?: V1AddVolumeOptions | V1RemoveVolumeOptions | V1StopOptions,
 ) => {
   const {
     metadata: { name, namespace },
@@ -105,10 +96,6 @@ export const migrateVM = async (vm: V1VirtualMachine) => {
     ns: namespace,
   });
 };
-export const addInterface = async (vm: V1VirtualMachine, body: V1AddInterfaceOptions) =>
-  VMActionRequest(vm, VMActionType.AddInterface, VirtualMachineModel, body);
-export const removeInterface = async (vm: V1VirtualMachine, body: V1RemoveInterfaceOptions) =>
-  VMActionRequest(vm, VMActionType.RemoveInterface, VirtualMachineModel, body);
 
 export const cancelMigration = async (vmim: V1VirtualMachineInstanceMigration) => {
   await k8sDelete({

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesEditNetworkInterfaceModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesEditNetworkInterfaceModal.tsx
@@ -6,7 +6,7 @@ import NetworkInterfaceModal from '@kubevirt-utils/components/NetworkInterfaceMo
 import {
   createInterface,
   createNetwork,
-  updateVMNetworkInterface,
+  updateVMNetworkInterfaces,
 } from '@kubevirt-utils/components/NetworkInterfaceModal/utils/helpers';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
@@ -45,7 +45,7 @@ const VirtualMachinesEditNetworkInterfaceModal: FC<
             []),
           resultInterface,
         ];
-        const updatedVM = updateVMNetworkInterface(vm, updatedNetworks, updatedInterfaces);
+        const updatedVM = updateVMNetworkInterfaces(vm, updatedNetworks, updatedInterfaces);
 
         return k8sUpdate({
           data: updatedVM,


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug where hot-plug NICs are not added upon completion of the Add network interface modal. This was caused by a change in the implementation of NIC hot-plug in the backend. The subresource API endpoints for `addInterface` and `removeInterface` were removed in favor of patching the YAML.

jira issue: https://issues.redhat.com/browse/CNV-33502

## 🎥 Demo

### Before

https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/75fa0a89-5691-4954-8dd5-c3cb5e512732

### After

https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/2d907a49-20ac-4668-9d9c-935e671b7c27
