### PR TITLE
CNV-69648: ACM treeview GA and CrossClusterMigration TP

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -593,7 +593,7 @@
   "Enable folders in Virtual Machines tree view": "Enable folders in Virtual Machines tree view",
   "Enable guest system log access": "Enable guest system log access",
   "Enable headless mode": "Enable headless mode",
-  "Enable Kubevirt multicluster tree view": "Enable Kubevirt multicluster tree view",
+  "Enable Kubevirt cross cluster migration": "Enable Kubevirt cross cluster migration",
   "Enable load-aware descheduling": "Enable load-aware descheduling",
   "Enable memory density": "Enable memory density",
   "Enable Passt binding for primary user-defined networks": "Enable Passt binding for primary user-defined networks",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -599,7 +599,7 @@
   "Enable folders in Virtual Machines tree view": "Habilitar carpetas en la vista de árbol de máquinas virtuales",
   "Enable guest system log access": "Habilitar el acceso al registro del sistema huésped",
   "Enable headless mode": "Habilitar el modo sin cabeza",
-  "Enable Kubevirt multicluster tree view": "Enable Kubevirt multicluster tree view",
+  "Enable Kubevirt cross cluster migration": "Enable Kubevirt cross cluster migration",
   "Enable load-aware descheduling": "Enable load-aware descheduling",
   "Enable memory density": "Habilitar la densidad de memoria",
   "Enable Passt binding for primary user-defined networks": "Enable Passt binding for primary user-defined networks",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -599,7 +599,7 @@
   "Enable folders in Virtual Machines tree view": "Activer les dossiers dans l'arborescence des machines virtuelles",
   "Enable guest system log access": "Activer l'accès au journal système invité",
   "Enable headless mode": "Activer le mode sans tête",
-  "Enable Kubevirt multicluster tree view": "Enable Kubevirt multicluster tree view",
+  "Enable Kubevirt cross cluster migration": "Enable Kubevirt cross cluster migration",
   "Enable load-aware descheduling": "Enable load-aware descheduling",
   "Enable memory density": "Activer la densité de mémoire",
   "Enable Passt binding for primary user-defined networks": "Enable Passt binding for primary user-defined networks",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -590,7 +590,7 @@
   "Enable folders in Virtual Machines tree view": "仮想マシンのツリービューでフォルダーを有効にする",
   "Enable guest system log access": "ゲストシステムログへのアクセスを有効にする",
   "Enable headless mode": "ヘッドレスモードを有効にする",
-  "Enable Kubevirt multicluster tree view": "Enable Kubevirt multicluster tree view",
+  "Enable Kubevirt cross cluster migration": "Enable Kubevirt cross cluster migration",
   "Enable load-aware descheduling": "Enable load-aware descheduling",
   "Enable memory density": "メモリー密度を有効にする",
   "Enable Passt binding for primary user-defined networks": "Enable Passt binding for primary user-defined networks",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -590,7 +590,7 @@
   "Enable folders in Virtual Machines tree view": "가상 머신 트리 보기에서 폴더 활성화",
   "Enable guest system log access": "게스트 시스템 로그 액세스 활성화",
   "Enable headless mode": "헤드리스 모드 활성화",
-  "Enable Kubevirt multicluster tree view": "Enable Kubevirt multicluster tree view",
+  "Enable Kubevirt cross cluster migration": "Enable Kubevirt cross cluster migration",
   "Enable load-aware descheduling": "Enable load-aware descheduling",
   "Enable memory density": "메모리 밀도 기능 활성화",
   "Enable Passt binding for primary user-defined networks": "Enable Passt binding for primary user-defined networks",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -590,7 +590,7 @@
   "Enable folders in Virtual Machines tree view": "在虚拟机树视图中启用文件夹",
   "Enable guest system log access": "启用客户机系统日志访问",
   "Enable headless mode": "启用无头模式",
-  "Enable Kubevirt multicluster tree view": "Enable Kubevirt multicluster tree view",
+  "Enable Kubevirt cross cluster migration": "Enable Kubevirt cross cluster migration",
   "Enable load-aware descheduling": "Enable load-aware descheduling",
   "Enable memory density": "启用内存密度",
   "Enable Passt binding for primary user-defined networks": "Enable Passt binding for primary user-defined networks",

