### PR TITLE
Cnv 62718 fix cpu display

### DIFF
--- a/src/utils/components/CPUMemory/CPUMemory.tsx
+++ b/src/utils/components/CPUMemory/CPUMemory.tsx
@@ -22,9 +22,9 @@ const CPUMemory: FC<CPUMemoryProps> = ({ vm, vmi }) => {
 
   if ((isVMRunning && !vmi) || !vm) return <Skeleton className="pf-m-width-sm" />;
 
-  const cpu = vCPUCount(getCPU(vm) || getCPU(vmi));
+  const cpu = vCPUCount(getCPU(vmi) || getCPU(vm));
 
-  const memory = readableSizeUnit(getMemory(vm) || getMemory(vmi));
+  const memory = readableSizeUnit(getMemory(vmi) || getMemory(vm));
 
   return (
     <span

--- a/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
@@ -85,6 +85,8 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
   const vmWorkload = getWorkload(vm);
   const vmName = getName(vm);
 
+  const cpuMemoryVM = instanceTypeVM?.metadata?.uid === vm?.metadata?.uid ? instanceTypeVM : vm;
+
   const isInstanceType = isInstanceTypeVM(vm);
   const deletionProtectionEnabled = isDeletionProtectionEnabled(vm);
 
@@ -178,7 +180,7 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
               }
               bodyContent={isInstanceType ? null : <CPUDescription cpu={getCPU(vm)} />}
               data-test-id={`${vmName}-cpu-memory`}
-              descriptionData={<CPUMemory vm={instanceTypeVM || vm} vmi={vmi} />}
+              descriptionData={<CPUMemory vm={cpuMemoryVM || vm} vmi={vmi} />}
               isEdit={canUpdateVM}
               isPopover
             />

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
@@ -74,6 +74,9 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
     true,
   );
 
+  const cpuMemoryVM =
+    instanceTypeExpandedSpec?.metadata?.uid === vm?.metadata?.uid ? instanceTypeExpandedSpec : vm;
+
   const timestampPluralized = pluralize(timestamp['value'], timestamp['time']);
 
   const { fallback, hostname, osName } = useMemo(() => {
@@ -159,7 +162,7 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
                   descriptionHeader={t('Operating system')}
                 />
                 <VirtualMachineDescriptionItem
-                  descriptionData={<CPUMemory vm={instanceTypeExpandedSpec || vm} vmi={vmi} />}
+                  descriptionData={<CPUMemory vm={cpuMemoryVM || vm} vmi={vmi} />}
                   descriptionHeader={t('CPU | Memory')}
                 />
                 <VirtualMachineDescriptionItem

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
@@ -6,6 +6,7 @@ import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { ServicesList } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { Card, CardBody, CardTitle, Divider } from '@patternfly/react-core';
@@ -35,7 +36,7 @@ const VirtualMachinesOverviewTabService: FC<VirtualMachinesOverviewTabServicePro
       </CardTitle>
       <Divider />
       <CardBody isFilled>
-        <ServicesList data={data || []} loaded={loaded} />
+        {!isEmpty(ServicesList) && <ServicesList data={data} loaded={loaded} />}
       </CardBody>
     </Card>
   );

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Services/Services.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Services/Services.tsx
@@ -4,6 +4,7 @@ import { modelToGroupVersionKind, ServiceModel } from '@kubevirt-ui/kubevirt-api
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { ServicesList } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { Icon, Title } from '@patternfly/react-core';
@@ -30,7 +31,7 @@ const Services = ({ pathname, vmi }) => {
       <Title className="co-section-heading" headingLevel="h2">
         {t('Services')}
       </Title>
-      <ServicesList data={data || []} loaded={loaded} />
+      {!isEmpty(ServicesList) && <ServicesList data={data} loaded={loaded} />}
     </div>
   );
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

CPU|Memory field of VM details page shows value of previously clicked VM - if the previous clicked VM comes from InstanceType and the latter from Template. VM from InstanceType value overrides the VM from Template value.

in CPUMemory I prioritized vmi to make sure the right information is being displayed and I added a check to make sure the instanceType was only being used if it matches the current vm to prevent the previous vm's cpu and memory details from being displayed when switching vm's from different types. 


## 🎥 Demo

before:
https://github.com/user-attachments/assets/d8e5035d-1c57-48d2-90cb-9ac3e550e324

after:
https://github.com/user-attachments/assets/797fdf7f-6fee-4ba6-b101-3842690b5dc9

