### PR TITLE
CNV-66097: Fixing the ability to change cpu when creating a vm from windows 11 template

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1586,7 +1586,7 @@
   "Top consumers": "Top consumers",
   "Topology key": "Topology key",
   "Topology key must not be empty": "Topology key must not be empty",
-  "Topology will be set to {{sockets}} socket, 1 core, 1 thread": "Topology will be set to {{sockets}} socket, 1 core, 1 thread",
+  "Topology will be set to {{sockets}} socket, {{cores}} core, {{threads}} thread": "Topology will be set to {{sockets}} socket, {{cores}} core, {{threads}} thread",
   "Total": "Total",
   "Total bytes": "Total bytes",
   "Total storage to migrate is {{totalAmount}}": "Total storage to migrate is {{totalAmount}}",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1594,7 +1594,7 @@
   "Top consumers": "Principales consumidores",
   "Topology key": "Clave de topología",
   "Topology key must not be empty": "La clave de topología no debe estar vacía",
-  "Topology will be set to {{sockets}} socket, 1 core, 1 thread": "La topología se establecerá en {{sockets}} socket, 1 núcleo, 1 hilo",
+  "Topology will be set to {{sockets}} socket, {{cores}} core, {{threads}} thread": "Topology will be set to {{sockets}} socket, {{cores}} core, {{threads}} thread",
   "Total": "Total",
   "Total bytes": "Bytes totales",
   "Total storage to migrate is {{totalAmount}}": "El total de almacenamiento que se debe migrar es {{totalAmount}}",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1594,7 +1594,7 @@
   "Top consumers": "Principaux consommateurs",
   "Topology key": "Clé de topologie",
   "Topology key must not be empty": "La clé de topologie ne doit pas être vide.",
-  "Topology will be set to {{sockets}} socket, 1 core, 1 thread": "La topologie sera définie sur {{sockets}} socket, 1 core, 1 thread",
+  "Topology will be set to {{sockets}} socket, {{cores}} core, {{threads}} thread": "Topology will be set to {{sockets}} socket, {{cores}} core, {{threads}} thread",
   "Total": "Total",
   "Total bytes": "Nombre total d'octets",
   "Total storage to migrate is {{totalAmount}}": "Le stockage total à migrer est de {{totalAmount}}",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1586,7 +1586,7 @@
   "Top consumers": "トップコンシューマー",
   "Topology key": "トポロジーキー",
   "Topology key must not be empty": "トポロジーキーは空にすることができません",
-  "Topology will be set to {{sockets}} socket, 1 core, 1 thread": "トポロジーは {{sockets}} ソケット、1 コア、1 スレッドに設定されます",
+  "Topology will be set to {{sockets}} socket, {{cores}} core, {{threads}} thread": "Topology will be set to {{sockets}} socket, {{cores}} core, {{threads}} thread",
   "Total": "合計",
   "Total bytes": "合計バイト数",
   "Total storage to migrate is {{totalAmount}}": "移行するストレージの合計は {{totalAmount}} です",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1586,7 +1586,7 @@
   "Top consumers": "상위 소비자",
   "Topology key": "토폴로지 키",
   "Topology key must not be empty": "토폴로지 키는 비워 둘 수 없습니다.",
-  "Topology will be set to {{sockets}} socket, 1 core, 1 thread": "토폴로지는 {{sockets}} 소켓, 코어 1개, 스레드 1개로 설정됩니다.",
+  "Topology will be set to {{sockets}} socket, {{cores}} core, {{threads}} thread": "Topology will be set to {{sockets}} socket, {{cores}} core, {{threads}} thread",
   "Total": "합계",
   "Total bytes": "총 바이트",
   "Total storage to migrate is {{totalAmount}}": "마이그레이션할 총 스토리지는 {{totalAmount}}입니다.",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1586,7 +1586,7 @@
   "Top consumers": "顶级消费者",
   "Topology key": "拓扑键",
   "Topology key must not be empty": "拓扑键不能为空",
-  "Topology will be set to {{sockets}} socket, 1 core, 1 thread": "拓扑将设置为 {{sockets}} 个插槽、1 个内核、1 个线程",
+  "Topology will be set to {{sockets}} socket, {{cores}} core, {{threads}} thread": "Topology will be set to {{sockets}} socket, {{cores}} core, {{threads}} thread",
   "Total": "总计",
   "Total bytes": "字节总数",
   "Total storage to migrate is {{totalAmount}}": "要迁移的总存储是 {{totalAmount}}",

