### PR TITLE
CNV-70526: fix Utilization elements overlapping

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1652,7 +1652,7 @@
   "Use volume already available on the cluster": "Use volume already available on the cluster",
   "Used": "Used",
   "Used bytes": "Used bytes",
-  "Used of ": "Used of ",
+  "Used of {{ total }}": "Used of {{ total }}",
   "User": "User",
   "User credentials": "User credentials",
   "User has no accessible namespaces for VirtualMachines": "User has no accessible namespaces for VirtualMachines",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1660,7 +1660,7 @@
   "Use volume already available on the cluster": "Utilizar el volumen ya disponible en el clúster",
   "Used": "Usado",
   "Used bytes": "Bytes usados",
-  "Used of ": "Usado de ",
+  "Used of {{ total }}": "Used of {{ total }}",
   "User": "Usuario",
   "User credentials": "Credenciales de usuario",
   "User has no accessible namespaces for VirtualMachines": "El usuario no tiene espacios de nombre accesibles para VirtualMachines.",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1660,7 +1660,7 @@
   "Use volume already available on the cluster": "Utiliser le volume déjà disponible sur le cluster",
   "Used": "Utilisée",
   "Used bytes": "Octets utilisés",
-  "Used of ": "Utilisé de ",
+  "Used of {{ total }}": "Used of {{ total }}",
   "User": "Utilisateur",
   "User credentials": "Informations d’identification de l’utilisateur",
   "User has no accessible namespaces for VirtualMachines": "L'utilisateur n'a pas d'espaces de noms accessibles pour les machines virtuelles",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1652,7 +1652,7 @@
   "Use volume already available on the cluster": "クラスターですでに利用可能なボリュームを使用する",
   "Used": "使用済み",
   "Used bytes": "使用中のバイト数",
-  "Used of ": "使用中 / ",
+  "Used of {{ total }}": "Used of {{ total }}",
   "User": "User",
   "User credentials": "ユーザーの認証情報",
   "User has no accessible namespaces for VirtualMachines": "ユーザーに VirtualMachine のアクセス可能な namespace がありません",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1652,7 +1652,7 @@
   "Use volume already available on the cluster": "클러스터에서 이미 사용 가능한 볼륨 사용",
   "Used": "사용됨",
   "Used bytes": "사용된 바이트",
-  "Used of ": "사용됨 ",
+  "Used of {{ total }}": "Used of {{ total }}",
   "User": "사용자",
   "User credentials": "사용자 인증 정보",
   "User has no accessible namespaces for VirtualMachines": "사용자에게 VirtualMachines에 대해 액세스 가능한 네임스페이스가 없습니다.",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1652,7 +1652,7 @@
   "Use volume already available on the cluster": "使用集群中已可用的卷",
   "Used": "使用了",
   "Used bytes": "使用的字节",
-  "Used of ": "使用 ",
+  "Used of {{ total }}": "Used of {{ total }}",
   "User": "用户",
   "User credentials": "用户凭证",
   "User has no accessible namespaces for VirtualMachines": "用户没有 VirtualMachines 可访问的命名空间",

--- a/src/utils/hooks/useContainerWidth.ts
+++ b/src/utils/hooks/useContainerWidth.ts
@@ -16,7 +16,7 @@ const useContainerWidth = (containerRef: MutableRefObject<HTMLElement>) => {
       }
     };
 
-    const resizeObserver = new ResizeObserver(debounce(updateWidth));
+    const resizeObserver = new ResizeObserver(debounce(updateWidth, 50));
 
     resizeObserver.observe(container);
 

--- a/src/views/virtualmachines/details/tabs/overview/VirtualMachinesOverviewTab.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/VirtualMachinesOverviewTab.tsx
@@ -1,8 +1,9 @@
-import React, { FC } from 'react';
+import React, { FC, useRef } from 'react';
 
 import AlertsCard from '@kubevirt-utils/components/AlertsCard/AlertsCard';
