### PR TITLE
CNV-56226: migrate only migratable disks

### DIFF
--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
@@ -14,7 +14,7 @@ import { Modal, Wizard, WizardHeader, WizardStep } from '@patternfly/react-core'
 import VirtualMachineMigrationDestinationTab from './tabs/VirtualMachineMigrationDestinationTab';
 import VirtualMachineMigrationDetails from './tabs/VirtualMachineMigrationDetails';
 import VirtualMachineMigrationReviewTab from './tabs/VirtualMachineMigrationReviewTab';
-import { entireVMSelected, migrateVM } from './utils';
+import { entireVMSelected, getMigratableVMPVCs, migrateVM } from './utils';
 import VirtualMachineMigrationStatus from './VirtualMachineMigrationStatus';
 
 import './virtual-machine-migration-modal.scss';
@@ -45,7 +45,9 @@ const VirtualMachineMigrateModal: FC<VirtualMachineMigrateModalProps> = ({
 
   const [{ clusterDefaultStorageClass, sortedStorageClasses }, scLoaded] = useDefaultStorageClass();
 
-  const pvcsToMigrate = entireVMSelected(selectedPVCs) ? pvcs : selectedPVCs;
+  const pvcsToMigrate = entireVMSelected(selectedPVCs)
+    ? getMigratableVMPVCs(vm, pvcs)
+    : selectedPVCs;
 
   const defaultStorageClassName = useMemo(
     () => getName(clusterDefaultStorageClass),

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/tabs/components/utils.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/tabs/components/utils.ts
@@ -1,11 +1,12 @@
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine, V1Volume } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getName } from '@kubevirt-utils/resources/shared';
 import { getDisks } from '@kubevirt-utils/resources/vm';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { getPrintableDiskDrive } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
 import { convertToBaseValue, humanizeBinaryBytes } from '@kubevirt-utils/utils/humanize.js';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+
+import { getVolumePVC, isDiskMigratable, isPVCMigratable } from '../../utils';
 
 export const getTableDiskData = (
   vm: V1VirtualMachine,
@@ -13,11 +14,7 @@ export const getTableDiskData = (
   pvcs: IoK8sApiCoreV1PersistentVolumeClaim[],
 ) => {
   const volumeDisk = getDisks(vm)?.find((disk) => disk.name === volume.name);
-  const volumePVC = pvcs?.find(
-    (pvc) =>
-      getName(pvc) === volume.dataVolume?.name ||
-      getName(pvc) === volume.persistentVolumeClaim?.claimName,
-  );
+  const volumePVC = getVolumePVC(volume, pvcs);
 
   const pvcSize = humanizeBinaryBytes(
     convertToBaseValue(volumePVC?.spec?.resources?.requests?.storage),
@@ -25,7 +22,7 @@ export const getTableDiskData = (
 
   return {
     drive: getPrintableDiskDrive(volumeDisk),
-    isSelectable: !volumeDisk?.shareable && !isEmpty(volumePVC),
+    isSelectable: isDiskMigratable(volumeDisk) && !isEmpty(volumePVC) && isPVCMigratable(volumePVC),
     name: volume.name,
     pvc: volumePVC,
     size: pvcSize?.value === 0 ? NO_DATA_DASH : pvcSize?.string,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Do not let the user migrate non-migratable volumes.

Migratable volume: Not shared disk and PVC with RWX accessMode

In the demo below, the disk `disk-teal-stingray-79` is connected to a PVC that do not have accessMode RWX but only RWO

## 🎥 Demo

**Before**

<img width="1131" alt="Screenshot 2025-02-19 at 16 57 39" src="https://github.com/user-attachments/assets/9b617062-bebd-498d-b5b6-2be4057023fc" />



**After**


<img width="1131" alt="Screenshot 2025-02-19 at 16 57 10" src="https://github.com/user-attachments/assets/dd967a8a-48cf-41c8-9995-00d25ebc6cb3" />

