### PR TITLE
CNV-71545: Filtering top consumers by namespace for vm and node scopes

### DIFF
--- a/src/views/clusteroverview/TopConsumersTab/utils/TopConsumerCard.tsx
+++ b/src/views/clusteroverview/TopConsumersTab/utils/TopConsumerCard.tsx
@@ -1,11 +1,13 @@
 import React, { FC, useMemo } from 'react';
 
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
+import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   SetTopConsumerData,
   TopConsumersData,
 } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
+import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { SelectOption } from '@patternfly/react-core';
 
 import { TopConsumerMetric } from './topConsumerMetric';
@@ -26,6 +28,8 @@ const TopConsumerCard: FC<TopConsumersMetricCard> = ({
   setLocalStorageData,
 }) => {
   const { t } = useKubevirtTranslation();
+  const [activeNamespace] = useActiveNamespace();
+  const isAllNamespaces = activeNamespace === ALL_NAMESPACES_SESSION_KEY;
 
   const metricKey = useMemo(
     () => localStorageData?.[cardID]?.metric?.value,
@@ -37,6 +41,13 @@ const TopConsumerCard: FC<TopConsumersMetricCard> = ({
     [cardID, localStorageData],
   );
 
+  const currentScope = TopConsumerScope.fromString(scopeKey);
+  const availableScopes = TopConsumerScope.getAll(isAllNamespaces);
+
+  const defaultScope = useMemo(() => {
+    return availableScopes.includes(currentScope) ? currentScope : TopConsumerScope.VM;
+  }, [availableScopes, currentScope]);
+
   const onMetricSelect = (value) => {
     setLocalStorageData(cardID, {
       ...localStorageData?.[cardID],
@@ -46,6 +57,7 @@ const TopConsumerCard: FC<TopConsumersMetricCard> = ({
       },
     });
   };
+
   const onScopeSelect = (value) => {
     setLocalStorageData(cardID, {
       ...localStorageData?.[cardID],
@@ -75,10 +87,10 @@ const TopConsumerCard: FC<TopConsumersMetricCard> = ({
         <div className="kv-top-consumer-card__scope-select">
           <FormPFSelect
             onSelect={(_e, value) => onScopeSelect(value)}
-            selected={t(TopConsumerScope.fromString(scopeKey)?.getDropdownLabel())}
+            selected={t(defaultScope?.getDropdownLabel())}
             toggleProps={{ id: 'kv-top-consumers-card-scope-select' }}
           >
-            {TopConsumerScope.getAll().map((scope) => (
+            {availableScopes.map((scope) => (
               <SelectOption key={scope?.getValue()} value={scope?.getDropdownLabel()}>
                 {t(scope?.getDropdownLabel())}
               </SelectOption>
@@ -93,7 +105,7 @@ const TopConsumerCard: FC<TopConsumersMetricCard> = ({
       <TopConsumersChartList
         localStorageData={localStorageData}
         metric={TopConsumerMetric.fromString(metricKey)}
-        scope={TopConsumerScope.fromString(scopeKey)}
+        scope={defaultScope}
       />
     </div>
   );

--- a/src/views/clusteroverview/TopConsumersTab/utils/TopConsumersChartList.tsx
+++ b/src/views/clusteroverview/TopConsumersTab/utils/TopConsumersChartList.tsx
@@ -2,7 +2,11 @@ import React, { FC, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { TopConsumersData } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
-import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  PrometheusEndpoint,
+  useActiveNamespace,
+  usePrometheusPoll,
+} from '@openshift-console/dynamic-plugin-sdk';
 import { CardBody } from '@patternfly/react-core';
 
 import {
@@ -31,6 +35,7 @@ export const TopConsumersChartList: FC<TopConsumersChartListProps> = ({
   scope,
 }) => {
   const { t } = useKubevirtTranslation();
+  const [activeNamespace] = useActiveNamespace();
   const duration = useMemo(
     () => localStorageData?.[TOP_CONSUMERS_DURATION_KEY],
     [localStorageData],
@@ -47,7 +52,13 @@ export const TopConsumersChartList: FC<TopConsumersChartListProps> = ({
   const [query] = usePrometheusPoll({
     endpoint: PrometheusEndpoint.QUERY,
     endTime: Date.now(),
-    query: getTopConsumerQuery(metric?.getValue(), scope?.getValue(), numItemsToShow, duration),
+    query: getTopConsumerQuery(
+      metric?.getValue(),
+      scope?.getValue(),
+      numItemsToShow,
+      duration,
+      activeNamespace,
+    ),
   });
   const numQueryResults = query?.data?.result?.length;
 

--- a/src/views/clusteroverview/TopConsumersTab/utils/queries.ts
+++ b/src/views/clusteroverview/TopConsumersTab/utils/queries.ts
@@ -1,62 +1,76 @@
+import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+
 import { TopConsumerMetric as Metric } from './topConsumerMetric';
 import { TopConsumerScope as Scope } from './topConsumerScope';
 
+const getNamespaceFilter = (namespace: string) =>
+  namespace && namespace !== ALL_NAMESPACES_SESSION_KEY ? `{namespace="${namespace}"}` : '';
+
 const topConsumerQueries = {
   [Scope.NODE.getValue()]: {
-    [Metric.CPU.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_cpu_usage_seconds_total[${duration}])) by (node))) > 0`,
-    [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow) =>
-      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_swap_in_traffic_bytes + kubevirt_vmi_memory_swap_out_traffic_bytes) by (node))) > 0`,
-    [Metric.MEMORY.getValue()]: (numItemsToShow) =>
-      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_used_bytes) by(node))) > 0`,
-    [Metric.STORAGE_IOPS.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_iops_read_total[${duration}]) + rate(kubevirt_vmi_storage_iops_write_total[${duration}])) by (node))) > 0`,
-    [Metric.STORAGE_READ_LATENCY.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum by (node)(rate(kubevirt_vmi_storage_read_times_seconds_total[${duration}]) / sum by (node)(rate(kubevirt_vmi_storage_iops_read_total[${duration}]) > 0))))`,
-    [Metric.STORAGE_THROUGHPUT.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total[${duration}]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total[${duration}])) by (node))) > 0`,
-    [Metric.STORAGE_WRITE_LATENCY.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum by (node)(rate(kubevirt_vmi_storage_write_times_seconds_total[${duration}]) / sum by (node)(rate(kubevirt_vmi_storage_iops_write_total[${duration}]) > 0))))`,
-    [Metric.VCPU_WAIT.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_vcpu_wait_seconds_total[${duration}])) by (node))) > 0`,
+    [Metric.CPU.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_cpu_usage_seconds_total${namespaceFilter}[${duration}])) by (node))) > 0`,
+    [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow, _duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_swap_in_traffic_bytes${namespaceFilter} + kubevirt_vmi_memory_swap_out_traffic_bytes${namespaceFilter}) by (node))) > 0`,
+    [Metric.MEMORY.getValue()]: (numItemsToShow, _duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_used_bytes${namespaceFilter}) by(node))) > 0`,
+    [Metric.STORAGE_IOPS.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_iops_read_total${namespaceFilter}[${duration}]) + rate(kubevirt_vmi_storage_iops_write_total${namespaceFilter}[${duration}])) by (node))) > 0`,
+    [Metric.STORAGE_READ_LATENCY.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum by (node)(rate(kubevirt_vmi_storage_read_times_seconds_total${namespaceFilter}[${duration}]) / sum by (node)(rate(kubevirt_vmi_storage_iops_read_total${namespaceFilter}[${duration}]) > 0))))`,
+    [Metric.STORAGE_THROUGHPUT.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total${namespaceFilter}[${duration}]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total${namespaceFilter}[${duration}])) by (node))) > 0`,
+    [Metric.STORAGE_WRITE_LATENCY.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum by (node)(rate(kubevirt_vmi_storage_write_times_seconds_total${namespaceFilter}[${duration}]) / sum by (node)(rate(kubevirt_vmi_storage_iops_write_total${namespaceFilter}[${duration}]) > 0))))`,
+    [Metric.VCPU_WAIT.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_vcpu_wait_seconds_total${namespaceFilter}[${duration}])) by (node))) > 0`,
   },
   [Scope.PROJECT.getValue()]: {
-    [Metric.CPU.getValue()]: (numItemsToShow, duration) =>
+    [Metric.CPU.getValue()]: (numItemsToShow, duration, _namespace) =>
       `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_cpu_usage_seconds_total[${duration}])) by (namespace))) > 0`,
-    [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow) =>
+    [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow, _duration, _namespace) =>
       `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_swap_in_traffic_bytes + kubevirt_vmi_memory_swap_out_traffic_bytes) by (namespace))) > 0`,
-    [Metric.MEMORY.getValue()]: (numItemsToShow) =>
+    [Metric.MEMORY.getValue()]: (numItemsToShow, _duration, _namespace) =>
       `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_used_bytes) by (namespace))) > 0`,
-    [Metric.STORAGE_IOPS.getValue()]: (numItemsToShow, duration) =>
+    [Metric.STORAGE_IOPS.getValue()]: (numItemsToShow, duration, _namespace) =>
       `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_iops_read_total[${duration}]) + rate(kubevirt_vmi_storage_iops_write_total[${duration}])) by (namespace))) > 0`,
-    [Metric.STORAGE_READ_LATENCY.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum by (namespace)(rate(kubevirt_vmi_storage_read_times_seconds_total[${duration}]) / sum by (node)(rate(kubevirt_vmi_storage_iops_read_total[${duration}]) > 0))))`,
-    [Metric.STORAGE_THROUGHPUT.getValue()]: (numItemsToShow, duration) =>
+    [Metric.STORAGE_READ_LATENCY.getValue()]: (numItemsToShow, duration, _namespace) =>
+      `sort_desc(topk(${numItemsToShow}, sum by (namespace)(rate(kubevirt_vmi_storage_read_times_seconds_total[${duration}]) / sum by (namespace)(rate(kubevirt_vmi_storage_iops_read_total[${duration}]) > 0))))`,
+    [Metric.STORAGE_THROUGHPUT.getValue()]: (numItemsToShow, duration, _namespace) =>
       `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total[${duration}]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total[${duration}])) by (namespace))) > 0`,
-    [Metric.STORAGE_WRITE_LATENCY.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum by (namespace)(rate(kubevirt_vmi_storage_write_times_seconds_total[${duration}]) / sum by (node)(rate(kubevirt_vmi_storage_iops_write_total[${duration}]) > 0))))`,
-    [Metric.VCPU_WAIT.getValue()]: (numItemsToShow, duration) =>
+    [Metric.STORAGE_WRITE_LATENCY.getValue()]: (numItemsToShow, duration, _namespace) =>
+      `sort_desc(topk(${numItemsToShow}, sum by (namespace)(rate(kubevirt_vmi_storage_write_times_seconds_total[${duration}]) / sum by (namespace)(rate(kubevirt_vmi_storage_iops_write_total[${duration}]) > 0))))`,
+    [Metric.VCPU_WAIT.getValue()]: (numItemsToShow, duration, _namespace) =>
       `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_vcpu_wait_seconds_total[${duration}])) by (namespace))) > 0`,
   },
   [Scope.VM.getValue()]: {
-    [Metric.CPU.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_cpu_usage_seconds_total[${duration}])) BY (name, namespace)))`,
-    [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk (${numItemsToShow}, sum(rate(kubevirt_vmi_memory_swap_in_traffic_bytes[${duration}]) + rate(kubevirt_vmi_memory_swap_out_traffic_bytes[${duration}]))by(name, namespace))) > 0`,
-    [Metric.MEMORY.getValue()]: (numItemsToShow) =>
-      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_used_bytes) by(name, namespace))) > 0`,
-    [Metric.STORAGE_IOPS.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_iops_read_total[${duration}]) + rate(kubevirt_vmi_storage_iops_write_total[${duration}])) by (namespace, name))) > 0`,
-    [Metric.STORAGE_READ_LATENCY.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, avg by (name, namespace)(rate(kubevirt_vmi_storage_read_times_seconds_total[${duration}]) / rate(kubevirt_vmi_storage_iops_read_total[${duration}]) > 0)))`,
-    [Metric.STORAGE_THROUGHPUT.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total[${duration}]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total[${duration}])) by (namespace, name))) > 0`,
-    [Metric.STORAGE_WRITE_LATENCY.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, avg by (name, namespace)(rate(kubevirt_vmi_storage_write_times_seconds_total[${duration}]) / rate(kubevirt_vmi_storage_iops_write_total[${duration}]) > 0)))`,
-    [Metric.VCPU_WAIT.getValue()]: (numItemsToShow, duration) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_vcpu_wait_seconds_total[${duration}])) by (namespace, name))) > 0`,
+    [Metric.CPU.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_cpu_usage_seconds_total${namespaceFilter}[${duration}])) BY (name, namespace)))`,
+    [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
+      `sort_desc(topk (${numItemsToShow}, sum(rate(kubevirt_vmi_memory_swap_in_traffic_bytes${namespaceFilter}[${duration}]) + rate(kubevirt_vmi_memory_swap_out_traffic_bytes${namespaceFilter}[${duration}]))by(name, namespace))) > 0`,
+    [Metric.MEMORY.getValue()]: (numItemsToShow, _duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_used_bytes${namespaceFilter}) by(name, namespace))) > 0`,
+    [Metric.STORAGE_IOPS.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_iops_read_total${namespaceFilter}[${duration}]) + rate(kubevirt_vmi_storage_iops_write_total${namespaceFilter}[${duration}])) by (namespace, name))) > 0`,
+    [Metric.STORAGE_READ_LATENCY.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, avg by (name, namespace)(rate(kubevirt_vmi_storage_read_times_seconds_total${namespaceFilter}[${duration}]) / rate(kubevirt_vmi_storage_iops_read_total${namespaceFilter}[${duration}]) > 0)))`,
+    [Metric.STORAGE_THROUGHPUT.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total${namespaceFilter}[${duration}]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total${namespaceFilter}[${duration}])) by (namespace, name))) > 0`,
+    [Metric.STORAGE_WRITE_LATENCY.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, avg by (name, namespace)(rate(kubevirt_vmi_storage_write_times_seconds_total${namespaceFilter}[${duration}]) / rate(kubevirt_vmi_storage_iops_write_total${namespaceFilter}[${duration}]) > 0)))`,
+    [Metric.VCPU_WAIT.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_vcpu_wait_seconds_total${namespaceFilter}[${duration}])) by (namespace, name))) > 0`,
   },
 };
 
-export const getTopConsumerQuery = (metric, scope, numItemsToShow = 5, duration = '5m') =>
-  topConsumerQueries?.[scope]?.[metric]?.(numItemsToShow, duration);
+export const getTopConsumerQuery = (
+  metric,
+  scope,
+  numItemsToShow = 5,
+  duration = '5m',
+  namespace?: string,
+) => {
+  const namespaceFilter = getNamespaceFilter(namespace);
+
+  return topConsumerQueries?.[scope]?.[metric]?.(numItemsToShow, duration, namespaceFilter);
+};

--- a/src/views/clusteroverview/TopConsumersTab/utils/topConsumerScope.ts
+++ b/src/views/clusteroverview/TopConsumersTab/utils/topConsumerScope.ts
@@ -44,7 +44,12 @@ export class TopConsumerScope extends TopConsumerScopeObjectEnum<string> {
 
   static fromString = (source: string): TopConsumerScope => TopConsumerScope.stringMapper[source];
 
-  static getAll = () => TopConsumerScope.all;
+  static getAll = (isAllNamespaces?: boolean) => {
+    if (isAllNamespaces || isAllNamespaces === undefined) {
+      return TopConsumerScope.all;
+    }
+    return [TopConsumerScope.VM, TopConsumerScope.NODE];
+  };
 
   private static readonly stringMapper = TopConsumerScope.all.reduce(
     (accumulator, scope: TopConsumerScope) => ({


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

previously, when in top consumers tab the charts would show metrics for all vm's in all projects regardless of what name space the user is on. this fix creates filtering according to the active name space showing only vm's and nodes in the current project. We also hide the "projects" chart scope for all namespaces except "all-projects"

## 🎥 Demo
Before:
<img width="1063" height="603" alt="image" src="https://github.com/user-attachments/assets/06378efe-c430-452a-bb73-472f474aef4c" />
<img width="1053" height="605" alt="image" src="https://github.com/user-attachments/assets/0d60b5f8-ce51-41a6-b61f-904bccc3752d" />

After:
<img width="1078" height="728" alt="image" src="https://github.com/user-attachments/assets/80b1cd0b-27fc-4025-afbc-b7f361fc9547" />
<img width="1044" height="590" alt="image" src="https://github.com/user-attachments/assets/7a2667c8-e2ca-4178-b238-8eff720355fe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Charts and queries are namespace-aware: show namespace-specific data when a namespace is selected and cluster-wide data when viewing all namespaces.
  * Scope selector adapts to namespace context, offering only relevant scopes for the current namespace.
  * Metric queries now respect the selected namespace for more accurate results.

* **Bug Fixes**
  * Improved default scope selection so charts fall back sensibly when a chosen scope is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->