### PR TITLE
CNV-38351: set autoattachPodInterface to false by default

### DIFF
--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -37,6 +37,7 @@ import {
   getTolerations,
   getVolumes,
 } from '@kubevirt-utils/resources/vm';
+import { DEFAULT_NETWORK_INTERFACE } from '@kubevirt-utils/resources/vm/utils/constants';
 import {
   DESCHEDULER_EVICT_LABEL,
   getEvictionStrategy as getVMIEvictionStrategy,
@@ -50,7 +51,11 @@ import {
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { isPendingHotPlugNIC } from '@virtualmachines/details/tabs/configuration/network/utils/utils';
 
-import { getBootloader, getDisks } from '../../../resources/vm/utils/selectors';
+import {
+  getAutoAttachPodInterface,
+  getBootloader,
+  getDisks,
+} from '../../../resources/vm/utils/selectors';
 
 import { PendingChange } from './types';
 
@@ -150,11 +155,13 @@ export const getChangedNICs = (vm: V1VirtualMachine, vmi: V1VirtualMachineInstan
   const vmNICsNames = vmInterfaces?.map((nic) => nic?.name) || [];
   const vmiNICsNames = vmiInterfaces?.map((nic) => nic?.name) || [];
 
+  const autoAttachPodInterface = getAutoAttachPodInterface(vm) !== false;
   if (
-    vmiInterfaces?.find((nic) => nic.name === 'default' && nic.masquerade) &&
-    !vmNICsNames.includes('default')
+    autoAttachPodInterface &&
+    vmiInterfaces?.find((nic) => nic.name === DEFAULT_NETWORK_INTERFACE.name) &&
+    !vmNICsNames.includes(DEFAULT_NETWORK_INTERFACE.name)
   ) {
-    vmNICsNames.push('default');
+    vmNICsNames.push(DEFAULT_NETWORK_INTERFACE.name);
   }
 
   const unchangedNICs = vmNICsNames?.filter((vmNicName) =>

--- a/src/utils/resources/vm/utils/constants.ts
+++ b/src/utils/resources/vm/utils/constants.ts
@@ -1,3 +1,5 @@
+import { V1Interface, V1Network } from '@kubevirt-ui/kubevirt-api/kubevirt';
+
 export const NO_DATA_DASH = '-';
 
 export const MILLISECONDS_TO_SECONDS_MULTIPLIER = 1000;
@@ -25,3 +27,7 @@ export const PATHS_TO_HIGHLIGHT = {
 };
 
 export const MIGRATION__PROMETHEUS_DELAY = 15 * MILLISECONDS_TO_SECONDS_MULTIPLIER;
+
+export const DEFAULT_NETWORK_INTERFACE: V1Interface = { masquerade: {}, name: 'default' };
+
+export const DEFAULT_NETWORK: V1Network = { name: 'default', pod: {} };

--- a/src/utils/resources/vm/utils/network/rowData.ts
+++ b/src/utils/resources/vm/utils/network/rowData.ts
@@ -1,18 +1,22 @@
 import { V1Interface, V1Network } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
+import { DEFAULT_NETWORK, DEFAULT_NETWORK_INTERFACE } from '../constants';
+
 import { NetworkPresentation } from './constants';
 
 /**
  * function to get network interfaces row data from networks and interfaces
  * @param {V1Network[]} networks networks
  * @param {V1Interface[]} interfaces networks interfaces
+ * @param autoattachPodInterface
  * @returns returns a network presentation array
  */
 export const getNetworkInterfaceRowData = (
   networks: V1Network[],
   interfaces: V1Interface[],
+  autoattachPodInterface?: boolean,
 ): NetworkPresentation[] => {
-  const data: NetworkPresentation[] = interfaces?.map((iface) => {
+  const data: NetworkPresentation[] = (interfaces || []).map((iface) => {
     const network = networks?.find((net) => net.name === iface.name);
     return {
       iface,
@@ -20,5 +24,13 @@ export const getNetworkInterfaceRowData = (
       network,
     };
   });
+
+  if (autoattachPodInterface)
+    data.push({
+      iface: DEFAULT_NETWORK_INTERFACE,
+      metadata: { name: DEFAULT_NETWORK.name },
+      network: DEFAULT_NETWORK,
+    } as NetworkPresentation);
+
   return data || [];
 };

--- a/src/utils/resources/vm/utils/network/utils.ts
+++ b/src/utils/resources/vm/utils/network/utils.ts
@@ -1,7 +1,12 @@
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
-import { getVMIInterfaces, getVMINetworks } from '@kubevirt-utils/resources/vmi/utils/selectors';
+import {
+  getVMIInterfaces,
+  getVMINetworks,
+  getVMIStatusInterfaces,
+} from '@kubevirt-utils/resources/vmi/utils/selectors';
 import { removeDuplicatesByName } from '@kubevirt-utils/utils/utils';
+import { isRunning } from '@virtualmachines/utils';
 
 import { NetworkPresentation } from './constants';
 import { getPrintableNetworkInterfaceType } from './selectors';
@@ -22,7 +27,7 @@ export const getInterfacesAndNetworks = (vm: V1VirtualMachine, vmi: V1VirtualMac
   const vmNetworks = getNetworks(vm) || [];
   const vmInterfaces = getInterfaces(vm) || [];
 
-  const vmiInterfaces = getVMIInterfaces(vmi) || [];
+  const vmiInterfaces = (isRunning(vm) ? getVMIStatusInterfaces(vmi) : getVMIInterfaces(vmi)) || [];
   const vmiNetworks = getVMINetworks(vmi) || [];
 
   const networks = removeDuplicatesByName([...vmNetworks, ...vmiNetworks]);

--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -15,6 +15,10 @@ import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAuto
 import { isBootableVolumePVCKind } from '@kubevirt-utils/resources/bootableresources/helpers';
 import { getLabel, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { OS_NAME_TYPES, OS_NAME_TYPES_NOT_SUPPORTED } from '@kubevirt-utils/resources/template';
+import {
+  DEFAULT_NETWORK,
+  DEFAULT_NETWORK_INTERFACE,
+} from '@kubevirt-utils/resources/vm/utils/constants';
 import { OS_WINDOWS_PREFIX } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import {
   HEADLESS_SERVICE_LABEL,
@@ -162,9 +166,12 @@ export const generateVM = (
         spec: {
           domain: {
             devices: {
+              autoattachPodInterface: false,
+              interfaces: [DEFAULT_NETWORK_INTERFACE],
               ...(isSysprep ? { disks: [sysprepDisk()] } : {}),
             },
           },
+          networks: [DEFAULT_NETWORK],
           subdomain: HEADLESS_SERVICE_NAME,
           volumes: [
             {

--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceList.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceList.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
+import {
+  getAutoAttachPodInterface,
+  getInterfaces,
+  getNetworks,
+} from '@kubevirt-utils/resources/vm';
 import { getNetworkInterfaceRowData } from '@kubevirt-utils/resources/vm/utils/network/rowData';
 import {
   ListPageFilter,
@@ -24,7 +28,11 @@ const NetworkInterfaceList: React.FC<NetworkInterfaceListProps> = ({ onUpdateVM,
   const interfaces = getInterfaces(vm);
   const filters = useNetworkRowFilters();
 
-  const networkInterfacesData = getNetworkInterfaceRowData(networks, interfaces);
+  const networkInterfacesData = getNetworkInterfaceRowData(
+    networks,
+    interfaces,
+    getAutoAttachPodInterface(vm),
+  );
   const [data, filteredData, onFilterChange] = useListPageFilter(networkInterfacesData, filters);
 
   const columns = useNetworkColumns(filteredData);

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceList.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceList.tsx
@@ -17,7 +17,7 @@ import {
 
 import useNetworkColumns from '../../hooks/useNetworkColumns';
 import useNetworkRowFilters from '../../hooks/useNetworkRowFilters';
-import { isPendingHotPlugNIC } from '../../utils/utils';
+import { isPendingHotPlugNIC, isPendingRemoval } from '../../utils/utils';
 
 import AutoAttachedNetworkEmptyState from './AutoAttachedNetworkEmptyState';
 import NetworkInterfaceRow from './NetworkInterfaceRow';
@@ -41,7 +41,8 @@ const NetworkInterfaceList: FC<NetworkInterfaceTableProps> = ({ vm, vmi }) => {
 
   const autoattachPodInterface = getAutoAttachPodInterface(vm) !== false;
 
-  const isPending = (network: V1Network): boolean => isPendingHotPlugNIC(vm, vmi, network?.name);
+  const isPending = (network: V1Network): boolean =>
+    isPendingHotPlugNIC(vm, vmi, network?.name) || isPendingRemoval(vm, vmi, network?.name);
 
   return (
     <>

--- a/src/views/virtualmachines/details/tabs/configuration/network/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/network/utils/utils.ts
@@ -1,12 +1,19 @@
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getInterfaces } from '@kubevirt-utils/resources/vm';
-import { getVMIStatusInterfaces } from '@kubevirt-utils/resources/vmi';
-import { isRunning } from '@virtualmachines/utils';
+import { getAutoAttachPodInterface, getInterfaces } from '@kubevirt-utils/resources/vm';
+import { DEFAULT_NETWORK_INTERFACE } from '@kubevirt-utils/resources/vm/utils/constants';
+import { getVMIInterfaces, getVMIStatusInterfaces } from '@kubevirt-utils/resources/vmi';
+import { isRunning, isStopped } from '@virtualmachines/utils';
 
 import { ABSENT } from './constants';
 
-export const isActiveOnGuest = (vmi: V1VirtualMachineInstance, nicName: string) =>
-  getVMIStatusInterfaces(vmi)?.some((iface) => iface?.name === nicName);
+export const isActiveOnGuest = (
+  vmi: V1VirtualMachineInstance,
+  nicName: string,
+  isVMRunning?: boolean,
+) =>
+  (isVMRunning ? getVMIStatusInterfaces(vmi) : getVMIInterfaces(vmi))?.some(
+    (iface) => iface?.name === nicName,
+  );
 
 export const isAbsent = (vm: V1VirtualMachine, nicName: string) =>
   getInterfaces(vm)?.find((iface) => iface?.name === nicName)?.state === ABSENT;
@@ -15,4 +22,32 @@ export const isPendingHotPlugNIC = (
   vm: V1VirtualMachine,
   vmi: V1VirtualMachineInstance,
   nicName: string,
-): boolean => isRunning(vm) && (!isActiveOnGuest(vmi, nicName) || isAbsent(vm, nicName));
+): boolean => {
+  const vmRunning = isRunning(vm);
+
+  return vmRunning && (!isActiveOnGuest(vmi, nicName, vmRunning) || isAbsent(vm, nicName));
+};
+
+export const interfaceNotFound = (vm: V1VirtualMachine, nicName: string) =>
+  !Boolean(getInterfaces(vm)?.find((iface) => iface?.name === nicName));
+
+export const isPendingRemoval = (
+  vm: V1VirtualMachine,
+  vmi: V1VirtualMachineInstance,
+  nicName: string,
+): boolean => {
+  if (!vmi || isStopped(vm)) return false;
+
+  const isVMRunning = isRunning(vm);
+
+  const autoAttachPodInterface = getAutoAttachPodInterface(vm) !== false;
+
+  if (
+    autoAttachPodInterface &&
+    nicName === DEFAULT_NETWORK_INTERFACE.name &&
+    isActiveOnGuest(vmi, nicName, isVMRunning)
+  )
+    return false;
+
+  return interfaceNotFound(vm, nicName) && isActiveOnGuest(vmi, nicName, isVMRunning);
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- set `autoattachPodInterface` to false for instanceType vms and explicitly defined the default network interface. Explicitly defining the interface, instead of relying on the default autoAttach, let the user delete all the network interfaces from the VM on customize or after creation.
- When the user deletes the last interface from existing vms, set the flag to false, so that the user will delete all the interfaces. Currently, If the user deletes all interfaces, the VM will always keep the default one. 
- In the network list, show the label 'pending' when the user try to remove one network from a running VM. Currently we show the pending label only when the user add the network and when it remove it, we just show the pending alert in top . 
- The first interface is marked as the default one and the default interface cannot be set to absent. In that case instead of mark as absent, just remove the interface

## 🎥 Demo

**Before**


As you can see here, the default network is implicitly declared by the autoAttachPodInterface flag (default: true). So there is no way in the UI to delete that. Even after creation, you cannot delete the default interface and there is no UI change so it seems that something is not working.

https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/e7a06ec6-4300-42bd-906c-6fc6920df00b


Here I added a network during the 'starting' status and there is no pending label. The pending label show up only on running, but the VM can be even stuck in some states like volume binding or some errors, and I'll never see the label


https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/79ace729-6197-415a-9d60-f69d87ef0121


Here I can't delete the default interface for this error. Cant' set absent because is the default interface. 

https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/f94e80af-c044-4b4e-95aa-0629b4ce89c7





**After**

Create VM with no networks.
When adding a new network, you can see the pending even when the VM is not in the running state. This is because the vmi is already and does not have the interface yey, you'll see the pending label.

https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/9b2e0b47-0afe-4b25-85a7-df4adbc0d818

When you delete the network from a running VM, you can see the pending label as the deletion is not reflected to the vmi. 
Note: as described before, here we cannot mark this interface as absent because it's the default one. 

https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/1d2ca8a5-69ab-405d-9764-50774a486c41

But the pending label will be gone when the vmi reflect the interfaces change


https://github.com/kubevirt-ui/kubevirt-plugin/assets/29160323/ea57d9c1-c891-492d-822f-b5ff72f513fb





