### PR TITLE
CNV-56959: Allow snapshot as boot source for Templates

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1260,6 +1260,7 @@
   "Size": "Size",
   "Size cannot be": "Size cannot be",
   "Small scale consumption, recommended for using the graphical console": "Small scale consumption, recommended for using the graphical console",
+  "Snapshot": "Snapshot",
   "Snapshots": "Snapshots",
   "Snapshots ({{snapshots}})": "Snapshots ({{snapshots}})",
   "Sockets": "Sockets",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1264,6 +1264,7 @@
   "Size": "Tamaño",
   "Size cannot be": "El tamaño no puede ser",
   "Small scale consumption, recommended for using the graphical console": "Consumo reducido, recomendado para usar la consola gráfica.",
+  "Snapshot": "Snapshot",
   "Snapshots": "Instantáneas",
   "Snapshots ({{snapshots}})": "Instantáneas ({{snapshots}})",
   "Sockets": "Sockets",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1264,6 +1264,7 @@
   "Size": "Taille",
   "Size cannot be": "La taille ne peut pas être",
   "Small scale consumption, recommended for using the graphical console": "Consommation à petite échelle, recommandée pour l’utilisation de la console graphique",
+  "Snapshot": "Snapshot",
   "Snapshots": "Instantanés",
   "Snapshots ({{snapshots}})": "Instantanés ({{snapshots}} )",
   "Sockets": "Sockets",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1260,6 +1260,7 @@
   "Size": "サイズ",
   "Size cannot be": "サイズは以下にできません",
   "Small scale consumption, recommended for using the graphical console": "小規模の消費量 (グラフィカルコンソールの使用に推奨)",
+  "Snapshot": "Snapshot",
   "Snapshots": "スナップショット",
   "Snapshots ({{snapshots}})": "スナップショット ({{snapshots}})",
   "Sockets": "ソケット",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1260,6 +1260,7 @@
   "Size": "크기",
   "Size cannot be": "크기 값이 올바르지 않습니다",
   "Small scale consumption, recommended for using the graphical console": "그래픽 콘솔 사용에 권장되는 소규모 소비량",
+  "Snapshot": "Snapshot",
   "Snapshots": "스냅 샷",
   "Snapshots ({{snapshots}})": "스냅 샷 ({{snapshots}})",
   "Sockets": "소켓",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1260,6 +1260,7 @@
   "Size": "大小",
   "Size cannot be": "大小不能是",
   "Small scale consumption, recommended for using the graphical console": "低资源消耗，建议使用图形控制台时使用",
+  "Snapshot": "Snapshot",
   "Snapshots": "快照",
   "Snapshots ({{snapshots}})": "快照 ({{snapshots}})",
   "Sockets": "插槽",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     ]
   },
   "name": "kubevirt-plugin",
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "private": true,
   "resolutions": {
     "@types/react": "^17.0.40",

--- a/src/utils/resources/template/hooks/useVmTemplateSource/useVMTemplateSource.ts
+++ b/src/utils/resources/template/hooks/useVmTemplateSource/useVMTemplateSource.ts
@@ -132,6 +132,19 @@ export const useVMTemplateSource = (template: V1Template): UseVMTemplateSourceVa
           setLoaded(true);
         }
         break;
+      case BOOT_SOURCE.SNAPSHOT:
+        {
+          setTemplateBootSource({
+            source: bootSource.source,
+            sourceValue: {
+              snapshot: bootSource?.source?.snapshot,
+            },
+            type: bootSource.type,
+          });
+          setIsBootSourceAvailable(true);
+          setLoaded(true);
+        }
+        break;
       default:
         setIsBootSourceAvailable(false);
         setLoaded(true);

