### PR TITLE
CNV-45435: Migrate all `.spec.running` usages to `.spec.runStrategy`

### DIFF
--- a/src/utils/components/CloneVMModal/utils/helpers.tsx
+++ b/src/utils/components/CloneVMModal/utils/helpers.tsx
@@ -8,6 +8,7 @@ import {
   V1beta1VirtualMachineSnapshot,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { RUNSTRATEGY_ALWAYS } from '@kubevirt-utils/constants/constants';
 import { MAX_K8S_NAME_LENGTH } from '@kubevirt-utils/utils/constants';
 import { getRandomChars } from '@kubevirt-utils/utils/utils';
 import { k8sCreate, k8sGet, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
@@ -69,8 +70,8 @@ export const runVM = (vmName: string, vmNamespace: string) =>
     data: [
       {
         op: 'replace',
-        path: '/spec/running',
-        value: true,
+        path: '/spec/runStrategy',
+        value: RUNSTRATEGY_ALWAYS,
       },
     ],
     model: VirtualMachineModel,

--- a/src/utils/components/EnvironmentEditor/tests/mocks.ts
+++ b/src/utils/components/EnvironmentEditor/tests/mocks.ts
@@ -1,4 +1,5 @@
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { RUNSTRATEGY_HALTED } from '@kubevirt-utils/constants/constants';
 
 export const exampleVirtualMachineWithEnvironments: V1VirtualMachine = {
   apiVersion: 'kubevirt.io/v1',
@@ -31,7 +32,7 @@ export const exampleVirtualMachineWithEnvironments: V1VirtualMachine = {
     namespace: 'default',
   },
   spec: {
-    running: false,
+    runStrategy: RUNSTRATEGY_HALTED,
     template: {
       metadata: {
         annotations: {

--- a/src/utils/components/GuidedTour/utils/constants.tsx
+++ b/src/utils/components/GuidedTour/utils/constants.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Step } from 'react-joyride';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { RUNSTRATEGY_ALWAYS } from '@kubevirt-utils/constants/constants';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { signal } from '@preact/signals-react';
 
@@ -135,7 +136,7 @@ export const tourGuideVM: V1VirtualMachine = {
     preference: {
       inferFromVolume: 'rhel9-volume-tour-guide',
     },
-    runStrategy: 'Always',
+    runStrategy: RUNSTRATEGY_ALWAYS,
     template: {
       spec: {
         domain: {

--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -14,6 +14,10 @@ export const ROOTDISK = 'rootdisk';
 export const KUBEVIRT_HYPERCONVERGED = 'kubevirt-hyperconverged';
 export const OPENSHIFT_CNV = 'openshift-cnv';
 
+export const RUNSTRATEGY_ALWAYS = 'Always';
+export const RUNSTRATEGY_HALTED = 'Halted';
+export const RUNSTRATEGY_RERUNONFAILURE = 'RerunOnFailure';
+
 export enum K8S_OPS {
   ADD = 'add',
   REMOVE = 'remove',

--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -14,6 +14,7 @@ import { InterfaceTypes } from '@kubevirt-utils/components/DiskModal/utils/types
 import { addSecretToVM } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import { sysprepDisk, sysprepVolume } from '@kubevirt-utils/components/SysprepModal/sysprep-utils';
 import { ROOTDISK } from '@kubevirt-utils/constants/constants';
+import { RUNSTRATEGY_ALWAYS, RUNSTRATEGY_HALTED } from '@kubevirt-utils/constants/constants';
 import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
 import {
   isBootableVolumeISO,
@@ -162,7 +163,7 @@ export const generateVM = (
         name: selectedPreference,
         ...(selectPreferenceKind && { kind: selectPreferenceKind }),
       },
-      running: startVM,
+      runStrategy: startVM ? RUNSTRATEGY_ALWAYS : RUNSTRATEGY_HALTED,
       template: {
         metadata: {
           labels: {

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -2,6 +2,10 @@ import React, { FC, memo } from 'react';
 
 import { DRAWER_FORM_ID } from '@catalog/templatescatalog/utils/consts';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
+import {
+  RUNSTRATEGY_ALWAYS,
+  RUNSTRATEGY_RERUNONFAILURE,
+} from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
 import {
@@ -87,6 +91,11 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
             <StackItem />
             <StackItem>
               <Checkbox
+                isChecked={
+                  startVM ||
+                  runStrategy === RUNSTRATEGY_ALWAYS ||
+                  runStrategy === RUNSTRATEGY_RERUNONFAILURE
+                }
                 label={
                   runStrategy
                     ? t('Start this VirtualMachine after creation ({{runStrategy}})', {
@@ -95,7 +104,6 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
                     : t('Start this VirtualMachine after creation')
                 }
                 id="start-after-create-checkbox"
-                isChecked={startVM || runStrategy === 'Always' || runStrategy === 'RerunOnFailure'}
                 onChange={(_, checked: boolean) => onChangeStartVM(checked)}
               />
             </StackItem>

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDrawerContext.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDrawerContext.tsx
@@ -14,6 +14,7 @@ import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1DataVolumeSpec, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { SSHSecretDetails } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
 import { ROOTDISK } from '@kubevirt-utils/constants/constants';
+import { RUNSTRATEGY_ALWAYS } from '@kubevirt-utils/constants/constants';
 import {
   DataUpload,
   UploadDataProps,
@@ -102,7 +103,7 @@ const useDrawer = (template: V1Template) => {
     const templateWithRunning = produce(templateWithGeneratedParams, (draftTemplate) => {
       const draftVM = getTemplateVirtualMachineObject(draftTemplate);
 
-      if (isEmpty(draftVM?.spec?.runStrategy)) draftVM.spec.running = true;
+      if (isEmpty(draftVM?.spec?.running)) draftVM.spec.runStrategy = RUNSTRATEGY_ALWAYS;
     });
 
     setCustomizedTemplate(templateWithRunning);

--- a/src/views/catalog/wizard/components/WizardFooter.tsx
+++ b/src/views/catalog/wizard/components/WizardFooter.tsx
@@ -4,6 +4,11 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import { useWizardSourceAvailable } from '@catalog/utils/useWizardSourceAvailable';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import {
+  RUNSTRATEGY_ALWAYS,
+  RUNSTRATEGY_HALTED,
+  RUNSTRATEGY_RERUNONFAILURE,
+} from '@kubevirt-utils/constants/constants';
 import { logTemplateFlowEvent } from '@kubevirt-utils/extensions/telemetry/telemetry';
 import {
   CANCEL_CUSTOMIZE_VM_BUTTON_CLICKED,
@@ -72,8 +77,8 @@ export const WizardFooter: FC<{ namespace: string }> = ({ namespace }) => {
   const onChangeStartVM = useCallback(
     (checked: boolean) => {
       updateVM((draftVM) => {
-        delete draftVM.spec.runStrategy;
-        draftVM.spec.running = checked;
+        delete draftVM.spec.running;
+        draftVM.spec.runStrategy = checked ? RUNSTRATEGY_ALWAYS : RUNSTRATEGY_HALTED;
       });
     },
     [updateVM],
@@ -87,7 +92,9 @@ export const WizardFooter: FC<{ namespace: string }> = ({ namespace }) => {
         <StackItem>
           <Checkbox
             isChecked={
-              vm?.spec?.running || runStrategy === 'Always' || runStrategy === 'RerunOnFailure'
+              vm?.spec?.running ||
+              runStrategy === RUNSTRATEGY_ALWAYS ||
+              runStrategy === RUNSTRATEGY_RERUNONFAILURE
             }
             label={
               runStrategy

--- a/src/views/virtualmachines/actions/tests/mocks.ts
+++ b/src/views/virtualmachines/actions/tests/mocks.ts
@@ -1,4 +1,5 @@
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { RUNSTRATEGY_HALTED } from '@kubevirt-utils/constants/constants';
 
 export const exampleRunningVirtualMachine: V1VirtualMachine = {
   apiVersion: 'kubevirt.io/v1',
@@ -24,7 +25,7 @@ export const exampleRunningVirtualMachine: V1VirtualMachine = {
     namespace: 'default',
   },
   spec: {
-    running: false,
+    runStrategy: RUNSTRATEGY_HALTED,
     template: {
       metadata: {
         annotations: {


### PR DESCRIPTION
As a part of the deprecation of the VM's .spec.running field, we need the UI plugin to stop using it, and use the runStrategy API everywhere by default.

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

> Add a brief description

## 🎥 Demo

> Please add a video or an image of the behavior/changes
