### PR TITLE
CNV-60418: single VM can be moved to project root via modal

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1006,6 +1006,7 @@
   "Project is required.": "Project is required.",
   "Project labels": "Project labels",
   "Project name to clone the template to": "Project name to clone the template to",
+  "Project root": "Project root",
   "Project selector": "Project selector",
   "Projects": "Projects",
   "Provider": "Provider",

--- a/src/utils/components/MoveVMToFolderModal/MoveBulkVMsToFolderModal.tsx
+++ b/src/utils/components/MoveVMToFolderModal/MoveBulkVMsToFolderModal.tsx
@@ -8,6 +8,7 @@ import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { Popover, PopoverPosition, Stack, StackItem } from '@patternfly/react-core';
 
 import BulkVMsPopover from './BulkVMsPopover';
+import SelectedFolderIndicator from './SelectedFolderIndicator';
 
 type MoveBulkVMToFolderModalProps = {
   isOpen: boolean;
@@ -58,6 +59,7 @@ const MoveBulkVMToFolderModal: FC<MoveBulkVMToFolderModalProps> = ({
             setSelectedFolder={setFolderName}
           />
         </StackItem>
+        <SelectedFolderIndicator folderName={folderName} />
       </Stack>
     </TabModal>
   );

--- a/src/utils/components/MoveVMToFolderModal/MoveVMToFolderModal.tsx
+++ b/src/utils/components/MoveVMToFolderModal/MoveVMToFolderModal.tsx
@@ -7,8 +7,9 @@ import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getLabel, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { Stack, StackItem } from '@patternfly/react-core';
-import { FolderIcon } from '@patternfly/react-icons';
 import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
+
+import SelectedFolderIndicator from './SelectedFolderIndicator';
 
 type MoveVMToFolderModalProps = {
   isOpen: boolean;
@@ -24,7 +25,6 @@ const MoveVMToFolderModal: FC<MoveVMToFolderModalProps> = ({ isOpen, onClose, on
   return (
     <TabModal<V1VirtualMachine>
       headerText={t('Move to folder')}
-      isDisabled={!folderName}
       isOpen={isOpen}
       onClose={onClose}
       onSubmit={() => onSubmit(folderName)}
@@ -44,12 +44,7 @@ const MoveVMToFolderModal: FC<MoveVMToFolderModalProps> = ({ isOpen, onClose, on
             setSelectedFolder={setFolderName}
           />
         </StackItem>
-        {folderName && (
-          <StackItem>
-            <FolderIcon />
-            <span className="pf-v6-u-ml-sm">{folderName}</span>
-          </StackItem>
-        )}
+        <SelectedFolderIndicator folderName={folderName} />
       </Stack>
     </TabModal>
   );

--- a/src/utils/components/MoveVMToFolderModal/SelectedFolderIndicator.tsx
+++ b/src/utils/components/MoveVMToFolderModal/SelectedFolderIndicator.tsx
@@ -1,0 +1,18 @@
+import React, { FC } from 'react';
+
+import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { StackItem } from '@patternfly/react-core';
+import { FolderIcon, ProjectDiagramIcon } from '@patternfly/react-icons';
+
+type SelectedFolderIndicatorProps = {
+  folderName: string;
+};
+
+const SelectedFolderIndicator: FC<SelectedFolderIndicatorProps> = ({ folderName }) => (
+  <StackItem>
+    {folderName ? <FolderIcon /> : <ProjectDiagramIcon />}
+    <span className="pf-v6-u-ml-sm">{folderName || t('Project root')}</span>
+  </StackItem>
+);
+
+export default SelectedFolderIndicator;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes a bug I created in [this PR](https://github.com/kubevirt-ui/kubevirt-plugin/pull/2565/files), that the Save button is disabled when no folder is selected
- it feels very non-intuitive that a VM is moved to project root when no folder is selected, so I added a little indicator for that. Maybe we need a design input to make it look good @yfrimanm
- I don't like that the text in the search, even if having the same name as some folder will not select that folder until specifically clicked as you can see in this video:


https://github.com/user-attachments/assets/de48209e-5eb6-4938-844c-b39b8665f240


maybe we should autoselect?

## 🎥 Demo

After:

https://github.com/user-attachments/assets/56a71e1f-68e8-477d-8d97-f7c9331335db

