### PR TITLE
CNV-54834: add datavolume link on diagnosis table

### DIFF
--- a/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineDiagnosticTabRow.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineDiagnosticTabRow.tsx
@@ -1,14 +1,28 @@
 import React from 'react';
 import cn from 'classnames';
 
+import { DataVolumeModelGroupVersionKind } from '@kubevirt-utils/models';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import {
   RedExclamationCircleIcon,
+  ResourceLink,
+  useActiveNamespace,
   YellowExclamationTriangleIcon,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { ExpandableRowContent, Tbody, Td, Tr } from '@patternfly/react-table';
 
-const VirtualMachineDiagnosticTabRow = ({ activeColumns, expend, index, obj, setExpend }) => {
+import { NAME_COLUMN_ID } from './hooks/constants';
+
+const VirtualMachineDiagnosticTabRow = ({
+  activeColumns,
+  dataVolumeResourceLink = false,
+  expend,
+  index,
+  obj,
+  setExpend,
+}) => {
+  const [namespace] = useActiveNamespace();
+
   const isExpanded = expend?.expended.has(obj?.id) && obj?.message;
   const activeColumnsObj = new Set<string>(activeColumns.map(({ id }) => id));
 
@@ -29,13 +43,19 @@ const VirtualMachineDiagnosticTabRow = ({ activeColumns, expend, index, obj, set
             }
           }
         />
-        {[...activeColumnsObj]?.map((column) => {
-          return (
-            <Td id={column} key={column}>
-              {obj?.[column]?.toString() || NO_DATA_DASH}
-            </Td>
-          );
-        })}
+        {[...activeColumnsObj]?.map((column) => (
+          <Td id={column} key={column}>
+            {column === NAME_COLUMN_ID && dataVolumeResourceLink ? (
+              <ResourceLink
+                groupVersionKind={DataVolumeModelGroupVersionKind}
+                name={obj?.[column]?.toString()}
+                namespace={namespace}
+              />
+            ) : (
+              obj?.[column]?.toString() || NO_DATA_DASH
+            )}
+          </Td>
+        ))}
       </Tr>
       {obj?.message && (
         <Tr isExpanded={isExpanded}>

--- a/src/views/virtualmachines/details/tabs/diagnostic/hooks/constants.ts
+++ b/src/views/virtualmachines/details/tabs/diagnostic/hooks/constants.ts
@@ -1,0 +1,1 @@
+export const NAME_COLUMN_ID = 'name';

--- a/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticDataVolumeStatusTableColumns.ts
+++ b/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticDataVolumeStatusTableColumns.ts
@@ -5,6 +5,7 @@ import { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/ba
 
 import { DiagnosticSort } from '../utils/types';
 
+import { NAME_COLUMN_ID } from './constants';
 import useDiagnosticSort from './useDiagnosticSort';
 
 type DiagnosticColumn = {
@@ -24,8 +25,8 @@ const useDiagnosticDataVolumeStatusTableColumns: UseDiagnosticDataVolumeStatusTa
 
   const columns: TableColumn<DiagnosticColumn>[] = [
     {
-      cell: { sort: (columnIndex) => getSorting('name', columnIndex) },
-      id: 'name',
+      cell: { sort: (columnIndex) => getSorting(NAME_COLUMN_ID, columnIndex) },
+      id: NAME_COLUMN_ID,
       title: t('Name'),
     },
     {

--- a/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabDataVolumeStatus.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabDataVolumeStatus.tsx
@@ -103,6 +103,7 @@ const VirtualMachineDiagnosticTabDataVolumeStatus: FC<
         {sortedData.map((row, index) => (
           <VirtualMachineDiagnosticTabRow
             activeColumns={columns}
+            dataVolumeResourceLink
             expend={expend}
             index={index}
             key={row?.name}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add diagnosis datavolume table list a link to datavolume so if there is a problem we can go directly into the datavolume page.

The UI clicks to go there without it are numerous  

## 🎥 Demo
**Before**

<img width="1920" alt="Screenshot 2025-01-24 at 12 51 00" src="https://github.com/user-attachments/assets/a45c77f0-26d4-425b-9445-bc039fdb7dd9" />


**After**
<img width="1920" alt="Screenshot 2025-01-24 at 12 50 36" src="https://github.com/user-attachments/assets/8ee8660b-589f-4e60-810e-b12dd1ce990e" />
