### PR TITLE
CNV-43052: Select multiple vms at a time

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1064,6 +1064,7 @@
   "Select boot source": "Select boot source",
   "Select console type": "Select console type",
   "Select InstanceType": "Select InstanceType",
+  "Select multiple VirtualMachines to perform an action for all of them": "Select multiple VirtualMachines to perform an action for all of them",
   "Select NetwrokAttachmentDefinition": "Select NetwrokAttachmentDefinition",
   "Select nodes": "Select nodes",
   "Select Nodes that must have all the following expressions.": "Select Nodes that must have all the following expressions.",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.11.0",
     "@kubevirt-ui/kubevirt-api": "^1.3.3",
-    "@openshift-console/dynamic-plugin-sdk": "1.7.0",
+    "@openshift-console/dynamic-plugin-sdk": "1.8.0",
     "@openshift-console/dynamic-plugin-sdk-internal": "1.0.0",
     "@openshift-console/dynamic-plugin-sdk-webpack": "^1.3.0",
     "@openshift-console/plugin-shared": "^0.0.3",

--- a/src/utils/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/src/utils/components/ActionsDropdown/ActionsDropdown.tsx
@@ -1,9 +1,9 @@
-import React, { FC, memo, useRef, useState } from 'react';
+import React, { FC, memo, ReactNode, useRef, useState } from 'react';
 
 import DropdownToggle from '@kubevirt-utils/components/toggles/DropdownToggle';
 import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Menu, MenuContent, MenuList, Popper } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuList, Popper, Tooltip } from '@patternfly/react-core';
 
 import ActionDropdownItem from '../ActionDropdownItem/ActionDropdownItem';
 
