### PR TITLE
CNV-63622: customize the migplan list page with the storage migration

### DIFF
--- a/src/views/storagemigrations/actions/useStorageMigrationActions.tsx
+++ b/src/views/storagemigrations/actions/useStorageMigrationActions.tsx
@@ -96,7 +96,7 @@ const useStorageMigrationActions: ExtensionHook<Action[], MigPlan> = (migPlan) =
           )),
         disabled: false,
         id: 'migplan-delete-action',
-        label: t('Delete'),
+        label: t('Delete {{kind}}', { kind: MigPlanModel.kind }),
       },
     ],
     [

--- a/src/views/storagemigrations/extensions.ts
+++ b/src/views/storagemigrations/extensions.ts
@@ -1,14 +1,14 @@
 import { EncodedExtension } from '@openshift/dynamic-plugin-sdk-webpack';
 import {
   FeatureFlagHookProvider,
-  HrefNavItem,
   NavSection,
-  RoutePage,
+  ResourceActionProvider,
 } from '@openshift-console/dynamic-plugin-sdk';
 import type { ConsolePluginBuildMetadata } from '@openshift-console/dynamic-plugin-sdk-webpack';
 
 export const exposedModules: ConsolePluginBuildMetadata['exposedModules'] = {
   StorageMigrationList: './views/storagemigrations/list/StorageMigrationList.tsx',
+  useStorageMigrationActions: './views/storagemigrations/actions/useStorageMigrationActions.tsx',
 };
 
 export const extensions: EncodedExtension[] = [
@@ -49,32 +49,17 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/section',
   } as EncodedExtension<NavSection>,
   {
-    flags: {
-      required: ['STORAGE_MIGRATION_ENABLED'],
-    },
     properties: {
       component: { $codeRef: 'StorageMigrationList' },
-      path: ['/k8s/storagemigrations'],
-    },
-    type: 'console.page/route',
-  } as EncodedExtension<RoutePage>,
-  {
-    flags: {
-      required: ['STORAGE_MIGRATION_ENABLED'],
-    },
-    properties: {
-      dataAttributes: {
-        'data-quickstart-id': 'qs-nav-storagemigrations',
-        'data-test-id': 'storagemigrations-nav-item',
+      model: {
+        group: 'migration.openshift.io',
+        kind: 'MigPlan',
+        version: 'v1alpha1',
       },
-      href: '/k8s/storagemigrations',
-      id: 'storagemigrations',
-      name: '%plugin__kubevirt-plugin~Storage MigrationPlans%',
-      prefixNamespaced: false,
-      section: 'migration',
     },
-    type: 'console.navigation/href',
-  } as EncodedExtension<HrefNavItem>,
+    type: 'console.page/resource/list',
+  },
+
   {
     flags: {
       required: ['STORAGE_MIGRATION_ENABLED'],
@@ -84,12 +69,51 @@ export const extensions: EncodedExtension[] = [
         'data-quickstart-id': 'qs-nav-storagemigrations-virt-perspective',
         'data-test-id': 'storagemigrations-virt-perspective-nav-item',
       },
-      href: '/k8s/storagemigrations',
       id: 'storagemigrations-virt-perspective',
-      name: '%plugin__kubevirt-plugin~Storage MigrationPlans%',
-      prefixNamespaced: false,
+      model: {
+        group: 'migration.openshift.io',
+        kind: 'MigPlan',
+        version: 'v1alpha1',
+      },
+      name: '%plugin__kubevirt-plugin~Storage migrations%',
       section: 'migration-virt-perspective',
     },
-    type: 'console.navigation/href',
-  } as EncodedExtension<HrefNavItem>,
+    type: 'console.navigation/resource-ns',
+  },
+  {
+    flags: {
+      required: ['STORAGE_MIGRATION_ENABLED'],
+    },
+    properties: {
+      dataAttributes: {
+        'data-quickstart-id': 'qs-nav-storagemigrations',
+        'data-test-id': 'storagemigrations-nav-item',
+      },
+      id: 'storagemigrations',
+      model: {
+        group: 'migration.openshift.io',
+        kind: 'MigPlan',
+        version: 'v1alpha1',
+      },
+      name: '%plugin__kubevirt-plugin~Storage migrations%',
+      section: 'migration',
+    },
+    type: 'console.navigation/resource-ns',
+  },
+  {
+    flags: {
+      required: ['STORAGE_MIGRATION_ENABLED'],
+    },
+    properties: {
+      model: {
+        group: 'migration.openshift.io',
+        kind: 'MigPlan',
+        version: 'v1alpha1',
+      },
+      provider: {
+        $codeRef: 'useStorageMigrationActions',
+      },
+    },
+    type: 'console.action/resource-provider',
+  } as EncodedExtension<ResourceActionProvider>,
 ];

--- a/src/views/storagemigrations/list/components/StorageMigrationRow.tsx
+++ b/src/views/storagemigrations/list/components/StorageMigrationRow.tsx
@@ -1,9 +1,8 @@
 import React, { FC } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
