### PR TITLE
CNV-58306: Use stricter typing for InstanceTypeModal

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/constants.ts
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/constants.ts
@@ -1,7 +1,7 @@
 import { ComponentClass } from 'react';
 
-import { InstanceTypeSize } from '@catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/utils/types';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { InstanceTypeSeries, InstanceTypeSize } from '@kubevirt-utils/resources/instancetype/types';
 import {
   MemoryIcon,
   MicrochipIcon,
@@ -41,7 +41,7 @@ export const initialMenuItems: InstanceTypesMenuItemsData = {
 };
 
 export const instanceTypeSeriesNameMapper: {
-  [key: string]: {
+  [key in 'server' | Exclude<InstanceTypeSeries, 'rt1'>]: {
     disabled?: boolean;
     Icon: ComponentClass;
     possibleSizes?: InstanceTypeSize[];

--- a/src/utils/components/InstanceTypeModal/InstanceTypeModal.tsx
+++ b/src/utils/components/InstanceTypeModal/InstanceTypeModal.tsx
@@ -1,8 +1,8 @@
 import React, { FC, useMemo, useState } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { InstanceTypeUnion } from '@kubevirt-utils/resources/instancetype/types';
 import { Content, Flex, FlexItem, SelectList, SelectOption } from '@patternfly/react-core';
-import { InstanceTypeUnion } from '@virtualmachines/details/tabs/configuration/utils/types';
 
 import FormPFSelect from '../FormPFSelect/FormPFSelect';
 import TabModal from '../TabModal/TabModal';
@@ -12,8 +12,8 @@ import {
   getInstanceTypeFromSeriesAndSize,
   getInstanceTypeSeriesAndSize,
   getInstanceTypeSeriesDisplayName,
+  getInstanceTypeSizes,
   getInstanceTypesPrettyDisplaySize,
-  getInstanceTypesSizes,
   mappedInstanceTypesToSelectOptions,
 } from './utils/util';
 
@@ -67,7 +67,7 @@ const InstanceTypeModal: FC<InstanceTypeModalProps> = ({
             onSelect={(_, value) => {
               if (value !== series) {
                 setSeries(value as string);
-                setSize(null);
+                setSize(undefined);
               }
             }}
             selected={series}
@@ -95,7 +95,7 @@ const InstanceTypeModal: FC<InstanceTypeModalProps> = ({
             selected={size}
             toggleProps={{ isFullWidth: true }}
           >
-            {getInstanceTypesSizes(mappedInstanceTypes, series)?.map((item) => (
+            {getInstanceTypeSizes(mappedInstanceTypes, series)?.map((item) => (
               <SelectOption key={item.prettyDisplaySize} value={item.prettyDisplaySize}>
                 {item?.prettyDisplaySize}
               </SelectOption>

--- a/src/utils/components/InstanceTypeModal/utils/types.ts
+++ b/src/utils/components/InstanceTypeModal/utils/types.ts
@@ -1,26 +1,9 @@
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { InstanceTypeUnion } from '@virtualmachines/details/tabs/configuration/utils/types';
-
-export type InstanceTypesSeries =
-  | 'cx1'
-  | 'gn1'
-  | 'highperformance'
-  | 'm1'
-  | 'n1'
-  | 'o1'
-  | 'rt1'
-  | 'u1';
-
-export type InstanceTypesSizes =
-  | '2xlarge'
-  | '4xlarge'
-  | '8xlarge'
-  | 'large'
-  | 'medium'
-  | 'micro'
-  | 'nano'
-  | 'small'
-  | 'xlarge';
+import {
+  InstanceTypeSeries,
+  InstanceTypeSize,
+  InstanceTypeUnion,
+} from '@kubevirt-utils/resources/instancetype/types';
 
 export type InstanceTypeRecord = {
   instanceType: InstanceTypeUnion;
@@ -31,10 +14,10 @@ export type InstanceTypeRecord = {
 };
 
 export type MappedInstanceTypes = Record<
-  InstanceTypesSeries,
+  InstanceTypeSeries,
   {
     sizes: {
-      [key in InstanceTypesSizes]?: InstanceTypeRecord;
+      [key in InstanceTypeSize]?: InstanceTypeRecord;
     };
   } & { descriptionSeries?: string; displayNameSeries?: string }
 >;

--- a/src/utils/resources/instancetype/selectors.ts
+++ b/src/utils/resources/instancetype/selectors.ts
@@ -1,0 +1,5 @@
+import { InstanceTypeUnion } from './types';
+
+export const getInstanceTypeCPU = (resource: InstanceTypeUnion) => resource?.spec?.cpu?.guest;
+
+export const getInstanceTypeMemory = (resource: InstanceTypeUnion) => resource?.spec?.memory?.guest;

--- a/src/utils/resources/instancetype/types.ts
+++ b/src/utils/resources/instancetype/types.ts
@@ -1,0 +1,30 @@
+import {
+  V1beta1VirtualMachineClusterInstancetype,
+  V1beta1VirtualMachineInstancetype,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
+
+export type InstanceTypeSize =
+  | '2xlarge'
+  | '2xmedium'
+  | '4xlarge'
+  | '8xlarge'
+  | 'large'
+  | 'medium'
+  | 'micro'
+  | 'nano'
+  | 'small'
+  | 'xlarge';
+
+export type InstanceTypeSeries =
+  | 'cx1'
+  | 'gn1'
+  | 'highperformance'
+  | 'm1'
+  | 'n1'
+  | 'o1'
+  | 'rt1'
+  | 'u1';
+
+export type InstanceTypeUnion =
+  | V1beta1VirtualMachineClusterInstancetype
+  | V1beta1VirtualMachineInstancetype;

--- a/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/utils/types.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/utils/types.ts
@@ -1,16 +1,6 @@
 import { MutableRefObject } from 'react';
 
-export type InstanceTypeSize =
-  | '2xlarge'
-  | '2xmedium'
-  | '4xlarge'
-  | '8xlarge'
-  | 'large'
-  | 'medium'
-  | 'micro'
-  | 'nano'
-  | 'small'
-  | 'xlarge';
+import { InstanceTypeSize } from '@kubevirt-utils/resources/instancetype/types';
 
 export enum InstanceTypeCategory {
   ComputeIntensive = 'ComputeIntensive',

--- a/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
@@ -20,6 +20,7 @@ import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeat
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
+import { InstanceTypeUnion } from '@kubevirt-utils/resources/instancetype/types';
 import { asAccessReview, getAnnotation, getName } from '@kubevirt-utils/resources/shared';
 import { WORKLOADS_LABELS } from '@kubevirt-utils/resources/template';
 import {
@@ -36,8 +37,6 @@ import { DescriptionList, Grid, GridItem, Switch, Title } from '@patternfly/reac
 import DeletionProtectionModal from '@virtualmachines/details/tabs/configuration/details/components/DeletionProtection/DeletionProtectionModal';
 import { VMDeletionProtectionOptions } from '@virtualmachines/details/tabs/configuration/details/components/DeletionProtection/utils/types';
 import { isDeletionProtectionEnabled } from '@virtualmachines/details/tabs/configuration/details/components/DeletionProtection/utils/utils';
-
-import { InstanceTypeUnion } from '../utils/types';
 
 import DetailsSectionBoot from './components/DetailsSectionBoot';
 import DetailsSectionHardware from './components/DetailsSectionHardware';

--- a/src/views/virtualmachines/details/tabs/configuration/utils/types.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/utils/types.ts
@@ -1,13 +1,5 @@
-import {
-  V1beta1VirtualMachineClusterInstancetype,
-  V1beta1VirtualMachineInstancetype,
-  V1VirtualMachine,
-  V1VirtualMachineInstance,
-} from '@kubevirt-ui/kubevirt-api/kubevirt';
-
-export type InstanceTypeUnion =
-  | V1beta1VirtualMachineClusterInstancetype
-  | V1beta1VirtualMachineInstancetype;
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { InstanceTypeUnion } from '@kubevirt-utils/resources/instancetype/types';
 
 export type ConfigurationInnerTabProps = {
   allInstanceTypes?: InstanceTypeUnion[];


### PR DESCRIPTION
## 📝 Description

Extend safeguards and consolidate existing types.
The crash while editing custom InstanceType should be already prevented with #2503     
For non-Red Hat InstanceType and/or instance type not following the naming convention there will be no initial selection (see the screenshot below).

## 🎥 Demo

### After
Editing  a VM based on custom InstanceType `foointancetype` 
![Screenshot From 2025-03-25 12-23-40](https://github.com/user-attachments/assets/fd751294-4eec-4edb-880c-17b309cffce4)


