### PR TITLE
CNV-48451: Windows autoattend.xml can not be created as a regular user

### DIFF
--- a/src/utils/components/SysprepModal/hooks/useConfigMaps.ts
+++ b/src/utils/components/SysprepModal/hooks/useConfigMaps.ts
@@ -1,5 +1,6 @@
 import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource, WatchK8sResult } from '@openshift-console/dynamic-plugin-sdk';
 
 import { AUTOUNATTEND, UNATTEND } from '../sysprep-utils';
@@ -16,7 +17,10 @@ const useSysprepConfigMaps = (namespace: string): WatchK8sResult<IoK8sApiCoreV1C
     namespace,
     namespaced: true,
   });
+
   const sysprepConfigMaps = configmaps?.filter((configmap) => {
+    if (isEmpty(configmap?.data)) return false;
+
     const dataKeys = Object.keys(configmap?.data);
     const hasSysprepXMLData = dataKeys.some((key) => {
       return (


### PR DESCRIPTION
## 📝 Description

Once migrating VMs with MTV, a config map is created with a property of binaryData and is missing the data prop.
This causes the sysprep modal to crash as it's missing the prop and trying to reach it.

## 🎥 Demo

#### Before

https://github.com/user-attachments/assets/3fdb4218-7f42-4fc4-8558-f960802510d6

#### After

https://github.com/user-attachments/assets/89f37c12-df05-4ad4-91d4-2badf972547b


