### PR TITLE
Fix additionalObjects with authorized ssh key

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
@@ -171,9 +171,10 @@ const useCreateDrawerForm = (
         // additional objects
         tabsDataDraft.additionalObjects = processedTemplate.objects.filter((obj) =>
           !isEmpty(authorizedSSHKey)
-            ? obj.kind !== VirtualMachineModel.kind || obj.kind !== SecretModel
+            ? obj.kind !== VirtualMachineModel.kind && obj.kind !== SecretModel
             : obj.kind !== VirtualMachineModel.kind,
         );
+
         // overview
         ensurePath(tabsDataDraft, 'overview.templateMetadata');
         tabsDataDraft.overview.templateMetadata.name = template.metadata.name;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description


With authorized keys we have a bug on customize.

In additionalObjects we are adding the actual VM.
On create action, the wizard try to create the additionalObjects first (and here we have the vm), after try to create the vm and it gets the error. After that remove the additionalObjects and for this reason we don't create the vm. 
  

## 🎥 Demo

![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/407030e1-dd60-4824-a7b4-9375638eabd8)


