### PR TITLE
CNV-55088: Scale VNC console

### DIFF
--- a/src/utils/components/Consoles/components/vnc-console/VncConsole.tsx
+++ b/src/utils/components/Consoles/components/vnc-console/VncConsole.tsx
@@ -34,7 +34,7 @@ export const VncConsole: FC<VncConsoleProps> = ({
   CustomConnectComponent,
   hasGPU,
   onConnect,
-  scaleViewport = false,
+  scaleViewport = true,
   viewOnly = false,
   vmi,
 }) => {
@@ -143,7 +143,7 @@ export const VncConsole: FC<VncConsoleProps> = ({
   }, [onConnect, connect, rfb, status]);
 
   return (
-    <div className="pf-c-console__vnc">
+    <>
       {status === disconnected &&
         (CustomConnectComponent ? (
           <CustomConnectComponent connect={connect} />
@@ -187,7 +187,7 @@ export const VncConsole: FC<VncConsoleProps> = ({
         </div>
       )}
       {StaticRenderLocation}
-    </div>
+    </>
   );
 };
 

--- a/src/utils/components/Consoles/components/vnc-console/vnc-console.scss
+++ b/src/utils/components/Consoles/components/vnc-console/vnc-console.scss
@@ -1,13 +1,15 @@
 .vnc-container {
   height: 100%;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+
   div:first-child {
     // vnc console use element as ref and inline styling on element to control auto resizing, we need to use important in this case.
     background-color: transparent !important;
     justify-content: center;
   }
   canvas {
-    width: 98% !important;
-    height: 100% !important;
     margin: 0 !important;
   }
 }
@@ -28,9 +30,4 @@
 .vnc-paste-button {
   margin-left: var(--pf-v5-global--spacer--sm);
   margin-right: var(--pf-v5-global--spacer--sm);
-}
-
-.pf-c-console__vnc {
-  width: 100%;
-  height: 100%;
 }

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
@@ -31,6 +31,20 @@ const VirtualMachinesOverviewTabDetailsConsole: FC<
   });
   return (
     <Bullseye className="bullseye">
+      <div className="link">
+        <Button
+          onClick={() =>
+            window.open(
+              `/k8s/ns/${vmi?.metadata?.namespace}/kubevirt.io~v1~VirtualMachine/${vmi?.metadata?.name}/console/standalone`,
+            )
+          }
+          isDisabled={!isVMRunning || isHeadlessMode || !canConnectConsole}
+          variant="link"
+        >
+          {t('Open web console')}
+          <ExternalLinkAltIcon className="icon" />
+        </Button>
+      </div>
       {isVMRunning && !isHeadlessMode && canConnectConsole ? (
         <>
           <VncConsole
@@ -47,20 +61,6 @@ const VirtualMachinesOverviewTabDetailsConsole: FC<
           />
         </div>
       )}
-      <div className="link">
-        <Button
-          onClick={() =>
-            window.open(
-              `/k8s/ns/${vmi?.metadata?.namespace}/kubevirt.io~v1~VirtualMachine/${vmi?.metadata?.name}/console/standalone`,
-            )
-          }
-          isDisabled={!isVMRunning || isHeadlessMode || !canConnectConsole}
-          variant="link"
-        >
-          {t('Open web console')}
-          <ExternalLinkAltIcon className="icon" />
-        </Button>
-      </div>
     </Bullseye>
   );
 };


### PR DESCRIPTION
## 📝 Description

Key points:
1. enable scaleViewport flag by default
2. move 'Open web console' link above the console - with insufficient
   width the link is pushed too far to the bottom. The console
   calculates the dimensions dynamically so it's not possible to assign
   the correct height in a static way.
3. remove unnecessary CSS

Based on works previously done for oVirt project - https://github.com/oVirt/ovirt-web-ui/pull/1585


## 🎥 Demo

### Before

https://github.com/user-attachments/assets/f38b2599-4cdb-4355-b7a0-ffe286b252f5


https://github.com/user-attachments/assets/dc6bb3d2-c704-4b4f-acaa-cc308990837e


### After

https://github.com/user-attachments/assets/947c6926-cfba-4e84-9621-19c5e9590970


https://github.com/user-attachments/assets/314c7a05-5f2e-47c4-b2e0-a9233a1769e6


