### PR TITLE
Fix Template's Disks title margin prop

### DIFF
--- a/src/views/templates/details/tabs/disks/TemplateDisksPage.scss
+++ b/src/views/templates/details/tabs/disks/TemplateDisksPage.scss
@@ -13,7 +13,7 @@
     margin: 0 0 0.5rem 0;
   }
 
-  .disk-list-title {
+  .pf-c-title {
     margin: 1.5rem 0 1rem 0;
   }
 }


### PR DESCRIPTION
## 📝 Description

Fix broken/not applied css `margin` prop for Template _Disks_ page title so the title looks the same as in the other Template tabs. This got probably broken during some refactoring or other related changes of the page/`DiskListTitle` component.

## 🎥 Screenshots
**Before:**
Title of the page too close to the upper border of the page:
![disks_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/c4796df6-0637-487b-af5f-55ba107e9563)

**After:**
More space around the title, same as in other VM Template's tabs/pages:
![disks_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/b966b6e8-0d91-44f4-8d3a-d9e3952cd313)
