### PR TITLE
CNV-70910: Closing the architecture list after selecting archtecture type in add volume

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/ArchitectureSelect/ArchitectureSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/ArchitectureSelect/ArchitectureSelect.tsx
@@ -31,7 +31,7 @@ const ArchitectureSelect: FC<ArchitectureSelectProps> = ({
     <>
       <FormGroup label={ARCHITECTURE_TITLE}>
         <FormPFSelect
-          closeOnSelect={false}
+          closeOnSelect={true}
           selected={architectures}
           selectedLabel={architectures?.join(', ') ?? t('Select architecture')}
           toggleProps={{ isFullWidth: true }}


### PR DESCRIPTION

## 📝 Description

Closing the architecture list after selecting archtecture type in add volume

## 🎥 Demo
Before: 
<img width="1935" height="1300" alt="image" src="https://github.com/user-attachments/assets/27960d42-b293-4cf9-b0e9-21373b873952" />

After: 
<img width="2093" height="1255" alt="image" src="https://github.com/user-attachments/assets/c9e65fa0-aad0-43b7-b7e7-4e2685aa9f30" />
