### PR TITLE
CNV-35782: Disable deleted NIC when VM is stopped

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceActions.tsx
@@ -28,12 +28,14 @@ import { isRunning } from '@virtualmachines/utils';
 import VirtualMachinesEditNetworkInterfaceModal from '../modal/VirtualMachinesEditNetworkInterfaceModal';
 
 type NetworkInterfaceActionsProps = {
+  nicDisabled: boolean;
   nicName: string;
   nicPresentation: NetworkPresentation;
   vm: V1VirtualMachine;
 };
 
 const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
+  nicDisabled,
   nicName,
   nicPresentation,
   vm,
@@ -116,16 +118,16 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
   ];
 
   return (
-    <>
-      <Dropdown
-        dropdownItems={items}
-        isOpen={isDropdownOpen}
-        isPlain
-        onSelect={() => setIsDropdownOpen(false)}
-        position={DropdownPosition.right}
-        toggle={<KebabToggle id="toggle-id-6" onToggle={setIsDropdownOpen} />}
-      />
-    </>
+    <Dropdown
+      toggle={
+        <KebabToggle id="toggle-id-6" isDisabled={nicDisabled} onToggle={setIsDropdownOpen} />
+      }
+      dropdownItems={items}
+      isOpen={isDropdownOpen}
+      isPlain
+      onSelect={() => setIsDropdownOpen(false)}
+      position={DropdownPosition.right}
+    />
   );
 };
 

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceRow.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceRow.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import classNames from 'classnames';
 
 import { V1Network, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import PendingBadge from '@kubevirt-utils/components/PendingBadge/PendingBadge';
@@ -7,6 +8,7 @@ import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { getPrintableNetworkInterfaceType } from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
+import { isStopped } from '@virtualmachines/utils';
 
 import NetworkInterfaceActions from './NetworkInterfaceActions';
 
@@ -21,31 +23,34 @@ const NetworkInterfaceRow: FC<
   >
 > = ({ activeColumnIDs, obj: { iface, network }, rowData: { isPending, vm } }) => {
   const { t } = useKubevirtTranslation();
+  const nicDisabled = isStopped(vm) && iface?.state === 'absent';
+  const className = classNames({ 'pf-u-disabled-color-100': nicDisabled });
 
   return (
     <>
-      <TableData activeColumnIDs={activeColumnIDs} id="name">
+      <TableData activeColumnIDs={activeColumnIDs} className={className} id="name">
         {network.name}
         {isPending(network) && <PendingBadge />}
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} id="model">
+      <TableData activeColumnIDs={activeColumnIDs} className={className} id="model">
         {iface.model || NO_DATA_DASH}
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} id="network">
+      <TableData activeColumnIDs={activeColumnIDs} className={className} id="network">
         {network.pod ? t('Pod networking') : network.multus?.networkName || NO_DATA_DASH}
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} id="type">
+      <TableData activeColumnIDs={activeColumnIDs} className={className} id="type">
         {getPrintableNetworkInterfaceType(iface)}
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} id="macAddress">
+      <TableData activeColumnIDs={activeColumnIDs} className={className} id="macAddress">
         {iface.macAddress || NO_DATA_DASH}
       </TableData>
       <TableData
         activeColumnIDs={activeColumnIDs}
-        className="dropdown-kebab-pf pf-v5-c-table__action"
+        className={['dropdown-kebab-pf pf-v5-c-table__action', className].join(' ')}
         id=""
       >
         <NetworkInterfaceActions
+          nicDisabled={nicDisabled}
           nicName={network.name}
           nicPresentation={{ iface, network }}
           vm={vm}


### PR DESCRIPTION
## 📝 Description

If a NIC is deleted when the VM is stopped it will not be removed until the VM is started. This PR disables the NIC to avoid confusing the user.

To Do: Determine if there are any other items that don't change until the VM is started.

Jira issue: https://issues.redhat.com/browse/CNV-35782

## 🎥 Demos

### Before

https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/1344aa39-b2ba-480f-891e-faaa60b43e72



### After

https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/f9f6a886-1d66-47c8-8ff4-07b8d423fd9e

