### PR TITLE
CNV-41210: Display 'virtctl ssh' example only once in VM SSH settings

### DIFF
--- a/src/utils/components/SSHAccess/components/VirtctlSSHCommandClipboardCopy.tsx
+++ b/src/utils/components/SSHAccess/components/VirtctlSSHCommandClipboardCopy.tsx
@@ -4,7 +4,7 @@ import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getVMSSHSecretName } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { ClipboardCopy, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { ClipboardCopy } from '@patternfly/react-core';
 
 import { getConsoleVirtctlCommand } from '../utils';
 
@@ -18,19 +18,7 @@ const VirtctlSSHCommandClipboardCopy: FC<VirtctlSSHCommandClipboardCopyProps> = 
   const sshSecretNotConfigured = isEmpty(getVMSSHSecretName(vm));
 
   if (sshSecretNotConfigured) {
-    return (
-      <>
-        <div className="pf-u-font-size-xs">{t('SSH secret not configured')}</div>
-        {sshSecretNotConfigured && (
-          <HelperText className="pf-u-mt-sm">
-            <HelperTextItem variant="indeterminate">
-              {t('Example: ')}
-              {getConsoleVirtctlCommand(vm)}
-            </HelperTextItem>
-          </HelperText>
-        )}
-      </>
-    );
+    return <div className="pf-u-font-size-xs">{t('SSH secret not configured')}</div>;
   }
 
   return (


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-41210

Remove unnecessary example text for _SSH access_ section, already displayed in the tooltip next to _SSH using virtctl_.

## 🎥 Screenshots
**Before**:
Example command displayed twice:
![virt_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/b2d51a42-6d92-4bd5-b916-4a6c55ac6204)

**After:**
Example displayed only once, as part of the tooltip:
![virt_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/edf81819-570a-4c79-a6b2-821414bfc324)






