### PR TITLE
CNV-58160: Move text input under the "SSH over NodePort service" heading on the settings page

### DIFF
--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralSettings/SSHConfiguration/SSHConfiguration.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralSettings/SSHConfiguration/SSHConfiguration.tsx
@@ -80,26 +80,24 @@ const SSHConfiguration: FC<SSHConfigurationProps> = ({ newBadge }) => {
           !isEmpty(featureConfigMap?.data?.[NODE_PORT_ADDRESS])
         }
         id="node-port-feature"
-        inlineCheckbox
         isDisabled={!loaded || !isAdmin || isEmpty(featureConfigMap?.data?.[NODE_PORT_ADDRESS])}
         isLoading={nodePortIsLoading}
         newBadge={newBadge}
         title={t('SSH over NodePort service')}
         turnOnSwitch={(checked) => onChange(checked.toString(), NODE_PORT_ENABLED)}
-      >
-        <TextInput
-          onChange={(_event, value: string) => {
-            setUrl(value);
-            onTextChange(value, NODE_PORT_ADDRESS);
-          }}
-          className="pf-v6-u-mr-md"
-          id="node-address"
-          isRequired
-          name="node-address"
-          placeholder={t('Enter node address')}
-          value={url ?? featureConfigMap?.data?.[NODE_PORT_ADDRESS]}
-        />
-      </SectionWithSwitch>
+      />
+      <TextInput
+        onChange={(_event, value: string) => {
+          setUrl(value);
+          onTextChange(value, NODE_PORT_ADDRESS);
+        }}
+        className="pf-v6-u-mr-md"
+        id="node-address"
+        isRequired
+        name="node-address"
+        placeholder={t('Enter node address')}
+        value={url ?? featureConfigMap?.data?.[NODE_PORT_ADDRESS]}
+      />
     </ExpandSection>
   );
 };


### PR DESCRIPTION
## 📝 Description

This PR moves the node address text input under the "SSH over NodePort service" heading on the settings page.

Jira: https://issues.redhat.com/browse/CNV-58160

## 🎥 Screenshots

### Before

![ssh-over-nodeport-service--BEFORE--2025-05-14_09-37](https://github.com/user-attachments/assets/2d27d972-352c-47cb-98a7-1b02ad0370db)

### After

![ssh-over-nodeport-service--AFTER--2025-05-14_09-33](https://github.com/user-attachments/assets/2755c509-7093-40c4-ab52-1db7fb8aaadd)

