### PR TITLE
CNV-64583: Fix error handling in re-creating features config map

### DIFF
--- a/src/utils/hooks/useFeatures/createFeaturesConfigMap.ts
+++ b/src/utils/hooks/useFeatures/createFeaturesConfigMap.ts
@@ -1,0 +1,43 @@
+import { ConfigMapModel, RoleBindingModel, RoleModel } from '@kubevirt-ui/kubevirt-api/console';
+import {
+  IoK8sApiCoreV1ConfigMap,
+  IoK8sApiRbacV1Role,
+  IoK8sApiRbacV1RoleBinding,
+} from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { k8sCreate, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
+
+import { featuresConfigMapInitialState, featuresRole, featuresRoleBinding } from './constants';
+
+export const createFeaturesConfigMap = async () => {
+  await k8sCreate<IoK8sApiCoreV1ConfigMap>({
+    data: featuresConfigMapInitialState,
+    model: ConfigMapModel,
+  });
+
+  await k8sCreate<IoK8sApiRbacV1Role>({
+    data: featuresRole,
+    model: RoleModel,
+  });
+
+  await k8sCreate<IoK8sApiRbacV1RoleBinding>({
+    data: featuresRoleBinding,
+    model: RoleBindingModel,
+  });
+};
+
+export const applyMissingFeatures = async (
+  featureName: string,
+  featureConfigMap: IoK8sApiCoreV1ConfigMap,
+) => {
+  await k8sPatch({
+    data: [
+      {
+        op: 'replace',
+        path: `/data/${featureName}`,
+        value: featuresConfigMapInitialState.data[featureName],
+      },
+    ],
+    model: ConfigMapModel,
+    resource: featureConfigMap,
+  });
+};

--- a/src/utils/hooks/useFeatures/useFeatures.ts
+++ b/src/utils/hooks/useFeatures/useFeatures.ts
@@ -1,61 +1,46 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { ConfigMapModel, RoleBindingModel, RoleModel } from '@kubevirt-ui/kubevirt-api/console';
-import {
-  IoK8sApiCoreV1ConfigMap,
-  IoK8sApiRbacV1Role,
-  IoK8sApiRbacV1RoleBinding,
-} from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { ConfigMapModel } from '@kubevirt-ui/kubevirt-api/console';
 import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
-import { k8sCreate, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
+import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
-import {
-  FEATURES_CONFIG_MAP_NAME,
-  featuresConfigMapInitialState,
-  featuresRole,
-  featuresRoleBinding,
-} from './constants';
+import { FEATURES_CONFIG_MAP_NAME, featuresConfigMapInitialState } from './constants';
+import { applyMissingFeatures, createFeaturesConfigMap } from './createFeaturesConfigMap';
 import { UseFeaturesValues } from './types';
 import useFeaturesConfigMap from './useFeaturesConfigMap';
 
 type UseFeatures = (featureName: string) => UseFeaturesValues;
 
 export const useFeatures: UseFeatures = (featureName) => {
-  const { featuresConfigMapData, isAdmin } = useFeaturesConfigMap();
+  const [createError, setCreateError] = useState(null);
+  const [createInProgress, setCreateInProgress] = useState(false);
+  const { featuresConfigMapData, isAdmin } = useFeaturesConfigMap(!createError);
   const [featureConfigMap, loaded, loadError] = featuresConfigMapData;
   const [featureEnabled, setFeatureEnabled] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error>(null);
 
   useEffect(() => {
+    if (createError || createInProgress) {
+      return;
+    }
+
     if (loadError?.code === 404) {
       setError(loadError);
 
-      const createResources = async () => {
-        await k8sCreate<IoK8sApiCoreV1ConfigMap>({
-          data: featuresConfigMapInitialState,
-          model: ConfigMapModel,
-        });
-
-        await k8sCreate<IoK8sApiRbacV1Role>({
-          data: featuresRole,
-          model: RoleModel,
-        });
-
-        await k8sCreate<IoK8sApiRbacV1RoleBinding>({
-          data: featuresRoleBinding,
-          model: RoleBindingModel,
-        });
-      };
-
-      try {
-        createResources();
-        setFeatureEnabled(featuresConfigMapInitialState.data[featureName] === 'true');
-        setLoading(false);
-        setError(null);
-      } catch (createError) {
-        setError(createError);
-      }
+      setCreateInProgress(true);
+      (async () => {
+        try {
+          await createFeaturesConfigMap();
+          setFeatureEnabled(featuresConfigMapInitialState.data[featureName] === 'true');
+          setError(null);
+          // eslint-disable-next-line @typescript-eslint/no-shadow
+        } catch (createError) {
+          setLoading(false);
+          setCreateError(createError);
+        }
+        setCreateInProgress(false);
+      })();
 
       return;
     }
@@ -77,26 +62,14 @@ export const useFeatures: UseFeatures = (featureName) => {
         // In case of features config-map exists but there is a new feature to enter that is missing
         case undefined:
         case null: {
-          const applyMissingFeatures = async () => {
-            await k8sPatch({
-              data: [
-                {
-                  op: 'replace',
-                  path: `/data/${featureName}`,
-                  value: featuresConfigMapInitialState.data[featureName],
-                },
-              ],
-              model: ConfigMapModel,
-              resource: featureConfigMap,
-            });
-          };
-
-          try {
-            applyMissingFeatures();
-            setFeatureEnabled(featuresConfigMapInitialState.data[featureName] === 'true');
-          } catch (updateError) {
-            setError(updateError);
-          }
+          (async () => {
+            try {
+              await applyMissingFeatures(featureName, featureConfigMap);
+              setFeatureEnabled(featuresConfigMapInitialState.data[featureName] === 'true');
+            } catch (updateError) {
+              setError(updateError);
+            }
+          })();
           break;
         }
         default:
@@ -105,7 +78,15 @@ export const useFeatures: UseFeatures = (featureName) => {
       setLoading(false);
       return;
     }
-  }, [loadError, featureConfigMap, loaded, featureName, featureEnabled]);
+  }, [
+    loadError,
+    featureConfigMap,
+    loaded,
+    featureName,
+    featureEnabled,
+    createError,
+    createInProgress,
+  ]);
 
   const toggleFeature = useCallback(
     async (value: boolean) => {

--- a/src/utils/hooks/useFeatures/useFeaturesConfigMap.ts
+++ b/src/utils/hooks/useFeatures/useFeaturesConfigMap.ts
@@ -11,20 +11,22 @@ import { useIsAdmin } from '../useIsAdmin';
 
 import { FEATURES_CONFIG_MAP_NAME } from './constants';
 
-type UseFeaturesConfigMap = () => {
+type UseFeaturesConfigMap = (enableQuery?: boolean) => {
   featuresConfigMapData: WatchK8sResult<IoK8sApiCoreV1ConfigMap>;
   isAdmin: boolean;
 };
 
-const useFeaturesConfigMap: UseFeaturesConfigMap = () => {
+const useFeaturesConfigMap: UseFeaturesConfigMap = (enableQuery: boolean = true) => {
   const isAdmin = useIsAdmin();
 
-  const featuresConfigMapData = useK8sWatchResource<IoK8sApiCoreV1ConfigMap>({
-    groupVersionKind: getGroupVersionKindForModel(ConfigMapModel),
-    isList: false,
-    name: FEATURES_CONFIG_MAP_NAME,
-    namespace: DEFAULT_OPERATOR_NAMESPACE,
-  });
+  const featuresConfigMapData = useK8sWatchResource<IoK8sApiCoreV1ConfigMap>(
+    enableQuery && {
+      groupVersionKind: getGroupVersionKindForModel(ConfigMapModel),
+      isList: false,
+      name: FEATURES_CONFIG_MAP_NAME,
+      namespace: DEFAULT_OPERATOR_NAMESPACE,
+    },
+  );
   return { featuresConfigMapData: [...featuresConfigMapData], isAdmin };
 };
 


### PR DESCRIPTION
>

## 📝 Description

1. handle rejected update promise - the catch statement was not part of async flow
2. prevent subsequent creation attempts if the first atempt failed
3. prevent creation attempts if the first attempt is in progress

## 🎥 Demo

### Before


https://github.com/user-attachments/assets/fbf64ca0-e428-4822-a337-eeb53986b085

### After


https://github.com/user-attachments/assets/eb5ff1fb-8690-4ebc-8cf3-991cd12b4e98

