### PR TITLE
CNV-37111: Adjust Bootable volumes list columns

### DIFF
--- a/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
+++ b/src/views/bootablevolumes/list/components/BootableVolumesRow.tsx
@@ -32,7 +32,7 @@ const BootableVolumesRow: FC<
 
   return (
     <>
-      <TableData activeColumnIDs={activeColumnIDs} id="name">
+      <TableData activeColumnIDs={activeColumnIDs} className="pf-m-width-20" id="name">
         <ResourceLink
           groupVersionKind={getBootableVolumeGroupVersionKind(obj)}
           inline

--- a/src/views/bootablevolumes/list/hooks/useBootableVolumesColumns.ts
+++ b/src/views/bootablevolumes/list/hooks/useBootableVolumesColumns.ts
@@ -28,6 +28,7 @@ const useBootableVolumesColumns = (
     () => [
       {
         id: 'name',
+        props: { className: 'pf-m-width-20' },
         sort: (_, direction) => sorting(direction, 'metadata.name'),
         title: t('Name'),
         transforms: [sortable],


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-37111

Adjust _Bootable volumes_ list columns sizes to look better, more balanced, prevent _Name_ column to take too much space, display _Namespace_ column as expected (available only for _All Projects_ project/namespace).

_Note:_
This PR/commit is just a partial fix for the provided jira bug. We still need to figure out how to make saving the settings from Manage columns for the specific user work as expected.

## 🎥 Demo
**Before:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/9227b7e1-816d-46c8-91e9-b8d8a4f5f953

**After:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/9da39a6a-b381-4365-9767-fcd5ebc99895


