### PR TITLE
CNV-41922: Alerts are displayed in the wrong order in the Virtualization Overview page

### DIFF
--- a/src/utils/components/AlertsCard/utils/utils.tsx
+++ b/src/utils/components/AlertsCard/utils/utils.tsx
@@ -47,7 +47,8 @@ export const removeVMAlerts = (sortedAlerts: SimplifiedAlerts) =>
 
       return acc;
     },
-    { critical: [], info: [], warning: [] },
+    // eslint-disable-next-line perfectionist/sort-objects
+    { critical: [], warning: [], info: [] },
   );
 
 export const createAlertKey = (activeAt: string, labels: PrometheusLabels) =>


### PR DESCRIPTION
## 📝 Description

arrange order for just virtualization scope alerts

## 🎥 Demo

Before:
![alerts](https://github.com/user-attachments/assets/f6c75ad7-7169-44f0-a514-eff02f3fa156)

After:
![alerts-right-order-after](https://github.com/user-attachments/assets/68b117ec-3ae2-4bbd-839c-53b05ac44e34)

