### PR TITLE
[release-4.18] CNV-69395: fix resizing disk defined in dataVolumeTemplates of a VM

### DIFF
--- a/src/utils/components/DiskModal/utils/submit.ts
+++ b/src/utils/components/DiskModal/utils/submit.ts
@@ -136,7 +136,7 @@ export const submit = async ({ data, editDiskName, onSubmit, pvc, vm }: SubmitIn
 
   const isInitialBootDisk = getBootDisk(vm)?.name === editDiskName;
 
-  if (data.volume.dataVolume) {
+  if (isCreatingDisk && data.volume.dataVolume && data.dataVolumeTemplate?.metadata) {
     const newDataVolumeName = createDataVolumeName(vm, data.disk.name);
     data.volume.dataVolume.name = newDataVolumeName;
     data.dataVolumeTemplate.metadata.name = newDataVolumeName;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes a bug that a new PVC and DV is created when resizing disk defined in `dataVolumeTemplates` of a VM

- the bug was caused by me when working on a request to derive disk name from VM name
  - this can only be done when creating a new disk, not when editing (it is already fixed in 4.19 and newer)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/b2d2d5c2-90b2-4659-8d55-85728d1bcecf




After:


https://github.com/user-attachments/assets/6373dff9-f883-4663-88b9-43f6b8eb3499



