### PR TITLE
CNV-37818: Set white background for PageSection component where needed

### DIFF
--- a/src/views/datasources/dataimportcron/details/DataImportCronDetailsPage.tsx
+++ b/src/views/datasources/dataimportcron/details/DataImportCronDetailsPage.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 import { RouteComponentProps } from 'react-router';
 
 import { V1beta1DataImportCron } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
@@ -7,7 +7,7 @@ import {
   K8sResourceCondition,
 } from '@kubevirt-utils/components/ConditionsTable/ConditionsTable';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Divider, PageSection, Title } from '@patternfly/react-core';
+import { Divider, PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
 
 import { DataImportCronDetailsGrid } from './DataImportCronDetailsGrid';
 
@@ -18,20 +18,19 @@ type DataImportCronDetailsPageProps = RouteComponentProps<{
   obj?: V1beta1DataImportCron;
 };
 
-const DataImportCronDetailsPage: React.FC<DataImportCronDetailsPageProps> = ({
-  obj: dataImportCron,
-}) => {
+const DataImportCronDetailsPage: FC<DataImportCronDetailsPageProps> = ({ obj: dataImportCron }) => {
   const { t } = useKubevirtTranslation();
+
   return (
     <div>
-      <PageSection>
+      <PageSection variant={PageSectionVariants.light}>
         <Title className="co-section-heading" headingLevel="h2">
           {t('DataImportCron details')}
         </Title>
         <DataImportCronDetailsGrid dataImportCron={dataImportCron} />
       </PageSection>
       <Divider />
-      <PageSection>
+      <PageSection variant={PageSectionVariants.light}>
         <Title className="co-section-heading" headingLevel="h2">
           {t('Conditions')}
         </Title>

--- a/src/views/datasources/details/DataSourceDetailsPage.tsx
+++ b/src/views/datasources/details/DataSourceDetailsPage.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 import { RouteComponentProps } from 'react-router';
 
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
@@ -7,7 +7,7 @@ import {
   K8sResourceCondition,
 } from '@kubevirt-utils/components/ConditionsTable/ConditionsTable';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Divider, PageSection, Title } from '@patternfly/react-core';
+import { Divider, PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
 
 import { DataSourceDetailsGrid } from './components/DataSourceDetailsGrid.tsx/DataSourceDetailsGrid';
 
@@ -18,19 +18,19 @@ type DataSourceDetailsPageProps = RouteComponentProps<{
   obj?: V1beta1DataSource;
 };
 
-const DataSourceDetailsPage: React.FC<DataSourceDetailsPageProps> = ({ obj: dataSource }) => {
+const DataSourceDetailsPage: FC<DataSourceDetailsPageProps> = ({ obj: dataSource }) => {
   const { t } = useKubevirtTranslation();
 
   return (
     <div>
-      <PageSection>
+      <PageSection variant={PageSectionVariants.light}>
         <Title className="co-section-heading" headingLevel="h2">
           {t('DataSource details')}
         </Title>
         <DataSourceDetailsGrid dataSource={dataSource} />
       </PageSection>
       <Divider />
-      <PageSection>
+      <PageSection variant={PageSectionVariants.light}>
         <Title className="co-section-heading" headingLevel="h2">
           {t('Conditions')}
         </Title>

--- a/src/views/migrationpolicies/details/tabs/details/MigrationPolicyDetailsPage.tsx
+++ b/src/views/migrationpolicies/details/tabs/details/MigrationPolicyDetailsPage.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 import { RouteComponentProps } from 'react-router';
 
 import { V1alpha1MigrationPolicy } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { PageSection } from '@patternfly/react-core';
+import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 import MigrationPolicyDetailsSection from './components/MigrationPolicyDetailsSection/MigrationPolicyDetailsSection';
 
@@ -11,17 +11,12 @@ import './MigrationPolicyDetailsPage.scss';
 type MigrationPolicyDetailsPageProps = RouteComponentProps & {
   obj: V1alpha1MigrationPolicy;
 };
-const MigrationPolicyDetailsPage: React.FC<MigrationPolicyDetailsPageProps> = ({
-  location,
-  obj: mp,
-}) => {
-  return (
-    <div className="migration-policy-details-page">
-      <PageSection>
-        <MigrationPolicyDetailsSection mp={mp} pathname={location?.pathname} />
-      </PageSection>
-    </div>
-  );
-};
+const MigrationPolicyDetailsPage: FC<MigrationPolicyDetailsPageProps> = ({ location, obj: mp }) => (
+  <div className="migration-policy-details-page">
+    <PageSection variant={PageSectionVariants.light}>
+      <MigrationPolicyDetailsSection mp={mp} pathname={location?.pathname} />
+    </PageSection>
+  </div>
+);
 
 export default MigrationPolicyDetailsPage;

--- a/src/views/templates/details/tabs/details/TemplateDetailsPage.tsx
+++ b/src/views/templates/details/tabs/details/TemplateDetailsPage.tsx
@@ -5,7 +5,7 @@ import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
-import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
+import { Grid, GridItem, PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
 
 import TemplateDetailsLeftGrid from './components/TemplateDetailsLeftGrid';
 import TemplateDetailsRightGrid from './components/TemplateDetailsRightGrid';
@@ -41,7 +41,7 @@ const TemplateDetailsPage: FC<TemplateDetailsPageProps> = ({ obj: template }) =>
   );
 
   return (
-    <PageSection>
+    <PageSection variant={PageSectionVariants.light}>
       <SidebarEditor<V1Template> onResourceUpdate={onSubmitTemplate} resource={template}>
         {(resource) => (
           <>

--- a/src/views/templates/details/tabs/parameters/TemplateParametersPage.tsx
+++ b/src/views/templates/details/tabs/parameters/TemplateParametersPage.tsx
@@ -17,6 +17,7 @@ import {
   EmptyState,
   Form,
   PageSection,
+  PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
 
@@ -79,7 +80,7 @@ const TemplateParametersPage: FC<TemplateParametersPageProps> = ({ obj: template
   };
 
   return (
-    <PageSection className="template-parameters-page">
+    <PageSection className="template-parameters-page" variant={PageSectionVariants.light}>
       <SidebarEditor
         onChange={(newTemplate) => setEditableTemplate(newTemplate)}
         resource={editableTemplate}

--- a/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.tsx
+++ b/src/views/templates/details/tabs/scheduling/TemplateSchedulingTab.tsx
@@ -5,7 +5,7 @@ import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
-import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core';
+import { Grid, GridItem, PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
 
 import useEditTemplateAccessReview from '../../hooks/useIsTemplateEditable';
 
@@ -37,7 +37,7 @@ const TemplateSchedulingTab: FC<TemplateSchedulingTabProps> = ({ obj: template }
   );
 
   return (
-    <PageSection>
+    <PageSection variant={PageSectionVariants.light}>
       <SidebarEditor<V1Template> onResourceUpdate={onSubmitTemplate} resource={template}>
         {(resource) => (
           <>

--- a/src/views/templates/details/tabs/scripts/TemplateScriptsPage.tsx
+++ b/src/views/templates/details/tabs/scripts/TemplateScriptsPage.tsx
@@ -24,6 +24,7 @@ import {
   Flex,
   FlexItem,
   PageSection,
+  PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
@@ -68,7 +69,7 @@ const TemplateScriptsPage: FC<TemplateScriptsPageProps> = ({ obj: template }) =>
   );
 
   return (
-    <PageSection>
+    <PageSection variant={PageSectionVariants.light}>
       <SidebarEditor<V1Template> onResourceUpdate={onSubmitTemplate} resource={template}>
         <DescriptionList className="template-scripts-tab__description-list">
           <DescriptionListGroup>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-37818

Set the background for Patternfly `PageSection` component we use back to white due to the change of the default setting of the component from white to grey. Adjust the component by adding `variant={PageSectionVariants.light}` to achieve the expected look in the following pages:
- Template _Details_ tab
- Template _Scheduling_ tab
- Template _Scripts_ tab
- Template _Parameters_ tab
- _DataSource details_ (from _Bootable volumes_ list), incl. _Conditions_ part
- _DataImportCron details_ (from _DataSource details_ page)
- _MigrationPolicy details_

## 🎥 Screenshots
**Before:**
![ds_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/d245a4b3-6596-4c34-be02-1834d80886a5)
![ex_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/7224bcf5-c4ea-4761-80c2-2e39f3ecc16b)

**After:**
![ds_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/1213edeb-86a2-4990-bbf3-37e6cc6f0fb5)
![ex_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/0850c786-3547-4893-be3f-22850c3bffd5)


