### PR TITLE
CNV-70170: fix reloading of Environment select

### DIFF
--- a/src/utils/components/EnvironmentEditor/EnvironmentForm.tsx
+++ b/src/utils/components/EnvironmentEditor/EnvironmentForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo } from 'react';
+import React, { FC, useEffect } from 'react';
 import { useImmer } from 'use-immer';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -13,6 +13,7 @@ import EnvironmentFormActions from './components/EnvironmentFormActions';
 import EnvironmentFormSkeleton from './components/EnvironmentFormSkeleton';
 import EnvironmentFormTitle from './components/EnvironmentFormTitle';
 import useEnvironments from './hooks/useEnvironments';
+import useEnvironmentSelectOptions from './hooks/useEnvironmentSelectOptions';
 
 import './EnvironmentForm.scss';
 
@@ -42,9 +43,9 @@ const EnvironmentForm: FC<EnvironmentFormProps> = ({ onEditChange, updateVM, vm 
     setFormError(null);
   }, [setFormError, setTemporaryVM, vm]);
 
-  const environmentNamesSelected = useMemo(
-    () => environments.map((env) => env.name),
-    [environments],
+  const { loaded, loadError, selectOptions } = useEnvironmentSelectOptions(
+    getNamespace(vm),
+    environments,
   );
 
   if (isEmpty(vm)) return <EnvironmentFormSkeleton />;
@@ -77,13 +78,14 @@ const EnvironmentForm: FC<EnvironmentFormProps> = ({ onEditChange, updateVM, vm 
           <EnvironmentEditor
             diskName={environment.diskName}
             environmentName={environment.name}
-            environmentNamesSelected={environmentNamesSelected}
             id={index}
             key={environment.name}
             kind={environment.kind}
-            namespace={getNamespace(vm)}
+            loaded={loaded}
+            loadError={loadError}
             onChange={onEnvironmentChange}
             onRemove={onEnvironmentRemove}
+            selectOptions={selectOptions}
             serial={environment?.serial}
           />
         ))}

