### PR TITLE
CNV-59145: fix tree view panel covering whole screen

### DIFF
--- a/src/utils/constants/window.ts
+++ b/src/utils/constants/window.ts
@@ -1,0 +1,9 @@
+// breakpoints from PatternFly (https://github.com/patternfly/patternfly/blob/main/src/patternfly/sass-utilities/scss-variables.scss#L30-L35)
+export const BREAKPOINTS = {
+  '2xl': 1450,
+  lg: 992,
+  md: 768,
+  sm: 576,
+  xl: 1200,
+  xs: 0,
+};

--- a/src/utils/hooks/useIsSmallScreen.ts
+++ b/src/utils/hooks/useIsSmallScreen.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+import { BREAKPOINTS } from '@kubevirt-utils/constants/window';
+
+const useIsSmallScreen = () => {
+  const [isSmallScreen, setIsSmallScreen] = useState(window.innerWidth < BREAKPOINTS.md);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsSmallScreen(window.innerWidth < BREAKPOINTS.md);
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return isSmallScreen;
+};
+
+export default useIsSmallScreen;

--- a/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
+++ b/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
@@ -89,16 +89,11 @@
   margin-left: 4.5rem;
 }
 
-.pf-v6-c-drawer__body.vms-tree-view-body {
-  padding: 0;
+.vms-tree-view-body {
+  padding: 0 var(--pf-t--global--spacer--sm);
+  height: fit-content;
 }
 
-.pf-v6-c-drawer__panel-main {
-  .pf-v6-c-drawer__body {
-    padding: 0 var(--pf-t--global--spacer--sm);
-    height: fit-content;
-  }
-}
 .pf-v6-c-toolbar__content.vms-tree-view-toolbar-content {
   width: 100%;
   padding: 0;

--- a/src/views/virtualmachines/tree/VirtualMachineTreeView.tsx
+++ b/src/views/virtualmachines/tree/VirtualMachineTreeView.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, FC, useMemo } from 'react';
 
+import useIsSmallScreen from '@kubevirt-utils/hooks/useIsSmallScreen';
 import useLocalStorage from '@kubevirt-utils/hooks/useLocalStorage';
 import { getContentScrollableElement } from '@kubevirt-utils/utils/utils';
 import { OnFilterChange } from '@openshift-console/dynamic-plugin-sdk';
@@ -40,6 +41,8 @@ const VirtualMachineTreeView: FC<VirtualMachineTreeViewProps> = ({
   onFilterChange,
   treeData,
 }) => {
+  const isSmallScreen = useIsSmallScreen();
+
   const [drawerWidth, setDrawerWidth] = useLocalStorage(TREE_VIEW_LAST_WIDTH, OPEN_DRAWER_SIZE);
   const [drawerOpen, setDrawerOpen] = useLocalStorage(SHOW_TREE_VIEW, SHOW);
 
@@ -69,32 +72,41 @@ const VirtualMachineTreeView: FC<VirtualMachineTreeViewProps> = ({
   };
 
   const styles = { ...widthStyles, ...heightStyles } as CSSProperties;
+
+  const treeView = (
+    <TreeViewContent
+      hideSwitch={hideSwitch}
+      isOpen={isOpen}
+      isSmallScreen={isSmallScreen}
+      loaded={loaded}
+      onSelect={onSelect}
+      selectedTreeItem={selected}
+      toggleDrawer={toggleDrawer}
+      treeData={treeData}
+    />
+  );
+
   return (
-    <Drawer isExpanded isInline position="start">
-      <DrawerContent
-        panelContent={
-          <DrawerPanelContent
-            className="vms-tree-view"
-            id={TREE_VIEW_PANEL_ID}
-            isResizable={isOpen}
-            onResize={(_, width: number) => setDrawerWidth(`${String(width)}px`)}
-            style={styles}
-          >
-            <TreeViewContent
-              hideSwitch={hideSwitch}
-              isOpen={isOpen}
-              loaded={loaded}
-              onSelect={onSelect}
-              selectedTreeItem={selected}
-              toggleDrawer={toggleDrawer}
-              treeData={treeData}
-            />
-          </DrawerPanelContent>
-        }
-      >
-        <DrawerContentBody style={heightStyles}>{children}</DrawerContentBody>
-      </DrawerContent>
-    </Drawer>
+    <>
+      {isSmallScreen && treeView}
+      <Drawer isExpanded={!isSmallScreen} isInline position="start">
+        <DrawerContent
+          panelContent={
+            <DrawerPanelContent
+              className="vms-tree-view"
+              id={TREE_VIEW_PANEL_ID}
+              isResizable={isOpen}
+              onResize={(_, width: number) => setDrawerWidth(`${String(width)}px`)}
+              style={styles}
+            >
+              {treeView}
+            </DrawerPanelContent>
+          }
+        >
+          <DrawerContentBody style={heightStyles}>{children}</DrawerContentBody>
+        </DrawerContent>
+      </Drawer>
+    </>
   );
 };
 

--- a/src/views/virtualmachines/tree/components/TreeViewContent.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewContent.tsx
@@ -24,6 +24,7 @@ import TreeViewToolbar from './TreeViewToolbar';
 type TreeViewContentProps = {
   hideSwitch: boolean;
   isOpen: boolean;
+  isSmallScreen: boolean;
   loaded: boolean;
   onSelect: (_event: React.MouseEvent, treeViewItem: TreeViewDataItem) => void;
   selectedTreeItem: TreeViewDataItem;
@@ -34,6 +35,7 @@ type TreeViewContentProps = {
 const TreeViewContent: FC<TreeViewContentProps> = ({
   hideSwitch,
   isOpen,
+  isSmallScreen,
   loaded,
   onSelect,
   selectedTreeItem,
@@ -56,13 +58,13 @@ const TreeViewContent: FC<TreeViewContentProps> = ({
 
   const panelToggleButton = <PanelToggleButton isOpen={isOpen} toggleDrawer={toggleDrawer} />;
 
-  if (!isOpen) {
+  if (!isOpen && !isSmallScreen) {
     return panelToggleButton;
   }
 
   return (
     <>
-      {panelToggleButton}
+      {!isSmallScreen && panelToggleButton}
       <TreeViewToolbar hideSwitch={hideSwitch} onSearch={onSearch} />
       <DrawerHead className="vms-tree-view__header-section">
         <Content className="vms-tree-view__title" component="p">


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes a bug where tree view drawer panel was covering whole screen on smaller screen size. It is done by design of the PF drawer component. This fix checks the width of screen and conditionally sets the `isExpanded` prop on Drawer and hides / shows other components.

Tree view on small screen is above summary and VM table.

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/1f7a3bbc-acb9-47b6-adbf-b0703a810f06



After:


https://github.com/user-attachments/assets/fe745cb4-0399-4756-98e2-cdcad2208d2d

