### PR TITLE
CNV-60997: Upload bootable volume to registry keeps animating

### DIFF
--- a/src/utils/components/ExportModal/ExportModal.tsx
+++ b/src/utils/components/ExportModal/ExportModal.tsx
@@ -20,7 +20,12 @@ import TabModal from '../TabModal/TabModal';
 
 import { ALREADY_CREATED_ERROR_CODE } from './constants';
 import ShowProgress from './ShowProgress';
-import { createServiceAccount, createUploaderPod, exportInProgress } from './utils';
+import {
+  createServiceAccount,
+  createUploaderPod,
+  exportInProgress,
+  exportSucceeded,
+} from './utils';
 import ViewPodLogLink from './ViewPodLogLink';
 
 import './export-modal.scss';
@@ -63,10 +68,15 @@ const ExportModal: FC<ExportModalProps> = ({
   );
 
   const uploadInProgress = exportInProgress(uploadPod || createdPod);
+  const isUploadSucceeded = exportSucceeded(uploadPod || createdPod);
 
   return (
     <TabModal
       onSubmit={async () => {
+        if (isUploadSucceeded) {
+          return onClose();
+        }
+
         const secretName = `registry-secret-${getRandomChars()}`;
 
         try {
@@ -94,7 +104,8 @@ const ExportModal: FC<ExportModalProps> = ({
       isLoading={uploadInProgress}
       isOpen={isOpen}
       onClose={onClose}
-      submitBtnText={t('Upload')}
+      shouldWrapInForm
+      submitBtnText={isUploadSucceeded ? t('Close') : t('Upload')}
     >
       <Stack className="kv-exportmodal" hasGutter>
         <Alert
@@ -108,6 +119,7 @@ const ExportModal: FC<ExportModalProps> = ({
           <FormGroup fieldId="registryName" isRequired label={t('Name')}>
             <TextInput
               id="registryName"
+              isDisabled={uploadInProgress}
               onChange={(_, value: string) => setRegistryName(value)}
               type="text"
               value={registryName}
@@ -118,6 +130,7 @@ const ExportModal: FC<ExportModalProps> = ({
           <FormGroup fieldId="destination" isRequired label={t('Destination')}>
             <TextInput
               id="destination"
+              isDisabled={uploadInProgress}
               onChange={(_, value: string) => setDestination(value)}
               type="text"
               value={destination}
@@ -128,6 +141,7 @@ const ExportModal: FC<ExportModalProps> = ({
           <FormGroup fieldId="username" isRequired label={t('Username')}>
             <TextInput
               id="username"
+              isDisabled={uploadInProgress}
               onChange={(_, value: string) => setUsername(value)}
               type="text"
               value={username}
@@ -138,6 +152,7 @@ const ExportModal: FC<ExportModalProps> = ({
           <FormGroup fieldId="password" isRequired label={t('Password')}>
             <TextInput
               id="password"
+              isDisabled={uploadInProgress}
               onChange={(_, value: string) => setPassword(value)}
               type="password"
               value={password}

--- a/src/utils/components/ExportModal/utils.ts
+++ b/src/utils/components/ExportModal/utils.ts
@@ -133,4 +133,8 @@ export const createUploaderPod: CreateUploaderPodType = ({
 export const exportFailed = (pod: IoK8sApiCoreV1Pod) =>
   [UPLOAD_STATUSES.FAILED, UPLOAD_STATUSES.UNKNOWN].includes(pod?.status?.phase as UPLOAD_STATUSES);
 
-export const exportInProgress = (pod: IoK8sApiCoreV1Pod) => !isEmpty(pod) && !exportFailed(pod);
+export const exportSucceeded = (pod: IoK8sApiCoreV1Pod) =>
+  [UPLOAD_STATUSES.SUCCEEDED].includes(pod?.status?.phase as UPLOAD_STATUSES);
+
+export const exportInProgress = (pod: IoK8sApiCoreV1Pod) =>
+  !isEmpty(pod) && !exportFailed(pod) && !exportSucceeded(pod);


### PR DESCRIPTION
## 📝 Description

- Disabled the inputs when the upload is in progress
- User can now close the dialog when the upload is completed with no spinning animation as shown below. 

Jira Ticket: [CNV-60997](https://issues.redhat.com/browse/CNV-60997)


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/c0d96b61-4687-4c88-be6d-bd3ccc3158b4


https://github.com/user-attachments/assets/b11a3ccd-e362-471a-b0d4-3cc2aeabf9c6


After:


https://github.com/user-attachments/assets/9079a85f-46e0-4b55-ad65-628de9ba5f39


https://github.com/user-attachments/assets/d16a4d70-ff3e-4eea-8939-7110ab1738f0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Export modal now properly detects when an export has succeeded and automatically closes after completion.
  * Form controls are now disabled while an upload is in progress to prevent accidental modifications.

* **New Features**
  * Submit button now displays "Close" instead of "Upload" after a successful export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->