### PR TITLE
CNV-57425: DurationDropdown closes on clicking outside or pressing Escape

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/SourceTypeSelection/SourceTypeSelection.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/SourceTypeSelection/SourceTypeSelection.tsx
@@ -58,7 +58,7 @@ const SourceTypeSelection: FC<SourceTypeSelectionProps> = ({
           selected: optionsValueLabelMapper[formSelection],
         })}
         isOpen={isOpen}
-        onOpenChange={(open: boolean) => setIsOpen(open)}
+        onOpenChange={setIsOpen}
         onSelect={onSelect}
         selected={formSelection}
       >

--- a/src/utils/components/AffinityModal/components/AffinityEditModal/AffinityForm/components/AffinityConditionSelect.tsx
+++ b/src/utils/components/AffinityModal/components/AffinityEditModal/AffinityForm/components/AffinityConditionSelect.tsx
@@ -37,7 +37,7 @@ const AffinityConditionSelect: FC<AffinityConditionSelectProps> = ({
           selected: AFFINITY_CONDITION_LABELS[focusedAffinity?.condition],
         })}
         isOpen={isOpen}
-        onOpenChange={(open: boolean) => setIsOpen(open)}
+        onOpenChange={setIsOpen}
         onSelect={handleChange}
         selected={focusedAffinity?.condition}
       >

--- a/src/utils/components/AffinityModal/components/AffinityEditModal/AffinityForm/components/AffinityTypeSelect.tsx
+++ b/src/utils/components/AffinityModal/components/AffinityEditModal/AffinityForm/components/AffinityTypeSelect.tsx
@@ -36,6 +36,7 @@ const AffinityTypeSelect: FC<AffinityTypeSelectProps> = ({
           selected: AFFINITY_TYPE_LABLES[focusedAffinity?.type],
         })}
         isOpen={isOpen}
+        onOpenChange={setIsOpen}
         onSelect={handleChange}
         selected={focusedAffinity?.type}
       >

