### PR TITLE
CNV-41290: Disable checkups storage install button for non cluster reader

### DIFF
--- a/src/views/checkups/storage/components/hooks/useCheckupsStoragePermissions.ts
+++ b/src/views/checkups/storage/components/hooks/useCheckupsStoragePermissions.ts
@@ -14,6 +14,7 @@ import {
   IoK8sApiRbacV1ClusterRoleBinding,
 } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useActiveNamespace, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 import {
@@ -44,7 +45,9 @@ export const useCheckupsStoragePermissions = () => {
     },
   );
 
-  const [clusterRoleBinding] = useK8sWatchResource<IoK8sApiRbacV1ClusterRoleBinding[]>(
+  const [clusterRoleBinding, loadedClusterRoleBinding] = useK8sWatchResource<
+    IoK8sApiRbacV1ClusterRoleBinding[]
+  >(
     !isAllNamespace && {
       groupVersionKind: modelToGroupVersionKind(ClusterRoleBindingModel),
       isList: true,
@@ -81,7 +84,11 @@ export const useCheckupsStoragePermissions = () => {
 
   return {
     clusterRoleBinding: isClusterRoleBinding,
-    isPermitted: Boolean(isServiceAccount && isConfigMapRole && isConfigMapRoleBinding),
-    loading: !loadingServiceAccounts && !loadingRoles && !loadingRolesBinding,
+    isPermitted: Boolean(
+      isServiceAccount && isConfigMapRole && isConfigMapRoleBinding && isClusterRoleBinding,
+    ),
+    isPermittedToInstall: !isEmpty(clusterRoleBinding),
+    loading:
+      !loadingServiceAccounts && !loadingRoles && !loadingRolesBinding && !loadedClusterRoleBinding,
   };
 };

--- a/src/views/checkups/storage/list/CheckupsStorageList.tsx
+++ b/src/views/checkups/storage/list/CheckupsStorageList.tsx
@@ -25,6 +25,7 @@ const CheckupsStorageList = () => {
   const {
     clusterRoleBinding,
     isPermitted,
+    isPermittedToInstall,
     loading: loadingPermissions,
   } = useCheckupsStoragePermissions();
   const { configMaps, error, jobs, loading } = useCheckupsStorageData();
@@ -38,6 +39,7 @@ const CheckupsStorageList = () => {
       <CheckupsStorageListEmptyState
         clusterRoleBinding={clusterRoleBinding}
         isPermitted={isPermitted}
+        isPermittedToInstall={isPermittedToInstall}
         loadingPermissions={loadingPermissions}
       />
     );

--- a/src/views/checkups/storage/list/CheckupsStorageListEmptyState.tsx
+++ b/src/views/checkups/storage/list/CheckupsStorageListEmptyState.tsx
@@ -27,12 +27,14 @@ import './CheckupsStorageListEmptyState.scss';
 type CheckupsStorageListEmptyStateProps = {
   clusterRoleBinding: IoK8sApiRbacV1ClusterRoleBinding;
   isPermitted: boolean;
+  isPermittedToInstall: boolean;
   loadingPermissions: boolean;
 };
 
 const CheckupsStorageListEmptyState: FC<CheckupsStorageListEmptyStateProps> = ({
   clusterRoleBinding,
   isPermitted,
+  isPermittedToInstall,
   loadingPermissions,
 }) => {
   const { t } = useKubevirtTranslation();
@@ -64,6 +66,12 @@ const CheckupsStorageListEmptyState: FC<CheckupsStorageListEmptyStateProps> = ({
         </EmptyStateActions>
         <EmptyStateActions>
           <Button
+            isDisabled={
+              isLoading ||
+              loadingPermissions ||
+              namespace === ALL_NAMESPACES_SESSION_KEY ||
+              !isPermittedToInstall
+            }
             onClick={async () => {
               setIsLoading(true);
               try {
@@ -76,7 +84,6 @@ const CheckupsStorageListEmptyState: FC<CheckupsStorageListEmptyStateProps> = ({
                 setIsLoading(false);
               }
             }}
-            isDisabled={isLoading || loadingPermissions || namespace === ALL_NAMESPACES_SESSION_KEY}
             isLoading={isLoading || loadingPermissions}
             variant={isLoading ? ButtonVariant.plain : ButtonVariant.secondary}
           >
@@ -84,7 +91,12 @@ const CheckupsStorageListEmptyState: FC<CheckupsStorageListEmptyStateProps> = ({
           </Button>
         </EmptyStateActions>
         <EmptyStateActions className="empty-state-secondary-action">
-          <ExternalLink href={'#'} text={t('Learn more about storage checkups')} />
+          <ExternalLink
+            href={
+              'https://docs.openshift.com/container-platform/4.16/virt/monitoring/virt-running-cluster-checkups.html'
+            }
+            text={t('Learn more about storage checkups')}
+          />
         </EmptyStateActions>
       </EmptyStateFooter>
     </EmptyState>


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Disable the install button for checkups storage for non cluster reader users, and adding a link to docs
according to - https://docs.openshift.com/container-platform/4.16/virt/monitoring/virt-running-cluster-checkups.html#virt-checking-storage-configuration_virt-running-cluster-checkups

## 🎥 Demo

> Please add a video or an image of the behavior/changes
