### PR TITLE
[WIP] CNV-38351: set autoattachPodInterface to false by default

### DIFF
--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -37,6 +37,7 @@ import {
   getTolerations,
   getVolumes,
 } from '@kubevirt-utils/resources/vm';
+import { DEFAULT_NETWORK_INTERFACE } from '@kubevirt-utils/resources/vm/utils/constants';
 import {
   DESCHEDULER_EVICT_LABEL,
   getEvictionStrategy as getVMIEvictionStrategy,
@@ -50,7 +51,11 @@ import {
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { isPendingHotPlugNIC } from '@virtualmachines/details/tabs/configuration/network/utils/utils';
 
-import { getBootloader, getDisks } from '../../../resources/vm/utils/selectors';
+import {
+  getAutoAttachPodInterface,
+  getBootloader,
+  getDisks,
+} from '../../../resources/vm/utils/selectors';
 
 import { PendingChange } from './types';
 
@@ -150,11 +155,15 @@ export const getChangedNICs = (vm: V1VirtualMachine, vmi: V1VirtualMachineInstan
   const vmNICsNames = vmInterfaces?.map((nic) => nic?.name) || [];
   const vmiNICsNames = vmiInterfaces?.map((nic) => nic?.name) || [];
 
+  const autoAttachDefaultNetwork = getAutoAttachPodInterface(vm);
+
+  const hasDefaultNetwork = autoAttachDefaultNetwork !== false;
+
   if (
-    vmiInterfaces?.find((nic) => nic.name === 'default' && nic.masquerade) &&
-    !vmNICsNames.includes('default')
+    hasDefaultNetwork &&
+    vmiInterfaces?.find((nic) => nic.name === DEFAULT_NETWORK_INTERFACE.name && nic.masquerade)
   ) {
-    vmNICsNames.push('default');
+    vmNICsNames.push(DEFAULT_NETWORK_INTERFACE.name);
   }
 
   const unchangedNICs = vmNICsNames?.filter((vmNicName) =>

--- a/src/utils/resources/vm/utils/constants.ts
+++ b/src/utils/resources/vm/utils/constants.ts
@@ -25,3 +25,7 @@ export const PATHS_TO_HIGHLIGHT = {
 };
 
 export const MIGRATION__PROMETHEUS_DELAY = 15 * MILLISECONDS_TO_SECONDS_MULTIPLIER;
+
+export const DEFAULT_NETWORK_INTERFACE = { masquerade: {}, model: 'virtio', name: 'default' };
+
+export const DEFAULT_NETWORK = { name: 'default', pod: {} };

--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -15,6 +15,10 @@ import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAuto
 import { isBootableVolumePVCKind } from '@kubevirt-utils/resources/bootableresources/helpers';
 import { getLabel, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { OS_NAME_TYPES, OS_NAME_TYPES_NOT_SUPPORTED } from '@kubevirt-utils/resources/template';
+import {
+  DEFAULT_NETWORK,
+  DEFAULT_NETWORK_INTERFACE,
+} from '@kubevirt-utils/resources/vm/utils/constants';
 import { OS_WINDOWS_PREFIX } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import {
   HEADLESS_SERVICE_LABEL,
@@ -162,9 +166,12 @@ export const generateVM = (
         spec: {
           domain: {
             devices: {
+              autoattachPodInterface: false,
+              interfaces: [DEFAULT_NETWORK_INTERFACE],
               ...(isSysprep ? { disks: [sysprepDisk()] } : {}),
             },
           },
+          networks: [DEFAULT_NETWORK],
           subdomain: HEADLESS_SERVICE_NAME,
           volumes: [
             {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

By default, let the user create vms with no network interfaces using instancetype.
The UI already handle this configuration in the networking list with no interfaces. 

Pending Changes:
If the vmi has the default interface and the VM does not have it, check the flag to make sure that we are correctly showing the alert. IF the flag is true, the VM has the default interface even if it's not declared in the structure.

## 🎥 Demo


VM network list with no interfaces

<img width="1701" alt="Screenshot 2024-06-25 at 15 07 35" src="https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/69859d44-7e0e-443a-bb33-0b2c976e0367">

instancetype customization page with no interfaces 

<img width="1701" alt="Screenshot 2024-06-25 at 15 07 57" src="https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/5295c8c8-2ead-47c1-adfa-a0eb3dfebd1c">
