### PR TITLE
CNV-67097: Fix bootable volume creation from a registry with credentials

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/RegistrySource.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/RegistrySource.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, FC } from 'react';
 
 import ContainerSource from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/Sources/ContainerSource';
+import { formatRegistryURL } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
 import { AddBootableVolumeState, SetBootableVolumeFieldType } from '../../../utils/constants';
@@ -15,7 +16,7 @@ const RegistrySource: FC<RegistrySourceProps> = ({ bootableVolume, setBootableVo
   const { registryCredentials = { password: '', username: '' }, registryURL = '' } = bootableVolume;
 
   const handleInputValueChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setBootableVolumeField('registryURL')(e.target.value);
+    setBootableVolumeField('registryURL')(formatRegistryURL(e.target.value));
   };
 
   const handleCredentialsChange = (updatedCreds: { password: string; username: string }) => {


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug that occurs when a bootable volume is created from a registry with username and password via the "Add bootable volume" modal that is accessed by clicking the "Add Volume" button on the "Bootable volumes" list page. The import of some volume types fails with a "Secret not found" error.

This occurs because the Secret is needed in both the `openshift-cnv` namespace and the target namespace in which the bootable volume is being created if there is no ImageStream for the container type. When there is no ImageStream a pod is created in the `openshift-cnv` namespace to determine the digest of the container and that pod requires access to the Secret.

This PR creates the Secret in both namespaces to ensure images are able to import successfully. It also strips `http://` and `https://` from the beginning of registry URLs to prevent errors.

Jira: https://issues.redhat.com/browse/CNV-67097
