### PR TITLE
CNV-43245: Use template runstrategy

### DIFF
--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -16,6 +16,7 @@ export const OPENSHIFT_CNV = 'openshift-cnv';
 
 export const RUNSTRATEGY_ALWAYS = 'Always';
 export const RUNSTRATEGY_HALTED = 'Halted';
+export const RUNSTRATEGY_MANUAL = 'Manual';
 export const RUNSTRATEGY_RERUNONFAILURE = 'RerunOnFailure';
 
 export enum K8S_OPS {

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDrawerContext.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDrawerContext.tsx
@@ -13,8 +13,12 @@ import { Updater, useImmer } from 'use-immer';
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1DataVolumeSpec, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { SSHSecretDetails } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
-import { ROOTDISK } from '@kubevirt-utils/constants/constants';
-import { RUNSTRATEGY_ALWAYS } from '@kubevirt-utils/constants/constants';
+import {
+  ROOTDISK,
+  RUNSTRATEGY_HALTED,
+  RUNSTRATEGY_MANUAL,
+  RUNSTRATEGY_RERUNONFAILURE,
+} from '@kubevirt-utils/constants/constants';
 import {
   DataUpload,
   UploadDataProps,
@@ -103,7 +107,11 @@ const useDrawer = (template: V1Template) => {
     const templateWithRunning = produce(templateWithGeneratedParams, (draftTemplate) => {
       const draftVM = getTemplateVirtualMachineObject(draftTemplate);
 
-      if (isEmpty(draftVM?.spec?.running)) draftVM.spec.runStrategy = RUNSTRATEGY_ALWAYS;
+      if (
+        isEmpty(draftVM?.spec?.running) &&
+        [RUNSTRATEGY_HALTED, RUNSTRATEGY_MANUAL].includes(draftVM?.spec?.runStrategy)
+      )
+        draftVM.spec.runStrategy = RUNSTRATEGY_RERUNONFAILURE;
     });
 
     setCustomizedTemplate(templateWithRunning);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

We want in the drawer to make the VM starting by default. 

Instead of using `Always` as a starting default, lets use `RerunOnFailures`. If the template already have something else defined like `Always` or `Once` do not modify that. Keep that. 
