### PR TITLE
Improve docs regarding running Console Bridge locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ OC_PASS=<password>
 ### Option 3:
 
 1. Set up [Console](https://github.com/openshift/console) and See the plugin development section in [Console Dynamic Plugins README](https://github.com/openshift/console/blob/master/frontend/packages/console-dynamic-plugin-sdk/README.md) for details on how to run OpenShift console using local plugins.
-2. Run bridge with `-plugins kubevirt-plugin=http://localhost:9001`
+2. Run bridge with `-plugins kubevirt-plugin=http://localhost:9001/ -i18n-namespaces=plugin__kubevirt-plugin`
 3. Run `yarn dev` inside the plugin.
 
 ---


### PR DESCRIPTION
## 📝 Description

When running Console Bridge locally,
```
-plugins kubevirt-plugin=http://localhost:9001/
```
(note the trailing slash) should be paired with
```
-i18n-namespaces=plugin__kubevirt-plugin
```
to ensure that the proper i18n namespace is registered for the plugin at Console runtime.

:information_source: Note that `.devcontainer/Dockerfile.console` already contains
```
-i18n-namespaces $OC_PLUGIN_I18N_NAMESPACES
```
which could also be updated to
```
-i18n-namespaces plugin__$OC_PLUGIN_NAME
```
(and thus removing the need for `OC_PLUGIN_I18N_NAMESPACES` env variable) but I leave that up to you :smiley: 