### PR TITLE
CNV-59121: show correct max number of columns to select

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1629,7 +1629,7 @@
   "You can edit the boot order in the <1>{t('Disks tab')}</1>": "You can edit the boot order in the <1>{t('Disks tab')}</1>",
   "You can host and manage virtualized workloads on the same platform as container-based workloads.": "You can host and manage virtualized workloads on the same platform as container-based workloads.",
   "You can select the boot source in the <2>Disks</2> tab.": "You can select the boot source in the <2>Disks</2> tab.",
-  "You can select up to {{MAX_VIEW_COLS}} columns": "You can select up to {{MAX_VIEW_COLS}} columns",
+  "You can select up to {{maxColumnsToSelect}} columns": "You can select up to {{maxColumnsToSelect}} columns",
   "You can set the cluster and your individual preferences in the Settings tab on the Overview page.": "You can set the cluster and your individual preferences in the Settings tab on the Overview page.",
   "You can use cloud-init to initialize the operating system with a specific configuration when the VirtualMachine is started.": "You can use cloud-init to initialize the operating system with a specific configuration when the VirtualMachine is started.",
   "You don't have access to this section due to cluster policy.": "You don't have access to this section due to cluster policy.",

--- a/src/utils/components/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/src/utils/components/ColumnManagementModal/ColumnManagementModal.tsx
@@ -18,9 +18,8 @@ import {
   Stack,
 } from '@patternfly/react-core';
 
-import { MAX_VIEW_COLS } from './constants';
 import DataListRow from './DataListRow';
-import { createInputId, getColumnId } from './utils';
+import { createInputId, getColumnId, getMaxColumnsToSelect } from './utils';
 
 import './column-management-modal.scss';
 
@@ -70,7 +69,9 @@ export const ColumnManagementModal: FC<ColumnManagementModalProps> = ({
     onClose();
   };
 
-  const areMaxColumnsDisplayed = checkedColumns.size >= MAX_VIEW_COLS;
+  const maxColumnsToSelect = getMaxColumnsToSelect(columns);
+  const areMaxColumnsDisplayed =
+    checkedColumns.size - (checkedColumns.has('') ? 1 : 0) >= maxColumnsToSelect;
 
   const resetColumns = (event: SyntheticEvent): void => {
     event.preventDefault();
@@ -87,7 +88,7 @@ export const ColumnManagementModal: FC<ColumnManagementModalProps> = ({
         <p className="co-m-form-row">{t('Selected columns will appear in the table.')}</p>
         <Alert
           isInline
-          title={t('You can select up to {{MAX_VIEW_COLS}} columns', { MAX_VIEW_COLS })}
+          title={t('You can select up to {{maxColumnsToSelect}} columns', { maxColumnsToSelect })}
           variant={AlertVariant.info}
         >
           {!showNamespaceOverride && t('The namespace column is only shown when in "All projects"')}

--- a/src/utils/components/ColumnManagementModal/constants.ts
+++ b/src/utils/components/ColumnManagementModal/constants.ts
@@ -1,4 +1,4 @@
-export const MAX_VIEW_COLS = 9;
+export const MAX_VIEW_COLS = 10;
 
 export const NAME_COLUMN_ID = 'name';
 

--- a/src/utils/components/ColumnManagementModal/utils.ts
+++ b/src/utils/components/ColumnManagementModal/utils.ts
@@ -1,5 +1,10 @@
-import { DATA_LIST_PREFIX } from './constants';
+import { ManagedColumn } from '@openshift-console/dynamic-plugin-sdk';
+
+import { DATA_LIST_PREFIX, MAX_VIEW_COLS } from './constants';
 
 export const createInputId = (columnId: string) => `${DATA_LIST_PREFIX}${columnId}`;
 
 export const getColumnId = (inputId: string) => inputId.replace(DATA_LIST_PREFIX, '');
+
+export const getMaxColumnsToSelect = (allColumns: ManagedColumn[]) =>
+  MAX_VIEW_COLS - allColumns.filter((column) => column.title === '').length;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Shows correct max number of columns to select in `ColumnManagementModal`. 

Adjusts the number based on number of "empty" columns, like the three-dots action button (and checkbox in case of VMs table).