### PR TITLE
CNV-70162: improve recalculation of shouldUseProxyPod

### DIFF
--- a/src/utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource.ts
+++ b/src/utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource.ts
@@ -25,13 +25,15 @@ const useKubevirtWatchResource = <T extends K8sResourceCommon | K8sResourceCommo
   const { featureEnabled, loading } = useFeatures(KUBEVIRT_APISERVER_PROXY);
   const query = useQuery();
 
+  const hasNoFilter = !filterOptions || query.size === 0;
+
   const shouldUseProxyPod = useMemo(() => {
     if (watchOptions?.cluster) return false;
-    if (!filterOptions || query.size === 0) return false;
+    if (hasNoFilter) return false;
     if (!featureEnabled && !loading) return false;
     if (featureEnabled && !loading && isProxyPodAlive !== null) return isProxyPodAlive;
     return null;
-  }, [featureEnabled, loading, isProxyPodAlive, watchOptions?.cluster, query.size, filterOptions]);
+  }, [featureEnabled, loading, isProxyPodAlive, watchOptions?.cluster, hasNoFilter]);
 
   return useRedirectWatchHooks<T>(watchOptions, filterOptions, searchQueries, shouldUseProxyPod);
 };

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -71,6 +71,7 @@ import useFiltersFromURL from './hooks/useFiltersFromURL';
 import useVirtualMachineColumns from './hooks/useVirtualMachineColumns';
 import { useVMListFilters } from './hooks/useVMListFilters/useVMListFilters';
 import useVMMetrics from './hooks/useVMMetrics';
+import { VM_FILTER_OPTIONS, VMI_FILTER_OPTIONS } from './utils/constants';
 import { filterVMsByClusterAndNamespace } from './utils/utils';
 import { getListPageBodySize, ListPageBodySize } from './listPageBodySize';
 
@@ -107,12 +108,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
       namespace,
       namespaced: true,
     },
-    {
-      labels: 'metadata.labels',
-      name: 'metadata.name',
-      'rowFilter-os': 'spec.template.metadata.annotations.vm\\.kubevirt\\.io/os',
-      'rowFilter-status': 'status.printableStatus',
-    },
+    VM_FILTER_OPTIONS,
     searchQueries?.vmQueries,
   );
 
@@ -127,10 +123,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
       namespace,
       namespaced: true,
     },
-    {
-      ip: 'status.interfaces',
-      'rowFilter-node': 'status.nodeName',
-    },
+    VMI_FILTER_OPTIONS,
     searchQueries?.vmiQueries,
   );
 

--- a/src/views/virtualmachines/list/utils/constants.ts
+++ b/src/views/virtualmachines/list/utils/constants.ts
@@ -1,0 +1,11 @@
+export const VM_FILTER_OPTIONS = {
+  labels: 'metadata.labels',
+  name: 'metadata.name',
+  'rowFilter-os': 'spec.template.metadata.annotations.vm\\.kubevirt\\.io/os',
+  'rowFilter-status': 'status.printableStatus',
+} as const;
+
+export const VMI_FILTER_OPTIONS = {
+  ip: 'status.interfaces',
+  'rowFilter-node': 'status.nodeName',
+} as const;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- improves unnecessary recalculation of `shouldUseProxyPod` variable in `useKubevirtWatchResource`
  - use boolean in the dependency array instead of `filterOptions` object
  - make `filterOptions` param in VirtualMachinesList a constant, so the object reference doesn't change with rerenders


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/bd2590be-0bd6-4751-b732-90965842f093



After:


https://github.com/user-attachments/assets/9461e95f-9193-4e28-b40b-e2ae5be3481c


