### PR TITLE
[release-4.16] CNV-56325: Fix snapshot model version

### DIFF
--- a/src/views/virtualmachines/details/tabs/snapshots/hooks/useSnapshotData.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/hooks/useSnapshotData.ts
@@ -1,9 +1,7 @@
 import * as React from 'react';
 
-import {
-  VirtualMachineRestoreModelGroupVersionKind,
-  VirtualMachineSnapshotModelGroupVersionKind,
-} from '@kubevirt-ui/kubevirt-api/console';
+import VirtualMachineRestoreModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineRestoreModel';
+import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
 import {
   V1beta1VirtualMachineRestore,
   V1beta1VirtualMachineSnapshot,
@@ -23,7 +21,11 @@ const useSnapshotData = (vmName: string, namespace: string): UseSnapshotData => 
   const [snapshots, snapshotsLoaded, snapshotsError] = useK8sWatchResource<
     V1beta1VirtualMachineSnapshot[]
   >({
-    groupVersionKind: VirtualMachineSnapshotModelGroupVersionKind,
+    groupVersionKind: {
+      group: VirtualMachineSnapshotModel.apiGroup,
+      kind: VirtualMachineSnapshotModel.kind,
+      version: 'v1alpha1',
+    },
     isList: true,
     namespace,
     namespaced: true,
@@ -32,7 +34,11 @@ const useSnapshotData = (vmName: string, namespace: string): UseSnapshotData => 
   const [restores, restoresLoaded, restoresError] = useK8sWatchResource<
     V1beta1VirtualMachineRestore[]
   >({
-    groupVersionKind: VirtualMachineRestoreModelGroupVersionKind,
+    groupVersionKind: {
+      group: VirtualMachineRestoreModel.apiGroup,
+      kind: VirtualMachineRestoreModel.kind,
+      version: 'v1alpha1',
+    },
     isList: true,
     namespace,
     namespaced: true,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

We have this bug as we bumped the kubevirt-api version for this https://issues.redhat.com/browse/CNV-51123

So I just fixed the snapshot and restore version is they are the only one installed in the cluster at this point. 
