### PR TITLE
CNV-48181: fix CPU and memory metrics

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1216,7 +1216,7 @@
   "Removing Resources": "Removing Resources",
   "Request sent": "Request sent",
   "Requested": "Requested",
-  "Requested of ": "Requested of ",
+  "Requested of {{cpuRequested}}": "Requested of {{cpuRequested}}",
   "Required": "Required",
   "Required parameters": "Required parameters",
   "Required when automatic update is enabled": "Required when automatic update is enabled",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1223,7 +1223,7 @@
   "Removing Resources": "Eliminando recursos",
   "Request sent": "Solicitud enviada",
   "Requested": "Solicitado",
-  "Requested of ": "Solicitado de",
+  "Requested of {{cpuRequested}}": "Requested of {{cpuRequested}}",
   "Required": "Requerido",
   "Required parameters": "Parámetros requeridos",
   "Required when automatic update is enabled": "Se requiere cuando la actualización automática está habilitada.",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1223,7 +1223,7 @@
   "Removing Resources": "Suppression des ressources",
   "Request sent": "Demande envoyée",
   "Requested": "Demandé",
-  "Requested of ": "Demandé de ",
+  "Requested of {{cpuRequested}}": "Requested of {{cpuRequested}}",
   "Required": "Requis",
   "Required parameters": "Paramètres requis",
   "Required when automatic update is enabled": "Obligatoire lorsque la mise à jour automatique est activée",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1213,7 +1213,7 @@
   "Removing Resources": "リソースの削除",
   "Request sent": "送信済みリクエスト",
   "Requested": "要求済み",
-  "Requested of ": "要求済み / ",
+  "Requested of {{cpuRequested}}": "Requested of {{cpuRequested}}",
   "Required": "必須",
   "Required parameters": "必須パラメーター",
   "Required when automatic update is enabled": "自動更新が有効な場合に必須",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1213,7 +1213,7 @@
   "Removing Resources": "리소스 제거 중",
   "Request sent": "요청 전송됨",
   "Requested": "요청됨",
-  "Requested of ": "요청됨",
+  "Requested of {{cpuRequested}}": "Requested of {{cpuRequested}}",
   "Required": "필수 항목",
   "Required parameters": "필수 매개 변수",
   "Required when automatic update is enabled": "자동 업데이트가 활성화된 경우 필수 사항",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1213,7 +1213,7 @@
   "Removing Resources": "删除资源",
   "Request sent": "请求发生",
   "Requested": "请求的",
-  "Requested of ": "请求的",
+  "Requested of {{cpuRequested}}": "Requested of {{cpuRequested}}",
   "Required": "必需",
   "Required parameters": "所需的参数",
   "Required when automatic update is enabled": "在启用自动更新时需要",

--- a/src/utils/hooks/useVMQueries.ts
+++ b/src/utils/hooks/useVMQueries.ts
@@ -8,10 +8,7 @@ import { getUtilizationQueries } from '@kubevirt-utils/components/Charts/utils/q
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
-const useVMQueries = (
-  vm: V1VirtualMachine | V1VirtualMachineInstance,
-  launcherPodName?: string,
-) => {
+const useVMQueries = (vm: V1VirtualMachine | V1VirtualMachineInstance) => {
   const { duration } = useDuration();
 
   const [hubClusterName] = useHubClusterName();
@@ -21,10 +18,9 @@ const useVMQueries = (
       getUtilizationQueries({
         duration,
         hubClusterName,
-        launcherPodName,
         obj: vm,
       }),
-    [duration, hubClusterName, launcherPodName, vm],
+    [duration, hubClusterName, vm],
   );
 };
 

--- a/src/utils/resources/vm/utils/utils.ts
+++ b/src/utils/resources/vm/utils/utils.ts
@@ -1,3 +1,4 @@
+import { V1CPU } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getVMListNamespacesURL, getVMListURL } from '@multicluster/urls';
 import { getRowFilterQueryKey } from '@search/utils/query';
@@ -19,3 +20,6 @@ export const getVMListPathWithRowFilters = (
   rowFilters: Record<string, string>,
   cluster?: string,
 ) => getVMListPath(namespace, getRowFiltersString(rowFilters), cluster);
+
+export const getVCPUCount = (cpu: V1CPU) =>
+  (cpu?.sockets || 1) * (cpu?.cores || 1) * (cpu?.threads || 1);

