### PR TITLE
CNV-41604: fix cdrom bootOrder

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/cd.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/cd.ts
@@ -68,7 +68,7 @@ export const addInstallationCDRom = (
     draftVM.spec.template.spec.domain.devices.disks =
       draftVM.spec.template.spec.domain.devices.disks.map((disk, index) => ({
         ...disk,
-        bootOrder: 2 + index,
+        bootOrder: disk.name === INSTALLATION_CDROM_NAME ? 1 : 2 + index,
       }));
 
     if (!getDisks(draftVM)?.find((disk) => disk.name === INSTALLATION_CDROM_NAME))


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

If the cdrom is edited, it's already in the disks array so in that case its bootOder gets modified. 
Check the disk name to determine which bootOrder to give. 

## 🎥 Demo

![Screenshot from 2024-05-17 14-28-53](https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/44b4c0ca-74c8-4096-ad73-d9077ee2609a)

