### PR TITLE
CNV-52283: inverted condition in next button disabled

### DIFF
--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
@@ -68,6 +68,8 @@ const VirtualMachineMigrateModal: FC<VirtualMachineMigrateModalProps> = ({
     setMigrationLoading(false);
   };
 
+  const nothingSelected = !entireVMSelected(selectedPVCs) && isEmpty(selectedPVCs);
+
   return (
     <Modal
       className="virtual-machine-migration-modal"
@@ -90,7 +92,7 @@ const VirtualMachineMigrateModal: FC<VirtualMachineMigrateModalProps> = ({
           title={t('Migrate VirtualMachine storage')}
         >
           <WizardStep
-            footer={{ isNextDisabled: entireVMSelected(selectedPVCs) || !isEmpty(selectedPVCs) }}
+            footer={{ isNextDisabled: nothingSelected }}
             id="wizard-migration-details"
             name={t('Migration details')}
           >


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The next button `isDisabled` condition was inverted. 
This button should be disabled if the user didn't selected any disk
 
## 🎥 Demo


**Before**

<img width="1920" alt="Screenshot 2024-12-03 at 10 33 41" src="https://github.com/user-attachments/assets/eed1c4a7-d2c9-4a52-a6c3-19a1366a4544">

<img width="1920" alt="Screenshot 2024-12-03 at 10 33 47" src="https://github.com/user-attachments/assets/e1ee238a-ff5c-4862-b133-5ef2ed2adaf4">
.
<img width="1920" alt="Screenshot 2024-12-03 at 10 33 50" src="https://github.com/user-attachments/assets/dfe6c3fe-a876-4d99-bdf9-8ed1a010b435">

**After**


https://github.com/user-attachments/assets/d2fee6f5-f364-484f-aef2-056ecbf013d9


