### PR TITLE
CNV-35635: Fix instance type different bios

### DIFF
--- a/src/utils/components/CPUMemory/CPUMemory.tsx
+++ b/src/utils/components/CPUMemory/CPUMemory.tsx
@@ -1,41 +1,28 @@
 import React, { FC } from 'react';
 
-import { V1InstancetypeMatcher, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { vCPUCount } from '@kubevirt-utils/resources/template/utils';
 import { getCPU, getMemory } from '@kubevirt-utils/resources/vm';
-import useInstanceType from '@kubevirt-utils/resources/vm/hooks/useInstanceType';
-import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Skeleton } from '@patternfly/react-core';
 import { isRunning } from '@virtualmachines/utils';
 
 type CPUMemoryProps = {
   fetchVMI?: boolean;
   vm: V1VirtualMachine;
+  vmi?: V1VirtualMachineInstance;
 };
 
-const CPUMemory: FC<CPUMemoryProps> = ({ fetchVMI = true, vm }) => {
+const CPUMemory: FC<CPUMemoryProps> = ({ vm, vmi }) => {
   const { t } = useKubevirtTranslation();
-  const itMatcher: V1InstancetypeMatcher = vm?.spec?.instancetype;
-  const { instanceType, instanceTypeLoaded, instanceTypeLoadError } = useInstanceType(itMatcher);
   const isVMRunning = isRunning(vm);
-  const { vmi, vmiLoadError } = useVMI(getName(vm), getNamespace(vm), fetchVMI);
 
-  if ((isVMRunning && vmiLoadError) || (!isEmpty(itMatcher) && instanceTypeLoadError))
-    return <MutedTextSpan text={t('Not available')} />;
+  if ((isVMRunning && !vmi) || !vm) return <Skeleton className="pf-m-width-sm" />;
 
-  if ((isVMRunning && !vmi) || !vm || !instanceTypeLoaded)
-    return <Skeleton className="pf-m-width-sm" />;
+  const cpu = vCPUCount(getCPU(vm) || getCPU(vmi));
 
-  const cpu = vCPUCount(getCPU(vm)) || getCPU(vmi) || instanceType?.spec?.cpu?.guest;
-
-  const memory = readableSizeUnit(
-    getMemory(vm) || instanceType?.spec?.memory?.guest || getMemory(vmi),
-  );
+  const memory = readableSizeUnit(getMemory(vm) || getMemory(vmi));
 
   return (
     <span data-test-id="virtual-machine-overview-details-cpu-memory">

--- a/src/utils/components/CloneVMModal/components/ConfigurationSummary.tsx
+++ b/src/utils/components/CloneVMModal/components/ConfigurationSummary.tsx
@@ -57,7 +57,7 @@ const ConfigurationSummary: FC<ConfigurationSummaryProps> = ({ vm }) => {
             {t('Flavor')}
           </TextListItem>
           <TextListItem component={TextListItemVariants.dd}>
-            <CPUMemory vm={vm} />
+            <CPUMemory vm={vm} vmi={vmi} />
           </TextListItem>
           <TextListItem className="text-muted" component={TextListItemVariants.dt}>
             {t('Workload profile')}

--- a/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
+++ b/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, useState } from 'react';
 import { Route, Switch, useHistory } from 'react-router-dom';
 
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { Nav, NavItem, NavList } from '@patternfly/react-core';
 
 import { NavPageKubevirt, trimLastHistoryPath } from './utils/utils';
@@ -9,11 +9,12 @@ import { NavPageKubevirt, trimLastHistoryPath } from './utils/utils';
 import './horizontal-nav-bar.scss';
 
 type HorizontalNavbarProps = {
+  instanceTypeExpandedSpec?: V1VirtualMachine;
   pages: NavPageKubevirt[];
-  resource?: K8sResourceCommon;
+  vm?: V1VirtualMachine;
 };
 
-const HorizontalNavbar: FC<HorizontalNavbarProps> = ({ pages, resource }) => {
+const HorizontalNavbar: FC<HorizontalNavbarProps> = ({ instanceTypeExpandedSpec, pages, vm }) => {
   const [activeItem, setActiveItem] = useState<number | string>(pages?.[0]?.name.toLowerCase());
   const history = useHistory();
   const paths = pages.map((page) => page.href);
@@ -64,7 +65,9 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({ pages, resource }) => {
           const Component = page.component;
           return (
             <Route
-              component={(props) => <Component {...props} obj={resource} />}
+              component={(props) => (
+                <Component instanceTypeExpandedSpec={instanceTypeExpandedSpec} vm={vm} {...props} />
+              )}
               exact
               key={page.href}
               path={trimLastHistoryPath(history, paths) + '/' + page.href}

--- a/src/utils/components/HorizontalNavbar/utils/utils.ts
+++ b/src/utils/components/HorizontalNavbar/utils/utils.ts
@@ -1,8 +1,8 @@
 import { ComponentType } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { NavPage } from '@openshift-console/dynamic-plugin-sdk';
+import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 export const trimLastHistoryPath = (
   history: RouteComponentProps['history'],
@@ -25,6 +25,6 @@ export const trimLastHistoryPath = (
 };
 
 export type NavPageKubevirt = Omit<NavPage, 'component'> & {
-  component: ComponentType<{ obj: V1VirtualMachine }>;
+  component: ComponentType<NavPageComponentProps>;
   isHidden?: boolean;
 };

--- a/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
+++ b/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
@@ -31,6 +31,7 @@ import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConverg
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
 import { getCPU, getGPUDevices, getHostDevices } from '@kubevirt-utils/resources/vm';
+import { isInstanceTypeVM } from '@kubevirt-utils/resources/vm/utils/instanceTypes';
 import { DESCHEDULER_EVICT_LABEL } from '@kubevirt-utils/resources/vmi';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { k8sUpdate, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
@@ -66,7 +67,6 @@ export const usePendingChanges = (
   vmi: V1VirtualMachineInstance,
 ): PendingChange[] => {
   const { t } = useKubevirtTranslation();
-  const isInstanceTypeVM = !isEmpty(vm?.spec?.instancetype) || !isEmpty(vm?.spec?.preference);
 
   const history = useHistory();
   const { createModal } = useModal();
@@ -137,7 +137,7 @@ export const usePendingChanges = (
           <CPUMemoryModal isOpen={isOpen} onClose={onClose} onSubmit={onSubmit} vm={vm} vmi={vmi} />
         ));
       },
-      hasPendingChange: !isInstanceTypeVM && cpuMemoryChanged,
+      hasPendingChange: !isInstanceTypeVM(vm) && cpuMemoryChanged,
       label: t('CPU | Memory'),
       tabLabel: VirtualMachineDetailsTabLabel.Details,
     },

--- a/src/utils/resources/vm/hooks/useInstanceTypeExpandSpec.ts
+++ b/src/utils/resources/vm/hooks/useInstanceTypeExpandSpec.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -6,6 +6,8 @@ import useDeepCompareMemoize from '@kubevirt-utils/hooks/useDeepCompareMemoize/u
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
+
+import { isInstanceTypeVM } from '../utils/instanceTypes';
 
 type UseInstanceTypeExpandSpec = (
   vm: V1VirtualMachine,
@@ -18,6 +20,7 @@ const useInstanceTypeExpandSpec: UseInstanceTypeExpandSpec = (vm) => {
   const [instanceTypeExpandedSpec, setInstanceTypeExpandedSpec] = useState<V1VirtualMachine>();
   const [loadingExpandedSpec, setLoadingExpandedSpec] = useState<boolean>();
   const [errorExpandedSpec, setErrorExpandedSpec] = useState<Error>();
+  const isInstanceType = useMemo(() => isInstanceTypeVM(vm), [vm]);
   const innerVM = useDeepCompareMemoize(vm);
 
   useEffect(() => {
@@ -40,8 +43,8 @@ const useInstanceTypeExpandSpec: UseInstanceTypeExpandSpec = (vm) => {
         setLoadingExpandedSpec(false);
       }
     };
-    !isEmpty(innerVM) && fetch();
-  }, [innerVM]);
+    !isEmpty(innerVM) && isInstanceType && fetch();
+  }, [innerVM, isInstanceType]);
 
   return [instanceTypeExpandedSpec, loadingExpandedSpec, errorExpandedSpec];
 };

--- a/src/utils/resources/vm/utils/instanceTypes.ts
+++ b/src/utils/resources/vm/utils/instanceTypes.ts
@@ -1,0 +1,5 @@
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+
+export const isInstanceTypeVM = (vm: V1VirtualMachine): boolean =>
+  !isEmpty(vm?.spec?.instancetype) || !isEmpty(vm?.spec?.preference);

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateInfoSection.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateInfoSection.tsx
@@ -119,7 +119,7 @@ export const TemplateInfoSection: FC = memo(() => {
               />
             ))
           }
-          descriptionData={<CPUMemory fetchVMI={false} vm={vm} />}
+          descriptionData={<CPUMemory vm={vm} />}
           descriptionHeader={t('CPU | Memory')}
           isEdit
           isPopover

--- a/src/views/catalog/wizard/Wizard.tsx
+++ b/src/views/catalog/wizard/Wizard.tsx
@@ -25,7 +25,7 @@ const Wizard: FC = () => {
       <Stack hasGutter>
         <WizardHeader namespace={ns} />
         <StackItem className="vm-wizard-body" isFilled>
-          <HorizontalNavbar pages={wizardNavPages} />
+          <HorizontalNavbar pages={wizardNavPages} vm={vm} />
         </StackItem>
         <WizardFooter namespace={ns} />
       </Stack>

--- a/src/views/catalog/wizard/tabs/overview/components/WizardOverviewGrid.tsx
+++ b/src/views/catalog/wizard/tabs/overview/components/WizardOverviewGrid.tsx
@@ -62,7 +62,7 @@ const WizardOverviewGrid: FC<WizardOverviewGridProps> = ({ tabsData, updateVM, v
   const disks = vm?.spec?.template?.spec?.domain?.devices?.disks;
   const displayName = tabsData?.overview?.templateMetadata?.displayName;
   const logSerialConsole = (
-    vm.spec.template.spec.domain.devices as V1Devices & {
+    vm?.spec?.template?.spec?.domain?.devices as V1Devices & {
       logSerialConsole: boolean;
     }
   )?.logSerialConsole;
@@ -104,7 +104,7 @@ const WizardOverviewGrid: FC<WizardOverviewGridProps> = ({ tabsData, updateVM, v
                 <VMNameModal {...modalProps} onSubmit={updateVM} vm={vm} />
               ))
             }
-            description={vm.metadata.name}
+            description={vm?.metadata?.name}
             helperPopover={{ content: t('Name of the VirtualMachine'), header: t('Name') }}
             isEdit
             testId="wizard-overview-name"
@@ -116,7 +116,7 @@ const WizardOverviewGrid: FC<WizardOverviewGridProps> = ({ tabsData, updateVM, v
               content: t('Namespace of the VirtualMachine'),
               header: t('Namespace'),
             }}
-            description={vm.metadata.namespace}
+            description={vm?.metadata?.namespace}
             testId="wizard-overview-namespace"
             title={t('Namespace')}
           />

--- a/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
@@ -4,7 +4,7 @@ import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import HorizontalNavbar from '@kubevirt-utils/components/HorizontalNavbar/HorizontalNavbar';
 import { SidebarEditorProvider } from '@kubevirt-utils/components/SidebarEditor/SidebarEditorContext';
 import useInstanceTypeExpandSpec from '@kubevirt-utils/resources/vm/hooks/useInstanceTypeExpandSpec';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { isInstanceTypeVM } from '@kubevirt-utils/resources/vm/utils/instanceTypes';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 import { useVirtualMachineTabs } from './hooks/useVirtualMachineTabs';
@@ -30,7 +30,6 @@ const VirtualMachineNavPage: React.FC<VirtualMachineDetailsPageProps> = ({
   });
 
   const [instanceTypeExpandedSpec] = useInstanceTypeExpandSpec(vm);
-  const isInstanceTypeVM = !isEmpty(vm?.spec?.instancetype) || !isEmpty(vm?.spec?.preference);
 
   const pages = useVirtualMachineTabs();
 
@@ -38,10 +37,14 @@ const VirtualMachineNavPage: React.FC<VirtualMachineDetailsPageProps> = ({
     <SidebarEditorProvider>
       <VirtualMachineNavPageTitle
         name={name}
-        vm={isInstanceTypeVM ? instanceTypeExpandedSpec : vm}
+        vm={isInstanceTypeVM(vm) ? instanceTypeExpandedSpec : vm}
       />
       <div className="VirtualMachineNavPage--tabs__main">
-        <HorizontalNavbar pages={pages} resource={vm} />
+        <HorizontalNavbar
+          instanceTypeExpandedSpec={instanceTypeExpandedSpec}
+          pages={pages}
+          vm={vm}
+        />
       </div>
     </SidebarEditorProvider>
   );

--- a/src/views/virtualmachines/details/tabs/configuration/VirtualMachineConfigurationTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/VirtualMachineConfigurationTab.tsx
@@ -1,11 +1,12 @@
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
 import { getName } from '@kubevirt-utils/resources/shared';
+import useInstanceTypeExpandSpec from '@kubevirt-utils/resources/vm/hooks/useInstanceTypeExpandSpec';
 import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
+import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 import { getNamespace } from '../../../../cdi-upload-provider/utils/selectors';
 
@@ -14,13 +15,10 @@ import { getInnerTabFromPath, includesConfigurationPath, tabs } from './utils/ut
 
 import './virtual-machine-configuration-tab.scss';
 
-type VirtualMachineConfigurationTabProps = {
-  obj?: V1VirtualMachine;
-};
-
-const VirtualMachineConfigurationTab: FC<VirtualMachineConfigurationTabProps> = (props) => {
+const VirtualMachineConfigurationTab: FC<NavPageComponentProps> = ({ vm }) => {
   const history = useHistory();
-  const { vmi } = useVMI(getName(props?.obj), getNamespace(props?.obj));
+  const { vmi } = useVMI(getName(vm), getNamespace(vm));
+  const [instanceTypeVM] = useInstanceTypeExpandSpec(vm);
   const [activeTabKey, setActiveTabKey] = useState<number | string>(
     VirtualMachineDetailsTab.Details,
   );
@@ -41,7 +39,7 @@ const VirtualMachineConfigurationTab: FC<VirtualMachineConfigurationTabProps> = 
 
   return (
     <div className="co-dashboard-body VirtualMachineConfigurationTab">
-      <VirtualMachineConfigurationTabSearch vm={props?.obj} />
+      <VirtualMachineConfigurationTabSearch vm={vm} />
       <div className="VirtualMachineConfigurationTab--body">
         <Tabs activeKey={activeTabKey} className="VirtualMachineConfigurationTab--main" isVertical>
           {tabs.map(({ Component, name, title }) => (
@@ -52,7 +50,9 @@ const VirtualMachineConfigurationTab: FC<VirtualMachineConfigurationTabProps> = 
               onClick={() => redirectTab(name)}
               title={<TabTitleText>{title}</TabTitleText>}
             >
-              {activeTabKey === name && <Component {...props} vm={props?.obj} vmi={vmi} />}
+              {activeTabKey === name && (
+                <Component instanceTypeVM={instanceTypeVM} vm={vm} vmi={vmi} />
+              )}
             </Tab>
           ))}
         </Tabs>

--- a/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
@@ -46,11 +46,12 @@ import {
 import './details-section.scss';
 
 type DetailsSectionProps = {
+  instanceTypeVM: V1VirtualMachine;
   vm: V1VirtualMachine;
   vmi: V1VirtualMachineInstance;
 };
 
-const DetailsSection: FC<DetailsSectionProps> = ({ vm, vmi }) => {
+const DetailsSection: FC<DetailsSectionProps> = ({ instanceTypeVM, vm, vmi }) => {
   const { createModal } = useModal();
   const { t } = useKubevirtTranslation();
   const accessReview = asAccessReview(VirtualMachineModel, vm, 'update' as K8sVerb);
@@ -148,7 +149,7 @@ const DetailsSection: FC<DetailsSectionProps> = ({ vm, vmi }) => {
               }
               bodyContent={vm?.spec?.instancetype ? null : <CPUDescription cpu={getCPU(vm)} />}
               data-test-id={`${vmName}-cpu-memory`}
-              descriptionData={<CPUMemory vm={vm} />}
+              descriptionData={<CPUMemory vm={instanceTypeVM || vm} vmi={vmi} />}
               descriptionHeader={<SearchItem id="cpu-memory">{t('CPU | Memory')}</SearchItem>}
               isDisabled={!!vm?.spec?.instancetype}
               isEdit={canUpdateVM}
@@ -212,7 +213,12 @@ const DetailsSection: FC<DetailsSectionProps> = ({ vm, vmi }) => {
         <GridItem span={5}>
           <DescriptionList>
             <DetailsSectionHardware vm={vm} vmi={vmi} />
-            <DetailsSectionBoot canUpdateVM={canUpdateVM} vm={vm} vmi={vmi} />
+            <DetailsSectionBoot
+              canUpdateVM={canUpdateVM}
+              instanceTypeVM={instanceTypeVM}
+              vm={vm}
+              vmi={vmi}
+            />
           </DescriptionList>
         </GridItem>
       </Grid>

--- a/src/views/virtualmachines/details/tabs/configuration/details/DetailsTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/DetailsTab.tsx
@@ -9,7 +9,7 @@ import { ConfigurationInnerTabProps } from '../utils/types';
 import { onSubmitYAML } from './utils/utils';
 import DetailsSection from './DetailsSection';
 
-const DetailsTab: FC<ConfigurationInnerTabProps> = ({ vm, vmi }) => (
+const DetailsTab: FC<ConfigurationInnerTabProps> = ({ instanceTypeVM, vm, vmi }) => (
   <SidebarEditor
     onResourceUpdate={onSubmitYAML}
     pathsToHighlight={PATHS_TO_HIGHLIGHT.DETAILS_TAB}
@@ -17,7 +17,7 @@ const DetailsTab: FC<ConfigurationInnerTabProps> = ({ vm, vmi }) => (
   >
     {(resource) => (
       <PageSection>
-        <DetailsSection vm={resource} vmi={vmi} />
+        <DetailsSection instanceTypeVM={instanceTypeVM} vm={resource} vmi={vmi} />
       </PageSection>
     )}
   </SidebarEditor>

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
@@ -20,11 +20,17 @@ import { updateBootLoader, updatedBootOrder, updateStartStrategy } from '../util
 
 type DetailsSectionBootProps = {
   canUpdateVM: boolean;
+  instanceTypeVM: V1VirtualMachine;
   vm: V1VirtualMachine;
   vmi: V1VirtualMachineInstance;
 };
 
-const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({ canUpdateVM, vm, vmi }) => {
+const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({
+  canUpdateVM,
+  instanceTypeVM,
+  vm,
+  vmi,
+}) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const location = useLocation();
@@ -46,7 +52,7 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({ canUpdateVM, vm, vmi 
       <VirtualMachineDescriptionItem
         descriptionData={
           <div className={classNames({ 'text-muted': !canUpdateVM })}>
-            {getBootloaderTitleFromVM(vm)}
+            {getBootloaderTitleFromVM(instanceTypeVM || vm)}
           </div>
         }
         onEditClick={() =>
@@ -55,7 +61,7 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({ canUpdateVM, vm, vmi 
               isOpen={isOpen}
               onClose={onClose}
               onSubmit={(updatedVM) => updateBootLoader(updatedVM, vm)}
-              vm={vm}
+              vm={instanceTypeVM}
               vmi={vmi}
             />
           ))

--- a/src/views/virtualmachines/details/tabs/configuration/utils/types.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/utils/types.ts
@@ -1,6 +1,7 @@
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
 export type ConfigurationInnerTabProps = {
+  instanceTypeVM?: V1VirtualMachine;
   vm?: V1VirtualMachine;
   vmi?: V1VirtualMachineInstance;
 };

--- a/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.tsx
+++ b/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 
 import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Consoles from '@kubevirt-utils/components/Consoles/Consoles';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -13,16 +13,13 @@ import {
   PageSection,
   PageSectionVariants,
 } from '@patternfly/react-core';
+import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 import { printableVMStatus } from '../../../utils';
 
 import VirtualMachineConsolePageTitle from './components/VirtualMachineConsolePageTitle';
 
-type VirtualMachineConsolePageProps = {
-  obj: V1VirtualMachine;
-};
-
-const VirtualMachineConsolePage: FC<VirtualMachineConsolePageProps> = ({ obj: vm }) => {
+const VirtualMachineConsolePage: FC<NavPageComponentProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
   const [vmi, vmiLoaded] = useK8sWatchResource<V1VirtualMachineInstance>({
     groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,

--- a/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineDiagnosticTab.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineDiagnosticTab.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
+import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 import useDiagnosticData from './hooks/useDianosticData';
 import VirtualMachineDiagnosticTabConditions from './tables/VirtualMachineDiagnosticTabConditions';
@@ -10,11 +10,7 @@ import VirtualMachineLogViewer from './VirtualMachineLogViewer/VirtualMachineLog
 
 import './virtual-machine-diagnostic-tab.scss';
 
-type VirtualMachineDiagnosticTabProps = {
-  obj: V1VirtualMachine;
-};
-
-const VirtualMachineDiagnosticTab: FC<VirtualMachineDiagnosticTabProps> = ({ obj: vm }) => {
+const VirtualMachineDiagnosticTab: FC<NavPageComponentProps> = ({ vm }) => {
   const { conditions, volumeSnapshotStatuses } = useDiagnosticData(vm);
   const [activeTabKey, setActiveTabKey] = useState<number>(0);
 

--- a/src/views/virtualmachines/details/tabs/events/VirtualMachinePageEvents.tsx
+++ b/src/views/virtualmachines/details/tabs/events/VirtualMachinePageEvents.tsx
@@ -1,18 +1,14 @@
 import React, { FC, Suspense } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ResourceEventStream } from '@openshift-console/dynamic-plugin-sdk';
 import { Bullseye, Title } from '@patternfly/react-core';
+import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 import './VirtualMachinePageEventsTab.scss';
 
-type VirtualMachinePageEventsTabProps = {
-  obj: V1VirtualMachine;
-};
-
-const VirtualMachinePageEventsTab: FC<VirtualMachinePageEventsTabProps> = ({ obj: vm }) => {
+const VirtualMachinePageEventsTab: FC<NavPageComponentProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
 
   return (

--- a/src/views/virtualmachines/details/tabs/metrics/VirtualMachineMetricsTab.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/VirtualMachineMetricsTab.tsx
@@ -1,12 +1,12 @@
 import React, { FC, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Overview } from '@openshift-console/dynamic-plugin-sdk';
 import { ExpandableSection, Title } from '@patternfly/react-core';
+import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 import MigrationCharts from './MigrationCharts/MigrationCharts';
 import NetworkCharts from './NetworkCharts/NetworkCharts';
@@ -17,11 +17,7 @@ import { MetricsTabExpendedSections } from './utils/utils';
 
 import './virtual-machine-metrics-tab.scss';
 
-type VirtualMachineMetricsTabProps = {
-  obj: V1VirtualMachine;
-};
-
-const VirtualMachineMetricsTab: FC<VirtualMachineMetricsTabProps> = ({ obj: vm }) => {
+const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
   const location = useLocation();
   const { loaded, pods, vmi } = useVMIAndPodsForVM(vm?.metadata?.name, vm?.metadata?.namespace);

--- a/src/views/virtualmachines/details/tabs/overview/VirtualMachinesOverviewTab.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/VirtualMachinesOverviewTab.tsx
@@ -1,10 +1,10 @@
 import React, { FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import AlertsCard from '@kubevirt-utils/components/AlertsCard/AlertsCard';
 import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
 import { useGuestOS } from '@kubevirt-utils/resources/vmi';
 import { Grid, GridItem } from '@patternfly/react-core';
+import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 import VirtualMachinesOverviewTabActiveUser from './components/VirtualMachinesOverviewTabActiveUser/VirtualMachinesOverviewTabActiveUser';
 import VirtualMachinesOverviewTabDetails from './components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails';
@@ -18,11 +18,10 @@ import VirtualMachinesOverviewTabSnapshots from './components/VirtualMachinesOve
 import VirtualMachinesOverviewTabUtilization from './components/VirtualMachinesOverviewTabUtilization/VirtualMachinesOverviewTabUtilization';
 import useVMAlerts from './utils/hook/useVMAlerts';
 
-type VirtualMachinesOverviewTabProps = {
-  obj: V1VirtualMachine;
-};
-
-const VirtualMachinesOverviewTab: FC<VirtualMachinesOverviewTabProps> = ({ obj: vm }) => {
+const VirtualMachinesOverviewTab: FC<NavPageComponentProps> = ({
+  instanceTypeExpandedSpec,
+  vm,
+}) => {
   const vmAlerts = useVMAlerts(vm);
   const { error, loaded, pods, vmi } = useVMIAndPodsForVM(
     vm?.metadata?.name,
@@ -39,6 +38,7 @@ const VirtualMachinesOverviewTab: FC<VirtualMachinesOverviewTabProps> = ({ obj: 
               error={error}
               guestAgentData={guestAgentData}
               guestAgentDataLoaded={guestAgentDataLoaded}
+              instanceTypeExpandedSpec={instanceTypeExpandedSpec}
               loaded={loaded}
               vm={vm}
               vmi={vmi}

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
@@ -52,6 +52,7 @@ type VirtualMachinesOverviewTabDetailsProps = {
   error: Error;
   guestAgentData: V1VirtualMachineInstanceGuestAgentInfo;
   guestAgentDataLoaded: boolean;
+  instanceTypeExpandedSpec: V1VirtualMachine;
   loaded: boolean;
   vm: V1VirtualMachine;
   vmi: V1VirtualMachineInstance;
@@ -61,6 +62,7 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
   error,
   guestAgentData,
   guestAgentDataLoaded,
+  instanceTypeExpandedSpec,
   loaded,
   vm,
   vmi,
@@ -162,7 +164,7 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('CPU | Memory')}</DescriptionListTerm>
                   <DescriptionListDescription>
-                    <CPUMemory vm={vm} />
+                    <CPUMemory vm={instanceTypeExpandedSpec || vm} vmi={vmi} />
                   </DescriptionListDescription>
                 </DescriptionListGroup>
 

--- a/src/views/virtualmachines/details/tabs/snapshots/SnapshotListPage.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/SnapshotListPage.tsx
@@ -1,10 +1,10 @@
 import React, { FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ListPageBody, ListPageCreateButton } from '@openshift-console/dynamic-plugin-sdk';
 import { Title } from '@patternfly/react-core';
+import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 import { printableVMStatus } from '../../../utils';
 
@@ -14,11 +14,7 @@ import useSnapshotData from './hooks/useSnapshotData';
 
 import './SnapshotListPage.scss';
 
-type SnapshotListPageProps = {
-  obj?: V1VirtualMachine;
-};
-
-const SnapshotListPage: FC<SnapshotListPageProps> = ({ obj: vm }) => {
+const SnapshotListPage: FC<NavPageComponentProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const { error, loaded, restoresMap, snapshots } = useSnapshotData(

--- a/src/views/virtualmachines/details/tabs/yaml/VirtualMachineYAMLPage.tsx
+++ b/src/views/virtualmachines/details/tabs/yaml/VirtualMachineYAMLPage.tsx
@@ -1,17 +1,13 @@
 import React, { FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
 import { Bullseye } from '@patternfly/react-core';
+import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 import './virtual-machine-yaml-page.scss';
 
-type VirtualMachineYAMLPageProps = {
-  obj?: V1VirtualMachine;
-};
-
-const VirtualMachineYAMLPage: FC<VirtualMachineYAMLPageProps> = ({ obj: vm }) => {
+const VirtualMachineYAMLPage: FC<NavPageComponentProps> = ({ vm }) => {
   const loading = (
     <Bullseye>
       <Loading />

--- a/src/views/virtualmachines/details/utils/types.ts
+++ b/src/views/virtualmachines/details/utils/types.ts
@@ -1,0 +1,6 @@
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+
+export type NavPageComponentProps = {
+  instanceTypeExpandedSpec?: V1VirtualMachine;
+  vm: V1VirtualMachine;
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fix instance type bios, presenting the correct value.
Instance type can have some fields with values that affect bios type when VM is created.
We cannot check all the fields and make assumptions. We need to use the expand-spec of instance type VM in order to compare to vmi and get right values of bios or anything else. This fix will send instanceTypeExpandedSpec to all tabs and can be used instead of VM when needed.

Also, I changed a bit of the CPU memory component while exploring the code; this component made a lot of network calls to instance type to get CPU and memory; now, it's not needed as instanceTypeExpandedType can deliver the same data.
## 🎥 Demo

After:
![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/14824964/02bf1fda-21e4-4ccf-a15b-61153c4ee13d)

Before:
![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/14824964/21ab4830-1467-4a50-9f50-c92d197dbc5e)
