### PR TITLE
CNV-54166: Admission webhook warning about non existing properties l2bridge and deviceIndex

### DIFF
--- a/src/utils/components/HardwareDevices/modal/HardwareDevicesModal.tsx
+++ b/src/utils/components/HardwareDevices/modal/HardwareDevicesModal.tsx
@@ -68,8 +68,15 @@ const HardwareDevicesModal: FC<HardwareDevicesModalProps> = ({
 
   const disableSubmit = devices.some((device) => isEmpty(device?.deviceName));
 
+  const toK8sDevice = ({ deviceName, name }: HardwareDeviceModalRow): V1GPU | V1HostDevice => ({
+    deviceName,
+    name,
+  });
+
   const updatedVM = produceVMDevices(vm, (vmDraft: V1VirtualMachine) => {
-    vmDraft.spec.template.spec.domain.devices[type] = !isEmpty(devices) ? devices : null;
+    vmDraft.spec.template.spec.domain.devices[type] = isEmpty(devices)
+      ? null
+      : devices.map(toK8sDevice);
   });
 
   return (

--- a/src/utils/components/NetworkInterfaceModal/utils/helpers.ts
+++ b/src/utils/components/NetworkInterfaceModal/utils/helpers.ts
@@ -9,7 +9,9 @@ import {
   getInterfaces,
   getNetworks,
 } from '@kubevirt-utils/resources/vm';
+import { UDN_BINDING_NAME } from '@kubevirt-utils/resources/vm/utils/constants';
 import {
+  interfaceLabels,
   interfacesTypes,
   NetworkPresentation,
 } from '@kubevirt-utils/resources/vm/utils/network/constants';
@@ -128,11 +130,15 @@ export const createInterface = (
   interfaceMACAddress: string,
   interfaceType = interfacesTypes.bridge,
 ): V1Interface => {
+  const resolvedInterfaceProp = interfaceLabels[interfaceType];
+  const validInterfaceProp: keyof V1Interface =
+    resolvedInterfaceProp === UDN_BINDING_NAME ? 'bridge' : resolvedInterfaceProp;
+
   return {
-    [interfaceType?.replace('-', '')?.toLowerCase()]: {},
     macAddress: interfaceMACAddress,
     model: interfaceModel,
     name: nicName,
+    [validInterfaceProp]: {},
   };
 };
 

--- a/src/utils/components/NetworkInterfaceModal/utils/helpers.ts
+++ b/src/utils/components/NetworkInterfaceModal/utils/helpers.ts
@@ -9,7 +9,7 @@ import {
   getInterfaces,
   getNetworks,
 } from '@kubevirt-utils/resources/vm';
-import { UDN_BINDING_NAME } from '@kubevirt-utils/resources/vm/utils/constants';
+import { BRIDGE, UDN_BINDING_NAME } from '@kubevirt-utils/resources/vm/utils/constants';
 import {
   interfaceLabels,
   interfacesTypes,
@@ -132,7 +132,7 @@ export const createInterface = (
 ): V1Interface => {
   const resolvedInterfaceProp = interfaceLabels[interfaceType];
   const validInterfaceProp: keyof V1Interface =
-    resolvedInterfaceProp === UDN_BINDING_NAME ? 'bridge' : resolvedInterfaceProp;
+    resolvedInterfaceProp === UDN_BINDING_NAME ? BRIDGE : resolvedInterfaceProp;
 
   return {
     macAddress: interfaceMACAddress,

--- a/src/utils/resources/vm/utils/constants.ts
+++ b/src/utils/resources/vm/utils/constants.ts
@@ -33,6 +33,9 @@ export const DEFAULT_NETWORK_INTERFACE: V1Interface = { masquerade: {}, name: 'd
 export const DEFAULT_NETWORK: V1Network = { name: 'default', pod: {} };
 
 export const UDN_BINDING_NAME = 'l2bridge';
+export const BRIDGE = 'bridge';
+export const MASQUERADE = 'masquerade';
+export const SRIOV = 'sriov';
 
 export enum UPDATE_STRATEGIES {
   Migration = 'Migration',

--- a/src/utils/resources/vm/utils/network/constants.ts
+++ b/src/utils/resources/vm/utils/network/constants.ts
@@ -9,18 +9,35 @@ export type NetworkPresentation = {
 };
 
 const typeHandler = {
-  get(target, prop) {
+  get(target: TypeMap, prop: string) {
     return target[prop] ?? target.bridge;
   },
 };
 
-const types = {
+const labelHandler = {
+  get(target: LabelMap, prop: string) {
+    return target[prop] ?? 'bridge';
+  },
+};
+
+export type InterfaceTypes = 'bridge' | 'masquerade' | 'sriov' | typeof UDN_BINDING_NAME;
+type LabelMap = { [key: string]: InterfaceTypes };
+type TypeMap = { [key in InterfaceTypes]: string };
+
+const types2labels: TypeMap = {
   bridge: 'Bridge',
   masquerade: 'Masquerade',
   sriov: 'SR-IOV',
   [UDN_BINDING_NAME]: 'L2 bridge',
 };
 
-export const interfacesTypes = new Proxy(types, typeHandler);
+const labels2types: LabelMap = Object.fromEntries(
+  Object.entries(types2labels).map(
+    ([type, label]: [InterfaceTypes, string]): [string, InterfaceTypes] => [label, type],
+  ),
+);
+
+export const interfacesTypes = new Proxy<TypeMap>(types2labels, typeHandler);
+export const interfaceLabels = new Proxy<LabelMap>(labels2types, labelHandler);
 
 export const PRIMARY_UDN_BINDING = 'primary-udn-kubevirt-binding';

--- a/src/utils/resources/vm/utils/network/constants.ts
+++ b/src/utils/resources/vm/utils/network/constants.ts
@@ -1,7 +1,7 @@
 /* eslint-disable require-jsdoc */
 import { V1Interface, V1Network } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
-import { UDN_BINDING_NAME } from '../constants';
+import { BRIDGE, MASQUERADE, SRIOV, UDN_BINDING_NAME } from '../constants';
 
 export type NetworkPresentation = {
   iface: V1Interface;
@@ -16,19 +16,23 @@ const typeHandler = {
 
 const labelHandler = {
   get(target: LabelMap, prop: string) {
-    return target[prop] ?? 'bridge';
+    return target[prop] ?? BRIDGE;
   },
 };
 
-export type InterfaceTypes = 'bridge' | 'masquerade' | 'sriov' | typeof UDN_BINDING_NAME;
+export type InterfaceTypes =
+  | typeof BRIDGE
+  | typeof MASQUERADE
+  | typeof SRIOV
+  | typeof UDN_BINDING_NAME;
 type LabelMap = { [key: string]: InterfaceTypes };
 type TypeMap = { [key in InterfaceTypes]: string };
 
 const types2labels: TypeMap = {
   bridge: 'Bridge',
+  l2bridge: 'L2 bridge',
   masquerade: 'Masquerade',
   sriov: 'SR-IOV',
-  [UDN_BINDING_NAME]: 'L2 bridge',
 };
 
 const labels2types: LabelMap = Object.fromEntries(

--- a/src/views/catalog/wizard/tabs/overview/components/WizardOverviewNetworksTable/WizardOverviewNetworksTable.tsx
+++ b/src/views/catalog/wizard/tabs/overview/components/WizardOverviewNetworksTable/WizardOverviewNetworksTable.tsx
@@ -3,14 +3,15 @@ import * as React from 'react';
 import { WizardDescriptionItem } from '@catalog/wizard/components/WizardDescriptionItem';
 import { V1Interface, V1Network } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { BRIDGE, MASQUERADE, SRIOV } from '@kubevirt-utils/resources/vm/utils/constants';
 import { getNetworkInterfaceRowData } from '@kubevirt-utils/resources/vm/utils/network/rowData';
 import { getPrintableNetworkInterfaceType } from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { DescriptionList, Stack, StackItem } from '@patternfly/react-core';
 
 export const interfacesTypes = {
-  bridge: 'Bridge',
-  masquerade: 'Masquerade',
-  sriov: 'SR-IOV',
+  [BRIDGE]: 'Bridge',
+  [MASQUERADE]: 'Masquerade',
+  [SRIOV]: 'SR-IOV',
 };
 
 export const WizardOverviewNetworksTable: React.FC<{


### PR DESCRIPTION


## 📝 Description

`deviceIndex` property most likely leaked from [HardwareDeviceModalRow](https://github.com/kubevirt-ui/kubevirt-plugin/blob/4b8c4a624581fdaa7a2e5d5d96a27093b416df15/src/utils/components/HardwareDevices/utils/constants.ts#L7)  type. 

`l2bridge` prop leaked from [network interface to label mapping](https://github.com/kubevirt-ui/kubevirt-plugin/blob/4b8c4a624581fdaa7a2e5d5d96a27093b416df15/src/utils/resources/vm/utils/network/constants.ts#L21) which treats the same keys of [V1Interface](https://kubevirt.io/api-reference/v0.38.1/definitions.html#_v1_interface) and synthetic type `l2bridge`. 

Both cases fixed by explicit filtering and better typing (to prevent similar cases in the future).


## 🎥 Demo

### Before
![Screenshot from 2025-01-24 14-06-48](https://github.com/user-attachments/assets/d87a8ba7-6869-4b70-95c9-1f5884f74545)


