### PR TITLE
fix: Clear revisionName when updating instance type

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/details/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/details/utils/utils.ts
@@ -201,7 +201,7 @@ export const updatedInstanceType = (
       {
         op: 'replace',
         path: `/spec/instancetype`,
-        value: { kind: instanceType.kind, name: instanceType.metadata.name },
+        value: { kind: instanceType.kind, name: instanceType.metadata.name, revisionName: '' },
       },
     ],
     model: VirtualMachineModel,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

While this behaviour is likely to change in the near future at present users looking to move between instance types need to clear the revisionName to ensure the correct LiveUpdate logic kicks in. While this is called out by the user-guide docs the current wording doesn't make this obvious and will be updated [1].

This commit ensures the UI clears the revisionName field when updating an instance type ensuring that LiveUpdate and any associated hot plug logic is activated correctly.

[1] https://kubevirt.io/user-guide/user_workloads/instancetypes/#versioning

> Add a brief description

## 🎥 Demo

> Please add a video or an image of the behavior/changes
