### PR TITLE
CNV-38883: Update the link to Activation key doc

### DIFF
--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/utils/constants.ts
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/utils/constants.ts
@@ -1,6 +1,6 @@
 export const ACTIVATION_KEYS_URL = 'https://console.redhat.com/settings/connector/activation-keys';
 export const ACTIVATION_KEYS_DOCUMENTATION_URL =
-  'https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/remote_host_configuration_and_management/activation-keys';
+  'https://access.redhat.com/documentation/en-us/red_hat_insights/1-latest/html/remote_host_configuration_and_management/activation-keys_intro-rhc';
 export const REDHAT_CONSOLE_URL = 'https://console.redhat.com/';
 
 export const AUTOMATIC_UPDATE_FEATURE_NAME = 'auto-update-rhel-vms';


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-38883

Fix the broken _Read more_ link to the documentation about activation key for automatic subscription of RHEL VirtualMachines. Use the newer working link:
https://access.redhat.com/documentation/en-us/red_hat_insights/1-latest/html/remote_host_configuration_and_management/activation-keys_intro-rhc

## 🎥 Screenshots
Clicking on Read more:
![read](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/1e2b7163-87da-4682-a9a6-42f2ea453b33)

**Before:**
![read_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/fd0fc62d-755b-463e-aba7-65cefd19679d)

**After:**
![read_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/fe977f6a-9aa5-49e1-b99e-261594880010)


