### PR TITLE
CNV-51468: Hide migration Limitations link for non-admin users

### DIFF
--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsLimitionsPopover/MigrationsLimitionsPopover.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsLimitionsPopover/MigrationsLimitionsPopover.tsx
@@ -1,13 +1,18 @@
 import * as React from 'react';
 
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Popover, Stack, StackItem, Title } from '@patternfly/react-core';
 
-import useHCMigrations from './hooks/useHCMigrations';
+import useHyperConvergedMigrations from './hooks/useHyperConvergedMigrations';
 
 const MigrationsLimitionsPopover: React.FC = () => {
   const { t } = useKubevirtTranslation();
-  const migrations = useHCMigrations();
+  const migrations = useHyperConvergedMigrations();
+  const isAdmin = useIsAdmin();
+
+  if (!isAdmin) return null;
+
   return (
     <Popover
       bodyContent={

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsLimitionsPopover/hooks/useHyperConvergedMigrations.ts
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsLimitionsPopover/hooks/useHyperConvergedMigrations.ts
@@ -1,9 +1,9 @@
 import { V1MigrationConfiguration } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 
-const useHCMigrations = (): V1MigrationConfiguration => {
+const useHyperConvergedMigrations = (): V1MigrationConfiguration => {
   const [hyperConverge] = useHyperConvergeConfiguration();
   return hyperConverge?.spec?.liveMigrationConfig || {};
 };
 
-export default useHCMigrations;
+export default useHyperConvergedMigrations;

--- a/src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData.ts
+++ b/src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData.ts
@@ -16,7 +16,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 
-import useHCMigrations from '../components/MigrationsLimitionsPopover/hooks/useHCMigrations';
+import useHyperConvergedMigrations from '../components/MigrationsLimitionsPopover/hooks/useHyperConvergedMigrations';
 import {
   getSourceNodeFilter,
   getStatusFilter,
@@ -40,7 +40,7 @@ export type UseMigrationCardDataAndFiltersValues = {
 type UseMigrationCardDataAndFilters = (duration: string) => UseMigrationCardDataAndFiltersValues;
 
 const useMigrationCardDataAndFilters: UseMigrationCardDataAndFilters = (duration: string) => {
-  const migrationsDefaultConfigurations = useHCMigrations();
+  const migrationsDefaultConfigurations = useHyperConvergedMigrations();
   const [activeNamespace] = useActiveNamespace();
   const namespace = activeNamespace !== ALL_NAMESPACES_SESSION_KEY ? activeNamespace : null;
 


### PR DESCRIPTION
## 📝 Description

The values shown in the Limitations popover on the Migrations card on the Virtualization Overview page aren't displayed to non-admin users because the values are pulled from a HyperConverged resource to which non-admin users do not have access. This PR hides the link from non-admin users since the popover isn't useful without the values.

Jira: https://issues.redhat.com/browse/CNV-51468

## 🎥 Screenshots

### Before

![hide-migration-limitations-for-nonadmin--BEFORE--2025-02-05_16-41](https://github.com/user-attachments/assets/a3dcd8a7-dfd9-411f-b44e-3e6d58e948de)

### After

![hide-migration-limitations-for-nonadmin--AFTER--2025-02-05_16-25](https://github.com/user-attachments/assets/6c3e454d-a60d-45d3-ba64-067a8b833ebb)