### PR TITLE
CNV-44890: fix diskmodal issues

### DIFF
--- a/src/utils/resources/vm/utils/disk/rowData.ts
+++ b/src/utils/resources/vm/utils/disk/rowData.ts
@@ -43,12 +43,13 @@ export const getDiskRowDataLayout = (
       storageClass: NO_DATA_DASH,
     };
 
-    if (device?.dataVolumeTemplate) {
+    const pvcSize = device?.pvc?.spec?.resources?.requests?.storage;
+    const dataVolumeCustomSize =
+      device?.dataVolumeTemplate?.spec?.storage?.resources?.requests?.storage;
+
+    if (device?.dataVolumeTemplate && (dataVolumeCustomSize || pvcSize)) {
       diskRowDataObject.size = humanizeBinaryBytes(
-        convertToBaseValue(
-          device?.dataVolumeTemplate?.spec?.storage?.resources?.requests?.storage ||
-            device?.pvc?.spec?.resources?.requests?.storage,
-        ),
+        convertToBaseValue(dataVolumeCustomSize || pvcSize),
       ).string;
 
       return diskRowDataObject;
@@ -57,9 +58,7 @@ export const getDiskRowDataLayout = (
     if (device?.pvc) {
       diskRowDataObject.source = device?.pvc?.metadata?.name;
       diskRowDataObject.sourceStatus = device?.pvc?.status?.phase;
-      diskRowDataObject.size = humanizeBinaryBytes(
-        convertToBaseValue(device?.pvc?.spec?.resources?.requests?.storage),
-      ).string;
+      diskRowDataObject.size = humanizeBinaryBytes(convertToBaseValue(pvcSize)).string;
       diskRowDataObject.storageClass = device?.pvc?.spec?.storageClassName;
     }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

BUgs when DataSources are connected to VolumeSnapshots instead of PVCs. We can't grab the PVC size because the chain is too long DS -> VS -> PVC . So just don't show the size. 

When hotplugging something, the dataVolume needs to be created from dataVolumeTemplates. We cannot create it directly from the dataVolumeTemplates (doesn't have kind , apiVersion and namespace )

## 🎥 Demo

**Before**

![no-disk-size-running-vm](https://github.com/user-attachments/assets/fbc37aa8-45cc-4369-a881-853eaac50256)


<img width="579" alt="Screenshot 2024-08-05 at 08 55 18" src="https://github.com/user-attachments/assets/a447928b-0e80-473a-acd9-31deec1a1b6e">


