### PR TITLE
CNV-59558: CNV-59559: fix disk modal CapacityInput

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -712,6 +712,7 @@
   "Learn more about templates": "Learn more about templates",
   "Learn more about working with projects": "Learn more about working with projects",
   "Learn more about<1> StorageProfile</1>.": "Learn more about<1> StorageProfile</1>.",
+  "less than": "less than",
   "Limitations": "Limitations",
   "Link state": "Link state",
   "Link state is not available for SR-IOV interfaces": "Link state is not available for SR-IOV interfaces",
@@ -827,6 +828,7 @@
   "Namespace": "Namespace",
   "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. Must be a DNS_LABEL. Cannot be updated. ": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. Must be a DNS_LABEL. Cannot be updated. ",
   "Namespace of the VirtualMachine": "Namespace of the VirtualMachine",
+  "negative": "negative",
   "Network": "Network",
   "Network ({{count}})_one": "Network ({{count}})",
   "Network ({{count}})_other": "Network ({{count}})",
@@ -1201,7 +1203,7 @@
   "Show VirtualMachine per Templates": "Show VirtualMachine per Templates",
   "Single user (RWO)": "Single user (RWO)",
   "Size": "Size",
-  "Size cannot be {{errorValue}}": "Size cannot be {{errorValue}}",
+  "Size cannot be": "Size cannot be",
   "Small scale consumption, recommended for using the graphical console": "Small scale consumption, recommended for using the graphical console",
   "Snapshots": "Snapshots",
   "Snapshots ({{snapshots}})": "Snapshots ({{snapshots}})",
@@ -1597,5 +1599,6 @@
   "You don't have access to this section due to cluster policy.": "You don't have access to this section due to cluster policy.",
   "You don't have permission to perform this action": "You don't have permission to perform this action",
   "You must ensure that the configuration is correct before starting the VirtualMachine.": "You must ensure that the configuration is correct before starting the VirtualMachine.",
-  "You're in view-only mode": "You're in view-only mode"
+  "You're in view-only mode": "You're in view-only mode",
+  "zero": "zero"
 }

