### PR TITLE
CNV-68471: Fixing installation CD-ROM with registry image to allow eject action

### DIFF
--- a/src/utils/resources/vm/utils/disk/utils.ts
+++ b/src/utils/resources/vm/utils/disk/utils.ts
@@ -8,5 +8,7 @@ export const isEmptyContainerDiskImage = (volume: V1Volume): boolean => {
   const image = getContainerDiskImage(volume);
   if (isEmpty(image)) return true;
 
-  return Object.values(EMPTY_DISK_IMAGE_PATTERNS).some((pattern) => image.includes(pattern));
+  return Object.values(EMPTY_DISK_IMAGE_PATTERNS).some(
+    (pattern) => pattern !== '' && image.includes(pattern),
+  );
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

fixing logic to correctly identify empty container disk image,
allowing the eject action on an installation cd-rom with registry image. 

## 🎥 Demo
Before:
<img width="1493" height="346" alt="image" src="https://github.com/user-attachments/assets/a95b201a-c543-419a-9d4c-89157691531d" />

After:
<img width="1468" height="335" alt="image" src="https://github.com/user-attachments/assets/d0fdf4ca-d182-4a25-88bf-d2441f9fbf8f" />
