### PR TITLE
CNV-57780: fix VM details configuration search closing expandable section

### DIFF
--- a/src/utils/hooks/useToggle.ts
+++ b/src/utils/hooks/useToggle.ts
@@ -18,9 +18,5 @@ export const useToggle: UseToggle = (key = '', defaultValue) => {
     localStorage.setItem(key, JSON.stringify(isToggled));
   }, [isToggled, key]);
 
-  const toggle = (): void => {
-    setIsToggled((prev) => !prev);
-  };
-
-  return [isToggled, toggle];
+  return [isToggled, setIsToggled];
 };


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes a bug in VM details configuration, where upon searching the expandable section was opening and closing back and forth.

Bug was that `expandURLHash` expected a `(val: boolean) => void` type. The return type of `useToggle` was wrong, although it was specified as `Dispatch<SetStateAction<boolean>>` a `() => void` was returned instead.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/f7fb8e04-ddbd-4a18-b4fc-138814648b07


After:

https://github.com/user-attachments/assets/9db2a290-5996-4fbb-957e-c7ff402cada7