### PR TITLE
CNV-58804: migrations chart change Bandwidth consumption title

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -868,7 +868,6 @@
   "Network ({{count}})_other": "Network ({{count}})",
   "Network bandwidth": "Network bandwidth",
   "Network binding types": "Network binding types",
-  "Network consumption": "Network consumption",
   "Network data": "Network data",
   "Network in": "Network in",
   "Network interface": "Network interface",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -872,7 +872,6 @@
   "Network ({{count}})_other": "Network ({{count}})",
   "Network bandwidth": "Network bandwidth",
   "Network binding types": "Network binding types",
-  "Network consumption": "Network consumption",
   "Network data": "Network data",
   "Network in": "Network in",
   "Network interface": "Network interface",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -872,7 +872,6 @@
   "Network ({{count}})_other": "Network ({{count}})",
   "Network bandwidth": "Network bandwidth",
   "Network binding types": "Network binding types",
-  "Network consumption": "Network consumption",
   "Network data": "Network data",
   "Network in": "Network in",
   "Network interface": "Network interface",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -864,7 +864,6 @@
   "Network ({{count}})_other": "Network ({{count}})",
   "Network bandwidth": "Network bandwidth",
   "Network binding types": "Network binding types",
-  "Network consumption": "Network consumption",
   "Network data": "Network data",
   "Network in": "Network in",
   "Network interface": "Network interface",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -864,7 +864,6 @@
   "Network ({{count}})_other": "Network ({{count}})",
   "Network bandwidth": "Network bandwidth",
   "Network binding types": "Network binding types",
-  "Network consumption": "Network consumption",
   "Network data": "Network data",
   "Network in": "Network in",
   "Network interface": "Network interface",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -864,7 +864,6 @@
   "Network ({{count}})_other": "Network ({{count}})",
   "Network bandwidth": "Network bandwidth",
   "Network binding types": "Network binding types",
-  "Network consumption": "Network consumption",
   "Network data": "Network data",
   "Network in": "Network in",
   "Network interface": "Network interface",

