### PR TITLE
CNV-50655: fix VirtualMachineList columns width with checkbox

### DIFF
--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
@@ -41,7 +41,7 @@ const VirtualMachineRowLayout: React.FC<
           onChange={() => (selected ? deselectVM(obj) : selectVM(obj))}
         />
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} className="pf-m-width-15 vm-column" id="name">
+      <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="name">
         <ResourceLink
           groupVersionKind={VirtualMachineModelGroupVersionKind}
           name={getName(obj)}
@@ -65,10 +65,10 @@ const VirtualMachineRowLayout: React.FC<
       >
         <VMStatusConditionLabelList conditions={obj?.status?.conditions?.filter((c) => c.reason)} />
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} className="pf-m-width-15 vm-column" id="node">
+      <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="node">
         {node}
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} className="pf-m-width-15 vm-column" id="created">
+      <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="created">
         <Timestamp timestamp={obj?.metadata?.creationTimestamp} />
       </TableData>
       <TableData

--- a/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
+++ b/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
@@ -35,7 +35,6 @@ const useVirtualMachineColumns = (
     () => [
       {
         id: 'name',
-        props: { className: 'pf-m-width-15' },
         sort: (_, direction) => sorting(direction, 'metadata.name'),
         title: t('Name'),
         transforms: [sortable],
@@ -67,7 +66,6 @@ const useVirtualMachineColumns = (
         ? [
             {
               id: 'node',
-              props: { className: 'pf-m-width-15' },
               title: t('Node'),
             },
           ]
@@ -75,7 +73,6 @@ const useVirtualMachineColumns = (
       {
         additional: true,
         id: 'created',
-        props: { className: 'pf-m-width-15' },
         sort: (_, direction) => sorting(direction, 'metadata.creationTimestamp'),
         title: t('Created'),
         transforms: [sortable],


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Because all columns have fixed sizes ( in percentage to the window size) the select column does not respect it's size and gets bigger when some column is hided. 

Having a couple of columns with a flexible width make sure that the row is much more readable.

For example, when all columns are on, the node name and the created timestamp can easily break the wording

With flexible width, when the user hides some columns, the node and created timestamp column take more space when needed. 

Note: the name column is the most important and can't be hided

## 🎥 Demo
**Before**

https://github.com/user-attachments/assets/1c193601-32c0-43d3-82a1-dd7a59a6cbb7



**After**

https://github.com/user-attachments/assets/bd6e2fc7-e5f5-473f-b081-56d4bce8a9fb


