### PR TITLE
CNV-71417: Improve i18n in lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,9 +2,9 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged
-yarn i18n
+
 translation_file_diff=$(git diff --name-only locales/en/plugin__kubevirt-plugin.json)
 
 if [ -n "$translation_file_diff" ]; then
-    git add $translation_file_diff
+    git add locales/*/plugin__kubevirt-plugin.json
 fi

--- a/package.json
+++ b/package.json
@@ -132,6 +132,9 @@
     "npm": "^9.5.0 || >=10.5.2"
   },
   "lint-staged": {
+    "src/**/*.{js,ts,tsx,jsx,json}": [
+      "yarn i18n"
+    ],
     "*.{js,ts,tsx,jsx}": [
       "eslint --fix"
     ],


### PR DESCRIPTION

## 📝 Description

Use "git add locales" if there are changes in the English translations. It's no longer required to add them manually after the commit.

Run i18n in parallel with eslint(TS code) and prettier(json) - the file patterns is overlapping but the translation files are not processed by eslint/prettier - we can write them without conflict. I18n script requires read access to the code/json files which should create no conflicts.
This change also disables i18n when there are no staged files i.e. during amending.

## 🎥 Demo

### Before - locales other then English are not added to commit
https://github.com/user-attachments/assets/3c007ef6-6317-4a15-a314-92b0ca977c64

### After
https://github.com/user-attachments/assets/53fb25a4-f928-466b-ae2c-603515de2d00




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit behavior to stage all plugin translation files when translation changes are detected, streamlining translation commits.
  * Moved the i18n processing step out of the pre-commit hook and integrated it into the lint-staged workflow for source files, improving internationalization checks before linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->