### PR TITLE
CNV-69718: fix tree view project item ID on single cluster

### DIFF
--- a/src/views/virtualmachines/tree/utils/utils.tsx
+++ b/src/views/virtualmachines/tree/utils/utils.tsx
@@ -157,7 +157,9 @@ const createProjectTreeItem = (
 
   const projectChildren = [...sortProjectFolders, ...(projectMap[project]?.ungrouped || [])];
 
-  const projectTreeItemID = `${PROJECT_SELECTOR_PREFIX}/${cluster}/${project}`;
+  const projectTreeItemID = `${PROJECT_SELECTOR_PREFIX}/${
+    cluster ?? SINGLE_CLUSTER_KEY
+  }/${project}`;
   const projectTreeItem: TreeViewDataItemWithHref = {
     children: projectChildren,
     customBadgeContent: projectMap[project]?.count || '0',


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes tree view project item ID on single cluster (from `projectSelector/undefined/default` to `projectSelector/#single-cluster#/default`)

  - other functionality then works correctly - link to Catalog and the other menu items are not disabled

## 🎥 Demo
Before:


https://github.com/user-attachments/assets/9aae65b4-854f-4a13-9931-44ddf6146843



After:


https://github.com/user-attachments/assets/54513b91-42e8-4549-9ab5-9ee9ea49910a


