### PR TITLE
Add save button to the environment sidebar editor

### DIFF
--- a/src/views/catalog/wizard/tabs/environment/WizardEnvironmentTab.tsx
+++ b/src/views/catalog/wizard/tabs/environment/WizardEnvironmentTab.tsx
@@ -10,7 +10,7 @@ import { Bullseye, PageSection, PageSectionVariants } from '@patternfly/react-co
 
 import './wizard-environment-tab.scss';
 
-const WizardEnvironmentTab: WizardTab = ({ setDisableVmCreate, updateVM, vm }) => {
+const WizardEnvironmentTab: WizardTab = ({ updateVM, vm }) => {
   if (!vm)
     return (
       <Bullseye>
@@ -21,11 +21,11 @@ const WizardEnvironmentTab: WizardTab = ({ setDisableVmCreate, updateVM, vm }) =
   return (
     <PageSection className="wizard-environment-tab" variant={PageSectionVariants.light}>
       <SidebarEditor<V1VirtualMachine>
-        onChange={updateVM}
+        onResourceUpdate={updateVM}
         pathsToHighlight={PATHS_TO_HIGHLIGHT.ENV_TAB}
         resource={vm}
       >
-        <EnvironmentForm onEditChange={setDisableVmCreate} updateVM={updateVM} vm={vm} />
+        <EnvironmentForm updateVM={updateVM} vm={vm} />
       </SidebarEditor>
     </PageSection>
   );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The issue is related to the `onEditChange={setDisableVmCreate}` 

This callback should disable the `Create` button in the wizard but this the trigger a re-loading.
I would remove that behaviour at this point as we do not do that in other tabs.

the sidebar editor triggers a VM update at the beginning and everytime we change something in the editor. 
Instead of using `onChange` we should use `onResourceUpdate`. It will show the Save button on the bottom like in all the other tabs. Clicking on the save button will trigger the reloading of the EnvironmentForm.



## 🎥 Demo

![Screenshot from 2024-02-12 16-04-21](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/4f15d852-9bdc-4f60-965e-01a9e56a1aee)

