### PR TITLE
CNV-70086: fix shrinking YAML editor in VirtualMachine details

### DIFF
--- a/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
+++ b/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
@@ -75,8 +75,8 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
   });
 
   return (
-    <div>
-      <nav className="pf-v6-c-tabs pf-m-page-insets">
+    <>
+      <nav className="pf-v6-c-tabs pf-m-page-insets pf-v6-u-flex-shrink-0">
         <ul className="pf-v6-c-tabs__list">
           {allPages.map((item) => {
             if (item?.isHidden) return null;
@@ -107,7 +107,7 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
         </ul>
       </nav>
       <Routes>{RoutesComponents}</Routes>
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- issue was that when `HorizontalNavbar` was wrapped in another div, YAML editor was not filling up full height, same issue was in Console tab
- without the wrapping div, the tabs in Overview tab were shrinking

Fix: use `flexShrink: 0` PatternFly utility class on the `nav`

## 🎥 Demo

Before:
<img width="1901" height="976" alt="Screenshot 2025-09-29 at 4 01 51 PM" src="https://github.com/user-attachments/assets/3569cb41-c176-47d6-b387-9f8fc5d78568" />

Only without wrapping div:

https://github.com/user-attachments/assets/4681cd53-f98f-46b0-972e-8ce955a857f1

- fixed with `flexShrink: 0`
