### PR TITLE
CNV-58601: right click treeview stop propagation

### DIFF
--- a/src/views/virtualmachines/tree/hooks/useTreeViewItemActions.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewItemActions.ts
@@ -28,6 +28,7 @@ const useTreeViewItemActions: UseTreeViewItemActions = (treeData) => {
 
     const handler = (event) => {
       event.preventDefault();
+      event.stopPropagation();
       setTriggerElement(element);
     };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Stop propagation. When user right clicks on folder, it propagate in all namespace VMs as the right click event propagate to the higher hierarchy element in the treeview
