### PR TITLE
CNV-68934: close menu on clicking outside in Catalog cards

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/components/RedHatProvidedInstanceTypesSection/components/RedHatSeriesMenuCard/RedHatSeriesMenuCard.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/components/RedHatProvidedInstanceTypesSection/components/RedHatSeriesMenuCard/RedHatSeriesMenuCard.tsx
@@ -10,6 +10,7 @@ import {
   seriesHasHugepagesVariant,
 } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/utils';
 import HugepagesCheckbox from '@kubevirt-utils/components/HugepagesCheckbox/HugepagesCheckbox';
+import { useClickOutside } from '@kubevirt-utils/hooks/useClickOutside/useClickOutside';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import {
@@ -37,7 +38,6 @@ type RedHatSeriesMenuCardProps = {
 
 const RedHatSeriesMenuCard: FC<RedHatSeriesMenuCardProps> = ({
   activeMenu,
-  menuRef,
   onMenuSelect,
   onMenuToggle,
   rhSeriesItem,
@@ -46,6 +46,7 @@ const RedHatSeriesMenuCard: FC<RedHatSeriesMenuCardProps> = ({
 
   const cardRef = useRef<HTMLDivElement>(null);
   const toggleRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const {
     instanceTypeVMState: { selectedInstanceType },
   } = useInstanceTypeVMStore();
@@ -63,6 +64,14 @@ const RedHatSeriesMenuCard: FC<RedHatSeriesMenuCardProps> = ({
       selectedInstanceType?.name?.startsWith(seriesName),
     [selectedInstanceType, seriesName],
   );
+
+  const handleMenuClose = () => {
+    if (isMenuExpanded) {
+      onMenuToggle(undefined, seriesName);
+    }
+  };
+
+  useClickOutside([menuRef], handleMenuClose);
 
   const selectedITLabel = useMemo(() => {
     const itSize = sizes?.find(

--- a/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/hooks/useInstanceTypeCardMenuSection.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/hooks/useInstanceTypeCardMenuSection.ts
@@ -1,16 +1,14 @@
-import { MouseEvent, useRef, useState } from 'react';
+import { MouseEvent, useState } from 'react';
 
 import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore';
 import { instanceTypeActionType } from '@catalog/CreateFromInstanceTypes/state/utils/types';
 import { logITFlowEvent } from '@kubevirt-utils/extensions/telemetry/telemetry';
 import { INSTANCETYPE_SELECTED } from '@kubevirt-utils/extensions/telemetry/utils/constants';
-import { useClickOutside } from '@kubevirt-utils/hooks/useClickOutside/useClickOutside';
 
 import { UseInstanceTypeCardMenuSectionValues } from '../utils/types';
 
 const useInstanceTypeCardMenuSection = (): UseInstanceTypeCardMenuSectionValues => {
   const [activeMenu, setActiveMenu] = useState<string>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
 
   const { setInstanceTypeVMState } = useInstanceTypeVMStore();
 
@@ -32,8 +30,7 @@ const useInstanceTypeCardMenuSection = (): UseInstanceTypeCardMenuSectionValues 
     });
   };
 
-  useClickOutside([menuRef], onMenuToggle);
-  return { activeMenu, menuRef, onMenuSelect, onMenuToggle };
+  return { activeMenu, onMenuSelect, onMenuToggle };
 };
 
 export default useInstanceTypeCardMenuSection;

--- a/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/utils/types.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/utils/types.ts
@@ -1,5 +1,3 @@
-import { MutableRefObject } from 'react';
-
 import { InstanceTypeSize } from '@kubevirt-utils/resources/instancetype/types';
 
 export enum InstanceTypeCategory {
@@ -29,7 +27,6 @@ export type CategoryDetailsMap = { [key in InstanceTypeCategory]: CategoryDetail
 
 export type UseInstanceTypeCardMenuSectionValues = {
   activeMenu: string;
-  menuRef: MutableRefObject<HTMLDivElement>;
   onMenuSelect: (itName: string) => void;
   onMenuToggle: (event?: React.MouseEvent, menuID?: string) => void;
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes a bug where menus in Catalog -> Select InstanceType cards were not closing on clicking outside (when you clicked one menu toggle, then another one, then outside, the other toggle didn't close)
- issue was with `menuRef` being shared between multiple menus and then `menuRef.current` became `null` when we opened second menu

## 🎥 Demo
Before:

https://github.com/user-attachments/assets/fdf6a9e0-8696-446d-acf0-d0c7e2ea744d

After:


https://github.com/user-attachments/assets/6d699e6f-1b18-4264-91f2-f9078b518dbc


