### PR TITLE
CNV-68390: make "Show only projects with VirtualMachines" switch permanent

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1030,6 +1030,7 @@
   "No owner": "No owner",
   "No parameters found in this template.": "No parameters found in this template.",
   "No preferences found": "No preferences found",
+  "No projects with VirtualMachines found": "No projects with VirtualMachines found",
   "No resource selected": "No resource selected",
   "No results found": "No results found",
   "No results found for \"{{searchQuery}}\"": "No results found for \"{{searchQuery}}\"",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1037,6 +1037,7 @@
   "No owner": "Sin propietario",
   "No parameters found in this template.": "No se encontraron parámetros en esta plantilla.",
   "No preferences found": "No se encontraron preferencias",
+  "No projects with VirtualMachines found": "No projects with VirtualMachines found",
   "No resource selected": "Ningún recurso seleccionado",
   "No results found": "No se encontraron resultados",
   "No results found for \"{{searchQuery}}\"": "No se encontraron resultados para “{{searchQuery}}”",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1037,6 +1037,7 @@
   "No owner": "Aucun propriétaire",
   "No parameters found in this template.": "Aucun paramètre trouvé dans ce modèle.",
   "No preferences found": "Aucune préférence trouvée",
+  "No projects with VirtualMachines found": "No projects with VirtualMachines found",
   "No resource selected": "Aucune ressource sélectionnée",
   "No results found": "Aucun résultat trouvé",
   "No results found for \"{{searchQuery}}\"": "Aucun résultat trouvé pour «\u00a0{{searchQuery}}\u00a0»",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1030,6 +1030,7 @@
   "No owner": "オーナーがありません",
   "No parameters found in this template.": "このテンプレートにはパラメーターが見つかりません。",
   "No preferences found": "設定が見つかりません",
+  "No projects with VirtualMachines found": "No projects with VirtualMachines found",
   "No resource selected": "リソースが選択されていません",
   "No results found": "結果が見つかりません",
   "No results found for \"{{searchQuery}}\"": "\"{{searchQuery}}\" の結果が見つかりません",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1030,6 +1030,7 @@
   "No owner": "소유자 없음",
   "No parameters found in this template.": "이 템플릿에 매개 변수를 찾을 수 없습니다.",
   "No preferences found": "기본 설정을 찾을 수 없음",
+  "No projects with VirtualMachines found": "No projects with VirtualMachines found",
   "No resource selected": "리소스가 선택되어 있지 않습니다",
   "No results found": "결과 없음",
   "No results found for \"{{searchQuery}}\"": "\"{{searchQuery}}\"의 결과를 찾을 수 없음",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1030,6 +1030,7 @@
   "No owner": "没有所有者",
   "No parameters found in this template.": "此模板中没有找到参数。",
   "No preferences found": "没有找到首选项",
+  "No projects with VirtualMachines found": "No projects with VirtualMachines found",
   "No resource selected": "未选择资源",
   "No results found": "未找到结果",
   "No results found for \"{{searchQuery}}\"": "没有为 \"{{searchQuery}}\" 找到结果",

