### PR TITLE
CNV-43245: use runStrategy if defined

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1129,6 +1129,7 @@
   "Start": "Start",
   "Start in pause mode": "Start in pause mode",
   "Start this VirtualMachine after creation": "Start this VirtualMachine after creation",
+  "Start this VirtualMachine after creation ({{runStrategy}})": "Start this VirtualMachine after creation ({{runStrategy}})",
   "Start this VirtualMachine in pause mode": "Start this VirtualMachine in pause mode",
   "Start time": "Start time",
   "Start VirtualMachine once created": "Start VirtualMachine once created",

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -48,6 +48,7 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
       onCustomize,
       onQuickCreate,
       onVMNameChange,
+      runStrategy,
       startVM,
     } = useCreateDrawerForm(namespace, subscriptionData, authorizedSSHKey);
 
@@ -86,9 +87,15 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
             <StackItem />
             <StackItem>
               <Checkbox
+                label={
+                  runStrategy
+                    ? t('Start this VirtualMachine after creation ({{runStrategy}})', {
+                        runStrategy,
+                      })
+                    : t('Start this VirtualMachine after creation')
+                }
                 id="start-after-create-checkbox"
-                isChecked={startVM}
-                label={t('Start this VirtualMachine after creation')}
+                isChecked={startVM || runStrategy === 'Always' || runStrategy === 'RerunOnFailure'}
                 onChange={(_, checked: boolean) => onChangeStartVM(checked)}
               />
             </StackItem>

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
@@ -60,6 +60,7 @@ const useCreateDrawerForm = (
     cdFile,
     diskFile,
     isBootSourceAvailable,
+    setVM,
     sshDetails,
     storageClassName,
     storageClassRequired,
@@ -71,7 +72,6 @@ const useCreateDrawerForm = (
 
   const { nameField, onVMNameChange } = useCreateVMName();
 
-  const [startVM, setStartVM] = useState(true);
   const [isQuickCreating, setIsQuickCreating] = useState(false);
   const [isCustomizing, setIsCustomizing] = useState(false);
   const [createError, setCreateError] = useState(undefined);
@@ -130,7 +130,6 @@ const useCreateDrawerForm = (
           isDisabledGuestSystemLogs,
           name: nameField,
           namespace,
-          startVM,
           subscriptionData,
         },
         template: templateToProcess,
@@ -235,10 +234,12 @@ const useCreateDrawerForm = (
   };
 
   const onChangeStartVM = (checked: boolean) => {
-    setStartVM(checked);
-    updateTabsData((currentTabsData) => {
-      return { ...currentTabsData, startVM: checked };
-    });
+    setVM(
+      produce(vm, (draftVM) => {
+        delete draftVM.spec.runStrategy;
+        draftVM.spec.running = checked;
+      }),
+    );
   };
 
   return {
@@ -259,7 +260,8 @@ const useCreateDrawerForm = (
     onCustomize,
     onQuickCreate,
     onVMNameChange,
-    startVM,
+    runStrategy: vm?.spec?.runStrategy,
+    startVM: vm?.spec?.running,
   };
 };
 

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDrawerContext.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDrawerContext.tsx
@@ -7,6 +7,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+import produce from 'immer';
 import { Updater, useImmer } from 'use-immer';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
@@ -94,9 +95,18 @@ const useDrawer = (template: V1Template) => {
   );
 
   useEffect(() => {
+    if (!templateWithGeneratedParams) return;
+
     updateDefaultDiskSource(getTemplateVirtualMachineObject(templateWithGeneratedParams));
 
-    setCustomizedTemplate(templateWithGeneratedParams);
+    const templateWithRunning = produce(templateWithGeneratedParams, (draftTemplate) => {
+      const draftVM = getTemplateVirtualMachineObject(draftTemplate);
+
+      if (isEmpty(draftVM?.spec?.runStrategy) && draftVM?.spec?.running === undefined)
+        draftVM.spec.running = true;
+    });
+
+    setCustomizedTemplate(templateWithRunning);
   }, [setCustomizedTemplate, templateWithGeneratedParams, updateDefaultDiskSource]);
 
   return {

--- a/src/views/catalog/utils/WizardVMContext/utils/tabs-data.ts
+++ b/src/views/catalog/utils/WizardVMContext/utils/tabs-data.ts
@@ -17,6 +17,5 @@ export type TabsData = {
       osType?: OS_NAME_TYPES;
     };
   };
-  startVM?: boolean;
   subscriptionData?: RHELAutomaticSubscriptionData;
 };

--- a/src/views/catalog/utils/quick-create-vm.ts
+++ b/src/views/catalog/utils/quick-create-vm.ts
@@ -24,7 +24,6 @@ type QuickCreateVMType = (inputs: {
     isDisabledGuestSystemLogs: boolean;
     name: string;
     namespace: string;
-    startVM: boolean;
     subscriptionData: RHELAutomaticSubscriptionData;
   };
   template: V1Template;
@@ -38,7 +37,6 @@ export const quickCreateVM: QuickCreateVMType = async ({
     isDisabledGuestSystemLogs,
     name,
     namespace = DEFAULT_NAMESPACE,
-    startVM,
     subscriptionData,
   },
   template,
@@ -61,9 +59,6 @@ export const quickCreateVM: QuickCreateVMType = async ({
 
     draftVM.metadata.labels[LABEL_USED_TEMPLATE_NAME] = processedTemplate.metadata.name;
     draftVM.metadata.labels[LABEL_USED_TEMPLATE_NAMESPACE] = template.metadata.namespace;
-    if (startVM) {
-      draftVM.spec.running = true;
-    }
 
     if (isDisabledGuestSystemLogs) {
       const devices = (<unknown>draftVM.spec.template.spec.domain.devices) as V1Devices & {

--- a/src/views/catalog/utils/useWizardVmCreate.ts
+++ b/src/views/catalog/utils/useWizardVmCreate.ts
@@ -18,15 +18,10 @@ import { useWizardVMContext } from './WizardVMContext';
 type CreateVMArguments = {
   isDisableGuestSystemAccessLog: boolean;
   onFullfilled: (vm: V1VirtualMachine) => void;
-  startVM: boolean;
 };
 
 type UseWizardVmCreateValues = {
-  createVM: ({
-    isDisableGuestSystemAccessLog,
-    onFullfilled,
-    startVM,
-  }: CreateVMArguments) => Promise<void>;
+  createVM: ({ isDisableGuestSystemAccessLog, onFullfilled }: CreateVMArguments) => Promise<void>;
   error: any;
   loaded: boolean;
 };
@@ -39,18 +34,12 @@ export const useWizardVmCreate = (): UseWizardVmCreateValues => {
   const [loaded, setLoaded] = useState<boolean>(true);
   const [error, setError] = useState<any>();
 
-  const createVM = async ({
-    isDisableGuestSystemAccessLog,
-    onFullfilled,
-    startVM,
-  }: CreateVMArguments) => {
+  const createVM = async ({ isDisableGuestSystemAccessLog, onFullfilled }: CreateVMArguments) => {
     try {
       setLoaded(false);
       setError(undefined);
 
       const vmToCrete = produce(vm, (vmDraft) => {
-        vmDraft.spec.running = startVM;
-
         if (isDisableGuestSystemAccessLog) {
           const devices = (<unknown>vmDraft.spec.template.spec.domain.devices) as V1Devices & {
             logSerialConsole: boolean;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Documentation: https://docs.openshift.com/container-platform/4.11/virt/virtual_machines/virt-create-vms.html#virt-about-runstrategies-vms_virt-create-vms

`spec.running` and `spec.runStrategy` are mutually exclusive. `spec.runStrategy` specified by user and we add `spec.running`

Solution: do not set `spec.running` if `spec.runStrategy` is already defined by the template. Show in the 'start vm' checkbox label the runStrategy if defined. runStrategy `always` or `runonfailure` are special cases of running: true so the checkbox will be checked. 

If the user changes the checkbox status, remove `spec.runStrategy` and use `spec.running`. 


Note: I removed the `startVM` from all the contexts as this is something that is defined in the VM itself. So instead of having another state in the context, I decided to change the VM property `spec.running` directly


## 🎥 Demo


**Catalog Drawer**
https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/f3ab2080-0069-4139-ba71-af2d040a0927


**Wizard**
https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/8ca13d13-60fc-4e2a-af95-6c4fef036989


