### PR TITLE
CNV-55111: get preference bootmode

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^6.0.2",
-    "@kubevirt-ui/kubevirt-api": "^1.3.5",
+    "@kubevirt-ui/kubevirt-api": "^1.3.6",
     "@openshift-console/dynamic-plugin-sdk": "1.8.0",
     "@openshift-console/dynamic-plugin-sdk-internal": "1.0.0",
     "@openshift-console/dynamic-plugin-sdk-webpack": "^1.3.0",

--- a/src/utils/components/DiskModal/components/StorageProfileSettings/ApplyStorageProfileSettings.tsx
+++ b/src/utils/components/DiskModal/components/StorageProfileSettings/ApplyStorageProfileSettings.tsx
@@ -45,7 +45,7 @@ const ApplyStorageProfileSettings: FC = () => {
     const propertySet = claimPropertySets?.[0];
 
     if (isEmpty(accessModes) && !isEmpty(propertySet?.accessModes[0])) {
-      setValue(ACCESS_MODE_FIELD, [propertySet?.accessModes[0]]);
+      setValue(ACCESS_MODE_FIELD, [propertySet?.accessModes?.[0]]);
     }
     if (isEmpty(volumeMode) && !isEmpty(propertySet?.volumeMode)) {
       setValue(VOLUME_MODE_FIELD, propertySet?.volumeMode as V1beta1StorageSpecVolumeModeEnum);

--- a/src/utils/components/DiskModal/components/StorageProfileSettings/VolumeMode.tsx
+++ b/src/utils/components/DiskModal/components/StorageProfileSettings/VolumeMode.tsx
@@ -1,7 +1,10 @@
 import React, { FC, useEffect, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { V1beta1StorageSpecVolumeModeEnum } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1beta1StorageSpecAccessModesEnum,
+  V1beta1StorageSpecVolumeModeEnum,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup, Radio } from '@patternfly/react-core';
 
@@ -12,11 +15,7 @@ import {
   VOLUME_MODE_FIELD,
   VOLUMEMODE_FIELDID,
 } from '../utils/constants';
-import {
-  ACCESS_MODES,
-  getVolumeModeForProvisioner,
-  VOLUME_MODE_RADIO_OPTIONS,
-} from '../utils/modesMapping';
+import { getVolumeModeForProvisioner, VOLUME_MODE_RADIO_OPTIONS } from '../utils/modesMapping';
 
 const VolumeMode: FC = () => {
   const { t } = useKubevirtTranslation();
@@ -24,7 +23,7 @@ const VolumeMode: FC = () => {
   const { control, setValue, watch } = useFormContext<V1DiskFormState>();
 
   const volumeMode = watch(VOLUME_MODE_FIELD);
-  const accessModes = watch(ACCESS_MODE_FIELD) as ACCESS_MODES[];
+  const accessModes = watch(ACCESS_MODE_FIELD) as V1beta1StorageSpecAccessModesEnum[];
   const storageClassProvisioner = watch(STORAGE_CLASS_PROVIDER_FIELD);
 
   const allowedVolumeModes = useMemo(

--- a/src/utils/components/DiskModal/components/utils/modesMapping.ts
+++ b/src/utils/components/DiskModal/components/utils/modesMapping.ts
@@ -1,16 +1,13 @@
-import { V1beta1StorageSpecVolumeModeEnum } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1beta1StorageSpecAccessModesEnum,
+  V1beta1StorageSpecVolumeModeEnum,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
-export enum ACCESS_MODES {
-  ROX = 'ReadOnlyMany',
-  RWO = 'ReadWriteOnce',
-  RWX = 'ReadWriteMany',
-}
-
-export const initialAccessModes: ACCESS_MODES[] = [
-  ACCESS_MODES.RWX,
-  ACCESS_MODES.RWO,
-  ACCESS_MODES.ROX,
+export const initialAccessModes: V1beta1StorageSpecAccessModesEnum[] = [
+  V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+  V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+  V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
 ];
 export const initialVolumeModes: V1beta1StorageSpecVolumeModeEnum[] = [
   V1beta1StorageSpecVolumeModeEnum.Filesystem,
@@ -18,7 +15,7 @@ export const initialVolumeModes: V1beta1StorageSpecVolumeModeEnum[] = [
 ];
 
 type ModeMapping = {
-  [volumeMode in V1beta1StorageSpecVolumeModeEnum]?: ACCESS_MODES[];
+  [volumeMode in V1beta1StorageSpecVolumeModeEnum]?: V1beta1StorageSpecAccessModesEnum[];
 };
 
 type ProvisionerAccessModeMapping = {
@@ -28,139 +25,190 @@ type ProvisionerAccessModeMapping = {
 // See https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes for more details
 export const provisionerAccessModeMapping: ProvisionerAccessModeMapping = {
   'cinder.csi.openstack.org': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [V1beta1StorageSpecAccessModesEnum.ReadWriteOnce],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+    ],
   },
   'csi.ovirt.org': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [V1beta1StorageSpecAccessModesEnum.ReadWriteOnce],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+    ],
   },
   'ebs.csi.aws.com': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [V1beta1StorageSpecAccessModesEnum.ReadWriteOnce],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+    ],
   },
   'kubernetes.io/aws-ebs': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [V1beta1StorageSpecAccessModesEnum.ReadWriteOnce],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+    ],
   },
   'kubernetes.io/azure-disk': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [V1beta1StorageSpecAccessModesEnum.ReadWriteOnce],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+    ],
   },
   'kubernetes.io/azure-file': {
     [V1beta1StorageSpecVolumeModeEnum.Block]: [
-      ACCESS_MODES.RWO,
-      ACCESS_MODES.RWX,
-      ACCESS_MODES.ROX,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
     ],
     [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
-      ACCESS_MODES.RWO,
-      ACCESS_MODES.RWX,
-      ACCESS_MODES.ROX,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
     ],
   },
   'kubernetes.io/cinder': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [V1beta1StorageSpecAccessModesEnum.ReadWriteOnce],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+    ],
   },
   'kubernetes.io/gce-pd': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO, ACCESS_MODES.ROX],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO, ACCESS_MODES.ROX],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
