### PR TITLE
CNV-38284: move features ConfigMap to openshift-cnv namespace

### DIFF
--- a/src/utils/hooks/useFeatures/constants.ts
+++ b/src/utils/hooks/useFeatures/constants.ts
@@ -4,7 +4,7 @@ import {
   IoK8sApiRbacV1Role,
   IoK8sApiRbacV1RoleBinding,
 } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import { OPENSHIFT_CNV } from '@kubevirt-utils/constants/constants';
 import { K8sVerb } from '@openshift-console/dynamic-plugin-sdk';
 
 export const AUTOMATIC_SUBSCRIPTION_ACTIVATION_KEY = 'automaticSubscriptionActivationKey';
@@ -39,14 +39,14 @@ export const featuresConfigMapInitialState: IoK8sApiCoreV1ConfigMap = {
   },
   metadata: {
     name: FEATURES_CONFIG_MAP_NAME,
-    namespace: DEFAULT_NAMESPACE,
+    namespace: OPENSHIFT_CNV,
   },
 };
 
 export const featuresRole: IoK8sApiRbacV1Role = {
   metadata: {
     name: FEATURES_ROLE_NAME,
-    namespace: DEFAULT_NAMESPACE,
+    namespace: OPENSHIFT_CNV,
   },
   rules: [
     {
@@ -61,7 +61,7 @@ export const featuresRole: IoK8sApiRbacV1Role = {
 export const featuresRoleBinding: IoK8sApiRbacV1RoleBinding = {
   metadata: {
     name: FEATURES_ROLE_BINDING_NAME,
-    namespace: DEFAULT_NAMESPACE,
+    namespace: OPENSHIFT_CNV,
   },
   roleRef: {
     apiGroup: RoleModel.apiGroup,

--- a/src/utils/hooks/useFeatures/useFeaturesConfigMap.ts
+++ b/src/utils/hooks/useFeatures/useFeaturesConfigMap.ts
@@ -1,6 +1,6 @@
 import { ConfigMapModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import { OPENSHIFT_CNV } from '@kubevirt-utils/constants/constants';
 import {
   getGroupVersionKindForModel,
   useK8sWatchResource,
@@ -23,7 +23,7 @@ const useFeaturesConfigMap: UseFeaturesConfigMap = () => {
     groupVersionKind: getGroupVersionKindForModel(ConfigMapModel),
     isList: false,
     name: FEATURES_CONFIG_MAP_NAME,
-    namespace: DEFAULT_NAMESPACE,
+    namespace: OPENSHIFT_CNV,
   });
   return { featuresConfigMapData: [...featuresConfigMapData], isAdmin };
 };


### PR DESCRIPTION
## 📝 Description

Moving the `kubevirt-ui-settings` config map to `openshift-cnv` namespace

## 🎥 Demo

> Please add a video or an image of the behavior/changes
