### PR TITLE
Fix search filters appearing in the dropdown

### DIFF
--- a/src/utils/components/ListPageFilter/ListPageFilter.tsx
+++ b/src/utils/components/ListPageFilter/ListPageFilter.tsx
@@ -2,7 +2,6 @@ import React, { FC, useMemo, useState } from 'react';
 
 import useDeepCompareMemoize from '@kubevirt-utils/hooks/useDeepCompareMemoize/useDeepCompareMemoize';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   ColumnLayout,
   FilterValue,
@@ -50,6 +49,7 @@ type ListPageFilterProps = {
   loaded?: boolean;
   onFilterChange?: OnFilterChange;
   rowFilters?: RowFilter[];
+  searchFilters?: RowFilter[];
 };
 
 const ListPageFilter: FC<ListPageFilterProps> = ({
@@ -59,13 +59,13 @@ const ListPageFilter: FC<ListPageFilterProps> = ({
   loaded,
   onFilterChange,
   rowFilters,
+  searchFilters = [],
 }) => {
   const { t } = useKubevirtTranslation();
 
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
 
-  const toolbarFilters = rowFilters.filter((filter) => !isEmpty(filter.items));
-  const searchFilters = rowFilters.filter((filter) => isEmpty(filter.items));
+  const toolbarFilters = rowFilters.filter((filter) => 'items' in filter);
 
   // Generate rowFilter items and counts. Memoize to minimize re-renders.
   const generatedRowFilters = useDeepCompareMemoize(generateRowFilters(toolbarFilters ?? [], data));

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -99,14 +99,14 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({ kind, namespace }) 
     namespaced: true,
   });
 
-  const { filters, vmiMapper, vmimMapper } = useVMListFilters(vmis, vms, vmims);
+  const { filters, searchFilters, vmiMapper, vmimMapper } = useVMListFilters(vmis, vms, vmims);
 
   const [pagination, setPagination] = useState(paginationInitialState);
 
   const [unfilterData, dataFilters, onFilterChange] = useListPageFilter<
     V1VirtualMachine,
     V1VirtualMachine
-  >(vms, filters);
+  >(vms, [...filters, ...searchFilters]);
 
   const [unfilteredData, data] = useMemo(() => {
     if (!featureEnabled || isProxyPodAlive === false) return [unfilterData, dataFilters];
@@ -166,6 +166,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({ kind, namespace }) 
             data={unfilteredData}
             loaded={loaded}
             rowFilters={filters}
+            searchFilters={searchFilters}
           />
           {!isEmpty(vms) && (
             <Pagination

--- a/src/views/virtualmachines/utils/virtualMachineRowFilter.ts
+++ b/src/views/virtualmachines/utils/virtualMachineRowFilter.ts
@@ -219,7 +219,12 @@ export const useVMListFilters = (
   vmis: V1VirtualMachineInstance[],
   vms: V1VirtualMachine[],
   vmims: V1VirtualMachineInstanceMigration[],
-): { filters: RowFilter<V1VirtualMachine>[]; vmiMapper: VmiMapper; vmimMapper: VmimMapper } => {
+): {
+  filters: RowFilter<V1VirtualMachine>[];
+  searchFilters: RowFilter<V1VirtualMachine>[];
+  vmiMapper: VmiMapper;
+  vmimMapper: VmimMapper;
+} => {
   const vmiMapper: VmiMapper = useMemo(() => {
     return (Array.isArray(vmis) ? vmis : [])?.reduce(
       (acc, vmi) => {
@@ -272,8 +277,8 @@ export const useVMListFilters = (
       liveMigratableFilter,
       nodesFilter,
       instanceTypesFilter,
-      searchByIP,
     ],
+    searchFilters: [searchByIP],
     vmiMapper,
     vmimMapper,
   };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When `filter.items` is empty for some filters like 'Node' as maybe all vms are stopped, the filters appears in the dropdown.


## 🎥 Demo

**Before**
![Screenshot from 2024-01-23 09-09-08](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/abb2262c-e589-4ddf-bc03-52800c903562)

**After**
![Screenshot from 2024-01-23 09-14-11](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/effba38d-a030-463d-ae87-283c776e1b29)

