### PR TITLE
CNV-53271: select one namespace in catalog page

### DIFF
--- a/src/views/catalog/Catalog.tsx
+++ b/src/views/catalog/Catalog.tsx
@@ -5,11 +5,15 @@ import { useSignals } from '@preact/signals-react/runtime';
 
 import CreateVMHorizontalNav from './CreateVMHorizontalNav/CreateVMHorizontalNav';
 import CustomizeInstanceTypeVirtualMachine from './CustomizeInstanceType/CustomizeInstanceTypeVirtualMachine';
+import useSelectNamespace from './utils/useSelectNamespace';
 import { WizardVMContextProvider } from './utils/WizardVMContext';
 import Wizard from './wizard/Wizard';
 
 const Catalog: FC = () => {
   useSignals();
+
+  useSelectNamespace();
+
   return (
     <WizardVMContextProvider>
       <Routes>

--- a/src/views/catalog/utils/useSelectNamespace.tsx
+++ b/src/views/catalog/utils/useSelectNamespace.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useProjects from '@kubevirt-utils/hooks/useProjects';
+import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import { isSystemNamespace } from '@virtualmachines/tree/utils/utils';
+
+const useSelectNamespace = () => {
+  const [activeNamespace, setActiveNamespace] = useActiveNamespace();
+  const [projects, projectsLoaded] = useProjects();
+
+  useEffect(() => {
+    if (activeNamespace !== ALL_NAMESPACES_SESSION_KEY) return;
+    if (!projectsLoaded) return;
+
+    const userNamespace = projects?.filter((project) => !isSystemNamespace(project));
+    const defaultNamespace = projects?.find((project) => project === DEFAULT_NAMESPACE);
+
+    const namespaceToSelect = defaultNamespace || userNamespace?.[0] || projects?.[0];
+
+    setActiveNamespace(namespaceToSelect);
+  }, [activeNamespace, projects, projectsLoaded, setActiveNamespace]);
+};
+
+export default useSelectNamespace;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

In catalog, non-admin users do not see the `Create VirtualMachine` button enabled when `All namespaces` is selected. Don't really know what to do to enable that, hey have to select a namespace. 

Using `default` as a default namespace does not work as non-admin users may not have permissions to that namespace as it happens in `https://console.redhat.com/openshift/sandbox`

Solution:

select a default namespace. If the user have access to the default namespace, select it, if not, select the first non-system namespace and if not found, select the first namespace that we can find

## 🎥 Demo

**Before**

Template catalog
<img width="1920" alt="Screenshot 2025-01-27 at 10 14 08" src="https://github.com/user-attachments/assets/2f2a3c81-2fe2-456e-8011-6d862bc6c8b4" />


Instance Type
https://github.com/user-attachments/assets/1a69cbc0-c5b5-4d0f-8a0f-09d87ca0fe74


**After**

https://github.com/user-attachments/assets/6dbfab8b-c3ad-4e56-9746-207893dc2a4b


