### PR TITLE
CNV-35730: Fix windows sysprep on vm init run tab

### DIFF
--- a/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
@@ -8,6 +8,7 @@ import CloudinitModal from '@kubevirt-utils/components/CloudinitModal/CloudinitM
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
 import {
   DescriptionList,
@@ -23,7 +24,7 @@ import Sysprep from './components/Sysprep';
 
 import './WizardScriptsTab.scss';
 
-const WizardScriptsTab: WizardTab = ({ updateVM, vm }) => {
+const WizardScriptsTab: WizardTab = ({ tabsData, updateVM, vm }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
 
@@ -45,6 +46,7 @@ const WizardScriptsTab: WizardTab = ({ updateVM, vm }) => {
               ))
             }
             description={<CloudInitDescription vm={vm} />}
+            isDisabled={tabsData.overview.templateMetadata.osType === OS_NAME_TYPES.windows}
             isEdit
             showEditOnTitle
             testId="wizard-cloudinit"

--- a/src/views/templates/details/tabs/scripts/components/SysPrepItem/sysprep-utils.ts
+++ b/src/views/templates/details/tabs/scripts/components/SysPrepItem/sysprep-utils.ts
@@ -109,4 +109,4 @@ export const updateSysprepObject = (
   }
 };
 
-export const getSyspredConfigMapName = (volume: V1Volume) => volume?.sysprep?.configMap?.name;
+export const getSysprepConfigMapName = (volume: V1Volume) => volume?.sysprep?.configMap?.name;

--- a/src/views/virtualmachines/details/tabs/configuration/initialrun/components/InitialRunTabSysprep.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/initialrun/components/InitialRunTabSysprep.tsx
@@ -1,27 +1,33 @@
 import React, { FC } from 'react';
-import { getSyspredConfigMapName } from 'src/views/templates/details/tabs/scripts/components/SysPrepItem/sysprep-utils';
+import { getSysprepConfigMapName } from 'src/views/templates/details/tabs/scripts/components/SysPrepItem/sysprep-utils';
 
 import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import WindowsLabel from '@kubevirt-utils/components/Labels/WindowsLabel';
+import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import { AUTOUNATTEND, UNATTEND } from '@kubevirt-utils/components/SysprepModal/sysprep-utils';
 import { SysprepDescription } from '@kubevirt-utils/components/SysprepModal/SysprepDescription';
