### PR TITLE
CNV-71253: Check subresource permissions for VM start/stop/restart actions

### DIFF
--- a/src/utils/models/index.ts
+++ b/src/utils/models/index.ts
@@ -65,3 +65,23 @@ export const ClusterManagementAddOnModel: K8sModel = {
   namespaced: true,
   plural: 'clustermanagementaddons',
 };
+
+export const VirtualMachineSubresourcesModel: K8sModel = {
+  abbr: 'VM',
+  apiGroup: 'subresources.kubevirt.io',
+  apiVersion: 'v1',
+  kind: 'VirtualMachine',
+  label: 'VirtualMachine',
+  labelPlural: 'VirtualMachines',
+  plural: 'virtualmachines',
+};
+
+export const VirtualMachineInstanceSubresourcesModel: K8sModel = {
+  abbr: 'VMI',
+  apiGroup: 'subresources.kubevirt.io',
+  apiVersion: 'v1',
+  kind: 'VirtualMachineInstance',
+  label: 'VirtualMachineInstance',
+  labelPlural: 'VirtualMachineInstances',
+  plural: 'virtualmachineinstances',
+};

--- a/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
@@ -15,6 +15,10 @@ import { ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalPr
 import SnapshotModal from '@kubevirt-utils/components/SnapshotModal/SnapshotModal';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
+  VirtualMachineInstanceSubresourcesModel,
+  VirtualMachineSubresourcesModel,
+} from '@kubevirt-utils/models';
+import {
   DEFAULT_MIGRATION_NAMESPACE,
   MigMigration,
   MigMigrationModel,
@@ -284,7 +288,7 @@ export const VirtualMachineActionFactory = {
     confirmVMActions: boolean,
   ): ActionDropdownItemType => {
     return {
-      accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
+      accessReview: asAccessReview(VirtualMachineInstanceSubresourcesModel, vm, 'update', 'pause'),
       cta: () =>
         confirmVMActions
           ? createModal(({ isOpen, onClose }) => (
@@ -308,7 +312,7 @@ export const VirtualMachineActionFactory = {
     confirmVMActions: boolean,
   ): ActionDropdownItemType => {
     return {
-      accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
+      accessReview: asAccessReview(VirtualMachineSubresourcesModel, vm, 'update', 'restart'),
       cta: () =>
         confirmVMActions
           ? createModal(({ isOpen, onClose }) => (
@@ -344,7 +348,7 @@ export const VirtualMachineActionFactory = {
   },
   start: (vm: V1VirtualMachine): ActionDropdownItemType => {
     return {
-      accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
+      accessReview: asAccessReview(VirtualMachineSubresourcesModel, vm, 'update', 'start'),
       cta: () => startVM(vm),
       disabled:
         [
@@ -369,7 +373,7 @@ export const VirtualMachineActionFactory = {
     confirmVMActions: boolean,
   ): ActionDropdownItemType => {
     return {
-      accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
+      accessReview: asAccessReview(VirtualMachineSubresourcesModel, vm, 'update', 'stop'),
       cta: () =>
         confirmVMActions
           ? createModal(({ isOpen, onClose }) => (
@@ -394,7 +398,12 @@ export const VirtualMachineActionFactory = {
   },
   unpause: (vm: V1VirtualMachine): ActionDropdownItemType => {
     return {
-      accessReview: asAccessReview(VirtualMachineModel, vm, 'patch'),
+      accessReview: asAccessReview(
+        VirtualMachineInstanceSubresourcesModel,
+        vm,
+        'update',
+        'unpause',
+      ),
       cta: () => unpauseVM(vm),
       disabled: vm?.status?.printableStatus !== Paused,
       id: 'vm-action-unpause',


### PR DESCRIPTION
## 📝 Description

Update VM action access reviews to check update permission on virtualmachines/{start,stop,restart} subresources instead of requiring patch permission on the main virtualmachines resource. This allows users with only subresource permissions to use these actions in the web console, matching CLI behavior.

Jira Ticket: [CNV-71253](https://issues.redhat.com/browse/CNV-71253)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/381a97ba-5e47-4f47-88ec-5ce98c7157c5

After:

https://github.com/user-attachments/assets/bc5ec8a3-a65a-441c-8c50-da2b06c2266a




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Access checks for VM actions (pause, restart, start, stop, unpause) now use subresource-level update permissions instead of general patch permissions, improving authorization accuracy.
* **Chores**
  * Added support for virtual machine and instance subresource models to enable the finer-grained permission checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->