### PR TITLE
[release-4.15] CNV-41495: Edit disk minimal info

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -229,7 +229,6 @@
   "Canceling ongoing migration": "Canceling ongoing migration",
   "Cancelling upload": "Cancelling upload",
   "Cannot cancel migration for \"{{ status }}\" status": "Cannot cancel migration for \"{{ status }}\" status",
-  "Cannot edit resources that already created": "Cannot edit resources that already created",
   "Cannot update": "Cannot update",
   "Catalog": "Catalog",
   "CatalogSource not found": "CatalogSource not found",

--- a/src/utils/components/DiskModal/utils/editDiskModalHelpers.ts
+++ b/src/utils/components/DiskModal/utils/editDiskModalHelpers.ts
@@ -5,7 +5,7 @@ import {
   V1Volume,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
-import { mapSourceTypeToVolumeType, sourceTypes } from '../DiskFormFields/utils/constants';
+import { mapSourceTypeToVolumeType, OTHER, sourceTypes } from '../DiskFormFields/utils/constants';
 import { DiskFormState, DiskSourceState } from '../state/initialState';
 
 import { requiresDataVolume } from './helpers';
@@ -23,6 +23,12 @@ export const updateVolume = (
   const oldVolumeSourceKey = Object.keys(oldVolume).find((key) => key !== 'name');
   const oldVolumeSource = mapSourceTypeToVolumeType[oldVolumeSourceKey];
   const newVolumeSource = mapSourceTypeToVolumeType[diskState.diskSource];
+
+  if (newVolumeSource === OTHER) {
+    updatedVolume[oldVolumeSourceKey] = oldVolume[oldVolumeSourceKey];
+    return updatedVolume;
+  }
+
   if (oldVolumeSource !== newVolumeSource) {
     delete updatedVolume[oldVolumeSource];
   }
@@ -31,11 +37,19 @@ export const updateVolume = (
     updatedVolume.containerDisk = {
       image: diskSourceState.ephemeralSource,
     };
-  } else if (diskState.diskSource === sourceTypes.PVC) {
+
+    return updatedVolume;
+  }
+
+  if (diskState.diskSource === sourceTypes.PVC) {
     updatedVolume.persistentVolumeClaim = {
       claimName: diskSourceState.pvcSourceName,
     };
-  } else if (diskState.diskSource === sourceTypes.UPLOAD) {
+
+    return updatedVolume;
+  }
+
+  if (diskState.diskSource === sourceTypes.UPLOAD) {
     return {
       name: diskState.diskName,
       persistentVolumeClaim: {
@@ -43,6 +57,7 @@ export const updateVolume = (
       },
     };
   }
+
   return updatedVolume;
 };
 

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
@@ -34,7 +34,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({ obj, vm, vmi }) => {
 
   const isVMRunning = isRunning(vm);
   const isHotplug = isHotplugVolume(vm, diskName, vmi);
-  const isEditDisabled = isVMRunning || pvcResourceExists;
+  const isEditDisabled = isVMRunning;
 
   const { initialDiskSourceState, initialDiskState } =
     !isEditDisabled && getEditDiskStates(vm, diskName, vmi);
@@ -49,11 +49,8 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({ obj, vm, vmi }) => {
     if (isVMRunning) {
       return t('Can edit only when VirtualMachine is stopped');
     }
-    if (pvcResourceExists) {
-      return t('Cannot edit resources that already created');
-    }
     return null;
-  }, [isVMRunning, pvcResourceExists, t]);
+  }, [isVMRunning, t]);
 
   const createEditDiskModal = () =>
     createModal(({ isOpen, onClose }) => (

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/utils/getEditDiskStates.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/utils/getEditDiskStates.ts
@@ -81,5 +81,5 @@ export const getEditDiskStates: UseEditDiskStates = (vm, diskName, vmi) => {
     volumeMode: null,
   };
 
-  return { initialDiskSourceState: initialStateDiskSource, initialDiskState };
+  return { initialDiskSourceState, initialDiskState };
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

backport of https://github.com/kubevirt-ui/kubevirt-plugin/pull/1914

on file `src/utils/components/DiskModal/utils/editDiskModalHelpers.ts` 

there was a bug after editing disk. To don't allow disk source editing (as probably PVC already created) the disk source in the edit modal is `Other` but on the way of creating the new volume with new data user input, the function create a volume with not source.


on `src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/utils/getEditDiskStates.ts`

in case of containerDisk type of volume, the modal was not showing the container disk image URL. 


## 🎥 Demo

![Screenshot from 2024-05-06 15-19-33](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/0b24ea14-5206-466b-8a5e-2926aea48140)
![Screenshot from 2024-05-06 15-19-26](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/9739db5c-594f-4d76-a046-d48660fbb546)

