### PR TITLE
CNV-37501: Move SSH using virtctl helper text to info popover

### DIFF
--- a/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.scss
+++ b/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.scss
@@ -1,0 +1,3 @@
+#ssh-using-virtctl--example {
+  margin-left: calc(var(--pf-global--spacer--lg) * -1);
+}

--- a/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.tsx
+++ b/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.tsx
@@ -1,16 +1,21 @@
 import React, { FC } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { getConsoleVirtctlCommand } from '@kubevirt-utils/components/SSHAccess/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  Grid,
+  GridItem,
   Popover,
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
 import VirtctlSSHCommandClipboardCopy from './VirtctlSSHCommandClipboardCopy';
+
+import './ConsoleOverVirtctl.scss';
 
 type ConsoleOverVirtctlProps = {
   vm: V1VirtualMachine;
@@ -23,10 +28,24 @@ const ConsoleOverVirtctl: FC<ConsoleOverVirtctlProps> = ({ vm }) => {
       <DescriptionListTerm className="pf-u-font-size-xs">
         {t('SSH using virtctl')}{' '}
         <Popover
-          bodyContent={t(
-            'SSH access using the virtctl command is possible only when the API server is reachable.',
-          )}
+          bodyContent={
+            <>
+              <div>
+                {t(
+                  'SSH access using the virtctl command is possible only when the API server is reachable.',
+                )}
+              </div>
+              <br />
+              <Grid>
+                <GridItem span={2}>{t('Example: ')}</GridItem>
+                <GridItem id="ssh-using-virtctl--example" span={10}>
+                  {getConsoleVirtctlCommand(vm)}
+                </GridItem>
+              </Grid>
+            </>
+          }
           aria-label={'Help'}
+          minWidth="585px"
           position="right"
         >
           <HelpIcon />

--- a/src/utils/components/SSHAccess/components/VirtctlSSHCommandClipboardCopy.tsx
+++ b/src/utils/components/SSHAccess/components/VirtctlSSHCommandClipboardCopy.tsx
@@ -6,7 +6,6 @@ import { getVMSSHSecretName } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ClipboardCopy, HelperText, HelperTextItem } from '@patternfly/react-core';
 
-import { exampleIdentityFilePath } from '../constants';
 import { getConsoleVirtctlCommand } from '../utils';
 
 type VirtctlSSHCommandClipboardCopyProps = {
@@ -16,26 +15,32 @@ type VirtctlSSHCommandClipboardCopyProps = {
 const VirtctlSSHCommandClipboardCopy: FC<VirtctlSSHCommandClipboardCopyProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
 
-  if (isEmpty(getVMSSHSecretName(vm))) {
-    return <div className="pf-u-font-size-xs">{t('SSH secret not configured')}</div>;
+  const sshSecretNotConfigured = isEmpty(getVMSSHSecretName(vm));
+
+  if (sshSecretNotConfigured) {
+    return (
+      <>
+        <div className="pf-u-font-size-xs">{t('SSH secret not configured')}</div>
+        {sshSecretNotConfigured && (
+          <HelperText className="pf-u-mt-sm">
+            <HelperTextItem variant="indeterminate">
+              {t('Example: ')}
+              {getConsoleVirtctlCommand(vm)}
+            </HelperTextItem>
+          </HelperText>
+        )}
+      </>
+    );
   }
 
   return (
-    <>
-      <ClipboardCopy
-        clickTip={t('Copied')}
-        data-test="ssh-over-virtctl"
-        hoverTip={t('Copy to clipboard')}
-      >
-        {getConsoleVirtctlCommand(vm)}
-      </ClipboardCopy>
-      <HelperText className="pf-u-mt-sm">
-        <HelperTextItem variant="indeterminate">
-          {t('Example: ')}
-          {getConsoleVirtctlCommand(vm, exampleIdentityFilePath)}
-        </HelperTextItem>
-      </HelperText>
-    </>
+    <ClipboardCopy
+      clickTip={t('Copied')}
+      data-test="ssh-over-virtctl"
+      hoverTip={t('Copy to clipboard')}
+    >
+      {getConsoleVirtctlCommand(vm)}
+    </ClipboardCopy>
   );
 };
 

--- a/src/utils/components/SSHAccess/constants.ts
+++ b/src/utils/components/SSHAccess/constants.ts
@@ -11,5 +11,3 @@ export enum SERVICE_TYPES {
   NODE_PORT = 'NodePort',
   NONE = 'None',
 }
-
-export const exampleIdentityFilePath = '--identity-file=/home/jdoe/.ssh/id_rsa';


### PR DESCRIPTION
## 📝 Description

This PR adds the example command to the info icon popover and beneath the "SSH secret not configured" text. It removes the example command when the SSH secret is configured. 

Jira: https://issues.redhat.com/browse/CNV-37501

## 🎥 Screenshots

#### Before - configured
![ssh-access-helper-text-BEFORE-2024-01-24_09-11](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/278be077-3a17-4678-8635-1a139d01bcb4)

#### Before - not configured
![ssh-using-virtctl-not-configured-popover-BEFORE-2024-01-29_22-03](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/b46ac809-a29d-4344-a1bb-751a6c66a7d7)



#### After - configured
![ssh-using-virtctl-configured-popover-AFTER-2024-01-29_21-24](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/ff788b83-cc88-4d50-83ea-40754c22cace)


#### After - not configured
![ssh-using-virtctl-not-configured-popover-AFTER-2024-01-29_21-36](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/fabc446f-bdab-4d10-8a68-a0ec581d1134)


