### PR TITLE
CNV-55087: Use custom chart styles based on PatternFly CSS variables

### DIFF
--- a/src/utils/components/Charts/CPUUtil/CPUThresholdChart.tsx
+++ b/src/utils/components/Charts/CPUUtil/CPUThresholdChart.tsx
@@ -22,6 +22,7 @@ import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
+import { tickLabels } from '../ChartLabels/styleOverrides';
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
 import { getUtilizationQueries } from '../utils/queries';
@@ -103,6 +104,7 @@ const CPUThresholdChart: FC<CPUThresholdChartProps> = ({ pods, vmi }) => {
                 grid: {
                   stroke: chart_color_black_200.value,
                 },
+                tickLabels,
               }}
               dependentAxis
               tickFormat={(tick: number) => tick?.toFixed(2)}
@@ -110,7 +112,7 @@ const CPUThresholdChart: FC<CPUThresholdChartProps> = ({ pods, vmi }) => {
             />
             <ChartAxis
               style={{
-                tickLabels: { padding: 2 },
+                tickLabels: { padding: 2, ...tickLabels },
                 ticks: { stroke: 'transparent' },
               }}
               axisComponent={<></>}

--- a/src/utils/components/Charts/ChartLabels/SubTitleChartLabel.tsx
+++ b/src/utils/components/Charts/ChartLabels/SubTitleChartLabel.tsx
@@ -1,0 +1,9 @@
+import React, { FC } from 'react';
+
+import { ChartLabel, ChartLabelProps } from '@patternfly/react-charts';
+
+const SubTitleChartLabel: FC<ChartLabelProps> = (props) => (
+  <ChartLabel {...props} style={{ fill: 'var(--pf-v5-global--Color--400)', fontSize: 14 }} />
+);
+
+export default SubTitleChartLabel;

--- a/src/utils/components/Charts/ChartLabels/TitleChartLabel.tsx
+++ b/src/utils/components/Charts/ChartLabels/TitleChartLabel.tsx
@@ -1,0 +1,9 @@
+import React, { FC } from 'react';
+
+import { ChartLabel, ChartLabelProps } from '@patternfly/react-charts';
+
+const TitleChartLabel: FC<ChartLabelProps> = (props) => (
+  <ChartLabel {...props} style={{ fill: 'var(--pf-v5-global--Color--100)', fontSize: 24 }} />
+);
+
+export default TitleChartLabel;

--- a/src/utils/components/Charts/ChartLabels/styleOverrides.ts
+++ b/src/utils/components/Charts/ChartLabels/styleOverrides.ts
@@ -1,0 +1,3 @@
+export const tickLabels = {
+  fill: 'var(--pf-v5-global--Color--200)',
+};

--- a/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
+++ b/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
@@ -20,6 +20,7 @@ import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
+import { tickLabels } from '../ChartLabels/styleOverrides';
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
 import { getUtilizationQueries } from '../utils/queries';
@@ -92,7 +93,7 @@ const MemoryThresholdChart: FC<MemoryThresholdChartProps> = ({ vmi }) => {
           >
             <ChartAxis
               style={{
-                tickLabels: { padding: 2 },
+                tickLabels: { padding: 2, ...tickLabels },
                 ticks: { stroke: 'transparent' },
               }}
               axisComponent={<></>}
@@ -104,6 +105,7 @@ const MemoryThresholdChart: FC<MemoryThresholdChartProps> = ({ vmi }) => {
                 grid: {
                   stroke: chart_color_black_200.value,
                 },
+                tickLabels,
               }}
               dependentAxis
               tickFormat={(tick: number) => xbytes(tick, { fixed: 2, iec: true })}

--- a/src/utils/components/Charts/MigrationUtil/MigrationThresholdChart.tsx
+++ b/src/utils/components/Charts/MigrationUtil/MigrationThresholdChart.tsx
@@ -19,6 +19,7 @@ import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
+import { tickLabels } from '../ChartLabels/styleOverrides';
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
 import { getUtilizationQueries } from '../utils/queries';
@@ -133,6 +134,7 @@ const MigrationThresholdChart: React.FC<MigrationThresholdChartProps> = ({ vmi }
                 grid: {
                   stroke: chart_color_black_200.value,
                 },
+                tickLabels,
               }}
               dependentAxis
               tickFormat={formatMemoryYTick(yMax, 2)}
