### PR TITLE
CNV-40445: Prevent reloading page when clicking on Degraded alerts

### DIFF
--- a/src/views/dashboard-extensions/KubevirtHealthPopup/KubevirtHealthPopup.tsx
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/KubevirtHealthPopup.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { Link } from 'react-router-dom-v5-compat';
 
 import { AlertType } from '@kubevirt-utils/components/AlertsCard/utils/types';
 import LoadingEmptyState from '@kubevirt-utils/components/LoadingEmptyState/LoadingEmptyState';
@@ -34,17 +35,17 @@ const KubevirtHealthPopup: FC = () => {
           <StackItem>
             <div className="kv-health-popup__alerts-count">
               <RedExclamationCircleIcon className="kv-health-popup__alerts-count--icon" />
-              <a href={`${ALERTS_BASE_PATH}${HealthImpactLevel.critical}`}>
+              <Link to={`${ALERTS_BASE_PATH}${HealthImpactLevel.critical}`}>
                 {`${alerts?.[HealthImpactLevel.critical]?.length} Critical`}
-              </a>
+              </Link>
             </div>
           </StackItem>
           <StackItem>
             <div className="kv-health-popup__alerts-count">
               <YellowExclamationTriangleIcon className="kv-health-popup__alerts-count--icon" />{' '}
-              <a href={`${ALERTS_BASE_PATH}${HealthImpactLevel.warning}`}>
+              <Link to={`${ALERTS_BASE_PATH}${HealthImpactLevel.warning}`}>
                 {`${alerts?.[AlertType.warning]?.length} Warning`}
-              </a>
+              </Link>
             </div>
           </StackItem>
         </Stack>

--- a/src/views/dashboard-extensions/KubevirtHealthPopup/utils/utils.ts
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/utils/utils.ts
@@ -1,5 +1,5 @@
 export const ALERTS_BASE_PATH =
-  'monitoring/alerts?rowFilter-alert-state=firing,silenced&rowFilter-alert-source=platform&alerts=kubernetes_operator_part_of%3Dkubevirt%2Coperator_health_impact%3D';
+  '/monitoring/alerts?rowFilter-alert-state=firing,silenced&rowFilter-alert-source=platform&alerts=kubernetes_operator_part_of%3Dkubevirt%2Coperator_health_impact%3D';
 
 export const alertTypeToColorMap = {
   critical: '#C9190B',


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-40445

Prevent unnecessary reloading whole page (incl. the whole left menu) when displaying _Openshift Virtualization Degraded_ warning alerts page, displayed after clicking on _Warning_ in the _Overview > Status_ card's related modal. Fix the not quite correct url of the page by adding missing "/" to the beginning of the url.

## 🎥 Demo
**Before:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/2a1acb21-403e-4eb7-b9e1-0ceba9de49bb

**After:**

https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/03acd4f6-eac0-412c-9d89-7bc4db2d3b45




