### PR TITLE
refactor download virtctl tool if needed

### DIFF
--- a/deploy-kubevirt-gating.sh
+++ b/deploy-kubevirt-gating.sh
@@ -164,4 +164,4 @@ oc annotate storageclass hostpath-provisioner storageclass.kubernetes.io/is-defa
 
 # ----------------------------------------------------------------------------------------------------
 # Download virtctl tool if needed
-command -v virtctl1 &> /dev/null || download_virtctl
+command -v virtctl &> /dev/null || download_virtctl

--- a/deploy-kubevirt-gating.sh
+++ b/deploy-kubevirt-gating.sh
@@ -27,6 +27,23 @@ wait_mcp_for_updated()
     fi
 }
 
+download_vritctl()
+{
+  VIRTCTL_DOWNLOAD_URL="https://github.com/kubevirt/kubevirt/releases/download/${VIRTCTL_VERSION}/virtctl-${VIRTCTL_VERSION}"
+  VIRTCTL_X86_64="${VIRTCTL_DOWNLOAD_URL}-linux-x86_64"
+  VIRTCTL_AMD64="${VIRTCTL_DOWNLOAD_URL}-linux-amd64"
+
+  # Install virtctl binary and add to PATH
+  mkdir virtctl
+
+  # --quiet as wget logs an URL that should not be logged since it provides access to download a file (it is a presigned URL)
+  wget ${VIRTCTL_AMD64} -O virtctl/virtctl --quiet || wget ${VIRTCTL_X86_64} -O virtctl/virtctl --quiet
+  [[ ! -f "virtctl/virtctl" ]] && echo "ERROR: virtctl binary is unavailable for download" && exit 1
+
+  chmod +x virtctl/virtctl
+
+  export PATH="${PATH}:$(pwd)/virtctl"
+}
 # ----------------------------------------------------------------------------------------------------
 # Install HCO (kubevirt and helper operators)
 
@@ -147,20 +164,4 @@ oc annotate storageclass hostpath-provisioner storageclass.kubernetes.io/is-defa
 
 # ----------------------------------------------------------------------------------------------------
 # Download virtctl tool if needed
-
-if ! type virtctl; then
-  VIRTCTL_DOWNLOAD_URL="https://github.com/kubevirt/kubevirt/releases/download/${VIRTCTL_VERSION}/virtctl-${VIRTCTL_VERSION}"
-  VIRTCTL_X86_64="${VIRTCTL_DOWNLOAD_URL}-linux-x86_64"
-  VIRTCTL_AMD64="${VIRTCTL_DOWNLOAD_URL}-linux-amd64"
-
-  # Install virtctl binary and add to PATH
-  mkdir virtctl
-
-  # --quiet as wget logs an URL that should not be logged since it provides access to download a file (it is a presigned URL)
-  wget ${VIRTCTL_AMD64} -O virtctl/virtctl --quiet || wget ${VIRTCTL_X86_64} -O virtctl/virtctl --quiet
-  [[ ! -f "virtctl/virtctl" ]] && echo "ERROR: virtctl binary is unavailable for download" && exit 1
-
-  chmod +x virtctl/virtctl
-
-  export PATH="${PATH}:$(pwd)/virtctl"
-fi
+command -v virtctl1 &> /dev/null || download_virtctl

--- a/deploy-kubevirt-gating.sh
+++ b/deploy-kubevirt-gating.sh
@@ -27,7 +27,7 @@ wait_mcp_for_updated()
     fi
 }
 
-download_vritctl()
+download_virtctl()
 {
   VIRTCTL_DOWNLOAD_URL="https://github.com/kubevirt/kubevirt/releases/download/${VIRTCTL_VERSION}/virtctl-${VIRTCTL_VERSION}"
   VIRTCTL_X86_64="${VIRTCTL_DOWNLOAD_URL}-linux-x86_64"


### PR DESCRIPTION
## 📝 Description

This should avoid the error we see in the logs, where the task abort if `type virtctl` exit code is not 0.

![image](https://github.com/user-attachments/assets/c1842392-80d7-4e64-a0d1-0971764500fc)
