### PR TITLE
Bump plugin metadata version to 4.17

### DIFF
--- a/plugin-metadata.ts
+++ b/plugin-metadata.ts
@@ -42,7 +42,7 @@ const metadata: ConsolePluginBuildMetadata = {
     yamlTemplates: 'src/templates/index.ts',
   },
   name: 'kubevirt-plugin',
-  version: '4.16.0',
+  version: '4.17.0',
 };
 
 export default metadata;


### PR DESCRIPTION
## 📝 Description

Bumping version for the plugin's metadata 

## 🎥 Demo

Before:
![bump-metadata-version-b4](https://github.com/user-attachments/assets/1f85f2f9-f02b-4eef-aba6-f3f405401afa)

After:
![bump-metadata-version](https://github.com/user-attachments/assets/a8e19980-53dd-4b00-8451-13e97d5524fb)

