### PR TITLE
CNV-64350: CNV-61710: Fix bugs in bootable volumes Preferences select menu

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/VolumeMetadata.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/VolumeMetadata.tsx
@@ -39,6 +39,7 @@ const VolumeMetadata: FC<VolumeMetadataProps> = ({
 
       <InstanceTypeDrilldownSelect
         selected={labels?.[DEFAULT_INSTANCETYPE_LABEL]}
+        setBootableVolumeField={setBootableVolumeField}
         setSelected={setBootableVolumeField('labels', DEFAULT_INSTANCETYPE_LABEL)}
       />
       <FormGroup label={t('Description')}>

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/VolumeMetadata.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/VolumeMetadata.tsx
@@ -34,6 +34,7 @@ const VolumeMetadata: FC<VolumeMetadataProps> = ({
         deleteLabel={deleteLabel}
         selectedPreference={labels?.[DEFAULT_PREFERENCE_LABEL]}
         setBootableVolumeField={setBootableVolumeField}
+        volumeLabels={bootableVolume?.labels}
       />
 
       <InstanceTypeDrilldownSelect

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/VolumeMetadata.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/VolumeMetadata.tsx
@@ -1,9 +1,6 @@
 import React, { FC } from 'react';
 
-import {
-  DEFAULT_INSTANCETYPE_LABEL,
-  DEFAULT_PREFERENCE_LABEL,
-} from '@catalog/CreateFromInstanceTypes/utils/constants';
+import { DEFAULT_INSTANCETYPE_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ANNOTATIONS } from '@kubevirt-utils/resources/template';
 import { FormGroup, TextInput } from '@patternfly/react-core';
@@ -31,10 +28,9 @@ const VolumeMetadata: FC<VolumeMetadataProps> = ({
   return (
     <>
       <PreferenceSelect
+        bootableVolume={bootableVolume}
         deleteLabel={deleteLabel}
-        selectedPreference={labels?.[DEFAULT_PREFERENCE_LABEL]}
         setBootableVolumeField={setBootableVolumeField}
-        volumeLabels={bootableVolume?.labels}
       />
 
       <InstanceTypeDrilldownSelect

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/InstanceTypeDrilldownSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/InstanceTypeDrilldownSelect.tsx
@@ -1,6 +1,10 @@
 import React, { FC, useCallback, useMemo, useState } from 'react';
 
 import useInstanceTypesAndPreferences from '@catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypesAndPreferences';
+import { DEFAULT_INSTANCETYPE_KIND_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
+import VirtualMachineClusterInstancetypeModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineClusterInstancetypeModel';
+import VirtualMachineInstancetypeModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstancetypeModel';
+import { SetBootableVolumeFieldType } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/constants';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup, PopoverPosition } from '@patternfly/react-core';
@@ -15,11 +19,13 @@ import { getInstanceTypeMenuItems } from './utils/utils';
 
 type InstanceTypeMenuItemsProps = {
   selected: string;
+  setBootableVolumeField: SetBootableVolumeFieldType;
   setSelected: (value: string) => void;
 };
 
 export const InstanceTypeDrilldownSelect: FC<InstanceTypeMenuItemsProps> = ({
   selected,
+  setBootableVolumeField,
   setSelected,
 }) => {
   const { t } = useKubevirtTranslation();
@@ -29,11 +35,12 @@ export const InstanceTypeDrilldownSelect: FC<InstanceTypeMenuItemsProps> = ({
   const menuItems = useMemo(() => getInstanceTypeMenuItems(allInstanceTypes), [allInstanceTypes]);
 
   const onSelect = useCallback(
-    (value: string) => {
+    (kind: string) => (value: string) => {
+      setBootableVolumeField('labels', DEFAULT_INSTANCETYPE_KIND_LABEL)(kind);
       setSelected(value);
       setIsOpen(false);
     },
-    [setSelected],
+    [setBootableVolumeField, setSelected],
   );
 
   return (
@@ -59,14 +66,14 @@ export const InstanceTypeDrilldownSelect: FC<InstanceTypeMenuItemsProps> = ({
           <RedHatInstanceTypeSeriesMenu
             selected={selected}
             series={menuItems.redHatProvided.items}
-            setSelected={onSelect}
+            setSelected={onSelect(VirtualMachineClusterInstancetypeModel.kind)}
           />
         </DrilldownMenuItem>
         <DrilldownMenuItem {...menuItems.userProvided}>
           <UserInstanceTypeMenu
             allInstanceTypes={allInstanceTypes}
             selected={selected}
-            setSelected={onSelect}
+            setSelected={onSelect(VirtualMachineInstancetypeModel.kind)}
           />
         </DrilldownMenuItem>
       </ComposableDrilldownSelect>

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/PreferenceSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/PreferenceSelect.tsx
@@ -2,7 +2,10 @@ import React, { FC } from 'react';
 
 import { DEFAULT_PREFERENCE_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
 import usePreferenceSelectOptions from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/hooks/usePreferenceSelectOptions';
-import { SetBootableVolumeFieldType } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/constants';
+import {
+  AddBootableVolumeState,
+  SetBootableVolumeFieldType,
+} from '@kubevirt-utils/components/AddBootableVolumeModal/utils/constants';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
@@ -13,21 +16,22 @@ import { getSelectedKeyByLabel } from './utils/utils';
 import PreferencePopoverContent from './PreferencePopoverContent';
 
 type PreferenceSelectProps = {
+  bootableVolume: AddBootableVolumeState;
   deleteLabel: (labelKey: string) => void;
-  selectedPreference: string;
   setBootableVolumeField: SetBootableVolumeFieldType;
-  volumeLabels: { [key: string]: string };
 };
 
 const PreferenceSelect: FC<PreferenceSelectProps> = ({
+  bootableVolume,
   deleteLabel,
-  selectedPreference,
   setBootableVolumeField,
-  volumeLabels,
 }) => {
   const { t } = useKubevirtTranslation();
+
+  const { bootableVolumeNamespace, labels } = bootableVolume;
   const { preferenceSelectOptions, preferencesLoaded } = usePreferenceSelectOptions(
     deleteLabel,
+    bootableVolumeNamespace,
     setBootableVolumeField,
   );
 
@@ -38,10 +42,11 @@ const PreferenceSelect: FC<PreferenceSelectProps> = ({
     setBootableVolumeField('labels', DEFAULT_PREFERENCE_LABEL)(selectedValue.label);
   };
 
+  const selectedPreference = labels?.[DEFAULT_PREFERENCE_LABEL];
   const selectedPreferenceKey = getSelectedKeyByLabel(
     selectedPreference,
     preferenceSelectOptions,
-    volumeLabels,
+    labels,
   );
 
   return (

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/hooks/usePreferenceSelectOptions.ts
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/hooks/usePreferenceSelectOptions.ts
@@ -13,11 +13,10 @@ import { SetBootableVolumeFieldType } from '@kubevirt-utils/components/AddBootab
 import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useUserPreferences from '@kubevirt-utils/hooks/useUserPreferences';
-import { getValidNamespace } from '@kubevirt-utils/utils/utils';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 
 type UsePreferenceSelectOptions = (
   deleteLabel: (labelKey: string) => void,
+  namespace: string,
   setBootableVolumeField: SetBootableVolumeFieldType,
 ) => {
   preferenceSelectOptions: EnhancedSelectOptionProps[];
@@ -26,11 +25,10 @@ type UsePreferenceSelectOptions = (
 
 const usePreferenceSelectOptions: UsePreferenceSelectOptions = (
   deleteLabel,
+  namespace,
   setBootableVolumeField,
 ) => {
   const { t } = useKubevirtTranslation();
-  const [activeNamespace] = useActiveNamespace();
-  const namespace = getValidNamespace(activeNamespace);
 
   const [preferences, preferencesLoaded] = useClusterPreferences();
   const [userPreferences = [], userPreferencesLoaded] = useUserPreferences(namespace);

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/hooks/usePreferenceSelectOptions.ts
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/hooks/usePreferenceSelectOptions.ts
@@ -13,6 +13,7 @@ import { SetBootableVolumeFieldType } from '@kubevirt-utils/components/AddBootab
 import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useUserPreferences from '@kubevirt-utils/hooks/useUserPreferences';
+import { getValidNamespace } from '@kubevirt-utils/utils/utils';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 
 type UsePreferenceSelectOptions = (
@@ -29,9 +30,10 @@ const usePreferenceSelectOptions: UsePreferenceSelectOptions = (
 ) => {
   const { t } = useKubevirtTranslation();
   const [activeNamespace] = useActiveNamespace();
+  const namespace = getValidNamespace(activeNamespace);
 
   const [preferences, preferencesLoaded] = useClusterPreferences();
-  const [userPreferences = [], userPreferencesLoaded] = useUserPreferences(activeNamespace);
+  const [userPreferences = [], userPreferencesLoaded] = useUserPreferences(namespace);
 
   const preferenceSelectOptions = useMemo(() => {
     const preferenceOptions: EnhancedSelectOptionProps[] = getResourceDropdownOptions({

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/hooks/usePreferenceSelectOptions.ts
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/hooks/usePreferenceSelectOptions.ts
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+
+import useClusterPreferences from '@catalog/CreateFromInstanceTypes/state/hooks/useClusterPreferences';
+import { DEFAULT_PREFERENCE_KIND_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
+import {
+  VirtualMachineClusterPreferenceModelGroupVersionKind,
+  VirtualMachinePreferenceModelGroupVersionKind,
+} from '@kubevirt-ui/kubevirt-api/console';
+import VirtualMachineClusterPreferenceModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineClusterPreferenceModel';
+import VirtualMachinePreferenceModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachinePreferenceModel';
+import { getResourceDropdownOptions } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/utils/utils';
+import { SetBootableVolumeFieldType } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/constants';
+import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useUserPreferences from '@kubevirt-utils/hooks/useUserPreferences';
+import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+
+type UsePreferenceSelectOptions = (
+  deleteLabel: (labelKey: string) => void,
+  setBootableVolumeField: SetBootableVolumeFieldType,
+) => {
+  preferenceSelectOptions: EnhancedSelectOptionProps[];
+  preferencesLoaded: boolean;
+};
+
+const usePreferenceSelectOptions: UsePreferenceSelectOptions = (
+  deleteLabel,
+  setBootableVolumeField,
+) => {
+  const { t } = useKubevirtTranslation();
+  const [activeNamespace] = useActiveNamespace();
+
+  const [preferences, preferencesLoaded] = useClusterPreferences();
+  const [userPreferences = [], userPreferencesLoaded] = useUserPreferences(activeNamespace);
+
+  const preferenceSelectOptions = useMemo(() => {
+    const preferenceOptions: EnhancedSelectOptionProps[] = getResourceDropdownOptions({
+      group: t('Cluster preferences'),
+      groupVersionKind: VirtualMachineClusterPreferenceModelGroupVersionKind,
+      kind: VirtualMachineClusterPreferenceModel.kind,
+      onClick: () =>
+        setBootableVolumeField(
+          'labels',
+          DEFAULT_PREFERENCE_KIND_LABEL,
+        )(VirtualMachineClusterPreferenceModelGroupVersionKind.kind),
+      resources: preferences,
+    });
+
+    const userPreferenceOptions: EnhancedSelectOptionProps[] = getResourceDropdownOptions({
+      group: t('User preferences'),
+      groupVersionKind: VirtualMachinePreferenceModelGroupVersionKind,
+      kind: VirtualMachinePreferenceModel.kind,
+      onClick: () =>
+        setBootableVolumeField(
+          'labels',
+          DEFAULT_PREFERENCE_KIND_LABEL,
+        )(VirtualMachinePreferenceModelGroupVersionKind.kind),
+      resources: userPreferences,
+    });
+    return [...userPreferenceOptions, ...preferenceOptions];
+  }, [preferences, userPreferences, deleteLabel, setBootableVolumeField, t]);
+
+  return {
+    preferenceSelectOptions,
+    preferencesLoaded: preferencesLoaded && userPreferencesLoaded,
+  };
+};
+
+export default usePreferenceSelectOptions;

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/utils/utils.ts
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/utils/utils.ts
@@ -1,13 +1,28 @@
+import { DEFAULT_PREFERENCE_KIND_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
+import {
+  VirtualMachineClusterPreferenceModelGroupVersionKind,
+  VirtualMachinePreferenceModelGroupVersionKind,
+} from '@kubevirt-ui/kubevirt-api/console';
+import VirtualMachineClusterPreferenceModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineClusterPreferenceModel';
 import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { K8sGroupVersionKind, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
-export const getResourceDropdownOptions = (
-  resources: K8sResourceCommon[],
-  groupVersionKind: K8sGroupVersionKind,
-  onClick: () => void,
-  group?: string,
-): EnhancedSelectOptionProps[] =>
+type ResourceDropdownOptionParams = {
+  group?: string;
+  groupVersionKind: K8sGroupVersionKind;
+  kind?: string;
+  onClick: () => void;
+  resources: K8sResourceCommon[];
+};
+
+export const getResourceDropdownOptions = ({
+  group,
+  groupVersionKind,
+  kind,
+  onClick,
+  resources,
+}: ResourceDropdownOptionParams): EnhancedSelectOptionProps[] =>
   resources
     ?.map(getName)
     ?.sort((a, b) => a.localeCompare(b))
@@ -15,6 +30,27 @@ export const getResourceDropdownOptions = (
       children: opt,
       group,
       groupVersionKind,
+      label: opt,
       onClick,
-      value: opt,
+      value: kind ? `${kind}-${opt}` : opt,
     }));
+
+export const getSelectedKeyByLabel = (
+  label: string,
+  options: EnhancedSelectOptionProps[],
+  volumeLabels: { [key: string]: string },
+) => {
+  // Name could be duplicated between cluster and user Preferences
+  const matchingOptions = options.filter((option) => option.label === label);
+
+  if (matchingOptions.length === 1) return matchingOptions[0]?.value;
+
+  const isClusterPreference =
+    volumeLabels?.[DEFAULT_PREFERENCE_KIND_LABEL] === VirtualMachineClusterPreferenceModel.kind;
+
+  const groupVersionKind = isClusterPreference
+    ? VirtualMachineClusterPreferenceModelGroupVersionKind
+    : VirtualMachinePreferenceModelGroupVersionKind;
+
+  return matchingOptions.find((option) => option.groupVersionKind === groupVersionKind)?.value;
+};

--- a/src/utils/components/FilterSelect/components/InlineFilterSelectOptionContent.tsx
+++ b/src/utils/components/FilterSelect/components/InlineFilterSelectOptionContent.tsx
@@ -11,7 +11,11 @@ type InlineFilterSelectOptionContentProps = {
 
 const InlineFilterSelectOptionContent: FC<InlineFilterSelectOptionContentProps> = ({ option }) =>
   !isEmpty(option?.groupVersionKind) ? (
-    <ResourceLink groupVersionKind={option.groupVersionKind} linkTo={false} name={option.value} />
+    <ResourceLink
+      groupVersionKind={option.groupVersionKind}
+      linkTo={false}
+      name={option?.label || option.value}
+    />
   ) : (
     <>{option?.children}</>
   );

--- a/src/utils/components/FilterSelect/utils/types.ts
+++ b/src/utils/components/FilterSelect/utils/types.ts
@@ -4,6 +4,7 @@ import { SelectOptionProps } from '@patternfly/react-core';
 export type EnhancedSelectOptionProps = SelectOptionProps & {
   group?: string;
   groupVersionKind?: K8sGroupVersionKind;
+  label?: string;
   value: string;
   /** Value for the text filter. Takes precedence over value, useful when value does not reflect the text content of the option. */
   valueForFilter?: string;

--- a/src/views/catalog/CreateFromInstanceTypes/utils/constants.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/constants.ts
@@ -7,5 +7,6 @@ export enum INSTANCE_TYPES_SECTIONS {
 export const DEFAULT_PREFERENCE_LABEL = 'instancetype.kubevirt.io/default-preference';
 export const DEFAULT_PREFERENCE_KIND_LABEL = 'instancetype.kubevirt.io/default-preference-kind';
 export const DEFAULT_INSTANCETYPE_LABEL = 'instancetype.kubevirt.io/default-instancetype';
+export const DEFAULT_INSTANCETYPE_KIND_LABEL = 'instancetype.kubevirt.io/default-instancetype-kind';
 export const PREFERENCE_DISPLAY_NAME_KEY = 'openshift.io/display-name';
 export const KUBEVIRT_OS = 'kubevirt.io/os';


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug in the Preferences select menu in the bootable volumes modal where the UI was unable to tell whether the user Preference or cluster Preference was selected if they had the same name. It also fixes a bug where the `instancetype.kubevirt.io/default-instancetype-kind` label wasn't set when an Instancetype was selected in the bootable volumes modal.

Jira issues: 

- https://issues.redhat.com/browse/CNV-61710
- https://issues.redhat.com/browse/CNV-64350

## 🎥 Demo

### Before

![instance-type-and-pref-kind-labels--BEFORE--2025-06-24 09-37](https://github.com/user-attachments/assets/fb75e1a7-e62d-465e-a82e-27dd4f25e23d)

### After

![instance-type-and-pref-kind-labels--AFTER--2025-06-24 09-34](https://github.com/user-attachments/assets/58d9e4c0-3015-4f77-883d-8ddcffc87cfd)