### PR TITLE
CNV-62315: fix project/folder menu being cut off

### DIFF
--- a/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
+++ b/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
@@ -16,10 +16,6 @@
     z-index: 100;
   }
 
-  .right-click-action-menu {
-    transform: translateY(30px) translateX(50px);
-  }
-
   &__toolbar-section {
     width: 100%;
   }
@@ -80,9 +76,17 @@
   }
 }
 
-.right-click-action-menu--vm {
+.right-click-action-menu {
   min-width: 0 !important;
+  margin-left: 2.5rem;
+}
+
+.right-click-action-menu--nested-1 {
   margin-left: 3.5rem;
+}
+
+.right-click-action-menu--nested-2 {
+  margin-left: 4.5rem;
 }
 
 .pf-v6-c-drawer__body.vms-tree-view-body {

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/DefaultRightClickActionMenu.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/DefaultRightClickActionMenu.tsx
@@ -1,11 +1,16 @@
 import React, { FC } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
+import classNames from 'classnames';
 
 import ActionDropdownItem from '@kubevirt-utils/components/ActionDropdownItem/ActionDropdownItem';
 import { Menu, MenuContent, MenuList, Popper } from '@patternfly/react-core';
 import useMultipleVirtualMachineActions from '@virtualmachines/actions/hooks/useMultipleVirtualMachineActions';
-import { PROJECT_SELECTOR_PREFIX } from '@virtualmachines/tree/utils/constants';
+import {
+  FOLDER_SELECTOR_PREFIX,
+  PROJECT_SELECTOR_PREFIX,
+} from '@virtualmachines/tree/utils/constants';
 
+import { MENU_DISTANCE } from './constants';
 import { getCreateVMAction, getElementComponentsFromID, getVMsTrigger } from './utils';
 
 type DefaultRightClickActionMenuProps = {
@@ -29,7 +34,13 @@ const DefaultRightClickActionMenu: FC<DefaultRightClickActionMenuProps> = ({
   return (
     <Popper
       popper={
-        <Menu className="right-click-action-menu" containsFlyout>
+        <Menu
+          className={classNames(
+            'right-click-action-menu',
+            prefix === FOLDER_SELECTOR_PREFIX ? 'right-click-action-menu--nested-1' : '',
+          )}
+          containsFlyout
+        >
           <MenuContent>
             <MenuList>
               {actions?.map((action) => (
@@ -39,9 +50,9 @@ const DefaultRightClickActionMenu: FC<DefaultRightClickActionMenuProps> = ({
           </MenuContent>
         </Menu>
       }
-      appendTo={triggerElement}
+      distance={MENU_DISTANCE}
       isVisible
-      position="end"
+      triggerRef={() => triggerElement.children.item(0) as HTMLElement}
     />
   );
 };

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/VMRightClickActionMenu.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/VMRightClickActionMenu.tsx
@@ -1,10 +1,12 @@
 import React, { FC } from 'react';
+import classNames from 'classnames';
 
 import ActionDropdownItem from '@kubevirt-utils/components/ActionDropdownItem/ActionDropdownItem';
 import useSingleNodeCluster from '@kubevirt-utils/hooks/useSingleNodeCluster';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getLabel, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { Menu, MenuContent, MenuList, Popper } from '@patternfly/react-core';
 import useVirtualMachineActionsProvider from '@virtualmachines/actions/hooks/useVirtualMachineActionsProvider';
+import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
 import { getVMIMFromMapper } from '@virtualmachines/utils/mappers';
 
 import { vmimMapperSignal, vmsSignal } from '../../utils/signals';
@@ -29,10 +31,18 @@ const VMRightClickActionMenu: FC<VMRightClickActionMenuProps> = ({ hideMenu, tri
 
   const [actions] = useVirtualMachineActionsProvider(vm, vmim, isSingleNodeCluster);
 
+  const vmHasFolder = !!getLabel(vm, VM_FOLDER_LABEL);
+
   return (
     <Popper
       popper={
-        <Menu className="right-click-action-menu--vm" containsFlyout>
+        <Menu
+          className={classNames(
+            'right-click-action-menu',
+            vmHasFolder ? 'right-click-action-menu--nested-2' : 'right-click-action-menu--nested-1',
+          )}
+          containsFlyout
+        >
           <MenuContent>
             <MenuList>
               {actions?.map((action) => (

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/constants.ts
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/constants.ts
@@ -1,2 +1,2 @@
-// moves Menu by 6px to the top direction
+// moves Menu by 6px closer to its trigger element
 export const MENU_DISTANCE = -6;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes a bug where the right-click menu for folders and projects was being cut off by tree-view panel or end of page.

Also fixes positioning of menu based on how much is the clicked element nested.

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/7ad5c005-99de-4eac-a8cd-0aa989c62be7



After:



https://github.com/user-attachments/assets/65220a6c-1a42-4748-bea4-087564a25886


