### PR TITLE
CNV-69349: make disk modal multicluster

### DIFF
--- a/src/utils/components/ApplyStorageProfileSettings/ApplyStorageProfileSettings.tsx
+++ b/src/utils/components/ApplyStorageProfileSettings/ApplyStorageProfileSettings.tsx
@@ -19,6 +19,7 @@ type ApplyStorageProfileSettingsProps = {
   setAccessMode: (accessMode?: V1beta1StorageSpecAccessModesEnum) => void;
   setVolumeMode: (volumeMode?: V1beta1StorageSpecVolumeModeEnum) => void;
   storageClassName: string;
+  vmCluster?: string;
   volumeMode: V1beta1StorageSpecVolumeModeEnum;
 };
 
@@ -27,10 +28,14 @@ const ApplyStorageProfileSettings: FC<ApplyStorageProfileSettingsProps> = ({
   setAccessMode,
   setVolumeMode,
   storageClassName,
+  vmCluster,
   volumeMode,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { claimPropertySets, error, loaded } = useStorageProfileClaimPropertySets(storageClassName);
+  const { claimPropertySets, error, loaded } = useStorageProfileClaimPropertySets(
+    storageClassName,
+    vmCluster,
+  );
   const storageRef = useRef<string>(undefined);
 
   useEffect(() => {

--- a/src/utils/components/DiskModal/PVCDiskModal.tsx
+++ b/src/utils/components/DiskModal/PVCDiskModal.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
+import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Form } from '@patternfly/react-core';
 import { isRunning } from '@virtualmachines/utils';
@@ -62,7 +63,7 @@ const PVCDiskModal: FC<V1SubDiskModalProps> = ({
         <Form>
           <BootSourceCheckbox editDiskName={editDiskName} isDisabled={isVMRunning} vm={vm} />
           <DiskNameInput />
-          <DiskSourcePVCSelect vmNamepace={vm?.metadata?.namespace} />
+          <DiskSourcePVCSelect vmNamepace={getNamespace(vm)} />
           {isCreated && <ExpandPVC pvc={pvc} />}
           <DiskTypeSelect isVMRunning={isVMRunning} />
           <DiskInterfaceSelect isVMRunning={isVMRunning} />

--- a/src/utils/components/DiskModal/UploadDiskModal.tsx
+++ b/src/utils/components/DiskModal/UploadDiskModal.tsx
@@ -5,6 +5,7 @@ import { useCDIUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
 import { UPLOAD_STATUS } from '@kubevirt-utils/hooks/useCDIUpload/utils';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
+import { getCluster } from '@multicluster/helpers/selectors';
 import { Form } from '@patternfly/react-core';
 import { isRunning } from '@virtualmachines/utils';
 
@@ -31,7 +32,7 @@ const UploadDiskModal: FC<V1SubDiskModalProps> = ({
   onUploadedDataVolume,
   vm,
 }) => {
-  const { upload, uploadData } = useCDIUpload();
+  const { upload, uploadData } = useCDIUpload(getCluster(vm));
   const isVMRunning = isRunning(vm);
   const vmNamespace = getNamespace(vm);
 

--- a/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceClonePVCSelect/DiskSourceClonePVCSelectName.tsx
+++ b/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceClonePVCSelect/DiskSourceClonePVCSelectName.tsx
@@ -21,6 +21,7 @@ import {
   DATAVOLUME_PVC_NAME,
   DATAVOLUME_PVC_NAMESPACE,
   DISK_SIZE_FIELD,
+  VM_CLUSTER_FIELD,
 } from '../../../utils/constants';
 import { getErrorPVCName } from '../../../utils/selectors';
 import { diskSourcePVCNameFieldID } from '../../utils/constants';
@@ -34,9 +35,10 @@ const DiskSourceClonePVCSelectName: FC = () => {
     watch,
   } = useFormContext<V1DiskFormState>();
 
+  const vmCluster = watch(VM_CLUSTER_FIELD);
   const namespace = watch(DATAVOLUME_PVC_NAMESPACE);
 
-  const [pvcs, pvcsLoaded] = usePVCs(namespace);
+  const [pvcs, pvcsLoaded] = usePVCs(namespace, vmCluster);
 
   const pvcNames = useMemo(() => pvcs?.map(getName), [pvcs]);
 

--- a/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceClonePVCSelect/DiskSourceClonePVCSelectNamespace.tsx
+++ b/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceClonePVCSelect/DiskSourceClonePVCSelectNamespace.tsx
@@ -10,7 +10,11 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import useProjects from '@kubevirt-utils/hooks/useProjects';
 import { FormGroup, ValidatedOptions } from '@patternfly/react-core';
 
-import { DATAVOLUME_PVC_NAME, DATAVOLUME_PVC_NAMESPACE } from '../../../utils/constants';
+import {
+  DATAVOLUME_PVC_NAME,
+  DATAVOLUME_PVC_NAMESPACE,
+  VM_CLUSTER_FIELD,
+} from '../../../utils/constants';
 import { diskSourcePVCNamespaceFieldID } from '../../utils/constants';
 
 const DiskSourcePVCSelectNamespace: FC = () => {
@@ -19,8 +23,11 @@ const DiskSourcePVCSelectNamespace: FC = () => {
     control,
     formState: { errors },
     setValue,
+    watch,
   } = useFormContext<V1DiskFormState>();
-  const [projectNames, projectsLoaded] = useProjects();
+
+  const vmCluster = watch(VM_CLUSTER_FIELD);
+  const [projectNames, projectsLoaded] = useProjects(vmCluster);
 
   if (!projectsLoaded) return <Loading />;
 

--- a/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourcePVCSelect/DiskSourcePVCSelectName.tsx
+++ b/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourcePVCSelect/DiskSourcePVCSelectName.tsx
@@ -15,7 +15,7 @@ import { getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { FormGroup, ValidatedOptions } from '@patternfly/react-core';
 
-import { PVC_CLAIMNAME_FIELD } from '../../../utils/constants';
+import { PVC_CLAIMNAME_FIELD, VM_CLUSTER_FIELD } from '../../../utils/constants';
 import { diskSourcePVCNameFieldID } from '../../utils/constants';
 
 type DiskSourcePVCSelectNameProps = {
@@ -27,9 +27,12 @@ const DiskSourcePVCSelectName: FC<DiskSourcePVCSelectNameProps> = ({ vmNamespace
   const {
     control,
     formState: { errors },
+    watch,
   } = useFormContext<V1DiskFormState>();
 
-  const [pvcs, pvcsLoaded] = usePVCs(vmNamespace);
+  const vmCluster = watch(VM_CLUSTER_FIELD);
+
+  const [pvcs, pvcsLoaded] = usePVCs(vmNamespace, vmCluster);
 
   const pvcNames = useMemo(() => pvcs?.map(getName), [pvcs]);
 

--- a/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceSnapshotVolumeSelect/DiskSourceSnapshotVolumeSelectName.tsx
+++ b/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceSnapshotVolumeSelect/DiskSourceSnapshotVolumeSelectName.tsx
@@ -17,6 +17,7 @@ import {
   DATAVOLUME_SNAPSHOT_NAME,
   DATAVOLUME_SNAPSHOT_NAMESPACE,
   DISK_SIZE_FIELD,
+  VM_CLUSTER_FIELD,
 } from '../../../utils/constants';
 import { getErrorSnapshotName } from '../../../utils/selectors';
 import { diskSourceSnapshotVolumeNameFieldID } from '../../utils/constants';
@@ -30,9 +31,10 @@ const DiskSourceSnapshotVolumeSelectName: FC = () => {
     watch,
   } = useFormContext<V1DiskFormState>();
 
+  const vmCluster = watch(VM_CLUSTER_FIELD);
   const namespace = watch(DATAVOLUME_SNAPSHOT_NAMESPACE);
 
-  const { snapshots, snapshotsLoaded } = useSnapshots(namespace);
+  const { snapshots, snapshotsLoaded } = useSnapshots(namespace, vmCluster);
 
   const snapshotNames = useMemo(() => snapshots?.map(getName), [snapshots]);
 

--- a/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceSnapshotVolumeSelect/DiskSourceSnapshotVolumeSelectNamespace.tsx
+++ b/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceSnapshotVolumeSelect/DiskSourceSnapshotVolumeSelectNamespace.tsx
@@ -10,7 +10,11 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import useProjects from '@kubevirt-utils/hooks/useProjects';
 import { FormGroup, ValidatedOptions } from '@patternfly/react-core';
 
-import { DATAVOLUME_SNAPSHOT_NAME, DATAVOLUME_SNAPSHOT_NAMESPACE } from '../../../utils/constants';
+import {
+  DATAVOLUME_SNAPSHOT_NAME,
+  DATAVOLUME_SNAPSHOT_NAMESPACE,
+  VM_CLUSTER_FIELD,
+} from '../../../utils/constants';
 import { getErrorSnapshotNamespace } from '../../../utils/selectors';
 import { diskSourceSnapshotVolumeNamespaceFieldID } from '../../utils/constants';
 
@@ -20,8 +24,11 @@ const DiskSourceSnapshotVolumeSelectNamespace: FC = () => {
     control,
     formState: { errors },
     setValue,
+    watch,
   } = useFormContext<V1DiskFormState>();
-  const [projectNames, projectsLoaded] = useProjects();
+
+  const vmCluster = watch(VM_CLUSTER_FIELD);
+  const [projectNames, projectsLoaded] = useProjects(vmCluster);
 
   if (!projectsLoaded) return <Loading />;
 

--- a/src/utils/components/DiskModal/components/StorageClassAndPreallocation/StorageClassSelect.tsx
+++ b/src/utils/components/DiskModal/components/StorageClassAndPreallocation/StorageClassSelect.tsx
@@ -16,6 +16,7 @@ import {
   STORAGE_CLASS_PROVIDER_FIELD,
   STORAGE_SOURCE_BLANK,
   STORAGECLASS_SELECT_FIELDID,
+  VM_CLUSTER_FIELD,
 } from '../utils/constants';
 
 import { getSCSelectOptions } from './utils/helpers';
@@ -29,9 +30,14 @@ const StorageClassSelect: FC<StorageClassSelectProps> = ({ checkSC, setShowSCAle
   const { t } = useKubevirtTranslation();
   const { control, setValue, watch } = useFormContext<V1DiskFormState>();
 
-  const [storageClass, blankSource] = watch([STORAGE_CLASS_FIELD, STORAGE_SOURCE_BLANK]);
+  const [storageClass, blankSource, vmCluster] = watch([
+    STORAGE_CLASS_FIELD,
+    STORAGE_SOURCE_BLANK,
+    VM_CLUSTER_FIELD,
+  ]);
 
-  const [{ clusterDefaultStorageClass, storageClasses }, loaded] = useDefaultStorageClass();
+  const [{ clusterDefaultStorageClass, storageClasses }, loaded] =
+    useDefaultStorageClass(vmCluster);
 
   const defaultSC = useMemo(() => clusterDefaultStorageClass, [clusterDefaultStorageClass]);
 

--- a/src/utils/components/DiskModal/components/StorageProfileSettings/ApplyStorageProfileSettings.tsx
+++ b/src/utils/components/DiskModal/components/StorageProfileSettings/ApplyStorageProfileSettings.tsx
@@ -7,16 +7,18 @@ import { V1DiskFormState } from '../../utils/types';
 import {
   ACCESS_MODE_FIELD,
   DATAVOLUME_TEMPLATE_STORAGE,
+  VM_CLUSTER_FIELD,
   VOLUME_MODE_FIELD,
 } from '../utils/constants';
 
 const ApplyStorageProfileSettingsToDisk: FC = () => {
   const { setValue, watch } = useFormContext<V1DiskFormState>();
 
-  const [storage, accessModes, volumeMode] = watch([
+  const [storage, accessModes, volumeMode, vmCluster] = watch([
     DATAVOLUME_TEMPLATE_STORAGE,
     ACCESS_MODE_FIELD,
     VOLUME_MODE_FIELD,
+    VM_CLUSTER_FIELD,
   ]);
   const { storageClassName = '' } = storage ?? {};
 
@@ -27,6 +29,7 @@ const ApplyStorageProfileSettingsToDisk: FC = () => {
       {...{ accessMode, storageClassName, volumeMode }}
       setAccessMode={(value) => setValue(ACCESS_MODE_FIELD, value ? [value] : undefined)}
       setVolumeMode={(value) => setValue(VOLUME_MODE_FIELD, value)}
+      vmCluster={vmCluster}
     />
   );
 };

--- a/src/utils/components/DiskModal/components/utils/constants.ts
+++ b/src/utils/components/DiskModal/components/utils/constants.ts
@@ -11,6 +11,7 @@ export const VOLUMEMODE_FIELDID = 'volume-mode';
 export const ENABLE_PREALLOCATION_FIELDID = 'enable-preallocation';
 
 export const EXPAND_PVC_SIZE = 'expandPVCSize';
+export const VM_CLUSTER_FIELD = 'cluster';
 export const SHARABLE_FIELD = 'disk.shareable';
 export const LUN_RESERVATION_FIELD = 'disk.lun.reservation';
 export const DATAVOLUME_PVC_NAME = 'dataVolumeTemplate.spec.source.pvc.name';

--- a/src/utils/components/DiskModal/hooks/usePVCDiskSource.tsx
+++ b/src/utils/components/DiskModal/hooks/usePVCDiskSource.tsx
@@ -1,16 +1,21 @@
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { modelToGroupVersionKind, PersistentVolumeClaimModel } from '@kubevirt-utils/models';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-const usePVCDiskSource = (pvcName: string, pvcNamespace: string) =>
-  useK8sWatchResource<IoK8sApiCoreV1PersistentVolumeClaim>(
+const usePVCDiskSource = (pvcName: string, pvcNamespace: string) => {
+  const cluster = useClusterParam();
+
+  return useK8sWatchData<IoK8sApiCoreV1PersistentVolumeClaim>(
     pvcName
       ? {
+          cluster,
           groupVersionKind: modelToGroupVersionKind(PersistentVolumeClaimModel),
           name: pvcName,
           namespace: pvcNamespace,
         }
       : null,
   );
+};
 
 export default usePVCDiskSource;

--- a/src/utils/components/DiskModal/utils/form.ts
+++ b/src/utils/components/DiskModal/utils/form.ts
@@ -17,6 +17,7 @@ import {
   DISK_DEVICE_NAME,
 } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import { generatePrettyName, isEmpty } from '@kubevirt-utils/utils/utils';
+import { getCluster } from '@multicluster/helpers/selectors';
 
 import { DEFAULT_DISK_SIZE } from './constants';
 import { createDataVolumeName, doesSourceRequireDataVolume } from './helpers';
@@ -68,6 +69,7 @@ export const getDefaultEditValues = (
   if (isEmpty(diskToEdit) && isInstanceTypeVM(vm)) diskToEdit = { name: editDiskName };
 
   return {
+    cluster: getCluster(vm),
     dataVolumeTemplate,
     disk: diskToEdit,
     isBootSource,
@@ -103,6 +105,7 @@ export const getDefaultCreateValues = (
     : { disk: { bus: InterfaceTypes.VIRTIO } };
 
   return {
+    cluster: getCluster(vm),
     dataVolumeTemplate,
     disk: {
       ...diskConfig,

--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -27,7 +27,8 @@ import { getBootDisk, getDataVolumeTemplates, getVolumes } from '@kubevirt-utils
 import { getOperatingSystem } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import { ensurePath, getRandomChars, isEmpty } from '@kubevirt-utils/utils/utils';
 import { isDNS1123Label } from '@kubevirt-utils/utils/validation';
-import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import { kubevirtK8sCreate } from '@multicluster/k8sRequests';
 import { addPersistentVolume, removeVolume } from '@virtualmachines/actions/actions';
 
 import { SourceTypes, V1DiskFormState } from './types';
@@ -114,7 +115,8 @@ const getDataVolumeHotplugPromise = (
     },
   };
 
-  return k8sCreate({
+  return kubevirtK8sCreate({
+    cluster: getCluster(vm),
     data: resultDataVolume,
     model: DataVolumeModel,
     ns: getNamespace(resultDataVolume),
@@ -285,7 +287,7 @@ export const mountISOToCDROM = async (
     dataVolume.metadata = diskState.dataVolumeTemplate.metadata;
     dataVolume.spec = { ...diskState.dataVolumeTemplate.spec } as unknown as V1beta1DataVolumeSpec;
 
-    await k8sCreate({ data: dataVolume, model: DataVolumeModel });
+    await kubevirtK8sCreate({ cluster: getCluster(vm), data: dataVolume, model: DataVolumeModel });
   }
 
   const newVolumeSource = getVolumeSourceForMount(diskState);

--- a/src/utils/components/DiskModal/utils/submit.ts
+++ b/src/utils/components/DiskModal/utils/submit.ts
@@ -13,7 +13,8 @@ import {
   getVolumes,
 } from '@kubevirt-utils/resources/vm';
 import { generatePrettyName, isEmpty } from '@kubevirt-utils/utils/utils';
-import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
 import { isRunning } from '@virtualmachines/utils';
 
 import { getDataVolumeTemplateSize } from '../components/utils/selectors';
@@ -143,7 +144,8 @@ export const submit = async ({ data, editDiskName, onSubmit, pvc, vm }: SubmitIn
   const newVM = reorderBootDisk(vmWithDisk, data.disk.name, data.isBootSource, isInitialBootDisk);
 
   if (data.expandPVCSize && pvc) {
-    await k8sPatch({
+    await kubevirtK8sPatch({
+      cluster: getCluster(vm),
       data: [
         {
           op: 'replace',

--- a/src/utils/components/DiskModal/utils/types.ts
+++ b/src/utils/components/DiskModal/utils/types.ts
@@ -40,6 +40,7 @@ export enum VolumeTypes {
 }
 
 export type V1DiskFormState = {
+  cluster?: string;
   dataVolumeTemplate?: V1DataVolumeTemplateSpec;
   disk: V1Disk;
   expandPVCSize?: string;

--- a/src/utils/components/SelectSnapshot/useSnapshots.ts
+++ b/src/utils/components/SelectSnapshot/useSnapshots.ts
@@ -5,7 +5,8 @@ import {
   ProjectModel,
   VolumeSnapshotModel,
 } from '@kubevirt-ui/kubevirt-api/console';
-import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 import { VolumeSnapshotKind } from './types';
 
@@ -17,8 +18,9 @@ type UseSnapshotsReturnType = {
   snapshotsLoaded: boolean;
 };
 
-const useSnapshots = (projectSelected: string): UseSnapshotsReturnType => {
-  const [projects, projectsLoaded, projectsErrors] = useK8sWatchResource<K8sResourceCommon[]>({
+const useSnapshots = (projectSelected: string, cluster?: string): UseSnapshotsReturnType => {
+  const [projects, projectsLoaded, projectsErrors] = useK8sWatchData<K8sResourceCommon[]>({
+    cluster,
     groupVersionKind: modelToGroupVersionKind(ProjectModel),
     isList: true,
     namespaced: false,
@@ -31,6 +33,7 @@ const useSnapshots = (projectSelected: string): UseSnapshotsReturnType => {
 
   const snapshotWathcResource = projectSelected
     ? {
+        cluster,
         groupVersionKind: modelToGroupVersionKind(VolumeSnapshotModel),
         isList: true,
         namespace: projectSelected,
@@ -39,7 +42,7 @@ const useSnapshots = (projectSelected: string): UseSnapshotsReturnType => {
     : null;
 
   const [snapshotsRaw, snapshotsLoaded, snapshotsErrors] =
-    useK8sWatchResource<VolumeSnapshotKind[]>(snapshotWathcResource);
+    useK8sWatchData<VolumeSnapshotKind[]>(snapshotWathcResource);
 
   const snapshots = useMemo(
     () => (snapshotsRaw || [])?.sort((a, b) => a?.metadata?.name?.localeCompare(b?.metadata?.name)),

--- a/src/utils/hooks/useCDIUpload/useCDIUpload.ts
+++ b/src/utils/hooks/useCDIUpload/useCDIUpload.ts
@@ -19,8 +19,9 @@ import {
   UPLOAD_STATUS,
 } from './utils';
 
-export const useCDIUpload = (): UseCDIUploadValues => {
-  const cluster = useClusterParam();
+export const useCDIUpload = (clusterInput?: string): UseCDIUploadValues => {
+  const clusterParam = useClusterParam();
+  const cluster = clusterParam || clusterInput;
   const { t } = useKubevirtTranslation();
   const [cdiConfig, configLoaded, configError] = useK8sWatchData<CDIConfig>({
     cluster,

--- a/src/utils/hooks/usePVCs.ts
+++ b/src/utils/hooks/usePVCs.ts
@@ -5,13 +5,17 @@ import {
   PersistentVolumeClaimModel,
 } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-type UsePVCs = (namespace: string) => [IoK8sApiCoreV1PersistentVolumeClaim[], boolean, any];
+type UsePVCs = (
+  namespace: string,
+  cluster?: string,
+) => [IoK8sApiCoreV1PersistentVolumeClaim[], boolean, any];
 
-const usePVCs: UsePVCs = (namespace: string) => {
+const usePVCs: UsePVCs = (namespace, cluster) => {
   const pvcWathcResource = namespace
     ? {
+        cluster,
         groupVersionKind: modelToGroupVersionKind(PersistentVolumeClaimModel),
         isList: true,
         namespace,
@@ -20,7 +24,7 @@ const usePVCs: UsePVCs = (namespace: string) => {
     : null;
 
   const [pvcsUnsorted, loaded, error] =
-    useK8sWatchResource<IoK8sApiCoreV1PersistentVolumeClaim[]>(pvcWathcResource);
+    useK8sWatchData<IoK8sApiCoreV1PersistentVolumeClaim[]>(pvcWathcResource);
 
   const pvcs = useMemo(
     () => (pvcsUnsorted || [])?.sort((a, b) => a?.metadata?.name?.localeCompare(b?.metadata?.name)),

--- a/src/utils/hooks/useStorageProfileClaimPropertySets.ts
+++ b/src/utils/hooks/useStorageProfileClaimPropertySets.ts
@@ -1,7 +1,7 @@
 import { modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import StorageProfileModel from '@kubevirt-ui/kubevirt-api/console/models/StorageProfileModel';
 import { ClaimPropertySets, StorageProfile } from '@kubevirt-utils/types/storage';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
 export type UseStorageProfileClaimPropertySetsValue = {
   claimPropertySets: ClaimPropertySets;
@@ -11,8 +11,10 @@ export type UseStorageProfileClaimPropertySetsValue = {
 
 const useStorageProfileClaimPropertySets = (
   storageClassName: string,
+  cluster?: string,
 ): UseStorageProfileClaimPropertySetsValue => {
-  const [storageProfile, loaded, error] = useK8sWatchResource<StorageProfile>({
+  const [storageProfile, loaded, error] = useK8sWatchData<StorageProfile>({
+    cluster,
     groupVersionKind: modelToGroupVersionKind(StorageProfileModel),
     isList: false,
     name: storageClassName,

--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/hooks/useGeneratedVM.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/hooks/useGeneratedVM.ts
@@ -13,11 +13,13 @@ import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN
 import { addWinDriverVolume } from '@kubevirt-utils/resources/vm/utils/disk/drivers';
 import { useDriversImage } from '@kubevirt-utils/resources/vm/utils/disk/useDriversImage';
 import { getValidNamespace } from '@kubevirt-utils/utils/utils';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { AUTOMATIC_UPDATE_FEATURE_NAME } from '@overview/SettingsTab/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/utils/constants';
 
 export type UseGeneratedVMType = () => V1VirtualMachine;
 
 const useGeneratedVM = () => {
+  const cluster = useClusterParam();
   const { featureEnabled: autoUpdateEnabled } = useFeatures(AUTOMATIC_UPDATE_FEATURE_NAME);
 
   const { subscriptionData } = useRHELAutomaticSubscription();
@@ -30,6 +32,7 @@ const useGeneratedVM = () => {
     () =>
       generateVM({
         autoUpdateEnabled,
+        cluster,
         instanceTypeState: instanceTypeVMState,
         isUDNManagedNamespace,
         startVM,
@@ -43,6 +46,7 @@ const useGeneratedVM = () => {
       startVM,
       subscriptionData,
       vmNamespaceTarget,
+      cluster,
     ],
   );
 

--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -101,6 +101,7 @@ export const createPopulatedCloudInitYAML = (
 };
 type GenerateVMArgs = {
   autoUpdateEnabled?: boolean;
+  cluster?: string;
   instanceTypeState: InstanceTypeVMState;
   isUDNManagedNamespace: boolean;
   startVM: boolean;
@@ -111,6 +112,7 @@ type GenerateVMCallback = (props: GenerateVMArgs) => V1VirtualMachine;
 
 export const generateVM: GenerateVMCallback = ({
   autoUpdateEnabled,
+  cluster,
   instanceTypeState,
   isUDNManagedNamespace,
   startVM,
@@ -240,6 +242,8 @@ export const generateVM: GenerateVMCallback = ({
       },
     },
   };
+
+  if (cluster) emptyVM.cluster = cluster;
 
   if (!isUDNManagedNamespace) {
     emptyVM.spec.template.metadata.labels[HEADLESS_SERVICE_LABEL] = HEADLESS_SERVICE_NAME;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Make sure disk modal show vm cluster PVCs and VolumeSnapshots and in general the DIskModal works in multicluster mode

I encountered an issue with the Customize horizontalnavbar. basically we have nested routes and the last route do not let `useParams` hook take the params cluster and namespace from the url. So i have to make sure cluster param is in the vm so we can take the cluster from there 
