### PR TITLE
CNV-57788: Update @console/pluginAPI dependency and other small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ cached containers will help you start developing in seconds.
 
 ```bash
 OC_PLUGIN_NAME=kubevirt-plugin
+OC_PLUGIN_I18N_NAMESPACES=plugin__kubevirt-plugin
 OC_URL=https://api.example.com:6443
 OC_USER=kubeadmin
 OC_PASS=<password>

--- a/package.json
+++ b/package.json
@@ -154,5 +154,5 @@
     "test-cypress-headless": "cd cypress && node --max-old-space-size=4096 ../node_modules/cypress/bin/cypress run --config-file ./cypress.config.js --env openshift=true --headless",
     "ts-node": "ts-node -O '{\"module\":\"commonjs\"}'"
   },
-  "version": "0.0.1"
+  "version": "0.0.0"
 }

--- a/plugin-metadata.ts
+++ b/plugin-metadata.ts
@@ -9,7 +9,7 @@ import { exposedModules as VirtualMachinesExposedModules } from './src/views/vir
 
 const metadata: ConsolePluginBuildMetadata = {
   dependencies: {
-    '@console/pluginAPI': '*',
+    '@console/pluginAPI': '~4.19.0',
   },
   displayName: 'Kubevirt Plugin',
   exposedModules: {
@@ -42,7 +42,7 @@ const metadata: ConsolePluginBuildMetadata = {
     yamlTemplates: 'src/templates/index.ts',
   },
   name: 'kubevirt-plugin',
-  version: '4.18.0',
+  version: '4.19.0',
 };
 
 export default metadata;

--- a/src/utils/components/SelectTypeahead/SelectTypeahead.tsx
+++ b/src/utils/components/SelectTypeahead/SelectTypeahead.tsx
@@ -16,8 +16,7 @@ import {
   TextInputGroupMain,
   TextInputGroupUtilities,
 } from '@patternfly/react-core';
-import { FolderIcon, SearchIcon } from '@patternfly/react-icons';
-import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import { FolderIcon, SearchIcon, TimesIcon } from '@patternfly/react-icons';
 
 import { CREATE_NEW, NOT_FOUND } from './utils/constants';
 import { createItemId } from './utils/utils';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2016", "es2019", "es2020.promise", "dom", "dom.iterable", "es2021.string"],
+    "lib": ["es2021", "dom"],
     "module": "esnext",
     "moduleResolution": "node",
     "noUnusedLocals": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "jsx": "react",
-    "lib": ["es2016", "es2019", "es2020.promise", "dom", "dom.iterable", "ES2021.String"],
+    "lib": ["es2016", "es2019", "es2020.promise", "dom", "dom.iterable", "es2021.string"],
     "module": "esnext",
     "moduleResolution": "node",
     "noUnusedLocals": true,
@@ -21,7 +21,7 @@
     },
     "skipLibCheck": true,
     "sourceMap": true,
-    "target": "es2016"
+    "target": "es2021"
   },
   "exclude": ["**/node_modules", "**/dist"],
   "include": ["src", "images"]


### PR DESCRIPTION
## 📝 Summary

- bump output JS build target to ES 2021
- simplify TS config `lib` compiler option to include all ES 2021 APIs and all DOM APIs
- modify plugin metadata `version` to `4.19.0`
- modify `@console/pluginAPI` (lowest compatible Console version) to `~4.19.0` meaning `>=4.19.0 <4.20.0`
- modify `version` in `package.json` to `0.0.0` since this package is marked as private
- refer to `OC_PLUGIN_I18N_NAMESPACES` in README for consistency
- fix `@patternfly/react-icons` import to avoid webpack build warning
```
<w> Non-index and non-dynamic module import @patternfly/react-icons/dist/esm/icons/times-icon
```

Console 4.19 supported browsers should all work with ES 2021 (see [Sam's comment](https://github.com/openshift/console/pull/14620#discussion_r1884067061)).