### PR TITLE
CNV-58163: Update custom URL with k9sPatch

### DIFF
--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/AutomaticSubscriptionRHELGuests.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/AutomaticSubscriptionRHELGuests.tsx
@@ -92,7 +92,6 @@ const AutomaticSubscriptionRHELGuests: FC<AutomaticSubscriptionRHELGuestsProps> 
                     selected?.value === AutomaticSubscriptionTypeEnum.ENABLE_PREDICTIVE_ANALYTICS
                   }
                   customUrl={formProps.subscriptionData?.customUrl}
-                  updateCustomUrl={formProps.updateSubscription}
                 />
               </>
             )}


### PR DESCRIPTION
## 📝 Description

Before, typing custom URL resulted in update operation for each typed character. Subsequent updates must include the whole resource. Each update changes the resource revision. If user types too quickly the updates were fired with previous revision and rejected by the server optimistic locking check.

After this PR:
1. the update method was changed to k8sPatch which allows overwriting the current resource (without providing revision)
2. debounce period was extended from 500ms to 1 second
3. server state is used for initialization only
4. error handling was added using inline error alert with the last error

## 🎥 Demo

### After

![Screenshot From 2025-03-27 22-32-31](https://github.com/user-attachments/assets/8c0587e5-6453-4b73-a938-3607f5a98512)

