### PR TITLE
CNV-34765: Add data-test-ids to VM action icons

### DIFF
--- a/src/views/virtualmachines/actions/components/VMActionsIconBar/components/ActionIconButton.tsx
+++ b/src/views/virtualmachines/actions/components/VMActionsIconBar/components/ActionIconButton.tsx
@@ -22,6 +22,7 @@ const ActionIconButton: FC<VMActionIconDetails> = ({ action, Icon, iconClassname
         <Tooltip content={action?.label}>
           <Button
             className="vm-actions-icon-bar__button"
+            data-test-id={`${action?.id}-button`}
             isDisabled={!actionAllowed}
             onClick={handleClick}
             variant={ButtonVariant.link}


### PR DESCRIPTION
## 📝 Description

This PR adds the `data-test-id` attribute to the VM action icons for testing purposes.

Jira issue: https://issues.redhat.com/browse/CNV-34765