### PR TITLE
CNV-56886: fix dashboard links to VMs with status

### DIFF
--- a/src/views/dashboard-extensions/Inventory.tsx
+++ b/src/views/dashboard-extensions/Inventory.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { StatusGroupMapper } from '@openshift-console/dynamic-plugin-sdk';
 import { OffIcon } from '@patternfly/react-icons';
+import { VirtualMachineRowFilterType } from '@virtualmachines/utils/constants';
 
 import {
   getVmStatusLabelFromPrintable,
@@ -14,20 +15,22 @@ import {
 import './inventory.scss';
 
 export const getVMStatusGroups: StatusGroupMapper = (vms) => {
+  const filterType = VirtualMachineRowFilterType.Status;
+
   const groups = {
     [InventoryStatusGroup.ERROR]: {
       count: 0,
-      filterType: 'vm-status',
+      filterType,
       statusIDs: [StatusSimpleLabel.Error],
     },
     [InventoryStatusGroup.NOT_MAPPED]: {
       count: 0,
-      filterType: 'vm-status',
+      filterType,
       statusIDs: [VMStatusSimpleLabel.Running],
     },
     [InventoryStatusGroup.PROGRESS]: {
       count: 0,
-      filterType: 'vm-status',
+      filterType,
       statusIDs: [
         StatusSimpleLabel.Importing,
         VMStatusSimpleLabel.Starting,
@@ -39,17 +42,17 @@ export const getVMStatusGroups: StatusGroupMapper = (vms) => {
     },
     [InventoryStatusGroup.UNKNOWN]: {
       count: 0,
-      filterType: 'vm-status',
+      filterType,
       statusIDs: [StatusSimpleLabel.Other],
     },
     [InventoryStatusGroup.WARN]: {
       count: 0,
-      filterType: 'vm-status',
+      filterType,
       statusIDs: [VMStatusSimpleLabel.Paused],
     },
     'vm-stopped': {
       count: 0,
-      filterType: 'vm-status',
+      filterType,
       statusIDs: [VMStatusSimpleLabel.Stopped],
     },
   };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes a link from the dashboard to filtered VMs: `rowFilter-vm-status` -> `rowFilter-status`

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/35aca9b6-b3e4-4c5f-ba89-2f8306c4e958



After:


https://github.com/user-attachments/assets/079acd5a-e5ff-44b3-815d-61a895f25567


