### PR TITLE
CNV-41589: Error "Cannot read properties of undefined (reading "push")" on creation of a VM with Sysprep

### DIFF
--- a/src/utils/components/SysprepModal/sysprep-utils.ts
+++ b/src/utils/components/SysprepModal/sysprep-utils.ts
@@ -28,7 +28,7 @@ export const addSysprepConfig = (vm: V1VirtualMachine, newSysprepName: string) =
       configMap: { name: newSysprepName },
     },
   });
-  getDisks(vm).push(sysprepDisk());
+  (getDisks(vm) || []).push(sysprepDisk());
 };
 
 export const removeSysprepConfig = (vm: V1VirtualMachine, sysprepVolumeName: string) => {


### PR DESCRIPTION
## 📝 Description

Since a VM in IT flow is created without disks, this error occurs

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/1520222a-c7f3-485b-9559-543d640921ae

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/68ad3919-81af-4dab-b11e-f5601a75dac7


