### PR TITLE
CNV-60543: Only show default columns if no kubevirtUserSettings values exist

### DIFF
--- a/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns.ts
@@ -27,7 +27,9 @@ const useKubevirtUserSettingsTableColumns: UseKubevirtUserSettingsTableColumnsTy
   };
 
   const activeColumns = columns?.filter((col) =>
-    userColumns?.[columnManagementID]?.includes(col?.id),
+    userColumns?.[columnManagementID]
+      ? userColumns?.[columnManagementID]?.includes(col?.id)
+      : !col?.additional,
   );
 
   return [


### PR DESCRIPTION
## 📝 Description

If no kubevirtUserSettings value exists for a specific column ID all columns are displayed. This PR changes that behavior to only show the default columns. 

Jira: https://issues.redhat.com/browse/CNV-60543