### PR TITLE
CNV-58161: moved guest system log above automatic subscription in settings- guest managment

### DIFF
--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/GuestManagementSection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/GuestManagementSection.tsx
@@ -24,13 +24,13 @@ const GuestManagementSection: FC<GuestManagementSectionProps> = ({
     <ExpandSection toggleText={t('Guest management')}>
       <Stack hasGutter>
         <StackItem isFilled>
-          <AutomaticSubscriptionRHELGuests newBadge={newBadge} />
-        </StackItem>
-        <StackItem isFilled>
           <GuestSystemLogsAccess
             hyperConvergeConfiguration={hyperConvergeConfiguration}
             newBadge={newBadge}
           />
+        </StackItem>
+        <StackItem isFilled>
+          <AutomaticSubscriptionRHELGuests newBadge={newBadge} />
         </StackItem>
       </Stack>
     </ExpandSection>

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/GuestSystemLogsAccess/GuestSystemLogsAccess.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/GuestSystemLogsAccess/GuestSystemLogsAccess.tsx
@@ -70,7 +70,7 @@ const GuestSystemLogsAccess: FC<GuestSystemLogsAccessProps> = ({
 
   return (
     <>
-      <Split>
+      <Split className="settings-tab--indented">
         <SplitItem isFilled>
           {t('Enable guest system log access')}{' '}
           <HelpTextIcon

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
@@ -58,7 +58,7 @@ const PersistentReservationSection: FC<PersistentReservationSectionProps> = ({
 
   return (
     <ExpandSection toggleText={t('SCSI persistent reservation')}>
-      <Split>
+      <Split className="settings-tab--indented">
         <SplitItem isFilled>
           {t('Enable persistent reservation')}{' '}
           <HelpTextIcon

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.tsx
@@ -36,7 +36,7 @@ const AutoComputeCPULimits: FC<AutoComputeCPULimitsProps> = ({
 
   return (
     <>
-      <Split>
+      <Split className="settings-tab--indented">
         <SplitItem isFilled>
           {t('Auto-compute CPU and memory limits')} {newBadge && <NewBadge />}
         </SplitItem>

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/KernelSamepageMerging/KernelSamepageMerging.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/KernelSamepageMerging/KernelSamepageMerging.tsx
@@ -67,7 +67,7 @@ const KernelSamepageMerging: FC<KernelSamepageMergingProps> = ({
 
   return (
     <>
-      <Split>
+      <Split className="settings-tab--indented">
         <SplitItem isFilled>
           {t('Kernel Samepage Merging (KSM)')}{' '}
           <HelpTextIcon

--- a/src/views/clusteroverview/SettingsTab/settings-tab.scss
+++ b/src/views/clusteroverview/SettingsTab/settings-tab.scss
@@ -14,6 +14,11 @@
     padding: var(--pf-t--global--spacer--2xl);
     padding-left: calc(var(--pf-t--global--spacer--3xl) * 2);
   }
+
+
+  &--indented {
+    margin-left: 0.8rem;
+  }
 }
 
 .section-divider {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->
changing position of " guest system log button option" to appear above " automatic subscription or RHEL mvirtualMachines" in the guest managment tab of cluster settings

> Add a brief description

## 🎥 Demo
before:
![image](https://github.com/user-attachments/assets/5f7eb2a1-d203-481e-9631-403f69115c00)


after:
![image](https://github.com/user-attachments/assets/efebb114-5783-4b14-b5e9-8492efbbfee9)

