### PR TITLE
CNV-59276: Recognize RT series predefined instance type as Red Hat provided

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1062,6 +1062,7 @@
   "Review": "Review",
   "RHEL download page ": "RHEL download page ",
   "Rollback": "Rollback",
+  "RT series": "RT series",
   "Rules with \"Preferred\" condition will stack with an \"AND\" relation between them.": "Rules with \"Preferred\" condition will stack with an \"AND\" relation between them.",
   "Rules with \"Required\" condition will stack with an \"OR\" relation between them.": "Rules with \"Required\" condition will stack with an \"OR\" relation between them.",
   "Run": "Run",

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/constants.ts
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/constants.ts
@@ -1,12 +1,17 @@
 import { ComponentClass } from 'react';
 
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { InstanceTypeSeries, InstanceTypeSize } from '@kubevirt-utils/resources/instancetype/types';
+import {
+  InstanceTypeSeries,
+  InstanceTypeSize,
+  InstanceTypeSizes,
+} from '@kubevirt-utils/resources/instancetype/types';
 import {
   MemoryIcon,
   MicrochipIcon,
   ModuleIcon,
   NetworkIcon,
+  OutlinedClockIcon,
   RedhatIcon,
   RegistryIcon,
   ServerGroupIcon,
@@ -41,7 +46,7 @@ export const initialMenuItems: InstanceTypesMenuItemsData = {
 };
 
 export const instanceTypeSeriesNameMapper: {
-  [key in 'server' | Exclude<InstanceTypeSeries, 'rt1'>]: {
+  [key in 'server' | InstanceTypeSeries]: {
     disabled?: boolean;
     Icon: ComponentClass;
     possibleSizes?: InstanceTypeSize[];
@@ -87,6 +92,11 @@ export const instanceTypeSeriesNameMapper: {
       '8xlarge',
     ],
     seriesLabel: t('O series'),
+  },
+  rt1: {
+    Icon: OutlinedClockIcon,
+    possibleSizes: [...InstanceTypeSizes],
+    seriesLabel: t('RT series'),
   },
   server: {
     disabled: true,

--- a/src/utils/resources/instancetype/types.ts
+++ b/src/utils/resources/instancetype/types.ts
@@ -3,17 +3,20 @@ import {
   V1beta1VirtualMachineInstancetype,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
-export type InstanceTypeSize =
-  | '2xlarge'
-  | '2xmedium'
-  | '4xlarge'
-  | '8xlarge'
-  | 'large'
-  | 'medium'
-  | 'micro'
-  | 'nano'
-  | 'small'
-  | 'xlarge';
+export const InstanceTypeSizes = [
+  '2xlarge',
+  '2xmedium',
+  '4xlarge',
+  '8xlarge',
+  'large',
+  'medium',
+  'micro',
+  'nano',
+  'small',
+  'xlarge',
+] as const;
+
+export type InstanceTypeSize = typeof InstanceTypeSizes[number];
 
 export type InstanceTypeSeries =
   | 'cx1'


### PR DESCRIPTION

## 📝 Description

The type was skipped in the mapper. Once stricter typing was added in #2535 this was explicitly captured with `Exclude<InstanceTypeSeries, 'rt1'>` .

## 🎥 Demo

### Before

![image](https://github.com/user-attachments/assets/b42d202b-1479-4582-a95d-9de24485c5b9)


### After
![image](https://github.com/user-attachments/assets/908807e3-1041-458f-80be-30d1216eb617)

![image](https://github.com/user-attachments/assets/51c775c0-f9e5-4ddb-8aed-56ebf17d0d22)


