### PR TITLE
CNV-38450: Display VM Console tab as expected

### DIFF
--- a/src/utils/resources/vmi/utils/cloud-init.ts
+++ b/src/utils/resources/vmi/utils/cloud-init.ts
@@ -28,7 +28,7 @@ export const getCloudInitCredentials = (
         users: [
           {
             name: userDataObject?.user || CLOUD_INIT_MISSING_USERNAME,
-            password: userDataObject?.password,
+            password: userDataObject?.password.toString(),
           },
         ],
       };


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-38450

Prevent the VM Console tab crashing if cloudInitNoCloud user's password is a number.

## 🎥 Screenshots
**Before:**
![cl_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/9a97e865-f37e-4afd-ac75-34353c671573)

**After:**
![cl_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/4db87b29-33ba-4936-bd00-eae4b71c8693)