-import ActionsDropdown from '@kubevirt-utils/components/ActionsDropdown/ActionsDropdown';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { modelToGroupVersionKind, StorageClassModel } from '@kubevirt-utils/models';
+import { modelToGroupVersionKind, modelToRef, StorageClassModel } from '@kubevirt-utils/models';
 import { MigPlan, MigPlanModel } from '@kubevirt-utils/resources/migrations/constants';
 import { getName, getNamespace, getResourceUrl } from '@kubevirt-utils/resources/shared';
 import {
@@ -12,9 +11,9 @@ import {
   TableData,
   Timestamp,
 } from '@openshift-console/dynamic-plugin-sdk';
+import { LazyActionMenu } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { Progress } from '@patternfly/react-core';
 
-import useStorageMigrationActions from '../../actions/useStorageMigrationActions';
 import { MigPlanMap } from '../constants';
 import { getSelectedPVFromMigPlan, getStorageClassesFromMigPlan } from '../utils';
 
@@ -37,8 +36,6 @@ const StorageMigrationRow: FC<StorageMigrationRowProps> = ({
   const directVolumeMigration = migPlanMap[migPlanName]?.directVolumeMigration;
 
   const statusMigration = getStatusMigration(migMigration, directVolumeMigration);
-
-  const [storageMigrationActions] = useStorageMigrationActions(obj);
 
   return (
     <>
@@ -78,11 +75,7 @@ const StorageMigrationRow: FC<StorageMigrationRowProps> = ({
         )}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="pf-v6-c-table__action" id="">
-        <ActionsDropdown
-          actions={storageMigrationActions}
-          id="storage-migplans-actions"
-          isKebabToggle
-        />
+        <LazyActionMenu context={{ [modelToRef(MigPlanModel)]: obj }} />
       </TableData>
     </>
   );

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
@@ -8,8 +8,15 @@ import Loading from '@kubevirt-utils/components/Loading/Loading';
 import StateHandler from '@kubevirt-utils/components/StateHandler/StateHandler';
 import useDefaultStorageClass from '@kubevirt-utils/hooks/useDefaultStorage/useDefaultStorageClass';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { modelToGroupVersionKind, PersistentVolumeClaimModel } from '@kubevirt-utils/models';
-import { MigPlanModel } from '@kubevirt-utils/resources/migrations/constants';
+import {
+  modelToGroupVersionKind,
+  modelToRef,
+  PersistentVolumeClaimModel,
+} from '@kubevirt-utils/models';
+import {
+  DEFAULT_MIGRATION_NAMESPACE,
+  MigPlanModel,
+} from '@kubevirt-utils/resources/migrations/constants';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { k8sDelete, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
@@ -164,7 +171,10 @@ const VirtualMachineMigrateModal: FC<VirtualMachineMigrateModalProps> = ({
                   >
                     <Trans ns="plugin__kubevirt-plugin" t={t}>
                       Click{' '}
-                      <Link onClick={onClose} to="/k8s/storagemigrations">
+                      <Link
+                        onClick={onClose}
+                        to={`/k8s/ns/${DEFAULT_MIGRATION_NAMESPACE}/${modelToRef(MigPlanModel)}`}
+                      >
                         {t('Storage Migrations')}
                       </Link>{' '}
                       to review and delete existing MigPlans.

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationStatus.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationStatus.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom-v5-compat';
 
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { modelToRef } from '@kubevirt-utils/models';
 import { Timestamp } from '@openshift-console/dynamic-plugin-sdk';
 import {
   ActionList,
@@ -17,8 +18,10 @@ import {
 import { CloseIcon } from '@patternfly/react-icons';
 
 import {
+  DEFAULT_MIGRATION_NAMESPACE,
   MigMigration,
   MigMigrationStatuses,
+  MigPlanModel,
 } from '../../../../../utils/resources/migrations/constants';
 
 import useProgressMigration from './hooks/useProgressMigration';
@@ -111,7 +114,10 @@ const VirtualMachineMigrationStatus: FC<VirtualMachineMigrationStatusProps> = ({
           )}
         </ActionListItem>
         <ActionListItem className="migration-status__view-report">
-          <Link onClick={onClose} to="/k8s/storagemigrations">
+          <Link
+            onClick={onClose}
+            to={`/k8s/ns/${DEFAULT_MIGRATION_NAMESPACE}/${modelToRef(MigPlanModel)}`}
+          >
             {t('View storage migrations')}
           </Link>
         </ActionListItem>


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Make sure storage migration is not a standalone page but it customize the migplan list page as migplan is only used for storage. 


So when users goes into migplan and then clicks on the breadcrum, it goes back to the storage migration page instead of default list page 

## 🎥 Demo


https://github.com/user-attachments/assets/bbe131c8-a98f-4544-b722-00b009f06ed2


