### PR TITLE
CNV-57788: Update @console/pluginAPI dependency for Console 4.17.0+

### DIFF
--- a/plugin-metadata.ts
+++ b/plugin-metadata.ts
@@ -9,7 +9,7 @@ import { exposedModules as VirtualMachinesExposedModules } from './src/views/vir
 
 const metadata: ConsolePluginBuildMetadata = {
   dependencies: {
-    '@console/pluginAPI': '~4.19.0',
+    '@console/pluginAPI': '>=4.17.0-0',
   },
   displayName: 'Kubevirt Plugin',
   exposedModules: {


### PR DESCRIPTION
## 📝 Description

This is a follow-up to #2504 

Kubevirt plugin version N supports Console versions from N-2 to N+2.

This PR updates `@console/pluginAPI` dependency to semver range `>=4.17.0-0` which means 4.17.0 and up, including any pre-release versions.

Quote from the Console [dynamic plugins README](https://github.com/openshift/console/blob/main/frontend/packages/console-dynamic-plugin-sdk/README.md):

> The `@console/pluginAPI` dependency is optional and refers to Console versions this dynamic plugin is compatible with. The `dependencies` object may also refer to other dynamic plugins that are required for this plugin to work correctly. For dependencies where the version string may include a [semver pre-release](https://semver.org/#spec-item-9) identifier, adapt your semver range constraint (dependency value) to include the relevant pre-release prefix, e.g. use `~4.11.0-0.ci` when targeting pre-release versions like `4.11.0-0.ci-1234`.
