### PR TITLE
Fix crash when sshDetails is null

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/AuthorizedSSHKey.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/AuthorizedSSHKey.tsx
@@ -71,14 +71,14 @@ const AuthorizedSSHKey: FC<AuthorizedSSHKeyProps> = ({ authorizedSSHKey, namespa
 
       if (
         secretOption === SecretSelectionOption.none &&
-        sshDetails.secretOption !== SecretSelectionOption.none
+        sshDetails?.secretOption !== SecretSelectionOption.none
       ) {
         setVM(removeSecretToVM(vm));
       }
 
       if (
         secretOption === SecretSelectionOption.useExisting &&
-        sshDetails.sshSecretName !== sshSecretName &&
+        sshDetails?.sshSecretName !== sshSecretName &&
         !isEmpty(sshSecretName)
       ) {
         setVM(addSecretToVM(vm, sshSecretName));


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

when `sshDetails` is `null`, the catalog drawer crash.

## 🎥 Demo

**Before**

![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/7c01124c-2294-495b-8c17-11cc05a083ca)


**After**

![Screenshot from 2024-02-20 13-40-14](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/c89574a7-1aac-4cd5-a848-140cca6856e3)

