### PR TITLE
CNV-58240: Use built-in styling for BootableVolume table

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.scss
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.scss
@@ -19,26 +19,3 @@
     }
   }
 }
-
-.BootableVolumeList {
-  &-table {
-    th:first-child {
-      padding-right: 0;
-      padding-left: var(--pf-t--global--spacer--sm);
-      margin-right: var(--pf-t--global--spacer--sm);
-      .pf-v6-c-table__sort-indicator {
-        margin: 0;
-      }
-    }
-    tbody {
-      tr {
-        td:first-child {
-          padding-left: 0;
-          width: unset;
-          display: flex;
-          justify-content: center;
-        }
-      }
-    }
-  }
-}

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.scss
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.scss
@@ -1,5 +1,0 @@
-.bootable-volume-row {
-  &__name--text {
-    margin-right: var(--pf-t--global--spacer--sm);
-  }
-}

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
@@ -33,12 +33,10 @@ import {
 } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { formatBytes } from '@kubevirt-utils/resources/vm/utils/disk/size';
-import { Content, ContentVariants, Label } from '@patternfly/react-core';
+import { Content, ContentVariants, Flex, Label } from '@patternfly/react-core';
 import { TableText, Tr, WrapModifier } from '@patternfly/react-table';
 
 import TableData from './TableData';
-
-import './BootableVolumeRow.scss';
 
 type BootableVolumeRowProps = {
   activeColumnIDs: string[];
@@ -93,7 +91,6 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
         getName(selectedBootableVolume) === bootVolumeName &&
         getNamespace(selectedBootableVolume) === bootVolumeNamespace
       }
-      className="bootable-volume-row"
       isClickable
       isSelectable
       onClick={() => handleOnClick()}
@@ -108,17 +105,18 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
         }}
         activeColumnIDs={activeColumnIDs}
         id="favorites"
+        modifier="fitContent"
       />
       <TableData activeColumnIDs={activeColumnIDs} id="name" width={20}>
