### PR TITLE
Fix preferences loading with error

### DIFF
--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -4,6 +4,7 @@ export const DEFAULT_NAMESPACE = 'default';
 export const OPENSHIFT_NAMESPACE = 'openshift';
 export const KUBEVIRT_OS_IMAGES_NS = 'kubevirt-os-images';
 export const OPENSHIFT_OS_IMAGES_NS = 'openshift-virtualization-os-images';
+
 export const OPENSHIFT_SRIOV_NETWORK_OPERATOR_NS = 'openshift-sriov-network-operator';
 export const OPENSHIFT_MULTUS_NS = 'openshift-multus';
 

--- a/src/utils/hooks/useUserPreferences.ts
+++ b/src/utils/hooks/useUserPreferences.ts
@@ -1,16 +1,25 @@
 import { VirtualMachinePreferenceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1VirtualMachinePreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Selector, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 import { ALL_NAMESPACES_SESSION_KEY } from './constants';
 
-const useUserPreferences = (namespace: string, fieldSelector?: string, selector?: Selector) =>
-  useK8sWatchResource<V1beta1VirtualMachinePreference[]>({
+const useUserPreferences = (namespace: string, fieldSelector?: string, selector?: Selector) => {
+  const [userPreferences, userPreferencesLoaded, userPreferencesError] = useK8sWatchResource<
+    V1beta1VirtualMachinePreference[]
+  >({
     groupVersionKind: VirtualMachinePreferenceModelGroupVersionKind,
     isList: true,
     ...(namespace !== ALL_NAMESPACES_SESSION_KEY && { namespace: namespace }),
     fieldSelector,
     selector,
   });
+  return [
+    userPreferences,
+    userPreferencesLoaded || !isEmpty(userPreferencesError),
+    userPreferencesError,
+  ];
+};
 
 export default useUserPreferences;

--- a/src/utils/utils/utils.ts
+++ b/src/utils/utils/utils.ts
@@ -4,7 +4,9 @@ import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import {
   DEFAULT_NAMESPACE,
   KUBEVIRT_HYPERCONVERGED,
+  KUBEVIRT_OS_IMAGES_NS,
   OPENSHIFT_CNV,
+  OPENSHIFT_OS_IMAGES_NS,
 } from '@kubevirt-utils/constants/constants';
 import { ALL_NAMESPACES, ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { FilterValue, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
@@ -53,6 +55,8 @@ export const pick = (object, keys) => {
 export const isUpstream = window.SERVER_FLAGS.branding === 'okd';
 
 export const DEFAULT_OPERATOR_NAMESPACE = isUpstream ? KUBEVIRT_HYPERCONVERGED : OPENSHIFT_CNV;
+
+export const OS_IMAGES_NS = isUpstream ? KUBEVIRT_OS_IMAGES_NS : OPENSHIFT_OS_IMAGES_NS;
 
 export const isString = (val: unknown) => val !== null && typeof val === 'string';
 

--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/BootableVolumeList.tsx
@@ -9,7 +9,6 @@ import {
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ListPageFilter from '@kubevirt-utils/components/ListPageFilter/ListPageFilter';
 import ProjectDropdown from '@kubevirt-utils/components/ProjectDropdown/ProjectDropdown';
-import { OPENSHIFT_OS_IMAGES_NS } from '@kubevirt-utils/constants/constants';
 import { ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -17,7 +16,7 @@ import { UserSettingFavorites } from '@kubevirt-utils/hooks/useKubevirtUserSetti
 import useHideDeprecatedBootableVolumes from '@kubevirt-utils/resources/bootableresources/hooks/useHideDeprecatedBootableVolumes';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { convertResourceArrayToMap, getName } from '@kubevirt-utils/resources/shared';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { isEmpty, OS_IMAGES_NS } from '@kubevirt-utils/utils/utils';
 import { useListPageFilter } from '@openshift-console/dynamic-plugin-sdk';
 import { FormGroup, Skeleton, Split, SplitItem } from '@patternfly/react-core';
 
@@ -109,7 +108,7 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
 
   useEffect(() => {
     if (!isAdmin && volumeListNamespace === ALL_PROJECTS) {
-      setVolumeListNamespace(OPENSHIFT_OS_IMAGES_NS);
+      setVolumeListNamespace(OS_IMAGES_NS);
     }
   }, [isAdmin, volumeListNamespace, setVolumeListNamespace]);
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When preference fetch is in error, the page keeps loading instead of showing the error.


This as `loaded` from `useK8sWatchResource` is false when the fetch go into the error state but we keep showing the spinner if not loaded 



note: on upstream we should fetch volums fron the upstream namespace