### PR TITLE
CNV-40907: Table column alignment issue with "volume to boot from" table

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.scss
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.scss
@@ -24,7 +24,8 @@
   &-table {
     th:first-child {
       padding-right: 0;
-      padding-left: 30px;
+      padding-left: var(--pf-v5-global--spacer--sm);
+      margin-right: var(--pf-v5-global--spacer--sm);
       .pf-c-table__sort-indicator {
         margin: 0;
       }
@@ -32,7 +33,7 @@
     tbody {
       tr {
         td:first-child {
-          padding-left: var(--pf-v5-global--spacer--md);
+          padding-left: 0;
           width: unset;
           display: flex;
           justify-content: center;


### PR DESCRIPTION
## 📝 Description

Favorite column header is overlapping with the name column header on firefox, adjusting padding values.

## 🎥 Demo

Before:

![Screenshot from 2024-06-11 17-24-57](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/f4034d9e-f44e-4e79-99ce-bf5cb1c57886)

After:
![Screenshot from 2024-06-11 17-25-34](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/68d85998-a910-4c35-9b08-5820c7577518)
