### PR TITLE
CNV-54221: Apply last namespace to project items in tree-view

### DIFF
--- a/src/views/virtualmachines/tree/hooks/useTreeViewSelect.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewSelect.ts
@@ -4,8 +4,10 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useQueryParamsMethods } from '@kubevirt-utils/components/ListPageFilter/hooks/useQueryParamsMethods';
+import { ALL_NAMESPACES, ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { convertResourceArrayToMap, getResourceUrl } from '@kubevirt-utils/resources/shared';
 import { FilterValue } from '@openshift-console/dynamic-plugin-sdk';
+import { useLastNamespace } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { TreeViewDataItem } from '@patternfly/react-core';
 import { TEXT_FILTER_LABELS_ID } from '@virtualmachines/list/hooks/constants';
 
@@ -21,6 +23,7 @@ const useTreeViewSelect = (
 ) => {
   const navigate = useNavigate();
   const { setOrRemoveQueryArgument } = useQueryParamsMethods();
+  const [_, setLastNamespace] = useLastNamespace();
 
   const vmsMapper = useMemo(() => convertResourceArrayToMap(vms, true), [vms]);
 
@@ -30,6 +33,7 @@ const useTreeViewSelect = (
     const treeItemName = treeViewItem.name as string;
     if (treeViewItem.id.startsWith(FOLDER_SELECTOR_PREFIX)) {
       const [__, folderNamespace] = treeViewItem.id.split('/');
+      setLastNamespace(folderNamespace);
       navigate(
         getResourceUrl({
           activeNamespace: folderNamespace,
@@ -43,9 +47,19 @@ const useTreeViewSelect = (
     }
 
     if (treeViewItem.id.startsWith(PROJECT_SELECTOR_PREFIX)) {
+      setLastNamespace(treeItemName);
       return navigate(
         getResourceUrl({
           activeNamespace: treeItemName,
+          model: VirtualMachineModel,
+        }),
+      );
+    }
+
+    if (treeViewItem.id.startsWith(ALL_NAMESPACES_SESSION_KEY)) {
+      setLastNamespace(ALL_NAMESPACES);
+      return navigate(
+        getResourceUrl({
           model: VirtualMachineModel,
         }),
       );


### PR DESCRIPTION
## 📝 Description

When clicking a project/all projects tree view item we need to apply the last namespace we visited so the breadcrumbs would behave properly

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/93e648d7-e1f0-4cfc-8986-b4c899edcff2

After:

https://github.com/user-attachments/assets/7f81ef40-9a55-4939-9f9f-bdabae007683


