### PR TITLE
CNV-59218: disable non migratable storageclasses

### DIFF
--- a/src/utils/utils/constants.ts
+++ b/src/utils/utils/constants.ts
@@ -1,1 +1,3 @@
 export const MAX_K8S_NAME_LENGTH = 63;
+
+export const POPPER_CONTAINER_ID = 'popper-container';

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useMigratableStorageClasses.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useMigratableStorageClasses.ts
@@ -1,0 +1,26 @@
+import { V1beta1StorageSpecAccessModesEnum } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { StorageProfileModelGroupVersionKind } from '@kubevirt-utils/models';
+import { getName } from '@kubevirt-utils/resources/shared';
+import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+const useMigratableStorageClasses = (): string[] => {
+  const [storageProfiles] = useK8sWatchResource<K8sResourceCommon[]>({
+    groupVersionKind: StorageProfileModelGroupVersionKind,
+    isList: true,
+  });
+
+  const allowedStorageProfilesNames = storageProfiles?.reduce((acc, storageProfile: any) => {
+    if (
+      storageProfile?.status?.claimPropertySets?.some((claimProperty) =>
+        claimProperty?.accessModes?.includes(V1beta1StorageSpecAccessModesEnum.ReadWriteMany),
+      )
+    )
+      acc.push(getName(storageProfile));
+
+    return acc;
+  }, []);
+
+  return allowedStorageProfilesNames;
+};
+
+export default useMigratableStorageClasses;

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/tabs/VirtualMachineMigrationDestinationTab.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/tabs/VirtualMachineMigrationDestinationTab.tsx
@@ -3,8 +3,11 @@ import React, { Dispatch, FC, SetStateAction } from 'react';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, StorageClassModel } from '@kubevirt-utils/models';
+import { POPPER_CONTAINER_ID } from '@kubevirt-utils/utils/constants';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import { Content, ContentVariants, Stack, StackItem, Title } from '@patternfly/react-core';
+
+import useMigratableStorageClasses from '../hooks/useMigratableStorageClasses';
 
 type VirtualMachineMigrationDestinationTabProps = {
   defaultStorageClassName: string;
@@ -22,6 +25,9 @@ const VirtualMachineMigrationDestinationTab: FC<VirtualMachineMigrationDestinati
   sortedStorageClasses,
 }) => {
   const { t } = useKubevirtTranslation();
+
+  const allowedStorageProfilesNames = useMigratableStorageClasses();
+
   return (
     <Stack hasGutter>
       <StackItem>
@@ -44,10 +50,11 @@ const VirtualMachineMigrationDestinationTab: FC<VirtualMachineMigrationDestinati
                 {defaultStorageClassName === storageClass ? t('(default)') : ''}
               </>
             ),
+            isDisabled: !allowedStorageProfilesNames?.includes(storageClass),
             value: storageClass,
           }))}
           popperProps={{
-            appendTo: () => document.getElementById('virtual-machine-migration-modal'),
+            appendTo: () => document.getElementById(POPPER_CONTAINER_ID),
           }}
           selected={destinationStorageClass}
           setSelected={setSelectedStorageClass}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Disable storageclasses that do not support RWX. RWX is mandatory for the migration to succeed 

## 🎥 Demo

<img width="1318" alt="Screenshot 2025-04-22 at 12 01 47" src="https://github.com/user-attachments/assets/e33b2e26-67f3-47e2-8ddf-6630dfd080f6" />

