### PR TITLE
CNV-53430: make examples compatible with s390x arch clusters

### DIFF
--- a/src/templates/vm-template-yaml.ts
+++ b/src/templates/vm-template-yaml.ts
@@ -1,95 +1,147 @@
-import { TemplateModel } from '@kubevirt-ui/kubevirt-api/console';
+import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { isClusterOnS390X, safeDump } from '@kubevirt-utils/utils/utils';
 
-export const defaultVMTemplateYamlTemplate = `
-apiVersion: ${TemplateModel.apiGroup}/${TemplateModel.apiVersion}
-kind: ${TemplateModel.kind}
-metadata:
-  name: example
-  labels:
-    template.kubevirt.io/type: vm
-    os.template.kubevirt.io/fedora: 'true'
-    workload.template.kubevirt.io/server: 'true'
-  annotations:
-    name.os.template.kubevirt.io/fedora: Fedora 
-    description: VM template example
-    openshift.io/display-name: "Fedora VM"
-    iconClass: icon-fedora
-objects:
-  - apiVersion: kubevirt.io/v1
-    kind: VirtualMachine
-    metadata:
-      name: '\${NAME}'
-      annotations:
-        description: VM example
-      labels:
-        app: '\${NAME}'
-        vm.kubevirt.io/template: example
-        os.template.kubevirt.io/fedora: 'true'
-    spec:
-      runStrategy: Halted
-      template:
-        metadata:
-          annotations:
-            vm.kubevirt.io/flavor: small
-            vm.kubevirt.io/os: fedora
-            vm.kubevirt.io/workload: server
-          labels:
-            kubevirt.io/domain: '\${NAME}'
-            kubevirt.io/size: small
-        spec:
-          domain:
-            cpu:
-              cores: 1
-              sockets: 1
-              threads: 1
-            devices:
-              disks:
-                - disk:
-                    bus: virtio
-                  name: rootdisk
-                - disk:
-                    bus: virtio
-                  name: cloudinitdisk
-              interfaces:
-                - masquerade: {}
-                  model: virtio
-                  name: default
-              networkInterfaceMultiqueue: true
-              rng: {}
-            features:
-              acpi: {}
-              smm:
-                enabled: true
-            firmware:
-              bootloader:
-                efi: {}
-            machine:
-              type: q35
-            memory:
-              guest: 2Gi
-          hostname: '\${NAME}'
-          networks:
-            - name: default
-              pod: {}
-          terminationGracePeriodSeconds: 180
-          volumes:
-            - name: rootdisk
-              containerDisk:
-                image: 'quay.io/containerdisks/fedora'
-            - cloudInitNoCloud:
-                userData: |-
-                  #cloud-config
-                  user: fedora
-                  password: '\${CLOUD_USER_PASSWORD}'
-                  chpasswd: { expire: False }
-              name: cloudinitdisk
-parameters:
-  - name: NAME
-    description: Name for the new VM
-    generate: expression
-    from: 'example-[a-z0-9]{16}'
-  - name: CLOUD_USER_PASSWORD
-    description: Randomized password for the cloud-init user
-    generate: expression
-    from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}'
-`;
+const defaultTemplate: V1Template = {
+  apiVersion: `${TemplateModel.apiGroup}/${TemplateModel.apiVersion}`,
+  kind: `${TemplateModel.kind}`,
+  metadata: {
+    annotations: {
+      description: 'VM template example',
+      iconClass: 'icon-fedora',
+      'name.os.template.kubevirt.io/fedora': 'Fedora',
+      'openshift.io/display-name': 'Fedora VM',
+    },
+    labels: {
+      'os.template.kubevirt.io/fedora': 'true',
+      'template.kubevirt.io/type': 'vm',
+      'workload.template.kubevirt.io/server': 'true',
+    },
+    name: 'example',
+  },
+  objects: [
+    {
+      apiVersion: 'kubevirt.io/v1',
+      kind: 'VirtualMachine',
+      metadata: {
+        annotations: {
+          description: 'VM example',
+        },
+        labels: {
+          app: '\\${NAME}',
+          'os.template.kubevirt.io/fedora': 'true',
+          'vm.kubevirt.io/template': 'example',
+        },
+        name: '\\${NAME}',
+      },
+      spec: {
+        runStrategy: 'Halted',
+        template: {
+          metadata: {
+            annotations: {
+              'vm.kubevirt.io/flavor': 'small',
+              'vm.kubevirt.io/os': 'fedora',
+              'vm.kubevirt.io/workload': 'server',
+            },
+            labels: {
+              'kubevirt.io/domain': '\\${NAME}',
+              'kubevirt.io/size': 'small',
+            },
+          },
+          spec: {
+            domain: {
+              cpu: {
+                cores: 1,
+                sockets: 1,
+                threads: 1,
+              },
+              devices: {
+                disks: [
+                  {
+                    disk: {
+                      bus: 'virtio',
+                    },
+                    name: 'rootdisk',
+                  },
+                  {
+                    disk: {
+                      bus: 'virtio',
+                    },
+                    name: 'cloudinitdisk',
+                  },
+                ],
+                interfaces: [
+                  {
+                    masquerade: {},
+                    model: 'virtio',
+                    name: 'default',
+                  },
+                ],
+                networkInterfaceMultiqueue: true,
+                rng: {},
+              },
+
+              ...(!isClusterOnS390X && {
+                features: {
+                  acpi: {},
+                  smm: {
+                    enabled: true,
+                  },
+                },
+                firmware: {
+                  bootloader: {
+                    efi: {},
+                  },
+                },
+                machine: {
+                  type: 'q35',
+                },
+              }),
+              memory: {
+                guest: '2Gi',
+              },
+            },
+            hostname: '\\${NAME}',
+            networks: [
+              {
+                name: 'default',
+                pod: {},
+              },
+            ],
+            terminationGracePeriodSeconds: 180,
+            volumes: [
+              {
+                containerDisk: {
+                  image: 'quay.io/containerdisks/fedora',
+                },
+                name: 'rootdisk',
+              },
+              {
+                cloudInitNoCloud: {
+                  userData:
+                    "#cloud-config\nuser: fedora\npassword: '\\${CLOUD_USER_PASSWORD}'\nchpasswd: { expire: False }",
+                },
+                name: 'cloudinitdisk',
+              },
+            ],
+          },
+        },
+      },
+    },
+  ],
+  parameters: [
+    {
+      description: 'Name for the new VM',
+      from: 'example-[a-z0-9]{16}',
+      generate: 'expression',
+      name: 'NAME',
+    },
+    {
+      description: 'Randomized password for the cloud-init user',
+      from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}',
+      generate: 'expression',
+      name: 'CLOUD_USER_PASSWORD',
+    },
+  ],
+};
+
+export const defaultVMTemplateYamlTemplate = safeDump(defaultTemplate);

