### PR TITLE
CNV-71606: filter only storage volumes

### DIFF
--- a/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
+++ b/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
@@ -9,17 +9,11 @@ import {
 import { getName } from '@kubevirt-utils/resources/shared';
 import { DiskRawData, DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 
-import {
-  getBootDisk,
-  getDataVolumeTemplates,
-  getDisks,
-  getInstanceTypeMatcher,
-  getVolumes,
-} from '../../utils';
+import { getBootDisk, getDataVolumeTemplates, getDisks, getVolumes } from '../../utils';
 import { getDiskRowDataLayout } from '../../utils/disk/rowData';
 
 import useDisksSources from './useDisksSources';
-import { getEjectedCDROMDrives } from './utils';
+import { getEjectedCDROMDrives, isStorageVolume } from './utils';
 
 type UseDisksTableDisks = (
   vm: V1VirtualMachine,
@@ -44,23 +38,22 @@ const useDisksTableData: UseDisksTableDisks = (vm, vmi) => {
     [vm, vmi, isVMRunning],
   );
 
-  const vmVolumes = useMemo(
-    () =>
-      !isVMRunning
-        ? getVolumes(vm)
-        : [
-            ...(getVolumes(vm) || []),
-            ...getRunningVMMissingVolumesFromVMI(getVolumes(vm) || [], vmi),
-          ],
-    [vm, vmi, isVMRunning],
-  );
+  const vmVolumes = useMemo(() => {
+    const detectedVolumes = !isVMRunning
+      ? getVolumes(vm)
+      : [
+          ...(getVolumes(vm) || []),
+          ...getRunningVMMissingVolumesFromVMI(getVolumes(vm) || [], vmi),
+        ];
+
+    return detectedVolumes?.filter(isStorageVolume);
+  }, [vm, vmi, isVMRunning]);
 
   const disks = useMemo(() => {
-    const isInstanceTypeVM = Boolean(getInstanceTypeMatcher(vm));
     const diskDevices: DiskRawData[] = (vmVolumes || []).map((volume) => {
       let disk = vmDisks?.find(({ name }) => name === volume?.name);
 
-      if (!disk && isInstanceTypeVM) disk = { name: volume?.name };
+      if (!disk) disk = { name: volume?.name };
 
       const dataVolumeTemplate = volume?.dataVolume?.name
         ? getDataVolumeTemplates(vm)?.find((dv) => getName(dv) === volume.dataVolume.name)

--- a/src/utils/resources/vm/hooks/disk/utils.ts
+++ b/src/utils/resources/vm/hooks/disk/utils.ts
@@ -2,6 +2,7 @@ import {
   V1beta1DataVolumeSourcePVC,
   V1Disk,
   V1VirtualMachine,
+  V1Volume,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import {
   DataVolumeModelGroupVersionKind,
@@ -67,4 +68,15 @@ export const getEjectedCDROMDrives = (diskDevices: DiskRawData[], vmDisks: V1Dis
     volume: disk,
   }));
   return mappedEjectedCDROMDrives;
+};
+
+export const isStorageVolume = (volume: V1Volume) => {
+  return Boolean(
+    volume.dataVolume ||
+      volume.persistentVolumeClaim ||
+      volume.containerDisk ||
+      volume.emptyDisk ||
+      volume.cloudInitNoCloud ||
+      volume.cloudInitConfigDrive,
+  );
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

In this bug, the VM have a configmap in the volumes that the details page try to show as a storage map. But this volume do not have a corresponding disk as its not a storage volume


Storage checkups create some vms that have volumes and datavolumes but no disks. So not just instancetypes vms can have no disks. Also other kind of vms


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disk table now correctly shows only storage-backed volumes, excluding non-storage entries from the disk layout view.
  * Improved detection of storage volumes to ensure accurate disk listing and prevent invalid devices from appearing.
  * Consistent fallback naming for volumes without matching disk records so unnamed volumes display predictably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->