### PR TITLE
CNV-57330: Use DataVolume size for InstanceType VM creation

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -1,18 +1,15 @@
 import React, { FC, useCallback, useState } from 'react';
 
+import { InstanceTypeVMStoreActions } from '@catalog/CreateFromInstanceTypes/state/utils/types';
 import { DEFAULT_PREFERENCE_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useCDIUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
 import { UPLOAD_STATUS } from '@kubevirt-utils/hooks/useCDIUpload/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { getValidNamespace, kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { Form, PopoverPosition, Title } from '@patternfly/react-core';
-
-import { VolumeSnapshotKind } from '../SelectSnapshot/types';
 
 import SchedulingSettings from './components/SchedulingSettings';
 import SourceTypeSelection from './components/SourceTypeSelection/SourceTypeSelection';
@@ -33,11 +30,7 @@ import './AddBootableVolumeModal.scss';
 type AddBootableVolumeModalProps = {
   isOpen: boolean;
   onClose: () => void;
-  onCreateVolume?: (
-    source: BootableVolume,
-    pvcSource?: IoK8sApiCoreV1PersistentVolumeClaim,
-    volumeSnapshotSource?: VolumeSnapshotKind,
-  ) => void;
+  onCreateVolume?: InstanceTypeVMStoreActions['onSelectCreatedVolume'];
 };
 
 const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({

--- a/src/utils/resources/bootableresources/selectors.ts
+++ b/src/utils/resources/bootableresources/selectors.ts
@@ -9,6 +9,12 @@ import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/ty
 export const getDataSourcePVCSource = (dataSource: V1beta1DataSource): V1beta1DataVolumeSourcePVC =>
   dataSource?.spec?.source?.pvc;
 
+export const getDataSourcePVCName = (dataSource: V1beta1DataSource) =>
+  getDataSourcePVCSource(dataSource)?.name;
+
+export const getDataSourcePVCNamespace = (dataSource: V1beta1DataSource) =>
+  getDataSourcePVCSource(dataSource)?.namespace;
+
 export const getVolumeSnapshotSize = (volumeSnapshot: VolumeSnapshotKind) =>
   volumeSnapshot?.status?.restoreSize;
 
@@ -17,6 +23,9 @@ export const getVolumeSnapshotStorageClass = (volumeSnapshot: VolumeSnapshotKind
 
 export const getPVCStorageCapacity = (pvc: IoK8sApiCoreV1PersistentVolumeClaim) =>
   pvc?.status?.capacity?.storage;
+
+export const getPVCSize = (pvc: IoK8sApiCoreV1PersistentVolumeClaim) =>
+  pvc?.spec?.resources?.requests?.storage;
 
 export const getPVCStorageClassName = (pvc: IoK8sApiCoreV1PersistentVolumeClaim) =>
   pvc?.spec?.storageClassName;

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.tsx
@@ -59,8 +59,9 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
     volumeListNamespace,
   } = useInstanceTypeVMStore();
 
-  const { pvcSource, selectedBootableVolume, volumeSnapshotSource } = instanceTypeVMState;
-  const { bootableVolumes, loaded, pvcSources, volumeSnapshotSources } = bootableVolumesData;
+  const { dvSource, pvcSource, selectedBootableVolume, volumeSnapshotSource } = instanceTypeVMState;
+  const { bootableVolumes, dvSources, loaded, pvcSources, volumeSnapshotSources } =
+    bootableVolumesData;
 
   const preferencesMap = useMemo(
     () => convertResourceArrayToMap(preferencesData),
@@ -92,6 +93,7 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
     volumeSnapshotSources,
     pagination,
     volumeListNamespace === ALL_PROJECTS,
+    dvSources,
   );
 
   useEffect(() => {
@@ -111,7 +113,7 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
 
     setPagination(getPaginationFromVolumeIndex(selectedVolumeIndex));
 
-    onSelectCreatedVolume(modalSelectedVolume, pvcSource, volumeSnapshotSource);
+    onSelectCreatedVolume(modalSelectedVolume, pvcSource, volumeSnapshotSource, dvSource);
   };
 
   return (

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DiskSize.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DiskSize.tsx
@@ -1,18 +1,17 @@
 import React, { FC } from 'react';
 
 import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore';
+import { getDiskSize } from '@catalog/CreateFromInstanceTypes/utils/utils';
 import CapacityInput from '@kubevirt-utils/components/CapacityInput/CapacityInput';
 import { DEFAULT_DISK_SIZE } from '@kubevirt-utils/components/DiskModal/utils/constants';
-import { getVolumeSnapshotSize } from '@kubevirt-utils/resources/bootableresources/selectors';
 import { convertToBaseValue, humanizeBinaryBytes } from '@kubevirt-utils/utils/humanize.js';
 
 const DiskSize: FC = () => {
   const { instanceTypeVMState, setCustomDiskSize } = useInstanceTypeVMStore();
 
-  const { customDiskSize, pvcSource, volumeSnapshotSource } = instanceTypeVMState;
+  const { customDiskSize, dvSource, pvcSource, volumeSnapshotSource } = instanceTypeVMState;
 
-  const pvcDiskSize =
-    pvcSource?.spec?.resources?.requests?.storage || getVolumeSnapshotSize(volumeSnapshotSource);
+  const pvcDiskSize = getDiskSize(dvSource, pvcSource, volumeSnapshotSource);
   const sizeData = humanizeBinaryBytes(convertToBaseValue(pvcDiskSize || DEFAULT_DISK_SIZE)).string;
 
   return <CapacityInput onChange={setCustomDiskSize} size={customDiskSize || sizeData} />;

--- a/src/views/catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore.ts
@@ -2,6 +2,7 @@ import produce from 'immer';
 import { create } from 'zustand';
 
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
+import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getInstanceTypeFromVolume } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/utils';
@@ -34,9 +35,11 @@ export const useInstanceTypeVMStore = create<InstanceTypeVMStore>()((set, get) =
       selectedVolume: BootableVolume,
       pvcSource: IoK8sApiCoreV1PersistentVolumeClaim,
       volumeSnapshotSource: VolumeSnapshotKind,
+      dvSource: V1beta1DataVolume,
     ) =>
       set(
         produce<InstanceTypeVMStore>(({ instanceTypeVMState }) => {
+          instanceTypeVMState.dvSource = dvSource;
           instanceTypeVMState.selectedBootableVolume = selectedVolume;
           instanceTypeVMState.pvcSource = pvcSource;
           instanceTypeVMState.volumeSnapshotSource = volumeSnapshotSource;

--- a/src/views/catalog/CreateFromInstanceTypes/state/utils/state.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/utils/state.ts
@@ -8,6 +8,7 @@ import { InstanceTypeVMState, InstanceTypeVMStoreState } from './types';
 
 export const instanceTypeVMInitialState: InstanceTypeVMState = {
   customDiskSize: '',
+  dvSource: null,
   folder: '',
   isDynamicSSHInjection: false,
   pvcSource: null,

--- a/src/views/catalog/CreateFromInstanceTypes/state/utils/types.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/utils/types.ts
@@ -1,6 +1,9 @@
 import { Dispatch } from 'react';
 
-import { V1beta1DataImportCron } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
+import {
+  V1beta1DataImportCron,
+  V1beta1DataVolume,
+} from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import {
   V1beta1VirtualMachineClusterInstancetype,
@@ -12,6 +15,7 @@ import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/ty
 import { SSHSecretDetails } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
 import { SysprepData } from '@kubevirt-utils/components/SysprepModal/sysprep-utils';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { NamespacedResourceMap } from '@kubevirt-utils/resources/shared';
 
 export type InstanceTypes = (
   | V1beta1VirtualMachineClusterInstancetype
@@ -29,11 +33,10 @@ export type UseInstanceTypeAndPreferencesValues = {
 export type UseBootableVolumesValues = {
   bootableVolumes: BootableVolume[];
   dataImportCrons: V1beta1DataImportCron[];
+  dvSources: NamespacedResourceMap<V1beta1DataVolume>;
   error: Error;
   loaded: boolean;
-  pvcSources: {
-    [resourceKeyName: string]: IoK8sApiCoreV1PersistentVolumeClaim;
-  };
+  pvcSources: NamespacedResourceMap<IoK8sApiCoreV1PersistentVolumeClaim>;
   volumeSnapshotSources: { [dataSourceName: string]: VolumeSnapshotKind };
 };
 
@@ -45,6 +48,7 @@ export type SysprepConfigMapData = {
 
 export type InstanceTypeVMState = {
   customDiskSize: string;
+  dvSource: V1beta1DataVolume;
   folder: string;
   isDynamicSSHInjection: boolean;
   pvcSource: IoK8sApiCoreV1PersistentVolumeClaim;
@@ -88,12 +92,13 @@ export type InstanceTypeVMStoreState = {
   volumeListNamespace: string;
 };
 
-type InstanceTypeVMStoreActions = {
+export type InstanceTypeVMStoreActions = {
   applySSHFromSettings: (sshSecretName: string, targetNamespace: string) => void;
   onSelectCreatedVolume: (
     selectedVolume: BootableVolume,
-    pvcSource: IoK8sApiCoreV1PersistentVolumeClaim,
-    volumeSnapshotSource: VolumeSnapshotKind,
+    pvcSource?: IoK8sApiCoreV1PersistentVolumeClaim,
+    volumeSnapshotSource?: VolumeSnapshotKind,
+    dvSource?: V1beta1DataVolume,
   ) => void;
   resetInstanceTypeVMState: () => void;
   setCustomDiskSize: (diskSize: null | string) => void;


### PR DESCRIPTION
## 📝 Description

This PR updates the Instance Types VM creation flow logic to use the size of the DataVolume over that of the PVC if it exists. The size of PVCs created using a filesystem-based storage class have already been increased to include overhead, so using the already increased size would result in double the overhead.

Jira: https://issues.redhat.com/browse/CNV-57330

## 🎥 Screenshots

### Before

![use-dv-size-for-instancetypes-vm-creation--BEFORE--2025-05-20_11-58](https://github.com/user-attachments/assets/5b4e0326-5a06-43c7-8f5b-52bd5485439c)

### After

![use-dv-size-for-instancetypes-vm-creation--AFTER--2025-05-20_11-45](https://github.com/user-attachments/assets/b6a2ba98-b6a4-4b2b-815f-4bafc09f8020)