### PR TITLE
ACM-20341: ACM metrics using useFleetPrometheusPoll

### DIFF
--- a/src/utils/components/Charts/CPUUtil/CPUThresholdChart.tsx
+++ b/src/utils/components/Charts/CPUUtil/CPUThresholdChart.tsx
@@ -5,11 +5,7 @@ import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getVMIPod } from '@kubevirt-utils/resources/vmi';
 import { humanizeCpuCores } from '@kubevirt-utils/utils/humanize.js';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import {
-  K8sResourceCommon,
-  PrometheusEndpoint,
-  usePrometheusPoll,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { K8sResourceCommon, PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Chart,
   ChartArea,
@@ -21,6 +17,7 @@ import {
 import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
 import { tickLabels } from '../ChartLabels/styleOverrides';
@@ -46,12 +43,22 @@ const CPUThresholdChart: FC<CPUThresholdChartProps> = ({ pods, vmi }) => {
   const vmiPod = useMemo(() => getVMIPod(vmi, pods), [pods, vmi]);
   const { currentTime, duration, timespan } = useDuration();
   const { height, ref, width } = useResponsiveCharts();
+
+  const [hubClusterName] = useHubClusterName();
+
   const queries = useMemo(
-    () => getUtilizationQueries({ duration, launcherPodName: vmiPod?.metadata?.name, obj: vmi }),
-    [vmi, vmiPod, duration],
+    () =>
+      getUtilizationQueries({
+        duration,
+        hubClusterName,
+        launcherPodName: vmiPod?.metadata?.name,
+        obj: vmi,
+      }),
+    [vmi, vmiPod, duration, hubClusterName],
   );
 
-  const [dataCPURequested] = usePrometheusPoll({
+  const [dataCPURequested] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,
@@ -59,7 +66,8 @@ const CPUThresholdChart: FC<CPUThresholdChartProps> = ({ pods, vmi }) => {
     timespan,
   });
 
-  const [dataCPUUsage] = usePrometheusPoll({
+  const [dataCPUUsage] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,

--- a/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
+++ b/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
@@ -6,7 +6,7 @@ import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
 import { getMemory } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
+import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Chart,
   ChartArea,
@@ -18,6 +18,7 @@ import {
 import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
 import { tickLabels } from '../ChartLabels/styleOverrides';
@@ -41,12 +42,17 @@ type MemoryThresholdChartProps = {
 
 const MemoryThresholdChart: FC<MemoryThresholdChartProps> = ({ vmi }) => {
   const { currentTime, duration, timespan } = useDuration();
-  const queries = useMemo(() => getUtilizationQueries({ duration, obj: vmi }), [vmi, duration]);
+  const [hubClusterName] = useHubClusterName();
+  const queries = useMemo(
+    () => getUtilizationQueries({ duration, hubClusterName, obj: vmi }),
+    [vmi, duration, hubClusterName],
+  );
   const { height, ref, width } = useResponsiveCharts();
 
   const memory = getMemorySize(getMemory(vmi));
 
-  const [data] = usePrometheusPoll({
+  const [data] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,

--- a/src/utils/components/Charts/MigrationUtil/MigrationThresholdChart.tsx
+++ b/src/utils/components/Charts/MigrationUtil/MigrationThresholdChart.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom-v5-compat';
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
+import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Chart,
   ChartArea,
@@ -16,6 +16,7 @@ import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import chart_color_green_300 from '@patternfly/react-tokens/dist/esm/chart_color_green_300';
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
 import { tickLabels } from '../ChartLabels/styleOverrides';
@@ -41,10 +42,16 @@ type MigrationThresholdChartProps = {
 const MigrationThresholdChart: React.FC<MigrationThresholdChartProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
   const { currentTime, duration, timespan } = useDuration();
-  const queries = useMemo(() => getUtilizationQueries({ duration, obj: vmi }), [vmi, duration]);
+  const [hubClusterName] = useHubClusterName();
+
+  const queries = useMemo(
+    () => getUtilizationQueries({ duration, hubClusterName, obj: vmi }),
+    [vmi, duration, hubClusterName],
+  );
   const { height, ref, width } = useResponsiveCharts();
 
-  const [migrationDataProcessed] = usePrometheusPoll({
+  const [migrationDataProcessed] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,
@@ -52,7 +59,8 @@ const MigrationThresholdChart: React.FC<MigrationThresholdChartProps> = ({ vmi }
     timespan,
   });
 
-  const [migrationDataRemaining] = usePrometheusPoll({
+  const [migrationDataRemaining] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,
@@ -60,7 +68,8 @@ const MigrationThresholdChart: React.FC<MigrationThresholdChartProps> = ({ vmi }
     timespan,
   });
 
-  const [migrationDataDirtyRate] = usePrometheusPoll({
+  const [migrationDataDirtyRate] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,

--- a/src/utils/components/Charts/MigrationUtil/MigrationThresholdChartDiskRate.tsx
+++ b/src/utils/components/Charts/MigrationUtil/MigrationThresholdChartDiskRate.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom-v5-compat';
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
+import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Chart,
   ChartArea,
@@ -14,6 +14,7 @@ import {
 } from '@patternfly/react-charts/victory';
 import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
 import { tickLabels } from '../ChartLabels/styleOverrides';
@@ -41,10 +42,15 @@ const MigrationThresholdChartDiskRate: React.FC<MigrationThresholdChartDiskRateP
 }) => {
   const { t } = useKubevirtTranslation();
   const { currentTime, duration, timespan } = useDuration();
-  const queries = useMemo(() => getUtilizationQueries({ duration, obj: vmi }), [vmi, duration]);
+  const [hubClusterName] = useHubClusterName();
+  const queries = useMemo(
+    () => getUtilizationQueries({ duration, hubClusterName, obj: vmi }),
+    [vmi, duration, hubClusterName],
+  );
   const { height, ref, width } = useResponsiveCharts();
 
-  const [diskRate] = usePrometheusPoll({
+  const [diskRate] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,

--- a/src/utils/components/Charts/StorageUtil/StorageIOPSTotalThresholdChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageIOPSTotalThresholdChart.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom-v5-compat';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
+import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Chart,
   ChartArea,
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-charts/victory';
 import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
 import ComponentReady from '../ComponentReady/ComponentReady';
@@ -34,13 +35,16 @@ type StorageIOPSTotalThresholdChartProps = {
 
 const StorageIOPSTotalThresholdChart: React.FC<StorageIOPSTotalThresholdChartProps> = ({ vmi }) => {
   const { currentTime, duration, timespan } = useDuration();
+
+  const [hubClusterName] = useHubClusterName();
   const queries = React.useMemo(
-    () => getUtilizationQueries({ duration, obj: vmi }),
-    [vmi, duration],
+    () => getUtilizationQueries({ duration, hubClusterName, obj: vmi }),
+    [vmi, duration, hubClusterName],
   );
   const { height, ref, width } = useResponsiveCharts();
 
-  const [data] = usePrometheusPoll({
+  const [data] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,

--- a/src/utils/components/Charts/StorageUtil/StorageReadThresholdChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageReadThresholdChart.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
+import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Chart,
   ChartArea,
@@ -11,6 +11,7 @@ import {
   ChartVoronoiContainer,
 } from '@patternfly/react-charts/victory';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
 import ComponentReady from '../ComponentReady/ComponentReady';
@@ -32,13 +33,16 @@ const GIB_IN_BYTES = 1024;
 
 const StorageReadThresholdChart: React.FC<StorageThresholdChartProps> = ({ vmi }) => {
   const { currentTime, duration, timespan } = useDuration();
+
+  const [hubClusterName] = useHubClusterName();
   const queries = React.useMemo(
-    () => getUtilizationQueries({ duration, obj: vmi }),
-    [vmi, duration],
+    () => getUtilizationQueries({ duration, hubClusterName, obj: vmi }),
+    [vmi, duration, hubClusterName],
   );
   const { height, ref, width } = useResponsiveCharts();
 
-  const [data] = usePrometheusPoll({
+  const [data] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,

--- a/src/utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart.tsx
@@ -5,7 +5,7 @@ import xbytes from 'xbytes';
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { tickLabels } from '@kubevirt-utils/components/Charts/ChartLabels/styleOverrides';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
+import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Chart,
   ChartArea,
@@ -17,6 +17,7 @@ import {
 import chart_color_black_200 from '@patternfly/react-tokens/dist/esm/chart_color_black_200';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
 import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
 import ComponentReady from '../ComponentReady/ComponentReady';
@@ -41,14 +42,16 @@ const StorageTotalReadWriteThresholdChart: React.FC<StorageTotalReadWriteThresho
   vmi,
 }) => {
   const { currentTime, duration, timespan } = useDuration();
+  const [hubClusterName] = useHubClusterName();
   const queries = React.useMemo(
-    () => getUtilizationQueries({ duration, obj: vmi }),
-    [vmi, duration],
+    () => getUtilizationQueries({ duration, hubClusterName, obj: vmi }),
+    [vmi, duration, hubClusterName],
   );
 
   const { height, ref, width } = useResponsiveCharts();
 
-  const [data] = usePrometheusPoll({
+  const [data] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,

--- a/src/utils/components/Charts/StorageUtil/StorageWriteThresholdChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageWriteThresholdChart.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
+import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Chart,
   ChartArea,
@@ -11,6 +11,7 @@ import {
   ChartVoronoiContainer,
 } from '@patternfly/react-charts/victory';
 import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
 import ComponentReady from '../ComponentReady/ComponentReady';
@@ -32,13 +33,15 @@ const GIB_IN_BYTES = 1024;
 
 const StorageWriteThresholdChart: React.FC<StorageThresholdChartProps> = ({ vmi }) => {
   const { currentTime, duration, timespan } = useDuration();
+  const [hubClusterName] = useHubClusterName();
   const queries = React.useMemo(
-    () => getUtilizationQueries({ duration, obj: vmi }),
-    [vmi, duration],
+    () => getUtilizationQueries({ duration, hubClusterName, obj: vmi }),
+    [vmi, duration, hubClusterName],
   );
   const { height, ref, width } = useResponsiveCharts();
 
-  const [data] = usePrometheusPoll({
+  const [data] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,

--- a/src/utils/components/Charts/utils/queries.ts
+++ b/src/utils/components/Charts/utils/queries.ts
@@ -1,4 +1,4 @@
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 enum VMQueries {
   CPU_REQUESTED = 'CPU_REQUESTED',
@@ -24,40 +24,53 @@ enum VMQueries {
 
 type UtilizationQueriesArgs = {
   duration?: string;
+  hubClusterName?: string;
   launcherPodName?: string;
   nic?: string;
   obj: K8sResourceCommon;
 };
 
-type GetUtilizationQueries = ({ duration, launcherPodName, nic, obj }: UtilizationQueriesArgs) => {
+type GetUtilizationQueries = ({
+  duration,
+  hubClusterName,
+  launcherPodName,
+  nic,
+  obj,
+}: UtilizationQueriesArgs) => {
   [key in VMQueries]: string;
 };
 
 export const getUtilizationQueries: GetUtilizationQueries = ({
   duration,
+  hubClusterName,
   launcherPodName,
   obj,
 }) => {
   const { name, namespace } = obj?.metadata || {};
+
+  const clusterFilter =
+    !isEmpty(obj?.cluster) && obj?.cluster === hubClusterName ? `,cluster='${obj.cluster}'` : '';
+
+  const sumByCluster = !isEmpty(obj?.cluster) && obj?.cluster === hubClusterName ? ', cluster' : '';
   return {
-    [VMQueries.CPU_REQUESTED]: `sum(kube_pod_resource_request{resource='cpu',pod='${launcherPodName}',namespace='${namespace}'}) BY (name, namespace)`,
-    [VMQueries.CPU_USAGE]: `sum(rate(kubevirt_vmi_cpu_usage_seconds_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
-    [VMQueries.FILESYSTEM_READ_USAGE]: `sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
-    [VMQueries.FILESYSTEM_USAGE_TOTAL]: `sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total{name='${name}',namespace='${namespace}'}[${duration}]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
-    [VMQueries.FILESYSTEM_WRITE_USAGE]: `sum(rate(kubevirt_vmi_storage_write_traffic_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
-    [VMQueries.INSTANT_MIGRATION_DATA_PROCESSED]: `kubevirt_vmi_migration_data_processed_bytes{name='${name}',namespace='${namespace}'}`,
-    [VMQueries.INSTANT_MIGRATION_DATA_REMAINING]: `kubevirt_vmi_migration_data_remaining_bytes{name='${name}',namespace='${namespace}'}`,
-    [VMQueries.MEMORY_USAGE]: `last_over_time(kubevirt_vmi_memory_used_bytes{name='${name}',namespace='${namespace}'}[${duration}])`,
-    [VMQueries.MIGRATION_DATA_PROCESSED]: `sum(sum_over_time(kubevirt_vmi_migration_data_processed_bytes{name='${name}',namespace='${namespace}'}[${duration}]))  BY (name, namespace)`,
-    [VMQueries.MIGRATION_DATA_REMAINING]: `sum(sum_over_time(kubevirt_vmi_migration_data_remaining_bytes{name='${name}',namespace='${namespace}'}[${duration}]))  BY (name, namespace)`,
-    [VMQueries.MIGRATION_DISK_TRANSFER_RATE]: `sum(sum_over_time(kubevirt_vmi_migration_disk_transfer_rate_bytes	{name='${name}',namespace='${namespace}'}[${duration}]))  BY (name, namespace)`,
-    [VMQueries.MIGRATION_MEMORY_DIRTY_RATE]: `sum(sum_over_time(kubevirt_vmi_migration_dirty_memory_rate_bytes{name='${name}',namespace='${namespace}'}[${duration}]))  BY (name, namespace)`,
-    [VMQueries.NETWORK_IN_BY_INTERFACE_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace, interface)`,
-    [VMQueries.NETWORK_IN_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
-    [VMQueries.NETWORK_OUT_BY_INTERFACE_USAGE]: `sum(rate(kubevirt_vmi_network_transmit_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace, interface)`,
-    [VMQueries.NETWORK_OUT_USAGE]: `sum(rate(kubevirt_vmi_network_transmit_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
-    [VMQueries.NETWORK_TOTAL_BY_INTERFACE_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace, interface)`,
-    [VMQueries.NETWORK_TOTAL_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
-    [VMQueries.STORAGE_IOPS_TOTAL]: `sum(rate(kubevirt_vmi_storage_iops_read_total{name='${name}',namespace='${namespace}'}[${duration}]) + rate(kubevirt_vmi_storage_iops_write_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
+    [VMQueries.CPU_REQUESTED]: `sum(kube_pod_resource_request{resource='cpu'${clusterFilter},pod='${launcherPodName}',namespace='${namespace}'}) BY (name, namespace${sumByCluster})`,
+    [VMQueries.CPU_USAGE]: `sum(rate(kubevirt_vmi_cpu_usage_seconds_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])) BY (name, namespace${sumByCluster})`,
+    [VMQueries.FILESYSTEM_READ_USAGE]: `sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])) BY (name, namespace${sumByCluster})`,
+    [VMQueries.FILESYSTEM_USAGE_TOTAL]: `sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])) BY (name, namespace${sumByCluster})`,
+    [VMQueries.FILESYSTEM_WRITE_USAGE]: `sum(rate(kubevirt_vmi_storage_write_traffic_bytes_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])) BY (name, namespace${sumByCluster})`,
+    [VMQueries.INSTANT_MIGRATION_DATA_PROCESSED]: `kubevirt_vmi_migration_data_processed_bytes{name='${name}',namespace='${namespace}'${clusterFilter}}`,
+    [VMQueries.INSTANT_MIGRATION_DATA_REMAINING]: `kubevirt_vmi_migration_data_remaining_bytes{name='${name}',namespace='${namespace}'${clusterFilter}}`,
+    [VMQueries.MEMORY_USAGE]: `last_over_time(kubevirt_vmi_memory_used_bytes{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])`,
+    [VMQueries.MIGRATION_DATA_PROCESSED]: `sum(sum_over_time(kubevirt_vmi_migration_data_processed_bytes{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}]))  BY (name, namespace${sumByCluster})`,
+    [VMQueries.MIGRATION_DATA_REMAINING]: `sum(sum_over_time(kubevirt_vmi_migration_data_remaining_bytes{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}]))  BY (name, namespace${sumByCluster})`,
+    [VMQueries.MIGRATION_DISK_TRANSFER_RATE]: `sum(sum_over_time(kubevirt_vmi_migration_disk_transfer_rate_bytes	{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}]))  BY (name, namespace${sumByCluster})`,
+    [VMQueries.MIGRATION_MEMORY_DIRTY_RATE]: `sum(sum_over_time(kubevirt_vmi_migration_dirty_memory_rate_bytes{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}]))  BY (name, namespace${sumByCluster})`,
+    [VMQueries.NETWORK_IN_BY_INTERFACE_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])) BY (name, namespace${sumByCluster}, interface)`,
+    [VMQueries.NETWORK_IN_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])) BY (name, namespace${sumByCluster})`,
+    [VMQueries.NETWORK_OUT_BY_INTERFACE_USAGE]: `sum(rate(kubevirt_vmi_network_transmit_bytes_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])) BY (name, namespace${sumByCluster}, interface)`,
+    [VMQueries.NETWORK_OUT_USAGE]: `sum(rate(kubevirt_vmi_network_transmit_bytes_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])) BY (name, namespace${sumByCluster})`,
+    [VMQueries.NETWORK_TOTAL_BY_INTERFACE_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])) BY (name, namespace${sumByCluster}, interface)`,
+    [VMQueries.NETWORK_TOTAL_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])) BY (name, namespace${sumByCluster})`,
+    [VMQueries.STORAGE_IOPS_TOTAL]: `sum(rate(kubevirt_vmi_storage_iops_read_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}]) + rate(kubevirt_vmi_storage_iops_write_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])) BY (name, namespace${sumByCluster})`,
   };
 };

--- a/src/utils/hooks/useIsACMPage.ts
+++ b/src/utils/hooks/useIsACMPage.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom-v5-compat';
+
+const useIsACMPage = () => {
+  const location = useLocation();
+
+  return useMemo(
+    () => location.pathname.startsWith('/multicloud/infrastructure/virtualmachines'),
+    [location],
+  );
+};
+
+export default useIsACMPage;

--- a/src/utils/resources/vm/hooks/useMigrationPercentage.tsx
+++ b/src/utils/resources/vm/hooks/useMigrationPercentage.tsx
@@ -6,6 +6,7 @@ import { getNamespace } from '@kubevirt-utils/resources/shared';
 import useVirtualMachineInstanceMigration from '@kubevirt-utils/resources/vmi/hooks/useVirtualMachineInstanceMigration';
 import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
 import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
+import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import { MIGRATION__PROMETHEUS_DELAY } from '../utils/constants';
 
@@ -19,8 +20,12 @@ const useMigrationPercentage: UseMigrationPercentage = (vm) => {
   const namespace = getNamespace(vm);
 
   const vmim = useVirtualMachineInstanceMigration(vm);
+  const [hubClusterName] = useHubClusterName();
 
-  const queries = useMemo(() => getUtilizationQueries({ obj: vm }), [vm]);
+  const queries = useMemo(
+    () => getUtilizationQueries({ hubClusterName, obj: vm }),
+    [vm, hubClusterName],
+  );
 
   const [dataProcessedBytes] = usePrometheusPoll({
     delay: MIGRATION__PROMETHEUS_DELAY,

--- a/src/views/virtualmachines/details/tabs/metrics/NetworkCharts/hook/useNetworkData.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/NetworkCharts/hook/useNetworkData.tsx
@@ -7,11 +7,8 @@ import {
   getPrometheusDataByNic,
   queriesToLink,
 } from '@kubevirt-utils/components/Charts/utils/utils';
-import {
-  PrometheusEndpoint,
-  PrometheusResult,
-  usePrometheusPoll,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { PrometheusEndpoint, PrometheusResult } from '@openshift-console/dynamic-plugin-sdk';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import useDuration from '../../hooks/useDuration';
 import { ALL_NETWORKS } from '../../utils/constants';
@@ -30,34 +27,39 @@ type UseNetworkData = (
 
 const useNetworkData: UseNetworkData = (vmi, nic) => {
   const { currentTime, duration, timespan } = useDuration();
+  const [hubClusterName] = useHubClusterName();
   const queries = useMemo(
-    () => getUtilizationQueries({ duration, nic, obj: vmi }),
-    [vmi, duration, nic],
+    () => getUtilizationQueries({ duration, hubClusterName, nic, obj: vmi }),
+    [vmi, duration, nic, hubClusterName],
   );
   const isAllNetwork = nic === ALL_NETWORKS;
 
-  const [networkByNICTotal] = usePrometheusPoll({
+  const [networkByNICTotal] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,
     query: queries?.NETWORK_TOTAL_BY_INTERFACE_USAGE,
     timespan,
   });
-  const [networkByNICIn] = usePrometheusPoll({
+  const [networkByNICIn] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,
     query: queries?.NETWORK_IN_BY_INTERFACE_USAGE,
     timespan,
   });
-  const [networkByNICOut] = usePrometheusPoll({
+  const [networkByNICOut] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,
     query: queries?.NETWORK_OUT_BY_INTERFACE_USAGE,
     timespan,
   });
-  const [networkTotal] = usePrometheusPoll({
+  const [networkTotal] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,
@@ -65,7 +67,8 @@ const useNetworkData: UseNetworkData = (vmi, nic) => {
     timespan,
   });
 
-  const [networkIn] = usePrometheusPoll({
+  const [networkIn] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,
@@ -73,13 +76,15 @@ const useNetworkData: UseNetworkData = (vmi, nic) => {
     timespan,
   });
 
-  const [networkOut] = usePrometheusPoll({
+  const [networkOut] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,
     query: isAllNetwork && queries?.NETWORK_OUT_USAGE,
     timespan,
   });
+
   return {
     data: {
       in: [

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/NetworkUtil/NetworkUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/NetworkUtil/NetworkUtil.tsx
@@ -9,8 +9,9 @@ import { getUtilizationQueries } from '@kubevirt-utils/components/Charts/utils/q
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
+import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, ButtonVariant, Content, ContentVariants, Popover } from '@patternfly/react-core';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
 type NetworkUtilProps = {
@@ -20,26 +21,30 @@ type NetworkUtilProps = {
 const NetworkUtil: React.FC<NetworkUtilProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
   const { currentTime, duration } = useDuration();
+  const [hubClusterName] = useHubClusterName();
   const queries = React.useMemo(
-    () => getUtilizationQueries({ duration, obj: vmi }),
-    [vmi, duration],
+    () => getUtilizationQueries({ duration, hubClusterName, obj: vmi }),
+    [vmi, duration, hubClusterName],
   );
   const interfacesNames = useMemo(() => vmi?.spec?.domain?.devices?.interfaces, [vmi]);
-  const [networkIn] = usePrometheusPoll({
+  const [networkIn] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,
     query: queries?.NETWORK_IN_USAGE,
   });
 
-  const [networkTotal] = usePrometheusPoll({
+  const [networkTotal] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,
     query: queries?.NETWORK_TOTAL_BY_INTERFACE_USAGE,
   });
 
-  const [networkOut] = usePrometheusPoll({
+  const [networkOut] = useFleetPrometheusPoll({
+    cluster: vmi?.cluster,
     endpoint: PrometheusEndpoint?.QUERY,
     endTime: currentTime,
     namespace: vmi?.metadata?.namespace,

--- a/src/views/virtualmachines/list/hooks/useVMTotalsMetrics.ts
+++ b/src/views/virtualmachines/list/hooks/useVMTotalsMetrics.ts
@@ -1,57 +1,68 @@
 import { useMemo } from 'react';
+import { useParams } from 'react-router-dom-v5-compat';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useIsACMPage from '@kubevirt-utils/hooks/useIsACMPage';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
-import {
-  PrometheusEndpoint,
-  useActiveNamespace,
-  usePrometheusPoll,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
 import { METRICS } from '@overview/OverviewTab/metric-charts-card/utils/constants';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import { getCpuText, getMemoryCapacityText, getMetricText } from '../utils/processVMTotalsMetrics';
 import { getVMTotalsQueries, VMTotalsQueries } from '../utils/totalsQueries';
 
 const useVMTotalsMetrics = (vms: V1VirtualMachine[], vmis: V1VirtualMachineInstance[]) => {
-  const [activeNamespace] = useActiveNamespace();
-  const allNamespace = activeNamespace === ALL_NAMESPACES_SESSION_KEY;
+  const { cluster, ns: namespace } = useParams<{ cluster?: string; ns?: string }>();
+
+  const [hubClusterName] = useHubClusterName();
+  const isACMPage = useIsACMPage();
+
+  const allClusters = isACMPage && isEmpty(cluster);
+
   const currentTime = useMemo<number>(() => Date.now(), []);
 
   const namespacesList = useMemo(() => [...new Set(vms.map((vm) => getNamespace(vm)))], [vms]);
 
   const queries = useMemo(
-    () => getVMTotalsQueries(activeNamespace, namespacesList),
-    [activeNamespace, namespacesList],
+    () =>
+      getVMTotalsQueries(
+        namespace,
+        namespacesList,
+        cluster === hubClusterName ? undefined : cluster,
+        allClusters,
+      ),
+    [namespace, namespacesList, cluster, hubClusterName, allClusters],
   );
 
   const prometheusPollProps = {
+    cluster,
     endpoint: PrometheusEndpoint?.QUERY,
     endTime: currentTime,
-    namespace: allNamespace ? undefined : activeNamespace,
+    namespace,
   };
 
-  const [cpuUsageResponse] = usePrometheusPoll({
+  const [cpuUsageResponse] = useFleetPrometheusPoll({
     ...prometheusPollProps,
     query: queries?.[VMTotalsQueries.TOTAL_CPU_USAGE],
   });
 
-  const [cpuRequestedResponse] = usePrometheusPoll({
+  const [cpuRequestedResponse] = useFleetPrometheusPoll({
     ...prometheusPollProps,
     query: queries?.[VMTotalsQueries.TOTAL_CPU_REQUESTED],
   });
 
-  const [memoryUsageResponse] = usePrometheusPoll({
+  const [memoryUsageResponse] = useFleetPrometheusPoll({
     ...prometheusPollProps,
     query: queries?.[VMTotalsQueries.TOTAL_MEMORY_USAGE],
   });
 
-  const [storageUsageResponse] = usePrometheusPoll({
+  const [storageUsageResponse] = useFleetPrometheusPoll({
     ...prometheusPollProps,
     query: queries?.[VMTotalsQueries.TOTAL_STORAGE_USAGE],
   });
 
-  const [storageCapacityResponse] = usePrometheusPoll({
+  const [storageCapacityResponse] = useFleetPrometheusPoll({
     ...prometheusPollProps,
     query: queries?.[VMTotalsQueries.TOTAL_STORAGE_CAPACITY],
   });

--- a/src/views/virtualmachines/list/utils/totalsQueries.ts
+++ b/src/views/virtualmachines/list/utils/totalsQueries.ts
@@ -1,4 +1,4 @@
-import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 export const VMTotalsQueries = {
   TOTAL_CPU_REQUESTED: 'TOTAL_CPU_REQUESTED',
@@ -8,20 +8,37 @@ export const VMTotalsQueries = {
   TOTAL_STORAGE_USAGE: 'TOTAL_STORAGE_USAGE',
 };
 
-export const getVMTotalsQueries = (namespace: string, namespacesList: string[]) => {
-  const isAllNamespaces = namespace === ALL_NAMESPACES_SESSION_KEY;
+export const getVMTotalsQueries = (
+  namespace: string,
+  namespacesList: string[],
+  cluster?: string,
+  allClusters = false,
+) => {
+  const isAllNamespaces = isEmpty(namespace);
 
+  const clusterFilter = cluster ? `cluster='${cluster}'` : '';
+
+  const sumByNamespaceWithCluster = isAllNamespaces
+    ? 'sum by (cluster)'
+    : 'sum by (namespace, cluster)';
   const sumByNamespace = isAllNamespaces ? 'sum' : 'sum by (namespace)';
-  const filterByNamespace = isAllNamespaces ? '' : `{namespace='${namespace}'}`;
+
+  const filterByNamespace = isAllNamespaces
+    ? `{${clusterFilter}}`
+    : `{namespace='${namespace}',${clusterFilter}}`;
+
   const filterCpuRequestedByNamespace = isAllNamespaces
-    ? `namespace=~'${namespacesList.join('|')}'`
-    : `namespace='${namespace}'`;
+    ? `namespace=~'${namespacesList.join('|')}',${clusterFilter}`
+    : `namespace='${namespace}',${clusterFilter}`;
+
+  const duration = cluster || allClusters ? '15m' : '30s';
+  const sumBy = cluster || allClusters ? sumByNamespaceWithCluster : sumByNamespace;
 
   return {
-    [VMTotalsQueries.TOTAL_CPU_REQUESTED]: `${sumByNamespace}(kube_pod_resource_request{resource='cpu',${filterCpuRequestedByNamespace}})`,
-    [VMTotalsQueries.TOTAL_CPU_USAGE]: `${sumByNamespace}(rate(kubevirt_vmi_cpu_usage_seconds_total${filterByNamespace}[30s]))`,
-    [VMTotalsQueries.TOTAL_MEMORY_USAGE]: `${sumByNamespace}(kubevirt_vmi_memory_available_bytes${filterByNamespace} - kubevirt_vmi_memory_usable_bytes${filterByNamespace})`,
-    [VMTotalsQueries.TOTAL_STORAGE_CAPACITY]: `${sumByNamespace}(max(kubevirt_vmi_filesystem_capacity_bytes${filterByNamespace}) by (namespace, name, disk_name))`,
-    [VMTotalsQueries.TOTAL_STORAGE_USAGE]: `${sumByNamespace}(max(kubevirt_vmi_filesystem_used_bytes${filterByNamespace}) by (namespace, name, disk_name))`,
+    [VMTotalsQueries.TOTAL_CPU_REQUESTED]: `${sumBy}(kube_pod_resource_request{resource='cpu',${filterCpuRequestedByNamespace}})`,
+    [VMTotalsQueries.TOTAL_CPU_USAGE]: `${sumBy}(rate(kubevirt_vmi_cpu_usage_seconds_total${filterByNamespace}[${duration}]))`,
+    [VMTotalsQueries.TOTAL_MEMORY_USAGE]: `${sumBy}(kubevirt_vmi_memory_available_bytes${filterByNamespace} - kubevirt_vmi_memory_usable_bytes${filterByNamespace})`,
+    [VMTotalsQueries.TOTAL_STORAGE_CAPACITY]: `${sumBy}(max(kubevirt_vmi_filesystem_capacity_bytes${filterByNamespace}) by (namespace, name, disk_name, cluster))`,
+    [VMTotalsQueries.TOTAL_STORAGE_USAGE]: `${sumBy}(max(kubevirt_vmi_filesystem_used_bytes${filterByNamespace}) by (namespace, name, disk_name, cluster))`,
   };
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Replace `usePrometheusPoll` with `useFleetPrometheusPoll`  for multicluster queries.



When on ACM page and there is no `cluster` parameter, it means that we need to fetch all clusters metrics and not local cluster metrics . 



ACM metrics do not support 30s duration but at least 15m duration. There will be a followup to restrict duration to 15min in the vm details page