### PR TITLE
 CNV-38902: Display MigrationPolicies page for nonprivileged user

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -530,9 +530,6 @@
     "type": "console.page/resource/details"
   },
   {
-    "flags": {
-      "required": ["CAN_LIST_NS"]
-    },
     "properties": {
       "dataAttributes": {
         "data-quickstart-id": "qs-nav-migrationpolicies",

--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1203,6 +1203,7 @@
   "To enable Quick create button, fill all the required parameters and storage fields": "To enable Quick create button, fill all the required parameters and storage fields",
   "To gain unlimited bandwidth, set to 0": "To gain unlimited bandwidth, set to 0",
   "To get started, install permissions and then run a checkup": "To get started, install permissions and then run a checkup",
+  "To perform this action you must get permission from your Organization Administrator.": "To perform this action you must get permission from your Organization Administrator.",
   "To see the vCPU metric, you must set the schedstats=enable kernel argument in the MachineConfig object.": "To see the vCPU metric, you must set the schedstats=enable kernel argument in the MachineConfig object.",
   "Today": "Today",
   "Tolerations": "Tolerations",

--- a/plugin-metadata.ts
+++ b/plugin-metadata.ts
@@ -1,12 +1,10 @@
 import { ConsolePluginBuildMetadata } from '@openshift-console/dynamic-plugin-sdk-webpack';
 
 const metadata: ConsolePluginBuildMetadata = {
-  name: 'kubevirt-plugin',
-  version: '0.0.0',
-  displayName: 'Kubevirt Plugin',
   dependencies: {
     '@console/pluginAPI': '*',
   },
+  displayName: 'Kubevirt Plugin',
   exposedModules: {
     BootableVolumesList: './views/bootablevolumes/list/BootableVolumesList.tsx',
     Catalog: './views/catalog/Catalog.tsx',
@@ -60,6 +58,8 @@ const metadata: ConsolePluginBuildMetadata = {
     VirtualMachineTemplatesList: './views/templates/list/VirtualMachineTemplatesList.tsx',
     yamlTemplates: 'src/templates/index.ts',
   },
+  name: 'kubevirt-plugin',
+  version: '0.0.0',
 };
 
 export default metadata;

--- a/src/utils/hooks/useMigrationPolicies.ts
+++ b/src/utils/hooks/useMigrationPolicies.ts
@@ -1,0 +1,12 @@
+import { MigrationPolicyModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { V1alpha1MigrationPolicy } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+const useMigrationPolicies = () =>
+  useK8sWatchResource<V1alpha1MigrationPolicy[]>({
+    groupVersionKind: MigrationPolicyModelGroupVersionKind,
+    isList: true,
+    namespaced: false,
+  });
+
+export default useMigrationPolicies;

--- a/src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData.ts
+++ b/src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData.ts
@@ -1,14 +1,13 @@
 import {
-  MigrationPolicyModelGroupVersionKind,
   VirtualMachineInstanceMigrationModelGroupVersionKind,
   VirtualMachineInstanceModelGroupVersionKind,
 } from '@kubevirt-ui/kubevirt-api/console';
 import {
-  V1alpha1MigrationPolicy,
   V1VirtualMachineInstance,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useMigrationPolicies from '@kubevirt-utils/hooks/useMigrationPolicies';
 import {
   OnFilterChange,
   RowFilter,
@@ -39,13 +38,6 @@ export type UseMigrationCardDataAndFiltersValues = {
 };
 
 type UseMigrationCardDataAndFilters = (duration: string) => UseMigrationCardDataAndFiltersValues;
-
-export const useMigrationPolicies = () =>
-  useK8sWatchResource<V1alpha1MigrationPolicy[]>({
-    groupVersionKind: MigrationPolicyModelGroupVersionKind,
-    isList: true,
-    namespaced: false,
-  });
 
 const useMigrationCardDataAndFilters: UseMigrationCardDataAndFilters = (duration: string) => {
   const migrationsDefaultConfigurations = useHCMigrations();

--- a/src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData.ts
+++ b/src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData.ts
@@ -40,6 +40,13 @@ export type UseMigrationCardDataAndFiltersValues = {
 
 type UseMigrationCardDataAndFilters = (duration: string) => UseMigrationCardDataAndFiltersValues;
 
+export const useMigrationPolicies = () =>
+  useK8sWatchResource<V1alpha1MigrationPolicy[]>({
+    groupVersionKind: MigrationPolicyModelGroupVersionKind,
+    isList: true,
+    namespaced: false,
+  });
+
 const useMigrationCardDataAndFilters: UseMigrationCardDataAndFilters = (duration: string) => {
   const migrationsDefaultConfigurations = useHCMigrations();
   const [activeNamespace] = useActiveNamespace();
@@ -59,10 +66,7 @@ const useMigrationCardDataAndFilters: UseMigrationCardDataAndFilters = (duration
     namespace,
   });
 
-  const [mps] = useK8sWatchResource<V1alpha1MigrationPolicy[]>({
-    groupVersionKind: MigrationPolicyModelGroupVersionKind,
-    isList: true,
-  });
+  const [mps] = useMigrationPolicies();
 
   const migrationsData = getMigrationsTableData(
     vmims,

--- a/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
+++ b/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
@@ -1,10 +1,10 @@
 import React, { FC } from 'react';
-import { useMigrationPolicies } from 'src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData';
 
 import { MigrationPolicyModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import { V1alpha1MigrationPolicy } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ListPageFilter from '@kubevirt-utils/components/ListPageFilter/ListPageFilter';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useMigrationPolicies from '@kubevirt-utils/hooks/useMigrationPolicies';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   ListPageBody,
@@ -47,18 +47,15 @@ const MigrationPoliciesList: FC = () => {
           loaded={loaded && loadedColumns}
           onFilterChange={onFilterChange}
         />
-        {isEmpty(mps) && <MigrationPoliciesEmptyState loadError={!loaded && loadError} />}
-        {loaded && (
-          <VirtualizedTable<V1alpha1MigrationPolicy>
-            columns={activeColumns}
-            data={data}
-            EmptyMsg={() => <></>}
-            loaded={loaded && loadedColumns}
-            loadError={loadError}
-            Row={MigrationPoliciesRow}
-            unfilteredData={unfilteredData}
-          />
-        )}
+        <VirtualizedTable<V1alpha1MigrationPolicy>
+          columns={activeColumns}
+          data={data}
+          EmptyMsg={() => <MigrationPoliciesEmptyState />}
+          loaded={loaded && loadedColumns}
+          loadError={loadError}
+          Row={MigrationPoliciesRow}
+          unfilteredData={unfilteredData}
+        />
       </ListPageBody>
     </>
   );

--- a/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
+++ b/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
@@ -1,9 +1,7 @@
 import React, { FC } from 'react';
+import { useMigrationPolicies } from 'src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData';
 
-import {
-  MigrationPolicyModelGroupVersionKind,
-  MigrationPolicyModelRef,
-} from '@kubevirt-ui/kubevirt-api/console';
+import { MigrationPolicyModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import { V1alpha1MigrationPolicy } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ListPageFilter from '@kubevirt-utils/components/ListPageFilter/ListPageFilter';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -11,7 +9,6 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   ListPageBody,
   ListPageHeader,
-  useK8sWatchResource,
   useListPageFilter,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
@@ -23,11 +20,7 @@ import useMigrationPoliciesListColumns from './hooks/useMigrationPoliciesListCol
 
 const MigrationPoliciesList: FC = () => {
   const { t } = useKubevirtTranslation();
-  const [mps, loaded, loadError] = useK8sWatchResource<V1alpha1MigrationPolicy[]>({
-    groupVersionKind: MigrationPolicyModelGroupVersionKind,
-    isList: true,
-    namespaced: false,
-  });
+  const [mps, loaded, loadError] = useMigrationPolicies();
 
   const [columns, activeColumns, loadedColumns] = useMigrationPoliciesListColumns();
   const [unfilteredData, data, onFilterChange] = useListPageFilter(mps);
@@ -54,16 +47,18 @@ const MigrationPoliciesList: FC = () => {
           loaded={loaded && loadedColumns}
           onFilterChange={onFilterChange}
         />
-        {loaded && isEmpty(mps) && <MigrationPoliciesEmptyState />}
-        <VirtualizedTable<V1alpha1MigrationPolicy>
-          columns={activeColumns}
-          data={data}
-          EmptyMsg={() => <></>}
-          loaded={loaded && loadedColumns}
-          loadError={loadError}
-          Row={MigrationPoliciesRow}
-          unfilteredData={unfilteredData}
-        />
+        {isEmpty(mps) && <MigrationPoliciesEmptyState loadError={!loaded && loadError} />}
+        {loaded && (
+          <VirtualizedTable<V1alpha1MigrationPolicy>
+            columns={activeColumns}
+            data={data}
+            EmptyMsg={() => <></>}
+            loaded={loaded && loadedColumns}
+            loadError={loadError}
+            Row={MigrationPoliciesRow}
+            unfilteredData={unfilteredData}
+          />
+        )}
       </ListPageBody>
     </>
   );

--- a/src/views/migrationpolicies/list/components/MigrationPoliciesCreateButton/MigrationPoliciesCreateButton.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPoliciesCreateButton/MigrationPoliciesCreateButton.tsx
@@ -2,8 +2,14 @@ import React, { FC } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { MigrationPolicyModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import MigrationPolicyModel from '@kubevirt-ui/kubevirt-api/console/models/MigrationPolicyModel';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { ListPageCreateDropdown } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  K8sVerb,
+  ListPageCreateDropdown,
+  useAccessReview,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { Button, Tooltip } from '@patternfly/react-core';
 
 import { createItems, migrationPoliciesPageBaseURL } from '../../utils/constants';
 
@@ -11,11 +17,29 @@ const MigrationPoliciesCreateButton: FC = () => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
 
+  const [canCreateMigrationPolicy] = useAccessReview({
+    group: MigrationPolicyModel.apiGroup,
+    resource: MigrationPolicyModel.plural,
+    verb: 'create' as K8sVerb,
+  });
+
   const onCreate = (type: string) => {
     return type === 'form'
       ? navigate(`${migrationPoliciesPageBaseURL}/form`)
       : navigate(`${migrationPoliciesPageBaseURL}/~new`);
   };
+
+  if (!canCreateMigrationPolicy) {
+    return (
+      <Tooltip
+        content={t(
+          'To perform this action you must get permission from your Organization Administrator.',
+        )}
+      >
+        <Button isAriaDisabled>{t('Create MigrationPolicy')}</Button>
+      </Tooltip>
+    );
+  }
 
   return (
     <ListPageCreateDropdown

--- a/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.scss
+++ b/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.scss
@@ -3,12 +3,3 @@
   height: 310px;
   padding: 40px;
 }
-
-.MigrationPoliciesEmptyState {
-  &__button {
-    .pf-v5-c-button.pf-m-primary {
-      color: var(--pf-v5-c-button--disabled--Color);
-      background-color: var(--pf-v5-c-button--disabled--BackgroundColor);
-    }
-  }
-}

--- a/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.scss
+++ b/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.scss
@@ -3,3 +3,12 @@
   height: 310px;
   padding: 40px;
 }
+
+.MigrationPoliciesEmptyState {
+  &__button {
+    .pf-v5-c-button.pf-m-primary {
+      color: var(--pf-v5-c-button--disabled--Color);
+      background-color: var(--pf-v5-c-button--disabled--BackgroundColor);
+    }
+  }
+}

--- a/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.tsx
@@ -5,6 +5,7 @@ import migrationPoliciesEmptyState from 'images/migrationPoliciesEmptyState.svg'
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
+  Button,
   EmptyState,
   EmptyStateActions,
   EmptyStateBody,
@@ -12,13 +13,21 @@ import {
   EmptyStateHeader,
   EmptyStateIcon,
   EmptyStateVariant,
+  Popover,
+  PopoverPosition,
 } from '@patternfly/react-core';
 
 import MigrationPoliciesCreateButton from '../MigrationPoliciesCreateButton/MigrationPoliciesCreateButton';
 
 import './MigrationPoliciesEmptyState.scss';
 
-const MigrationPoliciesEmptyState: FC = () => {
+export type MigrationPoliciesEmptyStateProps = {
+  loadError?: boolean;
+};
+
+const MigrationPoliciesEmptyState: FC<MigrationPoliciesEmptyStateProps> = ({
+  loadError = false,
+}) => {
   const { t } = useKubevirtTranslation();
 
   return (
@@ -39,6 +48,21 @@ const MigrationPoliciesEmptyState: FC = () => {
       </EmptyStateBody>
       <EmptyStateFooter>
         <EmptyStateActions>
+          {loadError && (
+            <Popover
+              bodyContent={() =>
+                t(
+                  'To perform this action you must get permission from your Organization Administrator.',
+                )
+              }
+              aria-label={'Help'}
+              position={PopoverPosition.right}
+            >
+              <div className="MigrationPoliciesEmptyState__button">
+                <Button>{t('Create MigrationPolicy')}</Button>
+              </div>
+            </Popover>
+          )}
           <MigrationPoliciesCreateButton />
         </EmptyStateActions>
         <EmptyStateActions>

--- a/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.tsx
@@ -5,7 +5,6 @@ import migrationPoliciesEmptyState from 'images/migrationPoliciesEmptyState.svg'
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
-  Button,
   EmptyState,
   EmptyStateActions,
   EmptyStateBody,
@@ -13,21 +12,11 @@ import {
   EmptyStateHeader,
   EmptyStateIcon,
   EmptyStateVariant,
-  Popover,
-  PopoverPosition,
 } from '@patternfly/react-core';
 
 import MigrationPoliciesCreateButton from '../MigrationPoliciesCreateButton/MigrationPoliciesCreateButton';
 
-import './MigrationPoliciesEmptyState.scss';
-
-export type MigrationPoliciesEmptyStateProps = {
-  loadError?: boolean;
-};
-
-const MigrationPoliciesEmptyState: FC<MigrationPoliciesEmptyStateProps> = ({
-  loadError = false,
-}) => {
+const MigrationPoliciesEmptyState: FC = () => {
   const { t } = useKubevirtTranslation();
 
   return (
@@ -48,21 +37,6 @@ const MigrationPoliciesEmptyState: FC<MigrationPoliciesEmptyStateProps> = ({
       </EmptyStateBody>
       <EmptyStateFooter>
         <EmptyStateActions>
-          {loadError && (
-            <Popover
-              bodyContent={() =>
-                t(
-                  'To perform this action you must get permission from your Organization Administrator.',
-                )
-              }
-              aria-label={'Help'}
-              position={PopoverPosition.right}
-            >
-              <div className="MigrationPoliciesEmptyState__button">
-                <Button>{t('Create MigrationPolicy')}</Button>
-              </div>
-            </Popover>
-          )}
           <MigrationPoliciesCreateButton />
         </EmptyStateActions>
         <EmptyStateActions>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-38902

Display the page also for the users without privileges to get a bit more familiar with the page, add popover for disabled _Create MigrationPolicy_ button to inform the user what to do to be able to see and create MigrationPolicies.

## 🎥 Screenshots
**Before:**
No MigrationPolicies menu item, nor the paqe displayed at all:
![mig_beforee](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/963609a3-9190-4119-ac14-24b24e35a081)

**After?:**
![mig_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/365ddea9-51db-4136-b0fe-d93b53bf5e67)