@@ -140,7 +142,7 @@ const MigrationThresholdChart: React.FC<MigrationThresholdChartProps> = ({ vmi }
             />
             <ChartAxis
               style={{
-                tickLabels: { padding: 2 },
+                tickLabels: { padding: 2, ...tickLabels },
                 ticks: { stroke: 'transparent' },
               }}
               axisComponent={<></>}

--- a/src/utils/components/Charts/MigrationUtil/MigrationThresholdChartDiskRate.tsx
+++ b/src/utils/components/Charts/MigrationUtil/MigrationThresholdChartDiskRate.tsx
@@ -17,6 +17,7 @@ import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
+import { tickLabels } from '../ChartLabels/styleOverrides';
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
 import { getUtilizationQueries } from '../utils/queries';
@@ -85,6 +86,7 @@ const MigrationThresholdChartDiskRate: React.FC<MigrationThresholdChartDiskRateP
                 grid: {
                   stroke: chart_color_black_200.value,
                 },
+                tickLabels,
               }}
               dependentAxis
               tickFormat={formatMemoryYTick(yMax, 2)}
@@ -92,7 +94,7 @@ const MigrationThresholdChartDiskRate: React.FC<MigrationThresholdChartDiskRateP
             />
             <ChartAxis
               style={{
-                tickLabels: { padding: 2 },
+                tickLabels: { padding: 2, ...tickLabels },
                 ticks: { stroke: 'transparent' },
               }}
               axisComponent={<></>}

--- a/src/utils/components/Charts/NetworkUtil/NetworkThresholdChart.tsx
+++ b/src/utils/components/Charts/NetworkUtil/NetworkThresholdChart.tsx
@@ -16,6 +16,7 @@ import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_
 import chart_color_blue_400 from '@patternfly/react-tokens/dist/esm/chart_color_blue_400';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
+import { tickLabels } from '../ChartLabels/styleOverrides';
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
 import { getUtilizationQueries } from '../utils/queries';
@@ -84,7 +85,7 @@ const NetworkThresholdChart: React.FC<NetworkThresholdChartProps> = ({ vmi }) =>
           >
             <ChartAxis
               style={{
-                tickLabels: { padding: 2 },
+                tickLabels: { padding: 2, ...tickLabels },
                 ticks: { stroke: 'transparent' },
               }}
               axisComponent={<></>}

--- a/src/utils/components/Charts/NetworkUtil/NetworkThresholdChartSingleSource.tsx
+++ b/src/utils/components/Charts/NetworkUtil/NetworkThresholdChartSingleSource.tsx
@@ -16,6 +16,7 @@ import {
 import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
+import { tickLabels } from '../ChartLabels/styleOverrides';
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
 import {
@@ -100,6 +101,7 @@ const NetworkThresholdSingleSourceChart: FC<NetworkThresholdSingleSourceChartPro
                 grid: {
                   stroke: chart_color_black_200.value,
                 },
+                tickLabels,
               }}
               dependentAxis
               tickFormat={formatNetworkYTick}
@@ -107,7 +109,7 @@ const NetworkThresholdSingleSourceChart: FC<NetworkThresholdSingleSourceChartPro
             />
             <ChartAxis
               style={{
-                tickLabels: { padding: 2 },
+                tickLabels: { padding: 2, ...tickLabels },
                 ticks: { stroke: 'transparent' },
               }}
               axisComponent={<></>}

--- a/src/utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom-v5-compat';
 import xbytes from 'xbytes';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { tickLabels } from '@kubevirt-utils/components/Charts/ChartLabels/styleOverrides';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
