### PR TITLE
CNV-52393: Fix missing storageclass in VM Details disk list

### DIFF
--- a/src/utils/resources/vm/hooks/disk/utils.ts
+++ b/src/utils/resources/vm/hooks/disk/utils.ts
@@ -15,7 +15,7 @@ export const getPVCWatch = (vm: V1VirtualMachine) => {
 
   pvcSources.push(
     ...(getVolumes(vm) || [])
-      .map((volume) => volume?.persistentVolumeClaim?.claimName)
+      .map((volume) => volume?.persistentVolumeClaim?.claimName || volume?.dataVolume?.name)
       .filter((claimName) => Boolean(claimName))
       .map(
         (claimName) =>


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug that caused the storageclass for disks added after VM creation from being displayed in the Disk list in the VM Details page.

Jira: https://issues.redhat.com/browse/CNV-52393

## 🎥 Screenshots

### Before

![missing-storageclass-vm-details-list--BEFORE--2025-01-17_15-19](https://github.com/user-attachments/assets/a6f2d728-2c8f-49a3-9901-24d256428006)

### After

![missing-storageclass-vm-details-disk-list--AFTER--2025-01-17_15-18](https://github.com/user-attachments/assets/42b1ef4c-9831-447f-9c8c-4387db360e4f)