### PR TITLE
CNV-67857: PatternFly Chart hover broken due to delaunator package version conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,8 @@
   "private": true,
   "resolutions": {
     "@types/react": "^17.0.40",
-    "@types/react-dom": "^17.0.0"
+    "@types/react-dom": "^17.0.0",
+    "delaunator": "4.0.1"
   },
   "scripts": {
     "build": "yarn clean && NODE_ENV=production NODE_OPTIONS=--max-old-space-size=8192 yarn ts-node node_modules/.bin/webpack",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4502,14 +4502,7 @@ define-properties@^1.1.3, define-properties@^1.1.4:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
-delaunator@5:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-5.0.1.tgz#39032b08053923e924d6094fe2cde1a99cc51278"
-  integrity sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==
-  dependencies:
-    robust-predicates "^3.0.2"
-
-delaunator@^4.0.0:
+delaunator@4.0.1, delaunator@5, delaunator@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-4.0.1.tgz#3d779687f57919a7a418f8ab947d3bddb6846957"
   integrity sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==
@@ -9710,11 +9703,6 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
-
-robust-predicates@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.2.tgz#d5b28528c4824d20fc48df1928d41d9efa1ad771"
-  integrity sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==
 
 rsvp@^4.8.2:
   version "4.8.5"


### PR DESCRIPTION

## 📝 Description

This fix resolves the TypeError: _delaunator.default is not a constructor that occurs when a user hovers over charts. 
The problem was caused by a dependency conflict where @patternfly/react-charts and @patternfly/react-topology were relying on different major versions of the delaunator package.
By explicitly restricting the version to 4.0.1 within the dependency tree, we've ensured that both libraries use a compatible version, allowing chart tooltips to function correctly again.

## 🎥 Demo


https://github.com/user-attachments/assets/997cfd15-e824-4fe9-adb6-21a6bfb625ed


