### PR TITLE
CNV-42619: Modifications to disk size on Templates details page don't persist

### DIFF
--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -17,7 +17,7 @@ import {
 import { buildOwnerReference, getName } from '@kubevirt-utils/resources/shared';
 import { hasTemplateParameter } from '@kubevirt-utils/resources/template';
 import { getBootDisk, getDataVolumeTemplates, getVolumes } from '@kubevirt-utils/resources/vm';
-import { ensurePath, getRandomChars } from '@kubevirt-utils/utils/utils';
+import { ensurePath, generatePrettyName } from '@kubevirt-utils/utils/utils';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import {
@@ -155,12 +155,12 @@ export const getDataVolumeFromState = ({
   const dvName =
     resultVolume?.dataVolume?.name ||
     resultVolume?.persistentVolumeClaim?.claimName ||
-    `${vm?.metadata?.name}-${diskState.diskName}`;
+    nameWithoutParameter(
+      `${vm?.metadata?.name}-${diskState.diskName}`,
+      generatePrettyName('volume'),
+    );
 
-  dataVolume.metadata.name = nameWithoutParameter(
-    dvName,
-    `${diskState.diskName}-${getRandomChars()}`,
-  );
+  dataVolume.metadata.name = dvName;
 
   dataVolume.spec.storage.resources.requests.storage = diskState.diskSize;
   dataVolume.spec.storage.storageClassName = diskState.storageClass;


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug where modifications to the size of a disk in the Edit disk modal on the Templates details page don't persist.

jira: https://issues.redhat.com/browse/CNV-42619

## 🎥 Demo

### Before

![modify-template-disk-size--BEFORE--2024-06-27 08-57](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/074fa08b-8a6e-431a-a098-bd6ec682dad8)

### After

![modify-template-disk-size--AFTER--2024-06-27 08-56](https://github.com/kubevirt-ui/kubevirt-plugin/assets/8544299/a217063b-7d9e-4b47-bee9-dbb8cbd8b5db)

