### PR TITLE
CNV-63222: fix storage checkup details YAML editor height

### DIFF
--- a/src/utils/components/CloudinitDescription/CloudInitDescription.tsx
+++ b/src/utils/components/CloudinitDescription/CloudInitDescription.tsx
@@ -25,11 +25,7 @@ export const CloudInitDescription: FC<{ vm: V1VirtualMachine }> = ({ vm }) => {
         <CloudInitInfoHelper />
       </StackItem>
       <StackItem>
-        <DescriptionList
-          className="pf-v6-c-description-list"
-          columnModifier={{ lg: '1Col', xl: '3Col' }}
-          isCompact
-        >
+        <DescriptionList columnModifier={{ lg: '1Col', xl: '3Col' }} isCompact>
           <VirtualMachineDescriptionItem
             descriptionData={userData?.user || NO_DATA_DASH}
             descriptionHeader={t('User')}

--- a/src/utils/components/Consoles/components/DesktopViewer/Components/ManualConnection.tsx
+++ b/src/utils/components/Consoles/components/DesktopViewer/Components/ManualConnection.tsx
@@ -38,7 +38,7 @@ const ManualConnection: React.FunctionComponent<ManualConnectionProps> = ({
         {textManualConnection || t('Manual Connection')}
       </Title>
       <p>{msg}</p>
-      <DescriptionList className="pf-v6-c-description-list">
+      <DescriptionList>
         {address && <Detail title={textAddress || t('Address')} value={address} />}
         {!address && spice && (
           <Detail title={textSpiceAddress || t('SPICE Address')} value={spice?.address} />

--- a/src/utils/components/Consoles/components/DesktopViewer/Components/MoreInformationDefault.tsx
+++ b/src/utils/components/Consoles/components/DesktopViewer/Components/MoreInformationDefault.tsx
@@ -26,7 +26,7 @@ const MoreInformationDefault: React.FC<MoreInformationDefaultProps> = ({ textMor
           </p>
         </Trans>
       )}
-      <DescriptionList className="pf-v6-c-description-list" isHorizontal>
+      <DescriptionList isHorizontal>
         <Detail title={'RHEL, CentOS'} value={'sudo yum install virt-viewer'} />
         <Detail title={'Fedora'} value={'sudo dnf install virt-viewer'} />
         <Detail title={'Ubuntu, Debian'} value={'sudo apt-get install virt-viewer'} />

--- a/src/utils/components/DescriptionItem/DescriptionItemHeader.tsx
+++ b/src/utils/components/DescriptionItem/DescriptionItemHeader.tsx
@@ -59,9 +59,7 @@ export const DescriptionItemHeader: FC<DescriptionItemHeaderProps> = ({
         headerContent={descriptionHeader}
         maxWidth={maxWidth || '30rem'}
       >
-        <DescriptionListTermHelpTextButton className="pf-v6-c-description-list__text">
-          {descriptionHeader}
-        </DescriptionListTermHelpTextButton>
+        <DescriptionListTermHelpTextButton>{descriptionHeader}</DescriptionListTermHelpTextButton>
       </Popover>
     );
   }

--- a/src/utils/components/DetailsPageBody/DetailsPageBody.tsx
+++ b/src/utils/components/DetailsPageBody/DetailsPageBody.tsx
@@ -1,0 +1,28 @@
+// This is a Console component https://github.com/openshift/console/blob/main/frontend/packages/console-shared/src/components/layout/PageBody.tsx
+
+import React from 'react';
+import classNames from 'classnames';
+
+import { Flex } from '@patternfly/react-core';
+
+type DetailsPageBodyProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+const DetailsPageBody: React.FC<DetailsPageBodyProps> = ({ children, className, ...props }) => {
+  return (
+    <Flex
+      className={classNames('co-m-page__body', className)}
+      direction={{ default: 'column' }}
+      flexWrap={{ default: 'nowrap' }}
+      rowGap={{ default: 'rowGapNone' }}
+      style={{ flex: '1 0 auto' }}
+      {...props}
+    >
+      {children}
+    </Flex>
+  );
+};
+
+export default DetailsPageBody;

--- a/src/utils/components/HardwareDevices/HardwareDevices.tsx
+++ b/src/utils/components/HardwareDevices/HardwareDevices.tsx
@@ -71,27 +71,27 @@ const HardwareDevices: FC<HardwareDevicesProps> = ({
   };
 
   return (
-    <DescriptionList className="pf-v6-c-description-list">
-      <DescriptionListGroup className="pf-v6-c-description-list__group">
+    <DescriptionList>
+      <DescriptionListGroup>
         <HardwareDeviceTitle
           canEdit={canEdit}
           hideEdit={hideEdit}
           onClick={onEditGPU}
           title={t('GPU devices')}
         />
-        <DescriptionListDescription className="pf-v6-c-description-list__description">
+        <DescriptionListDescription>
           <HardwareDevicesTable devices={gpus} />
         </DescriptionListDescription>
       </DescriptionListGroup>
 
-      <DescriptionListGroup className="pf-v6-c-description-list__group">
+      <DescriptionListGroup>
         <HardwareDeviceTitle
           canEdit={canEdit}
           hideEdit={hideEdit}
           onClick={onEditHostDevices}
           title={t('Host devices')}
         />
-        <DescriptionListDescription className="pf-v6-c-description-list__description">
+        <DescriptionListDescription>
           <HardwareDevicesTable devices={hostDevices} />
         </DescriptionListDescription>
       </DescriptionListGroup>

--- a/src/utils/components/HardwareDevices/HardwareDevicesTable.tsx
+++ b/src/utils/components/HardwareDevices/HardwareDevicesTable.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import classnames from 'classnames';
 
 import { V1GPU, V1HostDevice } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -20,10 +19,7 @@ const HardwareDevicesTable: React.FC<HardwareDevicesTableProps> = ({ devices }) 
     return <span className="pf-v6-u-text-color-subtle">{t('Not available')}</span>;
 
   return (
-    <DescriptionList
-      className={classnames('pf-v6-c-description-list', 'hardware-devices-table')}
-      columnModifier={{ default: '2Col' }}
-    >
+    <DescriptionList className="hardware-devices-table" columnModifier={{ default: '2Col' }}>
       <VirtualMachineDescriptionItem
         descriptionData={
           <Stack>

--- a/src/utils/components/OwnerDetailsItem/OwnerDetailsItem.tsx
+++ b/src/utils/components/OwnerDetailsItem/OwnerDetailsItem.tsx
@@ -24,13 +24,8 @@ const OwnerDetailsItem: React.FC<OwnerDetailsItemProps> = ({ className, obj }) =
   const { t } = useKubevirtTranslation();
 
   return (
-    <DescriptionListGroup
-      className={classNames(
-        'pf-v6-c-description-list__group topology-resource-summary__item',
-        className,
-      )}
-    >
-      <DescriptionListTermHelpText className="pf-v6-c-description-list__term">
+    <DescriptionListGroup className={classNames('topology-resource-summary__item', className)}>
+      <DescriptionListTermHelpText>
         <Popover
           bodyContent={
             <Trans ns="plugin__kubevirt-plugin">
@@ -51,12 +46,10 @@ const OwnerDetailsItem: React.FC<OwnerDetailsItemProps> = ({ className, obj }) =
           headerContent={t('Owner')}
           maxWidth="30rem"
         >
-          <DescriptionListTermHelpTextButton className="pf-v6-c-description-list__text">
-            {t('Owner')}
-          </DescriptionListTermHelpTextButton>
+          <DescriptionListTermHelpTextButton>{t('Owner')}</DescriptionListTermHelpTextButton>
         </Popover>
       </DescriptionListTermHelpText>
-      <DescriptionListDescription className="pf-v6-c-description-list__description">
+      <DescriptionListDescription>
         <OwnerReferences obj={obj} />
       </DescriptionListDescription>
     </DescriptionListGroup>

--- a/src/utils/components/SSHAccess/SSHAccess.tsx
+++ b/src/utils/components/SSHAccess/SSHAccess.tsx
@@ -21,7 +21,7 @@ const SSHAccess: FC<SSHAccessProps> = ({
   vm,
 }) => {
   return (
-    <DescriptionList className="pf-v6-c-description-list">
+    <DescriptionList>
       {!isCustomizeInstanceType && (
         <SSHCommand sshService={sshService} sshServiceLoaded={sshServiceLoaded} vm={vm} />
       )}

--- a/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.tsx
+++ b/src/utils/components/SSHAccess/components/ConsoleOverVirtctl.tsx
@@ -35,7 +35,7 @@ const ConsoleOverVirtctl: FC<ConsoleOverVirtctlProps> = ({ vm }) => {
   const [isNamespaceManagedByUDN, _, nad] = useNamespaceUDN(getNamespace(vm));
 
   return (
-    <DescriptionListGroup className="pf-v6-c-description-list__group">
+    <DescriptionListGroup>
       <DescriptionListTerm className="pf-v6-u-font-size-xs">
         <Content className="pf-v6-u-disabled-color-100" component="p">
           {t('SSH using virtctl')}{' '}
@@ -73,7 +73,7 @@ const ConsoleOverVirtctl: FC<ConsoleOverVirtctlProps> = ({ vm }) => {
           </Popover>
         </Content>
       </DescriptionListTerm>
-      <DescriptionListDescription className="pf-v6-c-description-list__description">
+      <DescriptionListDescription>
         {isNamespaceManagedByUDN ? (
           <>
             {t("Virtctl is disabled for this namespace as it's managed by")}{' '}

--- a/src/utils/components/SSHAccess/components/SSHCommand.tsx
+++ b/src/utils/components/SSHAccess/components/SSHCommand.tsx
@@ -70,12 +70,12 @@ const SSHCommand: React.FC<SSHCommandProps> = ({
     sshService?.spec?.type === SERVICE_TYPES.LOAD_BALANCER && !isLoadBalancerBonded(sshService);
 
   return (
-    <DescriptionListGroup className="pf-v6-c-description-list__group">
+    <DescriptionListGroup>
       <DescriptionListTerm className="pf-v6-u-font-size-xs">
         {t('SSH service type')}
       </DescriptionListTerm>
 
-      <DescriptionListDescription className="pf-v6-c-description-list__description">
+      <DescriptionListDescription>
         <Stack hasGutter>
           {sshServiceLoaded && !loading ? (
             <>

--- a/src/utils/components/SysprepModal/SysprepDescription.tsx
+++ b/src/utils/components/SysprepModal/SysprepDescription.tsx
@@ -35,11 +35,7 @@ export const SysprepDescription: FC<{
         <SysprepInfo />
       </StackItem>
       <StackItem>
-        <DescriptionList
-          className="pf-v6-c-description-list"
-          columnModifier={{ lg: '1Col', xl: '2Col' }}
-          isCompact
-        >
+        <DescriptionList columnModifier={{ lg: '1Col', xl: '2Col' }} isCompact>
           <VirtualMachineDescriptionItem
             descriptionData={
               isEmpty(selectedSysprepName) ? (

--- a/src/utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
+++ b/src/utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
@@ -70,8 +70,8 @@ const VirtualMachineDescriptionItem: FC<VirtualMachineDescriptionItemProps> = ({
   );
 
   return (
-    <DescriptionListGroup className={`pf-v6-c-description-list__group ${className && className}`}>
-      <DescriptionListTermHelpText className="pf-v6-c-description-list__term">
+    <DescriptionListGroup className={className}>
+      <DescriptionListTermHelpText>
         <Flex
           justifyContent={{
             default: editOnTitleJustify ? 'justifyContentSpaceBetween' : 'justifyContentFlexStart',
@@ -108,10 +108,7 @@ const VirtualMachineDescriptionItem: FC<VirtualMachineDescriptionItemProps> = ({
         </Flex>
       </DescriptionListTermHelpText>
 
-      <DescriptionListDescription
-        className="pf-v6-c-description-list__description"
-        data-test-id={testId}
-      >
+      <DescriptionListDescription data-test-id={testId}>
         {subTitle && <div className="pf-v6-c-description-list__text pf-v6-u-my-sm">{subTitle}</div>}
         {isEdit && !showEditOnTitle ? description : descriptionData}
       </DescriptionListDescription>

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsLeftGrid.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsLeftGrid.tsx
@@ -45,7 +45,7 @@ const DetailsLeftGrid: FC<DetailsLeftGridProps> = ({ instanceTypesAndPreferences
     : null;
 
   return (
-    <DescriptionList className="pf-v6-c-description-list" isHorizontal>
+    <DescriptionList isHorizontal>
       <VirtualMachineDescriptionItem
         descriptionData={
           <>

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsRightGrid.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsRightGrid.tsx
@@ -53,7 +53,7 @@ const DetailsRightGrid: FC = () => {
   };
 
   return (
-    <DescriptionList className="pf-v6-c-description-list" isHorizontal>
+    <DescriptionList isHorizontal>
       <VirtualMachineDescriptionItem
         descriptionData={isChangingNamespace ? <Loading /> : vmNamespaceTarget}
         descriptionHeader={t('Project')}

--- a/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeDetailsTab.tsx
+++ b/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeDetailsTab.tsx
@@ -69,7 +69,7 @@ const CustomizeInstanceTypeDetailsTab = () => {
       </Title>
       <Grid>
         <GridItem span={5}>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <VirtualMachineDescriptionItem
               descriptionData={
                 getAnnotation(vm, DESCRIPTION_ANNOTATION) || <MutedTextSpan text={t('None')} />
@@ -202,7 +202,7 @@ const CustomizeInstanceTypeDetailsTab = () => {
           </DescriptionList>
         </GridItem>
         <GridItem span={5}>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <DetailsSectionHardware
               onSubmit={(type: HARDWARE_DEVICE_TYPE, updatedVM: V1VirtualMachine) =>
                 Promise.resolve(

--- a/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeInitialRunTab.tsx
+++ b/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeInitialRunTab.tsx
@@ -25,7 +25,7 @@ const CustomizeInstanceTypeInitialRunTab = () => {
       <Title headingLevel="h2">
         <SearchItem id="initial-run">{t('Initial run')}</SearchItem>
       </Title>
-      <DescriptionList className="pf-v6-c-description-list">
+      <DescriptionList>
         <InitialRunTabCloudinit canUpdateVM onSubmit={updateVMCustomizeIT} vm={vm} />
         <Divider />
         <InitialRunTabSysprep canUpdateVM onSubmit={updateCustomizeInstanceType} vm={vm} />

--- a/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeMetadataTab.tsx
+++ b/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeMetadataTab.tsx
@@ -39,7 +39,7 @@ const CustomizeInstanceTypeMetadataTab = () => {
         <SearchItem id="metadata">{t('Metadata')}</SearchItem>
       </Title>
       <Grid span={6}>
-        <DescriptionList className="pf-v6-c-description-list">
+        <DescriptionList>
           <VirtualMachineDescriptionItem
             bodyContent={t(
               'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. ',

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/AuthorizedSSHKey.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/AuthorizedSSHKey.tsx
@@ -19,7 +19,7 @@ const AuthorizedSSHKey: FC<AuthorizedSSHKeyProps> = ({ authorizedSSHKey, namespa
 
   return (
     <SplitItem>
-      <DescriptionList className="pf-v6-c-description-list">
+      <DescriptionList>
         <VirtualMachineDescriptionItem
           onEditClick={() =>
             createModal((modalProps) => (

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateInfoSection.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplateInfoSection.tsx
@@ -55,7 +55,7 @@ export const TemplateInfoSection: FC = memo(() => {
       onToggle={(_event, val) => setIsTemplateInfoExpanded(val)}
       toggleText={t('Template info')}
     >
-      <DescriptionList className="pf-v6-c-description-list">
+      <DescriptionList>
         <VirtualMachineDescriptionItem
           descriptionData={displayName}
           descriptionHeader={t('Operating system')}

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -111,7 +111,7 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
                   </SplitItem>
                 )}
                 <SplitItem>
-                  <DescriptionList className="pf-v6-c-description-list">
+                  <DescriptionList>
                     <VirtualMachineDescriptionItem
                       descriptionData={namespace}
                       descriptionHeader={t('Project')}

--- a/src/views/catalog/wizard/components/WizardDescriptionItem/WizardDescriptionItem.tsx
+++ b/src/views/catalog/wizard/components/WizardDescriptionItem/WizardDescriptionItem.tsx
@@ -1,5 +1,4 @@
 import React, { FC, ReactNode } from 'react';
-import classnames from 'classnames';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
@@ -81,10 +80,7 @@ export const WizardDescriptionItem: FC<WizardDescriptionItemProps> = React.memo(
       if (helperPopover) {
         return (
           <Popover bodyContent={helperPopover?.content} headerContent={helperPopover?.header}>
-            <DescriptionListTermHelpTextButton className="pf-v6-c-description-list__text">
-              {' '}
-              {title}{' '}
-            </DescriptionListTermHelpTextButton>
+            <DescriptionListTermHelpTextButton> {title} </DescriptionListTermHelpTextButton>
           </Popover>
         );
       }
@@ -97,8 +93,8 @@ export const WizardDescriptionItem: FC<WizardDescriptionItemProps> = React.memo(
     };
 
     return (
-      <DescriptionListGroup className={classnames('pf-v6-c-description-list__group', className)}>
-        <DescriptionListTermHelpText className="pf-v6-c-description-list__term">
+      <DescriptionListGroup className={className}>
+        <DescriptionListTermHelpText>
           <Flex
             className="wizard-description-item__title"
             justifyContent={{ default: 'justifyContentFlexStart' }}
@@ -113,7 +109,6 @@ export const WizardDescriptionItem: FC<WizardDescriptionItemProps> = React.memo(
                   isDisabled={isDisabled}
                   isInline
                   onClick={onEditClick}
-                  type="button"
                   variant={ButtonVariant.link}
                 >
                   {t('Edit')}
@@ -125,14 +120,12 @@ export const WizardDescriptionItem: FC<WizardDescriptionItemProps> = React.memo(
         {isEdit && !showEditOnTitle ? (
           <DescriptionListDescription>
             <Button
-              className="pf-v6-c-description-list__description"
               data-test-id={`${testId}-edit`}
               icon={<PencilAltIcon />}
               iconPosition="end"
               isDisabled={isDisabled}
               isInline
               onClick={onEditClick}
-              type="button"
               variant={ButtonVariant.link}
             >
               {description ?? (
@@ -142,7 +135,7 @@ export const WizardDescriptionItem: FC<WizardDescriptionItemProps> = React.memo(
           </DescriptionListDescription>
         ) : (
           <div data-test-id={testId}>
-            <DescriptionListDescription className="pf-v6-c-description-list__description">
+            <DescriptionListDescription>
               {description ?? (
                 <span className="pf-v6-u-text-color-subtle">{t('Not available')}</span>
               )}

--- a/src/views/catalog/wizard/tabs/metadata/WizardMetadataTab.tsx
+++ b/src/views/catalog/wizard/tabs/metadata/WizardMetadataTab.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import classnames from 'classnames';
 
 import { WizardTab } from '@catalog/wizard/tabs';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
@@ -29,12 +28,7 @@ const WizardMetadataTab: WizardTab = ({ loaded, updateVM, vm }) => {
       >
         {(resource) => (
           <>
-            <DescriptionList
-              className={classnames(
-                'pf-v6-c-description-list',
-                'wizard-metadata-tab__description-list',
-              )}
-            >
+            <DescriptionList className="wizard-metadata-tab__description-list">
               <WizardDescriptionItem
                 description={
                   <MetadataLabels labels={resource?.metadata?.labels} model={VirtualMachineModel} />

--- a/src/views/catalog/wizard/tabs/overview/components/WizardOverviewDisksTable/WizardOverviewDisksTable.tsx
+++ b/src/views/catalog/wizard/tabs/overview/components/WizardOverviewDisksTable/WizardOverviewDisksTable.tsx
@@ -15,11 +15,7 @@ export const WizardOverviewDisksTable: React.FC<{
 
   const { t } = useKubevirtTranslation();
   return (
-    <DescriptionList
-      className="pf-v6-c-description-list"
-      columnModifier={{ default: '3Col' }}
-      isInlineGrid={isInlineGrid}
-    >
+    <DescriptionList columnModifier={{ default: '3Col' }} isInlineGrid={isInlineGrid}>
       <WizardDescriptionItem
         description={
           <Stack>

--- a/src/views/catalog/wizard/tabs/overview/components/WizardOverviewGrid.tsx
+++ b/src/views/catalog/wizard/tabs/overview/components/WizardOverviewGrid.tsx
@@ -103,7 +103,7 @@ const WizardOverviewGrid: FC<WizardOverviewGridProps> = ({ tabsData, updateVM, v
   return (
     <Grid className="wizard-overview-tab__grid" hasGutter>
       <GridItem rowSpan={4} span={6}>
-        <DescriptionList className="pf-v6-c-description-list">
+        <DescriptionList>
           <WizardDescriptionItem
             onEditClick={() =>
               createModal((modalProps) => (
@@ -286,7 +286,7 @@ const WizardOverviewGrid: FC<WizardOverviewGridProps> = ({ tabsData, updateVM, v
         </DescriptionList>
       </GridItem>
       <GridItem rowSpan={4} span={6}>
-        <DescriptionList className="pf-v6-c-description-list">
+        <DescriptionList>
           <WizardDescriptionItem
             description={
               <WizardOverviewNetworksTable

--- a/src/views/catalog/wizard/tabs/overview/components/WizardOverviewNetworksTable/WizardOverviewNetworksTable.tsx
+++ b/src/views/catalog/wizard/tabs/overview/components/WizardOverviewNetworksTable/WizardOverviewNetworksTable.tsx
@@ -23,11 +23,7 @@ export const WizardOverviewNetworksTable: React.FC<{
   const networkData = getNetworkInterfaceRowData(networks, interfaces);
 
   return (
-    <DescriptionList
-      className="pf-v6-c-description-list"
-      columnModifier={{ default: '3Col' }}
-      isInlineGrid={isInlineGrid}
-    >
+    <DescriptionList columnModifier={{ default: '3Col' }} isInlineGrid={isInlineGrid}>
       <WizardDescriptionItem
         description={
           <Stack>

--- a/src/views/catalog/wizard/tabs/scheduling/components/WizardSchedulingGrid.tsx
+++ b/src/views/catalog/wizard/tabs/scheduling/components/WizardSchedulingGrid.tsx
@@ -42,7 +42,7 @@ const WizardSchedulingGrid: FC<WizardSchedulingGridProps> = ({ updateVM, vm }) =
   return (
     <Grid className="wizard-scheduling-tab__grid" hasGutter>
       <GridItem rowSpan={4} span={6}>
-        <DescriptionList className="pf-v6-c-description-list">
+        <DescriptionList>
           <WizardDescriptionItem
             description={
               <NodeSelectorDetailItem nodeSelector={vm?.spec?.template?.spec?.nodeSelector} />
@@ -115,7 +115,7 @@ const WizardSchedulingGrid: FC<WizardSchedulingGridProps> = ({ updateVM, vm }) =
       </GridItem>
 
       <GridItem rowSpan={4} span={6}>
-        <DescriptionList className="pf-v6-c-description-list">
+        <DescriptionList>
           <WizardDescriptionItem
             onEditClick={() =>
               createModal(({ isOpen, onClose }) => (

--- a/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
+++ b/src/views/catalog/wizard/tabs/scripts/WizardScriptsTab.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import classnames from 'classnames';
 
 import { WizardDescriptionItem } from '@catalog/wizard/components/WizardDescriptionItem';
 import { WizardTab } from '@catalog/wizard/tabs';
@@ -35,9 +34,7 @@ const WizardScriptsTab: WizardTab = ({ tabsData, updateVM, vm }) => {
         pathsToHighlight={PATHS_TO_HIGHLIGHT.SCRIPTS_TAB}
         resource={vm}
       >
-        <DescriptionList
-          className={classnames('pf-v6-c-description-list', 'wizard-scripts-tab__description-list')}
-        >
+        <DescriptionList className="wizard-scripts-tab__description-list">
           <DescriptionListDescription>
             <AlertScripts />
           </DescriptionListDescription>

--- a/src/views/checkups/network/details/tabs/details/CheckupsNetworkDetailsPageSection.tsx
+++ b/src/views/checkups/network/details/tabs/details/CheckupsNetworkDetailsPageSection.tsx
@@ -48,7 +48,7 @@ const CheckupsNetworkDetailsPageSection: FC<CheckupsNetworkDetailsPageSectionPro
       </Title>
       <Grid>
         <GridItem span={6}>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <VirtualMachineDescriptionItem
               descriptionData={configMap?.metadata?.name}
               descriptionHeader={t('Name')}
@@ -97,7 +97,7 @@ const CheckupsNetworkDetailsPageSection: FC<CheckupsNetworkDetailsPageSectionPro
           </DescriptionList>
         </GridItem>
         <GridItem span={6}>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <VirtualMachineDescriptionItem
               descriptionData={
                 <ResourceLink

--- a/src/views/checkups/storage/components/CheckupsStorageActions.tsx
+++ b/src/views/checkups/storage/components/CheckupsStorageActions.tsx
@@ -34,7 +34,7 @@ const CheckupsStorageActions = ({
 
   const Toggle = isKebab
     ? KebabToggle({ isExpanded: isActionsOpen, onClick: onToggle })
-    : DropdownToggle({ isExpanded: isActionsOpen, onClick: onToggle, placeholder: t('Actions') });
+    : DropdownToggle({ children: t('Actions'), isExpanded: isActionsOpen, onClick: onToggle });
 
   const deleteCheckup = () => {
     setIsActionsOpen(false);

--- a/src/views/checkups/storage/details/CheckupsStorageDetailsPage.tsx
+++ b/src/views/checkups/storage/details/CheckupsStorageDetailsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 
+import DetailsPageBody from '@kubevirt-utils/components/DetailsPageBody/DetailsPageBody';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
@@ -32,34 +33,33 @@ const CheckupsStorageDetailsPage = () => {
     );
 
   return (
-    <PageSection>
+    <>
       <CheckupsStorageDetailsPageHeader configMap={configMap} jobs={jobMatches} />
-      <Tabs
-        onSelect={(_, tabIndex: number) => {
-          setActiveTabKey(tabIndex);
-        }}
-        activeKey={activeTabKey}
-      >
-        <Tab eventKey={0} title={<TabTitleText>{t('Details')}</TabTitleText>}>
-          <PageSection>
-            <CheckupsStorageDetailsPageSection configMap={configMap} job={jobMatches?.[0]} />
-          </PageSection>
-          <PageSection>
-            <Divider />
-          </PageSection>
-          <PageSection>
-            <CheckupsDetailsPageHistory error={error} jobs={jobMatches} loading={loading} />
-          </PageSection>
-        </Tab>
-        <Tab
-          className="CheckupsStorageDetailsPage--yaml"
-          eventKey={1}
-          title={<TabTitleText>{t('YAML')}</TabTitleText>}
+      <DetailsPageBody>
+        <Tabs
+          onSelect={(_, tabIndex: number) => {
+            setActiveTabKey(tabIndex);
+          }}
+          activeKey={activeTabKey}
+          className="co-horizontal-nav"
         >
-          <ResourceYAMLEditor initialResource={configMap} />
-        </Tab>
-      </Tabs>
-    </PageSection>
+          <Tab eventKey={0} title={<TabTitleText>{t('Details')}</TabTitleText>}>
+            <PageSection>
+              <CheckupsStorageDetailsPageSection configMap={configMap} job={jobMatches?.[0]} />
+            </PageSection>
+            <PageSection>
+              <Divider />
+            </PageSection>
+            <PageSection>
+              <CheckupsDetailsPageHistory error={error} jobs={jobMatches} loading={loading} />
+            </PageSection>
+          </Tab>
+          <Tab eventKey={1} title={<TabTitleText>{t('YAML')}</TabTitleText>}>
+            <ResourceYAMLEditor initialResource={configMap} />
+          </Tab>
+        </Tabs>
+      </DetailsPageBody>
+    </>
   );
 };
 

--- a/src/views/checkups/storage/details/CheckupsStorageDetailsPageHeader.tsx
+++ b/src/views/checkups/storage/details/CheckupsStorageDetailsPageHeader.tsx
@@ -2,6 +2,8 @@ import React, { FC } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { IoK8sApiBatchV1Job, IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import DetailsPageTitle from '@kubevirt-utils/components/DetailsPageTitle/DetailsPageTitle';
+import PaneHeading from '@kubevirt-utils/components/PaneHeading/PaneHeading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -9,7 +11,6 @@ import {
   BreadcrumbItem,
   Button,
   ButtonVariant,
-  Flex,
   FlexItem,
   Title,
 } from '@patternfly/react-core';
@@ -30,28 +31,29 @@ const CheckupsStorageDetailsPageHeader: FC<CheckupsStorageDetailsPageHeaderProps
   const [namespace] = useActiveNamespace();
 
   return (
-    <>
-      <Breadcrumb className="pf-v6-c-breadcrumb co-breadcrumb">
-        <BreadcrumbItem>
-          <Button
-            isInline
-            onClick={() => navigate(`/k8s/ns/${namespace}/checkups/storage`)}
-            variant={ButtonVariant.link}
-          >
-            {t('Storage checkup')}
-          </Button>
-        </BreadcrumbItem>
-        <BreadcrumbItem>{t('Storage checkup details')}</BreadcrumbItem>
-      </Breadcrumb>
-      <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
-        <Title className="co-section-heading" headingLevel="h2">
-          {configMap?.metadata?.name}
-        </Title>
+    <DetailsPageTitle
+      breadcrumb={
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Button
+              isInline
+              onClick={() => navigate(`/k8s/ns/${namespace}/checkups/storage`)}
+              variant={ButtonVariant.link}
+            >
+              {t('Storage checkup')}
+            </Button>
+          </BreadcrumbItem>
+          <BreadcrumbItem>{t('Storage checkup details')}</BreadcrumbItem>
+        </Breadcrumb>
+      }
+    >
+      <PaneHeading>
+        <Title headingLevel="h1">{configMap?.metadata?.name}</Title>
         <FlexItem>
           <CheckupsStorageActions configMap={configMap} jobs={jobs} />
         </FlexItem>
-      </Flex>
-    </>
+      </PaneHeading>
+    </DetailsPageTitle>
   );
 };
 

--- a/src/views/checkups/storage/details/CheckupsStorageDetailsPageSection.tsx
+++ b/src/views/checkups/storage/details/CheckupsStorageDetailsPageSection.tsx
@@ -57,7 +57,7 @@ const CheckupsStorageDetailsPageSection: FC<CheckupsStorageDetailsPageSectionPro
       </Title>
       <Grid>
         <GridItem span={6}>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <VirtualMachineDescriptionItem
               descriptionData={configMap?.metadata?.name}
               descriptionHeader={t('Name')}
@@ -122,7 +122,7 @@ const CheckupsStorageDetailsPageSection: FC<CheckupsStorageDetailsPageSectionPro
           </DescriptionList>
         </GridItem>
         <GridItem span={6}>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <VirtualMachineDescriptionItem
               descriptionData={
                 <ResourceLink

--- a/src/views/checkups/storage/details/checkups-storage-details-page.scss
+++ b/src/views/checkups/storage/details/checkups-storage-details-page.scss
@@ -2,9 +2,3 @@
 .pf-v6-c-tab-content {
   height: 100%;
 }
-
-.CheckupsStorageDetailsPage {
-  &--yaml {
-    height: 100%;
-  }
-}

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralInformation/GeneralInformation.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralInformation/GeneralInformation.tsx
@@ -61,7 +61,7 @@ const GeneralInformation: FC<GeneralInformationProps> = ({
       </SplitItem>
       <Divider orientation={{ default: 'vertical' }} />
       <SplitItem>
-        <DescriptionList className="pf-v6-c-description-list">
+        <DescriptionList>
           <VirtualMachineDescriptionItem
             descriptionData={
               loaded ? (

--- a/src/views/datasources/dataimportcron/details/DataImportCronDetailsGrid.tsx
+++ b/src/views/datasources/dataimportcron/details/DataImportCronDetailsGrid.tsx
@@ -41,7 +41,7 @@ export const DataImportCronDetailsGrid: React.FC<DataImportCronDetailsGridProps>
   return (
     <Grid hasGutter>
       <GridItem span={5}>
-        <DescriptionList className="pf-v6-c-description-list">
+        <DescriptionList>
           <VirtualMachineDescriptionItem
             // body-content text copied from: https://github.com/kubevirt-ui/kubevirt-api/blob/main/containerized-data-importer/models/V1ObjectMeta.ts#L96
             bodyContent={t(

--- a/src/views/datasources/dataimportcron/details/DataImportCronManageDetails/DataImportCronManageDetails.tsx
+++ b/src/views/datasources/dataimportcron/details/DataImportCronManageDetails/DataImportCronManageDetails.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import classnames from 'classnames';
 
 import {
   V1beta1DataImportCron,
@@ -41,9 +40,7 @@ export const DataImportCronManageDetails: React.FC<DataImportCronManageDetailsPr
   return (
     <VirtualMachineDescriptionItem
       descriptionData={
-        <DescriptionList
-          className={classnames('pf-v6-c-description-list', 'kv-dataimportcron-managed-details')}
-        >
+        <DescriptionList className="kv-dataimportcron-managed-details">
           <VirtualMachineDescriptionItem
             descriptionData={isAutoUpdated ? t('On') : t('Off')}
             descriptionHeader={t('Automatic updates')}
@@ -58,7 +55,7 @@ export const DataImportCronManageDetails: React.FC<DataImportCronManageDetailsPr
           />
           <VirtualMachineDescriptionItem
             descriptionData={
-              <DescriptionList className="pf-v6-c-description-list" isHorizontal>
+              <DescriptionList isHorizontal>
                 <DescriptionListGroup>
                   <DescriptionListTerm>{t('Cron expression')}</DescriptionListTerm>
                   <DescriptionListDescription>

--- a/src/views/datasources/details/components/DataSourceDetailsGrid.tsx/DataSourceDetailsGrid.tsx
+++ b/src/views/datasources/details/components/DataSourceDetailsGrid.tsx/DataSourceDetailsGrid.tsx
@@ -43,7 +43,7 @@ export const DataSourceDetailsGrid: React.FC<DataSourceDetailsGridProps> = ({ da
   return (
     <Grid hasGutter>
       <GridItem span={5}>
-        <DescriptionList className="pf-v6-c-description-list">
+        <DescriptionList>
           <VirtualMachineDescriptionItem
             // body-content text copied from: https://github.com/kubevirt-ui/kubevirt-api/blob/main/containerized-data-importer/models/V1ObjectMeta.ts#L96
             bodyContent={t(
@@ -158,7 +158,7 @@ export const DataSourceDetailsGrid: React.FC<DataSourceDetailsGridProps> = ({ da
       </GridItem>
       <GridItem span={1} />
       <GridItem span={5}>
-        <DescriptionList className="pf-v6-c-description-list">
+        <DescriptionList>
           {dataImportCron && (
             <DataSourceImportCronDescription
               dataImportCronName={dataImportCron}

--- a/src/views/migrationpolicies/details/tabs/details/components/MigrationPolicyDetailsSection/MigrationPolicyDetailsSection.tsx
+++ b/src/views/migrationpolicies/details/tabs/details/components/MigrationPolicyDetailsSection/MigrationPolicyDetailsSection.tsx
@@ -61,7 +61,7 @@ const MigrationPolicyDetailsSection: FC<MigrationPolicyDetailsSectionProps> = ({
       </Title>
       <Grid hasGutter>
         <GridItem span={5}>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <VirtualMachineDescriptionItem
               bodyContent={t(
                 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. ',
@@ -95,7 +95,7 @@ const MigrationPolicyDetailsSection: FC<MigrationPolicyDetailsSectionProps> = ({
               </DescriptionListTerm>
 
               <DescriptionListDescription>
-                <DescriptionList className="pf-v6-c-description-list">
+                <DescriptionList>
                   <VirtualMachineDescriptionItem
                     bodyContent={t(
                       'BandwidthPerMigration limits the amount of network bandwith live migrations are allowed to use. The value is in quantity per second. Defaults to 0 (no limit). ',

--- a/src/views/templates/details/tabs/details/components/TemplateDetailsLeftGrid.tsx
+++ b/src/views/templates/details/tabs/details/components/TemplateDetailsLeftGrid.tsx
@@ -31,7 +31,7 @@ const TemplateDetailsLeftGrid: FC<TemplateDetailsGridProps> = ({ template }) => 
   const { isTemplateEditable } = useEditTemplateAccessReview(template);
 
   return (
-    <DescriptionList className="pf-v6-c-description-list">
+    <DescriptionList>
       <Name name={getName(template)} />
       <Namespace namespace={getNamespace(template)} />
       <Labels editable={isTemplateEditable} template={template} />

--- a/src/views/templates/details/tabs/details/components/TemplateDetailsRightGrid.tsx
+++ b/src/views/templates/details/tabs/details/components/TemplateDetailsRightGrid.tsx
@@ -39,7 +39,7 @@ const TemplateDetailsRightGrid: React.FC<TemplateDetailsGridProps> = ({ template
   };
 
   return (
-    <DescriptionList className="pf-v6-c-description-list">
+    <DescriptionList>
       <BootOrderItem template={template} />
       <BootSource template={template} />
       <VirtualMachineDescriptionItem

--- a/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid.tsx
@@ -30,7 +30,7 @@ const TemplateSchedulingLeftGrid: React.FC<TemplateSchedulingGridProps> = ({
   );
 
   return (
-    <DescriptionList className="pf-v6-c-description-list">
+    <DescriptionList>
       <NodeSelector editable={editable} onSubmit={onSubmit} template={template} />
       <Tolerations editable={editable} onSubmit={onSubmit} template={template} />
       <AffinityRules editable={editable} onSubmit={onSubmit} template={template} />

--- a/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingRightGrid.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/TemplateSchedulingRightGrid.tsx
@@ -24,7 +24,7 @@ const TemplateSchedulingRightGrid: React.FC<TemplateSchedulingGridProps> = ({
   );
 
   return (
-    <DescriptionList className="pf-v6-c-description-list">
+    <DescriptionList>
       <DedicatedResources editable={editable} onSubmit={onSubmit} template={template} />
       <EvictionStrategy editable={editable} onSubmit={onSubmit} template={template} />
     </DescriptionList>

--- a/src/views/templates/details/tabs/scripts/TemplateScriptsPage.tsx
+++ b/src/views/templates/details/tabs/scripts/TemplateScriptsPage.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useCallback } from 'react';
-import classnames from 'classnames';
 
 import { TemplateModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -65,12 +64,7 @@ const TemplateScriptsPage: FC<TemplateScriptsPageProps> = ({ obj: template }) =>
   return (
     <PageSection>
       <SidebarEditor<V1Template> onResourceUpdate={onSubmitTemplate} resource={template}>
-        <DescriptionList
-          className={classnames(
-            'pf-v6-c-description-list',
-            'template-scripts-tab__description-list',
-          )}
-        >
+        <DescriptionList className="template-scripts-tab__description-list">
           <VirtualMachineDescriptionItem
             descriptionHeader={
               <Flex className="vm-description-item__title">

--- a/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
@@ -101,7 +101,7 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
       </Title>
       <Grid>
         <GridItem span={5}>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <VirtualMachineDescriptionItem
               descriptionData={
                 getAnnotation(vm, DESCRIPTION_ANNOTATION) || <MutedTextSpan text={t('None')} />
@@ -279,7 +279,7 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
           </DescriptionList>
         </GridItem>
         <GridItem span={5}>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <DetailsSectionHardware vm={vm} vmi={vmi} />
             <DetailsSectionBoot
               canUpdateVM={canUpdateVM}

--- a/src/views/virtualmachines/details/tabs/configuration/initialrun/InitialRunTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/initialrun/InitialRunTab.tsx
@@ -31,7 +31,7 @@ const InitialRunTab: FC<ConfigurationInnerTabProps> = ({ vm, vmi }) => {
           <Title headingLevel="h2">
             <SearchItem id="initial-run">{t('Initial run')}</SearchItem>
           </Title>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <InitialRunTabCloudinit
               canUpdateVM={canUpdateVM}
               onSubmit={onSubmitYAML}

--- a/src/views/virtualmachines/details/tabs/configuration/metadata/MetadataTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/metadata/MetadataTab.tsx
@@ -26,7 +26,7 @@ const MetadataTab: FC<ConfigurationInnerTabProps> = ({ vm }) => {
         <SearchItem id="metadata">{t('Metadata')}</SearchItem>
       </Title>
       <Grid span={6}>
-        <DescriptionList className="pf-v6-c-description-list">
+        <DescriptionList>
           <VirtualMachineDescriptionItem
             bodyContent={t(
               'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. ',

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionLeftGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionLeftGrid.tsx
@@ -54,7 +54,7 @@ const SchedulingSectionLeftGrid: FC<SchedulingSectionLeftGridProps> = ({
 
   return (
     <GridItem span={5}>
-      <DescriptionList className="pf-v6-c-description-list">
+      <DescriptionList>
         <VirtualMachineDescriptionItem
           descriptionData={
             <NodeSelectorDetailItem nodeSelector={vm?.spec?.template?.spec?.nodeSelector} />

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionRightGrid.tsx
@@ -49,7 +49,7 @@ const SchedulingSectionRightGrid: FC<SchedulingSectionRightGridProps> = ({
 
   return (
     <GridItem span={5}>
-      <DescriptionList className="pf-v6-c-description-list">
+      <DescriptionList>
         <VirtualMachineDescriptionItem
           descriptionHeader={
             <SearchItem id="dedicated-resources">{t('Dedicated resources')}</SearchItem>

--- a/src/views/virtualmachines/details/tabs/configuration/ssh/SSHTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/ssh/SSHTab.tsx
@@ -31,7 +31,7 @@ const SSHTab: FC<ConfigurationInnerTabProps> = ({ vm }) => {
         <Grid span={6}>
           <GridItem>
             <Stack hasGutter>
-              <DescriptionList className="pf-v6-c-description-list">
+              <DescriptionList>
                 <SSHTabSSHAccess vm={vm} />
                 <SSHTabAuthorizedSSHKey vm={vm} />
               </DescriptionList>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
@@ -111,7 +111,7 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
         <CardBody isFilled>
           <Grid>
             <GridItem span={5}>
-              <DescriptionList className="pf-v6-c-description-list" isHorizontal>
+              <DescriptionList isHorizontal>
                 <VirtualMachineDescriptionItem
                   data-test-id="virtual-machine-overview-details-name"
                   descriptionData={getName(vm)}

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabGeneral/VirtualMachinesOverviewTabGeneral.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabGeneral/VirtualMachinesOverviewTabGeneral.tsx
@@ -50,7 +50,7 @@ const VirtualMachinesOverviewTabGeneral: FC<VirtualMachinesOverviewTabGeneralPro
         <CardTitle className="pf-v6-u-text-color-subtle">{t('General')}</CardTitle>
         <Divider />
         <CardBody isFilled>
-          <DescriptionList className="pf-v6-c-description-list" isHorizontal>
+          <DescriptionList isHorizontal>
             <VirtualMachineDescriptionItem
               bodyContent={t(
                 'Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. Must be a DNS_LABEL. Cannot be updated. ',

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/components/VirtualMachinesOverviewTabNetworkFQDN.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/components/VirtualMachinesOverviewTabNetworkFQDN.tsx
@@ -28,7 +28,7 @@ const VirtualMachinesOverviewTabNetworkFQDN: FC<VirtualMachinesOverviewTabNetwor
   return (
     <>
       <Divider />
-      <DescriptionList className="pf-v6-c-description-list" isHorizontal>
+      <DescriptionList isHorizontal>
         <VirtualMachineDescriptionItem
           descriptionData={
             <ClipboardCopy

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/VirtualMachinesOverviewTabSnapshotsRow.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/VirtualMachinesOverviewTabSnapshotsRow.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useState } from 'react';
-import classnames from 'classnames';
 
 import {
   V1beta1VirtualMachineSnapshot,
@@ -57,10 +56,10 @@ const VirtualMachinesOverviewTabSnapshotsRow: FC<VirtualMachinesOverviewTabSnaps
     <div className="VirtualMachinesOverviewTabSnapshotsRow--main">
       <div className="name">
         <Icon />
-        <DescriptionListTermHelpText className="pf-v6-c-description-list__term">
+        <DescriptionListTermHelpText>
           <Popover
             bodyContent={
-              <DescriptionList className="pf-v6-c-description-list" isHorizontal>
+              <DescriptionList isHorizontal>
                 <VirtualMachineDescriptionItem
                   descriptionData={
                     <>
@@ -83,9 +82,7 @@ const VirtualMachinesOverviewTabSnapshotsRow: FC<VirtualMachinesOverviewTabSnaps
             headerContent={snapshot?.metadata?.name}
             position={PopoverPosition.left}
           >
-            <DescriptionListTermHelpTextButton
-              className={classnames('pf-v6-c-description-list__text', 'icon-spacer__offset')}
-            >
+            <DescriptionListTermHelpTextButton className="icon-spacer__offset">
               {snapshot?.metadata?.name}
             </DescriptionListTermHelpTextButton>
           </Popover>

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Details.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Details.tsx
@@ -60,7 +60,7 @@ const Details: React.FC<DetailsProps> = ({ pathname, vmi }) => {
       </Title>
       <Grid hasGutter>
         <GridItem span={5}>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <Name name={vmi?.metadata?.name} />
             <Namespace namespace={vmi?.metadata?.namespace} />
             <Labels vmi={vmi} />
@@ -84,7 +84,7 @@ const Details: React.FC<DetailsProps> = ({ pathname, vmi }) => {
         </GridItem>
         <GridItem span={1}></GridItem>
         <GridItem span={5}>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <VirtualMachineDescriptionItem
               descriptionData={<VirtualMachinesInstancesStatus status={vmi?.status?.phase} />}
               descriptionHeader={t('Status')}

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Details/HadwareDevices/HardwareDevices.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Details/HadwareDevices/HardwareDevices.tsx
@@ -18,7 +18,7 @@ const HardwareDevices: React.FC<HardwareDevices> = ({ devices }) => {
   const { t } = useKubevirtTranslation();
 
   return (
-    <DescriptionList className="pf-v6-c-description-list">
+    <DescriptionList>
       <DescriptionListGroup>
         <HardwareDeviceTitle canEdit={false} title={t('GPU devices')} />
         <DescriptionListDescription>

--- a/src/views/virtualmachinesinstance/details/tabs/scheduling/VirtualMachinesInstancePageSchedulingTab.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/scheduling/VirtualMachinesInstancePageSchedulingTab.tsx
@@ -25,7 +25,7 @@ const VirtualMachinesInstancePageSchedulingTab: FC<
     <PageSection>
       <Grid hasGutter>
         <GridItem span={6}>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <VirtualMachineDescriptionItem
               descriptionData={<NodeSelectorDetailItem nodeSelector={vmi?.spec?.nodeSelector} />}
               descriptionHeader={t('Node selector')}
@@ -45,7 +45,7 @@ const VirtualMachinesInstancePageSchedulingTab: FC<
           </DescriptionList>
         </GridItem>
         <GridItem span={6}>
-          <DescriptionList className="pf-v6-c-description-list">
+          <DescriptionList>
             <VirtualMachineDescriptionItem
               descriptionData={<DedicatedResources vmi={vmi} />}
               descriptionHeader={t('Dedicated resources')}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

**Commit 1)**
Fixes Checkups -> Storage -> details page -> YAML editor height.
Also changes layout of the page header to be consistent.

I introduced a `DetailsPageBody` component taken from console [PageBody component](https://github.com/openshift/console/blob/main/frontend/packages/console-shared/src/components/layout/PageBody.tsx). Console reuses it in `HorizontalNav`. I wanted to refactor the `CheckupsStorageDetailsPage` to use `HorizontalNav`, but there is not a clean typed way of passing props, so I decided to avoid that. Example of using HorizontalNav is e.g. [HardwareDevicesPage](https://github.com/kubevirt-ui/kubevirt-plugin/blob/main/src/utils/components/HardwareDevices/HardwareDevicesPage.tsx) that uses `pageData` prop, but I didn't find any documentation for that.

**Commit 2)**
Removes redundant `pf-v6-c-description-list` classes from the codebase

## 🎥 Demo

Before:
<img width="1718" alt="Screenshot 2025-06-06 at 14 53 58" src="https://github.com/user-attachments/assets/6172b683-d7b8-4d9f-8e73-c695e5e1d7bb" />


After:
<img width="1718" alt="Screenshot 2025-06-06 at 14 53 28" src="https://github.com/user-attachments/assets/adbf182b-97b9-44ab-8cfa-accb8db104b4" />


