### PR TITLE
CNV-40242: UI goes blank when changing the storage class field on add disk

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/AccessMode.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/AccessMode.tsx
@@ -48,7 +48,7 @@ const AccessMode: FC<AccessModeProps> = ({ diskState, dispatchDiskState, spAcces
       }
     } else if (!allowedAccessModes?.includes(accessMode)) {
       dispatchDiskState({
-        payload: allowedAccessModes[0],
+        payload: allowedAccessModes?.[0],
         type: diskReducerActions.SET_ACCESS_MODE,
       });
     }

--- a/src/utils/components/DiskModal/DiskFormFields/StorageClassAndPreallocation.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/StorageClassAndPreallocation.tsx
@@ -49,7 +49,7 @@ const StorageClassAndPreallocation: FC<StorageClassAndPreallocationProps> = ({
       type: diskReducerActions.SET_VOLUME_MODE,
     });
     dispatchDiskState({
-      payload: claimPropertySets?.[0]?.accessModes[0],
+      payload: claimPropertySets?.[0]?.accessModes?.[0],
       type: diskReducerActions.SET_ACCESS_MODE,
     });
   };


### PR DESCRIPTION
## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/521883a4-0e2d-4216-850c-2a37ef079137

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/76ec063b-e677-446a-9a43-b7548c008bcc