--- a/src/multicluster/constants.ts
+++ b/src/multicluster/constants.ts
@@ -5,7 +5,7 @@ export const BASE_K8S_API_PATH = '/api/kubernetes';
 export const KUBEVIRT_VM_PATH = 'kubevirt.io~v1~VirtualMachine';
 
 export const FLAG_KUBEVIRT_DYNAMIC_ACM = 'KUBEVIRT_DYNAMIC_ACM';
-export const FEATURE_KUBEVIRT_ACM_TREEVIEW = 'kubevirtACMTreeview';
+export const FEATURE_KUBEVIRT_CROSS_CLUSTER_MIGRATION = 'kubevirtCrossClusterMigration';
 
 export const CROSS_CLUSTER_MIGRATION_ACTION_ID = 'cross-cluster-migration';
 

--- a/src/multicluster/flags.ts
+++ b/src/multicluster/flags.ts
@@ -1,16 +1,16 @@
 import { useEffect } from 'react';
 
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { SetFeatureFlag } from '@openshift-console/dynamic-plugin-sdk';
+import { useIsFleetAvailable } from '@stolostron/multicluster-sdk';
 
-import { FEATURE_KUBEVIRT_ACM_TREEVIEW, FLAG_KUBEVIRT_DYNAMIC_ACM } from './constants';
+import { FLAG_KUBEVIRT_DYNAMIC_ACM } from './constants';
 
 export const useKubevirtDynamicACMFlag = (setFeatureFlag: SetFeatureFlag) => {
-  const { error, featureEnabled, loading } = useFeatures(FEATURE_KUBEVIRT_ACM_TREEVIEW);
+  const isFleetAvailable = useIsFleetAvailable();
 
   useEffect(() => {
-    if (!loading && !error) {
-      setFeatureFlag(FLAG_KUBEVIRT_DYNAMIC_ACM, featureEnabled);
+    if (isFleetAvailable) {
+      setFeatureFlag(FLAG_KUBEVIRT_DYNAMIC_ACM, isFleetAvailable);
     }
-  }, [error, loading, featureEnabled, setFeatureFlag]);
+  }, [isFleetAvailable, setFeatureFlag]);
 };

