### PR TITLE
CNV-42786: Windows VM with sysprep cannot be started due to configMap of sysprep not found

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
@@ -8,6 +8,7 @@ import {
 } from '@catalog/CreateFromInstanceTypes/utils/utils';
 import { ConfigMapModel } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
+import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { SecretSelectionOption } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
@@ -126,9 +127,11 @@ const CreateVMFooter: FC = () => {
               sysprepName: name,
             });
 
-            try {
-              await k8sCreate({ data: configMap, model: ConfigMapModel });
-            } catch {}
+            await k8sCreate<IoK8sApiCoreV1ConfigMap>({
+              data: configMap,
+              model: ConfigMapModel,
+              ns: vmNamespaceTarget,
+            });
           }
         }
 


### PR DESCRIPTION
## 📝 Description

missing namespace in CM create callback

## 🎥 Demo
Before:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/26c93805-684f-41be-a191-4590841ae89e

After:

https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/aad4e0f2-6b11-4e24-b82a-f9bf42e20c43


