### PR TITLE
CNV-36799: Disable volume and access mode when apply storage profile is checked

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/AccessMode.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/AccessMode.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { Dispatch, FC, useEffect, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup, Radio } from '@patternfly/react-core';
@@ -14,11 +14,11 @@ import {
 
 type AccessModeProps = {
   diskState: DiskFormState;
-  dispatchDiskState: React.Dispatch<DiskReducerActionType>;
+  dispatchDiskState: Dispatch<DiskReducerActionType>;
   spAccessMode?: string;
 };
 
-const AccessMode: React.FC<AccessModeProps> = ({ diskState, dispatchDiskState, spAccessMode }) => {
+const AccessMode: FC<AccessModeProps> = ({ diskState, dispatchDiskState, spAccessMode }) => {
   const { t } = useKubevirtTranslation();
 
   const {
@@ -29,11 +29,11 @@ const AccessMode: React.FC<AccessModeProps> = ({ diskState, dispatchDiskState, s
     volumeMode,
   } = diskState || {};
 
-  const allowedAccessModes = React.useMemo(() => {
+  const allowedAccessModes = useMemo(() => {
     return getAccessModeForProvisioner(storageClassProvisioner, volumeMode as VolumeMode);
   }, [storageClassProvisioner, volumeMode]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!storageProfileSettingsCheckboxDisabled) {
       if (applyStorageProfileSettings) {
         dispatchDiskState({
@@ -74,7 +74,7 @@ const AccessMode: React.FC<AccessModeProps> = ({ diskState, dispatchDiskState, s
           }
           id={value}
           isChecked={value === accessMode}
-          isDisabled={!allowedAccessModes?.includes(value)}
+          isDisabled={!allowedAccessModes?.includes(value) || applyStorageProfileSettings}
           key={value}
           label={label}
           name="accessMode"

--- a/src/utils/components/DiskModal/DiskFormFields/EnablePreallocationCheckbox.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/EnablePreallocationCheckbox.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
+import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Checkbox, FormGroup } from '@patternfly/react-core';
+import { Checkbox, Flex, FlexItem, FormGroup, PopoverPosition } from '@patternfly/react-core';
 
 import { diskReducerActions, DiskReducerActionType } from '../state/actions';
 
@@ -21,37 +22,47 @@ const EnablePreallocationCheckbox: React.FC<EnablePreallocationCheckboxProps> = 
   const { t } = useKubevirtTranslation();
 
   return (
-    <FormGroup
-      helperText={
-        <>
-          <Trans ns="plugin__kubevirt-plugin">
-            Refer to the
-            <Link
-              to={{
-                pathname:
-                  'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/virtualization/virtual-machines#virt-using-preallocation-for-datavolumes',
-              }}
-              target="_blank"
-            >
-              {' '}
-              Documentation{' '}
-            </Link>
-            or contact your system administrator for more information. Enabling preallocation is
-            available only for DataVolumes.
-          </Trans>
-        </>
-      }
-      fieldId="enable-preallocation"
-    >
-      <Checkbox
-        onChange={(checked) =>
-          dispatchDiskState({ payload: checked, type: diskReducerActions.SET_ENABLE_PREALLOCATION })
-        }
-        id="enable-preallocation"
-        isChecked={enablePreallocation}
-        isDisabled={isDisabled}
-        label={t('Enable preallocation')}
-      />
+    <FormGroup fieldId="enable-preallocation">
+      <Flex>
+        <FlexItem>
+          <Checkbox
+            onChange={(checked) =>
+              dispatchDiskState({
+                payload: checked,
+                type: diskReducerActions.SET_ENABLE_PREALLOCATION,
+              })
+            }
+            id="enable-preallocation"
+            isChecked={enablePreallocation}
+            isDisabled={isDisabled}
+            label={t('Enable preallocation')}
+          />
+        </FlexItem>
+        <FlexItem>
+          <HelpTextIcon
+            bodyContent={
+              <>
+                <Trans ns="plugin__kubevirt-plugin">
+                  Refer to the
+                  <Link
+                    to={{
+                      pathname:
+                        'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/virtualization/virtual-machines#virt-using-preallocation-for-datavolumes',
+                    }}
+                    target="_blank"
+                  >
+                    {' '}
+                    Documentation{' '}
+                  </Link>
+                  or contact your system administrator for more information. Enabling preallocation
+                  is available only for DataVolumes.
+                </Trans>
+              </>
+            }
+            position={PopoverPosition.right}
+          />
+        </FlexItem>
+      </Flex>
     </FormGroup>
   );
 };

--- a/src/utils/components/DiskModal/DiskFormFields/StorageClassAndPreallocation.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/StorageClassAndPreallocation.tsx
@@ -2,6 +2,7 @@ import React, { FC, useMemo } from 'react';
 
 import ApplyStorageProfileSettingsCheckbox from '@kubevirt-utils/components/ApplyStorageProfileSettingsCheckbox/ApplyStorageProfileSettingsCheckbox';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { Flex, FlexItem } from '@patternfly/react-core';
 
 import { diskReducerActions, DiskReducerActionType } from '../state/actions';
 import { DiskFormState } from '../state/initialState';
@@ -13,6 +14,8 @@ import { sourceTypes } from './utils/constants';
 import AccessMode from './AccessMode';
 import EnablePreallocationCheckbox from './EnablePreallocationCheckbox';
 import VolumeMode from './VolumeMode';
+
+import './storage-class-and-preallocation.scss';
 
 type StorageClassAndPreallocationProps = {
   checkSC?: (selectedStorageClass: string) => boolean;
@@ -36,11 +39,20 @@ const StorageClassAndPreallocation: FC<StorageClassAndPreallocationProps> = ({
 
   if (!sourceRequiresDataVolume && diskState.diskSource !== sourceTypes.UPLOAD) return null;
 
-  const handleApplyOptimizedSettingsChange = (checked: boolean) =>
+  const handleApplyOptimizedSettingsChange = (checked: boolean) => {
     dispatchDiskState({
       payload: checked,
       type: diskReducerActions.SET_APPLY_STORAGE_PROFILE_SETTINGS,
     });
+    dispatchDiskState({
+      payload: claimPropertySets?.[0]?.volumeMode,
+      type: diskReducerActions.SET_VOLUME_MODE,
+    });
+    dispatchDiskState({
+      payload: claimPropertySets?.[0]?.accessModes[0],
+      type: diskReducerActions.SET_ACCESS_MODE,
+    });
+  };
 
   return (
     <>
@@ -57,22 +69,33 @@ const StorageClassAndPreallocation: FC<StorageClassAndPreallocationProps> = ({
         checkSC={checkSC}
         storageClass={diskState.storageClass}
       />
-      <ApplyStorageProfileSettingsCheckbox
-        claimPropertySets={claimPropertySets}
-        disabled={!storageProfileLoaded || !claimPropertySets || isEmpty(claimPropertySets)}
-        handleChange={handleApplyOptimizedSettingsChange}
-        isChecked={diskState?.applyStorageProfileSettings}
-      />
-      <AccessMode
-        diskState={diskState}
-        dispatchDiskState={dispatchDiskState}
-        spAccessMode={claimPropertySets?.[0]?.accessModes?.[0]}
-      />
-      <VolumeMode
-        diskState={diskState}
-        dispatchDiskState={dispatchDiskState}
-        spVolumeMode={claimPropertySets?.[0]?.volumeMode}
-      />
+      <div>
+        <ApplyStorageProfileSettingsCheckbox
+          claimPropertySets={claimPropertySets}
+          disabled={!storageProfileLoaded || !claimPropertySets || isEmpty(claimPropertySets)}
+          handleChange={handleApplyOptimizedSettingsChange}
+          isChecked={diskState?.applyStorageProfileSettings}
+        />
+        <Flex
+          className="StorageClassAndPreallocation--volume-access-section"
+          spaceItems={{ default: 'spaceItems3xl' }}
+        >
+          <FlexItem>
+            <AccessMode
+              diskState={diskState}
+              dispatchDiskState={dispatchDiskState}
+              spAccessMode={claimPropertySets?.[0]?.accessModes?.[0]}
+            />
+          </FlexItem>
+          <FlexItem>
+            <VolumeMode
+              diskState={diskState}
+              dispatchDiskState={dispatchDiskState}
+              spVolumeMode={claimPropertySets?.[0]?.volumeMode}
+            />
+          </FlexItem>
+        </Flex>
+      </div>
       <EnablePreallocationCheckbox
         dispatchDiskState={dispatchDiskState}
         enablePreallocation={diskState.enablePreallocation}

--- a/src/utils/components/DiskModal/DiskFormFields/VolumeMode.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/VolumeMode.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { Dispatch, FC, useEffect, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup, Radio } from '@patternfly/react-core';
@@ -15,11 +15,11 @@ import {
 
 type VolumeModeProps = {
   diskState: DiskFormState;
-  dispatchDiskState: React.Dispatch<DiskReducerActionType>;
+  dispatchDiskState: Dispatch<DiskReducerActionType>;
   spVolumeMode?: string;
 };
 
-const VolumeMode: React.FC<VolumeModeProps> = ({ diskState, dispatchDiskState, spVolumeMode }) => {
+const VolumeMode: FC<VolumeModeProps> = ({ diskState, dispatchDiskState, spVolumeMode }) => {
   const { t } = useKubevirtTranslation();
 
   const {
@@ -30,12 +30,12 @@ const VolumeMode: React.FC<VolumeModeProps> = ({ diskState, dispatchDiskState, s
     volumeMode,
   } = diskState || {};
 
-  const allowedVolumeModes = React.useMemo(
+  const allowedVolumeModes = useMemo(
     () => getVolumeModeForProvisioner(storageClassProvisioner, accessMode as AccessMode),
     [accessMode, storageClassProvisioner],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!storageProfileSettingsCheckboxDisabled) {
       if (applyStorageProfileSettings) {
         dispatchDiskState({
@@ -76,7 +76,7 @@ const VolumeMode: React.FC<VolumeModeProps> = ({ diskState, dispatchDiskState, s
           }
           id={value}
           isChecked={value === volumeMode}
-          isDisabled={!allowedVolumeModes?.includes(value)}
+          isDisabled={!allowedVolumeModes?.includes(value) || applyStorageProfileSettings}
           key={value}
           label={label}
           name="volumeMode"

--- a/src/utils/components/DiskModal/DiskFormFields/storage-class-and-preallocation.scss
+++ b/src/utils/components/DiskModal/DiskFormFields/storage-class-and-preallocation.scss
@@ -1,0 +1,6 @@
+.StorageClassAndPreallocation {
+  &--volume-access-section {
+    margin-left: var(--pf-global--spacer--md);
+    margin-top: var(--pf-global--spacer--sm);
+  }
+}


### PR DESCRIPTION
Disable volume and access mode if the apply storage profile is checked, as they don't have any meaning. If u check apply, change the volume and access according to the claim. change appearance by new design

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Add a brief description

## 🎥 Demo

Before:
![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/14824964/fb60dcd7-a5ff-4150-babe-e52ecba7d218)


After:
<img width="888" alt="image" src="https://github.com/kubevirt-ui/kubevirt-plugin/assets/14824964/32d14207-29fb-47ce-b0b8-17d9edd188e9">