--- a/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
@@ -3,6 +3,7 @@ import produce from 'immer';
 
 import { V1CPU, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import CPUInput from '@kubevirt-utils/components/CPUMemoryModal/components/CPUInput/CPUInput';
+import { getCPULimitsFromVM } from '@kubevirt-utils/components/CPUMemoryModal/components/CPUInput/utils/utils';
 import MemoryInput from '@kubevirt-utils/components/CPUMemoryModal/components/MemoryInput/MemoryInput';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -62,6 +63,8 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
     vm?.metadata?.labels?.['vm.kubevirt.io/template.namespace'] || templateNamespace,
   );
   const { defaultCpu, defaultMemory } = templateDefaultsData || {};
+
+  const cpuLimits = getCPULimitsFromVM(vm);
   const { size: defaultMemorySize, unit: defaultMemoryUnit } = defaultMemory || {};
 
   const templateName = getLabel(vm, VM_TEMPLATE_ANNOTATION);
@@ -102,7 +105,12 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
       <ModalHeader title={t('Edit CPU | Memory')} />
       <ModalBody>
         <div className="inputs">
-          <CPUInput currentCPU={getCPU(vm)} setUserEnteredCPU={setCPU} userEnteredCPU={cpu} />
+          <CPUInput
+            cpuLimits={cpuLimits}
+            currentCPU={getCPU(vm)}
+            setUserEnteredCPU={setCPU}
+            userEnteredCPU={cpu}
+          />
           <MemoryInput
             memory={memory}
             memoryUnit={memoryUnit}

--- a/src/utils/components/CPUMemoryModal/components/CPUInput/components/CPUTopologyInput/CPUTopologyInput.tsx
+++ b/src/utils/components/CPUMemoryModal/components/CPUInput/components/CPUTopologyInput/CPUTopologyInput.tsx
@@ -9,12 +9,19 @@ import CPUComponentInput from './components/CPUComponentInput';
 
 type CPUTopologyInputProps = {
   cpu: V1CPU;
+  cpuLimits: Record<string, number>;
   hide: boolean;
   isDisabled: boolean;
   setCPU: Dispatch<SetStateAction<V1CPU>>;
 };
 
