### PR TITLE
CNV-67729: support multiple yaml paths for proxy filter

### DIFF
--- a/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPod.ts
+++ b/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPod.ts
@@ -16,18 +16,13 @@ import {
   getResourceVersion,
   registerResourceVersion,
 } from './utils/utils';
-import useKubevirtDataPodFilters from './useKubevirtDataPodFilters';
-
-type UseKubevirtDataPod = <T extends K8sResourceCommon | K8sResourceCommon[]>(
-  watchOptions: WatchK8sResource,
-  filterOptions?: { [key: string]: string },
-) => [T, boolean, Error];
+import useKubevirtDataPodFilters, { KubevirtDataPodFilters } from './useKubevirtDataPodFilters';
 
 const nullResponse: [undefined, boolean, Error] = [undefined, false, null];
 
-const useKubevirtDataPod: UseKubevirtDataPod = <T extends K8sResourceCommon | K8sResourceCommon[]>(
+const useKubevirtDataPod = <T extends K8sResourceCommon | K8sResourceCommon[]>(
   watchOptions: WatchK8sResource,
-  filterOptions?: { [key: string]: string },
+  filterOptions?: KubevirtDataPodFilters,
 ) => {
   const [data, setData] = useState<T>((<unknown>[]) as T);
   const [loaded, setLoaded] = useState<boolean>(false);

--- a/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPodFilters.ts
+++ b/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPodFilters.ts
@@ -1,19 +1,21 @@
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
 import useQuery from '@kubevirt-utils/hooks/useQuery';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import useDeepCompareMemoize from '../useDeepCompareMemoize/useDeepCompareMemoize';
 
-type UseKubevirtDataPodFilters = (filters: { [key: string]: string }) => any;
+import { YAML_PATH_DELIMITER } from './utils/constants';
 
-const updateQueryString = (setQueryString) => (url) =>
+export type KubevirtDataPodFilters = { [key: string]: string | string[] };
+
+const updateQueryString = (setQueryString: Dispatch<SetStateAction<string>>) => (url: string) =>
   setQueryString((prevQuery) => (prevQuery !== url ? url : prevQuery));
 
-const useKubevirtDataPodFilters: UseKubevirtDataPodFilters = (filters) => {
+const useKubevirtDataPodFilters = (filters: KubevirtDataPodFilters) => {
   const [queryString, setQueryString] = useState<string>('');
   const query = useQuery();
-  const filtersCompared = useDeepCompareMemoize(filters);
+  const filtersMemoized = useDeepCompareMemoize(filters);
 
   useEffect(() => {
     const url = new URLSearchParams();
@@ -23,12 +25,19 @@ const useKubevirtDataPodFilters: UseKubevirtDataPodFilters = (filters) => {
       if (key === 'rowFilter-status' && value === 'Error') {
         continue;
       }
-      filtersCompared?.[key] && url.set(filtersCompared?.[key], valueReplaced);
+
+      const yamlPath = filtersMemoized?.[key];
+      if (yamlPath) {
+        url.set(
+          Array.isArray(yamlPath) ? yamlPath.join(YAML_PATH_DELIMITER) : yamlPath,
+          valueReplaced,
+        );
+      }
     }
     const urlString = url.toString();
 
     (!isEmpty(urlString) || !isEmpty(queryString)) && updateQueryString(setQueryString)(urlString);
-  }, [filtersCompared, query, queryString]);
+  }, [filtersMemoized, query, queryString]);
 
   return queryString;
 };

--- a/src/utils/hooks/useKubevirtDataPod/utils/constants.ts
+++ b/src/utils/hooks/useKubevirtDataPod/utils/constants.ts
@@ -1,3 +1,5 @@
 export const PROXY_KUBEVIRT_URL = `/api/proxy/plugin/kubevirt-plugin/kubevirt-apiserver-proxy/`;
 
 export const PROXY_KUBEVIRT_URL_HEALTH_PATH = 'health';
+
+export const YAML_PATH_DELIMITER = '|';

--- a/src/utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource.ts
+++ b/src/utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource.ts
@@ -6,6 +6,7 @@ import { AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
 import { KUBEVIRT_APISERVER_PROXY } from '../useFeatures/constants';
 import { useFeatures } from '../useFeatures/useFeatures';
 import useKubevirtDataPodHealth from '../useKubevirtDataPod/hooks/useKubevirtDataPodHealth';
+import { KubevirtDataPodFilters } from '../useKubevirtDataPod/useKubevirtDataPodFilters';
 import useQuery from '../useQuery';
 
 import useRedirectWatchHooks from './useRedirectWatchHooks';
@@ -18,7 +19,7 @@ export type Result<R extends K8sResourceCommon | K8sResourceCommon[]> = [
 
 const useKubevirtWatchResource = <T extends K8sResourceCommon | K8sResourceCommon[]>(
   watchOptions: WatchK8sResource & { cluster?: string },
-  filterOptions?: { [key: string]: string },
+  filterOptions?: KubevirtDataPodFilters,
   searchQueries?: AdvancedSearchFilter,
 ): Result<T> => {
   const isProxyPodAlive = useKubevirtDataPodHealth();

--- a/src/utils/hooks/useKubevirtWatchResource/useRedirectWatchHooks.ts
+++ b/src/utils/hooks/useKubevirtWatchResource/useRedirectWatchHooks.ts
@@ -7,12 +7,13 @@ import { WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
 import { AdvancedSearchFilter, useFleetSearchPoll } from '@stolostron/multicluster-sdk';
 
 import useKubevirtDataPod from '../useKubevirtDataPod/useKubevirtDataPod';
+import { KubevirtDataPodFilters } from '../useKubevirtDataPod/useKubevirtDataPodFilters';
 
 import { Result } from './useKubevirtWatchResource';
 
 const useRedirectWatchHooks = <T extends K8sResourceCommon | K8sResourceCommon[]>(
   watchOptions: WatchK8sResource & { cluster?: string },
-  filterOptions?: { [key: string]: string },
+  filterOptions?: KubevirtDataPodFilters,
   searchQueries?: AdvancedSearchFilter,
   shouldUseProxyPod?: boolean,
 ): Result<T> => {

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -107,7 +107,10 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
     {
       labels: 'metadata.labels',
       name: 'metadata.name',
-      'rowFilter-os': 'spec.template.metadata.annotations.vm\\.kubevirt\\.io/os',
+      'rowFilter-os': [
+        'spec.template.metadata.annotations.vm\\.kubevirt\\.io/os',
+        'spec.preference.name',
+      ],
       'rowFilter-status': 'status.printableStatus',
     },
     searchQueries?.vmQueries,


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- BLOCKED by https://github.com/kubevirt-ui/kubevirt-apiserver-proxy/pull/35 which has to merge first

- adds support for multiple yaml paths for proxy filter, so sending this: `some.spec|some.other.spec=filterValue` to backend is possible
- fixes Operating system filter
