### PR TITLE
CNV-37075: Fix "Quick create VirtualMachine" is disabled 

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/utils.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/utils.ts
@@ -30,8 +30,11 @@ export const hasValidSource = (template: V1Template) => {
   return hasValidDVSources && hasValidVolumeSources;
 };
 
-const hasVMValidDVSources = (vm: V1VirtualMachine) =>
-  vm?.spec?.dataVolumeTemplates?.every((dataVolume) => {
+const hasVMValidDVSources = (vm: V1VirtualMachine) => {
+  if (!vm?.spec?.dataVolumeTemplates && !getVolumes(vm).find((volume) => volume.dataVolume))
+    return true;
+
+  return vm.spec.dataVolumeTemplates.every((dataVolume) => {
     if (dataVolume?.spec?.source?.http) return Boolean(dataVolume.spec.source.http.url);
 
     if (dataVolume?.spec?.source?.registry)
@@ -44,6 +47,7 @@ const hasVMValidDVSources = (vm: V1VirtualMachine) =>
 
     return true;
   });
+};
 
 const hasVMValidVolumeSources = (vm: V1VirtualMachine) =>
   vm.spec.template.spec.volumes.every((volume) => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

`hasVMValidDVSources` returns `undefined` when the VM does not have `dataVolumeTemplates` array. Instead, should return true if there should be no dataVolumeTemplates