### PR TITLE
CNV-23927: Do not count persistentVolumeClaim volumes in DeleteVMModal

### DIFF
--- a/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useDataVolumeConvertedVolumeNames.ts
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useDataVolumeConvertedVolumeNames.ts
@@ -5,7 +5,7 @@ import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 type UseDataVolumeConvertedVolumeNames = (vmVolumes: V1Volume[]) => {
   dvVolumesNames: string[];
-  pvcVolumesNames: string[];
+  isDataVolumeGarbageCollector: boolean;
 };
 
 const useDataVolumeConvertedVolumeNames: UseDataVolumeConvertedVolumeNames = (vmVolumes) => {
@@ -21,14 +21,9 @@ const useDataVolumeConvertedVolumeNames: UseDataVolumeConvertedVolumeNames = (vm
     .filter((volume) => volume?.dataVolume)
     ?.map((volume) => volume?.dataVolume?.name);
 
-  const pvcVolumesNames = (vmVolumes || [])
-    .filter((volume) => volume?.persistentVolumeClaim)
-    ?.map((volume) => volume?.persistentVolumeClaim?.claimName);
   return {
     dvVolumesNames,
-    pvcVolumesNames: isDataVolumeGarbageCollector
-      ? pvcVolumesNames.concat(dvVolumesNames)
-      : pvcVolumesNames,
+    isDataVolumeGarbageCollector,
   };
 };
 

--- a/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useDeleteVMResources.ts
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useDeleteVMResources.ts
@@ -24,7 +24,9 @@ type UseDeleteVMResources = (vm: V1VirtualMachine) => {
 };
 
 const useDeleteVMResources: UseDeleteVMResources = (vm) => {
-  const { dvVolumesNames, pvcVolumesNames } = useDataVolumeConvertedVolumeNames(getVolumes(vm));
+  const { dvVolumesNames, isDataVolumeGarbageCollector } = useDataVolumeConvertedVolumeNames(
+    getVolumes(vm),
+  );
   const namespace = vm?.metadata?.namespace;
   const [dataVolumes, dataVolumesLoaded, dataVolumesLoadError] = useK8sWatchResource<
     V1beta1DataVolume[]
@@ -48,7 +50,9 @@ const useDeleteVMResources: UseDeleteVMResources = (vm) => {
     namespaced: true,
   });
 
-  const filteredPvcs = pvcs?.filter((pvc) => pvcVolumesNames?.includes(pvc?.metadata?.name));
+  const filteredPvcs = isDataVolumeGarbageCollector
+    ? pvcs?.filter((pvc) => dvVolumesNames?.includes(pvc?.metadata?.name))
+    : [];
 
   const [snapshots, snapshotsLoaded, snapshotsLoadError] = useK8sWatchResource<
     V1alpha1VirtualMachineSnapshot[]


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

We should not count volumes that use PVC attached with `persistentVolumeClaim`  in the DeleteVM modal.

Those volumes are attached to the VM as `existing PVCs` so they do not have the same VM lifecycle. 

Maybe in the next version we can consider a checkbox list to let the user decide which disks wants to delete. 


## Demo

VM with one volume that use `persistVolumeClaim`

**Before**

![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/1fa40c30-969b-41bc-8ade-42f6d410c0ba)


**After**

     
![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/9db68bc5-3c29-4beb-8c36-4e138321c7b3)
