### PR TITLE
CNV-34692: Prevent VM stuck in starting status after detaching disk

### DIFF
--- a/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
+++ b/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { isRunning } from 'src/views/virtualmachines/utils';
 
+import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import {
   getRunningVMMissingDisksFromVMI,
@@ -9,7 +10,7 @@ import {
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { PersistentVolumeClaimModel } from '@kubevirt-utils/models';
 import { DiskRawData, DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
-import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 import { getBootDisk, getDisks, getVolumes } from '../../utils';
 import { getDiskRowDataLayout } from '../../utils/disk/rowData';
@@ -46,7 +47,7 @@ const useDisksTableData: UseDisksTableDisks = (vm, vmi) => {
     [vm, vmi, isVMRunning],
   );
 
-  const [pvcs, loaded, loadingError] = useK8sWatchResource<K8sResourceCommon[]>({
+  const [pvcs, loaded, loadingError] = useK8sWatchResource<IoK8sApiCoreV1PersistentVolumeClaim[]>({
     isList: true,
     kind: PersistentVolumeClaimModel.kind,
     namespace: vm?.metadata?.namespace,

--- a/src/utils/resources/vm/utils/disk/constants.ts
+++ b/src/utils/resources/vm/utils/disk/constants.ts
@@ -1,14 +1,10 @@
-import {
-  V1alpha1PersistentVolumeClaim,
-  V1DataVolumeTemplateSpec,
-  V1Disk,
-  V1Volume,
-} from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { V1DataVolumeTemplateSpec, V1Disk, V1Volume } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
 export type DiskRawData = {
   dataVolumeTemplate?: V1DataVolumeTemplateSpec;
   disk: V1Disk;
-  pvc?: V1alpha1PersistentVolumeClaim;
+  pvc?: IoK8sApiCoreV1PersistentVolumeClaim;
   volume: V1Volume;
 };
 
@@ -22,6 +18,7 @@ export type DiskRowDataLayout = {
   namespace?: string;
   size: string;
   source: string;
+  sourceStatus?: string;
   storageClass: string;
 };
 

--- a/src/utils/resources/vm/utils/disk/rowData.ts
+++ b/src/utils/resources/vm/utils/disk/rowData.ts
@@ -49,6 +49,7 @@ export const getDiskRowDataLayout = (
 
     if (device?.pvc) {
       diskRowDataObject.source = device?.pvc?.metadata?.name;
+      diskRowDataObject.sourceStatus = device?.pvc?.status?.phase;
       diskRowDataObject.size = formatBytes(device?.pvc?.spec?.resources?.requests?.storage);
       diskRowDataObject.storageClass = device?.pvc?.spec?.storageClassName;
     }

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRow.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRow.tsx
@@ -1,10 +1,6 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import {
-  CONTAINER_EPHERMAL,
-  OTHER,
-} from '@kubevirt-utils/components/DiskModal/DiskFormFields/utils/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, PersistentVolumeClaimModel } from '@kubevirt-utils/models';
 import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
@@ -12,14 +8,14 @@ import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 import { Label, Stack, StackItem } from '@patternfly/react-core';
 
+import { isPVCSource } from './utils/helpers';
 import DiskRowActions from './DiskRowActions';
 import { HotplugLabel } from './HotplugLabel';
 
-const DiskRow: React.FC<
+const DiskRow: FC<
   RowProps<DiskRowDataLayout, { vm: V1VirtualMachine; vmi?: V1VirtualMachineInstance }>
 > = ({ activeColumnIDs, obj, rowData: { vm, vmi } }) => {
   const { t } = useKubevirtTranslation();
-  const isPVCSource = ![CONTAINER_EPHERMAL, OTHER].includes(obj?.source);
 
   return (
     <>
@@ -46,7 +42,7 @@ const DiskRow: React.FC<
       </TableData>
 
       <TableData activeColumnIDs={activeColumnIDs} id="source">
-        {isPVCSource ? (
+        {isPVCSource(obj) ? (
           <ResourceLink
             groupVersionKind={modelToGroupVersionKind(PersistentVolumeClaimModel)}
             name={obj?.source}
@@ -73,7 +69,7 @@ const DiskRow: React.FC<
         className="dropdown-kebab-pf pf-v5-c-table__action"
         id=""
       >
-        <DiskRowActions diskName={obj?.name} pvcResourceExists={isPVCSource} vm={vm} vmi={vmi} />
+        <DiskRowActions obj={obj} vm={vm} vmi={vmi} />
       </TableData>
     </>
   );

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/utils/helpers.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/utils/helpers.ts
@@ -1,5 +1,10 @@
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  CONTAINER_EPHERMAL,
+  OTHER,
+} from '@kubevirt-utils/components/DiskModal/DiskFormFields/utils/constants';
 import { getVolumes } from '@kubevirt-utils/resources/vm';
+import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 
 export const isHotplugVolume = (
   vm: V1VirtualMachine,
@@ -14,3 +19,8 @@ export const isHotplugVolume = (
     vmVolume?.persistentVolumeClaim?.hotpluggable;
   return !!hotplugStatus;
 };
+
+export const isPVCSource = (obj: DiskRowDataLayout): boolean =>
+  ![CONTAINER_EPHERMAL, OTHER].includes(obj?.source);
+
+export const isPVCStatusBound = (obj: DiskRowDataLayout): boolean => obj?.sourceStatus === 'Bound';


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-34692

Prevent VM getting stuck in "Starting" status in case of detaching a disk that is in error (if PVC is not in "Bound" state, for example if you added wrong url when creating that disk) by disabling _Detach_ button for that specific disk in the VM's _Disks_ list.

## 🎥 Screenshots
**Before:**
Possible to detach the problematic disk leading to VM stuck in starting status:
![detach_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/07f543a5-57b8-4c50-888f-2c9cf1409105)

**After:**
_Detach_ button disabled if the disk is problematic/if PVC is not in Bound state:
![detach_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/4feab765-97c8-4323-99d9-f3ab52a685f2)







