### PR TITLE
CNV-41632: Make editing MigrationPolicy name and description work

### DIFF
--- a/src/views/migrationpolicies/components/MigrationPolicyEditModal/MigrationPolicyEditModal.tsx
+++ b/src/views/migrationpolicies/components/MigrationPolicyEditModal/MigrationPolicyEditModal.tsx
@@ -78,7 +78,7 @@ const MigrationPolicyEditModal: FC<MigrationPolicyEditModalProps> = ({ isOpen, m
       <Form>
         <FormGroup fieldId="migration-policy-name" isRequired label={t('MigrationPolicy name')}>
           <TextInput
-            onChange={setStateField('migrationPolicyName')}
+            onChange={(_, value) => setStateField('migrationPolicyName')(value)}
             value={state?.migrationPolicyName}
           />
           <FormGroupHelperText>{t('Unique name of the MigrationPolicy')}</FormGroupHelperText>

--- a/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/MigrationPolicyCreateForm.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/MigrationPolicyCreateForm.tsx
@@ -37,13 +37,16 @@ const MigrationPolicyCreateForm: FC = () => {
         </FormGroup>
         <FormGroup fieldId="migration-policy-name" isRequired label={t('MigrationPolicy name')}>
           <TextInput
-            onChange={setStateField('migrationPolicyName')}
+            onChange={(_, value) => setStateField('migrationPolicyName')(value)}
             value={state?.migrationPolicyName}
           />
           <FormGroupHelperText>{t('Unique name of the MigrationPolicy')}</FormGroupHelperText>
         </FormGroup>
         <FormGroup fieldId="migration-policy-description" label={t('Description')}>
-          <TextInput onChange={setStateField('description')} value={state?.description} />
+          <TextInput
+            onChange={(_, value) => setStateField('description')(value)}
+            value={state?.description}
+          />
         </FormGroup>
         <h2>{t('Configurations')}</h2>
         <MigrationPolicyConfigurations


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-41632

Make editing MigrationPolicy name and description work when creating new MigrationPolicy (which was even preventing creating this resource) and also when editing the name of already existing one in "Edit MigrationPolicy" modal.

## 🎥 Demo
**Before:**
Not possible to edit name and description and hence to create new MigrationPolicy:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/f22153b2-d8d7-487e-8924-cda2d1d62085


**After:**
Editing name and description works for both creating and editing already existing MigrationPolicy:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/4cdc3982-26d6-43b3-b9b2-42b532e86ac7

