### PR TITLE
CNV-46589: Auto-generate meaningful snapshot names

### DIFF
--- a/src/utils/components/SnapshotModal/SnapshotModal.tsx
+++ b/src/utils/components/SnapshotModal/SnapshotModal.tsx
@@ -5,20 +5,19 @@ import {
   V1beta1VirtualMachineSnapshot,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { generateSnapshotName } from '@kubevirt-utils/components/SnapshotModal/utils/utils';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { buildOwnerReference } from '@kubevirt-utils/resources/shared';
 import { getVolumeSnapshotStatuses } from '@kubevirt-utils/resources/vm';
-import { generatePrettyName } from '@kubevirt-utils/utils/utils';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 import { Form, FormGroup, TextArea, TextInput } from '@patternfly/react-core';
-
-import { deadlineUnits } from '../../../views/virtualmachines/details/tabs/snapshots/utils/consts';
+import { deadlineUnits } from '@virtualmachines/details/tabs/snapshots/utils/consts';
 import {
   getEmptyVMSnapshotResource,
   getVolumeSnapshotStatusesPartition,
-} from '../../../views/virtualmachines/details/tabs/snapshots/utils/helpers';
-import { printableVMStatus } from '../../../views/virtualmachines/utils';
+} from '@virtualmachines/details/tabs/snapshots/utils/helpers';
+import { printableVMStatus } from '@virtualmachines/utils';
 
 import SupportedVolumesAlert from './alerts/SupportedVolumesAlert';
 import UnsupportedVolumesAlert from './alerts/UnsupportedVolumesAlert';
@@ -33,7 +32,7 @@ type SnapshotModalProps = {
 
 const SnapshotModal: FC<SnapshotModalProps> = ({ isOpen, onClose, vm }) => {
   const { t } = useKubevirtTranslation();
-  const [snapshotName, setSnapshotName] = useState<string>(generatePrettyName('snapshot'));
+  const [snapshotName, setSnapshotName] = useState<string>(generateSnapshotName(vm));
   const [description, setDescription] = useState<string>(undefined);
   const [deadline, setDeadline] = useState<string>(undefined);
   const [deadlineUnit, setDeadlineUnit] = useState<deadlineUnits>(deadlineUnits.Seconds);

--- a/src/utils/components/SnapshotModal/utils/utils.ts
+++ b/src/utils/components/SnapshotModal/utils/utils.ts
@@ -1,0 +1,11 @@
+import { format } from 'date-fns';
+
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { getName } from '@kubevirt-utils/resources/shared';
+
+export const generateSnapshotName = (vm: V1VirtualMachine) => {
+  const date = new Date();
+  const formattedDate = format(date, 'yyyyMMdd-kkmmss');
+
+  return `${getName(vm)}-snapshot-${formattedDate}`;
+};


### PR DESCRIPTION
## 📝 Description

Previously, auto-generated snapshot names provided no useful information outside of the VM name. This PR modifies the name format to add creation date and time information to make the auto-generated names more meaningful.

Jira: https://issues.redhat.com/browse/CNV-46589

## 🎥 Screenshots

### Before

![generate-snapshot-name--BEFORE--2024-08-21_09-08](https://github.com/user-attachments/assets/f813492a-8026-4420-9afe-e176b74871c8)

### After

![generate-snapshot-name--AFTER--2024-08-21_09-03](https://github.com/user-attachments/assets/73bdc7cd-e6be-472a-885b-6d98c8e9b2ca)