### PR TITLE
CNV-38061: Missing SR-IOV binding to VM spec

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceTypeSelect.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceTypeSelect.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch, FC, SetStateAction, useMemo, useState } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { interfacesTypes } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { interfacesTypes, typeLabels } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { FormGroup, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 
 import { networkNameStartWithPod } from '../utils/helpers';
@@ -33,7 +33,7 @@ const NetworkInterfaceTypeSelect: FC<NetworkInterfaceTypeSelectProps> = ({
         'The VirtualMachine will be bridged to the selected network, ideal for L2 devices',
       ),
       id: interfacesTypes.bridge,
-      name: t('Bridge'),
+      name: typeLabels[interfacesTypes.bridge],
     },
     masquerade: {
       // in case of pod network, networkName is undefined
@@ -42,7 +42,7 @@ const NetworkInterfaceTypeSelect: FC<NetworkInterfaceTypeSelectProps> = ({
         'Put the VirtualMachine behind a NAT Proxy for high compatibility with different network providers. The VirtualMachines IP will differ from the IP seen on the pod network',
       ),
       id: interfacesTypes.masquerade,
-      name: t('Masquerade'),
+      name: typeLabels[interfacesTypes.masquerade],
     },
     sriov: {
       // in case of NAD network, networkName should be a string - enabled if nad type is sriov or undefined or no nad
@@ -53,14 +53,8 @@ const NetworkInterfaceTypeSelect: FC<NetworkInterfaceTypeSelectProps> = ({
         'Attach a virtual function network device to the VirtualMachine for high performance',
       ),
       id: interfacesTypes.sriov,
-      name: t('SR-IOV'),
+      name: typeLabels[interfacesTypes.sriov],
     },
-  };
-
-  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>, value: string) => {
-    event.preventDefault();
-    setInterfaceType(value);
-    setIsOpen(false);
   };
 
   return (
@@ -73,9 +67,9 @@ const NetworkInterfaceTypeSelect: FC<NetworkInterfaceTypeSelectProps> = ({
         <Select
           isOpen={isOpen}
           menuAppendTo="parent"
-          onSelect={handleChange}
+          onSelect={() => setIsOpen(false)}
           onToggle={setIsOpen}
-          selections={interfaceType}
+          selections={typeLabels[interfaceType] || typeLabels.bridge}
           variant={SelectVariant.single}
         >
           {Object.values(interfaceTypeOptions)
@@ -85,7 +79,8 @@ const NetworkInterfaceTypeSelect: FC<NetworkInterfaceTypeSelectProps> = ({
                 data-test-id={`network-interface-type-select-${id}`}
                 description={description}
                 key={id}
-                value={id}
+                onClick={() => setInterfaceType(id)}
+                value={name}
               >
                 {name}
               </SelectOption>

--- a/src/utils/components/NetworkInterfaceModal/utils/helpers.ts
+++ b/src/utils/components/NetworkInterfaceModal/utils/helpers.ts
@@ -96,7 +96,7 @@ export const createInterface = (
   interfaceType: string,
 ): V1Interface => {
   return {
-    [interfaceType.toLowerCase()]: {},
+    [interfaceType]: {},
     macAddress: interfaceMACAddress,
     model: interfaceModel,
     name: nicName,

--- a/src/utils/resources/vm/utils/network/constants.ts
+++ b/src/utils/resources/vm/utils/network/constants.ts
@@ -1,5 +1,6 @@
 /* eslint-disable require-jsdoc */
 import { V1Interface, V1Network } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
 export type NetworkPresentation = {
   iface: V1Interface;
@@ -13,9 +14,15 @@ const typeHandler = {
 };
 
 const types = {
-  bridge: 'Bridge',
-  masquerade: 'Masquerade',
-  sriov: 'SR-IOV',
+  bridge: 'bridge',
+  masquerade: 'masquerade',
+  sriov: 'sriov',
+};
+
+export const typeLabels = {
+  [types.bridge]: t('Bridge'),
+  [types.masquerade]: t('Masquerade'),
+  [types.sriov]: t('SR-IOV'),
 };
 
 export const interfacesTypes = new Proxy(types, typeHandler);

--- a/src/utils/resources/vm/utils/network/selectors.ts
+++ b/src/utils/resources/vm/utils/network/selectors.ts
@@ -2,7 +2,7 @@ import { V1Interface } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
 import { NO_DATA_DASH } from '../constants';
 
-import { interfacesTypes } from './constants';
+import { interfacesTypes, typeLabels } from './constants';
 
 /**
  * function to get network interface type
@@ -20,4 +20,4 @@ export const getNetworkInterfaceType = (iface: V1Interface): string => {
  * @returns interface type
  */
 export const getPrintableNetworkInterfaceType = (iface: V1Interface): string =>
-  interfacesTypes[getNetworkInterfaceType(iface)];
+  typeLabels[getNetworkInterfaceType(iface)];


### PR DESCRIPTION
## 📝 Description

we try to bind sr-iov to the VM interface when added but should be sriov, which causing to not add the sriov interface properly

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/e68be0b1-a08d-4365-9aae-472f2cca8831

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/41920848-833b-4924-86fb-5dbf2b136558


