### PR TITLE
CNV-39558: Add tooltip for disabled SSH over NodePort option

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -842,6 +842,7 @@
   "Node labels": "Node labels",
   "Node port": "Node port",
   "Node selector": "Node selector",
+  "NodePort service is disabled. Ask your cluster admin to enable it in cluster settings.": "NodePort service is disabled. Ask your cluster admin to enable it in cluster settings.",
   "Nodes": "Nodes",
   "None": "None",
   "Not available": "Not available",

--- a/src/utils/components/SSHAccess/components/SSHServiceSelect.tsx
+++ b/src/utils/components/SSHAccess/components/SSHServiceSelect.tsx
@@ -65,8 +65,15 @@ const SSHServiceSelect: FC<SSHServiceSelectProps> = ({
             'Opens a specific port on all Nodes in the cluster. If the Node is publicly accessible, any traffic sent to this port is forwarded to the Service.',
           )}
           id={SERVICE_TYPES.NODE_PORT}
-          isDisabled={!nodePortEnabled}
+          isAriaDisabled={!nodePortEnabled}
           value={SERVICE_TYPES.NODE_PORT}
+          {...(!nodePortEnabled && {
+            tooltipProps: {
+              content: t(
+                'NodePort service is disabled. Ask your cluster admin to enable it in cluster settings.',
+              ),
+            },
+          })}
         >
           {serviceTypeTitles.NodePort}
         </SelectOption>


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-39558

Add tooltip to provide more info to the user in case when "SSH over NodePort" service is disabled, in VM's SSH settings.
The final text: _NodePort service is disabled. Ask your cluster admin to enable it in cluster settings._

## 🎥 Screenshots
**Before:**
![node_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/6f3f7c89-dfd7-45a0-9237-70c7703638ad)

**After:**
![node_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/57c2bb94-e7c8-4c71-89e1-038d9963efbd)

