### PR TITLE
fixing the tree-view scroll to see all vm's blocked by footer

### DIFF
--- a/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
+++ b/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
@@ -91,7 +91,15 @@
 
 .vms-tree-view-body {
   padding: 0 var(--pf-t--global--spacer--sm);
-  height: fit-content;
+  height: 100%;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+
+  .pf-v6-c-tree-view {
+    flex: 1;
+    overflow-y: auto;
+  }
 }
 
 .pf-v6-c-toolbar__content.vms-tree-view-toolbar-content {

--- a/src/views/virtualmachines/tree/VirtualMachineTreeView.tsx
+++ b/src/views/virtualmachines/tree/VirtualMachineTreeView.tsx
@@ -71,8 +71,10 @@ const VirtualMachineTreeView: FC<VirtualMachineTreeViewProps> = ({
     setDrawerWidth(size);
   };
 
+  const contentBoundry = getContentScrollableElement().getBoundingClientRect();
+  const footerSpace = window.innerHeight - contentBoundry.bottom;
   const heightStyles: CSSProperties = {
-    height: getContentScrollableElement().offsetHeight || 0,
+    height: getContentScrollableElement().offsetHeight - footerSpace || 0,
   };
 
   const widthStyles: any = {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

fixing design to account for footer height in tree view so it is able to see all of the listed vm's

## 🎥 Demo
Before:
<img width="584" height="1187" alt="image" src="https://github.com/user-attachments/assets/753c5300-0e90-4890-902d-07ac8c427aa3" />

After: 
<img width="802" height="1161" alt="image" src="https://github.com/user-attachments/assets/ebf942a0-26b3-4e1a-bf58-a883c1bad211" />
