### PR TITLE
Provide stable reference for toggleFeature

### DIFF
--- a/src/utils/hooks/useFeatures/useFeatures.ts
+++ b/src/utils/hooks/useFeatures/useFeatures.ts
@@ -6,9 +6,15 @@ import {
   IoK8sApiRbacV1Role,
   IoK8sApiRbacV1RoleBinding,
 } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
 import { k8sCreate, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
-import { featuresConfigMapInitialState, featuresRole, featuresRoleBinding } from './constants';
+import {
+  FEATURES_CONFIG_MAP_NAME,
+  featuresConfigMapInitialState,
+  featuresRole,
+  featuresRoleBinding,
+} from './constants';
 import { UseFeaturesValues } from './types';
 import useFeaturesConfigMap from './useFeaturesConfigMap';
 
@@ -109,7 +115,13 @@ export const useFeatures: UseFeatures = (featureName) => {
         const promise = await k8sPatch({
           data: [{ op: 'replace', path: `/data/${featureName}`, value: value.toString() }],
           model: ConfigMapModel,
-          resource: featureConfigMap,
+          resource: {
+            data: {},
+            metadata: {
+              name: FEATURES_CONFIG_MAP_NAME,
+              namespace: DEFAULT_OPERATOR_NAMESPACE,
+            },
+          },
         });
         setError(null);
         setFeatureEnabled(promise?.data?.[featureName] === 'true');
@@ -120,7 +132,7 @@ export const useFeatures: UseFeatures = (featureName) => {
         setError(updateError);
       }
     },
-    [featureConfigMap, featureName],
+    [featureName],
   );
 
   return {


### PR DESCRIPTION
## 📝 Description

The Console uses resource object in k8sPatch for:
1. early return in case when no patches were provided - it's border condition not very useful in our scenarios (response ignored anyway). It's also questionable if the provided resource should be returned as-it-is. Most likely it's invalid/incomplete/outdated and should be re-fetched.
2. as a placeholder for name and namespace - this usage could be replaced with optional parameters "name" and "ns" - however the resource is the only source of truth here

The requirement to provide the complete resource has the side effect that the callbacks/memos need to be re-created with every resource modification. This PR substitutes the resource with a stub which results in stable references and prevents re-renders.

Reference-Url: https://github.com/openshift/console/blob/5ec380064538a91e1baa5c4ff9e04959bd6926bb/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/k8s-resource.ts#L210


## 🎥 Demo

### Before
`useEffect` hook updating the `disabledGuestSystemLogsAccess` feature flag being triggered with any update.
https://github.com/kubevirt-ui/kubevirt-plugin/blob/9a8af2b6d630928c760f6faad119575c3d34983e/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/GuestSystemLogsAccess/GuestSystemLogsAccess.tsx#L45


https://github.com/user-attachments/assets/20dcc016-9e2e-4f3f-af68-f33ba3cb7632




