### PR TITLE
CNV-64839: Moving the copy button out of text element making it always visible

### DIFF
--- a/src/utils/components/Consoles/components/CloudInitCredentials/CloudInitCredentialsContent.tsx
+++ b/src/utils/components/Consoles/components/CloudInitCredentials/CloudInitCredentialsContent.tsx
@@ -6,10 +6,7 @@ import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Flex } from '@patternfly/react-core';
 
-import { LINE_FEED } from '../vnc-console/utils/util';
-
 import CloudInitCredentialsItem from './CloudInitCredentialsItem';
-import InlineCodeClipboardCopy from './InlineCodeClipboardCopy';
 
 type CloudInitCredentialsContentProps = {
   vm: V1VirtualMachine;
@@ -19,7 +16,7 @@ const CloudInitCredentialsContent: FC<CloudInitCredentialsContentProps> = ({ vm 
   const { t } = useKubevirtTranslation();
   const { users } = getCloudInitCredentials(vm);
 
-  if (isEmpty(users)) {
+  if (!Array.isArray(users) || isEmpty(users)) {
     return (
       <div className="pf-v6-u-ml-md">
         {t('No credentials, see operating system documentation for the default username.')}
@@ -27,44 +24,27 @@ const CloudInitCredentialsContent: FC<CloudInitCredentialsContentProps> = ({ vm 
     );
   }
 
-  const { passwords, usernames } = users.reduce(
-    (acc, user) => ({
-      passwords: (
-        <>
-          {acc.passwords}
-          <InlineCodeClipboardCopy
-            clipboardText={user?.password?.concat(String.fromCharCode(LINE_FEED))}
-          />
-        </>
-      ),
-      usernames: (
-        <>
-          {acc.usernames}
-          <InlineCodeClipboardCopy
-            clipboardText={user?.name?.concat(String.fromCharCode(LINE_FEED))}
-          />
-        </>
-      ),
-    }),
-    { passwords: <></>, usernames: <></> },
-  );
   return (
-    <Flex className="cloud-init-credentials-user-pass">
-      <CloudInitCredentialsItem
-        button-data-test="username-show-hide-button"
-        credentials={usernames}
-        credentialTitle={t('User name')}
-        hideCredentialText={t('Hide username')}
-        showCredentialText={t('Show username')}
-      />
-      <CloudInitCredentialsItem
-        button-data-test="password-show-hide-button"
-        credentials={passwords}
-        credentialTitle={t('Password')}
-        hideCredentialText={t('Hide password')}
-        showCredentialText={t('Show password')}
-      />
-    </Flex>
+    <>
+      {users.map((user) => (
+        <Flex className="cloud-init-credentials-user-pass" key={user.name}>
+          <CloudInitCredentialsItem
+            button-data-test="username-show-hide-button"
+            credentials={user?.name || ''}
+            credentialTitle={t('User name')}
+            hideCredentialText={t('Hide username')}
+            showCredentialText={t('Show username')}
+          />
+          <CloudInitCredentialsItem
+            button-data-test="password-show-hide-button"
+            credentials={user?.password || ''}
+            credentialTitle={t('Password')}
+            hideCredentialText={t('Hide password')}
+            showCredentialText={t('Show password')}
+          />
+        </Flex>
+      ))}
+    </>
   );
 };
 

--- a/src/utils/components/Consoles/components/CloudInitCredentials/CloudInitCredentialsItem.tsx
+++ b/src/utils/components/Consoles/components/CloudInitCredentials/CloudInitCredentialsItem.tsx
@@ -1,11 +1,13 @@
-import React, { FC, ReactNode, useState } from 'react';
+import React, { FC, useState } from 'react';
 
-import { Button, FlexItem, Tooltip } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Tooltip } from '@patternfly/react-core';
 import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
+
+import InlineCodeClipboardCopy from './InlineCodeClipboardCopy';
 
 type CloudInitCredentialsItemProps = {
   'button-data-test'?: string;
-  credentials: ReactNode;
+  credentials: string;
   credentialTitle: string;
   hideCredentialText: string;
   showCredentialText: string;
@@ -18,20 +20,26 @@ const CloudInitCredentialsItem: FC<CloudInitCredentialsItemProps> = ({
   hideCredentialText,
   showCredentialText,
 }) => {
-  const [isVisible, setIsVisible] = useState(false);
+  const [isCredentialsVisible, setIsCredentialsVisible] = useState(false);
 
   return (
-    <FlexItem spacer={{ default: 'spacerSm' }}>
-      {credentialTitle} {isVisible ? credentials : '●●●●●●●●●'}{' '}
-      <Tooltip content={isVisible ? hideCredentialText : showCredentialText}>
-        <Button
-          data-test={buttonDataTest}
-          icon={isVisible ? <EyeSlashIcon /> : <EyeIcon />}
-          onClick={() => setIsVisible(!isVisible)}
-          variant="plain"
+    <>
+      <Flex display={{ default: 'inlineFlex' }} spaceItems={{ default: 'spaceItemsSm' }}>
+        <FlexItem>{credentialTitle}</FlexItem>
+        <InlineCodeClipboardCopy
+          clipboardText={credentials}
+          isCredentialsVisible={isCredentialsVisible}
         />
-      </Tooltip>
-    </FlexItem>
+        <Tooltip content={isCredentialsVisible ? hideCredentialText : showCredentialText}>
+          <Button
+            data-test={buttonDataTest}
+            icon={isCredentialsVisible ? <EyeSlashIcon /> : <EyeIcon />}
+            onClick={() => setIsCredentialsVisible(!isCredentialsVisible)}
+            variant="plain"
+          />
+        </Tooltip>
+      </Flex>
+    </>
   );
 };
 

--- a/src/utils/components/Consoles/components/CloudInitCredentials/InlineCodeClipboardCopy.tsx
+++ b/src/utils/components/Consoles/components/CloudInitCredentials/InlineCodeClipboardCopy.tsx
@@ -3,23 +3,34 @@ import React, { FC } from 'react';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ClipboardCopy } from '@patternfly/react-core';
 
-import { clipboardCopyFunc } from '../../utils/utils';
+import { writeToClipboard } from '../../utils/utils';
+import { LINE_FEED } from '../vnc-console/utils/util';
 
-const InlineCodeClipboardCopy: FC<{ clipboardText: string }> = ({ clipboardText }) => {
+type InlineCodeClipboardCopyProps = {
+  clipboardText: string;
+  isCredentialsVisible?: boolean;
+};
+
+const InlineCodeClipboardCopy: FC<InlineCodeClipboardCopyProps> = ({
+  clipboardText,
+  isCredentialsVisible = false,
+}) => {
   const { t } = useKubevirtTranslation();
 
+  const handleCopy = () => {
+    writeToClipboard(clipboardText.concat(String.fromCharCode(LINE_FEED)));
+  };
+
   return (
-    <>
-      <ClipboardCopy
-        clickTip={t('Copied')}
-        hoverTip={t('Copy to clipboard')}
-        isCode
-        onCopy={clipboardCopyFunc}
-        variant="inline-compact"
-      >
-        {clipboardText}
-      </ClipboardCopy>{' '}
-    </>
+    <ClipboardCopy
+      clickTip={t('Copied')}
+      hoverTip={t('Copy to clipboard')}
+      isCode
+      onCopy={handleCopy}
+      variant="inline-compact"
+    >
+      {isCredentialsVisible ? clipboardText : '●●●●●●●●●'}
+    </ClipboardCopy>
   );
 };
 

--- a/src/utils/components/Consoles/utils/utils.ts
+++ b/src/utils/components/Consoles/utils/utils.ts
@@ -1,13 +1,5 @@
 export const isConnectionEncrypted = () => window.location.protocol === 'https:';
 
-export const clipboardCopyFunc = (
-  _: React.ClipboardEvent<HTMLDivElement>,
-  text?: React.ReactNode,
-) => {
-  const textString = text?.toString();
-  navigator.clipboard.writeText(textString);
-};
-
 export const getConsoleBasePath = ({ apiPath = '/api/kubernetes', name, namespace }) =>
   `${apiPath}/apis/subresources.kubevirt.io/v1/namespaces/${namespace}/virtualmachineinstances/${name}`;
 
@@ -18,3 +10,9 @@ export const readFromClipboard = async () =>
     .readText()
     // eslint-disable-next-line no-console
     .catch((err) => console.error('Failed to read from clipboard', err));
+
+export const writeToClipboard = async (text: string) =>
+  navigator.clipboard
+    .writeText(text)
+    // eslint-disable-next-line no-console
+    .catch((err) => console.error('Failed to write to clipboard', err));


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Moving the copy button out of the hidden text field by creating new copy buttons and hiding only the credential text instead of the whole component, making the copy button always visible while only toggling the text display.

## 🎥 Demo
Before: 
![image](https://github.com/user-attachments/assets/cf77cd1d-90e5-47d5-a9e0-e4dc4c1044d1)
![image](https://github.com/user-attachments/assets/57fac5c4-9939-4dda-873a-39891ff8d5f0)

After:
<img width="1130" height="296" alt="Screenshot 2025-07-29 at 10 53 14" src="https://github.com/user-attachments/assets/eaa4193b-b704-4da3-8007-607c40a8204e" />

