### PR TITLE
CNV-50766: Cannot delete NIC from VM

### DIFF
--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
@@ -9,7 +9,6 @@ import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
-import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ButtonVariant, Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core';
 
@@ -19,17 +18,18 @@ type NetworkInterfaceActionsProps = {
   nicName: string;
   nicPresentation: NetworkPresentation;
   onUpdateVM?: (updateVM: V1VirtualMachine) => Promise<void>;
+  vm: V1VirtualMachine;
 };
 
 const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
   nicName,
   nicPresentation,
   onUpdateVM,
+  vm,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { updateVM, vm: vmContext } = useWizardVMContext();
+  const { updateVM } = useWizardVMContext();
   const { createModal } = useModal();
-  const vm = vmSignal.value || vmContext;
   const onUpdate = onUpdateVM || updateVM;
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const label = t('Delete NIC?');

--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceList.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceList.tsx
@@ -45,7 +45,7 @@ const NetworkInterfaceList: React.FC<NetworkInterfaceListProps> = ({ onUpdateVM,
         loaded
         loadError={false}
         Row={NetworkInterfaceRow}
-        rowData={{ onUpdateVM }}
+        rowData={{ onUpdateVM, vm }}
         unfilteredData={data}
       />
     </>

--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceRow.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceRow.tsx
@@ -14,8 +14,11 @@ export type NetworkInterfaceRowProps = {
 };
 
 const NetworkInterfaceRow: FC<
-  RowProps<NetworkPresentation, { onUpdateVM?: (updateVM: V1VirtualMachine) => Promise<void> }>
-> = ({ activeColumnIDs, obj: { iface, network }, rowData: { onUpdateVM } }) => {
+  RowProps<
+    NetworkPresentation,
+    { onUpdateVM?: (updateVM: V1VirtualMachine) => Promise<void>; vm: V1VirtualMachine }
+  >
+> = ({ activeColumnIDs, obj: { iface, network }, rowData: { onUpdateVM, vm } }) => {
   const { t } = useKubevirtTranslation();
   return (
     <>
@@ -43,6 +46,7 @@ const NetworkInterfaceRow: FC<
           nicName={network?.name}
           nicPresentation={{ iface, network }}
           onUpdateVM={onUpdateVM}
+          vm={vm}
         />
       </TableData>
     </>


### PR DESCRIPTION
## 📝 Description

If we first create a VM from IT flow, than customize a VM in template flow, the VM from IT flow is selected just from the network section. Drilling the actual VM as a prop instead of relaying on global signal VM being populated or not

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/a51fae9d-5e2c-46fe-8921-8d2c8519f2d7

After:

https://github.com/user-attachments/assets/62f3f423-2ee3-4bfb-8c0c-35f4e5c6ab39


