### PR TITLE
CNV-43091: Remove restart required msg from affinity and node selector

### DIFF
--- a/src/utils/components/AffinityModal/AffinityModal.tsx
+++ b/src/utils/components/AffinityModal/AffinityModal.tsx
@@ -2,9 +2,8 @@ import * as React from 'react';
 import produce from 'immer';
 
 import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
-import ModalPendingChangesAlert from '@kubevirt-utils/components/PendingChanges/ModalPendingChangesAlert/ModalPendingChangesAlert';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getAffinity } from '@kubevirt-utils/resources/vm';
@@ -30,7 +29,6 @@ type AffinityModalProps = {
   onClose: () => void;
   onSubmit: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine | void>;
   vm: V1VirtualMachine;
-  vmi?: V1VirtualMachineInstance;
 };
 
 const AffinityModal: React.FC<AffinityModalProps> = ({
@@ -40,7 +38,6 @@ const AffinityModal: React.FC<AffinityModalProps> = ({
   onClose,
   onSubmit,
   vm,
-  vmi,
 }) => {
   const { t } = useKubevirtTranslation();
 
@@ -145,7 +142,6 @@ const AffinityModal: React.FC<AffinityModalProps> = ({
       onSubmit={onSubmit}
       submitBtnText={t('Apply rules')}
     >
-      {vmi && <ModalPendingChangesAlert />}
       {list}
     </TabModal>
   );

--- a/src/utils/components/NodeSelectorModal/NodeSelectorModal.tsx
+++ b/src/utils/components/NodeSelectorModal/NodeSelectorModal.tsx
@@ -3,8 +3,7 @@ import produce from 'immer';
 
 import { NodeModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import ModalPendingChangesAlert from '@kubevirt-utils/components/PendingChanges/ModalPendingChangesAlert/ModalPendingChangesAlert';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getNodeSelector } from '@kubevirt-utils/resources/vm';
@@ -26,7 +25,6 @@ type NodeSelectorModalProps = {
   onClose: () => void;
   onSubmit: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine | void>;
   vm: V1VirtualMachine;
-  vmi?: V1VirtualMachineInstance;
 };
 
 const NodeSelectorModal: FC<NodeSelectorModalProps> = ({
@@ -36,7 +34,6 @@ const NodeSelectorModal: FC<NodeSelectorModalProps> = ({
   onClose,
   onSubmit,
   vm,
-  vmi,
 }) => {
   const { t } = useKubevirtTranslation();
   const {
@@ -81,7 +78,6 @@ const NodeSelectorModal: FC<NodeSelectorModalProps> = ({
       onSubmit={onSubmit}
     >
       <Form>
-        {vmi && <ModalPendingChangesAlert />}
         <LabelsList
           isEmpty={selectorLabels?.length === 0}
           model={!isEmpty(nodes) && NodeModel}

--- a/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
+++ b/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
@@ -322,7 +322,6 @@ export const usePendingChanges = (
             onClose={onClose}
             onSubmit={onSubmit}
             vm={vm}
-            vmi={vmi}
           />
         ));
       },
@@ -371,7 +370,6 @@ export const usePendingChanges = (
             onClose={onClose}
             onSubmit={onSubmit}
             vm={vm}
-            vmi={vmi}
           />
         ));
       },

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionLeftGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionLeftGrid.tsx
@@ -68,7 +68,6 @@ const SchedulingSectionLeftGrid: FC<SchedulingSectionLeftGridProps> = ({
                 onClose={onClose}
                 onSubmit={onSubmit}
                 vm={vm}
-                vmi={vmi}
               />
             ))
           }
@@ -105,7 +104,6 @@ const SchedulingSectionLeftGrid: FC<SchedulingSectionLeftGridProps> = ({
                 onClose={onClose}
                 onSubmit={onSubmit}
                 vm={vm}
-                vmi={vmi}
               />
             ))
           }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

I am removing the restart required message from the affinity and node selector models as they are now live update, and no restart is needed if they are live migratable. 

## 🎥 Demo

After:
![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/14824964/77f529fc-b404-4661-a5a5-e29a99b3807f)

![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/14824964/1995749e-90fa-4398-a4c2-f4d9ed523025)


Before:
![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/14824964/e2f93bb1-c6bd-4bda-a3f7-ec5807bdbad7)

![image](https://github.com/kubevirt-ui/kubevirt-plugin/assets/14824964/9f9b8472-51cb-4108-943c-7a8f30f2bffa)
