### PR TITLE
CNV-56219: fix guided tour

### DIFF
--- a/src/utils/components/GuidedTour/utils/constants.tsx
+++ b/src/utils/components/GuidedTour/utils/constants.tsx
@@ -89,7 +89,7 @@ export const tourSteps: Step[] = [
       'On the Configuration tab on the VirtualMachine page, you can search for and edit any configurable item using the search box.',
     ),
     data: {
-      route: '/k8s/all-namespaces/kubevirt.io~v1~VirtualMachine/rhel9-tour-guide/configuration',
+      route: '/k8s/ns/default/kubevirt.io~v1~VirtualMachine/rhel9-tour-guide/configuration',
     },
     disableBeacon: true,
     placement: 'bottom',

--- a/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  runningTourSignal,
+  tourGuideVM,
+} from '@kubevirt-utils/components/GuidedTour/utils/constants';
 import HorizontalNavbar from '@kubevirt-utils/components/HorizontalNavbar/HorizontalNavbar';
 import { SidebarEditorProvider } from '@kubevirt-utils/components/SidebarEditor/SidebarEditorContext';
 import useInstanceTypeExpandSpec from '@kubevirt-utils/resources/vm/hooks/useInstanceTypeExpandSpec';
@@ -24,13 +28,19 @@ const VirtualMachineNavPage: React.FC<VirtualMachineDetailsPageProps> = ({
   name,
   namespace,
 }) => {
-  const [vm, isLoaded, loadError] = useK8sWatchResource<V1VirtualMachine>({
-    kind,
-    name,
-    namespace,
-  });
+  const [vm, isLoaded, loadError] = useK8sWatchResource<V1VirtualMachine>(
+    runningTourSignal.value
+      ? null
+      : {
+          kind,
+          name,
+          namespace,
+        },
+  );
 
-  const [instanceTypeExpandedSpec, expandedSpecLoading] = useInstanceTypeExpandSpec(vm);
+  const vmToShow = runningTourSignal.value ? tourGuideVM : vm;
+
+  const [instanceTypeExpandedSpec, expandedSpecLoading] = useInstanceTypeExpandSpec(vmToShow);
 
   const pages = useVirtualMachineTabs();
 
@@ -39,7 +49,7 @@ const VirtualMachineNavPage: React.FC<VirtualMachineDetailsPageProps> = ({
       <VirtualMachineNavPageTitle
         isLoaded={isLoaded || !isEmpty(loadError)}
         name={name}
-        vm={isInstanceTypeVM(vm) ? instanceTypeExpandedSpec : vm}
+        vm={isInstanceTypeVM(vmToShow) ? instanceTypeExpandedSpec : vmToShow}
       />
       <div className="VirtualMachineNavPage--tabs__main">
         <HorizontalNavbar
@@ -47,7 +57,7 @@ const VirtualMachineNavPage: React.FC<VirtualMachineDetailsPageProps> = ({
           instanceTypeExpandedSpec={instanceTypeExpandedSpec}
           loaded={isLoaded && !expandedSpecLoading}
           pages={pages}
-          vm={vm}
+          vm={vmToShow}
         />
       </div>
     </SidebarEditorProvider>

--- a/src/views/virtualmachines/details/tabs/configuration/VirtualMachineConfigurationTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/VirtualMachineConfigurationTab.tsx
@@ -4,10 +4,6 @@ import { useLocation } from 'react-router-dom-v5-compat';
 
 import useInstanceTypesAndPreferences from '@catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypesAndPreferences';
 import GuidedTour from '@kubevirt-utils/components/GuidedTour/GuidedTour';
-import {
-  runningTourSignal,
-  tourGuideVM,
-} from '@kubevirt-utils/components/GuidedTour/utils/constants';
 import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
 import { getName } from '@kubevirt-utils/resources/shared';
 import useInstanceTypeExpandSpec from '@kubevirt-utils/resources/vm/hooks/useInstanceTypeExpandSpec';
@@ -26,10 +22,9 @@ const VirtualMachineConfigurationTab: FC<NavPageComponentProps> = ({ obj }) => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const vm = runningTourSignal.value ? tourGuideVM : obj;
-  const { vmi } = useVMI(getName(vm), getNamespace(vm));
+  const { vmi } = useVMI(getName(obj), getNamespace(obj));
   const { allInstanceTypes } = useInstanceTypesAndPreferences();
-  const [instanceTypeVM] = useInstanceTypeExpandSpec(vm);
+  const [instanceTypeVM] = useInstanceTypeExpandSpec(obj);
   const [activeTabKey, setActiveTabKey] = useState<number | string>(
     VirtualMachineDetailsTab.Details,
   );
@@ -53,7 +48,7 @@ const VirtualMachineConfigurationTab: FC<NavPageComponentProps> = ({ obj }) => {
 
   return (
     <div className="co-dashboard-body VirtualMachineConfigurationTab">
-      <VirtualMachineConfigurationTabSearch vm={vm} />
+      <VirtualMachineConfigurationTabSearch vm={obj} />
       <div className="VirtualMachineConfigurationTab--body">
         <Tabs activeKey={activeTabKey} className="VirtualMachineConfigurationTab--main" isVertical>
           {tabs.map(({ Component, name, title }) => (
@@ -69,7 +64,7 @@ const VirtualMachineConfigurationTab: FC<NavPageComponentProps> = ({ obj }) => {
                 <Component
                   allInstanceTypes={allInstanceTypes}
                   instanceTypeVM={instanceTypeVM}
-                  vm={vm}
+                  vm={obj}
                   vmi={vmi}
                 />
               )}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The state handling on top of the VM Configuration Tab component was in a infinite loading

AND 
the gouded tour was using the all-namespaces URL 

I changed the VM URL link removing /all-namespaces/ and use /ns/default (the tour VM has default namespace)

## 🎥 Demo


**Before**


https://github.com/user-attachments/assets/5647669b-0d5b-4efa-95fc-516fbb743774




**Fix**


https://github.com/user-attachments/assets/762f4f3f-9bf2-40d5-9b2f-908a051870a1