--- a/src/views/clusteroverview/SettingsTab/PreviewFeaturesTab/hooks/usePreviewFeaturesData.ts
+++ b/src/views/clusteroverview/SettingsTab/PreviewFeaturesTab/hooks/usePreviewFeaturesData.ts
@@ -4,7 +4,7 @@ import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { PASST_UDN_NETWORK, TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { FEATURE_KUBEVIRT_ACM_TREEVIEW } from '@multicluster/constants';
+import { FEATURE_KUBEVIRT_CROSS_CLUSTER_MIGRATION } from '@multicluster/constants';
 import { useIsFleetAvailable } from '@stolostron/multicluster-sdk';
 
 import PasstPopoverContent from '../PasstPopoverContent';
@@ -34,7 +34,7 @@ type UsePreviewFeaturesData = () => {
 const usePreviewFeaturesData: UsePreviewFeaturesData = () => {
   const { t } = useKubevirtTranslation();
   const treeViewFoldersFeature = useFeatures(TREE_VIEW_FOLDERS);
-  const kubevirtACMTreeviewFeature = useFeatures(FEATURE_KUBEVIRT_ACM_TREEVIEW);
+  const kubevirtCrossClusterMigration = useFeatures(FEATURE_KUBEVIRT_CROSS_CLUSTER_MIGRATION);
   const passtFeatureFlag = usePasstFeatureFlag();
 
   const isFleetAvailable = useIsFleetAvailable();
@@ -48,10 +48,10 @@ const usePreviewFeaturesData: UsePreviewFeaturesData = () => {
     },
     {
       externalLink: null,
-      id: FEATURE_KUBEVIRT_ACM_TREEVIEW,
-      label: t('Enable Kubevirt multicluster tree view'),
-      ...kubevirtACMTreeviewFeature,
-      canEdit: isFleetAvailable && kubevirtACMTreeviewFeature?.canEdit,
+      id: FEATURE_KUBEVIRT_CROSS_CLUSTER_MIGRATION,
+      label: t('Enable Kubevirt cross cluster migration'),
+      ...kubevirtCrossClusterMigration,
+      canEdit: isFleetAvailable && kubevirtCrossClusterMigration?.canEdit,
     },
     {
       externalLink: null,

--- a/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.tsx
+++ b/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.tsx
@@ -8,6 +8,7 @@ import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useProviderByClusterName from '@multicluster/components/CrossClusterMigration/hooks/useProviderByClusterName';
+import { FEATURE_KUBEVIRT_CROSS_CLUSTER_MIGRATION } from '@multicluster/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { isPaused, isRunning, isStopped } from '@virtualmachines/utils';
 
@@ -24,6 +25,12 @@ const useMultipleVirtualMachineActions: UseMultipleVirtualMachineActions = (vms)
   const { featureEnabled: confirmVMActionsEnabled } = useFeatures(CONFIRM_VM_ACTIONS);
   const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
   const mtvInstalled = useIsMTVInstalled();
+
+  const { featureEnabled: crossClusterMigrationFlagEnabled } = useFeatures(
+    FEATURE_KUBEVIRT_CROSS_CLUSTER_MIGRATION,
+  );
+  const crossClusterMigrationEnabled = mtvInstalled && crossClusterMigrationFlagEnabled;
+
   const [provider, providerLoaded] = useProviderByClusterName(getCluster(vms?.[0]));
 
   const mtcInstalled = useIsMTCInstalled();
@@ -34,7 +41,7 @@ const useMultipleVirtualMachineActions: UseMultipleVirtualMachineActions = (vms)
 
     const migrationActions = [];
 
-    if (clusters.size === 1 && namespaces.size === 1 && mtvInstalled) {
+    if (clusters.size === 1 && namespaces.size === 1 && crossClusterMigrationEnabled) {
       migrationActions.push(
         BulkVirtualMachineActionFactory.crossClusterMigration(
           vms,
@@ -81,7 +88,7 @@ const useMultipleVirtualMachineActions: UseMultipleVirtualMachineActions = (vms)
     confirmVMActionsEnabled,
     createModal,
     mtcInstalled,
-    mtvInstalled,
+    crossClusterMigrationEnabled,
     provider,
     providerLoaded,
     treeViewFoldersEnabled,

--- a/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
+++ b/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
@@ -11,7 +11,10 @@ import { CONFIRM_VM_ACTIONS, TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/use
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { VirtualMachineModelRef } from '@kubevirt-utils/models';
 import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
-import { CROSS_CLUSTER_MIGRATION_ACTION_ID } from '@multicluster/constants';
+import {
+  CROSS_CLUSTER_MIGRATION_ACTION_ID,
+  FEATURE_KUBEVIRT_CROSS_CLUSTER_MIGRATION,
+} from '@multicluster/constants';
 import useACMExtensionActions from '@multicluster/hooks/useACMExtensionActions/useACMExtensionActions';
 import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -35,6 +38,11 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, 
 
   const mtcInstalled = useIsMTCInstalled();
   const mtvInstalled = useIsMTVInstalled();
+  const { featureEnabled: crossClusterMigrationFlagEnabled } = useFeatures(
+    FEATURE_KUBEVIRT_CROSS_CLUSTER_MIGRATION,
+  );
+
+  const crossClusterMigrationEnabled = mtvInstalled && crossClusterMigrationFlagEnabled;
 
   const [currentStorageMigration, currentStorageMigrationLoaded] = useCurrentStorageMigration(vm);
 
@@ -80,7 +88,7 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, 
       ? [migrateCompute, migrateStorage]
       : [migrateCompute];
 
-    if (crossClusterMigration && mtvInstalled) {
+    if (crossClusterMigration && mtvInstalled && crossClusterMigrationEnabled) {
       startMigrationActions.unshift(crossClusterMigration);
     }
 
@@ -120,6 +128,7 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, 
     mtcInstalled,
     acmActions,
     mtvInstalled,
+    crossClusterMigrationEnabled,
   ]);
 
   return useMemo(


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

We decided to make multiclsuter treeview GA but crossclsutermigration remains a TP feature as the backend is on TP

Before this pr, the feature flag was covering the multicluster treeview and also the crossclsuter migration action as the action is only available in the multicluster treeeview.

Now the treeview is on GA and we'll see it when acm is installed 
Crosscluster migration needs to be covered under the feature flag anyway