### PR TITLE
CNV-57798: report also PVC disks in VM deletion modal

### DIFF
--- a/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useConvertedVolumeNames.ts
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useConvertedVolumeNames.ts
@@ -3,12 +3,13 @@ import { V1beta1CDIConfig } from '@kubevirt-ui/kubevirt-api/containerized-data-i
 import { V1Volume } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
-type UseDataVolumeConvertedVolumeNames = (vmVolumes: V1Volume[]) => {
+type UseConvertedVolumeNames = (vmVolumes: V1Volume[]) => {
   dvVolumesNames: string[];
   isDataVolumeGarbageCollector: boolean;
+  pvcVolumesNames: string[];
 };
 
-const useDataVolumeConvertedVolumeNames: UseDataVolumeConvertedVolumeNames = (vmVolumes) => {
+const useConvertedVolumeNames: UseConvertedVolumeNames = (vmVolumes) => {
   const [cdiConfig] = useK8sWatchResource<V1beta1CDIConfig>({
     groupVersionKind: CDIConfigModelGroupVersionKind,
     isList: false,
@@ -21,10 +22,15 @@ const useDataVolumeConvertedVolumeNames: UseDataVolumeConvertedVolumeNames = (vm
     .filter((volume) => volume?.dataVolume)
     ?.map((volume) => volume?.dataVolume?.name);
 
+  const pvcVolumesNames = (vmVolumes || [])
+    .filter((volume) => volume?.persistentVolumeClaim)
+    ?.map((volume) => volume?.persistentVolumeClaim?.claimName);
+
   return {
     dvVolumesNames,
     isDataVolumeGarbageCollector,
+    pvcVolumesNames,
   };
 };
 
-export default useDataVolumeConvertedVolumeNames;
+export default useConvertedVolumeNames;


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When we delete a VM, that was previously restored from a snapshot and has hotplugged disks, the hotplugged disks are now reported in the deletion modal

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/7e56c8b7-e317-4050-b524-10c5400d28d6


After:

https://github.com/user-attachments/assets/419ea720-ad2f-4e7a-ae07-a2284ee746dd


