### PR TITLE
CNV-37480: "auto updates for RHEL VirtualMachines" is enabled by default but does not work

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -175,7 +175,7 @@
   "Automatically apply this key to any new VirtualMachine you create in this project.": "Automatically apply this key to any new VirtualMachine you create in this project.",
   "Automatically compute CPU limits on projects containing labels": "Automatically compute CPU limits on projects containing labels",
   "Automatically compute CPU limits on projects containing these labels": "Automatically compute CPU limits on projects containing these labels",
-  "Automatically pull updates from the RHEL repository": "Automatically pull updates from the RHEL repository",
+  "Automatically pull updates from the RHEL repository. Activation key and Organization ID are mandatory to enable this.": "Automatically pull updates from the RHEL repository. Activation key and Organization ID are mandatory to enable this.",
   "Autounattend.xml answer file": "Autounattend.xml answer file",
   "Available": "Available",
   "Available only on Nodes with labels": "Available only on Nodes with labels",

--- a/src/utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription.ts
+++ b/src/utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription.ts
@@ -10,16 +10,9 @@ import useFeaturesConfigMap from '@kubevirt-utils/hooks/useFeatures/useFeaturesC
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 
-import { RHELAutomaticSubscriptionData } from './utils/types';
+import { RHELAutomaticSubscriptionFormProps } from './utils/types';
 
-type UseRHELAutomaticSubscription = () => {
-  canEdit: boolean;
-  loaded: boolean;
-  loadError: Error;
-  loading: boolean;
-  subscriptionData: RHELAutomaticSubscriptionData;
-  updateSubscription: (activationKey: string, organizationID: string) => void;
-};
+type UseRHELAutomaticSubscription = () => RHELAutomaticSubscriptionFormProps;
 
 const useRHELAutomaticSubscription: UseRHELAutomaticSubscription = () => {
   const {

--- a/src/utils/hooks/useRHELAutomaticSubscription/utils/types.ts
+++ b/src/utils/hooks/useRHELAutomaticSubscription/utils/types.ts
@@ -2,3 +2,12 @@ export type RHELAutomaticSubscriptionData = {
   activationKey: string;
   organizationID: string;
 };
+
+export type RHELAutomaticSubscriptionFormProps = {
+  canEdit: boolean;
+  loaded: boolean;
+  loadError: Error;
+  loading: boolean;
+  subscriptionData: RHELAutomaticSubscriptionData;
+  updateSubscription: (activationKey: string, organizationID: string) => void;
+};

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/AutomaticSubscriptionRHELGuests.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/AutomaticSubscriptionRHELGuests.tsx
@@ -1,10 +1,12 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import NewBadge from '@kubevirt-utils/components/NewBadge/NewBadge';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useRHELAutomaticSubscription from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Stack } from '@patternfly/react-core';
 
 import ExpandSection from '../../../../ExpandSection/ExpandSection';
@@ -21,6 +23,15 @@ const AutomaticSubscriptionRHELGuests: FC<AutomaticSubscriptionRHELGuestsProps> 
 }) => {
   const { t } = useKubevirtTranslation();
   const { featureEnabled, toggleFeature } = useFeatures(AUTOMATIC_UPDATE_FEATURE_NAME);
+  const formProps = useRHELAutomaticSubscription();
+
+  const isDisabled =
+    isEmpty(formProps?.subscriptionData?.activationKey) ||
+    isEmpty(formProps?.subscriptionData?.organizationID);
+
+  useEffect(() => {
+    if (isDisabled) toggleFeature(false);
+  }, [isDisabled, toggleFeature]);
 
   return (
     <ExpandSection
@@ -38,10 +49,13 @@ const AutomaticSubscriptionRHELGuests: FC<AutomaticSubscriptionRHELGuestsProps> 
         <MutedTextSpan
           text={t('Cluster administrator permissions are required to enable this feature.')}
         />
-        <AutomaticSubscriptionForm />
+        <AutomaticSubscriptionForm {...formProps} />
         <SectionWithSwitch
-          helpTextIconContent={t('Automatically pull updates from the RHEL repository')}
+          helpTextIconContent={t(
+            'Automatically pull updates from the RHEL repository. Activation key and Organization ID are mandatory to enable this.',
+          )}
           id={AUTOMATIC_UPDATE_FEATURE_NAME}
+          isDisabled={isDisabled}
           switchIsOn={featureEnabled}
           title={t('Enable auto updates for RHEL VirtualMachines')}
           turnOnSwitch={toggleFeature}

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/components/AutomaticSubscriptionForm/AutomaticSubscriptionForm.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/components/AutomaticSubscriptionForm/AutomaticSubscriptionForm.tsx
@@ -2,8 +2,7 @@ import React, { FC, useEffect, useState } from 'react';
 
 import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useRHELAutomaticSubscription from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { RHELAutomaticSubscriptionFormProps } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
 import {
   ActionGroup,
   Button,
@@ -22,10 +21,14 @@ import OrganizationIDHelpIcon from '../OrganizationIDHelpIcon/OrganizationIDHelp
 
 import './AutomaticSubscriptionForm.scss';
 
-const AutomaticSubscriptionForm: FC = () => {
+const AutomaticSubscriptionForm: FC<RHELAutomaticSubscriptionFormProps> = ({
+  canEdit,
+  loaded,
+  loading,
+  subscriptionData,
+  updateSubscription,
+}) => {
   const { t } = useKubevirtTranslation();
-  const { canEdit, loaded, loading, subscriptionData, updateSubscription } =
-    useRHELAutomaticSubscription();
 
   const [activationKey, setActivationKey] = useState<string>(null);
   const [organizationID, setOrganizationID] = useState<string>(null);
@@ -39,11 +42,7 @@ const AutomaticSubscriptionForm: FC = () => {
 
   if (!loaded) return <Skeleton />;
 
-  const isDisabled =
-    !canEdit ||
-    isEqualObject(subscriptionData, { activationKey, organizationID }) ||
-    (!isEmpty(organizationID) && isEmpty(activationKey)) ||
-    (isEmpty(organizationID) && !isEmpty(activationKey));
+  const isDisabled = !canEdit || isEqualObject(subscriptionData, { activationKey, organizationID });
 
   const handleSubmit = () => {
     !isDisabled && updateSubscription(activationKey, organizationID);


### PR DESCRIPTION
## 📝 Description

On a fresh cluster, the switch to allow RHEL auto updates was on by default, even if the key and id are missing, that caused the mechanism to not get the default unless you toggle it off and back on.
Allowing to set the switch on just if both id and key values are not empty after applying them is solving the issue

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/47c00d8a-201a-4959-bc8d-f92bd2d76fc7

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/380be26d-48ae-4b9e-9b24-cfbf6f875bfb


