### PR TITLE
CNV-62998: adjsting cpu usage units in vm utilization charts

### DIFF
--- a/src/utils/components/Charts/CPUUtil/CPUThresholdChart.tsx
+++ b/src/utils/components/Charts/CPUUtil/CPUThresholdChart.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom-v5-compat';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getVMIPod } from '@kubevirt-utils/resources/vmi';
+import { humanizeCpuCores } from '@kubevirt-utils/utils/humanize.js';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   K8sResourceCommon,
@@ -70,11 +71,19 @@ const CPUThresholdChart: FC<CPUThresholdChartProps> = ({ pods, vmi }) => {
   const cpuRequested = dataCPURequested?.data?.result?.[0]?.values;
 
   const chartData = cpuUsage?.map(([x, y]) => {
-    return { name: 'CPU usage', x: new Date(x * MILLISECONDS_MULTIPLIER), y: Number(y) };
+    return {
+      name: 'CPU usage',
+      x: new Date(x * MILLISECONDS_MULTIPLIER),
+      y: humanizeCpuCores(Number(y)).value,
+    };
   });
 
   const thresholdData = cpuRequested?.map(([x, y]) => {
-    return { name: 'CPU requested', x: new Date(x * MILLISECONDS_MULTIPLIER), y: Number(y) };
+    return {
+      name: 'CPU requested',
+      x: new Date(x * MILLISECONDS_MULTIPLIER),
+      y: humanizeCpuCores(Number(y)).value,
+    };
   });
 
   const isReady = !isEmpty(chartData) && !isEmpty(thresholdData);

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
@@ -7,6 +7,7 @@ import ComponentReady from '@kubevirt-utils/components/Charts/ComponentReady/Com
 import { getUtilizationQueries } from '@kubevirt-utils/components/Charts/utils/queries';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getVMIPod } from '@kubevirt-utils/resources/vmi';
+import { humanizeCpuCores } from '@kubevirt-utils/utils/humanize.js';
 import {
   K8sResourceCommon,
   PrometheusEndpoint,
@@ -43,8 +44,8 @@ const CPUUtil: FC<CPUUtilProps> = ({ pods, vmi }) => {
     query: queries?.CPU_USAGE,
   });
 
-  const cpuUsage = +dataCPUUsage?.data?.result?.[0]?.value?.[1];
-  const cpuRequested = +dataCPURequested?.data?.result?.[0]?.value?.[1];
+  const cpuUsage = humanizeCpuCores(+dataCPUUsage?.data?.result?.[0]?.value?.[1]).value;
+  const cpuRequested = humanizeCpuCores(+dataCPURequested?.data?.result?.[0]?.value?.[1]).value;
   const averageCPUUsage = (cpuUsage / cpuRequested) * 100;
   const isReady = !Number.isNaN(cpuUsage) && !Number.isNaN(cpuRequested);
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

in vm overview-> utilization CPU units were calculated and displayed wrongly. fix to display information correctly using humanizeCpuCores().

## 🎥 Demo
before:
![image](https://github.com/user-attachments/assets/12698d30-c8d2-420f-bcc8-563a93f80c63)

after:
![image](https://github.com/user-attachments/assets/2e6feaae-5ce3-456f-93bf-8d33f7ae698e)
