### PR TITLE
CNV-35740: Add Sysprep option for Windows VMs when creating from InstanceTypes

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/PreferenceSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/PreferenceSelect.tsx
@@ -56,7 +56,7 @@ const PreferenceSelect: FC<PreferenceSelectProps> = ({
         )(VirtualMachinePreferenceModelGroupVersionKind.kind),
     );
     return [...userPreferenceOptions, ...preferenceOptions];
-  }, [preferences, userPreferences]);
+  }, [preferences, userPreferences, deleteLabel, setBootableVolumeField]);
 
   if (!preferencesLoaded || !userPreferencesLoaded) return <Loading />;
 

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
@@ -108,7 +108,15 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
     else if (loaded && (loadError || !canCreateNetworkInterface)) {
       setSubmitDisabled(true);
     }
-  }, [loadError, canCreateNetworkInterface, loaded, networkName]);
+  }, [
+    loadError,
+    canCreateNetworkInterface,
+    loaded,
+    networkName,
+    networkOptions,
+    setNetworkName,
+    setSubmitDisabled,
+  ]);
 
   return (
     <FormGroup

--- a/src/utils/components/SysprepModal/SelectSysprep.tsx
+++ b/src/utils/components/SysprepModal/SelectSysprep.tsx
@@ -1,16 +1,14 @@
 import React, { FC } from 'react';
 
 import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName } from '@kubevirt-utils/resources/shared';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, AlertVariant, Button, ButtonVariant } from '@patternfly/react-core';
 
 import InlineFilterSelect from '../FilterSelect/InlineFilterSelect';
 import Loading from '../Loading/Loading';
 
