### PR TITLE
CNV-37915: fix crash on bootmode modal

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
@@ -61,7 +61,7 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({
               isOpen={isOpen}
               onClose={onClose}
               onSubmit={(updatedVM) => updateBootLoader(updatedVM, vm)}
-              vm={instanceTypeVM}
+              vm={instanceTypeVM || vm}
               vmi={vmi}
             />
           ))


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The crash happens when the user create a VM using a template.

The `instanceTypeVM` is `undefined` is this case and we need to use `vm`  