### PR TITLE
CNV-57475: make disk size not editable when using volume snapshot

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -491,6 +491,7 @@
   "Disabling Deletion Protection will allow you to delete this VirtualMachine. VirtualMachine deletion can result in data loss or service disruption.": "Disabling Deletion Protection will allow you to delete this VirtualMachine. VirtualMachine deletion can result in data loss or service disruption.",
   "Disconnect": "Disconnect",
   "Disk size": "Disk size",
+  "Disk size will be determined by the volume snapshot size": "Disk size will be determined by the volume snapshot size",
   "Disk source": "Disk source",
   "Disk Source represents the source for our disk, this can be HTTP, Registry or an existing PVC": "Disk Source represents the source for our disk, this can be HTTP, Registry or an existing PVC",
   "Disk Type": "Disk Type",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -493,6 +493,7 @@
   "Disabling Deletion Protection will allow you to delete this VirtualMachine. VirtualMachine deletion can result in data loss or service disruption.": "Deshabilitar la protección contra eliminación le permitirá eliminar esta VirtualMachine. Eliminar una VirtualMachine puede provocar la pérdida de datos o la interrupción del servicio.",
   "Disconnect": "Desconectar",
   "Disk size": "Tamaño del disco",
+  "Disk size will be determined by the volume snapshot size": "Disk size will be determined by the volume snapshot size",
   "Disk source": "Fuente del disco",
   "Disk Source represents the source for our disk, this can be HTTP, Registry or an existing PVC": "La fuente del disco representa la fuente de nuestro disco, que puede ser HTTP, registro o una PVC existente",
   "Disk Type": "Tipo de disco",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -493,6 +493,7 @@
   "Disabling Deletion Protection will allow you to delete this VirtualMachine. VirtualMachine deletion can result in data loss or service disruption.": "La désactivation de la protection contre la suppression vous permettra de supprimer cette machine virtuelle. La suppression d'une machine virtuelle peut entraîner une perte de données ou une interruption de service.",
   "Disconnect": "Déconnecter",
   "Disk size": "Taille du disque",
+  "Disk size will be determined by the volume snapshot size": "Disk size will be determined by the volume snapshot size",
   "Disk source": "Source du disque",
   "Disk Source represents the source for our disk, this can be HTTP, Registry or an existing PVC": "La source du disque représente la source de notre disque, cela peut être HTTP, le registre ou un PVC existant",
   "Disk Type": "Type de disque",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -491,6 +491,7 @@
   "Disabling Deletion Protection will allow you to delete this VirtualMachine. VirtualMachine deletion can result in data loss or service disruption.": "削除保護を無効にすると、この VirtualMachine を削除できるようになります。VirtualMachine を削除すると、データの損失やサービスの中断が発生する可能性があります。",
   "Disconnect": "接続の解除",
   "Disk size": "ディスクサイズ",
+  "Disk size will be determined by the volume snapshot size": "Disk size will be determined by the volume snapshot size",
   "Disk source": "ディスクソース",
   "Disk Source represents the source for our disk, this can be HTTP, Registry or an existing PVC": "ディスクソースはディスクのソースを表します。これには HTTP、レジストリー、または既存の PVC のいずれかです",
   "Disk Type": "ディスクタイプ",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -491,6 +491,7 @@
   "Disabling Deletion Protection will allow you to delete this VirtualMachine. VirtualMachine deletion can result in data loss or service disruption.": "삭제 보호를 비활성화하면 이 VirtualMachine을 삭제할 수 있습니다. VirtualMachine 삭제로 인해 데이터가 손실되거나 서비스 중단이 발생할 수 있습니다.",
   "Disconnect": "연결 해제",
   "Disk size": "디스크 크기",
+  "Disk size will be determined by the volume snapshot size": "Disk size will be determined by the volume snapshot size",
   "Disk source": "디스크 소스",
   "Disk Source represents the source for our disk, this can be HTTP, Registry or an existing PVC": "디스크 소스는 디스크의 소스, HTTP, Registry 또는 기존 PVC일 수 있습니다.",
   "Disk Type": "디스크 유형",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -491,6 +491,7 @@
   "Disabling Deletion Protection will allow you to delete this VirtualMachine. VirtualMachine deletion can result in data loss or service disruption.": "禁用删除保护将允许您删除此 VirtualMachine。VirtualMachine 删除可能会导致数据丢失或服务中断。",
   "Disconnect": "断开连接",
   "Disk size": "磁盘大小",
+  "Disk size will be determined by the volume snapshot size": "Disk size will be determined by the volume snapshot size",
   "Disk source": "磁盘源",
   "Disk Source represents the source for our disk, this can be HTTP, Registry or an existing PVC": "磁盘源代表磁盘的源，可以是 HTTP、Registry 或一个现有的 PVC",
   "Disk Type": "磁盘类型",

--- a/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -74,6 +74,9 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
       return { ...prev, labels: updatedLabels };
     });
   };
