### PR TITLE
CNV-43120: sysprep or sshcredentials in zustand

### DIFF
--- a/src/utils/components/SSHSecretModal/utils/constants.ts
+++ b/src/utils/components/SSHSecretModal/utils/constants.ts
@@ -9,6 +9,8 @@ export const initialSSHCredentials: SSHSecretDetails = {
   sshSecretNamespace: '',
 };
 
+export const initialSysprepData = { data: {}, name: '', shouldCreateNewConfigMap: false };
+
 export const MAX_NAME_LENGTH = 253;
 export const MAX_SUFFIX_LENGTH = 27;
 export const MIN_NAME_LENGTH_FOR_GENERATED_SUFFIX = MAX_NAME_LENGTH - MAX_SUFFIX_LENGTH;

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsRightGrid.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsRightGrid.tsx
@@ -7,6 +7,7 @@ import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFi
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SSHSecretModal from '@kubevirt-utils/components/SSHSecretModal/SSHSecretModal';
+import { initialSysprepData } from '@kubevirt-utils/components/SSHSecretModal/utils/constants';
 import { SSHSecretDetails } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import useDefaultStorageClass from '@kubevirt-utils/hooks/useDefaultStorage/useDefaultStorageClass';
@@ -46,6 +47,11 @@ const DetailsRightGrid: FC = () => {
     setInstanceTypeVMState({
       payload: { ...credentials, appliedDefaultKey: sshSecretCredentials?.appliedDefaultKey },
       type: instanceTypeActionType.setSSHCredentials,
+    });
+
+    setInstanceTypeVMState({
+      payload: initialSysprepData,
+      type: instanceTypeActionType.setSysprepConfigMapData,
     });
 
     return Promise.resolve();

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/SysprepDescriptionItem.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/SysprepDescriptionItem.tsx
@@ -7,6 +7,7 @@ import {
   SysprepConfigMapData,
 } from '@catalog/CreateFromInstanceTypes/state/utils/types';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { initialSSHCredentials } from '@kubevirt-utils/components/SSHSecretModal/utils/constants';
 import useSysprepConfigMaps from '@kubevirt-utils/components/SysprepModal/hooks/useConfigMaps';
 import {
   AUTOUNATTEND,
@@ -42,6 +43,11 @@ const SysprepDescriptionItem: FC = () => {
     setInstanceTypeVMState({
       payload: newConfigMapData,
       type: instanceTypeActionType.setSysprepConfigMapData,
+    });
+
+    setInstanceTypeVMState({
+      payload: initialSSHCredentials,
+      type: instanceTypeActionType.setSSHCredentials,
     });
   };
 

--- a/src/views/catalog/CreateFromInstanceTypes/state/utils/state.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/utils/state.ts
@@ -1,6 +1,9 @@
 import { getOSImagesNS } from 'src/views/clusteroverview/OverviewTab/inventory-card/utils/utils';
 
-import { initialSSHCredentials } from '@kubevirt-utils/components/SSHSecretModal/utils/constants';
+import {
+  initialSSHCredentials,
+  initialSysprepData,
+} from '@kubevirt-utils/components/SSHSecretModal/utils/constants';
 
 import { InstanceTypeVMState, InstanceTypeVMStoreState } from './types';
 
@@ -11,7 +14,7 @@ export const instanceTypeVMInitialState: InstanceTypeVMState = {
   selectedInstanceType: { name: '', namespace: null },
   selectedStorageClass: null,
   sshSecretCredentials: initialSSHCredentials,
-  sysprepConfigMapData: { data: {}, name: '', shouldCreateNewConfigMap: false },
+  sysprepConfigMapData: initialSysprepData,
   vmName: '',
   volumeSnapshotSource: null,
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

We can only have sysprep or ssh credentials. Not both. If the user change bootable volume, he can select both of them in the zustand state and produce some issues 