@@ -94,6 +95,7 @@ const StorageTotalReadWriteThresholdChart: React.FC<StorageTotalReadWriteThresho
                 grid: {
                   stroke: chart_color_black_200.value,
                 },
+                tickLabels,
               }}
               dependentAxis
               tickFormat={(tick: number) => xbytes(tick, { fixed: 2, iec: true })}
@@ -101,7 +103,7 @@ const StorageTotalReadWriteThresholdChart: React.FC<StorageTotalReadWriteThresho
             />
             <ChartAxis
               style={{
-                tickLabels: { padding: 2 },
+                tickLabels: { padding: 2, ...tickLabels },
                 ticks: { stroke: 'transparent' },
               }}
               axisComponent={<></>}

--- a/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/components/MigrationsTimeAxis.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/components/MigrationsTimeAxis.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { tickLabels } from '@kubevirt-utils/components/Charts/ChartLabels/styleOverrides';
 import useResponsiveCharts from '@kubevirt-utils/components/Charts/hooks/useResponsiveCharts';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ChartAxis, ChartContainer } from '@patternfly/react-charts';
@@ -31,6 +32,7 @@ const MigrationsTimeAxis: FC<MigrationsTimeAxisProps> = ({ domainX, timespan }) 
           orientation="top"
           padding={{ bottom: 0, left: 70, right: 0, top: 30 }}
           scale={{ x: 'time' }}
+          style={{ tickLabels }}
           tickFormat={(time) => formatTimestamp(timespan, time, true)}
           tickValues={getTimeTickValues(domainX)}
           width={width}

--- a/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/components/MigrationsUtilizationChart.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/components/MigrationsUtilizationChart.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { tickLabels } from '@kubevirt-utils/components/Charts/ChartLabels/styleOverrides';
 import useResponsiveCharts from '@kubevirt-utils/components/Charts/hooks/useResponsiveCharts';
 import { Chart, ChartAxis, ChartLine, createContainer } from '@patternfly/react-charts';
 import { GridItem } from '@patternfly/react-core';
@@ -56,6 +57,7 @@ const MigrationsUtilizationChart: FC<MigrationsUtilizationChartProps> = ({
             axisComponent={<></>}
             dependentAxis
             showGrid
+            style={{ tickLabels }}
             tickFormat={tickFormat}
             tickValues={tickValues}
           />

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationsChartDonut.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationsChartDonut.tsx
@@ -1,6 +1,8 @@
 import React, { FC } from 'react';
 
 import { V1VirtualMachineInstanceMigration } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/SubTitleChartLabel';
+import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { OnFilterChange } from '@openshift-console/dynamic-plugin-sdk';
 import { ChartDonut } from '@patternfly/react-charts';
@@ -51,7 +53,9 @@ const MigrationsChartDonut: FC<MigrationsChartDonutProps> = ({ onFilterChange, v
         legendPosition="bottom"
         padding={20}
         subTitle={t('Migrations')}
+        subTitleComponent={<SubTitleChartLabel />}
         title={vmims?.length.toString()}
+        titleComponent={<TitleChartLabel />}
         width={600}
       />
       <MigrationChartLegend legendItems={chartData} onFilterChange={onFilterChange} />

--- a/src/views/clusteroverview/OverviewTab/metric-charts-card/components/MetricChart.tsx
+++ b/src/views/clusteroverview/OverviewTab/metric-charts-card/components/MetricChart.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { tickLabels } from '@kubevirt-utils/components/Charts/ChartLabels/styleOverrides';
 import useResponsiveCharts from '@kubevirt-utils/components/Charts/hooks/useResponsiveCharts';
 import {
   Chart,
@@ -42,6 +43,7 @@ const MetricChart: React.FC<MetricChartProps> = ({ metric, metricChartData }) =>
             grid: {
               stroke: chart_color_black_200.value,
             },
+            tickLabels,
           }}
           axisComponent={<></>}
           dependentAxis
@@ -53,6 +55,7 @@ const MetricChart: React.FC<MetricChartProps> = ({ metric, metricChartData }) =>
             axis: {
               stroke: chart_color_black_200.value,
             },
+            tickLabels,
           }}
           fixLabelOverlap
           tickFormat={xAxisTickFormat}

--- a/src/views/clusteroverview/OverviewTab/vms-per-resource-card/VMsPerResourceChart.tsx
+++ b/src/views/clusteroverview/OverviewTab/vms-per-resource-card/VMsPerResourceChart.tsx
@@ -1,6 +1,8 @@
 import React, { FC, useMemo } from 'react';
 import { ReactNode } from 'react';
 
+import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/SubTitleChartLabel';
+import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
 import LoadingEmptyState from '@kubevirt-utils/components/LoadingEmptyState/LoadingEmptyState';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ChartDonut } from '@patternfly/react-charts';
