### PR TITLE
CNV-41209: Show default network in VM Overview for InstanceType VMs

### DIFF
--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/hooks/useVirtualMachinesOverviewTabInterfacesData.ts
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/hooks/useVirtualMachinesOverviewTabInterfacesData.ts
@@ -1,5 +1,5 @@
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
+import { getInterfacesAndNetworks } from '@kubevirt-utils/resources/vm/utils/network/utils';
 
 import { InterfacesData } from '../utils/types';
 
@@ -12,8 +12,7 @@ const useVirtualMachinesOverviewTabInterfacesData: UseVirtualMachinesOverviewTab
   vm: V1VirtualMachine,
   vmi: V1VirtualMachineInstance,
 ) => {
-  const networks = getNetworks(vm);
-  const interfaces = getInterfaces(vm);
+  const { interfaces, networks } = getInterfacesAndNetworks(vm, vmi);
   const interfacesIPs = vmi?.status?.interfaces?.filter((iface) => !!iface.name) || [];
 
   const networkInterfacesData = interfaces?.map((iface) => {


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug where no networks were displayed in the Network card on the VM Overview page for InstanceType VMs.

Jira: https://issues.redhat.com/browse/CNV-41209

## 🎥 Screenshots

### Before

![vm-overview-networks-card--BEFORE--2024-05-15_07-44](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/f3c257f8-df73-4ace-b5ea-aeb0e347ced7)

### After

![vm-overview-networks-card--AFTER--2024-05-15_07-42](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/2299f412-faa4-49a0-862d-9e88d0e19a92)
