### PR TITLE
CNV-37266: Allow saving Autocompute CPU limits modal with no labels

### DIFF
--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/ProjectSelectorModal.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/ProjectSelectorModal.tsx
@@ -115,7 +115,6 @@ const ProjectSelectorModal: FC<ProjectSelectorModalProps> = ({
           <ActionList>
             <ActionListItem>
               <Button
-                isDisabled={isEmpty(qualifiedProjects) || isEmpty(selectorLabels)}
                 isLoading={!projectsLoaded}
                 onClick={handleSubmit}
                 variant={ButtonVariant.primary}


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug wherein the Auto-compute CPU labels project selector modal can't be saved if no labels are entered.

Jira: https://issues.redhat.com/browse/CNV-37266

## 🎥 Screenshots

### Before
![CPU-limits-modal-save-button-BEFORE-2024-01-15_08-46](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/80039bb5-0a6b-49b8-9ea3-8f9075bc034d)

### After
![CPU-limits-modal-save-button-AFTER-2024-01-15_08-46](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/32f4e305-d138-4e5c-9f22-38cbb44c2210)
