### PR TITLE
CNV-62944: Fixing the disk size display in vm details to display the right size

### DIFF
--- a/src/utils/resources/vm/utils/disk/rowData.ts
+++ b/src/utils/resources/vm/utils/disk/rowData.ts
@@ -9,7 +9,7 @@ import {
   getDataVolumeSize,
   getDataVolumeStorageClassName,
   getPhase,
-  getPVCStorageCapacity,
+  getPVCSize,
   getPVCStorageClassName,
 } from '@kubevirt-utils/resources/bootableresources/selectors';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
@@ -52,9 +52,10 @@ export const getDiskRowDataLayout = (
       storageClass: dataVolumeTemplate?.spec?.storage?.storageClassName || NO_DATA_DASH,
     };
 
-    const dataSourceSize = getPVCStorageCapacity(pvc) || getDataVolumeSize(dataVolume);
+    const dataSourceSize = getPVCSize(pvc) || getDataVolumeSize(dataVolume);
     const dataVolumeCustomSize = dataVolumeTemplate?.spec?.storage?.resources?.requests?.storage;
-    const size = getHumanizedSize(dataSourceSize || dataVolumeCustomSize);
+
+    const size = getHumanizedSize(dataVolumeCustomSize || dataSourceSize);
 
     diskRowDataObject.size = size.value === 0 ? NO_DATA_DASH : size.string;
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixing the UI display of the vm's disk size in the vm's details overview storage tab and configuration storage table.

## 🎥 Demo
Before:
<img width="1379" height="613" alt="image" src="https://github.com/user-attachments/assets/444fbe9c-6962-4c18-95d0-341aac2e9d2c" />

After:
<img width="1277" height="585" alt="image" src="https://github.com/user-attachments/assets/65d106e5-9a58-4766-862e-4d2e4574ff45" />
