### PR TITLE
CNV-37382: Inconsistency between the cluster settings and VM settings for SSH over LoadBalancer

### DIFF
--- a/src/utils/components/SSHAccess/components/SSHServiceSelect.tsx
+++ b/src/utils/components/SSHAccess/components/SSHServiceSelect.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo } from 'react';
+import React, { ChangeEvent, FC, useState } from 'react';
 
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import {
@@ -7,10 +7,10 @@ import {
 } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { useK8sModels } from '@openshift-console/dynamic-plugin-sdk';
+import { useMetalLBOperatorInstalled } from '@kubevirt-utils/hooks/useMetalLBOperatorInstalled/useMetalLBOperatorInstalled';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 
-import { METALLB_GROUP, SERVICE_TYPES } from '../constants';
+import { SERVICE_TYPES } from '../constants';
 
 type SSHServiceSelectProps = {
   onSSHChange: (serviceType: SERVICE_TYPES) => void;
@@ -24,24 +24,16 @@ const SSHServiceSelect: FC<SSHServiceSelectProps> = ({
   sshServiceLoaded,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [models] = useK8sModels();
+  const [isOpen, setIsOpen] = useState(false);
+  const hasMetalLBInstalled = useMetalLBOperatorInstalled();
 
   const { featureEnabled: loadBalancerConfigFlag } = useFeatures(LOAD_BALANCER_ENABLED);
   const { featureEnabled: nodePortEnabled } = useFeatures(NODE_PORT_ENABLED);
 
-  const hasSomeMetalCrd = useMemo(
-    () =>
-      Object.keys(models).some((modelGroupVersionKind) =>
-        modelGroupVersionKind.startsWith(METALLB_GROUP),
-      ),
-    [models],
-  );
-
-  const loadBalancerEnabled = loadBalancerConfigFlag || hasSomeMetalCrd;
+  const loadBalancerEnabled = loadBalancerConfigFlag || hasMetalLBInstalled;
 
   const sshServiceType = sshService?.spec?.type ?? SERVICE_TYPES.NONE;
-  const handleChange = (event: React.ChangeEvent<Element>, newValue: string | undefined) => {
+  const handleChange = (event: ChangeEvent<Element>, newValue: string | undefined) => {
     setIsOpen(false);
 
     if (newValue === sshServiceType) return;

--- a/src/utils/components/SSHAccess/constants.ts
+++ b/src/utils/components/SSHAccess/constants.ts
@@ -12,6 +12,4 @@ export enum SERVICE_TYPES {
   NONE = 'None',
 }
 
-export const METALLB_GROUP = 'metallb.io';
-
 export const exampleIdentityFilePath = '--identity-file=/home/jdoe/.ssh/id_rsa';

--- a/src/utils/hooks/useMetalLBOperatorInstalled/constants.ts
+++ b/src/utils/hooks/useMetalLBOperatorInstalled/constants.ts
@@ -1,0 +1,2 @@
+export const METAL_LB_DEPLOYMENT_NAME = 'metallb-operator-controller-manager';
+export const METAL_LB_DEPLOYMENT_NAMESPACE = 'metallb-system';

--- a/src/utils/hooks/useMetalLBOperatorInstalled/useMetalLBOperatorInstalled.ts
+++ b/src/utils/hooks/useMetalLBOperatorInstalled/useMetalLBOperatorInstalled.ts
@@ -1,0 +1,24 @@
+import { DeploymentModel, modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+import { LOAD_BALANCER_ENABLED } from '../useFeatures/constants';
+import { useFeatures } from '../useFeatures/useFeatures';
+
+import { METAL_LB_DEPLOYMENT_NAME, METAL_LB_DEPLOYMENT_NAMESPACE } from './constants';
+
+export const useMetalLBOperatorInstalled = (): boolean => {
+  const { featureEnabled, toggleFeature } = useFeatures(LOAD_BALANCER_ENABLED);
+  const [metalLBDeployment] = useK8sWatchResource({
+    groupVersionKind: modelToGroupVersionKind(DeploymentModel),
+    isList: false,
+    name: METAL_LB_DEPLOYMENT_NAME,
+    namespace: METAL_LB_DEPLOYMENT_NAMESPACE,
+  });
+
+  const metalLBOperatorInstalled = !isEmpty(metalLBDeployment);
+
+  if (!featureEnabled && metalLBOperatorInstalled) toggleFeature(true);
+
+  return metalLBOperatorInstalled;
+};

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralSettings/SSHConfiguration/SSHConfiguration.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralSettings/SSHConfiguration/SSHConfiguration.tsx
@@ -10,6 +10,7 @@ import {
 } from '@kubevirt-utils/hooks/useFeatures/constants';
 import useFeaturesConfigMap from '@kubevirt-utils/hooks/useFeatures/useFeaturesConfigMap';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { useMetalLBOperatorInstalled } from '@kubevirt-utils/hooks/useMetalLBOperatorInstalled/useMetalLBOperatorInstalled';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 import { Form, FormGroup, TextInput } from '@patternfly/react-core';
@@ -25,6 +26,7 @@ const SSHConfiguration: FC<SSHConfigurationProps> = ({ newBadge }) => {
     featuresConfigMapData: [featureConfigMap, loaded],
     isAdmin,
   } = useFeaturesConfigMap();
+  const hasMetalLBInstalled = useMetalLBOperatorInstalled();
 
   const onChange = useCallback(
     (val: string, field: string) => {
@@ -53,10 +55,12 @@ const SSHConfiguration: FC<SSHConfigurationProps> = ({ newBadge }) => {
         helpTextIconContent={t(
           'Enable the creation of LoadBalancer services for SSH connections to VirtualMachines. A load balancer must be configured',
         )}
+        switchIsOn={
+          featureConfigMap?.data?.[LOAD_BALANCER_ENABLED] === 'true' || hasMetalLBInstalled
+        }
         id="load-balancer-feature"
-        isDisabled={!loaded || !isAdmin}
+        isDisabled={!loaded || !isAdmin || hasMetalLBInstalled}
         newBadge={newBadge}
-        switchIsOn={featureConfigMap?.data?.[LOAD_BALANCER_ENABLED] === 'true'}
         title={t('SSH over LoadBalancer service')}
         turnOnSwitch={(checked) => onChange(checked.toString(), LOAD_BALANCER_ENABLED)}
       />


### PR DESCRIPTION
## 📝 Description
This bug is introducing a few problematic behaviors:
1. Under Overview > Settings > Cluster > General settings > SSH configurations we have a switch to toggle the option of SSH over LB inside the VM's Configuration > SSH tab. If the metalLB operator is installed, the option inside the VM is always selectable no matter what state the switch has.

2. If the metalLB operator was installed in the cluster, then uninstalled, we still show as the operator is installed (the ssh over LB inside the VM is still selectable

The solution includes a tighter check if metalLB is installed, and if so we disable the switch as on.

## 🎥 Demo

###Before:
![metallb-not-installed-selectable-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/20a0c76a-17d9-4180-992f-33d128523c04)
![metallb-not-installed-switch-off-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/f919d1e0-8d05-43d9-9851-6470f019db1a)



### After:
MetalLB is installed:
![metallb-installed-lb-selectable](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/35aa1a75-06d2-4152-9da8-5651de3a3b9d)
![metallb-installed-switch-on](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/ecd01c78-ece9-4edc-89c3-f59c490407fd)

MetalLB is NOT installed:

switch is on:
![metallb-not-installed-4-lb-selectable](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/ffcda414-c24d-4fdd-8167-8461bac37156)
![metallb-not-installed-3](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/0960ddae-5d8f-41bf-a744-9bd683ebcac7)

switch is off:
![metallb-not-installed-2](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/5ae038a8-06d3-445c-a76f-6edfa085159e)
![metallb-not-installed](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/4fa1909d-ef80-456d-8a99-5615b6fd03cc)
