### PR TITLE
CNV-38598: Cascade delete for jobs and pods when checkups deleted

### DIFF
--- a/src/views/checkups/network/components/CheckupsNetworkActions.tsx
+++ b/src/views/checkups/network/components/CheckupsNetworkActions.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { FC, useState } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { IoK8sApiBatchV1Job, IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import DropdownToggle from '@kubevirt-utils/components/toggles/DropdownToggle';
 import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -10,12 +10,16 @@ import { Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core';
 import { STATUS_SUCCEEDED } from '../../utils/utils';
 import { deleteNetworkCheckup, rerunNetworkCheckup } from '../utils/utils';
 
-const CheckupsNetworkActions = ({
-  configMap,
-  isKebab = false,
-}: {
+type CheckupsNetworkActionsProps = {
   configMap: IoK8sApiCoreV1ConfigMap;
   isKebab?: boolean;
+  jobs: IoK8sApiBatchV1Job[];
+};
+
+const CheckupsNetworkActions: FC<CheckupsNetworkActionsProps> = ({
+  configMap,
+  isKebab = false,
+  jobs,
 }) => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
@@ -35,7 +39,7 @@ const CheckupsNetworkActions = ({
         <DropdownItem
           onClick={() => {
             setIsActionsOpen(false);
-            deleteNetworkCheckup(configMap);
+            deleteNetworkCheckup(configMap, jobs);
             navigate(`/k8s/ns/${configMap?.metadata?.namespace}/checkups`);
           }}
           key="delete"

--- a/src/views/checkups/network/details/CheckupsNetworkDetailsPage.tsx
+++ b/src/views/checkups/network/details/CheckupsNetworkDetailsPage.tsx
@@ -41,7 +41,7 @@ const CheckupsNetworkDetailsPage = () => {
 
   return (
     <PageSection variant={PageSectionVariants.light}>
-      <CheckupsNetworkDetailsPageHeader configMap={configMap} />
+      <CheckupsNetworkDetailsPageHeader configMap={configMap} jobs={jobMatches} />
       <Tabs
         onSelect={(_, tabIndex: number) => {
           setActiveTabKey(tabIndex);

--- a/src/views/checkups/network/details/CheckupsNetworkDetailsPageHeader.tsx
+++ b/src/views/checkups/network/details/CheckupsNetworkDetailsPageHeader.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { IoK8sApiBatchV1Job, IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -18,10 +18,12 @@ import CheckupsNetworkActions from '../components/CheckupsNetworkActions';
 
 type CheckupsNetworkDetailsPageHeaderProps = {
   configMap: IoK8sApiCoreV1ConfigMap;
+  jobs: IoK8sApiBatchV1Job[];
 };
 
 const CheckupsNetworkDetailsPageHeader: FC<CheckupsNetworkDetailsPageHeaderProps> = ({
   configMap,
+  jobs,
 }) => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
@@ -46,7 +48,7 @@ const CheckupsNetworkDetailsPageHeader: FC<CheckupsNetworkDetailsPageHeaderProps
           {configMap?.metadata?.name}
         </Title>
         <FlexItem>
-          <CheckupsNetworkActions configMap={configMap} />
+          <CheckupsNetworkActions configMap={configMap} jobs={jobs} />
         </FlexItem>
       </Flex>
     </>

--- a/src/views/checkups/network/list/CheckupsNetworkListRow.tsx
+++ b/src/views/checkups/network/list/CheckupsNetworkListRow.tsx
@@ -75,7 +75,11 @@ const CheckupsNetworkListRow = ({ activeColumnIDs, obj: configMap, rowData: { ge
         className="dropdown-kebab-pf pf-v5-c-table__action"
         id=""
       >
-        <CheckupsNetworkActions configMap={configMap} isKebab />
+        <CheckupsNetworkActions
+          configMap={configMap}
+          isKebab
+          jobs={getJobByName(configMap?.metadata?.name)}
+        />
       </TableData>
     </>
   );

--- a/src/views/checkups/network/utils/utils.ts
+++ b/src/views/checkups/network/utils/utils.ts
@@ -267,10 +267,21 @@ export const createNetworkCheckup: CreateNetworkCheckupType = async ({
   return await createJob(name, namespace);
 };
 
-export const deleteNetworkCheckup = async (resource: IoK8sApiCoreV1ConfigMap) => {
+export const deleteNetworkCheckup = async (
+  configMap: IoK8sApiCoreV1ConfigMap,
+  jobs: IoK8sApiBatchV1Job[],
+) => {
   try {
-    await k8sDelete({ model: ConfigMapModel, resource });
-    await k8sDelete({ model: JobModel, resource });
+    await k8sDelete({
+      model: ConfigMapModel,
+      resource: configMap,
+    });
+    jobs.map((job) =>
+      k8sDelete({
+        model: JobModel,
+        resource: job,
+      }),
+    );
   } catch (e) {
     kubevirtConsole.log(e?.message);
   }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Now, when deleting network latency checkups, it will also delete the jobs and cascade the deletion of the jobs pods.

## 🎥 Demo

