### PR TITLE
Make kubevirt works with okd

### DIFF
--- a/src/utils/hooks/useFeatures/constants.ts
+++ b/src/utils/hooks/useFeatures/constants.ts
@@ -4,7 +4,7 @@ import {
   IoK8sApiRbacV1Role,
   IoK8sApiRbacV1RoleBinding,
 } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { OPENSHIFT_CNV } from '@kubevirt-utils/constants/constants';
+import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
 import { K8sVerb } from '@openshift-console/dynamic-plugin-sdk';
 
 export const AUTOMATIC_SUBSCRIPTION_ACTIVATION_KEY = 'automaticSubscriptionActivationKey';
@@ -39,14 +39,14 @@ export const featuresConfigMapInitialState: IoK8sApiCoreV1ConfigMap = {
   },
   metadata: {
     name: FEATURES_CONFIG_MAP_NAME,
-    namespace: OPENSHIFT_CNV,
+    namespace: DEFAULT_OPERATOR_NAMESPACE,
   },
 };
 
 export const featuresRole: IoK8sApiRbacV1Role = {
   metadata: {
     name: FEATURES_ROLE_NAME,
-    namespace: OPENSHIFT_CNV,
+    namespace: DEFAULT_OPERATOR_NAMESPACE,
   },
   rules: [
     {
@@ -61,7 +61,7 @@ export const featuresRole: IoK8sApiRbacV1Role = {
 export const featuresRoleBinding: IoK8sApiRbacV1RoleBinding = {
   metadata: {
     name: FEATURES_ROLE_BINDING_NAME,
-    namespace: OPENSHIFT_CNV,
+    namespace: DEFAULT_OPERATOR_NAMESPACE,
   },
   roleRef: {
     apiGroup: RoleModel.apiGroup,

--- a/src/utils/hooks/useFeatures/useFeatures.ts
+++ b/src/utils/hooks/useFeatures/useFeatures.ts
@@ -54,7 +54,7 @@ export const useFeatures: UseFeatures = (featureName) => {
       return;
     }
 
-    if (!loaded && loadError && loadError?.code !== 404) {
+    if (!loaded && loadError) {
       setFeatureEnabled(false);
       setLoading(false);
     }
@@ -102,7 +102,7 @@ export const useFeatures: UseFeatures = (featureName) => {
     canEdit: isAdmin,
     error,
     featureEnabled,
-    loading,
+    loading: loading && !loadError,
     toggleFeature,
   };
 };

--- a/src/utils/hooks/useFeatures/useFeaturesConfigMap.ts
+++ b/src/utils/hooks/useFeatures/useFeaturesConfigMap.ts
@@ -1,6 +1,6 @@
 import { ConfigMapModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { OPENSHIFT_CNV } from '@kubevirt-utils/constants/constants';
+import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
 import {
   getGroupVersionKindForModel,
   useK8sWatchResource,
@@ -23,7 +23,7 @@ const useFeaturesConfigMap: UseFeaturesConfigMap = () => {
     groupVersionKind: getGroupVersionKindForModel(ConfigMapModel),
     isList: false,
     name: FEATURES_CONFIG_MAP_NAME,
-    namespace: OPENSHIFT_CNV,
+    namespace: DEFAULT_OPERATOR_NAMESPACE,
   });
   return { featuresConfigMapData: [...featuresConfigMapData], isAdmin };
 };

--- a/src/utils/hooks/useKubevirtHyperconvergeConfiguration.ts/index.ts
+++ b/src/utils/hooks/useKubevirtHyperconvergeConfiguration.ts/index.ts
@@ -1,6 +1,5 @@
 import { V1KubeVirtConfiguration } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { KUBEVIRT_HYPERCONVERGED, OPENSHIFT_CNV } from '@kubevirt-utils/constants/constants';
-import { isUpstream } from '@kubevirt-utils/utils/utils';
+import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
 import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 import { KUBEVIRT_HC_GROUP_VERSION_KIND, KUBEVIRT_HC_NAME } from './constants';
@@ -20,7 +19,7 @@ const useKubevirtHyperconvergeConfiguration = (): [
     {
       groupVersionKind: KUBEVIRT_HC_GROUP_VERSION_KIND,
       name: KUBEVIRT_HC_NAME,
-      namespace: isUpstream ? KUBEVIRT_HYPERCONVERGED : OPENSHIFT_CNV,
+      namespace: DEFAULT_OPERATOR_NAMESPACE,
     },
   );
 

--- a/src/utils/hooks/useKubevirtUserSettings/utils/const.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/utils/const.ts
@@ -3,7 +3,7 @@ import {
   IoK8sApiRbacV1Role,
   IoK8sApiRbacV1RoleBinding,
 } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { OPENSHIFT_CNV } from '@kubevirt-utils/constants/constants';
+import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
 
 export const TOP_CONSUMERS_CARD = 'topConsumersCard';
 
@@ -16,7 +16,7 @@ const KUBEVIRT_USER_SETTINGS_ROLE_BINDING_NAME = 'kubevirt-user-settings-reader-
 export const userSettingsRole: IoK8sApiRbacV1Role = {
   metadata: {
     name: KUBEVIRT_USER_SETTINGS_ROLE_NAME,
-    namespace: OPENSHIFT_CNV,
+    namespace: DEFAULT_OPERATOR_NAMESPACE,
   },
   rules: [
     {
@@ -31,7 +31,7 @@ export const userSettingsRole: IoK8sApiRbacV1Role = {
 export const userSettingsRoleBinding: IoK8sApiRbacV1RoleBinding = {
   metadata: {
     name: KUBEVIRT_USER_SETTINGS_ROLE_BINDING_NAME,
-    namespace: OPENSHIFT_CNV,
+    namespace: DEFAULT_OPERATOR_NAMESPACE,
   },
   roleRef: {
     apiGroup: RoleModel.apiGroup,

--- a/src/utils/utils/utils.ts
+++ b/src/utils/utils/utils.ts
@@ -1,7 +1,11 @@
 import { animals, colors, NumberDictionary, uniqueNamesGenerator } from 'unique-names-generator';
 
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import {
+  DEFAULT_NAMESPACE,
+  KUBEVIRT_HYPERCONVERGED,
+  OPENSHIFT_CNV,
+} from '@kubevirt-utils/constants/constants';
 import { ALL_NAMESPACES, ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { FilterValue, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { k8sBasePath } from '@openshift-console/dynamic-plugin-sdk/lib/utils/k8s/k8s';
@@ -31,6 +35,8 @@ export const get = (obj: unknown, path: string | string[], defaultValue = undefi
 };
 
 export const isUpstream = (window as any).SERVER_FLAGS?.branding === 'okd';
+
+export const DEFAULT_OPERATOR_NAMESPACE = isUpstream ? KUBEVIRT_HYPERCONVERGED : OPENSHIFT_CNV;
 
 export const isString = (val: unknown) => val !== null && typeof val === 'string';
 

--- a/src/views/clusteroverview/utils/constants.ts
+++ b/src/views/clusteroverview/utils/constants.ts
@@ -1,7 +1,5 @@
 export const VIRTCTL_DOWNLOADS = 'virtctl-clidownloads-kubevirt-hyperconverged';
 
-export const KUBEVIRT_HYPERCONVERGED = 'kubevirt-hyperconverged';
-export const OPENSHIFT_CNV = 'openshift-cnv';
 export const HCO_OPERATORHUB_NAME = 'hco-operatorhub';
 export const PACKAGESERVER = 'packageserver';
 export const OPENSHIFT_OPERATOR_LIFECYCLE_MANAGER_NAMESPACE =

--- a/src/views/clusteroverview/utils/hooks/useKubevirtCSVDetails.ts
+++ b/src/views/clusteroverview/utils/hooks/useKubevirtCSVDetails.ts
@@ -5,15 +5,11 @@ import ClusterServiceVersionModel, {
   ClusterServiceVersionModelGroupVersionKind,
 } from '@kubevirt-ui/kubevirt-api/console/models/ClusterServiceVersionModel';
 import { SubscriptionModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console/models/SubscriptionModel';
-import { isUpstream } from '@kubevirt-utils/utils/utils';
+import { KUBEVIRT_HYPERCONVERGED } from '@kubevirt-utils/constants/constants';
+import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
-import {
-  KUBEVIRT_HYPERCONVERGED,
-  OPENSHIFT_CNV,
-  OPENSHIFT_OPERATOR_LIFECYCLE_MANAGER_NAMESPACE,
-  PACKAGESERVER,
-} from '../constants';
+import { OPENSHIFT_OPERATOR_LIFECYCLE_MANAGER_NAMESPACE, PACKAGESERVER } from '../constants';
 import { CatalogSourceKind, ClusterServiceVersionKind, SubscriptionKind } from '../types';
 
 import { buildUrlForCSVSubscription } from './../utils';
@@ -37,7 +33,7 @@ export const useKubevirtCSVDetails = (): UseKubevirtCSVDetails => {
   >({
     groupVersionKind: SubscriptionModelGroupVersionKind,
     isList: true,
-    namespace: isUpstream ? KUBEVIRT_HYPERCONVERGED : OPENSHIFT_CNV,
+    namespace: DEFAULT_OPERATOR_NAMESPACE,
   });
 
   const subscription = useMemo(


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Using a kinD cluster i was able to install kubevirt, okd console, and make things work.

use `HYPERCONVERGED_NAMESPACE` to retrieve the right hyperconverged namespace. `kubevirt-hyperconverged` or `openshift-cnv` depending on okd or openshift. 

Also one other thing to fix for infinite loading:
in case of auth disabled mode (only development) we get an error on fetching the user (there is no user)
so if there is an error with the user in `useKubevirtUserSettings`, just stop loading. 
We'll have this error only in development but because we are just fetching the user settings, it's better to not have infinite loading.


solving the #2072  issue . Because kubevirt support plain k8s, it would be a nice thing to have also the UI plugin support this


## 🎥 Demo

**Before**

![Screenshot from 2024-10-11 16-48-13](https://github.com/user-attachments/assets/b08867c6-4b8d-4feb-9c93-01815252f290)
![Screenshot from 2024-10-11 16-48-09](https://github.com/user-attachments/assets/6fcace54-c65d-480b-96d3-5f391793f36f)
![Screenshot from 2024-10-11 16-48-03](https://github.com/user-attachments/assets/356710ca-1624-4ac2-bdef-493aaf00a5eb)

**After**

![Screenshot from 2024-10-11 16-37-56](https://github.com/user-attachments/assets/efc45d95-b835-4058-a873-311e9b0fcf8e)
![Screenshot from 2024-10-11 16-37-52](https://github.com/user-attachments/assets/5bd535fe-10ba-4f66-b3e9-549ef9a258f4)
![Screenshot from 2024-10-11 16-37-48](https://github.com/user-attachments/assets/12a691c0-fd84-4511-bf96-9776bad1d7c4)
