### PR TITLE
CNV-37373: VM IP address disappears from UI when migrating VM

### DIFF
--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRow.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRow.tsx
@@ -1,19 +1,19 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 
 import {
   V1VirtualMachine,
   V1VirtualMachineInstance,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { RowProps } from '@openshift-console/dynamic-plugin-sdk';
-
-import { printableVMStatus } from '../../../utils';
 
 import VirtualMachineRowLayout from './VirtualMachineRowLayout';
 import VirtualMachineRunningRow from './VirtualMachineRunningRow';
 
-const VirtualMachineRow: React.FC<
+const VirtualMachineRow: FC<
   RowProps<
     V1VirtualMachine,
     {
@@ -23,22 +23,25 @@ const VirtualMachineRow: React.FC<
       kind: string;
     }
   >
-> = ({ activeColumnIDs, obj, rowData: { getVmi, getVmim, isSingleNodeCluster, kind } }) => {
-  return obj?.status?.printableStatus === printableVMStatus.Running ? (
+> = ({ activeColumnIDs, obj: vm, rowData: { getVmi, getVmim, isSingleNodeCluster, kind } }) => {
+  const vmName = getName(vm);
+  const vmNamespace = getNamespace(vm);
+  const vmi = getVmi(vmNamespace, vmName);
+  return !isEmpty(vmi) ? (
     <VirtualMachineRunningRow
       rowData={{
         isSingleNodeCluster,
         kind,
-        vmi: getVmi(obj?.metadata?.namespace, obj?.metadata?.name),
-        vmim: getVmim(obj?.metadata?.namespace, obj?.metadata?.name),
+        vmi,
+        vmim: getVmim(vmNamespace, vmName),
       }}
       activeColumnIDs={activeColumnIDs}
-      obj={obj}
+      obj={vm}
     />
   ) : (
     <VirtualMachineRowLayout
       activeColumnIDs={activeColumnIDs}
-      obj={obj}
+      obj={vm}
       rowData={{ ips: NO_DATA_DASH, isSingleNodeCluster, kind, node: NO_DATA_DASH, vmim: null }}
     />
   );


### PR DESCRIPTION
## 📝 Description

The VM row would show IP and node only if the VM is in "Running" status, we should also show ip and node name even if VM is migrating (still running) or if the VM is paused.

## 🎥 Demo

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/3c0ab398-2f5b-4970-bec3-75a5929b0b06

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/b76eab52-31d6-41ca-97f0-f76ad2d8d9bd