+import { SysprepModal } from '@kubevirt-utils/components/SysprepModal/SysprepModal';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getVolumes } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
+import { createSysprepConfigMap, patchVMWithExistingSysprepConfigMap } from '../utils/utils';
+
 type InitialRunTabSysprepProps = {
   canUpdateVM: boolean;
   vm: V1VirtualMachine;
 };
 const InitialRunTabSysprep: FC<InitialRunTabSysprepProps> = ({ canUpdateVM, vm }) => {
+  const { createModal } = useModal();
   const vmVolumes = getVolumes(vm);
-  const currentSysprepVolume = vmVolumes?.find(getSyspredConfigMapName);
-  const currentVMSysprepName = getSyspredConfigMapName(currentSysprepVolume);
+
+  const currentSysprepVolume = vmVolumes?.find(getSysprepConfigMapName);
+  const currentVMSysprepName = getSysprepConfigMapName(currentSysprepVolume);
 
   const sysprepSelected = !isEmpty(currentVMSysprepName) && currentVMSysprepName;
   const [externalSysprepConfig, sysprepLoaded, sysprepLoadError] =
@@ -35,6 +41,11 @@ const InitialRunTabSysprep: FC<InitialRunTabSysprepProps> = ({ canUpdateVM, vm }
 
   const { [AUTOUNATTEND]: autoUnattend, [UNATTEND]: unattend } = externalSysprepConfig?.data || {};
 
+  const onSysprepSelected = (name: string) => patchVMWithExistingSysprepConfigMap(name, vm);
+
+  const onSysprepCreation = async (unattended: string, autounattend: string): Promise<void> =>
+    createSysprepConfigMap(unattended, autounattend, externalSysprepConfig, vm);
+
   return (
     <VirtualMachineDescriptionItem
       descriptionData={
@@ -46,9 +57,22 @@ const InitialRunTabSysprep: FC<InitialRunTabSysprepProps> = ({ canUpdateVM, vm }
           selectedSysprepName={currentVMSysprepName}
         />
       }
+      onEditClick={() =>
+        createModal((modalProps) => (
+          <SysprepModal
+            {...modalProps}
+            autoUnattend={autoUnattend}
+            namespace={vm?.metadata?.namespace}
+            onSysprepCreation={onSysprepCreation}
+            onSysprepSelected={onSysprepSelected}
+            sysprepSelected={sysprepSelected}
+            unattend={unattend}
+          />
+        ))
+      }
       data-test-id="sysprep-button"
       descriptionHeader={<SearchItem id="sysprep">{t('Sysprep')}</SearchItem>}
-      isDisabled
+      isDisabled={!canUpdateVM}
       isEdit={canUpdateVM}
       label={<WindowsLabel />}
       showEditOnTitle

--- a/src/views/virtualmachines/details/tabs/configuration/initialrun/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/initialrun/utils/utils.ts
@@ -1,0 +1,97 @@
+import { ConfigMapModel } from '@kubevirt-ui/kubevirt-api/console';
+import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
+import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  AUTOUNATTEND,
+  generateNewSysprepConfig,
+  SYSPREP,
+  sysprepDisk,
+  sysprepVolume,
+  UNATTEND,
+} from '@kubevirt-utils/components/SysprepModal/sysprep-utils';
+import { getDisks, getVolumes } from '@kubevirt-utils/resources/vm';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { k8sCreate, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
+
+export const patchVMWithExistingSysprepConfigMap = async (
+  name: string,
+  vm: V1VirtualMachine,
+): Promise<void> => {
+  const vmVolumes = getVolumes(vm);
+  const vmDisks = getDisks(vm);
+
+  await k8sPatch<V1VirtualMachine>({
+    data: [
+      {
+        op: 'replace',
+        path: `/spec/template/spec/domain/devices/disks`,
+        value: [
+          ...vmDisks.filter((disk) => disk?.name !== SYSPREP),
+          ...(!isEmpty(name) ? [sysprepDisk()] : []),
+        ],
+      },
+      {
+        op: 'replace',
+        path: `/spec/template/spec/volumes`,
+        value: [
+          ...vmVolumes.filter((vol) => vol?.name !== SYSPREP),
+          ...(!isEmpty(name) ? [sysprepVolume(name)] : []),
+        ],
+      },
+    ],
+    model: VirtualMachineModel,
+    resource: vm,
+  });
+};
+
+export const createSysprepConfigMap = async (
+  unattended: string,
+  autounattend: string,
+  externalSysprepConfig: IoK8sApiCoreV1ConfigMap,
+  vm: V1VirtualMachine,
+): Promise<void> => {
+  const vmVolumes = getVolumes(vm);
+  const vmDisks = getDisks(vm);
+
+  const sysprepData = { [AUTOUNATTEND]: autounattend, [UNATTEND]: unattended };
+
+  const configMap = generateNewSysprepConfig({
+    data: sysprepData,
+    sysprepName: externalSysprepConfig?.metadata?.name,
+    vm,
+  });
+
+  if (externalSysprepConfig) {
+    await k8sPatch({
+      data: [
+        {
+          op: 'replace',
+          path: `/data`,
+          value: configMap.data,
+        },
+      ],
+      model: ConfigMapModel,
+      resource: externalSysprepConfig,
+    });
+    return;
+  }
+
+  await k8sCreate({ data: configMap, model: ConfigMapModel });
+  await k8sPatch<V1VirtualMachine>({
+    data: [
+      {
+        op: 'replace',
+        path: `/spec/template/spec/domain/devices/disks`,
+        value: [...vmDisks, sysprepDisk()],
+      },
+      {
+        op: 'replace',
+        path: `/spec/template/spec/volumes`,
+        value: [...vmVolumes, sysprepVolume(configMap.metadata.name)],
+      },
+    ],
+    model: VirtualMachineModel,
+    resource: vm,
+  });
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

It seems like an old bug before the day that you could create a VM that won't start at the beginning.
The sysprep on the init run tab was missing the modal when clicking edit, and edit was hard coded disabled.

## 🎥 Demo

> Please add a video or an image of the behavior/changes
