### PR TITLE
[release-4.12] CNV-50618: Update dompurify from 2.3.10 to 2.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
   },
   "resolutions": {
     "webpack": "^5.68.0",
-    "@types/react": "17.0.40"
+    "@types/react": "17.0.40",
+    "dompurify": "^2.5.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3260,10 +3260,10 @@ domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^2.2.6:
-  version "2.3.10"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.10.tgz#901f7390ffe16a91a5a556b94043314cd4850385"
-  integrity sha512-o7Fg/AgC7p/XpKjf/+RC3Ok6k4St5F7Q6q6+Nnm3p2zGWioAY6dh0CbbuwOhH2UcSzKsdniE/YnE2/92JcsA+g==
+dompurify@^2.2.6, dompurify@^2.5.8:
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.8.tgz#2809d89d7e528dc7a071dea440d7376df676f824"
+  integrity sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==
 
 domutils@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION

## 📝 Description

Library dompurify is an indirect dependency of @patternfly/quickstarts. The updated version matches the requested pattern ^2.2.6. Accidental downgrade is prevented by enforcing the minimum version with the 'resolutions` section.


## 🎥 Demo

none