### PR TITLE
CNV-41206: Uncheck Dynamic SSH key injection if not supported

### DIFF
--- a/src/utils/components/DynamicSSHKeyInjection/DynamicSSHKeyInjection.tsx
+++ b/src/utils/components/DynamicSSHKeyInjection/DynamicSSHKeyInjection.tsx
@@ -1,20 +1,26 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getIsDynamicSSHInjectionEnabled } from '@kubevirt-utils/resources/vm';
 import { Switch } from '@patternfly/react-core';
 
 type DynamicSSHKeyInjectionProps = {
+  hasDynamicSSHLabel?: boolean;
   isDisabled: boolean;
   onSubmit: (checked: boolean) => void;
   vm?: V1VirtualMachine;
 };
 export const DynamicSSHKeyInjection: FC<DynamicSSHKeyInjectionProps> = ({
+  hasDynamicSSHLabel,
   isDisabled,
   onSubmit,
   vm,
 }) => {
   const [isChecked, setIsChecked] = useState<boolean>(getIsDynamicSSHInjectionEnabled(vm));
+
+  useEffect(() => {
+    if (!vm && !hasDynamicSSHLabel) setIsChecked(false);
+  }, [vm, hasDynamicSSHLabel, setIsChecked]);
 
   return (
     <Switch

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DynamicSSHKeyInjectionInstanceType.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DynamicSSHKeyInjectionInstanceType.tsx
@@ -25,6 +25,7 @@ const DynamicSSHKeyInjectionInstanceType = () => {
               type: instanceTypeActionType.setIsDynamicSSHInjection,
             });
           }}
+          hasDynamicSSHLabel={Boolean(hasDynamicSSHLabel)}
           isDisabled={isDisabled}
         />
       }


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-41206

Make the _Dynamic SSH key injection_ field not checked when creating VMs from InstanceTypes and changing volume to boot from to other than RHEL 9 one. Hence create the VM without dynamic SSH key injection as expected.

## 🎥 Demo
**Before:**
_Dynamic SSH key injection_ disabled after choosing RHEL 8 volume, but still checked:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/bfc471ae-35f7-4731-ada8-a46ae516a6cd

**After:**
_Dynamic SSH key injection_ disabled after choosing RHEL 8 volume, and also not checked - as expected:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/e73c1ebb-4963-446f-9d83-5ca3079d0349



