### PR TITLE
CNV-47229: Move the config of registry together in the add volume modal

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -124,6 +124,12 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
           sourceType={sourceType}
           upload={upload}
         />
+        {sourceType === DROPDOWN_FORM_SELECTION.USE_REGISTRY && (
+          <SchedulingSettings
+            bootableVolume={bootableVolume}
+            setBootableVolumeField={setBootableVolumeField}
+          />
+        )}
         <Title className="pf-u-mt-md" headingLevel="h5">
           {t('Destination details')}
         </Title>
@@ -133,13 +139,6 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
           claimPropertySetsData={claimPropertySetsData}
           setBootableVolumeField={setBootableVolumeField}
         />
-
-        {sourceType === DROPDOWN_FORM_SELECTION.USE_REGISTRY && (
-          <SchedulingSettings
-            bootableVolume={bootableVolume}
-            setBootableVolumeField={setBootableVolumeField}
-          />
-        )}
         <Title className="pf-u-mt-md" headingLevel="h5">
           {t('Volume metadata')}{' '}
           <HelpTextIcon


### PR DESCRIPTION
## 📝 Description

Moving the registry config to be under source details sub title and below the registry URL input instead of under the destination sub-title below the namespace input.

## 🎥 Demo

Before:
![registry-details-b4](https://github.com/user-attachments/assets/80a4d25b-af13-460c-96b7-d7c4f1d72ffe)

After:
![registry-details-relocation](https://github.com/user-attachments/assets/797fca08-f744-4061-b3a8-17357cdf9a3e)