### PR TITLE
fix horizontal navbar when vm called with specific names

### DIFF
--- a/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
+++ b/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
@@ -4,12 +4,15 @@ import classNames from 'classnames';
 import { VirtualMachineModel } from 'src/views/dashboard-extensions/utils';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { getCluster } from '@multicluster/helpers/selectors';
+import { getVMURL } from '@multicluster/urls';
 
 import StateHandler from '../StateHandler/StateHandler';
 
 import useDynamicPages from './utils/useDynamicPages';
-import { NavPageKubevirt, trimLastHistoryPath } from './utils/utils';
+import { NavPageKubevirt } from './utils/utils';
 
 type HorizontalNavbarProps = {
   error?: any;
@@ -37,17 +40,23 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
     [pages, dynamicPluginPages],
   );
 
-  const paths = allPages.map((page) => page.href);
+  const vmBasePath = vm ? getVMURL(getCluster(vm), getNamespace(vm), getName(vm)) : '';
+
+  const horizontalNavbarPath = useMemo(() => {
+    return location?.pathname.replace(vmBasePath, '');
+  }, [location?.pathname, vmBasePath]);
 
   useEffect(() => {
+    if (isEmpty(vmBasePath)) return;
+
     const defaultPage = allPages.find(({ href }) => isEmpty(href));
 
     const initialActiveTab =
-      allPages.find(({ href }) => !isEmpty(href) && location?.pathname.includes('/' + href)) ||
+      allPages.find(({ href }) => !isEmpty(href) && horizontalNavbarPath.includes('/' + href)) ||
       defaultPage;
 
     setActiveItem(initialActiveTab?.name?.toLowerCase());
-  }, [allPages, location?.pathname]);
+  }, [allPages, horizontalNavbarPath, vmBasePath]);
 
   const [activeItem, setActiveItem] = useState<number | string>();
 
@@ -89,7 +98,7 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
                   data-test-id={`horizontal-link-${item.name}`}
                   id={`horizontal-pageHeader-${item.name}`}
                   onClick={() => setActiveItem(item.name.toLowerCase())}
-                  to={trimLastHistoryPath(location, paths) + item.href}
+                  to={`${vmBasePath}/${item.href}`}
                 >
                   {item.name}
                 </NavLink>

--- a/src/utils/components/HorizontalNavbar/utils/utils.ts
+++ b/src/utils/components/HorizontalNavbar/utils/utils.ts
@@ -1,26 +1,7 @@
 import { ComponentType } from 'react';
-import { Location } from 'react-router-dom-v5-compat';
 
 import { NavPage } from '@openshift-console/dynamic-plugin-sdk';
 import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
-
-export const trimLastHistoryPath = (location: Location, paths: string[]): string => {
-  const pathName = location?.pathname;
-  let relativeUrl: string;
-  for (const path of paths) {
-    if (pathName.endsWith('/' + path)) {
-      if (path !== '') {
-        relativeUrl = pathName.slice(0, pathName.length - path.length);
-      }
-      if (path === '') {
-        relativeUrl = pathName;
-      }
-    }
-  }
-  if (!relativeUrl) relativeUrl = pathName + '/';
-
-  return relativeUrl;
-};
 
 export type NavPageKubevirt = Omit<NavPage, 'component'> & {
   component: ComponentType<NavPageComponentProps>;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

If you create a vm with a specific name, tabs will not work properly.

For example: vm is called `console`,it will only works on the console tab.  This because the horizontalnavbar is onlylooking at the end of the string and not stripping out the basepath 


## 🎥 Demo



**BEFORE**


https://github.com/user-attachments/assets/82f80228-cd95-451f-a2a6-3ca81c29e894




**AFTER**

https://github.com/user-attachments/assets/453cc4a7-29d5-49e2-9eb0-6c5618f60736


