### PR TITLE
CNV-37819: Adjust package.json, pre-commit to prevent i18n tests failing

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged
+git add locales/en/plugin__kubevirt-plugin.json

--- a/package.json
+++ b/package.json
@@ -165,8 +165,7 @@
     "*.{js,ts,tsx,jsx,json}": [
       "eslint . --fix",
       "prettier --write .",
-      "yarn i18n",
-      "git add locales/en/plugin__kubevirt-plugin.json"
+      "yarn i18n"
     ]
   },
   "name": "kubevirt-plugin",


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-37819

This is a followup PR of https://github.com/kubevirt-ui/kubevirt-plugin/pull/1787

Adjust _package.json_ and Husky _pre-commit_ files to achieve properly including _locales/en/plugin__kubevirt-plugin.json_ file in the commit, and hence prevent failing i18n tests for an opened PR on GitHub.
Add `git add locales/en/plugin__kubevirt-plugin.json` to _pre-commit_, after yarn i18n is ran.

_Q & A:_
What if no any i18n changes present after yarn i18n when creating commit? -> Nothing happens, including locales/en/plugin__kubevirt-plugin.json file changes in the commit is ignored.

_More on lint-staged and Husky:_
https://www.npmjs.com/package/lint-staged
https://typicode.github.io/husky/how-to.html
