### PR TITLE
CNV-68997: spec.architecture doesn't auto-populate on ARM clusters despite kubernetes.io/arch=arm64

### DIFF
--- a/src/utils/utils/architecture.ts
+++ b/src/utils/utils/architecture.ts
@@ -5,8 +5,6 @@ export const ARCHITECTURE_ID = 'architecture';
 export const ARCHITECTURE_TITLE = t('Architecture');
 // label on DS and Template resources
 export const ARCHITECTURE_LABEL = 'template.kubevirt.io/architecture';
-// label on Node resources
-export const NODE_ARCHITECTURE_LABEL = 'kubernetes.io/arch';
 
 export const getArchitecture = (resources: K8sResourceCommon): string =>
   getLabel(resources, ARCHITECTURE_LABEL);

--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/hooks/useGeneratedVM.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/hooks/useGeneratedVM.ts
@@ -8,6 +8,7 @@ import {
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import useRHELAutomaticSubscription from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription';
 import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
 import { addWinDriverVolume } from '@kubevirt-utils/resources/vm/utils/disk/drivers';
@@ -27,12 +28,15 @@ const useGeneratedVM = () => {
 
   const namespace = useActiveNamespace();
   const [isUDNManagedNamespace] = useNamespaceUDN(getValidNamespace(namespace));
-
+  const [hyperConverge] = useHyperConvergeConfiguration();
+  const enableMultiArchBootImageImport =
+    hyperConverge.spec.featureGates?.enableMultiArchBootImageImport;
   const generatedVM = useMemo(
     () =>
       generateVM({
         autoUpdateEnabled,
         cluster,
+        enableMultiArchBootImageImport,
         instanceTypeState: instanceTypeVMState,
         isUDNManagedNamespace,
         startVM,
@@ -41,12 +45,13 @@ const useGeneratedVM = () => {
       }),
     [
       autoUpdateEnabled,
+      cluster,
+      enableMultiArchBootImageImport,
       instanceTypeVMState,
       isUDNManagedNamespace,
       startVM,
       subscriptionData,
       vmNamespaceTarget,
-      cluster,
     ],
   );
 

--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/hooks/useGeneratedVM.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/hooks/useGeneratedVM.ts
@@ -30,7 +30,7 @@ const useGeneratedVM = () => {
   const [isUDNManagedNamespace] = useNamespaceUDN(getValidNamespace(namespace));
   const [hyperConverge] = useHyperConvergeConfiguration();
   const enableMultiArchBootImageImport =
-    hyperConverge.spec.featureGates?.enableMultiArchBootImageImport;
+    hyperConverge?.spec?.featureGates?.enableMultiArchBootImageImport;
   const generatedVM = useMemo(
     () =>
       generateVM({

--- a/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/components/RedHatProvidedInstanceTypesSection/components/RedHatSeriesMenuCard/RedHatSeriesMenuCard.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/SelectInstanceTypeSection/components/RedHatProvidedInstanceTypesSection/components/RedHatSeriesMenuCard/RedHatSeriesMenuCard.tsx
@@ -5,9 +5,9 @@ import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/u
 import RedHatInstanceTypeSeriesSizesMenuItems from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/components/RedHatInstanceTypeSeriesMenu/RedHatInstanceTypeSeriesSizesMenuItems';
 import { instanceTypeSeriesNameMapper } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/constants';
 import { RedHatInstanceTypeSeries } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/types';
-import { useClickOutside } from '@kubevirt-utils/hooks/useClickOutside/useClickOutside';
 import { seriesHasHugepagesVariant } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/utils';
 import HugepagesInfo from '@kubevirt-utils/components/HugepagesInfo/HugepagesInfo';
+import { useClickOutside } from '@kubevirt-utils/hooks/useClickOutside/useClickOutside';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import {

--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -38,7 +38,7 @@ import {
   UDN_BINDING_NAME,
 } from '@kubevirt-utils/resources/vm/utils/constants';
 import { OS_WINDOWS_PREFIX } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
-import { getArchitecture, NODE_ARCHITECTURE_LABEL } from '@kubevirt-utils/utils/architecture';
+import { getArchitecture } from '@kubevirt-utils/utils/architecture';
 import {
   HEADLESS_SERVICE_LABEL,
   HEADLESS_SERVICE_NAME,
@@ -102,6 +102,7 @@ export const createPopulatedCloudInitYAML = (
 type GenerateVMArgs = {
   autoUpdateEnabled?: boolean;
   cluster?: string;
+  enableMultiArchBootImageImport?: boolean;
   instanceTypeState: InstanceTypeVMState;
   isUDNManagedNamespace: boolean;
   startVM: boolean;
@@ -113,6 +114,7 @@ type GenerateVMCallback = (props: GenerateVMArgs) => V1VirtualMachine;
 export const generateVM: GenerateVMCallback = ({
   autoUpdateEnabled,
   cluster,
+  enableMultiArchBootImageImport,
   instanceTypeState,
   isUDNManagedNamespace,
   startVM,
@@ -207,11 +209,10 @@ export const generateVM: GenerateVMCallback = ({
           labels: {},
         },
         spec: {
-          ...(!isEmpty(volumeArchitecture) && {
-            nodeSelector: {
-              [NODE_ARCHITECTURE_LABEL]: volumeArchitecture,
-            },
-          }),
+          ...(!isEmpty(volumeArchitecture) &&
+            enableMultiArchBootImageImport && {
+              architecture: volumeArchitecture,
+            }),
           domain: {
             devices: {
               autoattachPodInterface: false,

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
@@ -127,7 +127,7 @@ const useCreateDrawerForm = (
 
   const [hyperConverge] = useHyperConvergeConfiguration();
   const enableMultiArchBootImageImport =
-    hyperConverge.spec.featureGates?.enableMultiArchBootImageImport;
+    hyperConverge?.spec?.featureGates?.enableMultiArchBootImageImport;
 
   const storageClassRequiredMissing = storageClassRequired && isEmpty(storageClassName);
 

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
@@ -34,6 +34,7 @@ import {
 } from '@kubevirt-utils/extensions/telemetry/utils/constants';
 import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
 import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
 import {
@@ -56,7 +57,7 @@ import {
   DEFAULT_NETWORK_INTERFACE,
   UDN_BINDING_NAME,
 } from '@kubevirt-utils/resources/vm/utils/constants';
-import { getArchitecture, NODE_ARCHITECTURE_LABEL } from '@kubevirt-utils/utils/architecture';
+import { getArchitecture } from '@kubevirt-utils/utils/architecture';
 import {
   HEADLESS_SERVICE_LABEL,
   HEADLESS_SERVICE_NAME,
@@ -123,6 +124,10 @@ const useCreateDrawerForm = (
     resource: ProcessedTemplatesModel.plural,
     verb: 'create',
   });
+
+  const [hyperConverge] = useHyperConvergeConfiguration();
+  const enableMultiArchBootImageImport =
+    hyperConverge.spec.featureGates?.enableMultiArchBootImageImport;
 
   const storageClassRequiredMissing = storageClassRequired && isEmpty(storageClassName);
 
@@ -195,6 +200,7 @@ const useCreateDrawerForm = (
         overrides: {
           autoUpdateEnabled,
           cluster,
+          enableMultiArchBootImageImport,
           isDisabledGuestSystemLogs,
           isUDNManagedNamespace,
           name: nameField,
@@ -292,10 +298,8 @@ const useCreateDrawerForm = (
         }
 
         const templateArchitecture = getArchitecture(processedTemplate);
-        if (!isEmpty(templateArchitecture)) {
-          vmDraft.spec.template.spec.nodeSelector = {
-            [NODE_ARCHITECTURE_LABEL]: templateArchitecture,
-          };
+        if (!isEmpty(templateArchitecture) && enableMultiArchBootImageImport) {
+          vmDraft.spec.template.spec.architecture = templateArchitecture;
         }
       });
 

--- a/src/views/catalog/utils/quick-create-vm.ts
+++ b/src/views/catalog/utils/quick-create-vm.ts
@@ -17,7 +17,7 @@ import {
   DEFAULT_NETWORK_INTERFACE,
   UDN_BINDING_NAME,
 } from '@kubevirt-utils/resources/vm/utils/constants';
-import { getArchitecture, NODE_ARCHITECTURE_LABEL } from '@kubevirt-utils/utils/architecture';
+import { getArchitecture } from '@kubevirt-utils/utils/architecture';
 import { createHeadlessService } from '@kubevirt-utils/utils/headless-service';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { kubevirtK8sCreate } from '@multicluster/k8sRequests';
@@ -30,6 +30,7 @@ type QuickCreateVMType = (inputs: {
   overrides: {
     autoUpdateEnabled: boolean;
     cluster?: string;
+    enableMultiArchBootImageImport?: boolean;
     isDisabledGuestSystemLogs: boolean;
     isUDNManagedNamespace?: boolean;
     name: string;
@@ -45,6 +46,7 @@ export const quickCreateVM: QuickCreateVMType = async ({
   overrides: {
     autoUpdateEnabled,
     cluster,
+    enableMultiArchBootImageImport,
     isDisabledGuestSystemLogs,
     isUDNManagedNamespace,
     name,
@@ -96,10 +98,8 @@ export const quickCreateVM: QuickCreateVMType = async ({
     }
 
     const templateArchitecture = getArchitecture(processedTemplate);
-    if (!isEmpty(templateArchitecture)) {
-      draftVM.spec.template.spec.nodeSelector = {
-        [NODE_ARCHITECTURE_LABEL]: templateArchitecture,
-      };
+    if (!isEmpty(templateArchitecture) && enableMultiArchBootImageImport) {
+      draftVM.spec.template.spec.architecture = templateArchitecture;
     }
   });
 


### PR DESCRIPTION
## 📝 Description

Populate architecture property on vm spec instead of applying nodeSelector 
 
## 🎥 Demo

> Please add a video or an image of the behavior/changes
