### PR TITLE
CNV-42316: VM Metrics page is lacking Y axis

### DIFF
--- a/src/utils/components/Charts/CPUUtil/CPUThresholdChart.tsx
+++ b/src/utils/components/Charts/CPUUtil/CPUThresholdChart.tsx
@@ -17,6 +17,7 @@ import {
   ChartThreshold,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
+import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
@@ -24,7 +25,13 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
 import { getUtilizationQueries } from '../utils/queries';
-import { MILLISECONDS_MULTIPLIER, queriesToLink, tickFormat, TICKS_COUNT } from '../utils/utils';
+import {
+  findMaxYValue,
+  MILLISECONDS_MULTIPLIER,
+  queriesToLink,
+  tickFormat,
+  TICKS_COUNT,
+} from '../utils/utils';
 
 type CPUThresholdChartProps = {
   pods: K8sResourceCommon[];
@@ -69,7 +76,7 @@ const CPUThresholdChart: FC<CPUThresholdChartProps> = ({ pods, vmi }) => {
 
   const isReady = !isEmpty(chartData) && !isEmpty(thresholdData);
   const linkToMetrics = queriesToLink(queries?.CPU_USAGE);
-
+  const yMax = findMaxYValue(thresholdData);
   return (
     <ComponentReady isReady={isReady} linkToMetrics={linkToMetrics}>
       <div className="util-threshold-chart" ref={ref}>
@@ -87,10 +94,20 @@ const CPUThresholdChart: FC<CPUThresholdChartProps> = ({ pods, vmi }) => {
               x: [currentTime - timespan, currentTime],
             }}
             height={height}
-            padding={35}
+            padding={{ bottom: 35, left: 70, right: 35, top: 35 }}
             scale={{ x: 'time', y: 'linear' }}
             width={width}
           >
+            <ChartAxis
+              style={{
+                grid: {
+                  stroke: chart_color_black_200.value,
+                },
+              }}
+              dependentAxis
+              tickFormat={(tick: number) => tick?.toFixed(2)}
+              tickValues={[0, yMax]}
+            />
             <ChartAxis
               style={{
                 tickLabels: { padding: 2 },

--- a/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
+++ b/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
@@ -15,6 +15,7 @@ import {
   ChartThreshold,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
+import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
@@ -22,7 +23,13 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
 import { getUtilizationQueries } from '../utils/queries';
-import { MILLISECONDS_MULTIPLIER, queriesToLink, tickFormat, TICKS_COUNT } from '../utils/utils';
+import {
+  findMaxYValue,
+  MILLISECONDS_MULTIPLIER,
+  queriesToLink,
+  tickFormat,
+  TICKS_COUNT,
+} from '../utils/utils';
 
 type MemoryThresholdChartProps = {
   vmi: V1VirtualMachineInstance;
@@ -58,6 +65,7 @@ const MemoryThresholdChart: FC<MemoryThresholdChartProps> = ({ vmi }) => {
 
   const isReady = !isEmpty(chartData) || !isEmpty(thresholdLine);
   const linkToMetrics = queriesToLink(queries?.MEMORY_USAGE);
+  const yMax = findMaxYValue(thresholdLine);
   return (
     <ComponentReady isReady={isReady} linkToMetrics={linkToMetrics}>
       <div className="util-threshold-chart" ref={ref}>
@@ -78,7 +86,7 @@ const MemoryThresholdChart: FC<MemoryThresholdChartProps> = ({ vmi }) => {
               x: [currentTime - timespan, currentTime],
             }}
             height={height}
-            padding={35}
+            padding={{ bottom: 35, left: 70, right: 35, top: 35 }}
             scale={{ x: 'time', y: 'linear' }}
             width={width}
           >
@@ -90,6 +98,16 @@ const MemoryThresholdChart: FC<MemoryThresholdChartProps> = ({ vmi }) => {
               axisComponent={<></>}
               tickCount={TICKS_COUNT}
               tickFormat={tickFormat(duration, currentTime)}
+            />
+            <ChartAxis
+              style={{
+                grid: {
+                  stroke: chart_color_black_200.value,
+                },
+              }}
+              dependentAxis
+              tickFormat={(tick: number) => xbytes(tick, { fixed: 2, iec: true })}
+              tickValues={[0, yMax]}
             />
             <ChartGroup>
               <ChartArea

--- a/src/utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart.tsx
@@ -14,6 +14,7 @@ import {
   ChartThreshold,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
+import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
@@ -84,10 +85,20 @@ const StorageTotalReadWriteThresholdChart: React.FC<StorageTotalReadWriteThresho
               y: [0, yMax],
             }}
             height={height}
-            padding={35}
+            padding={{ bottom: 35, left: 70, right: 35, top: 35 }}
             scale={{ x: 'time', y: 'linear' }}
             width={width}
           >
+            <ChartAxis
+              style={{
+                grid: {
+                  stroke: chart_color_black_200.value,
+                },
+              }}
+              dependentAxis
+              tickFormat={(tick: number) => xbytes(tick, { fixed: 2, iec: true })}
+              tickValues={[0, yMax]}
+            />
             <ChartAxis
               style={{
                 tickLabels: { padding: 2 },


### PR DESCRIPTION
## 📝 Description

Some VM charts are missing Y axis to it

## 🎥 Demo

Before:
![vm-y-axis-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/0e7ea616-c936-412f-896c-1616ec62a701)

After:
![vm-y-axis](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/516c33af-80ef-4a0b-bd82-359e99b9129c)
