### PR TITLE
CNV-58916: Show LiveMigratable=True label in VMs list

### DIFF
--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
@@ -18,6 +18,7 @@ import { Checkbox } from '@patternfly/react-core';
 import VirtualMachineActions from '@virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions';
 import useVirtualMachineActionsProvider from '@virtualmachines/actions/hooks/useVirtualMachineActionsProvider';
 import { getDeletionProtectionPrintableStatus } from '@virtualmachines/details/tabs/configuration/details/components/DeletionProtection/utils/utils';
+import { filterConditions } from '@virtualmachines/list/components/VirtualMachineRow/utils/utils';
 import { deselectVM, isVMSelected, selectVM } from '@virtualmachines/list/selectedVMs';
 import { getVirtualMachineStorageClasses, PVCMapper } from '@virtualmachines/utils/mappers';
 
@@ -84,7 +85,7 @@ const VirtualMachineRowLayout: FC<
         {status}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="conditions">
-        <VMStatusConditionLabelList conditions={obj?.status?.conditions?.filter((c) => c.reason)} />
+        <VMStatusConditionLabelList conditions={filterConditions(obj?.status?.conditions)} />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="node">
         {node}

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/utils/utils.ts
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/utils/utils.ts
@@ -1,0 +1,14 @@
+import { V1VirtualMachineCondition } from '@kubevirt-ui/kubevirt-api/kubevirt';
+
+const isLiveMigratableCondition = (condition: V1VirtualMachineCondition) =>
+  condition?.type === 'LiveMigratable' && condition?.status === 'True';
+
+const isNotLiveMigratableCondition = (condition: V1VirtualMachineCondition) =>
+  condition?.type === 'LiveMigratable' && condition?.status === 'False';
+
+export const filterConditions = (conditions: V1VirtualMachineCondition[]) =>
+  conditions?.filter(
+    (condition) =>
+      isLiveMigratableCondition(condition) ||
+      (condition?.reason && !isNotLiveMigratableCondition(condition)),
+  );


### PR DESCRIPTION
## 📝 Description

This PR changes the conditions filtering criteria to include showing the "LiveMigratable=True" condition label in the VirtualMachines list. It manually excludes the "LiveMigratable=False" condition to avoid it being displayed if the `reason` field for that condition exists.

Jira: https://issues.redhat.com/browse/CNV-58916

## 🎥 Screenshots

### Before

![livemigratable-condition-in-vm-list--BEFORE--2025-05-09_15-55](https://github.com/user-attachments/assets/233cd755-035c-41e4-bfb3-21ccba963013)

### After

![livemigratable-condition-in-vm-list--AFTER--2025-05-09_15-50](https://github.com/user-attachments/assets/f14bb4cb-4890-4f4a-adf6-5918da898904)
