### PR TITLE
CNV-59236: hide project switch in treeview

### DIFF
--- a/src/views/virtualmachines/tree/VirtualMachineTreeView.tsx
+++ b/src/views/virtualmachines/tree/VirtualMachineTreeView.tsx
@@ -33,7 +33,7 @@ type VirtualMachineTreeViewProps = {
 
 const VirtualMachineTreeView: FC<VirtualMachineTreeViewProps> = ({
   children,
-  isSwitchDisabled,
+  hideSwitch,
   loaded,
   loadError,
   onFilterChange,
@@ -80,8 +80,8 @@ const VirtualMachineTreeView: FC<VirtualMachineTreeViewProps> = ({
             style={styles}
           >
             <TreeViewContent
+              hideSwitch={hideSwitch}
               isOpen={isOpen}
-              isSwitchDisabled={isSwitchDisabled}
               loaded={loaded}
               onSelect={onSelect}
               selectedTreeItem={selected}

--- a/src/views/virtualmachines/tree/components/TreeViewContent.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewContent.tsx
@@ -22,8 +22,8 @@ import TreeViewCollapseExpand from './TreeViewCollapseExpand';
 import TreeViewToolbar from './TreeViewToolbar';
 
 type TreeViewContentProps = {
+  hideSwitch: boolean;
   isOpen: boolean;
-  isSwitchDisabled: boolean;
   loaded: boolean;
   onSelect: (_event: React.MouseEvent, treeViewItem: TreeViewDataItem) => void;
   selectedTreeItem: TreeViewDataItem;
@@ -32,8 +32,8 @@ type TreeViewContentProps = {
 };
 
 const TreeViewContent: FC<TreeViewContentProps> = ({
+  hideSwitch,
   isOpen,
-  isSwitchDisabled,
   loaded,
   onSelect,
   selectedTreeItem,
@@ -63,7 +63,7 @@ const TreeViewContent: FC<TreeViewContentProps> = ({
   return (
     <>
       {panelToggleButton}
-      <TreeViewToolbar isSwitchDisabled={isSwitchDisabled} onSearch={onSearch} />
+      <TreeViewToolbar hideSwitch={hideSwitch} onSearch={onSearch} />
       <DrawerHead className="vms-tree-view__header-section">
         <Content className="vms-tree-view__title" component="p">
           <TreeViewCollapseExpand setShowAll={setShowAll} showAll={showAll} />

--- a/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
@@ -18,11 +18,11 @@ import {
 import { HIDE, SHOW, SHOW_EMPTY_PROJECTS_KEY, TREE_VIEW_SEARCH_ID } from '../utils/constants';
 
 type TreeViewToolbarProps = {
-  isSwitchDisabled: boolean;
+  hideSwitch: boolean;
   onSearch: (event: ChangeEvent<HTMLInputElement>) => void;
 };
 
-const TreeViewToolbar: FC<TreeViewToolbarProps> = ({ isSwitchDisabled, onSearch }) => {
+const TreeViewToolbar: FC<TreeViewToolbarProps> = ({ hideSwitch, onSearch }) => {
   const { t } = useKubevirtTranslation();
   const [showEmptyProjects, setShowEmptyProjects] = useLocalStorage(SHOW_EMPTY_PROJECTS_KEY, HIDE);
 
@@ -39,22 +39,25 @@ const TreeViewToolbar: FC<TreeViewToolbarProps> = ({ isSwitchDisabled, onSearch 
               placeholder={t('Search')}
             />
           </StackItem>
-          <Divider />
-          <StackItem>
-            <Split>
-              <SplitItem className="pf-v6-u-ml-md">
-                <Content component="p">{t('Show only projects with VirtualMachines')}</Content>
-              </SplitItem>
-              <SplitItem isFilled />
-              <Switch
-                checked={!isSwitchDisabled && showEmptyProjects === HIDE}
-                className="vms-tree-view__toolbar-switch"
-                isDisabled={isSwitchDisabled}
-                isReversed
-                onChange={(_, checked) => setShowEmptyProjects(checked ? HIDE : SHOW)}
-              />
-            </Split>
-          </StackItem>
+          {!hideSwitch && (
+            <>
+              <Divider />
+              <StackItem>
+                <Split>
+                  <SplitItem className="pf-v6-u-ml-md">
+                    <Content component="p">{t('Show only projects with VirtualMachines')}</Content>
+                  </SplitItem>
+                  <SplitItem isFilled />
+                  <Switch
+                    checked={showEmptyProjects === HIDE}
+                    className="vms-tree-view__toolbar-switch"
+                    isReversed
+                    onChange={(_, checked) => setShowEmptyProjects(checked ? HIDE : SHOW)}
+                  />
+                </Split>
+              </StackItem>
+            </>
+          )}
           <Divider />
         </Stack>
       </ToolbarContent>

--- a/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
@@ -22,7 +22,7 @@ import { vmimMapperSignal, vmsSignal } from '../utils/signals';
 import { createTreeViewData, isSystemNamespace } from '../utils/utils';
 
 export type UseTreeViewData = {
-  isSwitchDisabled: boolean;
+  hideSwitch: boolean;
   loaded: boolean;
   loadError: any;
   treeData: TreeViewDataItem[];
@@ -118,10 +118,10 @@ export const useTreeViewData = (): UseTreeViewData => {
     [projectNames, memoizedVMs, loaded, isAdmin, treeViewFoldersEnabled, location.pathname],
   );
 
-  const isSwitchDisabled = useMemo(() => projectNames.every(isSystemNamespace), [projectNames]);
+  const hideSwitch = useMemo(() => projectNames.every(isSystemNamespace), [projectNames]);
 
   return {
-    isSwitchDisabled,
+    hideSwitch,
     loaded,
     loadError: projectNamesError,
     treeData,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description


**Current status**
When the user have no personal namespace but only system namespaces, the switch will not be clickable

When the user have personal namespaces, it will be available and it will show in the treeview, projects that do not have vms .

**Change**:
When the user have no personal namespace and the switch cannot be enabled, just hide it


## 🎥 Demo

**Example without switch**

<img width="429" alt="Screenshot 2025-04-18 at 16 58 26" src="https://github.com/user-attachments/assets/c8d83320-4f58-4d3e-a340-76ceedd7ef20" />

