### PR TITLE
CNV-69165: Use screenshot based thumbnail in the VM Details

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1268,6 +1268,7 @@
   "Scheduling and resource requirements": "Scheduling and resource requirements",
   "Scheduling settings": "Scheduling settings",
   "Scheduling will not be possible at this state": "Scheduling will not be possible at this state",
+  "Screenshot from the VM": "Screenshot from the VM",
   "Script": "Script",
   "Scripts": "Scripts",
   "SCSI": "SCSI",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1275,6 +1275,7 @@
   "Scheduling and resource requirements": "Requisitos de programación y recursos",
   "Scheduling settings": "Configuración de programación",
   "Scheduling will not be possible at this state": "No será posible programar en este estado",
+  "Screenshot from the VM": "Screenshot from the VM",
   "Script": "Guion",
   "Scripts": "Guiones",
   "SCSI": "SCSI",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1275,6 +1275,7 @@
   "Scheduling and resource requirements": "Planification et besoins en ressources",
   "Scheduling settings": "Paramètres de planification",
   "Scheduling will not be possible at this state": "La planification ne sera pas possible dans cet état.",
+  "Screenshot from the VM": "Screenshot from the VM",
   "Script": "Script",
   "Scripts": "Scripts",
   "SCSI": "SCSI",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1268,6 +1268,7 @@
   "Scheduling and resource requirements": "ススケジューリングおよびリソース要件",
   "Scheduling settings": "スケジューリング設定",
   "Scheduling will not be possible at this state": "この状態ではスケジューリングは不可能です",
+  "Screenshot from the VM": "Screenshot from the VM",
   "Script": "スクリプト",
   "Scripts": "スクリプト",
   "SCSI": "SCSI",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1268,6 +1268,7 @@
   "Scheduling and resource requirements": "일정 및 리소스 요구 사항",
   "Scheduling settings": "스케줄링 설정",
   "Scheduling will not be possible at this state": "이 상태에서는 예약이 불가능합니다.",
+  "Screenshot from the VM": "Screenshot from the VM",
   "Script": "스크립트",
   "Scripts": "스크립트",
   "SCSI": "SCSI",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1268,6 +1268,7 @@
   "Scheduling and resource requirements": "调度和资源的要求",
   "Scheduling settings": "调度设置",
   "Scheduling will not be possible at this state": "在这个状态下无法调度",
+  "Screenshot from the VM": "Screenshot from the VM",
   "Script": "脚本",
   "Scripts": "脚本",
   "SCSI": "SCSI",

--- a/src/utils/hooks/useScreenshot.tsx
+++ b/src/utils/hooks/useScreenshot.tsx
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
+
+const useScreenshot = (
+  basePath: string,
+): {
+  error: Error;
+  loaded: boolean;
+  refreshScreenshot: () => void;
+  screenshot: Blob;
+} => {
+  const [refreshTrigger, setRefreshTrigger] = useState(1);
+  const refreshScreenshot = useCallback(() => {
+    setRefreshTrigger((prev) => (prev + 1) % 2);
+  }, []);
+
+  const [data, setData] = useState<Blob>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<Error>(null);
+  const url = `${basePath}/vnc/screenshot`;
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoaded(false);
+        setError(null);
+        const response = await consoleFetch(url);
+        const blob = await response.blob();
+        setData(blob);
+      } catch (e) {
+        setError(e);
+      } finally {
+        setLoaded(true);
+      }
+    };
+
+    fetchData();
+  }, [url, refreshTrigger]);
+
+  return { error, loaded, refreshScreenshot, screenshot: data };
+};
+
+export default useScreenshot;

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/ScreenshotBasedThumbnail.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/ScreenshotBasedThumbnail.tsx
@@ -1,0 +1,55 @@
+import React, { memo, useEffect } from 'react';
+
+import { getConsoleBasePath } from '@kubevirt-utils/components/Consoles/utils/utils';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useScreenshot from '@kubevirt-utils/hooks/useScreenshot';
+
+import VirtualMachinesOverviewTabDetailsConsoleConnect from './VirtualMachinesOverviewTabDetailsConsoleConnect';
+
+const ScreenshotBasedThumbnail = ({
+  apiPath,
+  isDisabled,
+  isHeadlessMode,
+  refreshInterval = 5000,
+  vmName,
+  vmNamespace,
+}: {
+  apiPath: string;
+  isDisabled: boolean;
+  isHeadlessMode: boolean;
+  refreshInterval?: number;
+  vmName: string;
+  vmNamespace: string;
+}) => {
+  const { t } = useKubevirtTranslation();
+  const basePath = getConsoleBasePath({ apiPath, name: vmName, namespace: vmNamespace });
+  const { error, loaded, refreshScreenshot, screenshot } = useScreenshot(basePath);
+
+  useEffect(() => {
+    const interval = setInterval(refreshScreenshot, refreshInterval);
+    return () => clearInterval(interval);
+  }, [refreshScreenshot]);
+
+  if (!screenshot && (error || !loaded)) {
+    return (
+      <VirtualMachinesOverviewTabDetailsConsoleConnect
+        isConnecting={!loaded}
+        isDisabled={isDisabled}
+        isHeadlessMode={isHeadlessMode}
+        refresh={refreshScreenshot}
+      />
+    );
+  }
+  return (
+    <div>
+      <img
+        alt={t('Screenshot from the VM')}
+        onClick={refreshScreenshot}
+        src={URL.createObjectURL(screenshot)}
+        style={{ cursor: 'pointer' }}
+      />
+    </div>
+  );
+};
+
+export default memo(ScreenshotBasedThumbnail);

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
@@ -1,20 +1,12 @@
-import React, { FC, memo, useState } from 'react';
+import React, { FC, memo } from 'react';
 
