### PR TITLE
Unset KUBERNETES_* vars

### DIFF
--- a/test-prow-e2e.sh
+++ b/test-prow-e2e.sh
@@ -48,6 +48,16 @@ function generateLogsAndCopyArtifacts {
 trap generateLogsAndCopyArtifacts EXIT
 trap generateLogsAndCopyArtifacts ERR
 
+# Unset KUBERNETES_* vars which might conflict with OpenShift-CI
+unset KUBERNETES_SERVICE_PORT_HTTPS
+unset KUBERNETES_SERVICE_PORT
+unset KUBERNETES_PORT_443_TCP
+unset KUBERNETES_PORT_443_TCP_PROTO
+unset KUBERNETES_PORT_443_TCP_ADDR
+unset KUBERNETES_SERVICE_HOST
+unset KUBERNETES_PORT
+unset KUBERNETES_PORT_443_TCP_PORT
+
 PULL_SECRET_PATH="/var/run/operator-secret/dockerconfig" 
 NAMESPACE="openshift-marketplace"
 SECRET_NAME="ocs-secret"


### PR DESCRIPTION
## 📝 Description

Unset KUBERNETES_* vars which conflict with OpenShift-CI

```
{`cy.exec('oc patch virtualmachine example --type merge -p '{"spec":{"runStrategy": "Always"}}'')` failed because the command exited with a non-zero code.

Pass `{failOnNonZeroExit: false}` to ignore exit code failures.

Information about the failure:
Code: 1

Stderr:
Error from server (NotFound): namespaces "ci-op-fl2b7jdp" not found
```