### PR TITLE
CNV-32929: Display user-created Instancetypes in the User Provided tab

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/InstanceTypeDrilldownSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/InstanceTypeDrilldownSelect.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useCallback, useMemo, useState } from 'react';
 
-import useInstanceTypes from '@catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypes';
+import useClusterInstanceTypes from '@catalog/CreateFromInstanceTypes/state/hooks/useClusterInstanceTypes';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup, PopoverPosition } from '@patternfly/react-core';
@@ -25,7 +25,7 @@ export const InstanceTypeDrilldownSelect: FC<InstanceTypeMenuItemsProps> = ({
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  const [instanceTypes] = useInstanceTypes();
+  const [instanceTypes] = useClusterInstanceTypes();
   const menuItems = useMemo(() => getInstanceTypeMenuItems(instanceTypes), [instanceTypes]);
 
   const onSelect = useCallback(

--- a/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/SelectInstanceTypeSection.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/SelectInstanceTypeSection.tsx
@@ -20,12 +20,15 @@ const SelectInstanceTypeSection: FC<SelectInstanceTypeSectionProps> = ({
   instanceTypesAndPreferencesData,
 }) => {
   const [activeTabKey, setActiveTabKey] = useState<TabKey>(TabKey.RedHat);
-  const { instanceTypes, loaded } = instanceTypesAndPreferencesData;
+  const { clusterInstanceTypes, loaded } = instanceTypesAndPreferencesData;
 
   const {
     instanceTypeVMState: { selectedInstanceType },
   } = useInstanceTypeVMStore();
-  const menuItems = useMemo(() => getInstanceTypeMenuItems(instanceTypes), [instanceTypes]);
+  const menuItems = useMemo(
+    () => getInstanceTypeMenuItems(clusterInstanceTypes),
+    [clusterInstanceTypes],
+  );
 
   const menuProps = useInstanceTypeCardMenuSection();
 
@@ -64,7 +67,7 @@ const SelectInstanceTypeSection: FC<SelectInstanceTypeSectionProps> = ({
         </Tab>
         <Tab eventKey={TabKey.Users} title={menuItems.userProvided.label}>
           <UsersInstanceTypesList
-            instanceTypesAndPreferencesData={instanceTypesAndPreferencesData}
+            userInstanceTypes={instanceTypesAndPreferencesData.userInstanceTypes}
           />
         </Tab>
       </Tabs>

--- a/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/components/UsersInstanceTypeList/UsersInstanceTypeList.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/components/UsersInstanceTypeList/UsersInstanceTypeList.tsx
@@ -1,15 +1,11 @@
 import React, { FC, useMemo, useState } from 'react';
 
 import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore';
-import {
-  instanceTypeActionType,
-  UseInstanceTypeAndPreferencesValues,
-} from '@catalog/CreateFromInstanceTypes/state/utils/types';
+import { instanceTypeActionType } from '@catalog/CreateFromInstanceTypes/state/utils/types';
 import { VirtualMachineClusterInstancetypeModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { V1beta1VirtualMachineInstancetype } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { COMMON_INSTANCETYPES } from '@kubevirt-utils/resources/bootableresources/constants';
-import { getLabel, getName } from '@kubevirt-utils/resources/shared';
-import { APP_NAME_LABEL } from '@kubevirt-utils/resources/template';
+import { getName } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ResourceLink, Timestamp } from '@openshift-console/dynamic-plugin-sdk';
@@ -23,14 +19,11 @@ import { paginationDefaultValues, paginationInitialState } from './utils/constan
 import './UsersInstanceTypeList.scss';
 
 type UsersInstanceTypesListProps = {
-  instanceTypesAndPreferencesData: UseInstanceTypeAndPreferencesValues;
+  userInstanceTypes: V1beta1VirtualMachineInstancetype[];
 };
 
-const UsersInstanceTypesList: FC<UsersInstanceTypesListProps> = ({
-  instanceTypesAndPreferencesData,
-}) => {
+const UsersInstanceTypesList: FC<UsersInstanceTypesListProps> = ({ userInstanceTypes }) => {
   const { t } = useKubevirtTranslation();
-  const { instanceTypes } = instanceTypesAndPreferencesData;
 
   const {
     instanceTypeVMState: { selectedInstanceType },
@@ -48,11 +41,6 @@ const UsersInstanceTypesList: FC<UsersInstanceTypesListProps> = ({
       startIndex,
     });
   };
-
-  const userInstanceTypes = useMemo(
-    () => instanceTypes.filter((it) => getLabel(it, APP_NAME_LABEL) !== COMMON_INSTANCETYPES),
-    [instanceTypes],
-  );
 
   const filteredItems = useMemo(() => {
     return userInstanceTypes.filter(

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsLeftGrid.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsLeftGrid.tsx
@@ -21,10 +21,13 @@ const DetailsLeftGrid: FC<DetailsLeftGridProps> = ({ instanceTypesAndPreferences
   const { t } = useKubevirtTranslation();
   const { instanceTypeVMState, setInstanceTypeVMState } = useInstanceTypeVMStore();
   const { selectedBootableVolume, selectedInstanceType, vmName } = instanceTypeVMState;
-  const { instanceTypes, preferences } = instanceTypesAndPreferencesData;
+  const { clusterInstanceTypes, preferences } = instanceTypesAndPreferencesData;
 
   const preferencesMap = useMemo(() => convertResourceArrayToMap(preferences), [preferences]);
-  const instanceTypesMap = useMemo(() => convertResourceArrayToMap(instanceTypes), [instanceTypes]);
+  const instanceTypesMap = useMemo(
+    () => convertResourceArrayToMap(clusterInstanceTypes),
+    [clusterInstanceTypes],
+  );
 
   const operatingSystem = getOSFromDefaultPreference(selectedBootableVolume, preferencesMap);
   const cpuMemoryString = !isEmpty(instanceTypesMap?.[selectedInstanceType])

--- a/src/views/catalog/CreateFromInstanceTypes/state/hooks/useClusterInstanceTypes.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/hooks/useClusterInstanceTypes.ts
@@ -2,13 +2,13 @@ import { VirtualMachineClusterInstancetypeModelGroupVersionKind } from '@kubevir
 import { V1beta1VirtualMachineClusterInstancetype } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
-type UseInstanceTypes = () => [
+type UseClusterInstanceTypes = () => [
   instanceTypes: V1beta1VirtualMachineClusterInstancetype[],
   loaded: boolean,
   loadError: Error,
 ];
 
-const useInstanceTypes: UseInstanceTypes = () => {
+const useClusterInstanceTypes: UseClusterInstanceTypes = () => {
   const [instanceTypes, loaded, loadError] = useK8sWatchResource<
     V1beta1VirtualMachineClusterInstancetype[]
   >({
@@ -19,4 +19,4 @@ const useInstanceTypes: UseInstanceTypes = () => {
   return [instanceTypes || [], loaded || !!loadError, loadError];
 };
 
-export default useInstanceTypes;
+export default useClusterInstanceTypes;

--- a/src/views/catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypesAndPreferences.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypesAndPreferences.ts
@@ -1,23 +1,28 @@
+import useUserInstanceTypes from '@catalog/CreateFromInstanceTypes/state/hooks/useUserInstanceTypes';
+
 import { UseInstanceTypeAndPreferencesValues } from '../utils/types';
 
+import useClusterInstanceTypes from './useClusterInstanceTypes';
 import useClusterPreferences from './useClusterPreferences';
-import useInstanceTypes from './useInstanceTypes';
 
 type UseInstanceTypeAndPreferences = () => UseInstanceTypeAndPreferencesValues;
 
 const useInstanceTypesAndPreferences: UseInstanceTypeAndPreferences = () => {
-  const [instanceTypes, instanceTypesLoaded, instanceTypesLoadError] = useInstanceTypes();
+  const [clusterInstanceTypes, clusterITsLoaded, clusterITsLoadError] = useClusterInstanceTypes();
+
+  const [userInstanceTypes, userITsLoaded, userITsLoadError] = useUserInstanceTypes();
 
   const [preferences, preferencesLoaded, preferencesLoadError] = useClusterPreferences();
 
-  const loaded = preferencesLoaded && instanceTypesLoaded;
-  const loadError = preferencesLoadError || instanceTypesLoadError;
+  const loaded = preferencesLoaded && clusterITsLoaded && userITsLoaded;
+  const loadError = preferencesLoadError || clusterITsLoadError || userITsLoadError;
 
   return {
-    instanceTypes,
-    loaded: loaded || !!loadError,
+    clusterInstanceTypes,
+    loaded: loaded || Boolean(loadError),
     loadError,
     preferences,
+    userInstanceTypes,
   };
 };
 

--- a/src/views/catalog/CreateFromInstanceTypes/state/hooks/useUserInstanceTypes.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/hooks/useUserInstanceTypes.ts
@@ -1,0 +1,22 @@
+import { VirtualMachineInstancetypeModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { V1beta1VirtualMachineInstancetype } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+type UseUserInstanceTypes = () => [
+  instanceTypes: V1beta1VirtualMachineInstancetype[],
+  loaded: boolean,
+  loadError: Error,
+];
+
+const useUserInstanceTypes: UseUserInstanceTypes = () => {
+  const [instanceTypes, loaded, loadError] = useK8sWatchResource<
+    V1beta1VirtualMachineInstancetype[]
+  >({
+    groupVersionKind: VirtualMachineInstancetypeModelGroupVersionKind,
+    isList: true,
+  });
+
+  return [instanceTypes || [], loaded || !!loadError, loadError];
+};
+
+export default useUserInstanceTypes;

--- a/src/views/catalog/CreateFromInstanceTypes/state/utils/types.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/utils/types.ts
@@ -4,16 +4,18 @@ import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/k
 import {
   V1beta1VirtualMachineClusterInstancetype,
   V1beta1VirtualMachineClusterPreference,
+  V1beta1VirtualMachineInstancetype,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
 import { SSHSecretDetails } from '@kubevirt-utils/components/SSHSecretSection/utils/types';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 
 export type UseInstanceTypeAndPreferencesValues = {
-  instanceTypes: V1beta1VirtualMachineClusterInstancetype[];
+  clusterInstanceTypes: V1beta1VirtualMachineClusterInstancetype[];
   loaded: boolean;
   loadError: any;
   preferences: V1beta1VirtualMachineClusterPreference[];
+  userInstanceTypes: V1beta1VirtualMachineInstancetype[];
 };
 
 export type UseBootableVolumesValues = {

--- a/src/views/instancetypes/list/ClusterInstancetypeList.tsx
+++ b/src/views/instancetypes/list/ClusterInstancetypeList.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import useInstanceTypes from '@catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypes';
+import useClusterInstanceTypes from '@catalog/CreateFromInstanceTypes/state/hooks/useClusterInstanceTypes';
 import { V1beta1VirtualMachineClusterInstancetype } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import usePagination from '@kubevirt-utils/hooks/usePagination/usePagination';
@@ -26,7 +26,7 @@ type ClusterInstancetypeListProps = {
 
 const ClusterInstancetypeList: FC<ClusterInstancetypeListProps> = ({ kind }) => {
   const { t } = useKubevirtTranslation();
-  const [instanceTypes, loaded, loadError] = useInstanceTypes();
+  const [instanceTypes, loaded, loadError] = useClusterInstanceTypes();
 
   const { onPaginationChange, pagination } = usePagination();
   const [unfilteredData, data, onFilterChange] = useListPageFilter(instanceTypes);


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug that prevents user-created Instancetypes from being displayed in the User Provided tab on the Instancetypes page.

Jira ticket: https://issues.redhat.com/browse/CNV-32929

## 🎥 Screenshots

### Before
![show-user-instanceTypes-before-2024-01-08_21-21](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/3ea0b461-edab-4952-a9b4-d621d0fb655a)


### After
![show-user-instanceTypes-after-2024-01-08_21-21](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/90d6d794-1da9-488e-a730-b71fa7e84d79)
