### PR TITLE
CNV-52511: Keep formatting in VNC paste action

### DIFF
--- a/src/utils/components/Consoles/components/CloudInitCredentials/CloudInitCredentialsContent.tsx
+++ b/src/utils/components/Consoles/components/CloudInitCredentials/CloudInitCredentialsContent.tsx
@@ -6,6 +6,8 @@ import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
+import { LINE_FEED } from '../vnc-console/utils/util';
+
 import InlineCodeClipboardCopy from './InlineCodeClipboardCopy';
 
 type CloudInitCredentialsContentProps = {
@@ -26,14 +28,16 @@ const CloudInitCredentialsContent: FC<CloudInitCredentialsContentProps> = ({ vm 
         <>
           {acc.passwords}
           <InlineCodeClipboardCopy
-            clipboardText={user?.password?.concat(String.fromCharCode(13))}
+            clipboardText={user?.password?.concat(String.fromCharCode(LINE_FEED))}
           />
         </>
       ),
       usernames: (
         <>
           {acc.usernames}
-          <InlineCodeClipboardCopy clipboardText={user?.name?.concat(String.fromCharCode(13))} />
+          <InlineCodeClipboardCopy
+            clipboardText={user?.name?.concat(String.fromCharCode(LINE_FEED))}
+          />
         </>
       ),
     }),

--- a/src/utils/components/Consoles/components/vnc-console/utils/util.ts
+++ b/src/utils/components/Consoles/components/vnc-console/utils/util.ts
@@ -1,2 +1,9 @@
 // keyboard keys that need to press&hold the shiftKey
-export const isShiftKeyRequired = (char: string): boolean => '~!@#$%^&*()_+}{|":?><'.includes(char);
+export const isShiftKeyRequired = (char: string): boolean =>
+  !!char?.match(/[A-Z~!@#$%^&*()_+}{|\":?><]/);
+
+export const LINE_FEED = 10;
+export const HORIZONTAL_TAB = 9;
+
+export const LATIN_1_FIRST_CHAR = 0x20;
+export const LATIN_1_LAST_CHAR = 0xff;


### PR DESCRIPTION
## 📝 Description
1. iterate on code points to avoid splitting surrogate pairs
2. handle new line, tab and Latin-1 set
   a) detect new line as LF/NL char and map to XK_KP_Enter keysym
   b) map tab char to XK_Tab
   c) map Latin-1 directly to keysym
3. fix handling capital letters (limited to ASCII) 
4. replace new line marker used for login and password from CR(code 13)
   to LF/NL(code 10)


Reference-Url: https://github.com/novnc/noVNC/blob/b45f35c6d7b06c1d8641ceb8e7f5ee00c23484eb/core/input/keysym.js#L221
Reference-Url: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/codePointAt#looping_with_codepointat
Reference-Url: https://en.wikipedia.org/wiki/ISO/IEC_8859-1
## 🎥 Demo

### Before
https://github.com/user-attachments/assets/5369b6cd-08ff-4f17-ac14-3d319d897bd4

### After

https://github.com/user-attachments/assets/ef9c06b1-7215-4322-87c3-aad2af6aa759




