### PR TITLE
CNV-70150: Fix stale vm data in in useInstanceTypeExpandSpec hook

### DIFF
--- a/src/utils/components/GuidedTour/GuidedTour.tsx
+++ b/src/utils/components/GuidedTour/GuidedTour.tsx
@@ -3,7 +3,6 @@ import Joyride, { ACTIONS, CallBackProps, EVENTS } from 'react-joyride';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useSignals } from '@preact/signals-react/runtime';
 
 import TourPopover from './components/TourPopover/TourPopover';
 import {
@@ -16,7 +15,6 @@ import {
 } from './utils/constants';
 
 const GuidedTour: FC = () => {
-  useSignals();
   const location = useLocation();
   const navigate = useNavigate();
 

--- a/src/utils/resources/vm/hooks/useInstanceTypeExpandSpec.ts
+++ b/src/utils/resources/vm/hooks/useInstanceTypeExpandSpec.ts
@@ -43,7 +43,13 @@ const useInstanceTypeExpandSpec: UseInstanceTypeExpandSpec = (vm) => {
         setLoadingExpandedSpec(false);
       }
     };
-    !isEmpty(innerVM) && isExpandableSpec && fetch();
+
+    if (!isEmpty(innerVM) && isExpandableSpec) {
+      fetch();
+    } else {
+      setInstanceTypeExpandedSpec(undefined);
+      setErrorExpandedSpec(undefined);
+    }
   }, [namespace, name, isExpandableSpec, url, urlLoaded, innerVM]);
 
   return [instanceTypeExpandedSpec, loadingExpandedSpec, errorExpandedSpec];

--- a/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
@@ -16,6 +16,7 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { getVMURL } from '@multicluster/urls';
 import { DocumentTitle } from '@openshift-console/dynamic-plugin-sdk';
+import { useSignals } from '@preact/signals-react/runtime';
 
 import { useVirtualMachineTabs } from './hooks/useVirtualMachineTabs';
 import VirtualMachineNavPageTitle from './VirtualMachineNavPageTitle';
@@ -23,6 +24,7 @@ import VirtualMachineNavPageTitle from './VirtualMachineNavPageTitle';
 import './virtual-machine-page.scss';
 
 const VirtualMachineNavPage: FC = () => {
+  useSignals();
   const {
     cluster,
     name,


### PR DESCRIPTION
## 📝 Description

Jira: [CNV-70150](https://issues.redhat.com/browse/CNV-70150)
This PR fixes two issues; 
1. The original issue in the Jira ticket - the VM gets stale data from the `useInstanceTypeExpandSpec` hook, leading to incorrect data for the boot mode (and potentially other parts which show incorrect data as well). 
2. Right clicking a VM in the list after reloading the page while selecting the configuration tab crashes the app. 


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/536f1df3-78e5-400a-b50b-408ea1f20467


After:


https://github.com/user-attachments/assets/b7851a36-4086-4434-ac01-75e7882a8e26

