### PR TITLE
CNV-41633: Fix VM list EmptyState on filtering with pod proxy

### DIFF
--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -40,6 +40,7 @@ import { useVMListFilters } from '../utils';
 import VirtualMachineEmptyState from './components/VirtualMachineEmptyState/VirtualMachineEmptyState';
 import VirtualMachineRow from './components/VirtualMachineRow/VirtualMachineRow';
 import VirtualMachinesCreateButton from './components/VirtualMachinesCreateButton/VirtualMachinesCreateButton';
+import useSelectedFilters from './hooks/useSelectedFilters';
 import useVirtualMachineColumns from './hooks/useVirtualMachineColumns';
 
 import '@kubevirt-utils/styles/list-managment-group.scss';
@@ -108,6 +109,8 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({ kind, namespace }) 
     V1VirtualMachine
   >(vms, [...filters, ...searchFilters]);
 
+  const selectedFilters = useSelectedFilters(filters, searchFilters);
+
   const [unfilteredData, data] = useMemo(() => {
     if (!featureEnabled || isProxyPodAlive === false) return [unfilterData, dataFilters];
 
@@ -145,7 +148,11 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({ kind, namespace }) 
     !loadingFeatureProxy &&
     loadedColumns;
 
-  if (loaded && isEmpty(unfilteredData)) {
+  const vmsFilteredWithProxy = isProxyPodAlive && selectedFilters.length > 0;
+
+  const noVMs = isEmpty(unfilteredData) && !vmsFilteredWithProxy;
+
+  if (loaded && noVMs) {
     return <VirtualMachineEmptyState catalogURL={catalogURL} namespace={namespace} />;
   }
 

--- a/src/views/virtualmachines/list/hooks/constants.ts
+++ b/src/views/virtualmachines/list/hooks/constants.ts
@@ -1,0 +1,2 @@
+export const TEXT_FILTER_NAME_ID = 'name';
+export const TEXT_FILTER_LABELS_ID = 'labels';

--- a/src/views/virtualmachines/list/hooks/useSelectedFilters.ts
+++ b/src/views/virtualmachines/list/hooks/useSelectedFilters.ts
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom-v5-compat';
+
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
+
+import { TEXT_FILTER_LABELS_ID, TEXT_FILTER_NAME_ID } from './constants';
+
+const useSelectedFilters = (
+  rowFilters: RowFilter<V1VirtualMachine>[],
+  searchFilters: RowFilter<V1VirtualMachine>[],
+) => {
+  const [searchParams] = useSearchParams();
+
+  return useMemo(() => {
+    const selectedFilters = rowFilters.map((filter) =>
+      searchParams.get(`rowFilter-${filter.type}`) ? filter.type : null,
+    );
+
+    selectedFilters.push(
+      ...(searchFilters || []).map((filter) =>
+        searchParams.get(filter.type) ? filter.type : null,
+      ),
+    );
+
+    searchParams.get(TEXT_FILTER_NAME_ID) && selectedFilters.push(TEXT_FILTER_NAME_ID);
+    searchParams.get(TEXT_FILTER_LABELS_ID) && selectedFilters.push(TEXT_FILTER_LABELS_ID);
+
+    return selectedFilters.filter((f) => Boolean(f));
+  }, [searchParams, searchFilters, rowFilters]);
+};
+
+export default useSelectedFilters;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When cluster has proxy pod enabled, the `unfilteredData` is empty as the proxy pod return empty array from the fetch even if the user just filtered data. 

In that case, just watch the selected filters. If we are using the pod for fetching data and the user has selected a filter, don't show the empty state. 

Show the empty state if :

unfiltered data is empty if the cluster is not using the pod
if we are using the pod and unfiltered data is empty, check if the user has selected some filters from the query params (no other way to do it )  