### PR TITLE
CNV-39418: Use "VirtualMachineInstance labels" for MigrationPolicies

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1336,6 +1336,7 @@
   "VirtualMachineInstance": "VirtualMachineInstance",
   "VirtualMachineInstance details": "VirtualMachineInstance details",
   "VirtualMachineInstance Details": "VirtualMachineInstance Details",
+  "VirtualMachineInstance labels": "VirtualMachineInstance labels",
   "VirtualMachineInstanceMigration": "VirtualMachineInstanceMigration",
   "VirtualMachineInstanceMigration name": "VirtualMachineInstanceMigration name",
   "VirtualMachineInstanceMigrations information": "VirtualMachineInstanceMigrations information",

--- a/src/views/migrationpolicies/details/tabs/details/components/MigrationPolicyDetailsSection/components/MigrationPolicyVirtualMachineLabels.tsx
+++ b/src/views/migrationpolicies/details/tabs/details/components/MigrationPolicyDetailsSection/components/MigrationPolicyVirtualMachineLabels.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import MigrationPolicyModel from '@kubevirt-ui/kubevirt-api/console/models/MigrationPolicyModel';
 import { V1alpha1MigrationPolicy } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -22,7 +22,7 @@ import { ensureMigrationPolicyMatchLabels } from '../utils/utils';
 type MigrationPolicyVirtualMachineLabelsProps = {
   mp: V1alpha1MigrationPolicy;
 };
-const MigrationPolicyVirtualMachineLabels: React.FC<MigrationPolicyVirtualMachineLabelsProps> = ({
+const MigrationPolicyVirtualMachineLabels: FC<MigrationPolicyVirtualMachineLabelsProps> = ({
   mp,
 }) => {
   const { t } = useKubevirtTranslation();
@@ -33,7 +33,7 @@ const MigrationPolicyVirtualMachineLabels: React.FC<MigrationPolicyVirtualMachin
   return (
     <DescriptionListGroup>
       <DescriptionListTermHelpText className="migration-policy-description-item-header">
-        {t('VirtualMachine labels')}
+        {t('VirtualMachineInstance labels')}
         <Button
           onClick={() =>
             createModal(({ isOpen, onClose }) => (


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-39418

Change _VirtualMachine labels_ to _VirtualMachineInstance labels_ in _MigrationPolicies details_ page to reflect exactly which labels are shown in the page.

## 🎥 Screenshots
**Before:**
_VirtualMachine labels_  are shown in the page, which can be confusing to the user:
![pol_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/da9eea61-ce62-4204-a867-d46aa084a88f)

**After:**
 _VirtualMachineInstance labels_ are shown:
![pol_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/2f6282b8-0813-40ac-a81b-2efcb4db266b)


