### PR TITLE
CNV-50292: Fix conflict caused by separate namespace and template SSH secrets

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1330,6 +1330,7 @@
   "This key will override the SSH key secret set on the template": "This key will override the SSH key secret set on the template",
   "This Persistent Volume Claim will be created using a DataVolume through Containerized Data Importer (CDI)": "This Persistent Volume Claim will be created using a DataVolume through Containerized Data Importer (CDI)",
   "This process can take 1-2 minutes to complete.": "This process can take 1-2 minutes to complete.",
+  "This Secret will be copied to the destination project": "This Secret will be copied to the destination project",
   "This user is not allowed to edit this boot source": "This user is not allowed to edit this boot source",
   "This VirtualMachine has": "This VirtualMachine has",
   "This VirtualMachine is down. Please start it to access its console.": "This VirtualMachine is down. Please start it to access its console.",

--- a/src/utils/components/ExportModal/ExportModal.tsx
+++ b/src/utils/components/ExportModal/ExportModal.tsx
@@ -3,7 +3,7 @@ import React, { FC, useState } from 'react';
 import { IoK8sApiCoreV1Pod } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, PodModel } from '@kubevirt-utils/models';
-import { createSecret } from '@kubevirt-utils/resources/secret/utils';
+import { createUserPasswordSecret } from '@kubevirt-utils/resources/secret/utils';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getRandomChars } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
@@ -66,7 +66,7 @@ const ExportModal: FC<ExportModalProps> = ({ isOpen, namespace, onClose, pvcName
           if (error.code !== ALREADY_CREATED_ERROR_CODE) throw error;
         }
 
-        await createSecret({ namespace, password, secretName, username });
+        await createUserPasswordSecret({ namespace, password, secretName, username });
         const pod = await createUploaderPod({
           destination,
           namespace,

--- a/src/utils/components/SSHSecretModal/SSHSecretModal.tsx
+++ b/src/utils/components/SSHSecretModal/SSHSecretModal.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useMemo, useState } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { createSSHSecret } from '@kubevirt-utils/resources/secret/utils';
 import { isEmpty, validateSSHPublicKey } from '@kubevirt-utils/utils/utils';
 
 import MutedTextSpan from '../MutedTextSpan/MutedTextSpan';
@@ -9,7 +10,7 @@ import TabModal from '../TabModal/TabModal';
 import SSHSecretModalBody from './components/SSHSecretModalBody/SSHSecretModalBody';
 import useSecretsData from './hooks/useSecretsData';
 import { SecretSelectionOption, SSHSecretDetails } from './utils/types';
-import { createSSHSecret, validateSecretName, validateSecretNameUnique } from './utils/utils';
+import { validateSecretName, validateSecretNameUnique } from './utils/utils';
 
 type SSHSecretModalProps = {
   initialSSHSecretDetails: SSHSecretDetails;

--- a/src/utils/components/SSHSecretModal/components/SSHKeyUpload/SSHKeyUpload.tsx
+++ b/src/utils/components/SSHSecretModal/components/SSHKeyUpload/SSHKeyUpload.tsx
@@ -43,6 +43,7 @@ const SSHKeyUpload: FC<SSHKeyUploadProps> = ({ secrets, setSSHDetails, sshDetail
       ...sshDetails,
       secretOption: SecretSelectionOption.addNew,
       sshPubKey: sshPublicKey?.trim(),
+      sshSecretNamespace: activeNamespace,
     });
   };
 

--- a/src/utils/components/VMSSHSecretModal/VMSSHSecretModal.tsx
+++ b/src/utils/components/VMSSHSecretModal/VMSSHSecretModal.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useCallback, useMemo } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getInitialSSHDetails } from '@kubevirt-utils/resources/secret/utils';
+import { createSSHSecret, getInitialSSHDetails } from '@kubevirt-utils/resources/secret/utils';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getVMSSHSecretName } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -9,7 +9,7 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { isEqualObject } from '../NodeSelectorModal/utils/helpers';
 import SSHSecretModal from '../SSHSecretModal/SSHSecretModal';
 import { SecretSelectionOption, SSHSecretDetails } from '../SSHSecretModal/utils/types';
