### PR TITLE
Add ExpandSectionWithSwitch component

### DIFF
--- a/src/utils/components/ExpandSectionWithSwitch/ExpandSectionWithSwitch.scss
+++ b/src/utils/components/ExpandSectionWithSwitch/ExpandSectionWithSwitch.scss
@@ -1,0 +1,32 @@
+.expand-section-with-switch {
+  &__contents {
+    padding-left: var(--pf-global--spacer--lg);
+  }
+
+  &__help-text-popover {
+    .pf-c-popover__content {
+      width: 400px;
+    }
+  }
+
+  // Firefox
+  @-moz-document url-prefix() {
+    &__help-icon,
+    .pf-c-switch {
+      vertical-align: -moz-middle-with-baseline !important;
+    }
+  }
+
+  // Chrome
+  @media screen and (-webkit-min-device-pixel-ratio: 0) and (min-resolution: 0.001dpcm) {
+    &__help-icon,
+    .pf-c-switch {
+      vertical-align: -webkit-baseline-middle !important;
+    }
+  }
+
+  &__help-icon {
+    color: var(--pf-global--Color--100);
+    margin-left: calc(-1 * var(--pf-global--spacer--sm));
+  }
+}

--- a/src/utils/components/ExpandSectionWithSwitch/ExpandSectionWithSwitch.tsx
+++ b/src/utils/components/ExpandSectionWithSwitch/ExpandSectionWithSwitch.tsx
@@ -1,0 +1,51 @@
+import React, { FC, FormEvent, ReactNode } from 'react';
+
+import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
+import { PopoverPosition, Split, SplitItem, Switch } from '@patternfly/react-core';
+
+import ExpandSection from '../../../views/clusteroverview/SettingsTab/ExpandSection/ExpandSection';
+
+import './ExpandSectionWithSwitch.scss';
+
+type ExpandSectionWithSwitchProps = {
+  children: ReactNode;
+  helpTextIconContent?: ReactNode;
+  isDisabled?: boolean;
+  switchIsOn: boolean;
+  toggleContent?: ReactNode;
+  toggleText?: string;
+  turnOnSwitch: (checked: boolean, event: FormEvent<HTMLInputElement>) => void;
+};
+
+const ExpandSectionWithSwitch: FC<ExpandSectionWithSwitchProps> = ({
+  children,
+  helpTextIconContent,
+  isDisabled,
+  switchIsOn,
+  toggleContent,
+  toggleText,
+  turnOnSwitch,
+}) => (
+  <Split className="expand-section-with-switch">
+    <SplitItem>
+      <ExpandSection isDisabled={isDisabled} toggleContent={toggleContent} toggleText={toggleText}>
+        <div className="expand-section-with-switch__contents">{children}</div>
+      </ExpandSection>
+    </SplitItem>
+    {helpTextIconContent && (
+      <SplitItem isFilled>
+        <HelpTextIcon
+          bodyContent={helpTextIconContent}
+          className="expand-section-with-switch__help-text-popover"
+          helpIconClassName="expand-section-with-switch__help-icon"
+          position={PopoverPosition.right}
+        />
+      </SplitItem>
+    )}
+    <SplitItem>
+      <Switch isChecked={switchIsOn} isDisabled={isDisabled} onChange={turnOnSwitch} />
+    </SplitItem>
+  </Split>
+);
+
+export default ExpandSectionWithSwitch;

--- a/src/views/clusteroverview/SettingsTab/ExpandSection/ExpandSection.scss
+++ b/src/views/clusteroverview/SettingsTab/ExpandSection/ExpandSection.scss
@@ -1,0 +1,3 @@
+.expand-section__disabled .pf-c-expandable-section__toggle-icon {
+  color: var(--pf-global--disabled-color--100);
+}

--- a/src/views/clusteroverview/SettingsTab/ExpandSection/ExpandSection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ExpandSection/ExpandSection.tsx
@@ -1,9 +1,14 @@
-import React, { FC, ReactNode, useState } from 'react';
+import React, { FC, ReactNode, useEffect, useState } from 'react';
+import classNames from 'classnames';
 
 import { ExpandableSection } from '@patternfly/react-core';
 
+import './ExpandSection.scss';
+
 type ExpandSectionProps = {
   className?: string;
+  isDisabled?: boolean;
+  isIndented?: boolean;
   toggleContent?: ReactNode;
   toggleText?: string;
 };
@@ -11,16 +16,25 @@ type ExpandSectionProps = {
 const ExpandSection: FC<ExpandSectionProps> = ({
   children,
   className,
+  isDisabled = false,
+  isIndented = true,
   toggleContent = null,
   toggleText = '',
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
+  useEffect(() => {
+    if (isDisabled) setIsExpanded(false);
+  }, [isDisabled, setIsExpanded]);
+
+  const handleToggle = (expanded: boolean) => (isDisabled ? null : setIsExpanded(expanded));
+
   return (
     <ExpandableSection
-      className={className}
+      className={classNames(className, { 'expand-section__disabled': isDisabled })}
       isExpanded={isExpanded}
-      onToggle={setIsExpanded}
+      isIndented={isIndented}
+      onToggle={handleToggle}
       toggleContent={toggleContent}
       toggleText={toggleText}
     >


### PR DESCRIPTION
## 📝 Description

This PR:

- Adds the ExpandSectionWithSwitch component, which will be used by the kernel same-page merging and auto-compute CPU limits features on the Settings page
- Adds the `isIndented` and `isDisabled` options to the `ExpandSection` component
- Adds the `isIndented` prop to all expandable sections on the Settings page

## 🎥 Screenshots

### ExpandSectionWithSwitch example (enabled and switch on)

![expand-section-with-switch-example2023-10-12_09-09](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/757c13ab-899f-4792-9be2-d24452ca300a)

### ExpandSectionWithSwitch example (disabled)

![expand-section-with-switch-disabled-example-2023-10-12_09-09](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/38ab2e92-d5eb-4f8e-88d2-e13e24f93e68)

### Settings page before (without indents)

![settings-page-expanded-no-indent-2023-10-12_09-08](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/c447af4f-4757-40f6-a754-bbdbf2b5d420)

### Settings page after (with indents)

![settings-page-expanded-2023-10-12_09-04](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/7f50c2d1-777d-4989-a644-6a30e67c9b26)