### PR TITLE
CNV-62163: Prevent refreshing details page on VM change

### DIFF
--- a/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
+++ b/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
@@ -29,13 +29,6 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
   const location = useLocation();
 
   const params = useParams();
-  const [memoParams, setMemoParams] = useState(params);
-
-  useEffect(() => {
-    setMemoParams((preParams) =>
-      JSON.stringify(params) !== JSON.stringify(preParams) ? params : preParams,
-    );
-  }, [params]);
 
   const dynamicPluginPages = useDynamicPages(VirtualMachineModel);
 
@@ -58,27 +51,24 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
 
   const [activeItem, setActiveItem] = useState<number | string>();
 
-  const RoutesComponents = useMemo(() => {
-    return allPages.map((page) => {
-      const Component = page.component;
-      return (
-        <Route
-          Component={(props) => (
-            <StateHandler error={error} loaded={loaded} withBullseye>
-              <Component
-                instanceTypeExpandedSpec={instanceTypeExpandedSpec}
-                obj={vm}
-                params={memoParams}
-                {...props}
-              />
-            </StateHandler>
-          )}
-          key={page.href}
-          path={page.href}
-        />
-      );
-    });
-  }, [allPages, vm, error, loaded, instanceTypeExpandedSpec, memoParams]);
+  const RoutesComponents = allPages.map((page) => {
+    const Component = page.component;
+    return (
+      <Route
+        element={
+          <StateHandler error={error} hasData={!!vm} loaded={loaded} withBullseye>
+            <Component
+              instanceTypeExpandedSpec={instanceTypeExpandedSpec}
+              obj={vm}
+              params={params}
+            />
+          </StateHandler>
+        }
+        key={page.href}
+        path={page.href}
+      />
+    );
+  });
 
   return (
     <>

--- a/src/utils/components/StateHandler/StateHandler.tsx
+++ b/src/utils/components/StateHandler/StateHandler.tsx
@@ -16,11 +16,18 @@ import Loading from '../Loading/Loading';
 
 type StateHandlerProps = {
   error?: any;
+  hasData: boolean;
   loaded: boolean;
   withBullseye?: boolean;
 };
 
-const StateHandler: FC<StateHandlerProps> = ({ children, error, loaded, withBullseye = false }) => {
+const StateHandler: FC<StateHandlerProps> = ({
+  children,
+  error,
+  hasData,
+  loaded,
+  withBullseye = false,
+}) => {
   const { t } = useKubevirtTranslation();
 
   if (error) {
@@ -50,7 +57,7 @@ const StateHandler: FC<StateHandlerProps> = ({ children, error, loaded, withBull
     );
   }
 
-  if (!loaded) {
+  if (!loaded && !hasData) {
     return withBullseye ? (
       <Bullseye>
         <Loading />

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
@@ -126,7 +126,7 @@ const VirtualMachineMigrateModal: FC<VirtualMachineMigrateModalProps> = ({
       variant="large"
     >
       <ModalBody>
-        <StateHandler error={loadingError || migPlanCreationError} loaded>
+        <StateHandler error={loadingError || migPlanCreationError} hasData loaded>
           {migrationStarted ? (
             <VirtualMachineMigrationStatus
               migMigration={migMigration}

--- a/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
+++ b/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo, useRef } from 'react';
+import React, { FC, memo, useMemo, useRef } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
 import CreateResourceDefaultPage from '@kubevirt-utils/components/CreateResourceDefaultPage/CreateResourceDefaultPage';
@@ -24,12 +24,11 @@ import VirtualMachineTreeView from '@virtualmachines/tree/VirtualMachineTreeView
 
 import { defaultVMYamlTemplate } from '../../../templates';
 
-const VirtualMachineNavigator: FC = () => {
+const VirtualMachineNavigator: FC<{ activeNamespace: string }> = memo(({ activeNamespace }) => {
   useSignals();
   const { t } = useKubevirtTranslation();
   const vmListRef = useRef<{ onFilterChange: OnFilterChange } | null>(null);
   const location = useLocation();
-  const [activeNamespace] = useActiveNamespace();
   const namespace = activeNamespace === ALL_NAMESPACES_SESSION_KEY ? null : activeNamespace;
   const vmName = location.pathname.split('/')?.[5];
 
@@ -86,6 +85,11 @@ const VirtualMachineNavigator: FC = () => {
       </VirtualMachineTreeView>
     </>
   );
+});
+
+const VirtualMachineNavigatorWithNamespace: FC = () => {
+  const [activeNamespace] = useActiveNamespace();
+  return <VirtualMachineNavigator activeNamespace={activeNamespace} />;
 };
 
-export default VirtualMachineNavigator;
+export default VirtualMachineNavigatorWithNamespace;


### PR DESCRIPTION
## 📝 Description
Changes:
1. show spinner only if no data - prevents re-creating page
2. migrate to Router v6 element syntax as it enables re-rendering optimizations i.e. it effectively fixes #2612 (re-renders occur but have no visual impact).
3. re-implement #2612 on VirtualMachineNavigator level. Extra re-renders are triggered by useActiveNamespace hook.

Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/2612

## 🎥 Demo
### Before


https://github.com/user-attachments/assets/5af5657f-8c90-4d55-a43f-4feb898a5746


### After

https://github.com/user-attachments/assets/80242edb-0b7e-4711-a088-c35ed558ff35


