### PR TITLE
CNV-39531: Make Getting started card expandable

### DIFF
--- a/src/views/clusteroverview/OverviewTab/getting-started-card/utils/getting-started-grid/GettingStartedGrid.tsx
+++ b/src/views/clusteroverview/OverviewTab/getting-started-card/utils/getting-started-grid/GettingStartedGrid.tsx
@@ -27,6 +27,7 @@ export const GettingStartedGrid: FC<GettingStartedGridProps> = ({ children, onHi
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const onToggle = () => setIsOpen((prevIsOpen) => !prevIsOpen);
+  const [isExpanded, setIsExpanded] = useState(true);
 
   const actionDropdownItem: any[] = [];
 
@@ -69,6 +70,8 @@ export const GettingStartedGrid: FC<GettingStartedGridProps> = ({ children, onHi
           </Title>
         }
         className="kv-getting-started-grid__expandable pf-m-display-lg"
+        isExpanded={isExpanded}
+        onToggle={(_, expand) => setIsExpanded(expand)}
       >
         <CardHeader
           actions={


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-39531

Display _Getting started resources_ expandable section in the _Virtualization Overview_ **expanded by default** - same as in the console.

## 🎥 Demo
**Before:**
Getting started card not expanded when entering _Virtualization Overview_ for the 1st time:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/c3f88608-a495-46e2-bc10-8340ba8a5f47

**After:**
Getting started card expanded by default:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/87e3ab92-e29b-4ce7-a3cd-13fbcf0447ac