+import useContainerWidth from '@kubevirt-utils/hooks/useContainerWidth';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
+import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm/hooks/useVMIAndPodsForVM';
 import { useGuestOS } from '@kubevirt-utils/resources/vmi';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { Grid, GridItem, PageSection } from '@patternfly/react-core';
@@ -32,61 +33,67 @@ const VirtualMachinesOverviewTab: FC<NavPageComponentProps> = ({
   );
   const [guestAgentData, guestAgentDataLoaded, guestAgentDataLoadError] = useGuestOS(vmi);
 
+  const pageSectionRef = useRef<HTMLDivElement>(null);
+  const pageSectionWidth = useContainerWidth(pageSectionRef);
+  const isSmallPage = pageSectionWidth < 880;
+
   return (
-    <PageSection>
-      <Grid hasGutter>
-        <GridItem span={8}>
-          <Grid hasGutter>
-            <GridItem>
-              <VirtualMachinesOverviewTabDetails
-                error={error}
-                guestAgentData={guestAgentData}
-                guestAgentDataLoaded={guestAgentDataLoaded}
-                instanceTypeExpandedSpec={instanceTypeExpandedSpec}
-                loaded={loaded}
-                vm={vm}
-                vmi={vmi}
-              />
-            </GridItem>
-            <GridItem>
-              <VirtualMachinesOverviewTabUtilization vm={vm} vmi={vmi} />
-            </GridItem>
-          </Grid>
-        </GridItem>
-        <GridItem span={4}>
-          <Grid hasGutter>
-            <GridItem>
-              <AlertsCard sortedAlerts={vmAlerts} />
-            </GridItem>
-            <GridItem>
-              <VirtualMachinesOverviewTabGeneral pods={pods} vm={vm} vmi={vmi} />
-            </GridItem>
-            <GridItem>
-              <VirtualMachinesOverviewTabSnapshots vm={vm} />
-            </GridItem>
-            <GridItem>
-              <VirtualMachinesOverviewTabNetworkInterfaces vm={vm} vmi={vmi} />
-            </GridItem>
-            <GridItem>
-              <VirtualMachinesOverviewTabDisks vm={vm} vmi={vmi} />
-            </GridItem>
-          </Grid>
-        </GridItem>
-        <VirtualMachinesOverviewTabHardwareDevices vm={vm} />
-        <VirtualMachinesOverviewTabFilesystem
-          guestAgentData={guestAgentData}
-          guestAgentDataLoaded={guestAgentDataLoaded}
-          vm={vm}
-        />
-        <VirtualMachinesOverviewTabService vm={vm} />
-        <VirtualMachinesOverviewTabActiveUser
-          guestAgentData={guestAgentData}
-          guestAgentDataLoaded={guestAgentDataLoaded}
-          guestAgentDataLoadError={guestAgentDataLoadError}
-          vmi={vmi}
-        />
-      </Grid>
-    </PageSection>
+    <div ref={pageSectionRef}>
+      <PageSection>
+        <Grid hasGutter>
+          <GridItem span={isSmallPage ? 12 : 8}>
+            <Grid hasGutter>
+              <GridItem>
+                <VirtualMachinesOverviewTabDetails
+                  error={error}
+                  guestAgentData={guestAgentData}
+                  guestAgentDataLoaded={guestAgentDataLoaded}
+                  instanceTypeExpandedSpec={instanceTypeExpandedSpec}
+                  loaded={loaded}
+                  vm={vm}
+                  vmi={vmi}
+                />
+              </GridItem>
+              <GridItem>
+                <VirtualMachinesOverviewTabUtilization vm={vm} vmi={vmi} />
+              </GridItem>
+            </Grid>
+          </GridItem>
+          <GridItem span={isSmallPage ? 12 : 4}>
+            <Grid hasGutter>
+              <GridItem>
+                <AlertsCard sortedAlerts={vmAlerts} />
+              </GridItem>
+              <GridItem>
+                <VirtualMachinesOverviewTabGeneral pods={pods} vm={vm} vmi={vmi} />
+              </GridItem>
+              <GridItem>
+                <VirtualMachinesOverviewTabSnapshots vm={vm} />
+              </GridItem>
+              <GridItem>
+                <VirtualMachinesOverviewTabNetworkInterfaces vm={vm} vmi={vmi} />
+              </GridItem>
+              <GridItem>
+                <VirtualMachinesOverviewTabDisks vm={vm} vmi={vmi} />
+              </GridItem>
+            </Grid>
+          </GridItem>
+          <VirtualMachinesOverviewTabHardwareDevices vm={vm} />
+          <VirtualMachinesOverviewTabFilesystem
+            guestAgentData={guestAgentData}
+            guestAgentDataLoaded={guestAgentDataLoaded}
+            vm={vm}
+          />
+          <VirtualMachinesOverviewTabService vm={vm} />
+          <VirtualMachinesOverviewTabActiveUser
+            guestAgentData={guestAgentData}
+            guestAgentDataLoaded={guestAgentDataLoaded}
+            guestAgentDataLoadError={guestAgentDataLoadError}
+            vmi={vmi}
+          />
+        </Grid>
+      </PageSection>
+    </div>
   );
 };
 

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabFilesystem/VirtualMachinesOverviewTabFilesystemTitle.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabFilesystem/VirtualMachinesOverviewTabFilesystemTitle.tsx
@@ -9,11 +9,12 @@ const VirtualMachinesOverviewTabFilesystemTitle = () => {
 
   return (
     <CardTitle className="pf-v6-u-text-color-subtle">
-      {t('File systems')}{' '}
+      {t('File systems')}
       <HelpTextIcon
         bodyContent={t(
           'The following information regarding how the disks are partitioned is provided by the guest agent.',
         )}
+        helpIconClassName="pf-v6-u-ml-xs"
         position={PopoverPosition.right}
       />
     </CardTitle>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/VirtualMachinesOverviewTabUtilization.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/VirtualMachinesOverviewTabUtilization.tsx
@@ -3,17 +3,16 @@ import { Trans } from 'react-i18next';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ComponentReady from '@kubevirt-utils/components/Charts/ComponentReady/ComponentReady';
+import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Card,
   CardBody,
   CardTitle,
-  DescriptionListTermHelpText,
-  DescriptionListTermHelpTextButton,
   Divider,
+  Flex,
   Grid,
   GridItem,
-  Popover,
   PopoverPosition,
 } from '@patternfly/react-core';
 import { isRunning } from '@virtualmachines/utils';
@@ -22,6 +21,7 @@ import CPUUtil from './components/CPUUtil/CPUUtil';
 import MemoryUtil from './components/MemoryUtil/MemoryUtil';
 import NetworkUtil from './components/NetworkUtil/NetworkUtil';
 import StorageUtil from './components/StorageUtil/StorageUtil';
+import TimeDropdown from './components/TimeDropdown';
 import UtilizationThresholdCharts from './components/UtilizationThresholdCharts';
 
 import './virtual-machines-overview-tab-utilization.scss';
@@ -39,25 +39,24 @@ const VirtualMachinesOverviewTabUtilization: FC<VirtualMachinesOverviewTabUtiliz
 
   return (
     <Card className="VirtualMachinesOverviewTabUtilization--main">
-      <div className="title">
-        <CardTitle className="pf-v6-u-text-color-subtle">
-          <DescriptionListTermHelpText>
-            <Popover
+      <CardTitle className="pf-v6-u-text-color-subtle">
+        <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+          <div>
+            {t('Utilization')}
+            <HelpTextIcon
               bodyContent={
                 <Trans ns="plugin__kubevirt-plugin" t={t}>
                   <div>Donuts chart represent current values.</div>
                   <div>Sparkline charts represent data over time</div>
                 </Trans>
               }
-              position={PopoverPosition?.right}
-            >
-              <DescriptionListTermHelpTextButton>
-                {t('Utilization')}
-              </DescriptionListTermHelpTextButton>
-            </Popover>
-          </DescriptionListTermHelpText>
-        </CardTitle>
-      </div>
+              helpIconClassName="pf-v6-u-ml-xs"
+              position={PopoverPosition.right}
+            />
+          </div>
+          <TimeDropdown />
+        </Flex>
+      </CardTitle>
       <Divider />
       <CardBody isFilled>
         <ComponentReady isReady={isRunning(vm)} text={t('VirtualMachine is not running')}>
@@ -74,7 +73,9 @@ const VirtualMachinesOverviewTabUtilization: FC<VirtualMachinesOverviewTabUtiliz
             <GridItem span={3}>
               <NetworkUtil vmi={vmi} />
             </GridItem>
-            <UtilizationThresholdCharts vmi={vmi} />
+            <GridItem className="pf-v6-u-pl-md" span={12}>
+              <UtilizationThresholdCharts vmi={vmi} />
+            </GridItem>
           </Grid>
         </ComponentReady>
       </CardBody>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
@@ -15,6 +15,8 @@ import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
 import { useFleetPrometheusPoll } from '@stolostron/multicluster-sdk';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
+import { UtilizationBlock } from '../UtilizationBlock';
+
 type CPUUtilProps = {
   vmi: V1VirtualMachineInstance;
 };
@@ -51,39 +53,31 @@ const CPUUtil: FC<CPUUtilProps> = ({ vmi }) => {
   const isReady = !Number.isNaN(cpuUsage) && !Number.isNaN(cpuRequested);
 
   return (
-    <div className="util">
-      <div className="util-upper">
-        <div className="util-title">{t('CPU')}</div>
-        <div className="util-summary" data-test-id="util-summary-cpu">
-          <div className="util-summary-value">{`${isReady ? cpuUsageHumanized?.string : 0}`}</div>
-          <div className="util-summary-text pf-v6-u-text-color-subtle">
-            <div>
-              {t('Requested of {{cpuRequested}}', {
-                cpuRequested: isReady ? cpuRequestedHumanized?.string : 0,
-              })}
-            </div>
-          </div>
-        </div>
-      </div>
-      <div className="util-chart">
-        <ComponentReady isReady={isReady}>
-          <ChartDonutUtilization
-            data={{
-              x: t('CPU used'),
-              y: (averageCPUUsage > 100 ? 100 : averageCPUUsage) || 0,
-            }}
-            animate
-            constrainToVisibleArea
-            labels={({ datum }) => (datum.x ? `${datum.x}: ${cpuUsageHumanized?.string}` : null)}
-            style={{ labels: { fontSize: 20 } }}
-            subTitle={t('Used')}
-            subTitleComponent={<SubTitleChartLabel y={135} />}
-            title={`${averageCPUUsageStr}%`}
-            titleComponent={<TitleChartLabel />}
-          />
-        </ComponentReady>
-      </div>
-    </div>
+    <UtilizationBlock
+      usedOfTotalText={t('Requested of {{cpuRequested}}', {
+        cpuRequested: isReady ? cpuRequestedHumanized?.string : 0,
+      })}
+      dataTestId="util-summary-cpu"
+      title={t('CPU')}
+      usageValue={`${isReady ? cpuUsageHumanized?.string : 0}`}
+    >
+      <ComponentReady isReady={isReady}>
+        <ChartDonutUtilization
+          data={{
+            x: t('CPU used'),
+            y: (averageCPUUsage > 100 ? 100 : averageCPUUsage) || 0,
+          }}
+          animate
+          constrainToVisibleArea
+          labels={({ datum }) => (datum.x ? `${datum.x}: ${cpuUsageHumanized?.string}` : null)}
+          style={{ labels: { fontSize: 20 } }}
+          subTitle={t('Used')}
+          subTitleComponent={<SubTitleChartLabel y={135} />}
+          title={`${averageCPUUsageStr}%`}
+          titleComponent={<TitleChartLabel />}
+        />
+      </ComponentReady>
+    </UtilizationBlock>
   );
 };
 

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
@@ -17,6 +17,8 @@ import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
 import { useFleetPrometheusPoll } from '@stolostron/multicluster-sdk';
 import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration';
 
+import { UtilizationBlock } from '../UtilizationBlock';
+
 type MemoryUtilProps = {
   vmi: V1VirtualMachineInstance;
 };
@@ -42,40 +44,31 @@ const MemoryUtil: FC<MemoryUtilProps> = ({ vmi }) => {
   const isReady = !isEmpty(memory) && !Number.isNaN(percentageMemoryUsed);
 
   return (
-    <div className="util">
-      <div className="util-upper">
-        <div className="util-title">{t('Memory')}</div>
-        <div className="util-summary" data-test-id="util-summary-memory">
-          <div className="util-summary-value">
-            {xbytes(memoryUsed || 0, { fixed: 0, iec: true })}
-          </div>
-          <div className="util-summary-text pf-v6-u-text-color-subtle">
-            <div>{t('Used of ')}</div>
-            <div>{`${memory?.size} ${memory?.unit}B`}</div>
-          </div>
-        </div>
-      </div>
-      <div className="util-chart">
-        <ComponentReady isReady={isReady}>
-          <ChartDonutUtilization
-            data={{
-              x: t('Memory used'),
-              y: Number(percentageMemoryUsed?.toFixed(2)),
-            }}
-            labels={({ datum }) =>
-              datum.x ? `${datum.x}: ${xbytes(memoryUsed || 0, { iec: true })}` : null
-            }
-            animate
-            constrainToVisibleArea
-            style={{ labels: { fontSize: 20 } }}
-            subTitle={t('Used')}
-            subTitleComponent={<SubTitleChartLabel y={135} />}
-            title={`${Number(percentageMemoryUsed?.toFixed(2))}%`}
-            titleComponent={<TitleChartLabel />}
-          />
-        </ComponentReady>
-      </div>
-    </div>
+    <UtilizationBlock
+      dataTestId="util-summary-memory"
+      title={t('Memory')}
+      usageValue={xbytes(memoryUsed || 0, { fixed: 0, iec: true })}
+      usedOfTotalText={t('Used of {{ total }}', { total: `${memory?.size} ${memory?.unit}B` })}
+    >
+      <ComponentReady isReady={isReady}>
+        <ChartDonutUtilization
+          data={{
+            x: t('Memory used'),
+            y: Number(percentageMemoryUsed?.toFixed(2)),
+          }}
+          labels={({ datum }) =>
+            datum.x ? `${datum.x}: ${xbytes(memoryUsed || 0, { iec: true })}` : null
+          }
+          animate
+          constrainToVisibleArea
+          style={{ labels: { fontSize: 20 } }}
+          subTitle={t('Used')}
+          subTitleComponent={<SubTitleChartLabel y={135} />}
+          title={`${Number(percentageMemoryUsed?.toFixed(2))}%`}
+          titleComponent={<TitleChartLabel />}
+        />
+      </ComponentReady>
+    </UtilizationBlock>
   );
 };
 

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/NetworkUtil/NetworkBreakdownPopover.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/NetworkUtil/NetworkBreakdownPopover.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom-v5-compat';
+
+import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
+import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getResourceUrl } from '@kubevirt-utils/resources/shared';
+import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
+import { Button, ButtonVariant, Content, ContentVariants, Popover } from '@patternfly/react-core';
+
+type NetworkBreakdownPopoverProps = {
+  networkInterfaceTotal: string;
+  networkTotal: PrometheusResponse;
+  vmi: V1VirtualMachineInstance;
+};
+
+const NetworkBreakdownPopover: React.FC<NetworkBreakdownPopoverProps> = ({
+  networkInterfaceTotal,
+  networkTotal,
+  vmi,
+}) => {
+  const { t } = useKubevirtTranslation();
+
+  const interfacesNames = useMemo(() => vmi?.spec?.domain?.devices?.interfaces, [vmi]);
+
+  return (
+    <Popover
+      bodyContent={
+        <div>
+          <Content component={ContentVariants.h6}>{t('Top consumer')}</Content>
+          {interfacesNames?.map((networkInterface) => (
+            <div className="network-popover" key={networkInterface?.name}>
+              <Link
+                to={`${getResourceUrl({
+                  model: VirtualMachineModel,
+                  resource: vmi,
+                })}/metrics?network=${networkInterface?.name}`}
+              >
+                {networkInterface?.name}
+              </Link>
+              {networkInterface?.name === networkInterfaceTotal ? (
+                <div className="pf-v6-u-text-color-subtle">{`${networkInterfaceTotal} Bps`}</div>
+              ) : (
+                <div className="pf-v6-u-text-color-subtle">
+                  {networkTotal?.data?.result?.map(
+                    (name) =>
+                      name?.metric?.interface === networkInterface?.name &&
+                      `${Number(name?.value?.[1])?.toFixed(2)} Bps`,
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+          {interfacesNames?.length > 5 && (
+            <Link
+              to={`${getResourceUrl({
+                model: VirtualMachineModel,
+                resource: vmi,
+              })}/metrics?network`}
+            >
+              {t('View more')}
+            </Link>
+          )}
+        </div>
+      }
+      headerContent={t('Network transfer breakdown')}
+      position="bottom"
+    >
+      <div>
+        <Button isInline variant={ButtonVariant.link}>
+          {t('Breakdown by network')}
+        </Button>
+      </div>
+    </Popover>
+  );
+};
+
+export default NetworkBreakdownPopover;

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/NetworkUtil/NetworkMetricsRow.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/NetworkUtil/NetworkMetricsRow.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import xbytes from 'xbytes';
+
+import { Grid, GridItem } from '@patternfly/react-core';
+
+type NetworkMetricsRowProps = {
+  label: string;
+  value: number;
+};
+
+const NetworkMetricsRow: React.FC<NetworkMetricsRowProps> = ({ label, value }) => {
+  return (
+    <Grid className="pf-v6-u-text-color-subtle">
+      <GridItem span={6}>
+        {`${xbytes(value || 0, {
+          fixed: 0,
+        })}s`}
+      </GridItem>
+      <GridItem span={6}>{label}</GridItem>
+    </Grid>
+  );
+};
+
+export default NetworkMetricsRow;

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/StorageUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/StorageUtil.tsx
@@ -10,6 +10,8 @@ import { useGuestOS } from '@kubevirt-utils/resources/vmi';
 import { removeDuplicatesByName } from '@kubevirt-utils/utils/utils';
 import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
 
+import { UtilizationBlock } from '../UtilizationBlock';
+
 type StorageUtilProps = {
   vmi: V1VirtualMachineInstance;
 };
@@ -34,40 +36,33 @@ const StorageUtil: FC<StorageUtilProps> = ({ vmi }) => {
   const isReady = !Number.isNaN(usedPercentage) && loaded;
 
   return (
-    <div className="util">
-      <div className="util-upper">
-        <div className="util-title">{t('Storage')}</div>
-        <div className="util-summary" data-test-id="util-summary-storage">
-          <div className="util-summary-value">
-            {xbytes(usedBytes || 0, { fixed: 2, iec: true })}
-          </div>
-          <div className="util-summary-text pf-v6-u-text-color-subtle">
-            <div>{t('Used of ')}</div>
-            <div>{xbytes(totalBytes || 0, { fixed: 2, iec: true })}</div>
-          </div>
-        </div>
-      </div>
-      <div className="util-chart">
-        <ComponentReady isReady={isReady}>
-          <ChartDonutUtilization
-            data={{
-              x: t('Storage used'),
-              y: usedPercentage,
-            }}
-            labels={({ datum }) =>
-              datum.x ? `${datum.x}: ${xbytes(usedBytes || 0, { fixed: 2, iec: true })}` : null
-            }
-            animate
-            constrainToVisibleArea
-            style={{ labels: { fontSize: 20 } }}
-            subTitle={t('Used')}
-            subTitleComponent={<SubTitleChartLabel y={135} />}
-            title={`${usedPercentage.toFixed(2) || 0}%`}
-            titleComponent={<TitleChartLabel />}
-          />
-        </ComponentReady>
-      </div>
-    </div>
+    <UtilizationBlock
+      usedOfTotalText={t('Used of {{ total }}', {
+        total: xbytes(totalBytes || 0, { fixed: 2, iec: true }),
+      })}
+      dataTestId="util-summary-storage"
+      title={t('Storage')}
+      usageValue={xbytes(usedBytes || 0, { fixed: 2, iec: true })}
+    >
+      <ComponentReady isReady={isReady}>
+        <ChartDonutUtilization
+          data={{
+            x: t('Storage used'),
+            y: usedPercentage,
+          }}
+          labels={({ datum }) =>
+            datum.x ? `${datum.x}: ${xbytes(usedBytes || 0, { fixed: 2, iec: true })}` : null
+          }
+          animate
+          constrainToVisibleArea
+          style={{ labels: { fontSize: 20 } }}
+          subTitle={t('Used')}
+          subTitleComponent={<SubTitleChartLabel y={135} />}
+          title={`${usedPercentage.toFixed(2) || 0}%`}
+          titleComponent={<TitleChartLabel />}
+        />
+      </ComponentReady>
+    </UtilizationBlock>
   );
 };
 

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/TimeDropdown.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/TimeDropdown.tsx
@@ -11,7 +11,7 @@ const TimeDropdown: React.FC = () => {
     setDuration(DurationOption.fromDropdownLabel(value).toString());
 
   return (
-    <div className="duration-select" data-test-id="duration-select">
+    <div data-test-id="duration-select">
       <DurationDropdown selectedDuration={duration} selectHandler={onDurationSelect} />
     </div>
   );

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/UtilizationBlock.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/UtilizationBlock.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { Flex } from '@patternfly/react-core';
+
+type UtilizationBlockProps = {
+  dataTestId: string;
+  isNetworkUtil?: boolean;
+  title: string;
+  usageValue: string;
+  usedOfTotalText: string;
+};
+
+export const UtilizationBlock: React.FC<UtilizationBlockProps> = ({
+  children,
+  dataTestId,
+  isNetworkUtil = false,
+  title,
+  usageValue,
+  usedOfTotalText,
+}) => {
+  return (
+    <div className="util">
+      <div className="pf-v6-u-pl-lg">
+        <div className="pf-v6-u-pb-sm">{title}</div>
+        <Flex
+          data-test-id={dataTestId}
+          direction={isNetworkUtil ? null : { default: 'column' }}
+          spaceItems={isNetworkUtil ? null : { default: 'spaceItemsNone' }}
+        >
+          <div className="pf-v6-u-font-size-xl">{usageValue}</div>
+          <div className="pf-v6-u-text-color-subtle">{usedOfTotalText}</div>
+        </Flex>
+      </div>
+      {isNetworkUtil ? children : <div className="util-chart">{children}</div>}
+    </div>
+  );
+};

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/UtilizationThresholdCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/UtilizationThresholdCharts.tsx
@@ -5,19 +5,14 @@ import CPUThresholdChart from '@kubevirt-utils/components/Charts/CPUUtil/CPUThre
 import MemoryThresholdChart from '@kubevirt-utils/components/Charts/MemoryUtil/MemoryThresholdChart';
 import NetworkThresholdChart from '@kubevirt-utils/components/Charts/NetworkUtil/NetworkThresholdChart';
 import StorageTotalReadWriteThresholdChart from '@kubevirt-utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart';
-import { GridItem } from '@patternfly/react-core';
-
-import TimeDropdown from './TimeDropdown';
+import { Grid, GridItem } from '@patternfly/react-core';
 
 type UtilizationThresholdChartsProps = {
   vmi: V1VirtualMachineInstance;
 };
 const UtilizationThresholdCharts: React.FC<UtilizationThresholdChartsProps> = ({ vmi }) => {
   return (
-    <>
-      <GridItem span={12}>
-        <TimeDropdown />
-      </GridItem>
+    <Grid>
       <GridItem span={3}>
         <CPUThresholdChart vmi={vmi} />
       </GridItem>
@@ -30,7 +25,7 @@ const UtilizationThresholdCharts: React.FC<UtilizationThresholdChartsProps> = ({
       <GridItem span={3}>
         <NetworkThresholdChart vmi={vmi} />
       </GridItem>
-    </>
+    </Grid>
   );
 };
 

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/virtual-machines-overview-tab-utilization.scss
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/virtual-machines-overview-tab-utilization.scss
@@ -1,77 +1,30 @@
 .VirtualMachinesOverviewTabUtilization--main {
-  .title {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+  .pf-v6-c-card__body {
+    padding-left: var(--pf-t--global--spacer--sm);
   }
+
+  .pf-v6-c-card__title {
+    padding-top: var(--pf-t--global--spacer--md);
+    padding-bottom: var(--pf-t--global--spacer--sm);
+  }
+
   .util {
     display: flex;
     flex-direction: column;
     height: 100%;
-    .util-upper {
-      padding-inline: var(--pf-t--global--spacer--lg);
-      .util-title {
-        height: var(--pf-t--global--spacer--2xl);
-        &__subtitle {
-          font-size: var(--pf-t--global--font--size--md);
-        }
-      }
-      .util-summary {
-        width: 100%;
-        height: var(--pf-t--global--spacer--2xl);
-        display: flex;
-        align-items: flex-end;
-        .util-summary-value {
-          width: 50%;
-          font-weight: var(--pf-t--global--font--weight--body--default);
-          font-size: var(--pf-t--global--font--size--xl);
-          line-height: normal;
-        }
-        .util-summary-text {
-          width: 50%;
-        }
-      }
-    }
+
     .util-chart {
-      max-width: 80%;
+      margin-top: auto;
+
       .pf-v6-c-chart {
-        height: auto;
-      }
-    }
-    &.network {
-      display: flex;
-      flex-direction: column;
-      height: 100%;
-    }
-    .network-metrics {
-      padding-inline: var(--pf-t--global--spacer--lg);
-      display: flex;
-      flex-direction: column;
-      flex-grow: 1;
-      justify-content: center;
-      .network-metrics--row {
-        display: flex;
-        &__sum,
-        &__title {
-          width: 50%;
-        }
-        &__title {
-          margin-left: var(--pf-t--global--spacer--sm);
-        }
+        max-height: 260px;
+        max-width: 260px;
       }
     }
   }
+
   .util-threshold-chart {
-    width: 100%;
-    height: 100px;
-  }
-  .duration-select {
-    display: flex;
-    .pf-v6-c-select {
-      flex-basis: content;
-    }
-  }
-  .pf-v6-c-description-list__text.pf-m-help-text {
-    text-underline-offset: 0.25rem;
+    height: 120px;
+    margin-top: -1.5rem;
   }
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes Utilization card elements overlapping in VirtualMachine details
- when panel is smaller, changes the layout of cards so there is only one card per full panel width
  - I would prefer having "Alerts" and "General" cards above "Utilization", but did not come up with a way so React doesn't treat it as different children and rerenders the components

- improves performance when resizing drawer in VMs page by adding 50ms to debounce of `useContainerWidth`

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/66f95bc2-6ff3-4b82-abb4-57af95863166



After:


https://github.com/user-attachments/assets/d3fa18e7-29a7-479b-b857-836c9942b9fe