--- a/src/templates/vm-yaml.ts
+++ b/src/templates/vm-yaml.ts
@@ -1,71 +1,113 @@
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { isClusterOnS390X, safeDump } from '@kubevirt-utils/utils/utils';
 
-export const defaultVMYamlTemplate = `
-apiVersion: ${VirtualMachineModel.apiGroup}/${VirtualMachineModel.apiVersion}
-kind: ${VirtualMachineModel.kind}
-metadata:
-  name: example
-  annotations:
-    description: VM example
-  labels:
-    app: example
-    os.template.kubevirt.io/fedora: 'true'
-spec:
-  runStrategy: Halted
-  template:
-    metadata:
-      annotations:
-        vm.kubevirt.io/flavor: small
-        vm.kubevirt.io/os: fedora
-        vm.kubevirt.io/workload: server
-      labels:
-        kubevirt.io/domain: example
-        kubevirt.io/size: small
-    spec:
-      domain:
-        cpu:
-          cores: 1
-          sockets: 1
-          threads: 1
-        devices:
-          disks:
-            - disk:
-                bus: virtio
-              name: rootdisk
-            - disk:
-                bus: virtio
-              name: cloudinitdisk
-          interfaces:
-            - masquerade: {}
-              model: virtio
-              name: default
-          networkInterfaceMultiqueue: true
-          rng: {}
-        features:
-          acpi: {}
-          smm:
-            enabled: true
-        firmware:
-          bootloader:
-            efi: {}
-        machine:
-          type: q35
-        memory:
-          guest: 2Gi
-      hostname: example
-      networks:
-        - name: default
-          pod: {}
-      terminationGracePeriodSeconds: 180
-      volumes:
-        - name: rootdisk
-          containerDisk:
-            image: 'quay.io/containerdisks/fedora'
-        - cloudInitNoCloud:
-            userData: |-
-              #cloud-config
-              user: fedora
-              password: fedora
-              chpasswd: { expire: False }
-          name: cloudinitdisk
-`;
+const defaultVM: V1VirtualMachine = {
+  apiVersion: `${VirtualMachineModel.apiGroup}/${VirtualMachineModel.apiVersion}`,
+  kind: VirtualMachineModel.kind,
+  metadata: {
+    annotations: {
+      description: 'VM example',
+    },
+    labels: {
+      app: 'example',
+      'os.template.kubevirt.io/fedora': 'true',
+    },
+    name: 'example',
+    namespace: 'default',
+  },
+  spec: {
+    runStrategy: 'Halted',
+    template: {
+      metadata: {
+        annotations: {
+          'vm.kubevirt.io/flavor': 'small',
+          'vm.kubevirt.io/os': 'fedora',
+          'vm.kubevirt.io/workload': 'server',
+        },
+        labels: {
+          'kubevirt.io/domain': 'example',
+          'kubevirt.io/size': 'small',
+        },
+      },
+      spec: {
+        domain: {
+          cpu: {
+            cores: 1,
+            sockets: 1,
+            threads: 1,
+          },
+          devices: {
+            disks: [
+              {
+                disk: {
+                  bus: 'virtio',
+                },
+                name: 'rootdisk',
+              },
+              {
+                disk: {
+                  bus: 'virtio',
+                },
+                name: 'cloudinitdisk',
+              },
+            ],
+            interfaces: [
+              {
+                masquerade: {},
+                model: 'virtio',
+                name: 'default',
+              },
+            ],
+            networkInterfaceMultiqueue: true,
+            rng: {},
+          },
+          ...(!isClusterOnS390X && {
+            features: {
+              acpi: {},
+              smm: {
+                enabled: true,
+              },
+            },
+            firmware: {
+              bootloader: {
+                efi: {},
+              },
+            },
+            machine: {
+              type: 'q35',
+            },
+          }),
+          memory: {
+            guest: '2Gi',
+          },
+        },
+        hostname: 'example',
+        networks: [
+          {
+            name: 'default',
+            pod: {},
+          },
+        ],
+        terminationGracePeriodSeconds: 180,
+        volumes: [
+          {
+            containerDisk: {
+              image: 'quay.io/containerdisks/fedora',
+            },
+            name: 'rootdisk',
+          },
+          {
+            cloudInitNoCloud: {
+              userData:
+                '#cloud-config\nuser: fedora\npassword: fedora\nchpasswd: { expire: False }',
+            },
+            name: 'cloudinitdisk',
+          },
+        ],
+      },
+    },
+  },
+};
+
+export const defaultVMYamlTemplate = safeDump(defaultVM);

