### PR TITLE
Fix Form Submission Behavior for Virtual Machine Creation

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -70,7 +70,7 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
 
     const error = templateLoadingError || createError;
     return (
-      <form className="template-catalog-drawer-form" id="quick-create-form">
+      <div className="template-catalog-drawer-form" id="quick-create-form">
         <Stack hasGutter>
           <>
             <StackItem>
@@ -80,6 +80,7 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
                     <TextInput
                       aria-label="virtualmachine name"
                       data-test-id="template-catalog-vm-name-input"
+                      form={DRAWER_FORM_ID}
                       isDisabled={Boolean(templateLoadingError)}
                       isRequired
                       name="vmname"
@@ -198,7 +199,7 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
             </Split>
           </StackItem>
         </Stack>
-      </form>
+      </div>
     );
   },
 );


### PR DESCRIPTION

<img width="741" alt="Screenshot 2025-02-26 at 4 36 01 PM" src="https://github.com/user-attachments/assets/4196feca-e4c5-4c11-9d3e-9035dcf97366" />


## 📝 Description

PR ensures that pressing `Enter` key in the VM creation form correctly triggers the Quick Create VirtualMachine action (which is expected by users) instead of causing an unintended full-page reload (default browser behavior). 

## Changes

- Added a form submit handler (onSubmitForm) to prevent default submission behavior and trigger `onQuickCreate`.
- Removed `onClick={onQuickCreate}` from the Quick Create VirtualMachine button since form submission now handles it, and `button[type=submit]` automatically submits the form when clicked (so no need for an onClick handler).
- Remove `e: MouseEvent` from onQuickCreate parameters, as default browser behavior is already prevented on the form submission (`e.preventDefault()`)

## 🎥 Demo

Current behavior upon pressing `Enter` key.

https://github.com/user-attachments/assets/2a0893e3-dc4d-4e23-af4a-16ede9bd53cb




