### PR TITLE
CNV-68329: Enable focus after pasting values to console

### DIFF
--- a/src/utils/components/Consoles/components/AccessConsoles/AccessConsoles.tsx
+++ b/src/utils/components/Consoles/components/AccessConsoles/AccessConsoles.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-import React, { FC, useState } from 'react';
+import React, { FC, MouseEvent, useState } from 'react';
 
 import DropdownToggle from '@kubevirt-utils/components/toggles/DropdownToggle';
 import SelectToggle from '@kubevirt-utils/components/toggles/SelectToggle';
@@ -59,8 +59,11 @@ export const AccessConsoles: FC<AccessConsolesProps> = ({
             <PasteIcon /> {t('Paste to console')}
           </>
         }
+        onClick={(e: MouseEvent<HTMLButtonElement>) => {
+          actions.sendPaste(true);
+          e.currentTarget.blur();
+        }}
         className="vnc-paste-button"
-        onClick={actions.sendPaste}
         variant={ButtonVariant.link}
       />
       <Select

--- a/src/utils/components/Consoles/components/AccessConsoles/AccessConsoles.tsx
+++ b/src/utils/components/Consoles/components/AccessConsoles/AccessConsoles.tsx
@@ -11,10 +11,9 @@ import {
   DropdownItem,
   DropdownList,
   Select,
+  SelectList,
   SelectOption,
 } from '@patternfly/react-core';
-import { SelectList } from '@patternfly/react-core';
-import {} from '@patternfly/react-core';
 import { PasteIcon } from '@patternfly/react-icons';
 
 import { ConsoleState, isConsoleType, VNC_CONSOLE_TYPE } from '../utils/ConsoleConsts';

--- a/src/utils/components/Consoles/components/AccessConsoles/utils/accessConsoles.tsx
+++ b/src/utils/components/Consoles/components/AccessConsoles/utils/accessConsoles.tsx
@@ -15,7 +15,7 @@ export type AccessConsolesActions = {
   sendCtrlAlt1?: () => void;
   sendCtrlAlt2?: () => void;
   sendCtrlAltDel?: () => void;
-  sendPaste?: () => void;
+  sendPaste?: (consoleFocus?: boolean) => void;
 };
 
 export type AccessConsolesProps = {

--- a/src/utils/components/Consoles/components/vnc-console/actions.ts
+++ b/src/utils/components/Consoles/components/vnc-console/actions.ts
@@ -35,7 +35,7 @@ export function sendCtrlAlt2() {
   this.sendKey(KeyTable.XK_Control_L, 'ControlLeft', false);
 }
 
-export async function sendPasteCMD() {
+export async function sendPasteCMD(focusOnConsole?: boolean) {
   if (this._rfbConnectionState !== 'connected' || this._viewOnly) {
     return;
   }
@@ -61,6 +61,9 @@ export async function sendPasteCMD() {
       // Latin-1 set that maps directly to keysym
       this.sendKey(codePointIndex);
       shiftRequired && this.sendKey(KeyTable.XK_Shift_L, 'ShiftLeft', false);
+    }
+    if (focusOnConsole) {
+      this.focus();
     }
   }
 }


### PR DESCRIPTION
## 📝 Description

After pasting values to console we automatically focus on the console, improving the user experience. 
Previously before this enhancement the user had to click on the console in order to gain focus and be able to type inside.

## 🎥 Demo


https://github.com/user-attachments/assets/98d7b597-f033-417d-8fc7-6dec5432a1a1


