### PR TITLE
CNV-63859: Fixing the virtualization perspective route for non-priv users

### DIFF
--- a/plugin-extensions.ts
+++ b/plugin-extensions.ts
@@ -263,6 +263,15 @@ const extensions: EncodedExtension[] = [
     type: 'console.page/route',
   },
   {
+    properties: {
+      component: {
+        $codeRef: 'VirtualizationLandingPage',
+      },
+      path: ['/k8s/virtualization-landing'],
+    },
+    type: 'console.page/route',
+  },
+  {
     flags: {
       required: ['KUBEVIRT_DYNAMIC'],
     },

--- a/plugin-metadata.ts
+++ b/plugin-metadata.ts
@@ -40,6 +40,7 @@ const metadata: ConsolePluginBuildMetadata = {
     TemplateNavPage: './views/templates/details/TemplateNavPage.tsx',
     useVirtualMachineInstanceActionsProvider:
       './views/virtualmachinesinstance/actions/hooks/useVirtualMachineInstanceActionsProvider.tsx',
+    VirtualizationLandingPage: 'src/perspective/VirtualizationLandingPage.tsx',
     VirtualMachinesInstancePage:
       './views/virtualmachinesinstance/details/VirtualMachinesInstancePage.tsx',
     VirtualMachinesInstancesList:

--- a/src/perspective/VirtualizationLandingPage.tsx
+++ b/src/perspective/VirtualizationLandingPage.tsx
@@ -1,0 +1,42 @@
+import React, { FC, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom-v5-compat';
+
+import Loading from '@kubevirt-utils/components/Loading/Loading';
+import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
+import useProjects from '@kubevirt-utils/hooks/useProjects';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { Bullseye } from '@patternfly/react-core';
+
+const VirtualizationLandingPage: FC = () => {
+  const isAdmin = useIsAdmin();
+  const [projects, projectsLoaded] = useProjects();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!projectsLoaded) return;
+
+    if (isAdmin) {
+      navigate('/k8s/all-namespaces/virtualization-overview');
+      return;
+    }
+
+    if (!isEmpty(projects)) {
+      const preferredProject = projects.includes(DEFAULT_NAMESPACE)
+        ? DEFAULT_NAMESPACE
+        : projects[0];
+      navigate(`/k8s/ns/${preferredProject}/virtualization-overview`);
+      return;
+    }
+
+    navigate('/k8s/all-namespaces/virtualization-overview');
+  }, [isAdmin, projects, projectsLoaded, navigate]);
+
+  return (
+    <Bullseye>
+      <Loading />
+    </Bullseye>
+  );
+};
+
+export default VirtualizationLandingPage;

--- a/src/perspective/extensions.ts
+++ b/src/perspective/extensions.ts
@@ -608,7 +608,7 @@ export const extensions: EncodedExtension[] = [
       icon: { $codeRef: 'perspective.icon' },
       id: 'virtualization-perspective',
       importRedirectURL: { $codeRef: 'perspective.getImportRedirectURL' },
-      landingPageURL: { $codeRef: 'perspective.getLandingPageURL' },
+      landingPageURL: { $codeRef: 'perspective.getVirtualizationLandingPageURL' },
       name: '%plugin__kubevirt-plugin~Virtualization%',
     },
     type: 'console.perspective',

--- a/src/perspective/perspective.ts
+++ b/src/perspective/perspective.ts
@@ -11,6 +11,9 @@ export const icon: ResolvedExtension<Perspective>['properties']['icon'] = {
 export const getLandingPageURL: ResolvedExtension<Perspective>['properties']['landingPageURL'] =
   () => `/k8s/all-namespaces/virtualization-overview`;
 
+export const getVirtualizationLandingPageURL: ResolvedExtension<Perspective>['properties']['landingPageURL'] =
+  () => `/k8s/virtualization-landing`;
+
 export const getImportRedirectURL: ResolvedExtension<Perspective>['properties']['importRedirectURL'] =
   (namespace: string) => `/k8s/ns/${namespace}/virtualization-overview`;
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixing the routing to virtualization perspective to eliminate the automatic routing to all-projects before re-directing to the correct name space by privilege. 
when in virtualization perspective the routing is done according to permissions and available projects.

## 🎥 Demo
Before:
https://github.com/user-attachments/assets/a7e17a05-8e0e-4d2b-b230-7f44c0ef4e58

After:
https://github.com/user-attachments/assets/2d406919-3be1-4f1c-973d-b898521f4ad2
