### PR TITLE
CNV-56949: tree view UI changes

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -125,6 +125,7 @@
   "Affinity rules": "Affinity rules",
   "Alerts": "Alerts",
   "Alerts ({{alertsQuantity}})": "Alerts ({{alertsQuantity}})",
+  "All projects summary": "All projects summary",
   "All sources selected": "All sources selected",
   "All templates": "All templates",
   "Allocating resources": "Allocating resources",

--- a/src/utils/components/ListPageFilter/ListPageFilter.tsx
+++ b/src/utils/components/ListPageFilter/ListPageFilter.tsx
@@ -20,6 +20,7 @@ import {
   ToolbarToggleGroup,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
+import { ListManagementGroupSize } from '@virtualmachines/list/listManagementGroupSize';
 
 import ColumnManagement from '../ColumnManagementModal/ColumnManagement';
 import FormPFSelect from '../FormPFSelect/FormPFSelect';
@@ -51,6 +52,7 @@ type ListPageFilterProps = {
   hideColumnManagement?: boolean;
   hideLabelFilter?: boolean;
   hideNameLabelFilters?: boolean;
+  listManagementGroupSize?: ListManagementGroupSize;
   loaded?: boolean;
   nameFilterPlaceholder?: string;
   onFilterChange?: OnFilterChange;
@@ -64,6 +66,7 @@ const ListPageFilter: FC<ListPageFilterProps> = ({
   hideColumnManagement,
   hideLabelFilter,
   hideNameLabelFilters,
+  listManagementGroupSize,
   loaded,
   nameFilterPlaceholder,
   onFilterChange,
@@ -135,7 +138,6 @@ const ListPageFilter: FC<ListPageFilterProps> = ({
 
   return (
     <Toolbar
-      className="co-toolbar-no-padding pf-m-toggle-group-container"
       clearAllFilters={clearAll}
       clearFiltersButtonText={t('Clear all filters')}
       data-test="filter-toolbar"
@@ -147,6 +149,7 @@ const ListPageFilter: FC<ListPageFilterProps> = ({
             filters={filters}
             filtersNameMap={filtersNameMap}
             generatedRowFilters={generatedRowFilters}
+            listManagementGroupSize={listManagementGroupSize}
             rowFilters={toolbarFilters}
             selectedRowFilters={selectedRowFilters}
             updateRowFilterSelected={updateRowFilterSelected}

--- a/src/utils/components/ListPageFilter/RowFilters.tsx
+++ b/src/utils/components/ListPageFilter/RowFilters.tsx
@@ -13,6 +13,7 @@ import {
   ToolbarLabel,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
+import { ListManagementGroupSize } from '@virtualmachines/list/listManagementGroupSize';
 
 import FormPFSelect from '../FormPFSelect/FormPFSelect';
 
@@ -22,6 +23,7 @@ type RowFiltersProps = {
   filters: Filter;
   filtersNameMap: FilterKeys;
   generatedRowFilters: ReturnType<typeof generateRowFilters>;
+  listManagementGroupSize?: ListManagementGroupSize;
   rowFilters: RowFilter[];
   selectedRowFilters: string[];
   updateRowFilterSelected: (id: string[]) => void;
@@ -31,6 +33,7 @@ const RowFilters: FC<RowFiltersProps> = ({
   filters,
   filtersNameMap,
   generatedRowFilters,
+  listManagementGroupSize,
   rowFilters,
   selectedRowFilters,
   updateRowFilterSelected,
@@ -71,6 +74,9 @@ const RowFilters: FC<RowFiltersProps> = ({
         ),
         <div data-test-id="filter-dropdown-toggle">
           <FormPFSelect
+            selectedLabel={
+              listManagementGroupSize === ListManagementGroupSize.md ? <span></span> : t('Filter')
+            }
             toggleProps={{
               icon: (
                 <Icon className="span--icon__right-margin">
@@ -81,7 +87,6 @@ const RowFilters: FC<RowFiltersProps> = ({
             closeOnSelect={false}
             onSelect={onRowFilterSelect}
             selected={selectedRowFilters}
-            selectedLabel={t('Filter')}
           >
             {generatedRowFilters.map((rowFilter) => (
               <SelectGroup key={rowFilter.filterGroupName} label={rowFilter.filterGroupName}>

--- a/src/utils/hooks/useContainerWidth.ts
+++ b/src/utils/hooks/useContainerWidth.ts
@@ -1,0 +1,29 @@
+import { MutableRefObject, useEffect, useState } from 'react';
+
+import { debounce } from '@kubevirt-utils/utils/debounce';
+
+const useContainerWidth = (containerRef: MutableRefObject<HTMLElement>) => {
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  useEffect(() => {
+    const container = containerRef.current;
+
+    if (!container) return;
+
+    const updateWidth = (entries: ResizeObserverEntry[]) => {
+      for (const entry of entries) {
+        setContainerWidth(entry.contentRect.width);
+      }
+    };
+
+    const resizeObserver = new ResizeObserver(debounce(updateWidth));
+
+    resizeObserver.observe(container);
+
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  return containerWidth;
+};
+
+export default useContainerWidth;

--- a/src/utils/styles/list-managment-group.scss
+++ b/src/utils/styles/list-managment-group.scss
@@ -1,16 +1,18 @@
 .list-managment-group {
   display: flex;
   justify-content: space-between;
+  padding-block: var(--pf-t--global--spacer--md);
+
   &__pagination {
     flex-grow: 1;
   }
 
   .pf-v6-c-toolbar {
-    padding-block-start: var(--pf-t--global--spacer--md);
+    padding-block: 0;
   }
 
-  .pf-m-toggle-group-container {
-    width: 100%;
+  .pf-v6-c-toolbar__expandable-content {
+    width: fit-content;
   }
 }
 

--- a/src/views/virtualmachines/list/VirtualMachinesList.scss
+++ b/src/views/virtualmachines/list/VirtualMachinesList.scss
@@ -4,17 +4,44 @@
   }
 }
 
-.vm-listpagebody .pf-v6-c-table {
-  .selection-column {
-    --pf-v6-c-table--cell--Width: 5%;
+.vm-listpagebody {
+  .pf-v6-c-table {
+    .selection-column {
+      --pf-v6-c-table--cell--Width: 5%;
+    }
+  }
+
+  .list-managment-group {
+    flex-wrap: nowrap;
+    column-gap: var(--pf-t--global--spacer--md);
+
+    .pf-v6-c-toolbar__content-section {
+      flex-wrap: nowrap;
+    }
+
+    .pf-v6-c-toolbar__item {
+      column-gap: 0;
+    }
+
+    &__toolbar {
+      flex-wrap: nowrap;
+
+      &.is-compact {
+        .pf-v6-c-toolbar__group:where(.pf-m-toggle-group) {
+          .pf-v6-c-toolbar__toggle {
+            display: unset;
+          }
+
+          .pf-v6-c-toolbar__item {
+            display: none;
+          }
+        }
+      }
+    }
   }
 }
 
-.vm-list-page-header {
-  h1.co-m-pane__heading {
-    font-size: var(--pf-t--global--font--size--lg);
-  }
-
+.vm-actions-toggle {
   .kv-actions-dropdown {
     .pf-v6-c-menu-toggle {
       z-index: 0;

--- a/src/views/virtualmachines/list/components/VirtualMachineEmptyState/VirtualMachineEmptyState.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineEmptyState/VirtualMachineEmptyState.tsx
@@ -3,7 +3,7 @@ import { Trans } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom-v5-compat';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { ListPageBody, ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
+import { ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
   ButtonVariant,
@@ -29,42 +29,39 @@ const VirtualMachineEmptyState: FC<VirtualMachineEmptyStateProps> = ({ catalogUR
   const navigate = useNavigate();
 
   return (
-    <>
-      <ListPageHeader title={t('VirtualMachines')} />
-      <ListPageBody>
-        <EmptyState
-          className="VirtualMachineEmptyState"
-          headingLevel="h4"
-          icon={VirtualMachineIcon}
-          titleText={<>{t('No VirtualMachines found')}</>}
-          variant={EmptyStateVariant.lg}
-        >
-          <EmptyStateBody>
-            <Trans ns="plugin__kubevirt-plugin" t={t}>
-              Click <b>Create VirtualMachine</b> to create your first VirtualMachine or view the{' '}
-              <Button isInline onClick={() => navigate(catalogURL)} variant={ButtonVariant.link}>
-                catalog
-              </Button>{' '}
-              tab to create a VirtualMachine from the available options
-            </Trans>
-          </EmptyStateBody>
-          <EmptyStateFooter>
-            <EmptyStateActions>
-              <VirtualMachinesCreateButton
-                buttonText={t('Create VirtualMachine')}
-                namespace={namespace}
-              />
-            </EmptyStateActions>
-            <br />
-            <EmptyStateActions>
-              <Link to={'/quickstart?keyword=virtual+machine'}>
-                {t('Learn how to use VirtualMachines')} <RouteIcon />
-              </Link>
-            </EmptyStateActions>
-          </EmptyStateFooter>
-        </EmptyState>
-      </ListPageBody>
-    </>
+    <ListPageBody>
+      <EmptyState
+        className="VirtualMachineEmptyState"
+        headingLevel="h4"
+        icon={VirtualMachineIcon}
+        titleText={<>{t('No VirtualMachines found')}</>}
+        variant={EmptyStateVariant.lg}
+      >
+        <EmptyStateBody>
+          <Trans ns="plugin__kubevirt-plugin" t={t}>
+            Click <b>Create VirtualMachine</b> to create your first VirtualMachine or view the{' '}
+            <Button isInline onClick={() => navigate(catalogURL)} variant={ButtonVariant.link}>
+              catalog
+            </Button>{' '}
+            tab to create a VirtualMachine from the available options
+          </Trans>
+        </EmptyStateBody>
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            <VirtualMachinesCreateButton
+              buttonText={t('Create VirtualMachine')}
+              namespace={namespace}
+            />
+          </EmptyStateActions>
+          <br />
+          <EmptyStateActions>
+            <Link to={'/quickstart?keyword=virtual+machine'}>
+              {t('Learn how to use VirtualMachines')} <RouteIcon />
+            </Link>
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      </EmptyState>
+    </ListPageBody>
   );
 };
 

--- a/src/views/virtualmachines/list/components/VirtualMachineListSummary/VirtualMachineListSummary.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineListSummary/VirtualMachineListSummary.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useState } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VM_STATUS } from '@kubevirt-utils/resources/vm/utils/vmStatus';
 import { FilterValue } from '@openshift-console/dynamic-plugin-sdk';
@@ -34,7 +33,7 @@ const VirtualMachineListSummary: FC<VirtualMachineListSummaryProps> = ({
       toggleContent={
         <Content className="vm-list-summary__expand-section-toggle" component="h3">
           <ProjectDiagramIcon className="vm-list-summary__expand-section-toggle-icon" />{' '}
-          {namespace ?? ALL_PROJECTS}
+          {namespace ?? t('All projects summary')}
         </Content>
       }
       className="vm-list-summary__expand-section"

--- a/src/views/virtualmachines/list/components/VirtualMachineSelection/virtual-machine-selection.scss
+++ b/src/views/virtualmachines/list/components/VirtualMachineSelection/virtual-machine-selection.scss
@@ -1,4 +1,3 @@
 .virtual-machine-selection {
-  margin: var(--pf-t--global--spacer--md) 1rem auto 0;
   min-width: fit-content;
 }

--- a/src/views/virtualmachines/list/listManagementGroupSize.ts
+++ b/src/views/virtualmachines/list/listManagementGroupSize.ts
@@ -1,0 +1,11 @@
+export enum ListManagementGroupSize {
+  lg = 'lg',
+  md = 'md',
+  sm = 'sm',
+}
+
+export const getListManagementGroupSize = (width: number) => {
+  if (width < 880) return ListManagementGroupSize.sm;
+  if (width < 1090) return ListManagementGroupSize.md;
+  return ListManagementGroupSize.lg;
+};

--- a/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
+++ b/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
@@ -6,9 +6,15 @@ import GuidedTour from '@kubevirt-utils/components/GuidedTour/GuidedTour';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VirtualMachineModelRef } from '@kubevirt-utils/models';
-import { OnFilterChange, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  ListPageHeader,
+  OnFilterChange,
+  useActiveNamespace,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { Divider } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
 import VirtualMachineNavPage from '@virtualmachines/details/VirtualMachineNavPage';
+import VirtualMachinesCreateButton from '@virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton';
 import VirtualMachinesList from '@virtualmachines/list/VirtualMachinesList';
 import { useTreeViewData } from '@virtualmachines/tree/hooks/useTreeViewData';
 import VirtualMachineTreeView from '@virtualmachines/tree/VirtualMachineTreeView';
@@ -49,16 +55,30 @@ const VirtualMachineNavigator: FC = () => {
   }
 
   return (
-    <VirtualMachineTreeView onFilterChange={onFilterChange} {...treeProps}>
-      {isVirtualMachineListPage ? (
-        <>
-          <GuidedTour />
-          <VirtualMachinesList kind={VirtualMachineModelRef} namespace={namespace} ref={childRef} />
-        </>
-      ) : (
-        <VirtualMachineNavPage kind={VirtualMachineModelRef} name={vmName} namespace={namespace} />
-      )}
-    </VirtualMachineTreeView>
+    <>
+      <ListPageHeader title={t('VirtualMachines')}>
+        <VirtualMachinesCreateButton namespace={namespace} />
+      </ListPageHeader>
+      <Divider />
+      <VirtualMachineTreeView onFilterChange={onFilterChange} {...treeProps}>
+        {isVirtualMachineListPage ? (
+          <>
+            <GuidedTour />
+            <VirtualMachinesList
+              kind={VirtualMachineModelRef}
+              namespace={namespace}
+              ref={childRef}
+            />
+          </>
+        ) : (
+          <VirtualMachineNavPage
+            kind={VirtualMachineModelRef}
+            name={vmName}
+            namespace={namespace}
+          />
+        )}
+      </VirtualMachineTreeView>
+    </>
   );
 };
 

--- a/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
+++ b/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
@@ -22,10 +22,14 @@
     width: 100%;
   }
 
+  &__toolbar-top-panel {
+    align-items: center;
+    margin: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md) 0
+      var(--pf-t--global--spacer--sm);
+  }
+
   &__search-input {
     width: 100%;
-    margin: var(--pf-t--global--spacer--md) var(--pf-t--global--spacer--sm) 0
-      var(--pf-t--global--spacer--sm);
   }
 
   &__action {
@@ -43,18 +47,6 @@
   &__expand {
     padding: 0 var(--pf-t--global--spacer--xs) 0 var(--pf-t--global--spacer--xs);
     margin-right: calc(var(--pf-t--global--spacer--xs) * 2.5);
-  }
-
-  &__close-container {
-    display: flex;
-    align-self: flex-end;
-  }
-
-  &__close-button {
-    padding-top: 0;
-    padding-left: 0;
-    padding-right: var(--pf-t--global--spacer--xs);
-    padding-bottom: calc(var(--pf-t--global--spacer--xs) * 1.5);
   }
 
   &__toolbar-switch {

--- a/src/views/virtualmachines/tree/components/TreeViewContent.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewContent.tsx
@@ -67,13 +67,7 @@ const TreeViewContent: FC<TreeViewContentProps> = ({
   return (
     <>
       <TreeViewToolbar
-        closeComponent={
-          <PanelToggleButton
-            className="vms-tree-view__close-button"
-            isOpen={isOpen}
-            toggleDrawer={toggleDrawer}
-          />
-        }
+        closeComponent={<PanelToggleButton isOpen={isOpen} toggleDrawer={toggleDrawer} />}
         isSwitchDisabled={isSwitchDisabled}
         onSearch={onSearch}
       />

--- a/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
@@ -36,7 +36,7 @@ const TreeViewToolbar: FC<TreeViewToolbarProps> = ({
       <ToolbarContent className="vms-tree-view-toolbar-content">
         <Stack className="vms-tree-view__toolbar-section" hasGutter>
           <StackItem>
-            <Split>
+            <Split className="vms-tree-view__toolbar-top-panel" hasGutter>
               <SplitItem className="vms-tree-view__search-input" isFilled>
                 <TreeViewSearch
                   id={TREE_VIEW_SEARCH_ID}
@@ -45,7 +45,7 @@ const TreeViewToolbar: FC<TreeViewToolbarProps> = ({
                   placeholder={t('Search')}
                 />
               </SplitItem>
-              <SplitItem className="vms-tree-view__close-container">{closeComponent}</SplitItem>
+              <SplitItem>{closeComponent}</SplitItem>
             </Split>
           </StackItem>
           <Divider />


### PR DESCRIPTION
## 📝 Description

Updates VirtualMachines page UI according to [this doc](https://docs.google.com/document/d/1ZSfyxDfPxRuRNWggAKJ504wLe_t45MAd85jtsdZ34xw/edit?tab=t.0#heading=h.d7oxg5i37fkv).

## 🎥 Demo
Before:
![Screenshot 2025-03-28 at 12 37 40](https://github.com/user-attachments/assets/87f4e076-5148-4743-bb42-7cff413035a1)
![Screenshot 2025-03-28 at 12 37 46](https://github.com/user-attachments/assets/aac73132-ff8f-402a-bfa3-9d359fcefbe7)
![Screenshot 2025-03-28 at 12 38 32](https://github.com/user-attachments/assets/ab05fcaa-f42f-481b-946c-c2d10e62c778)
![Screenshot 2025-03-31 at 15 56 56](https://github.com/user-attachments/assets/b8ed1120-6eca-4b07-adf0-271d2e97aada)


After:
![Screenshot 2025-03-31 at 15 55 12](https://github.com/user-attachments/assets/a0817344-538c-4b98-a0ec-586877d7457f)
![Screenshot 2025-03-31 at 15 55 28](https://github.com/user-attachments/assets/38d75551-751e-488c-a59c-465e06727655)
![Screenshot 2025-03-31 at 15 55 41](https://github.com/user-attachments/assets/acea62a9-c538-4fa1-9d36-f1b4d3775fe4)
![Screenshot 2025-03-31 at 15 56 09](https://github.com/user-attachments/assets/f1ede939-7037-43de-a13d-5d4aa32252ad)
![Screenshot 2025-03-31 at 15 57 49](https://github.com/user-attachments/assets/98196902-8242-4d8f-a75f-5eed9eaccda0)

