### PR TITLE
CNV-39418: Use VirtualMachineInstance labels at MigrationPolicies pages

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1319,7 +1319,6 @@
   "VirtualMachine is currently provisioning": "VirtualMachine is currently provisioning",
   "VirtualMachine is not running": "VirtualMachine is not running",
   "VirtualMachine is not running.": "VirtualMachine is not running.",
-  "VirtualMachine labels": "VirtualMachine labels",
   "VirtualMachine live migration": "VirtualMachine live migration",
   "VirtualMachine name": "VirtualMachine name",
   "VirtualMachine name can not be empty.": "VirtualMachine name can not be empty.",

--- a/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/MigrationPolicyCreateForm.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/MigrationPolicyCreateForm.tsx
@@ -58,7 +58,10 @@ const MigrationPolicyCreateForm: FC = () => {
             setLabels={setStateField('namespaceSelectorMatchLabel')}
           />
         </FormGroup>
-        <FormGroup fieldId="migration-policy-vmi-selector" label={t('VirtualMachine labels')}>
+        <FormGroup
+          fieldId="migration-policy-vmi-selector"
+          label={t('VirtualMachineInstance labels')}
+        >
           <SelectorLabelMatchGroup
             isVMILabel
             labels={state?.vmiSelectorMatchLabel}

--- a/src/views/migrationpolicies/list/hooks/useMigrationPoliciesListColumns.ts
+++ b/src/views/migrationpolicies/list/hooks/useMigrationPoliciesListColumns.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useMemo } from 'react';
 
 import { MigrationPolicyModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import { V1alpha1MigrationPolicy } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -14,7 +14,7 @@ const useMigrationPoliciesListColumns = (): [
 ] => {
   const { t } = useKubevirtTranslation();
 
-  const columns: TableColumn<V1alpha1MigrationPolicy>[] = React.useMemo(
+  const columns: TableColumn<V1alpha1MigrationPolicy>[] = useMemo(
     () => [
       {
         id: 'name',
@@ -59,7 +59,7 @@ const useMigrationPoliciesListColumns = (): [
       {
         additional: true,
         id: 'vm-labels',
-        title: t('VirtualMachine labels'),
+        title: t('VirtualMachineInstance labels'),
       },
       {
         id: '',


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-39418

Change _VirtualMachine labels_ to _VirtualMachineInstance labels_ in _MigrationPolicies_ list page to reflect exactly which labels are shown in the page. Same for _Create MigrationPolicy_ form.

## 🎥 Screenshots
**Before:**
_Create MigrationPolicy_ form and incorrect _VirtualMachine labels_ used:
![mp_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/f52aea13-4768-42df-bd34-725f6910ec34)
_MigrationPolicies_ list page and incorrect _VirtualMachine labels_ used:
![mplist_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/bcea38de-3a8b-4a3b-bc99-677df0f0a0d1)

**After:**
_Create MigrationPolicy_ form and _VirtualMachineInstance labels_ used:
![mp_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/82f83fa0-c1b4-4c69-8dad-b44c69745375)
_MigrationPolicies_ list page and _VirtualMachineInstance labels_ used:
![mplist_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/fd92291b-8ab5-48db-9ed6-3160e8da4873)

