### PR TITLE
CNV-61191: Toggle autoResourceLimits feature by replacing only the flag value

### DIFF
--- a/src/utils/hooks/useHyperConvergeConfiguration.ts
+++ b/src/utils/hooks/useHyperConvergeConfiguration.ts
@@ -14,6 +14,7 @@ export type HyperConverged = K8sResourceCommon & {
     enableCommonBootImageImport?: boolean;
     evictionStrategy?: string;
     featureGates: {
+      autoResourceLimits?: boolean;
       deployKubeSecondaryDNS?: boolean;
       deployTektonTaskResources?: boolean;
       disableMDevConfiguration?: boolean;

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/utils/utils.ts
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/utils/utils.ts
@@ -9,9 +9,9 @@ export const updateAutoResourceLimitsFeatureGate = (hcoCR: HyperConverged, switc
   k8sPatch<HyperConverged>({
     data: [
       {
-        op: hcoCR?.spec?.featureGates ? K8S_OPS.ADD : K8S_OPS.REPLACE,
-        path: '/spec/featureGates',
-        value: { [AUTO_RESOURCE_LIMITS_FEATURE_GATE]: switchState },
+        op: K8S_OPS.REPLACE,
+        path: `/spec/featureGates/${AUTO_RESOURCE_LIMITS_FEATURE_GATE}`,
+        value: switchState,
       },
     ],
     model: HyperConvergedModel,


### PR DESCRIPTION
## 📝 Description

Use the same approach as for the persistentReservation feature.

https://github.com/kubevirt-ui/kubevirt-plugin/blob/b5f0400f4e921b5facf3ac399150b35fbd0ba4e9/src/views/clusteroverview/SettingsTab/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx#L43

## 🎥 Demo

### Before
https://github.com/user-attachments/assets/599e7e51-f4e3-4b5d-8802-c562b538a33a

### After
https://github.com/user-attachments/assets/45a5c7ac-a17c-4066-a2b7-ff84840fcbd8



