### PR TITLE
CNV-37819: Adjust package.json's lint-staged to include i18n json file in commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,8 @@
     "*.{js,ts,tsx,jsx,json}": [
       "eslint . --fix",
       "prettier --write .",
-      "yarn i18n"
+      "yarn i18n",
+      "git add locales/en/plugin__kubevirt-plugin.json"
     ]
   },
   "name": "kubevirt-plugin",


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-37819

~~The aim of this PR is to test if changes to new i18n json file after running yarn i18n will be added to the commit so the commit or PR could pass once on GitHub, and one won't need to add the json file to the commit manually.~~

Adjust _package.json_  file by adding `git add locales/en/plugin__kubevirt-plugin.json` for `lint-staged` to achieve including the related i18n json file with its changes in the commit so the related tests pass here on GH successfully.

_Q & A:_
What if no any i18n changes present after `yarn i18n` when creating commit? -> Nothing happens, including _locales/en/plugin__kubevirt-plugin.json_ file changes in the commit is ignored.

More on `lint-staged`:
https://www.npmjs.com/package/lint-staged


