### PR TITLE
CNV-64583:  Add read only access to feature flags

### DIFF
--- a/src/utils/components/DiskModal/components/AdvancedSettings/AdvancedSettings.tsx
+++ b/src/utils/components/DiskModal/components/AdvancedSettings/AdvancedSettings.tsx
@@ -3,7 +3,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { FEATURE_HCO_PERSISTENT_RESERVATION } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { diskTypes } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import { getDiskDrive } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
@@ -23,7 +23,7 @@ const AdvancedSettings: FC = () => {
   const sharable = getDiskSharable(disk);
   const lunReservation = getLunReservation(disk);
 
-  const { featureEnabled } = useFeatures(FEATURE_HCO_PERSISTENT_RESERVATION);
+  const { featureEnabled } = useFeatureReadOnly(FEATURE_HCO_PERSISTENT_RESERVATION);
 
   const isLunType = diskType === diskTypes.lun;
   return (

--- a/src/utils/components/SSHAccess/components/SSHServiceSelect.tsx
+++ b/src/utils/components/SSHAccess/components/SSHServiceSelect.tsx
@@ -6,7 +6,7 @@ import {
   LOAD_BALANCER_ENABLED,
   NODE_PORT_ENABLED,
 } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useMetalLBOperatorInstalled } from '@kubevirt-utils/hooks/useMetalLBOperatorInstalled/useMetalLBOperatorInstalled';
 import { SelectList, SelectOption } from '@patternfly/react-core';
@@ -27,8 +27,8 @@ const SSHServiceSelect: FC<SSHServiceSelectProps> = ({
   const { t } = useKubevirtTranslation();
   const hasMetalLBInstalled = useMetalLBOperatorInstalled();
 
-  const { featureEnabled: loadBalancerConfigFlag } = useFeatures(LOAD_BALANCER_ENABLED);
-  const { featureEnabled: nodePortEnabled } = useFeatures(NODE_PORT_ENABLED);
+  const { featureEnabled: loadBalancerConfigFlag } = useFeatureReadOnly(LOAD_BALANCER_ENABLED);
+  const { featureEnabled: nodePortEnabled } = useFeatureReadOnly(NODE_PORT_ENABLED);
 
   const loadBalancerEnabled = loadBalancerConfigFlag || hasMetalLBInstalled;
 

--- a/src/utils/components/SSHAccess/useSSHCommand.ts
+++ b/src/utils/components/SSHAccess/useSSHCommand.ts
@@ -1,10 +1,9 @@
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { NODE_PORT_ADDRESS } from '@kubevirt-utils/hooks/useFeatures/constants';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
 import { getSSHNodePort } from '@kubevirt-utils/utils/utils';
-
-import { useFeatures } from '../../hooks/useFeatures/useFeatures';
 
 import { SERVICE_TYPES } from './constants';
 
@@ -22,7 +21,7 @@ const useSSHCommand = (
   vm: V1VirtualMachine,
   sshService: IoK8sApiCoreV1Service,
 ): useSSHCommandResult => {
-  const { featureEnabled: nodePortAddress } = useFeatures(NODE_PORT_ADDRESS);
+  const { value: nodePortAddress } = useFeatureReadOnly(NODE_PORT_ADDRESS);
 
   const consoleHostname = () => {
     if (sshService?.spec?.type === SERVICE_TYPES.LOAD_BALANCER) {

--- a/src/utils/hooks/useFeatures/FeatureContext.tsx
+++ b/src/utils/hooks/useFeatures/FeatureContext.tsx
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+import { FeaturesType } from './types';
+
+export type FeaturesContextType = {
+  data: FeaturesType;
+  isLoading: boolean;
+};
+export const FeatureContext = createContext<FeaturesContextType>(null);

--- a/src/utils/hooks/useFeatures/constants.ts
+++ b/src/utils/hooks/useFeatures/constants.ts
@@ -7,6 +7,8 @@ import {
 import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
 import { K8sVerb } from '@openshift-console/dynamic-plugin-sdk';
 
+import { FeaturesType } from './types';
+
 export const AUTOMATIC_SUBSCRIPTION_ACTIVATION_KEY = 'automaticSubscriptionActivationKey';
 export const AUTOMATIC_SUBSCRIPTION_ORGANIZATION_ID = 'automaticSubscriptionOrganizationId';
 export const AUTOMATIC_SUBSCRIPTION_CUSTOM_URL = 'automaticSubscriptionCustomUrl';
@@ -28,20 +30,25 @@ const FEATURES_ROLE_NAME = 'kubevirt-ui-features-reader';
 const FEATURES_ROLE_BINDING_NAME = 'kubevirt-ui-features-reader-binding';
 
 export const FEATURE_HCO_PERSISTENT_RESERVATION = 'persistentReservationHCO';
+export const AUTOMATIC_UPDATE_FEATURE_NAME = 'auto-update-rhel-vms';
+
+export const defaultFeatures: FeaturesType = {
+  [ADVANCED_SEARCH]: 'false',
+  [AUTOMATIC_SUBSCRIPTION_ACTIVATION_KEY]: '',
+  [AUTOMATIC_SUBSCRIPTION_ORGANIZATION_ID]: '',
+  [AUTOMATIC_UPDATE_FEATURE_NAME]: 'false',
+  [CONFIRM_VM_ACTIONS]: 'false',
+  [DISABLED_GUEST_SYSTEM_LOGS_ACCESS]: 'false',
+  [FEATURE_HCO_PERSISTENT_RESERVATION]: 'false',
+  [KUBEVIRT_APISERVER_PROXY]: 'true',
+  [LOAD_BALANCER_ENABLED]: 'false',
+  [NODE_PORT_ADDRESS]: '',
+  [NODE_PORT_ENABLED]: 'false',
+  [TREE_VIEW_FOLDERS]: 'false',
+};
 
 export const featuresConfigMapInitialState: IoK8sApiCoreV1ConfigMap = {
-  data: {
-    [ADVANCED_SEARCH]: 'false',
-    [AUTOMATIC_SUBSCRIPTION_ACTIVATION_KEY]: '',
-    [AUTOMATIC_SUBSCRIPTION_ORGANIZATION_ID]: '',
-    [CONFIRM_VM_ACTIONS]: 'false',
-    [DISABLED_GUEST_SYSTEM_LOGS_ACCESS]: 'false',
-    [KUBEVIRT_APISERVER_PROXY]: 'true',
-    [LOAD_BALANCER_ENABLED]: 'false',
-    [NODE_PORT_ADDRESS]: '',
-    [NODE_PORT_ENABLED]: 'false',
-    [TREE_VIEW_FOLDERS]: 'false',
-  },
+  data: defaultFeatures,
   metadata: {
     name: FEATURES_CONFIG_MAP_NAME,
     namespace: DEFAULT_OPERATOR_NAMESPACE,

--- a/src/utils/hooks/useFeatures/types.ts
+++ b/src/utils/hooks/useFeatures/types.ts
@@ -1,9 +1,39 @@
 import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 
+import {
+  ADVANCED_SEARCH,
+  AUTOMATIC_SUBSCRIPTION_ACTIVATION_KEY,
+  AUTOMATIC_SUBSCRIPTION_ORGANIZATION_ID,
+  AUTOMATIC_UPDATE_FEATURE_NAME,
+  CONFIRM_VM_ACTIONS,
+  DISABLED_GUEST_SYSTEM_LOGS_ACCESS,
+  FEATURE_HCO_PERSISTENT_RESERVATION,
+  KUBEVIRT_APISERVER_PROXY,
+  LOAD_BALANCER_ENABLED,
+  NODE_PORT_ADDRESS,
+  NODE_PORT_ENABLED,
+  TREE_VIEW_FOLDERS,
+} from './constants';
+
 export type UseFeaturesValues = {
   canEdit: boolean;
   error: Error;
   featureEnabled: boolean;
   loading: boolean;
   toggleFeature: (val: boolean) => Promise<IoK8sApiCoreV1ConfigMap>;
+};
+
+export type FeaturesType = {
+  [ADVANCED_SEARCH]: string;
+  [AUTOMATIC_SUBSCRIPTION_ACTIVATION_KEY]: string;
+  [AUTOMATIC_SUBSCRIPTION_ORGANIZATION_ID]: string;
+  [AUTOMATIC_UPDATE_FEATURE_NAME]: string;
+  [CONFIRM_VM_ACTIONS]: string;
+  [DISABLED_GUEST_SYSTEM_LOGS_ACCESS]: string;
+  [FEATURE_HCO_PERSISTENT_RESERVATION]: string;
+  [KUBEVIRT_APISERVER_PROXY]: string;
+  [LOAD_BALANCER_ENABLED]: string;
+  [NODE_PORT_ADDRESS]: string;
+  [NODE_PORT_ENABLED]: string;
+  [TREE_VIEW_FOLDERS]: string;
 };

--- a/src/utils/hooks/useFeatures/useFeatureReadOnly.ts
+++ b/src/utils/hooks/useFeatures/useFeatureReadOnly.ts
@@ -1,0 +1,31 @@
+import { useContext } from 'react';
+
+import { defaultFeatures } from './constants';
+import { FeatureContext } from './FeatureContext';
+import { FeaturesType } from './types';
+import useFeaturesConfigMap from './useFeaturesConfigMap';
+
+const useFeatureReadOnly = (featureName: keyof FeaturesType) => {
+  const fromContext = useContext(FeatureContext);
+  const {
+    featuresConfigMapData: [configMap, loaded, loadError],
+  } = useFeaturesConfigMap(!fromContext);
+  if (fromContext) {
+    const data = fromContext.data ?? defaultFeatures;
+    return {
+      featureEnabled: data[featureName] === 'true',
+      loading: fromContext.isLoading,
+      value: data[featureName],
+    };
+  }
+
+  const data = configMap?.data ?? defaultFeatures;
+  const loadingQuery = !configMap && !loaded && !loadError;
+  return {
+    featureEnabled: data[featureName] === 'true',
+    loading: loadingQuery,
+    value: data[featureName],
+  };
+};
+
+export default useFeatureReadOnly;

--- a/src/utils/hooks/useFeatures/useFeatures.ts
+++ b/src/utils/hooks/useFeatures/useFeatures.ts
@@ -6,12 +6,12 @@ import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
 import { FEATURES_CONFIG_MAP_NAME, featuresConfigMapInitialState } from './constants';
 import { applyMissingFeatures, createFeaturesConfigMap } from './createFeaturesConfigMap';
-import { UseFeaturesValues } from './types';
+import { FeaturesType, UseFeaturesValues } from './types';
 import useFeaturesConfigMap from './useFeaturesConfigMap';
 
 type UseFeatures = (featureName: string) => UseFeaturesValues;
 
-export const useFeatures: UseFeatures = (featureName) => {
+export const useFeatures: UseFeatures = (featureName: keyof FeaturesType) => {
   const [createError, setCreateError] = useState(null);
   const [createInProgress, setCreateInProgress] = useState(false);
   const { featuresConfigMapData, isAdmin } = useFeaturesConfigMap(!createError);

--- a/src/utils/hooks/useFeatures/withFeatures.tsx
+++ b/src/utils/hooks/useFeatures/withFeatures.tsx
@@ -1,0 +1,75 @@
+import React, { FC, useMemo } from 'react';
+
+import { AUTOMATIC_UPDATE_FEATURE_NAME, defaultFeatures } from './constants';
+import { FeatureContext, FeaturesContextType } from './FeatureContext';
+import { FeaturesType } from './types';
+import useFeaturesConfigMap from './useFeaturesConfigMap';
+
+const withFeatures = <P,>(Component: FC) => {
+  const EnhancedComponent: FC<P> = (props) => {
+    const {
+      featuresConfigMapData: [featuresMap, loaded, loadError],
+    } = useFeaturesConfigMap();
+    const loading = !featuresMap && !loaded && !loadError;
+    const {
+      advancedSearch,
+      [AUTOMATIC_UPDATE_FEATURE_NAME]: autoUpdate,
+      automaticSubscriptionActivationKey,
+      automaticSubscriptionOrganizationId,
+      confirmVMActions,
+      disabledGuestSystemLogsAccess,
+      kubevirtApiserverProxy,
+      loadBalancerEnabled,
+      nodePortAddress,
+      nodePortEnabled,
+      persistentReservationHCO,
+      treeViewFolders,
+    } = (featuresMap?.data ?? defaultFeatures) as FeaturesType;
+
+    const memoFeatures: FeaturesContextType = useMemo(
+      () => ({
+        data: {
+          advancedSearch,
+          [AUTOMATIC_UPDATE_FEATURE_NAME]: autoUpdate,
+          automaticSubscriptionActivationKey,
+          automaticSubscriptionOrganizationId,
+          confirmVMActions,
+          disabledGuestSystemLogsAccess,
+          kubevirtApiserverProxy,
+          loadBalancerEnabled,
+          nodePortAddress,
+          nodePortEnabled,
+          persistentReservationHCO,
+          treeViewFolders,
+        },
+        isLoading: loading,
+      }),
+      [
+        autoUpdate,
+        persistentReservationHCO,
+        advancedSearch,
+        automaticSubscriptionActivationKey,
+        automaticSubscriptionOrganizationId,
+        confirmVMActions,
+        disabledGuestSystemLogsAccess,
+        kubevirtApiserverProxy,
+        loadBalancerEnabled,
+        nodePortAddress,
+        nodePortEnabled,
+        treeViewFolders,
+        loading,
+      ],
+    );
+    return (
+      <FeatureContext.Provider value={memoFeatures}>
+        <Component {...props} />
+      </FeatureContext.Provider>
+    );
+  };
+  EnhancedComponent.displayName = `${
+    Component.displayName || Component.displayName || ''
+  }WithFeatures`;
+  return EnhancedComponent;
+};
+
+export default withFeatures;

--- a/src/utils/hooks/useKubevirtWatchResource.ts
+++ b/src/utils/hooks/useKubevirtWatchResource.ts
@@ -7,7 +7,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 
 import { KUBEVIRT_APISERVER_PROXY } from './useFeatures/constants';
-import { useFeatures } from './useFeatures/useFeatures';
+import useFeatureReadOnly from './useFeatures/useFeatureReadOnly';
 import useKubevirtDataPodHealth from './useKubevirtDataPod/hooks/useKubevirtDataPodHealth';
 import useKubevirtDataPod from './useKubevirtDataPod/useKubevirtDataPod';
 type Result<R extends K8sResourceCommon | K8sResourceCommon[]> = [R, boolean, Error];
@@ -21,7 +21,7 @@ const useKubevirtWatchResource: UseKubevirtWatchResource = <T>(watchOptions, fil
   const [loadedData, setLoadedData] = useState<boolean>(false);
   const [loadErrorData, setLoadErrorData] = useState<Error>();
   const isProxyPodAlive = useKubevirtDataPodHealth();
-  const { featureEnabled, loading } = useFeatures(KUBEVIRT_APISERVER_PROXY);
+  const { featureEnabled, loading } = useFeatureReadOnly(KUBEVIRT_APISERVER_PROXY);
   const shouldUseProxyPod = useMemo(() => {
     if (!featureEnabled && !loading) return false;
     if (featureEnabled && !loading && isProxyPodAlive !== null) return isProxyPodAlive;

--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/hooks/useGeneratedVM.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/hooks/useGeneratedVM.ts
@@ -8,18 +8,18 @@ import {
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import { AUTOMATIC_UPDATE_FEATURE_NAME } from '@kubevirt-utils/hooks/useFeatures/constants';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import useRHELAutomaticSubscription from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription';
 import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
 import { addWinDriverVolume } from '@kubevirt-utils/resources/vm/utils/disk/drivers';
 import { useDriversImage } from '@kubevirt-utils/resources/vm/utils/disk/useDriversImage';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
-import { AUTOMATIC_UPDATE_FEATURE_NAME } from '@overview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/utils/constants';
 
 export type UseGeneratedVMType = () => V1VirtualMachine;
 
 const useGeneratedVM = () => {
-  const { featureEnabled: autoUpdateEnabled } = useFeatures(AUTOMATIC_UPDATE_FEATURE_NAME);
+  const { featureEnabled: autoUpdateEnabled } = useFeatureReadOnly(AUTOMATIC_UPDATE_FEATURE_NAME);
 
   const { subscriptionData } = useRHELAutomaticSubscription();
   const { instanceTypeVMState, startVM, vmNamespaceTarget } = useInstanceTypeVMStore();

--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsLeftGrid.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsLeftGrid.tsx
@@ -11,7 +11,7 @@ import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMac
 import { validateVMName } from '@kubevirt-utils/components/VMNameValidationHelperText/utils/utils';
 import VMNameValidationHelperText from '@kubevirt-utils/components/VMNameValidationHelperText/VMNameValidationHelperText';
 import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { convertResourceArrayToMap } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -29,7 +29,7 @@ const DetailsLeftGrid: FC<DetailsLeftGridProps> = ({
   userPreferencesData,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
+  const { featureEnabled: treeViewFoldersEnabled } = useFeatureReadOnly(TREE_VIEW_FOLDERS);
 
   const { instanceTypeVMState, setInstanceTypeVMState, vmNamespaceTarget } =
     useInstanceTypeVMStore();

--- a/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeDetailsTab.tsx
+++ b/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeDetailsTab.tsx
@@ -16,7 +16,7 @@ import {
   DISABLED_GUEST_SYSTEM_LOGS_ACCESS,
   TREE_VIEW_FOLDERS,
 } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getPreferredBootmode } from '@kubevirt-utils/resources/preference/helper';
 import { asAccessReview, getAnnotation, getLabel, getName } from '@kubevirt-utils/resources/shared';
@@ -40,10 +40,10 @@ const CustomizeInstanceTypeDetailsTab = () => {
   const accessReview = asAccessReview(VirtualMachineModel, vm, 'update' as K8sVerb);
   const [canUpdateVM] = useAccessReview(accessReview || {});
 
-  const { featureEnabled: isGuestSystemLogsDisabled } = useFeatures(
+  const { featureEnabled: isGuestSystemLogsDisabled } = useFeatureReadOnly(
     DISABLED_GUEST_SYSTEM_LOGS_ACCESS,
   );
-  const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
+  const { featureEnabled: treeViewFoldersEnabled } = useFeatureReadOnly(TREE_VIEW_FOLDERS);
 
   const logSerialConsole = vm?.spec?.template?.spec?.domain?.devices?.logSerialConsole;
   const [isCheckedGuestSystemAccessLog, setIsCheckedGuestSystemAccessLog] = useState<boolean>();

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -11,7 +11,7 @@ import {
   RUNSTRATEGY_RERUNONFAILURE,
 } from '@kubevirt-utils/constants/constants';
 import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
 import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
@@ -50,7 +50,7 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
     const { isBootSourceAvailable, templateLoadingError } = useDrawerContext();
     const [__, vmsNotSupported] = useNamespaceUDN(namespace);
 
-    const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
+    const { featureEnabled: treeViewFoldersEnabled } = useFeatureReadOnly(TREE_VIEW_FOLDERS);
 
     const {
       createError,

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
@@ -1,7 +1,6 @@
 import { MouseEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import produce from 'immer';
-import { AUTOMATIC_UPDATE_FEATURE_NAME } from 'src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/utils/constants';
 
 import { quickCreateVM } from '@catalog/utils/quick-create-vm';
 import { isRHELTemplate } from '@catalog/utils/utils';
@@ -32,8 +31,11 @@ import {
   CUSTOMIZE_VM_BUTTON_CLICKED,
   CUSTOMIZE_VM_FAILED,
 } from '@kubevirt-utils/extensions/telemetry/utils/constants';
-import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import {
+  AUTOMATIC_UPDATE_FEATURE_NAME,
+  DISABLED_GUEST_SYSTEM_LOGS_ACCESS,
+} from '@kubevirt-utils/hooks/useFeatures/constants';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
 import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
 import {
@@ -79,8 +81,8 @@ const useCreateDrawerForm = (
 
   const [isUDNManagedNamespace, vmsNotSupported] = useNamespaceUDN(namespace);
   const [authorizedSSHKeys, updateAuthorizedSSHKeys] = useKubevirtUserSettings('ssh');
-  const { featureEnabled: autoUpdateEnabled } = useFeatures(AUTOMATIC_UPDATE_FEATURE_NAME);
-  const { featureEnabled: isDisabledGuestSystemLogs } = useFeatures(
+  const { featureEnabled: autoUpdateEnabled } = useFeatureReadOnly(AUTOMATIC_UPDATE_FEATURE_NAME);
+  const { featureEnabled: isDisabledGuestSystemLogs } = useFeatureReadOnly(
     DISABLED_GUEST_SYSTEM_LOGS_ACCESS,
   );
 

--- a/src/views/catalog/wizard/components/WizardFooter.tsx
+++ b/src/views/catalog/wizard/components/WizardFooter.tsx
@@ -15,7 +15,7 @@ import {
   CUSTOMIZE_PAGE_CREATE_VM_BUTTON_CLICKED,
 } from '@kubevirt-utils/extensions/telemetry/utils/constants';
 import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getResourceUrl } from '@kubevirt-utils/resources/shared';
 import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
@@ -45,7 +45,7 @@ export const WizardFooter: FC<{ namespace: string }> = ({ namespace }) => {
   const { isBootSourceAvailable, loaded: bootSourceLoaded } = useWizardSourceAvailable();
   const { createVM, error, loaded: vmCreateLoaded } = useWizardVMCreate();
   const { createModal } = useModal();
-  const { featureEnabled: isDisableGuestSystemAccessLog } = useFeatures(
+  const { featureEnabled: isDisableGuestSystemAccessLog } = useFeatureReadOnly(
     DISABLED_GUEST_SYSTEM_LOGS_ACCESS,
   );
 

--- a/src/views/catalog/wizard/tabs/overview/components/WizardOverviewGrid.tsx
+++ b/src/views/catalog/wizard/tabs/overview/components/WizardOverviewGrid.tsx
@@ -19,7 +19,7 @@ import {
   DISABLED_GUEST_SYSTEM_LOGS_ACCESS,
   TREE_VIEW_FOLDERS,
 } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getAnnotation, getLabel } from '@kubevirt-utils/resources/shared';
 import { getVmCPUMemory, WORKLOADS_LABELS } from '@kubevirt-utils/resources/template';
@@ -53,9 +53,9 @@ const WizardOverviewGrid: FC<WizardOverviewGridProps> = ({ tabsData, updateVM, v
   const { ns } = useParams<{ ns: string }>();
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
-  const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
+  const { featureEnabled: treeViewFoldersEnabled } = useFeatureReadOnly(TREE_VIEW_FOLDERS);
   const { cpuCount, memory } = getVmCPUMemory(vm);
-  const { featureEnabled: isDisabledGuestSystemLogs } = useFeatures(
+  const { featureEnabled: isDisabledGuestSystemLogs } = useFeatureReadOnly(
     DISABLED_GUEST_SYSTEM_LOGS_ACCESS,
   );
   const description = getAnnotation(vm, 'description');

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/AutomaticSubscriptionRHELGuests.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/AutomaticSubscriptionRHELGuests.tsx
@@ -3,6 +3,7 @@ import React, { FC, useEffect, useMemo, useState } from 'react';
 import NewBadge from '@kubevirt-utils/components/badges/NewBadge/NewBadge';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
+import { AUTOMATIC_UPDATE_FEATURE_NAME } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useRHELAutomaticSubscription from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription';
@@ -17,7 +18,6 @@ import {
   AutomaticSubscriptionTypeEnum,
   getSubscriptionItem,
 } from './components/AutomaticSubscriptionType/utils/utils';
-import { AUTOMATIC_UPDATE_FEATURE_NAME } from './utils/constants';
 
 type AutomaticSubscriptionRHELGuestsProps = {
   newBadge?: boolean;

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/utils/constants.ts
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/utils/constants.ts
@@ -2,5 +2,3 @@ export const ACTIVATION_KEYS_URL = 'https://console.redhat.com/settings/connecto
 export const ACTIVATION_KEYS_DOCUMENTATION_URL =
   'https://access.redhat.com/documentation/en-us/red_hat_insights/1-latest/html/remote_host_configuration_and_management/activation-keys_intro-rhc';
 export const REDHAT_CONSOLE_URL = 'https://console.redhat.com/';
-
-export const AUTOMATIC_UPDATE_FEATURE_NAME = 'auto-update-rhel-vms';

--- a/src/views/virtualmachines/actions/components/VMActionsIconBar/VMActionsIconBar.tsx
+++ b/src/views/virtualmachines/actions/components/VMActionsIconBar/VMActionsIconBar.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { CONFIRM_VM_ACTIONS } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { Flex } from '@patternfly/react-core';
 import ActionIconButton from '@virtualmachines/actions/components/VMActionsIconBar/components/ActionIconButton';
 import { getVMActionIconsDetails } from '@virtualmachines/actions/components/VMActionsIconBar/utils/utils';
@@ -14,7 +14,7 @@ type VMActionsIconBarProps = {
 
 const VMActionsIconBar: FC<VMActionsIconBarProps> = ({ vm }) => {
   const { createModal } = useModal();
-  const { featureEnabled: confirmVMActionsEnabled } = useFeatures(CONFIRM_VM_ACTIONS);
+  const { featureEnabled: confirmVMActionsEnabled } = useFeatureReadOnly(CONFIRM_VM_ACTIONS);
 
   return (
     <Flex className="vm-actions-icon-bar" spaceItems={{ default: 'spaceItemsSm' }}>

--- a/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.tsx
+++ b/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.tsx
@@ -4,7 +4,7 @@ import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { CONFIRM_VM_ACTIONS, TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { isPaused, isRunning, isStopped } from '@virtualmachines/utils';
 
@@ -17,8 +17,8 @@ type UseMultipleVirtualMachineActions = (vms: V1VirtualMachine[]) => ActionDropd
 
 const useMultipleVirtualMachineActions: UseMultipleVirtualMachineActions = (vms) => {
   const { createModal } = useModal();
-  const { featureEnabled: confirmVMActionsEnabled } = useFeatures(CONFIRM_VM_ACTIONS);
-  const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
+  const { featureEnabled: confirmVMActionsEnabled } = useFeatureReadOnly(CONFIRM_VM_ACTIONS);
+  const { featureEnabled: treeViewFoldersEnabled } = useFeatureReadOnly(TREE_VIEW_FOLDERS);
 
   const mtcInstalled = useIsMTCInstalled();
 

--- a/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
+++ b/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
@@ -8,7 +8,7 @@ import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdo
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { getConsoleVirtctlCommand } from '@kubevirt-utils/components/SSHAccess/utils';
 import { CONFIRM_VM_ACTIONS, TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { VirtualMachineModelRef } from '@kubevirt-utils/models';
 import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
 import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
@@ -26,7 +26,7 @@ type UseVirtualMachineActionsProvider = (
 
 const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, vmim) => {
   const { createModal } = useModal();
-  const { featureEnabled: confirmVMActionsEnabled } = useFeatures(CONFIRM_VM_ACTIONS);
+  const { featureEnabled: confirmVMActionsEnabled } = useFeatureReadOnly(CONFIRM_VM_ACTIONS);
 
   const virtctlCommand = getConsoleVirtctlCommand(vm);
 
@@ -35,7 +35,7 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, 
 
   const [, inFlight] = useK8sModel(VirtualMachineModelRef);
 
-  const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
+  const { featureEnabled: treeViewFoldersEnabled } = useFeatureReadOnly(TREE_VIEW_FOLDERS);
 
   const actions: ActionDropdownItemType[] = useMemo(() => {
     const printableStatus = vm?.status?.printableStatus;

--- a/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
@@ -17,7 +17,7 @@ import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import WorkloadProfileModal from '@kubevirt-utils/components/WorkloadProfileModal/WorkloadProfileModal';
 import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { InstanceTypeUnion } from '@kubevirt-utils/resources/instancetype/types';
@@ -64,7 +64,7 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
   const { t } = useKubevirtTranslation();
   const accessReview = asAccessReview(VirtualMachineModel, vm, 'update' as K8sVerb);
   const [canUpdateVM] = useAccessReview(accessReview || {});
-  const { featureEnabled: isGuestSystemLogsDisabled } = useFeatures(
+  const { featureEnabled: isGuestSystemLogsDisabled } = useFeatureReadOnly(
     DISABLED_GUEST_SYSTEM_LOGS_ACCESS,
   );
 

--- a/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineLogViewer.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineLogViewer.tsx
@@ -4,7 +4,7 @@ import { V1Devices } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { getChangedGuestSystemAccessLog } from '@kubevirt-utils/components/PendingChanges/utils/helpers';
 import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getDevices, useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
 import { getVMIPod } from '@kubevirt-utils/resources/vmi';
@@ -18,7 +18,7 @@ const VirtualMachineLogViewer = ({ connect, vm }) => {
   const { t } = useKubevirtTranslation();
   const { loaded, pods, vmi } = useVMIAndPodsForVM(vm?.metadata?.name, vm?.metadata?.namespace);
   const pod = getVMIPod(vmi, pods);
-  const { featureEnabled: isClusterDisabledGuestSystemLogs } = useFeatures(
+  const { featureEnabled: isClusterDisabledGuestSystemLogs } = useFeatureReadOnly(
     DISABLED_GUEST_SYSTEM_LOGS_ACCESS,
   );
 

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
@@ -12,7 +12,7 @@ import { timestampFor } from '@kubevirt-utils/components/Timestamp/utils/datetim
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
 import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getLabel, getName, getVMStatus } from '@kubevirt-utils/resources/shared';
 import { getInstanceTypeMatcher } from '@kubevirt-utils/resources/vm';
@@ -66,7 +66,7 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
   vmi,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
+  const { featureEnabled: treeViewFoldersEnabled } = useFeatureReadOnly(TREE_VIEW_FOLDERS);
 
   const timestamp = timestampFor(
     new Date(vm?.metadata?.creationTimestamp),

--- a/src/views/virtualmachines/extensions.ts
+++ b/src/views/virtualmachines/extensions.ts
@@ -9,7 +9,7 @@ import type { ConsolePluginBuildMetadata } from '@openshift-console/dynamic-plug
 export const exposedModules: ConsolePluginBuildMetadata['exposedModules'] = {
   LogsStandAlone:
     './views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineLogViewerStandAlone/VirtualMachineLogViewerStandAlone.tsx',
-  Navigator: './views/virtualmachines/navigator/VirtualMachineNavigator.tsx',
+  Navigator: './views/virtualmachines/navigator/SingleClusterVirtualMachineNavigator.tsx',
   useVirtualMachineActionsProvider:
     './views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts',
   VirtualMachineSearchResults: './views/virtualmachines/search/VirtualMachineSearchResults.tsx',

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -37,7 +37,7 @@ import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { PageTitles } from '@kubevirt-utils/constants/page-constants';
 import useContainerWidth from '@kubevirt-utils/hooks/useContainerWidth';
 import { KUBEVIRT_APISERVER_PROXY } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import useKubevirtDataPodHealth from '@kubevirt-utils/hooks/useKubevirtDataPod/hooks/useKubevirtDataPodHealth';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource';
@@ -89,7 +89,8 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
   const { t } = useKubevirtTranslation();
   const { isSearchResultsPage = false, kind, namespace } = props;
   const catalogURL = `/k8s/ns/${namespace || DEFAULT_NAMESPACE}/catalog`;
-  const { featureEnabled, loading: loadingFeatureProxy } = useFeatures(KUBEVIRT_APISERVER_PROXY);
+  const { featureEnabled, loading: loadingFeatureProxy } =
+    useFeatureReadOnly(KUBEVIRT_APISERVER_PROXY);
   const isProxyPodAlive = useKubevirtDataPodHealth();
 
   const listPageFilterRef = useRef<{ resetTextSearch: ResetTextSearch } | null>(null);

--- a/src/views/virtualmachines/navigator/SingleClusterVirtualMachineNavigator.tsx
+++ b/src/views/virtualmachines/navigator/SingleClusterVirtualMachineNavigator.tsx
@@ -1,0 +1,12 @@
+import React, { FC } from 'react';
+
+import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+
+import { VirtualMachineNavigatorWithFeatures } from './VirtualMachineNavigator';
+
+const SingleClusterVirtualMachineNavigator: FC = () => {
+  const [activeNamespace] = useActiveNamespace();
+  return <VirtualMachineNavigatorWithFeatures activeNamespace={activeNamespace} />;
+};
+
+export default SingleClusterVirtualMachineNavigator;

--- a/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
+++ b/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
@@ -1,18 +1,15 @@
-import React, { FC, memo, useMemo, useRef } from 'react';
+import React, { ComponentProps, FC, memo, useMemo, useRef } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
 import CreateResourceDefaultPage from '@kubevirt-utils/components/CreateResourceDefaultPage/CreateResourceDefaultPage';
 import GuidedTour from '@kubevirt-utils/components/GuidedTour/GuidedTour';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { ADVANCED_SEARCH } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
+import withFeatures from '@kubevirt-utils/hooks/useFeatures/withFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VirtualMachineModelRef } from '@kubevirt-utils/models';
-import {
-  ListPageHeader,
-  OnFilterChange,
-  useActiveNamespace,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { ListPageHeader, OnFilterChange } from '@openshift-console/dynamic-plugin-sdk';
 import { Divider } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
 import SearchBar from '@search/components/SearchBar';
@@ -32,7 +29,8 @@ const VirtualMachineNavigator: FC<{ activeNamespace: string }> = memo(({ activeN
   const namespace = activeNamespace === ALL_NAMESPACES_SESSION_KEY ? null : activeNamespace;
   const vmName = location.pathname.split('/')?.[5];
 
-  const { featureEnabled: advancedSearchEnabled } = useFeatures(ADVANCED_SEARCH);
+  const { featureEnabled: advancedSearchEnabled, loading: loadingFeatureFlag } =
+    useFeatureReadOnly(ADVANCED_SEARCH);
 
   const isVirtualMachineListPage = useMemo(
     () =>
@@ -59,7 +57,9 @@ const VirtualMachineNavigator: FC<{ activeNamespace: string }> = memo(({ activeN
   return (
     <>
       <ListPageHeader title={t('VirtualMachines')}>
-        {advancedSearchEnabled && <SearchBar onFilterChange={onFilterChange} />}
+        {advancedSearchEnabled && !loadingFeatureFlag && (
+          <SearchBar onFilterChange={onFilterChange} />
+        )}
         <div>
           <VirtualMachinesCreateButton namespace={namespace} />
         </div>
@@ -87,9 +87,7 @@ const VirtualMachineNavigator: FC<{ activeNamespace: string }> = memo(({ activeN
   );
 });
 
-const VirtualMachineNavigatorWithNamespace: FC = () => {
-  const [activeNamespace] = useActiveNamespace();
-  return <VirtualMachineNavigator activeNamespace={activeNamespace} />;
-};
-
-export default VirtualMachineNavigatorWithNamespace;
+export const VirtualMachineNavigatorWithFeatures = memo(
+  withFeatures<ComponentProps<typeof VirtualMachineNavigator>>(VirtualMachineNavigator),
+);
+export default VirtualMachineNavigator;

--- a/src/views/virtualmachines/search/VirtualMachineSearchResults.tsx
+++ b/src/views/virtualmachines/search/VirtualMachineSearchResults.tsx
@@ -7,7 +7,7 @@ import {
 } from '@kubevirt-utils/components/ListPageFilter/types';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { ADVANCED_SEARCH } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VirtualMachineModelRef } from '@kubevirt-utils/models';
 import {
@@ -28,7 +28,7 @@ const VirtualMachineSearchResults: FC = () => {
   const namespace = activeNamespace === ALL_NAMESPACES_SESSION_KEY ? null : activeNamespace;
 
   const { featureEnabled: advancedSearchEnabled, loading: advancedSearchLoading } =
-    useFeatures(ADVANCED_SEARCH);
+    useFeatureReadOnly(ADVANCED_SEARCH);
 
   useHideNamespaceBar();
 

--- a/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, FC } from 'react';
 
 import { ADVANCED_SEARCH } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useLocalStorage from '@kubevirt-utils/hooks/useLocalStorage';
 import {
@@ -27,7 +27,7 @@ type TreeViewToolbarProps = {
 const TreeViewToolbar: FC<TreeViewToolbarProps> = ({ hideSwitch, onSearch }) => {
   const { t } = useKubevirtTranslation();
   const [showEmptyProjects, setShowEmptyProjects] = useLocalStorage(SHOW_EMPTY_PROJECTS_KEY, HIDE);
-  const { featureEnabled: advancedSearchEnabled } = useFeatures(ADVANCED_SEARCH);
+  const { featureEnabled: advancedSearchEnabled } = useFeatureReadOnly(ADVANCED_SEARCH);
 
   if (advancedSearchEnabled && hideSwitch) {
     return null;

--- a/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
@@ -10,7 +10,7 @@ import {
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useFeatureReadOnly from '@kubevirt-utils/hooks/useFeatures/useFeatureReadOnly';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
@@ -32,7 +32,7 @@ export const useTreeViewData = (): UseTreeViewData => {
   const isAdmin = useIsAdmin();
   const location = useLocation();
 
-  const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
+  const { featureEnabled: treeViewFoldersEnabled } = useFeatureReadOnly(TREE_VIEW_FOLDERS);
   const [projectNames, projectNamesLoaded, projectNamesError] = useProjects();
 
   const [allVMs, allVMsLoaded] = useK8sWatchResource<V1VirtualMachine[]>({


### PR DESCRIPTION
## 📝 Description
   
Before, the features were accessed via useFeatures hook which provides:
1. values
2. mutators
2. logic for auto-creating resources on the backend
Most of the consuming components use only the value.

After this PR, components that need read only access receive only
the requested functionality (no mutators, no side-effects).
On the Virtual Machine screen the value is provided by context which
allows pre-loading the value for all nested components.

Additionally strict typing was added to capture the list of supported
feature flags.


## 🎥 Demo

### Before
https://github.com/user-attachments/assets/f8ad34c5-73f5-404e-ad8f-deb502e3a732
### After

https://github.com/user-attachments/assets/a24f99fb-10e4-48e3-9056-97746669b536


