### PR TITLE
CNV-37383: Move "Not available" above "Dynamic SSH key injection .." msg

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/ssh/components/SSHTabAuthorizedSSHKey.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/ssh/components/SSHTabAuthorizedSSHKey.tsx
@@ -66,8 +66,8 @@ const SSHTabAuthorizedSSHKey = ({ vm }) => {
       onToggle={setIsExpanded}
     >
       <Stack hasGutter>
-        <DynamicSSHKeyInjectionDescription isDynamicSSHInjectionEnabled />
         <SecretNameLabel secretName={secretName} />
+        <DynamicSSHKeyInjectionDescription isDynamicSSHInjectionEnabled />
       </Stack>
     </ExpandableSection>
   );


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-37383

Move "Not available" text (or the name of the existing SSH key if present) above the message "Dynamic SSH key injection is not enabled in this virtual machine. Learn more" in the VM's Configuration SSH tab to make the information more clear to the user. Make this change according to the UX decisions.

## 🎥 Screenshots
**Before:**
![dyn_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/f13c746f-1e3d-4b2a-812c-0d7697ef8f17)

**After:**
![dyn_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/49b35c4d-cf10-4878-be09-11163bc29f44)


