### PR TITLE
CNV-60706: make sure summary and list filter use the same error statuses

### DIFF
--- a/src/utils/resources/vm/utils/vmStatus.ts
+++ b/src/utils/resources/vm/utils/vmStatus.ts
@@ -18,3 +18,15 @@ export enum VM_STATUS {
   Unknown = 'Unknown',
   WaitingForVolumeBinding = 'WaitingForVolumeBinding',
 }
+
+export const VM_ERROR_STATUSES = [
+  VM_STATUS.CrashLoopBackOff,
+  VM_STATUS.ErrorUnschedulable,
+  VM_STATUS.ErrImagePull,
+  VM_STATUS.ImagePullBackOff,
+  VM_STATUS.ErrorPvcNotFound,
+  VM_STATUS.ErrorDataVolumeNotFound,
+  VM_STATUS.DataVolumeError,
+  VM_STATUS.Unknown,
+  VM_STATUS.WaitingForVolumeBinding,
+];

--- a/src/views/clusteroverview/OverviewTab/vm-statuses-card/utils/utils.ts
+++ b/src/views/clusteroverview/OverviewTab/vm-statuses-card/utils/utils.ts
@@ -2,25 +2,13 @@ import { Fragment } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getVMStatus } from '@kubevirt-utils/resources/shared';
-import { VM_STATUS } from '@kubevirt-utils/resources/vm/utils/vmStatus';
+import { VM_ERROR_STATUSES, VM_STATUS } from '@kubevirt-utils/resources/vm/utils/vmStatus';
 import { RedExclamationCircleIcon } from '@openshift-console/dynamic-plugin-sdk';
 import { InProgressIcon, OffIcon, PausedIcon, SyncAltIcon } from '@patternfly/react-icons';
 
 import { ERROR } from './constants';
 
 const PRIMARY_STATUSES = [VM_STATUS.Running, VM_STATUS.Stopped, VM_STATUS.Paused, ERROR];
-
-const ERROR_STATUSES = [
-  VM_STATUS.CrashLoopBackOff,
-  VM_STATUS.ErrorUnschedulable,
-  VM_STATUS.ErrImagePull,
-  VM_STATUS.ImagePullBackOff,
-  VM_STATUS.ErrorPvcNotFound,
-  VM_STATUS.ErrorDataVolumeNotFound,
-  VM_STATUS.DataVolumeError,
-  VM_STATUS.Unknown,
-  VM_STATUS.WaitingForVolumeBinding,
-];
 
 export const vmStatusIcon = {
   Deleting: Fragment,
@@ -54,7 +42,7 @@ export const getVMStatuses = (vms: V1VirtualMachine[]): StatusCounts => {
     statusCounts[status] = statusCounts[status] + 1;
   });
 
-  statusCounts[ERROR] = ERROR_STATUSES.reduce((acc, state) => {
+  statusCounts[ERROR] = VM_ERROR_STATUSES.reduce((acc, state) => {
     const count = acc + (statusCounts?.[state] || 0);
     delete statusCounts[state];
     return count;

--- a/src/views/virtualmachines/utils/virtualMachineStatuses.ts
+++ b/src/views/virtualmachines/utils/virtualMachineStatuses.ts
@@ -7,6 +7,7 @@ import {
   getVMSnapshottingStatus,
   getVMStatus,
 } from '@kubevirt-utils/resources/shared';
+import { VM_ERROR_STATUSES, VM_STATUS } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   HourglassHalfIcon,
@@ -43,7 +44,7 @@ export const errorPrintableVMStatus = {
 };
 
 export const isErrorPrintableStatus = (printableStatus: string) =>
-  Object.values(errorPrintableVMStatus).includes(printableStatus);
+  Object.values(VM_ERROR_STATUSES).includes(printableStatus as VM_STATUS);
 
 export const getVMStatusIcon = (status: string): ComponentClass | FC => {
   switch (status) {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

`WaitingForVolumeBinding` was not considered an error during the vm list filtering.


Make sure to use the same error states 