### PR TITLE
[release-4.16] CNV-51123: bump kubevirt api version to handle v1beta1 version

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -140,7 +140,7 @@
       "model": {
         "group": "instancetype.kubevirt.io",
         "kind": "VirtualMachineClusterInstancetype",
-        "version": "v1alpha2"
+        "version": "v1beta1"
       },
       "name": "%plugin__kubevirt-plugin~InstanceTypes%",
       "section": "virtualization"
@@ -153,7 +153,7 @@
       "model": {
         "group": "instancetype.kubevirt.io",
         "kind": "VirtualMachineClusterInstancetype",
-        "version": "v1alpha2"
+        "version": "v1beta1"
       }
     },
     "type": "console.page/resource/list"
@@ -165,8 +165,8 @@
       },
       "exact": true,
       "path": [
-        "/k8s/ns/:ns/instancetype.kubevirt.io~v1alpha2~VirtualMachineInstancetype",
-        "/k8s/all-namespaces/instancetype.kubevirt.io~v1alpha2~VirtualMachineInstancetype"
+        "/k8s/ns/:ns/instancetype.kubevirt.io~v1beta1~VirtualMachineInstancetype",
+        "/k8s/all-namespaces/instancetype.kubevirt.io~v1beta1~VirtualMachineInstancetype"
       ],
       "prefixNamespaced": true
     },
@@ -185,7 +185,7 @@
       "model": {
         "group": "instancetype.kubevirt.io",
         "kind": "VirtualMachineClusterPreference",
-        "version": "v1alpha2"
+        "version": "v1beta1"
       },
       "name": "%plugin__kubevirt-plugin~Preferences%",
       "section": "virtualization"
@@ -200,7 +200,7 @@
       "model": {
         "group": "instancetype.kubevirt.io",
         "kind": "VirtualMachineClusterPreference",
-        "version": "v1alpha2"
+        "version": "v1beta1"
       }
     },
     "type": "console.page/resource/list"
@@ -213,7 +213,7 @@
       "model": {
         "group": "instancetype.kubevirt.io",
         "kind": "VirtualMachinePreference",
-        "version": "v1alpha2"
+        "version": "v1beta1"
       },
       "prefixNamespaced": true
     },
