### PR TITLE
ACM resource routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@patternfly/react-tokens": "^6.2.2",
     "@patternfly/react-topology": "^6.2.0",
     "@preact/signals-react": "^2.0.1",
-    "@stolostron/multicluster-sdk": "0.6.0",
+    "@stolostron/multicluster-sdk": "0.6.2",
     "@xterm/addon-clipboard": "^0.1.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",

--- a/src/multicluster/constants.ts
+++ b/src/multicluster/constants.ts
@@ -9,7 +9,7 @@ export const CROSS_CLUSTER_MIGRATION_ACTION_ID = 'cross-cluster-migration';
 
 export const ManagedClusterModel: K8sModel = {
   abbr: 'MC',
-  apiGroup: 'clusterview.open-cluster-management.io',
+  apiGroup: 'cluster.open-cluster-management.io',
   apiVersion: 'v1',
   crd: true,
   kind: 'ManagedCluster',

--- a/src/multicluster/extensions.ts
+++ b/src/multicluster/extensions.ts
@@ -6,6 +6,7 @@ import {
   StandaloneRoutePage,
 } from '@openshift-console/dynamic-plugin-sdk';
 import type { ConsolePluginBuildMetadata } from '@openshift-console/dynamic-plugin-sdk-webpack';
+import { ResourceRoute } from '@stolostron/multicluster-sdk';
 
 import { ACMVirtualMachineActionExtension } from './hooks/useACMExtensionActions/constants';
 import { CROSS_CLUSTER_MIGRATION_ACTION_ID } from './constants';
@@ -16,6 +17,7 @@ export const exposedModules: ConsolePluginBuildMetadata['exposedModules'] = {
   CrossClusterMigration:
     './multicluster/components/CrossClusterMigration/CrossClusterMigration.tsx',
   Navigator: './views/virtualmachines/navigator/VirtualMachineNavigator.tsx',
+  urls: './multicluster/urls.ts',
   VirtualMachineSearchResults: './views/virtualmachines/search/VirtualMachineSearchResults.tsx',
 };
 
@@ -142,4 +144,24 @@ export const extensions: EncodedExtension[] = [
     },
     type: 'console.page/route',
   } as EncodedExtension<RoutePage>,
+  {
+    properties: {
+      handler: { $codeRef: 'urls.getFleetResourceRoute' },
+      model: {
+        group: 'kubevirt.io',
+        kind: 'VirtualMachine',
+      },
+    },
+    type: 'acm.resource/route',
+  } as EncodedExtension<ResourceRoute>,
+  {
+    properties: {
+      handler: { $codeRef: 'urls.getFleetResourceRoute' },
+      model: {
+        group: 'kubevirt.io',
+        kind: 'VirtualMachineInstance',
+      },
+    },
+    type: 'acm.resource/route',
+  } as EncodedExtension<ResourceRoute>,
 ];

--- a/src/multicluster/urls.ts
+++ b/src/multicluster/urls.ts
@@ -1,5 +1,6 @@
 import { ALL_NAMESPACES } from '@kubevirt-utils/hooks/constants';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
+import { ResourceRouteHandler } from '@stolostron/multicluster-sdk';
 
 import { VirtualMachineModel } from '../views/dashboard-extensions/utils';
 
@@ -51,3 +52,19 @@ export const getVMListNamespacesURL = (cluster: string, namespace: string): stri
         activeNamespace: namespace,
         model: VirtualMachineModel,
       });
+
+export const getFleetResourceRoute: ResourceRouteHandler = ({
+  cluster,
+  model,
+  name,
+  namespace,
+}) => {
+  const { group, kind, version } = model;
+  switch (kind) {
+    case 'VirtualMachine':
+    case 'VirtualMachineInstance':
+      return `/k8s/cluster/${cluster}/ns/${namespace}/${group}~${version}~VirtualMachine/${name}`;
+    default:
+      return null;
+  }
+};

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
@@ -18,7 +18,7 @@ import ACMExtentionsTableData from '@multicluster/components/ACMExtentionsTableD
 import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
 import { ManagedClusterModel } from '@multicluster/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
-import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
+import { RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 import { Checkbox } from '@patternfly/react-core';
 import VirtualMachineActions from '@virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions';
 import useVirtualMachineActionsProvider from '@virtualmachines/actions/hooks/useVirtualMachineActionsProvider';
@@ -86,7 +86,7 @@ const VirtualMachineRowLayout: FC<
         />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="cluster">
-        <ResourceLink
+        <MulticlusterResourceLink
           groupVersionKind={modelToGroupVersionKind(ManagedClusterModel)}
           name={vmCluster}
           truncate

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,10 +1531,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stolostron/multicluster-sdk@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@stolostron/multicluster-sdk/-/multicluster-sdk-0.6.0.tgz#98915fbd5011db6d0bf7d39fb2f2b96e5bf500d2"
-  integrity sha512-F80eGpKSEHuSZbjtM7dEdbujyCrEk+nlcRh29+B82qJsZNz3POKRrTtWBXl4vvrD76lS8Ji+mtjxDkZyllXUqw==
+"@stolostron/multicluster-sdk@0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@stolostron/multicluster-sdk/-/multicluster-sdk-0.6.2.tgz#a8bc4bd734b355528dbb5af612305591cc789d0c"
+  integrity sha512-Idi2Q3sq8SwZ99gY3D5Kebsjvi0sGO6DhjSXM5LRdLohIHCpryMjeSPFGRCcwrWN8fx0iAySaCT3FF9zDeh+9A==
   dependencies:
     "@apollo/client" "3.10.8"
     "@patternfly/react-component-groups" "^6.2.1"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- Updates @stolostron/multicluster-sdk to version 0.6.2
- Adds extensions to declare the multicluster VM route to ACM/multicluster-SDK so that links and search results for VMs/VMIs can go to the correct page (removes hardcoding of these routes from SDK)
- Updates ManagedCluster links to use the main API group instead of the `clusterview` group for the aggregate API and adds a missing case
