### PR TITLE
CNV-56030: Projects not displayed in tree view for non-admin users

### DIFF
--- a/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
@@ -7,7 +7,6 @@ import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource, useK8sWatchResources } from '@openshift-console/dynamic-plugin-sdk';
 import { TreeViewDataItem } from '@patternfly/react-core';
 import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils';
@@ -55,9 +54,13 @@ export const useTreeViewData = (): UseTreeViewData => {
     [allVMs, allowedResources, isAdmin],
   );
 
+  const loaded =
+    projectNamesLoaded &&
+    (isAdmin ? allVMsLoaded : Object.values(allowedResources).some((resource) => resource.loaded));
+
   const treeData = useMemo(
     () =>
-      !isEmpty(memoizedVMs)
+      loaded
         ? createTreeViewData(
             projectNames,
             memoizedVMs,
@@ -66,18 +69,14 @@ export const useTreeViewData = (): UseTreeViewData => {
             treeViewFoldersEnabled,
           )
         : [],
-    [projectNames, memoizedVMs, isAdmin, treeViewFoldersEnabled, location.pathname],
+    [projectNames, memoizedVMs, loaded, isAdmin, treeViewFoldersEnabled, location.pathname],
   );
 
   const isSwitchDisabled = useMemo(() => projectNames.every(isSystemNamespace), [projectNames]);
 
   return {
     isSwitchDisabled,
-    loaded:
-      projectNamesLoaded &&
-      (isAdmin
-        ? allVMsLoaded
-        : Object.values(allowedResources).some((resource) => resource.loaded)),
+    loaded,
     loadError: projectNamesError,
     treeData,
   };


### PR DESCRIPTION
## 📝 Description

replacing the condition to create the tree to have loaded data rather than if data is not empty for non admin users

## 🎥 Demo

Before:
![showing-projects-b4](https://github.com/user-attachments/assets/cbb1d2ce-39f2-4bef-a026-7519dbb6e1ee)


After:
![showing-projects](https://github.com/user-attachments/assets/2b32b6c8-e4df-4f3a-9eac-235d9b4eb4ca)