--- a/src/utils/components/CapacityInput/utils.ts
+++ b/src/utils/components/CapacityInput/utils.ts
@@ -1,3 +1,5 @@
+import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+
 export enum CAPACITY_UNITS {
   GiB = 'GiB',
   MiB = 'MiB',
@@ -5,3 +7,20 @@ export enum CAPACITY_UNITS {
 }
 
 export const removeByteSuffix = (quantity: string): string => quantity?.replace(/[Bb]/, '');
+
+export const getValueFromSize = (size: string) => {
+  const [sizeValue = 0] = size?.replace(/,/g, '').match(/[0-9]+/g) || [];
+  return Number(sizeValue);
+};
+
+export const getUnitFromSize = (size: string) => {
+  const [unitValue = ''] = size?.match(/[a-zA-Z]+/g) || [];
+  return (!unitValue?.endsWith('B') ? `${unitValue}B` : unitValue) as CAPACITY_UNITS;
+};
+
+export const getErrorValue = (value: number) => {
+  if (value > 0) {
+    return t('less than');
+  }
+  return value < 0 ? t('negative') : t('zero');
+};

--- a/src/utils/components/DiskModal/components/DiskSizeInput/ExpandPVC.tsx
+++ b/src/utils/components/DiskModal/components/DiskSizeInput/ExpandPVC.tsx
@@ -3,11 +3,17 @@ import { useFormContext } from 'react-hook-form';
 
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import CapacityInput from '@kubevirt-utils/components/CapacityInput/CapacityInput';
+import {
+  getUnitFromSize,
+  getValueFromSize,
+  removeByteSuffix,
+} from '@kubevirt-utils/components/CapacityInput/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { convertToBaseValue, humanizeBinaryBytes } from '@kubevirt-utils/utils/humanize.js';
 
 import { V1DiskFormState } from '../../utils/types';
 import { EXPAND_PVC_SIZE } from '../utils/constants';
+
+import usePVCDefaultSize from './usePVCDefaultSize';
 
 type ExpandPVCProps = { pvc: IoK8sApiCoreV1PersistentVolumeClaim };
 
@@ -19,23 +25,39 @@ const ExpandPVC: FC<ExpandPVCProps> = ({ pvc }) => {
   const expandPVCSize = diskState.expandPVCSize;
 
   const pvcSize = pvc?.spec?.resources?.requests?.storage;
+  const { minSizes, selectedUnit, setSelectedUnit } = usePVCDefaultSize(pvcSize);
 
   const onQuantityChange = (quantity: string) => {
-    const newQuantityValue = convertToBaseValue(quantity)?.toString();
+    const newUnit = getUnitFromSize(quantity);
 
-    setValue(EXPAND_PVC_SIZE, newQuantityValue > pvcSize ? quantity : null);
+    if (newUnit !== selectedUnit) {
+      setSelectedUnit(newUnit);
+
+      const newSize = minSizes[newUnit];
+      if (newSize.value > getValueFromSize(quantity)) {
+        const newPvcSize = `${Math.ceil(newSize.value)}${removeByteSuffix(newSize.unit)}`;
+
+        setValue(EXPAND_PVC_SIZE, newPvcSize);
+        return;
+      }
+    }
+
+    setValue(EXPAND_PVC_SIZE, quantity);
   };
 
   if (!pvcSize) return null;
 
-  const size = expandPVCSize || humanizeBinaryBytes(convertToBaseValue(pvcSize)).string;
+  const minSize = minSizes[selectedUnit];
+  const size = expandPVCSize || minSize.string;
 
-  const isMinusDisabled = pvcSize === convertToBaseValue(expandPVCSize) || !expandPVCSize;
+  const isMinusDisabled =
+    Math.ceil(minSize.value) >= getValueFromSize(expandPVCSize) || !expandPVCSize;
 
   return (
     <CapacityInput
       isMinusDisabled={isMinusDisabled}
       label={t('PersistentVolumeClaim size')}
+      minValue={minSize.value}
       onChange={onQuantityChange}
       size={size}
     />

--- a/src/utils/components/DiskModal/components/DiskSizeInput/usePVCDefaultSize.ts
+++ b/src/utils/components/DiskModal/components/DiskSizeInput/usePVCDefaultSize.ts
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+
+import { CAPACITY_UNITS } from '@kubevirt-utils/components/CapacityInput/utils';
+import { convertToBaseValue, humanizeBinaryBytes } from '@kubevirt-utils/utils/humanize.js';
+
+const usePVCDefaultSize = (pvcSize: string) => {
+  const pvcSizeBytes = convertToBaseValue(pvcSize);
+
+  const minSizes = Object.fromEntries(
+    Object.values(CAPACITY_UNITS).map((unit) => [
+      unit,
+      humanizeBinaryBytes(pvcSizeBytes, null, unit),
+    ]),
+  );
+
+  const [selectedUnit, setSelectedUnit] = useState<CAPACITY_UNITS>(
+    humanizeBinaryBytes(pvcSizeBytes).unit,
+  );
+
+  return { minSizes, selectedUnit, setSelectedUnit };
+};
+
+export default usePVCDefaultSize;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes a bug, where clicking ` + ` in the Number input resulted in resetting the number to the initial value ([CNV-59559](https://issues.redhat.com//browse/CNV-59559))
   - it was because strings were compared instead of numbers
- another bug which is fixed was that user can't manually type in a smaller number ([CNV-59558](https://issues.redhat.com/browse/CNV-59558)) e.g. if the capacity is 4 GiB and you wanna set it to 12 GiB, when you type in "1" it results in the reset back to 4 GiB
  - also you couldn't change the unit to e.g. MiB, you have to write a bigger value first and then change it to MiB (e.g. if you wanna move from 4 GiB to 5.5 GiB you have to use MiB, because it doesn't support decimal values)
  
- there is a bug that the size of a created disk is larger than what was specified in the form:

https://github.com/user-attachments/assets/7a198896-7b2f-462c-b42e-65ea48a57fd2


## 🎥 Demo

BEFORE:
Jira bug [CNV-59559](https://issues.redhat.com//browse/CNV-59559):

https://github.com/user-attachments/assets/727f04d6-4ad8-42b4-a160-8a413fef1996

Jira bug [CNV-59558](https://issues.redhat.com//browse/CNV-59558):

https://github.com/user-attachments/assets/ff903a13-ae50-4e49-9996-1243de1928d2

Bug where you can set a smaller size without warning:

https://github.com/user-attachments/assets/34e52567-fe7a-4dde-b879-dffe6d6ebb5f




AFTER:
- one thing I don't like is having the default value lower than the current = minimum value. We could ceil it up, but than the value is changed by default (and user might overlook it). Or we could use the exact value (with a decimal point) - but decimal points are not supported in this NumberInput - you can't manually type it in.

WDYT? What should be the default value? In the current "before" version the value is just the whole number without the numbers after decimal point. And the form value is set to null, so nothing gets updated if you keep it like that - which is quite good, but it doesn't really reflect the actual size.

https://github.com/user-attachments/assets/3a61c9ac-3f4d-4c7b-9ceb-e9c22998231a

