### PR TITLE
CNV-58719: Fix broken Alerts links in the Virtualization perspective

### DIFF
--- a/src/utils/components/AlertsCard/AlertsCard.tsx
+++ b/src/utils/components/AlertsCard/AlertsCard.tsx
@@ -6,7 +6,7 @@ import AlertsDrawer from '@kubevirt-utils/components/AlertsCard/AlertsDrawer';
 import {
   ALERTS_SCOPE_KEY,
   ALL_ALERTS,
-  VIEW_ALL_ALERTS_PATH,
+  ALL_VIRT_ALERTS_URL_PARAMS,
   VIRTUALIZATION_ONLY_ALERTS,
 } from '@kubevirt-utils/components/AlertsCard/utils/constants';
 import { SimplifiedAlerts } from '@kubevirt-utils/components/AlertsCard/utils/types';
@@ -15,9 +15,11 @@ import {
   removeVMAlerts,
 } from '@kubevirt-utils/components/AlertsCard/utils/utils';
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
+import { getAlertsPath } from '@kubevirt-utils/constants/prometheus';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useLocalStorage from '@kubevirt-utils/hooks/useLocalStorage';
+import { useActivePerspective } from '@openshift-console/dynamic-plugin-sdk';
 import { Card, CardHeader, CardTitle, Popover, PopoverPosition } from '@patternfly/react-core';
 import { SelectOption } from '@patternfly/react-core';
 
