### PR TITLE
CNV-43742: fix interfacetype undefined

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
@@ -78,7 +78,13 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
   }, [isPodNetworkingOptionExists, nads, podNetworkingText]);
 
   useEffect(() => {
-    loaded && setInterfaceType(getNadType(nads?.[0]));
+    if (!loaded) return;
+
+    const initialInterfaceType = getNadType(nads?.[0]);
+
+    if (!initialInterfaceType) return;
+
+    setInterfaceType(initialInterfaceType);
   }, [loaded, nads, setInterfaceType]);
 
   const validated =


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Interface type is undefined here as there are no nads, `getNadType` raise an exception and the result is `setInterfaceType(undefined)`.

The default interface type is `bridge` and if there are some nads, it will set the type according to that logic. If there are some exception, it will remain `bridge` and it will not be changed to `undefined` 
