### PR TITLE
CNV-40059: Update Checkups lists for 0 results after filtering

### DIFF
--- a/src/views/checkups/network/list/CheckupsNetworkList.tsx
+++ b/src/views/checkups/network/list/CheckupsNetworkList.tsx
@@ -40,35 +40,39 @@ const CheckupsNetworkList = () => {
 
   const nadsInNamespace = !isEmpty(nads.filter((nad) => nad.metadata.namespace === namespace));
 
+  if (isEmpty(configMaps) && loading && !loadingPermissions && loadedColumns) {
+    return (
+      <CheckupsNetworkListEmptyState isPermitted={isPermitted} nadsInNamespace={nadsInNamespace} />
+    );
+  }
+
   return (
     <ListPageBody>
       <div className="list-managment-group">
-        {!isEmpty(unfilterData) && (
-          <ListPageFilter
-            columnLayout={{
-              columns: columns?.map(({ additional, id, title }) => ({
-                additional,
-                id,
-                title,
-              })),
-              id: 'checkups-network',
-              selectedColumns: new Set(activeColumns?.map((col) => col?.id)),
-              type: t('Checkups'),
-            }}
-            onFilterChange={(...args) => {
-              onFilterChange(...args);
-              onPaginationChange({
-                ...pagination,
-                endIndex: pagination?.perPage,
-                page: 1,
-                startIndex: 0,
-              });
-            }}
-            data={unfilterData}
-            loaded={loading && !loadingPermissions && loadedColumns}
-            rowFilters={filters}
-          />
-        )}
+        <ListPageFilter
+          columnLayout={{
+            columns: columns?.map(({ additional, id, title }) => ({
+              additional,
+              id,
+              title,
+            })),
+            id: 'checkups-network',
+            selectedColumns: new Set(activeColumns?.map((col) => col?.id)),
+            type: t('Checkups'),
+          }}
+          onFilterChange={(...args) => {
+            onFilterChange(...args);
+            onPaginationChange({
+              ...pagination,
+              endIndex: pagination?.perPage,
+              page: 1,
+              startIndex: 0,
+            });
+          }}
+          data={unfilterData}
+          loaded={loading && !loadingPermissions && loadedColumns}
+          rowFilters={filters}
+        />
         {!isEmpty(dataFilters) && loading && !loadingPermissions && (
           <Pagination
             onPerPageSelect={(_e, perPage, page, startIndex, endIndex) =>
@@ -86,13 +90,10 @@ const CheckupsNetworkList = () => {
           />
         )}
       </div>
-      {isEmpty(configMaps) && loading && !loadingPermissions && loadedColumns && (
-        <CheckupsNetworkListEmptyState
-          isPermitted={isPermitted}
-          nadsInNamespace={nadsInNamespace}
-        />
-      )}
       <VirtualizedTable<IoK8sApiCoreV1ConfigMap>
+        EmptyMsg={() => (
+          <div className="pf-u-text-align-center">{t('No network latency checkups found')}</div>
+        )}
         rowData={{
           getJobByName: (configMapName: string): IoK8sApiBatchV1Job[] =>
             getJobByName(jobs, configMapName),
@@ -101,7 +102,6 @@ const CheckupsNetworkList = () => {
         data={dataFilters}
         loaded={loading && !loadingPermissions && loadedColumns}
         loadError={error}
-        NoDataEmptyMsg={() => null}
         Row={CheckupsNetworkListRow}
         unfilteredData={unfilterData}
       />

--- a/src/views/checkups/storage/list/CheckupsStorageList.tsx
+++ b/src/views/checkups/storage/list/CheckupsStorageList.tsx
@@ -33,35 +33,43 @@ const CheckupsStorageList = () => {
   const [unfilterData, dataFilters, onFilterChange, filters] =
     useCheckupsStorageListFilters(configMaps);
 
+  if (isEmpty(configMaps) && loading && !loadingPermissions && loadedColumns) {
+    return (
+      <CheckupsStorageListEmptyState
+        clusterRoleBinding={clusterRoleBinding}
+        isPermitted={isPermitted}
+        loadingPermissions={loadingPermissions}
+      />
+    );
+  }
+
   return (
     <ListPageBody>
       <div className="list-managment-group">
-        {!isEmpty(unfilterData) && (
-          <ListPageFilter
-            columnLayout={{
-              columns: columns?.map(({ additional, id, title }) => ({
-                additional,
-                id,
-                title,
-              })),
-              id: 'checkups-storage',
-              selectedColumns: new Set(activeColumns?.map((col) => col?.id)),
-              type: t('Checkups'),
-            }}
-            onFilterChange={(...args) => {
-              onFilterChange(...args);
-              onPaginationChange({
-                ...pagination,
-                endIndex: pagination?.perPage,
-                page: 1,
-                startIndex: 0,
-              });
-            }}
-            data={unfilterData}
-            loaded={loading && !loadingPermissions && loadedColumns}
-            rowFilters={filters}
-          />
-        )}
+        <ListPageFilter
+          columnLayout={{
+            columns: columns?.map(({ additional, id, title }) => ({
+              additional,
+              id,
+              title,
+            })),
+            id: 'checkups-storage',
+            selectedColumns: new Set(activeColumns?.map((col) => col?.id)),
+            type: t('Checkups'),
+          }}
+          onFilterChange={(...args) => {
+            onFilterChange(...args);
+            onPaginationChange({
+              ...pagination,
+              endIndex: pagination?.perPage,
+              page: 1,
+              startIndex: 0,
+            });
+          }}
+          data={unfilterData}
+          loaded={loading && !loadingPermissions && loadedColumns}
+          rowFilters={filters}
+        />
         {!isEmpty(dataFilters) && loading && !loadingPermissions && (
           <Pagination
             onPerPageSelect={(_e, perPage, page, startIndex, endIndex) =>
@@ -79,14 +87,10 @@ const CheckupsStorageList = () => {
           />
         )}
       </div>
-      {isEmpty(configMaps) && loading && !loadingPermissions && loadedColumns && (
-        <CheckupsStorageListEmptyState
-          clusterRoleBinding={clusterRoleBinding}
-          isPermitted={isPermitted}
-          loadingPermissions={loadingPermissions}
-        />
-      )}
       <VirtualizedTable<IoK8sApiCoreV1ConfigMap>
+        EmptyMsg={() => (
+          <div className="pf-u-text-align-center">{t('No storage checkups found')}</div>
+        )}
         rowData={{
           getJobByName: (configMapName: string): IoK8sApiBatchV1Job[] =>
             getJobByName(jobs, configMapName),
@@ -95,7 +99,6 @@ const CheckupsStorageList = () => {
         data={dataFilters}
         loaded={loading && !loadingPermissions && loadedColumns}
         loadError={error}
-        NoDataEmptyMsg={() => null}
         Row={CheckupsStorageListRow}
         unfilteredData={unfilterData}
       />


### PR DESCRIPTION
## 📝 Description

**This is another PR belonging to the epic:**
https://issues.redhat.com/browse/CNV-40059

Display Network latency and storage checkups lists correctly after getting zero results from the list filtering. Update the message that is displayed in this scenario by adding the resource name to it. ~~Also display missing pagination.~~

## 🎥 Screenshots
**Before:**
Network latency checkups list:
![c_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/e86afd42-712a-48ef-814d-527c1188fac9)
Storage checkups list:
![cc_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/5296fc58-0ca4-444a-8cd1-f135566c2299)

**After:**
Network latency checkups list:
![ccc_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/1620f16d-343e-4dc5-9223-19276152b542)
Storage checkups list:
![cccc_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/80973c93-aef2-4a18-a575-e9bb5636936c)

