### PR TITLE
CNV-47590: Fix rhel registration apperance

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -269,7 +269,6 @@
   "Cloud-init": "Cloud-init",
   "Cloud-init and SSH key configurations will be applied to the VirtualMachine only at the first boot.": "Cloud-init and SSH key configurations will be applied to the VirtualMachine only at the first boot.",
   "Cluster": "Cluster",
-  "Cluster administrator permissions are required to enable this feature.": "Cluster administrator permissions are required to enable this feature.",
   "Cluster preferences": "Cluster preferences",
   "Cluster provided": "Cluster provided",
   "Cluster scope migrations": "Cluster scope migrations",

--- a/src/utils/hooks/useRHELAutomaticSubscription/utils/types.ts
+++ b/src/utils/hooks/useRHELAutomaticSubscription/utils/types.ts
@@ -9,7 +9,6 @@ export type RHELAutomaticSubscriptionFormProps = {
   canEdit: boolean;
   loaded: boolean;
   loadError: Error;
-  loading: boolean;
   subscriptionData: RHELAutomaticSubscriptionData;
   updateSubscription: (data: Partial<RHELAutomaticSubscriptionData>) => void;
 };

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/AutomaticSubscriptionRHELGuests.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/AutomaticSubscriptionRHELGuests.tsx
@@ -6,7 +6,6 @@ import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/Sect
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useRHELAutomaticSubscription from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Stack, Title } from '@patternfly/react-core';
 
 import ExpandSection from '../../../../ExpandSection/ExpandSection';
@@ -35,12 +34,7 @@ const AutomaticSubscriptionRHELGuests: FC<AutomaticSubscriptionRHELGuestsProps> 
   );
 
   const isDisabled =
-    isEmpty(formProps?.subscriptionData?.activationKey) ||
-    isEmpty(formProps?.subscriptionData?.organizationID);
-
-  useEffect(() => {
-    if (isDisabled) toggleFeature(false);
-  }, [isDisabled, toggleFeature]);
+    formProps?.subscriptionData?.type === AutomaticSubscriptionTypeEnum.NO_SUBSCRIPTION;
 
   useEffect(() => {
     if (!selected) {
@@ -63,18 +57,15 @@ const AutomaticSubscriptionRHELGuests: FC<AutomaticSubscriptionRHELGuestsProps> 
         <MutedTextSpan
           text={t('Enable automatic subscription for Red Hat Enterprise Linux VirtualMachines.\n')}
         />
-        <MutedTextSpan
-          text={t('Cluster administrator permissions are required to enable this feature.')}
+        <Title headingLevel="h5">{t('Subscription type')}</Title>
+        <AutomaticSubscriptionType
+          selected={selected}
+          setSelected={setSelected}
+          updateSubscriptionType={formProps.updateSubscription}
         />
-        <AutomaticSubscriptionForm {...formProps} />
         {!isDisabled && (
           <>
-            <Title headingLevel="h5">{t('Subscription type')}</Title>
-            <AutomaticSubscriptionType
-              selected={selected}
-              setSelected={setSelected}
-              updateSubscriptionType={formProps.updateSubscription}
-            />
+            <AutomaticSubscriptionForm {...formProps} />
             {selected?.value !== AutomaticSubscriptionTypeEnum.NO_SUBSCRIPTION && (
               <>
                 <SectionWithSwitch

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/components/AutomaticSubscriptionType/AutomaticSubscriptionType.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/components/AutomaticSubscriptionType/AutomaticSubscriptionType.tsx
@@ -1,9 +1,9 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 
-import DropdownToggle from '@kubevirt-utils/components/toggles/DropdownToggle';
-import { Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core';
+import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
+import { SelectList, SelectOption } from '@patternfly/react-core';
 
-import { dropDownItems } from './utils/utils';
+import { getSubscriptionItem, selectItems } from './utils/utils';
 
 import './automatic-subscription-type.scss';
 
@@ -14,37 +14,28 @@ type AutomaticSubscriptionTypeProps = {
 };
 
 const AutomaticSubscriptionType: FC<AutomaticSubscriptionTypeProps> = ({
-  selected = dropDownItems[0],
+  selected = selectItems[0],
   setSelected,
   updateSubscriptionType,
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
-
   return (
     <div className="AutomaticSubscriptionType--main">
-      <Dropdown
+      <FormPFSelect
         onSelect={(_e, value: string) => {
-          setSelected(dropDownItems.find((item) => item.value === value));
+          setSelected(getSubscriptionItem(value));
           updateSubscriptionType({ type: value });
-          setIsOpen(false);
         }}
-        toggle={DropdownToggle({
-          children: <>{selected.title}</>,
-          className: 'AutomaticSubscriptionType--toggle',
-          id: 'toggle-auto-register-rhel',
-          onClick: () => setIsOpen((prevIsOpen) => !prevIsOpen),
-        })}
-        isOpen={isOpen}
         selected={selected.value}
+        selectedLabel={selected.title}
       >
-        <DropdownList>
-          {dropDownItems.map((item) => (
-            <DropdownItem key={item.value} value={item.value}>
+        <SelectList>
+          {selectItems.map((item) => (
+            <SelectOption key={item.value} value={item.value}>
               {item.title}
-            </DropdownItem>
+            </SelectOption>
           ))}
-        </DropdownList>
-      </Dropdown>
+        </SelectList>
+      </FormPFSelect>
     </div>
   );
 };

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/components/AutomaticSubscriptionType/utils/utils.ts
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/components/AutomaticSubscriptionType/utils/utils.ts
@@ -6,7 +6,7 @@ export enum AutomaticSubscriptionTypeEnum {
   NO_SUBSCRIPTION = 'noSubscription',
 }
 
-export const dropDownItems = [
+export const selectItems = [
   {
     title: t('No subscription'),
     value: AutomaticSubscriptionTypeEnum.NO_SUBSCRIPTION,
@@ -22,4 +22,4 @@ export const dropDownItems = [
 ];
 
 export const getSubscriptionItem = (value: string) =>
-  dropDownItems.find((item) => item.value === value);
+  selectItems.find((item) => item.value === value);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fix rhel regiretion appearance

* no more apply button
* first select b value from dropdown then enter key and orgid 
* no more text regarding cluster admin permission

After:
![image](https://github.com/user-attachments/assets/80b192f2-e8e4-4c04-9914-2b455ba8ec87)


Before:
![image](https://github.com/user-attachments/assets/9d2af375-43c8-402a-8463-2b918315734c)

## 🎥 Demo

> Please add a video or an image of the behavior/changes