--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -24,3 +24,5 @@ export enum K8S_OPS {
   REMOVE = 'remove',
   REPLACE = 'replace',
 }
+
+export const S390X_ARCH = 's390x';

--- a/src/utils/utils/utils.ts
+++ b/src/utils/utils/utils.ts
@@ -1,3 +1,4 @@
+import { dump } from 'js-yaml';
 import { animals, colors, NumberDictionary, uniqueNamesGenerator } from 'unique-names-generator';
 
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes';
@@ -5,6 +6,7 @@ import {
   DEFAULT_NAMESPACE,
   KUBEVIRT_HYPERCONVERGED,
   OPENSHIFT_CNV,
+  S390X_ARCH,
 } from '@kubevirt-utils/constants/constants';
 import { ALL_NAMESPACES, ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { FilterValue, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
@@ -157,3 +159,17 @@ export const removeDockerPrefix = (image: string) => image?.replace(DOCKER_PREFI
 
 export const isAllNamespaces = (namespace: string) =>
   !namespace || namespace === ALL_NAMESPACES || namespace === ALL_NAMESPACES_SESSION_KEY;
+
+export const isClusterOnS390X = !isEmpty(
+  (window as any).SERVER_FLAGS?.nodeArchitectures?.find((arch) => arch === S390X_ARCH),
+);
+
+export const safeDump = (obj: any) => {
+  try {
+    return dump(obj);
+  } catch (error) {
+    kubevirtConsole.error(error);
+
+    return '';
+  }
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This piece is not compatible with s390x arch clusters.


```
            features:
              acpi: {}
              smm:
                enabled: true
            firmware:
              bootloader:
                efi: {}
            machine:
              type: q35
```

window.SERVER_FLAGS.nodeArchitectures has info on the arch in the clusters
