### PR TITLE
CNV-37607: "Upload data" dialog does not work in PVC -> "With Data upload form"

### DIFF
--- a/src/views/cdi-upload-provider/upload-pvc-form/UploadPVC.tsx
+++ b/src/views/cdi-upload-provider/upload-pvc-form/UploadPVC.tsx
@@ -168,9 +168,9 @@ const UploadPVCPage: FC = () => {
     setError('');
   };
 
-  const handleFileNameChange = (_, file: File) => {
-    setFileName(file.name);
-    setFileNameExtension(/[.][^.]+$/.exec(file.name)?.toString());
+  const handleFileNameChange = (_, filename: string) => {
+    setFileName(filename);
+    setFileNameExtension(/[.][^.]+$/.exec(filename)?.toString());
   };
 
   useEffect(() => {
@@ -236,7 +236,7 @@ const UploadPVCPage: FC = () => {
                 </p>
               </Alert>
             )}
-            <ActionGroup className="pf-c-form">
+            <ActionGroup className="pf-v5-c-form">
               <Button
                 id="save-changes"
                 isDisabled={disableFormSubmit || isCheckingCertificate}

--- a/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCForm.tsx
+++ b/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCForm.tsx
@@ -39,8 +39,8 @@ type UploadPVCFormProps = {
   fileName: string;
   fileValue: File | string;
   goldenPvcs: V1alpha1PersistentVolumeClaim[];
-  handleFileChange: (_, value: string) => void;
-  handleFileNameChange: (event, file: File) => void;
+  handleFileChange: (_, value: File) => void;
+  handleFileNameChange: (event, file: string) => void;
   isLoading: boolean;
   ns: string;
   onChange: (K8sResourceKind) => void;
@@ -200,17 +200,23 @@ const UploadPVCForm: FC<UploadPVCFormProps> = ({
       <div className="form-group">
         <FileUpload
           dropzoneProps={{
-            accept: { 'text/*': ['.iso,.img,.qcow2,.gz,.xz'] },
+            accept: { 'application/*': ['.iso,.img,.qcow2,.gz,.xz'] },
             onDropAccepted: () => setIsFileRejected(false),
             onDropRejected: () => setIsFileRejected(true),
           }}
+          onClearClick={(event) => {
+            handleFileChange(event, null);
+            handleFileNameChange(event, '');
+          }}
+          onFileInputChange={(event, file: File) => {
+            handleFileChange(event, file);
+            handleFileNameChange(event, file.name);
+          }}
+          browseButtonText="Upload"
           filename={fileName}
+          filenamePlaceholder="Drag and drop a file or upload one"
           hideDefaultPreview
           id="file-upload"
-          isRequired
-          onDataChange={handleFileChange}
-          onFileInputChange={handleFileNameChange}
-          onTextChange={handleFileChange}
           value={fileValue}
         />
         {operatingSystemHaveDV && (


### PR DESCRIPTION
## 📝 Description

Fixing use of FileUpload props to allow to click on `Browse` button

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/9c4c1082-bf75-4efb-b873-202fe7b0159e

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/b3411160-a71b-4d10-a8fb-9f7b103c815c

