### PR TITLE
CNV-42324: SC select is showing cluster default instead of virt default

### DIFF
--- a/src/utils/components/DiskModal/DiskFormFields/StorageClass/StorageClassSelect.tsx
+++ b/src/utils/components/DiskModal/DiskFormFields/StorageClass/StorageClassSelect.tsx
@@ -9,16 +9,13 @@ import React, {
   useState,
 } from 'react';
 
-import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
+import useDefaultStorageClass from '@kubevirt-utils/hooks/useDefaultStorage/useDefaultStorageClass';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { modelToGroupVersionKind, StorageClassModel } from '@kubevirt-utils/models';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { FormGroup, Select, SelectVariant } from '@patternfly/react-core';
 
 import { FilterSCSelect, getSCSelectOptions } from '../utils/Filters';
-import { getDefaultStorageClass } from '../utils/helpers';
 
 import { AlertedStorageClassSelectProps } from './AlertedStorageClassSelect';
 
@@ -36,12 +33,14 @@ const StorageClassSelect: FC<StorageClassSelectProps> = ({
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  const [storageClasses, loaded] = useK8sWatchResource<IoK8sApiStorageV1StorageClass[]>({
-    groupVersionKind: modelToGroupVersionKind(StorageClassModel),
-    isList: true,
-  });
+  const [{ clusterDefaultStorageClass, storageClasses, virtDefaultStorageClass }, loaded] =
+    useDefaultStorageClass();
 
-  const defaultSC = useMemo(() => getDefaultStorageClass(storageClasses), [storageClasses]);
+  const defaultSC = useMemo(() => {
+    if (!isEmpty(virtDefaultStorageClass)) return virtDefaultStorageClass;
+    if (!isEmpty(clusterDefaultStorageClass)) return clusterDefaultStorageClass;
+    return null;
+  }, [virtDefaultStorageClass, clusterDefaultStorageClass]);
 
   const onSelect = useCallback(
     (event: ChangeEvent<Element>, selection: string) => {

--- a/src/utils/hooks/useDefaultStorage/useDefaultStorageClass.ts
+++ b/src/utils/hooks/useDefaultStorage/useDefaultStorageClass.ts
@@ -17,6 +17,7 @@ type UseDefaultStorageClass = () => [
   {
     clusterDefaultStorageClass: IoK8sApiStorageV1StorageClass;
     sortedStorageClasses: string[];
+    storageClasses: IoK8sApiStorageV1StorageClass[];
     virtDefaultStorageClass: IoK8sApiStorageV1StorageClass;
   },
   boolean,
@@ -50,7 +51,7 @@ const useDefaultStorageClass: UseDefaultStorageClass = () => {
     [storageClasses],
   );
 
-  return [{ ...defaultStorageClass, sortedStorageClasses }, loaded];
+  return [{ ...defaultStorageClass, sortedStorageClasses, storageClasses }, loaded];
 };
 
 export default useDefaultStorageClass;


### PR DESCRIPTION
## 📝 Description

When the storage class is empty initially, the dropdown is selecting the cluster's default SC instead of virt default SC.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/9cd8b875-4801-47bd-b2b2-4055ccbf518f

After:

https://github.com/user-attachments/assets/ee33b0ad-71ba-414e-8617-eab7a77b72dc

