### PR TITLE
CNV-71151: Update service label selectors to use vmi.kubevirt.io/id for KubeVirt v1.7+ compatibility

### DIFF
--- a/src/utils/components/Consoles/components/DesktopViewer/Components/RDPServiceModal.tsx
+++ b/src/utils/components/Consoles/components/DesktopViewer/Components/RDPServiceModal.tsx
@@ -5,6 +5,10 @@ import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { usePods } from '@kubevirt-utils/hooks/usePods';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { getVMIPod } from '@kubevirt-utils/resources/vmi/utils/pod';
+import { getCluster } from '@multicluster/helpers/selectors';
 import {
   Alert,
   AlertVariant,
@@ -27,14 +31,17 @@ const RDPServiceModal: FC<RDPServiceModalProps> = ({ isOpen, onClose, vm, vmi })
   const { t } = useKubevirtTranslation();
   const [isChecked, setChecked] = useState<boolean>(false);
 
+  const [pods, podsLoaded] = usePods(getNamespace(vmi), getCluster(vmi));
+  const pod = getVMIPod(vmi, pods);
+
   return (
     <TabModal
       headerText={t('RDP Service')}
-      isDisabled={!isChecked}
+      isDisabled={!isChecked || !podsLoaded}
       isOpen={isOpen}
       modalVariant={ModalVariant.medium}
       onClose={onClose}
-      onSubmit={() => createRDPService(vm, vmi)}
+      onSubmit={() => createRDPService(vm, vmi, pod)}
     >
       <Stack hasGutter>
         <StackItem>

--- a/src/utils/components/Consoles/components/DesktopViewer/utils/utils.ts
+++ b/src/utils/components/Consoles/components/DesktopViewer/utils/utils.ts
@@ -9,10 +9,14 @@ import {
   IoK8sApiCoreV1ServicePort,
 } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { buildOwnerReference } from '@kubevirt-utils/resources/shared';
+import {
+  getServicesForVmi,
+  getVMILabelForServiceSelector,
+} from '@kubevirt-utils/resources/vmi/utils/services';
 import { escapeJsonPointerToken, kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { k8sCreate, k8sPatch, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
-import { buildOwnerReference } from '../../../../../resources/shared';
 import { RDP_CONSOLE_TYPE, SPICE_CONSOLE_TYPE, VNC_CONSOLE_TYPE } from '../../utils/ConsoleConsts';
 
 import {
@@ -21,8 +25,6 @@ import {
   DEFAULT_VV_MIMETYPE,
   MULTUS,
   POD,
-  TEMPLATE_VM_NAME_LABEL,
-  VMI_LABEL_AS_RDP_SERVICE_SELECTOR,
 } from './constants';
 import { ConsoleDetailPropType, Network } from './types';
 
@@ -36,21 +38,23 @@ const findVMServiceWithPort = (
   vmi: V1VirtualMachineInstance,
   allServices: IoK8sApiCoreV1Service[],
   targetPort: number,
-): IoK8sApiCoreV1Service =>
-  allServices?.find(
-    (service) =>
-      vmi?.metadata?.name === service?.spec?.selector?.[TEMPLATE_VM_NAME_LABEL] &&
-      !!getServicePort(service, targetPort),
-  );
+  pod?: IoK8sApiCoreV1Pod,
+): IoK8sApiCoreV1Service | undefined => {
+  if (!vmi) return undefined;
+
+  const matchingServices = getServicesForVmi(allServices, pod, undefined, vmi);
+  return matchingServices.find((service) => !!getServicePort(service, targetPort));
+};
 
 export const findRDPServiceAndPort = (
   vmi: V1VirtualMachineInstance,
   allServices: IoK8sApiCoreV1Service[],
+  pod?: IoK8sApiCoreV1Pod,
 ): [IoK8sApiCoreV1Service, IoK8sApiCoreV1ServicePort] => {
   if (!vmi) {
     return [null, null];
   }
-  const service = findVMServiceWithPort(vmi, allServices, DEFAULT_RDP_PORT);
+  const service = findVMServiceWithPort(vmi, allServices, DEFAULT_RDP_PORT, pod);
   return [service, getServicePort(service, DEFAULT_RDP_PORT)];
 };
 
@@ -59,7 +63,7 @@ export const getRdpAddressPort = (
   services: IoK8sApiCoreV1Service[],
   launcherPod: IoK8sApiCoreV1Pod,
 ): ConsoleDetailPropType => {
-  const [rdpService, rdpPortObj] = findRDPServiceAndPort(vmi, services);
+  const [rdpService, rdpPortObj] = findRDPServiceAndPort(vmi, services, launcherPod);
 
   if (!rdpService || !rdpPortObj) {
     return null;
@@ -228,19 +232,20 @@ export const getDefaultNetwork = (networks: Network[]) => {
 export const createRDPService = (
   vm: V1VirtualMachine,
   vmi: V1VirtualMachineInstance,
+  pod?: IoK8sApiCoreV1Pod,
 ): Promise<K8sResourceCommon[]> => {
-  const { name, namespace } = vm?.metadata || {};
-  const vmiLabels = vm?.spec?.template?.metadata?.labels;
-  const labelSelector = vmiLabels?.[VMI_LABEL_AS_RDP_SERVICE_SELECTOR] || name;
+  const { namespace } = vm?.metadata || {};
+
+  const labelSelector = getVMILabelForServiceSelector(pod, vm);
+
+  const { labelKey, labelValue } = labelSelector;
 
   const vmPromise = k8sPatch<V1VirtualMachine>({
     data: [
       {
         op: 'add',
-        path: `/spec/template/metadata/labels/${escapeJsonPointerToken(
-          VMI_LABEL_AS_RDP_SERVICE_SELECTOR,
-        )}`,
-        value: labelSelector,
+        path: `/spec/template/metadata/labels/${escapeJsonPointerToken(labelKey)}`,
+        value: labelValue,
       },
     ],
     model: VirtualMachineModel,
@@ -251,8 +256,8 @@ export const createRDPService = (
     data: [
       {
         op: 'add',
-        path: `/metadata/labels/${escapeJsonPointerToken(VMI_LABEL_AS_RDP_SERVICE_SELECTOR)}`,
-        value: labelSelector,
+        path: `/metadata/labels/${escapeJsonPointerToken(labelKey)}`,
+        value: labelValue,
       },
     ],
     model: VirtualMachineInstanceModel,
@@ -276,7 +281,7 @@ export const createRDPService = (
           },
         ],
         selector: {
-          [VMI_LABEL_AS_RDP_SERVICE_SELECTOR]: labelSelector,
+          [labelKey]: labelValue,
         },
         type: 'NodePort',
       },

--- a/src/utils/components/SSHAccess/components/SSHCommand.tsx
+++ b/src/utils/components/SSHAccess/components/SSHCommand.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState } from 'react';
 
-import { VirtualMachineInstanceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
+import { getVMIPod } from '@kubevirt-utils/resources/vmi/utils/pod';
+import { getVMILabelForServiceSelector } from '@kubevirt-utils/resources/vmi/utils/services';
 import { getCluster } from '@multicluster/helpers/selectors';
-import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import {
   Alert,
   AlertVariant,
@@ -24,8 +24,7 @@ import {
 
 import { SERVICE_TYPES } from '../constants';
 import useSSHCommand, { isLoadBalancerBonded } from '../useSSHCommand';
-import { addSSHSelectorLabelToVM } from '../utils';
-import { createSSHService, deleteSSHService } from '../utils';
+import { addSSHSelectorLabelToVM, createSSHService, deleteSSHService } from '../utils';
 
 import SSHServiceSelect from './SSHServiceSelect';
 import SSHServiceStateIcon from './SSHServiceState';
@@ -47,16 +46,12 @@ const SSHCommand: React.FC<SSHCommandProps> = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error>();
 
-  const [vmi] = useK8sWatchData<V1VirtualMachineInstance>({
-    cluster: getCluster(vm),
-    groupVersionKind: {
-      group: VirtualMachineInstanceModel.apiGroup,
-      kind: VirtualMachineInstanceModel.kind,
-      version: VirtualMachineInstanceModel.apiVersion,
-    },
-    name: getName(vm),
-    namespace: getNamespace(vm),
-  });
+  const {
+    loaded: vmiAndPodsLoaded,
+    pods,
+    vmi,
+  } = useVMIAndPodsForVM(getName(vm), getNamespace(vm), getCluster(vm));
+  const pod = getVMIPod(vmi, pods);
 
   const onSSHChange = async (newServiceType: SERVICE_TYPES) => {
     setLoading(true);
@@ -68,9 +63,10 @@ const SSHCommand: React.FC<SSHCommandProps> = ({
       }
 
       if (newServiceType && newServiceType !== SERVICE_TYPES.NONE) {
-        await addSSHSelectorLabelToVM(vm, vmi, getName(vm));
+        const labelSelector = getVMILabelForServiceSelector(pod, vm);
+        await addSSHSelectorLabelToVM(vm, vmi, labelSelector);
 
-        const newService = await createSSHService(vm, newServiceType);
+        const newService = await createSSHService(vm, newServiceType, pod);
         setSSHService(newService);
       }
     } catch (apiError) {
@@ -96,7 +92,7 @@ const SSHCommand: React.FC<SSHCommandProps> = ({
 
       <DescriptionListDescription>
         <Stack hasGutter>
-          {sshServiceLoaded && !loading ? (
+          {sshServiceLoaded && vmiAndPodsLoaded && !loading ? (
             <>
               <StackItem>
                 <Flex direction={{ default: 'row' }}>

--- a/src/utils/components/SSHAccess/useSSHService.tsx
+++ b/src/utils/components/SSHAccess/useSSHService.tsx
@@ -1,8 +1,10 @@
 import { modelToGroupVersionKind, ServiceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
+import { getVMIPod } from '@kubevirt-utils/resources/vmi/utils/pod';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
@@ -22,9 +24,16 @@ const useSSHService = (vm: V1VirtualMachine): UseSSHServiceReturnType => {
     vm && watchServiceResources,
   );
 
+  const { pods, vmi } = useVMIAndPodsForVM(
+    vm ? getName(vm) : '',
+    vm ? getNamespace(vm) : '',
+    vm ? getCluster(vm) : undefined,
+  );
+
   if (!vm) return [undefined, false];
 
-  const vmiServices = getServicesForVmi(services, vm?.spec?.template?.metadata?.labels);
+  const pod = getVMIPod(vmi, pods);
+  const vmiServices = getServicesForVmi(services, pod, vm, vmi);
 
   const sshVMIService = vmiServices.find((service) =>
     service?.spec?.ports?.find((port) => parseInt(port.targetPort, 10) === SSH_PORT),

--- a/src/utils/components/SSHAccess/utils.ts
+++ b/src/utils/components/SSHAccess/utils.ts
@@ -3,41 +3,55 @@ import produce from 'immer';
 import { ServiceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineInstanceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { IoK8sApiCoreV1Pod, IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
-import { ensurePath, getRandomChars, isEmpty } from '@kubevirt-utils/utils/utils';
+import { getVMILabelForServiceSelector } from '@kubevirt-utils/resources/vmi/utils/services';
+import {
+  ensurePath,
+  getRandomChars,
+  isEmpty,
+  truncateToK8sName,
+} from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { kubevirtK8sCreate, kubevirtK8sDelete, kubevirtK8sUpdate } from '@multicluster/k8sRequests';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 import { buildOwnerReference, getName, getNamespace } from './../../resources/shared';
-import { PORT, SERVICE_TYPES, SSH_PORT, VM_LABEL_AS_SSH_SERVICE_SELECTOR } from './constants';
+import { PORT, SERVICE_TYPES, SSH_PORT } from './constants';
 
-const buildSSHServiceFromVM = (vm: V1VirtualMachine, type: SERVICE_TYPES) => ({
-  apiVersion: ServiceModel.apiVersion,
-  kind: ServiceModel.kind,
-  metadata: {
-    // max name length is 63 characters
-    name: `${vm?.metadata?.name}-${type.toLowerCase()}-ssh-service`
-      .substring(0, 56)
-      .concat(`-${getRandomChars(4)}`),
-    namespace: vm?.metadata?.namespace,
-    ownerReferences: [buildOwnerReference(vm, { blockOwnerDeletion: false })],
-  },
-  spec: {
-    ports: [
-      {
-        port: PORT,
-        targetPort: SSH_PORT,
-      },
-    ],
-    selector: {
-      [VM_LABEL_AS_SSH_SERVICE_SELECTOR]: vm?.metadata?.name,
+const buildSSHServiceFromVM = (
+  vm: V1VirtualMachine,
+  type: SERVICE_TYPES,
+  pod?: IoK8sApiCoreV1Pod,
+) => {
+  const labelSelector = getVMILabelForServiceSelector(pod, vm);
+
+  return {
+    apiVersion: ServiceModel.apiVersion,
+    kind: ServiceModel.kind,
+    metadata: {
+      name: truncateToK8sName(
+        `${vm?.metadata?.name}-${type.toLowerCase()}-ssh-service`,
+        getRandomChars(4),
+      ),
+      namespace: vm?.metadata?.namespace,
+      ownerReferences: [buildOwnerReference(vm, { blockOwnerDeletion: false })],
     },
-    type,
-  },
-});
+    spec: {
+      ports: [
+        {
+          port: PORT,
+          targetPort: SSH_PORT,
+        },
+      ],
+      selector: {
+        [labelSelector.labelKey]: labelSelector.labelValue,
+      },
+      type,
+    },
+  };
+};
 
 export const deleteSSHService = (sshService: IoK8sApiCoreV1Service) =>
   kubevirtK8sDelete<IoK8sApiCoreV1Service>({
@@ -50,19 +64,21 @@ export const deleteSSHService = (sshService: IoK8sApiCoreV1Service) =>
 export const addSSHSelectorLabelToVM = async (
   vm: V1VirtualMachine,
   vmi: V1VirtualMachineInstance,
-  labelValue,
+  labelSelector: { labelKey: string; labelValue: string },
 ) => {
+  const { labelKey, labelValue } = labelSelector;
+
   const vmWithLabel = produce(vm, (draftVM) => {
     ensurePath(draftVM, 'spec.template.metadata.labels');
 
-    draftVM.spec.template.metadata.labels[VM_LABEL_AS_SSH_SERVICE_SELECTOR] = labelValue;
+    draftVM.spec.template.metadata.labels[labelKey] = labelValue;
   });
 
   if (vmi) {
     const vmiWithLabel = produce(vmi, (draftVMI) => {
       ensurePath(draftVMI, 'metadata.labels');
 
-      draftVMI.metadata.labels[VM_LABEL_AS_SSH_SERVICE_SELECTOR] = labelValue;
+      draftVMI.metadata.labels[labelKey] = labelValue;
     });
 
     await kubevirtK8sUpdate<V1VirtualMachineInstance>({
@@ -86,8 +102,9 @@ export const addSSHSelectorLabelToVM = async (
 export const createSSHService = async (
   vm: V1VirtualMachine,
   type: SERVICE_TYPES,
+  pod?: IoK8sApiCoreV1Pod,
 ): Promise<K8sResourceCommon> => {
-  const serviceResource = buildSSHServiceFromVM(vm, type);
+  const serviceResource = buildSSHServiceFromVM(vm, type, pod);
 
   return kubevirtK8sCreate({
     cluster: getCluster(vm),

--- a/src/utils/resources/vmi/utils/services.ts
+++ b/src/utils/resources/vmi/utils/services.ts
@@ -1,18 +1,86 @@
-import { IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { IoK8sApiCoreV1Pod, IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getName } from '@kubevirt-utils/resources/shared';
 
+export const VMI_ID_LABEL = 'vmi.kubevirt.io/id';
+export const VM_NAME_LABEL = 'vm.kubevirt.io/name';
+
+// Get the label key-value pair to use for service selector.
+// Priority: vmi.kubevirt.io/id (from pod) > vm.kubevirt.io/name (from pod) > VM name
+export const getVMILabelForServiceSelector = (
+  pod: IoK8sApiCoreV1Pod | undefined,
+  vm: V1VirtualMachine,
+): { labelKey: string; labelValue: string } => {
+  const podLabels = pod?.metadata?.labels || {};
+  const vmName = getName(vm);
+
+  if (podLabels[VMI_ID_LABEL]) {
+    return {
+      labelKey: VMI_ID_LABEL,
+      labelValue: podLabels[VMI_ID_LABEL],
+    };
+  }
+
+  if (podLabels[VM_NAME_LABEL]) {
+    return {
+      labelKey: VM_NAME_LABEL,
+      labelValue: podLabels[VM_NAME_LABEL],
+    };
+  }
+
+  return {
+    labelKey: VM_NAME_LABEL,
+    labelValue: vmName,
+  };
+};
+
+const getLabelsToMatch = (
+  pod?: IoK8sApiCoreV1Pod,
+  vm?: V1VirtualMachine,
+  vmi?: V1VirtualMachineInstance,
+): { [key: string]: string } | null => {
+  const podLabels = pod?.metadata?.labels;
+
+  if (podLabels && Object.keys(podLabels).length > 0) return podLabels;
+  if (vmi?.metadata?.labels) return vmi.metadata.labels;
+  if (vm?.spec?.template?.metadata?.labels) return vm.spec.template.metadata.labels;
+  if (vm) return { [VM_NAME_LABEL]: getName(vm) };
+
+  return null;
+};
+
+// Get services that match the VMI/pod labels.
+// Supports both vmi.kubevirt.io/id and vm.kubevirt.io/name for backward compatibility.
 export const getServicesForVmi = (
   services: IoK8sApiCoreV1Service[],
-  vmiLabels: {
-    [key: string]: string;
-  },
+  pod?: IoK8sApiCoreV1Pod,
+  vm?: V1VirtualMachine,
+  vmi?: V1VirtualMachineInstance,
 ): IoK8sApiCoreV1Service[] => {
-  if (!vmiLabels) return [];
+  if (!services || services.length === 0) return [];
 
-  return (services || []).filter((service) => {
+  const labelsToMatch = getLabelsToMatch(pod, vm, vmi);
+  if (!labelsToMatch) return [];
+
+  const vmiName = vmi?.metadata?.name;
+
+  return services.filter((service) => {
     const selectors = service?.spec?.selector || {};
-    return (
-      Object.keys(selectors).length > 0 &&
-      Object.keys(selectors).every((key) => vmiLabels?.[key] === selectors?.[key])
-    );
+    if (Object.keys(selectors).length === 0) return false;
+
+    return Object.keys(selectors).every((key) => {
+      const selectorValue = selectors[key];
+      const labelValue = labelsToMatch[key];
+
+      if (key === VMI_ID_LABEL) {
+        return labelValue === selectorValue || labelsToMatch[VM_NAME_LABEL] === selectorValue;
+      }
+
+      if (key === VM_NAME_LABEL && vmiName) {
+        return labelValue === selectorValue || vmiName === selectorValue;
+      }
+
+      return labelValue === selectorValue;
+    });
   });
 };

--- a/src/utils/resources/vmi/utils/tests/services.test.ts
+++ b/src/utils/resources/vmi/utils/tests/services.test.ts
@@ -1,59 +1,325 @@
-import { IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { IoK8sApiCoreV1Pod, IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 
-import { getServicesForVmi } from '../services';
+import { getServicesForVmi, getVMILabelForServiceSelector } from '../services';
 
 import {
   serviceWithMatchingSelectors,
   serviceWithoutMatchingSelectors,
   serviceWithoutSelectors,
   serviceWithUndefinedSelectors,
-  vmiMock,
 } from './mocks';
+
+const createMockPod = (labels: { [key: string]: string }): IoK8sApiCoreV1Pod => ({
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: {
+    labels,
+    name: 'test-pod',
+    namespace: 'default',
+  },
+  spec: {
+    containers: [],
+  },
+  status: {},
+});
+
+const createMockVM = (name: string): V1VirtualMachine => ({
+  apiVersion: 'v1',
+  kind: 'VirtualMachine',
+  metadata: {
+    name,
+    namespace: 'default',
+  },
+  spec: {
+    template: {
+      spec: {
+        domain: {
+          devices: {},
+        },
+      },
+    },
+  },
+});
+
+const createMockVMI = (labels: { [key: string]: string }): V1VirtualMachineInstance => ({
+  apiVersion: 'v1',
+  kind: 'VirtualMachineInstance',
+  metadata: {
+    labels,
+    name: 'test-vmi',
+    namespace: 'default',
+  },
+  spec: {
+    domain: {
+      devices: {},
+    },
+  },
+  status: {},
+});
 
 describe('Test getServicesForVmi', () => {
   it('No services', () => {
     const services: IoK8sApiCoreV1Service[] = [];
-    const vmi: V1VirtualMachineInstance = vmiMock;
+    const pod = createMockPod({ 'vm.kubevirt.io/name': 'fedora-proposed-rodent' });
+    const vm = createMockVM('fedora-proposed-rodent');
 
-    const result = getServicesForVmi(services, vmi?.metadata?.labels);
+    const result = getServicesForVmi(services, pod, vm);
 
     expect(result).toEqual([]);
   });
 
   it('Services with undefined selectors', () => {
     const services: IoK8sApiCoreV1Service[] = [serviceWithUndefinedSelectors];
-    const vmi: V1VirtualMachineInstance = vmiMock;
+    const pod = createMockPod({ 'vm.kubevirt.io/name': 'fedora-proposed-rodent' });
+    const vm = createMockVM('fedora-proposed-rodent');
 
-    const result = getServicesForVmi(services, vmi?.metadata?.labels);
+    const result = getServicesForVmi(services, pod, vm);
 
     expect(result).toEqual([]);
   });
 
   it('Services without selectors', () => {
     const services: IoK8sApiCoreV1Service[] = [serviceWithoutSelectors];
-    const vmi: V1VirtualMachineInstance = vmiMock;
+    const pod = createMockPod({ 'vm.kubevirt.io/name': 'fedora-proposed-rodent' });
+    const vm = createMockVM('fedora-proposed-rodent');
 
-    const result = getServicesForVmi(services, vmi?.metadata?.labels);
+    const result = getServicesForVmi(services, pod, vm);
 
     expect(result).toEqual([]);
   });
 
   it('No services with matching selectors', () => {
     const services: IoK8sApiCoreV1Service[] = [serviceWithoutMatchingSelectors];
-    const vmi: V1VirtualMachineInstance = vmiMock;
+    const pod = createMockPod({ 'vm.kubevirt.io/name': 'fedora-proposed-rodent' });
+    const vm = createMockVM('fedora-proposed-rodent');
 
-    const result = getServicesForVmi(services, vmi?.metadata?.labels);
+    const result = getServicesForVmi(services, pod, vm);
 
     expect(result).toEqual([]);
   });
 
   it('Services with matching selectors', () => {
     const services: IoK8sApiCoreV1Service[] = [serviceWithMatchingSelectors];
-    const vmi: V1VirtualMachineInstance = vmiMock;
+    const pod = createMockPod({ 'vm.kubevirt.io/name': 'fedora-proposed-rodent' });
+    const vm = createMockVM('fedora-proposed-rodent');
 
-    const result = getServicesForVmi(services, vmi?.metadata?.labels);
+    const result = getServicesForVmi(services, pod, vm);
 
     expect(result).toEqual([serviceWithMatchingSelectors]);
+  });
+
+  it('Services with vmi.kubevirt.io/id selector', () => {
+    const services: IoK8sApiCoreV1Service[] = [
+      {
+        ...serviceWithMatchingSelectors,
+        spec: {
+          ...serviceWithMatchingSelectors.spec,
+          selector: {
+            'vmi.kubevirt.io/id': 'fedora-proposed-rodent-hash',
+          },
+        },
+      },
+    ];
+    const pod = createMockPod({
+      'vm.kubevirt.io/name': 'fedora-proposed-rodent',
+      'vmi.kubevirt.io/id': 'fedora-proposed-rodent-hash',
+    });
+    const vm = createMockVM('fedora-proposed-rodent');
+
+    const result = getServicesForVmi(services, pod, vm);
+
+    expect(result).toEqual([services[0]]);
+  });
+
+  it('Services with vmi.kubevirt.io/id selector using VM name (backward compatibility)', () => {
+    const services: IoK8sApiCoreV1Service[] = [
+      {
+        ...serviceWithMatchingSelectors,
+        spec: {
+          ...serviceWithMatchingSelectors.spec,
+          selector: {
+            'vmi.kubevirt.io/id': 'fedora-proposed-rodent',
+          },
+        },
+      },
+    ];
+    const pod = createMockPod({
+      'vm.kubevirt.io/name': 'fedora-proposed-rodent',
+      'vmi.kubevirt.io/id': 'fedora-proposed-rodent-hash',
+    });
+    const vm = createMockVM('fedora-proposed-rodent');
+
+    const result = getServicesForVmi(services, pod, vm);
+
+    expect(result).toEqual([services[0]]);
+  });
+
+  it('Fallback to VMI labels when pod is not provided', () => {
+    const services: IoK8sApiCoreV1Service[] = [serviceWithMatchingSelectors];
+    const vmi = createMockVMI({ 'vm.kubevirt.io/name': 'fedora-proposed-rodent' });
+    const vm = createMockVM('fedora-proposed-rodent');
+
+    const result = getServicesForVmi(services, undefined, vm, vmi);
+
+    expect(result).toEqual([serviceWithMatchingSelectors]);
+  });
+
+  it('Fallback to VM name when pod and VMI are not provided', () => {
+    const services: IoK8sApiCoreV1Service[] = [serviceWithMatchingSelectors];
+    const vm = createMockVM('fedora-proposed-rodent');
+
+    const result = getServicesForVmi(services, undefined, vm);
+
+    expect(result).toEqual([serviceWithMatchingSelectors]);
+  });
+
+  it('Fallback to VMI labels when pod has empty labels', () => {
+    const services: IoK8sApiCoreV1Service[] = [serviceWithMatchingSelectors];
+    const pod = createMockPod({});
+    const vmi = createMockVMI({ 'vm.kubevirt.io/name': 'fedora-proposed-rodent' });
+    const vm = createMockVM('fedora-proposed-rodent');
+
+    const result = getServicesForVmi(services, pod, vm, vmi);
+
+    expect(result).toEqual([serviceWithMatchingSelectors]);
+  });
+
+  it('Fallback to VM template labels when pod and VMI are not available', () => {
+    const services: IoK8sApiCoreV1Service[] = [serviceWithMatchingSelectors];
+    const vm: V1VirtualMachine = {
+      ...createMockVM('fedora-proposed-rodent'),
+      spec: {
+        template: {
+          metadata: {
+            labels: { 'vm.kubevirt.io/name': 'fedora-proposed-rodent' },
+          },
+          spec: { domain: { devices: {} } },
+        },
+      },
+    };
+
+    const result = getServicesForVmi(services, undefined, vm);
+
+    expect(result).toEqual([serviceWithMatchingSelectors]);
+  });
+
+  it('Multi-key selectors require all keys to match', () => {
+    const services: IoK8sApiCoreV1Service[] = [
+      {
+        ...serviceWithMatchingSelectors,
+        spec: {
+          ...serviceWithMatchingSelectors.spec,
+          selector: {
+            'extra-label': 'extra-value',
+            'vm.kubevirt.io/name': 'fedora-proposed-rodent',
+          },
+        },
+      },
+    ];
+    const pod = createMockPod({
+      'extra-label': 'extra-value',
+      'vm.kubevirt.io/name': 'fedora-proposed-rodent',
+    });
+    const vm = createMockVM('fedora-proposed-rodent');
+
+    const result = getServicesForVmi(services, pod, vm);
+
+    expect(result).toEqual([services[0]]);
+  });
+
+  it('Multi-key selectors fail when not all keys match', () => {
+    const services: IoK8sApiCoreV1Service[] = [
+      {
+        ...serviceWithMatchingSelectors,
+        spec: {
+          ...serviceWithMatchingSelectors.spec,
+          selector: {
+            'extra-label': 'different-value',
+            'vm.kubevirt.io/name': 'fedora-proposed-rodent',
+          },
+        },
+      },
+    ];
+    const pod = createMockPod({
+      'extra-label': 'extra-value',
+      'vm.kubevirt.io/name': 'fedora-proposed-rodent',
+    });
+    const vm = createMockVM('fedora-proposed-rodent');
+
+    const result = getServicesForVmi(services, pod, vm);
+
+    expect(result).toEqual([]);
+  });
+
+  it('VM name fallback for vm.kubevirt.io/name selector when pod label differs', () => {
+    const services: IoK8sApiCoreV1Service[] = [serviceWithMatchingSelectors];
+    const vmi = createMockVMI({});
+    (vmi.metadata as { name: string }).name = 'fedora-proposed-rodent';
+
+    const result = getServicesForVmi(services, undefined, undefined, vmi);
+
+    expect(result).toEqual([serviceWithMatchingSelectors]);
+  });
+
+  it('Returns empty when no resources provided', () => {
+    const services: IoK8sApiCoreV1Service[] = [serviceWithMatchingSelectors];
+
+    const result = getServicesForVmi(services);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('Test getVMILabelForServiceSelector', () => {
+  it('Prefers vmi.kubevirt.io/id from pod labels', () => {
+    const pod = createMockPod({
+      'vm.kubevirt.io/name': 'my-vm',
+      'vmi.kubevirt.io/id': 'my-vm-hash-123',
+    });
+    const vm = createMockVM('my-vm');
+
+    const result = getVMILabelForServiceSelector(pod, vm);
+
+    expect(result).toEqual({
+      labelKey: 'vmi.kubevirt.io/id',
+      labelValue: 'my-vm-hash-123',
+    });
+  });
+
+  it('Falls back to vm.kubevirt.io/name from pod labels', () => {
+    const pod = createMockPod({ 'vm.kubevirt.io/name': 'my-vm' });
+    const vm = createMockVM('my-vm');
+
+    const result = getVMILabelForServiceSelector(pod, vm);
+
+    expect(result).toEqual({
+      labelKey: 'vm.kubevirt.io/name',
+      labelValue: 'my-vm',
+    });
+  });
+
+  it('Falls back to VM name when pod has no relevant labels', () => {
+    const pod = createMockPod({ 'some-other-label': 'value' });
+    const vm = createMockVM('my-vm');
+
+    const result = getVMILabelForServiceSelector(pod, vm);
+
+    expect(result).toEqual({
+      labelKey: 'vm.kubevirt.io/name',
+      labelValue: 'my-vm',
+    });
+  });
+
+  it('Falls back to VM name when pod has empty labels', () => {
+    const pod = createMockPod({});
+    const vm = createMockVM('my-vm');
+
+    const result = getVMILabelForServiceSelector(pod, vm);
+
+    expect(result).toEqual({
+      labelKey: 'vm.kubevirt.io/name',
+      labelValue: 'my-vm',
+    });
   });
 });

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
@@ -8,6 +8,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
+import { getVMIPod } from '@kubevirt-utils/resources/vmi/utils/pod';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { Card, CardBody, CardTitle, Divider } from '@patternfly/react-core';
@@ -24,12 +25,14 @@ const VirtualMachinesOverviewTabService: FC<VirtualMachinesOverviewTabServicePro
     namespace: vm?.metadata?.namespace,
   });
 
-  const { vmi } = useVMIAndPodsForVM(getName(vm), getNamespace(vm), getCluster(vm));
+  const {
+    loaded: vmiAndPodsLoaded,
+    pods,
+    vmi,
+  } = useVMIAndPodsForVM(getName(vm), getNamespace(vm), getCluster(vm));
 
-  const data = getServicesForVmi(
-    services,
-    vmi?.metadata?.labels || vm?.spec?.template?.metadata?.labels,
-  );
+  const pod = getVMIPod(vmi, pods);
+  const data = getServicesForVmi(services, pod, vm, vmi);
 
   return (
     <Card>
@@ -38,7 +41,7 @@ const VirtualMachinesOverviewTabService: FC<VirtualMachinesOverviewTabServicePro
       </CardTitle>
       <Divider />
       <CardBody isFilled>
-        <ServicesList data={data} loaded={loaded} loadError={loadError} />
+        <ServicesList data={data} loaded={loaded && vmiAndPodsLoaded} loadError={loadError} />
       </CardBody>
     </Card>
   );

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Services/Services.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Services/Services.tsx
@@ -4,8 +4,10 @@ import { modelToGroupVersionKind, ServiceModel } from '@kubevirt-ui-ext/kubevirt
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import ServicesList from '@kubevirt-utils/components/ServicesList/ServicesList';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { usePods } from '@kubevirt-utils/hooks/usePods';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
+import { getVMIPod } from '@kubevirt-utils/resources/vmi/utils/pod';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { Icon, Title } from '@patternfly/react-core';
@@ -21,7 +23,9 @@ const Services = ({ pathname, vmi }) => {
     namespace: getNamespace(vmi),
   });
 
-  const data = getServicesForVmi(services, vmi);
+  const [pods, podsLoaded] = usePods(getNamespace(vmi), getCluster(vmi));
+  const pod = getVMIPod(vmi, pods);
+  const data = getServicesForVmi(services, pod, undefined, vmi);
 
   return (
     <div>
@@ -33,7 +37,7 @@ const Services = ({ pathname, vmi }) => {
       <Title className="co-section-heading" headingLevel="h2">
         {t('Services')}
       </Title>
-      <ServicesList data={data} loaded={loaded} loadError={loadError} />
+      <ServicesList data={data} loaded={loaded && podsLoaded} loadError={loadError} />
     </div>
   );
 };


### PR DESCRIPTION
## 📝 Description

Adds VMI labels as a fallback in `getServicesForVmi` to improve service matching when pods are unavailable.

- Updated getServicesForVmi to accept optional vmi parameter
- Added VMI labels check in fallback chain: pod labels → VMI labels → VM template labels → VM name
- Updated call sites to pass VMI when available

KubeVirt v1.7+ introduces `vmi.kubevirt.io/id` on pods for service matching. Labels like `vm.kubevirt.io/name` can also exist on the VMI resource (e.g., manually set or inherited from templates). 
Checking VMI labels ensures matching when the pod is not available (stopped VMs, etc.).

Jira ticket: [CNV-71151](https://issues.redhat.com/browse/CNV-71151)
[KubeVirt PR #15783 introducing the change](https://github.com/kubevirt/kubevirt/pull/15783)

## 🎥 Demo

In addition to adding the support for the new selector (`vmi.kubevirt.io/id`), this PR also fixes a bug where the services are not listed under the VMI:

Before:

https://github.com/user-attachments/assets/d5392fea-1969-489a-847b-9ad82a3d790e


After:

https://github.com/user-attachments/assets/5518ccd6-f17a-481f-b258-76d01f189d1a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RDP and SSH service discovery by making label selection pod-aware and strengthening fallbacks when pod/VMI context is missing.

* **Refactor**
  * Centralized and optimized service lookup and label handling for VM consoles and access paths to ensure consistent selector generation.

* **Tests**
  * Updated unit tests to cover pod-aware selector logic and new fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->