### PR TITLE
CNV-57968: fix selected VMs state after deletion from CLI

### DIFF
--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -56,10 +56,10 @@ import VirtualMachineListSummary from './components/VirtualMachineListSummary/Vi
 import VirtualMachineRow from './components/VirtualMachineRow/VirtualMachineRow';
 import VirtualMachinesCreateButton from './components/VirtualMachinesCreateButton/VirtualMachinesCreateButton';
 import VirtualMachineSelection from './components/VirtualMachineSelection/VirtualMachineSelection';
+import useExistingSelectedVMs from './hooks/useExistingSelectedVMs';
 import useSelectedFilters from './hooks/useSelectedFilters';
 import useVirtualMachineColumns from './hooks/useVirtualMachineColumns';
 import useVMMetrics from './hooks/useVMMetrics';
-import { selectedVMs } from './selectedVMs';
 
 import '@kubevirt-utils/styles/list-managment-group.scss';
 import './VirtualMachinesList.scss';
@@ -202,7 +202,8 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef(({ kind, na
 
   const noVMs = isEmpty(unfilteredData) && !vmsFilteredWithProxy;
 
-  const allVMsSelected = data?.length === selectedVMs.value.length;
+  const existingSelectedVMs = useExistingSelectedVMs(data);
+  const allVMsSelected = data?.length === existingSelectedVMs.length;
 
   if (loaded && noVMs) {
     return (

--- a/src/views/virtualmachines/list/components/VirtualMachineBulkActionButton.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineBulkActionButton.tsx
@@ -1,13 +1,12 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ActionsDropdown from '@kubevirt-utils/components/ActionsDropdown/ActionsDropdown';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { convertResourceArrayToMap } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useMultipleVirtualMachineActions from '@virtualmachines/actions/hooks/useMultipleVirtualMachineActions';
 
-import { selectedVMs } from '../selectedVMs';
+import useExistingSelectedVMs from '../hooks/useExistingSelectedVMs';
 
 type VirtualMachineBulkActionButtonProps = {
   vms: V1VirtualMachine[];
@@ -15,12 +14,7 @@ type VirtualMachineBulkActionButtonProps = {
 const VirtualMachineBulkActionButton: FC<VirtualMachineBulkActionButtonProps> = ({ vms }) => {
   const { t } = useKubevirtTranslation();
 
-  const selectedVirtualMachines = useMemo(() => {
-    const vmsMapper = convertResourceArrayToMap(vms, true);
-    return selectedVMs.value.map(
-      (selectedVM) => vmsMapper?.[selectedVM.namespace]?.[selectedVM.name],
-    );
-  }, [vms]);
+  const selectedVirtualMachines = useExistingSelectedVMs(vms);
 
   const actions = useMultipleVirtualMachineActions(selectedVirtualMachines);
 
@@ -28,7 +22,7 @@ const VirtualMachineBulkActionButton: FC<VirtualMachineBulkActionButtonProps> = 
     <ActionsDropdown
       actions={actions}
       disabledTooltip={t('Select multiple VirtualMachines to perform an action for all of them')}
-      isDisabled={isEmpty(selectedVMs.value)}
+      isDisabled={isEmpty(selectedVirtualMachines)}
       variant="secondary"
     />
   );

--- a/src/views/virtualmachines/list/components/VirtualMachineSelection/VirtualMachineSelection.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineSelection/VirtualMachineSelection.tsx
@@ -11,8 +11,9 @@ import {
   MenuToggle,
   MenuToggleElement,
 } from '@patternfly/react-core';
+import useExistingSelectedVMs from '@virtualmachines/list/hooks/useExistingSelectedVMs';
 
-import { deselectAll, selectAll, selectedVMs } from '../../selectedVMs';
+import { deselectAll, selectAll } from '../../selectedVMs';
 
 import './virtual-machine-selection.scss';
 
@@ -25,6 +26,7 @@ type VirtualMachineSelectionProps = {
 const VirtualMachineSelection: FC<VirtualMachineSelectionProps> = ({ loaded, pagination, vms }) => {
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState(false);
+  const existingSelectedVMs = useExistingSelectedVMs(vms);
 
   if (!loaded) return null;
 
@@ -42,8 +44,9 @@ const VirtualMachineSelection: FC<VirtualMachineSelectionProps> = ({ loaded, pag
 
   const numCurrentPageVMs = currentPageVMs.length;
 
-  const partiallyChecked = !isEmpty(selectedVMs.value) && selectedVMs.value.length !== vms.length;
-  const isChecked = selectedVMs.value.length === vms.length;
+  const selectionIsEmpty = isEmpty(existingSelectedVMs);
+  const isChecked = !selectionIsEmpty && existingSelectedVMs.length === vms.length;
+  const partiallyChecked = !selectionIsEmpty && !isChecked;
 
   return (
     <Dropdown
@@ -56,8 +59,8 @@ const VirtualMachineSelection: FC<VirtualMachineSelectionProps> = ({ loaded, pag
         >
           <Checkbox
             label={
-              !isEmpty(selectedVMs.value)
-                ? t('{{length}} selected', { length: selectedVMs.value.length })
+              !selectionIsEmpty
+                ? t('{{length}} selected', { length: existingSelectedVMs.length })
                 : null
             }
             onChange={(event, checked) => {

--- a/src/views/virtualmachines/list/hooks/useExistingSelectedVMs.ts
+++ b/src/views/virtualmachines/list/hooks/useExistingSelectedVMs.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { convertResourceArrayToMap } from '@kubevirt-utils/resources/shared';
+
+import { selectedVMs } from '../selectedVMs';
+
+const useExistingSelectedVMs = (vms: V1VirtualMachine[]) => {
+  const vmsMapper = useMemo(() => convertResourceArrayToMap(vms, true), [vms]);
+
+  const existingSelectedVirtualMachines = useMemo(
+    () =>
+      selectedVMs.value
+        .map((selectedVM) => vmsMapper?.[selectedVM.namespace]?.[selectedVM.name])
+        .filter(Boolean),
+    [selectedVMs.value, vmsMapper],
+  );
+
+  return existingSelectedVirtualMachines;
+};
+
+export default useExistingSelectedVMs;


### PR DESCRIPTION
## 📝 Description

Actually fixes https://issues.redhat.com/browse/CNV-57968. Guohua found out that the state of selected VMs does not reflect changes to the VMs list from CLI. 

I kept the previous fix https://github.com/kubevirt-ui/kubevirt-plugin/pull/2515 (which was only fixing deletion from UI) so we don't keep unnecessary deleted VMs inside `selectedVMs` signal.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/97fdfd6f-12c5-4a2b-b90f-22405154b142

After:

https://github.com/user-attachments/assets/3d2d583a-fbff-46b0-84de-850a7961aea4


