### PR TITLE
CNV-51085: add data key to user settings configmap if no data

### DIFF
--- a/src/utils/hooks/useKubevirtUserSettings/utils/utils.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/utils/utils.ts
@@ -1,5 +1,6 @@
 import { ConfigMapModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
 export const parseNestedJSON = <T>(str: string): T => {
@@ -20,6 +21,7 @@ export const patchUserConfigMap = async (
 ) =>
   k8sPatch<IoK8sApiCoreV1ConfigMap>({
     data: [
+      ...(isEmpty(userConfigMap.data) ? [{ op: 'add', path: '/data', value: {} }] : []),
       {
         op: 'replace',
         path: `/data/${userName}`,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The patch was not working as we were trying to add `/data/username` but there was no `/data` key in the root of the configmap