### PR TITLE
CNV-55050: Read dedicatedCpuPlacement status from InstanceType

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -220,7 +220,7 @@
   "By memory swap traffic": "By memory swap traffic",
   "By throughput": "By throughput",
   "By vCPU wait": "By vCPU wait",
-  "Can not configure dedicated resources if the VirtualMachine is created from InstanceType": "Can not configure dedicated resources if the VirtualMachine is created from InstanceType",
+  "Can not configure dedicated resources if the VirtualMachine is created from Instance Type": "Can not configure dedicated resources if the VirtualMachine is created from Instance Type",
   "Can not delete in view-only mode": "Can not delete in view-only mode",
   "Can not edit in view-only mode": "Can not edit in view-only mode",
   "Cancel": "Cancel",

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/SchedulingTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/SchedulingTab.tsx
@@ -9,7 +9,7 @@ import { ConfigurationInnerTabProps } from '../utils/types';
 
 import SchedulingSection from './components/SchedulingSection';
 
-const SchedulingTab: FC<ConfigurationInnerTabProps> = ({ vm, vmi }) => (
+const SchedulingTab: FC<ConfigurationInnerTabProps> = ({ instanceTypeVM, vm, vmi }) => (
   <SidebarEditor
     onResourceUpdate={onSubmitYAML}
     pathsToHighlight={PATHS_TO_HIGHLIGHT.SCHEDULING_TAB}
@@ -17,7 +17,7 @@ const SchedulingTab: FC<ConfigurationInnerTabProps> = ({ vm, vmi }) => (
   >
     {(resource) => (
       <PageSection variant={PageSectionVariants.light}>
-        <SchedulingSection vm={resource} vmi={vmi} />
+        <SchedulingSection instanceTypeVM={instanceTypeVM} vm={resource} vmi={vmi} />
       </PageSection>
     )}
   </SidebarEditor>

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSection.tsx
@@ -18,12 +18,13 @@ import SchedulingSectionLeftGrid from './SchedulingSectionLeftGrid';
 import SchedulingSectionRightGrid from './SchedulingSectionRightGrid';
 
 type SchedulingSectionProps = {
+  instanceTypeVM?: V1VirtualMachine;
   onSubmit?: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine>;
   vm: V1VirtualMachine;
   vmi?: V1VirtualMachineInstance;
 };
 
-const SchedulingSection: FC<SchedulingSectionProps> = ({ onSubmit, vm, vmi }) => {
+const SchedulingSection: FC<SchedulingSectionProps> = ({ instanceTypeVM, onSubmit, vm, vmi }) => {
   const { t } = useKubevirtTranslation();
   const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
     groupVersionKind: modelToGroupVersionKind(NodeModel),
@@ -49,6 +50,7 @@ const SchedulingSection: FC<SchedulingSectionProps> = ({ onSubmit, vm, vmi }) =>
         <GridItem span={1}>{/* Spacer */}</GridItem>
         <SchedulingSectionRightGrid
           canUpdateVM={canUpdateVM}
+          instanceTypeVM={instanceTypeVM}
           onUpdateVM={onSubmit}
           vm={vm}
           vmi={vmi}

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionRightGrid.tsx
@@ -10,7 +10,7 @@ import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getEvictionStrategy } from '@kubevirt-utils/resources/vm';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { isInstanceTypeVM } from '@kubevirt-utils/resources/vm/utils/instanceTypes';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList, GridItem } from '@patternfly/react-core';
 
@@ -18,6 +18,7 @@ import DedicatedResources from './DedicatedResources';
 
 type SchedulingSectionRightGridProps = {
   canUpdateVM: boolean;
+  instanceTypeVM?: V1VirtualMachine;
   onUpdateVM?: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine>;
   vm: V1VirtualMachine;
   vmi?: V1VirtualMachineInstance;
@@ -25,6 +26,7 @@ type SchedulingSectionRightGridProps = {
 
 const SchedulingSectionRightGrid: FC<SchedulingSectionRightGridProps> = ({
   canUpdateVM,
+  instanceTypeVM,
   onUpdateVM,
   vm,
   vmi,
@@ -53,7 +55,7 @@ const SchedulingSectionRightGrid: FC<SchedulingSectionRightGridProps> = ({
             <SearchItem id="dedicated-resources">{t('Dedicated resources')}</SearchItem>
           }
           messageOnDisabled={t(
-            'Can not configure dedicated resources if the VirtualMachine is created from InstanceType',
+            'Can not configure dedicated resources if the VirtualMachine is created from Instance Type',
           )}
           onEditClick={() =>
             createModal(({ isOpen, onClose }) => (
@@ -68,8 +70,8 @@ const SchedulingSectionRightGrid: FC<SchedulingSectionRightGridProps> = ({
             ))
           }
           data-test-id="dedicated-resources"
-          descriptionData={<DedicatedResources vm={vm} />}
-          isDisabled={!isEmpty(vm?.spec?.instancetype)}
+          descriptionData={<DedicatedResources vm={isInstanceTypeVM(vm) ? instanceTypeVM : vm} />}
+          isDisabled={isInstanceTypeVM(vm)}
           isEdit={canUpdateVM}
         />
         <VirtualMachineDescriptionItem


### PR DESCRIPTION


## 📝 Description

Propagate `instanceTypeVM` to Scheduling section and use as source of `dedicatedCpuPlacement` property.
`dedicatedCpuPlacement`  seems the only type of dedicated resource that is currently handled.

## 🎥 Demo

### Before

![Screenshot from 2025-01-30 19-07-44](https://github.com/user-attachments/assets/e30f41bd-f1e8-4ff3-a312-fbd936c520b2)

### After

![Screenshot from 2025-01-30 18-56-10](https://github.com/user-attachments/assets/777b01ca-82b0-4d26-9126-edb6747df629)
