### PR TITLE
CNV-59354: Use the same styling for VM and VM Instance console tabs

### DIFF
--- a/src/utils/components/Consoles/consoles.scss
+++ b/src/utils/components/Consoles/consoles.scss
@@ -7,6 +7,11 @@
   }
 }
 
+.virtual-machine-console-page-section {
+  padding-top: 0;
+  height: 85%;
+}
+
 .virtual-machine-console-page {
   height: 100%;
 }

--- a/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.scss
+++ b/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.scss
@@ -1,6 +1,0 @@
-.VirtualMachineConsolePage {
-  &-page-section {
-    padding-top: 0;
-    height: 85%;
-  }
-}

--- a/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.tsx
+++ b/src/views/virtualmachines/details/tabs/console/VirtualMachineConsolePage.tsx
@@ -9,8 +9,6 @@ import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 import { isRunning, printableVMStatus } from '../../../utils';
 
-import './VirtualMachineConsolePage.scss';
-
 const VirtualMachineConsolePage: FC<NavPageComponentProps> = ({ obj: vm }) => {
   const { t } = useKubevirtTranslation();
   const { vmi, vmiLoaded } = useVMI(vm?.metadata?.name, vm?.metadata?.namespace, isRunning(vm));
@@ -34,7 +32,7 @@ const VirtualMachineConsolePage: FC<NavPageComponentProps> = ({ obj: vm }) => {
   }
 
   return (
-    <PageSection className="VirtualMachineConsolePage-page-section" hasBodyWrapper={false}>
+    <PageSection className="virtual-machine-console-page-section" hasBodyWrapper={false}>
       <Consoles consoleContainerClass="virtual-machine-console-page" vmi={vmi} />
     </PageSection>
   );

--- a/src/views/virtualmachinesinstance/details/tabs/console/VirtualMachinesInstancePageConsoleTab.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/console/VirtualMachinesInstancePageConsoleTab.tsx
@@ -11,8 +11,8 @@ type VirtualMachinesInstancePageConsoleTabProps = {
 const VirtualMachinesInstancePageConsoleTab: FC<VirtualMachinesInstancePageConsoleTabProps> = ({
   obj: vmi,
 }) => (
-  <PageSection>
-    <Consoles vmi={vmi} />
+  <PageSection className="virtual-machine-console-page-section" hasBodyWrapper={false}>
+    <Consoles consoleContainerClass="virtual-machine-console-page" vmi={vmi} />
   </PageSection>
 );
 


### PR DESCRIPTION
## 📝 Description

Follow the same approach as used for displaying the Console Tab in VM Details.

## Demo 
### Before
![image](https://github.com/user-attachments/assets/8a20446f-a2d9-48b1-a253-3072f74f289a)

### After
![image](https://github.com/user-attachments/assets/7ec01b81-b645-4c36-a98b-a4a48daa1f8b)
