### PR TITLE
CNV-48180: edit rootdisk causes VM create to fail

### DIFF
--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -371,16 +371,14 @@ const updateVolume = (
   }
   const oldVolumeSourceKey = Object.keys(oldVolume).find((key) => key !== 'name');
   const oldVolumeSource = mapSourceTypeToVolumeType[oldVolumeSourceKey];
-  const newVolumeSource = mapSourceTypeToVolumeType[diskState.diskSource];
-  if (oldVolumeSource !== newVolumeSource) {
-    delete updatedVolume[oldVolumeSource];
-  }
 
   if (diskState.diskSource === SourceTypes.EPHEMERAL) {
+    delete updatedVolume[oldVolumeSource];
     updatedVolume.containerDisk = {
       image: diskState.containerDisk.url,
     };
   } else if (diskState.diskSource === SourceTypes.PVC) {
+    delete updatedVolume[oldVolumeSource];
     updatedVolume.persistentVolumeClaim = {
       claimName: diskState.persistentVolumeClaim.pvcName,
     };


### PR DESCRIPTION
## 📝 Description

Clicking on the disk action edit is triggering a function also to update the correlated volume. 
This bug affects only 4.16.z. can't reproduce in main/4.17/4.15.z

## 🎥 Demo
#### Before

https://github.com/user-attachments/assets/b9a42839-5105-480c-ab7f-57960e2e0e95

#### After

https://github.com/user-attachments/assets/cfbbc3cc-3046-4412-830d-4706ef0d3e7d


