### PR TITLE
CNV-46434: Add HTTP DataSource option to the bootable volumes modal

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/SourceTypeSelection/SourceTypeSelection.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/SourceTypeSelection/SourceTypeSelection.tsx
@@ -102,6 +102,14 @@ const SourceTypeSelection: FC<SourceTypeSelectionProps> = ({
           >
             {optionsValueLabelMapper[DROPDOWN_FORM_SELECTION.USE_REGISTRY]}
           </SelectOption>
+          <SelectOption
+            data-test-id="use-http"
+            description={t('Import content via URL (HTTP or HTTPS endpoint).')}
+            isDisabled={!canCreateDS}
+            value={DROPDOWN_FORM_SELECTION.USE_HTTP}
+          >
+            {optionsValueLabelMapper[DROPDOWN_FORM_SELECTION.USE_HTTP]}
+          </SelectOption>
         </SelectGroup>
       </Select>
     </FormGroup>

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeSource/VolumeSource.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeSource/VolumeSource.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import HTTPSource from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeSource/components/HTTPSource';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import { DataUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -45,6 +46,9 @@ const VolumeSource: FC<VolumeSourceProps> = ({
     ),
     [DROPDOWN_FORM_SELECTION.USE_EXISTING_PVC]: (
       <PVCSource bootableVolume={bootableVolume} setBootableVolumeField={setBootableVolumeField} />
+    ),
+    [DROPDOWN_FORM_SELECTION.USE_HTTP]: (
+      <HTTPSource setBootableVolumeField={setBootableVolumeField} />
     ),
     [DROPDOWN_FORM_SELECTION.USE_REGISTRY]: (
       <FormGroup fieldId="volume-registry-url" isRequired label={t('Registry URL')}>

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/HTTPSource.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/HTTPSource.tsx
@@ -1,0 +1,37 @@
+import React, { FC } from 'react';
+
+import { SetBootableVolumeFieldType } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/constants';
+import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
+import { FormTextInput } from '@kubevirt-utils/components/FormTextInput/FormTextInput';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { FormGroup } from '@patternfly/react-core';
+
+type HTTPSourceProps = {
+  setBootableVolumeField: SetBootableVolumeFieldType;
+};
+
+const HTTPSource: FC<HTTPSourceProps> = ({ setBootableVolumeField }) => {
+  const { t } = useKubevirtTranslation();
+  const httpSourceHelperURL =
+    'https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2';
+
+  return (
+    <FormGroup className="disk-source-form-group" isRequired label={t('Image URL')}>
+      <FormTextInput
+        aria-label={t('Image URL')}
+        onChange={(event) => setBootableVolumeField('url')(event.currentTarget.value)}
+        type="text"
+      />
+      <FormGroupHelperText>
+        <>
+          {t('Enter URL to download. For example: ')}
+          <a href={httpSourceHelperURL} rel="noreferrer" target="_blank">
+            {httpSourceHelperURL}
+          </a>
+        </>
+      </FormGroupHelperText>
+    </FormGroup>
+  );
+};
+
+export default HTTPSource;

--- a/src/utils/components/AddBootableVolumeModal/utils/constants.ts
+++ b/src/utils/components/AddBootableVolumeModal/utils/constants.ts
@@ -18,6 +18,7 @@ import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 export enum DROPDOWN_FORM_SELECTION {
   UPLOAD_VOLUME = 'volume',
   USE_EXISTING_PVC = 'pvc',
+  USE_HTTP = 'http',
   USE_REGISTRY = 'registry',
   USE_SNAPSHOT = 'snapshot',
 }
@@ -25,6 +26,7 @@ export enum DROPDOWN_FORM_SELECTION {
 export const optionsValueLabelMapper = {
   [DROPDOWN_FORM_SELECTION.UPLOAD_VOLUME]: t('Volume'),
   [DROPDOWN_FORM_SELECTION.USE_EXISTING_PVC]: t('Volume'),
+  [DROPDOWN_FORM_SELECTION.USE_HTTP]: t('URL'),
   [DROPDOWN_FORM_SELECTION.USE_REGISTRY]: t('Registry'),
   [DROPDOWN_FORM_SELECTION.USE_SNAPSHOT]: t('Volume snapshot'),
 };
@@ -48,6 +50,7 @@ export type AddBootableVolumeState = {
   storageClassProvisioner?: string;
   uploadFile?: File | string;
   uploadFilename?: string;
+  url?: string;
   volumeMode?: V1beta1StorageSpecVolumeModeEnum;
 };
 


### PR DESCRIPTION
## 📝 Description

This adds the option to create a new DataSource from a URL to the bootable volumes modal.

Jira: https://issues.redhat.com/browse/CNV-46434

## 🎥 Demo

[create-bootable-volume-http--AFTER--2025-05-20 07-09.webm](https://github.com/user-attachments/assets/0e200c5e-e7ab-4072-ada9-9337d3605bd5)
