### PR TITLE
CNV-69687: use state management for setting loadingDriverValue and driverImageValue in useDriversImage

### DIFF
--- a/src/utils/resources/vm/utils/disk/useDriversImage.ts
+++ b/src/utils/resources/vm/utils/disk/useDriversImage.ts
@@ -1,18 +1,25 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { getDriversImage } from '@kubevirt-utils/resources/vm/utils/disk/drivers';
 import { driverImage, loadingDriver } from '@kubevirt-utils/store/drivers';
 
 export const useDriversImage = (): [string, boolean] => {
+  const [loadingDriverValue, setLoadingDriverValue] = useState(loadingDriver.value);
+  const [driverImageValue, setDriverImageValue] = useState(driverImage.value);
+
   useEffect(() => {
     if (!loadingDriver.value) return;
 
     getDriversImage()
       .then((image) => {
         driverImage.value = image;
+        setDriverImageValue(image);
       })
-      .finally(() => (loadingDriver.value = false));
+      .finally(() => {
+        loadingDriver.value = false;
+        setLoadingDriverValue(false);
+      });
   }, []);
 
-  return [driverImage.value, loadingDriver.value];
+  return [driverImageValue, loadingDriverValue];
 };


### PR DESCRIPTION
## 📝 Description

[CNV-69687](https://issues.redhat.com/browse/CNV-69687): Mount Windows drivers disk checkbox is not loaded on initial load (a loading indicator is displayed). 

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/ec53c2ac-e1e1-42cd-bd69-7812585f3a98


After:


https://github.com/user-attachments/assets/c3e0600b-0cc0-4c71-a932-b10b188310a4


