### PR TITLE
CNV-39030: preference link leads 404 blink page

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -57,6 +57,8 @@
   "5 min": "5 min",
   "8 min": "8 min",
   "8xlarge": "8xlarge",
+  "A ControllerRevision resource is cloned from the InstanceType when creating the VirtualMachine": "A ControllerRevision resource is cloned from the InstanceType when creating the VirtualMachine",
+  "A ControllerRevision resource is cloned from the Preference when creating the VirtualMachine": "A ControllerRevision resource is cloned from the Preference when creating the VirtualMachine",
   "A list of matching Nodes will be provided on label input below.": "A list of matching Nodes will be provided on label input below.",
   "A Project name must consist of lower case alphanumeric characters or ', and must start and end with an alphanumeric character (e.g. 'my-name' or '123-abc'). You must create a Namespace to be able to create projects that begin with 'openshift-', 'kubernetes-', or 'kube-'.": "A Project name must consist of lower case alphanumeric characters or ', and must start and end with an alphanumeric character (e.g. 'my-name' or '123-abc'). You must create a Namespace to be able to create projects that begin with 'openshift-', 'kubernetes-', or 'kube-'.",
   "A unique name for the storage claim within the project": "A unique name for the storage claim within the project",

--- a/src/utils/resources/instancetype/helper.ts
+++ b/src/utils/resources/instancetype/helper.ts
@@ -6,6 +6,6 @@ import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 export const getInstanceTypeModelFromMatcher = (
   instanceTypeMatcher: V1InstancetypeMatcher,
 ): K8sModel =>
-  instanceTypeMatcher.kind.includes('Cluster')
+  instanceTypeMatcher.kind.includes('cluster')
     ? VirtualMachineClusterInstancetypeModel
     : VirtualMachineInstancetypeModel;

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/InstanceTypeDescription.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/InstanceTypeDescription.tsx
@@ -1,12 +1,10 @@
 import React, { FC } from 'react';
 
 import { ControllerRevisionModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
-import VirtualMachineInstancetypeModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstancetypeModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getInstanceTypeModelFromMatcher } from '@kubevirt-utils/resources/instancetype/helper';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getInstanceTypeMatcher, getPreferenceMatcher } from '@kubevirt-utils/resources/vm';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
@@ -20,19 +18,20 @@ const InstanceTypeDescription: FC<InstanceTypeDescriptionProps> = ({ vm }) => {
   const None = <MutedTextSpan text={t('None')} />;
 
   const itMatcher = getInstanceTypeMatcher(vm);
-  const itModel = getInstanceTypeModelFromMatcher(itMatcher);
-  const includeNamespace = itModel === VirtualMachineInstancetypeModel;
   const preferenceMatcher = getPreferenceMatcher(vm);
 
   return (
     <>
       <VirtualMachineDescriptionItem
+        bodyContent={t(
+          'A ControllerRevision resource is cloned from the InstanceType when creating the VirtualMachine',
+        )}
         descriptionData={
           itMatcher ? (
             <ResourceLink
               groupVersionKind={ControllerRevisionModelGroupVersionKind}
               name={itMatcher.revisionName}
-              namespace={includeNamespace && getNamespace(vm)}
+              namespace={getNamespace(vm)}
             />
           ) : (
             None
@@ -40,13 +39,18 @@ const InstanceTypeDescription: FC<InstanceTypeDescriptionProps> = ({ vm }) => {
         }
         data-test-id="virtual-machine-overview-details-instance-type"
         descriptionHeader={t('InstanceType')}
+        isPopover
       />
       <VirtualMachineDescriptionItem
+        bodyContent={t(
+          'A ControllerRevision resource is cloned from the Preference when creating the VirtualMachine',
+        )}
         descriptionData={
           preferenceMatcher ? (
             <ResourceLink
               groupVersionKind={ControllerRevisionModelGroupVersionKind}
               name={preferenceMatcher.revisionName}
+              namespace={getNamespace(vm)}
             />
           ) : (
             None
@@ -54,6 +58,7 @@ const InstanceTypeDescription: FC<InstanceTypeDescriptionProps> = ({ vm }) => {
         }
         data-test-id="virtual-machine-overview-details-preference"
         descriptionHeader={t('Preference')}
+        isPopover
       />
     </>
   );


### PR DESCRIPTION
## 📝 Description

Preference link leads to 404 page for a second (missing namespace)
Instance type is not loading on create VM from snapshot.
Adding explanatory text for why linking ControllerReviosion clones to IT and Pref

## 🎥 Demo

After:

![it-appear-create-vm-from-snapshot](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/d190deda-9ee7-44eb-b3b1-539472493509)
![it-appear-create-vm-from-snapshot3](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/a897e159-4385-4c2b-97f2-6e54a874cb9d)
![it-appear-create-vm-from-snapshot2](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/28618ab5-2f9b-4ede-9d8d-d6671506f275)
