### PR TITLE
CNV-35729: Improve modal save while there are changes occurred in the back-end - part 2 network

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesEditNetworkInterfaceModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesEditNetworkInterfaceModal.tsx
@@ -1,6 +1,5 @@
 import React, { FC, useCallback } from 'react';
 
-import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1Interface, V1Network, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import NetworkInterfaceModal from '@kubevirt-utils/components/NetworkInterfaceModal/NetworkInterfaceModal';
 import {
@@ -11,7 +10,6 @@ import {
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
-import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 
 type VirtualMachinesEditNetworkInterfaceModalProps = {
   isOpen: boolean;
@@ -45,14 +43,8 @@ const VirtualMachinesEditNetworkInterfaceModal: FC<
             []),
           resultInterface,
         ];
-        const updatedVM = updateVMNetworkInterfaces(vm, updatedNetworks, updatedInterfaces);
 
-        return k8sUpdate({
-          data: updatedVM,
-          model: VirtualMachineModel,
-          name: updatedVM.metadata.name,
-          ns: updatedVM.metadata.namespace,
-        });
+        return updateVMNetworkInterfaces(vm, updatedNetworks, updatedInterfaces);
       },
     [vm, nicPresentation],
   );

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesNetworkInterfaceModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesNetworkInterfaceModal.tsx
@@ -1,6 +1,5 @@
 import React, { FC, useCallback } from 'react';
 
-import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import {
   V1Interface,
   V1Network,
@@ -15,7 +14,6 @@ import {
 } from '@kubevirt-utils/components/NetworkInterfaceModal/utils/helpers';
 import ModalPendingChangesAlert from '@kubevirt-utils/components/PendingChanges/ModalPendingChangesAlert/ModalPendingChangesAlert';
 import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
-import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 
 type VirtualMachinesNetworkInterfaceModalProps = {
   headerText: string;
@@ -45,14 +43,8 @@ const VirtualMachinesNetworkInterfaceModal: FC<VirtualMachinesNetworkInterfaceMo
 
         const updatedNetworks: V1Network[] = [...(getNetworks(vm) || []), resultNetwork];
         const updatedInterfaces: V1Interface[] = [...(getInterfaces(vm) || []), resultInterface];
-        const updatedVM = updateVMNetworkInterfaces(vm, updatedNetworks, updatedInterfaces);
 
-        return k8sUpdate({
-          data: updatedVM,
-          model: VirtualMachineModel,
-          name: updatedVM.metadata.name,
-          ns: updatedVM.metadata.namespace,
-        });
+        return updateVMNetworkInterfaces(vm, updatedNetworks, updatedInterfaces);
       },
     [vm],
   );


### PR DESCRIPTION
## 📝 Description

Changing from using k8sUpdate to K8sPatch as it can cause the promise to fail if the VM has changed
