### PR TITLE
CNV-39727: fix pagination on bootablevolume selection

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeListModal/BootableVolumeListModal.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeListModal/BootableVolumeListModal.tsx
@@ -16,6 +16,7 @@ type BootableVolumeListModalProps = {
   favorites: UserSettingFavorites;
   isOpen: boolean;
   onClose: () => void;
+  onSelect: (selectedBootableVolume: BootableVolume) => void;
   preferencesData: V1beta1VirtualMachineClusterPreference[];
 };
 
@@ -23,25 +24,29 @@ const BootableVolumeListModal: FC<BootableVolumeListModalProps> = ({
   favorites,
   isOpen,
   onClose,
+  onSelect,
   ...restProps
 }) => {
   const { t } = useKubevirtTranslation();
 
-  const { instanceTypeVMState, onSelectCreatedVolume } = useInstanceTypeVMStore();
-  const { pvcSource, selectedBootableVolume, volumeSnapshotSource } = instanceTypeVMState;
+  const { instanceTypeVMState } = useInstanceTypeVMStore();
+  const { selectedBootableVolume } = instanceTypeVMState;
   const selectedBootableVolumeState = useState<BootableVolume>(selectedBootableVolume);
 
   const onSave = () => {
-    onSelectCreatedVolume(selectedBootableVolumeState[0], pvcSource, volumeSnapshotSource);
+    onSelect(selectedBootableVolumeState[0]);
     onClose();
+
+    return Promise.resolve();
   };
+
   return (
     <TabModal
       headerText={t('Available volumes')}
       isOpen={isOpen}
       modalVariant={ModalVariant.large}
       onClose={onClose}
-      onSubmit={onSave as () => Promise<void>}
+      onSubmit={onSave}
       submitBtnText={t('Select')}
     >
       <BootableVolumeList

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/ShowAllBootableVolumesButton/ShowAllBootableVolumesButton.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/ShowAllBootableVolumesButton/ShowAllBootableVolumesButton.tsx
@@ -4,6 +4,7 @@ import { UseBootableVolumesValues } from '@catalog/CreateFromInstanceTypes/state
 import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { UserSettingFavorites } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
+import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { Button, ButtonVariant, SplitItem } from '@patternfly/react-core';
 
 import BootableVolumeListModal from '../BootableVolumeListModal/BootableVolumeListModal';
@@ -11,6 +12,7 @@ import BootableVolumeListModal from '../BootableVolumeListModal/BootableVolumeLi
 type ShowAllBootableVolumesButtonProps = {
   bootableVolumesData: UseBootableVolumesValues;
   favorites: UserSettingFavorites;
+  onSelect: (selectedBootableVolume: BootableVolume) => void;
   preferencesData: V1beta1VirtualMachineClusterPreference[];
 };
 

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
@@ -31,6 +31,7 @@ type UseBootVolumeSortColumns = (
 ) => {
   getSortType: (columnIndex: number) => ThSortType;
   sortedData: BootableVolume[];
+  sortedPaginatedData: BootableVolume[];
 };
 
 const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
@@ -98,13 +99,11 @@ const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
     return acc;
   };
 
-  const sortedData = unsortedData
-    .sort(sortVolumes)
-    .reduce(arrangeFavorites, [[], []])
-    .flat()
-    .slice(pagination.startIndex, pagination.endIndex);
+  const sortedData = unsortedData.sort(sortVolumes).reduce(arrangeFavorites, [[], []]).flat();
 
-  return { getSortType, sortedData };
+  const sortedPaginatedData = sortedData.slice(pagination.startIndex, pagination.endIndex);
+
+  return { getSortType, sortedData, sortedPaginatedData };
 };
 
 export default useBootVolumeSortColumns;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When selecting a bootable volume in instancetype VM creation, the list pagination gets on the first page.
This because we are using the unsorted list to calculate in which page we should be.

Why we do that? Because user can select the bootablevolume from a modal clicking on 'Show all' bootable volume. And clicking on 'select' should change the list page into the current selection page.

So we need a sorted array for identify the right page in which the selection is and a sortedPaginated array to show just the paginated volumes that we want in the list

Another fix:

TabModal expect a submit method that return a promise. So just return a promise.resolve instead of changing the type.
Just changing the type result into an infinite button loading in the modal .