### PR TITLE
CNV-51198: Fix YAML template displayed when clicking "Add volume" -> "By YAML" on the Bootable volumes page

### DIFF
--- a/src/views/bootablevolumes/list/components/BootableVolumeAddButton.tsx
+++ b/src/views/bootablevolumes/list/components/BootableVolumeAddButton.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
-import { DataSourceModelRef } from '@kubevirt-ui/kubevirt-api/console';
+import { DataVolumeModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import AddBootableVolumeModal from '@kubevirt-utils/components/AddBootableVolumeModal/AddBootableVolumeModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
@@ -30,7 +30,7 @@ const BootableVolumeAddButton: FC<BootableVolumeAddButtonProps> = ({ buttonText,
   const onCreate = (type: string) => {
     return type === 'form'
       ? createModal((props) => <AddBootableVolumeModal {...props} />)
-      : navigate(`/k8s/ns/${namespace || DEFAULT_NAMESPACE}/${DataSourceModelRef}/~new`);
+      : navigate(`/k8s/ns/${namespace || DEFAULT_NAMESPACE}/${DataVolumeModelRef}/~new`);
   };
 
   if ((canCreateDS || canCreatePVC) && canListInstanceTypesPreference) {


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug where the incorrect YAML template is shown when the user selects Add volume -> From YAML on the Bootable volumes page.

Jira: https://issues.redhat.com/browse/CNV-51198

## 🎥 Screenshots

### Before

![create-bootable-volume-by-yaml--BEFORE--2025-02-05_11-37](https://github.com/user-attachments/assets/4d86bff2-3219-468a-8996-e3dccaeca3e3)

### After

![create-bootable-volume-by-yaml--AFTER--2025-02-05_11-29](https://github.com/user-attachments/assets/97955220-6212-4353-be36-200590f4044e)