### PR TITLE
CNV-37821: Make column management for Preferences list work

### DIFF
--- a/src/views/preferences/list/ClusterPreferenceList.tsx
+++ b/src/views/preferences/list/ClusterPreferenceList.tsx
@@ -1,11 +1,11 @@
 import React, { FC } from 'react';
 
 import useClusterPreferences from '@catalog/CreateFromInstanceTypes/state/hooks/useClusterPreferences';
-import { VirtualMachineClusterInstancetypeModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import usePagination from '@kubevirt-utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@kubevirt-utils/hooks/usePagination/utils/constants';
+import { VirtualMachineClusterPreferenceModelRef } from '@kubevirt-utils/models';
 import {
   ListPageBody,
   ListPageFilter,
@@ -37,7 +37,7 @@ const ClusterPreferenceList: FC = () => {
               id,
               title,
             })),
-            id: VirtualMachineClusterInstancetypeModelGroupVersionKind.kind,
+            id: VirtualMachineClusterPreferenceModelRef,
             selectedColumns: new Set(activeColumns?.map((col) => col?.id)),
             type: '',
           }}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-37821

Make the column management responsible on saved changes by providing the correct `id` for `columnLayout` prop of the `ListPageFilter` component used in the related list page.

_Note:_
The saved change in the column management modal will be lost if the user leaves the page and returns back, unfortunately. To make this work as expected, https://github.com/kubevirt-ui/kubevirt-plugin/pull/1779 must be merged, too.

## 🎥 Demo
**Before:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/cfcf5cd3-8180-48fb-8838-69acbfdaaff2

**After:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/064a9819-1cef-411c-b183-7e324949d098


