### PR TITLE
CNV-60605: Fix rerendering all over vm details

### DIFF
--- a/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
+++ b/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
@@ -29,6 +29,13 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
   const location = useLocation();
 
   const params = useParams();
+  const [memoParams, setMemoParams] = useState(params);
+
+  useEffect(() => {
+    setMemoParams((preParams) =>
+      JSON.stringify(params) !== JSON.stringify(preParams) ? params : preParams,
+    );
+  }, [params]);
 
   const dynamicPluginPages = useDynamicPages(VirtualMachineModel);
 
@@ -50,6 +57,29 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
   }, [allPages, location?.pathname]);
 
   const [activeItem, setActiveItem] = useState<number | string>();
+
+  const RoutesComponents = useMemo(() => {
+    return allPages.map((page) => {
+      const Component = page.component;
+      return (
+        <Route
+          Component={(props) => (
+            <StateHandler error={error} loaded={loaded} withBullseye>
+              <Component
+                instanceTypeExpandedSpec={instanceTypeExpandedSpec}
+                obj={vm}
+                params={memoParams}
+                {...props}
+              />
+            </StateHandler>
+          )}
+          key={page.href}
+          path={page.href}
+        />
+      );
+    });
+  }, [allPages, vm, error, loaded, instanceTypeExpandedSpec, memoParams]);
+
   return (
     <>
       <nav className="pf-v6-c-tabs pf-m-page-insets">
@@ -78,27 +108,7 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
           })}
         </ul>
       </nav>
-      <Routes>
-        {allPages.map((page) => {
-          const Component = page.component;
-          return (
-            <Route
-              Component={(props) => (
-                <StateHandler error={error} loaded={loaded} withBullseye>
-                  <Component
-                    instanceTypeExpandedSpec={instanceTypeExpandedSpec}
-                    obj={vm}
-                    params={params}
-                    {...props}
-                  />
-                </StateHandler>
-              )}
-              key={page.href}
-              path={page.href}
-            />
-          );
-        })}
-      </Routes>
+      <Routes>{RoutesComponents}</Routes>
     </>
   );
 };

