### PR TITLE
CNV-53388: Bump plugin version to 4.18

### DIFF
--- a/plugin-metadata.ts
+++ b/plugin-metadata.ts
@@ -42,7 +42,7 @@ const metadata: ConsolePluginBuildMetadata = {
     yamlTemplates: 'src/templates/index.ts',
   },
   name: 'kubevirt-plugin',
-  version: '4.17.0',
+  version: '4.18.0',
 };
 
 export default metadata;


### PR DESCRIPTION
Before:

![about-version-4 17](https://github.com/user-attachments/assets/33783c0e-bc10-4f7f-b5b1-cfe5dccdfea3)

After:

![about-version-4 18](https://github.com/user-attachments/assets/68d489ad-61c7-46bd-be48-d43193e9d71a)
