### PR TITLE
CNV-59955: Fix alignment of state labels in the bootable volume list

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.scss
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.scss
@@ -19,3 +19,8 @@
     }
   }
 }
+
+.bootable-volume-row-icon {
+  width: var(--pf-t--global--spacer--xl);
+  vertical-align: bottom;
+}

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
@@ -33,10 +33,12 @@ import {
 } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { formatBytes } from '@kubevirt-utils/resources/vm/utils/disk/size';
-import { Content, ContentVariants, Flex, Label } from '@patternfly/react-core';
+import { Content, ContentVariants, Flex, FlexItem, Label } from '@patternfly/react-core';
 import { TableText, Tr, WrapModifier } from '@patternfly/react-table';
 
 import TableData from './TableData';
+
+import '../../BootableVolumeList.scss';
 
 type BootableVolumeRowProps = {
   activeColumnIDs: string[];
@@ -108,13 +110,15 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
         modifier="fitContent"
       />
       <TableData activeColumnIDs={activeColumnIDs} id="name" width={20}>
-        <Flex alignItems={{ default: 'alignItemsCenter' }} columnGap={{ default: 'columnGapNone' }}>
-          <img alt="os-icon" className="vm-catalog-row-icon" src={icon} />
-          <Content component={ContentVariants.small}>{bootVolumeName}</Content>
+        <Flex alignItems={{ default: 'alignItemsCenter' }} columnGap={{ default: 'columnGapXs' }}>
+          <img alt="os-icon" className="bootable-volume-row-icon" src={icon} />
+          <FlexItem>
+            <Content component={ContentVariants.small}>{bootVolumeName}</Content>
+          </FlexItem>
           {isDeprecated(bootVolumeName) && <DeprecatedBadge />}
-          {isCloning && <Label className="vm-catalog-row-label">{t('Clone in progress')}</Label>}
+          {isCloning && <Label isCompact>{t('Clone in progress')}</Label>}
           {isDataSourceUploading(bootableVolume as V1beta1DataSource) && (
-            <Label className="vm-catalog-row-label">{t('Upload in progress')}</Label>
+            <Label isCompact>{t('Upload in progress')}</Label>
           )}
         </Flex>
       </TableData>


### PR DESCRIPTION
## 📝 Description

1. rely on component level styling (FlexLayout)
2. separate remaining styling from template list to avoid future
   regressions
3. use compact label styling for all state labels


## 🎥 Demo

#### Before
![Screenshot From 2025-05-05 17-30-09](https://github.com/user-attachments/assets/3ad34f6e-0511-40bb-8732-8b16e1b3a128)


#### After
![Screenshot From 2025-05-05 17-49-31](https://github.com/user-attachments/assets/2a4bd932-bc67-473b-8ced-5eb490933449)



