### PR TITLE
CNV-44420: Fix detach disk crash

### DIFF
--- a/src/views/catalog/wizard/tabs/disks/components/DiskRowActions.tsx
+++ b/src/views/catalog/wizard/tabs/disks/components/DiskRowActions.tsx
@@ -72,10 +72,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({ diskName }) => {
         submitBtnText={deleteBtnText}
         submitBtnVariant={ButtonVariant.danger}
       >
-        <ConfirmActionMessage
-          action="detach"
-          obj={{ metadata: { name: diskName, namespace: vm?.metadata?.namespace } }}
-        />
+        <ConfirmActionMessage action="detach" obj={{ metadata: { name: diskName } }} />
       </TabModal>
     ));
   };

--- a/src/views/templates/details/tabs/disks/components/DiskRowActions.tsx
+++ b/src/views/templates/details/tabs/disks/components/DiskRowActions.tsx
@@ -60,10 +60,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({ diskName, isDisabled, onUpdat
         submitBtnText={deleteBtnText}
         submitBtnVariant={ButtonVariant.danger}
       >
-        <ConfirmActionMessage
-          action="detach"
-          obj={{ metadata: { name: diskName, namespace: vm?.metadata?.namespace } }}
-        />
+        <ConfirmActionMessage action="detach" obj={{ metadata: { name: diskName } }} />
       </TabModal>
     ));
   };

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/DeleteDiskModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/DeleteDiskModal.tsx
@@ -108,7 +108,7 @@ const DeleteDiskModal: FC<DeleteDiskModalProps> = ({ isOpen, onClose, vm, volume
         <StackItem>
           <ConfirmActionMessage
             obj={{
-              metadata: { name: diskName, namespace: updatedVirtualMachine?.metadata?.namespace },
+              metadata: { name: diskName },
             }}
             action="detach"
           />

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useVolumeOwnedResource.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useVolumeOwnedResource.tsx
@@ -42,7 +42,6 @@ const useVolumeOwnedResource: UseVolumeOwnedResource = (vm, volume) => {
     volumeGroupVersionKind && volumeResourceName && watchVolumeResource,
   );
 
-  volumeResourceModel.verbs;
   if (!volumeResourceModel || !volumeResourceName) {
     return {
       error: error || isCdiConfigError,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

**fix detach crash**

`useVolumeOwnedResource` was using `volumeResourceModel.verbs;` with no assignment. Strange.
`volumeResourceModel`can be undefined. 

it is crashing not only on cloudinit but also on containerDisk source disk.


**Fix detach message**

detach message has namespace. Do not make sense to have namespace in it. 

It was already fixed in VM but not in template and wizard


## 🎥 Demo

**Before**


<img width="1040" alt="Screenshot 2024-07-23 at 17 54 05" src="https://github.com/user-attachments/assets/16372ed4-a347-4b42-a3f4-2b7adbda24fd">


**After**

<img width="1040" alt="Screenshot 2024-07-23 at 17 46 23" src="https://github.com/user-attachments/assets/d3898d3f-f4b8-4a01-a93c-54f7ba76d55d">