+    ],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
+    ],
   },
   'kubernetes.io/glusterfs': {
     [V1beta1StorageSpecVolumeModeEnum.Block]: [
-      ACCESS_MODES.RWO,
-      ACCESS_MODES.RWX,
-      ACCESS_MODES.ROX,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
     ],
     [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
-      ACCESS_MODES.RWO,
-      ACCESS_MODES.RWX,
-      ACCESS_MODES.ROX,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
     ],
   },
   'kubernetes.io/no-provisioner': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [V1beta1StorageSpecAccessModesEnum.ReadWriteOnce],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+    ],
   },
   'kubernetes.io/portworx-volume': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO, ACCESS_MODES.RWX],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO, ACCESS_MODES.RWX],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+    ],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+    ],
   },
   'kubernetes.io/quobyte': {
     [V1beta1StorageSpecVolumeModeEnum.Block]: [
-      ACCESS_MODES.RWO,
-      ACCESS_MODES.RWX,
-      ACCESS_MODES.ROX,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
     ],
     [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
-      ACCESS_MODES.RWO,
-      ACCESS_MODES.RWX,
-      ACCESS_MODES.ROX,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
     ],
   },
   'kubernetes.io/rbd': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO, ACCESS_MODES.ROX],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO, ACCESS_MODES.ROX],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
+    ],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
+    ],
   },
   'kubernetes.io/scaleio': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO, ACCESS_MODES.ROX],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO, ACCESS_MODES.ROX],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
+    ],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
+    ],
   },
   'kubernetes.io/storageos': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [V1beta1StorageSpecAccessModesEnum.ReadWriteOnce],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+    ],
   },
   'kubernetes.io/vsphere-volume': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO, ACCESS_MODES.RWX],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO, ACCESS_MODES.RWX],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+    ],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+    ],
   },
   // Since 4.6 new provisioners names will be without the 'kubernetes.io/' prefix.
   'manila.csi.openstack.org': {
     [V1beta1StorageSpecVolumeModeEnum.Block]: [
-      ACCESS_MODES.RWO,
-      ACCESS_MODES.RWX,
-      ACCESS_MODES.ROX,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
     ],
     [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
-      ACCESS_MODES.RWO,
-      ACCESS_MODES.RWX,
-      ACCESS_MODES.ROX,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
     ],
   },
   'openshift-storage.cephfs.csi.ceph.com': {
     [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
-      ACCESS_MODES.RWO,
-      ACCESS_MODES.RWX,
-      ACCESS_MODES.ROX,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
     ],
   },
   'openshift-storage.rbd.csi.ceph.com': {
     [V1beta1StorageSpecVolumeModeEnum.Block]: [
-      ACCESS_MODES.RWO,
-      ACCESS_MODES.RWX,
-      ACCESS_MODES.ROX,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
     ],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO, ACCESS_MODES.ROX],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+      V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
