### PR TITLE
CNV-55048: Fix display of default SSH settings list

### DIFF
--- a/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/hooks/useSSHAuthKeys.ts
+++ b/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/hooks/useSSHAuthKeys.ts
@@ -42,11 +42,10 @@ const useSSHAuthKeys: UseSSHAuthKeys = () => {
     useKubevirtUserSettings('ssh');
 
   const [authKeyRows, setAuthKeyRows] = useState<AuthKeyRow[]>([initialAuthKeyRow]);
-  const [isInitEffect, setIsInitEffect] = useState<boolean>(true);
   const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    if (loadedSettings && isInitEffect) {
+    if (loadedSettings) {
       if (!isEmpty(authorizedSSHKeys)) {
         const authRows: AuthKeyRow[] = Object.entries(authorizedSSHKeys).map(
           ([projectName, secretName], id) => ({
@@ -64,10 +63,8 @@ const useSSHAuthKeys: UseSSHAuthKeys = () => {
       } else {
         setLoading(false);
       }
-
-      setIsInitEffect(false);
     }
-  }, [loadedSettings, authorizedSSHKeys, isInitEffect]);
+  }, [loadedSettings, authorizedSSHKeys]);
 
   const { loaded, selectableProjects } = useSSHAuthProjects(authKeyRows);
 


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug that caused the list in the "Manage SSH keys" section of the User settings page to not display existing keys.

Jira: https://issues.redhat.com/browse/CNV-55048

## 🎥 Screenshots

### Before

![default-ssh-key-list--BEFORE--2025-01-21_06-46](https://github.com/user-attachments/assets/de2c0129-da0b-4cde-9028-8c00c537178c)

### After

![default-ssh-key-list--AFTER--2025-01-21_06-41](https://github.com/user-attachments/assets/c2c33a5d-40ba-4650-82b3-d1759f239bfb)