### PR TITLE
CNV-37111: Make Bootable volumes list page column management work

### DIFF
--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -12,3 +12,5 @@ export const VENDOR_LABEL = 'instancetype.kubevirt.io/vendor';
 export const AUTO_COMPUTE_CPU_LIMITS_LABEL = 'cpu.autocompute.kubevirt.io=true';
 
 export const ROOTDISK = 'rootdisk';
+
+export const KUBEVIRT_V1_VIRTUALMACHINE = 'kubevirt.io~v1~VirtualMachine';

--- a/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react';
 
 import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
+import { KUBEVIRT_V1_VIRTUALMACHINE } from '@kubevirt-utils/constants/constants';
 import { TableColumn, useActiveColumns } from '@openshift-console/dynamic-plugin-sdk';
 import { useUserSettings } from '@openshift-console/dynamic-plugin-sdk-internal';
 
@@ -35,7 +36,11 @@ const useKubevirtUserSettingsTableColumns: UseKubevirtUserSettingsTableColumnsTy
     if (!loaded || error) return;
 
     if (
-      !isEqualObject(userColumns?.[columnManagementID], localStorageSettings?.[columnManagementID])
+      !isEqualObject(
+        userColumns?.[columnManagementID],
+        localStorageSettings?.[columnManagementID],
+      ) &&
+      columnManagementID === KUBEVIRT_V1_VIRTUALMACHINE
     ) {
       setLocalStorageSettings({
         ...localStorageSettings,

--- a/src/utils/tests/resource.test.ts
+++ b/src/utils/tests/resource.test.ts
@@ -1,5 +1,5 @@
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import { DEFAULT_NAMESPACE, KUBEVIRT_V1_VIRTUALMACHINE } from '@kubevirt-utils/constants/constants';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
@@ -15,10 +15,10 @@ test('getResourceUrl', () => {
   };
 
   const url = getResourceUrl({ model: VirtualMachineModel, resource });
-  expect(url).toBe('/k8s/ns/kube/kubevirt.io~v1~VirtualMachine/vm');
+  expect(url).toBe(`/k8s/ns/kube/${KUBEVIRT_V1_VIRTUALMACHINE}/vm`);
 
   const generalResourceURL = getResourceUrl({ model: VirtualMachineModel });
-  expect(generalResourceURL).toBe('/k8s/all-namespaces/kubevirt.io~v1~VirtualMachine/');
+  expect(generalResourceURL).toBe(`/k8s/all-namespaces/${KUBEVIRT_V1_VIRTUALMACHINE}/`);
 
   const nullUrl = getResourceUrl({ model: null, resource });
   expect(nullUrl).toBe(null);
@@ -27,5 +27,5 @@ test('getResourceUrl', () => {
     activeNamespace: DEFAULT_NAMESPACE,
     model: VirtualMachineModel,
   });
-  expect(urlWithNamespace).toBe(`/k8s/ns/${DEFAULT_NAMESPACE}/kubevirt.io~v1~VirtualMachine/`);
+  expect(urlWithNamespace).toBe(`/k8s/ns/${DEFAULT_NAMESPACE}/${KUBEVIRT_V1_VIRTUALMACHINE}/`);
 });

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.tsx
@@ -129,7 +129,6 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
                 hideLabelFilter
                 hideNameLabelFilters={!displayShowAllButton}
                 loaded={Boolean(loaded)}
-                // nameFilter={!displayShowAllButton && "modal-name"} can remove comment once this merged https://github.com/openshift/console/pull/12438 and build into new SDK version
                 rowFilters={filters}
               />
             </SplitItem>

--- a/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineBasicLogViewer/VirtualMachineBasicLogViewer.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineBasicLogViewer/VirtualMachineBasicLogViewer.tsx
@@ -3,6 +3,7 @@ import React, { FC, useState } from 'react';
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
+import { KUBEVIRT_V1_VIRTUALMACHINE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Bullseye, Checkbox, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
@@ -54,7 +55,7 @@ const VirtualMachineBasicLogViewer: FC<VirtualMachineBasicLogViewerProps> = ({
                 <ToolbarItem variant="separator" />
                 <ToolbarItem>
                   <ExternalLink
-                    href={`/k8s/ns/${vmi?.metadata?.namespace}/kubevirt.io~v1~VirtualMachine/${vmi?.metadata?.name}/diagnostics/logs/standalone`}
+                    href={`/k8s/ns/${vmi?.metadata?.namespace}/${KUBEVIRT_V1_VIRTUALMACHINE}/${vmi?.metadata?.name}/diagnostics/logs/standalone`}
                   >
                     {t('Open logs in a new window')}
                   </ExternalLink>

--- a/src/views/virtualmachines/details/tabs/metrics/NetworkCharts/NetworkCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/NetworkCharts/NetworkCharts.tsx
@@ -2,6 +2,7 @@ import React, { FC, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { KUBEVIRT_V1_VIRTUALMACHINE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Dropdown, DropdownItem, DropdownToggle, Title } from '@patternfly/react-core';
 
@@ -44,7 +45,7 @@ const NetworkCharts: FC<NetworkChartsProps> = ({ vmi }) => {
               setSelectedNetwork(e?.currentTarget?.innerText);
               setIsDropdownOpen(false);
               history?.push(
-                `/k8s/ns/${vmi?.metadata?.namespace}/kubevirt.io~v1~VirtualMachine/${vmi?.metadata?.name}/metrics?network=${nic}`,
+                `/k8s/ns/${vmi?.metadata?.namespace}/${KUBEVIRT_V1_VIRTUALMACHINE}/${vmi?.metadata?.name}/metrics?network=${nic}`,
               );
             }}
             key={nic}

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
@@ -8,6 +8,7 @@ import {
   isConnectionEncrypted,
   isHeadlessModeVMI,
 } from '@kubevirt-utils/components/Consoles/utils/utils';
+import { KUBEVIRT_V1_VIRTUALMACHINE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { vmiStatuses } from '@kubevirt-utils/resources/vmi';
 import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
@@ -62,7 +63,7 @@ const VirtualMachinesOverviewTabDetailsConsole: FC<
         <Button
           onClick={() =>
             window.open(
-              `/k8s/ns/${vmi?.metadata?.namespace}/kubevirt.io~v1~VirtualMachine/${vmi?.metadata?.name}/console/standalone`,
+              `/k8s/ns/${vmi?.metadata?.namespace}/${KUBEVIRT_V1_VIRTUALMACHINE}/${vmi?.metadata?.name}/console/standalone`,
             )
           }
           isDisabled={!isVMRunning || isHeadlessMode || !canConnectConsole}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-37111
https://issues.redhat.com/browse/CNV-37821

Make _Bootable volumes_ list page column management work so the settings are saved and applied when user enters the page repeatedly.

_Notes:_
- this change fixes "not saveable" column management also in some other pages, except _Preferences_ list page, where it didn't work at all and still doesn't with this change, probably needs some different fix (followup commit/PR)
- when being in "All namespaces" in _Bootable volumes_ list page, only in this case the _Namespace_ column is displayed (in case it is selected when managing columns, of course), otherwise not

## 🎥 Demo
**Before:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/0a60f8cc-15d8-4068-b0d8-63af0b330363

**After:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/d5f94938-b359-4a55-a777-4ef10a7fee87



