### PR TITLE
CNV-68596: Use l2bridge type for UDN-based Pod Network

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
@@ -16,6 +16,7 @@ import SelectTypeahead, {
 } from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
 import { getNetworks, POD_NETWORK } from '@kubevirt-utils/resources/vm';
 import { interfaceTypesProxy } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -55,6 +56,10 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
   const { t } = useKubevirtTranslation();
   const vmiNamespace = vm?.metadata?.namespace || namespace;
   const { loaded, loadError, nads } = useNADsData(vmiNamespace, getCluster(vm));
+  const [isNamespaceManagedByUDN] = useNamespaceUDN(vmiNamespace);
+  const podNetworkType = isNamespaceManagedByUDN
+    ? interfaceTypesProxy.l2bridge
+    : interfaceTypesProxy.masquerade;
   const [selectedFirstOnLoad, setSelectedFirstOnLoad] = useState(false);
   const [createdNetworkOptions, setCreatedNetworkOptions] = useState<
     NetworkSelectTypeaheadOptionProps[]
@@ -111,12 +116,12 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
         optionProps: {
           children: (
             <>
-              {podNetworkingText} <Label isCompact>{interfaceTypesProxy.masquerade} Binding</Label>
+              {podNetworkingText} <Label isCompact>{podNetworkType} Binding</Label>
             </>
           ),
           key: POD_NETWORK,
         },
-        type: interfaceTypesProxy.masquerade,
+        type: podNetworkType,
         value: POD_NETWORK,
       });
     }
@@ -133,6 +138,7 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
     podNetworkingText,
     vmiNamespace,
     createdNetworkOptions,
+    podNetworkType,
   ]);
 
   const validated =
@@ -143,11 +149,11 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
       setNetworkName(value);
       setInterfaceType(
         value === POD_NETWORK
-          ? interfaceTypesProxy.masquerade
+          ? podNetworkType
           : networkOptions.find((netOption) => value === netOption?.value)?.type,
       );
     },
-    [setNetworkName, setInterfaceType, networkOptions],
+    [setNetworkName, setInterfaceType, networkOptions, podNetworkType],
   );
 
   // This useEffect is to handle the submit button and init value


### PR DESCRIPTION
## 📝 Description

Use the same approach as in the Create VM wizard - detect that namespace is UDN-enabled.

## 🎥 Demo

### Before
https://github.com/user-attachments/assets/d41e1eb2-2d48-4e93-a499-79f83543dbaa

### After
https://github.com/user-attachments/assets/550fafd3-ec70-4ac8-9d7c-e47a0ada6067

