### PR TITLE
CNV-55454: Fix metrics freezing

### DIFF
--- a/src/utils/components/Charts/NetworkUtil/NetworkThresholdChartSingleSource.tsx
+++ b/src/utils/components/Charts/NetworkUtil/NetworkThresholdChartSingleSource.tsx
@@ -21,7 +21,6 @@ import useResponsiveCharts from '../hooks/useResponsiveCharts';
 import {
   findNetworkMaxYValue,
   formatNetworkYTick,
-  getNetworkTickValues,
   MILLISECONDS_MULTIPLIER,
   tickFormat,
   TICKS_COUNT,
@@ -88,7 +87,7 @@ const NetworkThresholdSingleSourceChart: FC<NetworkThresholdSingleSourceChartPro
             }
             domain={{
               x: [currentTime - timespan, currentTime],
-              y: [0, getNetworkTickValues(Ymax + 1)?.length],
+              y: [0, Ymax + 1],
             }}
             height={height}
             padding={{ bottom: 60, left: 70, right: 60, top: 30 }}
@@ -104,7 +103,7 @@ const NetworkThresholdSingleSourceChart: FC<NetworkThresholdSingleSourceChartPro
               }}
               dependentAxis
               tickFormat={formatNetworkYTick}
-              tickValues={getNetworkTickValues(Ymax)}
+              tickValues={[0, Ymax]}
             />
             <ChartAxis
               style={{

--- a/src/utils/components/Charts/utils/utils.ts
+++ b/src/utils/components/Charts/utils/utils.ts
@@ -89,20 +89,11 @@ export const findNetworkMaxYValue = (
   return isNaN(roundedMax) ? 0 : roundedMax;
 };
 
-export const getNetworkTickValues = (Ymax: number) => {
-  const tickValues = Array.from({ length: Ymax + 1 }, (_, index) => {
-    if (index === 0) return '1 Bps';
-    if (index === Math.round(Ymax)) return `${Math.round(Ymax + 1)} Bps`;
-    return index.toString() + ' Bps';
-  });
-  return tickValues;
-};
-
 export const formatNetworkYTick = (tick: any, index: number, ticks: any[]) => {
   const isFirst = index === 0;
   const isLast = index === ticks.length - 1;
   if (isLast || isFirst) {
-    return tick;
+    return xbytes(tick, { fixed: 1, iec: true });
   }
   return;
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The network chart is on bps. This means that when the VM does a network traffic in the order of kbs or mbs, our code creates hundreds and millions of ticks in the Y axis.

Ticks are the Y axis points that we see. 

As you can see from the *before* charts, they are darker in the background. This is because millions of ticks have been created. 1 kps? 1000 bps -> 1000 ticks. 1mps ? 1_000_000 bps -> 1_000_000 ticks.

the `getNetworkTickValues` function was responsible to create the ticks in the chart and `formatNetworkYTick` is responsible to give at each tick a label. As you can see we give labels only to the first and last tick


We defined a label for the first one (min in the chart) and the maximum in the chart, but our code creates the ticks in between anyway without labels.

I removed this code and made sure to just create two ticks (first and last one) that represent the min and max and convert everything using a Mps Kps and so on

## 🎥 Demo
**Before**

<img width="1623" alt="Screenshot 2025-01-29 at 19 18 11" src="https://github.com/user-attachments/assets/7a9a7011-4eee-4528-bcc5-ff0be0dad61e" />


**After**

<img width="1623" alt="Screenshot 2025-01-29 at 19 15 31" src="https://github.com/user-attachments/assets/02122ee5-04b9-4314-809f-79514460e16b" />

