### PR TITLE
CNV-69002: make sure catalog works with all namespaces selected

### DIFF
--- a/src/multicluster/urls.ts
+++ b/src/multicluster/urls.ts
@@ -1,5 +1,6 @@
 import { ALL_NAMESPACES } from '@kubevirt-utils/hooks/constants';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
+import { isAllNamespaces } from '@kubevirt-utils/utils/utils';
 import { ResourceRouteHandler } from '@stolostron/multicluster-sdk';
 
 import { VirtualMachineModel } from '../views/dashboard-extensions/utils';
@@ -26,8 +27,8 @@ export const getACMVMSearchURL = (): string =>
 export const getACMVMListNamespacesURL = (cluster: string, namespace: string): string =>
   `/k8s/cluster/${cluster}/ns/${namespace}/${KUBEVIRT_VM_PATH}`;
 
-export const getCatalogURL = (cluster?: string, namespace?: string): string => {
-  const namespacePath = namespace ? `ns/${namespace}` : ALL_NAMESPACES;
+export const getCatalogURL = (cluster: string, namespace?: string): string => {
+  const namespacePath = isAllNamespaces(namespace) ? ALL_NAMESPACES : `ns/${namespace}`;
 
   return cluster
     ? `/k8s/cluster/${cluster}/${namespacePath}/catalog`

--- a/src/utils/components/SSHSecretModal/components/SSHKeyUpload/SSHKeyUpload.tsx
+++ b/src/utils/components/SSHSecretModal/components/SSHKeyUpload/SSHKeyUpload.tsx
@@ -2,8 +2,8 @@ import React, { Dispatch, FC, SetStateAction, useState } from 'react';
 
 import { IoK8sApiCoreV1Secret } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
 import { getValidNamespace, validateSSHPublicKey } from '@kubevirt-utils/utils/utils';
 import {
   FileUpload,
@@ -28,7 +28,7 @@ type SSHKeyUploadProps = {
 
 const SSHKeyUpload: FC<SSHKeyUploadProps> = ({ secrets, setSSHDetails, sshDetails }) => {
   const { t } = useKubevirtTranslation();
-  const activeNamespace = useNamespaceParam();
+  const activeNamespace = useActiveNamespace();
   const [nameErrorMessage, setNameErrorMessage] = useState<string>(null);
   const [isValidKey, setIsValidKey] = useState<boolean>(true);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -43,7 +43,7 @@ const SSHKeyUpload: FC<SSHKeyUploadProps> = ({ secrets, setSSHDetails, sshDetail
       ...sshDetails,
       secretOption: SecretSelectionOption.addNew,
       sshPubKey: sshPublicKey?.trim(),
-      sshSecretNamespace: activeNamespace,
+      sshSecretNamespace: vmNamespaceTarget,
     });
   };
 

--- a/src/utils/hooks/useActiveNamespace.ts
+++ b/src/utils/hooks/useActiveNamespace.ts
@@ -1,0 +1,9 @@
+import { ALL_NAMESPACES_SESSION_KEY } from './constants';
+import useNamespaceParam from './useNamespaceParam';
+
+const useActiveNamespace = () => {
+  const namespaceParam = useNamespaceParam();
+  return namespaceParam || ALL_NAMESPACES_SESSION_KEY;
+};
+
+export default useActiveNamespace;

--- a/src/utils/resources/vm/utils/utils.ts
+++ b/src/utils/resources/vm/utils/utils.ts
@@ -1,10 +1,12 @@
 import { V1CPU } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { isAllNamespaces, isEmpty } from '@kubevirt-utils/utils/utils';
 import { getACMVMListURL, getVMListNamespacesURL, getVMListURL } from '@multicluster/urls';
 import { getRowFilterQueryKey } from '@search/utils/query';
 
 export const getVMListPath = (namespace: string, params: string, cluster?: string) => {
-  const vmListURL = namespace ? getVMListNamespacesURL(cluster, namespace) : getVMListURL(cluster);
+  const vmListURL = isAllNamespaces(namespace)
+    ? getVMListURL(cluster)
+    : getVMListNamespacesURL(cluster, namespace);
   return `${vmListURL}?${params}`;
 };
 

--- a/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
@@ -6,9 +6,9 @@ import { CREATE_VM_TAB } from '@catalog/CreateVMHorizontalNav/constants';
 import GuidedTour from '@kubevirt-utils/components/GuidedTour/GuidedTour';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { ALL_NAMESPACES_SESSION_KEY, ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
-import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
 import useUserPreferences from '@kubevirt-utils/hooks/useUserPreferences';
 import useBootableVolumes from '@kubevirt-utils/resources/bootableresources/hooks/useBootableVolumes';
 import { getValidNamespace } from '@kubevirt-utils/utils/utils';
@@ -31,7 +31,7 @@ type CreateFromInstanceTypeProps = { currentTab: CREATE_VM_TAB };
 const CreateFromInstanceType: FC<CreateFromInstanceTypeProps> = ({ currentTab }) => {
   const { t } = useKubevirtTranslation();
   const cluster = useClusterParam();
-  const namespace = useNamespaceParam();
+  const namespace = useActiveNamespace();
   const sectionState = useState<INSTANCE_TYPES_SECTIONS>(INSTANCE_TYPES_SECTIONS.SELECT_VOLUME);
 
   const { resetInstanceTypeVMState, setVMNamespaceTarget, volumeListNamespace } =

--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
@@ -23,9 +23,9 @@ import {
   CUSTOMIZE_VM_BUTTON_CLICKED,
   VIEW_YAML_AND_CLI_CLICKED,
 } from '@kubevirt-utils/extensions/telemetry/utils/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
-import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
 import { createSSHSecret } from '@kubevirt-utils/resources/secret/utils';
 import { getName } from '@kubevirt-utils/resources/shared';
 import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
@@ -50,7 +50,7 @@ const CreateVMFooter: FC = () => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
   const cluster = useClusterParam();
-  const namespace = useNamespaceParam();
+  const namespace = useActiveNamespace();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<any | Error>(null);
   const { createModal } = useModal();

--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/hooks/useGeneratedVM.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/hooks/useGeneratedVM.ts
@@ -6,8 +6,8 @@ import {
   useIsWindowsBootableVolume,
 } from '@catalog/CreateFromInstanceTypes/utils/utils';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
-import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
 import useRHELAutomaticSubscription from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription';
 import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
 import { addWinDriverVolume } from '@kubevirt-utils/resources/vm/utils/disk/drivers';
@@ -23,7 +23,7 @@ const useGeneratedVM = () => {
   const { subscriptionData } = useRHELAutomaticSubscription();
   const { instanceTypeVMState, startVM, vmNamespaceTarget } = useInstanceTypeVMStore();
 
-  const namespace = useNamespaceParam();
+  const namespace = useActiveNamespace();
   const [isUDNManagedNamespace] = useNamespaceUDN(getValidNamespace(namespace));
 
   const generatedVM = useMemo(


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

`useActiveNamespace` have been replaced by `useNamespaceParam` in a previous pr to support the namespace when the catalog page is in a multicluster mode. In the multicluster, we can't use `useActiveNamespace`.  [HERE](https://github.com/kubevirt-ui/kubevirt-plugin/pull/2935)

The multicluster catalog do not follow the console active namespace so active namespace can be different from what the user select.


To have a valid workaround for the future, i created in this pr a hook that returns the namespace if it's selected and  `ALL_NAMESPACES_SESSION_KEY` when the all-namespace is selected. Using the same name so it will be easier to replace in other pages


## 🎥 Demo

**BUG**

https://github.com/user-attachments/assets/2904d561-85c3-41bc-af13-ae6dc623cee6

