### PR TITLE
CNV-68854: improve expandable sections indentation

### DIFF
--- a/src/utils/components/ExpandSectionWithCustomToggle/ExpandSectionWithCustomToggle.tsx
+++ b/src/utils/components/ExpandSectionWithCustomToggle/ExpandSectionWithCustomToggle.tsx
@@ -86,6 +86,7 @@ const ExpandSectionWithCustomToggle: FC<ExpandSectionWithCustomToggleProps> = ({
         <ExpandableSection
           className={classNames(
             'expand-section-custom-toggle__expandable-section',
+            'ExpandSection',
             expandSectionClassName,
           )}
           contentId={contentID}

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/GuestSystemLogsAccess/GuestSystemLogsAccess.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GuestManagmentSection/GuestSystemLogsAccess/GuestSystemLogsAccess.tsx
@@ -70,7 +70,7 @@ const GuestSystemLogsAccess: FC<GuestSystemLogsAccessProps> = ({
 
   return (
     <>
-      <Split className="settings-tab--indented">
+      <Split>
         <SplitItem isFilled>
           {t('Enable guest system log access')}{' '}
           <HelpTextIcon

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
@@ -58,7 +58,7 @@ const PersistentReservationSection: FC<PersistentReservationSectionProps> = ({
 
   return (
     <ExpandSection toggleText={t('SCSI persistent reservation')}>
-      <Split className="settings-tab--indented">
+      <Split>
         <SplitItem isFilled>
           {t('Enable persistent reservation')}{' '}
           <HelpTextIcon

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.tsx
@@ -36,7 +36,7 @@ const AutoComputeCPULimits: FC<AutoComputeCPULimitsProps> = ({
 
   return (
     <>
-      <Split className="settings-tab--indented">
+      <Split>
         <SplitItem isFilled>
           {t('Auto-compute CPU and memory limits')} {newBadge && <NewBadge />}
         </SplitItem>

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/KernelSamepageMerging/KernelSamepageMerging.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/ResourceManagementSection/components/KernelSamepageMerging/KernelSamepageMerging.tsx
@@ -67,7 +67,7 @@ const KernelSamepageMerging: FC<KernelSamepageMergingProps> = ({
 
   return (
     <>
-      <Split className="settings-tab--indented">
+      <Split>
         <SplitItem isFilled>
           {t('Kernel Samepage Merging (KSM)')}{' '}
           <HelpTextIcon

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/VirtualizationFeaturesSection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/VirtualizationFeaturesSection.tsx
@@ -53,6 +53,7 @@ const VirtualizationFeaturesSection: FC = () => {
       className="virtualization-features-section"
       customContent={ConfigureButton}
       id="virtualization-features-section"
+      isIndented
       toggleContent={t('Virtualization features')}
     >
       <Stack hasGutter>

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/FeaturedOperatorItem.scss
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/FeaturedOperatorItem.scss
@@ -1,5 +1,7 @@
 .featured-operator-item {
-  padding-left: var(--pf-t--global--spacer--lg);
+  &__link-button {
+    margin-left: -0.5rem;
+  }
 
   &__icon-container {
     margin-inline-start: auto;

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/FeaturedOperatorItem.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/FeaturedOperatorItem.tsx
@@ -24,7 +24,11 @@ const FeaturedOperatorItem: FC<FeaturedOperatorItemProps> = ({ operatorName, tit
   return (
     <Split className="featured-operator-item" hasGutter>
       <SplitItem>
-        <Button onClick={() => navigate(operatorHubURL)} variant="link">
+        <Button
+          className="featured-operator-item__link-button"
+          onClick={() => navigate(operatorHubURL)}
+          variant="link"
+        >
           {title}
         </Button>
       </SplitItem>

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/SummaryStep/components/FeatureSummaryItem/FeatureSummaryItem.scss
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/SummaryStep/components/FeatureSummaryItem/FeatureSummaryItem.scss
@@ -4,7 +4,7 @@
   }
 
   &__name--indented {
-    width: 243px;
+    width: 253px;
   }
 
   &__status-icon {

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/SummaryStep/components/HighAvailabilitySection/HighAvailabilitySummarySection.scss
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/SummaryStep/components/HighAvailabilitySection/HighAvailabilitySummarySection.scss
@@ -1,6 +1,11 @@
 .high-availability-summary-section {
   &__toggle {
-    margin-right: 140px;
+    margin-right: 148px;
+    margin-left: -0.5rem;
+  }
+
+  &__expand-section .pf-v6-c-expandable-section__content {
+    padding-left: calc(var(--pf-v6-c-expandable-section__content--PaddingInlineStart) - 0.5rem);
   }
 
   &__status-icon {

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/SummaryStep/components/HighAvailabilitySection/HighAvailabilitySummarySection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/SummaryStep/components/HighAvailabilitySection/HighAvailabilitySummarySection.tsx
@@ -30,11 +30,13 @@ const HighAvailabilitySummarySection: FC<HighAvailabilitySummarySectionProps> = 
   return (
     <ExpandSectionWithCustomToggle
       customContent={<SummaryStatusIcon installState={jointInstallState} />}
+      expandSectionClassName="high-availability-summary-section__expand-section"
       id="high-availability-summary-section"
+      isIndented
       toggleClassname="high-availability-summary-section__toggle"
       toggleContent={t('High availability')}
     >
-      <Stack className="pf-v6-u-pl-xl" hasGutter>
+      <Stack hasGutter>
         <StackItem>
           <FeatureSummaryItem
             isIndented

--- a/src/views/clusteroverview/SettingsTab/ExpandSection/ExpandSection.scss
+++ b/src/views/clusteroverview/SettingsTab/ExpandSection/ExpandSection.scss
@@ -15,6 +15,12 @@
 
 .ExpandSection {
   .pf-v6-c-expandable-section__content {
-    padding-left: var(--pf-v6-c-expandable-section--m-display-lg--PaddingInlineStart) !important;
+    .pf-v6-c-expandable-section__toggle {
+      margin-left: -0.5rem;
+    }
+
+    .pf-v6-c-expandable-section__content {
+      padding-left: calc(var(--pf-v6-c-expandable-section__content--PaddingInlineStart) - 0.5rem);
+    }
   }
 }

--- a/src/views/clusteroverview/SettingsTab/settings-tab.scss
+++ b/src/views/clusteroverview/SettingsTab/settings-tab.scss
@@ -14,10 +14,6 @@
     padding: var(--pf-t--global--spacer--2xl);
     padding-left: calc(var(--pf-t--global--spacer--3xl) * 2);
   }
-
-  &--indented {
-    margin-left: 0.8rem;
-  }
 }
 
 .section-divider {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- applies general styling for expandable sections indentation, so setting `className="settings-tab--indented"` on individual Split components is not necessary
  - key thing is applying `margin-left: -0.5rem` on toggles
  - these toggles use link Button under the hood, so they have an "invisible" padding of 0.5 rem, which is only visible on hover -> in default state it looks misaligned
- fixes indentation of "Load balance" under "Virtualization features"

- note: the negative margin only applies to second and more nested expandable sections. The top level stays as before. In `.high-availability-summary-section` (in Wizard modal in video) it is an exception, because it is on the first level and it is aligned with other text
  - instead we could apply the style on the first level too and don't have this exception, wdyt?
- note#2: it breaks the default PatternFly styling, but I think the PF style is wrong in this case and it should count with these "invisible" paddings
  - you can see it was aligned well on PF5 and is not in PF6
  - I will open a bug on PatternFly
  
<img width="854" height="244" alt="Screenshot 2025-09-19 at 13 26 38" src="https://github.com/user-attachments/assets/58115b52-dfd0-4203-b70a-4f60adc9045a" />
<img width="854" height="169" alt="Screenshot 2025-09-19 at 13 27 14" src="https://github.com/user-attachments/assets/78339816-f565-4eb5-980e-4fe1d4067f1b" />


## 🎥 Demo

Before:


https://github.com/user-attachments/assets/8ac1578d-b7da-42d2-8a12-dcb5a4bbc7ea



After:


https://github.com/user-attachments/assets/e0b252fc-3083-4e19-a529-eab8ac0a3133



