### PR TITLE
CNV-43078: LUN type is greyed out from UI

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -583,7 +583,7 @@
   "Host devices ({{hostDevicesCount}})": "Host devices ({{hostDevicesCount}})",
   "Hostname": "Hostname",
   "Hot plug is enabled only for \"Bridge\" and \"SR-IOV\" types": "Hot plug is enabled only for \"Bridge\" and \"SR-IOV\" types",
-  "Hot plug is enabled only for \"Disk\" type": "Hot plug is enabled only for \"Disk\" type",
+  "Hot plug is enabled only for \"Disk\" and \"Lun\" types": "Hot plug is enabled only for \"Disk\" and \"Lun\" types",
   "Hot plug is enabled only for \"SCSI\" interface": "Hot plug is enabled only for \"SCSI\" interface",
   "How much time before the check will try to close itself": "How much time before the check will try to close itself",
   "HP series": "HP series",

--- a/src/utils/components/DiskModal/components/DiskTypeSelect/DiskTypeSelect.tsx
+++ b/src/utils/components/DiskModal/components/DiskTypeSelect/DiskTypeSelect.tsx
@@ -25,8 +25,6 @@ const DiskTypeSelect: FC<DiskTypeSelectProps> = ({ isVMRunning }) => {
 
   const [diskInterface, diskSource] = watch([diskInterfaceField, diskSourceField]);
 
-  const typeOptions = Object.values(diskTypes).filter((type) => type !== diskTypes.floppy);
-
   return (
     <Controller
       render={({ field: { onChange, value } }) => (
@@ -47,12 +45,13 @@ const DiskTypeSelect: FC<DiskTypeSelectProps> = ({ isVMRunning }) => {
               }}
               selected={value}
               selectedLabel={diskTypesLabels[value]}
-              toggleProps={{ isDisabled: isVMRunning, isFullWidth: true }}
+              toggleProps={{ isFullWidth: true }}
             >
               <SelectList>
-                {typeOptions.map((type) => (
+                {Object.values(diskTypes).map((type) => (
                   <SelectOption
                     data-test-id={`${diskTypeSelectFieldID}-${type}`}
+                    isDisabled={isVMRunning && type === diskTypes.cdrom}
                     key={type}
                     value={type}
                   >
@@ -62,7 +61,7 @@ const DiskTypeSelect: FC<DiskTypeSelectProps> = ({ isVMRunning }) => {
               </SelectList>
             </FormPFSelect>
             <FormGroupHelperText>
-              {t('Hot plug is enabled only for "Disk" type')}
+              {t('Hot plug is enabled only for "Disk" and "Lun" types')}
             </FormGroupHelperText>
           </FormGroup>
         </div>

--- a/src/utils/resources/vm/utils/disk/constants.ts
+++ b/src/utils/resources/vm/utils/disk/constants.ts
@@ -25,14 +25,12 @@ export type DiskRowDataLayout = {
 export const diskTypes = {
   cdrom: 'cdrom',
   disk: 'disk',
-  floppy: 'floppy',
   lun: 'lun',
 };
 
 export const diskTypesLabels = {
   cdrom: 'CD-ROM',
   disk: 'Disk',
-  floppy: 'Floppy',
   lun: 'LUN',
 };
 


### PR DESCRIPTION
## 📝 Description

Enable disk type on hotplug disk, also removing `floppy` disk type as it's only purpose is to be filtered out at all times.

## 🎥 Demo

Before:
![lun-hotplug-allowed-b4](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/1d38c365-bc71-406f-becf-320ddf4d03e6)

After:
![lun-hotplug-allowed3](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/6f6e9c39-f253-4d88-a757-8e098c63a509)

![lun-hotplug-allowed](https://github.com/kubevirt-ui/kubevirt-plugin/assets/67270715/b6d23888-e328-4e31-9ac0-d8fcaa85526c)

