### PR TITLE
CNV-66145: Update ssh command to 1.6 update version

### DIFF
--- a/src/utils/components/SSHAccess/utils.ts
+++ b/src/utils/components/SSHAccess/utils.ts
@@ -104,7 +104,7 @@ export const getConsoleVirtctlCommand = (vm: V1VirtualMachine, identityFlag?: st
     getCloudInitCredentials(vm)?.users?.[0]?.name,
   ];
 
-  return `virtctl -n ${vmNamespace} ssh ${userName}@${vmName} ${
+  return `virtctl -n ${vmNamespace} ssh ${userName}@vm/${vmName} ${
     !isEmpty(identityFlag) ? identityFlag : '--identity-file=<path_to_sshkey>'
   }`;
 };


### PR DESCRIPTION
## 📝 Description
The previous ssh command was deprecated - https://github.com/kubevirt/kubevirt/issues/15234, it now require `<type>` to be added at start.

Update ssh command to 1.6 update version

Jira: https://issues.redhat.com/browse/CNV-66145