--- a/src/views/clusteroverview/OverviewTab/metric-charts-card/utils/metricQueries.ts
+++ b/src/views/clusteroverview/OverviewTab/metric-charts-card/utils/metricQueries.ts
@@ -4,7 +4,7 @@ import { METRICS } from './constants';
 
 const metricQueriesForNamespace = {
   [METRICS.MEMORY]: (namespace) =>
-    `sum by (namespace)(kubevirt_vmi_memory_available_bytes{namespace="${namespace}"} - kubevirt_vmi_memory_usable_bytes{namespace="${namespace}"})`,
+    `sum by (namespace)(kubevirt_vmi_memory_used_bytes{namespace="${namespace}"})`,
   [METRICS.STORAGE]: (namespace) =>
     `sum by (namespace)(max(kubevirt_vmi_filesystem_used_bytes{namespace="${namespace}"}) by (namespace, name, disk_name))`,
   [METRICS.VCPU_USAGE]: (namespace) =>
@@ -14,8 +14,7 @@ const metricQueriesForNamespace = {
 };
 
 const metricQueriesForAllNamespaces = {
-  [METRICS.MEMORY]: () =>
-    `sum(kubevirt_vmi_memory_available_bytes - kubevirt_vmi_memory_usable_bytes)`,
+  [METRICS.MEMORY]: () => `sum(kubevirt_vmi_memory_used_bytes)`,
   [METRICS.STORAGE]: () =>
     `sum(max(kubevirt_vmi_filesystem_used_bytes) by (namespace, name, disk_name))`,
   [METRICS.VCPU_USAGE]: () => `count(kubevirt_vmi_vcpu_wait_seconds_total)`,

--- a/src/views/clusteroverview/TopConsumersTab/utils/queries.ts
+++ b/src/views/clusteroverview/TopConsumersTab/utils/queries.ts
@@ -8,7 +8,7 @@ const topConsumerQueries = {
     [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow) =>
       `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_swap_in_traffic_bytes + kubevirt_vmi_memory_swap_out_traffic_bytes) by (node))) > 0`,
     [Metric.MEMORY.getValue()]: (numItemsToShow) =>
-      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_available_bytes-kubevirt_vmi_memory_usable_bytes) by(node))) > 0`,
+      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_used_bytes) by(node))) > 0`,
     [Metric.STORAGE_IOPS.getValue()]: (numItemsToShow, duration) =>
       `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_iops_read_total[${duration}]) + rate(kubevirt_vmi_storage_iops_write_total[${duration}])) by (node))) > 0`,
     [Metric.STORAGE_READ_LATENCY.getValue()]: (numItemsToShow, duration) =>
@@ -26,7 +26,7 @@ const topConsumerQueries = {
     [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow) =>
       `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_swap_in_traffic_bytes + kubevirt_vmi_memory_swap_out_traffic_bytes) by (namespace))) > 0`,
     [Metric.MEMORY.getValue()]: (numItemsToShow) =>
-      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_available_bytes-kubevirt_vmi_memory_usable_bytes) by (namespace))) > 0`,
+      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_used_bytes) by (namespace))) > 0`,
     [Metric.STORAGE_IOPS.getValue()]: (numItemsToShow, duration) =>
       `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_iops_read_total[${duration}]) + rate(kubevirt_vmi_storage_iops_write_total[${duration}])) by (namespace))) > 0`,
     [Metric.STORAGE_READ_LATENCY.getValue()]: (numItemsToShow, duration) =>
@@ -44,7 +44,7 @@ const topConsumerQueries = {
     [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow, duration) =>
       `sort_desc(topk (${numItemsToShow}, sum(rate(kubevirt_vmi_memory_swap_in_traffic_bytes[${duration}]) + rate(kubevirt_vmi_memory_swap_out_traffic_bytes[${duration}]))by(name, namespace))) > 0`,
     [Metric.MEMORY.getValue()]: (numItemsToShow) =>
-      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_available_bytes-kubevirt_vmi_memory_usable_bytes) by(name, namespace))) > 0`,
+      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_used_bytes) by(name, namespace))) > 0`,
     [Metric.STORAGE_IOPS.getValue()]: (numItemsToShow, duration) =>
       `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_iops_read_total[${duration}]) + rate(kubevirt_vmi_storage_iops_write_total[${duration}])) by (namespace, name))) > 0`,
     [Metric.STORAGE_READ_LATENCY.getValue()]: (numItemsToShow, duration) =>

