### PR TITLE
CNV-35416: fix disappearing quick-create button

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerFooter.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerFooter.tsx
@@ -23,7 +23,6 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { useDrawerContext } from './hooks/useDrawerContext';
 import { TemplatesCatalogDrawerCreateForm } from './TemplatesCatalogDrawerCreateForm';
 import { TemplatesCatalogDrawerFooterSkeleton } from './TemplatesCatalogDrawerFooterSkeleton';
-import { allRequiredParametersAreFulfilled } from './utils';
 
 type TemplateCatalogDrawerFooterProps = {
   namespace: string;
@@ -38,7 +37,7 @@ export const TemplatesCatalogDrawerFooter: FC<TemplateCatalogDrawerFooterProps> 
   const [authorizedSSHKeys, updateAuthorizedSSHKeys, userSettingsLoaded] =
     useKubevirtUserSettings('ssh');
   const { loaded: loadedRHELSubscription, subscriptionData } = useRHELAutomaticSubscription();
-  const { isBootSourceAvailable, template, templateDataLoaded } = useDrawerContext();
+  const { isBootSourceAvailable, templateDataLoaded } = useDrawerContext();
 
   const [, , loadError] = useK8sWatchResource<IoK8sApiCoreV1Secret>(
     authorizedSSHKeys?.[namespace] && {
@@ -56,8 +55,6 @@ export const TemplatesCatalogDrawerFooter: FC<TemplateCatalogDrawerFooterProps> 
     }
   }, [authorizedSSHKeys, loadError, namespace, updateAuthorizedSSHKeys]);
 
-  const canQuickCreate =
-    Boolean(allRequiredParametersAreFulfilled(template)) && isBootSourceAvailable;
   const loaded = templateDataLoaded && userSettingsLoaded && loadedRHELSubscription;
 
   if (!loaded) {
@@ -72,12 +69,12 @@ export const TemplatesCatalogDrawerFooter: FC<TemplateCatalogDrawerFooterProps> 
             <Split hasGutter>
               <SplitItem>
                 <Title headingLevel="h1" size="lg">
-                  {canQuickCreate
+                  {isBootSourceAvailable
                     ? t('Quick create VirtualMachine')
                     : t('Customize VirtualMachine')}
                 </Title>
               </SplitItem>
-              {canQuickCreate && (
+              {isBootSourceAvailable && (
                 <SplitItem className="template-catalog-drawer-footer-tooltip">
                   <Tooltip
                     content={<div>{t('This Template supports quick create VirtualMachine')}</div>}
@@ -91,7 +88,7 @@ export const TemplatesCatalogDrawerFooter: FC<TemplateCatalogDrawerFooterProps> 
           </StackItem>
           <TemplatesCatalogDrawerCreateForm
             authorizedSSHKey={!loadError && authorizedSSHKeys?.[namespace]}
-            canQuickCreate={canQuickCreate}
+            canQuickCreate={isBootSourceAvailable}
             namespace={namespace}
             onCancel={onCancel}
             subscriptionData={subscriptionData}

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
@@ -32,7 +32,7 @@ import { ensurePath, isEmpty } from '@kubevirt-utils/utils/utils';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 import { useAccessReview, useK8sModels } from '@openshift-console/dynamic-plugin-sdk';
 
-import { uploadFiles } from '../utils';
+import { allRequiredParametersAreFulfilled, uploadFiles } from '../utils';
 
 import useCreateVMName from './useCreateVMName';
 import { useDrawerContext } from './useDrawerContext';
@@ -209,7 +209,11 @@ const useCreateDrawerForm = (
     isCustomizeDisabled: !processedTemplateAccessReview || isCustomizing,
     isCustomizeLoading: isCustomizing || modelsLoading,
     isQuickCreateDisabled:
-      !isBootSourceAvailable || isQuickCreating || !nameField || isEmpty(models),
+      !isBootSourceAvailable ||
+      isQuickCreating ||
+      !nameField ||
+      isEmpty(models) ||
+      !Boolean(allRequiredParametersAreFulfilled(template)),
     isQuickCreateLoading: isQuickCreating || modelsLoading,
     nameField,
     onChangeStartVM,

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/utils.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/utils.ts
@@ -20,7 +20,9 @@ import { ensurePath, isEmpty } from '@kubevirt-utils/utils/utils';
 import { INSTALLATION_CDROM_NAME } from './StorageSection/constants';
 
 export const allRequiredParametersAreFulfilled = (template: V1Template) =>
-  template.parameters.every((parameter) => parameter.required && parameter.value !== '');
+  template.parameters
+    .filter((parameter) => parameter.required)
+    .every((parameter) => parameter.value !== '');
 
 export const hasNameParameter = (template: V1Template): boolean =>
   !isEmpty((template?.parameters || [])?.find((param) => param?.name === NAME_INPUT_FIELD));


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fix the issue where quick create button was not showing up.

The issue: the variable `canQuickCreate` does not disable the button but it hide it. So i moved the `allRequiredParametersAreFulfilled` function in the hook to disabled the button if the template required parameters are not satisfied.

The every function was failing with templates that have at least one optional parameter so i splitted the every function with filter and every

