### PR TITLE
CNV-58790: VMI migration source and target node reported incorrectly on Migrations tab

### DIFF
--- a/src/utils/resources/vmim/selectors.ts
+++ b/src/utils/resources/vmim/selectors.ts
@@ -2,3 +2,11 @@ import { V1VirtualMachineInstanceMigration } from '@kubevirt-ui/kubevirt-api/kub
 
 export const getMigrationPod = (vmim: V1VirtualMachineInstanceMigration) =>
   vmim?.status?.migrationState?.sourcePod;
+
+export const getMigrationSourceNode = (vmim: V1VirtualMachineInstanceMigration) =>
+  vmim?.status?.migrationState?.sourceNode;
+
+export const getMigrationTargetNode = (vmim: V1VirtualMachineInstanceMigration) =>
+  vmim?.status?.migrationState?.targetNode;
+
+export const getMigrationPhase = (vmim: V1VirtualMachineInstanceMigration) => vmim?.status?.phase;

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/MigrationsRow.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/MigrationsRow.tsx
@@ -10,6 +10,11 @@ import {
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
+import {
+  getMigrationPhase,
+  getMigrationSourceNode,
+  getMigrationTargetNode,
+} from '@kubevirt-utils/resources/vmim/selectors';
 import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
 import {
   GenericStatus,
@@ -25,15 +30,21 @@ import { MigrationTableDataLayout } from './utils/utils';
 import MigrationActionsDropdown from './MigrationActionsDropdown';
 
 const MigrationsRow: FC<RowProps<MigrationTableDataLayout>> = ({ activeColumnIDs, obj }) => {
-  const StatusIcon = iconMapper?.[obj?.vmim?.status?.phase];
+  const { vmim, vmiObj } = obj;
+
+  const sourceNode = getMigrationSourceNode(vmim);
+  const targetNode = getMigrationTargetNode(vmim);
+  const migrationPhase = getMigrationPhase(vmim);
+
+  const StatusIcon = iconMapper?.[migrationPhase];
 
   return (
     <>
       <TableData activeColumnIDs={activeColumnIDs} id="vm-name">
         <ResourceLink
           groupVersionKind={VirtualMachineModelGroupVersionKind}
-          name={getName(obj.vmiObj)}
-          namespace={getNamespace(obj.vmiObj)}
+          name={getName(vmiObj)}
+          namespace={getNamespace(vmiObj)}
         />
       </TableData>
       <TableData
@@ -43,38 +54,29 @@ const MigrationsRow: FC<RowProps<MigrationTableDataLayout>> = ({ activeColumnIDs
       >
         <ResourceLink
           groupVersionKind={modelToGroupVersionKind(NamespaceModel)}
-          name={getNamespace(obj.vmiObj)}
+          name={getNamespace(vmiObj)}
         />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="status">
         <Tooltip
-          content={`${obj?.vmim?.status?.phase} ${
-            obj?.vmiObj?.status?.migrationState?.endTimestamp || ''
-          }`}
           hidden={
-            obj?.vmim?.status?.phase !== vmimStatuses.Failed &&
-            obj?.vmim?.status?.phase !== vmimStatuses.Succeeded
+            migrationPhase !== vmimStatuses.Failed && migrationPhase !== vmimStatuses.Succeeded
           }
+          content={`${migrationPhase} ${vmiObj?.status?.migrationState?.endTimestamp || ''}`}
         >
-          <GenericStatus Icon={StatusIcon} title={obj?.vmim?.status?.phase} />
+          <GenericStatus Icon={StatusIcon} title={migrationPhase} />
         </Tooltip>
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="source">
-        {obj?.vmiObj?.status?.migrationState?.sourceNode ? (
-          <ResourceLink
-            groupVersionKind={modelToGroupVersionKind(NodeModel)}
-            name={obj?.vmiObj?.status?.migrationState?.sourceNode}
-          />
+        {sourceNode ? (
+          <ResourceLink groupVersionKind={modelToGroupVersionKind(NodeModel)} name={sourceNode} />
         ) : (
           NO_DATA_DASH
         )}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="target">
-        {obj?.vmiObj?.status?.migrationState?.targetNode ? (
-          <ResourceLink
-            groupVersionKind={modelToGroupVersionKind(NodeModel)}
-            name={obj?.vmiObj?.status?.migrationState?.targetNode}
-          />
+        {targetNode ? (
+          <ResourceLink groupVersionKind={modelToGroupVersionKind(NodeModel)} name={targetNode} />
         ) : (
           NO_DATA_DASH
         )}
@@ -85,15 +87,15 @@ const MigrationsRow: FC<RowProps<MigrationTableDataLayout>> = ({ activeColumnIDs
       <TableData activeColumnIDs={activeColumnIDs} id="vmim-name">
         <ResourceLink
           groupVersionKind={VirtualMachineInstanceMigrationModelGroupVersionKind}
-          name={obj?.vmim?.metadata?.name}
-          namespace={obj?.vmim?.metadata?.namespace}
+          name={getName(vmim)}
+          namespace={getNamespace(vmim)}
         />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="created">
-        <Timestamp timestamp={obj?.vmim?.metadata?.creationTimestamp} />
+        <Timestamp timestamp={vmim?.metadata?.creationTimestamp} />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="pf-v6-c-table__action" id="">
-        <MigrationActionsDropdown isKebabToggle vmim={obj?.vmim} />
+        <MigrationActionsDropdown isKebabToggle vmim={vmim} />
       </TableData>
     </>
   );


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug that caused the source and target nodes for multiple migrations of the same VMI as those of the last migration.

Jira: https://issues.redhat.com/browse/CNV-58790

## 🎥 Screenshots

### Before

![vmim-source-and-target-node--BEFORE--2025-05-06_23-32](https://github.com/user-attachments/assets/4c57753d-3ce9-4709-954f-58bf77da33df)

### After

![vmim-source-and-target-node-incorrect--AFTER--2025-05-06_23-26](https://github.com/user-attachments/assets/da107668-197f-4887-b2c5-7099a676740f)