### PR TITLE
CNV-36884: Fix VMI scheduling tab is crashed if visit it quickly

### DIFF
--- a/src/views/virtualmachinesinstance/details/tabs/scheduling/DeticatedResources/DedicatedResources.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/scheduling/DeticatedResources/DedicatedResources.tsx
@@ -10,7 +10,7 @@ type DedicatedResourcesProps = {
 
 const DedicatedResources: FC<DedicatedResourcesProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
-  const isDedicatedResources = getCPU(vmi).dedicatedCpuPlacement;
+  const isDedicatedResources = getCPU(vmi)?.dedicatedCpuPlacement;
 
   return isDedicatedResources
     ? t('Workload scheduled with dedicated resources (guaranteed policy)')


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fix VMI scheduling tab is crashed if visit it quickly
## 🎥 Demo

> Please add a video or an image of the behavior/changes
