### PR TITLE
CNV-27329: Cover more flows of disk based VM creation

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -109,7 +109,7 @@ export const generateVM = (
                   },
                 }),
             storage: {
-              resources: { requests: { storage: pvcSource?.spec?.resources?.requests?.storage } },
+              resources: {},
               storageClassName:
                 instanceTypeState.selectedStorageClass || pvcSource?.spec?.storageClassName,
             },
@@ -136,25 +136,8 @@ export const generateVM = (
         },
         spec: {
           domain: {
-            devices: {
-              disks: [
-                {
-                  disk: {
-                    bus: 'virtio',
-                  },
-                  name: ROOTDISK,
-                },
-                {
-                  disk: {
-                    bus: 'virtio',
-                  },
-                  name: 'cloudinitdisk',
-                },
-              ],
-              interfaces: [{ masquerade: {}, name: 'default' }],
-            },
+            devices: {},
           },
-          networks: [{ name: 'default', pod: {} }],
           subdomain: HEADLESS_SERVICE_NAME,
           volumes: [
             {


### PR DESCRIPTION
## 📝 Description

Removing `spec.template.spec.domain.devices`, `spec.dataVolumeTemplates.spec.storage.resources` , and `spec.template.spec.networks` sections as they are auto populated by the BE.

## 🎥 Demo

After: (fedora YAML)

```
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  name: fedora-ivory-donkey-88
  namespace: default
spec:
  dataVolumeTemplates:
    - metadata:
        name: fedora-ivory-donkey-88-volume
      spec:
        sourceRef:
          kind: DataSource
          name: fedora
          namespace: openshift-virtualization-os-images
        storage:
          resources: {}
          storageClassName: hostpath-csi-basic
  instancetype:
    kind: VirtualMachineClusterInstancetype
    name: u1.medium
  preference:
    name: fedora
  running: true
  template:
    metadata:
      labels:
        app.kubernetes.io/name: headless
    spec:
      domain:
        devices: {}
      subdomain: headless
      volumes:
        - dataVolume:
            name: fedora-ivory-donkey-88-volume
          name: rootdisk
        - cloudInitNoCloud:
            userData: |
              #cloud-config
              chpasswd:
                expire: false
              password: fuc3-uyhm-n8fu
              user: fedora
          name: cloudinitdisk

```

Extra info:
https://redhat-internal.slack.com/archives/C04D5S20YP6/p1709654859391969 