### PR TITLE
CNV-62204: Stop HTTP-created bootable volumes from disappearing temporarily during import

### DIFF
--- a/src/utils/resources/template/hooks/useVmTemplateSource/utils.ts
+++ b/src/utils/resources/template/hooks/useVmTemplateSource/utils.ts
@@ -123,6 +123,8 @@ export const isDataSourceCloning = (dataSource: V1beta1DataSource): boolean =>
         'CloneInProgress',
         'CloneScheduled',
         'CSICloneInProgress',
+        'ImportInProgress',
+        'ImportScheduled',
         'Pending',
         'PVCBound',
         'SnapshotForSmartCloneInProgress',


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug wherein bootable volumes created from a URL disappeared from the list during the import phase.

Jira: https://issues.redhat.com/browse/CNV-62204

## 🎥 Demo

### Before

Catalog page
[http-volumes-disappear-temporarily--catalog--BEFORE--2025-05-21 09-31.webm](https://github.com/user-attachments/assets/3f2bc54f-e97e-4cbc-8504-0ab9526f8702)

Bootable volumes list page
[http-volumes-disappear-temporarily--bv-list--BEFORE--2025-05-21 09-33.webm](https://github.com/user-attachments/assets/2019d787-07f1-4068-8957-420d72f7519d)

### After

Catalog page
[http-volumes-disappear-temporarily--catalog--AFTER--2025-05-21 09-20.webm](https://github.com/user-attachments/assets/4da7c876-2fc6-4ea7-b5d0-40f7bdc7ab55)

Bootable volumes list page
[http-volumes-disappear-temporarily--bv-list--AFTER--2025-05-21 09-18.webm](https://github.com/user-attachments/assets/99b45de0-3841-421a-879b-2943e997e119)