-        <img alt="os-icon" className="vm-catalog-row-icon" src={icon} />
-        <Content className="bootable-volume-row__name--text" component={ContentVariants.small}>
-          {bootVolumeName}
-        </Content>
-        {isDeprecated(bootVolumeName) && <DeprecatedBadge />}
-        {isCloning && <Label className="vm-catalog-row-label">{t('Clone in progress')}</Label>}
-        {isDataSourceUploading(bootableVolume as V1beta1DataSource) && (
-          <Label className="vm-catalog-row-label">{t('Upload in progress')}</Label>
-        )}
+        <Flex alignItems={{ default: 'alignItemsCenter' }} columnGap={{ default: 'columnGapNone' }}>
+          <img alt="os-icon" className="vm-catalog-row-icon" src={icon} />
+          <Content component={ContentVariants.small}>{bootVolumeName}</Content>
+          {isDeprecated(bootVolumeName) && <DeprecatedBadge />}
+          {isCloning && <Label className="vm-catalog-row-label">{t('Clone in progress')}</Label>}
+          {isDataSourceUploading(bootableVolume as V1beta1DataSource) && (
+            <Label className="vm-catalog-row-label">{t('Upload in progress')}</Label>
+          )}
+        </Flex>
       </TableData>
       {volumeListNamespace === ALL_PROJECTS && (
         <TableData activeColumnIDs={activeColumnIDs} id="namespace" width={20}>

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/TableData.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/TableData.tsx
@@ -1,18 +1,14 @@
 import React, { FC } from 'react';
 
-import { BaseCellProps, Td } from '@patternfly/react-table';
-import { TdFavoritesType } from '@patternfly/react-table/dist/esm/components/Table/base/types';
+import { Td, TdProps } from '@patternfly/react-table';
 
-type TableDataProps = {
+type TableDataProps = Omit<TdProps, 'ref'> & {
   activeColumnIDs: string[];
-  favorites?: TdFavoritesType;
-  id: string;
-  width?: BaseCellProps['width'];
 };
 
-const TableData: FC<TableDataProps> = ({ activeColumnIDs, children, favorites, id, width = 10 }) =>
+const TableData: FC<TableDataProps> = ({ activeColumnIDs, children, id, ...otherProps }) =>
   activeColumnIDs?.some((activeID) => activeID === id) ? (
-    <Td favorites={favorites} id={id} width={width}>
+    <Td id={id} {...otherProps}>
       {children}
     </Td>
   ) : null;

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeTable/BootableVolumeTable.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeTable/BootableVolumeTable.tsx
@@ -18,6 +18,7 @@ import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { Table, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 import { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base/types';
 
+import { FAVORITES_COLUMN_ID } from '../../utils/constants';
 import BootableVolumeRow from '../BootableVolumeRow/BootableVolumeRow';
 
 type BootableVolumeTableProps = {
@@ -51,7 +52,7 @@ const BootableVolumeTable: FC<BootableVolumeTableProps> = ({
           {activeColumns.map((col, columnIndex) => (
             <Th
               sort={
-                columnIndex === 0
+                col.id === FAVORITES_COLUMN_ID
                   ? { ...getSortType(columnIndex), isFavorites: true }
                   : getSortType(columnIndex)
               }

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeColumns.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeColumns.ts
@@ -5,6 +5,16 @@ import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/type
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { ColumnLayout } from '@openshift-console/dynamic-plugin-sdk-internal/lib/extensions/console-types';
 
+import {
+  DESCRIPTION_COLUMN_ID,
+  FAVORITES_COLUMN_ID,
+  NAME_COLUMN_ID,
+  NAMESPACE_COLUMN_ID,
+  OPERATING_SYSTEM_COLUMN_ID,
+  SIZE_COLUMN_ID,
+  STORAGE_CLASS_COLUMN_ID,
+} from '../utils/constants';
+
 type UseBootVolumesColumns = (
   volumeListNamespace: string,
   isModal: boolean,
@@ -20,35 +30,35 @@ const useBootVolumeColumns: UseBootVolumesColumns = (volumeListNamespace, isModa
 
   const columns: TableColumn<BootableVolume>[] = [
     {
-      id: 'favorites',
+      id: FAVORITES_COLUMN_ID,
       title: '',
     },
     {
-      id: 'name',
+      id: NAME_COLUMN_ID,
       title: t('Volume name'),
     },
     ...(volumeListNamespace === ALL_PROJECTS
       ? [
           {
-            id: 'namespace',
+            id: NAMESPACE_COLUMN_ID,
             title: t('Namespace'),
           },
         ]
       : []),
     {
-      id: 'operating-system',
+      id: OPERATING_SYSTEM_COLUMN_ID,
       title: t('Operating system'),
     },
     {
-      id: 'storage-class',
+      id: STORAGE_CLASS_COLUMN_ID,
       title: t('Storage class'),
     },
     {
-      id: 'size',
+      id: SIZE_COLUMN_ID,
       title: t('Size'),
     },
     {
-      id: 'description',
+      id: DESCRIPTION_COLUMN_ID,
       title: t('Description'),
     },
   ];

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/utils/constants.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/utils/constants.ts
@@ -27,3 +27,11 @@ export const paginationInitialStateModal: PaginationState = {
 };
 
 export const WINDOWS_BOOTSOURCE_PIPELINE = 'windows-bootsource-pipeline';
+
+export const NAME_COLUMN_ID = 'name';
+export const NAMESPACE_COLUMN_ID = 'namespace';
+export const FAVORITES_COLUMN_ID = 'favorites';
+export const OPERATING_SYSTEM_COLUMN_ID = 'operating-system';
+export const STORAGE_CLASS_COLUMN_ID = 'storage-class';
+export const SIZE_COLUMN_ID = 'size';
+export const DESCRIPTION_COLUMN_ID = 'description';


### PR DESCRIPTION
## 📝 Description

Changes:
1. modifier "fitContent" to narrow down the favourites column. This change fixes problems with custom CSS incorrectly styling name column when the favourite column was hidden (#1653).
2. flex layout with columnGap and alignItems props. This fixes incorrect alignment of text wrapped in components (#2497).
3. setting isFavourite flag based on column ID. Before the sort was determined only on the column index which resulted in incorrect sort if the favourite column was hidden (#1637).

Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/1653
Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/2497
Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/1637

## 🎥 Demo


### All columns visible
#### Before
![Screenshot From 2025-04-08 16-43-57](https://github.com/user-attachments/assets/19cbc951-0278-4bc2-bb53-5dda2a2acca6)
#### After
![Screenshot From 2025-04-08 16-43-39](https://github.com/user-attachments/assets/f8f752dd-6638-4710-90b9-98a846decef7)

### Favorite column hidden
#### Before (note incorrect sort)
![Screenshot From 2025-04-08 16-42-32](https://github.com/user-attachments/assets/bc760d3a-918a-4332-80fd-925e5e2a27a1)
#### After
![Screenshot From 2025-04-08 16-43-11](https://github.com/user-attachments/assets/d7d3432b-0e12-4fb4-b335-27d19ffd3b1a)

### Multiple columns hidden
#### Before
![Screenshot From 2025-04-08 16-41-52](https://github.com/user-attachments/assets/ddff7dc3-cad2-427d-bc47-9df7ec5693db)
#### After
![Screenshot From 2025-04-08 16-43-23](https://github.com/user-attachments/assets/dd70d8d5-b2c2-4aa4-8d64-2e86665dffe9)



