### PR TITLE
CNV-68078: Add padding to the bottom of the tree view body

### DIFF
--- a/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
+++ b/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
@@ -90,6 +90,7 @@
 }
 
 .vms-tree-view-body {
+  --pf-v6-c-drawer__panel__body--PaddingBlockEnd: 30px;
   padding: 0 var(--pf-t--global--spacer--sm);
   height: 100%;
   overflow-y: auto;


### PR DESCRIPTION
## 📝 Description

Added padding to the bottom of the VM list. 

## 🎥 Demo

Without the fix: 
<img width="1433" height="893" alt="WithoutFix" src="https://github.com/user-attachments/assets/5de83220-856c-40e2-9540-7893885de306" />

After applying it:

<img width="1425" height="894" alt="WithFix" src="https://github.com/user-attachments/assets/0360174b-b503-4a74-9a36-c4d240559bb0" />

