### PR TITLE
CNV-62159: fix removing folder after editing labels

### DIFF
--- a/src/views/virtualmachines/actions/utils.ts
+++ b/src/views/virtualmachines/actions/utils.ts
@@ -127,8 +127,8 @@ export const getCommonLabels = (vms: V1VirtualMachine[]): Labels => {
     return intersection;
   }, {});
 
-  delete commonLabels[VM_FOLDER_LABEL];
-  return commonLabels;
+  const { [VM_FOLDER_LABEL]: _, ...commonLabelsWithoutFolder } = commonLabels;
+  return commonLabelsWithoutFolder;
 };
 
 export const getLabelsDiffPatch = (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes a bug where folder was removed for a while after clicking the "Edit labels" option.

Issue was in `getCommonLabels` helper - with `delete` we actually removed a property on an original object. We have to do a copy instead.

## 🎥 Demo
Before:


https://github.com/user-attachments/assets/cc64325d-1ae5-4a90-9702-db92080afe6e



After:


https://github.com/user-attachments/assets/653e1d9f-11ce-406c-88d3-6374ce52a22d


