### PR TITLE
fix check tab e2e tests

### DIFF
--- a/cypress/tests/e2e/check-tab-yaml.cy.ts
+++ b/cypress/tests/e2e/check-tab-yaml.cy.ts
@@ -66,7 +66,7 @@ describe('Check all virtualization pages can be loaded', () => {
       cy.contains('Status conditions').should('be.visible');
 
       tab.navigateToDiagnosticsGuestSystemLog();
-      cy.contains('Guest system logs').should('be.visible');
+      cy.contains('Guest system log').should('be.visible');
 
       // sub-tabs in configuration tab
       tab.navigateToConfiguration();


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

e2e tests are failing on this part of check tabs  

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/kubevirt-ui_kubevirt-plugin/2443/pull-ci-kubevirt-ui-kubevirt-plugin-main-kubevirt-e2e-aws/1888942441495531520/artifacts/kubevirt-e2e-aws/tests/artifacts/gui-test-screenshots/screenshots/all.cy.ts/2_Check%20all%20virtualization%20pages%20can%20be%20loaded%20--%20Check%20VM%20tabs%20--%20vm%20tabs%20are%20loaded%20(failed).png