### PR TITLE
CNV-69441: infinite loading on vm with preference but no instancetype

### DIFF
--- a/src/utils/components/DiskModal/utils/form.ts
+++ b/src/utils/components/DiskModal/utils/form.ts
@@ -4,7 +4,7 @@ import {
   V1VirtualMachine,
   V1Volume,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
+import { isExpandableSpecVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { getName } from '@kubevirt-utils/resources/shared';
 import {
   getBootDisk,
@@ -65,7 +65,7 @@ export const getDefaultEditValues = (
     (dv) => getName(dv) === volumeToEdit?.dataVolume?.name,
   );
 
-  if (isEmpty(diskToEdit) && isInstanceTypeVM(vm)) diskToEdit = { name: editDiskName };
+  if (isEmpty(diskToEdit) && isExpandableSpecVM(vm)) diskToEdit = { name: editDiskName };
 
   return {
     dataVolumeTemplate,

--- a/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
+++ b/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
@@ -31,7 +31,7 @@ import {
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
-import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
+import { isExpandableSpecVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { getCPU, getGPUDevices, getHostDevices } from '@kubevirt-utils/resources/vm';
 import { DESCHEDULER_EVICT_LABEL } from '@kubevirt-utils/resources/vmi';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -152,7 +152,7 @@ export const usePendingChanges = (
           <CPUMemoryModal isOpen={isOpen} onClose={onClose} onSubmit={onSubmit} vm={vm} />
         )),
       ),
-      hasPendingChange: !isInstanceTypeVM(vm) && cpuMemoryChanged && restartRequired(vm),
+      hasPendingChange: !isExpandableSpecVM(vm) && cpuMemoryChanged && restartRequired(vm),
       label: t('CPU | Memory'),
     },
     {
@@ -166,7 +166,7 @@ export const usePendingChanges = (
           />
         )),
       ),
-      hasPendingChange: isInstanceTypeVM(vm) && instanceTypeChanged && restartRequired(vm),
+      hasPendingChange: isExpandableSpecVM(vm) && instanceTypeChanged && restartRequired(vm),
       label: t('InstanceType'),
     },
     {

--- a/src/utils/resources/instancetype/helper.ts
+++ b/src/utils/resources/instancetype/helper.ts
@@ -25,10 +25,13 @@ export const getInstanceTypeModelFromMatcher = (
     ? VirtualMachineClusterInstancetypeModel
     : VirtualMachineInstancetypeModel;
 
-export const isInstanceTypeVM = (vm: V1VirtualMachine | V1VirtualMachineInstance): boolean =>
+export const isExpandableSpecVM = (vm: V1VirtualMachine | V1VirtualMachineInstance): boolean =>
   isVM(vm)
     ? !isEmpty(vm?.spec?.instancetype) || !isEmpty(vm?.spec?.preference)
     : !!getInstanceTypeNameFromAnnotation(vm) || !!getPreferenceNameFromAnnotation(vm);
+
+export const isInstanceTypeVM = (vm: V1VirtualMachine | V1VirtualMachineInstance): boolean =>
+  isVM(vm) ? !isEmpty(vm?.spec?.instancetype) : !!getInstanceTypeNameFromAnnotation(vm);
 
 export const getInstanceTypeNameFromAnnotation = (
   vm: V1VirtualMachine | V1VirtualMachineInstance,

--- a/src/utils/resources/vm/hooks/useInstanceTypeExpandSpec.ts
+++ b/src/utils/resources/vm/hooks/useInstanceTypeExpandSpec.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import useDeepCompareMemoize from '@kubevirt-utils/hooks/useDeepCompareMemoize/useDeepCompareMemoize';
-import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
+import { isExpandableSpecVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import useInstanceTypeSpecURL from '@multicluster/hooks/useInstanceTypeSpecURL';
@@ -19,7 +19,7 @@ const useInstanceTypeExpandSpec: UseInstanceTypeExpandSpec = (vm) => {
   const [instanceTypeExpandedSpec, setInstanceTypeExpandedSpec] = useState<V1VirtualMachine>();
   const [loadingExpandedSpec, setLoadingExpandedSpec] = useState<boolean>();
   const [errorExpandedSpec, setErrorExpandedSpec] = useState<Error>();
-  const isInstanceType = useMemo(() => isInstanceTypeVM(vm), [vm]);
+  const isExpandableSpec = useMemo(() => isExpandableSpecVM(vm), [vm]);
   const innerVM = useDeepCompareMemoize(vm);
   const name = getName(innerVM);
   const namespace = getNamespace(innerVM);
@@ -43,8 +43,8 @@ const useInstanceTypeExpandSpec: UseInstanceTypeExpandSpec = (vm) => {
         setLoadingExpandedSpec(false);
       }
     };
-    !isEmpty(innerVM) && isInstanceType && fetch();
-  }, [namespace, name, isInstanceType, url, urlLoaded, innerVM]);
+    !isEmpty(innerVM) && isExpandableSpec && fetch();
+  }, [namespace, name, isExpandableSpec, url, urlLoaded, innerVM]);
 
   return [instanceTypeExpandedSpec, loadingExpandedSpec, errorExpandedSpec];
 };

