### PR TITLE
CNV-49659: Update novnc from 1.5.0 to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@novnc/novnc": "^1.5.0",
+    "@novnc/novnc": "^1.6.0",
     "@patternfly/quickstarts": "6.1.0",
     "@patternfly/react-catalog-view-extension": "6.0.0",
     "@patternfly/react-charts": "8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -936,6 +936,11 @@
   resolved "https://registry.yarnpkg.com/@novnc/novnc/-/novnc-1.5.0.tgz#7df3e4aca48eaa7c0d6f690e7dee89480232e2f1"
   integrity sha512-4yGHOtUCnEJUCsgEt/L78eeJu00kthurLBWXFiaXfonNx0pzbs6R/3gJb1byZe6iAE8V9MF0syQb0xIL8MSOtQ==
 
+"@novnc/novnc@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@novnc/novnc/-/novnc-1.6.0.tgz#e68ac47d8d4151a34a80f408b5ffa3af5e4780d2"
+  integrity sha512-CJrmdSe9Yt2ZbLsJpVFoVkEu0KICEvnr3njW25Nz0jodaiFJtg8AYLGZogRYy0/N5HUWkGUsCmegKXYBSqwygw==
+
 "@openshift-console/dynamic-plugin-sdk-internal@4.19.0-prerelease.1":
   version "4.19.0-prerelease.1"
   resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk-internal/-/dynamic-plugin-sdk-internal-4.19.0-prerelease.1.tgz#b6c4c251e87f766209f5f3b08420459b59825876"


### PR DESCRIPTION
## 📝 Description

 Update novnc from 1.5.0(June 2024)  to 1.6.0 (March 2025)

## 🎥 Demo
