### PR TITLE
CNV-69840: Search IPv6 addresses by CIDR

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "fuzzysearch": "^1.0.3",
     "global": "^4.4.0",
     "immer": "^9.0.12",
+    "ipaddr.js": "2.2.0",
     "js-abbreviation-number": "^1.4.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",

--- a/src/utils/resources/vmi/utils/ips.ts
+++ b/src/utils/resources/vmi/utils/ips.ts
@@ -4,20 +4,13 @@ import { IpAddresses } from '@virtualmachines/details/tabs/overview/components/V
 
 /**
  * Get VMI IPs
- * @date 3/20/2022 - 12:18:23 PM
  *
  * @param {V1VirtualMachineInstance} vmi - VMI
  * @returns {string[]}
  */
-export const getVMIIPAddresses = (vmi: V1VirtualMachineInstance): string[] => {
-  const namedInterfaces = vmi?.status?.interfaces?.filter((iface) => !!iface.name) || [];
-  const ipAddresses = namedInterfaces?.flatMap((iface) => [
-    iface?.ipAddress,
-    ...(iface?.ipAddresses || []),
-  ]);
-  const trimmedIPAddresses = ipAddresses?.filter((ip) => !isEmpty(ip));
-  return [...new Set(trimmedIPAddresses)];
-};
+export const getVMIIPAddresses = (vmi: V1VirtualMachineInstance): string[] => [
+  ...new Set(getVMIIPAddressesWithName(vmi).map(({ ip }) => ip)),
+];
 
 export const getVMIIPAddressesWithName = (vmi: V1VirtualMachineInstance): IpAddresses => {
   const namedInterfaces = vmi?.status?.interfaces?.filter((iface) => !!iface.name) || [];

--- a/src/utils/utils/utils.ts
+++ b/src/utils/utils/utils.ts
@@ -1,3 +1,4 @@
+import * as ipaddr from 'ipaddr.js';
 import { animals, colors, NumberDictionary, uniqueNamesGenerator } from 'unique-names-generator';
 
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes';
@@ -12,7 +13,6 @@ import { ALL_NAMESPACES, ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hook
 import { FilterValue, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { k8sBasePath } from '@openshift-console/dynamic-plugin-sdk/lib/utils/k8s/k8s';
 import { SortByDirection } from '@patternfly/react-table';
-import { decimalToBinary } from '@virtualmachines/utils';
 
 import { IPAddress, ItemsToFilterProps } from './types';
 
@@ -222,15 +222,13 @@ export const compareWithDirection = (direction: SortByDirection, a: any, b: any)
  * Link-local address prefix (fe80::/10)
  * @see https://www.rfc-editor.org/rfc/rfc4291#section-2.5.6
  */
-export const IPV6_LINK_LOCAL_BLOCK = '1111111010';
+export const IPV6_LINK_LOCAL_CIDR = 'fe80::/10';
 
 export const isIPV6LinkLocal = (ip: string): boolean => {
-  if (!ip || ip.indexOf(':') === -1) {
+  if (!ipaddr.IPv6.isValid(ip)) {
     return false;
   }
-  const firstBlock = ip.substring(0, ip.indexOf(':'));
-  const binaryFirstBlock = decimalToBinary(parseInt(firstBlock, 16)).padStart(16, '0');
-  return binaryFirstBlock.startsWith(IPV6_LINK_LOCAL_BLOCK);
+  return ipaddr.parse(ip).match(ipaddr.parseCIDR(IPV6_LINK_LOCAL_CIDR));
 };
 
 export const removeLinkLocalIPV6 = (ipAddress: IPAddress[]) =>

--- a/src/views/virtualmachines/utils/utils.ts
+++ b/src/views/virtualmachines/utils/utils.ts
@@ -1,3 +1,5 @@
+import * as ipaddr from 'ipaddr.js';
+
 import {
   V1VirtualMachine,
   V1VirtualMachineInstanceMigration,
@@ -16,32 +18,11 @@ export const isLiveMigratable = (vm: V1VirtualMachine): boolean =>
 export const isRunning = (vm: V1VirtualMachine): boolean =>
   vm?.status?.printableStatus === printableVMStatus.Running;
 
-export const decimalToBinary = (decimalNumber: number) => (decimalNumber >>> 0).toString(2);
-
-const ipStringToBinary = (ip: string) =>
-  ip
-    .split('.')
-    .map((classes) => decimalToBinary(parseInt(classes)).padStart(8, '0'))
-    .join('');
-
-const isValidIP = (ip: string) =>
-  /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2]?\d))?$/.test(
-    ip,
-  );
-
 export const compareCIDR = (ipSearch: string, ip: string) => {
-  if (!isValidIP(ipSearch)) {
+  if (!ipaddr.isValidCIDR(ipSearch) || !ipaddr.isValid(ip)) {
     return false;
   }
-
-  const [baseIp, range] = ipSearch.split('/');
-  const baseIpBinary = ipStringToBinary(baseIp);
-  const ipBinary = ipStringToBinary(ip);
-  const rangeNumber = parseInt(range);
-  const baseIpBinarySlice = baseIpBinary.slice(0, rangeNumber);
-  const ipBinarySlice = ipBinary.slice(0, rangeNumber);
-
-  return baseIpBinarySlice === ipBinarySlice;
+  return ipaddr.parse(ip).match(ipaddr.parseCIDR(ipSearch));
 };
 
 export const sortVMIMByTimestampCreation = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -6534,7 +6534,7 @@ ipaddr.js@1.9.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
-ipaddr.js@^2.1.0:
+ipaddr.js@2.2.0, ipaddr.js@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.2.0.tgz#d33fa7bac284f4de7af949638c9d68157c6b92e8"
   integrity sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==


### PR DESCRIPTION
## 📝 Description

Add explicit dependency to ipaddr.js@2.2.0. The library is already used as dev dependency by webpack-dev-server.

Related refactoring: use ippaddr.js for isIPV6LinkLocal() helper
    
Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/3023

## 🎥 Demo

### Before

https://github.com/user-attachments/assets/609125b7-f3b2-4750-b6fa-40738ea7bb3f

### After

https://github.com/user-attachments/assets/62ad8c92-4563-40fd-aaa1-d6e4b06e049c




