### PR TITLE
CNV-47477: fix switching project from all-namespaces

### DIFF
--- a/src/views/instancetypes/list/InstanceTypePage.tsx
+++ b/src/views/instancetypes/list/InstanceTypePage.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import classNames from 'classnames';
 
@@ -29,31 +29,23 @@ const InstanceTypePage: FC<ListPageProps> = (props) => {
 
   const isSearchPage = useIsSearchPage();
 
-  const [activeTabKey, setActiveTabKey] = useState<number | string>(
-    location?.pathname.includes(VirtualMachineClusterInstancetypeModel.kind) ? 0 : 1,
+  const activeTabKey = useMemo(
+    () => (location?.pathname.includes(VirtualMachineClusterInstancetypeModel.kind) ? 0 : 1),
+    [location?.pathname],
   );
   const [instanceTypes, loaded, loadError] = useVirtualMachineInstanceTypes(
     props?.fieldSelector,
     props?.selector,
+    true,
   );
 
-  const urlUserPreference = useMemo(
+  const urlUserInstancetypes = useMemo(
     () =>
       activeNamespace === ALL_NAMESPACES
         ? `/k8s/all-namespaces/${VirtualMachineInstancetypeModelRef}`
         : `/k8s/ns/${activeNamespace}/${VirtualMachineInstancetypeModelRef}`,
     [activeNamespace],
   );
-
-  useEffect(() => {
-    if (isSearchPage) return;
-
-    navigate(
-      activeTabKey === 0
-        ? `/k8s/cluster/${VirtualMachineClusterInstancetypeModelRef}`
-        : urlUserPreference,
-    );
-  }, [activeTabKey, navigate, urlUserPreference, isSearchPage]);
 
   if (isSearchPage) {
     const searchParams = new URLSearchParams(location?.search);
@@ -83,7 +75,11 @@ const InstanceTypePage: FC<ListPageProps> = (props) => {
       </div>
       <Tabs
         onSelect={(_, tabIndex: number | string) => {
-          setActiveTabKey(tabIndex);
+          navigate(
+            tabIndex === 0
+              ? `/k8s/cluster/${VirtualMachineClusterInstancetypeModelRef}`
+              : urlUserInstancetypes,
+          );
         }}
         activeKey={activeTabKey}
         style={{ flexShrink: 0 }}

--- a/src/views/preferences/list/PreferencePage.tsx
+++ b/src/views/preferences/list/PreferencePage.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import classNames from 'classnames';
 
@@ -30,8 +30,12 @@ const PreferencePage: FC<ListPageProps> = (props) => {
 
   const isSearchPage = useIsSearchPage();
 
-  const [activeTabKey, setActiveTabKey] = useState<number | string>(
-    location?.pathname.includes(VirtualMachineClusterPreferenceModelGroupVersionKind.kind) ? 0 : 1,
+  const activeTabKey = useMemo(
+    () =>
+      location?.pathname.includes(VirtualMachineClusterPreferenceModelGroupVersionKind.kind)
+        ? 0
+        : 1,
+    [location?.pathname],
   );
   const [userPreferences, loaded, loadError] = useUserPreferences(
     activeNamespace,
@@ -46,16 +50,6 @@ const PreferencePage: FC<ListPageProps> = (props) => {
         : `/k8s/ns/${activeNamespace}/${VirtualMachinePreferenceModelRef}`,
     [activeNamespace],
   );
-
-  useEffect(() => {
-    if (isSearchPage) return;
-
-    navigate(
-      activeTabKey === 0
-        ? `/k8s/cluster/${VirtualMachineClusterPreferenceModelRef}`
-        : urlUserPreference,
-    );
-  }, [activeTabKey, navigate, urlUserPreference, isSearchPage]);
 
   if (isSearchPage) {
     const searchParams = new URLSearchParams(location?.search);
@@ -85,7 +79,11 @@ const PreferencePage: FC<ListPageProps> = (props) => {
       </div>
       <Tabs
         onSelect={(_, tabIndex: number | string) => {
-          setActiveTabKey(tabIndex);
+          navigate(
+            tabIndex === 0
+              ? `/k8s/cluster/${VirtualMachineClusterPreferenceModelRef}`
+              : urlUserPreference,
+          );
         }}
         activeKey={activeTabKey}
         style={{ flexShrink: 0 }}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Remove the `useEffect` that was causing a bug switching projects. Now the activeKey is not a state but we get it directly from the pathname. 

`useVirtualMachineInstanceTypes` hook now has a third parameter that we need to use.


## 🎥 Demo


**Before**


https://github.com/user-attachments/assets/35d5985b-d2b9-4e88-8d92-89a7c4032a94



**After**


https://github.com/user-attachments/assets/2869fc22-d564-4b50-871a-7a0b3793352e


