### PR TITLE
CNV-42368: A search icon appears in node selector labels

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/NodeSelector.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/NodeSelector.tsx
@@ -3,8 +3,6 @@ import React, { FC } from 'react';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getNodeSelector } from '@kubevirt-utils/resources/vmi';
-import { Icon } from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
 
 type NodeSelectorProps = {
   vm: V1VirtualMachine;
@@ -17,9 +15,6 @@ const NodeSelector: FC<NodeSelectorProps> = ({ vm }) => {
 
   return nodeSelector ? (
     <>
-      <Icon className="co-m-requirement__icon co-icon-flex-child co-text-node" size="sm">
-        <SearchIcon />
-      </Icon>
       <span className="co-text-node">{nodeSelector}</span>
     </>
   ) : (


### PR DESCRIPTION
## 📝 Description

Removing search icon from node selector in VM -> Configuration -> Scheduling

## 🎥 Demo

Before:
![search-icon-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/9b6c214e-a792-4113-8b9f-540ce37aa4fb)

After:
![search-icon](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/307b5d4a-b970-4669-a0ca-0a93861add47)