--- a/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
+++ b/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import {
   VirtualMachineDetailsTab,
   VirtualMachineDetailsTabLabel,
@@ -16,100 +18,104 @@ import VirtualMachineYAMLPage from '../tabs/yaml/VirtualMachineYAMLPage';
 export const useVirtualMachineTabs = () => {
   const { t } = useKubevirtTranslation();
 
-  return [
-    {
-      component: VirtualMachinesOverviewTab,
-      href: VirtualMachineDetailsTab.Overview,
-      name: t(VirtualMachineDetailsTabLabel.Overview),
-    },
-    {
-      component: VirtualMachineMetricsTab,
-      href: VirtualMachineDetailsTab.Metrics,
-      name: t(VirtualMachineDetailsTabLabel.Metrics),
-    },
-    {
-      component: VirtualMachineYAMLPage,
-      href: VirtualMachineDetailsTab.YAML,
-      name: t(VirtualMachineDetailsTabLabel.YAML),
-    },
-    {
-      component: VirtualMachineConfigurationTab,
-      href: VirtualMachineDetailsTab.Configurations,
-      name: t(VirtualMachineDetailsTabLabel.Configuration),
-    },
-    {
-      component: VirtualMachineConfigurationTab,
-      href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.SSH}`,
-      isHidden: true,
-      name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.SSH}`,
-    },
-    {
-      component: VirtualMachineConfigurationTab,
-      href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab['Initial-run']}`,
-      isHidden: true,
-      name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab['Initial-run']}`,
-    },
-    {
-      component: VirtualMachineConfigurationTab,
-      href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Storage}`,
-      isHidden: true,
-      name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Storage}`,
-    },
-    {
-      component: VirtualMachineConfigurationTab,
-      href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Details}`,
-      isHidden: true,
-      name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Details}`,
-    },
-    {
-      component: VirtualMachineConfigurationTab,
-      href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Metadata}`,
-      isHidden: true,
-      name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Metadata}`,
-    },
-    {
-      component: VirtualMachineConfigurationTab,
-      href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Network}`,
-      isHidden: true,
-      name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Network}`,
-    },
-    {
-      component: VirtualMachineConfigurationTab,
-      href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Scheduling}`,
-      isHidden: true,
-      name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Scheduling}`,
-    },
-    {
-      component: VirtualMachinePageEventsTab,
-      href: VirtualMachineDetailsTab.Events,
-      name: t(VirtualMachineDetailsTabLabel.Events),
-    },
-    {
-      component: VirtualMachineConsolePage,
-      href: VirtualMachineDetailsTab.Console,
-      name: t(VirtualMachineDetailsTabLabel.Console),
-    },
-    {
-      component: SnapshotListPage,
-      href: VirtualMachineDetailsTab.Snapshots,
-      name: t(VirtualMachineDetailsTabLabel.Snapshots),
-    },
-    {
-      component: VirtualMachineDiagnosticTab,
-      href: VirtualMachineDetailsTab.Diagnostics,
-      name: t(VirtualMachineDetailsTabLabel.Diagnostics),
-    },
-    {
-      component: VirtualMachineDiagnosticTab,
-      href: `${VirtualMachineDetailsTab.Diagnostics}/${VirtualMachineDetailsTab.Tables}`,
-      isHidden: true,
-      name: t(VirtualMachineDetailsTabLabel.Diagnostics),
-    },
-    {
-      component: VirtualMachineDiagnosticTab,
-      href: `${VirtualMachineDetailsTab.Diagnostics}/${VirtualMachineDetailsTab.Logs}`,
-      isHidden: true,
-      name: t(VirtualMachineDetailsTabLabel.Diagnostics),
-    },
-  ];
+  const tabs = useMemo(
+    () => [
+      {
+        component: VirtualMachinesOverviewTab,
+        href: VirtualMachineDetailsTab.Overview,
+        name: t(VirtualMachineDetailsTabLabel.Overview),
+      },
+      {
+        component: VirtualMachineMetricsTab,
+        href: VirtualMachineDetailsTab.Metrics,
+        name: t(VirtualMachineDetailsTabLabel.Metrics),
+      },
+      {
+        component: VirtualMachineYAMLPage,
+        href: VirtualMachineDetailsTab.YAML,
+        name: t(VirtualMachineDetailsTabLabel.YAML),
+      },
+      {
+        component: VirtualMachineConfigurationTab,
+        href: VirtualMachineDetailsTab.Configurations,
+        name: t(VirtualMachineDetailsTabLabel.Configuration),
+      },
+      {
+        component: VirtualMachineConfigurationTab,
+        href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.SSH}`,
+        isHidden: true,
+        name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.SSH}`,
+      },
+      {
+        component: VirtualMachineConfigurationTab,
+        href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab['Initial-run']}`,
+        isHidden: true,
+        name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab['Initial-run']}`,
+      },
+      {
+        component: VirtualMachineConfigurationTab,
+        href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Storage}`,
+        isHidden: true,
+        name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Storage}`,
+      },
+      {
+        component: VirtualMachineConfigurationTab,
+        href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Details}`,
+        isHidden: true,
+        name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Details}`,
+      },
+      {
+        component: VirtualMachineConfigurationTab,
+        href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Metadata}`,
+        isHidden: true,
+        name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Metadata}`,
+      },
+      {
+        component: VirtualMachineConfigurationTab,
+        href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Network}`,
+        isHidden: true,
+        name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Network}`,
+      },
+      {
+        component: VirtualMachineConfigurationTab,
+        href: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Scheduling}`,
+        isHidden: true,
+        name: `${VirtualMachineDetailsTab.Configurations}/${VirtualMachineDetailsTab.Scheduling}`,
+      },
+      {
+        component: VirtualMachinePageEventsTab,
+        href: VirtualMachineDetailsTab.Events,
+        name: t(VirtualMachineDetailsTabLabel.Events),
+      },
+      {
+        component: VirtualMachineConsolePage,
+        href: VirtualMachineDetailsTab.Console,
+        name: t(VirtualMachineDetailsTabLabel.Console),
+      },
+      {
+        component: SnapshotListPage,
+        href: VirtualMachineDetailsTab.Snapshots,
+        name: t(VirtualMachineDetailsTabLabel.Snapshots),
+      },
+      {
+        component: VirtualMachineDiagnosticTab,
+        href: VirtualMachineDetailsTab.Diagnostics,
+        name: t(VirtualMachineDetailsTabLabel.Diagnostics),
+      },
+      {
+        component: VirtualMachineDiagnosticTab,
+        href: `${VirtualMachineDetailsTab.Diagnostics}/${VirtualMachineDetailsTab.Tables}`,
+        isHidden: true,
+        name: t(VirtualMachineDetailsTabLabel.Diagnostics),
+      },
+      {
+        component: VirtualMachineDiagnosticTab,
+        href: `${VirtualMachineDetailsTab.Diagnostics}/${VirtualMachineDetailsTab.Logs}`,
+        isHidden: true,
+        name: t(VirtualMachineDetailsTabLabel.Diagnostics),
+      },
+    ],
+    [t],
+  );
+  return tabs;
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fix rerendering of VM details page

1. missing use memo over pages - as every props change create new array and new array did unmount and mount.
2. useParams act strange - it keep creating new object with each prop change even if params didn't changed - created a workaround to only change params if its really changed value. 

## 🎥 Demo

> Please add a video or an image of the behavior/changes
