### PR TITLE
CNV-43172: Fix checkups storage permissions

### DIFF
--- a/src/views/checkups/storage/components/hooks/useCheckupsStoragePermissions.ts
+++ b/src/views/checkups/storage/components/hooks/useCheckupsStoragePermissions.ts
@@ -44,9 +44,7 @@ export const useCheckupsStoragePermissions = () => {
     },
   );
 
-  const [clusterRoleBinding, loadingClusterRolesBinding] = useK8sWatchResource<
-    IoK8sApiRbacV1ClusterRoleBinding[]
-  >(
+  const [clusterRoleBinding] = useK8sWatchResource<IoK8sApiRbacV1ClusterRoleBinding[]>(
     !isAllNamespace && {
       groupVersionKind: modelToGroupVersionKind(ClusterRoleBindingModel),
       isList: true,
@@ -83,13 +81,7 @@ export const useCheckupsStoragePermissions = () => {
 
   return {
     clusterRoleBinding: isClusterRoleBinding,
-    isPermitted: Boolean(
-      isServiceAccount && isConfigMapRole && isConfigMapRoleBinding && isClusterRoleBinding,
-    ),
-    loading:
-      !loadingServiceAccounts &&
-      !loadingRoles &&
-      !loadingRolesBinding &&
-      !loadingClusterRolesBinding,
+    isPermitted: Boolean(isServiceAccount && isConfigMapRole && isConfigMapRoleBinding),
+    loading: !loadingServiceAccounts && !loadingRoles && !loadingRolesBinding,
   };
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fix permission for storage checkups, 
1. non-previlige user cant check clusterbindingroles
2. fix order of promises so role will be deleted/added before role binding.

## 🎥 Demo

> Please add a video or an image of the behavior/changes