--- a/src/utils/resources/template/hooks/useVmTemplateSource/utils.ts
+++ b/src/utils/resources/template/hooks/useVmTemplateSource/utils.ts
@@ -13,6 +13,7 @@ import {
   V1beta1DataVolumeSourcePVC,
   V1beta1DataVolumeSourceRef,
   V1beta1DataVolumeSourceRegistry,
+  V1beta1DataVolumeSourceSnapshot,
   V1beta1PersistentVolumeClaim,
   V1ContainerDiskSource,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -30,6 +31,7 @@ export type TemplateBootSource = {
     http?: V1beta1DataVolumeSourceHTTP;
     pvc?: V1beta1DataVolumeSourcePVC;
     registry?: V1beta1DataVolumeSourceRegistry;
+    snapshot?: V1beta1DataVolumeSourceSnapshot;
     sourceRef?: V1beta1DataVolumeSourceRef;
   };
   sourceValue?: {
@@ -37,6 +39,7 @@ export type TemplateBootSource = {
     http?: V1beta1DataVolumeSourceHTTP;
     pvc?: V1beta1PersistentVolumeClaim;
     registry?: V1beta1DataVolumeSourceRegistry;
+    snapshot?: V1beta1DataVolumeSourceSnapshot;
     sourceRef?: V1beta1PersistentVolumeClaim;
   };
   storageClassName?: string;

--- a/src/utils/resources/template/utils/constants.ts
+++ b/src/utils/resources/template/utils/constants.ts
@@ -103,6 +103,7 @@ export enum BOOT_SOURCE {
   NONE = 'NONE',
   PVC = 'PVC',
   REGISTRY = 'REGISTRY',
+  SNAPSHOT = 'SNAPSHOT',
   URL = 'URL',
 }
 
@@ -112,6 +113,7 @@ export enum BOOT_SOURCE {
 // t('Registry')
 // t('Container disk')
 // t('No boot source')
+// t('Snapshot')
 
 export const BOOT_SOURCE_LABELS = {
   [BOOT_SOURCE.CONTAINER_DISK]: 'Container disk',
@@ -120,6 +122,7 @@ export const BOOT_SOURCE_LABELS = {
   [BOOT_SOURCE.NONE]: 'No boot source',
   [BOOT_SOURCE.PVC]: 'PVC',
   [BOOT_SOURCE.REGISTRY]: 'Registry',
+  [BOOT_SOURCE.SNAPSHOT]: 'Snapshot',
   [BOOT_SOURCE.URL]: 'URL',
 };
 

--- a/src/utils/resources/vm/utils/source.ts
+++ b/src/utils/resources/vm/utils/source.ts
@@ -98,6 +98,12 @@ export const getVMBootSourceType = (vm: V1VirtualMachine): TemplateBootSource =>
         type: BOOT_SOURCE.PVC,
       };
     }
+    if (source?.snapshot) {
+      return {
+        source: { snapshot: source?.snapshot },
+        type: BOOT_SOURCE.SNAPSHOT,
+      };
+    }
   }
 
   if (volume?.containerDisk) {

--- a/src/views/templates/details/tabs/disks/hooks/useTemplateDisksTableData.ts
+++ b/src/views/templates/details/tabs/disks/hooks/useTemplateDisksTableData.ts
@@ -1,5 +1,6 @@
 import useWizardDisksTableData from '@catalog/wizard/tabs/disks/hooks/useWizardDisksTableData';
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 
@@ -13,7 +14,7 @@ type UseDisksTableDisks = (template: V1Template) => [DiskRowDataLayout[], boolea
 const useTemplateDisksTableData: UseDisksTableDisks = (template) => {
   const vm = getTemplateVirtualMachineObject(template);
 
-  const data = useWizardDisksTableData(vm, template?.metadata?.namespace);
+  const data = useWizardDisksTableData(vm, getNamespace(template));
   return data;
 };
 

--- a/start-console.sh
+++ b/start-console.sh
@@ -63,7 +63,7 @@ for arg in "$@"; do
     INITIAL_PORT=$((INITIAL_PORT + 1))
 done
 
-CONSOLE_IMAGE=${CONSOLE_IMAGE:-"quay.io/openshift/origin-console:latest"}
+CONSOLE_IMAGE=${CONSOLE_IMAGE:-"quay.io/openshift/origin-console:4.19"}
 CONSOLE_PORT=${CONSOLE_PORT:-9000}
 
 echo "Starting local OpenShift console..."


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug that prevented snapshots that had been added to Templates as boot sources weren't being recognized as boot sources in the Template-based VM creation flow.

Jira: https://issues.redhat.com/browse/CNV-56959

## 🎥 Demo

### Before

![add-snapshot-as-boot-source--BEFORE--2025-06-20 10-53](https://github.com/user-attachments/assets/ae35d875-5d52-4ec5-b226-0aca57dd9f41)

### After

![add-snapshot-as-boot-source--AFTER--2025-06-20 10-50](https://github.com/user-attachments/assets/019ffd1d-4211-4e90-8fe7-57c826c30dc6)