### PR TITLE
CNV-35271: Prevent changing disk size unit to B after PVC selection

### DIFF
--- a/src/views/catalog/utils/quantity.ts
+++ b/src/views/catalog/utils/quantity.ts
@@ -1,6 +1,6 @@
 import byteSize, { ByteSizeResult } from 'byte-size';
 
-import { binaryUnits, customUnits, multipliers, toIECUnit } from '@kubevirt-utils/utils/units';
+import { customUnits, multipliers, toIECUnit } from '@kubevirt-utils/utils/units';
 
 export const bytesToIECBytes = (
   bytes: number,
@@ -15,8 +15,8 @@ export const bytesToIECBytes = (
 };
 
 export const bytesToDiskSize = (size: string) => {
-  const bytesizeresult = bytesToIECBytes(parseFloat(size), 0, binaryUnits);
-  return [bytesizeresult.value, bytesizeresult.unit].join('');
+  const bytesizeresult = bytesFromQuantity(size, 0);
+  return [bytesizeresult[0], bytesizeresult[1]].join('');
 };
 
 export const bytesFromQuantity = (


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-35271

Prevent changing disk size unit to "B" after selecting a PVC when using an existing volume in _Add volume_ modal (_InstanceTypes_ tab in _Catalog_).

## 🎥 Screenshots
**Before:**
Disk size unit suddenly changed to "B" when selecting PVC from the _PVC name_ dropdown:
![volume_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/e6572777-0563-44e0-bf90-6681bf91c476)

**After:**
Correct disk size:
![volume_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/937674f5-a8e9-4227-a9fc-f479de706186)

