### PR TITLE
CNV-69204: Add  cluster select in the  bootable volume modal

### DIFF
--- a/src/multicluster/hooks/useK8sWatchData.ts
+++ b/src/multicluster/hooks/useK8sWatchData.ts
@@ -21,7 +21,10 @@ const useK8sWatchData = <T>(resource: FleetWatchK8sResource | null): WatchK8sRes
     useFleet ? null : resource,
   );
 
-  const defaultData: T = useMemo(() => (resource?.isList ? ([] as T) : undefined), [resource]);
+  const defaultData: T = useMemo(
+    () => (resource?.isList ? ([] as T) : undefined),
+    [resource?.isList],
+  );
 
   if (!resource || isEmpty(resource) || isEmpty(resource?.groupVersionKind))
     return [undefined, true, undefined];

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/ArchitectureSelect/ArchitectureSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/ArchitectureSelect/ArchitectureSelect.tsx
@@ -21,7 +21,9 @@ const ArchitectureSelect: FC<ArchitectureSelectProps> = ({
   setBootableVolumeField,
 }) => {
   const { t } = useKubevirtTranslation();
-  const workloadArchitectures = useHcoWorkloadArchitectures();
+  const workloadArchitectures = useHcoWorkloadArchitectures(
+    bootableVolumeState?.bootableVolumeCluster,
+  );
 
   if (isEmpty(workloadArchitectures)) return null;
 

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/ClusterSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/ClusterSelect.tsx
@@ -1,0 +1,51 @@
+import React, { FC, useCallback, useMemo } from 'react';
+
+import { AddBootableVolumeState } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/constants';
+import { SetBootableVolumeFieldType } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/constants';
+import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
+import Loading from '@kubevirt-utils/components/Loading/Loading';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { modelToGroupVersionKind } from '@kubevirt-utils/models';
+import { ManagedClusterModel } from '@multicluster/constants';
+import { FormGroup } from '@patternfly/react-core';
+import { useFleetClusterNames } from '@stolostron/multicluster-sdk';
+
+type ClusterSelectProps = {
+  bootableVolume: AddBootableVolumeState;
+  setBootableVolumeField: SetBootableVolumeFieldType;
+};
+
+const ClusterSelect: FC<ClusterSelectProps> = ({ bootableVolume, setBootableVolumeField }) => {
+  const { t } = useKubevirtTranslation();
+  const [clusters, clustersLoaded] = useFleetClusterNames();
+
+  const clusterOptions = useMemo(() => {
+    return (clusters || [])?.map((cluster) => ({
+      groupVersionKind: modelToGroupVersionKind(ManagedClusterModel),
+      label: cluster,
+      value: cluster,
+    }));
+  }, [clusters]);
+
+  const handleSelect = useCallback(
+    (value: string) => {
+      setBootableVolumeField('bootableVolumeCluster')(value);
+    },
+    [setBootableVolumeField],
+  );
+
+  if (!clustersLoaded) return <Loading />;
+
+  return (
+    <FormGroup isRequired label={t('Cluster')}>
+      <InlineFilterSelect
+        options={clusterOptions}
+        selected={bootableVolume.bootableVolumeCluster}
+        setSelected={handleSelect}
+        toggleProps={{ isFullWidth: true, placeholder: t('Select cluster') }}
+      />
+    </FormGroup>
+  );
+};
+
+export default ClusterSelect;

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/InstanceTypeDrilldownSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/InstanceTypeDrilldownSelect.tsx
@@ -36,8 +36,11 @@ export const InstanceTypeDrilldownSelect: FC<InstanceTypeMenuItemsProps> = ({
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  const { bootableVolumeNamespace, labels } = bootableVolume;
-  const { allInstanceTypes } = useInstanceTypesAndPreferences(bootableVolumeNamespace);
+  const { bootableVolumeCluster, bootableVolumeNamespace, labels } = bootableVolume;
+  const { allInstanceTypes } = useInstanceTypesAndPreferences(
+    bootableVolumeNamespace,
+    bootableVolumeCluster,
+  );
   const menuItems = useMemo(() => getInstanceTypeMenuItems(allInstanceTypes), [allInstanceTypes]);
 
   const selectedInstanceType = labels?.[DEFAULT_INSTANCETYPE_LABEL];

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/PreferenceSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/PreferenceSelect.tsx
@@ -31,10 +31,11 @@ const PreferenceSelect: FC<PreferenceSelectProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
 
-  const { bootableVolumeNamespace, labels } = bootableVolume;
+  const { bootableVolumeCluster, bootableVolumeNamespace, labels } = bootableVolume;
   const { preferenceSelectOptions, preferencesLoaded } = usePreferenceSelectOptions(
     bootableVolumeNamespace,
     setBootableVolumeField,
+    bootableVolumeCluster,
   );
 
   const handleSelect = (value: string) => {

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/hooks/usePreferenceSelectOptions.ts
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/hooks/usePreferenceSelectOptions.ts
@@ -17,6 +17,7 @@ import useUserPreferences from '@kubevirt-utils/hooks/useUserPreferences';
 type UsePreferenceSelectOptions = (
   namespace: string,
   setBootableVolumeField: SetBootableVolumeFieldType,
+  cluster: string,
 ) => {
   preferenceSelectOptions: EnhancedSelectOptionProps[];
   preferencesLoaded: boolean;
@@ -25,11 +26,17 @@ type UsePreferenceSelectOptions = (
 const usePreferenceSelectOptions: UsePreferenceSelectOptions = (
   namespace,
   setBootableVolumeField,
+  cluster,
 ) => {
   const { t } = useKubevirtTranslation();
 
-  const [preferences, preferencesLoaded] = useClusterPreferences();
-  const [userPreferences = [], userPreferencesLoaded] = useUserPreferences(namespace);
+  const [preferences, preferencesLoaded] = useClusterPreferences(null, null, cluster);
+  const [userPreferences = [], userPreferencesLoaded] = useUserPreferences(
+    namespace,
+    null,
+    null,
+    cluster,
+  );
 
   const preferenceSelectOptions = useMemo(() => {
     const preferenceOptions: EnhancedSelectOptionProps[] = getResourceDropdownOptions({

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/DiskSourcePVCSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/DiskSourcePVCSelect.tsx
@@ -9,6 +9,7 @@ import DiskSourcePVCSelectName from './DiskSourcePVCSelectName';
 import DiskSourcePVCSelectNamespace from './DiskSourcePVCSelectNamespace';
 
 type DiskSourcePVCSelectProps = {
+  cluster?: string;
   pvcNameSelected: string;
   pvcNamespaceSelected: string;
   selectPVCName: (value: string) => void;
@@ -17,14 +18,15 @@ type DiskSourcePVCSelectProps = {
 };
 
 const DiskSourcePVCSelect: FC<DiskSourcePVCSelectProps> = ({
+  cluster,
   pvcNameSelected,
   pvcNamespaceSelected,
   selectPVCName,
   selectPVCNamespace,
   setDiskSize,
 }) => {
-  const [projectsNames, projectNamesLoaded] = useProjects();
-  const [pvcs, pvcsLoaded] = usePVCs(pvcNamespaceSelected);
+  const [projectsNames, projectNamesLoaded] = useProjects(cluster);
+  const [pvcs, pvcsLoaded] = usePVCs(pvcNamespaceSelected, cluster);
 
   const onSelectProject = useCallback(
     (newProject) => {

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/PVCSource.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/PVCSource.tsx
@@ -17,11 +17,12 @@ type PVCSourceProps = {
 
 const PVCSource: FC<PVCSourceProps> = ({ bootableVolume, setBootableVolumeField }) => {
   const { t } = useKubevirtTranslation();
-  const { pvcName, pvcNamespace } = bootableVolume || {};
+  const { bootableVolumeCluster, pvcName, pvcNamespace } = bootableVolume || {};
 
   return (
     <>
       <DiskSourcePVCSelect
+        cluster={bootableVolumeCluster}
         pvcNameSelected={pvcName}
         pvcNamespaceSelected={pvcNamespace}
         selectPVCName={setBootableVolumeField('pvcName')}

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/SnapshotSource.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/SnapshotSource.tsx
@@ -12,9 +12,10 @@ type SnapshotSourceProps = {
 };
 
 const SnapshotSource: FC<SnapshotSourceProps> = ({ bootableVolume, setBootableVolumeField }) => {
-  const { snapshotName, snapshotNamespace } = bootableVolume || {};
+  const { bootableVolumeCluster, snapshotName, snapshotNamespace } = bootableVolume || {};
   return (
     <SelectSnapshot
+      cluster={bootableVolumeCluster}
       selectSnapshotName={setBootableVolumeField('snapshotName')}
       selectSnapshotNamespace={setBootableVolumeField('snapshotNamespace')}
       setDiskSize={setBootableVolumeField('size')}

--- a/src/utils/components/EvictionStrategy/ShowEvictionStrategy.tsx
+++ b/src/utils/components/EvictionStrategy/ShowEvictionStrategy.tsx
@@ -1,21 +1,18 @@
-import React, { FC } from 'react';
+import React, { FC, memo } from 'react';
 
-import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
-
-import { EVICTION_STRATEGY_DEFAULT } from './constants';
+import useHCOEvictionStrategy from './useHCOEvictionStrategy';
 
 type ShowEvictionStrategyProps = {
+  cluster?: string;
   evictionStrategy: string;
 };
 
-const ShowEvictionStrategy: FC<ShowEvictionStrategyProps> = ({ evictionStrategy }) => {
-  const [hyperConverge, hyperLoaded, hyperLoadingError] = useHyperConvergeConfiguration();
+const ShowEvictionStrategy: FC<ShowEvictionStrategyProps> = ({ cluster, evictionStrategy }) => {
+  const HCOEvictionStrategy = useHCOEvictionStrategy(cluster);
 
   if (evictionStrategy) return <>{evictionStrategy}</>;
 
-  if (hyperLoaded && !hyperLoadingError && !hyperConverge) return <>{EVICTION_STRATEGY_DEFAULT}</>;
-
-  return <>{hyperConverge?.spec?.evictionStrategy}</>;
+  return <>{HCOEvictionStrategy}</>;
 };
 
-export default ShowEvictionStrategy;
+export default memo(ShowEvictionStrategy);

--- a/src/utils/components/EvictionStrategy/useHCOEvictionStrategy.ts
+++ b/src/utils/components/EvictionStrategy/useHCOEvictionStrategy.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+
+import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+
+import { EVICTION_STRATEGY_DEFAULT } from './constants';
+
+const useHCOEvictionStrategy = (cluster?: string) => {
+  const [hyperConverge, hyperLoaded, hyperLoadingError] = useHyperConvergeConfiguration(cluster);
+
+  return useMemo(() => {
+    if (hyperLoaded && !hyperLoadingError && !hyperConverge) return EVICTION_STRATEGY_DEFAULT;
+
+    return hyperConverge?.spec?.evictionStrategy;
+  }, [hyperConverge, hyperLoaded, hyperLoadingError]);
+};
+
+export default useHCOEvictionStrategy;

--- a/src/utils/components/SelectSnapshot/SelectSnapshot.tsx
+++ b/src/utils/components/SelectSnapshot/SelectSnapshot.tsx
@@ -18,6 +18,7 @@ import useSnapshots from './useSnapshots';
 import './select-snapshot.scss';
 
 type SelectSnapshotProps = {
+  cluster?: string;
   selectSnapshotName: (value: string) => void;
   selectSnapshotNamespace?: (value: string) => void;
   setDiskSize?: (size: string) => void;
@@ -26,6 +27,7 @@ type SelectSnapshotProps = {
 };
 
 const SelectSnapshot: FC<SelectSnapshotProps> = ({
+  cluster,
   selectSnapshotName,
   selectSnapshotNamespace,
   setDiskSize,
@@ -33,8 +35,10 @@ const SelectSnapshot: FC<SelectSnapshotProps> = ({
   snapshotNamespaceSelected,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { projectsLoaded, projectsNames, snapshots, snapshotsLoaded } =
-    useSnapshots(snapshotNamespaceSelected);
+  const { projectsLoaded, projectsNames, snapshots, snapshotsLoaded } = useSnapshots(
+    snapshotNamespaceSelected,
+    cluster,
+  );
 
   const onSelectProject = useCallback(
     (newProject) => {

--- a/src/utils/components/VirtualMachineDescriptionItem/EditButtonWithTooltip.tsx
+++ b/src/utils/components/VirtualMachineDescriptionItem/EditButtonWithTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { FC, PropsWithChildren, ReactNode, SyntheticEvent } from 'react';
+import React, { FC, memo, PropsWithChildren, ReactNode, SyntheticEvent } from 'react';
 
 import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
@@ -47,4 +47,4 @@ const EditButtonWithTooltip: FC<EditButtonWithTooltipProps> = ({
   return <EditButton />;
 };
 
-export default EditButtonWithTooltip;
+export default memo(EditButtonWithTooltip);

--- a/src/utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
+++ b/src/utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { FC, ReactNode, useMemo } from 'react';
 
 import { DescriptionItemHeader } from '@kubevirt-utils/components/DescriptionItem/DescriptionItemHeader';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
@@ -60,18 +60,32 @@ const VirtualMachineDescriptionItem: FC<VirtualMachineDescriptionItemProps> = ({
   const { t } = useKubevirtTranslation();
   const NotAvailable = <MutedTextSpan text={t('Not available')} />;
 
-  const description = (
-    <>
-      <EditButtonWithTooltip
-        isEditable={!isDisabled}
-        onEditClick={onEditClick}
-        testId={testId}
-        tooltipContent={messageOnDisabled}
-      >
-        {descriptionData ?? NotAvailable}
-      </EditButtonWithTooltip>
-      {additionalContent}
-    </>
+  const description = useMemo(
+    () =>
+      isEdit && !showEditOnTitle ? (
+        <>
+          <EditButtonWithTooltip
+            isEditable={!isDisabled}
+            onEditClick={onEditClick}
+            testId={testId}
+            tooltipContent={messageOnDisabled}
+          >
+            {descriptionData ?? NotAvailable}
+          </EditButtonWithTooltip>
+          {additionalContent}
+        </>
+      ) : (
+        descriptionData
+      ),
+    [
+      descriptionData,
+      isDisabled,
+      onEditClick,
+      messageOnDisabled,
+      testId,
+      additionalContent,
+      showEditOnTitle,
+    ],
   );
 
   return (
@@ -115,7 +129,7 @@ const VirtualMachineDescriptionItem: FC<VirtualMachineDescriptionItemProps> = ({
 
       <DescriptionListDescription data-test-id={testId}>
         {subTitle && <div className="pf-v6-c-description-list__text pf-v6-u-my-sm">{subTitle}</div>}
-        {isEdit && !showEditOnTitle ? description : descriptionData}
+        {description}
       </DescriptionListDescription>
     </DescriptionListGroup>
   );

--- a/src/utils/hooks/useHcoWorkloadArchitectures.ts
+++ b/src/utils/hooks/useHcoWorkloadArchitectures.ts
@@ -1,7 +1,7 @@
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 
-const useHcoWorkloadArchitectures = () => {
-  const [hyperConverge] = useHyperConvergeConfiguration();
+const useHcoWorkloadArchitectures = (cluster?: string) => {
+  const [hyperConverge] = useHyperConvergeConfiguration(cluster);
 
   return hyperConverge?.status?.nodeInfo?.workloadsArchitectures ?? [];
 };

--- a/src/utils/hooks/useListMulticlusterFilters.ts
+++ b/src/utils/hooks/useListMulticlusterFilters.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import { isEmpty } from 'lodash';
+
+import { AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
+
+import useListClusters from './useListClusters';
+import useListNamespaces from './useListNamespaces';
+
+const useListMulticlusterFilters = (
+  additionalFilters?: AdvancedSearchFilter,
+): AdvancedSearchFilter => {
+  const clusters = useListClusters();
+  const namespaces = useListNamespaces();
+
+  return useMemo(
+    () => [
+      ...(isEmpty(clusters) ? [] : [{ property: 'cluster', values: clusters }]),
+      ...(isEmpty(namespaces) ? [] : [{ property: 'namespace', values: namespaces }]),
+      ...(additionalFilters || []),
+    ],
+    [clusters, namespaces, additionalFilters],
+  );
+};
+
+export default useListMulticlusterFilters;

--- a/src/utils/hooks/useUserPreferences.ts
+++ b/src/utils/hooks/useUserPreferences.ts
@@ -2,23 +2,37 @@ import { VirtualMachinePreferenceModelGroupVersionKind } from '@kubevirt-ui/kube
 import { V1beta1VirtualMachinePreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
-import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { Selector } from '@openshift-console/dynamic-plugin-sdk';
 
+import useKubevirtWatchResource from './useKubevirtWatchResource/useKubevirtWatchResource';
 import { ALL_NAMESPACES_SESSION_KEY } from './constants';
+import useListMulticlusterFilters from './useListMulticlusterFilters';
 
-const useUserPreferences = (namespace: string, fieldSelector?: string, selector?: Selector) => {
-  const cluster = useClusterParam();
-  const [userPreferences, userPreferencesLoaded, userPreferencesError] = useK8sWatchData<
+const useUserPreferences = (
+  namespace: string,
+  fieldSelector?: string,
+  selector?: Selector,
+  cluster?: string,
+): [V1beta1VirtualMachinePreference[], boolean, Error] => {
+  const clusterParam = useClusterParam();
+
+  const multiclusterFilters = useListMulticlusterFilters();
+
+  const [userPreferences, userPreferencesLoaded, userPreferencesError] = useKubevirtWatchResource<
     V1beta1VirtualMachinePreference[]
-  >({
-    cluster,
-    groupVersionKind: VirtualMachinePreferenceModelGroupVersionKind,
-    isList: true,
-    ...(namespace !== ALL_NAMESPACES_SESSION_KEY && { namespace: namespace }),
-    fieldSelector,
-    selector,
-  });
+  >(
+    {
+      cluster: cluster || clusterParam,
+      groupVersionKind: VirtualMachinePreferenceModelGroupVersionKind,
+      isList: true,
+      ...(namespace !== ALL_NAMESPACES_SESSION_KEY && { namespace: namespace }),
+      fieldSelector,
+      selector,
+    },
+    null,
+    multiclusterFilters,
+  );
+
   return [
     userPreferences,
     userPreferencesLoaded || !isEmpty(userPreferencesError),

--- a/src/views/catalog/CreateFromInstanceTypes/state/hooks/useClusterInstanceTypes.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/hooks/useClusterInstanceTypes.ts
@@ -1,27 +1,32 @@
 import { VirtualMachineClusterInstancetypeModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1VirtualMachineClusterInstancetype } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
-import useListClusters from '@kubevirt-utils/hooks/useListClusters';
+import useListMulticlusterFilters from '@kubevirt-utils/hooks/useListMulticlusterFilters';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { Selector } from '@openshift-console/dynamic-plugin-sdk';
 
 type UseClusterInstanceTypes = (
   fieldSelector?: string,
   selector?: Selector,
+  cluster?: string,
 ) => [instanceTypes: V1beta1VirtualMachineClusterInstancetype[], loaded: boolean, loadError: Error];
 
-const useClusterInstanceTypes: UseClusterInstanceTypes = (fieldSelector, selector) => {
-  const clusters = useListClusters();
+const useClusterInstanceTypes: UseClusterInstanceTypes = (fieldSelector, selector, cluster) => {
+  const multiclusterFilters = useListMulticlusterFilters();
+  const clusterParam = useClusterParam();
+
   const [instanceTypes, loaded, loadError] = useKubevirtWatchResource<
     V1beta1VirtualMachineClusterInstancetype[]
   >(
     {
+      cluster: cluster || clusterParam,
       fieldSelector,
       groupVersionKind: VirtualMachineClusterInstancetypeModelGroupVersionKind,
       isList: true,
       selector,
     },
     null,
-    [{ property: 'cluster', values: clusters }],
+    multiclusterFilters,
   );
 
   return [instanceTypes || [], loaded || !!loadError, loadError];

--- a/src/views/catalog/CreateFromInstanceTypes/state/hooks/useClusterPreferences.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/hooks/useClusterPreferences.ts
@@ -1,25 +1,33 @@
 import { VirtualMachineClusterPreferenceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
+import useListMulticlusterFilters from '@kubevirt-utils/hooks/useListMulticlusterFilters';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { Selector } from '@openshift-console/dynamic-plugin-sdk';
 
 type UseClusterPreferences = (
   fieldSelector?: string,
   selector?: Selector,
+  cluster?: string,
 ) => [preferences: V1beta1VirtualMachineClusterPreference[], loaded: boolean, loadError: Error];
 
-const useClusterPreferences: UseClusterPreferences = (fieldSelector, selector) => {
-  const cluster = useClusterParam();
+const useClusterPreferences: UseClusterPreferences = (fieldSelector, selector, cluster) => {
+  const clusterParam = useClusterParam();
+  const multiclusterFilters = useListMulticlusterFilters();
+
   const [preferences, loaded, loadError] = useKubevirtWatchResource<
     V1beta1VirtualMachineClusterPreference[]
-  >({
-    cluster,
-    fieldSelector,
-    groupVersionKind: VirtualMachineClusterPreferenceModelGroupVersionKind,
-    isList: true,
-    selector,
-  });
+  >(
+    {
+      cluster: cluster || clusterParam,
+      fieldSelector,
+      groupVersionKind: VirtualMachineClusterPreferenceModelGroupVersionKind,
+      isList: true,
+      selector,
+    },
+    null,
+    multiclusterFilters,
+  );
 
   return [preferences || [], loaded || !!loadError, loadError];
 };

--- a/src/views/catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypesAndPreferences.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/hooks/useInstanceTypesAndPreferences.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import useVirtualMachineInstanceTypes from '@catalog/CreateFromInstanceTypes/state/hooks/useVirtualMachineInstanceTypes';
 
 import { UseInstanceTypeAndPreferencesValues } from '../utils/types';
@@ -5,22 +7,39 @@ import { UseInstanceTypeAndPreferencesValues } from '../utils/types';
 import useClusterInstanceTypes from './useClusterInstanceTypes';
 import useClusterPreferences from './useClusterPreferences';
 
-type UseInstanceTypeAndPreferences = (namespace?: string) => UseInstanceTypeAndPreferencesValues;
+type UseInstanceTypeAndPreferences = (
+  namespace?: string,
+  cluster?: string,
+) => UseInstanceTypeAndPreferencesValues;
 
-const useInstanceTypesAndPreferences: UseInstanceTypeAndPreferences = (namespace) => {
-  const [clusterInstanceTypes, clusterITsLoaded, clusterITsLoadError] = useClusterInstanceTypes();
+const useInstanceTypesAndPreferences: UseInstanceTypeAndPreferences = (namespace, cluster) => {
+  const [clusterInstanceTypes, clusterITsLoaded, clusterITsLoadError] = useClusterInstanceTypes(
+    null,
+    null,
+    cluster,
+  );
 
   const [vmInstanceTypes, userITsLoaded, userITsLoadError] = useVirtualMachineInstanceTypes({
+    cluster,
     namespace,
   });
 
-  const [preferences, preferencesLoaded, preferencesLoadError] = useClusterPreferences();
+  const [preferences, preferencesLoaded, preferencesLoadError] = useClusterPreferences(
+    null,
+    null,
+    cluster,
+  );
 
   const loaded = preferencesLoaded && clusterITsLoaded && userITsLoaded;
   const loadError = preferencesLoadError || clusterITsLoadError || userITsLoadError;
 
+  const allInstanceTypes = useMemo(
+    () => [...clusterInstanceTypes, ...vmInstanceTypes],
+    [clusterInstanceTypes, vmInstanceTypes],
+  );
+
   return {
-    allInstanceTypes: [...clusterInstanceTypes, ...vmInstanceTypes],
+    allInstanceTypes,
     clusterInstanceTypes,
     loaded: loaded || Boolean(loadError),
     loadError,

--- a/src/views/catalog/CreateFromInstanceTypes/state/hooks/useVirtualMachineInstanceTypes.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/hooks/useVirtualMachineInstanceTypes.ts
@@ -1,40 +1,35 @@
-import { useMemo } from 'react';
-
 import { VirtualMachineInstancetypeModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1VirtualMachineInstancetype } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
-import useListClusters from '@kubevirt-utils/hooks/useListClusters';
-import useListNamespaces from '@kubevirt-utils/hooks/useListNamespaces';
-import { isAllNamespaces, isEmpty } from '@kubevirt-utils/utils/utils';
+import useListMulticlusterFilters from '@kubevirt-utils/hooks/useListMulticlusterFilters';
+import { isAllNamespaces } from '@kubevirt-utils/utils/utils';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { Selector } from '@openshift-console/dynamic-plugin-sdk';
 
 type UseVirtualMachineInstanceTypes = (params?: {
+  cluster?: string;
   fieldSelector?: string;
   namespace?: string;
   selector?: Selector;
 }) => [instanceTypes: V1beta1VirtualMachineInstancetype[], loaded: boolean, loadError: Error];
 
 const useVirtualMachineInstanceTypes: UseVirtualMachineInstanceTypes = ({
+  cluster,
   fieldSelector,
   namespace,
   selector,
 }) => {
-  const clusters = useListClusters();
-  const namespaces = useListNamespaces();
-  const isAllNamespace = isAllNamespaces(namespace);
+  const clusterParam = useClusterParam();
 
-  const multiclusterFilters = useMemo(
-    () => [
-      ...(isEmpty(clusters) ? [] : [{ property: 'cluster', values: clusters }]),
-      ...(isEmpty(namespaces) ? [] : [{ property: 'namespace', values: namespaces }]),
-    ],
-    [clusters, namespaces],
-  );
+  const multiclusterFilters = useListMulticlusterFilters();
+
+  const isAllNamespace = isAllNamespaces(namespace);
 
   const [instanceTypes, loaded, loadError] = useKubevirtWatchResource<
     V1beta1VirtualMachineInstancetype[]
   >(
     {
+      cluster: cluster || clusterParam,
       fieldSelector,
       groupVersionKind: VirtualMachineInstancetypeModelGroupVersionKind,
       isList: true,

--- a/src/views/catalog/wizard/tabs/scheduling/components/WizardSchedulingGrid.tsx
+++ b/src/views/catalog/wizard/tabs/scheduling/components/WizardSchedulingGrid.tsx
@@ -137,6 +137,12 @@ const WizardSchedulingGrid: FC<WizardSchedulingGridProps> = ({ updateVM, vm }) =
           />
 
           <WizardDescriptionItem
+            description={
+              <ShowEvictionStrategy
+                cluster={getCluster(vm)}
+                evictionStrategy={getEvictionStrategy(vm)}
+              />
+            }
             onEditClick={() =>
               createModal(({ isOpen, onClose }) => (
                 <EvictionStrategyModal
@@ -148,7 +154,6 @@ const WizardSchedulingGrid: FC<WizardSchedulingGridProps> = ({ updateVM, vm }) =
                 />
               ))
             }
-            description={<ShowEvictionStrategy evictionStrategy={getEvictionStrategy(vm)} />}
             isEdit
             testId="eviction-strategy"
             title={t('Eviction strategy')}

--- a/src/views/templates/details/tabs/scheduling/components/EvictionStrategy.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/EvictionStrategy.tsx
@@ -6,6 +6,7 @@ import ShowEvictionStrategy from '@kubevirt-utils/components/EvictionStrategy/Sh
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMachineDescriptionItem/VirtualMachineDescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getCluster } from '@multicluster/helpers/selectors';
 
 import EvictionStrategyModal from './EvictionStrategyModal';
 
@@ -30,7 +31,9 @@ const EvictionStrategy: React.FC<TemplateSchedulingGridProps> = ({
 
   return (
     <VirtualMachineDescriptionItem
-      descriptionData={<ShowEvictionStrategy evictionStrategy={strategy} />}
+      descriptionData={
+        <ShowEvictionStrategy cluster={getCluster(template)} evictionStrategy={strategy} />
+      }
       descriptionHeader={t('Eviction strategy')}
       isEdit={editable}
       onEditClick={onEditClick}

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/SchedulingTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/SchedulingTab.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, memo } from 'react';
 
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
@@ -23,4 +23,4 @@ const SchedulingTab: FC<ConfigurationInnerTabProps> = ({ instanceTypeVM, vm, vmi
   </SidebarEditor>
 );
 
-export default SchedulingTab;
+export default memo(SchedulingTab);

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSection.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, memo } from 'react';
 
 import { modelToGroupVersionKind, NodeModel } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
@@ -60,4 +60,4 @@ const SchedulingSection: FC<SchedulingSectionProps> = ({ instanceTypeVM, onSubmi
   );
 };
 
-export default SchedulingSection;
+export default memo(SchedulingSection);

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionRightGrid.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSectionRightGrid.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react';
+import React, { FC, useCallback, useMemo } from 'react';
 
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -11,6 +11,7 @@ import VirtualMachineDescriptionItem from '@kubevirt-utils/components/VirtualMac
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isExpandableSpecVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { getEvictionStrategy } from '@kubevirt-utils/resources/vm';
+import { getCluster } from '@multicluster/helpers/selectors';
 import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList, GridItem } from '@patternfly/react-core';
 
@@ -47,6 +48,26 @@ const SchedulingSectionRightGrid: FC<SchedulingSectionRightGridProps> = ({
     [onUpdateVM],
   );
 
+  const onEditEvictionStrategy = useCallback(() => {
+    createModal(({ isOpen, onClose }) => (
+      <EvictionStrategyModal
+        headerText={t('Eviction strategy')}
+        isOpen={isOpen}
+        onClose={onClose}
+        onSubmit={onSubmit}
+        vm={vm}
+        vmi={vmi}
+      />
+    ));
+  }, [createModal, onSubmit, vm, vmi]);
+
+  const evictionStrategy = useMemo(
+    () => (
+      <ShowEvictionStrategy cluster={getCluster(vm)} evictionStrategy={getEvictionStrategy(vm)} />
+    ),
+    [vm],
+  );
+
   return (
     <GridItem span={5}>
       <DescriptionList>
@@ -78,21 +99,10 @@ const SchedulingSectionRightGrid: FC<SchedulingSectionRightGridProps> = ({
           descriptionHeader={
             <SearchItem id="eviction-strategy">{t('Eviction strategy')}</SearchItem>
           }
-          onEditClick={() =>
-            createModal(({ isOpen, onClose }) => (
-              <EvictionStrategyModal
-                headerText={t('Eviction strategy')}
-                isOpen={isOpen}
-                onClose={onClose}
-                onSubmit={onSubmit}
-                vm={vm}
-                vmi={vmi}
-              />
-            ))
-          }
           data-test-id="eviction-strategy"
-          descriptionData={<ShowEvictionStrategy evictionStrategy={getEvictionStrategy(vm)} />}
+          descriptionData={evictionStrategy}
           isEdit={canUpdateVM}
+          onEditClick={onEditEvictionStrategy}
         />
       </DescriptionList>
     </GridItem>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add the bootable volume modal cluster select. In another pr i add the cluster and project dropdowns in the list 

## 🎥 Demo


https://github.com/user-attachments/assets/da951888-865f-457c-8501-e028132571ff








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cluster selection to the bootable volume modal; architectures, instance types, preferences, PVCs and snapshots are now scoped to the chosen cluster.
  * Eviction strategy display now respects cluster context.

* **Refactor**
  * Multicluster-aware resource loading and new multicluster filters for more accurate discovery.
  * Several UI components wrapped with memo/useMemo for improved rendering performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->