### PR TITLE
CNV-39030: point to controller revision IT and pref

### DIFF
--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
@@ -162,7 +162,7 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
                 <VirtualMachineDescriptionItem
                   data-test-id="virtual-machine-overview-details-timezone"
                   descriptionData={guestAgentData?.timezone?.split(',')[0] || NO_DATA_DASH}
-                  descriptionHeader={t('Hostname')}
+                  descriptionHeader={t('Time zone')}
                 />
                 {getInstanceTypeMatcher(vm) ? (
                   <InstanceTypeDescription vm={vm} />
@@ -172,7 +172,7 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
                 <VirtualMachineDescriptionItem
                   data-test-id="virtual-machine-overview-details-host"
                   descriptionData={hostname ?? fallback}
-                  descriptionHeader={t('Time zone')}
+                  descriptionHeader={t('Hostname')}
                 />
                 <VirtualMachineDescriptionItem
                   bodyContent={t(

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/InstanceTypeDescription.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/InstanceTypeDescription.tsx
@@ -1,9 +1,6 @@
 import React, { FC } from 'react';
 
-import {
-  modelToGroupVersionKind,
-  VirtualMachineClusterPreferenceModelGroupVersionKind,
-} from '@kubevirt-ui/kubevirt-api/console';
+import { ControllerRevisionModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineInstancetypeModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstancetypeModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
@@ -33,8 +30,8 @@ const InstanceTypeDescription: FC<InstanceTypeDescriptionProps> = ({ vm }) => {
         descriptionData={
           itMatcher ? (
             <ResourceLink
-              groupVersionKind={modelToGroupVersionKind(itModel)}
-              name={itMatcher.name}
+              groupVersionKind={ControllerRevisionModelGroupVersionKind}
+              name={itMatcher.revisionName}
               namespace={includeNamespace && getNamespace(vm)}
             />
           ) : (
@@ -48,8 +45,8 @@ const InstanceTypeDescription: FC<InstanceTypeDescriptionProps> = ({ vm }) => {
         descriptionData={
           preferenceMatcher ? (
             <ResourceLink
-              groupVersionKind={VirtualMachineClusterPreferenceModelGroupVersionKind}
-              name={preferenceMatcher.name}
+              groupVersionKind={ControllerRevisionModelGroupVersionKind}
+              name={preferenceMatcher.revisionName}
             />
           ) : (
             None


### PR DESCRIPTION
## 📝 Description

When creating a VM we point to the original resource and not the cloned one in the ControllerRevision.
There's also a mix in Timezone and Hostname.

## 🎥 Demo

After:

![point-to-controller-revision](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/d2fa0557-7313-4268-bb73-6983e73bbf29)
