### PR TITLE
CNV-41812: Add uncategorized VMs option to the VirtualMachines per resource char…

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1119,6 +1119,7 @@
   "Show less": "Show less",
   "Show top 10": "Show top 10",
   "Show top 5": "Show top 5",
+  "Show uncategorized VirtualMachines": "Show uncategorized VirtualMachines",
   "Show virtualization health alerts": "Show virtualization health alerts",
   "Show VirtualMachine per InstanceTypes": "Show VirtualMachine per InstanceTypes",
   "Show VirtualMachine per Templates": "Show VirtualMachine per Templates",

--- a/src/views/clusteroverview/OverviewTab/vms-per-resource-card/RunningVMsChartLegendLabel.tsx
+++ b/src/views/clusteroverview/OverviewTab/vms-per-resource-card/RunningVMsChartLegendLabel.tsx
@@ -7,7 +7,7 @@ import { getInstanceTypePrefix } from '@kubevirt-utils/resources/bootableresourc
 import { isAllNamespaces } from '@kubevirt-utils/utils/utils';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 
-import { getInstanceTypeSeriesLabel } from './utils/utils';
+import { getFilterKey, getInstanceTypeSeriesLabel } from './utils/utils';
 
 import './RunningVMsChartLegendLabel.scss';
 
@@ -18,6 +18,7 @@ export type RunningVMsChartLegendLabelItem = {
   namespace: string;
   percentage: number;
   templateNamespace?: string;
+  type: string;
   vmCount: number;
 };
 
@@ -29,7 +30,7 @@ const RunningVMsChartLegendLabel: React.FC<RunningVMsChartLegendLabelProps> = ({
   const [activeNamespace] = useActiveNamespace();
   const namespace = isAllNamespaces(activeNamespace) ? ALL_NAMESPACES : `ns/${activeNamespace}`;
   const iconStyle = { color: item.color };
-  const filterKey = item.isInstanceType ? 'instanceType' : 'template';
+  const filterKey = getFilterKey(item);
   const linkPath = `/k8s/${namespace}/${VirtualMachineModelRef}?rowFilter-${filterKey}=${getInstanceTypePrefix(
     item.name,
   )}`;
@@ -38,7 +39,7 @@ const RunningVMsChartLegendLabel: React.FC<RunningVMsChartLegendLabelProps> = ({
     <>
       <i className="fas fa-square kv-running-vms-card__legend-label--color" style={iconStyle} />
       <span className="kv-running-vms-card__legend-label--count">{item.vmCount}</span>{' '}
-      <Link to={linkPath}>{getInstanceTypeSeriesLabel(item.name)}</Link>
+      {filterKey ? <Link to={linkPath}>{getInstanceTypeSeriesLabel(item.name)}</Link> : item.name}
     </>
   );
 };

--- a/src/views/clusteroverview/OverviewTab/vms-per-resource-card/utils/constants.ts
+++ b/src/views/clusteroverview/OverviewTab/vms-per-resource-card/utils/constants.ts
@@ -2,6 +2,12 @@ import { TemplateModel } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineClusterInstancetypeModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineClusterInstancetypeModel';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
+export const UNCATEGORIZED_VM = 'UNCATEGORIZED_VM';
+export const UNCATEGORIZED_LABEL = 'Uncategorized';
+
+export const TEMPLATE_FILTER_KEY = 'template';
+export const INSTANCETYPE_FILTER_KEY = 'instanceType';
+
 export const vmsPerResourceOptions = [
   {
     title: t('Show VirtualMachine per Templates'),
@@ -10,6 +16,10 @@ export const vmsPerResourceOptions = [
   {
     title: t('Show VirtualMachine per InstanceTypes'),
     type: VirtualMachineClusterInstancetypeModel.kind,
+  },
+  {
+    title: t('Show uncategorized VirtualMachines'),
+    type: UNCATEGORIZED_VM,
   },
 ];
 


### PR DESCRIPTION
## 📝 Description

Templates without the `vm.kubevirt.io/template` label aren't shown in the VirtualMachines per template chart. This PR adds VMs that aren't able to be categorized as either template-based or instancetype based into an uncategorized category so that all VMs are accounted for.

Jira: https://issues.redhat.com/browse/CNV-41812

## 🎥 Screenshot

### After

![vms-per-resource-chart--AFTER--2024-11-20_17-33](https://github.com/user-attachments/assets/312e2712-8dd4-4973-803e-13744ca8b808)