### PR TITLE
CNV-55042: instancetype list sort memory fixed

### DIFF
--- a/src/utils/utils/utils.ts
+++ b/src/utils/utils/utils.ts
@@ -112,22 +112,34 @@ const getValueByPath = (obj: K8sResourceCommon, path: string) => {
   return pathArray?.reduce((acc, field) => acc?.[field], obj);
 };
 
-export const columnSorting = <T>(
-  data: T[],
-  direction: string,
-  pagination: { [key: string]: any },
-  path: string,
-) => {
-  const { endIndex, startIndex } = pagination;
-  const predicate = (a: T, b: T) => {
-    const { first, second } =
-      direction === 'asc' ? { first: a, second: b } : { first: b, second: a };
-    return getValueByPath(first, path)
+export const comparePathsValues =
+  <T>(path: string) =>
+  (first: T, second: T): number =>
+    getValueByPath(first, path)
       ?.toString()
       ?.localeCompare(getValueByPath(second, path)?.toString(), undefined, {
         numeric: true,
         sensitivity: 'base',
       });
+
+export const columnSorting = <T>(
+  data: T[],
+  direction: string,
+  pagination: { [key: string]: any },
+  path: string,
+) => columnSortingCompare(data, direction, pagination, comparePathsValues(path));
+
+export const columnSortingCompare = <T>(
+  data: T[],
+  direction: string,
+  pagination: { [key: string]: any },
+  compareFunction: (a: T, b: T) => number,
+) => {
+  const { endIndex, startIndex } = pagination;
+  const predicate = (a: T, b: T) => {
+    const { first, second } =
+      direction === 'asc' ? { first: a, second: b } : { first: b, second: a };
+    return compareFunction(first, second);
   };
   return data?.sort(predicate)?.slice(startIndex, endIndex);
 };

--- a/src/views/instancetypes/list/hooks/useClusterInstancetypeListColumns.ts
+++ b/src/views/instancetypes/list/hooks/useClusterInstancetypeListColumns.ts
@@ -9,6 +9,8 @@ import { columnSorting } from '@kubevirt-utils/utils/utils';
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 
+import { sortInstanceTypeByMemory } from './utils';
+
 type UseClusterInstancetypeListColumnsValues = [
   TableColumn<V1beta1VirtualMachineClusterInstancetype>[],
   TableColumn<V1beta1VirtualMachineClusterInstancetype>[],
@@ -28,6 +30,11 @@ const useClusterInstancetypeListColumns: UseClusterInstancetypeListColumns = (pa
     [data, pagination],
   );
 
+  const sortingMemory = useCallback(
+    (direction) => sortInstanceTypeByMemory(data, direction, pagination),
+    [data, pagination],
+  );
+
   const columns: TableColumn<V1beta1VirtualMachineClusterInstancetype>[] = useMemo(
     () => [
       {
@@ -44,7 +51,7 @@ const useClusterInstancetypeListColumns: UseClusterInstancetypeListColumns = (pa
       },
       {
         id: 'memory',
-        sort: (_, direction) => sorting(direction, 'spec.memory.guest'),
+        sort: (_, direction) => sortingMemory(direction),
         title: t('Memory'),
         transforms: [sortable],
       },

--- a/src/views/instancetypes/list/hooks/useUserInstancetypeListColumns.ts
+++ b/src/views/instancetypes/list/hooks/useUserInstancetypeListColumns.ts
@@ -10,6 +10,8 @@ import { columnSorting } from '@kubevirt-utils/utils/utils';
 import { TableColumn, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 
+import { sortInstanceTypeByMemory } from './utils';
+
 type UseUserInstancetypeListColumnsValues = [
   TableColumn<V1beta1VirtualMachineInstancetype>[],
   TableColumn<V1beta1VirtualMachineInstancetype>[],
@@ -27,6 +29,11 @@ const useUserInstancetypeListColumns: UseUserInstancetypeListColumns = (paginati
 
   const sorting = useCallback(
     (direction, path) => columnSorting(data, direction, pagination, path),
+    [data, pagination],
+  );
+
+  const sortingMemory = useCallback(
+    (direction) => sortInstanceTypeByMemory(data, direction, pagination),
     [data, pagination],
   );
 
@@ -55,7 +62,7 @@ const useUserInstancetypeListColumns: UseUserInstancetypeListColumns = (paginati
     },
     {
       id: 'memory',
-      sort: (_, direction) => sorting(direction, 'spec.memory.guest'),
+      sort: (_, direction) => sortingMemory(direction),
       title: t('Memory'),
       transforms: [sortable],
     },

--- a/src/views/instancetypes/list/hooks/utils.ts
+++ b/src/views/instancetypes/list/hooks/utils.ts
@@ -1,0 +1,25 @@
+import { parseSize } from 'xbytes';
+
+import {
+  V1beta1VirtualMachineClusterInstancetype,
+  V1beta1VirtualMachineInstancetype,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { columnSortingCompare } from '@kubevirt-utils/utils/utils';
+
+const compareMemory = (
+  a: V1beta1VirtualMachineClusterInstancetype | V1beta1VirtualMachineInstancetype,
+  b: V1beta1VirtualMachineClusterInstancetype | V1beta1VirtualMachineInstancetype,
+) => {
+  const memoryA = a?.spec?.memory?.guest;
+  const memoryB = b?.spec?.memory?.guest;
+
+  const bytesA = parseSize(`${memoryA}B`);
+  const bytesB = parseSize(`${memoryB}B`);
+
+  return bytesA - bytesB;
+};
+
+export const sortInstanceTypeByMemory = (data, direction, pagination) =>
+  columnSortingCompare<
+    V1beta1VirtualMachineClusterInstancetype | V1beta1VirtualMachineInstancetype
+  >(data, direction, pagination, compareMemory);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description


sorting was not working as memory was not converted in bytes but compared as string. 
So 4Gi was smaller than 512Mi


Create a generic function that can sort any columns, make the existing function use the generic function adding the compared function. Use the generic function to sort memory with a custom compared function


## 🎥 Demo


<img width="1623" alt="Screenshot 2025-01-29 at 11 48 32" src="https://github.com/user-attachments/assets/46a2f1a2-e67a-4aca-a9ef-851437a36778" />

