### PR TITLE
CNV-55749: fix editing disk error

### DIFF
--- a/src/utils/components/DiskModal/OtherDiskModal.tsx
+++ b/src/utils/components/DiskModal/OtherDiskModal.tsx
@@ -16,19 +16,18 @@ import DiskSizeInput from './components/DiskSizeInput/DiskSizeInput';
 import DiskTypeSelect from './components/DiskTypeSelect/DiskTypeSelect';
 import PendingChanges from './components/PendingChanges';
 import StorageClassAndPreallocation from './components/StorageClassAndPreallocation/StorageClassAndPreallocation';
-import usePVCDiskSource from './hooks/usePVCDiskSource';
 import { getDefaultCreateValues, getDefaultEditValues } from './utils/form';
 import { diskModalTitle, doesDataVolumeTemplateHaveDisk } from './utils/helpers';
 import { submit } from './utils/submit';
 import { SourceTypes, V1DiskFormState, V1SubDiskModalProps } from './utils/types';
 
 const OtherDiskModal: FC<V1SubDiskModalProps> = ({
-  createdPVCName,
   editDiskName,
   isCreated,
   isOpen,
   onClose,
   onSubmit,
+  pvc,
   vm,
 }) => {
   const isVMRunning = isRunning(vm);
@@ -41,8 +40,6 @@ const OtherDiskModal: FC<V1SubDiskModalProps> = ({
       : getDefaultCreateValues(vm, SourceTypes.OTHER),
     mode: 'all',
   });
-
-  const [pvc] = usePVCDiskSource(createdPVCName, namespace);
 
   const {
     formState: { isSubmitting, isValid },

--- a/src/utils/components/DiskModal/utils/submit.ts
+++ b/src/utils/components/DiskModal/utils/submit.ts
@@ -125,9 +125,10 @@ type SubmitInput = {
 export const submit = async ({ data, editDiskName, onSubmit, pvc, vm }: SubmitInput) => {
   const isVMRunning = isRunning(vm);
 
-  const shouldHotplug = isVMRunning && isEmpty(data.volume.containerDisk);
-
   const isEditDisk = !isEmpty(editDiskName);
+  const isCreatingDisk = isEmpty(editDiskName);
+  const shouldHotplug = isVMRunning && isCreatingDisk && isEmpty(data.volume.containerDisk);
+
   const isInitialBootDisk = getBootDisk(vm)?.name === editDiskName;
 
   const vmWithDisk = isEditDisk ? editDisk(data, editDiskName, vm) : addDisk(data, vm);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Editing a disk was triggering hotplug instead of just editing the VM


The 'Other' disk modal was fetching again the PVC but we already have a prop for that. We fetch it on DiskModal component 