--- a/src/utils/components/DescriptionItem/DescriptionItemHeader.tsx
+++ b/src/utils/components/DescriptionItem/DescriptionItemHeader.tsx
@@ -68,7 +68,8 @@ export const DescriptionItemHeader: FC<DescriptionItemHeaderProps> = ({
 
   return (
     <DescriptionListTerm className="DescriptionItemHeader--list-term">
-      {descriptionHeader} {label}
+      {descriptionHeader}
+      <span className="pf-v6-u-ml-xs">{label}</span>
     </DescriptionListTerm>
   );
 };

--- a/src/views/clusteroverview/MigrationsTab/MigrationsTab.tsx
+++ b/src/views/clusteroverview/MigrationsTab/MigrationsTab.tsx
@@ -85,9 +85,6 @@ const MigrationsTab: React.FC = () => {
                 </CardBody>
               </GridItem>
               <GridItem span={6}>
-                <CardHeader>
-                  <CardTitle>{t('Bandwidth consumption')}</CardTitle>
-                </CardHeader>
                 <CardBody className="kv-monitoring-card__body">
                   <BandwidthConsumptionCharts duration={duration} />
                 </CardBody>

--- a/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/BandwidthConsumptionCharts.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/BandwidthConsumptionCharts.tsx
@@ -5,7 +5,7 @@ import useResponsiveCharts from '@kubevirt-utils/components/Charts/hooks/useResp
 import DurationOption from '@kubevirt-utils/components/DurationOption/DurationOption';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { Bullseye, Divider, Grid, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { Divider, Grid } from '@patternfly/react-core';
 
 import MigrationsTimeAxis from './components/MigrationsTimeAxis';
 import MigrationsUtilizationChart from './components/MigrationsUtilizationChart';
@@ -28,41 +28,33 @@ const BandwidthConsumptionCharts: React.FC<BandwidthConsumptionChartsProps> = ({
     useMigrationChartsData(duration, currentTime, timespan);
 
   return (
-    <div>
-      {!isEmpty(bandwidthConsumed) || !isEmpty(migrationsCount) ? (
-        <Grid ref={ref}>
-          <MigrationsTimeAxis domainX={domainX} timespan={timespan} />
-          <MigrationsUtilizationChart
-            domain={{
-              x: domainX,
-              y: getDomainY(maxBandwidthConsumed),
-            }}
-            chartData={bandwidthConsumed}
-            labels={getLabel(timespan, bandwidthConsumed, true)}
-            tickFormat={(y) => xbytes(y, { fixed: 0, iec: true, prefixIndex: 3 })}
-            tickValues={getTickValuesAxisY(maxBandwidthConsumed)}
-            title={t('Network consumption')}
-          />
-          <Divider />
-          <MigrationsUtilizationChart
-            domain={{
-              x: domainX,
-              y: getDomainY(maxMigrationCount, 1),
-            }}
-            chartData={migrationsCount}
-            labels={getLabel(timespan, migrationsCount)}
-            tickValues={getTickValuesAxisY(maxMigrationCount, 1)}
-            title={t('Running migrations')}
-          />
-        </Grid>
-      ) : (
-        <Bullseye>
-          <HelperText>
-            <HelperTextItem variant="warning">{t('No Datapoints found')}</HelperTextItem>
-          </HelperText>
-        </Bullseye>
+    <Grid ref={ref}>
+      {(!isEmpty(bandwidthConsumed) || !isEmpty(migrationsCount)) && (
+        <MigrationsTimeAxis domainX={domainX} timespan={timespan} />
       )}
-    </div>
+      <MigrationsUtilizationChart
+        domain={{
+          x: domainX,
+          y: getDomainY(maxBandwidthConsumed),
+        }}
+        chartData={bandwidthConsumed}
+        labels={getLabel(timespan, bandwidthConsumed, true)}
+        tickFormat={(y) => xbytes(y, { fixed: 0, iec: true, prefixIndex: 3 })}
+        tickValues={getTickValuesAxisY(maxBandwidthConsumed)}
+        title={t('Bandwidth consumption')}
+      />
+      <Divider />
+      <MigrationsUtilizationChart
+        domain={{
+          x: domainX,
+          y: getDomainY(maxMigrationCount, 1),
+        }}
+        chartData={migrationsCount}
+        labels={getLabel(timespan, migrationsCount)}
+        tickValues={getTickValuesAxisY(maxMigrationCount, 1)}
+        title={t('Running migrations')}
+      />
+    </Grid>
   );
 };
 

--- a/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/components/MigrationsUtilizationChart.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/components/MigrationsUtilizationChart.tsx
@@ -2,8 +2,10 @@ import React, { FC } from 'react';
 
 import { tickLabels } from '@kubevirt-utils/components/Charts/ChartLabels/styleOverrides';
 import useResponsiveCharts from '@kubevirt-utils/components/Charts/hooks/useResponsiveCharts';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Chart, ChartAxis, ChartLine, createContainer } from '@patternfly/react-charts/victory';
-import { GridItem } from '@patternfly/react-core';
+import { GridItem, HelperText, HelperTextItem, Title } from '@patternfly/react-core';
 
 import { ChartDataObject } from '../constants';
 
@@ -27,43 +29,50 @@ const MigrationsUtilizationChart: FC<MigrationsUtilizationChartProps> = ({
   tickValues = null,
   title,
 }) => {
+  const { t } = useKubevirtTranslation();
   const { height, width } = useResponsiveCharts();
   const CursorVoronoiContainer = createContainer('voronoi', 'cursor');
 
   return (
     <GridItem className="co-utilization-card__item">
       <div className="co-utilization-card__item-description">
-        <h4>{title}</h4>
+        <Title headingLevel="h4">{title}</Title>
       </div>
-      <div>
-        <Chart
-          containerComponent={
-            <CursorVoronoiContainer
-              activateData={false}
-              cursorDimension="x"
-              key={title}
-              labels={labels}
-              mouseFollowTooltips
-              voronoiDimension="x"
+      {isEmpty(chartData) ? (
+        <HelperText>
+          <HelperTextItem variant="warning">{t('No Datapoints found')}</HelperTextItem>
+        </HelperText>
+      ) : (
+        <div>
+          <Chart
+            containerComponent={
+              <CursorVoronoiContainer
+                activateData={false}
+                cursorDimension="x"
+                key={title}
+                labels={labels}
+                mouseFollowTooltips
+                voronoiDimension="x"
+              />
+            }
+            domain={domain}
+            height={height}
+            padding={{ bottom: 40, left: 80, right: 0, top: 40 }}
+            scale={{ x: 'time', y: 'linear' }}
+            width={width}
+          >
+            <ChartAxis
+              axisComponent={<></>}
+              dependentAxis
+              showGrid
+              style={{ tickLabels }}
+              tickFormat={tickFormat}
+              tickValues={tickValues}
             />
-          }
-          domain={domain}
-          height={height}
-          padding={{ bottom: 40, left: 80, right: 0, top: 40 }}
-          scale={{ x: 'time', y: 'linear' }}
-          width={width}
-        >
-          <ChartAxis
-            axisComponent={<></>}
-            dependentAxis
-            showGrid
-            style={{ tickLabels }}
-            tickFormat={tickFormat}
-            tickValues={tickValues}
-          />
-          <ChartLine data={chartData} />
-        </Chart>
-      </div>
+            <ChartLine data={chartData} />
+          </Chart>
+        </div>
+      )}
     </GridItem>
   );
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- remove the main "Bandwidth consumption" title
- rename "Network consumption" subtitle to "Bandwidth consumption"
- always shows the two sections: "Bandwidth consumption" and "Running migrations"

## 🎥 Demo

Before - no data:

<img width="1392" alt="before_empty" src="https://github.com/user-attachments/assets/b401fda6-2fc3-4a81-aa51-6271262da2af" />

After - no data:

<img width="1392" alt="after_empty" src="https://github.com/user-attachments/assets/eb71fe65-80b6-4295-8f4b-371ab29e0f56" />


Before - chart:

<img width="1392" alt="before_chart" src="https://github.com/user-attachments/assets/188f85ad-74f5-48c2-ab0e-82a3a66d4264" />

After - chart:

<img width="1392" alt="after_chart" src="https://github.com/user-attachments/assets/29f6ac26-93f5-4731-99c3-0baa466da958" />


