### PR TITLE
CNV-69204: fix instancetype cluster and projects filters

### DIFF
--- a/src/multicluster/extensions.ts
+++ b/src/multicluster/extensions.ts
@@ -297,28 +297,6 @@ export const extensions: EncodedExtension[] = [
     properties: {
       handler: { $codeRef: 'urls.getFleetClusterResourceRoute' },
       model: {
-        group: 'instancetype.kubevirt.io',
-        kind: 'VirtualMachineClusterInstancetype',
-        version: 'v1beta1',
-      },
-    },
-    type: 'acm.resource/route',
-  } as EncodedExtension<ResourceRoute>,
-  {
-    properties: {
-      handler: { $codeRef: 'urls.getFleetNamespacedResourceRoute' },
-      model: {
-        group: 'instancetype.kubevirt.io',
-        kind: 'VirtualMachineInstancetype',
-        version: 'v1beta1',
-      },
-    },
-    type: 'acm.resource/route',
-  } as EncodedExtension<ResourceRoute>,
-  {
-    properties: {
-      handler: { $codeRef: 'urls.getFleetClusterResourceRoute' },
-      model: {
         group: 'migrations.kubevirt.io',
         kind: 'MigrationPolicy',
         version: 'v1alpha1',

--- a/src/views/instancetypes/list/ClusterInstancetypeList.tsx
+++ b/src/views/instancetypes/list/ClusterInstancetypeList.tsx
@@ -9,6 +9,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import usePagination from '@kubevirt-utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@kubevirt-utils/hooks/usePagination/utils/constants';
 import { ListPageProps } from '@kubevirt-utils/utils/types';
+import useIsACMPage from '@multicluster/useIsACMPage';
 import {
   ListPageBody,
   useListPageFilter,
@@ -35,7 +36,12 @@ const ClusterInstancetypeList: FC<ListPageProps> = ({
   const { onPaginationChange, pagination } = usePagination();
 
   const clusterFilter = useClusterFilter();
-  const filtersWithSelect = useMemo(() => [clusterFilter], [clusterFilter]);
+  const isACMPage = useIsACMPage();
+
+  const filtersWithSelect = useMemo(
+    () => (isACMPage ? [clusterFilter] : []),
+    [clusterFilter, isACMPage],
+  );
   const [unfilteredData, data, onFilterChange] = useListPageFilter(
     instanceTypes,
     filtersWithSelect,

--- a/src/views/instancetypes/list/UserInstancetypeList.tsx
+++ b/src/views/instancetypes/list/UserInstancetypeList.tsx
@@ -12,6 +12,7 @@ import useSelectedRowFilterClusters from '@kubevirt-utils/hooks/useSelectedRowFi
 import useSelectedRowFilterProjects from '@kubevirt-utils/hooks/useSelectedRowFilterProjects';
 import { ListPageProps } from '@kubevirt-utils/utils/types';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+import useIsACMPage from '@multicluster/useIsACMPage';
 import {
   ListPageBody,
   useListPageFilter,
@@ -49,10 +50,11 @@ const UserInstancetypeList: FC<UserInstancetypeListProps> = ({
 
   const clusterFilter = useClusterFilter();
   const projectFilter = useProjectFilter();
+  const isACMPage = useIsACMPage();
 
   const filtersWithSelect = useMemo(
-    () => [clusterFilter, projectFilter],
-    [clusterFilter, projectFilter],
+    () => (isACMPage ? [clusterFilter, projectFilter] : []),
+    [clusterFilter, projectFilter, isACMPage],
   );
 
   const [unfilteredData, data, onFilterChange] = useListPageFilter<


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Show the project and clsuter filters only on a multicluster view
For the single cluster view there is no way to remove the project selector in the top of the page other than change completely the page url



We don't customize the isntancetype page so in multicluster view we should use the ACM default link for instancetyps



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Instance type lists now show appropriate filters based on page context so users see relevant filter options in different app sections.
* **Chores**
  * Removed certain multicluster fleet-related instance-type entries, reducing unavailable/irrelevant options in multicluster views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->