### PR TITLE
CNV-69014: fix multicluster tree view VM links

### DIFF
--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
@@ -20,6 +20,7 @@ import ACMExtentionsTableData from '@multicluster/components/ACMExtentionsTableD
 import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
 import { ManagedClusterModel } from '@multicluster/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 import { Checkbox } from '@patternfly/react-core';
 import VirtualMachineActions from '@virtualmachines/actions/components/VirtualMachineActions/VirtualMachineActions';
@@ -56,7 +57,8 @@ const VirtualMachineRowLayout: FC<
 
   const vmName = useMemo(() => getName(obj), [obj]);
   const vmNamespace = useMemo(() => getNamespace(obj), [obj]);
-  const vmCluster = getCluster(obj);
+  const clusterParam = useClusterParam();
+  const vmCluster = getCluster(obj) ?? clusterParam;
 
   const storageClasses = useMemo(
     () => getVirtualMachineStorageClasses(obj, pvcMapper),


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes incorrect redirecting from multicluster tree view to normal tree view page 
  - after deleting a VirtualMachine
  - link to VM details from hub cluster
- fixes incorrect "all-namespaces" project

note: `useClusterParam` and `useNamespaceParam` don't work when called in `DeleteVMModal`, so params are passed as props

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/82ad4402-d537-4d60-b19c-82a41d086a4b


https://github.com/user-attachments/assets/0a17ba47-d19b-4d29-bf75-fca4edecf5b3


https://github.com/user-attachments/assets/13e0ee30-9e74-4064-8c2a-0cb6052ceb82



After:


https://github.com/user-attachments/assets/56715ef5-4ca4-40f2-b9a4-82961d1c3372


https://github.com/user-attachments/assets/1c41a20d-7d08-4465-9e8c-929b6bb283ef


