### PR TITLE
CNV-56841: show VirtualMachine utilization summary

### DIFF
--- a/src/views/clusteroverview/OverviewTab/metric-charts-card/utils/metricQueries.ts
+++ b/src/views/clusteroverview/OverviewTab/metric-charts-card/utils/metricQueries.ts
@@ -6,7 +6,7 @@ const metricQueriesForNamespace = {
   [METRICS.MEMORY]: (namespace) =>
     `sum by (namespace)(kubevirt_vmi_memory_available_bytes{namespace="${namespace}"} - kubevirt_vmi_memory_usable_bytes{namespace="${namespace}"})`,
   [METRICS.STORAGE]: (namespace) =>
-    `sum by (namespace)(kubevirt_vmi_filesystem_used_bytes{namespace="${namespace}"})`,
+    `sum by (namespace)(max(kubevirt_vmi_filesystem_used_bytes{namespace="${namespace}"}) by (namespace, name, disk_name))`,
   [METRICS.VCPU_USAGE]: (namespace) =>
     `count(kubevirt_vmi_vcpu_wait_seconds_total{namespace="${namespace}"})`,
   [METRICS.VM]: (namespace) =>
@@ -16,7 +16,8 @@ const metricQueriesForNamespace = {
 const metricQueriesForAllNamespaces = {
   [METRICS.MEMORY]: () =>
     `sum(kubevirt_vmi_memory_available_bytes - kubevirt_vmi_memory_usable_bytes)`,
-  [METRICS.STORAGE]: () => `sum(kubevirt_vmi_filesystem_used_bytes)`,
+  [METRICS.STORAGE]: () =>
+    `sum(max(kubevirt_vmi_filesystem_used_bytes) by (namespace, name, disk_name))`,
   [METRICS.VCPU_USAGE]: () => `count(kubevirt_vmi_vcpu_wait_seconds_total)`,
   [METRICS.VM]: () =>
     `sum(count by (name,namespace)(kubevirt_vm_error_status_last_transition_timestamp_seconds + kubevirt_vm_migrating_status_last_transition_timestamp_seconds + kubevirt_vm_non_running_status_last_transition_timestamp_seconds + kubevirt_vm_running_status_last_transition_timestamp_seconds + kubevirt_vm_starting_status_last_transition_timestamp_seconds))`,

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -218,6 +218,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef(({ kind, na
         <VirtualMachineListSummary
           namespace={namespace}
           onFilterChange={onFilterChange}
+          vmis={vmis}
           vms={data}
         />
         <VirtualMachineEmptyState catalogURL={catalogURL} namespace={namespace} />
@@ -231,6 +232,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef(({ kind, na
       <VirtualMachineListSummary
         namespace={namespace}
         onFilterChange={onFilterChange}
+        vmis={vmis}
         vms={unfilterData}
       />
       <ListPageBody>

--- a/src/views/virtualmachines/list/components/VirtualMachineListSummary/VirtualMachineListSummary.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineListSummary/VirtualMachineListSummary.tsx
@@ -1,32 +1,49 @@
 import React, { FC, useState } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VM_STATUS } from '@kubevirt-utils/resources/vm/utils/vmStatus';
 import { FilterValue } from '@openshift-console/dynamic-plugin-sdk';
 import { ERROR } from '@overview/OverviewTab/vm-statuses-card/utils/constants';
 import { getVMStatuses } from '@overview/OverviewTab/vm-statuses-card/utils/utils';
 import VMStatusItem from '@overview/OverviewTab/vm-statuses-card/VMStatusItem';
-import { Card, CardTitle, Content, ExpandableSection, Grid } from '@patternfly/react-core';
+import {
+  Card,
+  CardTitle,
+  Content,
+  Divider,
+  ExpandableSection,
+  Flex,
+  FlexItem,
+  Grid,
+} from '@patternfly/react-core';
 import { ProjectDiagramIcon } from '@patternfly/react-icons';
+import useVMTotalsMetrics from '@virtualmachines/list/hooks/useVMTotalsMetrics';
+
+import VirtualMachineUsageItem from '../VirtualMachineUsageItem/VirtualMachineUsageItem';
 
 import './VirtualMachineListSummary.scss';
 
 type VirtualMachineListSummaryProps = {
   namespace: string;
   onFilterChange?: (type: string, value: FilterValue) => void;
+  vmis: V1VirtualMachineInstance[];
   vms: V1VirtualMachine[];
 };
 
 const VirtualMachineListSummary: FC<VirtualMachineListSummaryProps> = ({
   namespace,
   onFilterChange,
+  vmis,
   vms,
 }) => {
   const { t } = useKubevirtTranslation();
   const [isExpanded, setIsExpanded] = useState<boolean>(true);
 
   const { primaryStatuses } = getVMStatuses(vms || []);
+
+  const { cpuRequested, cpuUsage, memoryCapacity, memoryUsage, storageCapacity, storageUsage } =
+    useVMTotalsMetrics(vms, vmis);
 
   return (
     <ExpandableSection
@@ -41,35 +58,67 @@ const VirtualMachineListSummary: FC<VirtualMachineListSummaryProps> = ({
       onToggle={() => setIsExpanded((prev) => !prev)}
     >
       <Card className="vm-list-summary" data-test-id="vm-list-summary">
-        <CardTitle component="h5">
-          {t('Virtual Machines ({{count}})', { count: vms?.length })}
-        </CardTitle>
-        <Grid hasGutter>
-          <VMStatusItem
-            count={primaryStatuses.Error}
-            namespace={namespace}
-            onFilterChange={() => onFilterChange('status', { selected: [ERROR] })}
-            status={ERROR}
+        <Flex spaceItems={{ default: 'spaceItemsNone' }}>
+          <FlexItem grow={{ default: 'grow' }}>
+            <CardTitle component="h5">
+              {t('Virtual Machines ({{count}})', { count: vms?.length })}
+            </CardTitle>
+            <Grid hasGutter>
+              <VMStatusItem
+                count={primaryStatuses.Error}
+                namespace={namespace}
+                onFilterChange={() => onFilterChange('status', { selected: [ERROR] })}
+                status={ERROR}
+              />
+              <VMStatusItem
+                count={primaryStatuses.Running}
+                namespace={namespace}
+                onFilterChange={() => onFilterChange('status', { selected: [VM_STATUS.Running] })}
+                status={VM_STATUS.Running}
+              />
+              <VMStatusItem
+                count={primaryStatuses.Stopped}
+                namespace={namespace}
+                onFilterChange={() => onFilterChange('status', { selected: [VM_STATUS.Stopped] })}
+                status={VM_STATUS.Stopped}
+              />
+              <VMStatusItem
+                count={primaryStatuses.Paused}
+                namespace={namespace}
+                onFilterChange={() => onFilterChange('status', { selected: [VM_STATUS.Paused] })}
+                status={VM_STATUS.Paused}
+              />
+            </Grid>
+          </FlexItem>
+          <Divider
+            orientation={{
+              default: 'vertical',
+            }}
           />
-          <VMStatusItem
-            count={primaryStatuses.Running}
-            namespace={namespace}
-            onFilterChange={() => onFilterChange('status', { selected: [VM_STATUS.Running] })}
-            status={VM_STATUS.Running}
-          />
-          <VMStatusItem
-            count={primaryStatuses.Stopped}
-            namespace={namespace}
-            onFilterChange={() => onFilterChange('status', { selected: [VM_STATUS.Stopped] })}
-            status={VM_STATUS.Stopped}
-          />
-          <VMStatusItem
-            count={primaryStatuses.Paused}
-            namespace={namespace}
-            onFilterChange={() => onFilterChange('status', { selected: [VM_STATUS.Paused] })}
-            status={VM_STATUS.Paused}
-          />
-        </Grid>
+          <FlexItem grow={{ default: 'grow' }}>
+            <CardTitle component="h5">{t('Usage')}</CardTitle>
+            <Flex
+              justifyContent={{ default: 'justifyContentSpaceBetween' }}
+              spaceItems={{ default: 'spaceItemsNone' }}
+            >
+              <VirtualMachineUsageItem
+                capacityText={`Requested of ${cpuRequested}`}
+                metricName="CPU"
+                usageText={cpuUsage}
+              />
+              <VirtualMachineUsageItem
+                capacityText={`Used of ${memoryCapacity}`}
+                metricName="Memory"
+                usageText={memoryUsage}
+              />
+              <VirtualMachineUsageItem
+                capacityText={`Used of ${storageCapacity}`}
+                metricName="Storage"
+                usageText={storageUsage}
+              />
+            </Flex>
+          </FlexItem>
+        </Flex>
       </Card>
     </ExpandableSection>
   );

--- a/src/views/virtualmachines/list/components/VirtualMachineUsageItem/VirtualMachineUsageItem.scss
+++ b/src/views/virtualmachines/list/components/VirtualMachineUsageItem/VirtualMachineUsageItem.scss
@@ -1,0 +1,16 @@
+.vm-usage-item {
+  padding: var(--pf-t--global--spacer--lg);
+
+  &__metric {
+    font-weight: var(--pf-t--global--font--weight--300);
+    margin-bottom: var(--pf-t--global--spacer--sm);
+  }
+
+  &__current {
+    font-size: var(--pf-t--global--font--size--body--lg);
+  }
+
+  &__total {
+    color: var(--pf-t--global--text--color--subtle);
+  }
+}

--- a/src/views/virtualmachines/list/components/VirtualMachineUsageItem/VirtualMachineUsageItem.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineUsageItem/VirtualMachineUsageItem.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react';
+
+import { Stack } from '@patternfly/react-core';
+
+import './VirtualMachineUsageItem.scss';
+
+type VirtualMachineUsageItemProps = {
+  capacityText: string;
+  metricName: string;
+  usageText: string;
+};
+
+const VirtualMachineUsageItem: FC<VirtualMachineUsageItemProps> = ({
+  capacityText,
+  metricName,
+  usageText,
+}) => (
+  <Stack className="vm-usage-item" span={4}>
+    <div className="vm-usage-item__metric">{metricName}</div>
+    <div className="vm-usage-item__current">{usageText}</div>
+    <div className="vm-usage-item__total">{capacityText}</div>
+  </Stack>
+);
+
+export default VirtualMachineUsageItem;

--- a/src/views/virtualmachines/list/hooks/useVMTotalsMetrics.ts
+++ b/src/views/virtualmachines/list/hooks/useVMTotalsMetrics.ts
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+import {
+  PrometheusEndpoint,
+  useActiveNamespace,
+  usePrometheusPoll,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { METRICS } from '@overview/OverviewTab/metric-charts-card/utils/constants';
+
+import { getCpuText, getMemoryCapacityText, getMetricText } from '../utils/processVMTotalsMetrics';
+import { getVMTotalsQueries, VMTotalsQueries } from '../utils/totalsQueries';
+
+const useVMTotalsMetrics = (vms: V1VirtualMachine[], vmis: V1VirtualMachineInstance[]) => {
+  const [activeNamespace] = useActiveNamespace();
+  const allNamespace = activeNamespace === ALL_NAMESPACES_SESSION_KEY;
+  const currentTime = useMemo<number>(() => Date.now(), []);
+
+  const namespacesList = useMemo(() => [...new Set(vms.map((vm) => getNamespace(vm)))], [vms]);
+
+  const queries = useMemo(
+    () => getVMTotalsQueries(activeNamespace, namespacesList),
+    [activeNamespace, namespacesList],
+  );
+
+  const prometheusPollProps = {
+    endpoint: PrometheusEndpoint?.QUERY,
+    endTime: currentTime,
+    namespace: allNamespace ? undefined : activeNamespace,
+  };
+
+  const [cpuUsageResponse] = usePrometheusPoll({
+    ...prometheusPollProps,
+    query: queries?.[VMTotalsQueries.TOTAL_CPU_USAGE],
+  });
+
+  const [cpuRequestedResponse] = usePrometheusPoll({
+    ...prometheusPollProps,
+    query: queries?.[VMTotalsQueries.TOTAL_CPU_REQUESTED],
+  });
+
+  const [memoryUsageResponse] = usePrometheusPoll({
+    ...prometheusPollProps,
+    query: queries?.[VMTotalsQueries.TOTAL_MEMORY_USAGE],
+  });
+
+  const [storageUsageResponse] = usePrometheusPoll({
+    ...prometheusPollProps,
+    query: queries?.[VMTotalsQueries.TOTAL_STORAGE_USAGE],
+  });
+
+  const [storageCapacityResponse] = usePrometheusPoll({
+    ...prometheusPollProps,
+    query: queries?.[VMTotalsQueries.TOTAL_STORAGE_CAPACITY],
+  });
+
+  return {
+    cpuRequested: getCpuText(cpuRequestedResponse),
+    cpuUsage: getCpuText(cpuUsageResponse),
+    memoryCapacity: getMemoryCapacityText(vmis),
+    memoryUsage: getMetricText(memoryUsageResponse, METRICS.MEMORY),
+    storageCapacity: getMetricText(storageCapacityResponse, METRICS.STORAGE),
+    storageUsage: getMetricText(storageUsageResponse, METRICS.STORAGE),
+  };
+};
+
+export default useVMTotalsMetrics;

--- a/src/views/virtualmachines/list/utils/processVMTotalsMetrics.ts
+++ b/src/views/virtualmachines/list/utils/processVMTotalsMetrics.ts
@@ -1,0 +1,47 @@
+import xbytes from 'xbytes';
+
+import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
+import { getMemory } from '@kubevirt-utils/resources/vm';
+import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
+import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
+import { METRICS } from '@overview/OverviewTab/metric-charts-card/utils/constants';
+import {
+  findUnit,
+  getHumanizedValue,
+} from '@overview/OverviewTab/metric-charts-card/utils/hooks/utils';
+
+const getRawNumber = (response: PrometheusResponse) =>
+  Number(response?.data?.result?.[0]?.value?.[1]);
+
+const getValueWithUnitText = (bytes: number, metric: string) => {
+  const unit = findUnit(metric, bytes);
+  const value = getHumanizedValue(metric, bytes, unit).toLocaleString();
+
+  return `${value} ${unit}`;
+};
+
+export const getCpuText = (response: PrometheusResponse) => {
+  const value = getRawNumber(response);
+
+  if (isNaN(value)) {
+    return NO_DATA_DASH;
+  }
+  return `${value.toLocaleString()} m`;
+};
+
+export const getMemoryCapacityText = (vmis: V1VirtualMachineInstance[]) => {
+  const bytes = vmis
+    .map((vmi) => {
+      const memorySize = getMemorySize(getMemory(vmi));
+      return xbytes.parseSize(`${memorySize?.size} ${memorySize?.unit}B`);
+    })
+    .reduce((acc, cur) => acc + cur, 0);
+
+  return getValueWithUnitText(bytes, METRICS.MEMORY);
+};
+
+export const getMetricText = (response: PrometheusResponse, metric: string) => {
+  const bytes = getRawNumber(response);
+  return getValueWithUnitText(bytes, metric);
+};

--- a/src/views/virtualmachines/list/utils/totalsQueries.ts
+++ b/src/views/virtualmachines/list/utils/totalsQueries.ts
@@ -1,0 +1,27 @@
+import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+
+export const VMTotalsQueries = {
+  TOTAL_CPU_REQUESTED: 'TOTAL_CPU_REQUESTED',
+  TOTAL_CPU_USAGE: 'TOTAL_CPU_USAGE',
+  TOTAL_MEMORY_USAGE: 'TOTAL_MEMORY_USAGE',
+  TOTAL_STORAGE_CAPACITY: 'TOTAL_STORAGE_CAPACITY',
+  TOTAL_STORAGE_USAGE: 'TOTAL_STORAGE_USAGE',
+};
+
+export const getVMTotalsQueries = (namespace: string, namespacesList: string[]) => {
+  const isAllNamespaces = namespace === ALL_NAMESPACES_SESSION_KEY;
+
+  const sumByNamespace = isAllNamespaces ? 'sum' : 'sum by (namespace)';
+  const filterByNamespace = isAllNamespaces ? '' : `{namespace='${namespace}'}`;
+  const filterCpuRequestedByNamespace = isAllNamespaces
+    ? `namespace=~'${namespacesList.join('|')}'`
+    : `namespace='${namespace}'`;
+
+  return {
+    [VMTotalsQueries.TOTAL_CPU_REQUESTED]: `${sumByNamespace}(kube_pod_resource_request{resource='cpu',${filterCpuRequestedByNamespace}})`,
+    [VMTotalsQueries.TOTAL_CPU_USAGE]: `${sumByNamespace}(rate(kubevirt_vmi_cpu_usage_seconds_total${filterByNamespace}[5m]))`,
+    [VMTotalsQueries.TOTAL_MEMORY_USAGE]: `${sumByNamespace}(kubevirt_vmi_memory_available_bytes${filterByNamespace} - kubevirt_vmi_memory_usable_bytes${filterByNamespace})`,
+    [VMTotalsQueries.TOTAL_STORAGE_CAPACITY]: `${sumByNamespace}(max(kubevirt_vmi_filesystem_capacity_bytes${filterByNamespace}) by (namespace, name, disk_name))`,
+    [VMTotalsQueries.TOTAL_STORAGE_USAGE]: `${sumByNamespace}(max(kubevirt_vmi_filesystem_used_bytes${filterByNamespace}) by (namespace, name, disk_name))`,
+  };
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Adds summary of CPU, Memory and Storage usage for the current namespace.

- also fixes a bug in Overview -> StorageUtil panel, which was counting too much storage because of duplicate mount points - it would get a sum of these:
<img width="800" alt="Screenshot 2025-04-02 at 9 18 24" src="https://github.com/user-attachments/assets/70961bb5-4821-4340-bcfb-03065704bd0e" />



**Question:**
For memory capacity I used a sum of rounded values for each VM, not an actual metric. For storage capacity however, I did use the metric value.
I based this on the Utilization board in VM details:
<img width="394" alt="Screenshot 2025-04-02 at 12 44 10" src="https://github.com/user-attachments/assets/92dffbcf-eceb-4d78-93d0-2010a80874b1" />

Should I rather use a rounded value for storage too? Or the metric for memory?



## 🎥 Demo
Before:
<img width="1419" alt="Screenshot 2025-04-02 at 12 52 02" src="https://github.com/user-attachments/assets/ac280278-6b17-4d28-8ace-b96f3eadfb78" />

After:

https://github.com/user-attachments/assets/d7cdf7c5-0ca3-426a-b3a8-39cb4a329e5f



