### PR TITLE
CNV-35122: Adjust user name in configmap to uuid

### DIFF
--- a/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings.ts
@@ -40,7 +40,7 @@ const useKubevirtUserSettings: UseKubevirtUserSettings = (key) => {
       setError(null);
       try {
         const user = await k8sGet({ model: UserModel, path: '~' });
-        setUserName(user?.metadata?.name?.replace(':', '-'));
+        setUserName(user?.metadata?.uid || user?.metadata?.name?.replace(/[^-._a-zA-Z0-9]+/g, '-'));
       } catch (e) {
         setError(e);
       }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

We had a bug with username containing @ or other special chars that cannot used as keys in obj.
Now we will try to use uuid if user has one, all should have one except kube:admin, and rest we will replace special chars with dashes.
## 🎥 Demo

> Please add a video or an image of the behavior/changes