+
+  const resetDiskSize = () => setBootableVolumeField('size')(initialBootableVolumeState.size);
+
   return (
     <TabModal
       onClose={() => {
@@ -99,6 +102,7 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
         <SourceTypeSelection
           formSelection={sourceType}
           namespace={namespace}
+          resetDiskSize={resetDiskSize}
           setFormSelection={setSourceType}
         />
         <Title headingLevel="h5">{t('Source details')}</Title>
@@ -119,6 +123,7 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
         </Title>
         <VolumeDestination
           bootableVolume={bootableVolume}
+          isSnapshotSourceType={sourceType === DROPDOWN_FORM_SELECTION.USE_SNAPSHOT}
           setBootableVolumeField={setBootableVolumeField}
         />
         <Title className="pf-v6-u-mt-md" headingLevel="h5">

--- a/src/utils/components/AddBootableVolumeModal/components/SourceTypeSelection/SourceTypeSelection.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/SourceTypeSelection/SourceTypeSelection.tsx
@@ -12,12 +12,14 @@ import { DROPDOWN_FORM_SELECTION, optionsValueLabelMapper } from '../../utils/co
 type SourceTypeSelectionProps = {
   formSelection: DROPDOWN_FORM_SELECTION;
   namespace: string;
+  resetDiskSize: () => void;
   setFormSelection: (value: DROPDOWN_FORM_SELECTION) => void;
 };
 
 const SourceTypeSelection: FC<SourceTypeSelectionProps> = ({
   formSelection,
   namespace,
+  resetDiskSize,
   setFormSelection,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -31,8 +33,15 @@ const SourceTypeSelection: FC<SourceTypeSelectionProps> = ({
       event.preventDefault();
       setFormSelection(value);
       setIsOpen(false);
+
+      if (
+        formSelection === DROPDOWN_FORM_SELECTION.USE_SNAPSHOT &&
+        value !== DROPDOWN_FORM_SELECTION.USE_SNAPSHOT
+      ) {
+        resetDiskSize();
+      }
     },
-    [setFormSelection],
+    [setFormSelection, resetDiskSize],
   );
 
   useEffect(() => {

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeDestination/VolumeDestination.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeDestination/VolumeDestination.tsx
@@ -13,11 +13,13 @@ import StorageClassSelect from './StorageClass/StorageClassSelect';
 
 type VolumeDestinationProps = {
   bootableVolume: AddBootableVolumeState;
+  isSnapshotSourceType?: boolean;
   setBootableVolumeField: SetBootableVolumeFieldType;
 };
 
 const VolumeDestination: FC<VolumeDestinationProps> = ({
   bootableVolume,
+  isSnapshotSourceType,
   setBootableVolumeField,
 }) => {
   const { t } = useKubevirtTranslation();
@@ -49,8 +51,12 @@ const VolumeDestination: FC<VolumeDestinationProps> = ({
             setVolumeMode={setBootableVolumeField('volumeMode')}
           />
         </GridItem>
-        <GridItem span={6}>
+        <GridItem>
           <CapacityInput
+            helperText={
+              isSnapshotSourceType && t('Disk size will be determined by the volume snapshot size')
+            }
+            isDisabled={isSnapshotSourceType}
             label={t('Disk size')}
             onChange={setBootableVolumeField('size')}
             size={size}

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/SnapshotSource.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/SnapshotSource.tsx
@@ -17,6 +17,7 @@ const SnapshotSource: FC<SnapshotSourceProps> = ({ bootableVolume, setBootableVo
     <SelectSnapshot
       selectSnapshotName={setBootableVolumeField('snapshotName')}
       selectSnapshotNamespace={setBootableVolumeField('snapshotNamespace')}
+      setDiskSize={setBootableVolumeField('size')}
       snapshotNameSelected={snapshotName}
       snapshotNamespaceSelected={snapshotNamespace}
     />

--- a/src/utils/components/CapacityInput/CapacityInput.tsx
+++ b/src/utils/components/CapacityInput/CapacityInput.tsx
@@ -23,6 +23,8 @@ import {
 } from './utils';
 
 type CapacityInputProps = {
+  helperText?: string;
+  isDisabled?: boolean;
   isEditingCreatedDisk?: boolean;
   isMinusDisabled?: boolean;
   label?: string;
@@ -32,6 +34,8 @@ type CapacityInputProps = {
 };
 
 const CapacityInput: FC<CapacityInputProps> = ({
+  helperText,
+  isDisabled,
   isEditingCreatedDisk,
   isMinusDisabled,
   label,
@@ -72,18 +76,18 @@ const CapacityInput: FC<CapacityInputProps> = ({
               Number(value) < Number.MAX_SAFE_INTEGER &&
               onChange(`${Number(value) + 1}${removeByteSuffix(unit)}`)
             }
-            isDisabled={isEditingCreatedDisk}
+            isDisabled={isDisabled || isEditingCreatedDisk}
             max={Number.MAX_SAFE_INTEGER}
             min={1}
             minusBtnAriaLabel={t('Decrement')}
-            minusBtnProps={{ isDisabled: isMinusDisabled }}
+            minusBtnProps={{ isDisabled: isDisabled || isMinusDisabled }}
             onMinus={() => onChange(`${Number(value) - 1}${removeByteSuffix(unit)}`)}
             plusBtnAriaLabel={t('Increment')}
             value={value}
           />
         </SplitItem>
         <SplitItem>
-          <FormPFSelect onSelect={onFormatChange} selected={unit}>
+          <FormPFSelect isDisabled={isDisabled} onSelect={onFormatChange} selected={unit}>
             <SelectList>
               {unitOptions.map((formatOption) => (
                 <SelectOption
@@ -106,6 +110,7 @@ const CapacityInput: FC<CapacityInputProps> = ({
           </>
         )}
       </FormGroupHelperText>
+      {helperText && <FormGroupHelperText>{helperText}</FormGroupHelperText>}
     </FormGroup>
   );
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When adding a bootable volume from "Volume snapshot", changing size of the disk had no effect - the size is always determined from the VolumeSnapshot size.

This PR disables the Disk size input when a "Volume snapshot" option is chosen and adjusts the size in the input + adds an info message for users.

## 🎥 Demo

Before:

 

https://github.com/user-attachments/assets/e65d8716-827d-4761-8cc5-0c1b03896cae



After:


https://github.com/user-attachments/assets/69c1dfbb-03a0-49ca-bdb5-0540abfa973c



