### PR TITLE
CNV-61395: fix advanced search when isProxyPodAlive

### DIFF
--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -185,7 +185,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
       return [filteredData, filteredData?.slice(pagination.startIndex, pagination.endIndex)];
     }
 
-    const matchedVMs = vmsToShow?.filter(
+    const matchedVMs = filteredData?.filter(
       ({ metadata: { name, namespace: ns }, status: { printableStatus = '' } = {} }) => {
         return (
           vmiMapper?.mapper?.[ns]?.[name] ||


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- Fixes filtering with advanced search fields, such as `projects` and `description` in case a proxy pod is used.

TODO (in a followup):
Extend `filterOptions` variable passed to `useKubevirtWatchResource` by advanced search fields.
```
{
      labels: 'metadata.labels',
      name: 'metadata.name',
      'rowFilter-instanceType': 'spec.instancetype.name',
      'rowFilter-live-migratable': 'status.conditions',
      'rowFilter-os': 'spec.template.metadata.annotations.vm\\.kubevirt\\.io/os',
      'rowFilter-status': 'status.printableStatus',
      'rowFilter-template': 'metadata.labels.vm\\.kubevirt\\.io/template',
}
```
