### PR TITLE
CNV-62896: fix useSSHService hook deprecated kind to groupVersionKind

### DIFF
--- a/src/utils/components/SSHAccess/useSSHService.tsx
+++ b/src/utils/components/SSHAccess/useSSHService.tsx
@@ -1,4 +1,4 @@
-import { ServiceModel } from '@kubevirt-ui/kubevirt-api/console';
+import { modelToGroupVersionKind, ServiceModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
@@ -12,8 +12,8 @@ export type UseSSHServiceReturnType = [service: IoK8sApiCoreV1Service, loaded: b
 const useSSHService = (vm: V1VirtualMachine): UseSSHServiceReturnType => {
   const watchServiceResources = {
     cluster: getCluster(vm),
+    groupVersionKind: modelToGroupVersionKind(ServiceModel),
     isList: true,
-    kind: ServiceModel.kind,
     namespace: vm?.metadata?.namespace,
   };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixed SSH LoadBalancer service not updating by replacing watch services depricated kind to groupVersionKind to allow services to be fetched



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal Kubernetes resource configuration handling for better consistency with system standards.

---

**Note:** This release includes internal improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->