### PR TITLE
Single 100 min waiting test for cluster exploration

### DIFF
--- a/cypress/tests/all.cy.ts
+++ b/cypress/tests/all.cy.ts
@@ -1,4 +1,1 @@
-import './e2e/a-setup.cy.ts';
-import './e2e/b-overview.cy.ts';
-import './e2e/check-tab-yaml.cy.ts';
-import './e2e/create-vm.cy.ts';
+import './e2e/post-action.cy.ts';

--- a/cypress/tests/e2e/post-action.cy.ts
+++ b/cypress/tests/e2e/post-action.cy.ts
@@ -1,0 +1,7 @@
+import { MINUTE } from '../../utils/const/index';
+
+describe('Holding cluster', () => {
+  it('wait 100 minutes', () => {
+    cy.wait(100 * MINUTE);
+  });
+});

--- a/setup.sh
+++ b/setup.sh
@@ -10,13 +10,12 @@ health_check () {
   echo "Health checklist before console test."
 
   #1 - download image from artifactory server
-  # curl ${CYPRESS_CIRROS_IMAGE} -u${CYPRESS_ARTIFACTORY_USER}:${CYPRESS_ARTIFACTORY_TOKEN} -kL -o ${CYPRESS_LOCAL_IMAGE}
+  curl ${CYPRESS_CIRROS_IMAGE} -u${CYPRESS_ARTIFACTORY_USER}:${CYPRESS_ARTIFACTORY_TOKEN} -kL -o ${CYPRESS_LOCAL_IMAGE}
 
   #2 - pvc upload is working
-  # virtctl image-upload -n default pvc auto-test-pvc --size=1Gi --image-path=${CYPRESS_LOCAL_IMAGE} --insecure --force-bind
+  virtctl image-upload -n default pvc auto-test-pvc --size=1Gi --image-path=${CYPRESS_LOCAL_IMAGE} --insecure --force-bind
 
   #3 - create VM from CLI to verify the webhook
-  oc delete -f cypress/fixtures/vm.yaml --ignore-not-found=true
   oc create -f cypress/fixtures/vm.yaml
   oc wait --for=condition=ready vm/rhel-10-vm --timeout=360s
   oc delete -f cypress/fixtures/vm.yaml

--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -7,7 +7,7 @@ source setup.sh
 
 # cleanup, setup and health check
 #cleanup
-health_check
+#health_check
 
 # Install dependencies.
 yarn install --ignore-engines


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 This PR should not be merged or closed

> This PR is created to allow cluster under test exploration. It's not intended to be merged\
In order to explore the cluster, the `ci/prow/kubevirt-e2e-aws` check has to be triggered. This will run 'Holding cluster' cypress test, which sleeps for 100 minutes, thus holding the cluster alive and allowing to connect to it via web-console.

## How to use

 1. Uncomment `post-actions.cy.ts` suite in `cypress/tests/all.cy.ts`
 2. Trigger `ci/prow/kubevirt-e2e-aws` check by /retest command
 3. Wait for `ci/prow/kubevirt-e2e-aws` to start, open it's log
 4.  At the start of the log (line 9) the there's a build cluster url, like 

console-openshift-console.apps.build11.ci.devcluster.openshift.com/k8s/cluster/projects/**ci-op-xxxxxxxx**

where **ci-op-xxxxxxxx** - the project name

 5. Login to this cluster with SSO, navigate to Workloads -> Secrets ->  kubevirt-e2e-aws secret
 6. In the Data section below find **kubeconfig** section - it holds cluster name, like **ci-op-xxxxxxxx-yyyy** and **kubeadmin-password** section with kubeadmin password to the cluster
