### PR TITLE
CNV-36438: Prevent deletion of pod network on Instancetype VM

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -136,8 +136,10 @@ export const generateVM = (
                   name: 'cloudinitdisk',
                 },
               ],
+              interfaces: [{ masquerade: {}, name: 'default' }],
             },
           },
+          networks: [{ name: 'default', pod: {} }],
           volumes: [
             {
               dataVolume: { name: `${virtualmachineName}-volume` },


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug wherein the pod network is deleted from an Instancetype VM when another network is added.

Jira: https://issues.redhat.com/browse/CNV-36438

## 🎥 Demo


https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/c6fb9c74-ecf9-4ca6-8548-aef07658fd71


