### PR TITLE
CNV-70912: Fixing upload display in add volume modal

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -99,12 +99,18 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
         }
         onClose();
       }}
-      onSubmit={createBootableVolume({
-        bootableVolume,
-        onCreateVolume,
-        sourceType,
-        uploadData,
-      })}
+      onSubmit={(dataSource) => {
+        if (sourceType === DROPDOWN_FORM_SELECTION.UPLOAD_VOLUME) {
+          document.getElementById('source-details-section').scrollIntoView();
+        }
+
+        return createBootableVolume({
+          bootableVolume,
+          onCreateVolume,
+          sourceType,
+          uploadData,
+        })(dataSource);
+      }}
       headerText={t('Add volume')}
       isDisabled={!isFormValid}
       isOpen={isOpen}
@@ -119,7 +125,9 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
           resetDiskSize={resetDiskSize}
           setFormSelection={setSourceType}
         />
-        <Title headingLevel="h5">{t('Source details')}</Title>
+        <Title headingLevel="h5" id="source-details-section">
+          {t('Source details')}
+        </Title>
         <VolumeSource
           bootableVolume={bootableVolume}
           setBootableVolumeField={setBootableVolumeField}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When adding a bootable volume as an uploaded file the user was not able to see the uploading display, this fix scrolls the upload section into view.

## 🎥 Demo
Before:

https://github.com/user-attachments/assets/62b056a1-8d23-40dc-b3aa-76048591fd8a


After:

https://github.com/user-attachments/assets/b363eb7f-eb63-4aeb-bbec-ce419c77aeb5
