### PR TITLE
CNV-51680: migrate or cancel migration and fix storage migration

### DIFF
--- a/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
@@ -149,7 +149,7 @@ export const VirtualMachineActionFactory = {
       label: t('Storage'),
     };
   },
-  migrationActions: (...migrationActions): ActionDropdownItemType => ({
+  migrationActions: (migrationActions): ActionDropdownItemType => ({
     id: 'migration-menu',
     label: 'Migration',
     options: migrationActions,

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/utils.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/utils.ts
@@ -13,13 +13,15 @@ import { getRandomChars, isEmpty } from '@kubevirt-utils/utils/utils';
 import { k8sCreate, k8sDelete, k8sPatch, Patch } from '@openshift-console/dynamic-plugin-sdk';
 
 const getBlankDataVolume = (
-  originName: string,
+  dataVolumeName: string,
   namespace: string,
   storageClassName: string,
   storage: string,
 ): V1beta1DataVolume => {
   const randomChars = getRandomChars();
-  const namePrefix = `clone-${originName}`.substring(0, MAX_NAME_LENGTH - 6 - randomChars.length);
+
+  const originName = dataVolumeName.replace(/-mig-\d+$/, '');
+  const namePrefix = `${originName}-mig`.substring(0, MAX_NAME_LENGTH - 5 - randomChars.length);
 
   return {
     apiVersion: `${DataVolumeModel.apiGroup}/${DataVolumeModel.apiVersion}`,
@@ -156,7 +158,7 @@ export const migrateVM = async (
   patchData.push({
     op: 'add',
     path: '/spec/updateVolumesStrategy',
-    value: 'migration',
+    value: 'Migration',
   });
 
   try {

--- a/src/views/virtualmachines/actions/tests/useVirtualMachineActionsProvider.test.tsx
+++ b/src/views/virtualmachines/actions/tests/useVirtualMachineActionsProvider.test.tsx
@@ -110,6 +110,6 @@ describe('useVirtualMachineActionsProvider tests', () => {
       'vm-action-delete',
     ]);
 
-    expect(migratingSubmenuIds).toEqual(['vm-action-cancel-migrate', 'vm-migrate-storage']);
+    expect(migratingSubmenuIds).toEqual(['vm-action-cancel-migrate']);
   });
 });


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description


- Do not let the user run multiple storage migrations in the same VM multiple times. If the user launches a storage migration let it cancel it. 
- Fix `migration` to `Migration` in the `updateVolumesStrategy` field. 
- the DV destination name in multiple sequential migrations tends to become larger and larger. So I fixed that by following what the MTV team did: add to the original name `mig-xxxx` . In a future migration we'll re-create the suffix removing `-mig-xxx` and adding again `-mig-yyyy`  

## 🎥 Demo


**Before**
<img width="455" alt="Screenshot 2024-12-13 at 15 30 03" src="https://github.com/user-attachments/assets/ef19ed9b-e217-4cdc-9f72-31954b2a960a" />



**After**

<img width="455" alt="Screenshot 2024-12-13 at 15 27 10" src="https://github.com/user-attachments/assets/fb20fda3-6f03-4fa3-8efe-3118450c3679" />