-import { AUTOUNATTEND, UNATTEND } from './sysprep-utils';
+import useSysprepConfigMaps from './hooks/useConfigMaps';
 
 type SelectSysprepProps = {
   id?: string;
@@ -26,18 +24,7 @@ const SelectSysprep: FC<SelectSysprepProps> = ({
   selectedSysprepName,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [configmaps, configmapsLoaded, configmapsError] = useK8sWatchResource<
-    IoK8sApiCoreV1ConfigMap[]
-  >({
-    groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
-    isList: true,
-    namespace,
-    namespaced: true,
-  });
-
-  const sysprepConfigMaps = configmaps?.filter(
-    (configmap) => configmap?.data?.[AUTOUNATTEND] || configmap?.data?.[UNATTEND],
-  );
+  const [sysprepConfigMaps, configmapsLoaded, configmapsError] = useSysprepConfigMaps(namespace);
 
   if (configmapsError)
     return (

--- a/src/utils/components/SysprepModal/Sysprep.tsx
+++ b/src/utils/components/SysprepModal/Sysprep.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 
 import { Form } from '@patternfly/react-core';
 
@@ -15,19 +15,17 @@ type SysprepProps = {
   unattend: string;
 };
 
-const Sysprep: React.FC<SysprepProps> = ({
+const Sysprep: FC<SysprepProps> = ({
   autoUnattend,
   onAutoUnattendChange,
   onUnattendChange,
   unattend,
-}) => {
-  return (
-    <Form className="kv-sysprep--main">
-      <SysprepInfo />
-      <SysprepAutounattend onChange={onAutoUnattendChange} value={autoUnattend} />
-      <SysprepUnattend onChange={onUnattendChange} value={unattend} />
-    </Form>
-  );
-};
+}) => (
+  <Form className="kv-sysprep--main">
+    <SysprepInfo />
+    <SysprepAutounattend onChange={onAutoUnattendChange} value={autoUnattend} />
+    <SysprepUnattend onChange={onUnattendChange} value={unattend} />
+  </Form>
+);
 
 export default Sysprep;

--- a/src/utils/components/SysprepModal/SysprepInfo.tsx
+++ b/src/utils/components/SysprepModal/SysprepInfo.tsx
@@ -8,6 +8,7 @@ import { SYSPREP_DOC_URL } from './consts';
 
 const SysprepInfo: FC = () => {
   const { t } = useKubevirtTranslation();
+
   return (
     <div data-test="sysprep-info">
       <Stack>

--- a/src/utils/components/SysprepModal/hooks/useConfigMaps.ts
+++ b/src/utils/components/SysprepModal/hooks/useConfigMaps.ts
@@ -1,0 +1,24 @@
+import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { useK8sWatchResource, WatchK8sResult } from '@openshift-console/dynamic-plugin-sdk';
+
+import { AUTOUNATTEND, UNATTEND } from '../sysprep-utils';
+
+const useSysprepConfigMaps = (namespace: string): WatchK8sResult<IoK8sApiCoreV1ConfigMap[]> => {
+  const [configmaps, configmapsLoaded, configmapsError] = useK8sWatchResource<
+    IoK8sApiCoreV1ConfigMap[]
+  >({
+    groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
+    isList: true,
+    namespace,
+    namespaced: true,
+  });
+
+  const sysprepConfigMaps = configmaps?.filter(
+    (configmap) => configmap?.data?.[AUTOUNATTEND] || configmap?.data?.[UNATTEND],
+  );
+
+  return [sysprepConfigMaps, configmapsLoaded, configmapsError];
+};
+
+export default useSysprepConfigMaps;

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsRightGrid.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsRightGrid.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 
 import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore';
 import { instanceTypeActionType } from '@catalog/CreateFromInstanceTypes/state/utils/types';
+import { useIsWindowsBootableVolume } from '@catalog/CreateFromInstanceTypes/utils/utils';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -15,6 +16,7 @@ import { formatBytes } from '@kubevirt-utils/resources/vm/utils/disk/size';
 import { DescriptionList } from '@patternfly/react-core';
 
 import DynamicSSHKeyInjectionInstanceType from './DynamicSSHKeyInjectionInstanceType';
+import SysprepDescriptionItem from './SysprepDescriptionItem';
 
 import './details-right-grid.scss';
 
@@ -23,6 +25,7 @@ const DetailsRightGrid: FC = () => {
   const { createModal } = useModal();
   const [{ clusterDefaultStorageClass, sortedStorageClasses, virtDefaultStorageClass }, loaded] =
     useDefaultStorageClass();
+  const isWindowsOSVolume = useIsWindowsBootableVolume();
 
   const {
     instanceTypeVMState,
@@ -76,28 +79,34 @@ const DetailsRightGrid: FC = () => {
         }
         descriptionHeader={t('Storage class')}
       />
-      <VirtualMachineDescriptionItem
-        descriptionData={
-          isChangingNamespace ? (
-            <Loading />
-          ) : (
-            sshSecretCredentials?.sshSecretName || t('Not configured')
-          )
-        }
-        onEditClick={() =>
-          createModal((modalProps) => (
-            <SSHSecretModal
-              {...modalProps}
-              initialSSHSecretDetails={sshSecretCredentials}
-              namespace={vmNamespaceTarget}
-              onSubmit={setSSHCredentials}
-            />
-          ))
-        }
-        descriptionHeader={t('Public SSH key')}
-        isEdit={!isChangingNamespace}
-      />
-      <DynamicSSHKeyInjectionInstanceType />
+      {isWindowsOSVolume ? (
+        <SysprepDescriptionItem />
+      ) : (
+        <>
+          <VirtualMachineDescriptionItem
+            descriptionData={
+              isChangingNamespace ? (
+                <Loading />
+              ) : (
+                sshSecretCredentials?.sshSecretName || t('Not configured')
+              )
+            }
+            onEditClick={() =>
+              createModal((modalProps) => (
+                <SSHSecretModal
+                  {...modalProps}
+                  initialSSHSecretDetails={sshSecretCredentials}
+                  namespace={vmNamespaceTarget}
+                  onSubmit={setSSHCredentials}
+                />
+              ))
+            }
+            descriptionHeader={t('Public SSH key')}
+            isEdit={!isChangingNamespace}
+          />
+          <DynamicSSHKeyInjectionInstanceType />
+        </>
+      )}
     </DescriptionList>
   );
 };

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/SimplifiedSysprepDescription.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/SimplifiedSysprepDescription.tsx
@@ -1,0 +1,53 @@
+import React, { FC } from 'react';
+
+import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+import { Stack, StackItem } from '@patternfly/react-core';
+
+type SimplifiedSysprepDescriptionProps = {
+  hasAutoUnattend: boolean;
+  hasUnattend: boolean;
+  selectedSysprepName?: string;
+};
+
+const SimplifiedSysprepDescription: FC<SimplifiedSysprepDescriptionProps> = ({
+  hasAutoUnattend,
+  hasUnattend,
+  selectedSysprepName,
+}) => {
+  const { t } = useKubevirtTranslation();
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        {selectedSysprepName ? (
+          <VirtualMachineDescriptionItem
+            descriptionData={
+              <ResourceLink
+                groupVersionKind={modelToGroupVersionKind(ConfigMapModel)}
+                linkTo={false}
+                name={selectedSysprepName}
+              />
+            }
+            descriptionHeader={t('Selected sysprep')}
+          />
+        ) : (
+          <>
+            <VirtualMachineDescriptionItem
+              descriptionData={hasAutoUnattend ? t('Available') : t('Not available')}
+              descriptionHeader={t('Autounattend.xml answer file')}
+            />
+            <VirtualMachineDescriptionItem
+              descriptionData={hasUnattend ? t('Available') : t('Not available')}
+              descriptionHeader={t('Unattend.xml answer file')}
+            />
+          </>
+        )}
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default SimplifiedSysprepDescription;

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/SysprepDescriptionItem.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/SysprepDescriptionItem.tsx
@@ -1,0 +1,108 @@
+import React, { FC, useState } from 'react';
+
+import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore';
+import { instanceTypeVMInitialState } from '@catalog/CreateFromInstanceTypes/state/utils/state';
+import {
+  instanceTypeActionType,
+  SysprepConfigMapData,
+} from '@catalog/CreateFromInstanceTypes/state/utils/types';
+import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import useSysprepConfigMaps from '@kubevirt-utils/components/SysprepModal/hooks/useConfigMaps';
+import { AUTOUNATTEND, UNATTEND } from '@kubevirt-utils/components/SysprepModal/sysprep-utils';
+import { SysprepModal } from '@kubevirt-utils/components/SysprepModal/SysprepModal';
+import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { Loading } from '@patternfly/quickstarts';
+
+import SimplifiedSysprepDescription from './SimplifiedSysprepDescription';
+
+const SysprepDescriptionItem: FC = () => {
+  const { t } = useKubevirtTranslation();
+  const { createModal } = useModal();
+
+  const { instanceTypeVMState, isChangingNamespace, setInstanceTypeVMState, vmNamespaceTarget } =
+    useInstanceTypeVMStore();
+
+  const [sysprepConfigMaps] = useSysprepConfigMaps(vmNamespaceTarget);
+  const sysprepInitialData = instanceTypeVMInitialState.sysprepConfigMapData;
+  const { sysprepConfigMapData } = instanceTypeVMState;
+  const { data, name: currentSysprepName } = sysprepConfigMapData || sysprepInitialData;
+  const [autounattend, setAutounattend] = useState<string>(data?.autounattend || '');
+  const [unattended, setUnattended] = useState<string>(data?.unattended || '');
+
+  const setSysprepConfigMapData = (newConfigMapData: SysprepConfigMapData) => {
+    setInstanceTypeVMState({
+      payload: newConfigMapData,
+      type: instanceTypeActionType.setSysprepConfigMapData,
+    });
+  };
+
+  const onSysprepCreation = (unattend: string, autoUnattend: string): Promise<void> => {
+    if (!unattend && !autoUnattend) {
+      setAutounattend('');
+      setUnattended('');
+      setSysprepConfigMapData(sysprepInitialData);
+      return;
+    }
+
+    setAutounattend(autoUnattend);
+    setUnattended(unattend);
+    setSysprepConfigMapData({
+      data: {
+        autounattend: autoUnattend,
+        unattended: unattend,
+      },
+      name: '', // name of new ConfigMap will be generated and attached to VM later on its creation
+    });
+  };
+
+  const onSysprepSelected = (name: string) => {
+    const dataObj = sysprepConfigMaps?.filter((configMap) => configMap.metadata.name === name)[0]
+      ?.data;
+    const { [AUTOUNATTEND]: autoUnattend, [UNATTEND]: unattend } = dataObj || {};
+
+    setAutounattend(autoUnattend);
+    setUnattended(unattend);
+    setSysprepConfigMapData({
+      data: {
+        autounattend: autoUnattend,
+        unattended: unattend,
+      },
+      name,
+    });
+  };
+
+  const sysprepDescription =
+    autounattend || unattended ? (
+      <SimplifiedSysprepDescription
+        hasAutoUnattend={!!autounattend}
+        hasUnattend={!!unattended}
+        selectedSysprepName={currentSysprepName}
+      />
+    ) : (
+      t('Not configured')
+    );
+
+  return (
+    <VirtualMachineDescriptionItem
+      onEditClick={() =>
+        createModal((modalProps) => (
+          <SysprepModal
+            {...modalProps}
+            autoUnattend={autounattend}
+            namespace={vmNamespaceTarget}
+            onSysprepCreation={onSysprepCreation}
+            onSysprepSelected={onSysprepSelected}
+            sysprepSelected={currentSysprepName}
+            unattend={unattended}
+          />
+        ))
+      }
+      descriptionData={isChangingNamespace ? <Loading /> : sysprepDescription}
+      descriptionHeader={t('Sysprep')}
+      isEdit={!isChangingNamespace}
+    />
+  );
+};
+
+export default SysprepDescriptionItem;

--- a/src/views/catalog/CreateFromInstanceTypes/state/utils/state.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/utils/state.ts
@@ -2,13 +2,14 @@ import { initialSSHCredentials } from '@kubevirt-utils/components/SSHSecretModal
 
 import { InstanceTypeVMState, InstanceTypeVMStoreState } from './types';
 
-const instanceTypeVMInitialState: InstanceTypeVMState = {
+export const instanceTypeVMInitialState: InstanceTypeVMState = {
   isDynamicSSHInjection: false,
   pvcSource: null,
   selectedBootableVolume: null,
   selectedInstanceType: { name: '', namespace: null },
   selectedStorageClass: null,
   sshSecretCredentials: initialSSHCredentials,
+  sysprepConfigMapData: { data: {}, name: '' },
   vmName: '',
 };
 

--- a/src/views/catalog/CreateFromInstanceTypes/state/utils/types.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/utils/types.ts
@@ -9,6 +9,7 @@ import {
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
 import { SSHSecretDetails } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
+import { SysprepData } from '@kubevirt-utils/components/SysprepModal/sysprep-utils';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 
 export type InstanceTypes = (
@@ -34,6 +35,11 @@ export type UseBootableVolumesValues = {
   volumeSnapshotSources: { [dataSourceName: string]: VolumeSnapshotKind };
 };
 
+export type SysprepConfigMapData = {
+  data: SysprepData;
+  name: string;
+};
+
 export type InstanceTypeVMState = {
   isDynamicSSHInjection: boolean;
   pvcSource: IoK8sApiCoreV1PersistentVolumeClaim;
@@ -41,6 +47,7 @@ export type InstanceTypeVMState = {
   selectedInstanceType: { name: string; namespace: string };
   selectedStorageClass: string;
   sshSecretCredentials: SSHSecretDetails;
+  sysprepConfigMapData: SysprepConfigMapData;
   vmName: string;
 };
 
@@ -50,6 +57,7 @@ export enum instanceTypeActionType {
   setSelectedBootableVolume = 'selectedBootableVolume',
   setSelectedInstanceType = 'selectedInstanceType',
   setSSHCredentials = 'sshSecretCredentials',
+  setSysprepConfigMapData = 'sysprepConfigMapData',
   setVMName = 'vmName',
 }
 
@@ -59,7 +67,8 @@ type InstanceTypeAction = {
     | boolean
     | BootableVolume
     | SSHSecretDetails
-    | string;
+    | string
+    | SysprepConfigMapData;
   type: string;
 };
 

--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -14,6 +14,7 @@ import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAuto
 import { isBootableVolumePVCKind } from '@kubevirt-utils/resources/bootableresources/helpers';
 import { getLabel, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
+import { OS_WINDOWS_PREFIX } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import {
   HEADLESS_SERVICE_LABEL,
   HEADLESS_SERVICE_NAME,
@@ -21,6 +22,7 @@ import {
 import { generatePrettyName, getRandomChars, isEmpty } from '@kubevirt-utils/utils/utils';
 import { K8sGroupVersionKind, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
+import { useInstanceTypeVMStore } from '../state/useInstanceTypeVMStore';
 import { InstanceTypeVMState } from '../state/utils/types';
 
 import {
@@ -178,4 +180,12 @@ export const groupVersionKindFromCommonResource = (
   const [group, version] = resource.apiVersion.split('/');
   const kind = resource.kind;
   return { group, kind, version };
+};
+
+export const useIsWindowsBootableVolume = (): boolean => {
+  const { instanceTypeVMState } = useInstanceTypeVMStore();
+  const { selectedBootableVolume } = instanceTypeVMState;
+  const defaultPreferenceName = getLabel(selectedBootableVolume, DEFAULT_PREFERENCE_LABEL);
+
+  return defaultPreferenceName?.startsWith(OS_WINDOWS_PREFIX) || false;
 };

--- a/src/views/catalog/wizard/tabs/scripts/components/Sysprep.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/components/Sysprep.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import React, { FC } from 'react';
+import { getSysprepConfigMapName } from 'src/views/templates/details/tabs/scripts/components/SysPrepItem/sysprep-utils';
 
 import { produceVMSysprep, useWizardVMContext } from '@catalog/utils/WizardVMContext';
 import { WizardDescriptionItem } from '@catalog/wizard/components/WizardDescriptionItem';
@@ -24,14 +25,14 @@ import {
   removeSysprepObject,
 } from './sysprep-utils';
 
-const Sysprep: React.FC = () => {
+const Sysprep: FC = () => {
   const { t } = useKubevirtTranslation();
 
   const { createModal } = useModal();
   const { tabsData, updateTabsData, updateVM, vm } = useWizardVMContext();
 
   const currentSysprepVolume = getVolumes(vm)?.find((volume) => volume?.sysprep?.configMap?.name);
-  const currentVMSysprepName = currentSysprepVolume?.sysprep?.configMap?.name;
+  const currentVMSysprepName = getSysprepConfigMapName(currentSysprepVolume);
 
   const filterSysprepByName = isSysprepConfig(currentVMSysprepName);
 


### PR DESCRIPTION
## 📝 Description

**Epic:**
https://issues.redhat.com/browse/CNV-35740

_Design doc:_
https://docs.google.com/document/d/1xwev8T5mR0lCp0oqMefa-etfgKayKrb7j2fEOxWYcNE/edit

_Useful resources:_
https://kubevirt.io/user-guide/virtual_machines/startup_scripts/#sysprep-examples

Adjust the third section of the form when creating VMs from InstanceTypes depending on the OS type that is being created: Linux or Windows (according to the InstanceType preference selection). Add _Sysprep_ option for Windows VMs instead of SSH data to the section.

## 🎥 Demo
**Before:**
When choosing bootable volume with Windows OS, SSH data section still present:
![win_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/2d00e10b-6c4f-4c2a-9afb-024dec5fc724)

**After:**
Adding new sysprep configuration:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/cd329db4-2b89-4a38-99df-489bfe09c53c

Attaching the existing sysprep:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/b0ccbc79-ca83-4a48-95b1-75aa611a5f1c

