### PR TITLE
CNV-61746: selected Nodes appear during network checkup

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { TsJestTransformerOptions, pathsToModuleNameMapper } from 'ts-jest';
+import { pathsToModuleNameMapper, TsJestTransformerOptions } from 'ts-jest';
+
 import { Config } from '@jest/types';
 
 const { compilerOptions } = require('./tsconfig');

--- a/src/utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
+++ b/src/utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
@@ -70,8 +70,8 @@ const VirtualMachineDescriptionItem: FC<VirtualMachineDescriptionItemProps> = ({
   );
 
   return (
-    <DescriptionListGroup className={`pf-v6-c-description-list__group ${className && className}`}>
-      <DescriptionListTermHelpText className="pf-v6-c-description-list__term">
+    <DescriptionListGroup className={className}>
+      <DescriptionListTermHelpText>
         <Flex
           justifyContent={{
             default: editOnTitleJustify ? 'justifyContentSpaceBetween' : 'justifyContentFlexStart',
@@ -108,10 +108,7 @@ const VirtualMachineDescriptionItem: FC<VirtualMachineDescriptionItemProps> = ({
         </Flex>
       </DescriptionListTermHelpText>
 
-      <DescriptionListDescription
-        className="pf-v6-c-description-list__description"
-        data-test-id={testId}
-      >
+      <DescriptionListDescription data-test-id={testId}>
         {subTitle && <div className="pf-v6-c-description-list__text pf-v6-u-my-sm">{subTitle}</div>}
         {isEdit && !showEditOnTitle ? description : descriptionData}
       </DescriptionListDescription>

--- a/src/views/checkups/network/details/tabs/details/CheckupsNetworkDetailsPageSection.tsx
+++ b/src/views/checkups/network/details/tabs/details/CheckupsNetworkDetailsPageSection.tsx
@@ -24,6 +24,8 @@ import {
   CONFIG_PARAM_NAD_NAME,
   CONFIG_PARAM_NAD_NAMESPACE,
   CONFIG_PARAM_SAMPLE_DURATION,
+  CONFIG_PARAM_SOURCE_NODE,
+  CONFIG_PARAM_TARGET_NODE,
   STATUS_AVG_LATENCY_NANO,
   STATUS_MAX_LATENCY_NANO,
   STATUS_MIN_LATENCY_NANO,
@@ -41,6 +43,12 @@ const CheckupsNetworkDetailsPageSection: FC<CheckupsNetworkDetailsPageSectionPro
   job,
 }) => {
   const { t } = useKubevirtTranslation();
+
+  const sourceNode =
+    configMap?.data?.[STATUS_SOURCE_NODE] || configMap?.data?.[CONFIG_PARAM_SOURCE_NODE];
+  const targetNode =
+    configMap?.data?.[STATUS_TARGET_NODE] || configMap?.data?.[CONFIG_PARAM_TARGET_NODE];
+
   return (
     <PageSection>
       <Title className="co-section-heading" headingLevel="h2">
@@ -130,10 +138,10 @@ const CheckupsNetworkDetailsPageSection: FC<CheckupsNetworkDetailsPageSectionPro
             />
             <VirtualMachineDescriptionItem
               descriptionData={
-                configMap?.data?.[STATUS_SOURCE_NODE] ? (
+                sourceNode ? (
                   <ResourceLink
                     groupVersionKind={modelToGroupVersionKind(NodeModel)}
-                    name={configMap?.data?.[STATUS_SOURCE_NODE]}
+                    name={sourceNode}
                   />
                 ) : (
                   NO_DATA_DASH
@@ -143,10 +151,10 @@ const CheckupsNetworkDetailsPageSection: FC<CheckupsNetworkDetailsPageSectionPro
             />
             <VirtualMachineDescriptionItem
               descriptionData={
-                configMap?.data?.[STATUS_TARGET_NODE] ? (
+                targetNode ? (
                   <ResourceLink
                     groupVersionKind={modelToGroupVersionKind(NodeModel)}
-                    name={configMap?.data?.[STATUS_TARGET_NODE]}
+                    name={targetNode}
                   />
                 ) : (
                   NO_DATA_DASH

--- a/src/views/checkups/network/hooks/useCheckupsNetworkListColumns.ts
+++ b/src/views/checkups/network/hooks/useCheckupsNetworkListColumns.ts
@@ -3,7 +3,7 @@ import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettingsTableColumns from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns';
 import { TableColumn, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
-import { sortable, SortByDirection } from '@patternfly/react-table';
+import { sortable } from '@patternfly/react-table';
 
 import {
   columnsSorting,
@@ -14,6 +14,8 @@ import {
 import {
   CONFIG_PARAM_NAD_NAME,
   CONFIG_PARAM_SAMPLE_DURATION,
+  CONFIG_PARAM_SOURCE_NODE,
+  CONFIG_PARAM_TARGET_NODE,
   STATUS_MAX_LATENCY_NANO,
   STATUS_SOURCE_NODE,
   STATUS_TARGET_NODE,
@@ -46,62 +48,58 @@ const useCheckupsNetworkCheckupsListColumns = (): [
       : []),
     {
       id: 'nad',
-      sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
-        columnsSorting(data, sortDirection, CONFIG_PARAM_NAD_NAME),
+      sort: (data, sortDirection) => columnsSorting(data, sortDirection, CONFIG_PARAM_NAD_NAME),
       title: t('NetworkAttachmentDefinition'),
       transforms: [sortable],
     },
     {
       id: 'status',
-      sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
-        columnsSorting(data, sortDirection, STATUS_SUCCEEDED),
+      sort: (data, sortDirection) => columnsSorting(data, sortDirection, STATUS_SUCCEEDED),
       title: t('Status'),
       transforms: [sortable],
     },
     {
       id: 'latency',
-      sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
-        columnsSorting(data, sortDirection, STATUS_MAX_LATENCY_NANO),
+      sort: (data, sortDirection) => columnsSorting(data, sortDirection, STATUS_MAX_LATENCY_NANO),
       title: t('Latency'),
       transforms: [sortable],
     },
     {
       additional: true,
       id: 'duration',
-      sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
-        columnsSorting(data, sortDirection, CONFIG_PARAM_SAMPLE_DURATION, true),
+      sort: (data, sortDirection) =>
+        columnsSorting(data, sortDirection, CONFIG_PARAM_SAMPLE_DURATION),
       title: t('Duration'),
       transforms: [sortable],
     },
     {
       additional: true,
       id: 'source-node',
-      sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
-        columnsSorting(data, sortDirection, STATUS_SOURCE_NODE),
+      sort: (data, sortDirection) =>
+        columnsSorting(data, sortDirection, STATUS_SOURCE_NODE, CONFIG_PARAM_SOURCE_NODE),
       title: t('Source node'),
       transforms: [sortable],
     },
     {
       additional: true,
       id: 'target-node',
-      sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
-        columnsSorting(data, sortDirection, STATUS_TARGET_NODE),
+      sort: (data, sortDirection) =>
+        columnsSorting(data, sortDirection, STATUS_TARGET_NODE, CONFIG_PARAM_TARGET_NODE),
       title: t('Target node'),
       transforms: [sortable],
     },
     {
       additional: true,
       id: 'start-time',
-      sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
-        columnsSorting(data, sortDirection, STATUS_START_TIME_STAMP, true),
+      sort: (data, sortDirection) => columnsSorting(data, sortDirection, STATUS_START_TIME_STAMP),
       title: t('Start time'),
       transforms: [sortable],
     },
     {
       additional: true,
       id: 'complete-time',
-      sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
-        columnsSorting(data, sortDirection, STATUS_COMPILATION_TIME_STAMP, true),
+      sort: (data, sortDirection) =>
+        columnsSorting(data, sortDirection, STATUS_COMPILATION_TIME_STAMP),
       title: t('Complete time'),
       transforms: [sortable],
     },

--- a/src/views/checkups/network/list/CheckupsNetworkListRow.tsx
+++ b/src/views/checkups/network/list/CheckupsNetworkListRow.tsx
@@ -12,6 +12,8 @@ import CheckupsNetworkActions from '../components/CheckupsNetworkActions';
 import {
   CONFIG_PARAM_NAD_NAME,
   CONFIG_PARAM_SAMPLE_DURATION,
+  CONFIG_PARAM_SOURCE_NODE,
+  CONFIG_PARAM_TARGET_NODE,
   STATUS_MAX_LATENCY_NANO,
   STATUS_MIN_LATENCY_NANO,
   STATUS_SOURCE_NODE,
@@ -67,10 +69,14 @@ const CheckupsNetworkListRow = ({
         {configMap?.data?.[STATUS_MAX_LATENCY_NANO]}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="source-node">
-        {configMap?.data?.[STATUS_SOURCE_NODE] || NO_DATA_DASH}
+        {configMap?.data?.[STATUS_SOURCE_NODE] ||
+          configMap?.data?.[CONFIG_PARAM_SOURCE_NODE] ||
+          NO_DATA_DASH}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="target-node">
-        {configMap?.data?.[STATUS_TARGET_NODE] || NO_DATA_DASH}
+        {configMap?.data?.[STATUS_TARGET_NODE] ||
+          configMap?.data?.[CONFIG_PARAM_TARGET_NODE] ||
+          NO_DATA_DASH}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="start-time">
         <Timestamp timestamp={configMap?.data?.[STATUS_START_TIME_STAMP]} />


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When running a network checkup on some pre-selected Nodes, they will now appear during the checkup in the table or details.

- also fixes sorting of Checkups 
**TODO** use sorting from https://github.com/kubevirt-ui/kubevirt-plugin/pull/2730
- removes duplicate `pf-v6-c-description-list*`classes

## 🎥 Demo

BEFORE:
Nodes:

https://github.com/user-attachments/assets/d0fe7890-d80b-4e2e-987d-5f67c4971758

Sorting:

https://github.com/user-attachments/assets/8ebb7783-3038-47d4-953f-1a8e8a3788c1


AFTER:
Nodes:

https://github.com/user-attachments/assets/652aa6c3-29ef-47f2-813f-6425c3d25c5a

Sorting:

https://github.com/user-attachments/assets/3a29ea63-04ad-4bba-a317-f93ed17933fc

