### PR TITLE
CNV-40341: Improve "Create VirtualMachine from snapshot" modal

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1099,7 +1099,6 @@
   "SSH settings": "SSH settings",
   "SSH using virtctl": "SSH using virtctl",
   "Start": "Start",
-  "Start cloned VM": "Start cloned VM",
   "Start in pause mode": "Start in pause mode",
   "Start this VirtualMachine after creation": "Start this VirtualMachine after creation",
   "Start this VirtualMachine in pause mode": "Start this VirtualMachine in pause mode",

--- a/src/utils/components/CloneVMModal/CloneVMModal.tsx
+++ b/src/utils/components/CloneVMModal/CloneVMModal.tsx
@@ -17,7 +17,7 @@ import CloningStatus from './components/CloningStatus';
 import ConfigurationSummary from './components/ConfigurationSummary';
 import NameInput from './components/NameInput';
 import SnapshotContentConfigurationSummary from './components/SnapshotContentConfigurationSummary';
-import StartClonedVMCheckbox from './components/StartClonedVMCheckbox';
+import StartClonedVMCheckbox from './components/StartClonedVMCheckbox/StartClonedVMCheckbox';
 import useCloneVMModal from './hooks/useCloneVMModal';
 import { CLONING_STATUSES } from './utils/constants';
 import { cloneVM, isVM, runVM, vmExist } from './utils/helpers';
@@ -35,7 +35,10 @@ const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, sour
   const namespace = source?.metadata?.namespace;
 
   const [cloneName, setCloneName] = useState(
-    `${source?.metadata?.name}-clone-${getRandomChars()}`.substring(0, MAX_K8S_NAME_LENGTH),
+    `${source?.metadata?.name}-${isVM(source) && 'clone-'}${getRandomChars()}`.substring(
+      0,
+      MAX_K8S_NAME_LENGTH,
+    ),
   );
 
   const [startCloneVM, setStartCloneVM] = useState(false);

--- a/src/utils/components/CloneVMModal/components/StartClonedVMCheckbox/StartClonedVMCheckbox.scss
+++ b/src/utils/components/CloneVMModal/components/StartClonedVMCheckbox/StartClonedVMCheckbox.scss
@@ -1,0 +1,15 @@
+.StartClonedVMCheckbox {
+  .pf-v5-c-check__label {
+    //we want to apply this rule only for Firefox to achieve expected look
+    @supports (-moz-appearance: none) {
+      align-self: center;
+      margin-top: 0;
+    }
+  }
+  .pf-v5-c-check__input {
+    //we want to apply this rule only for Firefox to achieve expected look
+    @supports (-moz-appearance: none) {
+      margin-top: 0;
+    }
+  }
+}

--- a/src/utils/components/CloneVMModal/components/StartClonedVMCheckbox/StartClonedVMCheckbox.tsx
+++ b/src/utils/components/CloneVMModal/components/StartClonedVMCheckbox/StartClonedVMCheckbox.tsx
@@ -3,6 +3,8 @@ import React, { Dispatch, FC, SetStateAction } from 'react';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Checkbox, FormGroup } from '@patternfly/react-core';
 
+import './StartClonedVMCheckbox.scss';
+
 type StartClonedVMCheckboxProps = {
   setStartCloneVM: Dispatch<SetStateAction<boolean>>;
   startCloneVM: boolean;
@@ -13,8 +15,9 @@ const StartClonedVMCheckbox: FC<StartClonedVMCheckboxProps> = ({
   startCloneVM,
 }) => {
   const { t } = useKubevirtTranslation();
+
   return (
-    <FormGroup fieldId="start-clone" hasNoPaddingTop label={t('Start cloned VM')}>
+    <FormGroup className="StartClonedVMCheckbox" fieldId="start-clone">
       <Checkbox
         id="start-clone"
         isChecked={startCloneVM}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-40341

Make small improvements in the modal according to the design doc:
- remove unnecessary field name for checkbox - _Start cloned VM_
- remove "clone" substring from the new generated VM name.

## 🎥 Screenshots
**Before:**
![sn_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/50586cd0-0eff-446b-8c16-afc298d6c401)

**After:**
![sn_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/f97f5619-359d-47d7-8e1f-2fec3411250e)


