### PR TITLE
CNV-48314: apply opt storage at beginning

### DIFF
--- a/src/utils/components/DiskModal/utils/form.ts
+++ b/src/utils/components/DiskModal/utils/form.ts
@@ -90,6 +90,7 @@ export const getDefaultCreateValues = (
       name: newDiskName,
     },
     isBootSource: false,
+    storageProfileSettingsApplied: true,
     volume,
   };
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

At beginning, set the storage profile as optimized. 
With anything specified in volume and access modes, we'll use the optimized way

## 🎥 Demo

![optimize_not_check](https://github.com/user-attachments/assets/b790a952-ed26-4244-a44d-48833e72acd2)


**After**


<img width="1551" alt="Screenshot 2024-09-20 at 10 24 28" src="https://github.com/user-attachments/assets/0a7ba376-2fd0-4001-8153-f39c7e1da47a">
