### PR TITLE
CNV-49299: use runStrategy on cloning

### DIFF
--- a/src/utils/components/CloneVMModal/CloneVMModal.tsx
+++ b/src/utils/components/CloneVMModal/CloneVMModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { VirtualMachineModelRef } from '@kubevirt-ui/kubevirt-api/console';
@@ -41,6 +41,13 @@ const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, sour
     ),
   );
 
+  const vmUseRunning = useMemo(
+    () =>
+      (source as V1VirtualMachine)?.spec?.running !== undefined &&
+      (source as V1VirtualMachine)?.spec?.running !== null,
+    [source],
+  );
+
   const [startCloneVM, setStartCloneVM] = useState(false);
 
   const [initialCloneRequest, setInitialCloneRequest] = useState<V1alpha1VirtualMachineClone>();
@@ -64,13 +71,13 @@ const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, sour
 
   useEffect(() => {
     if (cloneRequest?.status?.phase === CLONING_STATUSES.SUCCEEDED) {
-      startCloneVM && runVM(cloneName, namespace);
+      startCloneVM && runVM(cloneName, namespace, vmUseRunning);
 
       navigate(`/k8s/ns/${namespace}/${VirtualMachineModelRef}/${cloneName}`);
 
       onClose();
     }
-  }, [cloneRequest, startCloneVM, cloneName, namespace, onClose, navigate]);
+  }, [cloneRequest, startCloneVM, cloneName, namespace, onClose, navigate, vmUseRunning]);
 
   return (
     <TabModal

--- a/src/utils/components/CloneVMModal/utils/helpers.tsx
+++ b/src/utils/components/CloneVMModal/utils/helpers.tsx
@@ -65,14 +65,20 @@ export const cloneVM = (
   });
 };
 
-export const runVM = (vmName: string, vmNamespace: string) =>
+export const runVM = (vmName: string, vmNamespace: string, useRunning = false) =>
   k8sPatch({
     data: [
-      {
-        op: 'replace',
-        path: '/spec/runStrategy',
-        value: RUNSTRATEGY_ALWAYS,
-      },
+      useRunning
+        ? {
+            op: 'replace',
+            path: '/spec/running',
+            value: true,
+          }
+        : {
+            op: 'replace',
+            path: '/spec/runStrategy',
+            value: RUNSTRATEGY_ALWAYS,
+          },
     ],
     model: VirtualMachineModel,
     resource: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

`spec.running` and `spec.runStrategy` are mutual exclusive. YAML example now use `spec.runStrategy` so patching the VM with `spec.running: true` does not work. So if the VM use `spec.running` patch that spec attribute otherwise use `spec.runStrategy`