@@ -430,7 +430,7 @@
       "model": {
         "group": "instancetype.kubevirt.io",
         "kind": "VirtualMachineClusterInstancetype",
-        "version": "v1alpha2"
+        "version": "v1beta1"
       },
       "name": "default",
       "template": {
@@ -447,7 +447,7 @@
       "model": {
         "group": "instancetype.kubevirt.io",
         "kind": "VirtualMachineInstancetype",
-        "version": "v1alpha2"
+        "version": "v1beta1"
       },
       "name": "default",
       "template": {
@@ -464,7 +464,7 @@
       "model": {
         "group": "instancetype.kubevirt.io",
         "kind": "VirtualMachineClusterPreference",
-        "version": "v1alpha2"
+        "version": "v1beta1"
       },
       "name": "default",
       "template": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.11.0",
-    "@kubevirt-ui/kubevirt-api": "^1.2.2",
+    "@kubevirt-ui/kubevirt-api": "1.3.5",
     "@openshift-console/dynamic-plugin-sdk": "1.4.0",
     "@openshift-console/dynamic-plugin-sdk-internal": "1.0.0",
     "@openshift-console/dynamic-plugin-sdk-webpack": "1.1.1",

--- a/src/utils/components/AddBootableVolumeModal/utils/utils.ts
+++ b/src/utils/components/AddBootableVolumeModal/utils/utils.ts
@@ -8,7 +8,10 @@ import {
   V1beta1DataImportCron,
   V1beta1DataSource,
 } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
-import { V1beta1DataVolumeSource } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1beta1DataVolumeSource,
+  V1beta1StorageSpecVolumeModeEnum,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { UploadDataProps } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { buildOwnerReference } from '@kubevirt-utils/resources/shared';
@@ -105,7 +108,8 @@ const getDataVolumeWithSource = (
 
     if (!applyStorageProfileSettings) {
       draftBootableVolume.spec.storage.accessModes = claimPropertySets?.[0]?.accessModes;
-      draftBootableVolume.spec.storage.volumeMode = claimPropertySets?.[0]?.volumeMode;
+      draftBootableVolume.spec.storage.volumeMode = claimPropertySets?.[0]
+        ?.volumeMode as V1beta1StorageSpecVolumeModeEnum;
     }
 
     draftBootableVolume.spec.source = dataVolumeSource;

--- a/src/utils/components/CloneTemplateModal/utils.ts
+++ b/src/utils/components/CloneTemplateModal/utils.ts
@@ -1,10 +1,10 @@
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import DataVolumeModel from '@kubevirt-ui/kubevirt-api/console/models/DataVolumeModel';
-import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import {
-  V1beta1DataVolumeSourcePVC,
+  V1beta1DataVolume,
   V1beta1DataVolumeSpec,
-} from '@kubevirt-ui/kubevirt-api/kubevirt';
+} from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
+import { V1beta1DataVolumeSourcePVC } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { ROOTDISK } from '@kubevirt-utils/constants/constants';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { getDataVolumeTemplates, getVolumes } from '@kubevirt-utils/resources/vm';
@@ -41,7 +41,11 @@ const produceDataVolume = (
 
 export const cloneStorage = async (template: V1Template, pvcName: string, namespace: string) => {
   const rootDiskDataVolumeTemplate = getBootSourceDataVolumeTemplate(template);
-  const dataVolume = produceDataVolume(pvcName, namespace, rootDiskDataVolumeTemplate?.spec);
+  const dataVolume = produceDataVolume(
+    pvcName,
+    namespace,
+    rootDiskDataVolumeTemplate?.spec as unknown as V1beta1DataVolumeSpec,
+  );
   await k8sCreate({
     data: dataVolume,
     model: DataVolumeModel,

--- a/src/utils/components/CloneVMModal/CloneVMModal.tsx
+++ b/src/utils/components/CloneVMModal/CloneVMModal.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import { VirtualMachineModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import {
   V1alpha1VirtualMachineClone,
-  V1alpha1VirtualMachineSnapshot,
+  V1beta1VirtualMachineSnapshot,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
@@ -26,7 +26,7 @@ type CloneVMModalProps = {
   headerText?: string;
   isOpen: boolean;
   onClose: () => void;
-  source: V1alpha1VirtualMachineSnapshot | V1VirtualMachine;
+  source: V1beta1VirtualMachineSnapshot | V1VirtualMachine;
 };
 
 const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, source }) => {

--- a/src/utils/components/CloneVMModal/components/SnapshotContentConfigurationSummary.tsx
+++ b/src/utils/components/CloneVMModal/components/SnapshotContentConfigurationSummary.tsx
@@ -3,8 +3,8 @@ import React, { FC } from 'react';
 import { modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineSnapshotContentModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotContentModel';
 import {
-  V1alpha1VirtualMachineSnapshot,
-  V1alpha1VirtualMachineSnapshotContent,
+  V1beta1VirtualMachineSnapshot,
+  V1beta1VirtualMachineSnapshotContent,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
@@ -16,7 +16,7 @@ import { Alert, AlertVariant } from '@patternfly/react-core';
 import ConfigurationSummary from './ConfigurationSummary';
 
 type SnapshotContentConfigurationSummaryProps = {
-  snapshot: V1alpha1VirtualMachineSnapshot;
+  snapshot: V1beta1VirtualMachineSnapshot;
 };
 
 const SnapshotContentConfigurationSummary: FC<SnapshotContentConfigurationSummaryProps> = ({
@@ -25,7 +25,7 @@ const SnapshotContentConfigurationSummary: FC<SnapshotContentConfigurationSummar
   const { t } = useKubevirtTranslation();
 
   const [snapshotContent, loaded, error] =
-    useK8sWatchResource<V1alpha1VirtualMachineSnapshotContent>(
+    useK8sWatchResource<V1beta1VirtualMachineSnapshotContent>(
       snapshot && {
         groupVersionKind: modelToGroupVersionKind(VirtualMachineSnapshotContentModel),
         name: snapshot.status.virtualMachineSnapshotContentName,

--- a/src/utils/components/CloneVMModal/utils/helpers.tsx
+++ b/src/utils/components/CloneVMModal/utils/helpers.tsx
@@ -5,7 +5,7 @@ import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/Virtua
 import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
 import {
   V1alpha1VirtualMachineClone,
-  V1alpha1VirtualMachineSnapshot,
+  V1beta1VirtualMachineSnapshot,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { MAX_K8S_NAME_LENGTH } from '@kubevirt-utils/utils/constants';
@@ -33,11 +33,11 @@ const cloneVMToVM: V1alpha1VirtualMachineClone = {
 };
 
 export const isVM = (
-  source: V1alpha1VirtualMachineSnapshot | V1VirtualMachine,
+  source: V1beta1VirtualMachineSnapshot | V1VirtualMachine,
 ): source is V1VirtualMachine => source.kind === VirtualMachineModel.kind;
 
 export const cloneVM = (
-  source: V1alpha1VirtualMachineSnapshot | V1VirtualMachine,
+  source: V1beta1VirtualMachineSnapshot | V1VirtualMachine,
   newVMName: string,
   namespace: string,
 ) => {

--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -6,6 +6,7 @@ import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-
 import {
   V1AddVolumeOptions,
   V1beta1DataVolumeSpec,
+  V1beta1StorageSpecVolumeModeEnum,
   V1DataVolumeTemplateSpec,
   V1Disk,
   V1RemoveVolumeOptions,
@@ -160,7 +161,7 @@ const buildDataVolume = ({
 
   if (!diskState.storageProfileSettingsApplied) {
     dataVolume.spec.storage.accessModes = [diskState.accessMode];
-    dataVolume.spec.storage.volumeMode = diskState.volumeMode;
+    dataVolume.spec.storage.volumeMode = diskState.volumeMode as V1beta1StorageSpecVolumeModeEnum;
   }
 
   dataVolume.spec.preallocation = diskState.enablePreallocation;
@@ -184,7 +185,7 @@ const buildDataVolume = ({
 const getDataVolumeTemplate = (dataVolume: V1beta1DataVolume): V1DataVolumeTemplateSpec => {
   const dataVolumeTemplate: V1DataVolumeTemplateSpec = { metadata: {}, spec: {} };
   dataVolumeTemplate.metadata = { name: dataVolume.metadata.name };
-  dataVolumeTemplate.spec = dataVolume.spec as V1beta1DataVolumeSpec;
+  dataVolumeTemplate.spec = dataVolume.spec as unknown as V1beta1DataVolumeSpec;
   return dataVolumeTemplate;
 };
 

--- a/src/utils/resources/template/hooks/useVmTemplateSource/useVMTemplateSource.ts
+++ b/src/utils/resources/template/hooks/useVmTemplateSource/useVMTemplateSource.ts
@@ -2,9 +2,9 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import {
-  V1alpha1PersistentVolumeClaim,
   V1beta1DataVolumeSourcePVC,
   V1beta1DataVolumeSourceRef,
+  V1beta1PersistentVolumeClaim,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
 
@@ -29,7 +29,7 @@ export const useVMTemplateSource = (template: V1Template): UseVMTemplateSourceVa
   const getPVCSource = async ({ name, namespace }: V1beta1DataVolumeSourcePVC) => {
     setLoaded(false);
     try {
-      const pvc = (await getPVC(name, namespace)) as V1alpha1PersistentVolumeClaim;
+      const pvc = (await getPVC(name, namespace)) as V1beta1PersistentVolumeClaim;
       if (pvc) {
         setIsBootSourceAvailable(true);
         setTemplateBootSource({

--- a/src/utils/resources/template/hooks/useVmTemplateSource/utils.ts
+++ b/src/utils/resources/template/hooks/useVmTemplateSource/utils.ts
@@ -9,11 +9,11 @@ import {
 } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import {
-  V1alpha1PersistentVolumeClaim,
   V1beta1DataVolumeSourceHTTP,
   V1beta1DataVolumeSourcePVC,
   V1beta1DataVolumeSourceRef,
   V1beta1DataVolumeSourceRegistry,
+  V1beta1PersistentVolumeClaim,
   V1ContainerDiskSource,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getBootDisk, getVolumes } from '@kubevirt-utils/resources/vm';
@@ -35,9 +35,9 @@ export type TemplateBootSource = {
   sourceValue?: {
     containerDisk?: V1ContainerDiskSource;
     http?: V1beta1DataVolumeSourceHTTP;
-    pvc?: V1alpha1PersistentVolumeClaim;
+    pvc?: V1beta1PersistentVolumeClaim;
     registry?: V1beta1DataVolumeSourceRegistry;
-    sourceRef?: V1alpha1PersistentVolumeClaim;
+    sourceRef?: V1beta1PersistentVolumeClaim;
   };
   storageClassName?: string;
   type: BOOT_SOURCE;

--- a/src/views/cdi-upload-provider/PVCDeleteAlertExtension.tsx
+++ b/src/views/cdi-upload-provider/PVCDeleteAlertExtension.tsx
@@ -6,7 +6,7 @@ import {
   TemplateModel,
   V1Template,
 } from '@kubevirt-ui/kubevirt-api/console';
-import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1beta1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   TEMPLATE_TYPE_BASE,
@@ -28,7 +28,7 @@ const templatesResource: WatchK8sResource = {
   },
 };
 
-const PVCDeleteAlertExtension: React.FC<{ pvc: V1alpha1PersistentVolumeClaim }> = ({ pvc }) => {
+const PVCDeleteAlertExtension: React.FC<{ pvc: V1beta1PersistentVolumeClaim }> = ({ pvc }) => {
   const [commonTemplates, loadedTemplates, errorTemplates] =
     useK8sWatchResource<V1Template[]>(templatesResource);
   const { t } = useKubevirtTranslation();

--- a/src/views/cdi-upload-provider/hooks/useBaseImages.ts
+++ b/src/views/cdi-upload-provider/hooks/useBaseImages.ts
@@ -5,12 +5,12 @@ import {
   PersistentVolumeClaimModel,
   V1Template,
 } from '@kubevirt-ui/kubevirt-api/console';
-import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1beta1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useK8sWatchResources, WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
 
 import { getPVCNamespace } from '../utils/selectors';
 
-type BaseImages = [V1alpha1PersistentVolumeClaim[], boolean, any];
+type BaseImages = [V1beta1PersistentVolumeClaim[], boolean, any];
 
 const useBaseImages = (commonTemplates: V1Template[]): BaseImages => {
   const [pvcWatches] = React.useMemo(() => {
@@ -35,11 +35,11 @@ const useBaseImages = (commonTemplates: V1Template[]): BaseImages => {
     ];
   }, [commonTemplates]);
 
-  const pvcs = useK8sWatchResources<{ [key: string]: V1alpha1PersistentVolumeClaim[] }>(pvcWatches);
+  const pvcs = useK8sWatchResources<{ [key: string]: V1beta1PersistentVolumeClaim[] }>(pvcWatches);
   const pvcValues = Object.values(pvcs);
   const loaded = pvcValues?.every((value) => value.loaded || !!value.loadError);
   const loadError = pvcValues.find((value) => value.loadError);
-  const pvcData = pvcValues.reduce<V1alpha1PersistentVolumeClaim[]>(
+  const pvcData = pvcValues.reduce<V1beta1PersistentVolumeClaim[]>(
     (acc, pvc) => acc.concat(pvc.data),
     [],
   );

--- a/src/views/cdi-upload-provider/popover/UploadPVCPopover.tsx
+++ b/src/views/cdi-upload-provider/popover/UploadPVCPopover.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 
-import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1beta1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { killUploadPVC } from '@kubevirt-utils/hooks/useCDIUpload/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
@@ -10,7 +10,7 @@ import UploadPVCPopoverProgressStatus from './UploadPVCPopoverProgressStatus';
 import UploadPVCPopoverUploadStatus from './UploadPVCPopoverUploadStatus';
 
 type PVCUploadStatusProps = {
-  pvc: V1alpha1PersistentVolumeClaim;
+  pvc: V1beta1PersistentVolumeClaim;
   title?: string;
 };
 

--- a/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCForm.tsx
+++ b/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCForm.tsx
@@ -2,7 +2,7 @@ import React, { Dispatch, FC, SetStateAction, useEffect, useState } from 'react'
 
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1beta1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getDefaultStorageClass } from '@kubevirt-utils/components/DiskModal/components/StorageClassAndPreallocation/utils/helpers';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -38,7 +38,7 @@ type UploadPVCFormProps = {
   commonTemplates: V1Template[];
   fileName: string;
   fileValue: File | string;
-  goldenPvcs: V1alpha1PersistentVolumeClaim[];
+  goldenPvcs: V1beta1PersistentVolumeClaim[];
   handleFileChange: (_, value: File) => void;
   handleFileNameChange: (event, file: string) => void;
   isLoading: boolean;

--- a/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCFormGoldenImage.tsx
+++ b/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCFormGoldenImage.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 
 import { PersistentVolumeClaimModel } from '@kubevirt-ui/kubevirt-api/console';
-import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1beta1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, Checkbox, FormSelect, FormSelectOption } from '@patternfly/react-core';
@@ -12,7 +12,7 @@ import { OperatingSystemRecord } from '../utils/types';
 import UploadPVCFormPVCNamespace from './UploadPVCFormPVCNamespace';
 
 type UploadPVCFormGoldenImageProps = {
-  goldenPvcs: V1alpha1PersistentVolumeClaim[];
+  goldenPvcs: V1beta1PersistentVolumeClaim[];
   handleCDROMChange: (checked: boolean) => void;
   handleOs: (newOs: string) => void;
   handlePvcSizeTemplate: (checked: boolean) => void;

--- a/src/views/cdi-upload-provider/utils/selectors.ts
+++ b/src/views/cdi-upload-provider/utils/selectors.ts
@@ -3,7 +3,7 @@ import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/Virtua
 import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import {
   K8sIoApiCoreV1ResourceRequirements,
-  V1alpha1PersistentVolumeClaim,
+  V1beta1PersistentVolumeClaim,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { V1Template } from '@kubevirt-utils/models';
@@ -45,7 +45,7 @@ export const getAnnotations = (
 ): { [key: string]: string } => vm?.metadata.annotations || defaultValue;
 
 const getAnnotation = (
-  pvc: V1alpha1PersistentVolumeClaim,
+  pvc: V1beta1PersistentVolumeClaim,
   annotationName: string,
   defaultValue?: string,
 ): string => pvc?.metadata?.annotations?.[annotationName] || defaultValue;
@@ -73,36 +73,36 @@ export const getPVCName = (obj: V1Template): string =>
   getParameterValue(obj, TEMPLATE_BASE_IMAGE_NAME_PARAMETER) ||
   getParameterValue(obj, TEMPLATE_DATA_SOURCE_NAME_PARAMETER);
 
-export const getPvcResources = (pvc: V1alpha1PersistentVolumeClaim) => pvc?.spec?.resources;
+export const getPvcResources = (pvc: V1beta1PersistentVolumeClaim) => pvc?.spec?.resources;
 
-export const getPvcStorageSize = (pvc: V1alpha1PersistentVolumeClaim): string =>
+export const getPvcStorageSize = (pvc: V1beta1PersistentVolumeClaim): string =>
   getStorageSize(getPvcResources(pvc));
 
-export const getPvcAccessModes = (pvc: V1alpha1PersistentVolumeClaim) => pvc?.spec?.accessModes;
-export const getPvcVolumeMode = (pvc: V1alpha1PersistentVolumeClaim) => pvc?.spec?.volumeMode;
-export const getPvcStorageClassName = (pvc: V1alpha1PersistentVolumeClaim): string =>
+export const getPvcAccessModes = (pvc: V1beta1PersistentVolumeClaim) => pvc?.spec?.accessModes;
+export const getPvcVolumeMode = (pvc: V1beta1PersistentVolumeClaim) => pvc?.spec?.volumeMode;
+export const getPvcStorageClassName = (pvc: V1beta1PersistentVolumeClaim): string =>
   pvc?.spec?.storageClassName;
 
-export const getPvcImportPodName = (pvc: V1alpha1PersistentVolumeClaim) =>
+export const getPvcImportPodName = (pvc: V1beta1PersistentVolumeClaim) =>
   getAnnotation(pvc, STORAGE_IMPORT_POD_LABEL);
 
 // upload pvc selectors
-export const getPvcUploadPodName = (pvc: V1alpha1PersistentVolumeClaim) =>
+export const getPvcUploadPodName = (pvc: V1beta1PersistentVolumeClaim) =>
   getAnnotation(pvc, CDI_UPLOAD_POD_NAME_ANNOTATION);
 
-export const getPvcPhase = (pvc: V1alpha1PersistentVolumeClaim) =>
+export const getPvcPhase = (pvc: V1beta1PersistentVolumeClaim) =>
   getAnnotation(pvc, CDI_UPLOAD_POD_ANNOTATION);
 
-export const getPvcCloneToken = (pvc: V1alpha1PersistentVolumeClaim) =>
+export const getPvcCloneToken = (pvc: V1beta1PersistentVolumeClaim) =>
   getAnnotation(pvc, CDI_CLONE_TOKEN_ANNOTAION);
 
-export const isPvcUploading = (pvc: V1alpha1PersistentVolumeClaim) =>
+export const isPvcUploading = (pvc: V1beta1PersistentVolumeClaim) =>
   !getPvcCloneToken(pvc) && getPvcUploadPodName(pvc) && getPvcPhase(pvc) === CDI_PVC_PHASE_RUNNING;
 
-export const isPvcCloning = (pvc: V1alpha1PersistentVolumeClaim) =>
+export const isPvcCloning = (pvc: V1beta1PersistentVolumeClaim) =>
   !!getPvcCloneToken(pvc) && getPvcPhase(pvc) === CDI_PVC_PHASE_RUNNING;
 
-export const isPvcBoundToCDI = (pvc: V1alpha1PersistentVolumeClaim) =>
+export const isPvcBoundToCDI = (pvc: V1beta1PersistentVolumeClaim) =>
   pvc?.metadata?.ownerReferences?.some(
     (or) =>
       or.apiVersion.startsWith(CDI_KUBEVIRT_IO) &&
@@ -169,7 +169,8 @@ export const getTemplateOperatingSystems = (templates: V1Template[]) => {
       return {
         baseImageName: getPVCName(template),
         baseImageNamespace: getPVCNamespace(template),
-        baseImageRecomendedSize: dv && stringValueUnitSplit(getDataVolumeStorageSize(dv)),
+        baseImageRecomendedSize:
+          dv && stringValueUnitSplit(getDataVolumeStorageSize(dv as unknown as V1beta1DataVolume)),
         id: osId,
         isSourceRef: !!dv?.spec?.sourceRef,
         name: getAnnotation(template, nameAnnotation),

--- a/src/views/cdi-upload-provider/utils/utils.tsx
+++ b/src/views/cdi-upload-provider/utils/utils.tsx
@@ -2,7 +2,7 @@ import { Children, cloneElement } from 'react';
 
 import DataVolumeModel from '@kubevirt-ui/kubevirt-api/console/models/DataVolumeModel';
 import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
-import { V1alpha1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1beta1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import {
   getGroupVersionKindForModel,
   k8sDelete,
@@ -14,7 +14,7 @@ import { LABEL_CDROM_SOURCE, UPLOAD_STATUS } from './consts';
 import { getKubevirtModelAvailableAPIVersion } from './selectors';
 import { OperatingSystemRecord } from './types';
 
-export const killCDIBoundPVC = (pvc: V1alpha1PersistentVolumeClaim) =>
+export const killCDIBoundPVC = (pvc: V1beta1PersistentVolumeClaim) =>
   k8sDelete({
     model: DataVolumeModel,
     resource: pvc,

--- a/src/views/templates/actions/components/EditBootSourceModal.tsx
+++ b/src/views/templates/actions/components/EditBootSourceModal.tsx
@@ -6,8 +6,10 @@ import {
   TemplateModel,
   V1Template,
 } from '@kubevirt-ui/kubevirt-api/console';
-import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
-import { V1beta1DataVolumeSpec } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1beta1DataSource,
+  V1beta1DataVolumeSpec,
+} from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { K8sResourceCommon, ResourceLink } from '@openshift-console/dynamic-plugin-sdk';

--- a/src/views/templates/actions/components/SelectSource.tsx
+++ b/src/views/templates/actions/components/SelectSource.tsx
@@ -1,6 +1,6 @@
 import React, { FC, ReactNode } from 'react';
 
-import { V1beta1DataVolumeSpec } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1beta1DataVolumeSpec } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import CapacityInput from '@kubevirt-utils/components/CapacityInput/CapacityInput';
 import { DEFAULT_DISK_SIZE } from '@kubevirt-utils/components/DiskModal/utils/constants';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';

--- a/src/views/templates/actions/components/utils.ts
+++ b/src/views/templates/actions/components/utils.ts
@@ -1,5 +1,7 @@
-import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
-import { V1beta1DataVolumeSpec } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1beta1DataSource,
+  V1beta1DataVolumeSpec,
+} from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { DEFAULT_DISK_SIZE } from '@kubevirt-utils/components/DiskModal/utils/constants';
 
 import { SOURCE_OPTIONS_IDS, SOURCE_TYPES } from '../../utils/constants';

--- a/src/views/templates/actions/editBootSource.ts
+++ b/src/views/templates/actions/editBootSource.ts
@@ -6,11 +6,9 @@ import DataVolumeModel from '@kubevirt-ui/kubevirt-api/console/models/DataVolume
 import {
   V1beta1DataSource,
   V1beta1DataVolume,
-} from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
-import {
   V1beta1DataVolumeSpec,
-  V1DataVolumeTemplateSpec,
-} from '@kubevirt-ui/kubevirt-api/kubevirt';
+} from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
+import { V1DataVolumeTemplateSpec } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { DEFAULT_NAMESPACE, ROOTDISK } from '@kubevirt-utils/constants/constants';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {

--- a/src/views/virtualmachines/actions/components/DeleteVMModal/components/DeleteOwnedResourcesMessage.tsx
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/components/DeleteOwnedResourcesMessage.tsx
@@ -2,7 +2,7 @@ import React, { Dispatch, FC, SetStateAction } from 'react';
 
 import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
-import { V1alpha1VirtualMachineSnapshot } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1beta1VirtualMachineSnapshot } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Bullseye, Checkbox, StackItem } from '@patternfly/react-core';
@@ -15,7 +15,7 @@ type DeleteOwnedResourcesMessageProps = {
   loaded: boolean;
   pvcs: IoK8sApiCoreV1PersistentVolumeClaim[];
   setDeleteOwnedResource: Dispatch<SetStateAction<boolean>>;
-  snapshots: V1alpha1VirtualMachineSnapshot[];
+  snapshots: V1beta1VirtualMachineSnapshot[];
 };
 
 const DeleteOwnedResourcesMessage: FC<DeleteOwnedResourcesMessageProps> = ({

--- a/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useDeleteVMResources.ts
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useDeleteVMResources.ts
@@ -7,7 +7,7 @@ import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/model
 import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import {
-  V1alpha1VirtualMachineSnapshot,
+  V1beta1VirtualMachineSnapshot,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getVolumes } from '@kubevirt-utils/resources/vm';
@@ -20,7 +20,7 @@ type UseDeleteVMResources = (vm: V1VirtualMachine) => {
   error: any;
   loaded: boolean;
   pvcs: IoK8sApiCoreV1PersistentVolumeClaim[];
-  snapshots: V1alpha1VirtualMachineSnapshot[];
+  snapshots: V1beta1VirtualMachineSnapshot[];
 };
 
 const useDeleteVMResources: UseDeleteVMResources = (vm) => {
@@ -55,7 +55,7 @@ const useDeleteVMResources: UseDeleteVMResources = (vm) => {
     : [];
 
   const [snapshots, snapshotsLoaded, snapshotsLoadError] = useK8sWatchResource<
-    V1alpha1VirtualMachineSnapshot[]
+    V1beta1VirtualMachineSnapshot[]
   >({
     groupVersionKind: modelToGroupVersionKind(VirtualMachineSnapshotModel),
     isList: true,

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/VirtualMachinesOverviewTabSnapshotsRow.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/VirtualMachinesOverviewTabSnapshotsRow.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react';
 import classnames from 'classnames';
 
 import {
-  V1alpha1VirtualMachineSnapshot,
+  V1beta1VirtualMachineSnapshot,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -31,7 +31,7 @@ import { icon } from './utils/snapshotStatus';
 import './virtual-machines-overview-tab-snapshots.scss';
 
 type VirtualMachinesOverviewTabSnapshotsRowProps = {
-  snapshot: V1alpha1VirtualMachineSnapshot;
+  snapshot: V1beta1VirtualMachineSnapshot;
   vm: V1VirtualMachine;
 };
 

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/component/SnapshotDeleteModal.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/component/SnapshotDeleteModal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
-import { V1alpha1VirtualMachineSnapshot } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1beta1VirtualMachineSnapshot } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -11,7 +11,7 @@ import { ButtonVariant } from '@patternfly/react-core';
 const SnapshotDeleteModal = ({ isOpen, onClose, snapshot }) => {
   const { t } = useKubevirtTranslation();
   return (
-    <TabModal<V1alpha1VirtualMachineSnapshot>
+    <TabModal<V1beta1VirtualMachineSnapshot>
       onSubmit={(obj) =>
         k8sDelete({
           json: undefined,

--- a/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotActionsMenu.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotActionsMenu.tsx
@@ -2,7 +2,7 @@ import React, { FC, useCallback, useState } from 'react';
 
 import VirtualMachineCloneModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineCloneModel';
 import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
-import { V1alpha1VirtualMachineSnapshot } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1beta1VirtualMachineSnapshot } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import CloneVMModal from '@kubevirt-utils/components/CloneVMModal/CloneVMModal';
 import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -16,7 +16,7 @@ import RestoreModal from '../modal/RestoreModal';
 
 type SnapshotActionsMenuProps = {
   isRestoreDisabled: boolean;
-  snapshot: V1alpha1VirtualMachineSnapshot;
+  snapshot: V1beta1VirtualMachineSnapshot;
 };
 
 const SnapshotActionsMenu: FC<SnapshotActionsMenuProps> = ({ isRestoreDisabled, snapshot }) => {
@@ -54,7 +54,7 @@ const SnapshotActionsMenu: FC<SnapshotActionsMenuProps> = ({ isRestoreDisabled, 
 
   const onDeleteModalToggle = useCallback(() => {
     createModal(({ isOpen, onClose }) => (
-      <TabModal<V1alpha1VirtualMachineSnapshot>
+      <TabModal<V1beta1VirtualMachineSnapshot>
         onSubmit={(obj) =>
           k8sDelete({
             model: VirtualMachineSnapshotModel,

--- a/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotRow.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotRow.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 import { VirtualMachineSnapshotModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import {
-  V1alpha1VirtualMachineRestore,
-  V1alpha1VirtualMachineSnapshot,
+  V1beta1VirtualMachineRestore,
+  V1beta1VirtualMachineSnapshot,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
@@ -16,11 +16,11 @@ import SnapshotActionsMenu from './SnapshotActionsMenu';
 
 const SnapshotRow: React.FC<
   RowProps<
-    V1alpha1VirtualMachineSnapshot,
-    { isVMRunning: boolean; restores: Map<string, V1alpha1VirtualMachineRestore> }
+    V1beta1VirtualMachineSnapshot,
+    { isVMRunning: boolean; restores: Map<string, V1beta1VirtualMachineRestore> }
   >
 > = ({ activeColumnIDs, obj: snapshot, rowData: { isVMRunning, restores } }) => {
-  const relevantRestore: V1alpha1VirtualMachineRestore = restores?.[snapshot?.metadata?.name];
+  const relevantRestore: V1beta1VirtualMachineRestore = restores?.[snapshot?.metadata?.name];
   const isRestoreDisabled = isVMRunning || snapshot?.status?.phase !== snapshotStatuses.Succeeded;
   const readyCondition = snapshot?.status?.conditions?.find(({ type }) => type === 'Ready');
   return (

--- a/src/views/virtualmachines/details/tabs/snapshots/components/modal/RestoreModal.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/modal/RestoreModal.tsx
@@ -3,8 +3,8 @@ import { Trans } from 'react-i18next';
 
 import VirtualMachineRestoreModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineRestoreModel';
 import {
-  V1alpha1VirtualMachineRestore,
-  V1alpha1VirtualMachineSnapshot,
+  V1beta1VirtualMachineRestore,
+  V1beta1VirtualMachineSnapshot,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -17,19 +17,19 @@ import './restore-modal.scss';
 type DeleteResourceModalProps = {
   isOpen: boolean;
   onClose: () => void;
-  snapshot: V1alpha1VirtualMachineSnapshot;
+  snapshot: V1beta1VirtualMachineSnapshot;
 };
 
 const RestoreModal: FC<DeleteResourceModalProps> = ({ isOpen, onClose, snapshot }) => {
   const { t } = useKubevirtTranslation();
 
   const resultRestore = useMemo(() => {
-    const restore: V1alpha1VirtualMachineRestore = getVMRestoreSnapshotResource(snapshot);
+    const restore: V1beta1VirtualMachineRestore = getVMRestoreSnapshotResource(snapshot);
     return restore;
   }, [snapshot]);
 
   return (
-    <TabModal<V1alpha1VirtualMachineRestore>
+    <TabModal<V1beta1VirtualMachineRestore>
       onSubmit={(obj) =>
         k8sCreate({
           data: obj,

--- a/src/views/virtualmachines/details/tabs/snapshots/components/modal/SnapshotModal.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/modal/SnapshotModal.tsx
@@ -2,7 +2,7 @@ import React, { FC, useMemo, useState } from 'react';
 
 import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
 import {
-  V1alpha1VirtualMachineSnapshot,
+  V1beta1VirtualMachineSnapshot,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
@@ -60,9 +60,9 @@ const SnapshotModal: FC<SnapshotModalProps> = ({ isOpen, onClose, vm }) => {
   }, [deadline, deadlineUnit, description, snapshotName, vm]);
 
   return (
-    <TabModal<V1alpha1VirtualMachineSnapshot>
+    <TabModal<V1beta1VirtualMachineSnapshot>
       onSubmit={(obj) =>
-        k8sCreate<V1alpha1VirtualMachineSnapshot>({
+        k8sCreate<V1beta1VirtualMachineSnapshot>({
           data: obj,
           model: VirtualMachineSnapshotModel,
         })

--- a/src/views/virtualmachines/details/tabs/snapshots/hooks/useSnapshotColumns.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/hooks/useSnapshotColumns.ts
@@ -1,4 +1,4 @@
-import { V1alpha1VirtualMachineSnapshot } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1beta1VirtualMachineSnapshot } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
@@ -6,7 +6,7 @@ import { sortable } from '@patternfly/react-table';
 const useSnapshotColumns = () => {
   const { t } = useKubevirtTranslation();
 
-  const columns: TableColumn<V1alpha1VirtualMachineSnapshot>[] = [
+  const columns: TableColumn<V1beta1VirtualMachineSnapshot>[] = [
     {
       id: 'name',
       sort: 'metadata.name',

--- a/src/views/virtualmachines/details/tabs/snapshots/hooks/useSnapshotData.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/hooks/useSnapshotData.ts
@@ -5,8 +5,8 @@ import {
   VirtualMachineSnapshotModelGroupVersionKind,
 } from '@kubevirt-ui/kubevirt-api/console';
 import {
-  V1alpha1VirtualMachineRestore,
-  V1alpha1VirtualMachineSnapshot,
+  V1beta1VirtualMachineRestore,
+  V1beta1VirtualMachineSnapshot,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -16,12 +16,12 @@ export type UseSnapshotData = {
   error: any;
   loaded: boolean;
   restoresMap: any;
-  snapshots: V1alpha1VirtualMachineSnapshot[];
+  snapshots: V1beta1VirtualMachineSnapshot[];
 };
 
 const useSnapshotData = (vmName: string, namespace: string): UseSnapshotData => {
   const [snapshots, snapshotsLoaded, snapshotsError] = useK8sWatchResource<
-    V1alpha1VirtualMachineSnapshot[]
+    V1beta1VirtualMachineSnapshot[]
   >({
     groupVersionKind: VirtualMachineSnapshotModelGroupVersionKind,
     isList: true,
@@ -30,7 +30,7 @@ const useSnapshotData = (vmName: string, namespace: string): UseSnapshotData => 
   });
 
   const [restores, restoresLoaded, restoresError] = useK8sWatchResource<
-    V1alpha1VirtualMachineRestore[]
+    V1beta1VirtualMachineRestore[]
   >({
     groupVersionKind: VirtualMachineRestoreModelGroupVersionKind,
     isList: true,

--- a/src/views/virtualmachines/details/tabs/snapshots/utils/helpers.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/utils/helpers.ts
@@ -2,8 +2,8 @@ import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/Virtua
 import VirtualMachineRestoreModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineRestoreModel';
 import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
 import {
-  V1alpha1VirtualMachineRestore,
-  V1alpha1VirtualMachineSnapshot,
+  V1beta1VirtualMachineRestore,
+  V1beta1VirtualMachineSnapshot,
   V1VirtualMachine,
   V1VolumeSnapshotStatus,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -33,10 +33,8 @@ export const validateSnapshotDeadline = (deadline: string): string => {
   return undefined;
 };
 
-export const getEmptyVMSnapshotResource = (
-  vm: V1VirtualMachine,
-): V1alpha1VirtualMachineSnapshot => {
-  const snapshotResource: V1alpha1VirtualMachineSnapshot = {
+export const getEmptyVMSnapshotResource = (vm: V1VirtualMachine): V1beta1VirtualMachineSnapshot => {
+  const snapshotResource: V1beta1VirtualMachineSnapshot = {
     apiVersion: `${VirtualMachineSnapshotModel.apiGroup}/${VirtualMachineSnapshotModel.apiVersion}`,
     kind: VirtualMachineSnapshotModel.kind,
     metadata: {
@@ -55,9 +53,9 @@ export const getEmptyVMSnapshotResource = (
 };
 
 export const getVMRestoreSnapshotResource = (
-  snapshot: V1alpha1VirtualMachineSnapshot,
-): V1alpha1VirtualMachineRestore => {
-  const restoreResource: V1alpha1VirtualMachineRestore = {
+  snapshot: V1beta1VirtualMachineSnapshot,
+): V1beta1VirtualMachineRestore => {
+  const restoreResource: V1beta1VirtualMachineRestore = {
     apiVersion: `${VirtualMachineRestoreModel.apiGroup}/${VirtualMachineRestoreModel.apiVersion}`,
     kind: VirtualMachineRestoreModel.kind,
     metadata: {

--- a/src/views/virtualmachines/details/tabs/snapshots/utils/selectors.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/utils/selectors.ts
@@ -1,7 +1,7 @@
-import { V1alpha1VirtualMachineRestore } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1beta1VirtualMachineRestore } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
-export const getVmRestoreTime = (restore: V1alpha1VirtualMachineRestore) =>
+export const getVmRestoreTime = (restore: V1beta1VirtualMachineRestore) =>
   restore?.status?.restoreTime;
 
-export const getVmRestoreSnapshotName = (restore: V1alpha1VirtualMachineRestore) =>
+export const getVmRestoreSnapshotName = (restore: V1beta1VirtualMachineRestore) =>
   restore?.spec?.virtualMachineSnapshotName;

--- a/src/views/virtualmachinesinstance/details/tabs/disks/utils/virtualMachinesInstancePageDisksTabUtils.ts
+++ b/src/views/virtualmachinesinstance/details/tabs/disks/utils/virtualMachinesInstancePageDisksTabUtils.ts
@@ -1,6 +1,6 @@
 import byteSize from 'byte-size';
 
-import { V1alpha1PersistentVolumeClaim, V1Disk } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1beta1PersistentVolumeClaim, V1Disk } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 
 export type DiskPresentation = {
@@ -22,7 +22,7 @@ export type FileSystemPresentation = {
   usedBytes: number;
 };
 
-export type DiskRaw = V1Disk & { pvc?: V1alpha1PersistentVolumeClaim };
+export type DiskRaw = V1Disk & { pvc?: V1beta1PersistentVolumeClaim };
 
 export const diskTypes = {
   cdrom: 'CD-ROM',

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,10 +806,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@kubevirt-ui/kubevirt-api@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@kubevirt-ui/kubevirt-api/-/kubevirt-api-1.2.2.tgz#2a056159fb503d36bca94e62f9c2899aa2728202"
-  integrity sha512-8hcafV28OAnnNzQuCc5DOk/NCU8IR+h2/xCYW5gCZJFyziidWZwI3FAIcdalxQ9fgY9sgM2di65WeN5j/l4QNg==
+"@kubevirt-ui/kubevirt-api@1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@kubevirt-ui/kubevirt-api/-/kubevirt-api-1.3.5.tgz#c9c10b30d8cc9770fbc6b08077b9a997fdc3ca58"
+  integrity sha512-FI9RXYwVl3/INr4z7uemuJk3D218DzxOSm4iiVjJIiYp5DHj+r5EqwTaaWi9NQQYj+aZUw3a1akd8p/JO8lMZw==
 
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

bump kubevirt-api version to 1.3 (just before the 1.4 kubevirt bump) 
to have v1beta1 instancetype and preference model instead of the deprecated v1alpha1 models


I had to solve some typescript issues 