### PR TITLE
doc: include BRIDGE_BRANDING=openshift for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Click the Create button at the bottom then click on the link in the alert that p
 
 ### Option 1 (recommended):
 
-Open two terminals and navigate to the kubevirt-plugin directory in both of them. The first terminal will run a containerized instance of console and the second will run the kubevirt-plugin.
+Open two terminals and navigate to the kubevirt-plugin directory in both of them. The first terminal will run a containerized instance of console and the second will run the kubevirt-plugin. In case you are using Openshift, make sure to set the environment variable `BRIDGE_BRANDING=openshift` in both terminals before starting.
 
 In the first terminal:
 


### PR DESCRIPTION
Adds instructions to set the BRIDGE_BRANDING=openshift environment variable in both terminals when using Option 1 for local development.

