### PR TITLE
CNV-38284: UI settings should not be stored in default namespace

### DIFF
--- a/cypress/views/vm.ts
+++ b/cypress/views/vm.ts
@@ -82,7 +82,7 @@ export const vm = {
     }
   },
   createVMFromYAML: () => {
-    cy.byButtonText('Create').click();
+    cy.byTestID('item-create').click();
     cy.byButtonText('With YAML').click();
     cy.get(vmView.saveBtn).click();
   },

--- a/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings.ts
@@ -12,7 +12,7 @@ import {
   IoK8sApiRbacV1Role,
   IoK8sApiRbacV1RoleBinding,
 } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import { OPENSHIFT_CNV } from '@kubevirt-utils/constants/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { k8sCreate, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -42,7 +42,7 @@ const useKubevirtUserSettings: UseKubevirtUserSettings = (key) => {
       userName && {
         groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
         name: KUBEVIRT_USER_SETTINGS_CONFIG_MAP_NAME,
-        namespace: DEFAULT_NAMESPACE,
+        namespace: OPENSHIFT_CNV,
       },
     );
 
@@ -55,7 +55,7 @@ const useKubevirtUserSettings: UseKubevirtUserSettings = (key) => {
               data: { [userName]: JSON.stringify(userSettingsInitialState) },
               metadata: {
                 name: KUBEVIRT_USER_SETTINGS_CONFIG_MAP_NAME,
-                namespace: DEFAULT_NAMESPACE,
+                namespace: OPENSHIFT_CNV,
               },
             },
             model: ConfigMapModel,

--- a/src/utils/hooks/useKubevirtUserSettings/utils/const.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/utils/const.ts
@@ -3,7 +3,7 @@ import {
   IoK8sApiRbacV1Role,
   IoK8sApiRbacV1RoleBinding,
 } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import { OPENSHIFT_CNV } from '@kubevirt-utils/constants/constants';
 
 export const TOP_CONSUMERS_CARD = 'topConsumersCard';
 
@@ -16,7 +16,7 @@ const KUBEVIRT_USER_SETTINGS_ROLE_BINDING_NAME = 'kubevirt-user-settings-reader-
 export const userSettingsRole: IoK8sApiRbacV1Role = {
   metadata: {
     name: KUBEVIRT_USER_SETTINGS_ROLE_NAME,
-    namespace: DEFAULT_NAMESPACE,
+    namespace: OPENSHIFT_CNV,
   },
   rules: [
     {
@@ -31,7 +31,7 @@ export const userSettingsRole: IoK8sApiRbacV1Role = {
 export const userSettingsRoleBinding: IoK8sApiRbacV1RoleBinding = {
   metadata: {
     name: KUBEVIRT_USER_SETTINGS_ROLE_BINDING_NAME,
-    namespace: DEFAULT_NAMESPACE,
+    namespace: OPENSHIFT_CNV,
   },
   roleRef: {
     apiGroup: RoleModel.apiGroup,

--- a/src/views/checkups/Checkups.tsx
+++ b/src/views/checkups/Checkups.tsx
@@ -18,7 +18,7 @@ const CheckupsList: FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [activeTabKey, setActiveTabKey] = useState<number | string>(
-    location?.pathname.endsWith('network') ? 0 : 1,
+    location?.pathname.endsWith('storage') ? 1 : 0,
   );
 
   useEffect(() => {


### PR DESCRIPTION
## 📝 Description

We are moving the UI settings ConfigMap to `openshift-cnv` namespace.
If an existing CM is on the default namespace, we ignore it and create a new one to openshift-cnv namespace.


## 🎥 Demo

After:
![user-settings-cm-openshift-cnv](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/c87f4e4c-dec4-4853-b0b2-49fc514b3205)
