### PR TITLE
CNV-62217: fix VM count in "All projects" badge

### DIFF
--- a/src/views/virtualmachines/tree/utils/utils.tsx
+++ b/src/views/virtualmachines/tree/utils/utils.tsx
@@ -168,7 +168,7 @@ const createAllNamespacesTreeItem = (
 
   const allNamespacesTreeItem: TreeViewDataItemWithHref = {
     children: treeViewData,
-    customBadgeContent: allVMsCount || 0,
+    customBadgeContent: allVMsCount || '0',
     defaultExpanded: true,
     href: getResourceUrl({
       model: VirtualMachineModel,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes an incorrect VMs count in "All projects" badge in tree view.

The issue was that in PatternFly the badge is loaded this way:
```
<Badge {...badgeProps}>
    {customBadgeContent ? customBadgeContent : (children as React.ReactElement<any>).props.data.length}
</Badge>
```
So if `customBadgeContent` is number 0 (falsy), it returns the latter (length of children.props.data)

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/b6f374b1-7dc7-49cd-a64b-6a8ef5596e18



After:



https://github.com/user-attachments/assets/3c6fd3fc-4896-4168-bd36-b72ecfb65aa2


