### PR TITLE
CNV-52151: Allow changing NIC binding to l2bridge

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
+++ b/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
@@ -11,11 +11,7 @@ import {
   getInterfaces,
   getNetworks,
 } from '@kubevirt-utils/resources/vm';
-import {
-  BRIDGE,
-  PASST_BINDING_NAME,
-  UDN_BINDING_NAME,
-} from '@kubevirt-utils/resources/vm/utils/constants';
+import { PASST_BINDING_NAME, UDN_BINDING_NAME } from '@kubevirt-utils/resources/vm/utils/constants';
 import {
   interfaceLabelsProxy,
   interfaceTypesProxy,
@@ -144,8 +140,8 @@ export const createInterface = ({
   nicName,
 }: CreateInterfaceOptions): V1Interface => {
   const resolvedInterfaceProp = interfaceLabelsProxy[interfaceType];
-  const validInterfaceProp: keyof V1Interface =
-    resolvedInterfaceProp === UDN_BINDING_NAME ? BRIDGE : resolvedInterfaceProp;
+  const isBinding =
+    resolvedInterfaceProp === UDN_BINDING_NAME || resolvedInterfaceProp === PASST_BINDING_NAME;
 
   const createdInterface: V1Interface = {
     macAddress: interfaceMACAddress,
@@ -153,12 +149,11 @@ export const createInterface = ({
     name: nicName,
   };
 
-  if (resolvedInterfaceProp !== PASST_BINDING_NAME) {
-    createdInterface.state = interfaceLinkState;
-    createdInterface[validInterfaceProp] = {};
+  if (isBinding) {
+    createdInterface.binding = { name: resolvedInterfaceProp };
   } else {
-    createdInterface.binding = { name: PASST_BINDING_NAME };
-    return createdInterface;
+    createdInterface.state = interfaceLinkState;
+    createdInterface[resolvedInterfaceProp] = {};
   }
 
   return createdInterface;


### PR DESCRIPTION
## 📝 Description
Depends on: https://github.com/kubevirt-ui/kubevirt-plugin/pull/2875

Until #2869 it was not possible to change the binding. With adding Passt this limitation was removed but still user was not allowed to switch back to `l2bridge` binding.
Steps to reproduce:
1. edit Pod network - switch to Passt binding
2. restart the VM - the change should get applied
3. edit Pod network - switch back to `l2bridge` binding
4. restart the VM - the interface type will be `Bridge` (the default) as the change was blocked

## 🎥 Demo

### Before

https://github.com/user-attachments/assets/162a7c70-bf32-43dd-beec-c26e282a3ddf

### After

https://github.com/user-attachments/assets/6bbb6482-ef0d-4a73-a149-4cc2d5ae6912
