### PR TITLE
Bump sdk version for storageclass migration name fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@patternfly/react-tokens": "^6.2.2",
     "@patternfly/react-topology": "^6.2.0",
     "@preact/signals-react": "^2.0.1",
-    "@stolostron/multicluster-sdk": "0.6.2",
+    "@stolostron/multicluster-sdk": "0.7.1",
     "@xterm/addon-clipboard": "^0.1.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,10 +1531,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stolostron/multicluster-sdk@0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@stolostron/multicluster-sdk/-/multicluster-sdk-0.6.2.tgz#a8bc4bd734b355528dbb5af612305591cc789d0c"
-  integrity sha512-Idi2Q3sq8SwZ99gY3D5Kebsjvi0sGO6DhjSXM5LRdLohIHCpryMjeSPFGRCcwrWN8fx0iAySaCT3FF9zDeh+9A==
+"@stolostron/multicluster-sdk@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@stolostron/multicluster-sdk/-/multicluster-sdk-0.7.1.tgz#855796e96a8550e4f71dc15c816394db32d39d0e"
+  integrity sha512-A+dFRddjyqQeGEtfr02hZMiA17uaftWOUfJxgOGoeAx1lUQ/gSz2PhgoYC7MeR0xzJ/809/UYI9z3E2036pjpw==
   dependencies:
     "@apollo/client" "3.10.8"
     "@patternfly/react-component-groups" "^6.2.1"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Make sure we use the new sdk that gives vms the new indexes parameters and now we can show the storageclassmigration

## 🎥 Demo


<img width="1276" height="935" alt="Screenshot 2025-09-04 at 15 37 12" src="https://github.com/user-attachments/assets/eded7d76-0296-47a9-a2d1-323b7173233d" />

