### PR TITLE
CNV-40247: Make VM Diagnostics tab's help icons smaller

### DIFF
--- a/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabConditions.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabConditions.tsx
@@ -66,7 +66,7 @@ const VirtualMachineDiagnosticTabConditions: FC<VirtualMachineDiagnosticTabCondi
             bodyContent={t(
               'Conditions provide a standard mechanism for status reporting. Conditions are reported for all aspects of a VM.',
             )}
-            helpIconClassName="title-help-text-icon"
+            helpIconClassName="VirtualMachineDiagnosticTab--HelpTextIcon"
           />
         </Title>
 

--- a/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabDataVolumeStatus.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabDataVolumeStatus.tsx
@@ -54,7 +54,7 @@ const VirtualMachineDiagnosticTabDataVolumeStatus: FC<
                 bodyContent={t(
                   'DataVolume Status is a mechanism for reporting if a volume succeed.',
                 )}
-                helpIconClassName="title-help-text-icon"
+                helpIconClassName="VirtualMachineDiagnosticTab--HelpTextIcon"
               />
             </Title>
           </FlexItem>

--- a/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabVolumeStatus.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabVolumeStatus.tsx
@@ -54,7 +54,7 @@ const VirtualMachineDiagnosticTabVolumeStatus: FC<VirtualMachineDiagnosticTabVol
                 bodyContent={t(
                   'Volume Snapshot Status is a mechanism for reporting if a volume can be snapshotted or not.',
                 )}
-                helpIconClassName="title-help-text-icon"
+                helpIconClassName="VirtualMachineDiagnosticTab--HelpTextIcon"
               />
             </Title>
           </FlexItem>

--- a/src/views/virtualmachines/details/tabs/diagnostic/virtual-machine-diagnostic-tab.scss
+++ b/src/views/virtualmachines/details/tabs/diagnostic/virtual-machine-diagnostic-tab.scss
@@ -14,6 +14,10 @@
   &--header {
     margin-top: var(--pf-global--spacer--lg);
   }
+
+  &--HelpTextIcon {
+    font-size: var(--pf-global--FontSize--md);
+  }
 }
 
 .VirtualMachineDiagnosticTabRow--expanded {

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabFilesystem/VirtualMachinesOverviewTabFilesystemTitle.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabFilesystem/VirtualMachinesOverviewTabFilesystemTitle.tsx
@@ -14,7 +14,6 @@ const VirtualMachinesOverviewTabFilesystemTitle = () => {
         bodyContent={t(
           'The following information regarding how the disks are partitioned is provided by the guest agent.',
         )}
-        helpIconClassName="title-help-text-icon"
         position={PopoverPosition.right}
       />
     </CardTitle>

--- a/src/views/virtualmachinesinstance/details/tabs/disks/table/file-system/FileSystemTableTitle.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/disks/table/file-system/FileSystemTableTitle.tsx
@@ -14,7 +14,6 @@ const FileSystemTableTitle = () => {
         bodyContent={t(
           'The following information regarding how the disks are partitioned is provided by the guest agent.',
         )}
-        helpIconClassName="title-help-text-icon"
         position={PopoverPosition.right}
       />
     </Title>


### PR DESCRIPTION
## 📝 Description

Fixes:
https://issues.redhat.com/browse/CNV-40247

Make the icons smaller to look better, also delete non-existent `title-help-text-icon` class from `HelpTextIcon` components in more places of the codebase.

## 🎥 Screenshots
**Before:**
"?" icons too big in VM _Diagnostics_ tab:
![cyan_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/08519d82-cb42-4002-9220-df6d849160e1)

**After:**
"?" icons smaller, nicer:
![cyan_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/3bfbc1a7-9f8c-4d6d-8098-c7c56f1932c7)


