### PR TITLE
CNV-49608:  Default to raw VM in VirtualMachineNavPageTitle

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -492,7 +492,7 @@
   "Edit disk": "Edit disk",
   "Edit Display name": "Edit Display name",
   "Edit hostname": "Edit hostname",
-  "Edit Instancetype": "Edit Instancetype",
+  "Edit Instance Type": "Edit Instance Type",
   "Edit labels": "Edit labels",
   "Edit Labels": "Edit Labels",
   "Edit MigrationPolicy": "Edit MigrationPolicy",

--- a/src/utils/components/CloneVMModal/CloneVMModal.tsx
+++ b/src/utils/components/CloneVMModal/CloneVMModal.tsx
@@ -10,6 +10,7 @@ import {
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { MAX_K8S_NAME_LENGTH } from '@kubevirt-utils/utils/constants';
+import { isVM } from '@kubevirt-utils/utils/typeGuards';
 import { getRandomChars } from '@kubevirt-utils/utils/utils';
 import { Form } from '@patternfly/react-core';
 import { ModalVariant } from '@patternfly/react-core/deprecated';
@@ -21,7 +22,7 @@ import SnapshotContentConfigurationSummary from './components/SnapshotContentCon
 import StartClonedVMCheckbox from './components/StartClonedVMCheckbox/StartClonedVMCheckbox';
 import useCloneVMModal from './hooks/useCloneVMModal';
 import { CLONING_STATUSES } from './utils/constants';
-import { cloneVM, isVM, runVM, vmExist } from './utils/helpers';
+import { cloneVM, runVM, vmExist } from './utils/helpers';
 
 type CloneVMModalProps = {
   headerText?: string;

--- a/src/utils/components/CloneVMModal/utils/helpers.tsx
+++ b/src/utils/components/CloneVMModal/utils/helpers.tsx
@@ -10,6 +10,7 @@ import {
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { RUNSTRATEGY_ALWAYS } from '@kubevirt-utils/constants/constants';
 import { MAX_K8S_NAME_LENGTH } from '@kubevirt-utils/utils/constants';
+import { isVM } from '@kubevirt-utils/utils/typeGuards';
 import { getRandomChars } from '@kubevirt-utils/utils/utils';
 import { k8sCreate, k8sGet, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -32,10 +33,6 @@ const cloneVMToVM: V1alpha1VirtualMachineClone = {
     },
   },
 };
-
-export const isVM = (
-  source: V1beta1VirtualMachineSnapshot | V1VirtualMachine,
-): source is V1VirtualMachine => source.kind === VirtualMachineModel.kind;
 
 export const cloneVM = (
   source: V1beta1VirtualMachineSnapshot | V1VirtualMachine,

--- a/src/utils/components/Consoles/Consoles.tsx
+++ b/src/utils/components/Consoles/Consoles.tsx
@@ -4,7 +4,7 @@ import { VirtualMachineModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/c
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getGPUDevices } from '@kubevirt-utils/resources/vm';
+import { getGPUDevices, isHeadlessMode } from '@kubevirt-utils/resources/vm';
 import { isWindows } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { RFBCreate } from '@novnc/novnc/lib/rfb';
@@ -22,7 +22,6 @@ import {
   WSFactoryExtends,
 } from './components/utils/ConsoleConsts';
 import VncConsole from './components/vnc-console/VncConsole';
-import { isHeadlessModeVMI } from './utils/utils';
 
 import './consoles.scss';
 
@@ -44,7 +43,6 @@ const Consoles: FC<ConsolesProps> = ({ consoleContainerClass, isStandAlone, vmi 
   });
   const isWindowsVM = isWindows(vmi);
   const gpus = getGPUDevices(vm);
-  const isHeadlessMode = isHeadlessModeVMI(vmi);
 
   if (!vmi?.metadata) {
     return (
@@ -54,7 +52,7 @@ const Consoles: FC<ConsolesProps> = ({ consoleContainerClass, isStandAlone, vmi 
     );
   }
 
-  if (isHeadlessMode) {
+  if (isHeadlessMode(vmi)) {
     return <div>{t('Console is disabled in headless mode')}</div>;
   }
 

--- a/src/utils/components/Consoles/utils/utils.ts
+++ b/src/utils/components/Consoles/utils/utils.ts
@@ -1,13 +1,6 @@
-import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
-
 import { CONSOLE_PASTE_EVENT } from './constants';
 
 export const isConnectionEncrypted = () => window.location.protocol === 'https:';
-
-export const isHeadlessModeVMI = (vmi: V1VirtualMachineInstance) => {
-  const devices = vmi?.spec?.domain?.devices;
-  return devices?.hasOwnProperty('autoattachGraphicsDevice') && !devices?.autoattachGraphicsDevice;
-};
 
 export const clipboardCopyFunc = (
   _: React.ClipboardEvent<HTMLDivElement>,

--- a/src/utils/components/DiskModal/utils/form.ts
+++ b/src/utils/components/DiskModal/utils/form.ts
@@ -4,6 +4,7 @@ import {
   V1VirtualMachine,
   V1Volume,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { getName } from '@kubevirt-utils/resources/shared';
 import {
   getBootDisk,
@@ -11,7 +12,6 @@ import {
   getDisks,
   getVolumes,
 } from '@kubevirt-utils/resources/vm';
-import { isInstanceTypeVM } from '@kubevirt-utils/resources/vm/utils/instanceTypes';
 import { generatePrettyName, getRandomChars, isEmpty } from '@kubevirt-utils/utils/utils';
 import { isRunning } from '@virtualmachines/utils';
 

--- a/src/utils/components/HardwareDevices/HardwareDevicesHeadlessMode.tsx
+++ b/src/utils/components/HardwareDevices/HardwareDevicesHeadlessMode.tsx
@@ -3,6 +3,7 @@ import produce from 'immer';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isHeadlessMode } from '@kubevirt-utils/resources/vm';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 import { Flex, FlexItem, Switch } from '@patternfly/react-core';
 
@@ -15,10 +16,7 @@ type HardwareDevicesHeadlessModeProps = {
 const HardwareDevicesHeadlessMode: FC<HardwareDevicesHeadlessModeProps> = ({ onSubmit, vm }) => {
   const { t } = useKubevirtTranslation();
 
-  const devices = vm?.spec?.template?.spec?.domain?.devices;
-  const [isChecked, setIsChecked] = useState<boolean>(
-    devices?.hasOwnProperty('autoattachGraphicsDevice') && !devices?.autoattachGraphicsDevice,
-  );
+  const [isChecked, setIsChecked] = useState<boolean>(isHeadlessMode(vm));
 
   const updateHeadlessMode = (checked: boolean) => {
     const updatedVM = produce<V1VirtualMachine>(vm, (vmDraft: V1VirtualMachine) => {

--- a/src/utils/components/HardwareDevices/modal/HardwareDevicesHeadlessModeModal.tsx
+++ b/src/utils/components/HardwareDevices/modal/HardwareDevicesHeadlessModeModal.tsx
@@ -6,6 +6,7 @@ import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/
 import ModalPendingChangesAlert from '@kubevirt-utils/components/PendingChanges/ModalPendingChangesAlert/ModalPendingChangesAlert';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isHeadlessMode } from '@kubevirt-utils/resources/vm';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 import { Checkbox, Form, FormGroup } from '@patternfly/react-core';
 
@@ -24,11 +25,8 @@ const HardwareDevicesHeadlessModeModal: FC<HardwareDevicesHeadlessModeModalProps
   vm,
   vmi,
 }) => {
-  const devices = vm?.spec?.template?.spec?.domain?.devices;
   const { t } = useKubevirtTranslation();
-  const [checked, setChecked] = useState<boolean>(
-    devices?.hasOwnProperty('autoattachGraphicsDevice') && !devices?.autoattachGraphicsDevice,
-  );
+  const [checked, setChecked] = useState<boolean>(isHeadlessMode(vm));
 
   const updatedVirtualMachine = useMemo(() => {
     const updatedVM = produce<V1VirtualMachine>(vm, (vmDraft: V1VirtualMachine) => {

--- a/src/utils/components/HeadlessMode/HeadlessMode.tsx
+++ b/src/utils/components/HeadlessMode/HeadlessMode.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { isHeadlessMode } from '@kubevirt-utils/resources/vm';
 import { Switch } from '@patternfly/react-core';
 
 type HeadlessModeProps = {
@@ -9,11 +10,7 @@ type HeadlessModeProps = {
 };
 
 const HeadlessMode: FC<HeadlessModeProps> = ({ updateHeadlessMode, vm }) => {
-  const devices = vm?.spec?.template?.spec?.domain?.devices;
-  const [isChecked, setIsChecked] = useState<boolean>(
-    devices?.hasOwnProperty('autoattachGraphicsDevice') &&
-      devices?.autoattachGraphicsDevice === false,
-  );
+  const [isChecked, setIsChecked] = useState<boolean>(isHeadlessMode(vm));
   return (
     <Switch
       onChange={(_event, checked: boolean) => {

--- a/src/utils/components/InstanceTypeModal/InstanceTypeModal.tsx
+++ b/src/utils/components/InstanceTypeModal/InstanceTypeModal.tsx
@@ -1,6 +1,5 @@
 import React, { FC, useMemo, useState } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Content, Flex, FlexItem, SelectList, SelectOption } from '@patternfly/react-core';
 import { InstanceTypeUnion } from '@virtualmachines/details/tabs/configuration/utils/types';
@@ -8,6 +7,7 @@ import { InstanceTypeUnion } from '@virtualmachines/details/tabs/configuration/u
 import FormPFSelect from '../FormPFSelect/FormPFSelect';
 import TabModal from '../TabModal/TabModal';
 
+import { InstanceTypeModalProps } from './utils/types';
 import {
   getInstanceTypeFromSeriesAndSize,
   getInstanceTypeSeriesAndSize,
@@ -17,25 +17,13 @@ import {
   mappedInstanceTypesToSelectOptions,
 } from './utils/util';
 
-type InstanceTypeModalProps = {
-  allInstanceTypes: InstanceTypeUnion[];
-  instanceType: InstanceTypeUnion;
-  instanceTypeVM: V1VirtualMachine;
-  isOpen: boolean;
-  onClose: () => void;
-  onSubmit: (
-    updatedVM: V1VirtualMachine,
-    instanceType: InstanceTypeUnion,
-  ) => Promise<V1VirtualMachine>;
-};
-
 const InstanceTypeModal: FC<InstanceTypeModalProps> = ({
   allInstanceTypes,
   instanceType,
-  instanceTypeVM,
   isOpen,
   onClose,
   onSubmit,
+  vm,
 }) => {
   const { t } = useKubevirtTranslation();
   const mappedInstanceTypes = useMemo(
@@ -47,20 +35,20 @@ const InstanceTypeModal: FC<InstanceTypeModalProps> = ({
     [instanceType],
   );
 
-  const [series, setSeries] = useState<string>(
+  const [series, setSeries] = useState<string | undefined>(
     getInstanceTypeSeriesDisplayName(mappedInstanceTypes, instanceTypeSeries),
   );
 
-  const [size, setSize] = useState<string>(
+  const [size, setSize] = useState<string | undefined>(
     getInstanceTypesPrettyDisplaySize(mappedInstanceTypes, instanceTypeSeries, instanceTypeSize),
   );
 
   const handleSubmit = (selectedInstanceType: InstanceTypeUnion) =>
-    onSubmit(instanceTypeVM, selectedInstanceType);
+    onSubmit(vm, selectedInstanceType);
 
   return (
     <TabModal
-      headerText={t('Edit Instancetype')}
+      headerText={t('Edit Instance Type')}
       isOpen={isOpen}
       obj={getInstanceTypeFromSeriesAndSize(mappedInstanceTypes, series, size)}
       onClose={onClose}

--- a/src/utils/components/InstanceTypeModal/StandaloneInstanceTypeModal.tsx
+++ b/src/utils/components/InstanceTypeModal/StandaloneInstanceTypeModal.tsx
@@ -1,0 +1,40 @@
+import React, { FC, useMemo } from 'react';
+
+import useInstanceTypesAndPreferences from '@catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypesAndPreferences';
+
+import ErrorAlert from '../ErrorAlert/ErrorAlert';
+import Loading from '../Loading/Loading';
+
+import { InstanceTypeModalProps } from './utils/types';
+import InstanceTypeModal from './InstanceTypeModal';
+
+const StandaloneInstanceTypeModal: FC<
+  Pick<InstanceTypeModalProps, 'isOpen' | 'onClose' | 'onSubmit' | 'vm'>
+> = ({ isOpen, onClose, onSubmit, vm }) => {
+  const { allInstanceTypes, loaded, loadError } = useInstanceTypesAndPreferences();
+  const instanceTypeName = vm?.spec?.instancetype?.name;
+  const instanceType = useMemo(
+    () => allInstanceTypes.find((it) => it.metadata.name === instanceTypeName),
+    [instanceTypeName, allInstanceTypes],
+  );
+
+  if (!loaded) {
+    return <Loading />;
+  }
+  if (loadError) {
+    return <ErrorAlert error={loadError} />;
+  }
+
+  return (
+    <InstanceTypeModal
+      allInstanceTypes={allInstanceTypes}
+      instanceType={instanceType}
+      isOpen={isOpen}
+      onClose={onClose}
+      onSubmit={onSubmit}
+      vm={vm}
+    />
+  );
+};
+
+export default StandaloneInstanceTypeModal;

--- a/src/utils/components/InstanceTypeModal/utils/types.ts
+++ b/src/utils/components/InstanceTypeModal/utils/types.ts
@@ -1,3 +1,4 @@
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { InstanceTypeUnion } from '@virtualmachines/details/tabs/configuration/utils/types';
 
 export type InstanceTypesSeries =
@@ -37,3 +38,15 @@ export type MappedInstanceTypes = Record<
     };
   } & { descriptionSeries?: string; displayNameSeries?: string }
 >;
+
+export type InstanceTypeModalProps = {
+  allInstanceTypes: InstanceTypeUnion[];
+  instanceType: InstanceTypeUnion;
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (
+    vmToBeUpdated: V1VirtualMachine,
+    instanceType: InstanceTypeUnion,
+  ) => Promise<V1VirtualMachine>;
+  vm: V1VirtualMachine;
+};

--- a/src/utils/components/InstanceTypeModal/utils/util.ts
+++ b/src/utils/components/InstanceTypeModal/utils/util.ts
@@ -33,8 +33,11 @@ export const getInstanceTypeDescriptionAnnotation = (instanceType: InstanceTypeU
 
 export const getInstanceTypeSeriesAndSize = (
   instanceType: InstanceTypeUnion,
-): { series: InstanceTypesSeries; size: InstanceTypesSizes } => {
-  const [series, size] = instanceType?.metadata?.name?.split('.');
+): { series?: InstanceTypesSeries; size?: InstanceTypesSizes } => {
+  const [series, size] = instanceType?.metadata?.name?.split('.') ?? [];
+  if (!series || !size) {
+    return {};
+  }
   return { series: series as InstanceTypesSeries, size: size as InstanceTypesSizes };
 };
 
@@ -80,34 +83,42 @@ const sortInstanceTypeSizes = (a: InstanceTypeRecord, b: InstanceTypeRecord) => 
 
 export const getInstanceTypesPrettyDisplaySize = (
   mappedInstanceTypes: MappedInstanceTypes,
-  instanceTypeSeries: InstanceTypesSeries,
-  instanceTypeSize: InstanceTypeSize,
+  instanceTypeSeries?: InstanceTypesSeries,
+  instanceTypeSize?: InstanceTypeSize,
 ) => mappedInstanceTypes?.[instanceTypeSeries]?.sizes[instanceTypeSize]?.prettyDisplaySize;
 
-export const getInstanceTypesSizes = (mappedInstanceTypes: MappedInstanceTypes, series: string) => {
+export const getInstanceTypesSizes = (
+  mappedInstanceTypes: MappedInstanceTypes,
+  series?: string,
+) => {
   const matchedSeries = Object.values(mappedInstanceTypes).find(
     (it) => it.displayNameSeries === series,
   );
-  return Object.values(matchedSeries?.sizes).sort(sortInstanceTypeSizes);
+  return Object.values(matchedSeries?.sizes ?? {}).sort(sortInstanceTypeSizes);
 };
 
 export const getInstanceTypeSeriesDisplayName = (
   mappedInstanceTypes: MappedInstanceTypes,
-  instanceTypeSeries: InstanceTypesSeries,
+  instanceTypeSeries?: InstanceTypesSeries,
 ) => mappedInstanceTypes?.[instanceTypeSeries]?.displayNameSeries;
 
 export const getInstanceTypeFromSeriesAndSize = (
   mappedInstanceTypes: MappedInstanceTypes,
-  instanceTypeSeries: string,
-  instanceTypeSize: string,
+  instanceTypeSeries?: string,
+  instanceTypeSize?: string,
 ): InstanceTypeUnion => {
   const instanceTypesSeries = Object.values(mappedInstanceTypes);
 
   const matchedSeries = instanceTypesSeries.find(
-    (series) => series.displayNameSeries === instanceTypeSeries,
+    (series) => series?.displayNameSeries === instanceTypeSeries,
   );
-  const matchedSize = Object.values(matchedSeries?.sizes).find(
-    (size) => size.prettyDisplaySize === instanceTypeSize,
+
+  if (!matchedSeries) {
+    return undefined;
+  }
+
+  const matchedSize = Object.values(matchedSeries?.sizes ?? {}).find(
+    (size) => size?.prettyDisplaySize === instanceTypeSize,
   );
 
   return matchedSize?.instanceType;

--- a/src/utils/resources/instancetype/constants.ts
+++ b/src/utils/resources/instancetype/constants.ts
@@ -1,0 +1,4 @@
+export const NAMESPACED_INSTANCE_TYPE_NAME_ANNOTATION = 'kubevirt.io/instancetype-name';
+export const CLUSTER_INSTANCE_TYPE_NAME_ANNOTATION = 'kubevirt.io/cluster-instancetype-name';
+export const NAMESPACED_PREFERENCE_NAME_ANNOTATION = 'kubevirt.io/preference-name';
+export const CLUSTER_PREFERENCE_NAME_ANNOTATION = 'kubevirt.io/cluster-preference-name';

--- a/src/utils/resources/instancetype/helper.ts
+++ b/src/utils/resources/instancetype/helper.ts
@@ -1,7 +1,22 @@
 import VirtualMachineClusterInstancetypeModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineClusterInstancetypeModel';
 import VirtualMachineInstancetypeModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstancetypeModel';
-import { V1InstancetypeMatcher } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1InstancetypeMatcher,
+  V1VirtualMachine,
+  V1VirtualMachineInstance,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { isVM } from '@kubevirt-utils/utils/typeGuards';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
+
+import { getAnnotation } from '../shared';
+
+import {
+  CLUSTER_INSTANCE_TYPE_NAME_ANNOTATION,
+  CLUSTER_PREFERENCE_NAME_ANNOTATION,
+  NAMESPACED_INSTANCE_TYPE_NAME_ANNOTATION,
+  NAMESPACED_PREFERENCE_NAME_ANNOTATION,
+} from './constants';
 
 export const getInstanceTypeModelFromMatcher = (
   instanceTypeMatcher: V1InstancetypeMatcher,
@@ -9,3 +24,18 @@ export const getInstanceTypeModelFromMatcher = (
   instanceTypeMatcher.kind.includes('cluster')
     ? VirtualMachineClusterInstancetypeModel
     : VirtualMachineInstancetypeModel;
+
+export const isInstanceTypeVM = (vm: V1VirtualMachine | V1VirtualMachineInstance): boolean =>
+  isVM(vm)
+    ? !isEmpty(vm?.spec?.instancetype) || !isEmpty(vm?.spec?.preference)
+    : !!getInstanceTypeNameFromAnnotation(vm) || !!getPreferenceNameFromAnnotation(vm);
+
+export const getInstanceTypeNameFromAnnotation = (
+  vm: V1VirtualMachine | V1VirtualMachineInstance,
+) =>
+  getAnnotation(vm, NAMESPACED_INSTANCE_TYPE_NAME_ANNOTATION) ??
+  getAnnotation(vm, CLUSTER_INSTANCE_TYPE_NAME_ANNOTATION);
+
+export const getPreferenceNameFromAnnotation = (vm: V1VirtualMachine | V1VirtualMachineInstance) =>
+  getAnnotation(vm, NAMESPACED_PREFERENCE_NAME_ANNOTATION) ??
+  getAnnotation(vm, CLUSTER_PREFERENCE_NAME_ANNOTATION);

--- a/src/utils/resources/vm/hooks/useInstanceTypeExpandSpec.ts
+++ b/src/utils/resources/vm/hooks/useInstanceTypeExpandSpec.ts
@@ -3,16 +3,15 @@ import { useEffect, useMemo, useState } from 'react';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import useDeepCompareMemoize from '@kubevirt-utils/hooks/useDeepCompareMemoize/useDeepCompareMemoize';
+import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
 
-import { isInstanceTypeVM } from '../utils/instanceTypes';
-
 type UseInstanceTypeExpandSpec = (
   vm: V1VirtualMachine,
 ) => [
-  insstanceTypeExpandedSpec: V1VirtualMachine,
+  instanceTypeExpandedSpec: V1VirtualMachine,
   loadingExpandedSpec: boolean,
   errorExpandedSpec: Error,
 ];

--- a/src/utils/resources/vm/utils/instanceTypes.ts
+++ b/src/utils/resources/vm/utils/instanceTypes.ts
@@ -1,5 +1,0 @@
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
-
-export const isInstanceTypeVM = (vm: V1VirtualMachine): boolean =>
-  !isEmpty(vm?.spec?.instancetype) || !isEmpty(vm?.spec?.preference);

--- a/src/utils/resources/vm/utils/selectors.ts
+++ b/src/utils/resources/vm/utils/selectors.ts
@@ -11,6 +11,7 @@ import {
   V1PreferenceMatcher,
   V1VirtualMachine,
   V1VirtualMachineCondition,
+  V1VirtualMachineInstance,
   V1Volume,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { DYNAMIC_CREDENTIALS_SUPPORT } from '@kubevirt-utils/components/DynamicSSHKeyInjection/constants/constants';
@@ -18,6 +19,7 @@ import { ROOTDISK } from '@kubevirt-utils/constants/constants';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { getAnnotation, getLabel } from '@kubevirt-utils/resources/shared';
 import { WORKLOADS } from '@kubevirt-utils/resources/template';
+import { isVM } from '@kubevirt-utils/utils/typeGuards';
 
 import { VM_WORKLOAD_ANNOTATION } from './annotations';
 import { UPDATE_STRATEGIES, VirtualMachineStatusConditionTypes } from './constants';
@@ -301,3 +303,8 @@ export const getStatusConditionByType = (
 
 export const getUpdateStrategy = (vm: V1VirtualMachine): UPDATE_STRATEGIES =>
   vm?.spec?.updateVolumesStrategy as UPDATE_STRATEGIES;
+
+export const isHeadlessMode = (vm: V1VirtualMachine | V1VirtualMachineInstance) => {
+  const devices = isVM(vm) ? vm?.spec?.template?.spec?.domain?.devices : vm?.spec?.domain?.devices;
+  return devices?.autoattachGraphicsDevice === false;
+};

--- a/src/utils/utils/typeGuards.ts
+++ b/src/utils/utils/typeGuards.ts
@@ -1,0 +1,5 @@
+import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+
+export const isVM = (source: unknown): source is V1VirtualMachine =>
+  (source as V1VirtualMachine)?.kind === VirtualMachineModel.kind;

--- a/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
@@ -8,7 +8,6 @@ import {
 import HorizontalNavbar from '@kubevirt-utils/components/HorizontalNavbar/HorizontalNavbar';
 import { SidebarEditorProvider } from '@kubevirt-utils/components/SidebarEditor/SidebarEditorContext';
 import useInstanceTypeExpandSpec from '@kubevirt-utils/resources/vm/hooks/useInstanceTypeExpandSpec';
-import { isInstanceTypeVM } from '@kubevirt-utils/resources/vm/utils/instanceTypes';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -47,10 +46,10 @@ const VirtualMachineNavPage: React.FC<VirtualMachineDetailsPageProps> = ({
   return (
     <SidebarEditorProvider>
       <VirtualMachineNavPageTitle
+        instanceTypeExpandedSpec={instanceTypeExpandedSpec}
         isLoaded={isLoaded || !isEmpty(loadError)}
         name={name}
-        nonExpandedVM={vmToShow}
-        vm={isInstanceTypeVM(vmToShow) ? instanceTypeExpandedSpec : vmToShow}
+        vm={vmToShow}
       />
       <div className="VirtualMachineNavPage--tabs__main">
         <HorizontalNavbar

--- a/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
@@ -23,16 +23,16 @@ import { getVMStatusIcon } from '../utils';
 import { vmTabsWithYAML } from './utils/constants';
 
 type VirtualMachineNavPageTitleProps = {
+  instanceTypeExpandedSpec: V1VirtualMachine;
   isLoaded?: boolean;
   name: string;
-  nonExpandedVM: V1VirtualMachine;
   vm: V1VirtualMachine;
 };
 
 const VirtualMachineNavPageTitle: FC<VirtualMachineNavPageTitleProps> = ({
+  instanceTypeExpandedSpec,
   isLoaded,
   name,
-  nonExpandedVM,
   vm,
 }) => {
   const { t } = useKubevirtTranslation();
@@ -46,7 +46,7 @@ const VirtualMachineNavPageTitle: FC<VirtualMachineNavPageTitleProps> = ({
   });
   const vmim = useVirtualMachineInstanceMigration(vm);
   const [isSingleNodeCluster] = useSingleNodeCluster();
-  const [actions] = useVirtualMachineActionsProvider(nonExpandedVM, vmim, isSingleNodeCluster);
+  const [actions] = useVirtualMachineActionsProvider(vm, vmim, isSingleNodeCluster);
   const StatusIcon = getVMStatusIcon(vm?.status?.printableStatus);
 
   const isSidebarEditorDisplayed = vmTabsWithYAML.find((tab) =>
@@ -88,7 +88,11 @@ const VirtualMachineNavPageTitle: FC<VirtualMachineNavPageTitleProps> = ({
           )}
         </Split>
       </span>
-      <VirtualMachinePendingChangesAlert vm={vm} vmi={vmi} />
+      <VirtualMachinePendingChangesAlert
+        instanceTypeExpandedSpec={instanceTypeExpandedSpec}
+        vm={vm}
+        vmi={vmi}
+      />
     </div>
   );
 };

--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/VirtualMachinePendingChangesAlert.tsx
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/VirtualMachinePendingChangesAlert.tsx
@@ -14,6 +14,7 @@ import { isRunning } from '@virtualmachines/utils';
 import { splitPendingChanges } from '../utils/utils';
 
 type VirtualMachinePendingChangesAlertProps = {
+  instanceTypeExpandedSpec: V1VirtualMachine;
   vm: V1VirtualMachine;
   vmi: V1VirtualMachineInstance;
 };

--- a/src/views/virtualmachines/details/tabs/configuration/VirtualMachineConfigurationTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/VirtualMachineConfigurationTab.tsx
@@ -6,7 +6,6 @@ import useInstanceTypesAndPreferences from '@catalog/CreateFromInstanceTypes/sta
 import GuidedTour from '@kubevirt-utils/components/GuidedTour/GuidedTour';
 import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
 import { getName } from '@kubevirt-utils/resources/shared';
-import useInstanceTypeExpandSpec from '@kubevirt-utils/resources/vm/hooks/useInstanceTypeExpandSpec';
 import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
@@ -18,13 +17,15 @@ import { getInnerTabFromPath, includesConfigurationPath, tabs } from './utils/ut
 
 import './virtual-machine-configuration-tab.scss';
 
-const VirtualMachineConfigurationTab: FC<NavPageComponentProps> = ({ obj }) => {
+const VirtualMachineConfigurationTab: FC<NavPageComponentProps> = ({
+  instanceTypeExpandedSpec,
+  obj: vm,
+}) => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const { vmi } = useVMI(getName(obj), getNamespace(obj));
+  const { vmi } = useVMI(getName(vm), getNamespace(vm));
   const { allInstanceTypes } = useInstanceTypesAndPreferences();
-  const [instanceTypeVM] = useInstanceTypeExpandSpec(obj);
   const [activeTabKey, setActiveTabKey] = useState<number | string>(
     VirtualMachineDetailsTab.Details,
   );
@@ -48,7 +49,7 @@ const VirtualMachineConfigurationTab: FC<NavPageComponentProps> = ({ obj }) => {
 
   return (
     <div className="co-dashboard-body VirtualMachineConfigurationTab">
-      <VirtualMachineConfigurationTabSearch vm={obj} />
+      <VirtualMachineConfigurationTabSearch vm={vm} />
       <div className="VirtualMachineConfigurationTab--body">
         <Tabs activeKey={activeTabKey} className="VirtualMachineConfigurationTab--main" isVertical>
           {tabs.map(({ Component, name, title }) => (
@@ -63,8 +64,8 @@ const VirtualMachineConfigurationTab: FC<NavPageComponentProps> = ({ obj }) => {
               {activeTabKey === name && (
                 <Component
                   allInstanceTypes={allInstanceTypes}
-                  instanceTypeVM={instanceTypeVM}
-                  vm={obj}
+                  instanceTypeVM={instanceTypeExpandedSpec}
+                  vm={vm}
                   vmi={vmi}
                 />
               )}

--- a/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
@@ -19,6 +19,7 @@ import WorkloadProfileModal from '@kubevirt-utils/components/WorkloadProfileModa
 import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { asAccessReview, getAnnotation, getName } from '@kubevirt-utils/resources/shared';
 import { WORKLOADS_LABELS } from '@kubevirt-utils/resources/template';
 import {
@@ -85,10 +86,10 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
   const vmWorkload = getWorkload(vm);
   const vmName = getName(vm);
 
-  const isInstanceType = !isEmpty(vm?.spec?.instancetype?.name);
+  const isInstanceType = isInstanceTypeVM(vm);
   const deletionProtectionEnabled = isDeletionProtectionEnabled(vm);
 
-  const loadingInstanceType = isInstanceType && (isEmpty(instanceType) || isEmpty(instanceTypeVM));
+  const loadingInstanceType = isInstanceType && isEmpty(instanceType);
 
   if (!vm || loadingInstanceType) {
     return <Loading />;
@@ -158,10 +159,10 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
                     <InstanceTypeModal
                       allInstanceTypes={allInstanceTypes}
                       instanceType={instanceType}
-                      instanceTypeVM={instanceTypeVM}
                       isOpen={isOpen}
                       onClose={onClose}
                       onSubmit={updatedInstanceType}
+                      vm={vm}
                     />
                   ) : (
                     <CPUMemoryModal

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
@@ -49,7 +49,7 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({
 
   useEffect(() => {
     expandURLHash(getSearchItemsIds(getDetailsTabBootIds(vm)), location?.hash, setIsExpanded);
-  }, [vm, location?.hash]);
+  }, [vm, location?.hash, setIsExpanded]);
 
   return (
     <ExpandableSection

--- a/src/views/virtualmachines/details/tabs/configuration/details/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/details/utils/utils.ts
@@ -197,7 +197,7 @@ export const updatedVirtualMachine = (updatedVM: V1VirtualMachine) =>
   });
 
 export const updatedInstanceType = (
-  updatedVM: V1VirtualMachine,
+  vmToBeUpdated: V1VirtualMachine,
   instanceType: V1beta1VirtualMachineClusterInstancetype | V1beta1VirtualMachineInstancetype,
 ) =>
   k8sPatch({
@@ -209,7 +209,7 @@ export const updatedInstanceType = (
       },
     ],
     model: VirtualMachineModel,
-    resource: updatedVM,
+    resource: vmToBeUpdated,
   });
 
 export const updatedHostname = (updatedVM: V1VirtualMachine) =>

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionRightGrid.tsx
@@ -9,8 +9,8 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { getEvictionStrategy } from '@kubevirt-utils/resources/vm';
-import { isInstanceTypeVM } from '@kubevirt-utils/resources/vm/utils/instanceTypes';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList, GridItem } from '@patternfly/react-core';
 

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
@@ -2,8 +2,8 @@ import React, { FC } from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import VncConsole from '@kubevirt-utils/components/Consoles/components/vnc-console/VncConsole';
-import { isHeadlessModeVMI } from '@kubevirt-utils/components/Consoles/utils/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isHeadlessMode as isHeadlessModeVMI } from '@kubevirt-utils/resources/vm/utils/selectors';
 import { vmiStatuses } from '@kubevirt-utils/resources/vmi';
 import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 import { Bullseye, Button } from '@patternfly/react-core';


### PR DESCRIPTION
## 📝 Description

Before the fix, VirtualMachineNavPageTitle used the result of
expand-spec instead of a raw VM object. The approach failed
in scenarios where:
1. isInstanceTypeVM() was used as this information is by design
   erased by the backend.
2. the VM was sent to the backend - as expanded VM is considered a new
   VM (with references to old VM removed)
The main section distinguished both objects and passed them separately
as 'instanceTypeExpandedSpec' and 'vm' (both of type V1VirtualMachine).

After the fix the raw VM object will be used by default in
VirtualMachineNavPageTitle and the expanded VM will be passed as
'instanceTypeExpandedSpec'.

Key points:
1. hasOwnProperty() checks used for 'autoattachGraphicsDevice' were
   refactored to use isHeadlessMode() helper
3. created an independent version of InstanceTypeModal that retrieves
   all available instance types - the extra query will be fired only
   when the modal is opened
4. retrieve the instance type name used by VirtualMachineInstance
   from annotations

Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/2414
Reference-Url: https://github.com/kubevirt/kubevirt/blob/47d69dd7dbf57932cbc70c59bab6e930d26cda3d/staging/src/kubevirt.io/api/core/v1/types.go#L1060
Reference-Url: https://github.com/kubevirt/kubevirt/blob/4c2642b9101d9b734a906ccc2dd157ca6276cf69/pkg/instancetype/expand/expand.go#L114

## 🎥 Demo

### Before
![Screenshot From 2025-03-06 21-04-38](https://github.com/user-attachments/assets/a3bb6bd8-cd27-4d67-b45c-c4d764ca67d4)
### After
![Screenshot From 2025-03-06 21-35-13](https://github.com/user-attachments/assets/aee46508-dd8b-401b-a75c-c47bd7f5ea7c)
![Screenshot From 2025-03-17 19-37-54](https://github.com/user-attachments/assets/d41d2a0f-c47e-40ae-89fe-0f4c01431bbc)


