### PR TITLE
CNV-54463: Remove memoization from CPU/Memory/Network usage columns

### DIFF
--- a/src/views/virtualmachines/list/components/VirtualMachineRow/components/CPUPercentage.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/components/CPUPercentage.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo } from 'react';
+import React, { FC } from 'react';
 
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -18,4 +18,4 @@ const CPUPercentage: FC<CPUPercentageProps> = ({ vmName, vmNamespace }) => {
   return <span>{percentage.toFixed(2)}%</span>;
 };
 
-export default memo(CPUPercentage);
+export default CPUPercentage;

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/components/MemoryPercentage.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/components/MemoryPercentage.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo } from 'react';
+import React, { FC } from 'react';
 import xbytes from 'xbytes';
 
 import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
@@ -27,4 +27,4 @@ const MemoryPercentage: FC<MemoryPercentageProps> = ({ vmiMemory, vmName, vmName
   return <span>{percentage.toFixed(2)}%</span>;
 };
 
-export default memo(MemoryPercentage);
+export default MemoryPercentage;

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/components/NetworkUsage.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/components/NetworkUsage.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo } from 'react';
+import React, { FC } from 'react';
 import xbytes from 'xbytes';
 
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
@@ -22,4 +22,4 @@ const NetworkUsage: FC<NetworkUsageProps> = ({ vmName, vmNamespace }) => {
   return <div>{totalTransferred}ps</div>;
 };
 
-export default memo(NetworkUsage);
+export default NetworkUsage;


### PR DESCRIPTION

## 📝 Description
All three components rely on re-render to fetch new values via getVMMetrics() call. They are simple leaf nodes so there should be no measurable performance impact.
