### PR TITLE
CNV-66454: Fixing the display of CPU|Memory when creating a vm from a user instance type

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsLeftGrid.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/VMDetailsSection/components/DetailsLeftGrid.tsx
@@ -34,7 +34,7 @@ const DetailsLeftGrid: FC<DetailsLeftGridProps> = ({
   const { instanceTypeVMState, setInstanceTypeVMState, vmNamespaceTarget } =
     useInstanceTypeVMStore();
   const { folder, selectedBootableVolume, selectedInstanceType, vmName } = instanceTypeVMState;
-  const { clusterInstanceTypes, preferences } = instanceTypesAndPreferencesData;
+  const { allInstanceTypes, preferences } = instanceTypesAndPreferencesData;
 
   const preferencesMap = useMemo(() => convertResourceArrayToMap(preferences), [preferences]);
   const userPreferencesMap = useMemo(
@@ -42,8 +42,8 @@ const DetailsLeftGrid: FC<DetailsLeftGridProps> = ({
     [userPreferencesData],
   );
   const instanceTypesMap = useMemo(
-    () => convertResourceArrayToMap(clusterInstanceTypes),
-    [clusterInstanceTypes],
+    () => convertResourceArrayToMap(allInstanceTypes),
+    [allInstanceTypes],
   );
 
   const vmNameValidated = validateVMName(vmName);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

fixing the cpu|Memory display: when creating a vm from a user instance type the cpu|Memory would not display any details on the create page, leaving it empty. 

## 🎥 Demo
Before:
<img width="797" height="879" alt="image" src="https://github.com/user-attachments/assets/4394782c-4390-4ee8-9aae-3c57362d697f" />

After:
<img width="822" height="1198" alt="image" src="https://github.com/user-attachments/assets/51a015b0-dc63-4a79-9189-af90d3f2386e" />