### PR TITLE
CNV-41832: Hide Access/Volume Mode radio buttons when optimized storage profile …

### DIFF
--- a/src/utils/components/DiskModal/components/StorageProfileSettings/AccessMode.tsx
+++ b/src/utils/components/DiskModal/components/StorageProfileSettings/AccessMode.tsx
@@ -17,8 +17,7 @@ const AccessMode: FC = () => {
 
   const { control, setValue, watch } = useFormContext<DiskFormState>();
 
-  const { accessMode, storageClassProvisioner, storageProfileSettingsApplied, volumeMode } =
-    watch();
+  const { accessMode, storageClassProvisioner, volumeMode } = watch();
 
   const allowedAccessModes = useMemo(() => {
     return getAccessModeForProvisioner(storageClassProvisioner, volumeMode as VOLUME_MODES);
@@ -29,10 +28,6 @@ const AccessMode: FC = () => {
       setValue(accessModeField, allowedAccessModes?.[0]);
     }
   }, [accessMode, allowedAccessModes, setValue]);
-
-  if (storageProfileSettingsApplied) {
-    return null;
-  }
 
   return (
     <FormGroup fieldId={accessModeFieldID} label={t('Access Mode')}>

--- a/src/utils/components/DiskModal/components/StorageProfileSettings/ApplyStorageProfileSettings.tsx
+++ b/src/utils/components/DiskModal/components/StorageProfileSettings/ApplyStorageProfileSettings.tsx
@@ -48,17 +48,19 @@ const ApplyStorageProfileSettings: FC = () => {
         handleChange={handleApplyOptimizedSettingsChange}
         isChecked={storageProfileSettingsApplied}
       />
-      <Flex
-        className="ApplyStorageProfileSettings--volume-access-section"
-        spaceItems={{ default: 'spaceItems3xl' }}
-      >
-        <FlexItem>
-          <AccessMode />
-        </FlexItem>
-        <FlexItem>
-          <VolumeMode />
-        </FlexItem>
-      </Flex>
+      {!storageProfileSettingsApplied && (
+        <Flex
+          className="ApplyStorageProfileSettings--volume-access-section"
+          spaceItems={{ default: 'spaceItems3xl' }}
+        >
+          <FlexItem>
+            <AccessMode />
+          </FlexItem>
+          <FlexItem>
+            <VolumeMode />
+          </FlexItem>
+        </Flex>
+      )}
     </div>
   );
 };

--- a/src/utils/components/DiskModal/components/StorageProfileSettings/VolumeMode.tsx
+++ b/src/utils/components/DiskModal/components/StorageProfileSettings/VolumeMode.tsx
@@ -18,8 +18,7 @@ const VolumeMode: FC = () => {
 
   const { control, setValue, watch } = useFormContext<DiskFormState>();
 
-  const { accessMode, storageClassProvisioner, storageProfileSettingsApplied, volumeMode } =
-    watch();
+  const { accessMode, storageClassProvisioner, volumeMode } = watch();
 
   const allowedVolumeModes = useMemo(
     () => getVolumeModeForProvisioner(storageClassProvisioner, accessMode as ACCESS_MODES),
@@ -31,10 +30,6 @@ const VolumeMode: FC = () => {
       setValue(volumeModeField, allowedVolumeModes[0]);
     }
   }, [allowedVolumeModes, volumeMode, setValue]);
-
-  if (storageProfileSettingsApplied) {
-    return null;
-  }
 
   return (
     <FormGroup fieldId={volumeModeFieldID} label={t('Volume Mode')}>


### PR DESCRIPTION
## 📝 Description

This PR simplifies hiding the Access and Volume mode radio button groups when the "Apply optimized StorageProfile settings" checkbox is checked. This PR will be backported to 4.15 where the radio button groups are currently not being hidden when the checkbox is checked.

Jira: https://issues.redhat.com/browse/CNV-41832
