### PR TITLE
CNV-69370: Disable hot-unplug for Pod Networks

### DIFF
--- a/src/utils/constants/network-columns.tsx
+++ b/src/utils/constants/network-columns.tsx
@@ -1,6 +1,7 @@
 import { TFunction } from 'react-i18next';
 
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { isPodNetwork } from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { sortNICs } from '@kubevirt-utils/resources/vm/utils/network/utils';
 import { sortByDirection, universalComparator } from '@kubevirt-utils/utils/utils';
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
@@ -18,7 +19,7 @@ export const toNetworkNameLabel = <
 >(
   t: TFunction,
   nic: T,
-) => (nic?.network?.pod ? t('Pod networking') : nic?.network?.multus?.networkName);
+) => (isPodNetwork(nic?.network) ? t('Pod networking') : nic?.network?.multus?.networkName);
 
 export const Name = <T extends { network: { name: string } }>(t: TFunction): TableColumn<T> => ({
   id: 'name',

--- a/src/utils/resources/vm/utils/network/network-columns.tsx
+++ b/src/utils/resources/vm/utils/network/network-columns.tsx
@@ -1,7 +1,10 @@
 import { TFunction } from 'react-i18next';
 
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
-import { getConfigInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/selectors';
+import {
+  getConfigInterfaceState,
+  isPodNetwork,
+} from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { sortNICs } from '@kubevirt-utils/resources/vm/utils/network/utils';
 import { compareWithDirection } from '@kubevirt-utils/utils/utils';
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
@@ -12,7 +15,7 @@ export const getNetworkNameLabel = <
 >(
   t: TFunction,
   nic: T,
-) => (nic?.network?.pod ? t('Pod networking') : nic?.network?.multus?.networkName);
+) => (isPodNetwork(nic?.network) ? t('Pod networking') : nic?.network?.multus?.networkName);
 
 export const isSRIOVNetwork = <T extends { sriov?: object }>(iface: T) => !!iface?.sriov;
 

--- a/src/utils/resources/vm/utils/network/selectors.ts
+++ b/src/utils/resources/vm/utils/network/selectors.ts
@@ -1,4 +1,4 @@
-import { V1Interface, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1Interface, V1Network, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getAutoAttachPodInterface, getInterfaces } from '@kubevirt-utils/resources/vm';
 import { isNetworkInterfaceState } from '@kubevirt-utils/utils/typeGuards';
 
@@ -68,3 +68,6 @@ export const getConfigInterfaceState = (
 
   return isNetworkInterfaceState(ifaceState) ? ifaceState : NetworkInterfaceState.UP;
 };
+
+export const isPodNetwork = (network: Partial<V1Network>): boolean =>
+  Boolean(network?.pod) && typeof network.pod === 'object';

--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
@@ -10,7 +10,10 @@ import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
-import { hasAutoAttachedPodNetwork } from '@kubevirt-utils/resources/vm/utils/network/selectors';
+import {
+  hasAutoAttachedPodNetwork,
+  isPodNetwork,
+} from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
 import { ButtonVariant, Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core';
 import {
@@ -63,8 +66,11 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
       const vmInterfaces = getInterfaces(draftVM);
 
       const isExistingNetwork = getNetworks(draftVM)?.find(({ name }) => name === nicName);
-      const isPodNetwork = nicPresentation?.network?.pod;
-      if (!isExistingNetwork && hasAutoAttachedPodNetwork(draftVM) && isPodNetwork) {
+      if (
+        !isExistingNetwork &&
+        hasAutoAttachedPodNetwork(draftVM) &&
+        isPodNetwork(nicPresentation?.network)
+      ) {
         // artificial pod network added only to the table but missing in the vm
         draftVM.spec.template.spec.domain.devices.autoattachPodInterface = false;
       }

--- a/src/views/templates/details/tabs/network/components/list/NetworkInterfaceRow.tsx
+++ b/src/views/templates/details/tabs/network/components/list/NetworkInterfaceRow.tsx
@@ -8,7 +8,10 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
-import { getPrintableNetworkInterfaceType } from '@kubevirt-utils/resources/vm/utils/network/selectors';
+import {
+  getPrintableNetworkInterfaceType,
+  isPodNetwork,
+} from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 import { getConfigInterfaceStateFromVM } from '@virtualmachines/details/tabs/configuration/network/utils/utils';
 
@@ -35,7 +38,7 @@ const NetworkInterfaceRow: FC<RowProps<NetworkPresentation, { template: V1Templa
         {iface.model || NO_DATA_DASH}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="network">
-        {network.pod ? (
+        {isPodNetwork(network) ? (
           t('Pod networking')
         ) : (
           <TemplateValue value={network.multus?.networkName || NO_DATA_DASH} />


### PR DESCRIPTION
## 📝 Description

Fix disabling hot-unplug for Pod Network  - drop assumption that the Pod Network has the first interface and detect only based on the `pod` property.

## 🎥 Demo

### Before
https://github.com/user-attachments/assets/8aa1bad3-b2d8-48eb-9377-c7283cb3386c

### After
https://github.com/user-attachments/assets/53b91c32-26da-4bd5-876c-00ac7c586cf3