--- a/src/utils/components/EnvironmentEditor/components/EnvironmentEditor.tsx
+++ b/src/utils/components/EnvironmentEditor/components/EnvironmentEditor.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Button, ButtonVariant, Grid, GridItem, TextInput, Tooltip } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
@@ -13,24 +14,26 @@ import './EnvironmentEditor.scss';
 type EnvironmentEditorProps = {
   diskName: string;
   environmentName?: string;
-  environmentNamesSelected: string[];
   id: number;
   kind?: EnvironmentKind;
-  namespace: string;
+  loaded: boolean;
+  loadError: any;
   onChange: (diskName: string, name: string, serial: string, kind: EnvironmentKind) => void;
   onRemove?: (diskName: string) => void;
+  selectOptions: EnhancedSelectOptionProps[];
   serial?: string;
 };
 
 const EnvironmentEditor: FC<EnvironmentEditorProps> = ({
   diskName,
   environmentName,
-  environmentNamesSelected,
   id,
   kind,
-  namespace,
+  loaded,
+  loadError,
   onChange,
   onRemove,
+  selectOptions,
   serial,
 }) => {
   const { t } = useKubevirtTranslation();
@@ -41,10 +44,11 @@ const EnvironmentEditor: FC<EnvironmentEditorProps> = ({
         <EnvironmentSelectResource
           diskName={diskName}
           environmentName={environmentName}
-          environmentNamesSelected={environmentNamesSelected}
           kind={kind}
-          namespace={namespace}
+          loaded={loaded}
+          loadError={loadError}
           onChange={onChange}
+          selectOptions={selectOptions}
           serial={serial}
         />
       </GridItem>

--- a/src/utils/components/EnvironmentEditor/components/EnvironmentSelectResource.tsx
+++ b/src/utils/components/EnvironmentEditor/components/EnvironmentSelectResource.tsx
@@ -7,7 +7,6 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { Alert, AlertVariant } from '@patternfly/react-core';
 
 import { EnvironmentKind, MapKindToAbbr } from '../constants';
-import useEnvironmentsResources from '../hooks/useEnvironmentsResources';
 import {
   getEnvironmentOptionKind,
   getEnvironmentOptionName,
@@ -17,31 +16,25 @@ import {
 type EnvironmentSelectResourceProps = {
   diskName: string;
   environmentName?: string;
-  environmentNamesSelected: string[];
   kind?: EnvironmentKind;
-  namespace: string;
+  loaded: boolean;
+  loadError: any;
   onChange: (diskName: string, name: string, serial: string, kind: EnvironmentKind) => void;
+  selectOptions: EnhancedSelectOptionProps[];
   serial: string;
 };
 
 const EnvironmentSelectResource: FC<EnvironmentSelectResourceProps> = ({
   diskName,
   environmentName,
-  environmentNamesSelected,
   kind,
-  namespace,
+  loaded,
+  loadError,
   onChange,
+  selectOptions,
   serial,
 }) => {
   const { t } = useKubevirtTranslation();
-
-  const {
-    configMaps,
-    error: loadError,
-    loaded,
-    secrets,
-    serviceAccounts,
-  } = useEnvironmentsResources(namespace);
 
   if (!loaded) return <Loading />;
 
@@ -63,50 +56,15 @@ const EnvironmentSelectResource: FC<EnvironmentSelectResourceProps> = ({
 
   const selectedValue = getEnvironmentOptionValue(environmentName, kind);
 
-  const getEnhancedSelectOptionProps = (
-    optionName: string,
-    optionKind: EnvironmentKind,
-  ): EnhancedSelectOptionProps => ({
-    children: (
-      <>
-        <span className="sr-only">{optionKind}</span>
-        <span className={`co-m-resource-icon co-m-resource-${optionKind}`}>
-          {MapKindToAbbr[optionKind]}
-        </span>
-        {optionName}
-      </>
-    ),
-    isDisabled: environmentNamesSelected?.includes(optionName),
-    key: optionName,
-    value: getEnvironmentOptionValue(optionName, optionKind),
-    valueForFilter: optionName,
-  });
-
   return (
     <InlineFilterSelect
-      options={[
-        ...secrets.map((secret) => ({
-          group: t('Secrets'),
-          ...getEnhancedSelectOptionProps(secret.metadata.name, EnvironmentKind.secret),
-        })),
-        ...configMaps.map((configMap) => ({
-          group: t('Config Maps'),
-          ...getEnhancedSelectOptionProps(configMap.metadata.name, EnvironmentKind.configMap),
-        })),
-        ...serviceAccounts.map((serviceAccount) => ({
-          group: t('Service Accounts'),
-          ...getEnhancedSelectOptionProps(
-            serviceAccount.metadata.name,
-            EnvironmentKind.serviceAccount,
-          ),
-        })),
-      ]}
       toggleProps={{
         children: environmentName ?? t('Select a resource'),
         icon: kind ? (
           <span className={`co-m-resource-icon co-m-resource-${kind}`}>{MapKindToAbbr[kind]}</span>
         ) : null,
       }}
+      options={selectOptions}
       selected={selectedValue}
       selectProps={{ 'aria-labelledby': 'environment-name-header' }}
       setSelected={onSelect}

--- a/src/utils/components/EnvironmentEditor/hooks/useEnvironmentSelectOptions.tsx
+++ b/src/utils/components/EnvironmentEditor/hooks/useEnvironmentSelectOptions.tsx
@@ -1,0 +1,68 @@
+import React, { useCallback, useMemo } from 'react';
+
+import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+
+import { EnvironmentKind, EnvironmentVariable, MapKindToAbbr } from '../constants';
+import { getEnvironmentOptionValue } from '../utils';
+
+import useEnvironmentsResources from './useEnvironmentsResources';
+
+const useEnvironmentSelectOptions = (
+  namespace: string,
+  environments: EnvironmentVariable[],
+): { loaded: boolean; loadError: any; selectOptions: EnhancedSelectOptionProps[] } => {
+  const { t } = useKubevirtTranslation();
+  const {
+    configMaps,
+    error: loadError,
+    loaded,
+    secrets,
+    serviceAccounts,
+  } = useEnvironmentsResources(namespace);
+
+  const getEnhancedSelectOptionProps = useCallback(
+    (optionName: string, optionKind: EnvironmentKind): EnhancedSelectOptionProps => ({
+      children: (
+        <>
+          <span className="sr-only">{optionKind}</span>
+          <span className={`co-m-resource-icon co-m-resource-${optionKind}`}>
+            {MapKindToAbbr[optionKind]}
+          </span>
+          {optionName}
+        </>
+      ),
+      isDisabled: environments.some((env) => env.name === optionName),
+      key: optionName,
+      value: getEnvironmentOptionValue(optionName, optionKind),
+      valueForFilter: optionName,
+    }),
+    [environments],
+  );
+
+  const selectOptions = useMemo(() => {
+    if (!loaded) return [];
+
+    return [
+      ...secrets.map((secret) => ({
+        group: t('Secrets'),
+        ...getEnhancedSelectOptionProps(secret.metadata.name, EnvironmentKind.secret),
+      })),
+      ...configMaps.map((configMap) => ({
+        group: t('Config Maps'),
+        ...getEnhancedSelectOptionProps(configMap.metadata.name, EnvironmentKind.configMap),
+      })),
+      ...serviceAccounts.map((serviceAccount) => ({
+        group: t('Service Accounts'),
+        ...getEnhancedSelectOptionProps(
+          serviceAccount.metadata.name,
+          EnvironmentKind.serviceAccount,
+        ),
+      })),
+    ];
+  }, [loaded, secrets, configMaps, serviceAccounts, getEnhancedSelectOptionProps, t]);
+
+  return { loaded, loadError, selectOptions };
+};
+
+export default useEnvironmentSelectOptions;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes reloading of Environment select in VM details -> Configuration -> Storage
  - issue was with `useEnvironmentsResources` being called on the lowest level directly in the select component `EnvironmentSelectResource`
  - changing selected option rerendered the `EnvironmentSelectResource`, which caused `useEnvironmentsResources` to return `loaded=false` -> returning the spinner
  - you can see that if there were 2 Selects, the issue didn't occur - probably due to caching in `useK8sWatchResource` (used in `useEnvironmentsResources`), which still had `loaded=true` in the other Select
  
- this fix lifts the state up to `EnvironmentForm` - the options are same for every Select in that VM, there is no need to call `useEnvironmentsResources` for every Select

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/5eb2d950-a63b-4cbd-b1b3-babf783d8d24




After:


https://github.com/user-attachments/assets/13f723eb-3c19-4282-b824-a72dc745aadb


