### PR TITLE
CNV-38360: Fix NIC hot-unplug alert message

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -388,7 +388,7 @@
   "Delete VirtualMachineInstancetype?": "Delete VirtualMachineInstancetype?",
   "Delete VirtualMachinePreference?": "Delete VirtualMachinePreference?",
   "Delete VirtualMachineSnapshot?": "Delete VirtualMachineSnapshot?",
-  "Deleting a network interface is supported only on VirtualMachines that were created in versions greater than 4.13 or for network interfaces that were added to the VirtualMachine in these versions.": "Deleting a network interface is supported only on VirtualMachines that were created in versions greater than 4.13 or for network interfaces that were added to the VirtualMachine in these versions.",
+  "Deleting a network interface is supported only on VirtualMachines that were created in versions greater than 4.13.": "Deleting a network interface is supported only on VirtualMachines that were created in versions greater than 4.13.",
   "Deprecated": "Deprecated",
   "Descheduler": "Descheduler",
   "Descheduler settings": "Descheduler settings",

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceActions.tsx
@@ -39,6 +39,8 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
   const editBtnText = t('Edit');
   const deleteBtnText = t('Delete');
 
+  const isHotPlugNIC = Boolean(nicPresentation?.iface?.bridge);
+
   const onEditModalOpen = () => {
     createModal(({ isOpen, onClose }) => (
       <VirtualMachinesEditNetworkInterfaceModal
@@ -62,10 +64,10 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
         submitBtnVariant={ButtonVariant.danger}
       >
         <span>
-          {isRunning(vm) && (
+          {isRunning(vm) && isHotPlugNIC && (
             <Alert
               title={t(
-                'Deleting a network interface is supported only on VirtualMachines that were created in versions greater than 4.13 or for network interfaces that were added to the VirtualMachine in these versions.',
+                'Deleting a network interface is supported only on VirtualMachines that were created in versions greater than 4.13.',
               )}
               component={'h6'}
               isInline


### PR DESCRIPTION
## 📝 Description

This PR fixes the alert message shown when a NIC is deleted as well as the logic dictating when the alert is shown. The alert is to be shown only when a hot-plug NIC is being deleted while the VM is running.

Jira: https://issues.redhat.com/browse/CNV-38360

## 🎥 Screenshots

### Before

#### Hot-plug NIC
![fix-nic-unplug-message--hot-plug-nic--BEFORE-2024-02-20_22-09](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/da68bdad-0c26-4285-997e-60253be3a2d4)


#### Def
![fix-nic-unplug-message--default-nic--BEFORE-2024-02-20_22-10](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/5f3f6ae0-1fc6-46ff-9eb5-cdf62a1428d9)
ault NIC


### After

#### Ho
![fix-nic-unplug-message--hot-plug-nic--AFTER-2024-02-20_22-00](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/6400c147-17e3-45d2-9956-9a3f56e6b1f7)
t-plug NIC


#### Default NIC
![fix-nic-unplug-message--default-nic--AFTER-2024-02-20_22-00](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/d0d0d644-4188-4033-aecb-a44ad3850dde)