@@ -54,7 +56,9 @@ const VMsPerResourceChart: FC<VMsPerResourceChartProps> = ({ type }) => {
         height={150}
         labels={({ datum }) => `${getInstanceTypeSeriesLabel(datum.x)}: ${datum.y}%`}
         subTitle={t('VMs')}
+        subTitleComponent={<SubTitleChartLabel />}
         title={vmsPerResourcesCount?.toString()}
+        titleComponent={<TitleChartLabel />}
         width={300}
       />
     </div>

--- a/src/views/dashboard-extensions/KubevirtHealthPopup/components/HealthPopupChart.tsx
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/components/HealthPopupChart.tsx
@@ -1,5 +1,7 @@
 import React, { FC, useMemo } from 'react';
 
+import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/SubTitleChartLabel';
+import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
 import { AlertsByHealthImpact } from '@kubevirt-utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -52,7 +54,9 @@ const HealthPopupChart: FC<HealthPopupChartProps> = ({ alerts, numberOfAlerts })
         height={150}
         labels={({ datum }) => `${datum?.x}: ${datum?.y}%`}
         subTitle={t('Alerts')}
+        subTitleComponent={<SubTitleChartLabel />}
         title={totalNumberAlerts?.toString()}
+        titleComponent={<TitleChartLabel />}
         width={150}
       />
     </div>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
@@ -1,6 +1,8 @@
 import React, { FC, useMemo } from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/SubTitleChartLabel';
+import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
 import ComponentReady from '@kubevirt-utils/components/Charts/ComponentReady/ComponentReady';
 import { getUtilizationQueries } from '@kubevirt-utils/components/Charts/utils/queries';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -10,7 +12,7 @@ import {
   PrometheusEndpoint,
   usePrometheusPoll,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { ChartDonutUtilization, ChartLabel } from '@patternfly/react-charts';
+import { ChartDonutUtilization } from '@patternfly/react-charts';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
 type CPUUtilProps = {
@@ -70,8 +72,9 @@ const CPUUtil: FC<CPUUtilProps> = ({ pods, vmi }) => {
             labels={({ datum }) => (datum.x ? `${datum.x}: ${(cpuUsage || 0)?.toFixed(2)}m` : null)}
             style={{ labels: { fontSize: 20 } }}
             subTitle={t('Used')}
-            subTitleComponent={<ChartLabel y={135} />}
+            subTitleComponent={<SubTitleChartLabel y={135} />}
             title={`${averageCPUUsage.toFixed(2) || 0}%`}
+            titleComponent={<TitleChartLabel />}
           />
         </ComponentReady>
       </div>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
@@ -2,6 +2,8 @@ import React, { FC, useMemo } from 'react';
 import xbytes from 'xbytes';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/SubTitleChartLabel';
+import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
 import ComponentReady from '@kubevirt-utils/components/Charts/ComponentReady/ComponentReady';
 import { getUtilizationQueries } from '@kubevirt-utils/components/Charts/utils/queries';
 import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
@@ -9,7 +11,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { getMemory } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
-import { ChartDonutUtilization, ChartLabel } from '@patternfly/react-charts';
+import { ChartDonutUtilization } from '@patternfly/react-charts';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
 type MemoryUtilProps = {
@@ -63,8 +65,9 @@ const MemoryUtil: FC<MemoryUtilProps> = ({ vmi }) => {
             constrainToVisibleArea
             style={{ labels: { fontSize: 20 } }}
             subTitle={t('Used')}
-            subTitleComponent={<ChartLabel y={135} />}
+            subTitleComponent={<SubTitleChartLabel y={135} />}
             title={`${Number(percentageMemoryUsed?.toFixed(2))}%`}
+            titleComponent={<TitleChartLabel />}
           />
         </ComponentReady>
       </div>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/StorageUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/StorageUtil.tsx
@@ -2,11 +2,13 @@ import React, { FC } from 'react';
 import xbytes from 'xbytes';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/SubTitleChartLabel';
+import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
 import ComponentReady from '@kubevirt-utils/components/Charts/ComponentReady/ComponentReady';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useGuestOS } from '@kubevirt-utils/resources/vmi';
 import { removeDuplicatesByName } from '@kubevirt-utils/utils/utils';
-import { ChartDonutUtilization, ChartLabel } from '@patternfly/react-charts';
+import { ChartDonutUtilization } from '@patternfly/react-charts';
 
 type StorageUtilProps = {
   vmi: V1VirtualMachineInstance;
@@ -59,8 +61,9 @@ const StorageUtil: FC<StorageUtilProps> = ({ vmi }) => {
             constrainToVisibleArea
             style={{ labels: { fontSize: 20 } }}
             subTitle={t('Used')}
-            subTitleComponent={<ChartLabel y={135} />}
+            subTitleComponent={<SubTitleChartLabel y={135} />}
             title={`${usedPercentage.toFixed(2) || 0}%`}
+            titleComponent={<TitleChartLabel />}
           />
         </ComponentReady>
       </div>


### PR DESCRIPTION
## 📝 Description
Chart styles are not overwritten in dark theme. As a workaround use
the same approach as OpenShift Console: configure custom style based
on standard PatternFly CSS variables that are correctly overwritten in
dark theme.

Reference-Url: https://github.com/openshift/console/blob/0ec4d06857e6021c92edab3435794c5869194c82/frontend/public/components/graphs/themes.ts#L7
Reference-Url: https://github.com/openshift/console/blob/0ec4d06857e6021c92edab3435794c5869194c82/frontend/packages/pipelines-plugin/src/components/pipelines/pipeline-metrics/charts/successRatioDonut.tsx#L34



## 🎥 Demo

### Before
![Screenshot from 2025-02-04 19-55-03](https://github.com/user-attachments/assets/b01167ca-963f-4471-8dda-62f04bd67db2)
![Screenshot from 2025-02-04 19-54-53](https://github.com/user-attachments/assets/70efd507-69e2-45c0-94d0-e339b71877f8)

![Screenshot from 2025-02-04 18-50-52](https://github.com/user-attachments/assets/500d117c-25e9-4ed7-b301-79dd33096648)
![Screenshot from 2025-02-04 18-46-09](https://github.com/user-attachments/assets/5475e3d8-3fc6-48ab-b1bc-d2ed5f579fa9)
### After
![image](https://github.com/user-attachments/assets/7ab75407-c192-48f7-9338-05c2927100cb)

![Screenshot from 2025-02-04 17-42-36](https://github.com/user-attachments/assets/bc76d970-6529-4dd0-8447-dee7d42143c5)
![Screenshot from 2025-02-04 19-37-23](https://github.com/user-attachments/assets/f6989070-d5b3-4528-a506-0be4fb139c5b)
![Screenshot from 2025-02-04 18-49-23](https://github.com/user-attachments/assets/4f96ab50-ad71-44f8-b9a9-bad3b634fba9)



