### PR TITLE
CNV-35415: Fix hot plug NIC add/remove behavior

### DIFF
--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -166,10 +166,14 @@ export const nonHotPlugNICChangesExist = (
   pendingChanges: PendingChange[],
   nonHotPlugNICsExist: boolean,
 ) => {
-  const moreChangeTypesExist = pendingChanges?.every(
-    (change) => change?.tabLabel === VirtualMachineDetailsTabLabel.NetworkInterfaces,
-  );
-  return moreChangeTypesExist || nonHotPlugNICsExist;
+  const nonNICChangesExist =
+    pendingChanges.filter(
+      (change) =>
+        change.hasPendingChange &&
+        change.tabLabel !== VirtualMachineDetailsTabLabel.NetworkInterfaces,
+    ).length > 0;
+
+  return nonNICChangesExist || nonHotPlugNICsExist;
 };
 
 const getSortedNICs = (

--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
@@ -9,6 +9,8 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { getContentScrollableElement } from '@kubevirt-utils/utils/utils';
 import {
+  Alert,
+  AlertVariant,
   ButtonVariant,
   Dropdown,
   DropdownItem,
@@ -72,9 +74,20 @@ const NetworkInterfaceActions: React.FC<NetworkInterfaceActionsProps> = ({
         submitBtnText={submitBtnText}
         submitBtnVariant={ButtonVariant.danger}
       >
-        <ConfirmActionMessage
-          obj={{ metadata: { name: nicName, namespace: vm?.metadata?.namespace } }}
-        />
+        <span>
+          <Alert
+            title={t(
+              'Deleting a network interface is supported only on VirtualMachines that were created in versions greater than 4.13 or for network interfaces that were added to the VirtualMachine in these versions.',
+            )}
+            component={'h6'}
+            isInline
+            variant={AlertVariant.warning}
+          />
+          <br />
+          <ConfirmActionMessage
+            obj={{ metadata: { name: nicName, namespace: vm?.metadata?.namespace } }}
+          />
+        </span>
       </TabModal>
     ));
     setIsDropdownOpen(false);

--- a/src/views/virtualmachines/actions/actions.ts
+++ b/src/views/virtualmachines/actions/actions.ts
@@ -2,7 +2,9 @@ import VirtualMachineInstanceMigrationModel from '@kubevirt-ui/kubevirt-api/cons
 import VirtualMachineInstanceModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstanceModel';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import {
+  V1AddInterfaceOptions,
   V1AddVolumeOptions,
+  V1RemoveInterfaceOptions,
   V1RemoveVolumeOptions,
   V1StopOptions,
   V1VirtualMachine,
@@ -19,8 +21,10 @@ import {
 const generateRandomString = () => Math.random().toString(36).substring(2, 7);
 
 export enum VMActionType {
+  AddInterface = 'addinterface',
   AddVolume = 'addvolume',
   Pause = 'pause',
+  RemoveInterface = 'removeinterface',
   RemoveVolume = 'removevolume',
   Restart = 'restart',
   Start = 'start',
@@ -32,7 +36,12 @@ export const VMActionRequest = async (
   vm: V1VirtualMachine,
   action: VMActionType,
   model: K8sModel,
-  body?: V1AddVolumeOptions | V1RemoveVolumeOptions | V1StopOptions,
+  body?:
+    | V1AddInterfaceOptions
+    | V1AddVolumeOptions
+    | V1RemoveInterfaceOptions
+    | V1RemoveVolumeOptions
+    | V1StopOptions,
 ) => {
   const {
     metadata: { name, namespace },
@@ -110,3 +119,8 @@ export const deleteVM = async (vm: V1VirtualMachine) => {
     resource: vm,
   });
 };
+
+export const addInterface = async (vm: V1VirtualMachine, body: V1AddInterfaceOptions) =>
+  VMActionRequest(vm, VMActionType.AddInterface, VirtualMachineModel, body);
+export const removeInterface = async (vm: V1VirtualMachine, body: V1RemoveInterfaceOptions) =>
+  VMActionRequest(vm, VMActionType.RemoveInterface, VirtualMachineModel, body);

--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/RestartPendingChanges.tsx
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/RestartPendingChanges.tsx
@@ -23,6 +23,12 @@ const RestartPendingChanges: React.FC<RestartPendingChangesProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const { featureEnabled: nicHotPlugEnabled } = useFeatures(BRIDGED_NIC_HOTPLUG_ENABLED);
+
+  const showRestartSection =
+    !nicHotPlugEnabled ||
+    nonHotPlugNICChangesExist(pendingChanges, hasPendingChange(nonHotPlugPendingChanges));
+  if (!showRestartSection) return null;
+
   const pendingChangesTabs = getPendingChangesByTab(pendingChanges);
   const {
     pendingChangesDetailsTab,
@@ -32,11 +38,6 @@ const RestartPendingChanges: React.FC<RestartPendingChangesProps> = ({
     pendingChangesSchedulingTab,
     pendingChangesScriptsTab,
   } = pendingChangesTabs;
-  const showRestartSection =
-    !nicHotPlugEnabled ||
-    nonHotPlugNICChangesExist(pendingChanges, hasPendingChange(nonHotPlugPendingChanges)) ||
-    Object.values(pendingChangesTabs).some((changes) => changes.length > 0);
-  if (!showRestartSection) return null;
 
   return (
     <span>


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug wherein a bridged hot-plug NIC is not added after the VM has been migrated.

The root cause of this bug is that I changed the API for adding/removing hot-plug NICs too early. This PR reverts back to the correct hot-plug API for 4.14.

This PR can't be applied to main first and then backported because the hot-plug API for 4.15 is different.

Jira ticket: https://issues.redhat.com/browse/CNV-35415
