### PR TITLE
ACM-20341: use fleet link and useK8sWatchData

### DIFF
--- a/__mocks__/multicluster-sdk.ts
+++ b/__mocks__/multicluster-sdk.ts
@@ -4,6 +4,6 @@ module.exports = {
   FleetWatchK8sResource: multiclusterSDK.FleetWatchK8sResource,
   getFleetK8sAPIPath: () => Promise.resolve('/k8s/kubernetes'),
   useFleetK8sAPIPath: () => ['/k8s/kubernetes', true, undefined],
-  useFleetK8sWatchResource: multiclusterSDK.useFleetK8sWatchResource,
+  useFleetK8sWatchResource: () => [undefined, true, undefined],
   useHubClusterName: () => ['hub', true, undefined],
 };

--- a/src/multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink.tsx
+++ b/src/multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink.tsx
@@ -1,0 +1,9 @@
+import React, { FC } from 'react';
+
+import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+import { FleetResourceLink, FleetResourceLinkProps } from '@stolostron/multicluster-sdk';
+
+const MulticlusterResourceLink: FC<FleetResourceLinkProps> = (props) =>
+  props?.cluster ? <FleetResourceLink {...props} /> : <ResourceLink {...props} />;
+
+export default MulticlusterResourceLink;

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeDestination/VolumeDestination.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeDestination/VolumeDestination.tsx
@@ -27,6 +27,7 @@ const VolumeDestination: FC<VolumeDestinationProps> = ({
 
   const {
     accessMode,
+    bootableVolumeCluster,
     bootableVolumeName,
     bootableVolumeNamespace,
     size,
@@ -79,6 +80,7 @@ const VolumeDestination: FC<VolumeDestinationProps> = ({
       </FormGroup>
       <FormGroup label={t('Destination project')}>
         <ProjectDropdown
+          cluster={bootableVolumeCluster}
           includeAllProjects={false}
           onChange={setBootableVolumeField('bootableVolumeNamespace')}
           selectedProject={bootableVolumeNamespace}

--- a/src/utils/components/AddBootableVolumeModal/utils/constants.ts
+++ b/src/utils/components/AddBootableVolumeModal/utils/constants.ts
@@ -34,6 +34,7 @@ export const optionsValueLabelMapper = {
 export type AddBootableVolumeState = {
   accessMode?: V1beta1StorageSpecAccessModesEnum;
   annotations?: { [key: string]: string };
+  bootableVolumeCluster?: string;
   bootableVolumeName: string;
   bootableVolumeNamespace: string;
   cronExpression?: string;

--- a/src/utils/components/ProjectDropdown/ProjectDropdown.tsx
+++ b/src/utils/components/ProjectDropdown/ProjectDropdown.tsx
@@ -4,20 +4,24 @@ import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui/kubevirt-api
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import { getProjectOptions } from '@kubevirt-utils/components/ProjectDropdown/utils/utils';
 import { ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
-import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 type ProjectDropdownProps = {
+  cluster?: string;
   includeAllProjects?: boolean;
   onChange: (project: string) => void;
   selectedProject: string;
 };
 
 const ProjectDropdown: FC<ProjectDropdownProps> = ({
+  cluster,
   includeAllProjects = true,
   onChange,
   selectedProject,
 }) => {
-  const [projects] = useK8sWatchResource<K8sResourceCommon[]>({
+  const [projects] = useK8sWatchData<K8sResourceCommon[]>({
+    cluster,
     groupVersionKind: modelToGroupVersionKind(ProjectModel),
     isList: true,
     namespaced: false,

--- a/src/utils/components/SSHAccess/useSSHService.tsx
+++ b/src/utils/components/SSHAccess/useSSHService.tsx
@@ -2,7 +2,8 @@ import { ServiceModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
 import { SSH_PORT } from './constants';
 
@@ -10,12 +11,13 @@ export type UseSSHServiceReturnType = [service: IoK8sApiCoreV1Service, loaded: b
 
 const useSSHService = (vm: V1VirtualMachine): UseSSHServiceReturnType => {
   const watchServiceResources = {
+    cluster: getCluster(vm),
     isList: true,
     kind: ServiceModel.kind,
     namespace: vm?.metadata?.namespace,
   };
 
-  const [services, servicesLoaded, servicesError] = useK8sWatchResource<IoK8sApiCoreV1Service[]>(
+  const [services, servicesLoaded, servicesError] = useK8sWatchData<IoK8sApiCoreV1Service[]>(
     vm && watchServiceResources,
   );
 

--- a/src/utils/hooks/useDefaultStorage/useDefaultStorageClass.ts
+++ b/src/utils/hooks/useDefaultStorage/useDefaultStorageClass.ts
@@ -4,7 +4,7 @@ import { modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import { StorageClassModel } from '@kubevirt-utils/models';
 import { getName } from '@kubevirt-utils/resources/shared';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
 import { isEmpty } from '../../utils/utils';
 
@@ -13,7 +13,7 @@ import {
   DEFAULT_VIRT_STORAGE_CLASS_ANNOTATION,
 } from './constants';
 
-type UseDefaultStorageClass = () => [
+type UseDefaultStorageClass = (cluster?: string) => [
   {
     clusterDefaultStorageClass: IoK8sApiStorageV1StorageClass;
     sortedStorageClasses: string[];
@@ -23,8 +23,9 @@ type UseDefaultStorageClass = () => [
   boolean,
 ];
 
-const useDefaultStorageClass: UseDefaultStorageClass = () => {
-  const [storageClasses, loaded] = useK8sWatchResource<IoK8sApiStorageV1StorageClass[]>({
+const useDefaultStorageClass: UseDefaultStorageClass = (cluster) => {
+  const [storageClasses, loaded] = useK8sWatchData<IoK8sApiStorageV1StorageClass[]>({
+    cluster,
     groupVersionKind: modelToGroupVersionKind(StorageClassModel),
     isList: true,
   });

--- a/src/utils/resources/udn/hooks/useNamespaceUDN.ts
+++ b/src/utils/resources/udn/hooks/useNamespaceUDN.ts
@@ -3,19 +3,21 @@ import { useMemo } from 'react';
 import { NetworkAttachmentDefinitionModelGroupVersionKind } from '@kubevirt-utils/models';
 import { UserDefinedNetworkRole } from '@kubevirt-utils/resources/udn/types';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { NetworkAttachmentDefinitionKind } from '@overview/OverviewTab/inventory-card/utils/types';
 
 import { LAYER3_TOPOLOGY, PrimaryTopologies } from '../constants';
 
 const useNamespaceUDN = (
   namespace: string,
+  cluster?: string,
 ): [
   isNamespaceManagedByUDN: boolean,
   vmsNotSupported: boolean,
   nad?: NetworkAttachmentDefinitionKind,
 ] => {
-  const [nads] = useK8sWatchResource<NetworkAttachmentDefinitionKind[]>({
+  const [nads] = useK8sWatchData<NetworkAttachmentDefinitionKind[]>({
+    cluster,
     groupVersionKind: NetworkAttachmentDefinitionModelGroupVersionKind,
     isList: true,
     namespace,

--- a/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useConvertedVolumeNames.ts
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useConvertedVolumeNames.ts
@@ -1,16 +1,20 @@
 import { CDIConfigModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1CDIConfig } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { V1Volume } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-type UseConvertedVolumeNames = (vmVolumes: V1Volume[]) => {
+type UseConvertedVolumeNames = (
+  vmVolumes: V1Volume[],
+  cluster: string,
+) => {
   dvVolumesNames: string[];
   isDataVolumeGarbageCollector: boolean;
   pvcVolumesNames: string[];
 };
 
-const useConvertedVolumeNames: UseConvertedVolumeNames = (vmVolumes) => {
-  const [cdiConfig] = useK8sWatchResource<V1beta1CDIConfig>({
+const useConvertedVolumeNames: UseConvertedVolumeNames = (vmVolumes, cluster) => {
+  const [cdiConfig] = useK8sWatchData<V1beta1CDIConfig>({
+    cluster,
     groupVersionKind: CDIConfigModelGroupVersionKind,
     isList: false,
     namespaced: false,

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useCreateEmptyMigPlan.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useCreateEmptyMigPlan.ts
@@ -2,12 +2,13 @@ import { useEffect, useState } from 'react';
 
 import { MigPlan, MigPlanModel } from '@kubevirt-utils/resources/migrations/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
+import { kubevirtK8sCreate } from '@multicluster/k8sRequests';
 
 import { getEmptyMigPlan } from '../utils/migrateVMs';
 
 const useCreateEmptyMigPlan = (
   namespace: string,
+  cluster?: string,
 ): [migPlan: MigPlan, loaded: boolean, error: Error | null] => {
   const [migPlan, setMigPlan] = useState<MigPlan>(null);
   const [error, setError] = useState<Error | null>();
@@ -15,7 +16,8 @@ const useCreateEmptyMigPlan = (
   useEffect(() => {
     const emptyMigPlan = getEmptyMigPlan(namespace);
 
-    k8sCreate({
+    kubevirtK8sCreate({
+      cluster,
       data: emptyMigPlan,
       model: MigPlanModel,
     })
@@ -23,7 +25,7 @@ const useCreateEmptyMigPlan = (
         setMigPlan(createdMigPlan);
       })
       .catch(setError);
-  }, [namespace]);
+  }, [namespace, cluster]);
 
   return [migPlan, !isEmpty(migPlan), error];
 };

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useExistingMigrationPlan.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useExistingMigrationPlan.ts
@@ -5,13 +5,15 @@ import {
   MigPlanModel,
 } from '@kubevirt-utils/resources/migrations/constants';
 import { getName } from '@kubevirt-utils/resources/shared';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
 const useExistingMigrationPlan = (
   currentMigPlanCreation: MigPlan,
   namespace: string,
+  cluster?: string,
 ): [existingMigPlan: MigPlan[], loaded: boolean] => {
-  const [migrationPlans, loaded, loadError] = useK8sWatchResource<MigPlan[]>({
+  const [migrationPlans, loaded, loadError] = useK8sWatchData<MigPlan[]>({
+    cluster,
     groupVersionKind: modelToGroupVersionKind(MigPlanModel),
     isList: true,
     namespace: DEFAULT_MIGRATION_NAMESPACE,

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useProgressMigration.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useProgressMigration.ts
@@ -2,7 +2,8 @@ import { useMemo } from 'react';
 
 import { modelToGroupVersionKind } from '@kubevirt-utils/models';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
 import {
   DirectVolumeMigration,
@@ -23,9 +24,10 @@ type UseProgressMigration = (migMigration: MigMigration) => {
 };
 
 const useProgressMigration: UseProgressMigration = (migMigration) => {
-  const [watchMigMigration, _, migMigrationError] = useK8sWatchResource<MigMigration>(
+  const [watchMigMigration, _, migMigrationError] = useK8sWatchData<MigMigration>(
     migMigration
       ? {
+          cluster: getCluster(migMigration),
           groupVersionKind: modelToGroupVersionKind(MigMigrationModel),
           name: getName(migMigration),
           namespace: getNamespace(migMigration),
@@ -33,11 +35,10 @@ const useProgressMigration: UseProgressMigration = (migMigration) => {
       : null,
   );
 
-  const [directVolumeMigrations, __, directVolumeError] = useK8sWatchResource<
-    DirectVolumeMigration[]
-  >(
+  const [directVolumeMigrations, __, directVolumeError] = useK8sWatchData<DirectVolumeMigration[]>(
     migMigration
       ? {
+          cluster: getCluster(migMigration),
           groupVersionKind: modelToGroupVersionKind(DirectVolumeMigrationModel),
           isList: true,
           namespace: getNamespace(migMigration),

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/tabs/VirtualMachineMigrationDestinationTab.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/tabs/VirtualMachineMigrationDestinationTab.tsx
@@ -4,7 +4,8 @@ import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFi
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, StorageClassModel } from '@kubevirt-utils/models';
 import { POPPER_CONTAINER_ID } from '@kubevirt-utils/utils/constants';
-import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { Content, ContentVariants, Label, Stack, StackItem, Title } from '@patternfly/react-core';
 
 type VirtualMachineMigrationDestinationTabProps = {
@@ -24,6 +25,7 @@ const VirtualMachineMigrationDestinationTab: FC<VirtualMachineMigrationDestinati
   sortedStorageClasses,
   vmStorageClassNames,
 }) => {
+  const cluster = useClusterParam();
   const { t } = useKubevirtTranslation();
 
   return (
@@ -39,7 +41,8 @@ const VirtualMachineMigrationDestinationTab: FC<VirtualMachineMigrationDestinati
           options={sortedStorageClasses?.map((storageClass) => ({
             children: (
               <>
-                <ResourceLink
+                <MulticlusterResourceLink
+                  cluster={cluster}
                   groupVersionKind={StorageClassModelGroupVersionKind}
                   inline
                   linkTo={false}

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/tabs/VirtualMachineMigrationDetails.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/tabs/VirtualMachineMigrationDetails.tsx
@@ -8,7 +8,8 @@ import { VirtualMachineModelGroupVersionKind } from '@kubevirt-utils/models';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { convertToBaseValue, humanizeBinaryBytes } from '@kubevirt-utils/utils/humanize.js';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
+import { getCluster } from '@multicluster/helpers/selectors';
 import {
   Alert,
   AlertVariant,
@@ -64,7 +65,8 @@ const VirtualMachineMigrationDetails: FC<VirtualMachineMigrationDetailsProps> = 
             <Trans t={t}>
               <Content>
                 Select the storage to migrate for{' '}
-                <ResourceLink
+                <MulticlusterResourceLink
+                  cluster={getCluster(vms?.[0])}
                   groupVersionKind={VirtualMachineModelGroupVersionKind}
                   inline
                   name={getName(vms?.[0])}

--- a/src/views/virtualmachines/actions/hooks/useStorageMigrations.ts
+++ b/src/views/virtualmachines/actions/hooks/useStorageMigrations.ts
@@ -8,17 +8,20 @@ import {
   MigPlanModel,
 } from '@kubevirt-utils/resources/migrations/constants';
 import { getName } from '@kubevirt-utils/resources/shared';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
 import useIsMTCInstalled from './useIsMTCInstalled';
 import { getVMMigPlans, sortMigPlansByCreationTimestamp } from './utils';
 
 const useCurrentStorageMigration = (vm: V1VirtualMachine): [MigMigration, boolean] => {
   const mtcInstalled = useIsMTCInstalled();
+  const cluster = getCluster(vm);
 
-  const [migPlans, migPlansLoaded] = useK8sWatchResource<MigPlan[]>(
+  const [migPlans, migPlansLoaded] = useK8sWatchData<MigPlan[]>(
     mtcInstalled
       ? {
+          cluster,
           groupVersionKind: modelToGroupVersionKind(MigPlanModel),
           isList: true,
           namespace: DEFAULT_MIGRATION_NAMESPACE,
@@ -26,9 +29,10 @@ const useCurrentStorageMigration = (vm: V1VirtualMachine): [MigMigration, boolea
       : null,
   );
 
-  const [migMigrations, migMigrationsLoaded] = useK8sWatchResource<MigMigration[]>(
+  const [migMigrations, migMigrationsLoaded] = useK8sWatchData<MigMigration[]>(
     mtcInstalled
       ? {
+          cluster,
           groupVersionKind: modelToGroupVersionKind(MigMigrationModel),
           isList: true,
           namespace: DEFAULT_MIGRATION_NAMESPACE,

--- a/src/views/virtualmachines/details/tabs/configuration/initialrun/components/InitialRunTabSysprep.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/initialrun/components/InitialRunTabSysprep.tsx
@@ -18,7 +18,8 @@ import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getVolumes } from '@kubevirt-utils/resources/vm';
 import { UpdateCustomizeInstanceType } from '@kubevirt-utils/store/customizeInstanceType';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
 import { createSysprepConfigMap, patchVMWithExistingSysprepConfigMap } from '../utils/utils';
 
@@ -30,14 +31,16 @@ type InitialRunTabSysprepProps = {
 const InitialRunTabSysprep: FC<InitialRunTabSysprepProps> = ({ canUpdateVM, onSubmit, vm }) => {
   const { createModal } = useModal();
   const vmVolumes = getVolumes(vm);
+  const cluster = getCluster(vm);
 
   const currentSysprepVolume = vmVolumes?.find(getSysprepConfigMapName);
   const currentVMSysprepName = getSysprepConfigMapName(currentSysprepVolume);
 
   const sysprepSelected = !isEmpty(currentVMSysprepName) && currentVMSysprepName;
   const [externalSysprepConfig, sysprepLoaded, sysprepLoadError] =
-    useK8sWatchResource<IoK8sApiCoreV1ConfigMap>(
+    useK8sWatchData<IoK8sApiCoreV1ConfigMap>(
       sysprepSelected && {
+        cluster,
         groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
         name: sysprepSelected,
         namespace: vm?.metadata?.namespace,

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSection.tsx
@@ -7,11 +7,9 @@ import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevir
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { asAccessReview } from '@kubevirt-utils/resources/shared';
-import {
-  K8sVerb,
-  useAccessReview,
-  useK8sWatchResource,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { K8sVerb, useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 import { Grid, GridItem, Title } from '@patternfly/react-core';
 
 import SchedulingSectionLeftGrid from './SchedulingSectionLeftGrid';
@@ -26,7 +24,8 @@ type SchedulingSectionProps = {
 
 const SchedulingSection: FC<SchedulingSectionProps> = ({ instanceTypeVM, onSubmit, vm, vmi }) => {
   const { t } = useKubevirtTranslation();
-  const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
+  const [nodes, nodesLoaded] = useK8sWatchData<IoK8sApiCoreV1Node[]>({
+    cluster: getCluster(vm),
     groupVersionKind: modelToGroupVersionKind(NodeModel),
     isList: true,
   });

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/CreateBootableVolumeModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/CreateBootableVolumeModal.tsx
@@ -27,7 +27,8 @@ import { getInstanceTypeMatcher, getPreferenceMatcher } from '@kubevirt-utils/re
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import { hasSizeUnit } from '@kubevirt-utils/resources/vm/utils/disk/size';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { Form, PopoverPosition, Stack, Title } from '@patternfly/react-core';
 
 import { createBootableVolumeFromDisk } from './utils';
@@ -48,7 +49,8 @@ const CreateBootableVolumeModal: FC<CreateBootableVolumeModalProps> = ({
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
 
-  const [pvc, pvcLoaded] = useK8sWatchResource<IoK8sApiCoreV1PersistentVolumeClaim>({
+  const [pvc, pvcLoaded] = useK8sWatchData<IoK8sApiCoreV1PersistentVolumeClaim>({
+    cluster: getCluster(vm),
     groupVersionKind: modelToGroupVersionKind(PersistentVolumeClaimModel),
     name: diskObj.source,
     namespace: diskObj?.namespace,
@@ -56,6 +58,7 @@ const CreateBootableVolumeModal: FC<CreateBootableVolumeModalProps> = ({
 
   const [bootableVolume, setBootableVolume] = useState<AddBootableVolumeState>({
     ...initialBootableVolumeState,
+    bootableVolumeCluster: getCluster(vm),
     bootableVolumeName: `${getName(vm)}-${diskObj.name}`,
     bootableVolumeNamespace: getNamespace(vm),
     labels: {

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useVolumeOwnedResource.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useVolumeOwnedResource.tsx
@@ -2,7 +2,9 @@ import { V1beta1CDIConfig } from '@kubevirt-ui/kubevirt-api/containerized-data-i
 import { V1VirtualMachine, V1Volume } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { CDIConfigModelGroupVersionKind, modelToGroupVersionKind } from '@kubevirt-utils/models';
 import { buildOwnerReference, compareOwnerReferences } from '@kubevirt-utils/resources/shared';
-import { K8sModel, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk-internal/lib/extensions/console-types';
 
 import { mapVolumeTypeToK8sModel } from './utils/constants';
@@ -20,7 +22,10 @@ type UseVolumeOwnedResource = (
 };
 
 const useVolumeOwnedResource: UseVolumeOwnedResource = (vm, volume) => {
-  const [cdiConfig, isCdiConfigLoaded, isCdiConfigError] = useK8sWatchResource<V1beta1CDIConfig>({
+  const cluster = getCluster(vm);
+
+  const [cdiConfig, isCdiConfigLoaded, isCdiConfigError] = useK8sWatchData<V1beta1CDIConfig>({
+    cluster,
     groupVersionKind: CDIConfigModelGroupVersionKind,
     isList: false,
     namespaced: false,
@@ -33,12 +38,13 @@ const useVolumeOwnedResource: UseVolumeOwnedResource = (vm, volume) => {
     volumeResourceModel && modelToGroupVersionKind(volumeResourceModel);
   const volumeResourceName = getVolumeResourceName(volume);
   const watchVolumeResource = {
+    cluster,
     groupVersionKind: volumeGroupVersionKind,
     isList: false,
     name: volumeResourceName,
     namespace: vm.metadata.namespace,
   };
-  const [resource, loaded, error] = useK8sWatchResource<K8sResourceCommon>(
+  const [resource, loaded, error] = useK8sWatchData<K8sResourceCommon>(
     volumeGroupVersionKind && volumeResourceName && watchVolumeResource,
   );
 

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/utils.ts
@@ -26,7 +26,8 @@ import {
 import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import { getVMIDevices } from '@kubevirt-utils/resources/vmi';
 import { ensurePath, isEmpty } from '@kubevirt-utils/utils/utils';
-import { k8sGet } from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import { kubevirtK8sGet } from '@multicluster/k8sRequests';
 
 export const createBootableVolumeFromDisk = async (
   diskObj: DiskRowDataLayout,
@@ -64,7 +65,8 @@ const addDataVolumeToVM = async (
 
   if (dataVolumeTemplates.find((dataVolume) => dataVolume.metadata.name === dataVolumeName)) return;
 
-  const originDataVolume = await k8sGet<V1beta1DataVolume>({
+  const originDataVolume = await kubevirtK8sGet<V1beta1DataVolume>({
+    cluster: getCluster(draftVM),
     model: DataVolumeModel,
     name: dataVolumeName,
     ns: getNamespace(draftVM),

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRow.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRow.tsx
@@ -8,7 +8,9 @@ import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { NameWithPercentages } from '@kubevirt-utils/resources/vm/hooks/types';
 import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
-import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
+import { getCluster } from '@multicluster/helpers/selectors';
+import { RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Label,
   Popover,
@@ -98,10 +100,11 @@ const DiskRow: FC<
 
       <TableData activeColumnIDs={activeColumnIDs} id="source">
         {sourcesLoaded && (hasPVC || hasDataVolume) && (
-          <ResourceLink
+          <MulticlusterResourceLink
             groupVersionKind={modelToGroupVersionKind(
               hasDataVolume ? DataVolumeModel : PersistentVolumeClaimModel,
             )}
+            cluster={getCluster(vm)}
             name={source}
             namespace={namespace || getNamespace(vm)}
           />

--- a/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineDiagnosticTabRow.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineDiagnosticTabRow.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import cn from 'classnames';
 
+import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
 import { DataVolumeModelGroupVersionKind } from '@kubevirt-utils/models';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
+import { getCluster } from '@multicluster/helpers/selectors';
 import {
   RedExclamationCircleIcon,
-  ResourceLink,
-  useActiveNamespace,
   YellowExclamationTriangleIcon,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { ExpandableRowContent, Tbody, Td, Tr } from '@patternfly/react-table';
@@ -21,7 +22,7 @@ const VirtualMachineDiagnosticTabRow = ({
   obj,
   setExpend,
 }) => {
-  const [namespace] = useActiveNamespace();
+  const namespace = useNamespaceParam();
 
   const isExpanded = expend?.expended.has(obj?.id) && obj?.message;
   const activeColumnsObj = new Set<string>(activeColumns.map(({ id }) => id));
@@ -46,7 +47,8 @@ const VirtualMachineDiagnosticTabRow = ({
         {[...activeColumnsObj]?.map((column) => (
           <Td id={column} key={column}>
             {column === NAME_COLUMN_ID && dataVolumeResourceLink ? (
-              <ResourceLink
+              <MulticlusterResourceLink
+                cluster={getCluster(obj)}
                 groupVersionKind={DataVolumeModelGroupVersionKind}
                 name={obj?.[column]?.toString()}
                 namespace={namespace}

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
@@ -14,11 +14,14 @@ import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constan
 import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { modelToGroupVersionKind } from '@kubevirt-utils/models';
 import { getLabel, getName, getVMStatus } from '@kubevirt-utils/resources/shared';
 import { getInstanceTypeMatcher } from '@kubevirt-utils/resources/vm';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { getOSNameFromGuestAgent } from '@kubevirt-utils/resources/vmi';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
+import { ManagedClusterModel } from '@multicluster/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { Timestamp } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -34,7 +37,6 @@ import {
   Split,
   SplitItem,
 } from '@patternfly/react-core';
-import { FleetResourceLink } from '@stolostron/multicluster-sdk';
 import { createURL } from '@virtualmachines/details/tabs/overview/utils/utils';
 import VMNotMigratableLabel from '@virtualmachines/list/components/VMNotMigratableLabel/VMNotMigratableLabel';
 import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
@@ -126,12 +128,8 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
                 {cluster && (
                   <VirtualMachineDescriptionItem
                     descriptionData={
-                      <FleetResourceLink
-                        groupVersionKind={{
-                          group: 'cluster.open-cluster-management.io',
-                          kind: 'ManagedCluster',
-                          version: 'v1',
-                        }}
+                      <MulticlusterResourceLink
+                        groupVersionKind={modelToGroupVersionKind(ManagedClusterModel)}
                         name={cluster}
                         truncate
                       />

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/InstanceTypeDescription.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/InstanceTypeDescription.tsx
@@ -11,7 +11,8 @@ import {
 } from '@kubevirt-utils/resources/instancetype/selectors';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getInstanceTypeMatcher, getPreferenceMatcher } from '@kubevirt-utils/resources/vm';
-import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
+import { getCluster } from '@multicluster/helpers/selectors';
 
 type InstanceTypeDescriptionProps = {
   vm: V1VirtualMachine;
@@ -32,7 +33,8 @@ const InstanceTypeDescription: FC<InstanceTypeDescriptionProps> = ({ vm }) => {
         )}
         descriptionData={
           itMatcher ? (
-            <ResourceLink
+            <MulticlusterResourceLink
+              cluster={getCluster(vm)}
               displayName={itMatcher.name}
               groupVersionKind={ControllerRevisionModelGroupVersionKind}
               name={getInstanceTypeRevisionName(vm)}
@@ -52,7 +54,8 @@ const InstanceTypeDescription: FC<InstanceTypeDescriptionProps> = ({ vm }) => {
         )}
         descriptionData={
           preferenceMatcher ? (
-            <ResourceLink
+            <MulticlusterResourceLink
+              cluster={getCluster(vm)}
               displayName={preferenceMatcher.name}
               groupVersionKind={ControllerRevisionModelGroupVersionKind}
               name={getPreferenceRevisionName(vm)}

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/TemplateDescription.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/TemplateDescription.tsx
@@ -8,7 +8,8 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { getLabel } from '@kubevirt-utils/resources/shared';
 import { LABEL_USED_TEMPLATE_NAMESPACE } from '@kubevirt-utils/resources/template';
 import { VM_TEMPLATE_ANNOTATION } from '@kubevirt-utils/resources/vm';
-import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
+import { getCluster } from '@multicluster/helpers/selectors';
 
 type TemplateDescriptionProps = {
   vm: V1VirtualMachine;
@@ -24,7 +25,8 @@ const TemplateDescription: FC<TemplateDescriptionProps> = ({ vm }) => {
     <VirtualMachineDescriptionItem
       descriptionData={
         templateName && templateNamespace ? (
-          <ResourceLink
+          <MulticlusterResourceLink
+            cluster={getCluster(vm)}
             groupVersionKind={modelToGroupVersionKind(TemplateModel)}
             name={templateName}
             namespace={templateNamespace}

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachineStatusWithPopover/MigrationProgressPopover.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachineStatusWithPopover/MigrationProgressPopover.tsx
@@ -9,7 +9,8 @@ import { dateTimeFormatter } from '@kubevirt-utils/components/Timestamp/utils/da
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
 import useVirtualMachineInstanceMigration from '@kubevirt-utils/resources/vmi/hooks/useVirtualMachineInstanceMigration';
-import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
+import { getCluster } from '@multicluster/helpers/selectors';
 import { Popover, PopoverPosition, Stack, StackItem } from '@patternfly/react-core';
 
 import { getMigrationPhaseIcon } from './utils';
@@ -66,7 +67,8 @@ const MigrationProgressPopover: React.FC<MigrationProgressPopoverProps> = ({ chi
           <StackItem>
             <b>{t('Policy')}</b>{' '}
             {vmi?.status?.migrationState?.migrationPolicyName ? (
-              <ResourceLink
+              <MulticlusterResourceLink
+                cluster={getCluster(vmi)}
                 groupVersionKind={MigrationPolicyModelGroupVersionKind}
                 name={vmi.status.migrationState.migrationPolicyName}
               />

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/VirtualMachinesOverviewTabNetworkInterfaces.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/VirtualMachinesOverviewTabNetworkInterfaces.tsx
@@ -6,6 +6,7 @@ import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constan
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
+import { getCluster } from '@multicluster/helpers/selectors';
 import { VirtualizedTable } from '@openshift-console/dynamic-plugin-sdk';
 import { Card, CardBody, CardTitle, Divider } from '@patternfly/react-core';
 
@@ -31,7 +32,7 @@ const VirtualMachinesOverviewTabInterfaces: FC<VirtualMachinesOverviewTabInterfa
   const data = useVirtualMachinesOverviewTabInterfacesData(vm, vmi);
   const columns = useVirtualMachinesOverviewTabInterfacesColumns();
 
-  const [isNamespaceManagedByUDN] = useNamespaceUDN(getNamespace(vm));
+  const [isNamespaceManagedByUDN] = useNamespaceUDN(getNamespace(vm), getCluster(vm));
 
   return (
     <div className="VirtualMachinesOverviewTabInterfaces--main">

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
@@ -9,7 +9,7 @@ import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { ServicesList } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { Card, CardBody, CardTitle, Divider } from '@patternfly/react-core';
 
@@ -18,7 +18,8 @@ type VirtualMachinesOverviewTabServiceProps = { vm: V1VirtualMachine };
 const VirtualMachinesOverviewTabService: FC<VirtualMachinesOverviewTabServiceProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
 
-  const [services, loaded] = useK8sWatchResource<IoK8sApiCoreV1Service[]>({
+  const [services, loaded] = useK8sWatchData<IoK8sApiCoreV1Service[]>({
+    cluster: getCluster(vm),
     groupVersionKind: modelToGroupVersionKind(ServiceModel),
     isList: true,
     namespace: vm?.metadata?.namespace,

--- a/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotRow.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotRow.tsx
@@ -6,7 +6,9 @@ import {
   V1beta1VirtualMachineSnapshot,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
-import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
+import { getCluster } from '@multicluster/helpers/selectors';
+import { RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 
 import { snapshotStatuses } from '../../utils/consts';
 import IndicationLabelList from '../IndicationLabel/IndicationLabelList';
@@ -26,7 +28,8 @@ const SnapshotRow: React.FC<
   return (
     <>
       <TableData activeColumnIDs={activeColumnIDs} id="name">
-        <ResourceLink
+        <MulticlusterResourceLink
+          cluster={getCluster(snapshot)}
           groupVersionKind={VirtualMachineSnapshotModelGroupVersionKind}
           name={snapshot?.metadata?.name}
           namespace={snapshot?.metadata?.namespace}

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
@@ -2,6 +2,7 @@ import React, { FC, ReactNode, useMemo } from 'react';
 
 import {
   modelToGroupVersionKind,
+  NamespaceModel,
   StorageClassModel,
   VirtualMachineModelGroupVersionKind,
 } from '@kubevirt-ui/kubevirt-api/console';
@@ -14,6 +15,7 @@ import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import ACMExtentionsTableData from '@multicluster/components/ACMExtentionsTableData';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
 import { ManagedClusterModel } from '@multicluster/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
@@ -76,7 +78,8 @@ const VirtualMachineRowLayout: FC<
         />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="pf-m-width-20 vm-column" id="name">
-        <ResourceLink
+        <MulticlusterResourceLink
+          cluster={vmCluster}
           groupVersionKind={VirtualMachineModelGroupVersionKind}
           name={vmName}
           namespace={vmNamespace}
@@ -90,7 +93,12 @@ const VirtualMachineRowLayout: FC<
         />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="namespace">
-        <ResourceLink kind="Namespace" name={vmNamespace} truncate />
+        <MulticlusterResourceLink
+          cluster={vmCluster}
+          groupVersionKind={modelToGroupVersionKind(NamespaceModel)}
+          name={vmNamespace}
+          truncate
+        />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="status">
         {status}
@@ -123,7 +131,8 @@ const VirtualMachineRowLayout: FC<
         {isEmpty(storageClasses)
           ? NO_DATA_DASH
           : storageClasses.map((storageClass) => (
-              <ResourceLink
+              <MulticlusterResourceLink
+                cluster={vmCluster}
                 groupVersionKind={modelToGroupVersionKind(StorageClassModel)}
                 key={storageClass}
                 name={storageClass}

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
@@ -9,8 +9,9 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { modelToGroupVersionKind, NodeModel } from '@kubevirt-utils/models';
 import { getMemory } from '@kubevirt-utils/resources/vm';
 import { getVMIIPAddressesWithName } from '@kubevirt-utils/resources/vmi';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
+import { getCluster } from '@multicluster/helpers/selectors';
 import { RowProps } from '@openshift-console/dynamic-plugin-sdk';
-import { FleetResourceLink } from '@stolostron/multicluster-sdk';
 import { PVCMapper } from '@virtualmachines/utils/mappers';
 
 import FirstItemListPopover from '../FirstItemListPopover/FirstItemListPopover';
@@ -36,8 +37,8 @@ const VirtualMachineRunningRow: FC<
       rowData={{
         ips: <FirstItemListPopover headerContent={t('IP addresses')} items={ipAddressess} />,
         node: (
-          <FleetResourceLink
-            cluster={obj.cluster}
+          <MulticlusterResourceLink
+            cluster={getCluster(obj)}
             groupVersionKind={modelToGroupVersionKind(NodeModel)}
             name={vmi?.status?.nodeName}
             truncate


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description



use `MulticlusterResourceLink` for multiclusters view of vm and vm list pages  instead of `ResourceLink` 


use `kubevirtK8s*` methods instead of `k8s*` from sdk

use `useK8sWatchData` instead of `useK8sWatchResource` 