@@ -12,15 +12,21 @@ import { ActionDropdownItemType } from './constants';
 type ActionsDropdownProps = {
   actions: ActionDropdownItemType[];
   className?: string;
+  disabledTooltip?: ReactNode;
   id?: string;
+  isDisabled?: boolean;
   isKebabToggle?: boolean;
   onLazyClick?: () => void;
+  variant?: 'default' | 'plain' | 'plainText' | 'primary' | 'secondary' | 'typeahead';
 };
 
 const ActionsDropdown: FC<ActionsDropdownProps> = ({
   actions = [],
+  disabledTooltip,
+  isDisabled,
   isKebabToggle,
   onLazyClick,
+  variant,
 }) => {
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -37,11 +43,13 @@ const ActionsDropdown: FC<ActionsDropdownProps> = ({
   };
 
   const Toggle = isKebabToggle
-    ? KebabToggle({ isExpanded: isOpen, onClick: onToggle })
+    ? KebabToggle({ isDisabled, isExpanded: isOpen, onClick: onToggle })
     : DropdownToggle({
         children: t('Actions'),
+        isDisabled,
         isExpanded: isOpen,
         onClick: onToggle,
+        variant,
       });
 
   const menu = (
@@ -55,6 +63,15 @@ const ActionsDropdown: FC<ActionsDropdownProps> = ({
       </MenuContent>
     </Menu>
   );
+
+  if (isDisabled)
+    return (
+      <div className="kv-actions-dropdown" ref={containerRef}>
+        <Tooltip content={disabledTooltip}>
+          <span> {Toggle(toggleRef)}</span>
+        </Tooltip>
+      </div>
+    );
 
   return (
     <div className="kv-actions-dropdown" ref={containerRef}>

--- a/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.ts
+++ b/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+
+import { restartVM, startVM, stopVM, unpauseVM } from '../actions';
+
+type UseMultipleVirtualMachineActions = (vms: V1VirtualMachine[]) => ActionDropdownItemType[];
+
+const useMultipleVirtualMachineActions: UseMultipleVirtualMachineActions = (vms) => {
+  const { t } = useKubevirtTranslation();
+
+  const actions: ActionDropdownItemType[] = useMemo(() => {
+    return [
+      {
+        cta: () => vms.forEach((vm) => startVM(vm)),
+        id: 'vm-action-start',
+        label: t('Start'),
+      },
+      {
+        cta: () => vms.forEach((vm) => restartVM(vm)),
+        id: 'vm-action-restart',
+        label: t('Restart'),
+      },
+      {
+        cta: () => vms.forEach((vm) => stopVM(vm)),
+        id: 'vm-action-stop',
+        label: t('Stop'),
+      },
+      {
+        cta: () => vms.forEach((vm) => unpauseVM(vm)),
+        id: 'vm-action-unpause',
+        label: t('Unpause'),
+      },
+    ];
+  }, [t, vms]);
+
+  return actions;
+};
+
+export default useMultipleVirtualMachineActions;

--- a/src/views/virtualmachines/list/VirtualMachinesList.scss
+++ b/src/views/virtualmachines/list/VirtualMachinesList.scss
@@ -3,3 +3,15 @@
     height: fit-content;
   }
 }
+
+.vm-listpagebody .pf-v5-c-table {
+  .pf-v5-c-table__th.pf-v5-c-table__check {
+    width: 50px !important;
+    max-width: 50px;
+  }
+
+  .selection-column {
+    width: 50px;
+    max-width: 50px;
+  }
+}

--- a/src/views/virtualmachines/list/components/VirtualMachineActionButton.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineActionButton.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react';
+
+import ActionsDropdown from '@kubevirt-utils/components/ActionsDropdown/ActionsDropdown';
+import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import useMultipleVirtualMachineActions from '@virtualmachines/actions/hooks/useMultipleVirtualMachineActions';
+
+import { selectedVMs } from '../selectedVMs';
+
+const VirtualMachineActionButton: FC = () => {
+  const actions = useMultipleVirtualMachineActions(selectedVMs.value);
+
+  return (
+    <ActionsDropdown
+      actions={actions}
+      disabledTooltip={t('Select multiple VirtualMachines to perform an action for all of them')}
+      isDisabled={isEmpty(selectedVMs.value)}
+      variant="secondary"
+    />
+  );
+};
+
+export default VirtualMachineActionButton;

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
@@ -8,8 +8,10 @@ import {
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
+import { Checkbox } from '@patternfly/react-core';
 import VirtualMachineActions from '@virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions';
 import useVirtualMachineActionsProvider from '@virtualmachines/actions/hooks/useVirtualMachineActionsProvider';
+import { deselectVM, isVMSelected, selectVM } from '@virtualmachines/list/selectedVMs';
 
 import VirtualMachineStatus from '../VirtualMachineStatus/VirtualMachineStatus';
 import { VMStatusConditionLabelList } from '../VMStatusConditionLabel';
@@ -27,9 +29,18 @@ const VirtualMachineRowLayout: React.FC<
     }
   >
 > = ({ activeColumnIDs, obj, rowData: { ips, isSingleNodeCluster, node, vmim } }) => {
+  const selected = isVMSelected(obj);
+
   const [actions] = useVirtualMachineActionsProvider(obj, vmim, isSingleNodeCluster);
   return (
     <>
+      <TableData activeColumnIDs={activeColumnIDs} className="selection-column vm-column" id="">
+        <Checkbox
+          id={`select-${obj?.metadata?.uid}`}
+          isChecked={selected}
+          onChange={() => (selected ? deselectVM(obj) : selectVM(obj))}
+        />
+      </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="pf-m-width-15 vm-column" id="name">
         <ResourceLink
           groupVersionKind={VirtualMachineModelGroupVersionKind}

--- a/src/views/virtualmachines/list/selectedVMs.ts
+++ b/src/views/virtualmachines/list/selectedVMs.ts
@@ -1,0 +1,31 @@
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { signal } from '@preact/signals-core';
+
+export const selectedVMs = signal<V1VirtualMachine[]>([]);
+
+export const selectVM = (vm: V1VirtualMachine) => {
+  if (isEmpty(findVM(vm))) selectedVMs.value = [...selectedVMs.value, vm];
+};
+
+export const deselectVM = (vm: V1VirtualMachine) => {
+  selectedVMs.value = selectedVMs.value.filter(
+    (selectedVM) =>
+      getName(selectedVM) !== getName(vm) || getNamespace(selectedVM) !== getNamespace(vm),
+  );
+};
+
+export const selectAll = (vms: V1VirtualMachine[]) => {
+  selectedVMs.value = Array.from(new Set([...selectedVMs.value, ...vms]));
+};
+
+export const deselectAll = () => (selectedVMs.value = []);
+
+export const findVM = (vm: V1VirtualMachine) =>
+  selectedVMs.value.find(
+    (selectedVM) =>
+      getName(selectedVM) === getName(vm) && getNamespace(selectedVM) === getNamespace(vm),
+  );
+
+export const isVMSelected = (vm: V1VirtualMachine): boolean => !isEmpty(findVM(vm));

--- a/src/views/virtualmachines/utils/virtualMachineRowFilter.ts
+++ b/src/views/virtualmachines/utils/virtualMachineRowFilter.ts
@@ -29,7 +29,7 @@ type VmiMapper = {
   nodeNames: { [key: string]: { id: string; title: string } };
 };
 
-type VmimMapper = { [key: string]: { [key: string]: V1VirtualMachineInstance } };
+type VmimMapper = { [key: string]: { [key: string]: V1VirtualMachineInstanceMigration } };
 
 const ErrorStatus = { id: 'Error', title: 'Error' };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -938,10 +938,10 @@
     semver "6.x"
     webpack "^5.75.0"
 
-"@openshift-console/dynamic-plugin-sdk@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-1.7.0.tgz#13411d687fafb0b1b136f0705e259defbb6d4b7f"
-  integrity sha512-oj6NIJicfOT8oi/97iFP5zmWXPAKH0cpwem0WvQWjA5sECQeSv1p/6q28pW2RPgfhxPTLPavwdasBE7FU1GHeg==
+"@openshift-console/dynamic-plugin-sdk@1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-1.8.0.tgz#d966e4b5fe43126261f6c4a50de87f0b8568ea35"
+  integrity sha512-QS1SDD0jhlpBX5SAqDn8DsM3qsWigs6Y1LtNz9vm1cjqvN/pL7ioJrETnB1Hx3aAHnNrWuyKqYFBe5Tuo998XQ==
   dependencies:
     classnames "2.x"
     immutable "3.x"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Let the user select multiple vms to run actions in parallel

1. Should we have a loading state somewhere?
2. Currently we cannot have the selection for all vms for SDK VirtualizedList limitations. Are we sure to let the user select ALL vms in the namespace or cluster? Can this have issues with running the action for 100 or 1000 vms? 

## 🎥 Demo


https://github.com/user-attachments/assets/195a4d32-921b-40f4-a272-3eef5ad6617e



