### PR TITLE
CNV-41139: Change SSH key doc link to point at downstream doc

### DIFF
--- a/src/utils/components/DynamicSSHKeyInjection/constants/constants.ts
+++ b/src/utils/components/DynamicSSHKeyInjection/constants/constants.ts
@@ -1,4 +1,4 @@
 export const DYNAMIC_CREDENTIALS_SUPPORT = 'kubevirt.io/dynamic-credentials-support';
 
 export const DYNAMIC_SSH_KEY_INJECTION_LINK =
-  'https://kubevirt.io/user-guide/virtual_machines/accessing_virtual_machines/#dynamic-ssh-public-key-injection-via-qemu-guest-agent';
+  'https://docs.openshift.com/container-platform/4.15/virt/virtual_machines/virt-accessing-vm-ssh.html';


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-41139

Change Public SSH key's _Learn more_ link in the VM _Configuration_ page to point ad the correct downstream doc instead of upstream one:
https://docs.openshift.com/container-platform/4.15/virt/virtual_machines/virt-accessing-vm-ssh.html

## 🎥 Screenshots
Clicking on _Learn more_ link leading to...
![learn](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/c1068803-8135-420b-b16a-5272431ec76c)

**Before:**
... upstream doc:
![doc_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/bed54fe1-5339-46e9-a05c-699b7f3ac484)

**After:**
... downstream doc:
![doc_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/124a5354-f2d8-4f49-9313-dc04a3dfbb30)

