### PR TITLE
CNV-41592: unexpected behavior on '/' on creating a VM with sysprep

### DIFF
--- a/src/utils/components/ListPageFilter/SearchFilter.tsx
+++ b/src/utils/components/ListPageFilter/SearchFilter.tsx
@@ -25,10 +25,10 @@ const SearchFilter = forwardRef<HTMLInputElement, SearchFilterProps>((props, ref
       }
     };
 
-    document.addEventListener('keydown', onKeyDown);
+    inputRef.current.addEventListener('keydown', onKeyDown);
 
     return () => {
-      document.removeEventListener('keydown', onKeyDown);
+      inputRef.current.removeEventListener('keydown', onKeyDown);
     };
   }, [inputRef]);
 


### PR DESCRIPTION
## 📝 Description

document.addEventListener is adding an event listener for the entire document, instead of just adding to the listener to the proper element in the DOM.

## 🎥 Demo

After:
![slash-is-types](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/29e19497-d1a2-47d0-98a3-e46b96016e0a)