@@ -32,6 +34,7 @@ type AlertsCardProps = {
 const AlertsCard: FC<AlertsCardProps> = ({ className, isOverviewPage = false, sortedAlerts }) => {
   const { t } = useKubevirtTranslation();
   const isAdmin = useIsAdmin();
+  const [perspective] = useActivePerspective();
   const [alertScope, setAlertScope] = useLocalStorage(
     ALERTS_SCOPE_KEY,
     isAdmin ? VIRTUALIZATION_ONLY_ALERTS : ALL_ALERTS, // for admins show the number of virtualization health alerts by default
@@ -55,7 +58,10 @@ const AlertsCard: FC<AlertsCardProps> = ({ className, isOverviewPage = false, so
             actions: (
               <>
                 {isAdmin && (
-                  <Link className="alerts-card__view-all-link" to={VIEW_ALL_ALERTS_PATH}>
+                  <Link
+                    className="alerts-card__view-all-link"
+                    to={getAlertsPath(perspective, null, ALL_VIRT_ALERTS_URL_PARAMS)}
+                  >
                     {t('View all')}
                   </Link>
                 )}

--- a/src/utils/components/AlertsCard/utils/constants.ts
+++ b/src/utils/components/AlertsCard/utils/constants.ts
@@ -1,5 +1,5 @@
-export const VIEW_ALL_ALERTS_PATH =
-  '/monitoring/alerts?rowFilter-alert-state=firing&rowFilter-alert-source=platform&alerts=kubernetes_operator_part_of%3Dkubevirt';
+export const ALL_VIRT_ALERTS_URL_PARAMS =
+  '?rowFilter-alert-state=firing&rowFilter-alert-source=platform&alerts=kubernetes_operator_part_of%3Dkubevirt';
 
 export const ALERTS_SCOPE_KEY = 'overview-alerts-scope';
 

--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -24,3 +24,10 @@ export enum K8S_OPS {
   REMOVE = 'remove',
   REPLACE = 'replace',
 }
+
+export enum PERSPECTIVES {
+  ACM = 'acm',
+  ADMIN = 'admin',
+  DEVELOPER = 'dev',
+  VIRTUALIZATION = 'virtualization-perspective',
+}

--- a/src/utils/constants/prometheus.ts
+++ b/src/utils/constants/prometheus.ts
@@ -1,3 +1,22 @@
-export const MONITORING_URL_BASE = '/monitoring/alerts';
+import { PERSPECTIVES } from '@kubevirt-utils/constants/constants';
+import { AlertResource } from '@overview/OverviewTab/status-card/utils/utils';
+
 export const MONITORING_SALT = 'monitoring-salt';
 export const OPERATOR_LABEL_KEY = 'kubernetes_operator_part_of';
+
+export const getAlertsBasePath = (perspective: string, namespace?: string) => {
+  switch (perspective) {
+    case PERSPECTIVES.ACM:
+      return `/multicloud${AlertResource.plural}`;
+    case PERSPECTIVES.ADMIN:
+      return AlertResource.plural;
+    case PERSPECTIVES.VIRTUALIZATION:
+      return `/virt-monitoring/alerts`;
+    case PERSPECTIVES.DEVELOPER:
+    default:
+      return `/dev-monitoring/ns/${namespace}/alerts`;
+  }
+};
+
+export const getAlertsPath = (perspective: string, namespace?: string, suffix?: string) =>
+  `${getAlertsBasePath(perspective, namespace)}${suffix}`;

--- a/src/views/clusteroverview/OverviewTab/status-card/StatusCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/status-card/StatusCard.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
+import { getAlertsBasePath } from '@kubevirt-utils/constants/prometheus';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   DashboardsOverviewHealthSubsystem as DynamicDashboardsOverviewHealthSubsystem,
   isDashboardsOverviewHealthSubsystem as isDynamicDashboardsOverviewHealthSubsystem,
   isResolvedDashboardsOverviewHealthURLSubsystem,
   K8sResourceCommon,
+  useActivePerspective,
   useK8sWatchResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { HealthBody } from '@openshift-console/dynamic-plugin-sdk-internal';
@@ -23,6 +25,7 @@ import VirtualizationAlerts from './utils/VirtualizationAlerts';
 
 const StatusCard = () => {
   const { t } = useKubevirtTranslation();
+  const [perspective] = useActivePerspective();
   const subsystems = useDashboardSubsystems<DynamicDashboardsOverviewHealthSubsystem>(
     isDynamicDashboardsOverviewHealthSubsystem,
   );
@@ -59,7 +62,7 @@ const StatusCard = () => {
     <Card className="co-overview-card--gradient" data-test-id="kv-overview-status-card">
       <CardHeader
         actions={{
-          actions: <Link to="/monitoring/alerts">{t('View alerts')}</Link>,
+          actions: <Link to={getAlertsBasePath(perspective)}>{t('View alerts')}</Link>,
           className: 'co-overview-card__actions',
           hasNoOffset: false,
         }}

--- a/src/views/dashboard-extensions/KubevirtHealthPopup/KubevirtHealthPopup.tsx
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/KubevirtHealthPopup.tsx
@@ -3,28 +3,35 @@ import { Link } from 'react-router-dom-v5-compat';
 
 import { AlertType } from '@kubevirt-utils/components/AlertsCard/utils/types';
 import LoadingEmptyState from '@kubevirt-utils/components/LoadingEmptyState/LoadingEmptyState';
+import { getAlertsPath } from '@kubevirt-utils/constants/prometheus';
 import useInfrastructureAlerts from '@kubevirt-utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { YellowExclamationTriangleIcon } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  useActivePerspective,
+  YellowExclamationTriangleIcon,
+} from '@openshift-console/dynamic-plugin-sdk';
 import { RedExclamationCircleIcon } from '@openshift-console/dynamic-plugin-sdk/lib/app/components/status/icons';
 import { Divider, Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
 
 import Conditions from './components/Conditions/Conditions';
 import HealthPopupChart from './components/HealthPopupChart';
 import { HealthImpactLevel } from './utils/types';
-import { ALERTS_BASE_PATH } from './utils/utils';
+import { HEALTH_ALERTS_URL_PARAMS } from './utils/utils';
 
 import './KubevirtHealthPopup.scss';
 
 const KubevirtHealthPopup: FC = () => {
   const { alerts, loaded, numberOfAlerts } = useInfrastructureAlerts();
+  const [perspective] = useActivePerspective();
+
   const descriptionText = t(
     'You can host and manage virtualized workloads on the same platform as container-based workloads.',
   );
 
   const numCriticalAlerts = alerts?.[HealthImpactLevel.critical]?.length;
   const numWarningAlerts = alerts?.[AlertType.warning]?.length;
+  const healthAlertsURLBasePath = getAlertsPath(perspective, null, HEALTH_ALERTS_URL_PARAMS);
 
   return (
     <>
@@ -41,7 +48,7 @@ const KubevirtHealthPopup: FC = () => {
               <StackItem>
                 <div className="kv-health-popup__alerts-count">
                   <RedExclamationCircleIcon className="kv-health-popup__alerts-count--icon" />
-                  <Link to={`${ALERTS_BASE_PATH}${HealthImpactLevel.critical}`}>
+                  <Link to={`${healthAlertsURLBasePath}${HealthImpactLevel.critical}`}>
                     {numCriticalAlerts} {t('Critical')}
                   </Link>
                 </div>
@@ -51,7 +58,7 @@ const KubevirtHealthPopup: FC = () => {
               <StackItem>
                 <div className="kv-health-popup__alerts-count">
                   <YellowExclamationTriangleIcon className="kv-health-popup__alerts-count--icon" />{' '}
-                  <Link to={`${ALERTS_BASE_PATH}${HealthImpactLevel.warning}`}>
+                  <Link to={`${healthAlertsURLBasePath}${HealthImpactLevel.warning}`}>
                     {numWarningAlerts} {t('Warning')}
                   </Link>
                 </div>

--- a/src/views/dashboard-extensions/KubevirtHealthPopup/utils/utils.ts
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/utils/utils.ts
@@ -1,5 +1,5 @@
-export const ALERTS_BASE_PATH =
-  '/monitoring/alerts?rowFilter-alert-state=firing,silenced&rowFilter-alert-source=platform&alerts=kubernetes_operator_part_of%3Dkubevirt%2Coperator_health_impact%3D';
+export const HEALTH_ALERTS_URL_PARAMS =
+  '?rowFilter-alert-state=firing,silenced&rowFilter-alert-source=platform&alerts=kubernetes_operator_part_of%3Dkubevirt%2Coperator_health_impact%3D';
 
 export const alertTypeToColorMap = {
   critical: '#C9190B',


### PR DESCRIPTION
## 📝 Description

This PR fixes an issue with links to the Alerts monitoring page from the Virtualization perspective. The base path for the Alerts monitoring page is now different based on which perspective you are in.

Jira: https://issues.redhat.com/browse/CNV-58719

## 🎥 Demo

### Before

[alerts-page-from-virt-perspective--BEFORE--2025-06-11 09-37.webm](https://github.com/user-attachments/assets/c761f866-48a0-48fc-9021-036a83e99245)

### After

[alerts-page-from-virt-perspective--AFTER--2025-06-11 09-38.webm](https://github.com/user-attachments/assets/26cd75e4-7962-4028-856b-ad698519116b)