### PR TITLE
CNV-70575: Fix advaced search projects clsuter

### DIFF
--- a/src/views/virtualmachines/search/hooks/useVMSearchQueries.ts
+++ b/src/views/virtualmachines/search/hooks/useVMSearchQueries.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 
 import { STATIC_SEARCH_FILTERS } from '@kubevirt-utils/components/ListPageFilter/constants';
+import { getRowFilterQueryKey } from '@search/utils/query';
 import { AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
 
@@ -15,11 +16,15 @@ const useVMSearchQueries = (): VMSearchQueries => {
 
   const vmName = searchParams.get(STATIC_SEARCH_FILTERS.name);
 
-  const ip = searchParams.get(VirtualMachineRowFilterType.IP);
-  const project = searchParams.get(VirtualMachineRowFilterType.Project);
-  const clusters = searchParams.get(VirtualMachineRowFilterType.Cluster);
-  const createdFrom = searchParams.get(VirtualMachineRowFilterType.DateCreatedFrom);
-  const createdTo = searchParams.get(VirtualMachineRowFilterType.DateCreatedTo);
+  const ip = searchParams.get(getRowFilterQueryKey(VirtualMachineRowFilterType.IP));
+  const project = searchParams.get(getRowFilterQueryKey(VirtualMachineRowFilterType.Project));
+  const clusters = searchParams.get(getRowFilterQueryKey(VirtualMachineRowFilterType.Cluster));
+  const createdFrom = searchParams.get(
+    getRowFilterQueryKey(VirtualMachineRowFilterType.DateCreatedFrom),
+  );
+  const createdTo = searchParams.get(
+    getRowFilterQueryKey(VirtualMachineRowFilterType.DateCreatedTo),
+  );
 
   return useMemo(() => {
     const queries: VMSearchQueries = {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Filter VM by clusters 


Getting the wrong parameter in the URL to catch the cluster to filter the vms with.


Call the same `getRowFilterQueryKey`  function in order to filter vms from the fetch requests in the backend using the search api in the multicluster advanced search and skip the frontend filtering