### PR TITLE
CNV-38577: Fix initial load of serial console

### DIFF
--- a/src/utils/resources/vmi/utils/pod.ts
+++ b/src/utils/resources/vmi/utils/pod.ts
@@ -1,3 +1,4 @@
+import { IoK8sApiCoreV1Pod } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -19,7 +20,7 @@ export const isPodReady = (pod): boolean =>
  * @param {K8sResourceCommon[]} pods - The pods to check
  * @returns {*}
  */
-export const getVMIPod = (vmi: V1VirtualMachineInstance, pods: K8sResourceCommon[]) => {
+export const getVMIPod = (vmi: V1VirtualMachineInstance, pods: IoK8sApiCoreV1Pod[]) => {
   if (!pods || !vmi) {
     return null;
   }

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/GuestSystemLogsAccess/GuestSystemLogsAccess.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/GuestSystemLogsAccess/GuestSystemLogsAccess.tsx
@@ -39,7 +39,10 @@ const GuestSystemLogsAccess: FC<GuestSystemLogsAccessProps> = ({
   const [error, setError] = useState<Error>(null);
   const [isChecked, setIsChecked] = useState<boolean>();
 
-  useEffect(() => setIsChecked(!disableSerialConsoleLog), [disableSerialConsoleLog]);
+  useEffect(() => {
+    guestSystemLogsAccessToggle(!!disableSerialConsoleLog);
+    setIsChecked(!disableSerialConsoleLog);
+  }, [disableSerialConsoleLog, guestSystemLogsAccessToggle]);
 
   const onChange = async (checked: boolean) => {
     try {

--- a/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineLogViewer.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineLogViewer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { V1Devices } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { getChangedGuestSystemAccessLog } from '@kubevirt-utils/components/PendingChanges/utils/helpers';
 import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
@@ -15,29 +16,42 @@ import VirtualMachineBasicLogViewer from './VirtualMachineBasicLogViewer/Virtual
 
 const VirtualMachineLogViewer = ({ connect, vm }) => {
   const { t } = useKubevirtTranslation();
-  const { pods, vmi } = useVMIAndPodsForVM(vm?.metadata?.name, vm?.metadata?.namespace);
+  const { loaded, pods, vmi } = useVMIAndPodsForVM(vm?.metadata?.name, vm?.metadata?.namespace);
   const pod = getVMIPod(vmi, pods);
   const { featureEnabled: isClusterDisabledGuestSystemLogs } = useFeatures(
     DISABLED_GUEST_SYSTEM_LOGS_ACCESS,
   );
+
   const isDisabledAtVM =
     (getDevices(vm) as V1Devices & { logSerialConsole: boolean })?.logSerialConsole === false &&
     !isClusterDisabledGuestSystemLogs;
 
   const isNeededRestart = getChangedGuestSystemAccessLog(vm, vmi);
 
-  const { data } = useVirtualMachineLogData({ connect, pod });
+  const isPodLogContainerExist = Boolean(
+    pod?.spec?.containers?.find((container) => container?.name === 'guest-console-log'),
+  );
+
+  const { data } = useVirtualMachineLogData({ connect: connect && isPodLogContainerExist, pod });
+
+  if (!loaded) {
+    return (
+      <Bullseye>
+        <Loading />
+      </Bullseye>
+    );
+  }
 
   if (!isRunning(vm)) {
     return <Bullseye>{t('Virtual machine is not running')}</Bullseye>;
   }
 
-  if (isNeededRestart) {
-    return <Bullseye>{t('Guest system logs not ready. Restart required')}</Bullseye>;
-  }
-
   if (isClusterDisabledGuestSystemLogs) {
     return <Bullseye>{t('Guest system logs are disabled at cluster')}</Bullseye>;
+  }
+
+  if (isNeededRestart || !isPodLogContainerExist) {
+    return <Bullseye>{t('Guest system logs not ready. Restart required')}</Bullseye>;
   }
 
   if (isDisabledAtVM) {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The initial setting of the serial console wasn't loaded into the features config map.
More checks were added to tell if the VM needs to restart after enabling the setting in cluster scope.

## 🎥 Demo

Before:
as can be seen in the photos in the bug report https://issues.redhat.com/browse/CNV-38577

After:
![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/14824964/8083e4f0-983c-4331-aed1-532caae87f46)
