### PR TITLE
CNV-39425: Not able to select user prefereces in add volume modal

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -1,6 +1,5 @@
-import React, { FC, useCallback, useMemo, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 
-import useClusterPreferences from '@catalog/CreateFromInstanceTypes/state/hooks/useClusterPreferences';
 import { DEFAULT_PREFERENCE_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import useStorageProfileClaimPropertySets from '@kubevirt-utils/components/DiskModal/DiskFormFields/hooks/useStorageProfileClaimPropertySets';
@@ -12,7 +11,6 @@ import { useCDIUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
 import { UPLOAD_STATUS } from '@kubevirt-utils/hooks/useCDIUpload/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
-import { getName } from '@kubevirt-utils/resources/shared';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { Form, PopoverPosition, Title } from '@patternfly/react-core';
@@ -63,9 +61,6 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
   );
   const applyStorageProfileState = useState<boolean>(true);
 
-  const [preferences] = useClusterPreferences();
-  const preferencesNames = useMemo(() => preferences.map(getName), [preferences]);
-
   const { upload, uploadData } = useCDIUpload();
 
   const claimPropertySetsData = useStorageProfileClaimPropertySets(
@@ -85,6 +80,14 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
     [],
   );
 
+  const deleteLabel = (labelKey: string) => {
+    setBootableVolume((prev) => {
+      const updatedLabels = { ...prev?.labels };
+      delete updatedLabels[labelKey];
+
+      return { ...prev, labels: updatedLabels };
+    });
+  };
   return (
     <TabModal
       onClose={() => {
@@ -151,7 +154,7 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
         </Title>
         <VolumeMetadata
           bootableVolume={bootableVolume}
-          preferencesNames={preferencesNames}
+          deleteLabel={deleteLabel}
           setBootableVolumeField={setBootableVolumeField}
         />
       </Form>

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/VolumeMetadata.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/VolumeMetadata.tsx
@@ -15,13 +15,13 @@ import PreferenceSelect from './components/PreferenceSelect/PreferenceSelect';
 
 type VolumeMetadataProps = {
   bootableVolume: AddBootableVolumeState;
-  preferencesNames: string[];
+  deleteLabel: (labelKey: string) => void;
   setBootableVolumeField: SetBootableVolumeFieldType;
 };
 
 const VolumeMetadata: FC<VolumeMetadataProps> = ({
   bootableVolume,
-  preferencesNames,
+  deleteLabel,
   setBootableVolumeField,
 }) => {
   const { t } = useKubevirtTranslation();
@@ -31,7 +31,7 @@ const VolumeMetadata: FC<VolumeMetadataProps> = ({
   return (
     <>
       <PreferenceSelect
-        preferencesNames={preferencesNames}
+        deleteLabel={deleteLabel}
         selectedPreference={labels?.[DEFAULT_PREFERENCE_LABEL]}
         setBootableVolumeField={setBootableVolumeField}
       />

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/PreferenceSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/PreferenceSelect.tsx
@@ -1,27 +1,74 @@
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 
-import { DEFAULT_PREFERENCE_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
-import { VirtualMachineClusterPreferenceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import useClusterPreferences from '@catalog/CreateFromInstanceTypes/state/hooks/useClusterPreferences';
+import {
+  DEFAULT_PREFERENCE_KIND_LABEL,
+  DEFAULT_PREFERENCE_LABEL,
+} from '@catalog/CreateFromInstanceTypes/utils/constants';
+import {
+  VirtualMachineClusterPreferenceModelGroupVersionKind,
+  VirtualMachinePreferenceModelGroupVersionKind,
+} from '@kubevirt-ui/kubevirt-api/console';
+import { V1beta1VirtualMachinePreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { SetBootableVolumeFieldType } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/constants';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
+import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
+import Loading from '@kubevirt-utils/components/Loading/Loading';
+import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { useActiveNamespace, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { FormGroup, PopoverPosition } from '@patternfly/react-core';
 
+import { getResourceDropdownOptions } from './utils/utils';
 import PreferencePopoverContent from './PreferencePopoverContent';
 
 type PreferenceSelectProps = {
-  preferencesNames: string[];
+  deleteLabel: (labelKey: string) => void;
   selectedPreference: string;
   setBootableVolumeField: SetBootableVolumeFieldType;
 };
 
 const PreferenceSelect: FC<PreferenceSelectProps> = ({
-  preferencesNames,
+  deleteLabel,
   selectedPreference,
   setBootableVolumeField,
 }) => {
   const { t } = useKubevirtTranslation();
+  const [activeNamespace] = useActiveNamespace();
+
+  const [preferences, preferencesLoaded] = useClusterPreferences();
+  const [userPreferences = [], userPreferencesLoaded] = useK8sWatchResource<
+    V1beta1VirtualMachinePreference[]
+  >(
+    activeNamespace !== ALL_NAMESPACES_SESSION_KEY && {
+      groupVersionKind: VirtualMachinePreferenceModelGroupVersionKind,
+      isList: true,
+      namespace: activeNamespace,
+    },
+  );
+
+  const options = useMemo(() => {
+    const preferenceOptions: EnhancedSelectOptionProps[] = getResourceDropdownOptions(
+      preferences,
+      VirtualMachineClusterPreferenceModelGroupVersionKind,
+      () => deleteLabel(DEFAULT_PREFERENCE_KIND_LABEL),
+    );
+
+    const userPreferenceOptions: EnhancedSelectOptionProps[] = getResourceDropdownOptions(
+      userPreferences,
+      VirtualMachinePreferenceModelGroupVersionKind,
+      () =>
+        setBootableVolumeField(
+          'labels',
+          DEFAULT_PREFERENCE_KIND_LABEL,
+        )(VirtualMachinePreferenceModelGroupVersionKind.kind),
+    );
+    return [...userPreferenceOptions, ...preferenceOptions];
+  }, [preferences, userPreferences]);
+
+  if (!preferencesLoaded || !userPreferencesLoaded) return <Loading />;
+
   return (
     <FormGroup
       label={
@@ -36,13 +83,7 @@ const PreferenceSelect: FC<PreferenceSelectProps> = ({
       isRequired
     >
       <InlineFilterSelect
-        options={preferencesNames
-          ?.sort((a, b) => a.localeCompare(b))
-          ?.map((opt) => ({
-            children: opt,
-            groupVersionKind: VirtualMachineClusterPreferenceModelGroupVersionKind,
-            value: opt,
-          }))}
+        options={options}
         selected={selectedPreference}
         setSelected={setBootableVolumeField('labels', DEFAULT_PREFERENCE_LABEL)}
         toggleProps={{ isFullWidth: true, placeholder: t('Select preference') }}

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/utils/utils.ts
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/utils/utils.ts
@@ -1,0 +1,17 @@
+import { getName } from '@kubevirt-utils/resources/shared';
+import { K8sGroupVersionKind, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+export const getResourceDropdownOptions = (
+  resources: K8sResourceCommon[],
+  groupVersionKind: K8sGroupVersionKind,
+  onClick: () => void,
+) =>
+  resources
+    ?.map(getName)
+    ?.sort((a, b) => a.localeCompare(b))
+    ?.map((opt) => ({
+      children: opt,
+      groupVersionKind,
+      onClick,
+      value: opt,
+    }));

--- a/src/views/catalog/CreateFromInstanceTypes/utils/constants.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/constants.ts
@@ -5,5 +5,6 @@ export enum INSTANCE_TYPES_SECTIONS {
 }
 
 export const DEFAULT_PREFERENCE_LABEL = 'instancetype.kubevirt.io/default-preference';
+export const DEFAULT_PREFERENCE_KIND_LABEL = 'instancetype.kubevirt.io/default-preference-kind';
 export const DEFAULT_INSTANCETYPE_LABEL = 'instancetype.kubevirt.io/default-instancetype';
 export const PREFERENCE_DISPLAY_NAME_KEY = 'openshift.io/display-name';

--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -12,7 +12,7 @@ import { addSecretToVM } from '@kubevirt-utils/components/SSHSecretModal/utils/u
 import { ROOTDISK } from '@kubevirt-utils/constants/constants';
 import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
 import { isBootableVolumePVCKind } from '@kubevirt-utils/resources/bootableresources/helpers';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getLabel, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
 import {
   HEADLESS_SERVICE_LABEL,
@@ -23,7 +23,11 @@ import { K8sGroupVersionKind, K8sResourceCommon } from '@openshift-console/dynam
 
 import { InstanceTypeVMState } from '../state/utils/types';
 
-import { DEFAULT_INSTANCETYPE_LABEL, DEFAULT_PREFERENCE_LABEL } from './constants';
+import {
+  DEFAULT_INSTANCETYPE_LABEL,
+  DEFAULT_PREFERENCE_KIND_LABEL,
+  DEFAULT_PREFERENCE_LABEL,
+} from './constants';
 
 const generateCloudInitPassword = () =>
   `${getRandomChars(4)}-${getRandomChars(4)}-${getRandomChars(4)}`;
@@ -78,7 +82,12 @@ export const generateVM = (
     namespace: getNamespace(selectedBootableVolume),
   };
 
-  const selectedPreference = selectedBootableVolume?.metadata?.labels?.[DEFAULT_PREFERENCE_LABEL];
+  const selectedPreference = getLabel(selectedBootableVolume, DEFAULT_PREFERENCE_LABEL);
+  const selectPreferenceKind = getLabel(
+    selectedBootableVolume,
+    DEFAULT_PREFERENCE_KIND_LABEL,
+    null,
+  );
   const isDynamic = instanceTypeState?.isDynamicSSHInjection;
 
   const emptyVM: V1VirtualMachine = {
@@ -125,6 +134,7 @@ export const generateVM = (
       },
       preference: {
         name: selectedPreference,
+        ...(selectPreferenceKind && { kind: selectPreferenceKind }),
       },
       running: startVM,
       template: {


### PR DESCRIPTION
## 📝 Description

Allowing VirtualMachinePreference (namespace scoped) in the preference select dropdown in Add volume modal.

## 🎥 Demo

Before: 
![preference-select-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/0ff0ae3d-c118-4a33-b5fd-986e83cac4f3)


After:

![preference-select](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/b8a5f0b3-3f44-4146-9c87-f11929af0259)
