### PR TITLE
CNV-55855: test interface link state

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,4 +1,4 @@
-import { CNV_NS } from '../utils/const/index';
+import { CNV_NS, TEST_NS } from '../utils/const/index';
 
 export {};
 declare global {
@@ -6,6 +6,7 @@ declare global {
   namespace Cypress {
     interface Chainable {
       checkHCOSpec(spec: string, matchString: string, include: boolean): void;
+      checkVMSpec(vmName: string, spec: string, matchString: string, include: boolean): void;
     }
   }
 }
@@ -21,3 +22,16 @@ Cypress.Commands.add('checkHCOSpec', (spec: string, matchString: string, include
     }
   });
 });
+
+Cypress.Commands.add(
+  'checkVMSpec',
+  (vmName: string, spec: string, matchString: string, include: boolean) => {
+    cy.exec(`oc get -n ${TEST_NS} vm ${vmName} -o jsonpath='{${spec}}'`).then((result) => {
+      if (include) {
+        expect(result.stdout).contain(matchString);
+      } else {
+        expect(result.stdout).not.contain(matchString);
+      }
+    });
+  },
+);

--- a/cypress/tests/downstream/vm-tab.cy.ts
+++ b/cypress/tests/downstream/vm-tab.cy.ts
@@ -1,0 +1,1 @@
+import './vm-tabs/network.cy.ts';

--- a/cypress/tests/downstream/vm-tabs/network.cy.ts
+++ b/cypress/tests/downstream/vm-tabs/network.cy.ts
@@ -1,0 +1,37 @@
+import { Example } from '../../../utils/const/string';
+import { navigateToConfigurationSubTab, subTabName } from '../../../views/tab';
+
+const spec = '.spec.template.spec.domain.devices.interfaces';
+const state_down = `"state":"down"`;
+const state_up = `"state":"up"`;
+
+describe('Set network down/up', () => {
+  before(() => {
+    cy.login();
+    cy.visit('');
+    cy.visitVMs();
+  });
+
+  it('navigate to network tab', () => {
+    cy.get(`[data-test-id="${Example}"]`, { timeout: 180000 }).click();
+    navigateToConfigurationSubTab(subTabName.Network);
+  });
+
+  it('set network link down', () => {
+    cy.contains('Pod networking', { timeout: 120000 }).should('be.visible');
+    cy.wait(5000);
+    cy.get('#toggle-id-6').click({ force: true });
+    //cy.get('[data-test-id="set-link-down"]').should('be.visible').click();
+    cy.contains('.pf-v6-c-menu__item-text', 'Set link down').click();
+    cy.get('svg[fill="red"]', { timeout: 60000 }).should('exist');
+    cy.checkVMSpec(Example, spec, state_down, true);
+  });
+
+  it('set network link up', () => {
+    cy.get('#toggle-id-6').click({ force: true });
+    //cy.get('[data-test-id="set-link-up"]').should('be.visible').click();
+    cy.contains('.pf-v6-c-menu__item-text', 'Set link up').click();
+    cy.get('svg[fill="green"]', { timeout: 60000 }).should('exist');
+    cy.checkVMSpec(Example, spec, state_up, true);
+  });
+});

--- a/cypress/tests/e2e/a-setup.cy.ts
+++ b/cypress/tests/e2e/a-setup.cy.ts
@@ -40,7 +40,8 @@ describe('Prepare the cluster for test', () => {
   });
 
   it('configure public ssh key', () => {
-    cy.visitOverview();
+    cy.visitVMsVirt();
+    cy.visitOverviewVirt();
     tab.navigateToSettings();
     cy.contains('button[role="tab"]', 'User').click();
     cy.contains(manageKeysText).click();

--- a/cypress/views/tab.ts
+++ b/cypress/views/tab.ts
@@ -37,7 +37,7 @@ export enum subTabName {
 }
 
 export const navigateToTab = (name: string) => {
-  cy.get(horizontalLink(name)).should('be.visible');
+  cy.get(horizontalLink(name), { timeout: 120000 }).should('be.visible');
   cy.get(horizontalLink(name)).click();
 };
 

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceActions.tsx
@@ -107,6 +107,7 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
       <DropdownList>
         {interfaceState === NetworkInterfaceState.DOWN ? (
           <DropdownItem
+            data-test-id="set-link-up"
             isDisabled={isSRIOVIface}
             key="network-interface-state-up"
             onClick={() => setNetworkInterfaceState(vm, nicName, NetworkInterfaceState.UP)}
@@ -115,6 +116,7 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
           </DropdownItem>
         ) : (
           <DropdownItem
+            data-test-id="set-link-down"
             description={isSRIOVIface && t('Not available for SR-IOV interfaces')}
             isDisabled={isSRIOVIface}
             key="network-interface-state-down"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The test cannot pass in upstream, so add a new folder 'downstream' for this test.

test interface link state, it pass locally:

  Running:  tab.cy.ts                                                                       (1 of 1)


  Set network down/up
  Logging in as kubeadmin
    ✓ navigate to network tab (143239ms)
    ✓ set network link down (8313ms)
    ✓ set network link up



## 🎥 Demo

> Please add a video or an image of the behavior/changes
