### PR TITLE
Kubevirt api upgrade to 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.11.0",
-    "@kubevirt-ui/kubevirt-api": "^1.2.0",
+    "@kubevirt-ui/kubevirt-api": "^1.2.2",
     "@openshift-console/dynamic-plugin-sdk": "0.0.21",
     "@openshift-console/dynamic-plugin-sdk-internal": "0.0.11",
     "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -692,10 +692,10 @@
   resolved "https://registry.yarnpkg.com/@kubevirt-ui/kubevirt-api/-/kubevirt-api-0.0.35.tgz#9a567ea287b647cd37a47d70b87fbd75d4994a89"
   integrity sha512-3S374M9I8nHP+9lnBhL+Z3gMVssNk4vyK7uPI3lkAjal/X6zjR0+E9fWQEPv36K45KxRoUX9w/4pMGWQvVlDcQ==
 
-"@kubevirt-ui/kubevirt-api@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@kubevirt-ui/kubevirt-api/-/kubevirt-api-1.2.0.tgz#6c50bb96e6bb1a6b5864ab126cb9145b9b22c8e8"
-  integrity sha512-M3UAfhfeYmnAnQVBerVZz57vk2CsvuGp1MbXrMeb3ccQYjg93YryMSca0dJJe1Ob8ZBjFUBE3u9XVdUDVvHfcg==
+"@kubevirt-ui/kubevirt-api@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@kubevirt-ui/kubevirt-api/-/kubevirt-api-1.2.2.tgz#2a056159fb503d36bca94e62f9c2899aa2728202"
+  integrity sha512-8hcafV28OAnnNzQuCc5DOk/NCU8IR+h2/xCYW5gCZJFyziidWZwI3FAIcdalxQ9fgY9sgM2di65WeN5j/l4QNg==
 
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"


### PR DESCRIPTION
## 📝 Description

Upgrade Kubernetes API from 1.27 to 1.29
Upgrade KubeVirt API from 1.0 to 1.1
Set CDI API as v1.57.0 instead of main