--- a/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
@@ -46,7 +46,8 @@ const VirtualMachineNavPage: FC = () => {
 
   const vmToShow = useMemo(() => (runningTourSignal.value ? tourGuideVM : vm), [vm]);
 
-  const [instanceTypeExpandedSpec, expandedSpecLoading] = useInstanceTypeExpandSpec(vmToShow);
+  const [instanceTypeExpandedSpec, expandedSpecLoading, expandedSpecError] =
+    useInstanceTypeExpandSpec(vmToShow);
 
   const pages = useVirtualMachineTabs();
 
@@ -65,7 +66,7 @@ const VirtualMachineNavPage: FC = () => {
         <div className="VirtualMachineNavPage--tabs__main">
           <HorizontalNavbar
             basePath={getVMURL(cluster, namespace, name)}
-            error={loadError}
+            error={loadError || expandedSpecError}
             instanceTypeExpandedSpec={instanceTypeExpandedSpec}
             loaded={isLoaded && !expandedSpecLoading}
             pages={pages}

--- a/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
@@ -20,7 +20,7 @@ import WorkloadProfileModal from '@kubevirt-utils/components/WorkloadProfileModa
 import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
+import { isExpandableSpecVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { InstanceTypeUnion } from '@kubevirt-utils/resources/instancetype/types';
 import { asAccessReview, getAnnotation, getName } from '@kubevirt-utils/resources/shared';
 import { WORKLOADS_LABELS } from '@kubevirt-utils/resources/template';
@@ -93,10 +93,10 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
 
   const cpuMemoryVM = instanceTypeVM?.metadata?.uid === vm?.metadata?.uid ? instanceTypeVM : vm;
 
-  const isInstanceType = isInstanceTypeVM(vm);
+  const isExpandableSpec = isExpandableSpecVM(vm);
   const deletionProtectionEnabled = isDeletionProtectionEnabled(vm);
 
-  const loadingInstanceType = isInstanceType && isEmpty(instanceType);
+  const loadingInstanceType = isExpandableSpec && isEmpty(instanceTypeVM);
 
   if (!vm || loadingInstanceType) {
     return <Loading />;
@@ -157,12 +157,12 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
             <VirtualMachineDescriptionItem
               descriptionHeader={
                 <SearchItem id="cpu-memory">
-                  {isInstanceType ? t('InstanceType') : t('CPU | Memory')}
+                  {isExpandableSpec ? t('InstanceType') : t('CPU | Memory')}
                 </SearchItem>
               }
               onEditClick={() =>
                 createModal(({ isOpen, onClose }) => {
-                  return isInstanceType ? (
+                  return isExpandableSpec ? (
                     <InstanceTypeModal
                       allInstanceTypes={allInstanceTypes}
                       instanceType={instanceType}
@@ -185,7 +185,7 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
                 instanceType && getAnnotation(instanceType, INSTANCETYPE_CLASS_DISPLAY_NAME)
               }
               additionalContent={hasNUMAConfiguration(cpuMemoryVM) && <NUMABadge />}
-              bodyContent={isInstanceType ? null : <CPUDescription cpu={getCPU(vm)} />}
+              bodyContent={isExpandableSpec ? null : <CPUDescription cpu={getCPU(vm)} />}
               data-test-id={`${vmName}-cpu-memory`}
               descriptionData={<CPUMemory vm={cpuMemoryVM || vm} vmi={vmi} />}
               isEdit={canUpdateVM}

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionRightGrid.tsx
@@ -9,7 +9,7 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
+import { isExpandableSpecVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { getEvictionStrategy } from '@kubevirt-utils/resources/vm';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList, GridItem } from '@patternfly/react-core';
@@ -70,8 +70,8 @@ const SchedulingSectionRightGrid: FC<SchedulingSectionRightGridProps> = ({
             ))
           }
           data-test-id="dedicated-resources"
-          descriptionData={<DedicatedResources vm={isInstanceTypeVM(vm) ? instanceTypeVM : vm} />}
-          isDisabled={isInstanceTypeVM(vm)}
+          descriptionData={<DedicatedResources vm={isExpandableSpecVM(vm) ? instanceTypeVM : vm} />}
+          isDisabled={isExpandableSpecVM(vm)}
           isEdit={canUpdateVM}
         />
         <VirtualMachineDescriptionItem


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

VMs with preference but no instancetypes are having an infinite loading issue.

The fix is to make sure the code waits for the expanded spec VM instead of searching for the instancetype vm (that its `undefined`)


In case we don't have an expanded spec VM because of an error or something, the Horizontal NavBar will present an error
instead of the details tab 


Note: would like in the future to rename all the `instancetypeVM` to `expandedSpecVM` as the vm can also be expanded but not connected to an instancetype. I would not do that now as i can disrupt a release 
 

## 🎥 Demo
**BEFORE**
https://github.com/user-attachments/assets/82424837-0b32-4dd4-8b45-fd9e3e35eefb

**AFTER**
<img width="1920" height="994" alt="Screenshot 2025-09-16 at 11 04 22" src="https://github.com/user-attachments/assets/f33eb8a7-d28e-497e-b03a-57cdc49bc42c" />

