### PR TITLE
CNV-70130: change advanced search icon

### DIFF
--- a/src/views/search/components/AdvancedSearchIcon.tsx
+++ b/src/views/search/components/AdvancedSearchIcon.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import { createIcon } from '@patternfly/react-icons/dist/esm/createIcon';
+
+import './search-bar.scss';
+
+//https://fontawesome.com/icons/sliders?f=classic&s=solid
+const AdvancedSearchIconConfig = {
+  height: 640,
+  name: 'AdvancedSearchIcon',
+  svgPath:
+    'M96 128C78.3 128 64 142.3 64 160C64 177.7 78.3 192 96 192L182.7 192C195 220.3 223.2 240 256 240C288.8 240 317 220.3 329.3 192L544 192C561.7 192 576 177.7 576 160C576 142.3 561.7 128 544 128L329.3 128C317 99.7 288.8 80 256 80C223.2 80 195 99.7 182.7 128L96 128zM96 288C78.3 288 64 302.3 64 320C64 337.7 78.3 352 96 352L342.7 352C355 380.3 383.2 400 416 400C448.8 400 477 380.3 489.3 352L544 352C561.7 352 576 337.7 576 320C576 302.3 561.7 288 544 288L489.3 288C477 259.7 448.8 240 416 240C383.2 240 355 259.7 342.7 288L96 288zM96 448C78.3 448 64 462.3 64 480C64 497.7 78.3 512 96 512L150.7 512C163 540.3 191.2 560 224 560C256.8 560 285 540.3 297.3 512L544 512C561.7 512 576 497.7 576 480C576 462.3 561.7 448 544 448L297.3 448C285 419.7 256.8 400 224 400C191.2 400 163 419.7 150.7 448L96 448z',
+  width: 640,
+  xOffset: 0,
+  yOffset: 0,
+};
+
+const AdvancedSearchIconComponent = createIcon(AdvancedSearchIconConfig);
+
+type AdvancedSearchIconProps = {
+  isLarge?: boolean;
+};
+
+const AdvancedSearchIcon = ({ isLarge = false }: AdvancedSearchIconProps) => {
+  return (
+    <AdvancedSearchIconComponent className={classNames('advanced-search-icon', { isLarge })} />
+  );
+};
+
+export default AdvancedSearchIcon;

--- a/src/views/search/components/SearchBar.tsx
+++ b/src/views/search/components/SearchBar.tsx
@@ -14,7 +14,6 @@ import {
   SearchInputProps,
   Tooltip,
 } from '@patternfly/react-core';
-import SlidersHIcon from '@patternfly/react-icons/dist/esm/icons/sliders-h-icon';
 import { SearchSuggestResult } from '@search/utils/types';
 import { useVirtualMachineSearchSuggestions } from '@virtualmachines/search/hooks/useVirtualMachineSearchSuggestions';
 
@@ -24,6 +23,7 @@ import { AdvancedSearchInputs } from '../utils/types';
 
 import AdvancedSearchModal from './AdvancedSearchModal/AdvancedSearchModal';
 import SearchSuggestBox from './SearchSuggestBox/SearchSuggestBox';
+import AdvancedSearchIcon from './AdvancedSearchIcon';
 import SavedSearchesDropdown from './SavedSearchesDropdown';
 import SaveSearchModal from './SaveSearchModal';
 
@@ -169,7 +169,7 @@ const SearchBar: FC<SearchBarProps> = ({ onFilterChange }) => {
             showSearchModal();
           }}
           data-test="vm-advanced-search"
-          icon={<SlidersHIcon />}
+          icon={<AdvancedSearchIcon isLarge />}
           variant="control"
         />
       </Tooltip>

--- a/src/views/search/components/SearchSuggestBox/SearchSuggestBox.tsx
+++ b/src/views/search/components/SearchSuggestBox/SearchSuggestBox.tsx
@@ -15,7 +15,6 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import SlidersHIcon from '@patternfly/react-icons/dist/esm/icons/sliders-h-icon';
 import { FleetResourceLink } from '@stolostron/multicluster-sdk';
 
 import {
@@ -23,6 +22,7 @@ import {
   AdvancedSearchQueryInputs,
   SearchSuggestResult,
 } from '../../utils/types';
+import AdvancedSearchIcon from '../AdvancedSearchIcon';
 
 import RelatedSuggestions from './components/RelatedSuggestions';
 import SearchSuggestBoxFooter from './components/SearchSuggestBoxFooter';
@@ -95,7 +95,7 @@ const SearchSuggestBox: FC<SearchSuggestBoxProps> = ({
                               showSearchModal();
                             }}
                             data-test="try-advanced-search"
-                            icon={<SlidersHIcon />}
+                            icon={<AdvancedSearchIcon />}
                             iconPosition="end"
                             isInline
                             variant={ButtonVariant.link}

--- a/src/views/search/components/SearchSuggestBox/components/SearchSuggestBoxFooter.tsx
+++ b/src/views/search/components/SearchSuggestBox/components/SearchSuggestBoxFooter.tsx
@@ -9,7 +9,7 @@ import {
   Flex,
   PanelFooter,
 } from '@patternfly/react-core';
-import SlidersHIcon from '@patternfly/react-icons/dist/esm/icons/sliders-h-icon';
+import AdvancedSearchIcon from '@search/components/AdvancedSearchIcon';
 
 import { SearchSuggestBoxProps } from '../SearchSuggestBox';
 
@@ -40,7 +40,7 @@ const SearchSuggestBoxFooter: FC<SearchSuggestBoxFooterProps> = ({
           </Button>
           <Button
             data-test="results-advanced-search"
-            icon={<SlidersHIcon />}
+            icon={<AdvancedSearchIcon />}
             iconPosition="end"
             onClick={onAdvancedSearchClick}
             variant={ButtonVariant.secondary}

--- a/src/views/search/components/search-bar.scss
+++ b/src/views/search/components/search-bar.scss
@@ -6,3 +6,12 @@
 .saved-searches-dropdown-menu {
   max-width: 260px;
 }
+
+.advanced-search-icon {
+  transform: scale(1.25);
+  transform-origin: center;
+
+  &.isLarge {
+    transform: scale(1.5);
+  }
+}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- [new icon](https://fontawesome.com/icons/sliders?f=classic&s=solid) for advanced search

## 🎥 Demo
Before:
<img width="1170" height="238" alt="Screenshot 2025-10-13 at 9 45 45" src="https://github.com/user-attachments/assets/f388e9df-6d33-4f7b-8f58-df5845906f78" />
<img width="1170" height="238" alt="Screenshot 2025-10-13 at 9 45 50" src="https://github.com/user-attachments/assets/d3ce5fb2-7235-4f54-be7b-4460dc50e620" />


After:
<img width="1170" height="238" alt="Screenshot 2025-10-13 at 9 43 59" src="https://github.com/user-attachments/assets/102e4cfb-6891-45f7-aa05-acfc15a87308" />
<img width="1170" height="238" alt="Screenshot 2025-10-13 at 9 43 47" src="https://github.com/user-attachments/assets/8cef2073-fd3b-468d-b5f1-2d2e11eb8376" />

