### PR TITLE
CNV-37265: Fix default matching state for autocompute CPU limits

### DIFF
--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.scss
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.scss
@@ -1,0 +1,5 @@
+.auto-compute-cpu-limits-settings {
+  &__edit-icon {
+    margin-left: var(--pf-global--spacer--sm);
+  }
+}

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.tsx
@@ -16,6 +16,8 @@ import { PencilAltIcon } from '@patternfly/react-icons';
 import { addLabelsToHyperConvergedCR } from './utils/utils';
 import ProjectSelectorModal from './ProjectSelectorModal';
 
+import './AutoComputeCPULimits.scss';
+
 type AutoComputeCPULimitsProps = {
   hyperConvergeConfiguration: [hyperConvergeConfig: HyperConverged, loaded: boolean, error: Error];
   newBadge?: boolean;
@@ -42,13 +44,14 @@ const AutoComputeCPULimits: FC<AutoComputeCPULimitsProps> = ({
   return (
     <ExpandSectionWithSwitch
       helpTextIconContent={t('Automatically compute CPU limits on projects containing labels')}
+      id="auto-compute-cpu-limits-settings"
       isDisabled={!autoComputeCPUPreviewEnabled}
       newBadge={newBadge}
       switchIsOn={autoComputeCPUEnabled && autoComputeCPUPreviewEnabled}
       toggleContent={t('Auto-compute CPU limits')}
       turnOnSwitch={toggleCPULimits}
     >
-      <div>
+      <div className="auto-compute-cpu-limits-settings">
         {t('Project selector')}
         <Button
           onClick={() =>
@@ -66,7 +69,7 @@ const AutoComputeCPULimits: FC<AutoComputeCPULimitsProps> = ({
           isInline
           variant={ButtonVariant.link}
         >
-          <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain" />
+          <PencilAltIcon className="co-icon-space-l pf-c-button-icon--plain auto-compute-cpu-limits-settings__edit-icon" />
         </Button>
       </div>
       {error && (

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/ProjectSelectorModal.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/ProjectSelectorModal.tsx
@@ -106,7 +106,7 @@ const ProjectSelectorModal: FC<ProjectSelectorModalProps> = ({
             {projects?.length && (
               <ProjectCheckerAlert
                 projectsLoaded={projectsLoaded}
-                qualifiedProjects={isEmpty(selectorLabels) ? projects : qualifiedProjects}
+                qualifiedProjects={isEmpty(selectorLabels) ? [] : qualifiedProjects}
               />
             )}
           </Form>


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug wherein the CPU limits project selector modal indicates that all projects are selected if no labels have been entered.

It also adds space between the edit icon and "Project selector" label in the "Auto-compute CPU limits" setting in the Resource management section.

Jira: https://issues.redhat.com/browse/CNV-37265

## 🎥 Screenshots

### Before

#### Edit icon
![CPU-limits-edit-icon-BEFORE-2024-01-15_07-41](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/0fb35b14-3ea4-472c-b1aa-99dfcb441216)

#### Project selector modal
![CPU-limits-project-matcher-BEFORE-2024-01-15_07-41](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/c6866cff-4179-454c-8695-42e7912b39c1)

### After

#### Edit icon
![CPU-limits-edit-icon-AFTER-2024-01-15_07-41](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/942aada2-9d52-476b-875b-f5a0987a5c5a)

#### Project selector modal
![CPU-limits-project-matcher-AFTER-2024-01-15_07-41](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/94997d9e-4781-4beb-8acd-cbca772682e8)
