### PR TITLE
CNV-38819: Update CPU usage metric name

### DIFF
--- a/src/utils/components/Charts/utils/queries.ts
+++ b/src/utils/components/Charts/utils/queries.ts
@@ -39,7 +39,7 @@ export const getUtilizationQueries: GetUtilizationQueries = ({
   const { name, namespace } = obj?.metadata || {};
   return {
     [VMQueries.CPU_REQUESTED]: `sum(kube_pod_resource_request{resource='cpu',pod='${launcherPodName}',namespace='${namespace}'}) BY (name, namespace)`,
-    [VMQueries.CPU_USAGE]: `sum(rate(kubevirt_vmi_cpu_usage_seconds{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
+    [VMQueries.CPU_USAGE]: `sum(rate(kubevirt_vmi_cpu_usage_seconds_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
     [VMQueries.FILESYSTEM_READ_USAGE]: `sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
     [VMQueries.FILESYSTEM_USAGE_TOTAL]: `sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total{name='${name}',namespace='${namespace}'}[${duration}]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
     [VMQueries.FILESYSTEM_WRITE_USAGE]: `sum(rate(kubevirt_vmi_storage_write_traffic_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,

--- a/src/views/clusteroverview/TopConsumersTab/utils/queries.ts
+++ b/src/views/clusteroverview/TopConsumersTab/utils/queries.ts
@@ -4,7 +4,7 @@ import { TopConsumerScope as Scope } from './topConsumerScope';
 const topConsumerQueries = {
   [Scope.NODE.getValue()]: {
     [Metric.CPU.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_cpu_usage_seconds[${duration}])) by (node))) > 0`,
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_cpu_usage_seconds_total[${duration}])) by (node))) > 0`,
     [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow) =>
       `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_swap_in_traffic_bytes_total + kubevirt_vmi_memory_swap_out_traffic_bytes_total) by (node))) > 0`,
     [Metric.MEMORY.getValue()]: (numItemsToShow) =>
@@ -18,7 +18,7 @@ const topConsumerQueries = {
   },
   [Scope.PROJECT.getValue()]: {
     [Metric.CPU.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_cpu_usage_seconds[${duration}])) by (namespace))) > 0`,
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_cpu_usage_seconds_total[${duration}])) by (namespace))) > 0`,
     [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow) =>
       `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_swap_in_traffic_bytes_total + kubevirt_vmi_memory_swap_out_traffic_bytes_total) by (namespace))) > 0`,
     [Metric.MEMORY.getValue()]: (numItemsToShow) =>
@@ -32,7 +32,7 @@ const topConsumerQueries = {
   },
   [Scope.VM.getValue()]: {
     [Metric.CPU.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_cpu_usage_seconds[${duration}])) BY (name, namespace)))`,
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_cpu_usage_seconds_total[${duration}])) BY (name, namespace)))`,
     [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow, duration) =>
       `sort_desc(topk (${numItemsToShow}, sum(rate(kubevirt_vmi_memory_swap_in_traffic_bytes_total[${duration}]) + rate(kubevirt_vmi_memory_swap_out_traffic_bytes_total[${duration}]))by(name, namespace))) > 0`,
     [Metric.MEMORY.getValue()]: (numItemsToShow) =>


### PR DESCRIPTION
## 📝 Description

The `kubevirt_vmi_cpu_usage_seconds` metric was updated to `kubevirt_vmi_cpu_usage_seconds_total` in 4.14. This PR updates the UI to match.

jira: https://issues.redhat.com//browse/CNV-38819

## 🎥 Screenshots

### Before

#### VM Overview
![4 14-update-cpu-metric-name-vm-overview-BEFORE-2024-02-29_06-25](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/f3c76994-abb2-4870-919e-01a5d3a5c72d)


#### Top Consumers
![4 14-update-cpu-metric-name-top-consumers-BEFORE-2024-02-29_06-24](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/8647482e-cd90-4a5e-9805-e94ca4786303)



### After

#### VM Overview
![4 14-update-cpu-metric-name-2024-02-29_06-14](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/68ee2900-7470-43d1-a9bb-02982b906001)

#### Top Consumers
![4 14-update-cpu-metric-name-top-consumer-2024-02-29_06-15](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/e747e8a6-427f-475b-aa17-d1adcacade03)