### PR TITLE
CNV-57953: fixed disk size display in storage to reflect the right size after edit

### DIFF
--- a/src/utils/resources/vm/hooks/disk/useDisksSources.ts
+++ b/src/utils/resources/vm/hooks/disk/useDisksSources.ts
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResources } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -30,8 +29,8 @@ const useDisksSources = (vm: V1VirtualMachine) => {
     () =>
       Object.values(pvcWatchesResult || [])
         .map((watch) => watch.data)
-        .filter((pvc) => !isEmpty(pvc) && !dvs.some((dv) => getName(dv) === getName(pvc))),
-    [dvs, pvcWatchesResult],
+        .filter((pvc) => !isEmpty(pvc)),
+    [pvcWatchesResult],
   );
 
   const loaded = useMemo(


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

after adding a blank disk to a vm and then editing the size, the size would not update correctly, it was receiving and storing the right volume size but displaying it incorrectly. I deleted code in useDisksSource that created a race condition displaying the dv instead.

## 🎥 Demo
before:
![image](https://github.com/user-attachments/assets/31ffc246-38b0-4c26-9052-1710caee75c3)

after:
![image](https://github.com/user-attachments/assets/2510ea0f-d17f-4dc1-bbe4-cade78566008)

