### PR TITLE
CNV-62150: add option to edit labels on single VM

### DIFF
--- a/src/views/virtualmachines/actions/BulkVirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/BulkVirtualMachineActionFactory.tsx
@@ -33,7 +33,7 @@ export const BulkVirtualMachineActionFactory = {
     id: ACTIONS_ID.DELETE,
     label: t('Delete'),
   }),
-  editLabel: (vms: V1VirtualMachine[], createModal: (modal: ModalComponent) => void): Action => ({
+  editLabels: (vms: V1VirtualMachine[], createModal: (modal: ModalComponent) => void): Action => ({
     cta: () => {
       const commonLabels = getCommonLabels(vms);
 

--- a/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
@@ -10,6 +10,7 @@ import {
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
 import CloneVMModal from '@kubevirt-utils/components/CloneVMModal/CloneVMModal';
+import { LabelsModal } from '@kubevirt-utils/components/LabelsModal/LabelsModal';
 import { ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SnapshotModal from '@kubevirt-utils/components/SnapshotModal/SnapshotModal';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -149,6 +150,32 @@ export const VirtualMachineActionFactory = {
       label: t('Delete'),
     };
   },
+  editLabels: (vm: V1VirtualMachine, createModal: (modal: ModalComponent) => void): Action => ({
+    accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
+    cta: () =>
+      createModal(({ isOpen, onClose }) => (
+        <LabelsModal
+          onLabelsSubmit={(labels) =>
+            k8sPatch({
+              data: [
+                {
+                  op: 'replace',
+                  path: '/metadata/labels',
+                  value: labels,
+                },
+              ],
+              model: VirtualMachineModel,
+              resource: vm,
+            })
+          }
+          isOpen={isOpen}
+          obj={vm}
+          onClose={onClose}
+        />
+      )),
+    id: 'vm-action-edit-labels',
+    label: t('Edit labels'),
+  }),
   forceStop: (vm: V1VirtualMachine): Action => {
     return {
       accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),

--- a/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.tsx
+++ b/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.tsx
@@ -26,7 +26,7 @@ const useMultipleVirtualMachineActions: UseMultipleVirtualMachineActions = (vms)
     const namespaces = new Set(vms?.map((vm) => getNamespace(vm)));
 
     const actions: ActionDropdownItemType[] = [
-      BulkVirtualMachineActionFactory.editLabel(vms, createModal),
+      BulkVirtualMachineActionFactory.editLabels(vms, createModal),
       BulkVirtualMachineActionFactory.start(vms),
       BulkVirtualMachineActionFactory.restart(vms, createModal, confirmVMActionsEnabled),
       BulkVirtualMachineActionFactory.stop(vms, createModal, confirmVMActionsEnabled),

--- a/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
+++ b/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
@@ -82,6 +82,7 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (
         : VirtualMachineActionFactory.pause(vm, createModal, confirmVMActionsEnabled);
 
     return [
+      VirtualMachineActionFactory.editLabels(vm, createModal),
       startOrStop,
       VirtualMachineActionFactory.restart(vm, createModal, confirmVMActionsEnabled),
       pauseOrUnpause,

--- a/src/views/virtualmachines/actions/tests/useVirtualMachineActionsProvider.test.tsx
+++ b/src/views/virtualmachines/actions/tests/useVirtualMachineActionsProvider.test.tsx
@@ -27,6 +27,7 @@ describe('useVirtualMachineActionsProvider tests', () => {
 
     // Running vm should have stop, restart, pause, migrate and delete actions
     expect(runningVMActions).toEqual([
+      'vm-action-edit-labels',
       'vm-action-stop',
       'vm-action-restart',
       'vm-action-pause',
@@ -50,6 +51,7 @@ describe('useVirtualMachineActionsProvider tests', () => {
 
     // Stopped vm should have start, restart, pause, migrate and delete actions
     expect(stoppedVMActions).toEqual([
+      'vm-action-edit-labels',
       'vm-action-start',
       'vm-action-restart',
       'vm-action-pause',
@@ -73,6 +75,7 @@ describe('useVirtualMachineActionsProvider tests', () => {
 
     // Paused vm should have stop, restart, unpause, migrate and delete actions
     expect(pausedVMActions).toEqual([
+      'vm-action-edit-labels',
       'vm-action-stop',
       'vm-action-restart',
       'vm-action-unpause',
@@ -99,6 +102,7 @@ describe('useVirtualMachineActionsProvider tests', () => {
 
     // Migrating vm should have stop, restart, pause, migrate and delete actions
     expect(migratingVMActions).toEqual([
+      'vm-action-edit-labels',
       'vm-action-stop',
       'vm-action-restart',
       'vm-action-pause',


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- Adds the "Edit labels" option for single VM.

Note: I am not sure if the `accessReview: asAccessReview(VirtualMachineModel, vm, 'patch')` is the correct accessReview for this option (I copied it from other options and it seemed reasonable).

## 🎥 Demo


https://github.com/user-attachments/assets/e1011d0a-9e0c-4d21-b39c-0618a4712b62


