### PR TITLE
CNV-61190: Use default boot mode from the preference

### DIFF
--- a/src/utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal.tsx
+++ b/src/utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal.tsx
@@ -8,7 +8,7 @@ import { Form, FormGroup, SelectList, SelectOption } from '@patternfly/react-cor
 
 import FormPFSelect from '../FormPFSelect/FormPFSelect';
 
-import { bootloaderOptions, BootModeTitles } from './utils/constants';
+import { bootloaderOptions, BootMode, BootModeTitles } from './utils/constants';
 import { BootloaderOptionValue } from './utils/types';
 import { getBootloaderFromVM, updatedVMBootMode } from './utils/utils';
 
@@ -16,6 +16,7 @@ type FirmwareBootloaderModalProps = {
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine | void>;
+  preferredBootmode?: BootMode;
   vm: V1VirtualMachine;
   vmi?: V1VirtualMachineInstance;
 };
@@ -24,12 +25,13 @@ const FirmwareBootloaderModal: FC<FirmwareBootloaderModalProps> = ({
   isOpen,
   onClose,
   onSubmit,
+  preferredBootmode,
   vm,
   vmi,
 }) => {
   const { t } = useKubevirtTranslation();
   const [selectedFirmwareBootloader, setSelectedFirmwareBootloader] =
-    useState<BootloaderOptionValue>(getBootloaderFromVM(vm));
+    useState<BootloaderOptionValue>(getBootloaderFromVM(vm, preferredBootmode));
 
   const handleChange = (event: MouseEvent<HTMLSelectElement>, value: BootloaderOptionValue) => {
     event.preventDefault();

--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -119,7 +119,8 @@ export const checkBootModeChanged = (
   }
   const vmiBootloader = getVMIBootLoader(vmi);
   const vmBootloader = getBootloader(vm);
-  return !isEqualObject(vmiBootloader, vmBootloader);
+  const usesDefaultBootloader = vmBootloader === undefined;
+  return !usesDefaultBootloader && !isEqualObject(vmiBootloader, vmBootloader);
 };
 
 export const getChangedEnvDisks = (

--- a/src/utils/resources/preference/helper.ts
+++ b/src/utils/resources/preference/helper.ts
@@ -15,7 +15,7 @@ export const getPreferredBootmode = (preference: V1beta1VirtualMachinePreference
     return BootMode.uefiSecure;
   if (
     preference?.spec?.firmware?.preferredUseEfi ||
-    !preference?.spec?.firmware?.preferredEfi?.secureBoot
+    preference?.spec?.firmware?.preferredEfi?.secureBoot === false
   )
     return BootMode.uefi;
   if (
@@ -26,6 +26,6 @@ export const getPreferredBootmode = (preference: V1beta1VirtualMachinePreference
 };
 
 export const getPreferenceModelFromMatcher = (preferenceMatcher: V1PreferenceMatcher): K8sModel =>
-  preferenceMatcher?.kind?.includes('cluster')
-    ? VirtualMachineClusterPreferenceModel
-    : VirtualMachinePreferenceModel;
+  preferenceMatcher?.kind === VirtualMachinePreferenceModel.kind
+    ? VirtualMachinePreferenceModel
+    : VirtualMachineClusterPreferenceModel;

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
@@ -74,6 +74,7 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({
               }
               isOpen={isOpen}
               onClose={onClose}
+              preferredBootmode={preferredBootmode}
               vm={instanceTypeVM || vm}
               vmi={vmi}
             />


### PR DESCRIPTION

## 📝 Description

Fixed issues:
1. UEFI mode used as default boot mode in the customization details. Fixed by strict check in getPreferredBootmode()
2. BIOS mode used as default mode (regardless of preference) in the edit modal. Fixed by passing the preferred boot mode (already available).
3. pending changes warning displayed after creating a VM with preference that includes boot mode. Fixed by detecting that no override was provided in the VM resource.

Additionally, the preference resolving policy was changed. Before, the default was VirtualMachinePreference (if cluster preference was not matched). After this PR, the default is VirtualMachineClusterPreference. The reason for this change: some of the data source volumes are not providing the instancetype.kubevirt.io/default-preference-kind label which blocked resolving the preference (silently) on the test envs. As a result incorrect data was presented in the customization details - including incorrect boot mode. In this case the cluster preference seems a better fallback.


## 🎥 Demo

### Before 

https://github.com/user-attachments/assets/2d05d2b3-7fd2-41ee-a779-d58997b06f0a

### After

https://github.com/user-attachments/assets/c52fcf9c-81e9-49a1-b8f8-a86e4a967b91


