### PR TITLE
CNV-69165: Use preserveSession flag for VNC connections

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -365,6 +365,7 @@
   "Confirm requested VirtualMachine actions before executing them": "Confirm requested VirtualMachine actions before executing them",
   "Confirm VirtualMachine actions": "Confirm VirtualMachine actions",
   "Connect": "Connect",
+  "Connect in shared mode": "Connect in shared mode",
   "Connect with any viewer application for following protocols": "Connect with any viewer application for following protocols",
   "Connecting": "Connecting",
   "Console": "Console",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -370,6 +370,7 @@
   "Confirm requested VirtualMachine actions before executing them": "Confirme las acciones solicitadas de VirtualMachine antes de ejecutarlas.",
   "Confirm VirtualMachine actions": "Confirmar acciones de VirtualMachine",
   "Connect": "Conectar",
+  "Connect in shared mode": "Connect in shared mode",
   "Connect with any viewer application for following protocols": "Conéctese con cualquier aplicación de visualización en relación con los siguientes protocolos",
   "Connecting": "Conectando",
   "Console": "Consola",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -370,6 +370,7 @@
   "Confirm requested VirtualMachine actions before executing them": "Confirmer les actions demandées par la machine virtuelle avant de les exécuter",
   "Confirm VirtualMachine actions": "Confirmer les actions de la machine virtuelle",
   "Connect": "Connecter",
+  "Connect in shared mode": "Connect in shared mode",
   "Connect with any viewer application for following protocols": "Connectez-vous à n'importe quelle application de visualisation pour les protocoles suivants",
   "Connecting": "Connexion",
   "Console": "Console",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -365,6 +365,7 @@
   "Confirm requested VirtualMachine actions before executing them": "要求された VirtualMachine のアクションを実行する前に確認します",
   "Confirm VirtualMachine actions": "VirtualMachine のアクションの確認",
   "Connect": "接続",
+  "Connect in shared mode": "Connect in shared mode",
   "Connect with any viewer application for following protocols": "以下のプロトコルのビューアーアプリケーションに接続する",
   "Connecting": "接続中",
   "Console": "コンソール",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -365,6 +365,7 @@
   "Confirm requested VirtualMachine actions before executing them": "실행하기 전에 요청된 VirtualMachine 작업 확인",
   "Confirm VirtualMachine actions": "VirtualMachine 작업 확인",
   "Connect": "연결",
+  "Connect in shared mode": "Connect in shared mode",
   "Connect with any viewer application for following protocols": "다음 프로토콜을 위해 뷰어 애플리케이션에 연결",
   "Connecting": "연결 중",
   "Console": "콘솔",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -365,6 +365,7 @@
   "Confirm requested VirtualMachine actions before executing them": "在执行它们前确认请求的 VirtualMachine 操作",
   "Confirm VirtualMachine actions": "确认 VirtualMachine 操作",
   "Connect": "连接",
+  "Connect in shared mode": "Connect in shared mode",
   "Connect with any viewer application for following protocols": "为以下协议与任何 viewer 应用程序连接",
   "Connecting": "连接",
   "Console": "控制台",

--- a/src/utils/components/Consoles/components/AccessConsoles/AccessConsoles.tsx
+++ b/src/utils/components/Consoles/components/AccessConsoles/AccessConsoles.tsx
@@ -19,6 +19,7 @@ import { PasteIcon } from '@patternfly/react-icons';
 import { ConsoleState, isConsoleType, VNC_CONSOLE_TYPE } from '../utils/ConsoleConsts';
 
 import { AccessConsolesProps, typeMap } from './utils/accessConsoles';
+import VncSettingsMenu from './VncSettingsMenu';
 
 import './access-consoles.scss';
 
@@ -114,6 +115,7 @@ export const AccessConsoles: FC<AccessConsolesProps> = ({
           ))}
         </DropdownList>
       </Dropdown>
+      {actions.vncSettings && <VncSettingsMenu {...actions.vncSettings} />}
       <Button
         className="vnc-actions-disconnect-button"
         isDisabled={state !== connected || !actions.disconnect}

--- a/src/utils/components/Consoles/components/AccessConsoles/VncSettingsMenu.tsx
+++ b/src/utils/components/Consoles/components/AccessConsoles/VncSettingsMenu.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import {
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+} from '@patternfly/react-core';
+import { CogIcon } from '@patternfly/react-icons';
+
+import { VncSettings } from './utils/accessConsoles';
+
+const SHARED = 'SHARED';
+
+const VncSettingsMenu: React.FunctionComponent<VncSettings> = ({ setShared, shared }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { t } = useKubevirtTranslation();
+  const onToggleClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle icon={<CogIcon />} isExpanded={isOpen} onClick={onToggleClick} ref={toggleRef} />
+  );
+
+  return (
+    <Select
+      onSelect={(_, selection: string) => {
+        if (selection === SHARED) {
+          setShared(!shared);
+        }
+      }}
+      id="checkbox-select"
+      isOpen={isOpen}
+      onOpenChange={(nextOpen: boolean) => setIsOpen(nextOpen)}
+      role="menu"
+      selected={[shared ? SHARED : ''].filter(Boolean)}
+      toggle={toggle}
+    >
+      <SelectList>
+        <SelectOption hasCheckbox isSelected={shared} value={SHARED}>
+          {t('Connect in shared mode')}
+        </SelectOption>
+      </SelectList>
+    </Select>
+  );
+};
+
+export default VncSettingsMenu;

--- a/src/utils/components/Consoles/components/AccessConsoles/utils/accessConsoles.tsx
+++ b/src/utils/components/Consoles/components/AccessConsoles/utils/accessConsoles.tsx
@@ -9,6 +9,11 @@ import {
 } from '../../utils/ConsoleConsts';
 import { ConsoleType } from '../../utils/types';
 
+export type VncSettings = {
+  setShared?: (shared: boolean) => void;
+  shared?: boolean;
+};
+
 export type AccessConsolesActions = {
   connect?: () => void;
   disconnect?: () => void;
@@ -16,6 +21,7 @@ export type AccessConsolesActions = {
   sendCtrlAlt2?: () => void;
   sendCtrlAltDel?: () => void;
   sendPaste?: (shouldFocusOnConsole?: boolean) => Promise<void>;
+  vncSettings?: VncSettings;
 };
 
 export type AccessConsolesProps = {


### PR DESCRIPTION
## 📝 Description

Key points:
1. connect by default with preserve-session flag
2. sync the preserve-session flag with VNC shared flag (RFC 6143)
3. allow users to force exclusive mode (after initial connection)

Depends on backend feature: Add preserve-session option to help avoid disconnect VNC sessions (#15267)

Reference-Url: https://datatracker.ietf.org/doc/html/rfc6143#section-7.3.1
Reference-Url: https://github.com/kubevirt/kubevirt/pull/15267

## 🎥 Demo

<img width="1809" height="681" alt="Screenshot From 2025-09-29 18-27-44" src="https://github.com/user-attachments/assets/332fcc6d-c1ee-4b3e-bdc1-54a76e1c686e" />

