### PR TITLE
CNV-40200: Use "Clone" submit button for VM cloning instead of "Create"

### DIFF
--- a/src/utils/components/CloneVMModal/CloneVMModal.tsx
+++ b/src/utils/components/CloneVMModal/CloneVMModal.tsx
@@ -80,7 +80,7 @@ const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, sour
       obj={source}
       onClose={onClose}
       onSubmit={sendCloneRequest}
-      submitBtnText={t('Create')}
+      submitBtnText={isVM(source) ? t('Clone') : t('Create')}
     >
       <Form className="pf-u-w-75-on-md pf-u-w-66-on-lg pf-u-m-auto" isHorizontal>
         <NameInput name={cloneName} setName={setCloneName} />


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-40200

Display _Clone_ submit button text in _Clone VirtualMachine_ modal window instead of _Create_.
Keep displaying _Create_ submit button text for cloning VM snapshots.

## 🎥 Demo
**Before:**
_Create_ button text in the modal:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/e1a88120-22d0-42da-9b18-b07ffef36f23

**After:**
_Clone_ button text:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/3ed07577-f2d2-4047-8ac6-7b52c5657889




