### PR TITLE
CNV-39531: Align Getting started card with console

### DIFF
--- a/src/views/clusteroverview/OverviewTab/getting-started-card/utils/getting-started-grid/GettingStartedGrid.scss
+++ b/src/views/clusteroverview/OverviewTab/getting-started-card/utils/getting-started-grid/GettingStartedGrid.scss
@@ -5,12 +5,11 @@
   &__header.pf-v5-c-card__header {
     // Use padding sm instead of lg to fix alignment of the KebabToggle action button.
     padding-right: var(--pf-global--spacer--sm);
+    padding-block-start: 0;
   }
-  &__tooltip {
-    white-space: pre-line;
-  }
+
   &__tooltip-icon {
-    padding-left: var(--pf-global--spacer--sm);
+    margin-left: var(--pf-global--spacer--sm);
   }
 
   &__action-dropdown {
@@ -42,6 +41,18 @@
       padding-bottom: calc(var(--pf-v5-c-card--child--PaddingBottom) / 2);
       padding-left: var(--pf-v5-c-card--child--PaddingLeft);
       padding-right: var(--pf-v5-c-card--child--PaddingRight);
+    }
+  }
+
+  &__tooltip {
+    background: var(--pf-c-page__main-section--m-light--BackgroundColor);
+  }
+
+  &__expandable {
+    background: var(--pf-c-page__main-section--m-light--BackgroundColor);
+
+    .pf-v5-c-expandable-section__toggle-text {
+      color: var(--pf-v5-global--Color--dark-100);
     }
   }
 }

--- a/src/views/clusteroverview/OverviewTab/getting-started-card/utils/getting-started-grid/GettingStartedGrid.tsx
+++ b/src/views/clusteroverview/OverviewTab/getting-started-card/utils/getting-started-grid/GettingStartedGrid.tsx
@@ -6,13 +6,13 @@ import {
   Card,
   CardBody,
   CardHeader,
-  CardTitle,
   Dropdown,
   DropdownItem,
   DropdownList,
-  Popover,
+  ExpandableSection,
   Title,
   TitleSizes,
+  Tooltip,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
@@ -47,40 +47,17 @@ export const GettingStartedGrid: FC<GettingStartedGridProps> = ({ children, onHi
   }
 
   const title = t('Getting started resources');
-  const titleTooltip = (
-    <span className="kv-getting-started-grid__tooltip">
-      {t('Use our collection of resources to help you get started with virtualization.')}
-    </span>
+  const titleTooltip = t(
+    'Use our collection of resources to help you get started with virtualization.',
   );
 
   return (
     <Card className="kv-getting-started-grid" data-test="getting-started">
-      <CardHeader
-        actions={
-          actionDropdownItem.length > 0
-            ? {
-                actions: (
-                  <Dropdown
-                    className="ocs-getting-started-grid__action-dropdown"
-                    isOpen={isOpen}
-                    onOpenChange={(open: boolean) => setIsOpen(open)}
-                    popperProps={{ position: 'right' }}
-                    toggle={KebabToggle({ isExpanded: isOpen, onClick: onToggle })}
-                  >
-                    <DropdownList>{actionDropdownItem}</DropdownList>
-                  </Dropdown>
-                ),
-                className: null,
-                hasNoOffset: false,
-              }
-            : null
-        }
-        className="kv-getting-started-grid__header"
-      >
-        <CardTitle>
+      <ExpandableSection
+        toggleContent={
           <Title data-test="title" headingLevel="h2" size={TitleSizes.lg}>
             {title}{' '}
-            <Popover bodyContent={titleTooltip}>
+            <Tooltip className="kv-getting-started-grid__tooltip" content={titleTooltip}>
               <span
                 aria-label={t('More info')}
                 className="kv-getting-started-grid__tooltip-icon"
@@ -88,11 +65,35 @@ export const GettingStartedGrid: FC<GettingStartedGridProps> = ({ children, onHi
               >
                 <OutlinedQuestionCircleIcon />
               </span>
-            </Popover>
+            </Tooltip>
           </Title>
-        </CardTitle>
-      </CardHeader>
-      <CardBody className="kv-getting-started-grid__content">{children}</CardBody>
+        }
+        className="kv-getting-started-grid__expandable pf-m-display-lg"
+      >
+        <CardHeader
+          actions={
+            actionDropdownItem.length > 0
+              ? {
+                  actions: (
+                    <Dropdown
+                      className="ocs-getting-started-grid__action-dropdown"
+                      isOpen={isOpen}
+                      onOpenChange={setIsOpen}
+                      popperProps={{ position: 'right' }}
+                      toggle={KebabToggle({ isExpanded: isOpen, onClick: onToggle })}
+                    >
+                      <DropdownList>{actionDropdownItem}</DropdownList>
+                    </Dropdown>
+                  ),
+                  className: null,
+                  hasNoOffset: false,
+                }
+              : null
+          }
+          className="kv-getting-started-grid__header"
+        />
+        <CardBody className="kv-getting-started-grid__content">{children}</CardBody>
+      </ExpandableSection>
     </Card>
   );
 };


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-39531

Display _Getting started_ card as the expandable section, same as the new format in the console. Also use the `Tooltip` PF React component instead of popover to show help text on hovering the help icon in the title of the card and hence fix the incorrect cursor when hovering on the "?" icon.

_Important note:_
Please, recognize the difference between tooltip and popover components: tooltip is displayed on hover vs. popover on click. In this PR, I am using tooltip, which provides better user experience and is also aligned with console (even when the style for that help text in console looks like PF Popover component and not tooltip, which is incorrect).

## 🎥 Demo
**Before:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/84767c06-c074-4dfe-8dcc-1bc71ba3e28c

**After:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/bc4bcac9-bbea-43bf-9a1b-2d5d19f285e8




