### PR TITLE
[release-4.16] CNV-56674: use v1alpha1 snapshot and restore on 4.16 plugin

### DIFF
--- a/src/utils/components/CloneVMModal/utils/helpers.tsx
+++ b/src/utils/components/CloneVMModal/utils/helpers.tsx
@@ -2,12 +2,12 @@ import produce from 'immer';
 
 import VirtualMachineCloneModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineCloneModel';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
-import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
 import {
   V1alpha1VirtualMachineClone,
   V1beta1VirtualMachineSnapshot,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1Alpha1VirtualMachineSnapshotModel } from '@kubevirt-utils/models';
 import { MAX_K8S_NAME_LENGTH } from '@kubevirt-utils/utils/constants';
 import { getRandomChars } from '@kubevirt-utils/utils/utils';
 import { k8sCreate, k8sGet, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
@@ -43,7 +43,9 @@ export const cloneVM = (
 ) => {
   const cloningRequest = produce(cloneVMToVM, (draftCloneData) => {
     draftCloneData.spec.source = {
-      apiGroup: isVM(source) ? VirtualMachineModel.apiGroup : VirtualMachineSnapshotModel.apiGroup,
+      apiGroup: isVM(source)
+        ? VirtualMachineModel.apiGroup
+        : V1Alpha1VirtualMachineSnapshotModel.apiGroup,
       kind: source.kind,
       name: source.metadata.name,
     };

--- a/src/utils/models/index.ts
+++ b/src/utils/models/index.ts
@@ -1,3 +1,5 @@
+import VirtualMachineRestoreModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineRestoreModel';
+import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
 export * from '@kubevirt-ui/kubevirt-api/console';
@@ -26,4 +28,14 @@ export const QuickStartModel: K8sModel = {
   namespaced: false,
   plural: 'consolequickstarts',
   propagationPolicy: 'Background',
+};
+
+export const V1Alpha1VirtualMachineSnapshotModel = {
+  ...VirtualMachineSnapshotModel,
+  apiVersion: 'v1alpha1',
+};
+
+export const V1Alpha1VirtualMachineRestoreModel = {
+  ...VirtualMachineRestoreModel,
+  apiVersion: 'v1alpha1',
 };

--- a/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useDeleteVMResources.ts
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useDeleteVMResources.ts
@@ -3,13 +3,13 @@ import {
   PersistentVolumeClaimModel,
 } from '@kubevirt-ui/kubevirt-api/console';
 import DataVolumeModel from '@kubevirt-ui/kubevirt-api/console/models/DataVolumeModel';
-import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
 import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import {
   V1beta1VirtualMachineSnapshot,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1Alpha1VirtualMachineSnapshotModel } from '@kubevirt-utils/models';
 import { getVolumes } from '@kubevirt-utils/resources/vm';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -57,7 +57,7 @@ const useDeleteVMResources: UseDeleteVMResources = (vm) => {
   const [snapshots, snapshotsLoaded, snapshotsLoadError] = useK8sWatchResource<
     V1beta1VirtualMachineSnapshot[]
   >({
-    groupVersionKind: modelToGroupVersionKind(VirtualMachineSnapshotModel),
+    groupVersionKind: modelToGroupVersionKind(V1Alpha1VirtualMachineSnapshotModel),
     isList: true,
     namespace,
     namespaced: true,

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/component/SnapshotDeleteModal.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/component/SnapshotDeleteModal.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
-import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
 import { V1beta1VirtualMachineSnapshot } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { V1Alpha1VirtualMachineSnapshotModel } from '@kubevirt-utils/models';
 import { k8sDelete } from '@openshift-console/dynamic-plugin-sdk';
 import { ButtonVariant } from '@patternfly/react-core';
 
@@ -15,7 +15,7 @@ const SnapshotDeleteModal = ({ isOpen, onClose, snapshot }) => {
       onSubmit={(obj) =>
         k8sDelete({
           json: undefined,
-          model: VirtualMachineSnapshotModel,
+          model: V1Alpha1VirtualMachineSnapshotModel,
           requestInit: undefined,
           resource: obj,
         })

--- a/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotActionsMenu.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotActionsMenu.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useCallback, useState } from 'react';
 
 import VirtualMachineCloneModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineCloneModel';
-import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
 import { V1beta1VirtualMachineSnapshot } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import CloneVMModal from '@kubevirt-utils/components/CloneVMModal/CloneVMModal';
 import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
@@ -9,6 +8,7 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { V1Alpha1VirtualMachineSnapshotModel } from '@kubevirt-utils/models';
 import { k8sDelete, useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 import { ButtonVariant, Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core';
 
@@ -57,7 +57,7 @@ const SnapshotActionsMenu: FC<SnapshotActionsMenuProps> = ({ isRestoreDisabled, 
       <TabModal<V1beta1VirtualMachineSnapshot>
         onSubmit={(obj) =>
           k8sDelete({
-            model: VirtualMachineSnapshotModel,
+            model: V1Alpha1VirtualMachineSnapshotModel,
             resource: obj,
           })
         }

--- a/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotRow.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotRow.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 
-import { VirtualMachineSnapshotModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import {
   V1beta1VirtualMachineRestore,
   V1beta1VirtualMachineSnapshot,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
+import { V1Alpha1VirtualMachineSnapshotModel } from '@kubevirt-utils/models';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 
 import { snapshotStatuses } from '../../utils/consts';
@@ -27,7 +28,7 @@ const SnapshotRow: React.FC<
     <>
       <TableData activeColumnIDs={activeColumnIDs} id="name">
         <ResourceLink
-          groupVersionKind={VirtualMachineSnapshotModelGroupVersionKind}
+          groupVersionKind={modelToGroupVersionKind(V1Alpha1VirtualMachineSnapshotModel)}
           name={snapshot?.metadata?.name}
           namespace={snapshot?.metadata?.namespace}
         />

--- a/src/views/virtualmachines/details/tabs/snapshots/components/modal/RestoreModal.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/modal/RestoreModal.tsx
@@ -1,13 +1,13 @@
 import React, { FC, useMemo } from 'react';
 import { Trans } from 'react-i18next';
 
-import VirtualMachineRestoreModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineRestoreModel';
 import {
   V1beta1VirtualMachineRestore,
   V1beta1VirtualMachineSnapshot,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { V1Alpha1VirtualMachineRestoreModel } from '@kubevirt-utils/models';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import { getVMRestoreSnapshotResource } from '../../utils/helpers';
@@ -33,7 +33,7 @@ const RestoreModal: FC<DeleteResourceModalProps> = ({ isOpen, onClose, snapshot 
       onSubmit={(obj) =>
         k8sCreate({
           data: obj,
-          model: VirtualMachineRestoreModel,
+          model: V1Alpha1VirtualMachineRestoreModel,
         })
       }
       headerText={t('Restore snapshot')}

--- a/src/views/virtualmachines/details/tabs/snapshots/components/modal/SnapshotModal.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/modal/SnapshotModal.tsx
@@ -1,12 +1,12 @@
 import React, { FC, useMemo, useState } from 'react';
 
-import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
 import {
   V1beta1VirtualMachineSnapshot,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { V1Alpha1VirtualMachineSnapshotModel } from '@kubevirt-utils/models';
 import { buildOwnerReference } from '@kubevirt-utils/resources/shared';
 import { getVolumeSnapshotStatuses } from '@kubevirt-utils/resources/vm';
 import { generatePrettyName } from '@kubevirt-utils/utils/utils';
@@ -64,7 +64,7 @@ const SnapshotModal: FC<SnapshotModalProps> = ({ isOpen, onClose, vm }) => {
       onSubmit={(obj) =>
         k8sCreate<V1beta1VirtualMachineSnapshot>({
           data: obj,
-          model: VirtualMachineSnapshotModel,
+          model: V1Alpha1VirtualMachineSnapshotModel,
         })
       }
       headerText={t('Take snapshot')}

--- a/src/views/virtualmachines/details/tabs/snapshots/hooks/useSnapshotData.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/hooks/useSnapshotData.ts
@@ -1,11 +1,14 @@
 import * as React from 'react';
 
-import VirtualMachineRestoreModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineRestoreModel';
-import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
 import {
   V1beta1VirtualMachineRestore,
   V1beta1VirtualMachineSnapshot,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  modelToGroupVersionKind,
+  V1Alpha1VirtualMachineRestoreModel,
+  V1Alpha1VirtualMachineSnapshotModel,
+} from '@kubevirt-utils/models';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 import { getVmRestoreSnapshotName, getVmRestoreTime } from '../utils/selectors';
@@ -21,11 +24,7 @@ const useSnapshotData = (vmName: string, namespace: string): UseSnapshotData => 
   const [snapshots, snapshotsLoaded, snapshotsError] = useK8sWatchResource<
     V1beta1VirtualMachineSnapshot[]
   >({
-    groupVersionKind: {
-      group: VirtualMachineSnapshotModel.apiGroup,
-      kind: VirtualMachineSnapshotModel.kind,
-      version: 'v1alpha1',
-    },
+    groupVersionKind: modelToGroupVersionKind(V1Alpha1VirtualMachineSnapshotModel),
     isList: true,
     namespace,
     namespaced: true,
@@ -34,11 +33,7 @@ const useSnapshotData = (vmName: string, namespace: string): UseSnapshotData => 
   const [restores, restoresLoaded, restoresError] = useK8sWatchResource<
     V1beta1VirtualMachineRestore[]
   >({
-    groupVersionKind: {
-      group: VirtualMachineRestoreModel.apiGroup,
-      kind: VirtualMachineRestoreModel.kind,
-      version: 'v1alpha1',
-    },
+    groupVersionKind: modelToGroupVersionKind(V1Alpha1VirtualMachineRestoreModel),
     isList: true,
     namespace,
     namespaced: true,

--- a/src/views/virtualmachines/details/tabs/snapshots/utils/helpers.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/utils/helpers.ts
@@ -1,6 +1,4 @@
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
-import VirtualMachineRestoreModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineRestoreModel';
-import VirtualMachineSnapshotModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineSnapshotModel';
 import {
   V1beta1VirtualMachineRestore,
   V1beta1VirtualMachineSnapshot,
@@ -8,6 +6,10 @@ import {
   V1VolumeSnapshotStatus,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import {
+  V1Alpha1VirtualMachineRestoreModel,
+  V1Alpha1VirtualMachineSnapshotModel,
+} from '@kubevirt-utils/models';
 
 export const getVolumeSnapshotStatusesPartition = (
   volumeSnaoshotStatuses: V1VolumeSnapshotStatus[],
@@ -35,8 +37,8 @@ export const validateSnapshotDeadline = (deadline: string): string => {
 
 export const getEmptyVMSnapshotResource = (vm: V1VirtualMachine): V1beta1VirtualMachineSnapshot => {
   const snapshotResource: V1beta1VirtualMachineSnapshot = {
-    apiVersion: `${VirtualMachineSnapshotModel.apiGroup}/${VirtualMachineSnapshotModel.apiVersion}`,
-    kind: VirtualMachineSnapshotModel.kind,
+    apiVersion: `${V1Alpha1VirtualMachineSnapshotModel.apiGroup}/${V1Alpha1VirtualMachineSnapshotModel.apiVersion}`,
+    kind: V1Alpha1VirtualMachineSnapshotModel.kind,
     metadata: {
       name: '',
       namespace: vm?.metadata?.namespace,
@@ -56,8 +58,8 @@ export const getVMRestoreSnapshotResource = (
   snapshot: V1beta1VirtualMachineSnapshot,
 ): V1beta1VirtualMachineRestore => {
   const restoreResource: V1beta1VirtualMachineRestore = {
-    apiVersion: `${VirtualMachineRestoreModel.apiGroup}/${VirtualMachineRestoreModel.apiVersion}`,
-    kind: VirtualMachineRestoreModel.kind,
+    apiVersion: `${V1Alpha1VirtualMachineRestoreModel.apiGroup}/${V1Alpha1VirtualMachineRestoreModel.apiVersion}`,
+    kind: V1Alpha1VirtualMachineRestoreModel.kind,
     metadata: {
       name: `restore-${snapshot.metadata.name}-${new Date().getTime()}`,
       namespace: snapshot.metadata.namespace,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Upgrading on 4.16 the kubevirt-api led to using a v1beta1 version for snapshot and restore that do not match with what we should use on 4.16 clusters. 



## 🎥 Demo



https://github.com/user-attachments/assets/fb77bbc4-ed36-4fc0-8bb5-891c65591f78