-import {
-  ConsoleState,
-  VNC_CONSOLE_TYPE,
-} from '@kubevirt-utils/components/Consoles/components/utils/ConsoleConsts';
-import { ConsoleComponentState } from '@kubevirt-utils/components/Consoles/components/utils/types';
-import HideConsole from '@kubevirt-utils/components/Consoles/components/vnc-console/HideConsole';
-import VncConsole from '@kubevirt-utils/components/Consoles/components/vnc-console/VncConsole';
-import { getConsoleBasePath } from '@kubevirt-utils/components/Consoles/utils/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useK8sBaseAPIPath from '@multicluster/hooks/useK8sBaseAPIPath';
 import { getConsoleStandaloneURL } from '@multicluster/urls';
 import { Bullseye, Button, ButtonVariant, Spinner } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import VirtualMachinesOverviewTabDetailsConsoleConnect from './VirtualMachinesOverviewTabDetailsConsoleConnect';
+import ScreenshotBasedThumbnail from './ScreenshotBasedThumbnail';
 
 type VirtualMachinesOverviewTabDetailsConsoleProps = {
   canConnectConsole: boolean;
@@ -30,16 +22,8 @@ const VirtualMachinesOverviewTabDetailsConsole: FC<
 > = ({ canConnectConsole, isHeadlessMode, isVMRunning, vmCluster, vmName, vmNamespace }) => {
   const { t } = useKubevirtTranslation();
   const [apiPath, apiPathLoaded] = useK8sBaseAPIPath(vmCluster);
-  const [{ actions, state }, setState] = useState<ConsoleComponentState>({
-    actions: {},
-    state: ConsoleState.init,
-    type: VNC_CONSOLE_TYPE,
-  });
+
   const enableConsole = isVMRunning && !isHeadlessMode && canConnectConsole;
-  const showConnect =
-    !enableConsole || // connect component is also empty state here
-    state === ConsoleState.disconnected ||
-    state === ConsoleState.connecting;
 
   if (!apiPathLoaded)
     return (
@@ -61,25 +45,13 @@ const VirtualMachinesOverviewTabDetailsConsole: FC<
           {t('Open web console')}
         </Button>
       </div>
-      {enableConsole && (
-        <HideConsole isHidden={state !== ConsoleState.connected}>
-          <VncConsole
-            basePath={getConsoleBasePath({ apiPath, name: vmName, namespace: vmNamespace })}
-            setState={setState}
-            viewOnly
-          />
-        </HideConsole>
-      )}
-      {showConnect && (
-        <div className="console-vnc">
-          <VirtualMachinesOverviewTabDetailsConsoleConnect
-            connect={actions?.connect}
-            isConnecting={state === ConsoleState.connecting}
-            isDisabled={!enableConsole}
-            isHeadlessMode={isHeadlessMode}
-          />
-        </div>
-      )}
+      <ScreenshotBasedThumbnail
+        apiPath={apiPath}
+        isDisabled={!enableConsole}
+        isHeadlessMode={isHeadlessMode}
+        vmName={vmName}
+        vmNamespace={vmNamespace}
+      />
     </Bullseye>
   );
 };

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsoleConnect.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsoleConnect.tsx
@@ -4,18 +4,18 @@ import cn from 'classnames';
 import LoadingEmptyState from '@kubevirt-utils/components/LoadingEmptyState/LoadingEmptyState';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Icon } from '@patternfly/react-core';
-import { PlayIcon } from '@patternfly/react-icons';
+import { RedoIcon } from '@patternfly/react-icons';
 
 type VirtualMachinesOverviewTabDetailsConsoleConnectProps = {
-  connect?: () => void;
   isConnecting?: boolean;
   isDisabled?: boolean;
   isHeadlessMode?: boolean;
+  refresh?: () => void;
 };
 
 const VirtualMachinesOverviewTabDetailsConsoleConnect: FC<
   VirtualMachinesOverviewTabDetailsConsoleConnectProps
-> = ({ connect, isConnecting, isDisabled, isHeadlessMode }) => {
+> = ({ isConnecting, isDisabled, isHeadlessMode, refresh }) => {
   const { t } = useKubevirtTranslation();
 
   return (
@@ -24,8 +24,8 @@ const VirtualMachinesOverviewTabDetailsConsoleConnect: FC<
       {!isConnecting && (
         <div className={cn('vnc-grey-background', isDisabled && 'disabled')}>
           {!isDisabled && (
-            <Icon onClick={connect} size="md">
-              <PlayIcon />
+            <Icon onClick={refresh} size="md">
+              <RedoIcon />
             </Icon>
           )}
           {isHeadlessMode && t('Console is disabled in headless mode')}


### PR DESCRIPTION
## 📝 Description
Replace live read-only VNC session with static screenshot retrieved using endpoint:
< server >/api/kubernetes/apis/subresources.kubevirt.io/v1/namespaces/ < ns >/virtualmachineinstances/< name >/vnc/screenshot

Screenshot is refreshed periodically every 5 seconds. User is also able to refresh on demand by clicking at the screenshot.

Depends on backend feature "Screenshot without VNC" (#15238). Otherwise each screenshot disconnects the exisiting VNC session.

Reference-Url: https://github.com/kubevirt/kubevirt/pull/15238

## 🎥 Demo

Minor visual changes.
