### PR TITLE
CNV-57718: update deprecated Modal to PF6 promoted version

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -17,6 +17,7 @@
   "(In seconds)": "(In seconds)",
   "(requires login) and copy the download link URL of the KVM guest image (expires quickly)": "(requires login) and copy the download link URL of the KVM guest image (expires quickly)",
   "{{ osName }} VirtualMachine can not be edited because it is provided by OpenShift Virtualization Operator.": "{{ osName }} VirtualMachine can not be edited because it is provided by OpenShift Virtualization Operator.",
+  "{{actionType}} {{numVMs}} VirtualMachines?": "{{actionType}} {{numVMs}} VirtualMachines?",
   "{{actionType}} VirtualMachine?": "{{actionType}} VirtualMachine?",
   "{{annotations}} Annotations": "{{annotations}} Annotations",
   "{{annotationsCount}} Annotations": "{{annotationsCount}} Annotations",

--- a/src/utils/components/AccessDenied/AccessDenied.tsx
+++ b/src/utils/components/AccessDenied/AccessDenied.tsx
@@ -3,7 +3,14 @@ import React, { FC } from 'react';
 import restrictedSignImg from '@images/restricted-sign.svg';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { Alert, Panel, PanelMain, PanelMainBody, Title } from '@patternfly/react-core';
