### PR TITLE
CNV-69369: Fix disabling autoattachPodInterface on deleting Pod Network

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
+++ b/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
@@ -22,7 +22,7 @@ import {
   NetworkPresentation,
 } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
-import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
+import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 import { ABSENT } from '@virtualmachines/details/tabs/configuration/network/utils/constants';
 import { isStopped } from '@virtualmachines/utils';
@@ -59,15 +59,6 @@ export const updateVMNetworkInterfaces = (
         path: '/spec/template/spec/domain/devices/interfaces',
         value: updatedInterfaces,
       },
-      ...(isEmpty(updatedInterfaces)
-        ? [
-            {
-              op: getAutoAttachPodInterface(vm) === undefined ? 'add' : 'replace',
-              path: '/spec/template/spec/domain/devices/autoattachPodInterface',
-              value: false,
-            },
-          ]
-        : []),
     ],
     model: VirtualMachineModel,
     resource: vm,

--- a/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
+++ b/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
@@ -5,12 +5,7 @@ import produce from 'immer';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1Interface, V1Network, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import TechPreviewBadge from '@kubevirt-utils/components/TechPreviewBadge/TechPreviewBadge';
-import {
-  getAutoAttachPodInterface,
-  getInterface,
-  getInterfaces,
-  getNetworks,
-} from '@kubevirt-utils/resources/vm';
+import { getInterface, getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
 import {
   PASST_BINDING_NAME,
   POD_NETWORK,
@@ -21,6 +16,7 @@ import {
   interfaceTypesProxy,
   NetworkPresentation,
 } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { hasAutoAttachedPodNetwork } from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
@@ -31,7 +27,7 @@ import { NetworkAttachmentDefinition } from '../components/hooks/types';
 
 export const podNetworkExists = (vm: V1VirtualMachine): boolean =>
   !!vm?.spec?.template?.spec?.networks?.find((network) => typeof network.pod === 'object') ||
-  getAutoAttachPodInterface(vm) !== false;
+  hasAutoAttachedPodNetwork(vm);
 
 export const isPodNetworkName = (networkName: string): boolean => networkName === POD_NETWORK;
 
@@ -180,7 +176,7 @@ export const deleteNetworkInterface = (
   nicPresentation: NetworkPresentation,
 ) => {
   const vmInterfaces = getInterfaces(vm);
-  const noAutoAttachPodInterface = getAutoAttachPodInterface(vm) === false;
+  const noAutoAttachPodInterface = !hasAutoAttachedPodNetwork(vm);
   const isDefaultInterface = noAutoAttachPodInterface && vmInterfaces?.[0]?.name === nicName;
 
   const isHotPlug = Boolean(nicPresentation?.iface?.bridge);

--- a/src/utils/resources/vm/utils/network/selectors.ts
+++ b/src/utils/resources/vm/utils/network/selectors.ts
@@ -1,11 +1,14 @@
 import { V1Interface, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getInterfaces } from '@kubevirt-utils/resources/vm';
+import { getAutoAttachPodInterface, getInterfaces } from '@kubevirt-utils/resources/vm';
 import { isNetworkInterfaceState } from '@kubevirt-utils/utils/typeGuards';
 
 import { NO_DATA_DASH, PASST_BINDING_NAME, UDN_BINDING_NAME } from '../constants';
 
 import { interfaceTypesProxy } from './constants';
 import { NetworkInterfaceState } from './types';
+
+export const hasAutoAttachedPodNetwork = (vm: V1VirtualMachine): boolean =>
+  getAutoAttachPodInterface(vm) !== false;
 
 /**
  * function to get network interface type

--- a/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/components/RedHatProvidedInstanceTypesSection/components/RedHatSeriesMenuCard/RedHatSeriesMenuCard.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/components/RedHatProvidedInstanceTypesSection/components/RedHatSeriesMenuCard/RedHatSeriesMenuCard.tsx
@@ -5,9 +5,9 @@ import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/u
 import RedHatInstanceTypeSeriesSizesMenuItems from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/components/RedHatInstanceTypeSeriesMenu/RedHatInstanceTypeSeriesSizesMenuItems';
 import { instanceTypeSeriesNameMapper } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/constants';
 import { RedHatInstanceTypeSeries } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/types';
-import { useClickOutside } from '@kubevirt-utils/hooks/useClickOutside/useClickOutside';
 import { seriesHasHugepagesVariant } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/utils';
 import HugepagesInfo from '@kubevirt-utils/components/HugepagesInfo/HugepagesInfo';
+import { useClickOutside } from '@kubevirt-utils/hooks/useClickOutside/useClickOutside';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import {

--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
@@ -8,12 +8,9 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import {
-  getAutoAttachPodInterface,
-  getInterfaces,
-  getNetworks,
-} from '@kubevirt-utils/resources/vm';
+import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { hasAutoAttachedPodNetwork } from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
 import { ButtonVariant, Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core';
 import {
@@ -64,10 +61,10 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
   const onDelete = useCallback(() => {
     const updatedVM = produceVMNetworks(vm, (draftVM) => {
       const vmInterfaces = getInterfaces(draftVM);
-      const hasAutoAttachedPodNetwork = getAutoAttachPodInterface(draftVM) !== false;
+
       const isExistingNetwork = getNetworks(draftVM)?.find(({ name }) => name === nicName);
       const isPodNetwork = nicPresentation?.network?.pod;
-      if (!isExistingNetwork && hasAutoAttachedPodNetwork && isPodNetwork) {
+      if (!isExistingNetwork && hasAutoAttachedPodNetwork(draftVM) && isPodNetwork) {
         // artificial pod network added only to the table but missing in the vm
         draftVM.spec.template.spec.domain.devices.autoattachPodInterface = false;
       }

--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
@@ -8,10 +8,13 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
+import {
+  getAutoAttachPodInterface,
+  getInterfaces,
+  getNetworks,
+} from '@kubevirt-utils/resources/vm';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ButtonVariant, Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core';
 import {
   getConfigInterfaceStateFromVM,
@@ -61,9 +64,12 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
   const onDelete = useCallback(() => {
     const updatedVM = produceVMNetworks(vm, (draftVM) => {
       const vmInterfaces = getInterfaces(draftVM);
-      if (isEmpty(vmInterfaces)) {
+      const hasAutoAttachedPodNetwork = getAutoAttachPodInterface(draftVM) !== false;
+      const isExistingNetwork = getNetworks(draftVM)?.find(({ name }) => name === nicName);
+      const isPodNetwork = nicPresentation?.network?.pod;
+      if (!isExistingNetwork && hasAutoAttachedPodNetwork && isPodNetwork) {
+        // artificial pod network added only to the table but missing in the vm
         draftVM.spec.template.spec.domain.devices.autoattachPodInterface = false;
-        return;
       }
 
       draftVM.spec.template.spec.networks = getNetworks(draftVM)?.filter(

--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceList.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceList.tsx
@@ -2,12 +2,9 @@ import * as React from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import useNetworkColumns from '@kubevirt-utils/hooks/useNetworkColums';
-import {
-  getAutoAttachPodInterface,
-  getInterfaces,
-  getNetworks,
-} from '@kubevirt-utils/resources/vm';
+import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
 import { getNetworkInterfaceRowData } from '@kubevirt-utils/resources/vm/utils/network/rowData';
+import { hasAutoAttachedPodNetwork } from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import {
   ListPageFilter,
   useListPageFilter,
@@ -31,7 +28,7 @@ const NetworkInterfaceList: React.FC<NetworkInterfaceListProps> = ({ onUpdateVM,
   const networkInterfacesData = getNetworkInterfaceRowData(
     networks,
     interfaces,
-    getAutoAttachPodInterface(vm) !== false,
+    hasAutoAttachedPodNetwork(vm),
   );
   const [data, filteredData, onFilterChange] = useListPageFilter(networkInterfacesData, filters);
 

--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceList.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceList.tsx
@@ -31,7 +31,7 @@ const NetworkInterfaceList: React.FC<NetworkInterfaceListProps> = ({ onUpdateVM,
   const networkInterfacesData = getNetworkInterfaceRowData(
     networks,
     interfaces,
-    getAutoAttachPodInterface(vm),
+    getAutoAttachPodInterface(vm) !== false,
   );
   const [data, filteredData, onFilterChange] = useListPageFilter(networkInterfacesData, filters);
 

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceList.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceList.tsx
@@ -1,8 +1,10 @@
 import React, { FC, useMemo } from 'react';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getAutoAttachPodInterface } from '@kubevirt-utils/resources/vm';
-import { getPrintableNetworkInterfaceType } from '@kubevirt-utils/resources/vm/utils/network/selectors';
+import {
+  getPrintableNetworkInterfaceType,
+  hasAutoAttachedPodNetwork,
+} from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { getInterfacesAndNetworks } from '@kubevirt-utils/resources/vm/utils/network/utils';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
@@ -65,7 +67,7 @@ const NetworkInterfaceList: FC<NetworkInterfaceTableProps> = ({ vm, vmi }) => {
 
   const columns = useNetworkColumns();
 
-  const autoattachPodInterface = getAutoAttachPodInterface(vm) !== false;
+  const autoattachPodInterface = hasAutoAttachedPodNetwork(vm);
 
   return (
     <>

--- a/src/views/virtualmachines/details/tabs/configuration/network/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/network/utils/utils.ts
@@ -7,17 +7,14 @@ import {
   V1VirtualMachineInstance,
   V1VirtualMachineInstanceNetworkInterface,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import {
-  getAutoAttachPodInterface,
-  getInterface,
-  getInterfaces,
-} from '@kubevirt-utils/resources/vm';
+import { getInterface, getInterfaces } from '@kubevirt-utils/resources/vm';
 import { DEFAULT_NETWORK_INTERFACE } from '@kubevirt-utils/resources/vm/utils/constants';
 import { interfaceTypesProxy } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import {
   getNetworkInterface,
   getNetworkInterfaceState,
   getNetworkInterfaceType,
+  hasAutoAttachedPodNetwork,
 } from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
 import { getVMIInterfaces, getVMIStatusInterfaces } from '@kubevirt-utils/resources/vmi';
@@ -77,7 +74,7 @@ export const isPendingNICRemoval = (
 
   const isVMRunning = isRunning(vm);
 
-  const autoAttachPodInterface = getAutoAttachPodInterface(vm) !== false;
+  const autoAttachPodInterface = hasAutoAttachedPodNetwork(vm);
 
   if (
     autoAttachPodInterface &&


### PR DESCRIPTION
## 📝 Description

Before, removing the last NIC resulted in disabling also autoattachPodInterface flag. The approach was used for both existing VMs and while creating a VM from instance types.
Problems:
1. for existing but shutdown VM only NICs defined explicitly are shown. The auto-attached Pod Network is not visible. Removing the last explicitly defined NIC resulted also in toggling the flag and effectively dropping Pod Network.
2. for creating VM: it was not possible to delete the auto-attached Pod Network until all other NICs were deleted.

Related fix:
When creating a VM from instance type, missing autoattachPodInterface
flag (undefined) was treated as disabled. As a result the Pod Network
was missing in the presented table.

Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/2062

## 🎥 Demo

### Before - existing VM loses auto-attached Pod Network 
https://github.com/user-attachments/assets/f1627575-9bc3-44d7-b940-22ef2c0be6ac

### After - existing VM keeps the Pod Network even after last explicit NIC is deleted


https://github.com/user-attachments/assets/bde279e3-d87a-409c-b2bd-ec180bd1b33b

### Before - unable to delete Pod Network if other NIC present




https://github.com/user-attachments/assets/6e8f85bc-f31b-4452-a228-fa3fecafe30d


### After - auto-attached Pod Network can be removed (via toggling autoattachPodInterface)

https://github.com/user-attachments/assets/2d688d9d-3cc5-447a-b26f-b4763b006a94

### Before - missing autoattachPodInterface flag incorrectly interpreted as no NIC
https://github.com/user-attachments/assets/ecf44287-2a6a-44fe-be13-f72a974c88ef


### After - missing autoattachPodInterface flag

https://github.com/user-attachments/assets/24967f51-c8b3-49b5-acb1-84b33afeff6d