--- a/src/views/virtualmachines/tree/VirtualMachineTreeView.tsx
+++ b/src/views/virtualmachines/tree/VirtualMachineTreeView.tsx
@@ -39,7 +39,6 @@ type VirtualMachineTreeViewProps = {
 
 const VirtualMachineTreeView: FC<VirtualMachineTreeViewProps> = ({
   children,
-  hideSwitch,
   loaded,
   loadError,
   onFilterChange,
@@ -85,7 +84,6 @@ const VirtualMachineTreeView: FC<VirtualMachineTreeViewProps> = ({
 
   const treeView = (
     <TreeViewContent
-      hideSwitch={hideSwitch}
       isOpen={isOpen}
       isSmallScreen={isSmallScreen}
       loaded={loaded}

--- a/src/views/virtualmachines/tree/components/TreeViewContent.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewContent.tsx
@@ -2,12 +2,14 @@ import React, { FC, useState } from 'react';
 
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   Bullseye,
   Content,
   DrawerActions,
   DrawerHead,
   DrawerPanelBody,
+  EmptyState,
   TreeView,
   TreeViewDataItem,
 } from '@patternfly/react-core';
@@ -22,7 +24,6 @@ import TreeViewCollapseExpand from './TreeViewCollapseExpand';
 import TreeViewToolbar from './TreeViewToolbar';
 
 type TreeViewContentProps = {
-  hideSwitch: boolean;
   isOpen: boolean;
   isSmallScreen: boolean;
   loaded: boolean;
@@ -33,7 +34,6 @@ type TreeViewContentProps = {
 };
 
 const TreeViewContent: FC<TreeViewContentProps> = ({
-  hideSwitch,
   isOpen,
   isSmallScreen,
   loaded,
@@ -65,7 +65,7 @@ const TreeViewContent: FC<TreeViewContentProps> = ({
   return (
     <>
       {!isSmallScreen && panelToggleButton}
-      <TreeViewToolbar hideSwitch={hideSwitch} />
+      <TreeViewToolbar />
       <DrawerHead className="vms-tree-view__header-section">
         <Content className="vms-tree-view__title" component="p">
           <TreeViewCollapseExpand setShowAll={setShowAll} showAll={showAll} />
@@ -76,15 +76,23 @@ const TreeViewContent: FC<TreeViewContentProps> = ({
         </DrawerActions>
       </DrawerHead>
       <DrawerPanelBody className="vms-tree-view-body">
-        <TreeView
-          activeItems={[selectedTreeItem]}
-          allExpanded={showAll}
-          data={filteredTreeData}
-          hasBadges={loaded}
-          hasSelectableNodes
-          onExpand={addListeners}
-          onSelect={onSelect}
-        />
+        {isEmpty(filteredTreeData) ? (
+          <EmptyState
+            headingLevel="h4"
+            titleText={t('No projects with VirtualMachines found')}
+            variant="xs"
+          />
+        ) : (
+          <TreeView
+            activeItems={[selectedTreeItem]}
+            allExpanded={showAll}
+            data={filteredTreeData}
+            hasBadges={loaded}
+            hasSelectableNodes
+            onExpand={addListeners}
+            onSelect={onSelect}
+          />
+        )}
         <TreeViewRightClickActionMenu hideMenu={hideMenu} triggerElement={triggerElement} />
       </DrawerPanelBody>
     </>

--- a/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
@@ -16,17 +16,9 @@ import {
 
 import { HIDE, SHOW, SHOW_EMPTY_PROJECTS_KEY } from '../utils/constants';
 
-type TreeViewToolbarProps = {
-  hideSwitch: boolean;
-};
-
-const TreeViewToolbar: FC<TreeViewToolbarProps> = ({ hideSwitch }) => {
+const TreeViewToolbar: FC = () => {
   const { t } = useKubevirtTranslation();
   const [showEmptyProjects, setShowEmptyProjects] = useLocalStorage(SHOW_EMPTY_PROJECTS_KEY, HIDE);
-
-  if (hideSwitch) {
-    return null;
-  }
 
   return (
     <Toolbar className="vms-tree-view-toolbar" isSticky>

--- a/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
@@ -24,14 +24,9 @@ import { useFleetClusterNames } from '@stolostron/multicluster-sdk';
 import { getLatestMigrationForEachVM, OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils';
 
 import { vmimMapperSignal, vmsSignal } from '../utils/signals';
-import {
-  createMultiClusterTreeViewData,
-  createSingleClusterTreeViewData,
-  isSystemNamespace,
-} from '../utils/utils';
+import { createMultiClusterTreeViewData, createSingleClusterTreeViewData } from '../utils/utils';
 
 export type UseTreeViewData = {
-  hideSwitch: boolean;
   loaded: boolean;
   loadError: any;
   treeData: TreeViewDataItem[];
@@ -161,15 +156,12 @@ export const useTreeViewData = (): UseTreeViewData => {
     location.search,
   ]);
 
-  const hideSwitch = useMemo(() => projectNames?.every(isSystemNamespace), [projectNames]);
-
   return useMemo(
     () => ({
-      hideSwitch,
       loaded,
       loadError: projectNamesError || multiclusterNamespacesError,
       treeData,
     }),
-    [hideSwitch, loaded, multiclusterNamespacesError, projectNamesError, treeData],
+    [loaded, multiclusterNamespacesError, projectNamesError, treeData],
   );
 };


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- makes the "Show only projects with VirtualMachines" switch permanent
  - previously it was hidden if no non-system namespaces were existing

## 🎥 Demo

Before (no non-system projects):
<img width="1489" height="829" alt="Screenshot 2025-09-23 at 10 35 16" src="https://github.com/user-attachments/assets/458520ac-50ae-44b8-a8e8-4b45e6a93a64" />

Before (no VMs):
<img width="1489" height="829" alt="Screenshot 2025-09-23 at 10 26 18" src="https://github.com/user-attachments/assets/90012368-601c-4431-a5c5-3b2ccd60a18c" />

After:
<img width="1489" height="829" alt="Screenshot 2025-09-23 at 10 21 05" src="https://github.com/user-attachments/assets/f694562b-3b28-40f7-ba4e-b4d2d477ba41" />

