### PR TITLE
CNV-70610: Use only hub cluster feature flag configmaps

### DIFF
--- a/src/utils/hooks/useFeatures/constants.ts
+++ b/src/utils/hooks/useFeatures/constants.ts
@@ -5,6 +5,7 @@ import {
   IoK8sApiRbacV1RoleBinding,
 } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
+import { FEATURE_KUBEVIRT_CROSS_CLUSTER_MIGRATION } from '@multicluster/constants';
 import { K8sVerb } from '@openshift-console/dynamic-plugin-sdk';
 
 export const AUTOMATIC_SUBSCRIPTION_ACTIVATION_KEY = 'automaticSubscriptionActivationKey';
@@ -28,6 +29,12 @@ const FEATURES_ROLE_NAME = 'kubevirt-ui-features-reader';
 const FEATURES_ROLE_BINDING_NAME = 'kubevirt-ui-features-reader-binding';
 
 export const FEATURE_HCO_PERSISTENT_RESERVATION = 'persistentReservationHCO';
+
+export const UI_FEATURES = [
+  FEATURE_KUBEVIRT_CROSS_CLUSTER_MIGRATION,
+  CONFIRM_VM_ACTIONS,
+  TREE_VIEW_FOLDERS,
+];
 
 export const featuresConfigMapInitialState: IoK8sApiCoreV1ConfigMap = {
   data: {

--- a/src/utils/hooks/useFeatures/useFeatures.ts
+++ b/src/utils/hooks/useFeatures/useFeatures.ts
@@ -2,9 +2,10 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { ConfigMapModel } from '@kubevirt-ui/kubevirt-api/console';
 import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
-import { FEATURES_CONFIG_MAP_NAME, featuresConfigMapInitialState } from './constants';
+import { FEATURES_CONFIG_MAP_NAME, featuresConfigMapInitialState, UI_FEATURES } from './constants';
 import { applyMissingFeatures, createFeaturesConfigMap } from './createFeaturesConfigMap';
 import { UseFeaturesValues } from './types';
 import useFeaturesConfigMap from './useFeaturesConfigMap';
@@ -14,7 +15,15 @@ type UseFeatures = (featureName: string) => UseFeaturesValues;
 export const useFeatures: UseFeatures = (featureName) => {
   const [createError, setCreateError] = useState(null);
   const [createInProgress, setCreateInProgress] = useState(false);
-  const { featuresConfigMapData, isAdmin } = useFeaturesConfigMap(!createError);
+
+  const isUIFeature = UI_FEATURES.includes(featureName);
+  const cluster = useClusterParam();
+
+  const { featuresConfigMapData, isAdmin } = useFeaturesConfigMap(
+    isUIFeature ? null : cluster,
+    !createError,
+  );
+
   const [featureConfigMap, loaded, loadError] = featuresConfigMapData;
   const [featureEnabled, setFeatureEnabled] = useState(null);
   const [loading, setLoading] = useState(true);

--- a/src/utils/hooks/useFeatures/useFeaturesConfigMap.ts
+++ b/src/utils/hooks/useFeatures/useFeaturesConfigMap.ts
@@ -1,7 +1,6 @@
 import { ConfigMapModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
-import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { getGroupVersionKindForModel, WatchK8sResult } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -9,13 +8,15 @@ import { useIsAdmin } from '../useIsAdmin';
 
 import { FEATURES_CONFIG_MAP_NAME } from './constants';
 
-type UseFeaturesConfigMap = (enableQuery?: boolean) => {
+type UseFeaturesConfigMap = (
+  cluster?: string,
+  enableQuery?: boolean,
+) => {
   featuresConfigMapData: WatchK8sResult<IoK8sApiCoreV1ConfigMap>;
   isAdmin: boolean;
 };
 
-const useFeaturesConfigMap: UseFeaturesConfigMap = (enableQuery: boolean = true) => {
-  const cluster = useClusterParam();
+const useFeaturesConfigMap: UseFeaturesConfigMap = (cluster, enableQuery: boolean = true) => {
   const isAdmin = useIsAdmin();
 
   const featuresConfigMapData = useK8sWatchData<IoK8sApiCoreV1ConfigMap>(


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

The feature flag configmap  have different kind of features. Some are just UI thing so we don't have to fetch them in each clusters. Others are also backend stuff and we need to fetch them per-cluster
