### PR TITLE
CNV-32929: Correct resource badge for user-created VM InstanceTypes in Add boot volume modal

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/InstanceTypeDrilldownSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/InstanceTypeDrilldownSelect.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useCallback, useMemo, useState } from 'react';
 
-import useClusterInstanceTypes from '@catalog/CreateFromInstanceTypes/state/hooks/useClusterInstanceTypes';
+import useInstanceTypesAndPreferences from '@catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypesAndPreferences';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup, PopoverPosition } from '@patternfly/react-core';
@@ -25,8 +25,8 @@ export const InstanceTypeDrilldownSelect: FC<InstanceTypeMenuItemsProps> = ({
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  const [instanceTypes] = useClusterInstanceTypes();
-  const menuItems = useMemo(() => getInstanceTypeMenuItems(instanceTypes), [instanceTypes]);
+  const { allInstanceTypes } = useInstanceTypesAndPreferences();
+  const menuItems = useMemo(() => getInstanceTypeMenuItems(allInstanceTypes), [allInstanceTypes]);
 
   const onSelect = useCallback(
     (value: string) => {
@@ -64,7 +64,7 @@ export const InstanceTypeDrilldownSelect: FC<InstanceTypeMenuItemsProps> = ({
         </DrilldownMenuItem>
         <DrilldownMenuItem {...menuItems.userProvided}>
           <UserInstanceTypeMenu
-            items={menuItems.userProvided.items}
+            allInstanceTypes={allInstanceTypes}
             selected={selected}
             setSelected={onSelect}
           />

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/components/UserInstanceTypeMenu/UserInstanceTypeMenu.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/components/UserInstanceTypeMenu/UserInstanceTypeMenu.tsx
@@ -1,36 +1,47 @@
 import React, { Dispatch, FC, SetStateAction, useMemo, useState } from 'react';
 
+import { InstanceTypes } from '@catalog/CreateFromInstanceTypes/state/utils/types';
+import { VirtualMachineInstancetypeModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { isRedHatInstanceType } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VirtualMachineClusterInstancetypeModelGroupVersionKind } from '@kubevirt-utils/models';
+import { getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ResourceIcon } from '@openshift-console/dynamic-plugin-sdk';
 import { MenuItem, MenuSearch, MenuSearchInput, SearchInput } from '@patternfly/react-core';
 
 type UserInstanceTypeMenuProps = {
-  items: string[];
+  allInstanceTypes: InstanceTypes;
   selected: string;
   setSelected: Dispatch<SetStateAction<string>>;
 };
 
-const UserInstanceTypeMenu: FC<UserInstanceTypeMenuProps> = ({ items, selected, setSelected }) => {
+const UserInstanceTypeMenu: FC<UserInstanceTypeMenuProps> = ({
+  allInstanceTypes,
+  selected,
+  setSelected,
+}) => {
   const { t } = useKubevirtTranslation();
 
   const [searchInput, setSearchInput] = useState('');
 
+  const userCreatedInstanceTypes = allInstanceTypes.filter((it) => !isRedHatInstanceType(it));
+
   const filteredItems = useMemo(
     () =>
-      items.filter(
-        (opt) =>
-          isEmpty(searchInput) || opt.toLowerCase().includes(searchInput.toString().toLowerCase()),
+      userCreatedInstanceTypes.filter(
+        (it) =>
+          isEmpty(searchInput) ||
+          getName(it).toLowerCase().includes(searchInput.toString().toLowerCase()),
       ),
-    [items, searchInput],
+    [userCreatedInstanceTypes, searchInput],
   );
 
   if (isEmpty(filteredItems)) return <MenuItem isDisabled>{t('No results found')}</MenuItem>;
 
   return (
     <>
-      {items.length > 5 && (
+      {filteredItems.length > 5 && (
         <MenuSearch>
           <MenuSearchInput>
             <SearchInput
@@ -42,21 +53,28 @@ const UserInstanceTypeMenu: FC<UserInstanceTypeMenuProps> = ({ items, selected, 
           </MenuSearchInput>
         </MenuSearch>
       )}
-      {filteredItems.map((userITName) => (
-        <MenuItem
-          icon={
-            <ResourceIcon
-              groupVersionKind={VirtualMachineClusterInstancetypeModelGroupVersionKind}
-            />
-          }
-          isSelected={selected === userITName}
-          itemId={userITName}
-          key={userITName}
-          onClick={() => setSelected(userITName)}
-        >
-          {userITName}
-        </MenuItem>
-      ))}
+      {filteredItems.map((it) => {
+        const itName = getName(it);
+        return (
+          <MenuItem
+            icon={
+              <ResourceIcon
+                groupVersionKind={
+                  it?.kind === 'VirtualMachineClusterInstancetype'
+                    ? VirtualMachineClusterInstancetypeModelGroupVersionKind
+                    : VirtualMachineInstancetypeModelGroupVersionKind
+                }
+              />
+            }
+            isSelected={selected === itName}
+            itemId={itName}
+            key={itName}
+            onClick={() => setSelected(itName)}
+          >
+            {itName}
+          </MenuItem>
+        );
+      })}
     </>
   );
 };


### PR DESCRIPTION
## 📝 Description

A side effect from https://github.com/kubevirt-ui/kubevirt-plugin/pull/1803 caused user-created VM InstanceTypes to be displayed in the Add boot volume modal, but the resource badge used is for `VirtualMachineClusterInstanceTypes`. This PR corrects that behavior and directly fixes the issue created by the side effect to ensure a regression doesn't happen in the future.

Jira: https://issues.redhat.com/browse/CNV-32929

## 🎥 Screenshots

### Before
![show-user-created-vm-its-add-volume-modal-BEFORE-2024-02-20_12-05](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/8d4f14a4-3774-40cc-85d1-d9e49df7b225)

### After
![show-user-created-vm-its-add-volume-modal-AFTER-2024-02-20_12-02](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/4a953c97-bfc1-4589-afa2-96a75f6b9cd0)
