### PR TITLE
CNV-63722: fix crashing settings

### DIFF
--- a/src/views/clusteroverview/SettingsTab/ClusterTab/ClusterTab.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/ClusterTab.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
 
+import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
-import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Alert, AlertVariant, Divider } from '@patternfly/react-core';
+import { Divider } from '@patternfly/react-core';
 
 import { useKubevirtCSVDetails } from '../../utils/hooks/useKubevirtCSVDetails';
 import { isNewBadgeNeeded } from '../../utils/utils';
@@ -14,7 +14,6 @@ import PersistentReservationSection from './components/PersistentReservationSect
 import ResourceManagementSection from './components/ResourceManagementSection/ResourceManagementSection';
 
 const ClusterTab: FC = () => {
-  const { t } = useKubevirtTranslation();
   const hyperConvergeConfiguration = useHyperConvergeConfiguration();
   const error = hyperConvergeConfiguration?.[2];
   const { installedCSV, ...CSVDetails } = useKubevirtCSVDetails();
@@ -39,11 +38,7 @@ const ClusterTab: FC = () => {
       <Divider className="section-divider" />
 
       <PersistentReservationSection hyperConvergeConfiguration={hyperConvergeConfiguration} />
-      {error && (
-        <Alert isInline title={t('Error')} variant={AlertVariant.danger}>
-          {error}
-        </Alert>
-      )}
+      <ErrorAlert error={error} />
     </>
   );
 };

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/GuestSystemLogsAccess/GuestSystemLogsAccess.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/GuestSystemLogsAccess/GuestSystemLogsAccess.tsx
@@ -36,7 +36,7 @@ const GuestSystemLogsAccess: FC<GuestSystemLogsAccessProps> = ({
   const disableSerialConsoleLog =
     hyperConverge?.spec?.virtualMachineOptions?.disableSerialConsoleLog;
 
-  const [error, setError] = useState<Error>(null);
+  const [error, setError] = useState<string>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isChecked, setIsChecked] = useState<boolean>();
 

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
@@ -29,7 +29,7 @@ const PersistentReservationSection: FC<PersistentReservationSectionProps> = ({
   const [hyperConverge, hyperLoaded] = hyperConvergeConfiguration;
   const persistentReservation = Boolean(hyperConverge?.spec?.featureGates?.persistentReservation);
 
-  const [error, setError] = useState<Error>(null);
+  const [error, setError] = useState<string>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const { toggleFeature } = useFeatures(FEATURE_HCO_PERSISTENT_RESERVATION);
 

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.tsx
@@ -24,7 +24,7 @@ const AutoComputeCPULimits: FC<AutoComputeCPULimitsProps> = ({
     Boolean(featureGates?.[AUTO_RESOURCE_LIMITS_FEATURE_GATE]),
   );
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState<Error>();
+  const [error, setError] = useState<string>();
 
   const onFeatureChange = (switchOn: boolean) => {
     setIsLoading(true);

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/KernelSamepageMerging/KernelSamepageMerging.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/KernelSamepageMerging/KernelSamepageMerging.tsx
@@ -45,7 +45,7 @@ const KernelSamepageMerging: FC<KernelSamepageMergingProps> = ({
   );
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<null | string>(null);
 
   const onKSMchange = (value: boolean) => {
     setIsLoading(true);

--- a/src/views/templates/details/tabs/parameters/TemplateParametersPage.tsx
+++ b/src/views/templates/details/tabs/parameters/TemplateParametersPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import { useImmer } from 'use-immer';
 
 import { TemplateModel, TemplateParameter, V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -96,11 +97,8 @@ const TemplateParametersPage: FC<TemplateParametersPageProps> = ({ obj: template
               {index !== parameters.length - 1 && <Divider />}
             </>
           ))}
-          {error && (
-            <Alert isInline title={t('Error')} variant={AlertVariant.danger}>
-              {error}
-            </Alert>
-          )}
+
+          <ErrorAlert error={error} />
 
           {success && (
             <Alert isInline title={t('Success')} variant={AlertVariant.info}>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description


The error that react show in the crash

```
Objects are not valid as a React child (found: e: hyperconvergeds.hco.kubevirt.io is forbidden: User "test2" cannot list resource "hyperconvergeds" in API group "hco.kubevirt.io" at the cluster scope). If you meant to render a collection of children, use an array instead.
````

The crash is because we are displaing the error object that react cannot handle . We should show the `error.message` that its a string. We have a component that do that . ErrorAlert. And if the error is `null`, it will return `null`
