### PR TITLE
CNV-52273: Virtualization icon is bigger than others in perspective switcher

### DIFF
--- a/src/perspective/virtualization-icon.tsx
+++ b/src/perspective/virtualization-icon.tsx
@@ -5,10 +5,10 @@ export default () => (
     <svg
       aria-hidden="true"
       fill="currentColor"
-      height="2em"
+      height="1em"
       role="img"
       viewBox="0 0 38 38"
-      width="2em"
+      width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>Red Hat OpenShift Virtualization icon</title>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Resize Virt icon to same size as the rest of switcher icons

This fixes [CNV-52273: Virtualization icon is bigger than others in perspective switcher](https://issues.redhat.com/browse/CNV-52273) bug.



**Before**
![image](https://github.com/user-attachments/assets/e05a4614-46e4-4e4b-906a-bd55463c99dd)

**After**
![Screenshot 2024-12-09 at 21 53 53](https://github.com/user-attachments/assets/863922f9-c27f-4c6f-84a6-c13babffa88a)

