### PR TITLE
CNV-39028: UI generated VirtualMachine provides an instance type kind when one isn't required

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -1,4 +1,3 @@
-import { VirtualMachineClusterInstancetypeModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import DataSourceModel from '@kubevirt-ui/kubevirt-api/console/models/DataSourceModel';
 import VirtualMachineInstancetypeModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstancetypeModel';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
@@ -117,9 +116,9 @@ export const generateVM = (
         },
       ],
       instancetype: {
-        kind: instanceTypeState?.selectedInstanceType?.namespace
-          ? VirtualMachineInstancetypeModel.kind
-          : VirtualMachineClusterInstancetypeModelGroupVersionKind?.kind,
+        ...(instanceTypeState?.selectedInstanceType?.namespace && {
+          kind: VirtualMachineInstancetypeModel.kind,
+        }),
         name:
           selectedInstanceType?.name ||
           selectedBootableVolume?.metadata?.labels?.[DEFAULT_INSTANCETYPE_LABEL],


### PR DESCRIPTION
## 📝 Description

Remove un-needed kind when selecting cluster instance type

## 🎥 Demo

Before:
![unneeded-kind-it-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/e0469f52-4780-4056-850d-bd6f4b7bfdea)

After:
![unneeded-kind-it](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/13605ddc-0a95-47bf-b8e6-a324b0ea8d57)

