### PR TITLE
Add instructions for opening issues to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@
 This project is a standalone repository hosting the Kubevirt plugin
 for OpenShift Console.
 
+## Opening issues
+
+Please follow the steps below to open an issue for this repository.
+
+### Ensure the issue doesn't already exist
+
+Navigate to the [OpenShift Virtualization issues page](https://issues.redhat.com/projects/CNV/issues) and search for the issue using the search bar in the upper right-hand corner. If your issue doesn't exist you'll need to open a new one. 
+
+### Log into Jira
+
+You must be logged in with a Red Hat account to open an issue. If you already have an account click the Log In button in the upper right-hand corner and enter your credentials. If you don't, follow the instructions [here](https://access.redhat.com/articles/5832311) to create one.
+
+### Open an issue
+
+Once you're logged in, navigate back to the [OpenShift Virtualization issues page](https://issues.redhat.com/projects/CNV/issues) and click the blue Create button in the top navigation bar to open the Create Issue form.
+
+Enter a concise, but descriptive summary of the problem in the Summary field, provide the requested information in the Description field, and select 'CNV User Interface' from the Component/s dropdown menu. The information in the Description field is critical to ensuring a prompt fix, so please be thorough.
+
+Click the Create button at the bottom then click on the link in the alert that pops up on the right side of the screen to open the issue. Do this quickly as it won't be displayed for very long. Write down the issue ID (Ex: CNV-12345) so you can easily locate the issue later.  
+
 ## Local development
 
 ### Option 1 (recommended):


### PR DESCRIPTION
## 📝 Description

The issues feature in GitHub has been turned off to maintain a single source of truth for issues, which is Jira.

This PR adds instructions on how to open an issue to the README.
