### PR TITLE
CNV-39659: Change "Enable CPU limit" to "limits" in Overview settings

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -459,7 +459,7 @@
   "Elapsed time since login": "Elapsed time since login",
   "Enable auto updates for RHEL VirtualMachines": "Enable auto updates for RHEL VirtualMachines",
   "Enable automatic subscription for Red Hat Enterprise Linux VirtualMachines.\n": "Enable automatic subscription for Red Hat Enterprise Linux VirtualMachines.\n",
-  "Enable CPU limit": "Enable CPU limit",
+  "Enable CPU limits": "Enable CPU limits",
   "Enable Descheduler": "Enable Descheduler",
   "Enable guest system log access": "Enable guest system log access",
   "Enable headless mode": "Enable headless mode",

--- a/src/views/clusteroverview/SettingsTab/PreviewFeaturesTab/hooks/usePreviewFeaturesData.ts
+++ b/src/views/clusteroverview/SettingsTab/PreviewFeaturesTab/hooks/usePreviewFeaturesData.ts
@@ -38,7 +38,7 @@ const usePreviewFeaturesData: UsePreviewFeaturesData = () => {
       externalLink: AUTOCOMPUTE_CPU_LIMITS_LINK,
       featureEnabled: isEnabledCpuLimits,
       id: AUTOCOMPUTE_CPU_LIMITS_PREVIEW_ENABLED,
-      label: t('Enable CPU limit'),
+      label: t('Enable CPU limits'),
       loading: loadingCpuLimits,
       toggleFeature: toggleCpuLimits,
     },


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-39659

Change "limit" to use plural in _Enable CPU limit_ string in the _Overview_ > _Settings_ page - _Preview features_ section to reflect the related documentation: https://kubevirt.io/user-guide/virtual_machines/resources_requests_and_limits/

## 🎥 Screenshots
**Before:**
 _Enable CPU limit_ used in the page:
![en_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/5407e95e-0b20-4a23-b582-d8efcd912557)

**After:**
 _Enable CPU limits_ used in the page:

