### PR TITLE
CNV-40457: Instancetype list is empty on catalog -> instanceTypes page

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/constants.ts
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/constants.ts
@@ -110,6 +110,6 @@ export const instanceTypeSeriesNameMapper: {
   },
 };
 
-export const COMMON_INSTANCETYPES = 'common-instancetypes';
+export const REDHAT_COM = 'redhat.com';
 export const INSTANCETYPE_CLASS_ANNOTATION = 'instancetype.kubevirt.io/class';
 export const INSTANCETYPE_DESCRIPTION_ANNOTATION = 'instancetype.kubevirt.io/description';

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/utils.ts
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/utils.ts
@@ -5,17 +5,17 @@ import {
   V1beta1VirtualMachineInstancetype,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
+import { VENDOR_LABEL } from '@kubevirt-utils/constants/constants';
 import { getAnnotation, getLabel, getName } from '@kubevirt-utils/resources/shared';
-import { APP_NAME_LABEL } from '@kubevirt-utils/resources/template';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import {
-  COMMON_INSTANCETYPES,
   initialMenuItems,
   INSTANCETYPE_CLASS_ANNOTATION,
   INSTANCETYPE_DESCRIPTION_ANNOTATION,
   instanceTypeSeriesNameMapper,
+  REDHAT_COM,
 } from './constants';
 import { InstanceTypeSize, InstanceTypesMenuItemsData, RedHatInstanceTypeSeries } from './types';
 
@@ -58,7 +58,7 @@ const hasRedHatSeriesSizeLabel = (
 export const isRedHatInstanceType = (
   instanceType: V1beta1VirtualMachineClusterInstancetype | V1beta1VirtualMachineInstancetype,
 ): boolean => {
-  if (getLabel(instanceType, APP_NAME_LABEL) !== COMMON_INSTANCETYPES) return false;
+  if (getLabel(instanceType, VENDOR_LABEL) !== REDHAT_COM) return false;
   return hasRedHatSeriesSizeLabel(instanceType);
 };
 


### PR DESCRIPTION
## 📝 Description

The common instance types are missing since deployment has changed, changing to a common label both deployments ways have.

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/c97c1e09-b125-4109-b724-df6f65470eb8

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/1e5cb10a-f69d-40f0-a17f-4d60e65b7c15


