### PR TITLE
CNV-42015: SSH key is cleared when creating VM from template

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
@@ -48,7 +48,7 @@ const useCreateDrawerForm = (
   subscriptionData: RHELAutomaticSubscriptionData,
   authorizedSSHKey: string,
 ) => {
-  const { tabsData, updateTabsData, updateVM } = useWizardVMContext();
+  const { updateTabsData, updateVM } = useWizardVMContext();
   const [authorizedSSHKeys, updateAuthorizedSSHKeys] = useKubevirtUserSettings('ssh');
   const { featureEnabled: autoUpdateEnabled } = useFeatures(AUTOMATIC_UPDATE_FEATURE_NAME);
   const { featureEnabled: isDisabledGuestSystemLogs } = useFeatures(
@@ -113,10 +113,10 @@ const useCreateDrawerForm = (
 
         draftTemplate.objects = modifiedTemplateObjects;
 
-        if (sshDetails.sshSecretName && sshDetails?.applyKeyToProject) {
+        if (sshDetails?.sshSecretName && sshDetails?.applyKeyToProject) {
           updateAuthorizedSSHKeys({
             ...authorizedSSHKeys,
-            [namespace]: tabsData.authorizedSSHKey,
+            [namespace]: sshDetails?.sshSecretName,
           });
         }
       }


### PR DESCRIPTION
## 📝 Description

tabsData will always be undefined as it gets defined only on customize VM flow.

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/8657a2f0-a7c3-43e4-a50f-979344a18be1


After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/22c744e5-2ef5-4e3c-b606-beaacf7302fc


