### PR TITLE
CNV-40344: Make expanded sections indented as expected

### DIFF
--- a/src/views/clusteroverview/SettingsTab/ExpandSection/ExpandSection.scss
+++ b/src/views/clusteroverview/SettingsTab/ExpandSection/ExpandSection.scss
@@ -1,3 +1,9 @@
 .expand-section__disabled .pf-c-expandable-section__toggle-icon {
   color: var(--pf-global--disabled-color--100);
 }
+
+.ExpandSection {
+  .pf-v5-c-expandable-section__content {
+    padding-left: var(--pf-v5-c-expandable-section--m-display-lg__content--PaddingLeft) !important;
+  }
+}

--- a/src/views/clusteroverview/SettingsTab/ExpandSection/ExpandSection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ExpandSection/ExpandSection.tsx
@@ -31,7 +31,7 @@ const ExpandSection: FC<ExpandSectionProps> = ({
 
   return (
     <ExpandableSection
-      className={classNames(className, { 'expand-section__disabled': isDisabled })}
+      className={classNames(className, { 'expand-section__disabled': isDisabled }, 'ExpandSection')}
       isExpanded={isExpanded}
       isIndented={isIndented}
       onToggle={(_event, expanded: boolean) => handleToggle(expanded)}


### PR DESCRIPTION
## 📝 Description

**Fixes:**
https://issues.redhat.com/browse/CNV-40344

Our console folks broke our css by using `!important`, which is not a good practice, exactly here:
https://github.com/hstastna/console/blob/master/frontend/packages/console-shared/src/components/getting-started/GettingStartedExpandableGrid.scss#L58

Hence, to fix broken expandable sections in our UI, we must use `!important`, too. 

## 🎥 Screenshots
**Before:**
Sections in Overview settings not indented at all:
![expand_before](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/31b05510-000d-4af9-ab17-f09e39dca93d)

**After:**
![expand_after](https://github.com/kubevirt-ui/kubevirt-plugin/assets/13417815/ef618918-148d-4ae0-8a89-27e540085e4f)

