### PR TITLE
Add script for creating test translations

### DIFF
--- a/i18n-scripts/dummy-locale.js
+++ b/i18n-scripts/dummy-locale.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+const messages = require( '../locales/en/plugin__kubevirt-plugin.json');
+
+const TARGETS_FOR_DUMMY_LOCALE = ['es','fr'];
+const wrappers = {
+  es:(message) => `\u21d2 ${message} \u21d0`,
+  fr: (message) => `@ ${message} @`
+}
+
+function insertDummyLocaleAndSave(messages, destination, wrap) {
+  const dummyMessages = {};
+  Object.keys(messages).forEach((key) => {
+    const message = messages[key] ?? key;
+    dummyMessages[key] = wrap(message);
+  });
+
+  const serializedContent = JSON.stringify(dummyMessages, null, "  ") + '\n';
+  const dirname = path.dirname(destination)
+  if( !fs.existsSync(dirname)) {
+    fs.mkdirSync(dirname);
+  }
+  fs.writeFileSync(destination, serializedContent);
+}
+
+TARGETS_FOR_DUMMY_LOCALE.forEach(target => {
+  const destination = path.join('locales', target, 'plugin__kubevirt-plugin.json');
+  insertDummyLocaleAndSave(
+    messages, 
+    destination, 
+    wrappers[target]);
+  console.log(   
+      `[i18n-scripts] dummy locale for ${target} inserted to ${destination} ✔`,
+  );
+})
+
+

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "dev": "yarn clean && NODE_ENV=development NODE_OPTIONS=--max-old-space-size=8192 yarn ts-node node_modules/.bin/webpack serve --progress",
     "export-pos": "./i18n-scripts/export-pos.sh",
     "i18n": "i18next && node ./i18n-scripts/set-english-defaults.js && ./i18n-scripts/replace-br.sh",
+    "i18n-dummy-locale": "node ./i18n-scripts/dummy-locale.js",
     "i18n-to-po": "node ./i18n-scripts/i18n-to-po.js",
     "lint": "eslint src cypress --color",
     "lint:fix": "yarn lint --fix",


### PR DESCRIPTION
## 📝 Description

Port dummy-locale script developed for VM Portal. The script reads English translations and generates test messages by adding special chars as prefix/suffix. By default Spanish and French locales are replaced.

Usage: yarn i18n-dummy-locale

Reference-Url: https://github.com/oVirt/ovirt-web-ui/blob/dfe0c4b8c92638f6e41b9fe0b09e0d07509618ae/scripts/intl/dummy-locale.js

## 🎥 Demo


https://github.com/user-attachments/assets/e8fdb197-f34c-4d05-898d-12d133df42ac


