### PR TITLE
CNV-57314: Display correct max latency value on network checkup page

### DIFF
--- a/src/views/checkups/network/details/tabs/details/CheckupsNetworkDetailsPageSection.tsx
+++ b/src/views/checkups/network/details/tabs/details/CheckupsNetworkDetailsPageSection.tsx
@@ -80,7 +80,7 @@ const CheckupsNetworkDetailsPageSection: FC<CheckupsNetworkDetailsPageSectionPro
               descriptionData={
                 configMap?.data?.[STATUS_MAX_LATENCY_NANO]
                   ? t('{{time}} Nanoseconds', {
-                      time: configMap?.data?.[STATUS_MIN_LATENCY_NANO],
+                      time: configMap?.data?.[STATUS_MAX_LATENCY_NANO],
                     })
                   : NO_DATA_DASH
               }


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug where the maximum latency field was reporting the minimum latency.

Jira: https://issues.redhat.com/browse/CNV-57314

## 🎥 Screenshots

### Before

![max-latency-incorrect--BEFORE--2025-04-28_11-17](https://github.com/user-attachments/assets/7196b482-4544-46f3-a7d1-1c7498bc5e9f)

### After

![max-latency-incorrect--AFTER--2025-04-28_10-55](https://github.com/user-attachments/assets/983a8303-2ac9-46d9-8023-bd7e6b9ea87f)