### PR TITLE
CNV-51653: Fix bootable volume column sorting on create VM from IT page

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.tsx
@@ -91,6 +91,7 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
     pvcSources,
     volumeSnapshotSources,
     pagination,
+    volumeListNamespace === ALL_PROJECTS,
   );
 
   useEffect(() => {

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeTable/BootableVolumeTable.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeTable/BootableVolumeTable.tsx
@@ -43,6 +43,7 @@ const BootableVolumeTable: FC<BootableVolumeTableProps> = ({
 }) => {
   const [volumeFavorites, updateFavorites] = favorites;
   const { dataImportCrons, pvcSources, volumeSnapshotSources } = bootableVolumesData;
+
   return (
     <Table className="BootableVolumeList-table" variant={TableVariant.compact}>
       <Thead>

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
@@ -11,7 +11,7 @@ import {
   getVolumeSnapshotStorageClass,
 } from '@kubevirt-utils/resources/bootableresources/selectors';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
-import { getName } from '@kubevirt-utils/resources/shared';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { DESCRIPTION_ANNOTATION } from '@kubevirt-utils/resources/vm';
 import { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base/types';
 
@@ -28,6 +28,7 @@ type UseBootVolumeSortColumns = (
     [datSourceName: string]: VolumeSnapshotKind;
   },
   pagination: PaginationState,
+  includeNamespaceColumn: boolean,
 ) => {
   getSortType: (columnIndex: number) => ThSortType;
   sortedData: BootableVolume[];
@@ -41,6 +42,7 @@ const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
   pvcSources,
   volumeSnapshotSources,
   pagination,
+  includeNamespaceColumn,
 ) => {
   const [activeSortIndex, setActiveSortIndex] = useState<null | number>(0);
   const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc' | null>('asc');
@@ -51,6 +53,7 @@ const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
 
     return [
       getName(bootableVolume),
+      ...(includeNamespaceColumn ? [getNamespace(bootableVolume)] : []),
       getName(preferences[bootableVolume?.metadata?.labels?.[DEFAULT_PREFERENCE_LABEL]]),
       pvcSource?.spec?.storageClassName || getVolumeSnapshotStorageClass(volumeSnapshotSource),
       pvcSource?.spec?.resources?.requests?.storage || getVolumeSnapshotSize(volumeSnapshotSource),


### PR DESCRIPTION
## 📝 Description

This PR fixes the sorting of bootable volumes table columns on the create VM from InstanceTypes page. The sorting algorithm wasn't accounting for the namespace column which is present when All Projects is selected, which threw off which column was being sorted by one index.

Jira: https://issues.redhat.com/browse/CNV-51653

## 🎥 Demo

### Before

[bootable-volumes-sort--BEFORE--2025-01-13 06-55.webm](https://github.com/user-attachments/assets/e0d43311-59d6-4822-ad18-2ea7a463a0f8)


### After

[bootable-volumes-sort--AFTER--2025-01-13 06-52.webm](https://github.com/user-attachments/assets/8ea78e70-51a5-49b0-83b6-d7f5505d287c)

