### PR TITLE
CNV-69947: fix VirtualMachine summary filters not clearing

### DIFF
--- a/src/utils/components/ListPageFilter/components/CheckboxSelectFilter.tsx
+++ b/src/utils/components/ListPageFilter/components/CheckboxSelectFilter.tsx
@@ -34,8 +34,7 @@ const CheckboxSelectFilter: FC<CheckboxSelectFilterProps> = ({
     [allValues, selectedValues],
   );
 
-  const applyFilters = (values?: string[]) =>
-    applyFiltersProp(getRowFilterQueryKey(filterType), values);
+  const applyFilters = (values?: string[]) => applyFiltersProp(filterType, values);
 
   const onSelect: SelectProps['onSelect'] = (_event, value: string) => {
     if (selectedValues.includes(value)) {

--- a/src/utils/components/ListPageFilter/hooks/useAdvancedFiltersParameters.ts
+++ b/src/utils/components/ListPageFilter/hooks/useAdvancedFiltersParameters.ts
@@ -12,11 +12,10 @@ export const useAdvancedFiltersParameters = (advancedFilters: RowFilter[]) => {
   const advancedFiltersObject = useMemo(() => {
     const filters = advancedFilters.reduce<Record<string, FilterInfo>>(
       (acc, { filterGroupName, type }) => {
-        const queryKey = getRowFilterQueryKey(type);
-        const query = queryParams.get(queryKey);
+        const query = queryParams.get(getRowFilterQueryKey(type));
 
         if (query) {
-          acc[queryKey] = {
+          acc[type] = {
             filterGroupName,
             query,
           };

--- a/src/utils/components/ListPageFilter/hooks/useApplyFiltersWithQuery.ts
+++ b/src/utils/components/ListPageFilter/hooks/useApplyFiltersWithQuery.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 
 import { OnFilterChange } from '@openshift-console/dynamic-plugin-sdk';
+import { getRowFilterQueryKey } from '@search/utils/query';
 
 import { STATIC_SEARCH_FILTERS } from '../constants';
 import { ApplyTextFilters } from '../types';
@@ -14,7 +15,7 @@ export const useApplyFiltersWithQuery = (applyFilters: OnFilterChange) => {
     (type, value) => {
       const valueIsArray = Array.isArray(value);
 
-      setOrRemoveQueryArgument(type, valueIsArray ? value.join(',') : value);
+      setOrRemoveQueryArgument(getRowFilterQueryKey(type), valueIsArray ? value.join(',') : value);
 
       const values = valueIsArray ? value : [value];
       const selectedValues = value ? values : [];

--- a/src/views/virtualmachines/search/VirtualMachineFilterToolbar.tsx
+++ b/src/views/virtualmachines/search/VirtualMachineFilterToolbar.tsx
@@ -6,7 +6,6 @@ import { useApplyFiltersWithQuery } from '@kubevirt-utils/components/ListPageFil
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { OnFilterChange, RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 import { Toolbar, ToolbarContent } from '@patternfly/react-core';
-import { getRowFilterQueryKey } from '@search/utils/query';
 import { ListPageBodySize } from '@virtualmachines/list/listPageBodySize';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils/constants';
 
@@ -47,7 +46,7 @@ const VirtualMachineFilterToolbar: FC<VirtualMachineFilterToolbarProps> = ({
     applyFiltersWithQuery(VirtualMachineRowFilterType.Labels);
 
     [...filtersWithSelect, ...hiddenFilters].forEach(
-      (filter) => filter && applyFiltersWithQuery(getRowFilterQueryKey(filter.type)),
+      (filter) => filter && applyFiltersWithQuery(filter.type),
     );
   };
 


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes VirtualMachine summary filters, which were not clearing
  - issue was that to `onFilterChange` `type` argument used in "clear filters" function, we were passing `"rowFilter-status"`, but in VM summary filters, `type` argument was just `"status"`
  
- Solution: don't wrap `type` argument in `onFilterChange` function with the `"rowFilter-"` preposition (`getRowFilterQueryKey` helper)
  - `getRowFilterQueryKey` helper should be used only to create query string, not as a filter type

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/b4c46cc3-061c-48e7-999c-353c7ba55f27


After:


https://github.com/user-attachments/assets/1053b930-5948-4908-895b-a5ffeae80bdc


