### PR TITLE
CNV-33541: Removing spec.template.spec.domain.devices.disks from VM definition leads to "Pending Changes" message

### DIFF
--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -48,7 +48,7 @@ import {
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { isPendingHotPlugNIC } from '@virtualmachines/details/tabs/configuration/network/utils/utils';
 
-import { getBootloader } from '../../../resources/vm/utils/selectors';
+import { getBootloader, getDisks } from '../../../resources/vm/utils/selectors';
 
 import { PendingChange } from './types';
 
@@ -72,7 +72,7 @@ export const checkBootOrderChanged = (
   vm: V1VirtualMachine,
   vmi: V1VirtualMachineInstance,
 ): boolean => {
-  if (isEmpty(vm) || isEmpty(vmi)) {
+  if (isEmpty(vm) || isEmpty(vmi) || isEmpty(getDisks(vm))) {
     return false;
   }
 


### PR DESCRIPTION
## 📝 Description

VirtualMachine API doesn't require disks to be populated and can automatically populate based on the volumes provided.
Hence when removing the disks section, it wouldn't change the boot order and we can remove the pending changes alert.

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/caa4cb28-8b38-49a6-9c1f-6bd454fa49c0

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/99dfb76b-5da2-4773-b07a-11a9bc92ce61


