### PR TITLE
CNV-55111: fix get bootmode bios when seelcted

### DIFF
--- a/src/utils/components/FirmwareBootloaderModal/utils/utils.ts
+++ b/src/utils/components/FirmwareBootloaderModal/utils/utils.ts
@@ -20,6 +20,9 @@ export const getBootloaderFromVM = (
   if (secureBoot?.secureBoot === false) {
     return BootMode.uefi;
   }
+
+  if (vm?.spec?.template?.spec?.domain?.firmware?.bootloader?.bios) return BootMode.bios;
+
   return defaultBootmode;
 };
 

--- a/src/views/catalog/CustomizeInstanceType/tabs/configuration/hooks/usePreference.ts
+++ b/src/views/catalog/CustomizeInstanceType/tabs/configuration/hooks/usePreference.ts
@@ -1,3 +1,4 @@
+import VirtualMachinePreferenceModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachinePreferenceModel';
 import {
   V1beta1VirtualMachinePreference,
   V1VirtualMachine,
@@ -18,7 +19,7 @@ const usePreference = (
     useK8sWatchResource<V1beta1VirtualMachinePreference>({
       groupVersionKind: modelToGroupVersionKind(getPreferenceModelFromMatcher(vmPreference)),
       name: vmPreference?.name,
-      namespace: getNamespace(vm),
+      namespace: vmPreference.kind === VirtualMachinePreferenceModel.kind ? getNamespace(vm) : null,
     });
 
   const preferenceLoading = !preferenceLoaded && isEmpty(preferenceError);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- when `vmPreference` has no `kind` means its a cluster preference so we should not fetch it using the namespace field.
- before the fix here we're returning `bios` boot mode after verifying `uefi` and `uefi secure` . Not that this function have a default boot mode, we have to verify that the VM has bios enabled before returning the default mode 

## 🎥 Demo

**Before**

https://github.com/user-attachments/assets/7d9c6fd6-3798-4a44-b9a9-1cc67db5604c



**After**


https://github.com/user-attachments/assets/98a9da32-fdf5-4dd7-af2c-6d38a824f4ae


