### PR TITLE
CNV-46447: do not add securty context

### DIFF
--- a/src/utils/components/ExportModal/utils.ts
+++ b/src/utils/components/ExportModal/utils.ts
@@ -138,10 +138,6 @@ export const createUploaderPod: CreateUploaderPodType = ({
                 memory: '3Gi',
               },
             },
-            securityContext: {
-              allowPrivilegeEscalation: false,
-              capabilities: { drop: ['ALL'] },
-            },
             volumeMounts: [
               {
                 mountPath: '/tmp',
@@ -151,12 +147,6 @@ export const createUploaderPod: CreateUploaderPodType = ({
           },
         ],
         restartPolicy: 'Never',
-        securityContext: {
-          runAsNonRoot: true,
-          seccompProfile: {
-            type: 'RuntimeDefault',
-          },
-        },
         serviceAccountName: 'kubevirt-disk-uploader',
         volumes: [
           {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

BE says that we should not create pods with security context as it can leads to some issues in particular cases. 
There are namespaces with `restricted` policies  in our developer clusters that will not allow creating pods like that but the BE ensured me that in production people will not configure namespaces like that
