### PR TITLE
CNV-67141: add loading indicator to VMs list

### DIFF
--- a/cypress/tests/setup/setup.cy.ts
+++ b/cypress/tests/setup/setup.cy.ts
@@ -48,7 +48,7 @@ describe('Cluster Test Preparation', () => {
 
   it('create example VM', () => {
     cy.visitVMsVirt();
-    cy.get(itemCreateBtn, { timeout: 60000 }).click();
+    cy.get(itemCreateBtn, { timeout: 60000 }).first().click();
     cy.byButtonText(YAML).click();
     cy.get(saveBtn).click();
   });

--- a/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPodFilters.ts
+++ b/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPodFilters.ts
@@ -1,15 +1,14 @@
 import { useEffect, useState } from 'react';
 
 import useQuery from '@kubevirt-utils/hooks/useQuery';
-import { debounce } from '@kubevirt-utils/utils/debounce';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import useDeepCompareMemoize from '../useDeepCompareMemoize/useDeepCompareMemoize';
 
 type UseKubevirtDataPodFilters = (filters: { [key: string]: string }) => any;
 
-const updateQueryString = (setQueryString) =>
-  debounce((url) => setQueryString((prevQuery) => (prevQuery !== url ? url : prevQuery)), 700);
+const updateQueryString = (setQueryString) => (url) =>
+  setQueryString((prevQuery) => (prevQuery !== url ? url : prevQuery));
 
 const useKubevirtDataPodFilters: UseKubevirtDataPodFilters = (filters) => {
   const [queryString, setQueryString] = useState<string>('');

--- a/src/utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource.ts
+++ b/src/utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource.ts
@@ -6,31 +6,32 @@ import { AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
 import { KUBEVIRT_APISERVER_PROXY } from '../useFeatures/constants';
 import { useFeatures } from '../useFeatures/useFeatures';
 import useKubevirtDataPodHealth from '../useKubevirtDataPod/hooks/useKubevirtDataPodHealth';
+import useQuery from '../useQuery';
 
 import useRedirectWatchHooks from './useRedirectWatchHooks';
 
-export type Result<R extends K8sResourceCommon | K8sResourceCommon[]> = [R, boolean, Error];
+export type Result<R extends K8sResourceCommon | K8sResourceCommon[]> = [
+  resource: R,
+  resourceLoaded: boolean,
+  resourceLoadError: Error,
+];
 
-type UseKubevirtWatchResource = <T extends K8sResourceCommon | K8sResourceCommon[]>(
+const useKubevirtWatchResource = <T extends K8sResourceCommon | K8sResourceCommon[]>(
   watchOptions: WatchK8sResource & { cluster?: string },
   filterOptions?: { [key: string]: string },
   searchQueries?: AdvancedSearchFilter,
-) => Result<T>;
-
-const useKubevirtWatchResource: UseKubevirtWatchResource = <T>(
-  watchOptions,
-  filterOptions,
-  searchQueries,
-) => {
+): Result<T> => {
   const isProxyPodAlive = useKubevirtDataPodHealth();
   const { featureEnabled, loading } = useFeatures(KUBEVIRT_APISERVER_PROXY);
+  const query = useQuery();
 
   const shouldUseProxyPod = useMemo(() => {
     if (watchOptions?.cluster) return false;
+    if (query.size === 0) return false;
     if (!featureEnabled && !loading) return false;
     if (featureEnabled && !loading && isProxyPodAlive !== null) return isProxyPodAlive;
     return null;
-  }, [featureEnabled, loading, isProxyPodAlive, watchOptions?.cluster]);
+  }, [featureEnabled, loading, isProxyPodAlive, watchOptions?.cluster, query.size]);
 
   return useRedirectWatchHooks<T>(watchOptions, filterOptions, searchQueries, shouldUseProxyPod);
 };

--- a/src/utils/hooks/useKubevirtWatchResource/useRedirectWatchHooks.ts
+++ b/src/utils/hooks/useKubevirtWatchResource/useRedirectWatchHooks.ts
@@ -23,7 +23,7 @@ const useRedirectWatchHooks = <T extends K8sResourceCommon | K8sResourceCommon[]
   const usePod = shouldUseProxyPod && !isACMTreeView;
 
   const k8sWatch = useK8sWatchData<T>(!usePod && !useMulticlusterSearch ? watchOptions : null);
-  const [multiSearchData, multiSearchLoading, multiSearchError] = useFleetSearchPoll<T>(
+  const [multiSearchData, multiSearchLoaded, multiSearchError] = useFleetSearchPoll<T>(
     !usePod && useMulticlusterSearch && watchOptions,
     searchQueries,
   );
@@ -38,7 +38,7 @@ const useRedirectWatchHooks = <T extends K8sResourceCommon | K8sResourceCommon[]
     if (usePod) return kubevirtPodWatch;
 
     if (useMulticlusterSearch)
-      return [multiSearchData, multiSearchLoading, multiSearchError] as Result<T>;
+      return [multiSearchData, multiSearchLoaded, multiSearchError] as Result<T>;
 
     return k8sWatch;
   }, [
@@ -46,7 +46,7 @@ const useRedirectWatchHooks = <T extends K8sResourceCommon | K8sResourceCommon[]
     shouldUseProxyPod,
     useMulticlusterSearch,
     multiSearchData,
-    multiSearchLoading,
+    multiSearchLoaded,
     multiSearchError,
     usePod,
     kubevirtPodWatch,

--- a/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
+++ b/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
@@ -59,6 +59,7 @@ const VirtualMachineNavigator: FC = () => {
               <>
                 <GuidedTour />
                 <VirtualMachinesList
+                  allVMsLoaded={treeProps.loaded}
                   cluster={cluster}
                   kind={VirtualMachineModelRef}
                   namespace={namespace}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- adds back the loading skeleton to VMs table
- removes a 700ms debounce which was causing a late loading
- removes some filterOptions passed to `useKubevirtWatchResource` which are no longer used
- exposes `allVMsLoaded` variable to VirtualMachinesList to show the empty state correctly
- `useKubevirtWatchResource` was modified to use proxy pod only when there are some filters

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/4e50091f-da2f-4b99-a297-32d37ae8f9ed


After:

https://github.com/user-attachments/assets/767386a8-95cd-4f17-a8bb-3d5a72e23b25