-const CPUTopologyInput: FC<CPUTopologyInputProps> = ({ cpu, hide, isDisabled, setCPU }) => {
+const CPUTopologyInput: FC<CPUTopologyInputProps> = ({
+  cpu,
+  cpuLimits,
+  hide,
+  isDisabled,
+  setCPU,
+}) => {
   if (hide) return null;
 
   return (
@@ -22,18 +29,21 @@ const CPUTopologyInput: FC<CPUTopologyInputProps> = ({ cpu, hide, isDisabled, se
       <CPUComponentInput
         cpu={cpu}
         cpuComponent={CPUComponent.cores}
+        cpuLimits={cpuLimits}
         isDisabled={isDisabled}
         setCPU={setCPU}
       />
       <CPUComponentInput
         cpu={cpu}
         cpuComponent={CPUComponent.sockets}
+        cpuLimits={cpuLimits}
         isDisabled={isDisabled}
         setCPU={setCPU}
       />
       <CPUComponentInput
         cpu={cpu}
         cpuComponent={CPUComponent.threads}
+        cpuLimits={cpuLimits}
         isDisabled={isDisabled}
         setCPU={setCPU}
       />

--- a/src/utils/components/CPUMemoryModal/components/CPUInput/components/CPUTopologyInput/components/CPUComponentInput.tsx
+++ b/src/utils/components/CPUMemoryModal/components/CPUInput/components/CPUTopologyInput/components/CPUComponentInput.tsx
@@ -11,6 +11,7 @@ import { Content, GridItem, NumberInput } from '@patternfly/react-core';
 type CPUComponentInputProps = {
   cpu: V1CPU;
   cpuComponent: CPUComponent;
+  cpuLimits?: Record<string, number>;
   isDisabled: boolean;
   setCPU: Dispatch<SetStateAction<V1CPU>>;
 };
@@ -18,9 +19,19 @@ type CPUComponentInputProps = {
 const CPUComponentInput: FC<CPUComponentInputProps> = ({
   cpu,
   cpuComponent,
+  cpuLimits,
   isDisabled,
   setCPU,
 }) => {
+  // Get minimum value from validation rules
+  const minValue = cpuLimits?.[cpuComponent] || 1;
+
+  const updateCPU = (newValue: number) => {
+    if (newValue >= minValue) {
+      setCPU(getUpdatedCPU(cpu, newValue, cpuComponent));
+    }
+  };
+
   return (
     <>
       <GridItem span={3}>
@@ -31,14 +42,17 @@ const CPUComponentInput: FC<CPUComponentInputProps> = ({
       <GridItem span={9}>
         <NumberInput
           onChange={(e: ChangeEvent<HTMLInputElement>) => {
-            const newNumber = +e?.target?.value;
-            setCPU(getUpdatedCPU(cpu, newNumber, cpuComponent));
+            updateCPU(+e?.target?.value);
+          }}
+          onMinus={() => {
+            updateCPU(+cpu?.[cpuComponent] - 1);
+          }}
+          onPlus={() => {
+            updateCPU(+cpu?.[cpuComponent] + 1);
           }}
           inputName="cpu-sockets-input"
           isDisabled={isDisabled}
-          min={1}
-          onMinus={() => setCPU(getUpdatedCPU(cpu, +cpu?.[cpuComponent] - 1, cpuComponent))}
-          onPlus={() => setCPU(getUpdatedCPU(cpu, +cpu?.[cpuComponent] + 1, cpuComponent))}
+          min={minValue}
           value={cpu?.[cpuComponent]}
           widthChars={1}
         />

--- a/src/utils/components/CPUMemoryModal/components/CPUInput/components/vCPUInput/VCPUInput.tsx
+++ b/src/utils/components/CPUMemoryModal/components/CPUInput/components/vCPUInput/VCPUInput.tsx
@@ -2,6 +2,7 @@ import React, { ChangeEvent, Dispatch, FC, SetStateAction } from 'react';
 
 import { V1CPU } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import {
+  convertTopologyToVCPUs,
   CPUComponent,
   getUpdatedCPU,
 } from '@kubevirt-utils/components/CPUMemoryModal/components/CPUInput/utils/utils';
@@ -45,7 +46,7 @@ const VCPUInput: FC<vCPUInputProps> = ({ cpu, isDisabled, setCPU }) => {
           inputName="cpu-input"
           isDisabled={isDisabled}
           min={1}
-          value={cpu?.sockets}
+          value={convertTopologyToVCPUs(cpu)}
           widthChars={1}
         />
       </GridItem>

--- a/src/utils/components/CPUMemoryModal/components/CPUInput/components/vCPUInput/components/CPUHelperText/CPUHelperText.tsx
+++ b/src/utils/components/CPUMemoryModal/components/CPUInput/components/vCPUInput/components/CPUHelperText/CPUHelperText.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 import { V1CPU } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { formatVCPUsAsSockets } from '@kubevirt-utils/components/CPUMemoryModal/components/CPUInput/utils/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { parseCPU } from '@kubevirt-utils/resources/template/utils';
 
 import './CPUHelperText.scss';
 
@@ -16,11 +17,14 @@ const CPUHelperText: FC<CPUHelperTextProps> = ({ cpu, hide }) => {
 
   if (hide) return null;
 
+  const formattedCPU = formatVCPUsAsSockets(cpu);
+
   return (
     <div id="cpu-helper-text">
-      {t('Topology will be set to {{sockets}} socket, 1 core, 1 thread', {
-        sockets: formatVCPUsAsSockets(cpu)?.sockets,
-      })}
+      {t(
+        'Topology will be set to {{sockets}} socket, {{cores}} core, {{threads}} thread',
+        parseCPU(formattedCPU),
+      )}
     </div>
   );
 };

--- a/src/utils/components/CPUMemoryModal/components/CPUInput/utils/utils.ts
+++ b/src/utils/components/CPUMemoryModal/components/CPUInput/utils/utils.ts
@@ -1,4 +1,5 @@
-import { V1CPU } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1CPU, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { parseJSONAnnotation } from '@overview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/utils/VirtualizationFeaturesContext/utils/utils';
 
 export enum CPUInputType {
   editTopologyManually = 'editTopologyManually',
@@ -20,6 +21,51 @@ export const convertTopologyToVCPUs = (cpu: V1CPU): number =>
   cpu?.cores * cpu?.sockets * (cpu?.threads || 1);
 
 export const formatVCPUsAsSockets = (cpu: V1CPU): V1CPU => {
-  const numVCPUs = convertTopologyToVCPUs(cpu);
-  return { ...cpu, ...{ cores: 1, sockets: numVCPUs, threads: 1 } };
+  return { ...cpu };
+};
+
+type VMValidationRule = {
+  max?: number;
+  message: string;
+  min?: number;
+  name: string;
+  path: string;
+  rule: string;
+};
+
+const parseValidationAnnotations = (
+  annotations?: Record<string, string>,
+): Record<string, number> => {
+  const validations = parseJSONAnnotation<VMValidationRule[]>(
+    annotations,
+    'vm.kubevirt.io/validations',
+    {},
+  );
+
+  if (!validations?.length) {
+    return { cores: 1, sockets: 1, threads: 1 };
+  }
+
+  const coresValidation = validations.find((value) => value.path?.includes('cpu.cores'));
+  const socketsValidation = validations.find((value) => value.path?.includes('cpu.sockets'));
+  const threadsValidation = validations.find((value) => value.path?.includes('cpu.threads'));
+
+  return {
+    cores: coresValidation?.min || 1,
+    sockets: socketsValidation?.min || 1,
+    threads: threadsValidation?.min || 1,
+  };
+};
+
+export const getCPULimitsFromVM = (vm: V1VirtualMachine): Record<string, number> => {
+  return parseValidationAnnotations(vm?.metadata?.annotations);
+};
+
+export const getCPULimitsFromTemplate = (template: V1Template): Record<string, number> => {
+  return parseValidationAnnotations(template?.metadata?.annotations);
+};
+
+export const getInitialCPUInputType = (cpu: V1CPU): CPUInputType => {
+  const isSimpleCPU = (cpu?.cores || 1) === 1 && (cpu?.threads || 1) === 1;
+  return isSimpleCPU ? CPUInputType.editVCPU : CPUInputType.editTopologyManually;
 };

--- a/src/views/templates/details/tabs/details/components/CPUMemoryModal/CPUMemoryModal.tsx
+++ b/src/views/templates/details/tabs/details/components/CPUMemoryModal/CPUMemoryModal.tsx
@@ -4,6 +4,7 @@ import produce from 'immer';
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import { V1CPU } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import CPUInput from '@kubevirt-utils/components/CPUMemoryModal/components/CPUInput/CPUInput';
+import { getCPULimitsFromTemplate } from '@kubevirt-utils/components/CPUMemoryModal/components/CPUInput/utils/utils';
 import MemoryInput from '@kubevirt-utils/components/CPUMemoryModal/components/MemoryInput/MemoryInput';
 import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -78,6 +79,8 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({ isOpen, onClose, onSubmit, te
   const { defaultCPU, defaultMemory } = getDefaultCPUMemoryValues(template);
   const { defaultMemorySize, defaultMemoryUnit } = defaultMemory;
 
+  const cpuLimits = getCPULimitsFromTemplate(template);
+
   useEffect(() => {
     if (vm?.metadata) {
       const { size: memSize, unit: memUnit } = getMemorySize(getMemory(vm));
@@ -98,7 +101,12 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({ isOpen, onClose, onSubmit, te
       <ModalHeader title={t('Edit CPU | Memory')} />
       <ModalBody>
         <div className="inputs">
-          <CPUInput currentCPU={defaultCPU} setUserEnteredCPU={setCPU} userEnteredCPU={cpu} />
+          <CPUInput
+            cpuLimits={cpuLimits}
+            currentCPU={defaultCPU}
+            setUserEnteredCPU={setCPU}
+            userEnteredCPU={cpu}
+          />
           <MemoryInput
             memory={memory}
             memoryUnit={memoryUnit}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

the vcpu logic was set so when updating the number it updated the socket amount while hardcoding core number and thread number to 1 each. in windows11 template there is a minimal requierment for 2 cores causing a failure to update. 
This fix allows to keep updating the sockets alone when updating vcpu but displaying in the CPU|Memory actual vcpu number and adds validation checks to define minimum core number in windows11 template as 2. 

## 🎥 Demo
before:
<img width="3914" height="3280" alt="image" src="https://github.com/user-attachments/assets/77c6f89f-15ed-4a93-8583-253ab23a78bd" />

After:
<img width="1531" height="1209" alt="image" src="https://github.com/user-attachments/assets/51c4b565-2bf9-4292-970f-4ab2e719ac3d" />

