### PR TITLE
CNV-41385: Remove labels when auto-compute CPU limits is disabled

### DIFF
--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 
 import ExpandSectionWithSwitch from '@kubevirt-utils/components/ExpandSectionWithSwitch/ExpandSectionWithSwitch';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -13,7 +13,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { Alert, AlertVariant, Button, ButtonVariant } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
-import { addLabelsToHyperConvergedCR } from './utils/utils';
+import { addLabelsToHyperConvergedCR, removeLabelsFromHyperConvergedCR } from './utils/utils';
 import ProjectSelectorModal from './ProjectSelectorModal';
 
 import './AutoComputeCPULimits.scss';
@@ -36,6 +36,14 @@ const AutoComputeCPULimits: FC<AutoComputeCPULimitsProps> = ({
   const { featureEnabled: autoComputeCPUPreviewEnabled } = useFeatures(
     AUTOCOMPUTE_CPU_LIMITS_PREVIEW_ENABLED,
   );
+
+  useEffect(() => {
+    if (!hco) return null;
+
+    if (!autoComputeCPUEnabled) {
+      removeLabelsFromHyperConvergedCR(hco).catch((err) => setError(err.message));
+    }
+  }, [autoComputeCPUEnabled, hco]);
 
   const handleSubmit = (idLabels: IDLabel[]) => {
     addLabelsToHyperConvergedCR(hco, idLabels).catch((err) => setError(err.message));

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/utils/utils.ts
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/utils/utils.ts
@@ -21,3 +21,16 @@ export const addLabelsToHyperConvergedCR = (hcoCR: HyperConverged, idLabels: IDL
     resource: hcoCR,
   });
 };
+
+export const removeLabelsFromHyperConvergedCR = (hcoCR: HyperConverged) => {
+  return k8sPatch<HyperConverged>({
+    data: [
+      {
+        op: 'remove',
+        path: '/spec/resourceRequirements/autoCPULimitNamespaceLabelSelector',
+      },
+    ],
+    model: HyperConvergedModel,
+    resource: hcoCR,
+  });
+};


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug where the labels selected in the Auto-compute CPU Limits modal aren't deleted when the feature is disabled.

Jira: https://issues.redhat.com/browse/CNV-41385

## 🎥 Demo

### Before

https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/341c3aa5-3f40-4c8c-8a43-575f2db48094

### After

https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/23b2083f-f09e-46f8-a9ef-09bcff30a55a
