### PR TITLE
CNV-57942: Show actual storage capacity in VM disks list

### DIFF
--- a/src/utils/resources/bootableresources/selectors.ts
+++ b/src/utils/resources/bootableresources/selectors.ts
@@ -15,8 +15,8 @@ export const getVolumeSnapshotSize = (volumeSnapshot: VolumeSnapshotKind) =>
 export const getVolumeSnapshotStorageClass = (volumeSnapshot: VolumeSnapshotKind) =>
   volumeSnapshot?.spec?.volumeSnapshotClassName;
 
-export const getPVCSize = (pvc: IoK8sApiCoreV1PersistentVolumeClaim) =>
-  pvc?.spec?.resources?.requests?.storage;
+export const getPVCStorageCapacity = (pvc: IoK8sApiCoreV1PersistentVolumeClaim) =>
+  pvc?.status?.capacity?.storage;
 
 export const getPVCStorageClassName = (pvc: IoK8sApiCoreV1PersistentVolumeClaim) =>
   pvc?.spec?.storageClassName;

--- a/src/utils/resources/vm/utils/disk/constants.ts
+++ b/src/utils/resources/vm/utils/disk/constants.ts
@@ -12,6 +12,7 @@ export type DiskRawData = {
 
 export type DiskRowDataLayout = {
   drive: string;
+  hasDataVolume?: boolean;
   interface: string;
   isBootDisk: boolean;
   isEnvDisk: boolean;

--- a/src/utils/resources/vm/utils/disk/rowData.ts
+++ b/src/utils/resources/vm/utils/disk/rowData.ts
@@ -9,7 +9,7 @@ import {
   getDataVolumeSize,
   getDataVolumeStorageClassName,
   getPhase,
-  getPVCSize,
+  getPVCStorageCapacity,
   getPVCStorageClassName,
 } from '@kubevirt-utils/resources/bootableresources/selectors';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
@@ -40,6 +40,7 @@ export const getDiskRowDataLayout = (
 
     const diskRowDataObject: DiskRowDataLayout = {
       drive: isEmpty(disk) ? NO_DATA_DASH : getPrintableDiskDrive(disk),
+      hasDataVolume: Boolean(dataVolume),
       interface: isEmpty(disk) ? NO_DATA_DASH : getPrintableDiskInterface(disk),
       isBootDisk: disk?.name === bootDisk?.name,
       isEnvDisk: !!volume?.configMap || !!volume?.secret || !!volume?.serviceAccount,
@@ -51,7 +52,7 @@ export const getDiskRowDataLayout = (
       storageClass: dataVolumeTemplate?.spec?.storage?.storageClassName || NO_DATA_DASH,
     };
 
-    const dataSourceSize = getPVCSize(pvc) || getDataVolumeSize(dataVolume);
+    const dataSourceSize = getPVCStorageCapacity(pvc) || getDataVolumeSize(dataVolume);
     const dataVolumeCustomSize = dataVolumeTemplate?.spec?.storage?.resources?.requests?.storage;
     const size = humanizeBinaryBytes(convertToBaseValue(dataSourceSize || dataVolumeCustomSize));
 


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug where the disk size shown in the VM disks list didn't match the actual capacity of the PVC linked in the source column. It does this by:

1. Reporting the actual capacity of the PVC instead of the requested capacity
2. Linking to the DataVolume instead of the PVC if one exists (Per [CNV-57330](https://issues.redhat.com/browse/CNV-57330)) 

Jira: https://issues.redhat.com/browse/CNV-57942

## 🎥 Screenshots

### Before

![dv-resource-link--BEFORE--2025-05-18_09-18](https://github.com/user-attachments/assets/cfce762e-0c7a-4e56-b6d1-70af5cb8321c)

### After

![dv-resource-link--AFTER--2025-05-18_09-06](https://github.com/user-attachments/assets/dbed70e9-c6f1-404d-9325-0431bb60f12a)