### PR TITLE
CNV-37629: Keep name when configuring existing SSH key in same namespace

### DIFF
--- a/src/utils/components/SSHSecretSection/components/SecretDropdown/SecretDropdown.tsx
+++ b/src/utils/components/SSHSecretSection/components/SecretDropdown/SecretDropdown.tsx
@@ -56,7 +56,7 @@ const SecretDropdown: FC<SecretDropdownProps> = ({
       ...prev,
       secretOption: addNew ? SecretSelectionOption.addNew : SecretSelectionOption.useExisting,
       sshPubKey,
-      sshSecretName: generatePrettyName(newSecretName),
+      sshSecretName: addNew ? generatePrettyName(newSecretName) : newSecretName,
       sshSecretNamespace: selectedSecret?.metadata?.namespace,
     }));
     setSecretName(newSecretName);


### PR DESCRIPTION
## 📝 Description

When configuring an existing SSH secret for the namespace in which that secret resides in the "Manage SSH keys" section the UI displays the secret name with a randomly generated suffix. In actuality, that secret wasn't created and doesn't exist. This can be demonstrated by navigating away from that screen and returning to it. Upon doing so "Not configured" will be displayed for that namespace instead of the generated secret name.

This PR makes it so that the existing secret is used instead of generating a new name.

Jira: https://issues.redhat.com/browse/CNV-37629

