### PR TITLE
CNV-61216: Fix StorageClass migration rollback

### DIFF
--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationRollback.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationRollback.tsx
@@ -2,6 +2,7 @@ import React, { FC, useState } from 'react';
 import { Trans } from 'react-i18next';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { MigMigration, MigMigrationModel } from '@kubevirt-utils/resources/migrations/constants';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 import {
   ActionList,
@@ -14,11 +15,6 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { CloseIcon, WarningTriangleIcon } from '@patternfly/react-icons';
-
-import {
-  MigMigration,
-  MigMigrationModel,
-} from '../../../../../utils/resources/migrations/constants';
 
 type VirtualMachineMigrationRollbackProps = {
   migMigration?: MigMigration;
@@ -41,7 +37,7 @@ const VirtualMachineMigrationRollback: FC<VirtualMachineMigrationRollbackProps> 
     try {
       await k8sPatch({
         data: [
-          { op: 'replace', path: '/spec/rollback', value: 'true' },
+          { op: 'replace', path: '/spec/rollback', value: true },
           { op: 'remove', path: '/spec/migrateState' },
         ],
         model: MigMigrationModel,
@@ -49,7 +45,7 @@ const VirtualMachineMigrationRollback: FC<VirtualMachineMigrationRollbackProps> 
       });
       onClose();
     } catch (apiError) {
-      setErrorRollback(errorRollback);
+      setErrorRollback(apiError);
     } finally {
       setLoadingRollback(false);
     }


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug that prevented StorageClass migration rollbacks from working properly and another that prevented rollback errors from being displayed.

Jira: https://issues.redhat.com/browse/CNV-61216

## 🎥 Demo

### Before

[storageclass-migration-rollback--BEFORE--2025-05-07 10-01.webm](https://github.com/user-attachments/assets/fea1dcf6-ccd7-4cf5-95b8-1d7a27888d33)

### After

[storageclass-migration-rollback--AFTER--2025-05-07 09-59.webm](https://github.com/user-attachments/assets/44845b60-6be1-4b64-a253-221f20058b78)

![sc-migration-error--AFTER--2025-05-07_09-47](https://github.com/user-attachments/assets/0e29769f-4892-4614-8461-563463676a07)
