### PR TITLE
CNV-58425: don't disable switch on click

### DIFF
--- a/src/utils/styles/cursor.scss
+++ b/src/utils/styles/cursor.scss
@@ -1,0 +1,5 @@
+.kv-cursor--loading {
+  :hover {
+    cursor: wait;
+  }
+}

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
@@ -18,6 +18,8 @@ import {
 
 import ExpandSection from '../../../ExpandSection/ExpandSection';
 
+import '@kubevirt-utils/styles/cursor.scss';
+
 type PersistentReservationSectionProps = {
   hyperConvergeConfiguration: [hyperConvergeConfig: HyperConverged, loaded: boolean, error: Error];
 };
@@ -70,9 +72,9 @@ const PersistentReservationSection: FC<PersistentReservationSectionProps> = ({
         {hyperLoaded && (
           <SplitItem>
             <Switch
+              className={isLoading && 'kv-cursor--loading'}
               id="persistent-reservation-section"
               isChecked={persistentReservation}
-              isDisabled={isLoading}
               onChange={(_, checked: boolean) => onChange(checked)}
             />
           </SplitItem>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Doesn't disable switch while waiting for the option to change.

I am not sure if this fix doesn't break something, and whether it should rather stay disabled while loading. We could make it disabled, but not apply the disabled styles.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/8ff4d98d-ca36-40d0-b3b6-9b37d9ef492c



After:


https://github.com/user-attachments/assets/edac3da3-e58f-49dc-ba97-2f855b7e6c76


