### PR TITLE
CNV-68335: fix mappers identifiers by including cluster

### DIFF
--- a/src/utils/hooks/usePVCMapper.ts
+++ b/src/utils/hooks/usePVCMapper.ts
@@ -5,12 +5,13 @@ import {
   PersistentVolumeClaimModel,
 } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
-import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils/constants';
 import { convertIntoPVCMapper } from '@virtualmachines/utils/mappers';
 
+import useKubevirtWatchResource from './useKubevirtWatchResource/useKubevirtWatchResource';
+
 export const usePVCMapper = (namespace: string, cluster?: string) => {
-  const [pvcs] = useK8sWatchData<IoK8sApiCoreV1PersistentVolumeClaim[]>({
+  const [pvcs] = useKubevirtWatchResource<IoK8sApiCoreV1PersistentVolumeClaim[]>({
     cluster,
     groupVersionKind: modelToGroupVersionKind(PersistentVolumeClaimModel),
     isList: true,

--- a/src/utils/resources/constants.ts
+++ b/src/utils/resources/constants.ts
@@ -1,0 +1,1 @@
+export const SINGLE_CLUSTER_KEY = '#single-cluster#';

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -39,8 +39,10 @@ import {
 } from '@kubevirt-utils/hooks/usePagination/utils/constants';
 import { usePVCMapper } from '@kubevirt-utils/hooks/usePVCMapper';
 import useQuery from '@kubevirt-utils/hooks/useQuery';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { getCluster } from '@multicluster/helpers/selectors';
 import { getCatalogURL } from '@multicluster/urls';
 import {
   DocumentTitle,
@@ -55,6 +57,7 @@ import { VMSearchQueries } from '@virtualmachines/search/hooks/useVMSearchQuerie
 import VirtualMachineFilterToolbar from '@virtualmachines/search/VirtualMachineFilterToolbar';
 import { vmsSignal } from '@virtualmachines/tree/utils/signals';
 import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils';
+import { getVMIFromMapper, getVMIMFromMapper } from '@virtualmachines/utils/mappers';
 
 import VirtualMachineBulkActionButton from './components/VirtualMachineBulkActionButton';
 import VirtualMachineEmptyState from './components/VirtualMachineEmptyState/VirtualMachineEmptyState';
@@ -133,7 +136,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
 
   const pvcMapper = usePVCMapper(namespace, cluster);
 
-  const [vmims, vmimsLoaded] = useK8sWatchData<V1VirtualMachineInstanceMigration[]>({
+  const [vmims, vmimsLoaded] = useKubevirtWatchResource<V1VirtualMachineInstanceMigration[]>({
     cluster,
     groupVersionKind: VirtualMachineInstanceMigrationModelGroupVersionKind,
     isList: true,
@@ -284,8 +287,9 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
                   <div className="pf-v6-u-text-align-center">{t('No VirtualMachines found')}</div>
                 )}
                 rowData={{
-                  getVmi: (ns: string, name: string) => vmiMapper?.mapper?.[ns]?.[name],
-                  getVmim: (ns: string, name: string) => vmimMapper?.[ns]?.[name],
+                  getVmi: (vm: V1VirtualMachine) => getVMIFromMapper(vmiMapper, vm),
+                  getVmim: (vm: V1VirtualMachine) =>
+                    getVMIMFromMapper(vmimMapper, getName(vm), getNamespace(vm), getCluster(vm)),
                   kind,
                   pvcMapper,
                 }}

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRow.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRow.tsx
@@ -5,7 +5,6 @@ import {
   V1VirtualMachineInstance,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { RowProps } from '@openshift-console/dynamic-plugin-sdk';
@@ -21,15 +20,13 @@ const VirtualMachineRow: FC<
   RowProps<
     V1VirtualMachine,
     {
-      getVmi: (namespace: string, name: string) => V1VirtualMachineInstance;
-      getVmim: (ns: string, name: string) => V1VirtualMachineInstanceMigration;
+      getVmi: (vm: V1VirtualMachine) => V1VirtualMachineInstance;
+      getVmim: (vm: V1VirtualMachine) => V1VirtualMachineInstanceMigration;
       pvcMapper: PVCMapper;
     }
   >
 > = ({ activeColumnIDs, index, obj: vm, rowData: { getVmi, getVmim, pvcMapper } }) => {
-  const vmName = getName(vm);
-  const vmNamespace = getNamespace(vm);
-  const vmi = getVmi(vmNamespace, vmName);
+  const vmi = getVmi(vm);
   const status = (
     <>
       <StatusWithPopover vm={vm} vmi={vmi} />
@@ -44,7 +41,7 @@ const VirtualMachineRow: FC<
         pvcMapper,
         status,
         vmi,
-        vmim: getVmim(vmNamespace, vmName),
+        vmim: getVmim(vm),
       }}
       activeColumnIDs={activeColumnIDs}
       index={index}

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/components/CPUPercentage.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/components/CPUPercentage.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 
 import { V1CPU, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCPUUsagePercentage } from '@virtualmachines/list/metrics';
@@ -13,7 +12,7 @@ type CPUPercentageProps = {
 };
 
 const CPUPercentage: FC<CPUPercentageProps> = ({ vm, vmiCPU }) => {
-  const cpuUsagePercentage = getCPUUsagePercentage(getName(vm), getNamespace(vm), vmiCPU);
+  const cpuUsagePercentage = getCPUUsagePercentage(vm, vmiCPU);
 
   if (isEmpty(cpuUsagePercentage) || !isRunning(vm)) return <span>{NO_DATA_DASH}</span>;
 

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/components/MemoryPercentage.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/components/MemoryPercentage.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getMemoryUsagePercentage } from '@virtualmachines/list/metrics';
@@ -13,7 +12,7 @@ type MemoryPercentageProps = {
 };
 
 const MemoryPercentage: FC<MemoryPercentageProps> = ({ vm, vmiMemory }) => {
-  const memoryUsagePercentage = getMemoryUsagePercentage(getName(vm), getNamespace(vm), vmiMemory);
+  const memoryUsagePercentage = getMemoryUsagePercentage(vm, vmiMemory);
 
   if (isEmpty(memoryUsagePercentage) || !isRunning(vm)) return <span>{NO_DATA_DASH}</span>;
 

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/components/NetworkUsage.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/components/NetworkUsage.tsx
@@ -2,7 +2,6 @@ import React, { FC } from 'react';
 import xbytes from 'xbytes';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getNetworkUsagePercentage } from '@virtualmachines/list/metrics';
@@ -13,7 +12,7 @@ type NetworkUsageProps = {
 };
 
 const NetworkUsage: FC<NetworkUsageProps> = ({ vm }) => {
-  const totalTransferred = getNetworkUsagePercentage(getName(vm), getNamespace(vm));
+  const totalTransferred = getNetworkUsagePercentage(vm);
 
   if (isEmpty(totalTransferred) || !isRunning(vm)) return <>{NO_DATA_DASH}</>;
 

--- a/src/views/virtualmachines/list/hooks/sortColumns.ts
+++ b/src/views/virtualmachines/list/hooks/sortColumns.ts
@@ -1,5 +1,4 @@
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCPU, getMemory } from '@kubevirt-utils/resources/vm';
 import { columnSortingCompare, isEmpty } from '@kubevirt-utils/utils/utils';
 import { SortByDirection } from '@patternfly/react-table';
@@ -45,8 +44,8 @@ export const sortByCPUUsage = (
     const aCPU = getCPU(getVMIFromMapper(vmiMapper, a));
     const bCPU = getCPU(getVMIFromMapper(vmiMapper, b));
 
-    const cpuUsageA = getCPUUsagePercentage(getName(a), getNamespace(a), aCPU);
-    const cpuUsageB = getCPUUsagePercentage(getName(b), getNamespace(b), bCPU);
+    const cpuUsageA = getCPUUsagePercentage(a, aCPU);
+    const cpuUsageB = getCPUUsagePercentage(b, bCPU);
 
     if (isEmpty(cpuUsageA)) return -1;
     if (isEmpty(cpuUsageB)) return 1;
@@ -83,8 +82,8 @@ export const sortByMemoryUsage = (
   const compareMemoryUsage = (a: V1VirtualMachine, b: V1VirtualMachine): number => {
     const aVMI = getVMIFromMapper(vmiMapper, a);
     const bVMI = getVMIFromMapper(vmiMapper, b);
-    const memoryUsageA = getMemoryUsagePercentage(getName(a), getNamespace(a), getMemory(aVMI));
-    const memoryUsageB = getMemoryUsagePercentage(getName(b), getNamespace(b), getMemory(bVMI));
+    const memoryUsageA = getMemoryUsagePercentage(a, getMemory(aVMI));
+    const memoryUsageB = getMemoryUsagePercentage(b, getMemory(bVMI));
 
     if (isEmpty(memoryUsageA)) return -1;
     if (isEmpty(memoryUsageB)) return 1;
@@ -115,8 +114,8 @@ export const sortByNetworkUsage = (
   pagination: { [key: string]: any },
 ) => {
   const compareNetworkUsage = (a: V1VirtualMachine, b: V1VirtualMachine): number => {
-    const networkUsageA = getNetworkUsagePercentage(getName(a), getNamespace(a));
-    const networkUsageB = getNetworkUsagePercentage(getName(b), getNamespace(b));
+    const networkUsageA = getNetworkUsagePercentage(a);
+    const networkUsageB = getNetworkUsagePercentage(b);
 
     if (isEmpty(networkUsageA)) return -1;
     if (isEmpty(networkUsageB)) return 1;

--- a/src/views/virtualmachines/list/hooks/useExistingSelectedVMs.ts
+++ b/src/views/virtualmachines/list/hooks/useExistingSelectedVMs.ts
@@ -1,17 +1,23 @@
 import { useMemo } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { convertResourceArrayToMap } from '@kubevirt-utils/resources/shared';
+import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
+import { convertResourceArrayToMapWithCluster } from '@kubevirt-utils/resources/shared';
 
 import { selectedVMs } from '../selectedVMs';
 
 const useExistingSelectedVMs = (vms: V1VirtualMachine[]) => {
-  const vmsMapper = useMemo(() => convertResourceArrayToMap(vms, true), [vms]);
+  const vmsMapper = useMemo(() => convertResourceArrayToMapWithCluster(vms, true), [vms]);
 
   const existingSelectedVirtualMachines = useMemo(
     () =>
       selectedVMs.value
-        .map((selectedVM) => vmsMapper?.[selectedVM.namespace]?.[selectedVM.name])
+        .map(
+          (selectedVM) =>
+            vmsMapper?.[selectedVM.cluster || SINGLE_CLUSTER_KEY]?.[selectedVM.namespace]?.[
+              selectedVM.name
+            ],
+        )
         .filter(Boolean),
     [vmsMapper],
   );

--- a/src/views/virtualmachines/list/hooks/useVMListFilters/useNodesFilter.ts
+++ b/src/views/virtualmachines/list/hooks/useVMListFilters/useNodesFilter.ts
@@ -1,11 +1,10 @@
 import { useMemo } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { universalComparator } from '@kubevirt-utils/utils/utils';
 import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
-import { VMIMapper } from '@virtualmachines/utils/mappers';
+import { getVMIFromMapper, VMIMapper } from '@virtualmachines/utils/mappers';
 
 export const useNodesFilter = (vmiMapper: VMIMapper): RowFilter<V1VirtualMachine> => {
   const sortedNodeNamesItems = useMemo(() => {
@@ -14,12 +13,12 @@ export const useNodesFilter = (vmiMapper: VMIMapper): RowFilter<V1VirtualMachine
 
   return {
     filter: (selectedNodes, vm) => {
-      const nodeName = vmiMapper?.mapper?.[getNamespace(vm)]?.[getName(vm)]?.status?.nodeName;
+      const nodeName = getVMIFromMapper(vmiMapper, vm)?.status?.nodeName;
       return selectedNodes.selected?.length === 0 || selectedNodes.selected?.includes(nodeName);
     },
     filterGroupName: 'Node',
     items: sortedNodeNamesItems,
-    reducer: (vm) => vmiMapper?.mapper?.[getNamespace(vm)]?.[getName(vm)]?.status?.nodeName,
+    reducer: (vm) => getVMIFromMapper(vmiMapper, vm)?.status?.nodeName,
     type: VirtualMachineRowFilterType.Node,
   };
 };

--- a/src/views/virtualmachines/list/hooks/useVMMetrics.ts
+++ b/src/views/virtualmachines/list/hooks/useVMMetrics.ts
@@ -47,9 +47,10 @@ const useVMMetrics = () => {
     networkTotalResponse?.data?.result?.forEach((result) => {
       const vmName = result?.metric?.name;
       const vmNamespace = result?.metric?.namespace;
+      const vmCluster = result?.metric?.cluster;
       const memoryUsage = parseFloat(result?.value?.[1]);
 
-      setVMNetworkUsage(vmName, vmNamespace, memoryUsage);
+      setVMNetworkUsage(vmName, vmNamespace, vmCluster, memoryUsage);
     });
   }, [networkTotalResponse]);
 
@@ -57,9 +58,10 @@ const useVMMetrics = () => {
     memoryUsageResponse?.data?.result?.forEach((result) => {
       const vmName = result?.metric?.name;
       const vmNamespace = result?.metric?.namespace;
+      const vmCluster = result?.metric?.cluster;
       const memoryUsage = parseFloat(result?.value?.[1]);
 
-      setVMMemoryUsage(vmName, vmNamespace, memoryUsage);
+      setVMMemoryUsage(vmName, vmNamespace, vmCluster, memoryUsage);
     });
   }, [memoryUsageResponse]);
 
@@ -67,9 +69,10 @@ const useVMMetrics = () => {
     cpuUsageResponse?.data?.result?.forEach((result) => {
       const vmName = result?.metric?.name;
       const vmNamespace = result?.metric?.namespace;
+      const vmCluster = result?.metric?.cluster;
       const cpuUsage = parseFloat(result?.value?.[1]);
 
-      setVMCPUUsage(vmName, vmNamespace, cpuUsage);
+      setVMCPUUsage(vmName, vmNamespace, vmCluster, cpuUsage);
     });
   }, [cpuUsageResponse]);
 };

--- a/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
+++ b/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
@@ -171,14 +171,16 @@ const useVirtualMachineColumns = (
       },
     ],
     [
-      canGetNode,
-      namespace,
-      sorting,
-      sortingUsingFunction,
-      sortingUsingFunctionWithMapper,
-      sortingUsingFunctionWithPVCMapper,
       t,
+      isACMPage,
+      cluster,
+      namespace,
+      canGetNode,
       acmHeaders,
+      sorting,
+      sortingUsingFunctionWithMapper,
+      sortingUsingFunction,
+      sortingUsingFunctionWithPVCMapper,
     ],
   );
 

--- a/src/views/virtualmachines/list/metrics.ts
+++ b/src/views/virtualmachines/list/metrics.ts
@@ -1,9 +1,13 @@
 import xbytes from 'xbytes';
 
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { V1CPU } from '@kubevirt-ui/kubevirt-api/kubevirt/models/V1CPU';
 import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
+import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getVCPUCount } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { getCluster } from '@multicluster/helpers/selectors';
 import { signal } from '@preact/signals-core';
 
 export type MetricsType = {
@@ -17,32 +21,60 @@ export type MetricsType = {
 
 export const vmsMetrics = signal<MetricsType>({});
 
-export const getVMMetrics = (vmName: string, vmNamespace: string) => {
-  const vmMetrics = vmsMetrics.value?.[`${vmNamespace}-${vmName}`];
+export const getVMMetrics = (vm: V1VirtualMachine) => {
+  const cluster = getCluster(vm) || SINGLE_CLUSTER_KEY;
+  const namespace = getNamespace(vm);
+  const name = getName(vm);
+  const vmMetrics = vmsMetrics.value?.[`${cluster}-${namespace}-${name}`];
+  if (isEmpty(vmMetrics)) vmsMetrics.value[`${cluster}-${namespace}-${name}`] = {};
 
-  if (isEmpty(vmMetrics)) vmsMetrics.value[`${vmNamespace}-${vmName}`] = {};
-
-  return vmsMetrics.value?.[`${vmNamespace}-${vmName}`];
+  return vmsMetrics.value?.[`${cluster}-${namespace}-${name}`];
 };
 
-export const setVMMemoryUsage = (vmName: string, vmNamespace: string, memoryUsage: number) => {
-  const vmMetrics = getVMMetrics(vmName, vmNamespace);
+export const getVMMetricsWithParams = (
+  name: string,
+  namespace: string,
+  cluster = SINGLE_CLUSTER_KEY,
+) => {
+  const vmMetrics = vmsMetrics.value?.[`${cluster}-${namespace}-${name}`];
+  if (isEmpty(vmMetrics)) vmsMetrics.value[`${cluster}-${namespace}-${name}`] = {};
+
+  return vmsMetrics.value?.[`${cluster}-${namespace}-${name}`];
+};
+
+export const setVMMemoryUsage = (
+  name: string,
+  namespace: string,
+  cluster = SINGLE_CLUSTER_KEY,
+  memoryUsage: number,
+) => {
+  const vmMetrics = getVMMetricsWithParams(name, namespace, cluster);
 
   vmMetrics.memoryUsage = memoryUsage;
 };
 
-export const setVMNetworkUsage = (vmName: string, vmNamespace: string, networkUsage: number) => {
-  const vmMetrics = getVMMetrics(vmName, vmNamespace);
+export const setVMNetworkUsage = (
+  name: string,
+  namespace: string,
+  cluster = SINGLE_CLUSTER_KEY,
+  networkUsage: number,
+) => {
+  const vmMetrics = getVMMetricsWithParams(name, namespace, cluster);
   vmMetrics.networkUsage = networkUsage;
 };
 
-export const setVMCPUUsage = (vmName: string, vmNamespace: string, cpuUsage: number) => {
-  const vmMetrics = getVMMetrics(vmName, vmNamespace);
+export const setVMCPUUsage = (
+  name: string,
+  namespace: string,
+  cluster = SINGLE_CLUSTER_KEY,
+  cpuUsage: number,
+) => {
+  const vmMetrics = getVMMetricsWithParams(name, namespace, cluster);
   vmMetrics.cpuUsage = cpuUsage;
 };
 
-export const getCPUUsagePercentage = (vmName: string, vmNamespace: string, vmiCPU: V1CPU) => {
-  const { cpuUsage } = getVMMetrics(vmName, vmNamespace);
+export const getCPUUsagePercentage = (vm: V1VirtualMachine, vmiCPU: V1CPU) => {
+  const { cpuUsage } = getVMMetrics(vm);
 
   if (isEmpty(cpuUsage)) return;
 
@@ -51,12 +83,8 @@ export const getCPUUsagePercentage = (vmName: string, vmNamespace: string, vmiCP
   return (cpuUsage * 100) / cpuRequested;
 };
 
-export const getMemoryUsagePercentage = (
-  vmName: string,
-  vmNamespace: string,
-  vmiMemory: string,
-) => {
-  const { memoryUsage } = getVMMetrics(vmName, vmNamespace);
+export const getMemoryUsagePercentage = (vm: V1VirtualMachine, vmiMemory: string) => {
+  const { memoryUsage } = getVMMetrics(vm);
 
   if (isEmpty(memoryUsage) || isEmpty(vmiMemory)) return;
 
@@ -70,8 +98,8 @@ export const getMemoryUsagePercentage = (
   return percentage;
 };
 
-export const getNetworkUsagePercentage = (vmName: string, vmNamespace: string) => {
-  const { networkUsage } = getVMMetrics(vmName, vmNamespace);
+export const getNetworkUsagePercentage = (vm: V1VirtualMachine) => {
+  const { networkUsage } = getVMMetrics(vm);
 
   if (isEmpty(networkUsage)) return;
 

--- a/src/views/virtualmachines/list/selectedVMs.ts
+++ b/src/views/virtualmachines/list/selectedVMs.ts
@@ -1,19 +1,20 @@
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { getCluster } from '@multicluster/helpers/selectors';
 import { signal } from '@preact/signals-core';
 
-export const selectedVMs = signal<{ name: string; namespace: string }[]>([]);
+export const selectedVMs = signal<{ cluster?: string; name: string; namespace: string }[]>([]);
 
 export const selectVM = (vm: V1VirtualMachine) => {
-  const vmIdentifier = { name: getName(vm), namespace: getNamespace(vm) };
+  const vmIdentifier = { cluster: getCluster(vm), name: getName(vm), namespace: getNamespace(vm) };
   if (isEmpty(findVM(vm))) {
     selectedVMs.value = [...selectedVMs.value, vmIdentifier];
   }
 };
 
 export const deselectVM = (vm: V1VirtualMachine) => {
-  const vmIdentifier = { name: getName(vm), namespace: getNamespace(vm) };
+  const vmIdentifier = { cluster: getCluster(vm), name: getName(vm), namespace: getNamespace(vm) };
   selectedVMs.value = selectedVMs.value.filter(
     (selectedVM) =>
       selectedVM.name !== vmIdentifier.name || selectedVM.namespace !== vmIdentifier.namespace,
@@ -21,7 +22,11 @@ export const deselectVM = (vm: V1VirtualMachine) => {
 };
 
 export const selectAll = (vms: V1VirtualMachine[]) => {
-  const vmIdentifiers = vms.map((vm) => ({ name: getName(vm), namespace: getNamespace(vm) }));
+  const vmIdentifiers = vms.map((vm) => ({
+    cluster: getCluster(vm),
+    name: getName(vm),
+    namespace: getNamespace(vm),
+  }));
   selectedVMs.value = [...vmIdentifiers];
 };
 
@@ -30,10 +35,12 @@ export const deselectAll = () => {
 };
 
 export const findVM = (vm: V1VirtualMachine) => {
-  const vmIdentifier = { name: getName(vm), namespace: getNamespace(vm) };
+  const vmIdentifier = { cluster: getCluster(vm), name: getName(vm), namespace: getNamespace(vm) };
   return selectedVMs.value.find(
     (selectedVM) =>
-      selectedVM.name === vmIdentifier.name && selectedVM.namespace === vmIdentifier.namespace,
+      selectedVM.name === vmIdentifier.name &&
+      selectedVM.namespace === vmIdentifier.namespace &&
+      selectedVM.cluster === vmIdentifier.cluster,
   );
 };
 

--- a/src/views/virtualmachines/list/utils/filters/getIPFilter.ts
+++ b/src/views/virtualmachines/list/utils/filters/getIPFilter.ts
@@ -3,7 +3,7 @@ import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getVMIIPAddresses } from '@kubevirt-utils/resources/vmi';
 import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 import { compareCIDR, VirtualMachineRowFilterType } from '@virtualmachines/utils';
-import { VMIMapper } from '@virtualmachines/utils/mappers';
+import { getVMIFromMapper, VMIMapper } from '@virtualmachines/utils/mappers';
 
 export const getIPFilter = (vmiMapper: VMIMapper): RowFilter<V1VirtualMachine> => ({
   filter: (input, obj) => {
@@ -11,8 +11,7 @@ export const getIPFilter = (vmiMapper: VMIMapper): RowFilter<V1VirtualMachine> =
 
     if (!search) return true;
 
-    const vmi = vmiMapper.mapper?.[obj?.metadata?.namespace]?.[obj?.metadata?.name];
-
+    const vmi = getVMIFromMapper(vmiMapper, obj);
     const ipAddresses = getVMIIPAddresses(vmi);
 
     return search.includes('/')

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/DefaultRightClickActionMenu.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/DefaultRightClickActionMenu.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import classNames from 'classnames';
 
 import ActionDropdownItem from '@kubevirt-utils/components/ActionDropdownItem/ActionDropdownItem';
-import { getCluster } from '@multicluster/helpers/selectors';
 import { Menu, MenuContent, MenuList, Popper } from '@patternfly/react-core';
 import useMultipleVirtualMachineActions from '@virtualmachines/actions/hooks/useMultipleVirtualMachineActions';
 import {
@@ -23,10 +22,9 @@ const DefaultRightClickActionMenu: FC<DefaultRightClickActionMenuProps> = ({
   hideMenu,
   triggerElement,
 }) => {
-  const { namespace, prefix } = getElementComponentsFromID(triggerElement);
+  const { cluster, namespace, prefix } = getElementComponentsFromID(triggerElement);
 
   const vms = getVMsTrigger(triggerElement);
-  const cluster = getCluster(vms?.[0]);
   const actions = useMultipleVirtualMachineActions(vms);
 
   const navigate = useNavigate();

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/VMRightClickActionMenu.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/VMRightClickActionMenu.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 
 import ActionDropdownItem from '@kubevirt-utils/components/ActionDropdownItem/ActionDropdownItem';
 import { getLabel, getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getCluster } from '@multicluster/helpers/selectors';
 import { Menu, MenuContent, MenuList, Popper } from '@patternfly/react-core';
 import useVirtualMachineActionsProvider from '@virtualmachines/actions/hooks/useVirtualMachineActionsProvider';
 import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
@@ -19,11 +20,14 @@ type VMRightClickActionMenuProps = {
 };
 
 const VMRightClickActionMenu: FC<VMRightClickActionMenuProps> = ({ hideMenu, triggerElement }) => {
-  const { vmName, vmNamespace } = getVMComponentsFromID(triggerElement);
+  const { vmCluster, vmName, vmNamespace } = getVMComponentsFromID(triggerElement);
 
-  const vmim = getVMIMFromMapper(vmimMapperSignal.value, vmName, vmNamespace);
+  const vmim = getVMIMFromMapper(vmimMapperSignal.value, vmName, vmNamespace, vmCluster);
   const vm = vmsSignal?.value?.find(
-    (resource) => getName(resource) === vmName && getNamespace(resource) === vmNamespace,
+    (resource) =>
+      getName(resource) === vmName &&
+      getNamespace(resource) === vmNamespace &&
+      getCluster(resource) === vmCluster,
   );
 
   const [actions] = useVirtualMachineActionsProvider(vm, vmim);

--- a/src/views/virtualmachines/tree/utils/utils.tsx
+++ b/src/views/virtualmachines/tree/utils/utils.tsx
@@ -7,6 +7,7 @@ import {
   tourGuideVM,
 } from '@kubevirt-utils/components/GuidedTour/utils/constants';
 import { ALL_NAMESPACES_SESSION_KEY, ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
+import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
 import { getLabel, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { UseMulticlusterNamespacesReturnType } from '@multicluster/hooks/useMulticlusterProjects';
@@ -64,13 +65,14 @@ const buildProjectMap = (
   vms?.forEach((vm) => {
     const vmNamespace = getNamespace(vm);
     const vmName = getName(vm);
+    const vmCluster = getCluster(vm);
     const folder = foldersEnabled ? getLabel(vm, VM_FOLDER_LABEL) : null;
-    const vmTreeItemID = `${vmNamespace}/${vmName}`;
+    const vmTreeItemID = `${vmCluster || SINGLE_CLUSTER_KEY}/${vmNamespace}/${vmName}`;
     const VMStatusIcon = statusIcon[vm?.status?.printableStatus];
 
     const vmTreeItem: TreeViewDataItemWithHref = {
       defaultExpanded: currentPageVMName && currentPageVMName === vmName,
-      href: `${getVMURL(getCluster(vm), vmNamespace, vmName)}/${currentVMTab}`,
+      href: `${getVMURL(vmCluster, vmNamespace, vmName)}/${currentVMTab}`,
       icon: <VMStatusIcon />,
       id: vmTreeItemID,
       name: vmName,
@@ -107,7 +109,9 @@ const createFolderTreeItems = (
   cluster?: string,
 ): TreeViewDataItemWithHref[] =>
   Object.entries(folders).map(([folder, vmItems]) => {
-    const folderTreeItemID = `${FOLDER_SELECTOR_PREFIX}/${project}/${folder}`;
+    const folderTreeItemID = `${FOLDER_SELECTOR_PREFIX}/${
+      cluster || SINGLE_CLUSTER_KEY
+    }/${project}/${folder}`;
     const folderExpanded =
       currentPageVMName && vmItems.some((item) => (item.name as string) === currentPageVMName);
 
@@ -153,7 +157,7 @@ const createProjectTreeItem = (
 
   const projectChildren = [...sortProjectFolders, ...(projectMap[project]?.ungrouped || [])];
 
-  const projectTreeItemID = `${PROJECT_SELECTOR_PREFIX}/${project}`;
+  const projectTreeItemID = `${PROJECT_SELECTOR_PREFIX}/${cluster}/${project}`;
   const projectTreeItem: TreeViewDataItemWithHref = {
     children: projectChildren,
     customBadgeContent: projectMap[project]?.count || '0',

--- a/src/views/virtualmachines/utils/utils.ts
+++ b/src/views/virtualmachines/utils/utils.ts
@@ -2,6 +2,8 @@ import {
   V1VirtualMachine,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
+import { getCluster } from '@multicluster/helpers/selectors';
 
 import { printableVMStatus } from './virtualMachineStatuses';
 
@@ -53,11 +55,15 @@ export const getLatestMigrationForEachVM = (vmims: V1VirtualMachineInstanceMigra
   (Array.isArray(vmims) ? vmims : [])?.sort(sortVMIMByTimestampCreation)?.reduce((acc, vmim) => {
     const name = vmim?.spec?.vmiName;
     const namespace = vmim?.metadata?.namespace;
-    if (!acc[namespace]) {
-      acc[namespace] = {};
+    const cluster = getCluster(vmim) || SINGLE_CLUSTER_KEY;
+
+    if (!acc[cluster]) {
+      acc[cluster] = {};
+    } else if (!acc[cluster][namespace]) {
+      acc[cluster][namespace] = {};
     }
 
-    acc[namespace][name] = vmim;
+    acc[cluster][namespace][name] = vmim;
 
     return acc;
   }, {});


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

make sure the treeview ids and the mappers take into account the vm cluster . 
Without that, vms with the same name but into different clusters can have conflicts



Make sure to fetch pvcs and vmim with multicluster hooks
