### PR TITLE
CNV-71560: add architecture label near VM name

### DIFF
--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails.tsx
@@ -6,6 +6,7 @@ import {
   V1VirtualMachineInstance,
   V1VirtualMachineInstanceGuestAgentInfo,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import ArchitectureLabel from '@kubevirt-utils/components/ArchitectureLabel/ArchitectureLabel';
 import NUMABadge from '@kubevirt-utils/components/badges/NUMABadge/NUMABadge';
 import CPUMemory from '@kubevirt-utils/components/CPUMemory/CPUMemory';
 import GuestAgentIsRequiredText from '@kubevirt-utils/components/GuestAgentIsRequiredText/GuestAgentIsRequiredText';
@@ -17,7 +18,11 @@ import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind } from '@kubevirt-utils/models';
 import { getLabel, getName, getVMStatus } from '@kubevirt-utils/resources/shared';
-import { getInstanceTypeMatcher, hasNUMAConfiguration } from '@kubevirt-utils/resources/vm';
+import {
+  getArchitecture,
+  getInstanceTypeMatcher,
+  hasNUMAConfiguration,
+} from '@kubevirt-utils/resources/vm';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { getOSNameFromGuestAgent } from '@kubevirt-utils/resources/vmi';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -123,8 +128,13 @@ const VirtualMachinesOverviewTabDetails: FC<VirtualMachinesOverviewTabDetailsPro
             <GridItem span={5}>
               <DescriptionList isHorizontal>
                 <VirtualMachineDescriptionItem
+                  descriptionData={
+                    <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+                      <span>{getName(vm)}</span>
+                      <ArchitectureLabel architecture={getArchitecture(vm)} />
+                    </Flex>
+                  }
                   data-test-id="virtual-machine-overview-details-name"
-                  descriptionData={getName(vm)}
                   descriptionHeader={t('Name')}
                 />
                 {cluster && (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- add architecture label near VM name

## 🎥 Demo

After:
<img width="1717" height="952" alt="Screenshot 2025-11-04 at 14 29 28" src="https://github.com/user-attachments/assets/27c62ebf-47d4-49a5-a1b7-bb5f6897b208" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Virtual machine overview now displays the architecture alongside the VM name in the details section for improved visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->