### PR TITLE
WIP: CNV-62665: fix search by CPU and Memory for stopped InstanceType VMs

### DIFF
--- a/src/utils/components/CPUMemory/CPUMemory.tsx
+++ b/src/utils/components/CPUMemory/CPUMemory.tsx
@@ -11,7 +11,6 @@ import { isRunning } from '@virtualmachines/utils';
 import './CPUMemory.scss';
 
 type CPUMemoryProps = {
-  fetchVMI?: boolean;
   vm: V1VirtualMachine;
   vmi?: V1VirtualMachineInstance;
 };

--- a/src/utils/hooks/useVMExpandSpecMap.ts
+++ b/src/utils/hooks/useVMExpandSpecMap.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  getInstanceTypeExpandSpecURL,
+  isInstanceTypeVM,
+} from '@kubevirt-utils/resources/instancetype/helper';
+import { NamespacedResourceMap } from '@kubevirt-utils/resources/shared';
+import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
+
+const useVMExpandSpecMap = (vms: V1VirtualMachine[]) => {
+  const [vmExpandSpecMap, setVMExpandSpecMap] = useState<NamespacedResourceMap<V1VirtualMachine>>(
+    {},
+  );
+
+  useEffect(() => {
+    const tempMap = {};
+
+    const fetchPromises = vms.map(async (vm) => {
+      if (isInstanceTypeVM(vm)) {
+        const name = vm?.metadata?.name;
+        const namespace = vm?.metadata?.namespace;
+
+        if (!tempMap[namespace]) {
+          tempMap[namespace] = {};
+        }
+
+        const url = getInstanceTypeExpandSpecURL(vm);
+        try {
+          const response = await consoleFetch(url);
+          const json = await response.json();
+          tempMap[namespace][name] = json;
+        } catch {}
+      }
+    });
+
+    Promise.all(fetchPromises).then(() => {
+      setVMExpandSpecMap(tempMap);
+    });
+  }, [vms]);
+
+  return vmExpandSpecMap;
+};
+
+export default useVMExpandSpecMap;

--- a/src/utils/resources/instancetype/helper.ts
+++ b/src/utils/resources/instancetype/helper.ts
@@ -1,5 +1,6 @@
 import VirtualMachineClusterInstancetypeModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineClusterInstancetypeModel';
 import VirtualMachineInstancetypeModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstancetypeModel';
