### PR TITLE
CNV-46660: show disk pvc not the original source

### DIFF
--- a/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
+++ b/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
@@ -6,7 +6,7 @@ import {
   getRunningVMMissingDisksFromVMI,
   getRunningVMMissingVolumesFromVMI,
 } from '@kubevirt-utils/components/DiskModal/utils/helpers';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getName } from '@kubevirt-utils/resources/shared';
 import { DiskRawData, DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 
 import {
@@ -52,7 +52,7 @@ const useDisksTableData: UseDisksTableDisks = (vm, vmi) => {
     [vm, vmi, isVMRunning],
   );
 
-  const { dataSources, loaded, loadingError, pvcs } = useDisksSources(vm);
+  const { loaded, loadingError, pvcs } = useDisksSources(vm);
 
   const disks = useMemo(() => {
     const isInstanceTypeVM = Boolean(getInstanceTypeMatcher(vm));
@@ -66,25 +66,17 @@ const useDisksTableData: UseDisksTableDisks = (vm, vmi) => {
         ? getDataVolumeTemplates(vm)?.find((dv) => getName(dv) === volume.dataVolume.name)
         : null;
 
-      const sourceRef = dataVolumeTemplate?.spec?.sourceRef;
-
-      const dataSource = dataSources.find(
-        (ds) => getName(ds) === sourceRef?.name && getNamespace(ds) === sourceRef?.namespace,
-      );
-
       const pvc = pvcs?.find(
         ({ metadata }) =>
           metadata?.name === volume?.persistentVolumeClaim?.claimName ||
-          metadata?.name === volume?.dataVolume?.name ||
-          (dataSource?.spec?.source?.pvc?.name === metadata?.name &&
-            dataSource?.spec?.source?.pvc?.namespace === metadata?.namespace),
+          metadata?.name === volume?.dataVolume?.name,
       );
 
       return { dataVolumeTemplate, disk, pvc, volume };
     });
 
     return getDiskRowDataLayout(diskDevices, getBootDisk(vm));
-  }, [vm, vmVolumes, vmDisks, pvcs, dataSources]);
+  }, [vm, vmVolumes, vmDisks, pvcs]);
 
   return [disks || [], loaded, loadingError, isVMRunning ? vmi : null];
 };

--- a/src/utils/resources/vm/hooks/disk/utils.ts
+++ b/src/utils/resources/vm/hooks/disk/utils.ts
@@ -1,35 +1,17 @@
-import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { V1beta1DataVolumeSourcePVC, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import {
-  DataSourceModelGroupVersionKind,
-  modelToGroupVersionKind,
-  PersistentVolumeClaimModel,
-} from '@kubevirt-utils/models';
-import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { modelToGroupVersionKind, PersistentVolumeClaimModel } from '@kubevirt-utils/models';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import { getDataVolumeTemplates, getVolumes } from '../../utils';
 
 const PersistentVolumeClaimGroupVersionKind = modelToGroupVersionKind(PersistentVolumeClaimModel);
 
-export const getDataSourceWatch = (vm: V1VirtualMachine) =>
-  getDataVolumeTemplates(vm)
-    ?.map((dataVolume) => dataVolume?.spec?.sourceRef)
-    .filter((sourceRef) => Boolean(sourceRef))
-    .reduce((acc, dataSource) => {
-      acc[`${dataSource.name}-${dataSource.namespace}`] = {
-        groupVersionKind: DataSourceModelGroupVersionKind,
-        name: dataSource.name,
-        namespace: dataSource.namespace,
-      };
-
-      return acc;
-    }, {});
-
-export const getPVCWatch = (vm: V1VirtualMachine, dataSources: V1beta1DataSource[]) => {
-  const pvcSources = getDataVolumeTemplates(vm)?.map((dataVolume) => dataVolume?.spec?.source?.pvc);
-
-  pvcSources.push(...dataSources.map((dataSource) => dataSource?.spec?.source?.pvc));
+export const getPVCWatch = (vm: V1VirtualMachine) => {
+  const pvcSources = getDataVolumeTemplates(vm)?.map((dataVolume) => ({
+    name: getName(dataVolume),
+    namespace: getNamespace(vm),
+  }));
 
   pvcSources.push(
     ...(getVolumes(vm) || [])

--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -138,7 +138,13 @@ export const generateVM = (
               namespace: getNamespace(selectedBootableVolume),
             },
             storage: {
-              resources: {},
+              resources: pvcSource
+                ? {
+                    requests: {
+                      storage: pvcSource?.spec?.resources?.requests?.storage,
+                    },
+                  }
+                : {},
               storageClassName,
             },
           },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

**Before**

VM disk list show the original PVC where data source clone the data for the disk

VM -> DataSource -> PVC (source cloned)

The PVC that you see here is not the PVC that the VM will use but what the datavolume will clone. This will probably create confusion to the user.


<img width="1920" alt="Screenshot 2024-09-16 at 08 56 47" src="https://github.com/user-attachments/assets/b0c91278-7dcf-4196-ba81-da97027d788c">



**After**

Vm disk list show the actual PVC used by the VM 

VM -> DataVolume -> Actual PVC used (The one that we have to resize, not the source cloned)


<img width="1920" alt="Screenshot 2024-09-16 at 08 55 57" src="https://github.com/user-attachments/assets/03b4f7e9-0782-4e54-9b24-e12b4af46696">



**Why we did that?**

Because in the instancetype we want to show in the disk list the source size that will be cloned. In order to do that, we have to set the `storage.resources.requests.storage` property
