### PR TITLE
CNV-62756: Detect concurrent conflicting NIC updates

### DIFF
--- a/src/utils/resources/vm/utils/network/patch.ts
+++ b/src/utils/resources/vm/utils/network/patch.ts
@@ -1,0 +1,149 @@
+import { VirtualMachineModel } from 'src/views/dashboard-extensions/utils';
+
+import { V1Interface, V1Network, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
+
+export type PatchItem<T> = {
+  op: 'add' | 'remove' | 'replace' | 'test';
+  path: string;
+  value: T;
+};
+
+export const NETWORK_PATH = '/spec/template/spec/networks';
+export const INTERFACE_PATH = '/spec/template/spec/domain/devices/interfaces';
+
+export const addNetwork = ({
+  index,
+  value,
+}: {
+  index: number;
+  value: V1Network;
+}): PatchItem<V1Network>[] => appendWithIndex({ index, path: NETWORK_PATH, value });
+
+export const addInterface = ({
+  index,
+  value,
+}: {
+  index: number;
+  value: V1Interface;
+}): PatchItem<V1Interface>[] => appendWithIndex({ index, path: INTERFACE_PATH, value });
+
+export const appendWithIndex = <T>({
+  index,
+  path,
+  value,
+}: {
+  index: number;
+  path: string;
+  value: T;
+}): PatchItem<T>[] => [
+  ...(index === 0
+    ? [
+        // index based add will fail if array does not exist
+        {
+          op: 'test',
+          path,
+          value: null,
+        } as PatchItem<T>,
+        {
+          op: 'add',
+          path,
+          value: [],
+        } as PatchItem<T>,
+      ]
+    : []),
+  {
+    op: 'add',
+    path: `${path}/-`,
+    value,
+  },
+];
+
+export const updateNetwork = ({
+  currentValue,
+  index,
+  nextValue,
+}: {
+  currentValue: V1Network;
+  index: number;
+  nextValue: V1Network;
+}): PatchItem<V1Network>[] =>
+  mergeAndUpdateAtIndex({ currentValue, index, nextValue, path: NETWORK_PATH });
+
+export const updateInterface = ({
+  currentValue,
+  index,
+  nextValue,
+}: {
+  currentValue: V1Interface;
+  index: number;
+  nextValue: V1Interface;
+}): PatchItem<V1Interface>[] =>
+  mergeAndUpdateAtIndex({ currentValue, index, nextValue, path: INTERFACE_PATH });
+
+export const mergeAndUpdateAtIndex = <T>({
+  currentValue,
+  index,
+  nextValue,
+  path,
+}: {
+  currentValue: T;
+  index: number;
+  nextValue: T;
+  path: string;
+}): PatchItem<T>[] => [
+  {
+    op: 'test',
+    path: `${path}/${index}`,
+    value: currentValue,
+  },
+  {
+    op: 'replace',
+    path: `${path}/${index}`,
+    value: { ...currentValue, ...nextValue },
+  },
+];
+
+export const removeNetwork = ({
+  index,
+  value,
+}: {
+  index: number;
+  value: V1Network;
+}): PatchItem<V1Network>[] => removeAtIndex({ index, path: NETWORK_PATH, value });
+
+export const removeInterface = ({
+  index,
+  value,
+}: {
+  index: number;
+  value: V1Interface;
+}): PatchItem<V1Interface>[] => removeAtIndex({ index, path: INTERFACE_PATH, value });
+
+export const removeAtIndex = <T>({
+  index,
+  path,
+  value,
+}: {
+  index: number;
+  path: string;
+  value: T;
+}): PatchItem<T>[] => [
+  {
+    op: 'test',
+    path: `${path}/${index}`,
+    value,
+  },
+  {
+    op: 'remove',
+    path: `${path}/${index}`,
+    value: undefined,
+  },
+];
+
+export const patchVM = (vm: V1VirtualMachine, items: PatchItem<unknown>[]) =>
+  k8sPatch({
+    data: items,
+    model: VirtualMachineModel,
+    resource: vm,
+  });


### PR DESCRIPTION
## 📝 Description
Depends on: #2979

The network and interface section of the VM config are modified by the
backend i.e. during hot-plug flow.
Before, the UI could overwrite background modifications by patching the
config without checking if the data changed in the meantime.

After this PR, a PATCH test operation will be used before network and
interface replace/remove operations to ensure the resource didn't change.
Additionally the updates will be limited to a single NIC - not the
entire array of networks/interfaces..

Reference-Url: https://datatracker.ietf.org/doc/html/rfc6902#section-4.6
Reference-Url: https://github.com/kubernetes/kubernetes/issues/70281

## 🎥 Demo

### Default error message provided by the backend when a test operation failed
<img width="817" height="174" alt="image" src="https://github.com/user-attachments/assets/143ed0f1-a154-4a05-ad95-98ad4515b949" />

### Before - edit conflict - one operation wins, RestartCondition set


https://github.com/user-attachments/assets/eaf76a79-a5f9-4824-a660-62304038a9b8

### After - edit conflict - one operation is blocked
https://github.com/user-attachments/assets/b6ef617d-77c4-4184-99c2-ff7c61f029f9



### Before - add operations conflicting due to replacing the entire array of interfaces/networks

https://github.com/user-attachments/assets/ec1bd983-a57d-4d85-92c1-f0d649b4f206

### After - add operations restricted to single element


https://github.com/user-attachments/assets/f5b4c3e2-a789-4de9-b4d8-3cf357987990





