### PR TITLE
CNV-54192: Make VNC Console in the Overview page read only

### DIFF
--- a/src/utils/components/Consoles/components/vnc-console/vnc-console.scss
+++ b/src/utils/components/Consoles/components/vnc-console/vnc-console.scss
@@ -13,6 +13,13 @@
     margin: 0 !important;
   }
 }
+
+.console-overview .vnc-container {
+  canvas {
+    cursor: auto !important;
+  }
+}
+
 .hide {
   display: none;
 }

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
@@ -30,7 +30,7 @@ const VirtualMachinesOverviewTabDetailsConsole: FC<
     verb: 'get',
   });
   return (
-    <Bullseye className="bullseye">
+    <Bullseye className="console-overview">
       <div className="link">
         <Button
           onClick={() =>
@@ -49,7 +49,7 @@ const VirtualMachinesOverviewTabDetailsConsole: FC<
         <>
           <VncConsole
             CustomConnectComponent={VirtualMachinesOverviewTabDetailsConsoleConnect}
-            scaleViewport
+            viewOnly
             vmi={vmi}
           />
         </>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/virtual-machines-overview-tab-details.scss
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/virtual-machines-overview-tab-details.scss
@@ -8,7 +8,7 @@
     height: 70%;
     width: 100%;
   }
-  .bullseye {
+  .console-overview {
     flex-direction: column;
     justify-content: space-around;
   }


### PR DESCRIPTION
## 📝 Description

Toggle `viewOnly` flag and adjust cursor styling.

