### PR TITLE
CNV-43588: Start/Restart/Stop icon controls disappear during shutdown

### DIFF
--- a/src/views/virtualmachines/actions/components/VMActionsIconBar/components/ActionIconButton.tsx
+++ b/src/views/virtualmachines/actions/components/VMActionsIconBar/components/ActionIconButton.tsx
@@ -7,7 +7,13 @@ import { VMActionIconDetails } from '@virtualmachines/actions/components/VMActio
 
 import '../VMActionsIconBar.scss';
 
-const ActionIconButton: FC<VMActionIconDetails> = ({ action, Icon, iconClassname, isHidden }) => {
+const ActionIconButton: FC<VMActionIconDetails> = ({
+  action,
+  Icon,
+  iconClassname,
+  isDisabled,
+  isHidden,
+}) => {
   const [actionAllowed] = useAccessReview(action?.accessReview);
 
   const handleClick = () => {
@@ -23,7 +29,7 @@ const ActionIconButton: FC<VMActionIconDetails> = ({ action, Icon, iconClassname
           <Button
             className="vm-actions-icon-bar__button"
             data-test-id={`${action?.id}-button`}
-            isDisabled={!actionAllowed}
+            isDisabled={!actionAllowed || isDisabled}
             onClick={handleClick}
             variant={ButtonVariant.link}
           >

--- a/src/views/virtualmachines/actions/components/VMActionsIconBar/utils/types.ts
+++ b/src/views/virtualmachines/actions/components/VMActionsIconBar/utils/types.ts
@@ -7,5 +7,6 @@ export type VMActionIconDetails = {
   action: Action;
   Icon: ComponentClass<SVGIconProps, any>;
   iconClassname?: string;
-  isHidden: boolean;
+  isDisabled?: boolean;
+  isHidden?: boolean;
 };

--- a/src/views/virtualmachines/actions/components/VMActionsIconBar/utils/utils.ts
+++ b/src/views/virtualmachines/actions/components/VMActionsIconBar/utils/utils.ts
@@ -17,17 +17,18 @@ export const getVMActionIconsDetails = (vm: V1VirtualMachine): VMActionIconDetai
     {
       action: VirtualMachineActionFactory.stop(vm),
       Icon: SquareIcon,
-      isHidden: !isRunning(vm) && !isPaused(vm),
+      isDisabled: !isRunning(vm) && !isPaused(vm),
     },
     {
       action: VirtualMachineActionFactory.restart(vm),
       Icon: RedoIcon,
-      isHidden: !isRunning(vm) && !isPaused(vm),
+      isDisabled: !isRunning(vm) && !isPaused(vm),
     },
     {
       action: VirtualMachineActionFactory.pause(vm),
       Icon: PauseIcon,
-      isHidden: !isRunning(vm),
+      isDisabled: !isRunning(vm),
+      isHidden: isPaused(vm),
     },
     {
       action: VirtualMachineActionFactory.unpause(vm),
@@ -38,7 +39,7 @@ export const getVMActionIconsDetails = (vm: V1VirtualMachine): VMActionIconDetai
     {
       action: VirtualMachineActionFactory.start(vm),
       Icon: PlayIcon,
-      isHidden: !isStopped(vm),
+      isDisabled: !isStopped(vm),
     },
   ];
 };


### PR DESCRIPTION
## 📝 Description

Show the icon actions and disable instead of hiding

## 🎥 Demo

#### Before
![image-2024-06-28-11-16-07-821](https://github.com/user-attachments/assets/517f71ae-d62e-4ca8-998b-281663acbfa3)

#### After
![icon-actions-stopped](https://github.com/user-attachments/assets/42a6e637-d595-4735-895c-48487d8d26f7)
![icon-actions-stopping](https://github.com/user-attachments/assets/5183b235-d543-4292-813d-29259e62dbdb)
![icon-actions-paused](https://github.com/user-attachments/assets/64fe1966-926c-431d-8a72-073ff6fa952a)
![icon-actions-1](https://github.com/user-attachments/assets/11d0fecc-90be-47e0-a177-8ec3a1de5976)
