### PR TITLE
CNV-37818: Set white background to all PageSection component occurrences

### DIFF
--- a/src/views/checkups/network/details/CheckupsNetworkDetailsPage.tsx
+++ b/src/views/checkups/network/details/CheckupsNetworkDetailsPage.tsx
@@ -4,7 +4,15 @@ import { useParams } from 'react-router-dom-v5-compat';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
-import { Bullseye, Divider, PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
+import {
+  Bullseye,
+  Divider,
+  PageSection,
+  PageSectionVariants,
+  Tab,
+  Tabs,
+  TabTitleText,
+} from '@patternfly/react-core';
 
 import CheckupsDetailsPageHistory from '../../CheckupsDetailsPageHistory';
 import { getJobByName } from '../../utils/utils';
@@ -32,7 +40,7 @@ const CheckupsNetworkDetailsPage = () => {
     );
 
   return (
-    <PageSection>
+    <PageSection variant={PageSectionVariants.light}>
       <CheckupsNetworkDetailsPageHeader configMap={configMap} />
       <Tabs
         onSelect={(_, tabIndex: number) => {
@@ -41,13 +49,13 @@ const CheckupsNetworkDetailsPage = () => {
         activeKey={activeTabKey}
       >
         <Tab eventKey={0} title={<TabTitleText>{t('Details')}</TabTitleText>}>
-          <PageSection>
+          <PageSection variant={PageSectionVariants.light}>
             <CheckupsNetworkDetailsPageSection configMap={configMap} job={jobMatches?.[0]} />
           </PageSection>
-          <PageSection>
+          <PageSection variant={PageSectionVariants.light}>
             <Divider />
           </PageSection>
-          <PageSection>
+          <PageSection variant={PageSectionVariants.light}>
             <CheckupsDetailsPageHistory error={error} jobs={jobMatches} loading={loading} />
           </PageSection>
         </Tab>

--- a/src/views/checkups/storage/details/CheckupsStorageDetailsPage.tsx
+++ b/src/views/checkups/storage/details/CheckupsStorageDetailsPage.tsx
@@ -4,7 +4,15 @@ import { useParams } from 'react-router-dom-v5-compat';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
-import { Bullseye, Divider, PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
+import {
+  Bullseye,
+  Divider,
+  PageSection,
+  PageSectionVariants,
+  Tab,
+  Tabs,
+  TabTitleText,
+} from '@patternfly/react-core';
 
 import CheckupsDetailsPageHistory from '../../CheckupsDetailsPageHistory';
 import { getJobByName } from '../../utils/utils';
@@ -32,7 +40,7 @@ const CheckupsStorageDetailsPage = () => {
     );
 
   return (
-    <PageSection>
+    <PageSection variant={PageSectionVariants.light}>
       <CheckupsStorageDetailsPageHeader configMap={configMap} jobs={jobMatches} />
       <Tabs
         onSelect={(_, tabIndex: number) => {
@@ -41,13 +49,13 @@ const CheckupsStorageDetailsPage = () => {
         activeKey={activeTabKey}
       >
         <Tab eventKey={0} title={<TabTitleText>{t('Details')}</TabTitleText>}>
-          <PageSection>
+          <PageSection variant={PageSectionVariants.light}>
             <CheckupsStorageDetailsPageSection configMap={configMap} job={jobMatches?.[0]} />
           </PageSection>
-          <PageSection>
+          <PageSection variant={PageSectionVariants.light}>
             <Divider />
           </PageSection>
-          <PageSection>
+          <PageSection variant={PageSectionVariants.light}>
             <CheckupsDetailsPageHistory error={error} jobs={jobMatches} loading={loading} />
           </PageSection>
         </Tab>

--- a/src/views/virtualmachines/details/tabs/configuration/details/DetailsTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/DetailsTab.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
-import { PageSection } from '@patternfly/react-core';
+import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 import { ConfigurationInnerTabProps } from '../utils/types';
 
@@ -16,7 +16,7 @@ const DetailsTab: FC<ConfigurationInnerTabProps> = ({ instanceTypeVM, vm, vmi })
     resource={vm}
   >
     {(resource) => (
-      <PageSection>
+      <PageSection variant={PageSectionVariants.light}>
         <DetailsSection instanceTypeVM={instanceTypeVM} vm={resource} vmi={vmi} />
       </PageSection>
     )}

--- a/src/views/virtualmachines/details/tabs/configuration/initialrun/InitialRunTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/initialrun/InitialRunTab.tsx
@@ -7,7 +7,13 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { asAccessReview } from '@kubevirt-utils/resources/shared';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
 import { K8sVerb, useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
-import { DescriptionList, Divider, PageSection, Title } from '@patternfly/react-core';
+import {
+  DescriptionList,
+  Divider,
+  PageSection,
+  PageSectionVariants,
+  Title,
+} from '@patternfly/react-core';
 
 import { onSubmitYAML } from '../details/utils/utils';
 import { ConfigurationInnerTabProps } from '../utils/types';
@@ -27,7 +33,7 @@ const InitialRunTab: FC<ConfigurationInnerTabProps> = ({ vm, vmi }) => {
       resource={vm}
     >
       {(resource) => (
-        <PageSection>
+        <PageSection variant={PageSectionVariants.light}>
           <Title headingLevel="h2">
             <SearchItem id="initial-run">{t('Initial run')}</SearchItem>
           </Title>

--- a/src/views/virtualmachines/details/tabs/configuration/metadata/MetadataTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/metadata/MetadataTab.tsx
@@ -7,7 +7,13 @@ import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName } from '@kubevirt-utils/resources/shared';
-import { DescriptionList, Grid, PageSection, Title } from '@patternfly/react-core';
+import {
+  DescriptionList,
+  Grid,
+  PageSection,
+  PageSectionVariants,
+  Title,
+} from '@patternfly/react-core';
 
 import { updateAnnotation, updateLabels } from '../details/utils/utils';
 import { ConfigurationInnerTabProps } from '../utils/types';
@@ -20,7 +26,7 @@ const MetadataTab: FC<ConfigurationInnerTabProps> = ({ vm }) => {
   const { createModal } = useModal();
 
   return (
-    <PageSection>
+    <PageSection variant={PageSectionVariants.light}>
       <Title headingLevel="h2">
         <SearchItem id="metadata">{t('Metadata')}</SearchItem>
       </Title>

--- a/src/views/virtualmachines/details/tabs/configuration/network/NetworkTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/NetworkTab.tsx
@@ -4,7 +4,7 @@ import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
-import { PageSection, Title } from '@patternfly/react-core';
+import { PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
 
 import { onSubmitYAML } from '../details/utils/utils';
 import { ConfigurationInnerTabProps } from '../utils/types';
@@ -24,7 +24,7 @@ const NetworkTab: FC<ConfigurationInnerTabProps> = ({ vm, vmi }) => {
       pathsToHighlight={PATHS_TO_HIGHLIGHT.NETWORK_TAB}
       resource={vm}
     >
-      <PageSection>
+      <PageSection variant={PageSectionVariants.light}>
         <Title headingLevel="h2">
           <SearchItem id="network">{t('Network interfaces')}</SearchItem>
         </Title>

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/SchedulingTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/SchedulingTab.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
-import { PageSection } from '@patternfly/react-core';
+import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 import { onSubmitYAML } from '../details/utils/utils';
 import { ConfigurationInnerTabProps } from '../utils/types';
@@ -16,7 +16,7 @@ const SchedulingTab: FC<ConfigurationInnerTabProps> = ({ vm, vmi }) => (
     resource={vm}
   >
     {(resource) => (
-      <PageSection>
+      <PageSection variant={PageSectionVariants.light}>
         <SchedulingSection vm={resource} vmi={vmi} />
       </PageSection>
     )}

--- a/src/views/virtualmachines/details/tabs/configuration/ssh/SSHTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/ssh/SSHTab.tsx
@@ -4,7 +4,14 @@ import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
-import { Grid, GridItem, PageSection, Stack, Title } from '@patternfly/react-core';
+import {
+  Grid,
+  GridItem,
+  PageSection,
+  PageSectionVariants,
+  Stack,
+  Title,
+} from '@patternfly/react-core';
 
 import { onSubmitYAML } from '../details/utils/utils';
 import { ConfigurationInnerTabProps } from '../utils/types';
@@ -21,7 +28,7 @@ const SSHTab: FC<ConfigurationInnerTabProps> = ({ vm, vmi }) => {
       pathsToHighlight={PATHS_TO_HIGHLIGHT.SCRIPTS_TAB}
       resource={vm}
     >
-      <PageSection>
+      <PageSection variant={PageSectionVariants.light}>
         <Title headingLevel="h2">
           <SearchItem id="ssh">{t('SSH settings')} </SearchItem>
         </Title>

--- a/src/views/virtualmachines/details/tabs/configuration/storage/StorageTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/StorageTab.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react';
 import EnvironmentForm from '@kubevirt-utils/components/EnvironmentEditor/EnvironmentForm';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
-import { Divider, Grid, GridItem, PageSection } from '@patternfly/react-core';
+import { Divider, Grid, GridItem, PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 import { onSubmitYAML } from '../details/utils/utils';
 import { ConfigurationInnerTabProps } from '../utils/types';
@@ -18,7 +18,7 @@ const StorageTab: FC<ConfigurationInnerTabProps> = ({ vm, vmi }) => (
   >
     <Grid hasGutter>
       <GridItem>
-        <PageSection>
+        <PageSection variant={PageSectionVariants.light}>
           <DiskList vm={vm} vmi={vmi} />
         </PageSection>
       </GridItem>
@@ -26,7 +26,7 @@ const StorageTab: FC<ConfigurationInnerTabProps> = ({ vm, vmi }) => (
         <Divider />
       </GridItem>
       <GridItem>
-        <PageSection>
+        <PageSection variant={PageSectionVariants.light}>
           <EnvironmentForm updateVM={onSubmitYAML} vm={vm} />
         </PageSection>
       </GridItem>

--- a/src/views/virtualmachinesinstance/details/tabs/console/VirtualMachinesInstancePageConsoleTab.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/console/VirtualMachinesInstancePageConsoleTab.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Consoles from '@kubevirt-utils/components/Consoles/Consoles';
-import { PageSection } from '@patternfly/react-core';
+import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 type VirtualMachinesInstancePageConsoleTabProps = {
   obj: V1VirtualMachineInstance;
@@ -10,12 +10,10 @@ type VirtualMachinesInstancePageConsoleTabProps = {
 
 const VirtualMachinesInstancePageConsoleTab: FC<VirtualMachinesInstancePageConsoleTabProps> = ({
   obj: vmi,
-}) => {
-  return (
-    <PageSection>
-      <Consoles vmi={vmi} />
-    </PageSection>
-  );
-};
+}) => (
+  <PageSection variant={PageSectionVariants.light}>
+    <Consoles vmi={vmi} />
+  </PageSection>
+);
 
 export default VirtualMachinesInstancePageConsoleTab;

--- a/src/views/virtualmachinesinstance/details/tabs/details/VirtualMachinesInstancePageDetailsTab.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/VirtualMachinesInstancePageDetailsTab.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { Divider, PageSection } from '@patternfly/react-core';
+import { Divider, PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 import Details from './components/Details/Details';
 import Services from './components/Services/Services';
@@ -13,21 +13,22 @@ import './virtual-machines-instance-details-tab.scss';
 type VirtualMachinesInstancePageDetailsTabProps = {
   obj: V1VirtualMachineInstance;
 };
-const VirtualMachinesInstancePageDetailsTab: React.FC<
-  VirtualMachinesInstancePageDetailsTabProps
-> = ({ obj: vmi }) => {
+const VirtualMachinesInstancePageDetailsTab: FC<VirtualMachinesInstancePageDetailsTabProps> = ({
+  obj: vmi,
+}) => {
   const location = useLocation();
+
   return (
     <div className="VirtualMachinesInstanceDetailsTab">
-      <PageSection>
+      <PageSection variant={PageSectionVariants.light}>
         <Details pathname={location?.pathname} vmi={vmi} />
       </PageSection>
       <Divider />
-      <PageSection>
+      <PageSection variant={PageSectionVariants.light}>
         <Services pathname={location?.pathname} vmi={vmi} />
       </PageSection>
       <Divider />
-      <PageSection>
+      <PageSection variant={PageSectionVariants.light}>
         <ActiveUserList pathname={location?.pathname} vmi={vmi} />
       </PageSection>
     </div>

--- a/src/views/virtualmachinesinstance/details/tabs/scheduling/VirtualMachinesInstancePageSchedulingTab.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/scheduling/VirtualMachinesInstancePageSchedulingTab.tsx
@@ -10,6 +10,7 @@ import {
   Grid,
   GridItem,
   PageSection,
+  PageSectionVariants,
 } from '@patternfly/react-core';
 
 import Affinity from './Affinity/Affinity';
@@ -29,7 +30,7 @@ const VirtualMachinesInstancePageSchedulingTab: FC<
   const { t } = useKubevirtTranslation();
 
   return (
-    <PageSection>
+    <PageSection variant={PageSectionVariants.light}>
       <Grid hasGutter>
         <GridItem span={6}>
           <DescriptionList>


### PR DESCRIPTION
## 📝 Description

Fixes https://issues.redhat.com/browse/CNV-37818

This is a followup PR of https://github.com/kubevirt-ui/kubevirt-plugin/pull/1777

Set the background for Patternfly `PageSection` component (all occurrences) we use back to white due to the change of the default setting of the component from white to grey. Adjust the component by adding `variant={PageSectionVariants.light}` to achieve the expected look in the various pages.

## 🎥 Screenshots
**Before:**
Example: VMI Details tab and the grey background of the page:
![vmi_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/2a102b1f-b954-4063-a81d-26f0e8e5ae3b)

**After:**
Example: VMI Details tab and the expected white background of the page:
![vmi_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/1655bd92-6bfb-4708-9ddf-c2d103230e04)

