### PR TITLE
CNV-55086: persist vm tab on treeview vm switch

### DIFF
--- a/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
+++ b/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
@@ -15,15 +15,17 @@ import { NavPageKubevirt, trimLastHistoryPath } from './utils/utils';
 import './horizontal-nav-bar.scss';
 
 type HorizontalNavbarProps = {
-  expandedSpecLoading?: boolean;
+  error?: any;
   instanceTypeExpandedSpec?: V1VirtualMachine;
+  loaded?: boolean;
   pages: NavPageKubevirt[];
   vm?: V1VirtualMachine;
 };
 
 const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
-  expandedSpecLoading,
+  error,
   instanceTypeExpandedSpec,
+  loaded,
   pages,
   vm,
 }) => {
@@ -81,7 +83,7 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
           return (
             <Route
               Component={(props) => (
-                <StateHandler loaded={!expandedSpecLoading} withBullseye>
+                <StateHandler error={error} loaded={loaded} withBullseye>
                   <Component
                     instanceTypeExpandedSpec={instanceTypeExpandedSpec}
                     obj={vm}

--- a/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import HorizontalNavbar from '@kubevirt-utils/components/HorizontalNavbar/HorizontalNavbar';
 import { SidebarEditorProvider } from '@kubevirt-utils/components/SidebarEditor/SidebarEditorContext';
-import StateHandler from '@kubevirt-utils/components/StateHandler/StateHandler';
 import useInstanceTypeExpandSpec from '@kubevirt-utils/resources/vm/hooks/useInstanceTypeExpandSpec';
 import { isInstanceTypeVM } from '@kubevirt-utils/resources/vm/utils/instanceTypes';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -42,16 +41,15 @@ const VirtualMachineNavPage: React.FC<VirtualMachineDetailsPageProps> = ({
         name={name}
         vm={isInstanceTypeVM(vm) ? instanceTypeExpandedSpec : vm}
       />
-      <StateHandler error={loadError} loaded={isLoaded} withBullseye>
-        <div className="VirtualMachineNavPage--tabs__main">
-          <HorizontalNavbar
-            expandedSpecLoading={expandedSpecLoading}
-            instanceTypeExpandedSpec={instanceTypeExpandedSpec}
-            pages={pages}
-            vm={vm}
-          />
-        </div>
-      </StateHandler>
+      <div className="VirtualMachineNavPage--tabs__main">
+        <HorizontalNavbar
+          error={loadError}
+          instanceTypeExpandedSpec={instanceTypeExpandedSpec}
+          loaded={isLoaded && !expandedSpecLoading}
+          pages={pages}
+          vm={vm}
+        />
+      </div>
     </SidebarEditorProvider>
   );
 };

--- a/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom-v5-compat';
 
 import { VirtualMachineModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -22,6 +23,8 @@ export type UseTreeViewData = {
 
 export const useTreeViewData = (): UseTreeViewData => {
   const isAdmin = useIsAdmin();
+  const location = useLocation();
+
   const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
   const [projectNames, projectNamesLoaded, projectNamesError] = useProjects();
 
@@ -63,7 +66,7 @@ export const useTreeViewData = (): UseTreeViewData => {
             treeViewFoldersEnabled,
           )
         : [],
-    [projectNames, memoizedVMs, isAdmin, treeViewFoldersEnabled],
+    [projectNames, memoizedVMs, isAdmin, treeViewFoldersEnabled, location.pathname],
   );
 
   const isSwitchDisabled = useMemo(() => projectNames.every(isSystemNamespace), [projectNames]);

--- a/src/views/virtualmachines/tree/utils/utils.tsx
+++ b/src/views/virtualmachines/tree/utils/utils.tsx
@@ -26,6 +26,7 @@ export interface TreeViewDataItemWithHref extends TreeViewDataItem {
 const buildProjectMap = (
   vms: V1VirtualMachine[],
   currentPageVMName: string,
+  currentVMTab: string,
   treeViewDataMap: Record<string, TreeViewDataItemWithHref>,
   foldersEnabled: boolean,
 ) => {
@@ -47,11 +48,11 @@ const buildProjectMap = (
 
     const vmTreeItem: TreeViewDataItemWithHref = {
       defaultExpanded: currentPageVMName && currentPageVMName === vmName,
-      href: getResourceUrl({
+      href: `${getResourceUrl({
         activeNamespace: vmNamespace,
         model: VirtualMachineModel,
         resource: { metadata: { name: vmName, namespace: vmNamespace } },
-      }),
+      })}/${currentVMTab}`,
       icon: <VMStatusIcon />,
       id: vmTreeItemID,
       name: vmName,
@@ -175,6 +176,15 @@ const createAllNamespacesTreeItem = (
   return allNamespacesTreeItem;
 };
 
+const getVMInfoFromPathname = (pathname: string) => {
+  const splitPathname = pathname.split('/');
+  const currentVMTab = splitPathname?.[6] || '';
+  const vmName = splitPathname?.[5];
+  const vmNamespace = splitPathname?.[3];
+
+  return { currentVMTab, vmName, vmNamespace };
+};
+
 export const createTreeViewData = (
   projectNames: string[],
   vms: V1VirtualMachine[],
@@ -182,19 +192,13 @@ export const createTreeViewData = (
   pathname: string,
   foldersEnabled: boolean,
 ): TreeViewDataItem[] => {
-  const currentPageVMName = pathname.split('/')[5];
-  const currentPageNamespace = pathname.split('/')[3];
+  const { currentVMTab, vmName, vmNamespace } = getVMInfoFromPathname(pathname);
+
   const treeViewDataMap: Record<string, TreeViewDataItem> = {};
-  const projectMap = buildProjectMap(vms, currentPageVMName, treeViewDataMap, foldersEnabled);
+  const projectMap = buildProjectMap(vms, vmName, currentVMTab, treeViewDataMap, foldersEnabled);
 
   const treeViewData = projectNames.map((project) =>
-    createProjectTreeItem(
-      project,
-      projectMap,
-      currentPageVMName,
-      currentPageNamespace,
-      treeViewDataMap,
-    ),
+    createProjectTreeItem(project, projectMap, vmName, vmNamespace, treeViewDataMap),
   );
 
   const allNamespacesTreeItem = isAdmin


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When switching between vms, persist the tab

During the switch make sure to visualize all the tabs and have the loading inside them.
Previously there were two StateHandler for the loading. As you can see from the demo, there was a loading before displaying the tabs and another loading for the tab content. Now we display the tabs and the loading inside so the switch between vms does not have so much shifts


## 🎥 Demo

**Before**

https://github.com/user-attachments/assets/61ff03c4-5974-41af-a05b-6b369de4c674



**After**

https://github.com/user-attachments/assets/afe75262-3184-4fc3-b6db-85ea16e81767


