### PR TITLE
CNV-36169: Display correct disk size in Catalog drawer for cloning PVC

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/utils.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/utils.ts
@@ -1,4 +1,5 @@
 import { TFunction } from 'react-i18next';
+import xbytes from 'xbytes';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import {
@@ -6,8 +7,10 @@ import {
   V1beta1DataVolumeSpec,
   V1ContainerDiskSource,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { removeByteSuffix } from '@kubevirt-utils/components/CapacityInput/utils';
 import { DEFAULT_DISK_SIZE } from '@kubevirt-utils/components/DiskModal/state/initialState';
 import { getTemplateContainerDisks } from '@kubevirt-utils/resources/template';
+import { hasSizeUnit } from '@kubevirt-utils/resources/vm/utils/disk/size';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import {
@@ -21,8 +24,14 @@ import {
   UPLOAD_SOURCE_NAME,
 } from '../constants';
 
-export const getQuantityFromSource = (source: V1beta1DataVolumeSpec) =>
-  source?.storage?.resources?.requests?.storage;
+export const getQuantityFromSource = (source: V1beta1DataVolumeSpec) => {
+  const storage = source?.storage?.resources?.requests?.storage;
+  const quantity = hasSizeUnit(storage)
+    ? storage
+    : xbytes(Number(storage), { iec: true, space: false });
+
+  return removeByteSuffix(quantity);
+};
 
 export const getSourceTypeFromDiskSource = (
   diskSource: V1beta1DataVolumeSpec | V1ContainerDiskSource,


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-36169

Display correct disk size when creating a new VM from template and choosing "PVC (clone PVC)" as a disk source in the drawer.

## 🎥 Demo
**Before**:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/509b9e87-03ab-42eb-8b0b-b96f64af962a

**After:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/d867ce12-8dac-48ef-9205-b14a804ad463


