### PR TITLE
CNV-70883: Fix for 'By' and 'VM' drop-downs in top consumers page

### DIFF
--- a/src/utils/components/DurationOption/DurationDropdown.tsx
+++ b/src/utils/components/DurationOption/DurationDropdown.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState } from 'react';
 
 import DurationOption from '@kubevirt-utils/components/DurationOption/DurationOption';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Select, SelectList, SelectOption } from '@patternfly/react-core';
 
 import SelectToggle from '../toggles/SelectToggle';
@@ -11,6 +12,8 @@ export type DurationDropdownProps = {
 };
 
 const DurationDropdown: FC<DurationDropdownProps> = ({ selectedDuration, selectHandler }) => {
+  const { t } = useKubevirtTranslation();
+
   const [isOpen, setIsOpen] = useState(false);
 
   const onSelect = (_, durationOption: string) => {
@@ -20,7 +23,7 @@ const DurationDropdown: FC<DurationDropdownProps> = ({ selectedDuration, selectH
 
   const onToggle = () => setIsOpen((prevIsOpen) => !prevIsOpen);
 
-  const selected = DurationOption.fromString(selectedDuration)?.getDropdownLabel();
+  const selected = t(DurationOption.fromString(selectedDuration)?.getDropdownLabel());
   return (
     <Select
       data-test-id="duration-select-dropdown"
@@ -45,7 +48,7 @@ const DurationDropdown: FC<DurationDropdownProps> = ({ selectedDuration, selectH
 
             return (
               <SelectOption data-test-id={durationValue} key={durationValue} value={dropdownLabel}>
-                {dropdownLabel}
+                {t(dropdownLabel)}
               </SelectOption>
             );
           })}

--- a/src/views/clusteroverview/TopConsumersTab/TopConsumersTab.tsx
+++ b/src/views/clusteroverview/TopConsumersTab/TopConsumersTab.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
 import DurationDropdown from '@kubevirt-utils/components/DurationOption/DurationDropdown';
@@ -11,14 +11,14 @@ import { Card, CardBody, CardHeader, CardTitle, SelectOption } from '@patternfly
 
 import { TOP_CONSUMERS_DURATION_KEY, TOP_CONSUMERS_NUM_ITEMS_KEY } from './utils/constants';
 import TopConsumersGridRow from './utils/TopConsumersGridRow';
-import { TOP_AMOUNT_SELECT_OPTIONS } from './utils/utils';
+import { getTopAmountSelectOptions } from './utils/utils';
 
 import './TopConsumersTab.scss';
 
 const TopConsumersTab: FC = () => {
   const { t } = useKubevirtTranslation();
-
   const [localStorageData, setLocalStorageData] = useKubevirtUserSettingsTopConsumerCards();
+  const TOP_AMOUNT_SELECT_OPTIONS = useMemo(() => getTopAmountSelectOptions(t), [t]);
   const onNumItemsSelect = (value) => setLocalStorageData(TOP_CONSUMERS_NUM_ITEMS_KEY, value);
   const onDurationSelect = (value: string) =>
     setLocalStorageData(
@@ -45,7 +45,7 @@ const TopConsumersTab: FC = () => {
                 <div className="kv-top-consumers-card__dropdown--num-items">
                   <FormPFSelect
                     onSelect={(_e, value) => onNumItemsSelect(value)}
-                    selected={localStorageData?.[TOP_CONSUMERS_NUM_ITEMS_KEY]}
+                    selected={t(localStorageData?.[TOP_CONSUMERS_NUM_ITEMS_KEY])}
                     toggleProps={{ id: 'kv-top-consumers-card-amount-select' }}
                   >
                     {TOP_AMOUNT_SELECT_OPTIONS.map((opt) => (

--- a/src/views/clusteroverview/TopConsumersTab/utils/TopConsumerCard.tsx
+++ b/src/views/clusteroverview/TopConsumersTab/utils/TopConsumerCard.tsx
@@ -66,7 +66,7 @@ const TopConsumerCard: FC<TopConsumersMetricCard> = ({
             toggleProps={{ id: 'kv-top-consumers-card-metric-select' }}
           >
             {TopConsumerMetric.getAll().map((metric) => (
-              <SelectOption key={metric?.getValue()} value={t(metric?.getDropdownLabel())}>
+              <SelectOption key={metric?.getValue()} value={metric?.getDropdownLabel()}>
                 {t(metric?.getDropdownLabel())}
               </SelectOption>
             ))}
@@ -79,7 +79,7 @@ const TopConsumerCard: FC<TopConsumersMetricCard> = ({
             toggleProps={{ id: 'kv-top-consumers-card-scope-select' }}
           >
             {TopConsumerScope.getAll().map((scope) => (
-              <SelectOption key={scope?.getValue()} value={t(scope?.getDropdownLabel())}>
+              <SelectOption key={scope?.getValue()} value={scope?.getDropdownLabel()}>
                 {t(scope?.getDropdownLabel())}
               </SelectOption>
             ))}

--- a/src/views/clusteroverview/TopConsumersTab/utils/utils.ts
+++ b/src/views/clusteroverview/TopConsumersTab/utils/utils.ts
@@ -1,4 +1,4 @@
-import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { TFunction } from 'react-i18next';
 
 import {
   humanizeBinaryBytes,
@@ -55,7 +55,7 @@ export const getHumanizedValue = (value, metric) => {
 export const getTopConsumerCardID = (rowNumber, cardNumber) =>
   `topConsumerCard-${rowNumber}-${cardNumber}`;
 
-export const TOP_AMOUNT_SELECT_OPTIONS = [
+export const getTopAmountSelectOptions = (t: TFunction) => [
   {
     key: 'top-5',
     value: t('Show top 5'),


### PR DESCRIPTION
## 📝 Description

Before the fix, the translated value was used to obtain the dropdown value. Since it did not exist the app errored out. 
In order to fix it, only the label is translated and the value is retained. 

In addition, regardless to [CNV-70883](https://issues.redhat.com/browse/CNV-70883), these drop-downs were not translated:
<img width="604" height="99" alt="Screenshot 2025-10-20 at 10 25 08 AM" src="https://github.com/user-attachments/assets/6e9404f6-15d0-4808-86d6-94bb24f73849" />


## 🎥 Demo

Before: 

https://github.com/user-attachments/assets/79c422fa-052c-4244-93aa-eef2240a111c


After: 


https://github.com/user-attachments/assets/f072c37c-edc3-4cb6-8071-8c3e0420a839

