### PR TITLE
CNV-41199: Remove InstanceType link from Create VM from snapshot modal

### DIFF
--- a/src/utils/components/CloneVMModal/components/InstanceTypeConfiguration.tsx
+++ b/src/utils/components/CloneVMModal/components/InstanceTypeConfiguration.tsx
@@ -26,10 +26,10 @@ const InstanceTypeConfiguration: FC<InstanceTypeConfigurationProps> = ({ itMatch
         {instanceTypeLoaded ? (
           <ResourceLink
             groupVersionKind={modelToGroupVersionKind(getInstanceTypeModelFromMatcher(itMatcher))}
-            linkTo={true}
-            name={instanceType.metadata.name}
             namespace={instanceType.metadata.namespace}
-          />
+          >
+            {instanceType.metadata.name}
+          </ResourceLink>
         ) : (
           <Skeleton className="pf-m-width-sm" />
         )}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-41199

Remove the unnecessary resource link from InstanceType's name displayed in _Create VirtualMachine from snapshot_ modal.

## 🎥 Screenshots
**Before:**
Possible to click on the resource's name and redirect to its details page:
![vmci_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/727ae779-4e28-427c-8b30-da8d06a40d41)

**After:**
![vmci_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/8ce2eed0-aefe-4cf3-8e9e-c63ede58ec5d)


