### PR TITLE
CNV-49438: Add 2xmedium to InstanceTypeSize

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/constants.ts
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/constants.ts
@@ -100,6 +100,7 @@ export const instanceTypeSeriesNameMapper: {
       'micro',
       'small',
       'medium',
+      '2xmedium',
       'large',
       'xlarge',
       '2xlarge',

--- a/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/utils/types.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/utils/types.ts
@@ -2,6 +2,7 @@ import { MutableRefObject } from 'react';
 
 export type InstanceTypeSize =
   | '2xlarge'
+  | '2xmedium'
   | '4xlarge'
   | '8xlarge'
   | 'large'


### PR DESCRIPTION

## 📝 Description

Extend existing type by adding `2xmedium` option.

## 🎥 Demo

### Before

![Screenshot from 2025-01-22 18-04-24](https://github.com/user-attachments/assets/4de48db2-be09-404b-811b-7edbc65a09f2)
![Screenshot from 2025-01-22 18-04-11](https://github.com/user-attachments/assets/92ff395f-6c63-4361-a097-774432abde6c)

### After
![Screenshot from 2025-01-22 17-57-53](https://github.com/user-attachments/assets/0e43a3cd-34d3-43f1-837b-4cd13504f742)
![Screenshot from 2025-01-22 17-57-38](https://github.com/user-attachments/assets/126685ff-8d07-453f-bdfd-3a75c63a6821)

