### PR TITLE
CNV-49906: fix docker image builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN command -v yarn || npm i -g yarn
 COPY . /opt/app-root/src
 WORKDIR /opt/app-root/src
 ENV NODE_OPTIONS=--max-old-space-size=8192
-RUN yarn install --frozen-lockfile --ignore-engines && yarn build
+ENV YARN_NETWORK_TIMEOUT 1200000
+RUN yarn install --frozen-lockfile && yarn build
 
 FROM registry.access.redhat.com/ubi8/nginx-120
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

[here](https://github.com/kubevirt-ui/kubevirt-plugin/pull/2208) we added docker support for s390x archs.
Github on creating images cross-arch is giving network errors.
This is because the network is very slow on those cross-arch docker builds. So just make sure to have github be patient :) 

## 🎥 Demo

> Please add a video or an image of the behavior/changes
