### PR TITLE
CNV-45441: New VM template: Use `runStrategy` field instead of deprecated `running`

### DIFF
--- a/src/templates/vm-template-yaml.ts
+++ b/src/templates/vm-template-yaml.ts
@@ -26,7 +26,7 @@ objects:
         vm.kubevirt.io/template: example
         os.template.kubevirt.io/fedora: 'true'
     spec:
-      running: false
+      runStrategy: Halted
       template:
         metadata:
           annotations:

--- a/src/templates/vm-yaml.ts
+++ b/src/templates/vm-yaml.ts
@@ -11,7 +11,7 @@ metadata:
     app: example
     os.template.kubevirt.io/fedora: 'true'
 spec:
-  running: false
+  runStrategy: Halted
   template:
     metadata:
       annotations:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
The `running` field in the VirtualMachine's spec is being deprecated in kubevirt in favor of the `runStrategy` field, therefore all examples show be using the `runStrategy` for specifying the requested running state of the VMI.
Reference: https://github.com/kubevirt/kubevirt/issues/11993


## 🎥 Demo

> Please add a video or an image of the behavior/changes
