### PR TITLE
CNV-69492: UI blocked during VM creation/customization and deletion

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
@@ -51,7 +51,8 @@ const CreateVMFooter: FC = () => {
   const navigate = useNavigate();
   const cluster = useClusterParam();
   const namespace = useActiveNamespace();
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCreateLoading, setIsCreateLoading] = useState(false);
+  const [isCustomizeLoading, setIsCustomizeLoading] = useState(false);
   const [error, setError] = useState<any | Error>(null);
   const { createModal } = useModal();
   const [_, driversImageLoading] = useDriversImage();
@@ -69,9 +70,9 @@ const CreateVMFooter: FC = () => {
   const generatedVM = useGeneratedVM();
 
   const handleSubmit = async () => {
-    setIsSubmitting(true);
-    setError(null);
+    setIsCreateLoading(true);
 
+    setError(null);
     logITFlowEvent(CREATE_VM_BUTTON_CLICKED, generatedVM);
 
     if (
@@ -112,20 +113,21 @@ const CreateVMFooter: FC = () => {
         }
 
         if (!isUDNManagedNamespace) createHeadlessService(createdVM);
-
         navigate(getVMURL(cluster, vmNamespaceTarget, getName(createdVM)));
-
         logITFlowEvent(CREATE_VM_SUCCEEDED, createdVM);
       })
       .catch((err) => {
         setError(err);
         logITFlowEvent(CREATE_VM_FAILED, null, { vmName: vmName });
       })
-      .finally(() => setIsSubmitting(false));
+      .finally(() => {
+        setIsCreateLoading(false);
+      });
   };
 
   const handleCustomize = async () => {
-    setIsSubmitting(true);
+    setIsCustomizeLoading(true);
+
     setError(null);
 
     try {
@@ -142,7 +144,7 @@ const CreateVMFooter: FC = () => {
     } catch (err) {
       setError(err);
     } finally {
-      setIsSubmitting(false);
+      setIsCustomizeLoading(false);
     }
   };
 
@@ -168,7 +170,8 @@ const CreateVMFooter: FC = () => {
               logITFlowEvent(VIEW_YAML_AND_CLI_CLICKED, null, { vmName: vmName });
               createModal((props) => <YamlAndCLIViewerModal vm={generatedVM} {...props} />);
             }}
-            isLoading={isSubmitting || driversImageLoading}
+            isCreateLoading={isCreateLoading || driversImageLoading}
+            isCustomizeLoading={isCustomizeLoading || driversImageLoading}
             onCreate={handleSubmit}
             onCustomize={handleCustomize}
           />

--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/components/ActionButtons/ActionButtons.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/components/ActionButtons/ActionButtons.tsx
@@ -21,14 +21,16 @@ import {
 import useStatusActionButtons from './useStatusActionButtons';
 
 type ActionButtonsProps = {
-  isLoading?: boolean;
+  isCreateLoading?: boolean;
+  isCustomizeLoading: boolean;
   onCreate: () => void;
   onCustomize: () => void;
   onViewYAML: () => void;
 };
 
 const ActionButtons: FC<ActionButtonsProps> = ({
-  isLoading = false,
+  isCreateLoading,
+  isCustomizeLoading,
   onCreate,
   onCustomize,
   onViewYAML,
@@ -48,8 +50,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({
   }, [navigate, namespace, vmName]);
 
   const { disableButtonTooltipContent, isCreationDisabled, isViewYAMLDisabled } =
-    useStatusActionButtons(isLoading);
-
+    useStatusActionButtons(isCreateLoading || isCustomizeLoading);
   return (
     <Split hasGutter>
       <SplitItem>
@@ -60,7 +61,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({
         >
           <Button
             isAriaDisabled={isCreationDisabled}
-            isLoading={isLoading}
+            isLoading={isCreateLoading}
             onClick={onCreate}
             variant={ButtonVariant.primary}
           >
@@ -76,7 +77,7 @@ const ActionButtons: FC<ActionButtonsProps> = ({
         >
           <Button
             isDisabled={isCreationDisabled}
-            isLoading={isLoading}
+            isLoading={isCustomizeLoading}
             onClick={onCustomize}
             variant={ButtonVariant.secondary}
           >


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

the loader on the create or Customize is work in the 2 buttons and not only the one that was pressed

## 🎥 Demo
<img width="1056" height="766" alt="image" src="https://github.com/user-attachments/assets/7af073c7-3f77-4cd5-b977-be139406f64a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Action buttons now show separate loading indicators for "Create" and "Customize" actions, so only the button for the actively running operation displays a spinner.
  * Submission and customization flows have clearer start/stop loading behavior, reducing confusing or persistent loading states during create/customize workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->