--- a/src/views/virtualmachines/details/tabs/metrics/UtilizationCharts/UtilizationCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/UtilizationCharts/UtilizationCharts.tsx
@@ -4,15 +4,13 @@ import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import CPUThresholdChart from '@kubevirt-utils/components/Charts/CPUUtil/CPUThresholdChart';
 import MemoryThresholdChart from '@kubevirt-utils/components/Charts/MemoryUtil/MemoryThresholdChart';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { Card, CardBody, CardTitle, Grid, GridItem } from '@patternfly/react-core';
 
 type UtilizationChartsProps = {
-  pods: K8sResourceCommon[];
   vmi: V1VirtualMachineInstance;
 };
 
-const UtilizationCharts: FC<UtilizationChartsProps> = ({ pods, vmi }) => {
+const UtilizationCharts: FC<UtilizationChartsProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
 
   return (
@@ -29,7 +27,7 @@ const UtilizationCharts: FC<UtilizationChartsProps> = ({ pods, vmi }) => {
         <Card>
           <CardTitle>{t('CPU')}</CardTitle>
           <CardBody>
-            <CPUThresholdChart pods={pods} vmi={vmi} />
+            <CPUThresholdChart vmi={vmi} />
           </CardBody>
         </Card>
       </GridItem>

--- a/src/views/virtualmachines/details/tabs/metrics/VirtualMachineMetricsTab.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/VirtualMachineMetricsTab.tsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom-v5-compat';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
+import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { Overview } from '@openshift-console/dynamic-plugin-sdk';
@@ -22,7 +22,7 @@ import './virtual-machine-metrics-tab.scss';
 const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
   const { t } = useKubevirtTranslation();
   const location = useLocation();
-  const { loaded, pods, vmi } = useVMIAndPodsForVM(getName(vm), getNamespace(vm), getCluster(vm));
+  const { vmi, vmiLoaded } = useVMI(getName(vm), getNamespace(vm), getCluster(vm));
 
   const [expended, setExpended] = useState<{ [key in MetricsTabExpendedSections]: boolean }>({
     [MetricsTabExpendedSections.migration]: true,
@@ -35,14 +35,14 @@ const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
     setExpended((currentOpen) => ({ ...currentOpen, [value]: !currentOpen?.[value] }));
 
   useEffect(() => {
-    if (!isEmpty(location?.search) && loaded) {
+    if (!isEmpty(location?.search) && vmiLoaded) {
       const focusedSectionId = Object.values(MetricsTabExpendedSections).find((focusedSection) =>
         location?.search?.includes(focusedSection),
       );
       const focusedExpandableSection = document.getElementById(focusedSectionId);
       focusedExpandableSection.scrollIntoView();
     }
-  }, [location?.search, loaded]);
+  }, [location?.search, vmiLoaded]);
 
   return (
     <div className="virtual-machine-metrics-tab__main">
@@ -57,7 +57,7 @@ const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
           onToggle={onToggle(MetricsTabExpendedSections.utilization)}
           toggleText={t('Utilization')}
         >
-          <UtilizationCharts pods={pods} vmi={vmi} />
+          <UtilizationCharts vmi={vmi} />
         </ExpandableSection>
 
         <ExpandableSection

--- a/src/views/virtualmachines/details/tabs/overview/VirtualMachinesOverviewTab.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/VirtualMachinesOverviewTab.tsx
@@ -49,7 +49,7 @@ const VirtualMachinesOverviewTab: FC<NavPageComponentProps> = ({
               />
             </GridItem>
             <GridItem>
-              <VirtualMachinesOverviewTabUtilization pods={pods} vm={vm} vmi={vmi} />
+              <VirtualMachinesOverviewTabUtilization vm={vm} vmi={vmi} />
             </GridItem>
           </Grid>
         </GridItem>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/VirtualMachinesOverviewTabUtilization.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/VirtualMachinesOverviewTabUtilization.tsx
@@ -4,7 +4,6 @@ import { Trans } from 'react-i18next';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ComponentReady from '@kubevirt-utils/components/Charts/ComponentReady/ComponentReady';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Card,
   CardBody,
@@ -28,13 +27,11 @@ import UtilizationThresholdCharts from './components/UtilizationThresholdCharts'
 import './virtual-machines-overview-tab-utilization.scss';
 
 type VirtualMachinesOverviewTabUtilizationProps = {
-  pods: K8sResourceCommon[];
   vm: V1VirtualMachine;
   vmi: V1VirtualMachineInstance;
 };
 
 const VirtualMachinesOverviewTabUtilization: FC<VirtualMachinesOverviewTabUtilizationProps> = ({
-  pods,
   vm,
   vmi,
 }) => {
@@ -66,7 +63,7 @@ const VirtualMachinesOverviewTabUtilization: FC<VirtualMachinesOverviewTabUtiliz
         <ComponentReady isReady={isRunning(vm)} text={t('VirtualMachine is not running')}>
           <Grid>
             <GridItem span={3}>
-              <CPUUtil pods={pods} vmi={vmi} />
+              <CPUUtil vmi={vmi} />
             </GridItem>
             <GridItem span={3}>
               <MemoryUtil vmi={vmi} />
@@ -77,7 +74,7 @@ const VirtualMachinesOverviewTabUtilization: FC<VirtualMachinesOverviewTabUtiliz
             <GridItem span={3}>
               <NetworkUtil vmi={vmi} />
             </GridItem>
-            <UtilizationThresholdCharts pods={pods} vmi={vmi} />
+            <UtilizationThresholdCharts vmi={vmi} />
           </Grid>
         </ComponentReady>
       </CardBody>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/UtilizationThresholdCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/UtilizationThresholdCharts.tsx
@@ -5,23 +5,21 @@ import CPUThresholdChart from '@kubevirt-utils/components/Charts/CPUUtil/CPUThre
 import MemoryThresholdChart from '@kubevirt-utils/components/Charts/MemoryUtil/MemoryThresholdChart';
 import NetworkThresholdChart from '@kubevirt-utils/components/Charts/NetworkUtil/NetworkThresholdChart';
 import StorageTotalReadWriteThresholdChart from '@kubevirt-utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { GridItem } from '@patternfly/react-core';
 
 import TimeDropdown from './TimeDropdown';
 
 type UtilizationThresholdChartsProps = {
-  pods: K8sResourceCommon[];
   vmi: V1VirtualMachineInstance;
 };
-const UtilizationThresholdCharts: React.FC<UtilizationThresholdChartsProps> = ({ pods, vmi }) => {
+const UtilizationThresholdCharts: React.FC<UtilizationThresholdChartsProps> = ({ vmi }) => {
   return (
     <>
       <GridItem span={12}>
         <TimeDropdown />
       </GridItem>
       <GridItem span={3}>
-        <CPUThresholdChart pods={pods} vmi={vmi} />
+        <CPUThresholdChart vmi={vmi} />
       </GridItem>
       <GridItem span={3}>
         <MemoryThresholdChart vmi={vmi} />

--- a/src/views/virtualmachines/list/components/VirtualMachineListSummary/VirtualMachineListSummary.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineListSummary/VirtualMachineListSummary.tsx
@@ -48,7 +48,7 @@ const VirtualMachineListSummary: FC<VirtualMachineListSummaryProps> = ({
   const { primaryStatuses } = getVMStatuses(vms || []);
 
   const { cpuRequested, cpuUsage, memoryCapacity, memoryUsage, storageCapacity, storageUsage } =
-    useVMTotalsMetrics(vms, vmis);
+    useVMTotalsMetrics(vmis);
 
   const onStatusChange = (status: 'Error' | VM_STATUS) => () =>
     onFilterChange(VirtualMachineRowFilterType.Status, { selected: [status] });

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
@@ -8,10 +8,12 @@ import {
 } from '@kubevirt-ui/kubevirt-api/console';
 import {
   V1VirtualMachine,
+  V1VirtualMachineInstance,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getCPU, getMemory } from '@kubevirt-utils/resources/vm';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import ACMExtentionsTableData from '@multicluster/components/ACMExtentionsTableData';
@@ -43,16 +45,11 @@ const VirtualMachineRowLayout: FC<
       node: ReactNode | string;
       pvcMapper: PVCMapper;
       status: ReactNode;
+      vmi?: V1VirtualMachineInstance;
       vmim: V1VirtualMachineInstanceMigration;
-      vmiMemory?: string;
     }
   >
-> = ({
-  activeColumnIDs,
-  index,
-  obj,
-  rowData: { ips, node, pvcMapper, status, vmim, vmiMemory },
-}) => {
+> = ({ activeColumnIDs, index, obj, rowData: { ips, node, pvcMapper, status, vmi, vmim } }) => {
   // TODO: investigate using the index prop
   index;
   const selected = isVMSelected(obj);
@@ -116,10 +113,10 @@ const VirtualMachineRowLayout: FC<
         {ips}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="memory-usage">
-        <MemoryPercentage vm={obj} vmiMemory={vmiMemory} />
+        <MemoryPercentage vm={obj} vmiMemory={getMemory(vmi)} />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="cpu-usage">
-        <CPUPercentage vm={obj} />
+        <CPUPercentage vm={obj} vmiCPU={getCPU(vmi)} />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="network-usage">
         <NetworkUsage vm={obj} />

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
@@ -8,7 +8,6 @@ import {
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, NodeModel } from '@kubevirt-utils/models';
-import { getMemory } from '@kubevirt-utils/resources/vm';
 import { getVMIIPAddressesWithName } from '@kubevirt-utils/resources/vmi';
 import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -48,8 +47,8 @@ const VirtualMachineRunningRow: FC<
         ),
         pvcMapper,
         status,
+        vmi,
         vmim,
-        vmiMemory: getMemory(vmi),
       }}
       activeColumnIDs={activeColumnIDs}
       index={index}

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/components/CPUPercentage.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/components/CPUPercentage.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1CPU, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -9,10 +9,11 @@ import { isRunning } from '@virtualmachines/utils';
 
 type CPUPercentageProps = {
   vm: V1VirtualMachine;
+  vmiCPU: V1CPU;
 };
 
-const CPUPercentage: FC<CPUPercentageProps> = ({ vm }) => {
-  const cpuUsagePercentage = getCPUUsagePercentage(getName(vm), getNamespace(vm));
+const CPUPercentage: FC<CPUPercentageProps> = ({ vm, vmiCPU }) => {
+  const cpuUsagePercentage = getCPUUsagePercentage(getName(vm), getNamespace(vm), vmiCPU);
 
   if (isEmpty(cpuUsagePercentage) || !isRunning(vm)) return <span>{NO_DATA_DASH}</span>;
 

--- a/src/views/virtualmachines/list/hooks/sortColumns.ts
+++ b/src/views/virtualmachines/list/hooks/sortColumns.ts
@@ -1,6 +1,6 @@
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { getMemory } from '@kubevirt-utils/resources/vm';
+import { getCPU, getMemory } from '@kubevirt-utils/resources/vm';
 import { columnSortingCompare, isEmpty } from '@kubevirt-utils/utils/utils';
 import { SortByDirection } from '@patternfly/react-table';
 import { getDeletionProtectionPrintableStatus } from '@virtualmachines/details/tabs/configuration/details/components/DeletionProtection/utils/utils';
@@ -39,10 +39,14 @@ export const sortByCPUUsage = (
   data: V1VirtualMachine[],
   direction: SortByDirection,
   pagination: { [key: string]: any },
+  vmiMapper: VMIMapper,
 ) => {
   const compareCPUUsage = (a: V1VirtualMachine, b: V1VirtualMachine): number => {
-    const cpuUsageA = getCPUUsagePercentage(getName(a), getNamespace(a));
-    const cpuUsageB = getCPUUsagePercentage(getName(b), getNamespace(b));
+    const aCPU = getCPU(getVMIFromMapper(vmiMapper, a));
+    const bCPU = getCPU(getVMIFromMapper(vmiMapper, b));
+
+    const cpuUsageA = getCPUUsagePercentage(getName(a), getNamespace(a), aCPU);
+    const cpuUsageB = getCPUUsagePercentage(getName(b), getNamespace(b), bCPU);
 
     if (isEmpty(cpuUsageA)) return -1;
     if (isEmpty(cpuUsageB)) return 1;

--- a/src/views/virtualmachines/list/hooks/useVMMetrics.ts
+++ b/src/views/virtualmachines/list/hooks/useVMMetrics.ts
@@ -1,20 +1,15 @@
 import { useEffect, useMemo } from 'react';
 
-import { IoK8sApiCoreV1Pod } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
-import { modelToGroupVersionKind, PodModel } from '@kubevirt-utils/models';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useIsAllClustersPage from '@multicluster/hooks/useIsAllClustersPage';
-import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import useVMListQueries from '@multicluster/hooks/useVMListQueries';
 import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
 import { useFleetPrometheusPoll } from '@stolostron/multicluster-sdk';
 
-import { setVMCPURequested, setVMCPUUsage, setVMMemoryUsage, setVMNetworkUsage } from '../metrics';
+import { setVMCPUUsage, setVMMemoryUsage, setVMNetworkUsage } from '../metrics';
 
 import { VMListQueries } from './constants';
-import { getVMNamesFromPodsNames } from './utils';
 
 const useVMMetrics = () => {
   const namespace = useNamespaceParam();
@@ -22,15 +17,6 @@ const useVMMetrics = () => {
   const allClusters = useIsAllClustersPage();
 
   const currentTime = useMemo<number>(() => Date.now(), []);
-
-  const [pods] = useK8sWatchData<IoK8sApiCoreV1Pod[]>({
-    cluster,
-    groupVersionKind: modelToGroupVersionKind(PodModel),
-    isList: true,
-    namespace,
-  });
-
-  const launcherNameToVMName = useMemo(() => getVMNamesFromPodsNames(pods), [pods]);
 
   const queries = useVMListQueries();
 
@@ -55,11 +41,6 @@ const useVMMetrics = () => {
   const [cpuUsageResponse] = useFleetPrometheusPoll({
     ...prometheusPollProps,
     query: queries?.[VMListQueries.CPU_USAGE],
-  });
-
-  const [cpuRequestedResponse] = useFleetPrometheusPoll({
-    ...prometheusPollProps,
-    query: queries?.[VMListQueries.CPU_REQUESTED],
   });
 
   useEffect(() => {
@@ -91,19 +72,6 @@ const useVMMetrics = () => {
       setVMCPUUsage(vmName, vmNamespace, cpuUsage);
     });
   }, [cpuUsageResponse]);
-
-  useEffect(() => {
-    cpuRequestedResponse?.data?.result?.forEach((result) => {
-      const vmName = launcherNameToVMName?.[`${result?.metric?.namespace}-${result?.metric?.pod}`];
-
-      if (isEmpty(vmName)) return;
-
-      const vmNamespace = result?.metric?.namespace;
-      const cpuRequested = parseFloat(result?.value?.[1]);
-
-      setVMCPURequested(vmName, vmNamespace, cpuRequested);
-    });
-  }, [cpuRequestedResponse, launcherNameToVMName]);
 };
 
 export default useVMMetrics;

--- a/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
+++ b/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
@@ -137,7 +137,7 @@ const useVirtualMachineColumns = (
       {
         additional: true,
         id: 'cpu-usage',
-        sort: (_, direction) => sortingUsingFunction(direction, sortByCPUUsage),
+        sort: (_, direction) => sortingUsingFunctionWithMapper(direction, sortByCPUUsage),
         title: t('CPU'),
         transforms: [sortable],
       },

--- a/src/views/virtualmachines/list/metrics.ts
+++ b/src/views/virtualmachines/list/metrics.ts
@@ -1,12 +1,13 @@
 import xbytes from 'xbytes';
 
+import { V1CPU } from '@kubevirt-ui/kubevirt-api/kubevirt/models/V1CPU';
 import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
+import { getVCPUCount } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { signal } from '@preact/signals-core';
 
 export type MetricsType = {
   [key in string]: {
-    cpuRequested?: number;
     cpuUsage?: number;
     memoryRequested?: number;
     memoryUsage?: number;
@@ -40,18 +41,14 @@ export const setVMCPUUsage = (vmName: string, vmNamespace: string, cpuUsage: num
   vmMetrics.cpuUsage = cpuUsage;
 };
 
-export const setVMCPURequested = (vmName: string, vmNamespace: string, cpuRequested: number) => {
-  const vmMetrics = getVMMetrics(vmName, vmNamespace);
-  vmMetrics.cpuRequested = cpuRequested;
-};
+export const getCPUUsagePercentage = (vmName: string, vmNamespace: string, vmiCPU: V1CPU) => {
+  const { cpuUsage } = getVMMetrics(vmName, vmNamespace);
 
-export const getCPUUsagePercentage = (vmName: string, vmNamespace: string) => {
-  const { cpuRequested, cpuUsage } = getVMMetrics(vmName, vmNamespace);
+  if (isEmpty(cpuUsage)) return;
 
-  if (isEmpty(cpuRequested) || isEmpty(cpuUsage)) return;
+  const cpuRequested = getVCPUCount(vmiCPU);
 
-  const percentage = (cpuUsage * 100) / cpuRequested;
-  return percentage;
+  return (cpuUsage * 100) / cpuRequested;
 };
 
 export const getMemoryUsagePercentage = (

--- a/src/views/virtualmachines/list/utils/processVMTotalsMetrics.ts
+++ b/src/views/virtualmachines/list/utils/processVMTotalsMetrics.ts
@@ -2,7 +2,7 @@ import xbytes from 'xbytes';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
-import { getMemory } from '@kubevirt-utils/resources/vm';
+import { getCPU, getMemory, getVCPUCount } from '@kubevirt-utils/resources/vm';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { humanizeCpuCores } from '@kubevirt-utils/utils/humanize.js';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
@@ -45,4 +45,10 @@ export const getMemoryCapacityText = (vmis: V1VirtualMachineInstance[]) => {
 export const getMetricText = (response: PrometheusResponse, metric: string) => {
   const bytes = getRawNumber(response);
   return getValueWithUnitText(bytes, metric);
+};
+
+export const getCpuRequestedText = (vmis: V1VirtualMachineInstance[]) => {
+  const totalCPU = vmis.map((vmi) => getCPU(vmi)).reduce((acc, cpu) => acc + getVCPUCount(cpu), 0);
+
+  return humanizeCpuCores(totalCPU).string;
 };

--- a/src/views/virtualmachines/list/utils/totalsQueries.ts
+++ b/src/views/virtualmachines/list/utils/totalsQueries.ts
@@ -16,12 +16,7 @@ const getSumBy = (isAllNamespaces: boolean, cluster?: string, allClusters = fals
   return 'sum by (namespace)';
 };
 
-export const getVMTotalsQueries = (
-  namespace: string,
-  namespacesList: string[],
-  cluster?: string,
-  allClusters = false,
-) => {
+export const getVMTotalsQueries = (namespace: string, cluster?: string, allClusters = false) => {
   const isAllNamespaces = isEmpty(namespace);
 
   const clusterFilter = cluster ? `cluster='${cluster}'` : '';
@@ -30,17 +25,12 @@ export const getVMTotalsQueries = (
     ? `{${clusterFilter}}`
     : `{namespace='${namespace}',${clusterFilter}}`;
 
-  const filterCpuRequestedByNamespace = isAllNamespaces
-    ? `namespace=~'${namespacesList.join('|')}',${clusterFilter}`
-    : `namespace='${namespace}',${clusterFilter}`;
-
   const duration = cluster || allClusters ? '15m' : '30s';
   const sumBy = getSumBy(isAllNamespaces, cluster, allClusters);
 
   return {
-    [VMTotalsQueries.TOTAL_CPU_REQUESTED]: `${sumBy}(kube_pod_resource_request{resource='cpu',${filterCpuRequestedByNamespace}})`,
     [VMTotalsQueries.TOTAL_CPU_USAGE]: `${sumBy}(rate(kubevirt_vmi_cpu_usage_seconds_total${filterByNamespace}[${duration}]))`,
-    [VMTotalsQueries.TOTAL_MEMORY_USAGE]: `${sumBy}(kubevirt_vmi_memory_available_bytes${filterByNamespace} - kubevirt_vmi_memory_usable_bytes${filterByNamespace})`,
+    [VMTotalsQueries.TOTAL_MEMORY_USAGE]: `${sumBy}(kubevirt_vmi_memory_used_bytes${filterByNamespace})`,
     [VMTotalsQueries.TOTAL_STORAGE_CAPACITY]: `${sumBy}(max(kubevirt_vmi_filesystem_capacity_bytes${filterByNamespace}) by (namespace, name, disk_name, cluster))`,
     [VMTotalsQueries.TOTAL_STORAGE_USAGE]: `${sumBy}(max(kubevirt_vmi_filesystem_used_bytes${filterByNamespace}) by (namespace, name, disk_name, cluster))`,
   };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

For CPU requested metric we don't have to fetch it form prometheus using `kube_pod_resource_request` 
We need to take it from the VMI. `kube_pod_resource_request` is not directly related to the VMI CPU requested, but it's scaled using HCO configuration. 

For memory we ofter use `kubevirt_vmi_memory_available_bytes - kubevirt_vmi_memory_usable_bytes` but the right metric is `kubevirt_vmi_memory_used_bytes` 


<img width="1920" height="935" alt="Screenshot 2025-09-04 at 10 05 52" src="https://github.com/user-attachments/assets/e0e6785d-9a29-4f19-b802-28d64f76f0fc" />
