### PR TITLE
CNV-38295: fix PF5 regression

### DIFF
--- a/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.scss
+++ b/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.scss
@@ -1,3 +1,7 @@
 #ssh-using-virtctl--example {
   margin-left: calc(var(--pf-global--spacer--lg) * -1);
 }
+
+.virtctl-popover {
+  min-width: 585px !important;
+}

--- a/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.tsx
+++ b/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from 'react';
-import classnames from 'classnames';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getConsoleVirtctlCommand } from '@kubevirt-utils/components/SSHAccess/utils';
@@ -38,24 +37,21 @@ const ConsoleOverVirtctl: FC<ConsoleOverVirtctlProps> = ({ vm }) => {
               </div>
               <br />
               <Grid>
-                <GridItem span={3}>{t('Example: ')}</GridItem>
-                <GridItem id="ssh-using-virtctl--example" span={9}>
+                <GridItem span={2}>{t('Example: ')}</GridItem>
+                <GridItem id="ssh-using-virtctl--example" span={10}>
                   {getConsoleVirtctlCommand(vm)}
                 </GridItem>
               </Grid>
             </>
           }
-          aria-label={'Help'}
-          minWidth="585px" // FIX
+          aria-label="Help"
+          className="virtctl-popover"
           position="right"
         >
           <HelpIcon />
         </Popover>
       </DescriptionListTerm>
-
-      <DescriptionListDescription
-        className={classnames('pf-c-description-list__description', 'sshcommand-body')}
-      >
+      <DescriptionListDescription className="pf-c-description-list__description">
         <VirtctlSSHCommandClipboardCopy vm={vm} />
       </DescriptionListDescription>
     </DescriptionListGroup>


### PR DESCRIPTION
## 📝 Description

To apply specific min-width in a popover we need to enforce `!important` due to this change: https://github.com/openshift/console/blob/00e15520c97e200b53cd1850b5f534063292b7dc/frontend/public/style/_overrides.scss#L404 

## 🎥 Demo

Before:
![ssh-popover-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/d6bdabe3-509b-47eb-ad56-12a3a16550c1)

After:
![ssh-popover](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/0eacf837-7e3c-474c-905e-5184aa323ecc)

