### PR TITLE
CNV-36232: Vertical submenu of the VM Configuration tab is white in dark mode

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/virtual-machine-configuration-tab.scss
+++ b/src/views/virtualmachines/details/tabs/configuration/virtual-machine-configuration-tab.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: row;
   height: 100%;
-  background: white;
+  background: var(--pf-c-page__main-section--m-light--BackgroundColor);
   &--main {
     margin: var(--pf-global--spacer--sm);
     width: fit-content;


### PR DESCRIPTION
## 📝 Description

The background color of the vertical subtab of the Configuration tab on the VM page stays white in dark mode.

Jira issue: https://issues.redhat.com/browse/CNV-36232

## 🎥 Screenshots

### Before
![configuration-sub-tab-bg-in-dark-mode-wrong-2023-12-08_16-01](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/33c768ad-f776-4212-af10-e34bef494aeb)


### After
![configuration-sub-tab-bg-correct-2023-12-08_16-03](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/c9e70dcf-2638-424f-aa7b-95a1dbf32e44)

