### PR TITLE
CNV-57045: improve InlineFilterSelect

### DIFF
--- a/src/utils/components/EnvironmentEditor/components/EnvironmentSelectResource.tsx
+++ b/src/utils/components/EnvironmentEditor/components/EnvironmentSelectResource.tsx
@@ -79,6 +79,7 @@ const EnvironmentSelectResource: FC<EnvironmentSelectResourceProps> = ({
     isDisabled: environmentNamesSelected?.includes(optionName),
     key: optionName,
     value: getEnvironmentOptionValue(optionName, optionKind),
+    valueForFilter: optionName,
   });
 
   return (

--- a/src/utils/components/FilterSelect/InlineFilterSelect.tsx
+++ b/src/utils/components/FilterSelect/InlineFilterSelect.tsx
@@ -21,6 +21,8 @@ import { NO_RESULTS } from './utils/constants';
 import { EnhancedSelectOptionProps } from './utils/types';
 import { getGroupedOptions } from './utils/utils';
 
+import './inline-filter-select.scss';
+
 type InlineFilterSelectProps = {
   className?: string;
   menuFooter?: ReactNode;
@@ -67,7 +69,9 @@ const InlineFilterSelect: FC<InlineFilterSelectProps> = ({
 
   const filterOptions = useMemo(
     () =>
-      options.filter((option) => option.value.toLowerCase().includes(filterValue.toLowerCase())),
+      options.filter((option) =>
+        (option.valueForFilter ?? option.value).toLowerCase().includes(filterValue.toLowerCase()),
+      ),
     [options, filterValue],
   );
 

--- a/src/utils/components/FilterSelect/components/InlineFilterSelectOptions.tsx
+++ b/src/utils/components/FilterSelect/components/InlineFilterSelectOptions.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { SelectGroup, SelectOption } from '@patternfly/react-core';
+import { Divider, SelectGroup, SelectOption } from '@patternfly/react-core';
 
 import { NO_RESULTS } from '../utils/constants';
 import { EnhancedSelectOptionProps } from '../utils/types';
@@ -31,18 +31,22 @@ const InlineFilterSelectOptions: FC<InlineFilterSelectOptionsProps> = ({
   }
 
   if (groupedOptions) {
+    const lastGroupIndex = Object.keys(groupedOptions).length - 1;
     return (
       <>
-        {Object.entries(groupedOptions).map(([group, opts]) => (
-          <SelectGroup key={group} label={group}>
-            {opts.map((option, index) => (
-              <InlineFilterSelectOption
-                isFocused={focusedItemIndex === index}
-                key={option.value}
-                option={option}
-              />
-            ))}
-          </SelectGroup>
+        {Object.entries(groupedOptions).map(([group, opts], groupIndex) => (
+          <>
+            <SelectGroup key={group} label={group}>
+              {opts.map((option, index) => (
+                <InlineFilterSelectOption
+                  isFocused={focusedItemIndex === index}
+                  key={option.value}
+                  option={option}
+                />
+              ))}
+            </SelectGroup>
+            {groupIndex !== lastGroupIndex && <Divider />}
+          </>
         ))}
       </>
     );

--- a/src/utils/components/FilterSelect/inline-filter-select.scss
+++ b/src/utils/components/FilterSelect/inline-filter-select.scss
@@ -1,0 +1,15 @@
+#select-inline-filter {
+  .pf-v6-c-menu__search {
+    padding-block: var(--pf-t--global--spacer--md);
+  }
+
+  .pf-v6-c-menu__content {
+    gap: 0;
+  }
+}
+
+#select-inline-filter-listbox {
+  .pf-v6-c-divider {
+    margin-block: var(--pf-t--global--spacer--sm);
+  }
+}

--- a/src/utils/components/FilterSelect/utils/types.ts
+++ b/src/utils/components/FilterSelect/utils/types.ts
@@ -5,4 +5,6 @@ export type EnhancedSelectOptionProps = SelectOptionProps & {
   group?: string;
   groupVersionKind?: K8sGroupVersionKind;
   value: string;
+  /** Value for the text filter. Takes precedence over value, useful when value does not reflect the text content of the option. */
+  valueForFilter?: string;
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

InlineFilterSelect improvements:
- adds ability to filter by different text than the option value
- adds Divider between groups
- fixes alignment issues

Also changes filtering values in EnvironmentSelectResource (can be seen in demo)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/072be2bb-ac05-4414-ae59-6a1907f18d1b


After:


https://github.com/user-attachments/assets/4c3e6bd4-b679-4e0a-bdff-aba1f0a8092d



Note: because before, the value of options included also the "option type", e.g. `secret:some-name-123`, typing "secret" would also list all secrets. It might be a good feature, but also might be a bug in case we want to find some specific secret called e.g. "secret-abc" and we end up getting all of them - then the filter doesn't really help. What do you think?