### PR TITLE
CNV-38101: "Boot management" became folded after editing something on the page

### DIFF
--- a/src/utils/hooks/useToggle.ts
+++ b/src/utils/hooks/useToggle.ts
@@ -1,0 +1,26 @@
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+
+type UseToggle = (
+  key: string,
+  defaultValue?: boolean,
+) => [isToggled: boolean, toggle: Dispatch<SetStateAction<boolean>>];
+
+export const useToggle: UseToggle = (key = '', defaultValue) => {
+  const [isToggled, setIsToggled] = useState<boolean>(() => {
+    // Retrieve initial value from localStorage (if available)
+    const storedValue = localStorage.getItem(key);
+    const parsedValue = storedValue && JSON.parse(storedValue);
+    return defaultValue !== undefined ? defaultValue : parsedValue ?? false;
+  });
+
+  // Update localStorage on toggle change
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(isToggled));
+  }, [isToggled, key]);
+
+  const toggle = (): void => {
+    setIsToggled((prev) => !prev);
+  };
+
+  return [isToggled, toggle];
+};

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
@@ -11,6 +11,7 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { useToggle } from '@kubevirt-utils/hooks/useToggle';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { getDisks, getInterfaces } from '@kubevirt-utils/resources/vm';
 import { updateCustomizeInstanceType } from '@kubevirt-utils/store/customizeInstanceType';
@@ -40,7 +41,7 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({
   const { createModal } = useModal();
   const location = useLocation();
   const [isChecked, setIsChecked] = useState<boolean>(!!vm?.spec?.template?.spec?.startStrategy);
-  const [isExpanded, setIsExpanded] = useState<boolean>();
+  const [isExpanded, setIsExpanded] = useToggle('boot-management');
   const vmName = getName(vm);
 
   useEffect(() => {

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionHardware.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionHardware.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -9,6 +9,7 @@ import { HARDWARE_DEVICE_TYPE } from '@kubevirt-utils/components/HardwareDevices
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { useToggle } from '@kubevirt-utils/hooks/useToggle';
 import { getGPUDevices, getHostDevices } from '@kubevirt-utils/resources/vm';
 import { Bullseye, Divider, ExpandableSection, Flex, Grid, GridItem } from '@patternfly/react-core';
 
@@ -30,7 +31,7 @@ const DetailsSectionHardware: FC<DetailsSectionHardwareProps> = ({
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const location = useLocation();
-  const [isExpanded, setIsExpanded] = useState<boolean>();
+  const [isExpanded, setIsExpanded] = useToggle('hardware-devices');
   const onSubmit = onSubmitProp || updateHardwareDevices;
   const hostDevices = getHostDevices(vm);
   const gpus = getGPUDevices(vm);


### PR DESCRIPTION
## 📝 Description

Every VM update the component gets re-rendered, when the default value is folded expandable section it will close on every VM change. Using localStorage to save the folded value with useToggle new hook

## 🎥 Demo

Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/bda87e18-1a3c-488e-9f89-5b714eb1b2cc

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/099a66f1-eb7a-43a5-adc6-fde11251f692


