### PR TITLE
[release-4.15] CNV-23832: fix SC select placholder

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsRightGrid.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsRightGrid.tsx
@@ -72,6 +72,7 @@ const DetailsRightGrid: FC = () => {
             hasInlineFilter
             isOpen={isOpenStorageClass}
             onToggle={setIsOpenStorageClass}
+            placeholderText={t('Select StorageClass')}
           >
             {sortedStorageClasses?.map((name) => (
               <SelectOption key={name} value={name} />


### PR DESCRIPTION
## 📝 Description

The select is missing a placeholderText property which causing a confusion when the placeholder is the first item in the list and it's not selected actually

## 🎥 Demo

Before:
![sc-placeholder-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/94fa3178-0f4a-450e-812e-bc796b37aef5)

After:
![sc-placeholder](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/2ff90001-0ba1-4bba-a712-ef45554730b9)

