### PR TITLE
Fix detach emphemeral disk

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useVolumeOwnedResource.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useVolumeOwnedResource.tsx
@@ -34,14 +34,18 @@ const useVolumeOwnedResource: UseVolumeOwnedResource = (vm, volume) => {
   const updatedVolume = volume.dataVolume ? convertDataVolumeToPVC(volume, cdiConfig) : volume;
   const volumeType = getVolumeType(updatedVolume);
   const volumeResourceModel = mapVolumeTypeToK8sModel[volumeType];
+  const volumeGroupVersionKind =
+    volumeResourceModel && modelToGroupVersionKind(volumeResourceModel);
   const volumeResourceName = getVolumeResourceName(volume);
   const watchVolumeResource = {
-    groupVersionKind: volumeResourceModel && modelToGroupVersionKind(volumeResourceModel),
+    groupVersionKind: volumeGroupVersionKind,
     isList: false,
     name: volumeResourceName,
     namespace: vm.metadata.namespace,
   };
-  const [resource, loaded, error] = useK8sWatchResource<K8sResourceCommon>(watchVolumeResource);
+  const [resource, loaded, error] = useK8sWatchResource<K8sResourceCommon>(
+    volumeGroupVersionKind && volumeResourceName && watchVolumeResource,
+  );
 
   if (!volumeResourceModel || !volumeResourceName) {
     return {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Opening the detach modal for an ephemeral disk (`containerDisk`) triggers a loading error as the `groupVersionKind` in `useVolumeOwnedResource` is `undefined`.

Fix: Do not load anything if the `groupVersionKind` is `undefined`. There is no resource to show in the modal and delete after submit if the volume is emphemeral 

## 🎥 Demo


**Before**

![Screenshot from 2023-12-06 11-03-58](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/c040cf70-3bda-454f-bbe0-81f3b66b1b09)


**After**

![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/1425547b-bcd2-4771-a950-96e46b787720)

