### PR TITLE
CNV-49577: nodeSelector and tolerations edit shows alert

### DIFF
--- a/src/utils/components/NodeSelectorModal/NodeSelectorModal.tsx
+++ b/src/utils/components/NodeSelectorModal/NodeSelectorModal.tsx
@@ -49,7 +49,7 @@ const NodeSelectorModal: FC<NodeSelectorModalProps> = ({
 
   const updatedVirtualMachine = useMemo(() => {
     const updatedVM = produce<V1VirtualMachine>(vm, (vmDraft: V1VirtualMachine) => {
-      ensurePath(vmDraft, ['spec.template.template.spec.nodeSelector']);
+      ensurePath(vmDraft, ['spec.template.spec.nodeSelector']);
       if (!vmDraft.spec.template.spec.nodeSelector) {
         vmDraft.spec.template.spec.nodeSelector = {};
       }

--- a/src/utils/components/TolerationsModal/TolerationsModal.tsx
+++ b/src/utils/components/TolerationsModal/TolerationsModal.tsx
@@ -69,7 +69,7 @@ const TolerationsModal: React.FC<TolerationsModalProps> = ({
 
   const updatedVirtualMachine = React.useMemo(() => {
     const updatedVM = produce<V1VirtualMachine>(vm, (vmDraft: V1VirtualMachine) => {
-      ensurePath(vmDraft, ['spec.template.template.spec.tolerations']);
+      ensurePath(vmDraft, ['spec.template.spec.tolerations']);
 
       const updatedTolerations: K8sIoApiCoreV1Toleration[] = (tolerationsLabels || []).map(
         (toleration) => {


### PR DESCRIPTION
## 📝 Description

Wrong path verified caused the toast alert to pop.

## 🎥 Demo

#### Before

https://github.com/user-attachments/assets/a810f70f-b692-4618-b9d8-b6d81b9c46fe

#### After

https://github.com/user-attachments/assets/05c911b8-cb11-4fe9-8ea1-a308a5de2153


