### PR TITLE
CNV-69165: Use link tag to render Open web console button

### DIFF
--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachinesOverviewTabDetailsConsole.tsx
@@ -52,10 +52,16 @@ const VirtualMachinesOverviewTabDetailsConsole: FC<
     <Bullseye className="console-overview">
       <div className="link">
         <Button
+          onClick={(e) => {
+            e.preventDefault();
+            actions?.disconnect?.();
+            window.open(getConsoleStandaloneURL(vmNamespace, vmName, vmCluster));
+          }}
+          component="a"
+          href={getConsoleStandaloneURL(vmNamespace, vmName, vmCluster)}
           icon={<ExternalLinkAltIcon className="icon" />}
           iconPosition="end"
           isDisabled={!enableConsole}
-          onClick={() => window.open(getConsoleStandaloneURL(vmNamespace, vmName, vmCluster))}
           variant={ButtonVariant.link}
         >
           {t('Open web console')}


### PR DESCRIPTION
## 📝 Description

Allow standard link actions i.e. copy or opening in a new tab/window.

Disconnect the VNC session running in the VM Details before opening a new console to allow a more graceful session handover.


## 🎥 Demo

<img width="601" height="538" alt="Screenshot From 2025-10-17 09-33-45" src="https://github.com/user-attachments/assets/1b8b6d54-55ca-4a6a-af98-f49d0db02035" />

