### PR TITLE
CNV-65247: add default interface model selection based on OS type in PendingChanges helper functions

### DIFF
--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -190,8 +190,9 @@ export const getChangedNICs = (vm: V1VirtualMachine, vmi: V1VirtualMachineInstan
         getNetworkInterfaceType(state.config.iface) !==
           getNetworkInterfaceType(state.runtime.iface) ||
         // model change (virtio <-> e1000e)
-        (state.config.iface?.model ?? getDefaultInterfaceModel(vmi)) !==
-          (state.runtime.iface?.model ?? getDefaultInterfaceModel(vmi)),
+        (state.config.iface?.model &&
+          state.config.iface?.model !==
+            (state.runtime.iface?.model ?? getDefaultInterfaceModel(vmi))),
     )
     .map((state) => state.runtime?.network?.name);
 


### PR DESCRIPTION
## 📝 Description

Fix false positive pending changes for Windows VMs. 
Windows VMs automatically get e1000e network interface model at runtime when no model is specified in config, but pending changes detection was comparing this against the default virtio model, causing false positive pending changes.


## 🎥 Demo

**Before (right after creating a windows VM):**

<img width="1197" height="285" alt="Screenshot 2025-09-11 at 12 54 59 PM" src="https://github.com/user-attachments/assets/9a93946e-5426-4731-be49-6fc884aa1e00" />

**After:**

<img width="1228" height="282" alt="Screenshot 2025-09-11 at 12 53 53 PM" src="https://github.com/user-attachments/assets/6bc995f9-90f1-43d0-9803-c3f9cf03e426" />
