### PR TITLE
CNV-41776: Console is showing incorrect value's for disks attached to VMs

### DIFF
--- a/src/utils/resources/vm/utils/disk/rowData.ts
+++ b/src/utils/resources/vm/utils/disk/rowData.ts
@@ -10,7 +10,7 @@ import {
   getPrintableDiskDrive,
   getPrintableDiskInterface,
 } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
-import { formatBytes } from '@kubevirt-utils/resources/vm/utils/disk/size';
+import { convertToBaseValue, humanizeBinaryBytes } from '@kubevirt-utils/utils/humanize.js';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import { NO_DATA_DASH } from '../constants';
@@ -46,7 +46,9 @@ export const getDiskRowDataLayout = (
     if (device?.pvc) {
       diskRowDataObject.source = device?.pvc?.metadata?.name;
       diskRowDataObject.sourceStatus = device?.pvc?.status?.phase;
-      diskRowDataObject.size = formatBytes(device?.pvc?.spec?.resources?.requests?.storage);
+      diskRowDataObject.size = humanizeBinaryBytes(
+        convertToBaseValue(device?.pvc?.spec?.resources?.requests?.storage),
+      ).string;
       diskRowDataObject.storageClass = device?.pvc?.spec?.storageClassName;
     }
 


### PR DESCRIPTION
## 📝 Description

When we attach a pvc to a VM and the PVC size is ending with 000 or 000000 and so on, k8s shortens the actual number to have either k/m/g suffix and so on. this is getting the wrong size in the disk list

## 🎥 Demo

Before:
![disk-size-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/d35afd81-9bc1-48a7-ae19-78196a711479)

After:
![disk-size](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/35797fd4-eb0a-4a78-83d0-eea79cfb6dfc)


