### PR TITLE
CNV-40445: Display OpenshiftVirtualization Degraded warning alerts

### DIFF
--- a/src/views/dashboard-extensions/KubevirtHealthPopup/KubevirtHealthPopup.tsx
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/KubevirtHealthPopup.tsx
@@ -35,17 +35,17 @@ const KubevirtHealthPopup: FC = () => {
           <StackItem>
             <div className="kv-health-popup__alerts-count">
               <RedExclamationCircleIcon className="kv-health-popup__alerts-count--icon" />
-              <Link to={`${ALERTS_BASE_PATH}${HealthImpactLevel.critical}`}>{`${
-                alerts?.[HealthImpactLevel.critical]?.length
-              } Critical`}</Link>
+              <Link replace to={`${ALERTS_BASE_PATH}${HealthImpactLevel.critical}`}>
+                {`${alerts?.[HealthImpactLevel.critical]?.length} Critical`}
+              </Link>
             </div>
           </StackItem>
           <StackItem>
             <div className="kv-health-popup__alerts-count">
               <YellowExclamationTriangleIcon className="kv-health-popup__alerts-count--icon" />{' '}
-              <Link to={`${ALERTS_BASE_PATH}${HealthImpactLevel.warning}`}>{`${
-                alerts?.[AlertType.warning]?.length
-              } Warning`}</Link>
+              <Link replace to={`${ALERTS_BASE_PATH}${HealthImpactLevel.warning}`}>
+                {`${alerts?.[AlertType.warning]?.length} Warning`}
+              </Link>
             </div>
           </StackItem>
         </Stack>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-40445

Display OpenshiftVirtualization Degraded Alerting page correctly, when clicking on _Warning_ in _Overview > Status_ card's related modal.

## 🎥 Demo
**Before:**
Clicking on _Warning_ leads to an empty page:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/2f9d0a45-9916-4d37-ad66-062e4802c2a7

**After:**
The related page displays correctly with all the relevant alerts:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/4c575079-86b7-484a-99d8-b919a7418e6b




