### PR TITLE
CNV-60994: condition labels remove width limit

### DIFF
--- a/src/views/virtualmachines/list/components/VMStatusConditionLabel/VMStatusConditionLabel.tsx
+++ b/src/views/virtualmachines/list/components/VMStatusConditionLabel/VMStatusConditionLabel.tsx
@@ -15,7 +15,6 @@ export const VMStatusConditionLabel: FC<V1VirtualMachineCondition> = memo((condi
           e.preventDefault();
         }}
         color="grey"
-        textMaxWidth="6ch"
       >
         {condition?.type}={condition?.status}
       </Label>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Looks like the `textMaxWidth="6ch"` was intentional, if we remove it, the labels can go over multiple lines, I think it is ok like this, but let me know what do you think @avivtur as you did this change.

## 🎥 Demo
Before
![Screenshot 2025-05-09 at 12 24 51](https://github.com/user-attachments/assets/76d5e803-4ca6-4f42-b2d0-5d716588e96e)

After
![Screenshot 2025-05-09 at 12 24 32](https://github.com/user-attachments/assets/ce0ee75c-6894-4342-84c9-298cedae867d)



