### PR TITLE
Remove comma from DataSource actions dropdown

### DIFF
--- a/src/views/datasources/actions/DataSourceActions.tsx
+++ b/src/views/datasources/actions/DataSourceActions.tsx
@@ -73,7 +73,7 @@ const DataSourceActions: FC<DataSourceActionProps> = ({ dataSource, isKebabToggl
             </DropdownItem>
           ))}
         </DropdownGroup>
-        <Divider key="divider" />,
+        <Divider key="divider" />
         <DropdownGroup key="datasource-manage" label={t('DataImportCron')}>
           <DropdownItem
             data-test-id="datasource-manage"


### PR DESCRIPTION
## 📝 Description

A comma got in the dropdown by accident

## 🎥 Demo

Before:
![comma-action](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/4237e4eb-75e2-457a-a0d6-d2f4e81b55cb)

After:
![comma-action-aft](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/c18f6f11-94b1-424a-8967-e184b1e8826a)

