### PR TITLE
SSH modal saves state even if error encountered

### DIFF
--- a/src/views/catalog/wizard/tabs/scripts/components/SSHKey.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/components/SSHKey.tsx
@@ -42,14 +42,13 @@ const SSHKey: FC = () => {
   );
 
   const onSubmit = useCallback(
-    (details: SSHSecretDetails) => {
+    async (details: SSHSecretDetails) => {
       const { applyKeyToProject, secretOption, sshPubKey, sshSecretName } = details;
 
       if (isEqualObject(details, sshDetails)) {
-        return Promise.resolve();
+        return;
       }
 
-      setSSHDetails(details);
       removeSSHKeyObject(updateTabsData, sshDetails.sshSecretName);
       updateTabsData((currentTabsData) => {
         currentTabsData.authorizedSSHKey = sshSecretName;
@@ -60,7 +59,7 @@ const SSHKey: FC = () => {
         secretOption === SecretSelectionOption.none &&
         sshDetails.secretOption !== SecretSelectionOption.none
       ) {
-        return updateVM(removeSecretToVM(vm));
+        await updateVM(removeSecretToVM(vm));
       }
 
       if (
@@ -68,7 +67,7 @@ const SSHKey: FC = () => {
         sshDetails.sshSecretName !== sshSecretName &&
         !isEmpty(sshSecretName)
       ) {
-        return updateVM(addSecretToVM(vm, sshSecretName));
+        await updateVM(addSecretToVM(vm, sshSecretName));
       }
 
       if (
@@ -77,9 +76,10 @@ const SSHKey: FC = () => {
         !isEmpty(sshSecretName)
       ) {
         updateSSHKeyObject(vm, updateTabsData, sshPubKey, sshSecretName);
-        return updateVM(addSecretToVM(vm, sshSecretName));
+        await updateVM(addSecretToVM(vm, sshSecretName));
       }
 
+      setSSHDetails(details);
       return Promise.resolve();
     },
     [sshDetails, updateTabsData, updateVM, vm],


### PR DESCRIPTION
## 📝 Description

When adding a new SSH key we get an error (BE bug), but even though we get an error and close the modal dialog, the state is saved to the form

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/e585aa34-7ca5-4e5e-a89b-e24235fd6bd2

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/d9ee4ccf-0684-4e22-84d0-8cc6cdef0e45


