### PR TITLE
CNV-37788: Fix instancetype link on vm details tab

### DIFF
--- a/src/utils/resources/instancetype/helper.ts
+++ b/src/utils/resources/instancetype/helper.ts
@@ -6,6 +6,6 @@ import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 export const getInstanceTypeModelFromMatcher = (
   instanceTypeMatcher: V1InstancetypeMatcher,
 ): K8sModel =>
-  instanceTypeMatcher.kind.includes('cluster')
+  instanceTypeMatcher.kind.includes('Cluster')
     ? VirtualMachineClusterInstancetypeModel
     : VirtualMachineInstancetypeModel;

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/InstanceTypeDescription.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/InstanceTypeDescription.tsx
@@ -4,10 +4,12 @@ import {
   modelToGroupVersionKind,
   VirtualMachineClusterPreferenceModelGroupVersionKind,
 } from '@kubevirt-ui/kubevirt-api/console';
+import VirtualMachineInstancetypeModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstancetypeModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getInstanceTypeModelFromMatcher } from '@kubevirt-utils/resources/instancetype/helper';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getInstanceTypeMatcher, getPreferenceMatcher } from '@kubevirt-utils/resources/vm';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -25,7 +27,8 @@ const InstanceTypeDescription: FC<InstanceTypeDescriptionProps> = ({ vm }) => {
   const None = <MutedTextSpan text={t('None')} />;
 
   const itMatcher = getInstanceTypeMatcher(vm);
-
+  const itModel = getInstanceTypeModelFromMatcher(itMatcher);
+  const includeNamespace = itModel === VirtualMachineInstancetypeModel;
   const preferenceMatcher = getPreferenceMatcher(vm);
 
   return (
@@ -35,8 +38,9 @@ const InstanceTypeDescription: FC<InstanceTypeDescriptionProps> = ({ vm }) => {
         <DescriptionListDescription data-test-id="virtual-machine-overview-details-instance-type">
           {itMatcher ? (
             <ResourceLink
-              groupVersionKind={modelToGroupVersionKind(getInstanceTypeModelFromMatcher(itMatcher))}
+              groupVersionKind={modelToGroupVersionKind(itModel)}
               name={itMatcher.name}
+              namespace={includeNamespace && getNamespace(vm)}
             />
           ) : (
             None


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixing instancetype link in VM details tab
there are 2 kinds of instance type , cluster and user.
user type need to add a namespace to it.

## 🎥 Demo

