### PR TITLE
CNV-39727: fix pagination on bootablevolume selection

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeListModal/BootableVolumeListModal.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeListModal/BootableVolumeListModal.tsx
@@ -34,14 +34,17 @@ const BootableVolumeListModal: FC<BootableVolumeListModalProps> = ({
   const onSave = () => {
     onSelectCreatedVolume(selectedBootableVolumeState[0], pvcSource, volumeSnapshotSource);
     onClose();
+
+    return Promise.resolve();
   };
+
   return (
     <TabModal
       headerText={t('Available volumes')}
       isOpen={isOpen}
       modalVariant={ModalVariant.large}
       onClose={onClose}
-      onSubmit={onSave as () => Promise<void>}
+      onSubmit={onSave}
       submitBtnText={t('Select')}
     >
       <BootableVolumeList

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumesPipelinesHint/QuickStartLauncherLink/QuickStartLauncherLink.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumesPipelinesHint/QuickStartLauncherLink/QuickStartLauncherLink.tsx
@@ -31,9 +31,9 @@ const QuickStartLauncherLink: FC<QuickStartLauncherLinkProps> = ({
   const quickStartLink: GettingStartedLink = quickStartLoaded && {
     id: getName(quickStart),
     onClick: () => {
-      setActiveQuickStart(quickStart.metadata.name, quickStart.spec.tasks.length);
+      setActiveQuickStart(quickStart?.metadata?.name, quickStart?.spec?.tasks?.length);
     },
-    title: quickStart.spec.displayName,
+    title: quickStart?.spec?.displayName,
   };
 
   const handleClick = quickStartLink.onClick;

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
@@ -31,6 +31,7 @@ type UseBootVolumeSortColumns = (
 ) => {
   getSortType: (columnIndex: number) => ThSortType;
   sortedData: BootableVolume[];
+  sortedPaginatedData: BootableVolume[];
 };
 
 const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
@@ -98,13 +99,11 @@ const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
     return acc;
   };
 
-  const sortedData = unsortedData
-    .sort(sortVolumes)
-    .reduce(arrangeFavorites, [[], []])
-    .flat()
-    .slice(pagination.startIndex, pagination.endIndex);
+  const sortedData = unsortedData.sort(sortVolumes).reduce(arrangeFavorites, [[], []]).flat();
 
-  return { getSortType, sortedData };
+  const sortedPaginatedData = sortedData.slice(pagination.startIndex, pagination.endIndex);
+
+  return { getSortType, sortedData, sortedPaginatedData };
 };
 
 export default useBootVolumeSortColumns;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When selecting a bootable volume in instancetype VM creation, the list pagination gets on the first page. 
This because we are using the unsorted list to calculate in which page we should be. 

Why we do that? Because user can select the bootablevolume from a modal clicking on 'Show all' bootable volume. And clicking on 'select' should change the list page into the current selection page.

So we need a sorted array for identify the right page in which the selection is and a sortedPaginated array to show just the paginated volumes that we want in the list

Another fix:

TabModal expect a submit method that return a promise. So just return a promise.resolve instead of changing the type. 
Just changing the type result into an infinite button loading in the modal .   

