### PR TITLE
CNV-40445: Display OpenshiftVirtualization Degraded warning alerts

### DIFF
--- a/src/views/dashboard-extensions/KubevirtHealthPopup/KubevirtHealthPopup.tsx
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/KubevirtHealthPopup.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from 'react';
-import { Link } from 'react-router-dom-v5-compat';
 
 import { AlertType } from '@kubevirt-utils/components/AlertsCard/utils/types';
 import LoadingEmptyState from '@kubevirt-utils/components/LoadingEmptyState/LoadingEmptyState';
@@ -35,17 +34,17 @@ const KubevirtHealthPopup: FC = () => {
           <StackItem>
             <div className="kv-health-popup__alerts-count">
               <RedExclamationCircleIcon className="kv-health-popup__alerts-count--icon" />
-              <Link replace to={`${ALERTS_BASE_PATH}${HealthImpactLevel.critical}`}>
+              <a href={`${ALERTS_BASE_PATH}${HealthImpactLevel.critical}`}>
                 {`${alerts?.[HealthImpactLevel.critical]?.length} Critical`}
-              </Link>
+              </a>
             </div>
           </StackItem>
           <StackItem>
             <div className="kv-health-popup__alerts-count">
               <YellowExclamationTriangleIcon className="kv-health-popup__alerts-count--icon" />{' '}
-              <Link replace to={`${ALERTS_BASE_PATH}${HealthImpactLevel.warning}`}>
+              <a href={`${ALERTS_BASE_PATH}${HealthImpactLevel.warning}`}>
                 {`${alerts?.[AlertType.warning]?.length} Warning`}
-              </Link>
+              </a>
             </div>
           </StackItem>
         </Stack>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-40445

Display _OpenshiftVirtualization Degraded_ warning alerts page correctly, when clicking on "Warning" in the _Overview_ > _Status_ card's related modal. Use "a" element to replace the url instead of `Link` component that was just appending the generated link (no, using `replace` prop with it doesn't seem to do the job).

## 🎥 Demo
**Before:**
 Clicking on Warning leads to an empty page:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/2f9d0a45-9916-4d37-ad66-062e4802c2a7

**After:**
The related page displays correctly with all the relevant alerts:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/4c575079-86b7-484a-99d8-b919a7418e6b

