### PR TITLE
CNV-57378: Show completed QuickStarts in Getting Started card

### DIFF
--- a/src/views/clusteroverview/OverviewTab/getting-started-card/quick-starts-section/QuickStartsSection.tsx
+++ b/src/views/clusteroverview/OverviewTab/getting-started-card/quick-starts-section/QuickStartsSection.tsx
@@ -41,10 +41,6 @@ const QuickStartsSection: FC<QuickStartsSectionProps> = ({
         );
         const slicedQuickStarts = orderedQuickStarts.slice(0, 2);
 
-        if (loaded && slicedQuickStarts.length === 0) {
-          return null;
-        }
-
         const links: GettingStartedLink[] = loaded
           ? slicedQuickStarts.map((quickStart: QuickStart) => ({
               id: quickStart.metadata.name,

--- a/src/views/clusteroverview/OverviewTab/getting-started-card/quick-starts-section/utils.ts
+++ b/src/views/clusteroverview/OverviewTab/getting-started-card/quick-starts-section/utils.ts
@@ -16,10 +16,12 @@ export const orderQuickStarts = (
 ): Merge<QuickStart[], { metadata: ObjectMetadata }>[] => {
   const orderedQuickStarts: Merge<QuickStart, { metadata: ObjectMetadata }>[] = [];
   const filteredQuickStarts = filter ? allQuickStarts.filter(filter) : allQuickStarts;
+
   const isFeatured = (quickStart: Merge<QuickStart, { metadata: ObjectMetadata }>) =>
     featured?.includes(quickStart?.metadata?.name);
   const getStatus = (quickStart: Merge<QuickStart, { metadata: ObjectMetadata }>) =>
     getQuickStartStatus(allQuickStartStates, quickStart?.metadata?.name);
+
   // Prioritize featured quick starts and keep specified order
   if (featured) {
     const featuredQuickStartsByName = filteredQuickStarts.reduce((acc, q) => {
@@ -35,16 +37,21 @@ export const orderQuickStarts = (
       }
     });
   }
-  // Show other in progress quick starts (which are not featured)
+
+  // Show non-featured in progress quick starts
   orderedQuickStarts.push(
     ...filteredQuickStarts.filter(
       (q) => !isFeatured(q) && getStatus(q) === QuickStartStatus.IN_PROGRESS,
     ),
   );
-  // Show other not started quick starts (which are not featured)
+
+  // Show non-featured completed and unstarted quick starts
   orderedQuickStarts.push(
     ...filteredQuickStarts.filter(
-      (q) => !isFeatured(q) && getStatus(q) === QuickStartStatus.NOT_STARTED,
+      (q) =>
+        !isFeatured(q) &&
+        (getStatus(q) === QuickStartStatus.NOT_STARTED ||
+          getStatus(q) === QuickStartStatus.COMPLETE),
     ),
   );
   return orderedQuickStarts;


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug where the Quick Starts section of the Getting Started card disappears after completing the "Create a virtual machine from a volume" QuickStart. The card disappeared because that's the only QuickStart and QuickStarts were being hidden once completed.

To fix the problem I changed the behavior to show completed QuickStarts at the bottom of the list.

Jira: https://issues.redhat.com/browse/CNV-57378

## 🎥 Demo

### Before

[quick-starts-bug--BEFORE--2025-04-23 10-32.webm](https://github.com/user-attachments/assets/9c7f695e-4abd-4166-941d-91fadf6b1aa6)

### After

[quick-starts-bug--AFTER--2025-04-23 10-26.webm](https://github.com/user-attachments/assets/0bceeead-07c0-46e7-9733-1eef3f583876)
