### PR TITLE
fixing the rendering on empty servicesList causing react error 130

### DIFF
--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
@@ -6,6 +6,7 @@ import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { ServicesList } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { Card, CardBody, CardTitle, Divider } from '@patternfly/react-core';
@@ -35,7 +36,7 @@ const VirtualMachinesOverviewTabService: FC<VirtualMachinesOverviewTabServicePro
       </CardTitle>
       <Divider />
       <CardBody isFilled>
-        <ServicesList data={data || []} loaded={loaded} />
+        {!isEmpty(ServicesList) && <ServicesList data={data} loaded={loaded} />}
       </CardBody>
     </Card>
   );

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Services/Services.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Services/Services.tsx
@@ -4,6 +4,7 @@ import { modelToGroupVersionKind, ServiceModel } from '@kubevirt-ui/kubevirt-api
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { ServicesList } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { Icon, Title } from '@patternfly/react-core';
@@ -30,7 +31,7 @@ const Services = ({ pathname, vmi }) => {
       <Title className="co-section-heading" headingLevel="h2">
         {t('Services')}
       </Title>
-      <ServicesList data={data || []} loaded={loaded} />
+      {!isEmpty(ServicesList) && <ServicesList data={data} loaded={loaded} />}
     </div>
   );
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

there is an error when trying to access vm details caused by servicesList from console SDK-internal rendering as undefined,  it brings up react error 130.  Since this is an unsupported console SDK I created a workaround to make sure the component only renders when defined. 

> Add a brief description
before:
![image](https://github.com/user-attachments/assets/1c3d3609-a9f9-49e0-b8b8-7161754f82c1)

after:
![image](https://github.com/user-attachments/assets/9e0bbf54-7b17-497e-ae25-a56ab1496535)

