### PR TITLE
CNV-64588: Filter out IPv6 link-local addresses

### DIFF
--- a/src/utils/components/FormPFSelect/FormPFSelect.tsx
+++ b/src/utils/components/FormPFSelect/FormPFSelect.tsx
@@ -11,7 +11,18 @@ type FormPFSelectProps = Omit<SelectProps, 'isOpen' | 'toggle'> & {
   toggleProps?: MenuToggleProps;
 };
 
-/** PatternFly Select component wrapper for convenient usage. Options should be passed as children and shouldn't be wrapped in SelectList. */
+/**
+ * PatternFly Select component wrapper for convenient usage. Options should be passed as children and shouldn't be wrapped in SelectList.
+ * @param root0
+ * @param root0.children
+ * @param root0.className
+ * @param root0.closeOnSelect
+ * @param root0.isDisabled
+ * @param root0.onSelect
+ * @param root0.selected
+ * @param root0.selectedLabel
+ * @param root0.toggleProps
+ */
 const FormPFSelect: FC<FormPFSelectProps> = ({
   children,
   className,

--- a/src/utils/utils/utils.test.ts
+++ b/src/utils/utils/utils.test.ts
@@ -1,5 +1,5 @@
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { ensurePath } from '@kubevirt-utils/utils/utils';
+import { ensurePath, isIPV6LinkLocal } from '@kubevirt-utils/utils/utils';
 
 describe('Test ensurePath', () => {
   describe('Only one path', () => {
@@ -64,5 +64,26 @@ describe('Test ensurePath', () => {
 
       expect(data.spec.template).toBeDefined();
     });
+  });
+});
+
+describe('Test isIPV6LinkLocal', () => {
+  test('IPv6 link-local address', () => {
+    expect(isIPV6LinkLocal('fe80::1')).toBe(true);
+    expect(isIPV6LinkLocal('fe81::1')).toBe(true);
+    expect(isIPV6LinkLocal('fea0::1')).toBe(true);
+  });
+
+  test('regular IPv4 and IPv6 addresses', () => {
+    expect(isIPV6LinkLocal('192.168.1.1')).toBe(false);
+    expect(isIPV6LinkLocal('2001:db8::1')).toBe(false);
+    expect(isIPV6LinkLocal('fec0:db8::1')).toBe(false);
+    expect(isIPV6LinkLocal('::1')).toBe(false);
+  });
+
+  test('invalid input', () => {
+    expect(isIPV6LinkLocal(undefined)).toBe(false);
+    expect(isIPV6LinkLocal(null)).toBe(false);
+    expect(isIPV6LinkLocal('')).toBe(false);
   });
 });

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/VirtualMachinesOverviewTabNetworkInterfacesRow.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/VirtualMachinesOverviewTabNetworkInterfacesRow.tsx
@@ -7,6 +7,7 @@ import useIsFQDNEnabled from '@kubevirt-utils/hooks/useFQDN/useIsFQDNEnabled';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { getPrintableNetworkInterfaceType } from '@kubevirt-utils/resources/vm/utils/network/selectors';
+import { removeLinkLocalIPV6 } from '@kubevirt-utils/utils/utils';
 import { TableData } from '@openshift-console/dynamic-plugin-sdk';
 import {
   DescriptionList,
@@ -38,7 +39,7 @@ const VirtualMachinesOverviewTabInterfacesRow: FC<
 
   const fqdn = useFQDN(obj?.network?.name, obj?.vm);
   const isFQDNEnabled = useIsFQDNEnabled();
-
+  const ipAddresses = removeLinkLocalIPV6(obj?.ipAddresses ?? []);
   return (
     <>
       <TableData activeColumnIDs={activeColumnIDs} id="name">
@@ -77,11 +78,11 @@ const VirtualMachinesOverviewTabInterfacesRow: FC<
         </div>
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="ip">
-        <div data-test-id={`network-interface-${obj?.ipAddresses}`}>
+        <div data-test-id={`network-interface-${ipAddresses}`}>
           <FirstItemListPopover
             headerContent={'IP addresses'}
             includeCopyFirstItem
-            items={obj?.ipAddresses}
+            items={ipAddresses}
           />
         </div>
       </TableData>

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
@@ -1,5 +1,4 @@
 import React, { FC, ReactNode } from 'react';
-import { removeIPV6 } from 'src/utils/utils/utils';
 
 import {
   V1VirtualMachine,
@@ -31,7 +30,7 @@ const VirtualMachineRunningRow: FC<
 > = ({ activeColumnIDs, index, obj, rowData: { pvcMapper, status, vmi, vmim } }) => {
   const { t } = useKubevirtTranslation();
 
-  const ipAddresses = removeIPV6(vmi && getVMIIPAddressesWithName(vmi));
+  const ipAddresses = getVMIIPAddressesWithName(vmi);
 
   return (
     <VirtualMachineRowLayout

--- a/src/views/virtualmachines/utils/utils.ts
+++ b/src/views/virtualmachines/utils/utils.ts
@@ -16,7 +16,7 @@ export const isLiveMigratable = (vm: V1VirtualMachine): boolean =>
 export const isRunning = (vm: V1VirtualMachine): boolean =>
   vm?.status?.printableStatus === printableVMStatus.Running;
 
-const decimalToBinary = (decimalNumber: number) => (decimalNumber >>> 0).toString(2);
+export const decimalToBinary = (decimalNumber: number) => (decimalNumber >>> 0).toString(2);
 
 const ipStringToBinary = (ip: string) =>
   ip


### PR DESCRIPTION
## 📝 Description

Filter all IP addresses that start with fe80::/10 as defined in section 2.5.6 of RC4291.

Replaces #2895.

Related fix - skip IP addresses that are empty string.

Reference-Url: https://www.rfc-editor.org/rfc/rfc4291#section-2.5.6
Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/2895

## 🎥 Demo

### Before - link-local IPv6 address visible
<img width="693" height="385" alt="Screenshot From 2025-09-23 19-32-58" src="https://github.com/user-attachments/assets/a260d663-c92d-4c26-aa5f-32d52a0473e5" />
<img width="672" height="381" alt="Screenshot From 2025-09-23 19-32-20" src="https://github.com/user-attachments/assets/c328052d-bc92-4985-b4bb-c92a065be5fe" />


### After - link-local filtered out
<img width="700" height="409" alt="Screenshot From 2025-09-23 19-26-21" src="https://github.com/user-attachments/assets/f23e8061-2d8e-4444-9415-1ef870e3d8d5" />

<img width="693" height="385" alt="Screenshot From 2025-09-23 21-26-52" src="https://github.com/user-attachments/assets/c0891363-314e-4060-a4eb-83947ad41c0e" />

### Before - multiple empty addresses 
<img width="535" height="381" alt="Screenshot From 2025-09-23 19-34-17" src="https://github.com/user-attachments/assets/749215b2-11d6-4955-904d-fb6349be5af8" />

### After - empty addresses collapsed into one dash

<img width="291" height="303" alt="image" src="https://github.com/user-attachments/assets/ce368da1-903e-4bea-88df-05075d364a4e" />
