### PR TITLE
CNV-34180: fetch user accessible hyperconverge config resource

### DIFF
--- a/src/utils/components/HardwareDevices/HardwareDevicesPage.tsx
+++ b/src/utils/components/HardwareDevices/HardwareDevicesPage.tsx
@@ -11,7 +11,7 @@ import HardwareDevicesPageTable from './HardwareDevicesPageTable';
 
 const HardwareDevicesPage: React.FC<any> = (props) => {
   const { t } = useKubevirtTranslation();
-  const { errorHcList, loadedHcList, permittedHostDevices } = useHCPermittedHostDevices();
+  const { hcError, hcLoaded, permittedHostDevices } = useHCPermittedHostDevices();
 
   const pages = [
     {
@@ -31,8 +31,8 @@ const HardwareDevicesPage: React.FC<any> = (props) => {
             selector: device?.pciVendorSelector || device?.pciDeviceSelector,
           }),
         ),
-        error: errorHcList,
-        loaded: loadedHcList,
+        error: hcError,
+        loaded: hcLoaded,
       },
     },
     {
@@ -50,8 +50,8 @@ const HardwareDevicesPage: React.FC<any> = (props) => {
           ...device,
           selector: device?.mdevNameSelector,
         })),
-        error: errorHcList,
-        loaded: loadedHcList,
+        error: hcError,
+        loaded: hcLoaded,
       },
     },
   ];

--- a/src/utils/components/HardwareDevices/hooks/useHCPermittedHostDevices.ts
+++ b/src/utils/components/HardwareDevices/hooks/useHCPermittedHostDevices.ts
@@ -2,24 +2,20 @@ import {
   V1KubeVirtConfiguration,
   V1PermittedHostDevices,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { HyperConvergedModelGroupVersionKind } from '@kubevirt-utils/models';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration.ts';
 
 type UseHCPermittedHostDevicesType = () => {
-  errorHcList: Error;
-  loadedHcList: boolean;
+  hcError: Error;
+  hcLoaded: boolean;
   permittedHostDevices: V1PermittedHostDevices;
 };
 
 const useHCPermittedHostDevices: UseHCPermittedHostDevicesType = () => {
-  const [hcList, loadedHcList, errorHcList] = useK8sWatchResource({
-    groupVersionKind: HyperConvergedModelGroupVersionKind,
-    isList: true,
-  });
+  const [hcConfig, hcLoaded, hcError] = useKubevirtHyperconvergeConfiguration();
 
-  const { permittedHostDevices }: V1KubeVirtConfiguration = hcList?.[0]?.spec || {};
+  const { permittedHostDevices }: V1KubeVirtConfiguration = hcConfig?.spec?.configuration || {};
 
-  return { errorHcList, loadedHcList, permittedHostDevices };
+  return { hcError, hcLoaded, permittedHostDevices };
 };
 
 export default useHCPermittedHostDevices;

--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -12,3 +12,6 @@ export const VENDOR_LABEL = 'instancetype.kubevirt.io/vendor';
 export const AUTO_COMPUTE_CPU_LIMITS_LABEL = 'cpu.autocompute.kubevirt.io=true';
 
 export const ROOTDISK = 'rootdisk';
+
+export const KUBEVIRT_HYPERCONVERGED = 'kubevirt-hyperconverged';
+export const OPENSHIFT_CNV = 'openshift-cnv';

--- a/src/utils/hooks/useKubevirtHyperconvergeConfiguration.ts/constants.ts
+++ b/src/utils/hooks/useKubevirtHyperconvergeConfiguration.ts/constants.ts
@@ -1,0 +1,7 @@
+export const KUBEVIRT_HC_NAME = 'kubevirt-kubevirt-hyperconverged';
+
+export const KUBEVIRT_HC_GROUP_VERSION_KIND = {
+  group: 'kubevirt.io',
+  kind: 'KubeVirt',
+  version: 'v1',
+};

--- a/src/utils/hooks/useKubevirtHyperconvergeConfiguration.ts/index.ts
+++ b/src/utils/hooks/useKubevirtHyperconvergeConfiguration.ts/index.ts
@@ -1,0 +1,30 @@
+import { V1KubeVirtConfiguration } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { KUBEVIRT_HYPERCONVERGED, OPENSHIFT_CNV } from '@kubevirt-utils/constants/constants';
+import { isUpstream } from '@kubevirt-utils/utils/utils';
+import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+import { KUBEVIRT_HC_GROUP_VERSION_KIND, KUBEVIRT_HC_NAME } from './constants';
+
+export type KubevirtHyperconverged = K8sResourceCommon & {
+  spec: {
+    configuration: V1KubeVirtConfiguration;
+  };
+};
+
+const useKubevirtHyperconvergeConfiguration = (): [
+  hcConfig: KubevirtHyperconverged,
+  configLoaded: boolean,
+  configError: any,
+] => {
+  const [kubevirtHCConfig, configLoaded, configError] = useK8sWatchResource<KubevirtHyperconverged>(
+    {
+      groupVersionKind: KUBEVIRT_HC_GROUP_VERSION_KIND,
+      name: KUBEVIRT_HC_NAME,
+      namespace: isUpstream ? KUBEVIRT_HYPERCONVERGED : OPENSHIFT_CNV,
+    },
+  );
+
+  return [kubevirtHCConfig, configLoaded, configError];
+};
+
+export default useKubevirtHyperconvergeConfiguration;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Regular users cannot access Hyperconverge configuration. 
in order to fix this bug we have to fetch the new Kubevirt Hyperconverge configuration made exactly for that

## 🎥 Demo


![Screenshot from 2024-02-14 12-01-51](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/3cefbf64-b230-48ce-8e10-ea3ee0760149)

