### PR TITLE
CNV-35753: fix suggestion focus/blur logic

### DIFF
--- a/src/utils/components/ListPageFilter/AutocompleteInput.tsx
+++ b/src/utils/components/ListPageFilter/AutocompleteInput.tsx
@@ -1,9 +1,10 @@
-import React, { Dispatch, FC, SetStateAction, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Dispatch, FC, SetStateAction, useMemo, useState } from 'react';
 import classNames from 'classnames';
 
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
-import { MAX_SUGGESTIONS } from './constants';
+import { useDocumentListener } from './hooks/useDocumentListener';
+import { MAX_SUGGESTIONS, suggestionBoxKeyHandler } from './constants';
 import SearchFilter from './SearchFilter';
 import SuggestionLine from './SuggestionLine';
 import { fuzzyCaseInsensitive, labelParser } from './utils';
@@ -27,8 +28,7 @@ const AutocompleteInput: FC<AutocompleteInputProps> = ({
   textValue,
 }) => {
   const [suggestions, setSuggestions] = useState<string[]>();
-  const [visible, setVisible] = useState<boolean>(true);
-  const inputRef = useRef<HTMLInputElement>();
+  const { ref, setVisible, visible } = useDocumentListener<HTMLDivElement>(suggestionBoxKeyHandler);
 
   const processedData = useMemo(() => Array.from(labelParser(data)), [data]);
 
@@ -48,36 +48,9 @@ const AutocompleteInput: FC<AutocompleteInputProps> = ({
     setSuggestions(filtered);
   };
 
-  useEffect(() => {
-    const inputElement = inputRef.current;
-
-    if (!inputElement) return;
-
-    const onFocus = () => {
-      setVisible(true);
-    };
-
-    const onBlur = () => {
-      setVisible(false);
-    };
-
-    inputElement.addEventListener('focus', onFocus);
-    inputElement.addEventListener('blur', onBlur);
-
-    return () => {
-      inputElement.removeEventListener('focus', onFocus);
-      inputElement.removeEventListener('blur', onBlur);
-    };
-  }, []);
-
   return (
-    <div className="co-suggestion-box">
-      <SearchFilter
-        onChange={handleInput}
-        placeholder={placeholder}
-        ref={inputRef}
-        value={textValue}
-      />
+    <div className="co-suggestion-box" ref={ref}>
+      <SearchFilter onChange={handleInput} placeholder={placeholder} value={textValue} />
       {visible && (
         <div
           className={classNames('co-suggestion-box__suggestions', {

--- a/src/utils/components/ListPageFilter/constants.ts
+++ b/src/utils/components/ListPageFilter/constants.ts
@@ -16,3 +16,27 @@ export const STATIC_SEARCH_FILTERS_PLACEHOLDERS = {
 } as const;
 
 export const MAX_SUGGESTIONS = 5;
+
+const KEYBOARD_SHORTCUTS = {
+  blurFilterInput: 'Escape',
+  focusFilterInput: '/',
+  focusNamespaceDropdown: 'n',
+};
+
+export enum KeyEventModes {
+  FOCUS = 'FOCUS',
+  HIDE = 'HIDE',
+}
+
+export const textInputKeyHandler = {
+  [KEYBOARD_SHORTCUTS.blurFilterInput]: KeyEventModes.HIDE,
+  [KEYBOARD_SHORTCUTS.focusFilterInput]: KeyEventModes.FOCUS,
+};
+
+export const suggestionBoxKeyHandler = {
+  Escape: KeyEventModes.HIDE,
+};
+
+export type KeyEventMap = {
+  [key: string]: KeyEventModes;
+};

--- a/src/utils/components/ListPageFilter/hooks/useDocumentListener.ts
+++ b/src/utils/components/ListPageFilter/hooks/useDocumentListener.ts
@@ -1,0 +1,55 @@
+import React, { useRef, useState } from 'react';
+
+import { KeyEventMap, KeyEventModes, textInputKeyHandler } from '../constants';
+
+/**
+ * Use this hook for components that require visibility only
+ * when the user is actively interacting with the document.
+ */
+
+export const useDocumentListener = <T extends HTMLElement>(
+  keyEventMap: KeyEventMap = textInputKeyHandler,
+) => {
+  const [visible, setVisible] = useState(true);
+  const ref = useRef<T>(null);
+
+  const handleEvent = (e) => {
+    if (!ref?.current?.contains(e.target)) {
+      setVisible(false);
+    }
+  };
+
+  const handleKeyEvents = (e) => {
+    const { nodeName } = e.target;
+    switch (keyEventMap[e.key]) {
+      case KeyEventModes.HIDE:
+        setVisible(false);
+        ref.current.blur();
+        break;
+      case KeyEventModes.FOCUS:
+        if (
+          document.activeElement !== ref.current &&
+          // Don't steal focus if the user types the focus shortcut in another text input.
+          nodeName !== 'INPUT' &&
+          nodeName !== 'TEXTAREA'
+        ) {
+          ref.current.focus();
+          e.preventDefault();
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  React.useEffect(() => {
+    document.addEventListener('click', handleEvent, true);
+    document.addEventListener('keydown', handleKeyEvents, true);
+    return () => {
+      document.removeEventListener('click', handleEvent, true);
+      document.removeEventListener('keydown', handleKeyEvents, true);
+    };
+  });
+
+  return { ref, setVisible, visible };
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Label suggestions were not working so with this pr I fix this issue.

When the user clicks on one suggestion, the onBlur method is called and before firing the suggestion onClick, the suggestion element is removed from the dom.

Fixing it by copying the useDocumentListener method from the console

## 🎥 Demo

**Before**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/9565acfd-7ece-45e9-b9b1-7102820d92e5


**After**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/949b9158-947e-4cfe-b0ad-1728c5d29cf9



