### PR TITLE
CNV-61770: fix linking to User Preferences in Bootable volumes

### DIFF
--- a/src/utils/resources/bootableresources/constants.ts
+++ b/src/utils/resources/bootableresources/constants.ts
@@ -1,6 +1,3 @@
-export const DEFAULT_PREFERENCE_LABEL = 'instancetype.kubevirt.io/default-preference';
-export const DEFAULT_INSTANCETYPE_LABEL = 'instancetype.kubevirt.io/default-instancetype';
-
 export const COMMON_INSTANCETYPES = 'common-instancetypes';
 export const INSTANCETYPE_CLASS_ANNOTATION = 'instancetype.kubevirt.io/class';
 export const KUBEVIRT_ISO_LABEL = 'kubevirt.io/iso';

--- a/src/utils/resources/preference/types.ts
+++ b/src/utils/resources/preference/types.ts
@@ -1,0 +1,8 @@
+import {
+  V1beta1VirtualMachineClusterPreference,
+  V1beta1VirtualMachinePreference,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
+
+export type VirtualMachinePreference =
+  | V1beta1VirtualMachineClusterPreference
+  | V1beta1VirtualMachinePreference;

--- a/src/views/bootablevolumes/actions/components/EditBootableVolumesModal.tsx
+++ b/src/views/bootablevolumes/actions/components/EditBootableVolumesModal.tsx
@@ -5,6 +5,10 @@ import {
   InstanceTypeCategory,
 } from '@catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/utils/types';
 import { categoryDetailsMap } from '@catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/utils/utils';
+import {
+  DEFAULT_INSTANCETYPE_LABEL,
+  DEFAULT_PREFERENCE_LABEL,
+} from '@catalog/CreateFromInstanceTypes/utils/constants';
 import { VirtualMachineClusterPreferenceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
@@ -14,10 +18,6 @@ import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import {
-  DEFAULT_INSTANCETYPE_LABEL,
-  DEFAULT_PREFERENCE_LABEL,
-} from '@kubevirt-utils/resources/bootableresources/constants';
 import { convertResourceArrayToMap } from '@kubevirt-utils/resources/shared';
 import { ANNOTATIONS } from '@kubevirt-utils/resources/template';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';

--- a/src/views/bootablevolumes/utils/utils.ts
+++ b/src/views/bootablevolumes/utils/utils.ts
@@ -1,10 +1,10 @@
-import { PersistentVolumeClaimModel } from '@kubevirt-ui/kubevirt-api/console';
-import DataSourceModel from '@kubevirt-ui/kubevirt-api/console/models/DataSourceModel';
-import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import {
   DEFAULT_INSTANCETYPE_LABEL,
   DEFAULT_PREFERENCE_LABEL,
-} from '@kubevirt-utils/resources/bootableresources/constants';
+} from '@catalog/CreateFromInstanceTypes/utils/constants';
+import { PersistentVolumeClaimModel } from '@kubevirt-ui/kubevirt-api/console';
+import DataSourceModel from '@kubevirt-ui/kubevirt-api/console/models/DataSourceModel';
+import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { isBootableVolumePVCKind } from '@kubevirt-utils/resources/bootableresources/helpers';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { ANNOTATIONS, OS_NAME_TYPES } from '@kubevirt-utils/resources/template';

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.tsx
@@ -3,7 +3,10 @@ import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore';
 import { UseBootableVolumesValues } from '@catalog/CreateFromInstanceTypes/state/utils/types';
 import { CREATE_VM_TAB } from '@catalog/CreateVMHorizontalNav/constants';
-import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1beta1VirtualMachineClusterPreference,
+  V1beta1VirtualMachinePreference,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ListPageFilter from '@kubevirt-utils/components/ListPageFilter/ListPageFilter';
 import ProjectDropdown from '@kubevirt-utils/components/ProjectDropdown/ProjectDropdown';
 import { OPENSHIFT_OS_IMAGES_NS } from '@kubevirt-utils/constants/constants';
@@ -39,6 +42,7 @@ type BootableVolumeListProps = {
   favorites: UserSettingFavorites;
   preferencesData: V1beta1VirtualMachineClusterPreference[];
   selectedBootableVolumeState?: [BootableVolume, (selectedVolume: BootableVolume) => void];
+  userPreferencesData: V1beta1VirtualMachinePreference[];
 };
 
 const BootableVolumeList: FC<BootableVolumeListProps> = ({
@@ -48,6 +52,7 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
   favorites,
   preferencesData,
   selectedBootableVolumeState,
+  userPreferencesData,
 }) => {
   const { t } = useKubevirtTranslation();
   const isAdmin = useIsAdmin();
@@ -66,6 +71,11 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
   const preferencesMap = useMemo(
     () => convertResourceArrayToMap(preferencesData),
     [preferencesData],
+  );
+
+  const userPreferencesMap = useMemo(
+    () => convertResourceArrayToMap(userPreferencesData, true),
+    [userPreferencesData],
   );
 
   const { activeColumns, columnLayout, loadedColumns } = useBootVolumeColumns(
@@ -89,6 +99,7 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
     data,
     volumeFavorites,
     preferencesMap,
+    userPreferencesMap,
     pvcSources,
     volumeSnapshotSources,
     pagination,
@@ -168,6 +179,7 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
                 favorites={favorites}
                 onSelect={onModalBootableVolumeSelect}
                 preferencesData={preferencesData}
+                userPreferencesData={userPreferencesData}
               />
             )}
           </>
@@ -187,6 +199,7 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
             getSortType={getSortType}
             preferencesMap={preferencesMap}
             sortedPaginatedData={sortedPaginatedData}
+            userPreferencesMap={userPreferencesMap}
           />
           <BootableVolumesPipelinesHint bootableVolumes={bootableVolumes} />
         </>

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeListModal/BootableVolumeListModal.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeListModal/BootableVolumeListModal.tsx
@@ -2,7 +2,10 @@ import React, { FC, useState } from 'react';
 
 import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore';
 import { UseBootableVolumesValues } from '@catalog/CreateFromInstanceTypes/state/utils/types';
-import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1beta1VirtualMachineClusterPreference,
+  V1beta1VirtualMachinePreference,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { UserSettingFavorites } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
@@ -18,6 +21,7 @@ type BootableVolumeListModalProps = {
   onClose: () => void;
   onSelect: (selectedBootableVolume: BootableVolume) => void;
   preferencesData: V1beta1VirtualMachineClusterPreference[];
+  userPreferencesData: V1beta1VirtualMachinePreference[];
 };
 
 const BootableVolumeListModal: FC<BootableVolumeListModalProps> = ({

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
@@ -2,6 +2,7 @@ import React, { FC, MouseEvent } from 'react';
 
 import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore';
 import { InstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/utils/types';
+import { PREFERENCE_DISPLAY_NAME_KEY } from '@catalog/CreateFromInstanceTypes/utils/constants';
 import { getDiskSize } from '@catalog/CreateFromInstanceTypes/utils/utils';
 import { getTemplateOSIcon, getVolumeNameOSIcon } from '@catalog/templatescatalog/utils/os-icons';
 import {
@@ -10,7 +11,6 @@ import {
   V1beta1DataVolume,
 } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import DeprecatedBadge from '@kubevirt-utils/components/badges/DeprecatedBadge/DeprecatedBadge';
 import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
 import { logITFlowEvent } from '@kubevirt-utils/extensions/telemetry/telemetry';
@@ -20,7 +20,9 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { isDeprecated } from '@kubevirt-utils/resources/bootableresources/helpers';
 import { getVolumeSnapshotStorageClass } from '@kubevirt-utils/resources/bootableresources/selectors';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { VirtualMachinePreference } from '@kubevirt-utils/resources/preference/types';
 import {
+  getAnnotation,
   getName,
   getNamespace,
   isDataImportCronProgressing,
@@ -47,7 +49,7 @@ type BootableVolumeRowProps = {
     dataImportCron: V1beta1DataImportCron;
     dvSource: V1beta1DataVolume;
     favorites: [isFavorite: boolean, updaterFavorites: (val: boolean) => void];
-    preference: V1beta1VirtualMachineClusterPreference;
+    preference: VirtualMachinePreference;
     pvcSource: IoK8sApiCoreV1PersistentVolumeClaim;
     volumeSnapshotSource: VolumeSnapshotKind;
   };
@@ -127,7 +129,7 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
         </TableData>
       )}
       <TableData activeColumnIDs={activeColumnIDs} id="operating-system" width={20}>
-        {preference?.metadata?.annotations?.[ANNOTATIONS.displayName] || NO_DATA_DASH}
+        {getAnnotation(preference, PREFERENCE_DISPLAY_NAME_KEY, NO_DATA_DASH)}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="storage-class" width={15}>
         {getVolumeSnapshotStorageClass(volumeSnapshotSource) ||
@@ -139,7 +141,7 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id={ANNOTATIONS.description} width={30}>
         <TableText wrapModifier={WrapModifier.truncate}>
-          {bootableVolume?.metadata?.annotations?.[ANNOTATIONS.description] || NO_DATA_DASH}
+          {getAnnotation(bootableVolume, ANNOTATIONS.description, NO_DATA_DASH)}
         </TableText>
       </TableData>
     </Tr>

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeTable/BootableVolumeTable.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeTable/BootableVolumeTable.tsx
@@ -4,17 +4,20 @@ import {
   InstanceTypeVMStore,
   UseBootableVolumesValues,
 } from '@catalog/CreateFromInstanceTypes/state/utils/types';
-import { DEFAULT_PREFERENCE_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
-import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1beta1VirtualMachineClusterPreference,
+  V1beta1VirtualMachinePreference,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { UserSettingFavorites } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
 import {
   getBootableVolumePVCSource,
   getDataImportCronFromDataSource,
   getDataVolumeForPVC,
+  getPreference,
 } from '@kubevirt-utils/resources/bootableresources/helpers';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
-import { getLabel, getName } from '@kubevirt-utils/resources/shared';
+import { getName, NamespacedResourceMap, ResourceMap } from '@kubevirt-utils/resources/shared';
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { Table, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 import { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base/types';
@@ -27,11 +30,10 @@ type BootableVolumeTableProps = {
   bootableVolumesData: UseBootableVolumesValues;
   favorites: UserSettingFavorites;
   getSortType: (columnIndex: number) => ThSortType;
-  preferencesMap: {
-    [resourceKeyName: string]: V1beta1VirtualMachineClusterPreference;
-  };
+  preferencesMap: ResourceMap<V1beta1VirtualMachineClusterPreference>;
   selectedBootableVolumeState?: [BootableVolume, InstanceTypeVMStore['onSelectCreatedVolume']];
   sortedPaginatedData: BootableVolume[];
+  userPreferencesMap: NamespacedResourceMap<V1beta1VirtualMachinePreference>;
 };
 
 const BootableVolumeTable: FC<BootableVolumeTableProps> = ({
@@ -42,6 +44,7 @@ const BootableVolumeTable: FC<BootableVolumeTableProps> = ({
   preferencesMap,
   selectedBootableVolumeState,
   sortedPaginatedData,
+  userPreferencesMap,
 }) => {
   const [volumeFavorites, updateFavorites] = favorites;
   const { dataImportCrons, dvSources, pvcSources, volumeSnapshotSources } = bootableVolumesData;
@@ -88,7 +91,7 @@ const BootableVolumeTable: FC<BootableVolumeTableProps> = ({
                         : volumeFavorites.filter((fav: string) => fav !== bootSourceName),
                     ),
                 ],
-                preference: preferencesMap[getLabel(bootSource, DEFAULT_PREFERENCE_LABEL)],
+                preference: getPreference(bootSource, preferencesMap, userPreferencesMap),
                 pvcSource,
                 volumeSnapshotSource: volumeSnapshotSources?.[bootSourceName],
               }}

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/ShowAllBootableVolumesButton/ShowAllBootableVolumesButton.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/ShowAllBootableVolumesButton/ShowAllBootableVolumesButton.tsx
@@ -1,7 +1,10 @@
 import React, { FC, useState } from 'react';
 
 import { UseBootableVolumesValues } from '@catalog/CreateFromInstanceTypes/state/utils/types';
-import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1beta1VirtualMachineClusterPreference,
+  V1beta1VirtualMachinePreference,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { UserSettingFavorites } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
@@ -14,6 +17,7 @@ type ShowAllBootableVolumesButtonProps = {
   favorites: UserSettingFavorites;
   onSelect: (selectedBootableVolume: BootableVolume) => void;
   preferencesData: V1beta1VirtualMachineClusterPreference[];
+  userPreferencesData: V1beta1VirtualMachinePreference[];
 };
 
 const ShowAllBootableVolumesButton: FC<ShowAllBootableVolumesButtonProps> = (props) => {

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 
-import { DEFAULT_PREFERENCE_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
 import { getDiskSize } from '@catalog/CreateFromInstanceTypes/utils/utils';
 import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1beta1VirtualMachineClusterPreference,
+  V1beta1VirtualMachinePreference,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
 import { PaginationState } from '@kubevirt-utils/hooks/usePagination/utils/types';
 import {
@@ -22,10 +24,13 @@ import {
 import { DESCRIPTION_ANNOTATION } from '@kubevirt-utils/resources/vm';
 import { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base/types';
 
+import { getOSFromDefaultPreference } from '../../VMDetailsSection/utils/utils';
+
 type UseBootVolumeSortColumns = (
   unsortedData: BootableVolume[],
   volumeFavorites: string[],
-  preferences: ResourceMap<V1beta1VirtualMachineClusterPreference>,
+  clusterPreferencesMap: ResourceMap<V1beta1VirtualMachineClusterPreference>,
+  userPreferencesMap: NamespacedResourceMap<V1beta1VirtualMachinePreference>,
   pvcSources: NamespacedResourceMap<IoK8sApiCoreV1PersistentVolumeClaim>,
   volumeSnapshotSources: {
     [datSourceName: string]: VolumeSnapshotKind;
@@ -42,7 +47,8 @@ type UseBootVolumeSortColumns = (
 const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
   unsortedData = [],
   volumeFavorites,
-  preferences,
+  clusterPreferencesMap,
+  userPreferencesMap,
   pvcSources,
   volumeSnapshotSources,
   pagination,
@@ -60,7 +66,7 @@ const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
     return [
       getName(bootableVolume),
       ...(includeNamespaceColumn ? [getNamespace(bootableVolume)] : []),
-      getName(preferences[bootableVolume?.metadata?.labels?.[DEFAULT_PREFERENCE_LABEL]]),
+      getOSFromDefaultPreference(bootableVolume, clusterPreferencesMap, userPreferencesMap),
       pvcSource?.spec?.storageClassName || getVolumeSnapshotStorageClass(volumeSnapshotSource),
       getDiskSize(dvSource, pvcSource, volumeSnapshotSource),
       bootableVolume?.metadata?.annotations?.[DESCRIPTION_ANNOTATION],

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/VMDetailsSection.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/VMDetailsSection.tsx
@@ -1,23 +1,18 @@
 import React, { FC } from 'react';
 
-import { UseInstanceTypeAndPreferencesValues } from '@catalog/CreateFromInstanceTypes/state/utils/types';
 import { Grid, GridItem } from '@patternfly/react-core';
 
-import DetailsLeftGrid from './components/DetailsLeftGrid';
+import DetailsLeftGrid, { DetailsLeftGridProps } from './components/DetailsLeftGrid';
 import DetailsRightGrid from './components/DetailsRightGrid';
 
 import './VMDetailsSection.scss';
 
-type DetailsLeftGridProps = {
-  instanceTypesAndPreferencesData: UseInstanceTypeAndPreferencesValues;
-};
-
-const VMDetailsSection: FC<DetailsLeftGridProps> = ({ instanceTypesAndPreferencesData }) => {
+const VMDetailsSection: FC<DetailsLeftGridProps> = (props) => {
   return (
     <div className="instancetypes-vm-details-section instancetypes-vm-details-body">
       <Grid hasGutter>
         <GridItem span={5}>
-          <DetailsLeftGrid instanceTypesAndPreferencesData={instanceTypesAndPreferencesData} />
+          <DetailsLeftGrid {...props} />
         </GridItem>
         <GridItem span={1}>{/* Spacer */}</GridItem>
         <GridItem span={6}>

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsLeftGrid.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsLeftGrid.tsx
@@ -5,6 +5,7 @@ import {
   instanceTypeActionType,
   UseInstanceTypeAndPreferencesValues,
 } from '@catalog/CreateFromInstanceTypes/state/utils/types';
+import { V1beta1VirtualMachinePreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import FolderSelect from '@kubevirt-utils/components/FolderSelect/FolderSelect';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import { validateVMName } from '@kubevirt-utils/components/VMNameValidationHelperText/utils/utils';
@@ -18,11 +19,15 @@ import { DescriptionList, TextInput } from '@patternfly/react-core';
 
 import { getCPUAndMemoryFromDefaultInstanceType, getOSFromDefaultPreference } from '../utils/utils';
 
-type DetailsLeftGridProps = {
+export type DetailsLeftGridProps = {
   instanceTypesAndPreferencesData: UseInstanceTypeAndPreferencesValues;
+  userPreferencesData: V1beta1VirtualMachinePreference[];
 };
 
-const DetailsLeftGrid: FC<DetailsLeftGridProps> = ({ instanceTypesAndPreferencesData }) => {
+const DetailsLeftGrid: FC<DetailsLeftGridProps> = ({
+  instanceTypesAndPreferencesData,
+  userPreferencesData,
+}) => {
   const { t } = useKubevirtTranslation();
   const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
 
@@ -32,6 +37,10 @@ const DetailsLeftGrid: FC<DetailsLeftGridProps> = ({ instanceTypesAndPreferences
   const { clusterInstanceTypes, preferences } = instanceTypesAndPreferencesData;
 
   const preferencesMap = useMemo(() => convertResourceArrayToMap(preferences), [preferences]);
+  const userPreferencesMap = useMemo(
+    () => convertResourceArrayToMap(userPreferencesData, true),
+    [userPreferencesData],
+  );
   const instanceTypesMap = useMemo(
     () => convertResourceArrayToMap(clusterInstanceTypes),
     [clusterInstanceTypes],
@@ -39,7 +48,12 @@ const DetailsLeftGrid: FC<DetailsLeftGridProps> = ({ instanceTypesAndPreferences
 
   const vmNameValidated = validateVMName(vmName);
 
-  const operatingSystem = getOSFromDefaultPreference(selectedBootableVolume, preferencesMap);
+  const operatingSystem = getOSFromDefaultPreference(
+    selectedBootableVolume,
+    preferencesMap,
+    userPreferencesMap,
+  );
+
   const cpuMemoryString = !isEmpty(instanceTypesMap?.[selectedInstanceType?.name])
     ? getCPUAndMemoryFromDefaultInstanceType(instanceTypesMap[selectedInstanceType?.name])
     : null;

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/utils/utils.ts
@@ -1,27 +1,28 @@
-import {
-  DEFAULT_PREFERENCE_LABEL,
-  PREFERENCE_DISPLAY_NAME_KEY,
-} from '@catalog/CreateFromInstanceTypes/utils/constants';
+import { PREFERENCE_DISPLAY_NAME_KEY } from '@catalog/CreateFromInstanceTypes/utils/constants';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import {
   V1beta1VirtualMachineClusterInstancetype,
   V1beta1VirtualMachineClusterPreference,
+  V1beta1VirtualMachinePreference,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { DYNAMIC_CREDENTIALS_SUPPORT } from '@kubevirt-utils/components/DynamicSSHKeyInjection/constants/constants';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getPreference } from '@kubevirt-utils/resources/bootableresources/helpers';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
-import { getAnnotation, getLabel } from '@kubevirt-utils/resources/shared';
+import {
+  getAnnotation,
+  getLabel,
+  NamespacedResourceMap,
+  ResourceMap,
+} from '@kubevirt-utils/resources/shared';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 
 export const getOSFromDefaultPreference = (
   bootableVolume: BootableVolume,
-  preferencesMap: {
-    [resourceKeyName: string]: V1beta1VirtualMachineClusterPreference;
-  },
+  preferencesMap: ResourceMap<V1beta1VirtualMachineClusterPreference>,
+  userPreferencesMap: NamespacedResourceMap<V1beta1VirtualMachinePreference>,
 ): string => {
-  const defaultPreferenceName = getLabel(bootableVolume, DEFAULT_PREFERENCE_LABEL);
-
-  const defaultPreference = preferencesMap?.[defaultPreferenceName];
+  const defaultPreference = getPreference(bootableVolume, preferencesMap, userPreferencesMap);
 
   const defaultPreferenceDisplayName = getAnnotation(
     defaultPreference,

--- a/src/views/catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore.ts
@@ -1,13 +1,13 @@
 import produce from 'immer';
 import { create } from 'zustand';
 
+import { DEFAULT_PREFERENCE_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1beta1DataVolume } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getInstanceTypeFromVolume } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/utils';
 import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
-import { DEFAULT_PREFERENCE_LABEL } from '@kubevirt-utils/resources/bootableresources/constants';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { getLabel } from '@kubevirt-utils/resources/shared';
 import { generatePrettyName } from '@kubevirt-utils/utils/utils';

--- a/src/views/datasources/details/components/DataSourceDetailsGrid.tsx/DataSourceDetailsGrid.tsx
+++ b/src/views/datasources/details/components/DataSourceDetailsGrid.tsx/DataSourceDetailsGrid.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { getDataSourceCronJob } from 'src/views/datasources/utils';
 
-import {
-  PersistentVolumeClaimModel,
-  VirtualMachineClusterPreferenceModelGroupVersionKind,
-} from '@kubevirt-ui/kubevirt-api/console';
+import { DEFAULT_INSTANCETYPE_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
+import { PersistentVolumeClaimModel } from '@kubevirt-ui/kubevirt-api/console';
 import DataSourceModel from '@kubevirt-ui/kubevirt-api/console/models/DataSourceModel';
 import { VirtualMachineClusterInstancetypeModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineClusterInstancetypeModel';
 import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
@@ -18,16 +16,14 @@ import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import {
-  DEFAULT_INSTANCETYPE_LABEL,
-  DEFAULT_PREFERENCE_LABEL,
-} from '@kubevirt-utils/resources/bootableresources/constants';
 import { getLabel } from '@kubevirt-utils/resources/shared';
 import { k8sPatch, ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList, Grid, GridItem } from '@patternfly/react-core';
 
 import DataSourceAnnotations from '../DataSourceAnnotations/DataSourceAnnotations';
 import DataSourceImportCronDescription from '../DataSourceImportCronDescription/DataSourceImportCronDescription';
+
+import DataSourcePreferenceLink from './DataSourcePreferenceLink';
 
 type DataSourceDetailsGridProps = {
   dataSource: V1beta1DataSource;
@@ -189,13 +185,8 @@ export const DataSourceDetailsGrid: React.FC<DataSourceDetailsGridProps> = ({ da
             isPopover
           />
           <VirtualMachineDescriptionItem
-            descriptionData={
-              <ResourceLink
-                groupVersionKind={VirtualMachineClusterPreferenceModelGroupVersionKind}
-                name={getLabel(dataSource, DEFAULT_PREFERENCE_LABEL)}
-              />
-            }
             bodyContent={<PreferencePopoverContent />}
+            descriptionData={<DataSourcePreferenceLink dataSource={dataSource} />}
             descriptionHeader={t('Preference')}
             isPopover
           />

--- a/src/views/datasources/details/components/DataSourceDetailsGrid.tsx/DataSourcePreferenceLink.tsx
+++ b/src/views/datasources/details/components/DataSourceDetailsGrid.tsx/DataSourcePreferenceLink.tsx
@@ -1,0 +1,33 @@
+import React, { FC } from 'react';
+
+import { DEFAULT_PREFERENCE_LABEL } from '@catalog/CreateFromInstanceTypes/utils/constants';
+import {
+  VirtualMachineClusterPreferenceModelGroupVersionKind,
+  VirtualMachinePreferenceModelGroupVersionKind,
+} from '@kubevirt-ui/kubevirt-api/console';
+import { V1beta1DataSource } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
+import { hasUserPreference } from '@kubevirt-utils/resources/bootableresources/helpers';
+import { getLabel, getNamespace } from '@kubevirt-utils/resources/shared';
+import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+
+type DataSourcePreferenceLinkProps = {
+  dataSource: V1beta1DataSource;
+};
+
+const DataSourcePreferenceLink: FC<DataSourcePreferenceLinkProps> = ({ dataSource }) => {
+  const hasDataSourceUserPreference = hasUserPreference(dataSource);
+
+  return (
+    <ResourceLink
+      groupVersionKind={
+        hasDataSourceUserPreference
+          ? VirtualMachinePreferenceModelGroupVersionKind
+          : VirtualMachineClusterPreferenceModelGroupVersionKind
+      }
+      name={getLabel(dataSource, DEFAULT_PREFERENCE_LABEL)}
+      namespace={hasDataSourceUserPreference && getNamespace(dataSource)}
+    />
+  );
+};
+
+export default DataSourcePreferenceLink;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes link to a VirtualMachinePreference (VMP) in Bootable volume details
- BootableVolumeTable shows correct icon + Operating system for a volume with a VMP; sorting is fixed
- Catalog -> InstanceTypes -> VM details shows correct Operating system


## 🎥 Demo

BEFORE:


https://github.com/user-attachments/assets/a886296c-a3cd-4e1b-9dba-80cd0ab74445



AFTER:


https://github.com/user-attachments/assets/d2227fce-3266-4d37-9a14-2cb65b1edcc6


