### PR TITLE
start command for start-console networking plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "po-to-i18n": "node ./i18n-scripts/po-to-i18n.js",
     "postinstall": "cp node_modules/@openshift-console/dynamic-plugin-sdk/docs/console-extensions.md .",
     "prepare": "husky install",
+    "start": "yarn ts-node node_modules/.bin/webpack serve",
     "start-console": "./start-console.sh",
     "start-console-with-monitoring": "./start-console.sh monitoring-plugin",
     "test": "jest",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

make sure to have the `start` command so other plugins can run `start-console` with the kubevirt plugin (like networking)
