### PR TITLE
CNV-51525: Remove "Start" button from ICON action list when VM in pause

### DIFF
--- a/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
@@ -246,9 +246,16 @@ export const VirtualMachineActionFactory = {
       accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
       cta: () => startVM(vm),
       disabled:
-        [Migrating, Provisioning, Running, Starting, Stopping, Terminating, Unknown].includes(
-          vm?.status?.printableStatus,
-        ) ||
+        [
+          Migrating,
+          Paused,
+          Provisioning,
+          Running,
+          Starting,
+          Stopping,
+          Terminating,
+          Unknown,
+        ].includes(vm?.status?.printableStatus) ||
         isSnapshotting(vm) ||
         isRestoring(vm),
       id: 'vm-action-start',


### PR DESCRIPTION
## 📝 Description

Adding paused to list of statuses start should be disabled in.

## 🎥 Demo

Before:
![start-icon-non-disabled-when-vm-paused](https://github.com/user-attachments/assets/0ed31214-b5fb-4a0d-85fd-76565adcbb3d)

After:
![start-icon-non-disabled-when-vm-paused-after](https://github.com/user-attachments/assets/b1ba1cd7-a5d2-49fe-bc23-66cade029b75)

