### PR TITLE
CNV-40059: Update MigrationPolicies list for 0 results after filtering

### DIFF
--- a/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
+++ b/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
@@ -25,35 +25,38 @@ const MigrationPoliciesList: FC = () => {
   const [columns, activeColumns, loadedColumns] = useMigrationPoliciesListColumns();
   const [unfilteredData, data, onFilterChange] = useListPageFilter(mps);
 
+  if (loaded && isEmpty(unfilteredData)) {
+    return <MigrationPoliciesEmptyState />;
+  }
+
   return (
     <>
       <ListPageHeader title={t('MigrationPolicies')}>
-        {!isEmpty(mps) && <MigrationPoliciesCreateButton />}
+        <MigrationPoliciesCreateButton />
       </ListPageHeader>
 
       <ListPageBody>
-        {!isEmpty(mps) && (
-          <ListPageFilter
-            columnLayout={{
-              columns: columns?.map(({ additional, id, title }) => ({
-                additional,
-                id,
-                title,
-              })),
-              id: MigrationPolicyModelRef,
-              selectedColumns: new Set(activeColumns?.map((col) => col?.id)),
-              type: t('MigrationPolicy'),
-            }}
-            data={unfilteredData}
-            loaded={loaded && loadedColumns}
-            onFilterChange={onFilterChange}
-          />
-        )}
-        {loaded && isEmpty(data) && <MigrationPoliciesEmptyState />}
+        <ListPageFilter
+          columnLayout={{
+            columns: columns?.map(({ additional, id, title }) => ({
+              additional,
+              id,
+              title,
+            })),
+            id: MigrationPolicyModelRef,
+            selectedColumns: new Set(activeColumns?.map((col) => col?.id)),
+            type: t('MigrationPolicy'),
+          }}
+          data={unfilteredData}
+          loaded={loaded && loadedColumns}
+          onFilterChange={onFilterChange}
+        />
         <VirtualizedTable<V1alpha1MigrationPolicy>
+          EmptyMsg={() => (
+            <div className="pf-u-text-align-center">{t('No MigrationPolicies found')}</div>
+          )}
           columns={activeColumns}
           data={data}
-          EmptyMsg={() => <></>}
           loaded={loaded && loadedColumns}
           loadError={loadError}
           Row={MigrationPoliciesRow}

--- a/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPoliciesEmptyState/MigrationPoliciesEmptyState.tsx
@@ -3,6 +3,7 @@ import { Trans } from 'react-i18next';
 
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { ListPageBody, ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
 import {
   EmptyState,
   EmptyStateActions,
@@ -20,32 +21,38 @@ const MigrationPoliciesEmptyState: FC = () => {
   const { t } = useKubevirtTranslation();
 
   return (
-    <EmptyState variant={EmptyStateVariant.lg}>
-      <EmptyStateHeader
-        headingLevel="h4"
-        icon={<EmptyStateIcon icon={MigrationIcon} />}
-        titleText={<>{t('No MigrationPolicies found')}</>}
-      />
+    <>
+      <ListPageHeader title={t('MigrationPolicies')} />
 
-      <EmptyStateBody>
-        <Trans ns="plugin__kubevirt-plugin" t={t}>
-          Click <b>Create MigrationPolicy</b> to create your first policy
-        </Trans>
-      </EmptyStateBody>
-
-      <EmptyStateFooter>
-        <EmptyStateActions>
-          <MigrationPoliciesCreateButton />
-        </EmptyStateActions>
-        <br />
-        <EmptyStateActions>
-          <ExternalLink
-            href="https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/virtualization/live-migration#live-migration-policies"
-            text={t('Learn more about MigrationPolicies')}
+      <ListPageBody>
+        <EmptyState variant={EmptyStateVariant.lg}>
+          <EmptyStateHeader
+            headingLevel="h4"
+            icon={<EmptyStateIcon icon={MigrationIcon} />}
+            titleText={<>{t('No MigrationPolicies found')}</>}
           />
-        </EmptyStateActions>
-      </EmptyStateFooter>
-    </EmptyState>
+
+          <EmptyStateBody>
+            <Trans ns="plugin__kubevirt-plugin" t={t}>
+              Click <b>Create MigrationPolicy</b> to create your first policy
+            </Trans>
+          </EmptyStateBody>
+
+          <EmptyStateFooter>
+            <EmptyStateActions>
+              <MigrationPoliciesCreateButton />
+            </EmptyStateActions>
+            <br />
+            <EmptyStateActions>
+              <ExternalLink
+                href="https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/virtualization/live-migration#live-migration-policies"
+                text={t('Learn more about MigrationPolicies')}
+              />
+            </EmptyStateActions>
+          </EmptyStateFooter>
+        </EmptyState>
+      </ListPageBody>
+    </>
   );
 };
 


### PR DESCRIPTION
## 📝 Description

**This is another PR belonging to the epic:**
https://issues.redhat.com/browse/CNV-40059

Display _MigrationPolicies_ list correctly after getting zero results from the list filtering. Do not display empty state page in this scenario.

## 🎥 Screenshots
**Before:**
Empty state displayed even when there are some MigrationPolicies, but just zero results after filtering:
![m_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/2f80ff39-8d3a-40a7-9b67-c28165fefe83)

**After:**
![m_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/98c1ae5f-8418-4885-b02c-16e1edcc54f8)



