### PR TITLE
Show selected project in Manage SSH keys section

### DIFF
--- a/src/utils/components/FilterSelect/InlineFilterSelect.tsx
+++ b/src/utils/components/FilterSelect/InlineFilterSelect.tsx
@@ -143,15 +143,7 @@ const InlineFilterSelect: FC<InlineFilterSelectProps> = ({
               value={option.value}
               {...option}
             >
-              {!isEmpty(option.groupVersionKind) ? (
-                <ResourceLink
-                  groupVersionKind={option.groupVersionKind}
-                  linkTo={false}
-                  name={option.value}
-                />
-              ) : (
-                option.children
-              )}
+              {getOptionComponent(option)}
             </SelectOption>
           );
         })}

--- a/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/components/SSHAuthKeyRow/SSHAuthKeyRow.tsx
+++ b/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/components/SSHAuthKeyRow/SSHAuthKeyRow.tsx
@@ -78,7 +78,7 @@ const SSHAuthKeyRow: FC<SSHAuthKeyRowProps> = ({
       <GridItem className="ssh-auth-row__project-name" span={5}>
         {isEmpty(secretName) ? (
           <InlineFilterSelect
-            options={selectableProjects?.map((opt) => ({
+            options={selectableProjects?.sort().map((opt) => ({
               children: opt,
               groupVersionKind: modelToGroupVersionKind(ProjectModel),
               value: opt,

--- a/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/hooks/useSSHAuthProjects.ts
+++ b/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/hooks/useSSHAuthProjects.ts
@@ -34,7 +34,7 @@ const useSSHAuthProjects: UseSSHAuthProjects = (authKeyRows) => {
   const selectedProjects = useMemo(
     () =>
       authKeyRows.reduce((acc, row) => {
-        !isEmpty(row.projectName) && acc.push(row.projectName);
+        !isEmpty(row.projectName) && !isEmpty(row.secretName) && acc.push(row.projectName);
         return acc;
       }, []) || [],
     [authKeyRows],


### PR DESCRIPTION
## 📝 Description

Once a project is selected, it couldn't be selected again as each project can have only one secret.
We should check if a project has a secret name attached to it, before eliminating him from the select list.
## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/6cc41971-22a8-4194-8a3d-a5f907c6e0c9

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/74919f1e-dd87-45a0-98ec-5bddc3e72fcd




