### PR TITLE
CNV-41591: unexpected "headless" on creating a VM with sysprep

### DIFF
--- a/src/utils/utils/headless-service.ts
+++ b/src/utils/utils/headless-service.ts
@@ -2,7 +2,7 @@ import { ServiceModel } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
-export const HEADLESS_SERVICE_LABEL = 'app.kubernetes.io/name';
+export const HEADLESS_SERVICE_LABEL = 'network.kubevirt.io/headlessService';
 export const HEADLESS_SERVICE_NAME = 'headless';
 export const HEADLESS_SERVICE_PORT = 5434;
 


### PR DESCRIPTION
## 📝 Description

Changing the headless service selector to network.kubevirt.io/headlessService so it could be more unique

## 🎥 Demo

After:
![headless-service-label](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/812c4f4b-b626-449c-bd14-f625451df73f)

