### PR TITLE
CNV-68440: fix detach of added CD-ROM breaking the app

### DIFF
--- a/src/utils/components/DiskModal/components/DiskSourceSelect/DiskSourceSelect.tsx
+++ b/src/utils/components/DiskModal/components/DiskSourceSelect/DiskSourceSelect.tsx
@@ -28,7 +28,7 @@ const DiskSourceSelect: FC<DiskSourceSelectProps> = ({ className, onSelect }) =>
     >
       <SelectList>
         <DiskSourceOption {...blankOption} onSelect={onSelect} />
-        <Divider />
+        <Divider component="li" />
         <SelectGroup
           className="disk-source-select__group-title"
           label={attachExistingGroupOptions.groupLabel}
@@ -37,7 +37,7 @@ const DiskSourceSelect: FC<DiskSourceSelectProps> = ({ className, onSelect }) =>
             <DiskSourceOption key={item.id} {...item} onSelect={onSelect} />
           ))}
         </SelectGroup>
-        <Divider />
+        <Divider component="li" />
         <DiskSourceOption {...cdromOption} onSelect={onSelect} />
       </SelectList>
     </FormPFSelect>

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useVolumeOwnedResource.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useVolumeOwnedResource.tsx
@@ -31,7 +31,7 @@ const useVolumeOwnedResource: UseVolumeOwnedResource = (vm, volume) => {
     namespaced: false,
   });
 
-  const updatedVolume = volume.dataVolume ? convertDataVolumeToPVC(volume, cdiConfig) : volume;
+  const updatedVolume = volume?.dataVolume ? convertDataVolumeToPVC(volume, cdiConfig) : volume;
   const volumeType = getVolumeType(updatedVolume);
   const volumeResourceModel = mapVolumeTypeToK8sModel[volumeType];
   const volumeGroupVersionKind =

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/utils/utils.ts
@@ -15,6 +15,7 @@ export const convertDataVolumeToPVC = (volume: V1Volume, cdiConfig: V1beta1CDICo
 };
 
 export const getVolumeType = (volume: V1Volume): string => {
+  if (!volume) return null;
   const volumeType = Object.keys(volume)?.find((key: VolumeTypes) =>
     Object.values(VolumeTypes).includes(key),
   );

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
@@ -64,13 +64,8 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
   const isCDROM = vmDisk ? isCDROMDisk(vmDisk) : false;
 
   const { isCDROMMountedState, volume } = useMemo(() => {
-    const vols = isVMRunning ? vmi?.spec?.volumes : getVolumes(vm);
+    const vols = isVMRunning && !isCDROM ? vmi?.spec?.volumes : getVolumes(vm);
     const vol = vols?.find(({ name }) => name === diskName);
-
-    const vmVols = getVolumes(vm);
-    const vmVol = vmVols?.find(({ name }) => name === diskName);
-
-    const effective = isCDROM ? vmVol : vol;
 
     const isMountedVolume = (targetVolume: undefined | V1Volume): boolean => {
       if (!targetVolume) return false;
@@ -80,7 +75,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
       return hasDataVolume(targetVolume) || hasPersistentVolumeClaim(targetVolume);
     };
 
-    const mounted = isMountedVolume(effective);
+    const mounted = isMountedVolume(vol);
 
     return {
       isCDROMMountedState: mounted,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes detach of added CD-ROM to a running VM causing breaking the app
  - `DiskRowActions.tsx` -> line 66 -> `volume` variable was incorrectly initialized with undefined in case of `isCDROM`
- make the code more safe in case `volume` would ever be undefined again
- styling update in DiskSourceSelect

**TODO in a followup:**
- hide the "Restart required" alert upon detaching the cd-rom (seems non-trivial and may require backend support)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/6a52ac6c-f4b7-4dce-9048-17449e4398ee



After:


https://github.com/user-attachments/assets/06b093ca-68dc-4612-8714-fd5e0602a037


