### PR TITLE
CNV-69370: Hot-unplug NIC in stopped state

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
+++ b/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
@@ -27,7 +27,6 @@ import {
 import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { ABSENT } from '@virtualmachines/details/tabs/configuration/network/utils/constants';
-import { isStopped } from '@virtualmachines/utils';
 
 import { NetworkAttachmentDefinition } from '../components/hooks/types';
 
@@ -132,8 +131,7 @@ export const deleteNetworkInterface = (
   }
 
   const isHotUnPlug = Boolean(nicPresentation?.iface?.bridge);
-  const canBeMarkedAbsent =
-    isHotUnPlug && !isStopped(vm) && !isPodNetwork(nicPresentation?.network);
+  const canBeMarkedAbsent = isHotUnPlug && !isPodNetwork(nicPresentation?.network);
 
   if (canBeMarkedAbsent) {
     return patchVM(


### PR DESCRIPTION
## 📝 Description
Depends on: #2979

Before, the UI used 2 different approaches for deleting a hot-unplug
capable NIC:
1. for running VM - hot-unplug via setting state to "absent"
2. for stopped VM - standard way via deleting sections in config

On a heavily used cluster the VM state was sometimes detected as stopped
too early which resulted in not using hot-unplug.
    
After this PR, only the hot-unplug approach will be used.

## 🎥 Demo


