### PR TITLE
CNV-69817: fix memory reading in bytes

### DIFF
--- a/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
@@ -77,7 +77,7 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
       ]);
 
       vmDraft.spec.template.spec.domain.cpu = cpu;
-      vmDraft.spec.template.spec.domain.memory.guest = `${memory}${memoryUnit}`;
+      vmDraft.spec.template.spec.domain.memory.guest = `${memory}${memoryUnit || ''}`;
     });
 
     try {

--- a/src/utils/components/CPUMemoryModal/utils/CpuMemoryUtils.ts
+++ b/src/utils/components/CPUMemoryModal/utils/CpuMemoryUtils.ts
@@ -11,7 +11,7 @@ const unitsConvertor = new Proxy(
   {
     // eslint-disable-next-line require-jsdoc
     get(target, prop) {
-      return target[prop] || target.Gi;
+      return target[prop] || '';
     },
   },
 );

--- a/src/views/templates/details/tabs/details/components/CPUMemoryModal/CPUMemoryModal.tsx
+++ b/src/views/templates/details/tabs/details/components/CPUMemoryModal/CPUMemoryModal.tsx
@@ -61,7 +61,7 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({ isOpen, onClose, onSubmit, te
       ]);
 
       draftVM.spec.template.spec.domain.cpu = cpu;
-      draftVM.spec.template.spec.domain.memory.guest = `${memory}${memoryUnit}`;
+      draftVM.spec.template.spec.domain.memory.guest = `${memory}${memoryUnit || ''}`;
     });
 
     try {


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

In ACM, VMI memory is indexed as bytes 

**BEFORE**
<img width="1222" height="827" alt="Screenshot 2025-09-23 at 11 39 51" src="https://github.com/user-attachments/assets/bbd6dd32-e728-4407-a8b8-c0ab931c3212" />


**AFTER**

<img width="1222" height="827" alt="Screenshot 2025-09-23 at 11 33 20" src="https://github.com/user-attachments/assets/090f1a4f-cc40-4469-835d-cb1ef462971c" />