### PR TITLE
CNV-56585: Change format for Y axis tick based on max value

### DIFF
--- a/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
+++ b/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
@@ -26,6 +26,7 @@ import useResponsiveCharts from '../hooks/useResponsiveCharts';
 import { getUtilizationQueries } from '../utils/queries';
 import {
   findMaxYValue,
+  getNumberOfDigitsAfterDecimalPoint,
   MILLISECONDS_MULTIPLIER,
   queriesToLink,
   tickFormat,
@@ -107,8 +108,10 @@ const MemoryThresholdChart: FC<MemoryThresholdChartProps> = ({ vmi }) => {
                 },
                 tickLabels,
               }}
+              tickFormat={(tick: number) =>
+                xbytes(tick, { fixed: getNumberOfDigitsAfterDecimalPoint(yMax), iec: true })
+              }
               dependentAxis
-              tickFormat={(tick: number) => xbytes(tick, { fixed: 2, iec: true })}
               tickValues={[0, yMax]}
             />
             <ChartGroup>

--- a/src/utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart.tsx
@@ -25,6 +25,7 @@ import useResponsiveCharts from '../hooks/useResponsiveCharts';
 import { getUtilizationQueries } from '../utils/queries';
 import {
   findMaxYValue,
+  getNumberOfDigitsAfterDecimalPoint,
   MILLISECONDS_MULTIPLIER,
   queriesToLink,
   tickFormat,
@@ -97,8 +98,10 @@ const StorageTotalReadWriteThresholdChart: React.FC<StorageTotalReadWriteThresho
                 },
                 tickLabels,
               }}
+              tickFormat={(tick: number) =>
+                xbytes(tick, { fixed: getNumberOfDigitsAfterDecimalPoint(yMax), iec: true })
+              }
               dependentAxis
-              tickFormat={(tick: number) => xbytes(tick, { fixed: 2, iec: true })}
               tickValues={[0, yMax]}
             />
             <ChartAxis

--- a/src/utils/components/Charts/utils/utils.ts
+++ b/src/utils/components/Charts/utils/utils.ts
@@ -118,3 +118,27 @@ export const findMigrationMaxYValue = (processedData, remainingData, dirtyRateDa
   );
   return Math.max(...max);
 };
+
+/**
+ * Calculate the number of digits that should be displayed after decimal point
+ * based on a static list of threshold values.
+ * @param bytes
+ */
+export const getNumberOfDigitsAfterDecimalPoint = (bytes: number) => {
+  const threshold2digits: [string, number][] = [
+    ['1 GiB', 0],
+    ['10 GiB', 2],
+    ['100 GiB', 1],
+    ['1 TiB', 0],
+    ['10 TiB', 2],
+    ['100 TiB', 1],
+    ['1 PiB', 0],
+  ];
+
+  const [, digitsAfterDecimalPoint = 2] =
+    threshold2digits
+      .map(([threshold, value]) => [xbytes.parse(threshold).bytes, value])
+      .find(([threshold]) => bytes < threshold) ?? [];
+
+  return digitsAfterDecimalPoint;
+};


### PR DESCRIPTION
## 📝 Description
The change applied to memory and storage charts in VM details.

Calculate the number of digits that should be displayed after decimal point based on a static list of threshold values.
The general rule is to keep the displayed number at 3 ciphers or less. Threshold list:
1. x < 1 GiB :  0
2. 1 GiB <= x < 10 GiB : 2
3. 10 GiB <= x < 100 GiB : 1
4. 100 GiB <= x < 1 TiB : 0
5. 1 TiB <= x < 10 TiB : 2
6. 10 TiB <= x < 100 TiB : 1
7. 100 TiB <= x < 1 PiB :  0
8. x > 1 PiB : 2

## 🎥 Demo

### Before - truncated label with corresponding source
![truncated_chart_label](https://github.com/user-attachments/assets/3e79978a-589d-4362-89a6-8e36c2b6ab36)


### Before - range  100 GiB <= x < 1 TiB 

![Screenshot From 2025-04-25 15-20-39](https://github.com/user-attachments/assets/0504b4bc-5f59-4d9a-8ada-65336f657b5c)

### After
![Screenshot From 2025-04-25 14-27-52](https://github.com/user-attachments/assets/44b84429-ed9a-4c73-91bb-14d73c838cd7)
