### PR TITLE
CNV-56712: Fix network namespace handling in NetworkInterfaceNetworkSelect

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/utils/helpers.ts
+++ b/src/utils/components/NetworkInterfaceModal/utils/helpers.ts
@@ -3,7 +3,6 @@ import produce from 'immer';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1Interface, V1Network, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { NetworkInterfaceState } from '@kubevirt-utils/components/NetworkInterfaceModal/utils/types';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   getAutoAttachPodInterface,
@@ -115,8 +114,7 @@ export const createNetwork = (nicName: string, networkName: string): V1Network =
   };
 
   if (!networkNameStartWithPod(networkName) && networkName) {
-    const [namespace, name] = networkName?.split('/');
-    network.multus = { networkName: namespace === DEFAULT_NAMESPACE ? networkName : name };
+    network.multus = { networkName };
   } else {
     network.pod = {};
   }


### PR DESCRIPTION
## 📝 Description

Fixed use cases:
1. editing NADs from the same namespace as the VM - when retrieved from network.multus.networkName they are not prefixed with namespace
2. adding NADs from global namespace other then "default" - currently it's openshift-multus and openshift-sriov-network-operator
3. filtering out already used NADs from the same namespace as the VM

Reference-Url: https://github.com/kubevirt-ui/kubevirt-api/blob/ee8a84b48b35930556b0df632909563fa2021b61/kubevirt/models/V1MultusNetwork.ts#L29
Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/blob/c1bb89119db643b35379b33fca47091fcde107a8/src/utils/components/NetworkInterfaceModal/components/hooks/utils.ts#L10

## 🎥 Demo

### Editing NADs from the same namespace as the VM (but different then `default`)
#### Before
https://github.com/user-attachments/assets/9d52da54-218d-4f5c-a626-0bb56330546c
#### After
https://github.com/user-attachments/assets/574cadc1-506e-448b-983e-dfd3bccf860c

### Adding NADs from `openshift-multus`
#### Before
![Screenshot From 2025-04-16 16-27-39](https://github.com/user-attachments/assets/ce380e4d-5276-4f0e-8d31-6d40b329c574)
#### After
![Screenshot From 2025-04-16 15-36-51](https://github.com/user-attachments/assets/125392d9-efca-4a21-95cf-f8ba66b35f54)

### Filtering our already used NADs from the same namespace
#### Before
![Screenshot From 2025-04-16 15-44-04](https://github.com/user-attachments/assets/f2145809-7173-4549-b876-ca331e3b84e8)
#### After
![Screenshot From 2025-04-16 16-25-25](https://github.com/user-attachments/assets/842d160e-52e0-46b8-be78-734c5da747aa)




