### PR TITLE
CNV-69485: prevent user for accessing Dedicated resources dialog when VirtualMachine is created from Instance Type

### DIFF
--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -21,7 +21,10 @@ import {
   VirtualMachineConfigurationTabInner,
   VirtualMachineDetailsTab,
 } from '@kubevirt-utils/constants/tabs-constants';
-import { getInstanceTypeNameFromAnnotation } from '@kubevirt-utils/resources/instancetype/helper';
+import {
+  getInstanceTypeNameFromAnnotation,
+  isInstanceTypeVM,
+} from '@kubevirt-utils/resources/instancetype/helper';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import {
   getAffinity,
@@ -290,7 +293,7 @@ export const getChangedDedicatedResources = (
   vmi: V1VirtualMachineInstance,
   currentSelection: boolean,
 ): boolean => {
-  if (isEmpty(vm) || isEmpty(vmi)) {
+  if (isEmpty(vm) || isEmpty(vmi) || isInstanceTypeVM(vm)) {
     return false;
   }
   const vmDedicatedResources = getCPU(vm)?.dedicatedCpuPlacement || false;


### PR DESCRIPTION
## 📝 Description

[CNV-69485](https://issues.redhat.com/browse/CNV-69485): After user is manually editing the VM YAML, they are able to access the Dedicated resources Modal through the pending changes, even though we are blocking it in the configuration page based on the rule: 
- Can not configure dedicated resources if the VirtualMachine is created from Instance Type


## 🎥 Demo

Before: 

https://github.com/user-attachments/assets/c5a3fb56-411e-4173-b0a1-7af493946d06

After: 


https://github.com/user-attachments/assets/c6e663a9-7d4c-4a29-84bb-020430124614


