### PR TITLE
CNV-39946: Regular user cannot create vm with their own volumes from UI

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useEffect, useState } from 'react';
-import { getOSImagesNS } from 'src/views/clusteroverview/OverviewTab/inventory-card/utils/utils';
 
 import SelectInstanceTypeSection from '@catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/SelectInstanceTypeSection';
 import VMDetailsSection from '@catalog/CreateFromInstanceTypes/components/VMDetailsSection/VMDetailsSection';
@@ -27,12 +26,12 @@ const CreateFromInstanceType: FC = () => {
   const { t } = useKubevirtTranslation();
   const sectionState = useState<INSTANCE_TYPES_SECTIONS>(INSTANCE_TYPES_SECTIONS.SELECT_VOLUME);
 
-  const bootableVolumesData = useBootableVolumes(getOSImagesNS());
+  const { resetInstanceTypeVMState, setVMNamespaceTarget, volumeListNamespace } =
+    useInstanceTypeVMStore();
+  const bootableVolumesData = useBootableVolumes(volumeListNamespace);
   const instanceTypesAndPreferencesData = useInstanceTypesAndPreferences();
   const [activeNamespace] = useActiveNamespace();
   const [authorizedSSHKeys, , loaded] = useKubevirtUserSettings('ssh');
-
-  const { resetInstanceTypeVMState, setVMNamespaceTarget } = useInstanceTypeVMStore();
 
   useEffect(() => {
     resetInstanceTypeVMState();

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.scss
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.scss
@@ -13,7 +13,7 @@
   }
 
   &__volume-namespace {
-    width: 240px;
+    width: fit-content;
     .pf-v5-c-form__label {
       margin-bottom: 0;
     }

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeListNamespaceSelect/BootableVolumeListNamespaceSelect.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeListNamespaceSelect/BootableVolumeListNamespaceSelect.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from 'react';
+
+import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore';
+import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui/kubevirt-api/console';
+import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
+import useProjects from '@kubevirt-utils/hooks/useProjects';
+
+const BootableVolumeListNamespaceSelect: FC = () => {
+  const { setVolumeListNamespace, volumeListNamespace } = useInstanceTypeVMStore();
+  const [projectNames] = useProjects();
+  return (
+    <InlineFilterSelect
+      options={projectNames?.map((name) => ({
+        children: name,
+        groupVersionKind: modelToGroupVersionKind(ProjectModel),
+        value: name,
+      }))}
+      toggleProps={{
+        isFullWidth: true,
+      }}
+      popperProps={{ enableFlip: true }}
+      selected={volumeListNamespace}
+      setSelected={setVolumeListNamespace}
+    />
+  );
+};
+
+export default BootableVolumeListNamespaceSelect;

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeListPagination/BootableVolumeListPagination.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeListPagination/BootableVolumeListPagination.tsx
@@ -1,0 +1,50 @@
+import React, { Dispatch, FC, SetStateAction } from 'react';
+
+import { PaginationState } from '@kubevirt-utils/hooks/usePagination/utils/types';
+import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { Pagination } from '@patternfly/react-core';
+
+import { paginationDefaultValuesForm, paginationDefaultValuesModal } from '../../utils/constants';
+
+type BootableVolumeListPaginationProps = {
+  data: BootableVolume[];
+  displayShowAllButton: boolean;
+  pagination: PaginationState;
+  setPagination: Dispatch<SetStateAction<PaginationState>>;
+};
+
+const BootableVolumeListPagination: FC<BootableVolumeListPaginationProps> = ({
+  data,
+  displayShowAllButton,
+  pagination,
+  setPagination,
+}) => {
+  const onPageChange = ({ endIndex, page, perPage, startIndex }) => {
+    setPagination(() => ({
+      endIndex,
+      page,
+      perPage,
+      startIndex,
+    }));
+  };
+  return (
+    <Pagination
+      onPerPageSelect={(_e, perPage, page, startIndex, endIndex) =>
+        onPageChange({ endIndex, page, perPage, startIndex })
+      }
+      onSetPage={(_e, page, perPage, startIndex, endIndex) =>
+        onPageChange({ endIndex, page, perPage, startIndex })
+      }
+      perPageOptions={
+        displayShowAllButton ? paginationDefaultValuesForm : paginationDefaultValuesModal
+      }
+      isCompact={displayShowAllButton}
+      isLastFullPageShown
+      itemCount={data?.length}
+      page={pagination?.page}
+      perPage={pagination?.perPage}
+    />
+  );
+};
+
+export default BootableVolumeListPagination;

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeTable/BootableVolumeTable.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeTable/BootableVolumeTable.tsx
@@ -1,0 +1,89 @@
+import React, { FC } from 'react';
+
+import {
+  InstanceTypeVMStore,
+  UseBootableVolumesValues,
+} from '@catalog/CreateFromInstanceTypes/state/utils/types';
+import { DEFAULT_PREFERENCE_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
+import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { UserSettingFavorites } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
+import { getBootableVolumePVCSource } from '@kubevirt-utils/resources/bootableresources/helpers';
+import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { getLabel, getName } from '@kubevirt-utils/resources/shared';
+import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
+import { Table, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
+import { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base/types';
+
+import BootableVolumeRow from '../BootableVolumeRow/BootableVolumeRow';
+
+type BootableVolumeTableProps = {
+  activeColumns: TableColumn<BootableVolume>[];
+  bootableVolumesData: UseBootableVolumesValues;
+  favorites: UserSettingFavorites;
+  getSortType: (columnIndex: number) => ThSortType;
+  preferencesMap: {
+    [resourceKeyName: string]: V1beta1VirtualMachineClusterPreference;
+  };
+  selectedBootableVolumeState?: [BootableVolume, InstanceTypeVMStore['onSelectCreatedVolume']];
+  sortedPaginatedData: BootableVolume[];
+};
+
+const BootableVolumeTable: FC<BootableVolumeTableProps> = ({
+  activeColumns,
+  bootableVolumesData,
+  favorites,
+  getSortType,
+  preferencesMap,
+  selectedBootableVolumeState,
+  sortedPaginatedData,
+}) => {
+  const [volumeFavorites, updateFavorites] = favorites;
+  const { pvcSources, volumeSnapshotSources } = bootableVolumesData;
+  return (
+    <Table className="BootableVolumeList-table" variant={TableVariant.compact}>
+      <Thead>
+        <Tr>
+          {activeColumns.map((col, columnIndex) => (
+            <Th
+              sort={
+                columnIndex === 0
+                  ? { ...getSortType(columnIndex), isFavorites: true }
+                  : getSortType(columnIndex)
+              }
+              id={col?.id}
+              key={col?.id}
+            >
+              {col?.title}
+            </Th>
+          ))}
+        </Tr>
+      </Thead>
+      <Tbody>
+        {sortedPaginatedData.map((bs) => (
+          <BootableVolumeRow
+            rowData={{
+              bootableVolumeSelectedState: selectedBootableVolumeState,
+              favorites: [
+                volumeFavorites?.includes(bs?.metadata?.name),
+                (addTofavorites: boolean) =>
+                  updateFavorites(
+                    addTofavorites
+                      ? [...volumeFavorites, bs?.metadata?.name]
+                      : volumeFavorites.filter((fav: string) => fav !== bs?.metadata?.name),
+                  ),
+              ],
+              preference: preferencesMap[getLabel(bs, DEFAULT_PREFERENCE_LABEL)],
+              pvcSource: getBootableVolumePVCSource(bs, pvcSources),
+              volumeSnapshotSource: volumeSnapshotSources?.[bs?.metadata?.name],
+            }}
+            activeColumnIDs={activeColumns?.map((col) => col?.id)}
+            bootableVolume={bs}
+            key={getName(bs)}
+          />
+        ))}
+      </Tbody>
+    </Table>
+  );
+};
+
+export default BootableVolumeTable;

--- a/src/views/catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore.ts
@@ -81,5 +81,8 @@ export const useInstanceTypeVMStore = create<InstanceTypeVMStore>()((set, get) =
       get().setIsChangingNamespace();
       get().applySSHFromSettings(sshSecretName, targetNamespace);
     },
+    setVolumeListNamespace: (namespace) => {
+      set({ volumeListNamespace: namespace });
+    },
   };
 });

--- a/src/views/catalog/CreateFromInstanceTypes/state/utils/state.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/utils/state.ts
@@ -1,3 +1,5 @@
+import { getOSImagesNS } from 'src/views/clusteroverview/OverviewTab/inventory-card/utils/utils';
+
 import { initialSSHCredentials } from '@kubevirt-utils/components/SSHSecretModal/utils/constants';
 
 import { InstanceTypeVMState, InstanceTypeVMStoreState } from './types';
@@ -20,4 +22,5 @@ export const instanceTypeVMStoreInitialState: InstanceTypeVMStoreState = {
   startVM: true,
   vm: null,
   vmNamespaceTarget: '',
+  volumeListNamespace: getOSImagesNS(),
 };

--- a/src/views/catalog/CreateFromInstanceTypes/state/utils/types.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/utils/types.ts
@@ -79,6 +79,7 @@ export type InstanceTypeVMStoreState = {
   startVM: boolean;
   vm: V1VirtualMachine; // vm object for customization flow
   vmNamespaceTarget: string;
+  volumeListNamespace: string;
 };
 
 type InstanceTypeVMStoreActions = {
@@ -95,6 +96,7 @@ type InstanceTypeVMStoreActions = {
   setStartVM: (checked: boolean) => void;
   setVM: (vm: V1VirtualMachine) => Promise<void>;
   setVMNamespaceTarget: (sshSecretName: string, targetNamespace: string) => void;
+  setVolumeListNamespace: (namespace: string) => void;
 };
 
 export type InstanceTypeVMStore = InstanceTypeVMStoreState & InstanceTypeVMStoreActions;


### PR DESCRIPTION
## 📝 Description

Allow changing the namespace in the volumes list under Catalog > Instance type so a user can select a volume from a different namespace than the openshift-virtualization-os-images / kubevirt-os-images.


## 🎥 Demo

After:
![volumeListProjectDropdown](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/3e315cf7-6a32-4743-a34b-f122d82207e2)

