### PR TITLE
OCPBUGS-42765: Show all bootable volumes on all projects selected

### DIFF
--- a/src/utils/hooks/useWatchNamespacedResources/constants.ts
+++ b/src/utils/hooks/useWatchNamespacedResources/constants.ts
@@ -1,0 +1,3 @@
+import { WatchK8sResource, WatchK8sResources } from '@openshift-console/dynamic-plugin-sdk';
+
+export type WatchNamespacedResources = WatchK8sResources<{ [project in string]: WatchK8sResource }>;

--- a/src/utils/hooks/useWatchNamespacedResources/useWatchNamespacedResources.ts
+++ b/src/utils/hooks/useWatchNamespacedResources/useWatchNamespacedResources.ts
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+
+import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-utils/models';
+import {
+  K8sResourceCommon,
+  useK8sWatchResource,
+  useK8sWatchResources,
+  WatchK8sResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+
+import { useIsAdmin } from '../useIsAdmin';
+
+import { createWatchNamespacedResources } from './utils';
+
+const useWatchNamespacedResources = <T>(watchResources: null | WatchK8sResource) => {
+  const isAdmin = useIsAdmin();
+
+  const [projects, projectsLoaded, projectsError] = useK8sWatchResource<K8sResourceCommon[]>({
+    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+    isList: true,
+    namespaced: false,
+  });
+
+  const watchNamespacedResources = useMemo(
+    () =>
+      projectsLoaded ? createWatchNamespacedResources(watchResources, projects, isAdmin) : null,
+    [projectsLoaded, watchResources, projects, isAdmin],
+  );
+
+  const namespacedResources = useK8sWatchResources<{ [key: string]: T[] }>(
+    watchNamespacedResources,
+  );
+
+  const resources = useMemo(
+    () =>
+      Object.values(namespacedResources)
+        .map((namespaceRequest) => namespaceRequest.data)
+        .flat(),
+    [namespacedResources],
+  );
+  const resourcesLoaded = useMemo(
+    () => Object.values(namespacedResources).every((namespaceRequest) => namespaceRequest.loaded),
+    [namespacedResources],
+  );
+  const resourcesError = useMemo(
+    () => Object.values(namespacedResources).find((namespaceRequest) => namespaceRequest.loadError),
+    [namespacedResources],
+  );
+
+  return [resources, resourcesLoaded && projectsLoaded, resourcesError || projectsError];
+};
+
+export default useWatchNamespacedResources;

--- a/src/utils/hooks/useWatchNamespacedResources/utils.ts
+++ b/src/utils/hooks/useWatchNamespacedResources/utils.ts
@@ -1,0 +1,22 @@
+import { getName } from '@kubevirt-utils/resources/shared';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { K8sResourceCommon, WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
+
+import { WatchNamespacedResources } from './constants';
+
+export const createWatchNamespacedResources = (
+  watchResources: null | WatchK8sResource,
+  projects: K8sResourceCommon[],
+  isAdmin: boolean,
+): WatchNamespacedResources => {
+  if (isEmpty(watchResources)) return;
+
+  if (isEmpty(watchResources?.namespace) && !isAdmin)
+    return projects.reduce((acc, project) => {
+      const projectName = getName(project);
+      acc[projectName] = { ...watchResources, namespace: projectName };
+      return acc;
+    }, {} as WatchNamespacedResources);
+
+  return { [watchResources?.namespace]: watchResources };
+};

--- a/src/utils/resources/bootableresources/hooks/useBootableVolumes.ts
+++ b/src/utils/resources/bootableresources/hooks/useBootableVolumes.ts
@@ -16,20 +16,21 @@ import {
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
 import { ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
+import useWatchNamespacedResources from '@kubevirt-utils/hooks/useWatchNamespacedResources/useWatchNamespacedResources';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import {
   convertResourceArrayToMap,
   getReadyOrCloningOrUploadingDataSources,
 } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { Operator, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { Operator } from '@openshift-console/dynamic-plugin-sdk';
 
 type UseBootableVolumes = (namespace?: string) => UseBootableVolumesValues;
 
 const useBootableVolumes: UseBootableVolumes = (namespace) => {
   const projectsNamespace = namespace === ALL_PROJECTS ? null : namespace;
 
-  const [dataSources, loadedDataSources, dataSourcesError] = useK8sWatchResource<
+  const [dataSources, loadedDataSources, dataSourcesError] = useWatchNamespacedResources<
     V1beta1DataSource[]
   >({
     groupVersionKind: DataSourceModelGroupVersionKind,
@@ -40,16 +41,15 @@ const useBootableVolumes: UseBootableVolumes = (namespace) => {
     },
   });
 
-  const [dataImportCrons, loadedDataImportCrons, dataImportCronsError] = useK8sWatchResource<
-    V1beta1DataImportCron[]
-  >({
-    groupVersionKind: modelToGroupVersionKind(DataImportCronModel),
-    isList: true,
-    namespace: projectsNamespace,
-  });
+  const [dataImportCrons, loadedDataImportCrons, dataImportCronsError] =
+    useWatchNamespacedResources<V1beta1DataImportCron[]>({
+      groupVersionKind: modelToGroupVersionKind(DataImportCronModel),
+      isList: true,
+      namespace: projectsNamespace,
+    });
 
   // getting all pvcs since there could be a case where a DS has the label and it's underlying PVC does not
-  const [pvcs, loadedPVCs, loadErrorPVCs] = useK8sWatchResource<
+  const [pvcs, loadedPVCs, loadErrorPVCs] = useWatchNamespacedResources<
     IoK8sApiCoreV1PersistentVolumeClaim[]
   >({
     groupVersionKind: modelToGroupVersionKind(PersistentVolumeClaimModel),
@@ -58,7 +58,7 @@ const useBootableVolumes: UseBootableVolumes = (namespace) => {
   });
 
   // getting volumesnapshot as this can also be a source of DS
-  const [volumeSnapshots] = useK8sWatchResource<VolumeSnapshotKind[]>({
+  const [volumeSnapshots] = useWatchNamespacedResources<VolumeSnapshotKind[]>({
     groupVersionKind: modelToGroupVersionKind(VolumeSnapshotModel),
     isList: true,
     namespace: projectsNamespace,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

With non-admin users and when `All projects` is selected, the list of bootable volumes is empty. Fetch all the bootable volumes.

How?

Create a hook that fetches all projects. If the user is not admin, use `useK8sWatchResources` to fetch the requested resource from all namespaces. 


Cons: We fetch `DataImportCron`, `PVC`, `VolumeSnapshots` and `DataSources` on all namespaces. 
This means that we'll fire `4 x NUMBER_OF_NAMESPACES` requests at the same time. If we have lots of namespaces this can be an issue. 

Pros: Switching to other namespaces will be faster as we cache the results for all single namespaces so we don't make other requests.

Another option to solve the problem is to disable `All projects` for non admin users



## 🎥 Demo

**Before**

<img width="1715" alt="Screenshot 2024-10-04 at 11 31 24" src="https://github.com/user-attachments/assets/cb5a0481-1b6e-451e-81a6-e0f5560b35fb">


**After**

<img width="1715" alt="Screenshot 2024-10-04 at 11 29 45" src="https://github.com/user-attachments/assets/4e280516-0095-44cb-aac2-e08957f263d4">
