### PR TITLE
CNV-38842: Create VM from upload file does not work

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/Sources/UploadSource.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/Sources/UploadSource.tsx
@@ -51,6 +51,7 @@ const UploadSource: FC<UploadSourceProps> = ({ onFileSelected, relevantUpload, t
                   onChange({ value: data });
                 }}
                 onFileInputChange={(event: DropEvent, file: File) => {
+                  onFileSelected(file);
                   onChange({ filename: file.name });
                 }}
                 onTextChange={(event: ChangeEvent, text: string) => {

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
@@ -129,6 +129,7 @@ const useCreateDrawerForm = (
           uploadFiles({
             cdFile,
             diskFile,
+            namespace,
             updateTabsData,
             uploadCDData,
             uploadDiskData,
@@ -162,6 +163,7 @@ const useCreateDrawerForm = (
       const vmObject = await uploadFiles({
         cdFile,
         diskFile,
+        namespace,
         updateTabsData,
         uploadCDData,
         uploadDiskData,

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/utils.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/utils.ts
@@ -11,7 +11,7 @@ import {
   DEFAULT_CDROM_DISK_SIZE,
   DEFAULT_DISK_SIZE,
 } from '@kubevirt-utils/components/DiskModal/state/initialState';
-import { DEFAULT_NAMESPACE, ROOTDISK } from '@kubevirt-utils/constants/constants';
+import { ROOTDISK } from '@kubevirt-utils/constants/constants';
 import { UploadDataProps } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
 import {
   getTemplateParameterValue,
@@ -112,21 +112,18 @@ export const getUploadDataVolume = (
   },
 });
 
-export const uploadFile = async (
+const uploadFile = async (
   vm: V1VirtualMachine,
   file: File | string,
   uploadData: (data: UploadDataProps) => Promise<void>,
   storage: string,
   dataVolumeName: string,
+  namespace: string,
   updateTabsData?: Updater<TabsData>,
 ): Promise<V1Volume | void> => {
   if (!storage || !file) return Promise.resolve();
 
-  const uploadDV = getUploadDataVolume(
-    dataVolumeName,
-    vm.metadata.namespace || DEFAULT_NAMESPACE,
-    storage,
-  );
+  const uploadDV = getUploadDataVolume(dataVolumeName, namespace, storage);
 
   await uploadData({ dataVolume: uploadDV, file: file as File });
 
@@ -162,6 +159,7 @@ const replaceVolume = (vm: V1VirtualMachine, oldDVName: string, volume: V1Volume
 type UploadFiles = (input: {
   cdFile?: File | string;
   diskFile?: File | string;
+  namespace: string;
   updateTabsData?: Updater<TabsData>;
   uploadCDData: ({ dataVolume, file }: UploadDataProps) => Promise<void>;
   uploadDiskData: ({ dataVolume, file }: UploadDataProps) => Promise<void>;
@@ -171,6 +169,7 @@ type UploadFiles = (input: {
 export const uploadFiles: UploadFiles = ({
   cdFile,
   diskFile,
+  namespace,
   updateTabsData,
   uploadCDData,
   uploadDiskData,
@@ -192,6 +191,7 @@ export const uploadFiles: UploadFiles = ({
       uploadDiskData,
       dataVolumeTemplate?.spec?.storage?.resources?.requests?.storage || DEFAULT_DISK_SIZE,
       diskDVName,
+      namespace,
       updateTabsData,
     ),
     uploadFile(
@@ -200,6 +200,7 @@ export const uploadFiles: UploadFiles = ({
       uploadCDData,
       cdDataVolumeTemplate?.spec?.storage?.resources?.requests?.storage || DEFAULT_CDROM_DISK_SIZE,
       cdDVName,
+      namespace,
       updateTabsData,
     ),
   ]).then(([newDiskVolume, newCDVolume]) => {


### PR DESCRIPTION
## 📝 Description

File was needed to be set in `onFileInputChange` property and when uploading a file from create VM flow, we upload the disk before the proccessed template's VM is getting populated with a namespace.

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/07acf543-ea54-4422-a01d-58a7d0576d5e

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/2266f98c-c24c-4de5-b328-289ded248050