--- a/src/utils/components/AffinityModal/components/AffinityList/components/AffinityRowActionsDropdown.tsx
+++ b/src/utils/components/AffinityModal/components/AffinityList/components/AffinityRowActionsDropdown.tsx
@@ -28,7 +28,7 @@ const AffinityRowActionsDropdown: FC<AffinityRowActionsDropdownProps> = ({
   return (
     <Dropdown
       isOpen={isOpen}
-      onOpenChange={(open: boolean) => setIsOpen(open)}
+      onOpenChange={setIsOpen}
       toggle={KebabToggle({ isExpanded: isOpen, onClick: onToggle })}
     >
       <DropdownList>

--- a/src/utils/components/Consoles/components/AccessConsoles/AccessConsoles.tsx
+++ b/src/utils/components/Consoles/components/AccessConsoles/AccessConsoles.tsx
@@ -95,7 +95,7 @@ export const AccessConsoles: FC<AccessConsolesProps> = ({
         })}
         aria-label={t('Select console type')}
         isOpen={isOpenSelectType}
-        onOpenChange={(open: boolean) => setIsOpenSelectType(open)}
+        onOpenChange={setIsOpenSelectType}
         placeholder={t('Select console type')}
         selected={type}
       >
@@ -119,7 +119,7 @@ export const AccessConsoles: FC<AccessConsolesProps> = ({
           onClick: () => setIsOpenSendKey((prevIsOpen) => !prevIsOpen),
         })}
         isOpen={isOpenSendKey}
-        onOpenChange={(open: boolean) => setIsOpenSendKey(open)}
+        onOpenChange={setIsOpenSendKey}
         onSelect={() => setIsOpenSendKey(false)}
       >
         <DropdownList>

--- a/src/utils/components/DurationOption/DurationDropdown.tsx
+++ b/src/utils/components/DurationOption/DurationDropdown.tsx
@@ -25,6 +25,7 @@ const DurationDropdown: FC<DurationDropdownProps> = ({ selectedDuration, selectH
     <Select
       data-test-id="duration-select-dropdown"
       isOpen={isOpen}
+      onOpenChange={setIsOpen}
       onSelect={onSelect}
       selected={selected}
       toggle={SelectToggle({ isExpanded: isOpen, onClick: onToggle, selected })}

--- a/src/utils/components/FilterSelect/InlineFilterSelect.tsx
+++ b/src/utils/components/FilterSelect/InlineFilterSelect.tsx
@@ -89,7 +89,7 @@ const InlineFilterSelect: FC<InlineFilterSelectProps> = ({
       id="select-inline-filter"
       isOpen={isOpen}
       isScrollable
-      onOpenChange={(open: boolean) => setIsOpen(open)}
+      onOpenChange={setIsOpen}
       onSelect={onSelect}
       popperProps={popperProps}
       selected={selected}

--- a/src/utils/components/HardwareDevices/form/DeviceNameSelect.tsx
+++ b/src/utils/components/HardwareDevices/form/DeviceNameSelect.tsx
@@ -40,7 +40,7 @@ const DeviceNameSelect: FC<DeviceNameSelectProps> = ({
           })}
           id="deviceName"
           isOpen={isOpen}
-          onOpenChange={(open: boolean) => setIsOpen(open)}
+          onOpenChange={setIsOpen}
           onSelect={onSelect}
           popperProps={{ appendTo: () => document.getElementById('tab-modal') }}
           selected={deviceName}

--- a/src/views/catalog/wizard/tabs/disks/components/DiskRowActions.tsx
+++ b/src/views/catalog/wizard/tabs/disks/components/DiskRowActions.tsx
@@ -118,7 +118,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({ diskName }) => {
   return (
     <Dropdown
       isOpen={isDropdownOpen}
-      onOpenChange={(open: boolean) => setIsDropdownOpen(open)}
+      onOpenChange={setIsDropdownOpen}
       onSelect={() => setIsDropdownOpen(false)}
       toggle={KebabToggle({ id: 'toggle-id-disk', onClick: onToggle })}
     >

--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
@@ -91,7 +91,7 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
   return (
     <Dropdown
       isOpen={isDropdownOpen}
-      onOpenChange={(open: boolean) => setIsDropdownOpen(open)}
+      onOpenChange={setIsDropdownOpen}
       onSelect={() => setIsDropdownOpen(false)}
       toggle={KebabToggle({ id: 'toggle-id-network', onClick: onToggle })}
     >

--- a/src/views/checkups/network/components/CheckupsNetworkActions.tsx
+++ b/src/views/checkups/network/components/CheckupsNetworkActions.tsx
@@ -41,11 +41,7 @@ const CheckupsNetworkActions: FC<CheckupsNetworkActionsProps> = ({
   };
 
   return (
-    <Dropdown
-      isOpen={isActionsOpen}
-      onOpenChange={(open: boolean) => setIsActionsOpen(open)}
-      toggle={Toggle}
-    >
+    <Dropdown isOpen={isActionsOpen} onOpenChange={setIsActionsOpen} toggle={Toggle}>
       <DropdownList>
         <DropdownItem
           onClick={() =>

--- a/src/views/checkups/storage/components/CheckupsStorageActions.tsx
+++ b/src/views/checkups/storage/components/CheckupsStorageActions.tsx
@@ -40,11 +40,7 @@ const CheckupsStorageActions = ({
   };
 
   return (
-    <Dropdown
-      isOpen={isActionsOpen}
-      onOpenChange={(open: boolean) => setIsActionsOpen(open)}
-      toggle={Toggle}
-    >
+    <Dropdown isOpen={isActionsOpen} onOpenChange={setIsActionsOpen} toggle={Toggle}>
       <DropdownList>
         <DropdownItem
           onClick={() =>

--- a/src/views/datasources/actions/DataSourceActions.tsx
+++ b/src/views/datasources/actions/DataSourceActions.tsx
@@ -55,7 +55,7 @@ const DataSourceActions: FC<DataSourceActionProps> = ({ dataSource, isKebabToggl
       className="kubevirt-data-source-actions"
       data-test-id="data-source-actions"
       isOpen={isOpen}
-      onOpenChange={(open: boolean) => setIsOpen(open)}
+      onOpenChange={setIsOpen}
       popperProps={{ appendTo: getContentScrollableElement, position: 'right' }}
       toggle={Toggle}
     >

--- a/src/views/migrationpolicies/components/MigrationPolicyConfigurations/compnents/MigrationPolicyConfigurationDropdown/MigrationPolicyConfigurationDropdown.tsx
+++ b/src/views/migrationpolicies/components/MigrationPolicyConfigurations/compnents/MigrationPolicyConfigurationDropdown/MigrationPolicyConfigurationDropdown.tsx
@@ -44,7 +44,7 @@ const MigrationPolicyConfigurationDropdown: FC<MigrationPolicyConfigurationDropd
       className="migration-policy__form-config-dropdown"
       data-test-id="migration-policies-configurations"
       isOpen={isOpen}
-      onOpenChange={(open: boolean) => setIsOpen(open)}
+      onOpenChange={setIsOpen}
     >
       <DropdownList>
         {Object.entries(options).map(([key, { defaultValue, description, label }]) => (

--- a/src/views/templates/details/tabs/disks/components/DiskRowActions.tsx
+++ b/src/views/templates/details/tabs/disks/components/DiskRowActions.tsx
@@ -79,7 +79,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({ diskName, isDisabled, onUpdat
   return (
     <Dropdown
       isOpen={isDropdownOpen}
-      onOpenChange={(open: boolean) => setIsDropdownOpen(open)}
+      onOpenChange={setIsDropdownOpen}
       onSelect={() => setIsDropdownOpen(false)}
       popperProps={{ appendTo: getContentScrollableElement, position: 'right' }}
       toggle={KebabToggle({ id: 'toggle-id-disk', isDisabled, onClick: onToggle })}

--- a/src/views/templates/details/tabs/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/templates/details/tabs/network/components/list/NetworkInterfaceActions.tsx
@@ -94,7 +94,7 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
         onClick: onToggle,
       })}
       isOpen={isDropdownOpen}
-      onOpenChange={(open: boolean) => setIsDropdownOpen(open)}
+      onOpenChange={setIsDropdownOpen}
       onSelect={() => setIsDropdownOpen(false)}
       popperProps={{ appendTo: getContentScrollableElement, position: 'right' }}
     >

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceActions.tsx
@@ -93,7 +93,7 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
         onClick: onToggle,
       })}
       isOpen={isDropdownOpen}
-      onOpenChange={(open: boolean) => setIsDropdownOpen(open)}
+      onOpenChange={setIsDropdownOpen}
       onSelect={() => setIsDropdownOpen(false)}
       popperProps={{ position: 'right' }}
     >

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
@@ -127,7 +127,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
   return (
     <Dropdown
       isOpen={isDropdownOpen}
-      onOpenChange={(open: boolean) => setIsDropdownOpen(open)}
+      onOpenChange={setIsDropdownOpen}
       onSelect={() => setIsDropdownOpen(false)}
       popperProps={{ appendTo: getContentScrollableElement, position: 'right' }}
       toggle={KebabToggle({ id: 'toggle-id-6', isExpanded: isDropdownOpen, onClick: onToggle })}

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/VirtualMachinesOverviewTabSnapshotsRow.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/VirtualMachinesOverviewTabSnapshotsRow.tsx
@@ -94,7 +94,7 @@ const VirtualMachinesOverviewTabSnapshotsRow: FC<VirtualMachinesOverviewTabSnaps
       </div>
       <Dropdown
         isOpen={isKebabOpen}
-        onOpenChange={(open: boolean) => setIsKebabOpen(open)}
+        onOpenChange={setIsKebabOpen}
         onSelect={() => setIsKebabOpen(false)}
         popperProps={{ position: 'right' }}
         toggle={KebabToggle({ isExpanded: isKebabOpen, onClick: onToggle })}

--- a/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotActionsMenu.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotActionsMenu.tsx
@@ -78,6 +78,7 @@ const SnapshotActionsMenu: FC<SnapshotActionsMenuProps> = ({ isRestoreDisabled, 
   return (
     <Dropdown
       isOpen={isDropdownOpen}
+      onOpenChange={setIsDropdownOpen}
       onSelect={() => setIsDropdownOpen(false)}
       popperProps={{ position: 'right' }}
       toggle={KebabToggle({ id: 'toggle-id-6', isExpanded: isDropdownOpen, onClick: onToggle })}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes a bug when DurationDropdown couldn't be closed on clicking outside the menu or pressing escape.

Also refactors `(open: boolean) => setIsOpen(open)` to `setIsOpen` in other Dropdowns and Selects

## 🎥 Demo
After fix:

https://github.com/user-attachments/assets/3b0dd5cc-55dd-432d-9b3c-25edcccc05f7


