### PR TITLE
CNV-51588: Fix network selection behavior change in Add network interface modal

### DIFF
--- a/src/utils/components/SelectTypeahead/SelectTypeahead.tsx
+++ b/src/utils/components/SelectTypeahead/SelectTypeahead.tsx
@@ -40,10 +40,7 @@ const SelectTypeahead: FC<SelectTypeaheadProps> = ({
 
   const onSelect = (value: string) => {
     if (value) {
-      setSelected(selected === value ? null : value);
-
-      if (selected === value) setInputValue('');
-
+      setInputValue(value);
       setIsOpen(true);
     }
 


### PR DESCRIPTION
## 📝 Description

The component used to select a network in the "Add network interface" modal was recently changed to a typeahead component exhibiting the standard selection behavior found in the Patternfly typeahead component [1]. This change introduced a change in behavior where selecting the currently selected option deselects that option and reverts to a placeholder value.

This PR modifies the behavior such that selecting the currently selected option does nothing.

Jira: https://issues.redhat.com/browse/CNV-51588

[1] https://v5-archive.patternfly.org/components/menus/select/react-templates/#typeahead

## 🎥 Demo

### Before

[select-nad-behavior-change--BEFORE--2024-11-21 16-44.webm](https://github.com/user-attachments/assets/d30808ba-4097-4d76-97dd-4920e2a7a0eb)

### After

[select-nad-behavior-change--AFTER--2024-11-21 15-58.webm](https://github.com/user-attachments/assets/8fc4d3cc-8dc5-4f1a-a176-f978934efeac)

