### PR TITLE
CNV-60407: folder input fix

### DIFF
--- a/src/utils/components/SelectTypeahead/SelectTypeahead.tsx
+++ b/src/utils/components/SelectTypeahead/SelectTypeahead.tsx
@@ -46,7 +46,7 @@ const SelectTypeahead: FC<SelectTypeaheadProps> = ({
   getCreateOption,
   getCreationNotAllowedMessage,
   getToggleStatus,
-  initialOptions = [],
+  initialOptions,
   isFullWidth = false,
   placeholder,
   selected,
@@ -64,10 +64,10 @@ const SelectTypeahead: FC<SelectTypeaheadProps> = ({
 
   useEffect(() => {
     const filteredOptions: SelectOptionProps[] = filterValue
-      ? initialOptions.filter((menuItem) =>
+      ? (initialOptions || [])?.filter((menuItem) =>
           String(menuItem.value).toLowerCase().includes(filterValue.toLowerCase()),
         )
-      : initialOptions;
+      : initialOptions || [];
 
     if (canCreate) {
       const creationNotAllowedMessage = getCreationNotAllowedMessage?.(filterValue);
@@ -137,7 +137,7 @@ const SelectTypeahead: FC<SelectTypeaheadProps> = ({
     if (!value) return;
 
     if (value === CREATE_NEW) {
-      if (!initialOptions.some((item) => item.value === filterValue)) {
+      if (!initialOptions?.some((item) => item.value === filterValue)) {
         setInitialOptions?.((prevOptions) => [
           ...(prevOptions || []),
           createNewOption(filterValue),


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes a bug I accidentally introduced in [this PR](https://github.com/kubevirt-ui/kubevirt-plugin/pull/2565/files).

`initialOptions` could have been undefined (coming from `folderOptions` in FolderSelect.tsx), causing an infinite loop in the useEffect in SelectTypeahead - therefore the input component was constantly reloading so it seemed like it was disabled.

