### PR TITLE
CNV-49651: put a default disk size if user have no access to the pvcs

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DiskSize.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DiskSize.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 
 import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore';
 import CapacityInput from '@kubevirt-utils/components/CapacityInput/CapacityInput';
+import { DEFAULT_DISK_SIZE } from '@kubevirt-utils/components/DiskModal/utils/constants';
 import { getVolumeSnapshotSize } from '@kubevirt-utils/resources/bootableresources/selectors';
 import { convertToBaseValue, humanizeBinaryBytes } from '@kubevirt-utils/utils/humanize.js';
 
@@ -12,9 +13,7 @@ const DiskSize: FC = () => {
 
   const pvcDiskSize =
     pvcSource?.spec?.resources?.requests?.storage || getVolumeSnapshotSize(volumeSnapshotSource);
-  const sizeData = humanizeBinaryBytes(convertToBaseValue(pvcDiskSize)).string;
-
-  if (!pvcDiskSize) return null;
+  const sizeData = humanizeBinaryBytes(convertToBaseValue(pvcDiskSize || DEFAULT_DISK_SIZE)).string;
 
   return <CapacityInput onChange={setCustomDiskSize} size={customDiskSize || sizeData} />;
 };

--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -10,6 +10,7 @@ import {
   CloudInitUserData,
   convertUserDataObjectToYAML,
 } from '@kubevirt-utils/components/CloudinitModal/utils/cloudinit-utils';
+import { DEFAULT_DISK_SIZE } from '@kubevirt-utils/components/DiskModal/utils/constants';
 import { InterfaceTypes } from '@kubevirt-utils/components/DiskModal/utils/types';
 import { addSecretToVM } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import { sysprepDisk, sysprepVolume } from '@kubevirt-utils/components/SysprepModal/sysprep-utils';
@@ -145,7 +146,11 @@ export const generateVM = (
                       storage: pvcSource?.spec?.resources?.requests?.storage,
                     },
                   }
-                : {},
+                : {
+                    requests: {
+                      storage: DEFAULT_DISK_SIZE,
+                    },
+                  },
               storageClassName,
             },
           },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

If the user has no permission to access the PVC size, use the default value of `30Gi`

## 🎥 Demo


<img width="1625" alt="Screenshot 2024-11-18 at 10 16 52" src="https://github.com/user-attachments/assets/c4e72098-073a-45c6-a314-670e5d6b86ec">
<img width="1625" alt="Screenshot 2024-11-18 at 10 16 56" src="https://github.com/user-attachments/assets/e34d198c-f43e-49cb-8c30-18ba88ca051e">