-import { addSecretToVM, createSSHSecret, detachVMSecret } from '../SSHSecretModal/utils/utils';
+import { addSecretToVM, detachVMSecret } from '../SSHSecretModal/utils/utils';
 
 type VMSSHSecretModalProps = {
   authorizedSSHKeys: { [namespace: string]: string };

--- a/src/utils/resources/secret/utils.ts
+++ b/src/utils/resources/secret/utils.ts
@@ -1,14 +1,14 @@
 import { Buffer } from 'buffer';
 
+import { SecretModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1Secret } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import {
   SecretSelectionOption,
   SSHSecretDetails,
 } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
-import { SecretModel } from '@kubevirt-utils/models';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { k8sCreate, k8sDelete } from '@openshift-console/dynamic-plugin-sdk';
+import { k8sCreate, k8sDelete, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 import { getName } from '../shared';
 
@@ -44,10 +44,12 @@ export const getInitialSSHDetails = ({
   applyKeyToProject = false,
   secretToCreate,
   sshSecretName,
+  sshSecretNamespace = '',
 }: {
   applyKeyToProject?: boolean;
   secretToCreate?: IoK8sApiCoreV1Secret;
   sshSecretName: string;
+  sshSecretNamespace?: string;
 }): SSHSecretDetails =>
   !isEmpty(secretToCreate)
     ? {
@@ -56,7 +58,7 @@ export const getInitialSSHDetails = ({
         secretOption: SecretSelectionOption.addNew,
         sshPubKey: decodeSecret(secretToCreate),
         sshSecretName: getName(secretToCreate),
-        sshSecretNamespace: '',
+        sshSecretNamespace,
       }
     : {
         appliedDefaultKey: true,
@@ -66,17 +68,22 @@ export const getInitialSSHDetails = ({
           : SecretSelectionOption.none,
         sshPubKey: '',
         sshSecretName: sshSecretName || '',
-        sshSecretNamespace: '',
+        sshSecretNamespace,
       };
 
-type CreateSecretType = (input: {
+type CreateUserPasswordSecretType = (input: {
   namespace: string;
   password: string;
   secretName: string;
   username: string;
 }) => Promise<IoK8sApiCoreV1Secret>;
 
-export const createSecret: CreateSecretType = ({ namespace, password, secretName, username }) =>
+export const createUserPasswordSecret: CreateUserPasswordSecretType = ({
+  namespace,
+  password,
+  secretName,
+  username,
+}) =>
   k8sCreate({
     data: {
       apiVersion: 'v1',
@@ -93,6 +100,26 @@ export const createSecret: CreateSecretType = ({ namespace, password, secretName
     },
     model: SecretModel,
     ns: namespace,
+  });
+
+export const createSSHSecret = (
+  sshKey: string,
+  secretName: string,
+  secretNamespace: string,
+  dryRun = false,
+) =>
+  k8sCreate<K8sResourceCommon & { data?: { [key: string]: string } }>({
+    data: {
+      apiVersion: SecretModel.apiVersion,
+      data: { key: encodeSecretKey(sshKey) },
+      kind: SecretModel.kind,
+      metadata: {
+        name: secretName,
+        namespace: secretNamespace,
+      },
+    },
+    model: SecretModel,
+    ...(dryRun && { queryParams: { dryRun: 'All' } }),
   });
 
 export const deleteSecret = (secret: IoK8sApiCoreV1Secret) =>

--- a/src/utils/resources/secret/utils/selectors.ts
+++ b/src/utils/resources/secret/utils/selectors.ts
@@ -1,0 +1,8 @@
+import { IoK8sApiCoreV1Secret } from '@kubevirt-ui/kubevirt-api/kubernetes';
+
+/**
+ *  A selector for the Secret's encoded SSH key
+ * @param {IoK8sApiCoreV1Secret} secret - secret
+ * @return {string} key - encoded SSH key
+ */
+export const getSecretEncodedSSHKey = (secret: IoK8sApiCoreV1Secret) => secret?.data?.['key'];

--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
@@ -9,7 +9,6 @@ import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { SecretSelectionOption } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
-import { createSSHSecret } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import {
   AUTOUNATTEND,
   generateNewSysprepConfig,
@@ -28,6 +27,7 @@ import {
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { createSSHSecret } from '@kubevirt-utils/resources/secret/utils';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
 import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
 import { useDriversImage } from '@kubevirt-utils/resources/vm/utils/disk/useDriversImage';

--- a/src/views/catalog/CustomizeInstanceType/components/CustomizeITVMFooter.tsx
+++ b/src/views/catalog/CustomizeInstanceType/components/CustomizeITVMFooter.tsx
@@ -5,7 +5,6 @@ import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/u
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import { SecretSelectionOption } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
-import { createSSHSecret } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import { logITFlowEvent } from '@kubevirt-utils/extensions/telemetry/telemetry';
 import {
   CANCEL_CUSTOMIZE_VM_BUTTON_CLICKED,
@@ -14,6 +13,7 @@ import {
 } from '@kubevirt-utils/extensions/telemetry/utils/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { createSSHSecret } from '@kubevirt-utils/resources/secret/utils';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
 import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
 import { clearCustomizeInstanceType, vmSignal } from '@kubevirt-utils/store/customizeInstanceType';

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/AuthorizedSSHKey.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/AuthorizedSSHKey.tsx
@@ -1,26 +1,11 @@
-import React, { FC, useCallback, useEffect, useMemo } from 'react';
+import React, { FC } from 'react';
 
-import { SecretModel } from '@kubevirt-ui/kubevirt-api/console';
-import { IoK8sApiCoreV1Secret } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import useTemplateSecrets from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/useTemplateSecrets';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
 import SSHSecretModal from '@kubevirt-utils/components/SSHSecretModal/SSHSecretModal';
-import {
-  SecretSelectionOption,
-  SSHSecretDetails,
-} from '@kubevirt-utils/components/SSHSecretModal/utils/types';
-import {
-  addSecretToVM,
-  removeSecretToVM,
-} from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getInitialSSHDetails } from '@kubevirt-utils/resources/secret/utils';
-import { getVMSSHSecretName } from '@kubevirt-utils/resources/vm';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { DescriptionList, HelperText, HelperTextItem, SplitItem } from '@patternfly/react-core';
-
-import { useDrawerContext } from './hooks/useDrawerContext';
 
 type AuthorizedSSHKeyProps = {
   authorizedSSHKey: string;
@@ -29,66 +14,8 @@ type AuthorizedSSHKeyProps = {
 const AuthorizedSSHKey: FC<AuthorizedSSHKeyProps> = ({ authorizedSSHKey, namespace }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
-  const { setSSHDetails, setVM, sshDetails, template, vm } = useDrawerContext();
-
-  const vmAttachedSecretName = useMemo(() => getVMSSHSecretName(vm), [vm]);
-  const secretName = authorizedSSHKey || vmAttachedSecretName;
-
-  const additionalSecretResource: IoK8sApiCoreV1Secret = template?.objects?.find(
-    (object) => object?.kind === SecretModel.kind,
-  );
-
-  const onSSHChange = useCallback(
-    (details: SSHSecretDetails) => {
-      const { secretOption, sshPubKey, sshSecretName } = details;
-
-      if (isEqualObject(details, sshDetails)) {
-        return;
-      }
-
-      if (
-        secretOption === SecretSelectionOption.none &&
-        sshDetails?.secretOption !== SecretSelectionOption.none
-      ) {
-        setVM(removeSecretToVM(vm));
-      }
-
-      if (
-        secretOption === SecretSelectionOption.useExisting &&
-        sshDetails?.sshSecretName !== sshSecretName &&
-        !isEmpty(sshSecretName)
-      ) {
-        setVM(addSecretToVM(vm, sshSecretName));
-      }
-
-      if (
-        secretOption === SecretSelectionOption.addNew &&
-        !isEmpty(sshPubKey) &&
-        !isEmpty(sshSecretName)
-      ) {
-        setVM(addSecretToVM(vm, sshSecretName));
-      }
-
-      setSSHDetails(details);
-      return Promise.resolve();
-    },
-    [sshDetails, setVM, vm, setSSHDetails],
-  );
-
-  useEffect(() => {
-    if (isEmpty(sshDetails)) {
-      const initialSSHDetails = getInitialSSHDetails({
-        applyKeyToProject: !isEmpty(authorizedSSHKey),
-        secretToCreate:
-          isEmpty(authorizedSSHKey) && !isEmpty(additionalSecretResource)
-            ? additionalSecretResource
-            : null,
-        sshSecretName: secretName,
-      });
-
-      onSSHChange(initialSSHDetails);
-    }
-  }, [additionalSecretResource, authorizedSSHKey, onSSHChange, secretName, sshDetails]);
+  const { copyTemplateSecretToTargetNS, onSSHChange, overwriteTemplateSSHKey, sshDetails } =
+    useTemplateSecrets(authorizedSSHKey, namespace);
 
   return (
     <SplitItem>
@@ -108,10 +35,17 @@ const AuthorizedSSHKey: FC<AuthorizedSSHKeyProps> = ({ authorizedSSHKey, namespa
           descriptionHeader={t('Public SSH key')}
           isEdit
         />
-        {!isEmpty(additionalSecretResource) && (
+        {overwriteTemplateSSHKey && (
           <HelperText>
             <HelperTextItem variant="warning">
               {t('This key will override the SSH key secret set on the template')}
+            </HelperTextItem>
+          </HelperText>
+        )}
+        {copyTemplateSecretToTargetNS && (
+          <HelperText>
+            <HelperTextItem variant="warning">
+              {t('This Secret will be copied to the destination project')}
             </HelperTextItem>
           </HelperText>
         )}

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/useTemplateSecrets.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/useTemplateSecrets.ts
@@ -1,0 +1,121 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { useDrawerContext } from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDrawerContext';
+import { TemplateSSHDetails } from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/utils/types';
+import { getTemplateSSHSecret } from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/utils/utils';
+import {
+  getSecretByNameAndNS,
+  getSSHSecretCopy,
+  sshSecretExistsInNamespace,
+} from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/utils';
+import { IoK8sApiCoreV1Secret } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
+import useSecretsData from '@kubevirt-utils/components/SSHSecretModal/hooks/useSecretsData';
+import {
+  SecretSelectionOption,
+  SSHSecretDetails,
+} from '@kubevirt-utils/components/SSHSecretModal/utils/types';
+import {
+  addSecretToVM,
+  removeSecretFromVM,
+} from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
+import { getInitialSSHDetails } from '@kubevirt-utils/resources/secret/utils';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+
+type UseTemplateSecrets = (
+  namespaceDefaultSecretName: string,
+  targetNamespace: string,
+) => {
+  copyTemplateSecretToTargetNS: boolean;
+  onSSHChange: (details: SSHSecretDetails) => Promise<void>;
+  overwriteTemplateSSHKey: boolean;
+  sshDetails: SSHSecretDetails;
+};
+
+const useTemplateSecrets: UseTemplateSecrets = (namespaceDefaultSecretName, targetNamespace) => {
+  const { setSSHDetails, setVM, sshDetails, template, vm } = useDrawerContext();
+
+  const [templateSecretDetails] = useState<TemplateSSHDetails>(getTemplateSSHSecret(template));
+  const { templateSecretName, templateSecretNamespace } = templateSecretDetails;
+
+  const secretsData = useSecretsData(targetNamespace, templateSecretNamespace);
+  const templateSecret: IoK8sApiCoreV1Secret = getSecretByNameAndNS(
+    templateSecretName,
+    templateSecretNamespace,
+    secretsData?.projectsWithSecrets,
+  );
+
+  const secretName = namespaceDefaultSecretName || templateSecretName;
+
+  const templateSecretExistsInTargetNS = sshSecretExistsInNamespace(
+    secretsData,
+    templateSecretNamespace,
+    targetNamespace,
+    templateSecretName,
+  );
+  const copyTemplateSecretToTargetNS =
+    secretName === templateSecretName && !templateSecretExistsInTargetNS;
+
+  const onSSHChange = useCallback(
+    (newSSHDetails: SSHSecretDetails) => {
+      const { secretOption, sshPubKey, sshSecretName } = newSSHDetails;
+
+      if (isEqualObject(newSSHDetails, sshDetails)) return;
+
+      const removeCurrentSecretFromVM =
+        secretOption === SecretSelectionOption.none &&
+        sshDetails?.secretOption !== SecretSelectionOption.none;
+
+      const addExistingSecretToVM =
+        secretOption === SecretSelectionOption.useExisting &&
+        sshDetails?.sshSecretName !== sshSecretName &&
+        !isEmpty(sshSecretName);
+
+      const addNewSecretToVM =
+        secretOption === SecretSelectionOption.addNew &&
+        !isEmpty(sshPubKey) &&
+        !isEmpty(sshSecretName);
+
+      if (removeCurrentSecretFromVM) setVM(removeSecretFromVM(vm));
+
+      if (addExistingSecretToVM || addNewSecretToVM) setVM(addSecretToVM(vm, sshSecretName));
+
+      setSSHDetails(newSSHDetails);
+      return Promise.resolve();
+    },
+    [sshDetails, setVM, vm, setSSHDetails],
+  );
+
+  useEffect(() => {
+    if (isEmpty(sshDetails) || !secretsData?.secretsLoaded) {
+      const initialSSHDetails = getInitialSSHDetails({
+        applyKeyToProject: !isEmpty(namespaceDefaultSecretName),
+        secretToCreate: copyTemplateSecretToTargetNS
+          ? getSSHSecretCopy(templateSecret, targetNamespace)
+          : null,
+        sshSecretName: secretName,
+        sshSecretNamespace: targetNamespace,
+      });
+
+      onSSHChange(initialSSHDetails);
+    }
+  }, [
+    namespaceDefaultSecretName,
+    onSSHChange,
+    secretsData.secretsLoaded,
+    secretName,
+    sshDetails,
+    copyTemplateSecretToTargetNS,
+    templateSecret,
+    targetNamespace,
+  ]);
+
+  return {
+    copyTemplateSecretToTargetNS,
+    onSSHChange,
+    overwriteTemplateSSHKey: !isEmpty(namespaceDefaultSecretName) && !isEmpty(templateSecretName),
+    sshDetails,
+  };
+};
+
+export default useTemplateSecrets;

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/utils/types.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/utils/types.ts
@@ -1,0 +1,4 @@
+export type TemplateSSHDetails = {
+  templateSecretName: string;
+  templateSecretNamespace: string;
+};

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/utils/utils.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/utils/utils.ts
@@ -1,0 +1,13 @@
+import { TemplateSSHDetails } from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/utils/types';
+import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
+import { getVMSSHSecretName } from '@kubevirt-utils/resources/vm';
+
+export const getTemplateSSHSecret = (template: V1Template): TemplateSSHDetails => {
+  const templateVM = getTemplateVirtualMachineObject(template);
+  return {
+    templateSecretName: getVMSSHSecretName(templateVM) || '',
+    templateSecretNamespace: getNamespace(template) || '',
+  };
+};

--- a/src/views/catalog/utils/WizardVMContext/utils/tabs-data.ts
+++ b/src/views/catalog/utils/WizardVMContext/utils/tabs-data.ts
@@ -1,12 +1,11 @@
 import { RegistryCredentials } from '@catalog/utils/useRegistryCredentials/utils/types';
 import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
+import { SSHSecretDetails } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
 import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
 import { OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
 
 export type TabsData = {
   additionalObjects?: any[];
-  applySSHToSettings?: boolean;
-  authorizedSSHKey?: string;
   disks?: {
     dataVolumesToAddOwnerRef?: V1beta1DataVolume[];
     rootDiskRegistryCredentials?: RegistryCredentials;
@@ -19,5 +18,6 @@ export type TabsData = {
       osType?: OS_NAME_TYPES;
     };
   };
+  sshDetails?: SSHSecretDetails;
   subscriptionData?: RHELAutomaticSubscriptionData;
 };

--- a/src/views/catalog/wizard/components/WizardFooter.tsx
+++ b/src/views/catalog/wizard/components/WizardFooter.tsx
@@ -32,7 +32,7 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 
-import { useWizardVmCreate } from '../../utils/useWizardVmCreate';
+import { useWizardVMCreate } from '../../utils/useWizardVMCreate';
 import { clearSessionStorageVM, useWizardVMContext } from '../../utils/WizardVMContext';
 
 import { WizardNoBootModal } from './WizardNoBootModal';
@@ -43,7 +43,7 @@ export const WizardFooter: FC<{ namespace: string }> = ({ namespace }) => {
   const [isUDNManagedNamespace] = useNamespaceUDN(namespace);
   const { disableVmCreate, loaded: vmContextLoaded, updateVM, vm } = useWizardVMContext();
   const { isBootSourceAvailable, loaded: bootSourceLoaded } = useWizardSourceAvailable();
-  const { createVM, error, loaded: vmCreateLoaded } = useWizardVmCreate();
+  const { createVM, error, loaded: vmCreateLoaded } = useWizardVMCreate();
   const { createModal } = useModal();
   const { featureEnabled: isDisableGuestSystemAccessLog } = useFeatures(
     DISABLED_GUEST_SYSTEM_LOGS_ACCESS,

--- a/src/views/catalog/wizard/tabs/scripts/components/SSHKey.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/components/SSHKey.tsx
@@ -1,89 +1,20 @@
-import React, { FC, useCallback, useMemo, useState } from 'react';
+import React, { FC } from 'react';
 import { Trans } from 'react-i18next';
 
-import { useWizardVMContext } from '@catalog/utils/WizardVMContext';
 import { WizardDescriptionItem } from '@catalog/wizard/components/WizardDescriptionItem';
+import useTemplateWizardSecrets from '@catalog/wizard/tabs/scripts/hooks/useTemplateWizardSecrets';
 import LinuxLabel from '@kubevirt-utils/components/Labels/LinuxLabel';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
 import SecretNameLabel from '@kubevirt-utils/components/SSHSecretModal/components/SecretNameLabel';
 import SSHSecretModal from '@kubevirt-utils/components/SSHSecretModal/SSHSecretModal';
-import {
-  SecretSelectionOption,
-  SSHSecretDetails,
-} from '@kubevirt-utils/components/SSHSecretModal/utils/types';
-import {
-  addSecretToVM,
-  removeSecretToVM,
-} from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { SecretModel } from '@kubevirt-utils/models';
-import { getInitialSSHDetails } from '@kubevirt-utils/resources/secret/utils';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
-import { getVMSSHSecretName } from '@kubevirt-utils/resources/vm';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Content, ContentVariants, Stack } from '@patternfly/react-core';
-
-import { removeSSHKeyObject, updateSSHKeyObject } from './sshkey-utils';
 
 const SSHKey: FC = () => {
   const { t } = useKubevirtTranslation();
-  const { tabsData, updateTabsData, updateVM, vm } = useWizardVMContext();
   const { createModal } = useModal();
-
-  const vmAttachedSecretName = useMemo(() => getVMSSHSecretName(vm), [vm]);
-
-  const [sshDetails, setSSHDetails] = useState<SSHSecretDetails>(
-    getInitialSSHDetails({
-      applyKeyToProject: tabsData.applySSHToSettings,
-      secretToCreate: tabsData.additionalObjects?.find((obj) => obj?.kind === SecretModel.kind),
-      sshSecretName: vmAttachedSecretName,
-    }),
-  );
-
-  const onSubmit = useCallback(
-    async (details: SSHSecretDetails) => {
-      const { applyKeyToProject, secretOption, sshPubKey, sshSecretName } = details;
-
-      if (isEqualObject(details, sshDetails)) {
-        return;
-      }
-
-      removeSSHKeyObject(updateTabsData, sshDetails.sshSecretName);
-      updateTabsData((currentTabsData) => {
-        currentTabsData.authorizedSSHKey = sshSecretName;
-        currentTabsData.applySSHToSettings = applyKeyToProject;
-      });
-
-      if (
-        secretOption === SecretSelectionOption.none &&
-        sshDetails.secretOption !== SecretSelectionOption.none
-      ) {
-        await updateVM(removeSecretToVM(vm));
-      }
-
-      if (
-        secretOption === SecretSelectionOption.useExisting &&
-        sshDetails.sshSecretName !== sshSecretName &&
-        !isEmpty(sshSecretName)
-      ) {
-        await updateVM(addSecretToVM(vm, sshSecretName));
-      }
-
-      if (
-        secretOption === SecretSelectionOption.addNew &&
-        !isEmpty(sshPubKey) &&
-        !isEmpty(sshSecretName)
-      ) {
-        updateSSHKeyObject(vm, updateTabsData, sshPubKey, sshSecretName);
-        await updateVM(addSecretToVM(vm, sshSecretName));
-      }
-
-      setSSHDetails(details);
-      return Promise.resolve();
-    },
-    [sshDetails, updateTabsData, updateVM, vm],
-  );
+  const { onSubmit, sshDetails, vm, vmAttachedSecretName } = useTemplateWizardSecrets();
 
   return (
     <WizardDescriptionItem

--- a/src/views/catalog/wizard/tabs/scripts/hooks/useTemplateWizardSecrets.ts
+++ b/src/views/catalog/wizard/tabs/scripts/hooks/useTemplateWizardSecrets.ts
@@ -1,0 +1,95 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { useWizardVMContext } from '@catalog/utils/WizardVMContext';
+import {
+  removeSSHKeyObject,
+  updateSSHKeyObject,
+} from '@catalog/wizard/tabs/scripts/components/sshkey-utils';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
+import {
+  SecretSelectionOption,
+  SSHSecretDetails,
+} from '@kubevirt-utils/components/SSHSecretModal/utils/types';
+import {
+  addSecretToVM,
+  removeSecretFromVM,
+} from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
+import { SecretModel } from '@kubevirt-utils/models';
+import { getInitialSSHDetails } from '@kubevirt-utils/resources/secret/utils';
+import { getVMSSHSecretName } from '@kubevirt-utils/resources/vm';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+
+type UseTemplateWizardSecrets = () => {
+  onSubmit: (details: SSHSecretDetails) => Promise<void>;
+  sshDetails: SSHSecretDetails;
+  vm: V1VirtualMachine;
+  vmAttachedSecretName: string;
+};
+
+const useTemplateWizardSecrets: UseTemplateWizardSecrets = () => {
+  const { tabsData, updateTabsData, updateVM, vm } = useWizardVMContext();
+  const { applyKeyToProject } = tabsData?.sshDetails;
+
+  const vmAttachedSecretName = useMemo(() => getVMSSHSecretName(vm), [vm]);
+
+  const [sshDetails, setSSHDetails] = useState<SSHSecretDetails>(
+    getInitialSSHDetails({
+      applyKeyToProject: applyKeyToProject,
+      secretToCreate: tabsData.additionalObjects?.find((obj) => obj?.kind === SecretModel.kind),
+      sshSecretName: vmAttachedSecretName,
+    }),
+  );
+
+  const onSubmit = useCallback(
+    async (details: SSHSecretDetails) => {
+      const { secretOption, sshPubKey, sshSecretName } = details;
+
+      if (isEqualObject(details, sshDetails)) {
+        return;
+      }
+
+      removeSSHKeyObject(updateTabsData, sshDetails.sshSecretName);
+      updateTabsData((currentTabsData) => {
+        currentTabsData.sshDetails = sshDetails;
+      });
+
+      if (
+        secretOption === SecretSelectionOption.none &&
+        sshDetails.secretOption !== SecretSelectionOption.none
+      ) {
+        await updateVM(removeSecretFromVM(vm));
+      }
+
+      if (
+        secretOption === SecretSelectionOption.useExisting &&
+        sshDetails.sshSecretName !== sshSecretName &&
+        !isEmpty(sshSecretName)
+      ) {
+        await updateVM(addSecretToVM(vm, sshSecretName));
+      }
+
+      if (
+        secretOption === SecretSelectionOption.addNew &&
+        !isEmpty(sshPubKey) &&
+        !isEmpty(sshSecretName)
+      ) {
+        updateSSHKeyObject(vm, updateTabsData, sshPubKey, sshSecretName);
+        await updateVM(addSecretToVM(vm, sshSecretName));
+      }
+
+      setSSHDetails(details);
+      return Promise.resolve();
+    },
+    [sshDetails, updateTabsData, updateVM, vm],
+  );
+
+  return {
+    onSubmit,
+    sshDetails,
+    vm,
+    vmAttachedSecretName,
+  };
+};
+
+export default useTemplateWizardSecrets;

--- a/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/components/SSHAuthKeyRow/SSHAuthKeyRow.tsx
+++ b/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/components/SSHAuthKeyRow/SSHAuthKeyRow.tsx
@@ -7,8 +7,8 @@ import {
   SecretSelectionOption,
   SSHSecretDetails,
 } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
-import { createSSHSecret } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { createSSHSecret } from '@kubevirt-utils/resources/secret/utils';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Button, ButtonVariant, Grid, GridItem, Truncate } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';

--- a/src/views/templates/details/tabs/scripts/components/SSHKey/sshkey-utils.ts
+++ b/src/views/templates/details/tabs/scripts/components/SSHKey/sshkey-utils.ts
@@ -1,20 +1,11 @@
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
-import { IoK8sApiCoreV1Secret } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { addSecretToVM } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
-import { generateSSHKeySecret } from '@kubevirt-utils/resources/secret/utils';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { getAccessCredentials } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
-export const getTemplateSSHKeySecret = (
-  template: V1Template,
-  vmSSHKeySecretName: string,
-): IoK8sApiCoreV1Secret | undefined =>
-  template?.objects?.find((object) => getName(object) === vmSSHKeySecretName);
-
-export const updateSecretName = (template: V1Template, secretName: string) => {
+export const updateAccessCredential = (template: V1Template, secretName: string) => {
   const vm = getTemplateVirtualMachineObject(template);
 
   template.objects = (template?.objects || []).map((object) =>
@@ -22,30 +13,7 @@ export const updateSecretName = (template: V1Template, secretName: string) => {
   );
 };
 
-export const updateSSHKeyObject = (
-  template: V1Template,
-  sshKey: string,
-  existingSecretName: string,
-  newSSHSecretName: string,
-) => {
-  const sshKeySecretObject = getTemplateSSHKeySecret(template, existingSecretName);
-
-  if (sshKeySecretObject) {
-    sshKeySecretObject.data.key = sshKey;
-  } else {
-    const vm = getTemplateVirtualMachineObject(template);
-
-    updateSecretName(template, newSSHSecretName);
-
-    template.objects.push(generateSSHKeySecret(newSSHSecretName, getNamespace(vm), sshKey));
-  }
-};
-
-export const removeSecretObject = (template: V1Template, secretName: string) => {
-  template.objects = (template?.objects || []).filter((object) => getName(object) !== secretName);
-};
-
-export const removeCredential = (template: V1Template, secretName: string) => {
+export const removeAccessCredential = (template: V1Template, secretName: string) => {
   const vm = getTemplateVirtualMachineObject(template);
   const accessCredentials = getAccessCredentials(vm);
 


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug that occurs when a default SSH Secret is configured for a namespace and a separate SSH Secret is configured on a template within that namespace.

Reproduction steps:

1. Configure a Secret named "auto-test-secret" as the default Secret for the namespace in the User settings section
2. Clone a Template and add a Secret named "auto-test-secret1" to the Template
3. Create a VM from this Template
4. Create a VM from this Template again

Jira: https://issues.redhat.com/browse/CNV-50292

## 🎥 Demo

[fix-template-ssh-secret-conflict--2025-03-24 10-59.webm](https://github.com/user-attachments/assets/27e25061-c91c-49fd-a3e3-e810acf1cf23)


