### PR TITLE
OCPBUGS-42769: Get user default project

### DIFF
--- a/src/utils/resources/namespaces/constants.ts
+++ b/src/utils/resources/namespaces/constants.ts
@@ -1,0 +1,3 @@
+export const SYSTEM_NAMESPACES_PREFIX = ['kube-', 'openshift-', 'kubernetes-'];
+
+export const SYSTEM_NAMESPACES = ['default', 'openshift'];

--- a/src/utils/resources/namespaces/helpers.ts
+++ b/src/utils/resources/namespaces/helpers.ts
@@ -1,0 +1,22 @@
+import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+import { getName } from '../shared';
+
+import { SYSTEM_NAMESPACES, SYSTEM_NAMESPACES_PREFIX } from './constants';
+
+export const isSystemNamespace = (namespace: string) => {
+  const startsWithNamespace = SYSTEM_NAMESPACES_PREFIX.some((ns) => namespace?.startsWith(ns));
+  const isNamespace = SYSTEM_NAMESPACES.includes(namespace);
+
+  return startsWithNamespace || isNamespace;
+};
+
+export const getUserDefaultNamespaceName = (namespaces: K8sResourceCommon[]) => {
+  const defaultNamespace =
+    namespaces.find((project) => getName(project) === DEFAULT_NAMESPACE) ||
+    namespaces.find((project) => !isSystemNamespace(getName(project))) ||
+    namespaces?.[0];
+
+  return getName(defaultNamespace);
+};

--- a/src/utils/resources/namespaces/hooks/useHasProjects.ts
+++ b/src/utils/resources/namespaces/hooks/useHasProjects.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react';
+
+import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-utils/models';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+
+const useHasProjects = () => {
+  const [model] = useK8sModel(modelToGroupVersionKind(ProjectModel));
+
+  return useMemo(() => !isEmpty(model), [model]);
+};
+
+export default useHasProjects;

--- a/src/utils/resources/namespaces/hooks/useUserDefaultNamespace.ts
+++ b/src/utils/resources/namespaces/hooks/useUserDefaultNamespace.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+
+import { modelToGroupVersionKind, NamespaceModel, ProjectModel } from '@kubevirt-utils/models';
+import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+import { getUserDefaultNamespaceName } from '../helpers';
+
+import useHasProjects from './useHasProjects';
+
+const useUserDefaultNamespace = (): [defaultNamespace: string, loaded: boolean] => {
+  const hasProjects = useHasProjects();
+  const [namespaces, namespacesLoaded] = useK8sWatchResource<K8sResourceCommon[]>({
+    groupVersionKind: modelToGroupVersionKind(hasProjects ? ProjectModel : NamespaceModel),
+    isList: true,
+    namespaced: false,
+  });
+
+  const userDefaultNamespace = useMemo(() => getUserDefaultNamespaceName(namespaces), [namespaces]);
+  return [userDefaultNamespace, namespacesLoaded];
+};
+
+export default useUserDefaultNamespace;

--- a/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
@@ -5,11 +5,12 @@ import VMDetailsSection from '@catalog/CreateFromInstanceTypes/components/VMDeta
 import { CREATE_VM_TAB } from '@catalog/CreateVMHorizontalNav/constants';
 import GuidedTour from '@kubevirt-utils/components/GuidedTour/GuidedTour';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
 import useBootableVolumes from '@kubevirt-utils/resources/bootableresources/hooks/useBootableVolumes';
+import useUserDefaultNamespace from '@kubevirt-utils/resources/namespaces/hooks/useUserDefaultNamespace';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { Bullseye, Card, Divider, Grid, GridItem, List } from '@patternfly/react-core';
 
@@ -30,6 +31,7 @@ const CreateFromInstanceType: FC<CreateFromInstanceTypeProps> = ({ currentTab })
   const { t } = useKubevirtTranslation();
   const sectionState = useState<INSTANCE_TYPES_SECTIONS>(INSTANCE_TYPES_SECTIONS.SELECT_VOLUME);
 
+  const [userDefaultNamespace, namespacesLoaded] = useUserDefaultNamespace();
   const { resetInstanceTypeVMState, setVMNamespaceTarget, volumeListNamespace } =
     useInstanceTypeVMStore();
   const bootableVolumesData = useBootableVolumes(volumeListNamespace);
@@ -42,10 +44,18 @@ const CreateFromInstanceType: FC<CreateFromInstanceTypeProps> = ({ currentTab })
   }, [resetInstanceTypeVMState]);
 
   useEffect(() => {
+    if (!namespacesLoaded || isEmpty(userDefaultNamespace)) return;
+
     const targetNS =
-      activeNamespace === ALL_NAMESPACES_SESSION_KEY ? DEFAULT_NAMESPACE : activeNamespace;
+      activeNamespace === ALL_NAMESPACES_SESSION_KEY ? userDefaultNamespace : activeNamespace;
     setVMNamespaceTarget(authorizedSSHKeys?.[targetNS], targetNS);
-  }, [activeNamespace, authorizedSSHKeys, setVMNamespaceTarget]);
+  }, [
+    activeNamespace,
+    authorizedSSHKeys,
+    setVMNamespaceTarget,
+    namespacesLoaded,
+    userDefaultNamespace,
+  ]);
 
   const [favorites = [], updaterFavorites, loadedFavorites] =
     useKubevirtUserSettings('favoriteBootableVolumes');


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

`DEFAULT_NAMESPACE` is not always a good namespace to use. 
Users may not have access to the `default` namespace.
So I added the logic:

Use `default` if it's listed in the accessible namespaces. If not, use the first non-system namespace. Otherwise, take the first that you have. What do you think? But the important thing is that we do not show this info anywhere when the user is in `all-namespaces` 

## 🎥 Demo

**Before**


https://github.com/user-attachments/assets/08922ede-508e-49c8-ab5e-7de30b5bb24e


**After**


https://github.com/user-attachments/assets/32ac35be-b1ee-4b92-b3c7-4f7199d5a183


