### PR TITLE
CNV-55963: Fix right click on expanded elements

### DIFF
--- a/src/views/virtualmachines/tree/VirtualMachineTreeView.tsx
+++ b/src/views/virtualmachines/tree/VirtualMachineTreeView.tsx
@@ -11,7 +11,6 @@ import {
 } from '@patternfly/react-core';
 
 import TreeViewContent from './components/TreeViewContent';
-import TreeViewRightClickActionMenu from './components/TreeViewRightClickActionMenu';
 import { useHideNamespaceBar } from './hooks/useHideNamespaceBar';
 import { UseTreeViewData } from './hooks/useTreeViewData';
 import useTreeViewSelect from './hooks/useTreeViewSelect';
@@ -89,7 +88,6 @@ const VirtualMachineTreeView: FC<VirtualMachineTreeViewProps> = ({
               toggleDrawer={toggleDrawer}
               treeData={treeData}
             />
-            <TreeViewRightClickActionMenu treeData={treeData} />
           </DrawerPanelContent>
         }
       >

--- a/src/views/virtualmachines/tree/components/TreeViewContent.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewContent.tsx
@@ -13,10 +13,12 @@ import {
 } from '@patternfly/react-core';
 
 import useFilteredTreeView from '../hooks/useFilteredTreeView';
+import useTreeViewItemRightClick from '../hooks/useTreeViewItemRightClick';
 
 import CreateProject from './CreateProject';
 import PanelToggleButton from './PanelToggleButton';
 import TreeViewCollapseExpand from './TreeViewCollapseExpand';
+import TreeViewRightClickActionMenu from './TreeViewRightClickActionMenu';
 import TreeViewToolbar from './TreeViewToolbar';
 
 type TreeViewContentProps = {
@@ -41,6 +43,8 @@ const TreeViewContent: FC<TreeViewContentProps> = ({
   const { t } = useKubevirtTranslation();
   const [showAll, setShowAll] = useState<boolean>();
   const { filteredTreeData, onSearch } = useFilteredTreeView(treeData, setShowAll);
+
+  const { addListenerToRightClick, hideMenu, triggerElement } = useTreeViewItemRightClick(treeData);
 
   if (!loaded) {
     return (
@@ -89,8 +93,10 @@ const TreeViewContent: FC<TreeViewContentProps> = ({
           data={filteredTreeData}
           hasBadges={loaded}
           hasSelectableNodes
+          onExpand={addListenerToRightClick}
           onSelect={onSelect}
         />
+        <TreeViewRightClickActionMenu hideMenu={hideMenu} triggerElement={triggerElement} />
       </DrawerPanelBody>
     </>
   );

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu.tsx
@@ -3,24 +3,22 @@ import React, { FC } from 'react';
 import ActionDropdownItem from '@kubevirt-utils/components/ActionDropdownItem/ActionDropdownItem';
 import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { Menu, MenuContent, MenuList, Popper, TreeViewDataItem } from '@patternfly/react-core';
+import { Menu, MenuContent, MenuList, Popper } from '@patternfly/react-core';
 import useVirtualMachineActionsProvider from '@virtualmachines/actions/hooks/useVirtualMachineActionsProvider';
 import { getVMIMFromMapper } from '@virtualmachines/utils/mappers';
 
-import useTreeViewItemRightClick from '../hooks/useTreeViewItemRightClick';
 import { vmimMapperSignal, vmsSignal } from '../utils/signals';
 
 type TreeViewRightClickActionMenuProps = {
-  treeData: TreeViewDataItem[];
+  hideMenu: () => void;
+  triggerElement: HTMLElement | null;
 };
 
-const TreeViewRightClickActionMenu: FC<TreeViewRightClickActionMenuProps> = ({ treeData }) => {
-  const {
-    hideMenu,
-    triggeredVMName: vmName,
-    triggeredVMNamespace: vmNamespace,
-    triggerElement: treeViewItemTrigger,
-  } = useTreeViewItemRightClick(treeData);
+const TreeViewRightClickActionMenu: FC<TreeViewRightClickActionMenuProps> = ({
+  hideMenu,
+  triggerElement,
+}) => {
+  const [vmNamespace, vmName] = triggerElement?.id?.split('/') || ['', ''];
 
   const [isSingleNodeCluster] = useSingleNodeCluster();
 
@@ -31,7 +29,7 @@ const TreeViewRightClickActionMenu: FC<TreeViewRightClickActionMenuProps> = ({ t
 
   const [actions] = useVirtualMachineActionsProvider(vm, vmim, isSingleNodeCluster);
 
-  if (!treeViewItemTrigger) return null;
+  if (!triggerElement) return null;
 
   return (
     <>
@@ -47,7 +45,7 @@ const TreeViewRightClickActionMenu: FC<TreeViewRightClickActionMenuProps> = ({ t
             </MenuContent>
           </Menu>
         }
-        appendTo={treeViewItemTrigger}
+        appendTo={triggerElement}
         isVisible
         position="end"
       />

--- a/src/views/virtualmachines/tree/utils/utils.tsx
+++ b/src/views/virtualmachines/tree/utils/utils.tsx
@@ -264,3 +264,12 @@ export const isSystemNamespace = (projectName: string) => {
 
   return startsWithNamespace || isNamespace;
 };
+
+export const getAllTreeViewItems = (treeData: TreeViewDataItem[]) => {
+  return treeData
+    ?.map((treeItem) => [treeItem, ...getAllTreeViewItems(treeItem.children || [])])
+    ?.flat();
+};
+
+export const getAllTreeViewVMsItems = (treeData: TreeViewDataItem[]) =>
+  getAllTreeViewItems(treeData).filter((treeItem) => !treeItem.children);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

On hiding and expanding elements, the elements are destroyed and re-created by react so we have to add listeners to the re-created elements on `onExpand` event

Additionally do some logic to add and remove listeners on multiple `useLayoutEffect` runs over time 

## 🎥 Demo

**Before**



https://github.com/user-attachments/assets/aa76133d-bd3f-43af-860e-24d691335c3a



**After**

https://github.com/user-attachments/assets/0b9c0678-16f3-453b-bb20-bba890ed0d07