+import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import {
   V1InstancetypeMatcher,
   V1VirtualMachine,
@@ -9,7 +10,7 @@ import { isVM } from '@kubevirt-utils/utils/typeGuards';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
-import { getAnnotation } from '../shared';
+import { getAnnotation, getName, getNamespace } from '../shared';
 
 import {
   CLUSTER_INSTANCE_TYPE_NAME_ANNOTATION,
@@ -39,3 +40,8 @@ export const getInstanceTypeNameFromAnnotation = (
 export const getPreferenceNameFromAnnotation = (vm: V1VirtualMachine | V1VirtualMachineInstance) =>
   getAnnotation(vm, NAMESPACED_PREFERENCE_NAME_ANNOTATION) ??
   getAnnotation(vm, CLUSTER_PREFERENCE_NAME_ANNOTATION);
+
+export const getInstanceTypeExpandSpecURL = (vm: V1VirtualMachine) =>
+  `api/kubernetes/apis/subresources.${VirtualMachineModel.apiGroup}/${
+    VirtualMachineModel.apiVersion
+  }/namespaces/${getNamespace(vm)}/${VirtualMachineModel.plural}/${getName(vm)}/expand-spec`;

--- a/src/utils/resources/vm/hooks/useInstanceTypeExpandSpec.ts
+++ b/src/utils/resources/vm/hooks/useInstanceTypeExpandSpec.ts
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import useDeepCompareMemoize from '@kubevirt-utils/hooks/useDeepCompareMemoize/useDeepCompareMemoize';
-import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import {
+  getInstanceTypeExpandSpecURL,
+  isInstanceTypeVM,
+} from '@kubevirt-utils/resources/instancetype/helper';
 import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -24,11 +25,7 @@ const useInstanceTypeExpandSpec: UseInstanceTypeExpandSpec = (vm) => {
 
   useEffect(() => {
     const fetch = async () => {
-      const url = `api/kubernetes/apis/subresources.${VirtualMachineModel.apiGroup}/${
-        VirtualMachineModel.apiVersion
-      }/namespaces/${getNamespace(innerVM)}/${VirtualMachineModel.plural}/${getName(
-        innerVM,
-      )}/expand-spec`;
+      const url = getInstanceTypeExpandSpecURL(innerVM);
 
       setLoadingExpandedSpec(true);
       try {

--- a/src/views/virtualmachines/list/hooks/useVMListFilters/useCPUFilter.ts
+++ b/src/views/virtualmachines/list/hooks/useVMListFilters/useCPUFilter.ts
@@ -1,5 +1,6 @@
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getName, getNamespace, NamespacedResourceMap } from '@kubevirt-utils/resources/shared';
 import { vCPUCount } from '@kubevirt-utils/resources/template';
 import { getCPU } from '@kubevirt-utils/resources/vm';
 import { numberOperatorInfo } from '@kubevirt-utils/utils/constants';
@@ -7,20 +8,27 @@ import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
 import { VMIMapper } from '@virtualmachines/utils/mappers';
 
-export const useCPUFilter = (vmiMapper: VMIMapper): RowFilter<V1VirtualMachine> => ({
-  filter: (input, obj) => {
+export const useCPUFilter = (
+  vmiMapper: VMIMapper,
+  vmExpandSpecMap: NamespacedResourceMap<V1VirtualMachine>,
+): RowFilter<V1VirtualMachine> => ({
+  filter: (input, vm) => {
     const cpuInfo = input.selected?.[0];
 
     if (!cpuInfo) {
       return true;
     }
 
-    const vmi = vmiMapper.mapper?.[obj?.metadata?.namespace]?.[obj?.metadata?.name];
+    const name = getName(vm);
+    const namespace = getNamespace(vm);
+
+    const vmi = vmiMapper.mapper?.[namespace]?.[name];
+    const vmExpandSpec = vmExpandSpecMap?.[namespace]?.[name];
 
     const [operator, cpu] = cpuInfo.split(' ');
     const filterCPU = Number(cpu);
 
-    const vmCPU = vCPUCount(getCPU(obj) || getCPU(vmi));
+    const vmCPU = vCPUCount(getCPU(vmExpandSpec) || getCPU(vm) || getCPU(vmi));
 
     const compareFunction = numberOperatorInfo[operator].compareFunction;
     return compareFunction(vmCPU, filterCPU);

--- a/src/views/virtualmachines/list/hooks/useVMListFilters/useMemoryFilter.ts
+++ b/src/views/virtualmachines/list/hooks/useVMListFilters/useMemoryFilter.ts
@@ -1,5 +1,6 @@
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getName, getNamespace, NamespacedResourceMap } from '@kubevirt-utils/resources/shared';
 import { getMemory } from '@kubevirt-utils/resources/vm';
 import { numberOperatorInfo } from '@kubevirt-utils/utils/constants';
 import { convertToBaseValue } from '@kubevirt-utils/utils/humanize.js';
@@ -7,21 +8,28 @@ import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
 import { VMIMapper } from '@virtualmachines/utils/mappers';
 
-export const useMemoryFilter = (vmiMapper: VMIMapper): RowFilter<V1VirtualMachine> => ({
-  filter: (input, obj) => {
+export const useMemoryFilter = (
+  vmiMapper: VMIMapper,
+  vmExpandSpecMap: NamespacedResourceMap<V1VirtualMachine>,
+): RowFilter<V1VirtualMachine> => ({
+  filter: (input, vm) => {
     const memoryInfo = input.selected?.[0];
 
     if (!memoryInfo) {
       return true;
     }
 
-    const vmi = vmiMapper.mapper?.[obj?.metadata?.namespace]?.[obj?.metadata?.name];
+    const name = getName(vm);
+    const namespace = getNamespace(vm);
+
+    const vmi = vmiMapper.mapper?.[namespace]?.[name];
+    const vmExpandSpec = vmExpandSpecMap?.[namespace]?.[name];
 
     const [operator, memoryFilterValue, memoryFilterUnit] = memoryInfo.split(' ');
 
     const filterBytes = convertToBaseValue(`${memoryFilterValue} ${memoryFilterUnit.slice(0, -1)}`);
 
-    const vmMemory = getMemory(obj) || getMemory(vmi);
+    const vmMemory = getMemory(vmExpandSpec) || getMemory(vm) || getMemory(vmi);
     const vmBytes = convertToBaseValue(vmMemory);
 
     const compareFunction = numberOperatorInfo[operator].compareFunction;

--- a/src/views/virtualmachines/list/hooks/useVMListFilters/useVMListFilters.ts
+++ b/src/views/virtualmachines/list/hooks/useVMListFilters/useVMListFilters.ts
@@ -5,6 +5,7 @@ import {
   V1VirtualMachineInstance,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import useVMExpandSpecMap from '@kubevirt-utils/hooks/useVMExpandSpecMap';
 import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 
 import { PVCMapper, VMIMapper, VMIMMapper } from '../../../utils/mappers';
@@ -61,6 +62,8 @@ export const useVMListFilters = (
 
   const vmimMapper: VMIMMapper = useMemo(() => getLatestMigrationForEachVM(vmims), [vmims]);
 
+  const vmExpandSpecMap = useVMExpandSpecMap(vms);
+
   const statusFilter = useStatusFilter();
   const templatesFilter = useTemplatesFilter(vms);
   const osFilters = useOSFilter();
@@ -72,8 +75,8 @@ export const useVMListFilters = (
   const projectFilter = useProjectFilter();
   const dateFromFilter = useDateFilter('from');
   const dateToFilter = useDateFilter('to');
-  const cpuFilter = useCPUFilter(vmiMapper);
-  const memoryFilter = useMemoryFilter(vmiMapper);
+  const cpuFilter = useCPUFilter(vmiMapper, vmExpandSpecMap);
+  const memoryFilter = useMemoryFilter(vmiMapper, vmExpandSpecMap);
 
   const searchByIP = useIPSearchFilter(vmiMapper);
   const searchByDescription = useDescriptionFilter();

--- a/src/views/virtualmachines/utils/mappers.ts
+++ b/src/views/virtualmachines/utils/mappers.ts
@@ -4,16 +4,16 @@ import {
   V1VirtualMachineInstance,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getName, getNamespace, NamespacedResourceMap } from '@kubevirt-utils/resources/shared';
 import { getVolumes } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 export type VMIMapper = {
-  mapper: { [key: string]: { [key: string]: V1VirtualMachineInstance } };
+  mapper: NamespacedResourceMap<V1VirtualMachineInstance>;
   nodeNames: { [key: string]: { id: string; title: string } };
 };
 
-export type VMIMMapper = { [key: string]: { [key: string]: V1VirtualMachineInstanceMigration } };
+export type VMIMMapper = NamespacedResourceMap<V1VirtualMachineInstanceMigration>;
 
 export const getVMIFromMapper = (VMIMapper: VMIMapper, vm: V1VirtualMachine) =>
   VMIMapper?.mapper?.[getNamespace(vm)]?.[getName(vm)];


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes advanced search by CPU and Memory for stopped InstanceType VMs.

I don't like the fact that the `useVMExpandSpecMap` hook is refetching everything whenever the vms array change, if you have any ideas how to make it more efficient, yet simple, let me know.
 
## 🎥 Demo

Before:


https://github.com/user-attachments/assets/7976ff34-9604-4a9f-be02-4b168a0c6696



After:


https://github.com/user-attachments/assets/2dd886bb-b92b-4381-ac14-200955026c3a


