### PR TITLE
CNV-61727: Fix setting link state on already added network interface

### DIFF
--- a/src/views/catalog/wizard/tabs/network/utils/utils.ts
+++ b/src/views/catalog/wizard/tabs/network/utils/utils.ts
@@ -12,6 +12,6 @@ export const setInterfaceLinkState = (
 ) =>
   produce(vm, (draftVM) => {
     ensurePath(draftVM, ['spec.template.spec.domain.devices.interfaces']);
-    const interfaceToUpdate = getInterface(vm, nicName);
+    const interfaceToUpdate = getInterface(draftVM, nicName);
     if (interfaceToUpdate) interfaceToUpdate.state = desiredState;
   });


### PR DESCRIPTION

## 📝 Description

The problem occurs during VM creation from instance type.

Split from #2662.

Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/2662

## 🎥 Demo

See #2662 
