### PR TITLE
CNV-57386: use size of the volume for InstanceType VMs

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore.ts
@@ -13,6 +13,8 @@ import { getLabel } from '@kubevirt-utils/resources/shared';
 import { generatePrettyName } from '@kubevirt-utils/utils/utils';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
+import { getDiskSize } from '../utils/utils';
+
 import { instanceTypeVMStoreInitialState } from './utils/state';
 import { InstanceTypeVMStore } from './utils/types';
 import { getSSHCredentials } from './utils/utils';
@@ -43,6 +45,11 @@ export const useInstanceTypeVMStore = create<InstanceTypeVMStore>()((set, get) =
           instanceTypeVMState.selectedBootableVolume = selectedVolume;
           instanceTypeVMState.pvcSource = pvcSource;
           instanceTypeVMState.volumeSnapshotSource = volumeSnapshotSource;
+          instanceTypeVMState.customDiskSize = getDiskSize(
+            dvSource,
+            pvcSource,
+            volumeSnapshotSource,
+          );
           instanceTypeVMState.selectedInstanceType = {
             name: getInstanceTypeFromVolume(selectedVolume),
             namespace: null,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Changes state of `customDiskSize` upon clicking a volume from the table. So the correct size is used instead of the default 30Gi.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/e5d84ef7-2090-44a1-8a5c-3c7ade485937



After:

https://github.com/user-attachments/assets/a910bb8e-0f68-4c77-9593-0cc7d5766f9a


