### PR TITLE
CNV-68513: fix customize vm validation using multicluster ks8Create

### DIFF
--- a/src/views/catalog/utils/WizardVMContext/useValidatedVm.ts
+++ b/src/views/catalog/utils/WizardVMContext/useValidatedVm.ts
@@ -5,7 +5,8 @@ import { useImmer } from 'use-immer';
 
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import { kubevirtK8sCreate } from '@multicluster/k8sRequests';
 
 export type UpdateValidatedVM = (
   updateVM: ((vmDraft: WritableDraft<V1VirtualMachine>) => void) | V1VirtualMachine,
@@ -30,7 +31,8 @@ export const useValidatedVM = (initialVM: V1VirtualMachine): UseValidatedVMValue
     setError(undefined);
 
     // validate the updated vm with the backend (dry run)
-    return k8sCreate<V1VirtualMachine>({
+    return kubevirtK8sCreate<V1VirtualMachine>({
+      cluster: getCluster(vm),
       data: typeof updatedVM === 'function' ? produce(vm, updatedVM) : updatedVM,
       model: VirtualMachineModel,
       queryParams: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

for customize validation we were using k8sCreate instead of `kubevirtK8sCreate` that has multicluster capabilities
