### PR TITLE
CNV-55748: fix pvc size on disk table

### DIFF
--- a/src/utils/resources/vm/utils/disk/rowData.ts
+++ b/src/utils/resources/vm/utils/disk/rowData.ts
@@ -46,7 +46,7 @@ export const getDiskRowDataLayout = (
     const pvcSize = device?.pvc?.spec?.resources?.requests?.storage;
     const dataVolumeCustomSize =
       device?.dataVolumeTemplate?.spec?.storage?.resources?.requests?.storage;
-    const size = humanizeBinaryBytes(convertToBaseValue(dataVolumeCustomSize || pvcSize));
+    const size = humanizeBinaryBytes(convertToBaseValue(pvcSize || dataVolumeCustomSize));
 
     diskRowDataObject.size = size.value === 0 ? NO_DATA_DASH : size.string;
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Use PVC size first because if we catch the PVC, its the more reliable way to know the disk size.

If the PVC do not exist because we are in the wizard or something with that, fetch it from the dv.

DV size its true only in the creation process. IF the PVC disk changes, its not correct anymore