+import {
+  Alert,
+  AlertVariant,
+  Panel,
+  PanelMain,
+  PanelMainBody,
+  Title,
+} from '@patternfly/react-core';
 
 type AccessDeniedProps = {
   message?: string;
@@ -26,7 +33,12 @@ const AccessDenied: FC<AccessDeniedProps> = ({ message }) => {
             {t("You don't have access to this section due to cluster policy.")}
           </div>
           {!isEmpty(message) && (
-            <Alert className="co-alert" isInline title={t('Error details')} variant="danger">
+            <Alert
+              className="co-alert"
+              isInline
+              title={t('Error details')}
+              variant={AlertVariant.danger}
+            >
               {message}
             </Alert>
           )}

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/DiskSourceUploadPVCProgress.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/DiskSourceUploadPVCProgress.tsx
@@ -9,6 +9,7 @@ import {
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Button,
+  ButtonVariant,
   FormGroup,
   Progress,
   ProgressMeasureLocation,
@@ -38,7 +39,7 @@ export const DiskSourceUploadPVCProgress: React.FC<{ upload: DataUpload }> = ({ 
             }
             isInline
             onClick={() => upload?.cancelUpload()}
-            variant="link"
+            variant={ButtonVariant.link}
           >
             {t('Cancel upload')}
           </Button>

--- a/src/utils/components/AffinityModal/AffinityModal.tsx
+++ b/src/utils/components/AffinityModal/AffinityModal.tsx
@@ -8,7 +8,7 @@ import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getAffinity } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { ModalVariant } from '@patternfly/react-core';
 
 import AffinityEditModal from './components/AffinityEditModal/AffinityEditModal';
 import AffinityEmptyState from './components/AffinityEmptyState';

--- a/src/utils/components/AffinityModal/components/AffinityEditModal/AffinityEditModal.tsx
+++ b/src/utils/components/AffinityModal/components/AffinityEditModal/AffinityEditModal.tsx
@@ -3,8 +3,15 @@ import React, { Dispatch, FC, SetStateAction } from 'react';
 import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { useIDEntities } from '@kubevirt-utils/components/NodeSelectorModal/hooks/useIDEntities';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { ActionGroup, Button, ButtonVariant } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  ButtonVariant,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 
 import { getIntersectedQualifiedNodes } from '../../utils/helpers';
 import { AffinityLabel, AffinityRowData } from '../../utils/types';
@@ -44,48 +51,47 @@ const AffinityEditModal: FC<AffinityEditModalProps> = ({
   const qualifiedFieldNodes = useNodeFieldQualifier(nodes, nodesLoaded, fields?.entities);
   return (
     <Modal
-      footer={
-        <ActionGroup>
-          <Button
-            onClick={() =>
-              onSubmit({
-                ...focusedAffinity,
-                expressions: expressions?.entities,
-                fields: fields?.entities,
-              })
-            }
-            isDisabled={isDisabled}
-            variant={ButtonVariant.primary}
-          >
-            {t('Save affinity rule')}
-          </Button>
-          <Button onClick={onCancel} size="sm" variant="link">
-            {t('Cancel')}
-          </Button>
-        </ActionGroup>
-      }
       className="ocs-modal co-catalog-page__overlay"
       isOpen={isOpen}
       onClose={onCancel}
       position="top"
-      title={title}
       variant={ModalVariant.medium}
     >
-      <AffinityForm
-        qualifiedNodes={getIntersectedQualifiedNodes({
-          expressionNodes: qualifiedExpressionNodes,
-          expressions: expressions?.entities,
-          fieldNodes: qualifiedFieldNodes,
-          fields: fields?.entities,
-        })}
-        expressions={expressions}
-        fields={fields}
-        focusedAffinity={focusedAffinity}
-        isSubmitDisabled={isDisabled}
-        nodesLoaded={nodesLoaded}
-        setFocusedAffinity={setFocusedAffinity}
-        setSubmitDisabled={setIsDisabled}
-      />
+      <ModalHeader title={title} />
+      <ModalBody>
+        <AffinityForm
+          qualifiedNodes={getIntersectedQualifiedNodes({
+            expressionNodes: qualifiedExpressionNodes,
+            expressions: expressions?.entities,
+            fieldNodes: qualifiedFieldNodes,
+            fields: fields?.entities,
+          })}
+          expressions={expressions}
+          fields={fields}
+          focusedAffinity={focusedAffinity}
+          isSubmitDisabled={isDisabled}
+          nodesLoaded={nodesLoaded}
+          setFocusedAffinity={setFocusedAffinity}
+          setSubmitDisabled={setIsDisabled}
+        />
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          onClick={() =>
+            onSubmit({
+              ...focusedAffinity,
+              expressions: expressions?.entities,
+              fields: fields?.entities,
+            })
+          }
+          isDisabled={isDisabled}
+        >
+          {t('Save affinity rule')}
+        </Button>
+        <Button onClick={onCancel} size="sm" variant={ButtonVariant.link}>
+          {t('Cancel')}
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/utils/components/AffinityModal/components/AffinityEditModal/AffinityForm/components/AffinityEditRowValues.tsx
+++ b/src/utils/components/AffinityModal/components/AffinityEditModal/AffinityForm/components/AffinityEditRowValues.tsx
@@ -3,6 +3,7 @@ import React, { FC, useState } from 'react';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Button,
+  ButtonVariant,
   InputGroup,
   InputGroupItem,
   KeyTypes,
@@ -70,7 +71,7 @@ export const AffinityEditRowValues: FC<AffinityEditRowValuesProps> = ({
           />
         </InputGroupItem>
         <InputGroupItem>
-          <Button isDisabled={addingIsDisabled} onClick={onAdd} variant="control">
+          <Button isDisabled={addingIsDisabled} onClick={onAdd} variant={ButtonVariant.control}>
             {t('Add')}
           </Button>
         </InputGroupItem>

--- a/src/utils/components/AnnotationsModal/AnnotationsModal.tsx
+++ b/src/utils/components/AnnotationsModal/AnnotationsModal.tsx
@@ -3,7 +3,7 @@ import React, { FC, useEffect, useState } from 'react';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, Grid } from '@patternfly/react-core';
+import { Button, ButtonVariant, Grid } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 
 import { AnnotationsModalRow } from './AnnotationsModalRow';
@@ -99,7 +99,7 @@ export const AnnotationsModal: FC<{
             icon={<PlusCircleIcon />}
             onClick={() => onAnnotationAdd()}
             size="sm"
-            variant="link"
+            variant={ButtonVariant.link}
           >
             {t('Add more')}
           </Button>

--- a/src/utils/components/AnnotationsModal/AnnotationsModalRow.tsx
+++ b/src/utils/components/AnnotationsModal/AnnotationsModalRow.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button, GridItem, TextInput } from '@patternfly/react-core';
+import { Button, ButtonVariant, GridItem, TextInput } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 
 export const AnnotationsModalRow: FC<{
@@ -39,7 +39,11 @@ export const AnnotationsModalRow: FC<{
         />
       </GridItem>
       <GridItem span={2}>
-        <Button icon={<MinusCircleIcon />} onClick={() => onDelete()} variant="plain" />
+        <Button
+          icon={<MinusCircleIcon />}
+          onClick={() => onDelete()}
+          variant={ButtonVariant.plain}
+        />
       </GridItem>
     </>
   );

--- a/src/utils/components/BootOrderModal/BootOrderEmptyState.tsx
+++ b/src/utils/components/BootOrderModal/BootOrderEmptyState.tsx
@@ -4,6 +4,7 @@ import {
   Alert,
   AlertVariant,
   Button,
+  ButtonVariant,
   EmptyState,
   EmptyStateActions,
   EmptyStateBody,
@@ -25,7 +26,7 @@ export const BootOrderEmptyState: FC<BootOrderEmptyProps> = ({
     <EmptyStateFooter>
       <EmptyStateActions>
         {!addItemIsDisabled ? (
-          <Button onClick={onClick} variant="secondary">
+          <Button onClick={onClick} variant={ButtonVariant.secondary}>
             {addItemMessage}
           </Button>
         ) : (

--- a/src/utils/components/BootOrderModal/BootOrderModalBody.tsx
+++ b/src/utils/components/BootOrderModal/BootOrderModalBody.tsx
@@ -7,6 +7,7 @@ import {
 } from '@kubevirt-utils/resources/vm/utils/boot-order/bootOrder';
 import {
   Button,
+  ButtonVariant,
   DataList,
   DataListCell,
   DataListControl,
@@ -120,7 +121,7 @@ export const BootOrderModalBody: React.FC<{
                                       icon={<MinusCircleIcon />}
                                       id={`${value.name}-delete-btn`}
                                       onClick={() => onDelete(value.name)}
-                                      variant="link"
+                                      variant={ButtonVariant.link}
                                     />
                                   )}
                                 </SplitItem>

--- a/src/utils/components/BootOrderModal/add-device-button.tsx
+++ b/src/utils/components/BootOrderModal/add-device-button.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Button, Content, ContentVariants } from '@patternfly/react-core';
+import { Button, ButtonVariant, Content, ContentVariants } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export const AddDeviceButton: React.FC<AddDeviceButtonType> = ({
@@ -18,7 +18,7 @@ export const AddDeviceButton: React.FC<AddDeviceButtonType> = ({
       icon={<PlusCircleIcon />}
       id={id}
       onClick={onClick}
-      variant="link"
+      variant={ButtonVariant.link}
     >
       {message}
     </Button>

--- a/src/utils/components/BootOrderModal/add-device-form-select.tsx
+++ b/src/utils/components/BootOrderModal/add-device-form-select.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 
 import { BootableDeviceType } from '@kubevirt-utils/resources/vm/utils/boot-order/bootOrder';
-import { Button, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { Button, ButtonVariant, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 
 export const AddDeviceFormSelect: FC<AddDeviceFormSelectProps> = ({
@@ -31,7 +31,7 @@ export const AddDeviceFormSelect: FC<AddDeviceFormSelectProps> = ({
       className="kubevirt-boot-order__add-device-delete-btn"
       icon={<MinusCircleIcon />}
       onClick={onDelete}
-      variant="link"
+      variant={ButtonVariant.link}
     />
   </>
 );

--- a/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
@@ -10,8 +10,17 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { getLabel } from '@kubevirt-utils/resources/shared';
 import { getCPU, getMemory, VM_TEMPLATE_ANNOTATION } from '@kubevirt-utils/resources/vm';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
-import { Alert, AlertVariant, Button, ButtonVariant } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Alert,
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 
 import useTemplateDefaultCpuMemory from './hooks/useTemplateDefaultCpuMemory';
 import { getMemorySize } from './utils/CpuMemoryUtils';
@@ -85,7 +94,40 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
 
   return (
     <Modal
-      actions={[
+      className="cpu-memory-modal"
+      isOpen={isOpen}
+      onClose={onClose}
+      variant={ModalVariant.small}
+      width="650px"
+    >
+      <ModalHeader title={t('Edit CPU | Memory')} />
+      <ModalBody>
+        <Alert
+          title={
+            <Trans ns="plugin__kubevirt-plugin" t={t}>
+              Updates to the sockets value are applied immediately.{<br />}To apply changes to the
+              cores or threads values, you must restart the VirtualMachine.
+            </Trans>
+          }
+          isInline
+          variant={AlertVariant.info}
+        />
+        <div className="inputs">
+          <CPUInput currentCPU={getCPU(vm)} setUserEnteredCPU={setCPU} userEnteredCPU={cpu} />
+          <MemoryInput
+            memory={memory}
+            memoryUnit={memoryUnit}
+            setMemory={setMemory}
+            setMemoryUnit={setMemoryUnit}
+          />
+        </div>
+        {updateError && (
+          <Alert isInline title={t('Error')} variant={AlertVariant.danger}>
+            {updateError}
+          </Alert>
+        )}
+      </ModalBody>
+      <ModalFooter>
         <Button
           isDisabled={updateInProcess}
           isLoading={updateInProcess}
@@ -94,7 +136,7 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
           variant={ButtonVariant.primary}
         >
           {t('Save')}
-        </Button>,
+        </Button>
         <Button
           isDisabled={
             !templateName || !defaultsLoaded || !defaultCpu || !defaultMemory || defaultLoadError
@@ -109,42 +151,11 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
           variant={ButtonVariant.secondary}
         >
           {t('Restore template settings')}
-        </Button>,
-        <Button key="cancel" onClick={onClose} variant="link">
+        </Button>
+        <Button key="cancel" onClick={onClose} variant={ButtonVariant.link}>
           {t('Cancel')}
-        </Button>,
-      ]}
-      className="cpu-memory-modal"
-      isOpen={isOpen}
-      onClose={onClose}
-      title={t('Edit CPU | Memory')}
-      variant={ModalVariant.small}
-      width="650px"
-    >
-      <Alert
-        title={
-          <Trans ns="plugin__kubevirt-plugin" t={t}>
-            Updates to the sockets value are applied immediately.{<br />}To apply changes to the
-            cores or threads values, you must restart the VirtualMachine.
-          </Trans>
-        }
-        isInline
-        variant={AlertVariant.info}
-      />
-      <div className="inputs">
-        <CPUInput currentCPU={getCPU(vm)} setUserEnteredCPU={setCPU} userEnteredCPU={cpu} />
-        <MemoryInput
-          memory={memory}
-          memoryUnit={memoryUnit}
-          setMemory={setMemory}
-          setMemoryUnit={setMemoryUnit}
-        />
-      </div>
-      {updateError && (
-        <Alert isInline title={t('Error')} variant="danger">
-          {updateError}
-        </Alert>
-      )}
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/utils/components/CloneVMModal/CloneVMModal.tsx
+++ b/src/utils/components/CloneVMModal/CloneVMModal.tsx
@@ -11,8 +11,7 @@ import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { MAX_K8S_NAME_LENGTH } from '@kubevirt-utils/utils/constants';
 import { getRandomChars } from '@kubevirt-utils/utils/utils';
-import { Form } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { Form, ModalVariant } from '@patternfly/react-core';
 
 import CloningStatus from './components/CloningStatus';
 import ConfigurationSummary from './components/ConfigurationSummary';

--- a/src/utils/components/CloudinitDescription/CloudinitInfoHelper.tsx
+++ b/src/utils/components/CloudinitDescription/CloudinitInfoHelper.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button, Stack, StackItem } from '@patternfly/react-core';
+import { Button, ButtonVariant, Stack, StackItem } from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 
 const CloudInitInfoHelper = () => {
@@ -22,7 +22,7 @@ const CloudInitInfoHelper = () => {
             iconPosition="right"
             isInline
             size="sm"
-            variant="link"
+            variant={ButtonVariant.link}
           >
             <a href={documentationURL.CLOUDINIT_INFO} rel="noopener noreferrer" target="_blank">
               {t('Learn more')}

--- a/src/utils/components/CloudinitModal/CloudInitEditor/CloudInitEditor.tsx
+++ b/src/utils/components/CloudinitModal/CloudInitEditor/CloudInitEditor.tsx
@@ -4,7 +4,7 @@ import { dump } from 'js-yaml';
 import { V1Volume } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
-import { Alert, AlertActionCloseButton, Divider } from '@patternfly/react-core';
+import { Alert, AlertActionCloseButton, AlertVariant, Divider } from '@patternfly/react-core';
 
 import { getCloudInitData } from '../utils/cloudinit-utils';
 
@@ -49,7 +49,7 @@ export const _CloudInitEditor: FC<CloudInitEditorProps> = ({ cloudInitVolume, on
           className="co-alert"
           isInline
           title={t('Saved')}
-          variant="success"
+          variant={AlertVariant.success}
         />
       )}
       <Divider />

--- a/src/utils/components/ColumnManagementModal/ColumnManagement.tsx
+++ b/src/utils/components/ColumnManagementModal/ColumnManagement.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ColumnLayout } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, ToolbarGroup, ToolbarItem, Tooltip } from '@patternfly/react-core';
+import { Button, ButtonVariant, ToolbarGroup, ToolbarItem, Tooltip } from '@patternfly/react-core';
 import { ColumnsIcon } from '@patternfly/react-icons';
 
 import { ColumnManagementModal } from '../ColumnManagementModal/ColumnManagementModal';
@@ -35,7 +35,7 @@ const ColumnManagement: FC<ColumnManagementProps> = ({ columnLayout, hideColumnM
             aria-label={t('Column management')}
             data-test="manage-columns"
             icon={<ColumnsIcon />}
-            variant="plain"
+            variant={ButtonVariant.plain}
           />
         </Tooltip>
       </ToolbarItem>

--- a/src/utils/components/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/src/utils/components/ColumnManagementModal/ColumnManagementModal.tsx
@@ -4,17 +4,19 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import useKubevirtUserSettingsTableColumns from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns';
 import { ColumnLayout } from '@openshift-console/dynamic-plugin-sdk';
 import {
-  ActionList,
-  ActionListItem,
   Alert,
   AlertVariant,
   Button,
   ButtonVariant,
   DataList,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
   Stack,
-  StackItem,
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 
 import { MAX_VIEW_COLS } from './constants';
 import DataListRow from './DataListRow';
@@ -79,54 +81,9 @@ export const ColumnManagementModal: FC<ColumnManagementModalProps> = ({
   };
 
   return (
-    <Modal
-      footer={
-        <Stack className="kv-tabmodal-footer" hasGutter>
-          {error && (
-            <StackItem>
-              <Alert isInline title={t('An error occurred')} variant={AlertVariant.danger}>
-                <Stack hasGutter>
-                  <StackItem>{error.message}</StackItem>
-                </Stack>
-              </Alert>
-            </StackItem>
-          )}
-          <StackItem>
-            <ActionList className="column-management-modal__action-list">
-              <ActionListItem>
-                <Button key="reset" onClick={resetColumns} variant={ButtonVariant.link}>
-                  {t('Restore default columns')}
-                </Button>
-              </ActionListItem>
-
-              <ActionListItem>
-                <Button onClick={onClose} variant={ButtonVariant.secondary}>
-                  {t('Cancel')}
-                </Button>
-              </ActionListItem>
-              <ActionListItem>
-                <Button
-                  form="modal-with-form-form"
-                  isDisabled={!loaded}
-                  isLoading={!loaded}
-                  key="create"
-                  onClick={submit}
-                  variant={ButtonVariant.primary}
-                >
-                  {t('Save')}
-                </Button>
-              </ActionListItem>
-            </ActionList>
-          </StackItem>
-        </Stack>
-      }
-      isOpen={isOpen}
-      onClose={onClose}
-      position="top"
-      title={t('Manage columns')}
-      variant={ModalVariant.small}
-    >
-      <>
+    <Modal isOpen={isOpen} onClose={onClose} position="top" variant={ModalVariant.small}>
+      <ModalHeader title={t('Manage columns')} />
+      <ModalBody>
         <p className="co-m-form-row">{t('Selected columns will appear in the table.')}</p>
         <Alert
           className="co-alert"
@@ -180,7 +137,34 @@ export const ColumnManagementModal: FC<ColumnManagementModalProps> = ({
             </span>
           </div>
         </div>
-      </>
+      </ModalBody>
+      <ModalFooter>
+        <Stack className="kv-tabmodal-footer" hasGutter>
+          {error && (
+            <Alert isInline title={t('An error occurred')} variant={AlertVariant.danger}>
+              {error.message}
+            </Alert>
+          )}
+          <Flex className="column-management-modal__action-list">
+            <Button key="reset" onClick={resetColumns} variant={ButtonVariant.link}>
+              {t('Restore default columns')}
+            </Button>
+            <Button onClick={onClose} variant={ButtonVariant.secondary}>
+              {t('Cancel')}
+            </Button>
+            <Button
+              form="modal-with-form-form"
+              isDisabled={!loaded}
+              isLoading={!loaded}
+              key="create"
+              onClick={submit}
+              variant={ButtonVariant.primary}
+            >
+              {t('Save')}
+            </Button>
+          </Flex>
+        </Stack>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/utils/components/Consoles/components/DesktopViewer/Components/MultusNetwork.tsx
+++ b/src/utils/components/Consoles/components/DesktopViewer/Components/MultusNetwork.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isGuestAgentConnected } from '@kubevirt-utils/resources/vmi/utils/guest-agent';
-import { Alert } from '@patternfly/react-core';
+import { Alert, AlertVariant } from '@patternfly/react-core';
 
 import { DEFAULT_RDP_PORT } from '../utils/constants';
 import { MultusNetworkProps } from '../utils/types';
@@ -15,7 +15,7 @@ const MultusNetwork: React.FC<MultusNetworkProps> = ({ selectedNetwork, vmi }) =
 
   if (!guestAgent) {
     return (
-      <Alert isInline title={t('Missing guest agent')} variant="warning">
+      <Alert isInline title={t('Missing guest agent')} variant={AlertVariant.warning}>
         {t('Guest agent is not installed on VirtualMachine')}
       </Alert>
     );
@@ -23,7 +23,7 @@ const MultusNetwork: React.FC<MultusNetworkProps> = ({ selectedNetwork, vmi }) =
 
   if (!selectedNetwork || !selectedNetwork?.ip) {
     return (
-      <Alert isInline title={t('Networks misconfigured')} variant="warning">{`${t(
+      <Alert isInline title={t('Networks misconfigured')} variant={AlertVariant.warning}>{`${t(
         'No IP address is reported for network interface',
       )} ${selectedNetwork?.name || ''}`}</Alert>
     );

--- a/src/utils/components/Consoles/components/DesktopViewer/Components/RDPServiceModal.tsx
+++ b/src/utils/components/Consoles/components/DesktopViewer/Components/RDPServiceModal.tsx
@@ -5,8 +5,14 @@ import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Alert, AlertVariant, Checkbox, Stack, StackItem } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Alert,
+  AlertVariant,
+  Checkbox,
+  ModalVariant,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 
 import { createRDPService } from '../utils/utils';
 

--- a/src/utils/components/Consoles/components/vnc-console/VncConnect.tsx
+++ b/src/utils/components/Consoles/components/vnc-console/VncConnect.tsx
@@ -14,9 +14,7 @@ const VncConnect: FC<CustomConnectComponentProps> = ({ connect, isConnecting }) 
         <EmptyState>
           <EmptyStateBody>{t('Click Connect to open the VNC console.')}</EmptyStateBody>
           <EmptyStateFooter>
-            <Button onClick={connect} variant="primary">
-              {t('Connect')}
-            </Button>
+            <Button onClick={connect}>{t('Connect')}</Button>
           </EmptyStateFooter>
         </EmptyState>
       )}

--- a/src/utils/components/DedicatedResourcesModal/DedicatedResourcesModal.tsx
+++ b/src/utils/components/DedicatedResourcesModal/DedicatedResourcesModal.tsx
@@ -17,6 +17,7 @@ import {
   Alert,
   AlertVariant,
   Button,
+  ButtonVariant,
   Checkbox,
   Form,
   FormGroup,
@@ -135,7 +136,7 @@ const DedicatedResourcesModal: FC<DedicatedResourcesModalProps> = ({
                     qualifiedNodesCount: qualifiedNodes?.length,
                   })}
                 >
-                  <Button isInline onClick={() => setChecked(false)} variant="link">
+                  <Button isInline onClick={() => setChecked(false)} variant={ButtonVariant.link}>
                     {t('view {{qualifiedNodesCount}} matching nodes', {
                       qualifiedNodesCount: qualifiedNodes?.length,
                     })}

--- a/src/utils/components/EnvironmentEditor/EnvironmentForm.tsx
+++ b/src/utils/components/EnvironmentEditor/EnvironmentForm.tsx
@@ -5,7 +5,7 @@ import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { Button, Form } from '@patternfly/react-core';
+import { Button, ButtonVariant, Form } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 
 import EnvironmentEditor from './components/EnvironmentEditor';
@@ -87,7 +87,7 @@ const EnvironmentForm: FC<EnvironmentFormProps> = ({ onEditChange, updateVM, vm 
               icon={<PlusCircleIcon />}
               onClick={onEnvironmentAdd}
               type="button"
-              variant="link"
+              variant={ButtonVariant.link}
             >
               {t('Add Config Map, Secret or Service Account')}
             </Button>

--- a/src/utils/components/EnvironmentEditor/components/EnvironmentEditor.tsx
+++ b/src/utils/components/EnvironmentEditor/components/EnvironmentEditor.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button, TextInput, Tooltip } from '@patternfly/react-core';
+import { Button, ButtonVariant, TextInput, Tooltip } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 
 import { EnvironmentKind } from '../constants';
@@ -64,8 +64,7 @@ const EnvironmentEditor: FC<EnvironmentEditorProps> = ({
             className="pairs-list__span-btns"
             data-test-id="pairs-list__delete-from-btn"
             onClick={() => onRemove(diskName)}
-            type="button"
-            variant="plain"
+            variant={ButtonVariant.plain}
           >
             <MinusCircleIcon className="pairs-list__side-btn pairs-list__delete-icon" />
             <span className="sr-only">{t('Delete')}</span>

--- a/src/utils/components/EnvironmentEditor/components/EnvironmentFormActions.tsx
+++ b/src/utils/components/EnvironmentEditor/components/EnvironmentFormActions.tsx
@@ -5,7 +5,9 @@ import {
   ActionGroup,
   Alert,
   AlertActionCloseButton,
+  AlertVariant,
   Button,
+  ButtonVariant,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
@@ -62,7 +64,7 @@ const EnvironmentFormActions: React.FC<EnvironmentFormActionsProps> = ({
             className="co-alert co-alert--scrollable"
             isInline
             title={t('An error occurred')}
-            variant="danger"
+            variant={AlertVariant.danger}
           >
             <div className="co-pre-line">{error?.message || apiError?.message}</div>
           </Alert>
@@ -73,7 +75,7 @@ const EnvironmentFormActions: React.FC<EnvironmentFormActionsProps> = ({
             className="co-alert"
             isInline
             title={t('Success')}
-            variant="success"
+            variant={AlertVariant.success}
           />
         )}
       </StackItem>
@@ -84,11 +86,10 @@ const EnvironmentFormActions: React.FC<EnvironmentFormActionsProps> = ({
             isLoading={loading}
             onClick={onSubmit}
             type="submit"
-            variant="primary"
           >
             {t('Save')}
           </Button>
-          <Button onClick={onReload} type="button" variant="secondary">
+          <Button onClick={onReload} type="button" variant={ButtonVariant.secondary}>
             {t('Reload')}
           </Button>
         </ActionGroup>

--- a/src/utils/components/EnvironmentEditor/components/EnvironmentSelectResource.tsx
+++ b/src/utils/components/EnvironmentEditor/components/EnvironmentSelectResource.tsx
@@ -4,7 +4,7 @@ import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFi
 import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Alert } from '@patternfly/react-core';
+import { Alert, AlertVariant } from '@patternfly/react-core';
 
 import { EnvironmentKind, MapKindToAbbr } from '../constants';
 import useEnvironmentsResources from '../hooks/useEnvironmentsResources';
@@ -51,7 +51,7 @@ const EnvironmentSelectResource: FC<EnvironmentSelectResourceProps> = ({
         className="co-alert co-alert--scrollable"
         isInline
         title={t('An error occurred')}
-        variant="danger"
+        variant={AlertVariant.danger}
       >
         <div className="co-pre-line">{loadError?.message}</div>
       </Alert>

--- a/src/utils/components/HardwareDevices/HardwareDeviceTitle.tsx
+++ b/src/utils/components/HardwareDevices/HardwareDeviceTitle.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button, DescriptionListTerm } from '@patternfly/react-core';
+import { Button, ButtonVariant, DescriptionListTerm } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
 import SearchItem from '../SearchItem/SearchItem';
@@ -32,7 +32,7 @@ const HardwareDeviceTitle: FC<HardwareDeviceTitleProps> = ({
         isDisabled={!canEdit}
         isInline
         onClick={onClick}
-        variant="link"
+        variant={ButtonVariant.link}
       >
         <SearchItem id={title.replace(' ', '-')}>{title}</SearchItem>
       </Button>

--- a/src/utils/components/HardwareDevices/HardwareDevicesPage.tsx
+++ b/src/utils/components/HardwareDevices/HardwareDevicesPage.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react';
 import { V1PciHostDevice } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { HorizontalNav } from '@openshift-console/dynamic-plugin-sdk';
-import { Bullseye, Button, Popover } from '@patternfly/react-core';
+import { Bullseye, Button, ButtonVariant, Popover } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
 import useHCPermittedHostDevices from './hooks/useHCPermittedHostDevices';
@@ -66,7 +66,7 @@ const HardwareDevicesPage: FC<any> = (props) => {
               'Various types of hardware devices are assigned to virtual machines in the cluster',
             )}
           >
-            <Button aria-label="Action" icon={<HelpIcon />} variant="plain" />
+            <Button aria-label="Action" icon={<HelpIcon />} variant={ButtonVariant.plain} />
           </Popover>
         </h1>
       </div>

--- a/src/utils/components/HardwareDevices/form/PlainIconButton.tsx
+++ b/src/utils/components/HardwareDevices/form/PlainIconButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Button, FormGroup, GridItem } from '@patternfly/react-core';
+import { Button, ButtonVariant, FormGroup, GridItem } from '@patternfly/react-core';
 
 type PlainIconButtonProps = {
   fieldId: string;
@@ -12,7 +12,7 @@ const PlainIconButton: React.FC<PlainIconButtonProps> = ({ fieldId, icon, onClic
   return (
     <GridItem span={1}>
       <FormGroup fieldId={fieldId} label=" ">
-        <Button icon={icon} onClick={onClick} variant="plain" />
+        <Button icon={icon} onClick={onClick} variant={ButtonVariant.plain} />
       </FormGroup>
     </GridItem>
   );

--- a/src/utils/components/HardwareDevices/list/HardwareDeviceRow.tsx
+++ b/src/utils/components/HardwareDevices/list/HardwareDeviceRow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { V1GPU, V1HostDevice } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
-import { Button } from '@patternfly/react-core';
+import { Button, ButtonVariant } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 
 export type HardwareDeviceRowProps = {
@@ -24,7 +24,7 @@ const HardwareDeviceRow: React.FC<
         <Button
           icon={<MinusCircleIcon />}
           onClick={() => handleRemoveDevice(device)}
-          variant="plain"
+          variant={ButtonVariant.plain}
         />
       </TableData>
     </>

--- a/src/utils/components/HardwareDevices/modal/HardwareDevicesModal.tsx
+++ b/src/utils/components/HardwareDevices/modal/HardwareDevicesModal.tsx
@@ -137,7 +137,7 @@ const HardwareDevicesModal: FC<HardwareDevicesModalProps> = ({
             className="pf-m-link--align-left"
             icon={<PlusCircleIcon />}
             onClick={onAddDevice}
-            variant="link"
+            variant={ButtonVariant.link}
           >
             {btnText}
           </Button>

--- a/src/utils/components/NodeSelectorModal/components/LabelList.tsx
+++ b/src/utils/components/NodeSelectorModal/components/LabelList.tsx
@@ -3,7 +3,7 @@ import { FC, ReactNode } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, Grid, Split, SplitItem } from '@patternfly/react-core';
+import { Button, ButtonVariant, Grid, Split, SplitItem } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 type LabelsListProps = {
@@ -36,7 +36,7 @@ const LabelsList: FC<LabelsListProps> = ({
             icon={<PlusCircleIcon />}
             id="vm-labels-list-add-btn"
             onClick={() => onLabelAdd()}
-            variant="link"
+            variant={ButtonVariant.link}
           >
             {isEmpty ? emptyStateAddRowTxt : addRowTxt}
           </Button>
@@ -52,7 +52,7 @@ const LabelsList: FC<LabelsListProps> = ({
               iconPosition="right"
               id="explore-nodes-btn"
               target="_blank"
-              variant="link"
+              variant={ButtonVariant.link}
             >
               {t('Explore {{kind}} list', { kind: model.kind })}
             </Button>

--- a/src/utils/components/NodeSelectorModal/components/NodeCheckerAlert.tsx
+++ b/src/utils/components/NodeSelectorModal/components/NodeCheckerAlert.tsx
@@ -9,6 +9,7 @@ import {
   Alert,
   AlertVariant,
   Button,
+  ButtonVariant,
   Flex,
   FlexItem,
   pluralize,
@@ -110,7 +111,7 @@ const NodeCheckerAlert: React.FC<NodeCheckerAlertProps> = ({
             </>
           }
         >
-          <Button isInline variant="link">
+          <Button isInline variant={ButtonVariant.link}>
             {t('View matching {{matchingNodeText}}', {
               matchingNodeText,
             })}

--- a/src/utils/components/SysprepModal/SysprepInfo.tsx
+++ b/src/utils/components/SysprepModal/SysprepInfo.tsx
@@ -2,7 +2,14 @@ import React, { FC } from 'react';
 
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button, Content, ContentVariants, Stack, StackItem } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  Content,
+  ContentVariants,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 
 const SysprepInfo: FC = () => {
@@ -27,7 +34,7 @@ const SysprepInfo: FC = () => {
             iconPosition="right"
             isInline
             size="sm"
-            variant="link"
+            variant={ButtonVariant.link}
           >
             <a href={documentationURL.SYSPREP} rel="noopener noreferrer" target="_blank">
               {t('Learn more')}

--- a/src/utils/components/SysprepModal/SysprepModal.tsx
+++ b/src/utils/components/SysprepModal/SysprepModal.tsx
@@ -1,8 +1,7 @@
 import React, { FC, useState } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { ExpandableSection, FormGroup } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { ExpandableSection, FormGroup, ModalVariant } from '@patternfly/react-core';
 
 import TabModal from '../TabModal/TabModal';
 

--- a/src/utils/components/SysprepModal/sysprep-autounattend/SysprepAutounattendHelperPopup.tsx
+++ b/src/utils/components/SysprepModal/sysprep-autounattend/SysprepAutounattendHelperPopup.tsx
@@ -3,7 +3,7 @@ import { Trans } from 'react-i18next';
 
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button, Content, ContentVariants, Popover } from '@patternfly/react-core';
+import { Button, ButtonVariant, Content, ContentVariants, Popover } from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
 const SysprepUnattendHelperPopup: FC = () => {
@@ -24,7 +24,7 @@ const SysprepUnattendHelperPopup: FC = () => {
               iconPosition="right"
               isInline
               size="sm"
-              variant="link"
+              variant={ButtonVariant.link}
             >
               <a href={documentationURL.SYSPREP} rel="noopener noreferrer" target="_blank">
                 {t('Learn more')}
@@ -42,7 +42,7 @@ const SysprepUnattendHelperPopup: FC = () => {
         data-test-id="ssh-popover-button"
         icon={<OutlinedQuestionCircleIcon className="co-field-level-help__icon" />}
         isInline
-        variant="link"
+        variant={ButtonVariant.link}
       />
     </Popover>
   );

--- a/src/utils/components/SysprepModal/sysprep-unattend/SysprepUnattendHelperPopup.tsx
+++ b/src/utils/components/SysprepModal/sysprep-unattend/SysprepUnattendHelperPopup.tsx
@@ -3,7 +3,7 @@ import { Trans } from 'react-i18next';
 
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button, Content, ContentVariants, Popover } from '@patternfly/react-core';
+import { Button, ButtonVariant, Content, ContentVariants, Popover } from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
 const SysprepUnattendHelperPopup: FC = () => {
@@ -23,7 +23,7 @@ const SysprepUnattendHelperPopup: FC = () => {
               iconPosition="right"
               isInline
               size="sm"
-              variant="link"
+              variant={ButtonVariant.link}
             >
               <a href={documentationURL.SYSPREP} rel="noopener noreferrer" target="_blank">
                 {t('Learn more')}
@@ -41,7 +41,7 @@ const SysprepUnattendHelperPopup: FC = () => {
         data-test-id="ssh-popover-button"
         icon={<OutlinedQuestionCircleIcon className="co-field-level-help__icon" />}
         isInline
-        variant="link"
+        variant={ButtonVariant.link}
       />
     </Popover>
   );

--- a/src/utils/components/TabModal/TabModal.tsx
+++ b/src/utils/components/TabModal/TabModal.tsx
@@ -11,10 +11,14 @@ import {
   AlertVariant,
   Button,
   ButtonVariant,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 
 import './TabModal.scss';
 
@@ -92,7 +96,16 @@ const TabModal: TabModalFC = memo(
 
     return (
       <Modal
-        footer={
+        className="ocs-modal"
+        id="tab-modal"
+        isOpen={isOpen}
+        onClose={closeModal}
+        position={positionTop ? 'top' : undefined}
+        variant={modalVariant ?? ModalVariant.small}
+      >
+        <ModalHeader title={headerText} titleIconVariant={titleIconVariant} />
+        <ModalBody>{children}</ModalBody>
+        <ModalFooter>
           <Stack className="kv-tabmodal-footer" hasGutter>
             {error && (
               <StackItem>
@@ -117,13 +130,13 @@ const TabModal: TabModalFC = memo(
                     isDisabled={isDisabled || isSubmitting}
                     isLoading={isLoading || isSubmitting}
                     onClick={handleSubmit}
-                    variant={submitBtnVariant ?? 'primary'}
+                    variant={submitBtnVariant ?? ButtonVariant.primary}
                   >
                     {submitBtnText || t('Save')}
                   </Button>
                 </ActionListItem>
                 <ActionListItem>
-                  <Button onClick={closeModal} variant="link">
+                  <Button onClick={closeModal} variant={ButtonVariant.link}>
                     {t('Cancel')}
                   </Button>
                 </ActionListItem>
@@ -135,17 +148,7 @@ const TabModal: TabModalFC = memo(
               </ActionList>
             </StackItem>
           </Stack>
-        }
-        className="ocs-modal"
-        id="tab-modal"
-        isOpen={isOpen}
-        onClose={closeModal}
-        position={positionTop ? 'top' : undefined}
-        title={headerText}
-        titleIconVariant={titleIconVariant}
-        variant={modalVariant ?? 'small'}
-      >
-        {children}
+        </ModalFooter>
       </Modal>
     );
   },

--- a/src/utils/components/TolerationsModal/TolerationsModal.tsx
+++ b/src/utils/components/TolerationsModal/TolerationsModal.tsx
@@ -18,8 +18,7 @@ import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getTolerations } from '@kubevirt-utils/resources/vm';
 import { ensurePath, isEmpty } from '@kubevirt-utils/utils/utils';
-import { Form, Stack, StackItem } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { Form, ModalVariant, Stack, StackItem } from '@patternfly/react-core';
 
 import { TolerationLabel } from './utils/constants';
 import { getNodeTaintQualifier } from './utils/helpers';

--- a/src/utils/components/VirtualMachineDescriptionItem/EditButtonWithTooltip.tsx
+++ b/src/utils/components/VirtualMachineDescriptionItem/EditButtonWithTooltip.tsx
@@ -1,6 +1,6 @@
 import React, { FC, PropsWithChildren, ReactNode, SyntheticEvent } from 'react';
 
-import { Button, Tooltip } from '@patternfly/react-core';
+import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
 type EditButtonWithTooltipProps = PropsWithChildren<{
@@ -28,7 +28,7 @@ const EditButtonWithTooltip: FC<EditButtonWithTooltipProps> = ({
       iconPosition="end"
       isDisabled={!isEditable}
       isInline
-      variant="link"
+      variant={ButtonVariant.link}
     >
       {children}
     </Button>

--- a/src/utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
+++ b/src/utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
@@ -5,6 +5,7 @@ import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpa
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Button,
+  ButtonVariant,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTermHelpText,
@@ -98,7 +99,7 @@ const VirtualMachineDescriptionItem: FC<VirtualMachineDescriptionItemProps> = ({
                 isInline
                 onClick={onEditClick}
                 type="button"
-                variant="link"
+                variant={ButtonVariant.link}
               >
                 {t('Edit')}
               </Button>

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeListModal/BootableVolumeListModal.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeListModal/BootableVolumeListModal.tsx
@@ -7,7 +7,7 @@ import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { UserSettingFavorites } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { ModalVariant } from '@patternfly/react-core';
 
 import BootableVolumeList from '../../BootableVolumeList';
 

--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/components/YamlAndCLIEditor/YamlAndCLIEditor.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/components/YamlAndCLIEditor/YamlAndCLIEditor.tsx
@@ -3,7 +3,7 @@ import { saveAs } from 'file-saver';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { YAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, Tooltip } from '@patternfly/react-core';
+import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 import { CopyIcon, DownloadIcon } from '@patternfly/react-icons';
 
 type YamlAndCLIEditorProps = {
@@ -30,13 +30,17 @@ const YamlAndCLIEditor: FC<YamlAndCLIEditorProps> = ({ code, minHeight }) => {
     <YAMLEditor
       toolbarLinks={[
         <Tooltip content={t('Download')} key="download">
-          <Button icon={<DownloadIcon />} onClick={handleDownload} variant="secondary" />
+          <Button
+            icon={<DownloadIcon />}
+            onClick={handleDownload}
+            variant={ButtonVariant.secondary}
+          />
         </Tooltip>,
         <Tooltip
           content={copySuccess ? t('Successfully copied to clipboard!') : t('Copy to clipboard')}
           key="copy"
         >
-          <Button icon={<CopyIcon />} onClick={handleCopy} variant="secondary" />
+          <Button icon={<CopyIcon />} onClick={handleCopy} variant={ButtonVariant.secondary} />
         </Tooltip>,
       ]}
       minHeight={minHeight}

--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/components/YamlAndCLIViewerModal/YamlAndCLIViewerModal.scss
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/components/YamlAndCLIViewerModal/YamlAndCLIViewerModal.scss
@@ -1,0 +1,8 @@
+.yaml-cli-viewer-modal-body {
+  .ocs-yaml-editor {
+    // setting definite height so the flex-grow calculation works
+    height: 0px;
+
+    margin-block-start: var(--pf-t--global--spacer--sm);
+  }
+}

--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/components/YamlAndCLIViewerModal/YamlAndCLIViewerModal.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/components/YamlAndCLIViewerModal/YamlAndCLIViewerModal.tsx
@@ -5,13 +5,14 @@ import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/u
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Tab, Tabs } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import { Modal, ModalBody, ModalHeader, ModalVariant, Tab, Tabs } from '@patternfly/react-core';
 
 import YamlAndCLIEditor from '../YamlAndCLIEditor/YamlAndCLIEditor';
 
 import { TAB } from './utils/constants';
 import { getCreateVMVirtctlCommand } from './utils/utils';
+
+import './YamlAndCLIViewerModal.scss';
 
 type YamlAndCLIViewerModalProps = {
   isOpen: boolean;
@@ -32,29 +33,27 @@ const YamlAndCLIViewerModal: FC<YamlAndCLIViewerModalProps> = ({ isOpen, onClose
   };
 
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      title={`${activeTabKey} for ${vmName}`}
-      variant={ModalVariant.large}
-    >
-      <Suspense fallback={<Loading />}>
-        <Tabs activeKey={activeTabKey} onSelect={handleTabClick}>
-          <Tab eventKey={TAB.YAML} title={t('YAML')}>
-            <YamlAndCLIEditor code={dump(vm || '')} minHeight={350} />
-          </Tab>
-          <Tab eventKey={TAB.CLI} title={t('CLI')}>
-            <YamlAndCLIEditor
-              code={getCreateVMVirtctlCommand(
-                vm,
-                selectedBootableVolume,
-                sshSecretCredentials?.sshPubKey,
-              )}
-              minHeight={150}
-            />
-          </Tab>
-        </Tabs>
-      </Suspense>
+    <Modal isOpen={isOpen} onClose={onClose} variant={ModalVariant.large}>
+      <ModalHeader title={`${activeTabKey} for ${vmName}`} />
+      <ModalBody className="yaml-cli-viewer-modal-body">
+        <Suspense fallback={<Loading />}>
+          <Tabs activeKey={activeTabKey} onSelect={handleTabClick}>
+            <Tab eventKey={TAB.YAML} title={t('YAML')}>
+              <YamlAndCLIEditor code={dump(vm || '')} minHeight={350} />
+            </Tab>
+            <Tab eventKey={TAB.CLI} title={t('CLI')}>
+              <YamlAndCLIEditor
+                code={getCreateVMVirtctlCommand(
+                  vm,
+                  selectedBootableVolume,
+                  sshSecretCredentials?.sshPubKey,
+                )}
+                minHeight={150}
+              />
+            </Tab>
+          </Tabs>
+        </Suspense>
+      </ModalBody>
     </Modal>
   );
 };

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/Sources/SelectSourceUploadPVCProgress.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/Sources/SelectSourceUploadPVCProgress.tsx
@@ -9,6 +9,7 @@ import {
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Button,
+  ButtonVariant,
   FormGroup,
   Progress,
   ProgressMeasureLocation,
@@ -38,7 +39,7 @@ export const SelectSourceUploadPVCProgress: React.FC<{ upload: DataUpload }> = (
             }
             isInline
             onClick={() => upload?.cancelUpload()}
-            variant="link"
+            variant={ButtonVariant.link}
           >
             {t('Cancel upload')}
           </Button>

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateExpandableDescription.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateExpandableDescription.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button, ExpandableSection, Stack, StackItem } from '@patternfly/react-core';
+import { Button, ButtonVariant, ExpandableSection, Stack, StackItem } from '@patternfly/react-core';
 
 const TemplateExpandableDescription: FC<{ description: string }> = ({ description }) => {
   const { t } = useKubevirtTranslation();
@@ -16,7 +16,7 @@ const TemplateExpandableDescription: FC<{ description: string }> = ({ descriptio
       </StackItem>
       {description.length > 120 && (
         <StackItem>
-          <Button isInline onClick={() => setIsExpanded(!isExpanded)} variant="link">
+          <Button isInline onClick={() => setIsExpanded(!isExpanded)} variant={ButtonVariant.link}>
             {isExpanded ? t('Collapse') : t('Read more')}
           </Button>
         </StackItem>

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawer.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawer.tsx
@@ -5,7 +5,7 @@ import { logTemplateFlowEvent } from '@kubevirt-utils/extensions/telemetry/telem
 import { CANCEL_CREATE_VM_BUTTON_CLICKED } from '@kubevirt-utils/extensions/telemetry/utils/constants';
 import { getTemplateName } from '@kubevirt-utils/resources/template/utils/selectors';
 import { CatalogItemHeader } from '@patternfly/react-catalog-view-extension';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from '@patternfly/react-core';
 
 import { getTemplateOSIcon } from '../../utils/os-icons';
 
@@ -41,24 +41,28 @@ export const TemplatesCatalogDrawer: FC<TemplatesCatalogDrawerProps> = ({
   return (
     <DrawerContextProvider template={template}>
       <Modal
-        footer={
-          template && <TemplatesCatalogDrawerFooter namespace={namespace} onCancel={handleCancel} />
-        }
-        header={
+        aria-label="Template drawer"
+        className="ocs-modal co-catalog-page__overlay co-catalog-page__overlay--right template-catalog-drawer"
+        disableFocusTrap
+        isOpen={isOpen}
+        onClose={onClose}
+      >
+        <ModalHeader>
           <CatalogItemHeader
             className="co-catalog-page__overlay-header"
             iconImg={osIcon}
             title={templateName}
             vendor={template?.metadata?.name}
           />
-        }
-        aria-label="Template drawer"
-        className="pf-v6-c-modal-box ocs-modal co-catalog-page__overlay co-catalog-page__overlay--right template-catalog-drawer"
-        disableFocusTrap
-        isOpen={isOpen}
-        onClose={onClose}
-      >
-        <TemplatesCatalogDrawerPanel />
+        </ModalHeader>
+        <ModalBody>
+          <TemplatesCatalogDrawerPanel />
+        </ModalBody>
+        {template && (
+          <ModalFooter>
+            <TemplatesCatalogDrawerFooter namespace={namespace} onCancel={handleCancel} />
+          </ModalFooter>
+        )}
       </Modal>
     </DrawerContextProvider>
   );

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogEmptyState.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogEmptyState.tsx
@@ -4,6 +4,7 @@ import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Button,
+  ButtonVariant,
   EmptyState,
   EmptyStateActions,
   EmptyStateBody,
@@ -42,7 +43,7 @@ export const TemplatesCatalogEmptyState: React.FC<{
       </EmptyStateBody>
       <EmptyStateFooter>
         <EmptyStateActions>
-          <Button onClick={() => onClearFilters()} variant="link">
+          <Button onClick={() => onClearFilters()} variant={ButtonVariant.link}>
             {t('Clear all filters')}
           </Button>
         </EmptyStateActions>

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogRow.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogRow.tsx
@@ -16,7 +16,7 @@ import { getVMBootSourceLabel } from '@kubevirt-utils/resources/vm/utils/source'
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, Label } from '@patternfly/react-core';
+import { Button, ButtonVariant, Label } from '@patternfly/react-core';
 
 import { getTemplateOSIcon } from '../utils/os-icons';
 
@@ -50,7 +50,7 @@ export const TemplatesCatalogRow: React.FC<
       <>
         <TableData activeColumnIDs={activeColumnIDs} className="pf-m-width-40" id="name">
           <img alt="" className="vm-catalog-row-icon" src={getTemplateOSIcon(obj)} />
-          <Button isInline onClick={() => onTemplateClick(obj)} variant="link">
+          <Button isInline onClick={() => onTemplateClick(obj)} variant={ButtonVariant.link}>
             {getTemplateName(obj)}{' '}
             {!isEmpty(getAnnotation(obj, ANNOTATIONS.displayName)) && (
               <Label isCompact variant="outline">

--- a/src/views/catalog/wizard/components/WizardDescriptionItem/WizardDescriptionItem.tsx
+++ b/src/views/catalog/wizard/components/WizardDescriptionItem/WizardDescriptionItem.tsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Button,
+  ButtonVariant,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
@@ -67,7 +68,12 @@ export const WizardDescriptionItem: FC<WizardDescriptionItemProps> = React.memo(
     const getItemHeader = () => {
       if (onTitleClick)
         return (
-          <Button isDisabled={isDisabled} isInline onClick={onTitleClick} variant="link">
+          <Button
+            isDisabled={isDisabled}
+            isInline
+            onClick={onTitleClick}
+            variant={ButtonVariant.link}
+          >
             <DescriptionListTerm>{titleWithCount}</DescriptionListTerm>
           </Button>
         );
@@ -108,7 +114,7 @@ export const WizardDescriptionItem: FC<WizardDescriptionItemProps> = React.memo(
                   isInline
                   onClick={onEditClick}
                   type="button"
-                  variant="link"
+                  variant={ButtonVariant.link}
                 >
                   {t('Edit')}
                 </Button>
@@ -127,7 +133,7 @@ export const WizardDescriptionItem: FC<WizardDescriptionItemProps> = React.memo(
               isInline
               onClick={onEditClick}
               type="button"
-              variant="link"
+              variant={ButtonVariant.link}
             >
               {description ?? <span className="text-muted">{t('Not available')}</span>}
             </Button>

--- a/src/views/catalog/wizard/components/WizardFooter.tsx
+++ b/src/views/catalog/wizard/components/WizardFooter.tsx
@@ -22,7 +22,9 @@ import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN
 import { createHeadlessService } from '@kubevirt-utils/utils/headless-service';
 import {
   Alert,
+  AlertVariant,
   Button,
+  ButtonVariant,
   Checkbox,
   Split,
   SplitItem,
@@ -114,7 +116,7 @@ export const WizardFooter: FC<{ namespace: string }> = ({ namespace }) => {
         <StackItem />
         {error && (
           <StackItem>
-            <Alert isInline title={t('Create VirtualMachine error')} variant="danger">
+            <Alert isInline title={t('Create VirtualMachine error')} variant={AlertVariant.danger}>
               {error.message}
             </Alert>
           </StackItem>
@@ -126,7 +128,6 @@ export const WizardFooter: FC<{ namespace: string }> = ({ namespace }) => {
                 isDisabled={!loaded || disableVmCreate}
                 isLoading={!vmCreateLoaded}
                 onClick={onSubmit}
-                variant="primary"
               >
                 {t('Create VirtualMachine')}
               </Button>
@@ -142,7 +143,7 @@ export const WizardFooter: FC<{ namespace: string }> = ({ namespace }) => {
                     navigate(`/k8s/ns/${namespace}/catalog/template`);
                   }
                 }}
-                variant="link"
+                variant={ButtonVariant.link}
               >
                 {t('Cancel')}
               </Button>

--- a/src/views/catalog/wizard/components/WizardHeader.tsx
+++ b/src/views/catalog/wizard/components/WizardHeader.tsx
@@ -10,6 +10,7 @@ import {
   Breadcrumb,
   BreadcrumbItem,
   Button,
+  ButtonVariant,
   Content,
   ContentVariants,
   Split,
@@ -41,7 +42,7 @@ export const WizardHeader: FC<{ namespace: string }> = memo(({ namespace }) => {
               onBreadcrumbClick(`/k8s/ns/${namespace || DEFAULT_NAMESPACE}/catalog/template`)
             }
             isInline
-            variant="link"
+            variant={ButtonVariant.link}
           >
             {t('Catalog')}
           </Button>

--- a/src/views/catalog/wizard/components/WizardNoBootModal.tsx
+++ b/src/views/catalog/wizard/components/WizardNoBootModal.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button, Stack, StackItem } from '@patternfly/react-core';
+import { Button, ButtonVariant, Stack, StackItem } from '@patternfly/react-core';
 
 export const WizardNoBootModal: React.VFC<{
   isOpen: boolean;
@@ -42,7 +42,7 @@ export const WizardNoBootModal: React.VFC<{
         <StackItem>
           <Trans ns="plugin__kubevirt-plugin">
             You can select the boot source in the{' '}
-            <Button isInline onClick={goToDisksTab} variant="link">
+            <Button isInline onClick={goToDisksTab} variant={ButtonVariant.link}>
               Disks
             </Button>{' '}
             tab.

--- a/src/views/cdi-upload-provider/popover/UploadPVCPopoverProgressStatus.tsx
+++ b/src/views/cdi-upload-provider/popover/UploadPVCPopoverProgressStatus.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ProgressStatus } from '@openshift-console/dynamic-plugin-sdk';
-import { Button } from '@patternfly/react-core';
+import { Button, ButtonVariant } from '@patternfly/react-core';
 
 type UploadPVCPopoverProgressStatusProps = {
   onCancelClick: () => void;
@@ -21,7 +21,7 @@ const UploadPVCPopoverProgressStatus: React.FC<UploadPVCPopoverProgressStatusPro
         className="pf-m-link--align-left"
         id="cdi-upload-cancel-btn"
         onMouseUp={onCancelClick}
-        variant="link"
+        variant={ButtonVariant.link}
       >
         {t('Cancel upload')}
       </Button>

--- a/src/views/cdi-upload-provider/popover/UploadPVCPopoverUploadStatus.tsx
+++ b/src/views/cdi-upload-provider/popover/UploadPVCPopoverUploadStatus.tsx
@@ -89,7 +89,7 @@ const UploadPVCPopoverUploadStatus: React.FC<UploadPVCPopoverUploadStatusProps> 
                 className="pf-m-link--align-left"
                 id="cdi-upload-cancel-btn"
                 onMouseUp={onCancelClick}
-                variant="link"
+                variant={ButtonVariant.link}
               >
                 {t('Cancel upload')}
               </Button>
@@ -102,7 +102,7 @@ const UploadPVCPopoverUploadStatus: React.FC<UploadPVCPopoverUploadStatusProps> 
                 id="cdi-upload-delete-btn"
                 isDanger
                 onMouseUp={onErrorDeleteSource}
-                variant="link"
+                variant={ButtonVariant.link}
               >
                 {t('Delete source')}
               </Button>

--- a/src/views/cdi-upload-provider/upload-pvc-form/UploadPVC.tsx
+++ b/src/views/cdi-upload-provider/upload-pvc-form/UploadPVC.tsx
@@ -30,7 +30,7 @@ import {
   useK8sWatchResource,
   WatchK8sResource,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { ActionGroup, Alert, Button, ButtonVariant } from '@patternfly/react-core';
+import { ActionGroup, Alert, AlertVariant, Button, ButtonVariant } from '@patternfly/react-core';
 
 import useBaseImages from '../hooks/useBaseImages';
 import useMultipleAccessReviews from '../hooks/useMultipleAccessReviews';
@@ -217,7 +217,7 @@ const UploadPVCPage: FC = () => {
             uploadProxyURL={uploadProxyURL}
           >
             {isFileRejected && (
-              <Alert isInline title={t('File type extension')} variant="warning">
+              <Alert isInline title={t('File type extension')} variant={AlertVariant.warning}>
                 <p>
                   {t(
                     'Based on the file extension it seems like you are trying to upload a file which is not supported ({{fileNameExtText}}).',
@@ -237,11 +237,10 @@ const UploadPVCPage: FC = () => {
                 id="save-changes"
                 isDisabled={disableFormSubmit || isCheckingCertificate}
                 type="submit"
-                variant={ButtonVariant.primary}
               >
                 {t('Upload')}
               </Button>
-              <Button onClick={() => navigate(-1)} type="button" variant="secondary">
+              <Button onClick={() => navigate(-1)} type="button" variant={ButtonVariant.secondary}>
                 {t('Cancel')}
               </Button>
             </ActionGroup>

--- a/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCErrorMessage.tsx
+++ b/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCErrorMessage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Trans } from 'react-i18next';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Alert } from '@patternfly/react-core';
+import { Alert, AlertVariant } from '@patternfly/react-core';
 
 import { uploadErrorType } from '../utils/consts';
 
@@ -37,7 +37,7 @@ const UploadPVCErrorMessage: React.FC<UploadErrorMessageProps> = ({ message, upl
       className="co-alert co-alert--scrollable"
       isInline
       title={t('An error occurred')}
-      variant="danger"
+      variant={AlertVariant.danger}
     >
       <div className="co-pre-line">{Error?.[message] || message}</div>
     </Alert>

--- a/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCFormGoldenImage.tsx
+++ b/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCFormGoldenImage.tsx
@@ -4,7 +4,13 @@ import { PersistentVolumeClaimModel } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
-import { Alert, Checkbox, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import {
+  Alert,
+  AlertVariant,
+  Checkbox,
+  FormSelect,
+  FormSelectOption,
+} from '@patternfly/react-core';
 
 import { getName, getNamespace } from '../utils/selectors';
 import { OperatingSystemRecord } from '../utils/types';
@@ -103,7 +109,11 @@ const UploadPVCFormGoldenImage: FC<UploadPVCFormGoldenImageProps> = ({
       </div>
       {osImageExists && (
         <div className="form-group">
-          <Alert isInline title={t('Operating system source already defined')} variant="danger">
+          <Alert
+            isInline
+            title={t('Operating system source already defined')}
+            variant={AlertVariant.danger}
+          >
             {t(
               'In order to add a new source for {{osName}} you will need to delete the following PVC:',
               { osName: os?.name },

--- a/src/views/cdi-upload-provider/upload-pvc-form/statuses/CDIInitErrorStatus.tsx
+++ b/src/views/cdi-upload-provider/upload-pvc-form/statuses/CDIInitErrorStatus.tsx
@@ -73,7 +73,7 @@ const CDIInitErrorStatus: FC<CDIInitErrorStatus> = ({ namespace, onErrorClick, p
           </StackItem>
         </Stack>
       </EmptyStateBody>
-      <Button id="cdi-upload-error-btn" onClick={onClick} variant="primary">
+      <Button id="cdi-upload-error-btn" onClick={onClick}>
         {shouldKillDv ? t('Back to form (Deletes DataVolume)') : t('Back to form')}
       </Button>
       {podLoaded && !podError && pod && (

--- a/src/views/cdi-upload-provider/upload-pvc-form/statuses/ErrorStatus.tsx
+++ b/src/views/cdi-upload-provider/upload-pvc-form/statuses/ErrorStatus.tsx
@@ -19,7 +19,7 @@ const ErrorStatus: React.FC<ErrorStatusProps> = ({ error, onErrorClick }) => {
       titleText={t('Error uploading data')}
     >
       <EmptyStateBody>{error}</EmptyStateBody>
-      <Button id="cdi-upload-error-btn" onClick={onErrorClick} variant="primary">
+      <Button id="cdi-upload-error-btn" onClick={onErrorClick}>
         {error ? t('Back to form') : t('View PersistentVolumeClaim details')}
       </Button>
     </EmptyState>

--- a/src/views/cdi-upload-provider/upload-pvc-form/statuses/UploadingStatus.tsx
+++ b/src/views/cdi-upload-provider/upload-pvc-form/statuses/UploadingStatus.tsx
@@ -5,6 +5,7 @@ import {
   Alert,
   AlertVariant,
   Button,
+  ButtonVariant,
   EmptyState,
   EmptyStateActions,
   EmptyStateBody,
@@ -51,13 +52,13 @@ const UploadingStatus: FC<UploadingStatusProps> = ({ onCancelClick, onSuccessCli
         </Stack>
       </EmptyStateBody>
       {onSuccessClick && (
-        <Button id="cdi-upload-primary-pvc" onClick={onSuccessClick} variant="primary">
+        <Button id="cdi-upload-primary-pvc" onClick={onSuccessClick}>
           {t('View Persistent Volume Claim details')}
         </Button>
       )}
       {onCancelClick && upload?.uploadStatus === UPLOAD_STATUS.UPLOADING && (
         <EmptyStateActions>
-          <Button id="cdi-upload-cancel-btn" onClick={onCancelClick} variant="link">
+          <Button id="cdi-upload-cancel-btn" onClick={onCancelClick} variant={ButtonVariant.link}>
             {t('Cancel Upload')}
           </Button>
         </EmptyStateActions>

--- a/src/views/checkups/components/DeleteCheckupModal.tsx
+++ b/src/views/checkups/components/DeleteCheckupModal.tsx
@@ -2,8 +2,15 @@ import React, { FC } from 'react';
 
 import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { ActionGroup, Button, ButtonVariant } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  ButtonVariant,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 
 type DeleteCheckupModalProps = {
   isOpen: boolean;
@@ -22,29 +29,25 @@ const DeleteCheckupModal: FC<DeleteCheckupModalProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   return (
-    <Modal
-      footer={
-        <ActionGroup>
-          <Button
-            onClick={() => {
-              onDelete();
-              onClose();
-            }}
-            variant={ButtonVariant.danger}
-          >
-            {t('Delete')}
-          </Button>
-          <Button onClick={onClose} variant={ButtonVariant.link}>
-            {t('Cancel')}
-          </Button>
-        </ActionGroup>
-      }
-      isOpen={isOpen}
-      onClose={onClose}
-      title={t('Delete checkup')}
-      variant={ModalVariant.medium}
-    >
-      <ConfirmActionMessage obj={{ metadata: { name, namespace } }} />
+    <Modal isOpen={isOpen} onClose={onClose} variant={ModalVariant.medium}>
+      <ModalHeader title={t('Delete checkup')} />
+      <ModalBody>
+        <ConfirmActionMessage obj={{ metadata: { name, namespace } }} />
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          onClick={() => {
+            onDelete();
+            onClose();
+          }}
+          variant={ButtonVariant.danger}
+        >
+          {t('Delete')}
+        </Button>
+        <Button onClick={onClose} variant={ButtonVariant.link}>
+          {t('Cancel')}
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/views/clusteroverview/OverviewTab/getting-started-card/utils/getting-started-content/GettingStartedMoreLinkContent.tsx
+++ b/src/views/clusteroverview/OverviewTab/getting-started-card/utils/getting-started-content/GettingStartedMoreLinkContent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
-import { Button } from '@patternfly/react-core';
+import { Button, ButtonVariant } from '@patternfly/react-core';
 
 import { GettingStartedLink } from '../types';
 
@@ -19,7 +19,12 @@ const GettingStartedMoreLinkContent: React.FC<GettingStartedMoreLinkContentProps
   if (moreLink?.onClick) {
     const handleClick = moreLink.onClick;
     return (
-      <Button data-test={`item ${moreLink.id}`} isInline onClick={handleClick} variant="link">
+      <Button
+        data-test={`item ${moreLink.id}`}
+        isInline
+        onClick={handleClick}
+        variant={ButtonVariant.link}
+      >
         {moreLink.title}
       </Button>
     );

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/components/OrganizationIDHelpIcon/OrganizationIDHelpIcon.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/components/OrganizationIDHelpIcon/OrganizationIDHelpIcon.tsx
@@ -3,7 +3,7 @@ import { Trans } from 'react-i18next';
 
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button } from '@patternfly/react-core';
+import { Button, ButtonVariant } from '@patternfly/react-core';
 
 import { REDHAT_CONSOLE_URL } from '../../utils/constants';
 
@@ -14,7 +14,13 @@ const OrganizationIDHelpIcon: FC = () => {
       bodyContent={
         <Trans ns="plugin__kubevirt-plugin" t={t}>
           Log into{' '}
-          <Button component="a" href={REDHAT_CONSOLE_URL} isInline target="_blank" variant="link">
+          <Button
+            component="a"
+            href={REDHAT_CONSOLE_URL}
+            isInline
+            target="_blank"
+            variant={ButtonVariant.link}
+          >
             Hybrid Cloud Console
           </Button>{' '}
           to track your Organization ID.

--- a/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/SSHAuthKeysList.tsx
+++ b/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/SSHAuthKeysList.tsx
@@ -4,6 +4,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   Button,
+  ButtonVariant,
   Content,
   ContentVariants,
   Grid,
@@ -63,7 +64,7 @@ const SSHAuthKeysList: FC = () => {
         isDisabled={isEmpty(selectableProjects)}
         isInline
         onClick={onAuthKeyAdd}
-        variant="link"
+        variant={ButtonVariant.link}
       >
         {t('Add public SSH key to project')}
       </Button>

--- a/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/components/AddProjectAuthKeyButton/AddProjectAuthKeyButton.tsx
+++ b/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/components/AddProjectAuthKeyButton/AddProjectAuthKeyButton.tsx
@@ -9,7 +9,7 @@ import {
 } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { Button } from '@patternfly/react-core';
+import { Button, ButtonVariant } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
 type AddProjectAuthKeyButtonProps = {
@@ -54,7 +54,7 @@ const AddProjectAuthKeyButton: FC<AddProjectAuthKeyButtonProps> = ({
       iconPosition="end"
       isDisabled={isEmpty(selectedProject)}
       isInline
-      variant="link"
+      variant={ButtonVariant.link}
     >
       {isEmpty(secretName) ? t('Not configured') : secretName}
     </Button>

--- a/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/components/SSHAuthKeyRow/SSHAuthKeyRow.tsx
+++ b/src/views/clusteroverview/SettingsTab/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/components/SSHAuthKeyRow/SSHAuthKeyRow.tsx
@@ -10,7 +10,7 @@ import {
 import { createSSHSecret } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { Button, Grid, GridItem, Truncate } from '@patternfly/react-core';
+import { Button, ButtonVariant, Grid, GridItem, Truncate } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 
 import { AuthKeyRow } from '../../utils/types';
@@ -105,7 +105,7 @@ const SSHAuthKeyRow: FC<SSHAuthKeyRowProps> = ({
           isDisabled={isRemoveDisabled}
           isInline
           onClick={() => onAuthKeyDelete(row)}
-          variant="plain"
+          variant={ButtonVariant.plain}
         />
       </GridItem>
     </Grid>

--- a/src/views/templates/actions/components/EditBootSourceModal.tsx
+++ b/src/views/templates/actions/components/EditBootSourceModal.tsx
@@ -13,7 +13,15 @@ import {
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { K8sResourceCommon, ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
-import { Alert, Button, Form, FormGroup, Popover } from '@patternfly/react-core';
+import {
+  Alert,
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  Popover,
+} from '@patternfly/react-core';
 
 import { SOURCE_TYPES } from '../../utils/constants';
 import { editBootSource } from '../editBootSource';
@@ -66,10 +74,15 @@ const EditBootSourceModal: FC<EditBootSourceModalProps> = ({
         onClose={onClose}
         onSubmit={onSubmit}
       >
-        <Alert className="margin-bottom-md" isInline title={t('Warning')} variant="warning">
+        <Alert
+          className="margin-bottom-md"
+          isInline
+          title={t('Warning')}
+          variant={AlertVariant.warning}
+        >
           <Trans ns="plugin__kubevirt-plugin">
             Editing the DataSource will affect{' '}
-            <Button isInline ref={popoverRef} variant="link">
+            <Button isInline ref={popoverRef} variant={ButtonVariant.link}>
               all templates
             </Button>{' '}
             that are currently using this DataSource.

--- a/src/views/templates/details/TemplatePageTitle.tsx
+++ b/src/views/templates/details/TemplatePageTitle.tsx
@@ -11,6 +11,7 @@ import {
   Breadcrumb,
   BreadcrumbItem,
   Button,
+  ButtonVariant,
   Label,
   Split,
   SplitItem,
@@ -45,7 +46,7 @@ const TemplatePageTitle: FC<TemplatePageTitleTitleProps> = ({ template }) => {
           <Button
             isInline
             onClick={() => navigate(`/k8s/${lastNamespacePath}/templates`)}
-            variant="link"
+            variant={ButtonVariant.link}
           >
             {t('Templates')}
           </Button>

--- a/src/views/templates/details/tabs/details/components/CPUMemoryModal/CPUMemoryModal.tsx
+++ b/src/views/templates/details/tabs/details/components/CPUMemoryModal/CPUMemoryModal.tsx
@@ -10,8 +10,17 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { getCPU, getMemory } from '@kubevirt-utils/resources/vm';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
-import { Alert, Button, ButtonVariant } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Alert,
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 
 import useEditTemplateAccessReview from '../../../../hooks/useIsTemplateEditable';
 
@@ -80,16 +89,38 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({ isOpen, onClose, onSubmit, te
 
   return (
     <Modal
-      actions={[
+      className="cpu-memory-modal"
+      isOpen={isOpen}
+      onClose={onClose}
+      variant={ModalVariant.small}
+      width="650px"
+    >
+      <ModalHeader title={t('Edit CPU | Memory')} />
+      <ModalBody>
+        <div className="inputs">
+          <CPUInput currentCPU={defaultCPU} setUserEnteredCPU={setCPU} userEnteredCPU={cpu} />
+          <MemoryInput
+            memory={memory}
+            memoryUnit={memoryUnit}
+            setMemory={setMemory}
+            setMemoryUnit={setMemoryUnit}
+          />
+        </div>
+        {updateError && (
+          <Alert isInline title={t('Error')} variant={AlertVariant.danger}>
+            {updateError}
+          </Alert>
+        )}
+      </ModalBody>
+      <ModalFooter>
         <Button
           isDisabled={updateInProcess}
           isLoading={updateInProcess}
           key="confirm"
           onClick={handleSubmit}
-          variant={ButtonVariant.primary}
         >
           {t('Save')}
-        </Button>,
+        </Button>
         <Button
           onClick={() => {
             setCPU(defaultCPU);
@@ -101,32 +132,11 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({ isOpen, onClose, onSubmit, te
           variant={ButtonVariant.secondary}
         >
           {t('Restore template settings')}
-        </Button>,
-        <Button key="cancel" onClick={onClose} variant="link">
+        </Button>
+        <Button key="cancel" onClick={onClose} variant={ButtonVariant.link}>
           {t('Cancel')}
-        </Button>,
-      ]}
-      className="cpu-memory-modal"
-      isOpen={isOpen}
-      onClose={onClose}
-      title={t('Edit CPU | Memory')}
-      variant={ModalVariant.small}
-      width="650px"
-    >
-      <div className="inputs">
-        <CPUInput currentCPU={defaultCPU} setUserEnteredCPU={setCPU} userEnteredCPU={cpu} />
-        <MemoryInput
-          memory={memory}
-          memoryUnit={memoryUnit}
-          setMemory={setMemory}
-          setMemoryUnit={setMemoryUnit}
-        />
-      </div>
-      {updateError && (
-        <Alert isInline title={t('Error')} variant="danger">
-          {updateError}
-        </Alert>
-      )}
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/views/templates/details/tabs/parameters/TemplateParametersPage.tsx
+++ b/src/views/templates/details/tabs/parameters/TemplateParametersPage.tsx
@@ -13,6 +13,7 @@ import {
   Alert,
   AlertVariant,
   Button,
+  ButtonVariant,
   Divider,
   EmptyState,
   Form,
@@ -107,16 +108,10 @@ const TemplateParametersPage: FC<TemplateParametersPageProps> = ({ obj: template
             </Alert>
           )}
           <ActionGroup className="pf-v6-c-form">
-            <Button
-              isDisabled={isSaveDisabled}
-              isLoading={loading}
-              onClick={onSave}
-              type="submit"
-              variant="primary"
-            >
+            <Button isDisabled={isSaveDisabled} isLoading={loading} onClick={onSave} type="submit">
               {t('Save')}
             </Button>
-            <Button onClick={goBack} type="button" variant="secondary">
+            <Button onClick={goBack} type="button" variant={ButtonVariant.secondary}>
               {t('Cancel')}
             </Button>
           </ActionGroup>

--- a/src/views/templates/details/tabs/scheduling/components/AffinityRulesModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/AffinityRulesModal.tsx
@@ -21,7 +21,7 @@ import { modelToGroupVersionKind, NodeModel, V1Template } from '@kubevirt-utils/
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { ModalVariant } from '@patternfly/react-core';
 
 type AffinityModalProps = {
   isOpen: boolean;

--- a/src/views/templates/details/tabs/scheduling/components/DedicatedResourcesModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/DedicatedResourcesModal.tsx
@@ -20,6 +20,7 @@ import {
   Alert,
   AlertVariant,
   Button,
+  ButtonVariant,
   Checkbox,
   Form,
   FormGroup,
@@ -131,7 +132,7 @@ const DedicatedResourcesModal: FC<DedicatedResourcesModalProps> = ({
                     qualifiedNodesCount: qualifiedNodes?.length,
                   })}
                 >
-                  <Button isInline onClick={() => setChecked(false)} variant="link">
+                  <Button isInline onClick={() => setChecked(false)} variant={ButtonVariant.link}>
                     {t('view {{qualifiedNodesCount}} matching nodes', {
                       qualifiedNodesCount: qualifiedNodes?.length,
                     })}

--- a/src/views/templates/details/tabs/scheduling/components/Descheduler.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/Descheduler.tsx
@@ -11,7 +11,7 @@ import { V1Template } from '@kubevirt-utils/models';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { DESCHEDULER_EVICT_LABEL } from '@kubevirt-utils/resources/vmi';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
-import { Button, Switch } from '@patternfly/react-core';
+import { Button, ButtonVariant, Switch } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 type DeschedulerProps = {
@@ -56,7 +56,7 @@ const Descheduler: FC<DeschedulerProps> = ({ onSubmit, template }) => {
                 icon={<ExternalLinkAltIcon />}
                 iconPosition="right"
                 target="_blank"
-                variant="link"
+                variant={ButtonVariant.link}
               >
                 {t('Learn more')}
               </Button>

--- a/src/views/templates/details/tabs/scheduling/components/TolerationsModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/TolerationsModal.tsx
@@ -22,8 +22,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { Form } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { Form, ModalVariant } from '@patternfly/react-core';
 
 type TolerationsModalProps = {
   isOpen: boolean;

--- a/src/views/templates/details/tabs/scripts/TemplateScriptsPage.tsx
+++ b/src/views/templates/details/tabs/scripts/TemplateScriptsPage.tsx
@@ -16,6 +16,7 @@ import {
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
+  ButtonVariant,
   DescriptionList,
   Divider,
   Flex,
@@ -93,7 +94,7 @@ const TemplateScriptsPage: FC<TemplateScriptsPageProps> = ({ obj: template }) =>
                     isDisabled={!isTemplateEditable}
                     isInline
                     type="button"
-                    variant="link"
+                    variant={ButtonVariant.link}
                   >
                     {t('Edit')}
                   </Button>

--- a/src/views/templates/details/tabs/scripts/components/SysPrepItem/SysPrepItem.tsx
+++ b/src/views/templates/details/tabs/scripts/components/SysPrepItem/SysPrepItem.tsx
@@ -19,7 +19,7 @@ import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/templ
 import { getVolumes } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, Flex, FlexItem, Title } from '@patternfly/react-core';
+import { Button, ButtonVariant, Flex, FlexItem, Title } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 
 import useEditTemplateAccessReview from '../../../../hooks/useIsTemplateEditable';
@@ -111,7 +111,7 @@ const SysPrepItem: FC<SysPrepItemProps> = ({ template }) => {
               isDisabled={!isTemplateEditable}
               isInline
               type="button"
-              variant="link"
+              variant={ButtonVariant.link}
             >
               {t('Edit')}
             </Button>

--- a/src/views/templates/list/components/VirtualMachineTemplateSupport/VirtualMachineTemplateSupport.tsx
+++ b/src/views/templates/list/components/VirtualMachineTemplateSupport/VirtualMachineTemplateSupport.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button } from '@patternfly/react-core';
+import { Button, ButtonVariant } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import './VirtualMachineTemplateSupport.scss';
@@ -20,7 +20,7 @@ const VirtualMachineTemplateSupport: FC = () => {
         icon={<ExternalLinkAltIcon />}
         iconPosition="right"
         target="_blank"
-        variant="link"
+        variant={ButtonVariant.link}
       >
         {t('Learn more about Red Hat support')}
       </Button>

--- a/src/views/virtualmachines/actions/components/ConfirmMultipleVMActionsModal/ConfirmMultipleVMActionsModal.tsx
+++ b/src/views/virtualmachines/actions/components/ConfirmMultipleVMActionsModal/ConfirmMultipleVMActionsModal.tsx
@@ -2,8 +2,16 @@ import React, { FC } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button, ButtonVariant, Popover, PopoverPosition } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  ButtonVariant,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Popover,
+  PopoverPosition,
+} from '@patternfly/react-core';
 import VMsByNamespacePopover from '@virtualmachines/actions/components/ConfirmMultipleVMActionsModal/components/VMsByNamespacePopover';
 import { getVMNamesByNamespace } from '@virtualmachines/actions/components/ConfirmMultipleVMActionsModal/utils/utils';
 
@@ -38,34 +46,38 @@ const ConfirmMultipleVMActionsModal: FC<ConfirmMultipleVMActionsModalProps> = ({
 
   return (
     <Modal
-      actions={[
-        <Button key="confirm" onClick={submitHandler} variant={ButtonVariant.primary}>
-          {t(actionType)}
-        </Button>,
-        <Button key="cancel" onClick={onClose} variant="link">
-          {t('Cancel')}
-        </Button>,
-      ]}
       className="confirm-multiple-vm-actions-modal"
       isOpen={isOpen}
       onClose={onClose}
       onSubmit={() => submitHandler()}
-      title={t(`${actionType} ${numVMs} VirtualMachines?`)}
       variant={'small'}
     >
-      {t('Are you sure you want to stop ')}
-      <Popover
-        bodyContent={<VMsByNamespacePopover vmsByNamespace={vmsByNamespace} />}
-        className="confirm-multiple-vm-actions-modal__popover"
-        position={PopoverPosition.right}
-      >
-        <a>
-          {t('{{numVMs}} VirtualMachines in {{numVMNamespaces}} namespaces?', {
-            numVMNamespaces,
-            numVMs,
-          })}
-        </a>
-      </Popover>
+      <ModalHeader
+        title={t('{{actionType}} {{numVMs}} VirtualMachines?', { actionType, numVMs })}
+      />
+      <ModalBody>
+        {t('Are you sure you want to stop ')}
+        <Popover
+          bodyContent={<VMsByNamespacePopover vmsByNamespace={vmsByNamespace} />}
+          className="confirm-multiple-vm-actions-modal__popover"
+          position={PopoverPosition.right}
+        >
+          <a>
+            {t('{{numVMs}} VirtualMachines in {{numVMNamespaces}} namespaces?', {
+              numVMNamespaces,
+              numVMs,
+            })}
+          </a>
+        </Popover>
+      </ModalBody>
+      <ModalFooter>
+        <Button key="confirm" onClick={submitHandler}>
+          {t(actionType)}
+        </Button>
+        <Button key="cancel" onClick={onClose} variant={ButtonVariant.link}>
+          {t('Cancel')}
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/views/virtualmachines/actions/components/ConfirmVMActionModal/ConfirmVMActionModal.tsx
+++ b/src/views/virtualmachines/actions/components/ConfirmVMActionModal/ConfirmVMActionModal.tsx
@@ -3,8 +3,14 @@ import React, { FC } from 'react';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { Button, ButtonVariant } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  ButtonVariant,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from '@patternfly/react-core';
 
 type ConfirmVMActionModalProps = {
   action: (vm: V1VirtualMachine) => Promise<string>;
@@ -30,26 +36,28 @@ const ConfirmVMActionModal: FC<ConfirmVMActionModalProps> = ({
 
   return (
     <Modal
-      actions={[
-        <Button key="confirm" onClick={submitHandler} variant={ButtonVariant.primary}>
-          {t(actionType)}
-        </Button>,
-        <Button key="cancel" onClick={onClose} variant="link">
-          {t('Cancel')}
-        </Button>,
-      ]}
       className="confirm-multiple-vm-actions-modal"
       isOpen={isOpen}
       onClose={onClose}
       onSubmit={submitHandler}
-      title={t('{{actionType}} VirtualMachine?', { actionType })}
       variant={'small'}
     >
-      {t(
-        `Are you sure you want to ${actionType?.toLowerCase()} ${getName(
-          vm,
-        )} in namespace ${getNamespace(vm)}?`,
-      )}
+      <ModalHeader title={t('{{actionType}} VirtualMachine?', { actionType })} />
+      <ModalBody>
+        {t(
+          `Are you sure you want to ${actionType?.toLowerCase()} ${getName(
+            vm,
+          )} in namespace ${getNamespace(vm)}?`,
+        )}
+      </ModalBody>
+      <ModalFooter>
+        <Button key="confirm" onClick={submitHandler}>
+          {t(actionType)}
+        </Button>
+        <Button key="cancel" onClick={onClose} variant={ButtonVariant.link}>
+          {t('Cancel')}
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
@@ -9,8 +9,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { getName } from '@kubevirt-utils/resources/shared';
 import useDisksSources from '@kubevirt-utils/resources/vm/hooks/disk/useDisksSources';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { Wizard, WizardHeader, WizardStep } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import { Modal, ModalBody, Wizard, WizardHeader, WizardStep } from '@patternfly/react-core';
 
 import VirtualMachineMigrationDestinationTab from './tabs/VirtualMachineMigrationDestinationTab';
 import VirtualMachineMigrationDetails from './tabs/VirtualMachineMigrationDetails';
@@ -81,69 +80,70 @@ const VirtualMachineMigrateModal: FC<VirtualMachineMigrateModalProps> = ({
       className="virtual-machine-migration-modal"
       id="virtual-machine-migration-modal"
       isOpen={isOpen}
-      showClose={false}
       variant="large"
     >
-      <StateHandler error={loadingError} loaded>
-        {migrationStarted ? (
-          <VirtualMachineMigrationStatus onClose={onClose} vm={vm} />
-        ) : (
-          <Wizard
-            header={
-              <WizardHeader
-                closeButtonAriaLabel={t('Close header')}
-                description={t('Migrate VirtualMachine storage to a different StorageClass.')}
-                onClose={onClose}
-                title={t('Migrate VirtualMachine storage')}
-              />
-            }
-            onClose={onClose}
-            onSave={onSubmit}
-            title={t('Migrate VirtualMachine storage')}
-          >
-            <WizardStep
-              footer={{ isNextDisabled: nothingSelected }}
-              id="wizard-migration-details"
-              name={t('Migration details')}
+      <ModalBody>
+        <StateHandler error={loadingError} loaded>
+          {migrationStarted ? (
+            <VirtualMachineMigrationStatus onClose={onClose} vm={vm} />
+          ) : (
+            <Wizard
+              header={
+                <WizardHeader
+                  closeButtonAriaLabel={t('Close header')}
+                  description={t('Migrate VirtualMachine storage to a different StorageClass.')}
+                  onClose={onClose}
+                  title={t('Migrate VirtualMachine storage')}
+                />
+              }
+              onClose={onClose}
+              onSave={onSubmit}
+              title={t('Migrate VirtualMachine storage')}
             >
-              {loaded && scLoaded ? (
-                <VirtualMachineMigrationDetails
-                  pvcs={pvcs}
-                  selectedPVCs={selectedPVCs}
-                  setSelectedPVCs={setSelectedPVCs}
+              <WizardStep
+                footer={{ isNextDisabled: nothingSelected }}
+                id="wizard-migration-details"
+                name={t('Migration details')}
+              >
+                {loaded && scLoaded ? (
+                  <VirtualMachineMigrationDetails
+                    pvcs={pvcs}
+                    selectedPVCs={selectedPVCs}
+                    setSelectedPVCs={setSelectedPVCs}
+                    vm={vm}
+                  />
+                ) : (
+                  <Loading />
+                )}
+              </WizardStep>
+              <WizardStep id="wizard-migrate-destination" name={t('Destination StorageClass')}>
+                <VirtualMachineMigrationDestinationTab
+                  defaultStorageClassName={defaultStorageClassName}
+                  destinationStorageClass={destinationStorageClass}
+                  setSelectedStorageClass={setSelectedStorageClass}
+                  sortedStorageClasses={sortedStorageClasses}
+                />
+              </WizardStep>
+              <WizardStep
+                footer={{
+                  isNextDisabled: migrationLoading,
+                  nextButtonText: t('Migrate VirtualMachine storage'),
+                }}
+                id="wizard-migrate-review"
+                name={t('Review')}
+              >
+                <VirtualMachineMigrationReviewTab
+                  defaultStorageClassName={defaultStorageClassName}
+                  destinationStorageClass={destinationStorageClass}
+                  migrationError={migrationError}
+                  pvcs={pvcsToMigrate}
                   vm={vm}
                 />
-              ) : (
-                <Loading />
-              )}
-            </WizardStep>
-            <WizardStep id="wizard-migrate-destination" name={t('Destination StorageClass')}>
-              <VirtualMachineMigrationDestinationTab
-                defaultStorageClassName={defaultStorageClassName}
-                destinationStorageClass={destinationStorageClass}
-                setSelectedStorageClass={setSelectedStorageClass}
-                sortedStorageClasses={sortedStorageClasses}
-              />
-            </WizardStep>
-            <WizardStep
-              footer={{
-                isNextDisabled: migrationLoading,
-                nextButtonText: t('Migrate VirtualMachine storage'),
-              }}
-              id="wizard-migrate-review"
-              name={t('Review')}
-            >
-              <VirtualMachineMigrationReviewTab
-                defaultStorageClassName={defaultStorageClassName}
-                destinationStorageClass={destinationStorageClass}
-                migrationError={migrationError}
-                pvcs={pvcsToMigrate}
-                vm={vm}
-              />
-            </WizardStep>
-          </Wizard>
-        )}
-      </StateHandler>
+              </WizardStep>
+            </Wizard>
+          )}
+        </StateHandler>
+      </ModalBody>
     </Modal>
   );
 };

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DeletionProtection/DeletionProtectionModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DeletionProtection/DeletionProtectionModal.tsx
@@ -3,8 +3,16 @@ import React, { FC } from 'react';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { Button, ButtonVariant } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  ButtonVariant,
+  Content,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 import { VMDeletionProtectionOptions } from '@virtualmachines/details/tabs/configuration/details/components/DeletionProtection/utils/types';
 import { setDeletionProtectionForVM } from '@virtualmachines/details/tabs/configuration/details/components/DeletionProtection/utils/utils';
 
@@ -33,55 +41,61 @@ const DeletionProtectionModal: FC<DeletionProtectionModalProps> = ({
 
   return (
     <Modal
-      actions={[
-        <Button key="confirm" onClick={submitHandler} variant={ButtonVariant.primary}>
-          {enableDeletionProtection ? t('Enable') : t('Disable')}
-        </Button>,
-        <Button key="cancel" onClick={onClose} variant={ButtonVariant.link}>
-          {t('Cancel')}
-        </Button>,
-      ]}
-      title={
-        enableDeletionProtection
-          ? t('Enable deletion protection?')
-          : t('Disable deletion protection?')
-      }
       className="deletion-protection-modal"
       isOpen={isOpen}
       onClose={onClose}
       onSubmit={submitHandler}
-      titleIconVariant="warning"
       variant={ModalVariant.medium}
     >
-      {enableDeletionProtection ? (
-        <>
-          {t(
-            'The VirtualMachine cannot be deleted if Deletion Protection is enabled to safeguard from accidental deletion. You can disable Deletion Protection at any time.',
+      <ModalHeader
+        title={
+          enableDeletionProtection
+            ? t('Enable deletion protection?')
+            : t('Disable deletion protection?')
+        }
+        titleIconVariant="warning"
+      />
+      <ModalBody>
+        <Content>
+          {enableDeletionProtection ? (
+            <>
+              <p>
+                {t(
+                  'The VirtualMachine cannot be deleted if Deletion Protection is enabled to safeguard from accidental deletion. You can disable Deletion Protection at any time.',
+                )}
+              </p>
+              <b>
+                {t(
+                  'Are you sure you want to enable deletion protection for {{vmName}} in {{vmNamespace}}?',
+                  { vmName, vmNamespace },
+                )}
+              </b>
+            </>
+          ) : (
+            <>
+              <p>
+                {t(
+                  'Disabling Deletion Protection will allow you to delete this VirtualMachine. VirtualMachine deletion can result in data loss or service disruption.',
+                )}
+              </p>
+              <b>
+                {t(
+                  'Are you sure you want to disable deletion protection for {{vmName}} in {{vmNamespace}}?',
+                  { vmName, vmNamespace },
+                )}
+              </b>
+            </>
           )}
-          <br />
-          <br />
-          <b>
-            {t(
-              'Are you sure you want to enable deletion protection for {{vmName}} in {{vmNamespace}}?',
-              { vmName, vmNamespace },
-            )}
-          </b>
-        </>
-      ) : (
-        <>
-          {t(
-            'Disabling Deletion Protection will allow you to delete this VirtualMachine. VirtualMachine deletion can result in data loss or service disruption.',
-          )}
-          <br />
-          <br />
-          <b>
-            {t(
-              'Are you sure you want to disable deletion protection for {{vmName}} in {{vmNamespace}}?',
-              { vmName, vmNamespace },
-            )}
-          </b>
-        </>
-      )}
+        </Content>
+      </ModalBody>
+      <ModalFooter>
+        <Button key="confirm" onClick={submitHandler}>
+          {enableDeletionProtection ? t('Enable') : t('Disable')}
+        </Button>
+        <Button key="cancel" onClick={onClose} variant={ButtonVariant.link}>
+          {t('Cancel')}
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/views/virtualmachines/details/tabs/configuration/ssh/components/DynamicSSHKeyInjectionDescription.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/ssh/components/DynamicSSHKeyInjectionDescription.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button, StackItem } from '@patternfly/react-core';
+import { Button, ButtonVariant, StackItem } from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 
 const DynamicSSHKeyInjectionDescription = ({ isDynamicSSHInjectionEnabled }) => {
@@ -22,7 +22,7 @@ const DynamicSSHKeyInjectionDescription = ({ isDynamicSSHInjectionEnabled }) => 
         rel="noopener noreferrer"
         size="sm"
         target="_blank"
-        variant="link"
+        variant={ButtonVariant.link}
       >
         {t('Learn more')}
       </Button>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
@@ -6,7 +6,7 @@ import { isHeadlessModeVMI } from '@kubevirt-utils/components/Consoles/utils/uti
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { vmiStatuses } from '@kubevirt-utils/resources/vmi';
 import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
-import { Bullseye, Button } from '@patternfly/react-core';
+import { Bullseye, Button, ButtonVariant } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import VirtualMachinesOverviewTabDetailsConsoleConnect from './VirtualMachinesOverviewTabDetailsConsoleConnect';
@@ -41,7 +41,7 @@ const VirtualMachinesOverviewTabDetailsConsole: FC<
           icon={<ExternalLinkAltIcon className="icon" />}
           iconPosition="end"
           isDisabled={!isVMRunning || isHeadlessMode || !canConnectConsole}
-          variant="link"
+          variant={ButtonVariant.link}
         >
           {t('Open web console')}
         </Button>

--- a/src/views/virtualmachines/list/components/VirtualMachineBreadcrumb/VirtualMachineBreadcrumb.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineBreadcrumb/VirtualMachineBreadcrumb.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import { VirtualMachineModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useLastNamespacePath } from '@kubevirt-utils/hooks/useLastNamespacePath';
-import { Breadcrumb, BreadcrumbItem, Button } from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, Button, ButtonVariant } from '@patternfly/react-core';
 
 export const VirtualMachineBreadcrumb: React.FC = React.memo(() => {
   const namespacePath = useLastNamespacePath();
@@ -19,7 +19,7 @@ export const VirtualMachineBreadcrumb: React.FC = React.memo(() => {
           <Button
             isInline
             onClick={() => navigate(`/k8s/${namespacePath}/${VirtualMachineModelRef}`)}
-            variant="link"
+            variant={ButtonVariant.link}
           >
             {t('VirtualMachines')}
           </Button>

--- a/src/views/welcome/WelcomeModal.tsx
+++ b/src/views/welcome/WelcomeModal.tsx
@@ -11,10 +11,12 @@ import {
   ContentVariants,
   Grid,
   GridItem,
+  Modal,
+  ModalBody,
+  ModalVariant,
   Stack,
   Title,
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 
 import WelcomeButtons from './components/WelcomeButtons';
 
@@ -36,39 +38,41 @@ const WelcomeModal: FC = () => {
       onClose={onClose}
       variant={ModalVariant.large}
     >
-      <Grid className="WelcomeModal__grid" hasGutter>
-        <GridItem span={4}>
-          <img className="WelcomeModal__image" src={openCulture} />
-        </GridItem>
+      <ModalBody>
+        <Grid className="WelcomeModal__grid" hasGutter>
+          <GridItem span={4}>
+            <img className="WelcomeModal__image" src={openCulture} />
+          </GridItem>
 
-        <GridItem span={8}>
-          <Stack>
-            <Trans ns="plugin__kubevirt-plugin" t={t}>
-              <Title headingLevel="h2">Welcome to</Title>
-              <Title headingLevel="h1">OpenShift Virtualization</Title>
+          <GridItem span={8}>
+            <Stack>
+              <Trans ns="plugin__kubevirt-plugin" t={t}>
+                <Title headingLevel="h2">Welcome to</Title>
+                <Title headingLevel="h1">OpenShift Virtualization</Title>
 
-              <Content className="text-muted WelcomeModal__text" component={ContentVariants.p}>
-                Use OpenShift Virtualization to run and manage virtualized workloads alongside
-                container workloads. You can manage both Linux and Windows virtual machines.
-              </Content>
+                <Content className="text-muted WelcomeModal__text" component={ContentVariants.p}>
+                  Use OpenShift Virtualization to run and manage virtualized workloads alongside
+                  container workloads. You can manage both Linux and Windows virtual machines.
+                </Content>
 
-              <Title headingLevel="h3">What do you want to do next?</Title>
+                <Title headingLevel="h3">What do you want to do next?</Title>
 
-              <WelcomeButtons onClose={onClose} />
+                <WelcomeButtons onClose={onClose} />
 
-              <Checkbox
-                onChange={(_event, value) =>
-                  setQuickStarts({ ...quickStarts, dontShowWelcomeModal: value })
-                }
-                className="WelcomeModal__checkbox"
-                id="welcome-modal-checkbox"
-                isChecked={quickStarts?.dontShowWelcomeModal}
-                label={t('Do not show this again')}
-              />
-            </Trans>
-          </Stack>
-        </GridItem>
-      </Grid>
+                <Checkbox
+                  onChange={(_event, value) =>
+                    setQuickStarts({ ...quickStarts, dontShowWelcomeModal: value })
+                  }
+                  className="WelcomeModal__checkbox"
+                  id="welcome-modal-checkbox"
+                  isChecked={quickStarts?.dontShowWelcomeModal}
+                  label={t('Do not show this again')}
+                />
+              </Trans>
+            </Stack>
+          </GridItem>
+        </Grid>
+      </ModalBody>
     </Modal>
   );
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Updates deprecated Modal to PF6 promoted version
- also fixes YamlAndCLIViewerModal which was not showing the code editor
- removes ActionList and ActionGroup causing visual bugs

Also replaces `variant="something"` with `variant={ButtonVariant.something}` on Buttons and Alerts

Before:
![Screenshot 2025-03-18 at 11 22 17](https://github.com/user-attachments/assets/c86745c5-a140-4c9e-bcc2-26f47dc1f16e)
![Screenshot 2025-03-18 at 11 16 04](https://github.com/user-attachments/assets/82b6db9e-a068-450c-b870-6f82e1fbd6a7)


After:
![Screenshot 2025-03-18 at 12 18 16](https://github.com/user-attachments/assets/700b67e6-356d-47e8-b796-90f95d626a44)
![Screenshot 2025-03-18 at 11 15 29](https://github.com/user-attachments/assets/7404c532-0bc6-4fdb-a2ff-c80518fa52ee)

