### PR TITLE
CNV-40903: Fix SSH key injection when DataSource is a VolumeSnapshot

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DynamicSSHKeyInjectionInstanceType.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DynamicSSHKeyInjectionInstanceType.tsx
@@ -2,17 +2,18 @@ import React from 'react';
 
 import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore';
 import { instanceTypeActionType } from '@catalog/CreateFromInstanceTypes/state/utils/types';
-import { DYNAMIC_CREDENTIALS_SUPPORT } from '@kubevirt-utils/components/DynamicSSHKeyInjection/constants/constants';
 import { DynamicSSHKeyInjection } from '@kubevirt-utils/components/DynamicSSHKeyInjection/DynamicSSHKeyInjection';
 import DynamicSSHKeyInjectionHelpTextIcon from '@kubevirt-utils/components/DynamicSSHKeyInjection/DynamicSSHKeyInjectionHelpTextIcon';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
+import { dataSourceHasDynamicSSHLabel } from '../utils/utils';
+
 const DynamicSSHKeyInjectionInstanceType = () => {
   const { instanceTypeVMState, setInstanceTypeVMState } = useInstanceTypeVMStore();
-  const { sshSecretCredentials } = instanceTypeVMState;
-  const hasDynamicSSHLabel =
-    instanceTypeVMState?.pvcSource?.metadata?.labels?.[DYNAMIC_CREDENTIALS_SUPPORT];
+  const { pvcSource, selectedBootableVolume, sshSecretCredentials } = instanceTypeVMState;
+
+  const hasDynamicSSHLabel = dataSourceHasDynamicSSHLabel(pvcSource, selectedBootableVolume);
   const isDisabled = !sshSecretCredentials?.sshSecretName || !hasDynamicSSHLabel;
 
   return (

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/utils/utils.ts
@@ -2,10 +2,12 @@ import {
   DEFAULT_PREFERENCE_LABEL,
   PREFERENCE_DISPLAY_NAME_KEY,
 } from '@catalog/CreateFromInstanceTypes/utils/constants';
+import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import {
   V1beta1VirtualMachineClusterInstancetype,
   V1beta1VirtualMachineClusterPreference,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { DYNAMIC_CREDENTIALS_SUPPORT } from '@kubevirt-utils/components/DynamicSSHKeyInjection/constants/constants';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { getAnnotation, getLabel } from '@kubevirt-utils/resources/shared';
@@ -38,3 +40,10 @@ export const getCPUAndMemoryFromDefaultInstanceType = (
 
   return t('{{cpu}} CPU | {{memory}} Memory', { cpu, memory });
 };
+
+export const dataSourceHasDynamicSSHLabel = (
+  pvcSource: IoK8sApiCoreV1PersistentVolumeClaim,
+  selectedBootableVolume: BootableVolume,
+) =>
+  getLabel(pvcSource, DYNAMIC_CREDENTIALS_SUPPORT) ||
+  getLabel(selectedBootableVolume, DYNAMIC_CREDENTIALS_SUPPORT);


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug where dynamic SSH key injection is disabled when the RHEL 9 DataSource is backed by a VolumeSnapshot instead of a PVC.

Jira: https://issues.redhat.com/browse/CNV-40903

## 🎥 Demo

### Before

https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/b844a326-addc-4314-9554-edadf15db7af

### After

https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/223f9e82-9277-4c4b-83fd-34d3266d2dc3
