### PR TITLE
WIP: CNV-38608: Show Migrations tab for non-admin users

### DIFF
--- a/src/views/clusteroverview/ClusterOverviewPage.tsx
+++ b/src/views/clusteroverview/ClusterOverviewPage.tsx
@@ -26,11 +26,6 @@ const ClusterOverviewPage: FC = () => {
         href: 'top-consumers',
         name: t('Top consumers'),
       },
-      {
-        component: MigrationsTab,
-        href: 'migrations',
-        name: t('Migrations'),
-      },
     ];
 
     return [
@@ -40,6 +35,11 @@ const ClusterOverviewPage: FC = () => {
         name: t('Overview'),
       },
       ...(isAdmin ? [...adminPages] : []),
+      {
+        component: MigrationsTab,
+        href: 'migrations',
+        name: t('Migrations'),
+      },
       {
         component: SettingsTab,
         href: 'settings',


### PR DESCRIPTION
## 📝 Description

This PR makes the Migrations tab available to non-admin users.

jira: https://issues.redhat.com/browse/CNV-38608

## 🎥 Screenshots

### Before
![migrations-tab-unavailable-to-nonadmin-BEFORE-2024-03-02_21-47](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/ce97d91c-1291-40ba-be0a-a74e55b132b5)

### After
![migrations-tab-unavailable-to-nonadmin-AFTER-2024-03-02_21-25](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/2afa63a2-c6f0-4efa-a20d-2b4ceaf6ddd5)