### PR TITLE
CNV-51122: fix cloud init default name

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -50,7 +50,7 @@ const generateCloudInitPassword = () =>
   `${getRandomChars(4)}-${getRandomChars(4)}-${getRandomChars(4)}`;
 
 const getCloudInitUserNameByOS = (selectedPreferenceName: string, osLabel: string): string => {
-  for (const name in [
+  for (const name of [
     ...Object.values(OS_NAME_TYPES),
     ...Object.values(OS_NAME_TYPES_NOT_SUPPORTED),
   ]) {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

A `for` with `in` iterate on the indexes. The first index `0` satisfy the condition `osLabel?.includes(name)` for `rhel10` as the `10` have the `0`.  This is why the bug was found only now. The default username for cloud-init was always `cloud-user` 
Using `of` in the `for`, we iterate over the values of the array so `rhel`, `fedora`, `windows` etc etc. Now the default username for cloud-init depends on the os so for windows is `windows`, for rhel is `rhel` and so on.

With this fix 

## 🎥 Demo
<img width="1129" alt="Screenshot 2024-11-19 at 11 32 14" src="https://github.com/user-attachments/assets/77dcdae5-428b-48ac-918f-34f4dc0f27e5">
<img width="1129" alt="Screenshot 2024-11-19 at 11 32 25" src="https://github.com/user-attachments/assets/1cbb1e1d-3c08-45e5-8a86-3cc8b05d9f7a">


