### PR TITLE
CNV-60059: Descriptions for UEFI and UEFI (secure) are the same

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1547,6 +1547,7 @@
   "Use template size PVC": "Use template size PVC",
   "Use the default Template disk source": "Use the default Template disk source",
   "Use this disk as a boot source": "Use this disk as a boot source",
+  "Use UEFI when bootloading the guest OS.": "Use UEFI when bootloading the guest OS.",
   "Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true": "Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true",
   "Use volume already available on the cluster": "Use volume already available on the cluster",
   "Used": "Used",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1555,6 +1555,7 @@
   "Use template size PVC": "Utilizar PVC de tamaño de plantilla",
   "Use the default Template disk source": "Utilizar la fuente de disco de la plantilla predeterminada",
   "Use this disk as a boot source": "Utilizar el disco como una fuente de arranque",
+  "Use UEFI when bootloading the guest OS.": "Use UEFI when bootloading the guest OS.",
   "Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true": "Utilice UEFI al momento de iniciar el sistema operativo huésped. Se requiere la funcionalidad SMM. Si no está establecida, cuando se seleccione este método se establecerá como true (verdadera).",
   "Use volume already available on the cluster": "Utilizar el volumen ya disponible en el clúster",
   "Used": "Usado",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1555,6 +1555,7 @@
   "Use template size PVC": "Utiliser une revendication de volume persistant de la taille du modèle",
   "Use the default Template disk source": "Utiliser la source de disque de modèle par défaut",
   "Use this disk as a boot source": "Utilisez ce disque comme source de démarrage",
+  "Use UEFI when bootloading the guest OS.": "Use UEFI when bootloading the guest OS.",
   "Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true": "Utiliser l'UEFI lors du démarrage du système d'exploitation invité. Nécessite la fonctionnalité SMM. Si elle n'est pas activée, cette méthode la définira sur «\u00a0true\u00a0».",
   "Use volume already available on the cluster": "Utiliser le volume déjà disponible sur le cluster",
   "Used": "Utilisée",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1544,6 +1544,7 @@
   "Use template size PVC": "テンプレートサイズ PVC の使用",
   "Use the default Template disk source": "デフォルトのテンプレートディスクソースの使用",
   "Use this disk as a boot source": "このディスクをブートソースとして使用する",
+  "Use UEFI when bootloading the guest OS.": "Use UEFI when bootloading the guest OS.",
   "Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true": "ゲスト OS のブートロード時に UEFI を使用します。SMM 機能が必要です。SMM 機能が設定されていない場合にこの方法を選択すると、機能が true に設定されます",
   "Use volume already available on the cluster": "クラスターですでに利用可能なボリュームを使用する",
   "Used": "使用済み",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1544,6 +1544,7 @@
   "Use template size PVC": "템플릿 크기 PVC 사용",
   "Use the default Template disk source": "기본 템플릿 디스크 소스 사용",
   "Use this disk as a boot source": "이 디스크를 부팅 소스로 사용",
+  "Use UEFI when bootloading the guest OS.": "Use UEFI when bootloading the guest OS.",
   "Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true": "게스트 OS를 부팅할 때 UEFI를 사용합니다. SMM 기능이 설정되지 않은 경우 이 방법을 선택하면 해당 기능이 true로 설정됩니다.",
   "Use volume already available on the cluster": "클러스터에서 이미 사용 가능한 볼륨 사용",
   "Used": "사용됨",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1544,6 +1544,7 @@
   "Use template size PVC": "使用模板大小 PVC",
   "Use the default Template disk source": "使用默认模板磁盘源",
   "Use this disk as a boot source": "使用此磁盘作为一个引导源",
+  "Use UEFI when bootloading the guest OS.": "Use UEFI when bootloading the guest OS.",
   "Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true": "在引导加载客户机操作系统时使用 UEFI。如果未设置 SMM 功能，则需要 SMM 功能，选择此方法会将它设置为 true",
   "Use volume already available on the cluster": "使用集群中已可用的卷",
   "Used": "使用了",

--- a/src/utils/components/FirmwareBootloaderModal/utils/constants.ts
+++ b/src/utils/components/FirmwareBootloaderModal/utils/constants.ts
@@ -21,9 +21,7 @@ export const bootloaderOptions: BootloaderLabel[] = [
     value: BootMode.bios,
   },
   {
-    description: t(
-      'Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true',
-    ),
+    description: t('Use UEFI when bootloading the guest OS.'),
     title: BootModeTitles[BootMode.uefi],
     value: BootMode.uefi,
   },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Two last "Boot mode" dialog options have the same description text, without explaining the difference between UEFI and UEFI (secure).     I spoke with Ronen sde-or who told me ti ask Igor Bezukh . Igor said to put in the UFEI :Use UEFI when bootloading the guest OS

## 🎥 Demo
before 
<img width="1450" height="815" alt="image" src="https://github.com/user-attachments/assets/65397079-257d-43f2-8dc1-3c3a098a5e46" />

after

<img width="1456" height="786" alt="image" src="https://github.com/user-attachments/assets/d45a5016-d1f0-4a5e-ac1a-732019a53c94" />


> Please add a video or an image of the behavior/changes
