### PR TITLE
CNV-52010: Fetch VMI resource only for running VMs

### DIFF
--- a/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
@@ -1,17 +1,16 @@
 import React, { FC } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
-import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import DetailsPageTitle from '@kubevirt-utils/components/DetailsPageTitle/DetailsPageTitle';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import PaneHeading from '@kubevirt-utils/components/PaneHeading/PaneHeading';
 import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
+import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
 import useVirtualMachineInstanceMigration from '@kubevirt-utils/resources/vmi/hooks/useVirtualMachineInstanceMigration';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Label, Split, SplitItem, Title } from '@patternfly/react-core';
 import VirtualMachineActions from '@virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions';
 import VMActionsIconBar from '@virtualmachines/actions/components/VMActionsIconBar/VMActionsIconBar';
@@ -20,7 +19,7 @@ import VirtualMachinePendingChangesAlert from '@virtualmachines/details/VirtualM
 import VMNotMigratableLabel from '@virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel';
 
 import VirtualMachineBreadcrumb from '../list/components/VirtualMachineBreadcrumb/VirtualMachineBreadcrumb';
-import { getVMStatusIcon } from '../utils';
+import { getVMStatusIcon, isRunning } from '../utils';
 
 import { vmTabsWithYAML } from './utils/constants';
 
@@ -40,12 +39,7 @@ const VirtualMachineNavPageTitle: FC<VirtualMachineNavPageTitleProps> = ({
   const { t } = useKubevirtTranslation();
   const location = useLocation();
 
-  const [vmi] = useK8sWatchResource<V1VirtualMachineInstance>({
-    groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
-    isList: false,
-    name: vm?.metadata?.name,
-    namespace: vm?.metadata?.namespace,
-  });
+  const { vmi } = useVMI(vm?.metadata?.name, vm?.metadata?.namespace, isRunning(vm));
   const vmim = useVirtualMachineInstanceMigration(vm);
   const [isSingleNodeCluster] = useSingleNodeCluster();
   const [actions] = useVirtualMachineActionsProvider(vm, vmim, isSingleNodeCluster);

--- a/src/views/virtualmachines/details/tabs/configuration/VirtualMachineConfigurationTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/VirtualMachineConfigurationTab.tsx
@@ -9,6 +9,7 @@ import { getName } from '@kubevirt-utils/resources/shared';
 import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
 import { PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
+import { isRunning } from '@virtualmachines/utils';
 
 import { getNamespace } from '../../../../cdi-upload-provider/utils/selectors';
 
@@ -24,7 +25,7 @@ const VirtualMachineConfigurationTab: FC<NavPageComponentProps> = ({
   const navigate = useNavigate();
   const location = useLocation();
 
-  const { vmi } = useVMI(getName(vm), getNamespace(vm));
+  const { vmi } = useVMI(getName(vm), getNamespace(vm), isRunning(vm));
   const { allInstanceTypes } = useInstanceTypesAndPreferences();
   const [activeTabKey, setActiveTabKey] = useState<number | string>(
     VirtualMachineDetailsTab.Details,

--- a/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.tsx
+++ b/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.tsx
@@ -1,26 +1,19 @@
 import React, { FC } from 'react';
 
-import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
-import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Consoles from '@kubevirt-utils/components/Consoles/Consoles';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
 import { Bullseye, EmptyState, EmptyStateBody, PageSection } from '@patternfly/react-core';
 import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
-import { printableVMStatus } from '../../../utils';
+import { isRunning, printableVMStatus } from '../../../utils';
 
 import './VirtualMachineConsolePage.scss';
 
 const VirtualMachineConsolePage: FC<NavPageComponentProps> = ({ obj: vm }) => {
   const { t } = useKubevirtTranslation();
-  const [vmi, vmiLoaded] = useK8sWatchResource<V1VirtualMachineInstance>({
-    groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
-    isList: false,
-    name: vm?.metadata?.name,
-    namespace: vm?.metadata?.namespace,
-  });
+  const { vmi, vmiLoaded } = useVMI(vm?.metadata?.name, vm?.metadata?.namespace, isRunning(vm));
 
   if (!vmi || vm?.status?.printableStatus === printableVMStatus.Stopped) {
     return (


### PR DESCRIPTION
## 📝 Description

In case of loading error the useK8sWatchResource hook returns the previous value. For temporary errors this may be beneficial but unfortunately the same happens for a permanent shutdown.

Disabling the fetch:
1. fixes problems with stale VMI resource in the UI
2. prevents unnecessary fetch requests (resulting in 404 error)

## 🎥 Demo

### Before (note 404 errors)

https://github.com/user-attachments/assets/54bb7557-19c9-49d9-b8aa-6b50fdc7ec3c

### After 

https://github.com/user-attachments/assets/cebc7103-360d-40d9-b17c-0d8372dcd220


