### PR TITLE
CNV-57476: Fix VM action confirmation modal not closing on confirmation

### DIFF
--- a/src/views/virtualmachines/actions/components/ConfirmVMActionModal/ConfirmVMActionModal.tsx
+++ b/src/views/virtualmachines/actions/components/ConfirmVMActionModal/ConfirmVMActionModal.tsx
@@ -30,7 +30,7 @@ const ConfirmVMActionModal: FC<ConfirmVMActionModalProps> = ({
   return (
     <Modal
       actions={[
-        <Button key="confirm" onClick={() => action(vm)} variant={ButtonVariant.primary}>
+        <Button key="confirm" onClick={submitHandler} variant={ButtonVariant.primary}>
           {t(actionType)}
         </Button>,
         <Button key="cancel" onClick={onClose} variant="link">
@@ -40,7 +40,7 @@ const ConfirmVMActionModal: FC<ConfirmVMActionModalProps> = ({
       className="confirm-multiple-vm-actions-modal"
       isOpen={isOpen}
       onClose={onClose}
-      onSubmit={() => submitHandler()}
+      onSubmit={submitHandler}
       title={t('{{actionType}} VirtualMachine?', { actionType })}
       variant={'small'}
     >


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug where the VM action confirmation modal would remain open after clicking the confirmation button.

Jira: https://issues.redhat.com/browse/CNV-57476

## 🎥 Demo

[fix-confirm-vm-actions--2025-03-05 20-55.webm](https://github.com/user-attachments/assets/294df094-ce70-4b84-b483-8f8d9868ef3e)