### PR TITLE
CNV-60945: Fix add new SSH key by file upload for Templates

### DIFF
--- a/src/views/templates/details/tabs/scripts/components/SSHKey/SSHKey.tsx
+++ b/src/views/templates/details/tabs/scripts/components/SSHKey/SSHKey.tsx
@@ -59,14 +59,14 @@ const SSHKey: FC<SSHKeyProps> = ({ template }) => {
   );
 
   const onSubmit = async (sshDetails: SSHSecretDetails) => {
-    const { secretOption, sshPubKey, sshSecretName, sshSecretNamespace } = sshDetails;
+    const { secretOption, sshPubKey, sshSecretName } = sshDetails;
 
     if (isEqualObject(sshDetails, initialSSHDetails)) {
       return Promise.resolve();
     }
 
     if (secretOption === SecretSelectionOption.addNew) {
-      await createSSHSecret(sshPubKey, sshSecretName, sshSecretNamespace);
+      await createSSHSecret(sshPubKey, sshSecretName, getNamespace(template));
     }
 
     const newTemplate = produce(template, (draftTemplate) => {


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug that caused an error to be displayed when adding a new SSH Secret to a Template by file upload.

Jira: https://issues.redhat.com/browse/CNV-60945

## 🎥 Demo

### Before

[ssh-secret-file-upload-bug--BEFORE--2025-05-01 11-10.webm](https://github.com/user-attachments/assets/03d4ac69-ea4c-4292-9a3d-66ab0a99a14f)

### After

[ssh-secret-file-upload-bug--AFTER--2025-05-01 11-08.webm](https://github.com/user-attachments/assets/b7b46ef0-17b0-4bb1-9ce4-1aef5c4ce44c)

