### PR TITLE
CNV-67947: Detect autoattached Pod Network

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
+++ b/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
@@ -30,7 +30,8 @@ import { isStopped } from '@virtualmachines/utils';
 import { NetworkAttachmentDefinition } from '../components/hooks/types';
 
 export const podNetworkExists = (vm: V1VirtualMachine): boolean =>
-  !!vm?.spec?.template?.spec?.networks?.find((network) => typeof network.pod === 'object');
+  !!vm?.spec?.template?.spec?.networks?.find((network) => typeof network.pod === 'object') ||
+  getAutoAttachPodInterface(vm) !== false;
 
 export const networkNameStartWithPod = (networkName: string): boolean =>
   networkName?.startsWith('Pod');


### PR DESCRIPTION
## 📝 Description

If the Pod Network is added via `autoattachPodInterface` then it's possible to add a second Pod Network.

## 🎥 Demo

### Before
https://github.com/user-attachments/assets/7cb43065-b2de-4ff4-93fc-7e875e023f4f

### After
https://github.com/user-attachments/assets/fb7ec306-d982-4fd2-981f-c924eed1474e






