### PR TITLE
[release-4.18] CNV-58790: VMI migration source and target nodes reported incorrectly on Migrations tab

### DIFF
--- a/src/utils/resources/vmim/selectors.ts
+++ b/src/utils/resources/vmim/selectors.ts
@@ -2,3 +2,11 @@ import { V1VirtualMachineInstanceMigration } from '@kubevirt-ui/kubevirt-api/kub
 
 export const getMigrationPod = (vmim: V1VirtualMachineInstanceMigration) =>
   vmim?.status?.migrationState?.sourcePod;
+
+export const getMigrationSourceNode = (vmim: V1VirtualMachineInstanceMigration) =>
+  vmim?.status?.migrationState?.sourceNode;
+
+export const getMigrationTargetNode = (vmim: V1VirtualMachineInstanceMigration) =>
+  vmim?.status?.migrationState?.targetNode;
+
+export const getMigrationPhase = (vmim: V1VirtualMachineInstanceMigration) => vmim?.status?.phase;


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug that caused the source and target nodes for multiple migrations of the same VMI as those of the last migration.

Jira: https://issues.redhat.com/browse/CNV-58790

## 🎥 Screenshot

### After

![vmim-source-and-target-node-incorrect-418--AFTER--2025-05-09_14-52](https://github.com/user-attachments/assets/138b2c30-7238-4bcd-ba16-b434d715699e)
