### PR TITLE
CNV-47291: public ssh key credential does not get created

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
@@ -13,9 +13,11 @@ import {
 } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { updateCloudInitRHELSubscription } from '@kubevirt-utils/components/CloudinitModal/utils/cloudinit-utils';
+import { SecretSelectionOption } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
 import {
   addSecretToVM,
   applyCloudDriveCloudInitVolume,
+  createSSHSecret,
 } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import { logTemplateFlowEvent } from '@kubevirt-utils/extensions/telemetry/telemetry';
 import {
@@ -154,6 +156,11 @@ const useCreateDrawerForm = (
             vm: getTemplateVirtualMachineObject(processedTemplate),
           }),
       });
+
+      if (sshDetails?.secretOption === SecretSelectionOption.addNew) {
+        await createSSHSecret(sshDetails?.sshPubKey, sshDetails?.sshSecretName, namespace);
+      }
+
       setIsQuickCreating(false);
       navigate(getResourceUrl({ model: VirtualMachineModel, resource: quickCreatedVM }));
       logTemplateFlowEvent(CREATE_VM_SUCCEEDED, templateToProcess);


### PR DESCRIPTION
## 📝 Description

When createing a VM with ssh key on Catalog > Templates > Quick create flow, the secret is not created because of a missing request to create such secret. The missing secret causes the VM's pod to fail running, and the VM is not operable.

## 🎥 Demo

#### Before
![missing-secret](https://github.com/user-attachments/assets/7547234c-8b5a-4185-837e-71c3c4cc3d7f)

#### After
![secret-exists](https://github.com/user-attachments/assets/e5623d20-9e56-47e7-b15a-b22873475aa2)

