### PR TITLE
CNV-60995: Pass documentation URL as string to the Link component

### DIFF
--- a/src/utils/components/DiskModal/components/StorageClassAndPreallocation/EnablePreallocationCheckbox.tsx
+++ b/src/utils/components/DiskModal/components/StorageClassAndPreallocation/EnablePreallocationCheckbox.tsx
@@ -43,12 +43,7 @@ const EnablePreallocationCheckbox: FC<EnablePreallocationCheckboxProps> = ({ isD
               <>
                 <Trans ns="plugin__kubevirt-plugin">
                   Refer to the
-                  <Link
-                    to={{
-                      pathname: documentationURL.DATAVOLUME_PREALLOCATIONS,
-                    }}
-                    target="_blank"
-                  >
+                  <Link target="_blank" to={documentationURL.DATAVOLUME_PREALLOCATIONS}>
                     {' '}
                     Documentation{' '}
                   </Link>


### PR DESCRIPTION

## 📝 Description

When URL is passed as object each part needs to fullfil the contract. If anchor(hash) is present in the pathname part the Link component will throw an exception and crash the entire page.

## 🎥 Demo

none