+    ],
   },
   'pd.csi.storage.gke.io': {
-    [V1beta1StorageSpecVolumeModeEnum.Block]: [ACCESS_MODES.RWO],
-    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [ACCESS_MODES.RWO],
+    [V1beta1StorageSpecVolumeModeEnum.Block]: [V1beta1StorageSpecAccessModesEnum.ReadWriteOnce],
+    [V1beta1StorageSpecVolumeModeEnum.Filesystem]: [
+      V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
+    ],
   },
 };
 
 export const ACCESS_MODE_RADIO_OPTIONS = [
   {
     label: t('Single user (RWO)'),
-    value: ACCESS_MODES.RWO,
+    value: V1beta1StorageSpecAccessModesEnum.ReadWriteOnce,
   },
   {
     label: t('Shared access (RWX)'),
-    value: ACCESS_MODES.RWX,
+    value: V1beta1StorageSpecAccessModesEnum.ReadWriteMany,
   },
   {
     label: t('Read only (ROX)'),
-    value: ACCESS_MODES.ROX,
+    value: V1beta1StorageSpecAccessModesEnum.ReadOnlyMany,
   },
 ];
 
@@ -181,7 +229,7 @@ export const getAccessModeForProvisioner = (
 ) => {
   const modeMap = provisionerAccessModeMapping[provisioner] || {};
 
-  const volumeModes = Object.keys(modeMap) as ACCESS_MODES[];
+  const volumeModes = Object.keys(modeMap) as V1beta1StorageSpecAccessModesEnum[];
   if (volumeModes?.length > 0) {
     return volumeMode ? modeMap[volumeMode] : volumeModes.map((mode) => modeMap[mode]).flat();
   }
@@ -189,7 +237,10 @@ export const getAccessModeForProvisioner = (
   return initialAccessModes;
 };
 
-export const getVolumeModeForProvisioner = (provisioner: string, accessMode: ACCESS_MODES) => {
+export const getVolumeModeForProvisioner = (
+  provisioner: string,
+  accessMode: V1beta1StorageSpecAccessModesEnum,
+) => {
   const modeMap = provisionerAccessModeMapping[provisioner] || {};
 
   const volumeModes = Object.keys(modeMap) as V1beta1StorageSpecVolumeModeEnum[];

--- a/src/utils/components/FirmwareBootloaderModal/utils/utils.ts
+++ b/src/utils/components/FirmwareBootloaderModal/utils/utils.ts
@@ -8,7 +8,10 @@ import { BootloaderOptionValue } from './types';
 
 export const isObjectEmpty = (obj: object): boolean => obj && isEmpty(obj);
 
-export const getBootloaderFromVM = (vm: V1VirtualMachine): BootloaderOptionValue => {
+export const getBootloaderFromVM = (
+  vm: V1VirtualMachine,
+  defaultBootmode = BootMode.bios,
+): BootloaderOptionValue => {
   const secureBoot = vm?.spec?.template?.spec?.domain?.firmware?.bootloader?.efi;
 
   if (secureBoot?.secureBoot === true || isObjectEmpty(secureBoot)) {
@@ -17,11 +20,14 @@ export const getBootloaderFromVM = (vm: V1VirtualMachine): BootloaderOptionValue
   if (secureBoot?.secureBoot === false) {
     return BootMode.uefi;
   }
-  return BootMode.bios;
+  return defaultBootmode;
 };
 
-export const getBootloaderTitleFromVM = (vm: V1VirtualMachine): string => {
-  const bootloader = getBootloaderFromVM(vm);
+export const getBootloaderTitleFromVM = (
+  vm: V1VirtualMachine,
+  defaultBootmode?: BootMode,
+): string => {
+  const bootloader = getBootloaderFromVM(vm, defaultBootmode);
 
   return BootModeTitles[bootloader];
 };

--- a/src/utils/resources/preference/helper.ts
+++ b/src/utils/resources/preference/helper.ts
@@ -1,0 +1,31 @@
+import VirtualMachineClusterPreferenceModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineClusterPreferenceModel';
+import VirtualMachinePreferenceModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachinePreferenceModel';
+import {
+  V1beta1VirtualMachinePreference,
+  V1PreferenceMatcher,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { BootMode } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/constants';
+import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
+
+export const getPreferredBootmode = (preference: V1beta1VirtualMachinePreference) => {
+  if (
+    preference?.spec?.firmware?.preferredUseSecureBoot ||
+    preference?.spec?.firmware?.preferredEfi?.secureBoot
+  )
+    return BootMode.uefiSecure;
+  if (
+    preference?.spec?.firmware?.preferredUseEfi ||
+    !preference?.spec?.firmware?.preferredEfi?.secureBoot
+  )
+    return BootMode.uefi;
+  if (
+    preference?.spec?.firmware?.preferredUseBios ||
+    preference?.spec?.firmware?.preferredUseBiosSerial
+  )
+    return BootMode.bios;
+};
+
+export const getPreferenceModelFromMatcher = (preferenceMatcher: V1PreferenceMatcher): K8sModel =>
+  preferenceMatcher?.kind?.includes('cluster')
+    ? VirtualMachineClusterPreferenceModel
+    : VirtualMachinePreferenceModel;

--- a/src/utils/types/storage.ts
+++ b/src/utils/types/storage.ts
@@ -1,20 +1,24 @@
+import { V1beta1StorageSpecAccessModesEnum } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
-export type ClaimPropertySet = { accessModes: string[]; volumeMode?: string };
+export type ClaimPropertySet = {
+  accessModes: V1beta1StorageSpecAccessModesEnum[];
+  volumeMode?: string;
+};
 export type ClaimPropertySets = ClaimPropertySet[];
 
 // type is not existing on kubevirt-api
 export type StorageProfile = {
   spec: {
     claimPropertySets?: {
-      accessModes: string[];
+      accessModes: V1beta1StorageSpecAccessModesEnum[];
       volumeMode?: string;
     }[];
     cloneStrategy?: string;
   };
   status: {
     claimPropertySets?: {
-      accessModes: string[];
+      accessModes: V1beta1StorageSpecAccessModesEnum[];
       volumeMode?: string;
     }[];
     cloneStrategy?: string;

--- a/src/views/catalog/CustomizeInstanceType/tabs/configuration/hooks/usePreference.ts
+++ b/src/views/catalog/CustomizeInstanceType/tabs/configuration/hooks/usePreference.ts
@@ -1,0 +1,29 @@
+import {
+  V1beta1VirtualMachinePreference,
+  V1VirtualMachine,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { modelToGroupVersionKind } from '@kubevirt-utils/models';
+import { getPreferenceModelFromMatcher } from '@kubevirt-utils/resources/preference/helper';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { getPreferenceMatcher } from '@kubevirt-utils/resources/vm';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+const usePreference = (
+  vm: V1VirtualMachine,
+): [preference: V1beta1VirtualMachinePreference, loading: boolean] => {
+  const vmPreference = getPreferenceMatcher(vm);
+
+  const [preference, preferenceLoaded, preferenceError] =
+    useK8sWatchResource<V1beta1VirtualMachinePreference>({
+      groupVersionKind: modelToGroupVersionKind(getPreferenceModelFromMatcher(vmPreference)),
+      name: vmPreference?.name,
+      namespace: getNamespace(vm),
+    });
+
+  const preferenceLoading = !preferenceLoaded && isEmpty(preferenceError);
+
+  return [preference, preferenceLoading];
+};
+
+export default usePreference;

--- a/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeDetailsTab.tsx
+++ b/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeDetailsTab.tsx
@@ -19,6 +19,7 @@ import {
 } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getPreferredBootmode } from '@kubevirt-utils/resources/preference/helper';
 import { asAccessReview, getAnnotation, getLabel, getName } from '@kubevirt-utils/resources/shared';
 import { DESCRIPTION_ANNOTATION, getDevices, getHostname } from '@kubevirt-utils/resources/vm';
 import { updateCustomizeInstanceType, vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
@@ -28,8 +29,13 @@ import DetailsSectionBoot from '@virtualmachines/details/tabs/configuration/deta
 import DetailsSectionHardware from '@virtualmachines/details/tabs/configuration/details/components/DetailsSectionHardware';
 import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
 
+import usePreference from '../../hooks/usePreference';
+
 const CustomizeInstanceTypeDetailsTab = () => {
   const vm = vmSignal.value;
+
+  const [preference, preferenceLoading] = usePreference(vm);
+
   const { createModal } = useModal();
   const { t } = useKubevirtTranslation();
   const accessReview = asAccessReview(VirtualMachineModel, vm, 'update' as K8sVerb);
@@ -54,7 +60,7 @@ const CustomizeInstanceTypeDetailsTab = () => {
 
   const vmName = getName(vm);
 
-  if (!vm) {
+  if (!vm || preferenceLoading) {
     return <Loading />;
   }
 
@@ -212,7 +218,12 @@ const CustomizeInstanceTypeDetailsTab = () => {
               }
               vm={vm}
             />
-            <DetailsSectionBoot canUpdateVM={canUpdateVM} isCustomizeInstanceType vm={vm} />
+            <DetailsSectionBoot
+              canUpdateVM={canUpdateVM}
+              isCustomizeInstanceType
+              preferredBootmode={getPreferredBootmode(preference)}
+              vm={vm}
+            />
           </DescriptionList>
         </GridItem>
       </Grid>

--- a/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCFormVolumeMode.tsx
+++ b/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCFormVolumeMode.tsx
@@ -1,8 +1,8 @@
 import React, { FC, useMemo } from 'react';
 import { Trans } from 'react-i18next';
 
+import { V1beta1StorageSpecAccessModesEnum } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import {
-  ACCESS_MODES,
   getVolumeModeForProvisioner,
   VOLUME_MODE_RADIO_OPTIONS,
 } from '@kubevirt-utils/components/DiskModal/components/utils/modesMapping';
@@ -10,7 +10,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { FormGroup, Radio } from '@patternfly/react-core';
 
 type UploadPVCFormModeVolumeModeVolumeModeProps = {
-  accessMode: ACCESS_MODES;
+  accessMode: V1beta1StorageSpecAccessModesEnum;
   loaded: boolean;
   onChange: (volumeMode: string) => void;
   provisioner: string;

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
@@ -6,6 +6,7 @@ import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevir
 import BootOrderSummary from '@kubevirt-utils/components/BootOrder/BootOrderSummary';
 import BootOrderModal from '@kubevirt-utils/components/BootOrderModal/BootOrderModal';
 import FirmwareBootloaderModal from '@kubevirt-utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal';
+import { BootMode } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/constants';
 import { getBootloaderTitleFromVM } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/utils';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
@@ -26,6 +27,7 @@ type DetailsSectionBootProps = {
   canUpdateVM: boolean;
   instanceTypeVM?: V1VirtualMachine;
   isCustomizeInstanceType?: boolean;
+  preferredBootmode?: BootMode;
   vm: V1VirtualMachine;
   vmi?: V1VirtualMachineInstance;
 };
@@ -34,6 +36,7 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({
   canUpdateVM,
   instanceTypeVM,
   isCustomizeInstanceType,
+  preferredBootmode,
   vm,
   vmi,
 }) => {
@@ -58,7 +61,7 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({
       <VirtualMachineDescriptionItem
         descriptionData={
           <div className={classNames({ 'text-muted': !canUpdateVM })}>
-            {getBootloaderTitleFromVM(instanceTypeVM || vm)}
+            {getBootloaderTitleFromVM(instanceTypeVM || vm, preferredBootmode)}
           </div>
         }
         onEditClick={() =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,10 +881,10 @@
   resolved "https://registry.yarnpkg.com/@jsonjoy.com/util/-/util-1.5.0.tgz#6008e35b9d9d8ee27bc4bfaa70c8cbf33a537b4c"
   integrity sha512-ojoNsrIuPI9g6o8UxhraZQSyF2ByJanAY4cTFbc8Mf2AXEF4aQRGY1dJxyJpuyav8r9FGflEt/Ff3u5Nt6YMPA==
 
-"@kubevirt-ui/kubevirt-api@^1.3.5":
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/@kubevirt-ui/kubevirt-api/-/kubevirt-api-1.3.5.tgz#c9c10b30d8cc9770fbc6b08077b9a997fdc3ca58"
-  integrity sha512-FI9RXYwVl3/INr4z7uemuJk3D218DzxOSm4iiVjJIiYp5DHj+r5EqwTaaWi9NQQYj+aZUw3a1akd8p/JO8lMZw==
+"@kubevirt-ui/kubevirt-api@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@kubevirt-ui/kubevirt-api/-/kubevirt-api-1.3.6.tgz#1b5336d29b379dfdaadd75b948d078efdabde23e"
+  integrity sha512-RVVD6iJHQ9hMC6XR7kDP+Vp5z8R97HlW1iycQXAJSAB1dXjB9PX87LtVE9qhne2G/sfi3oB04X9RWuwKLt0Q1g==
 
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.5"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The default mode for us if we don't have anything specified is bios but preference overrides this if firmware fields are specified. 

On customized we cant fetch the extended VM with preference and instacetype info like we do in the VM details page. So we have to fetch the preference and see what we got

## 🎥 Demo


**Before**


<img width="1904" alt="Screenshot 2025-01-23 at 12 17 16" src="https://github.com/user-attachments/assets/38a3f41b-68c4-4783-b744-443fd6057f5f" />


**After**

<img width="1904" alt="Screenshot 2025-01-23 at 12 07 58" src="https://github.com/user-attachments/assets/76add661-8cff-4afb-a0c8-547d276a2520" />

