### PR TITLE
CNV-34075: Display "With Data upload form" in Create PVC drop down once

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -655,16 +655,6 @@
       "required": ["KUBEVIRT"]
     },
     "properties": {
-      "label": "%plugin__kubevirt-plugin~With Data upload form%",
-      "path": "~new/data"
-    },
-    "type": "console.pvc/create-prop"
-  },
-  {
-    "flags": {
-      "required": ["KUBEVIRT"]
-    },
-    "properties": {
       "alert": { "$codeRef": "pvcAlert" }
     },
     "type": "console.pvc/alert"

--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1307,7 +1307,6 @@
   "Whether to attach the default graphics device or not. VNC will not be available if checked <2><0>VirtualMachine</0><1>spec</1><2>template</2><3>devices</3><4>autoattachGraphicsDevice</4></2>": "Whether to attach the default graphics device or not. VNC will not be available if checked <2><0>VirtualMachine</0><1>spec</1><2>template</2><3>devices</3><4>autoattachGraphicsDevice</4></2>",
   "Will make disk persistent on next reboot": "Will make disk persistent on next reboot",
   "Windows only": "Windows only",
-  "With Data upload form": "With Data upload form",
   "With form": "With form",
   "With grace period": "With grace period",
   "With YAML": "With YAML",


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-34075

Display _With Data upload form_ drop down item only once, not twice, in the _Create PersistentVolumeClaim_ drop down present in the PVCs list page.

## 🎥 Screenshots
**Before:**
Two _With Data upload form_ drop down items:
![pvc_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/18dd44e2-f260-437b-8c5b-deddbf98bbc7)

**After:**
![pvc_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/1a6d33c6-61fa-4aae-ac5e-1a26eb27230a)



