### PR TITLE
CNV-39940: UI does not show installed version

### DIFF
--- a/src/views/clusteroverview/utils/hooks/useKubevirtCSVDetails.ts
+++ b/src/views/clusteroverview/utils/hooks/useKubevirtCSVDetails.ts
@@ -9,7 +9,6 @@ import { isUpstream } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 import {
-  HCO_OPERATORHUB_NAME,
   KUBEVIRT_HYPERCONVERGED,
   OPENSHIFT_CNV,
   OPENSHIFT_OPERATOR_LIFECYCLE_MANAGER_NAMESPACE,
@@ -33,12 +32,18 @@ type UseKubevirtCSVDetails = {
 };
 
 export const useKubevirtCSVDetails = (): UseKubevirtCSVDetails => {
-  const [subscription, loadedSubscription, loadSubscriptionError] =
-    useK8sWatchResource<SubscriptionKind>({
-      groupVersionKind: SubscriptionModelGroupVersionKind,
-      name: HCO_OPERATORHUB_NAME,
-      namespace: isUpstream ? KUBEVIRT_HYPERCONVERGED : OPENSHIFT_CNV,
-    });
+  const [subscriptions, loadedSubscription, loadSubscriptionError] = useK8sWatchResource<
+    SubscriptionKind[]
+  >({
+    groupVersionKind: SubscriptionModelGroupVersionKind,
+    isList: true,
+    namespace: isUpstream ? KUBEVIRT_HYPERCONVERGED : OPENSHIFT_CNV,
+  });
+
+  const subscription = useMemo(
+    () => subscriptions?.find((sub) => sub?.spec?.name.endsWith(KUBEVIRT_HYPERCONVERGED)),
+    [subscriptions],
+  );
 
   const [installedCSV, loadedCSV, loadCSVError] = useK8sWatchResource<ClusterServiceVersionKind>(
     subscription && {


### PR DESCRIPTION
## 📝 Description

The UI assumes that the subscription that holds the version metadata has a unique name.
Since the name of the subscription CR is arbitrary, we now check if the subscription is from the package of `kubevirt-hyperconverged` or in some community upstream cases the package named `community-kubevirt-hyperconverged`.

## 🎥 Demo

Before:
![version-missing](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/cefb1df6-0787-4005-80f9-1d0bdc85769b)

After:
![version-missing-after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/c58d1e5f-2167-4c4f-9bf1-bbf7c0041220)

