### PR TITLE
Fix nginx config for okd installation

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -4,7 +4,7 @@ server {
     ssl_certificate_key /var/serving-cert/tls.key;
     ssl_protocols TLSv1.2 TLSv1.3;
     location / {
-        root   /opt/app-root/src;
+        root   /usr/share/nginx/html;
     }
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

fix nginx config according to https://github.com/kubevirt-ui/kubevirt-plugin/issues/2072


We don't have issues with the installation through the openshift operator tho.

The operator uses a ConfigMap to override the nginx config. But for external people that come in this repo and use only the quay dockerfile, this config is wrong

