### PR TITLE
CNV-69216: make checkups lists multicluster

### DIFF
--- a/src/multicluster/extensions.ts
+++ b/src/multicluster/extensions.ts
@@ -144,6 +144,21 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
   {
+    properties: {
+      dataAttributes: {
+        'data-border': 'no-border',
+        'data-class': 'kv-plugin-virt-perspective-element',
+        'data-quickstart-id': 'qs-nav-checkups',
+        'data-test-id': 'checkups-nav-item',
+      },
+      href: `/k8s/all-clusters/all-namespaces/checkups/network`,
+      id: 'checkups-virt-perspective',
+      name: '%plugin__kubevirt-plugin~Checkups%',
+      perspective: 'fleet-virtualization-perspective',
+    },
+    type: 'console.navigation/href',
+  } as EncodedExtension<HrefNavItem>,
+  {
     flags: {
       required: ['KUBEVIRT_DYNAMIC_ACM'],
     },
@@ -344,6 +359,44 @@ export const extensions: EncodedExtension[] = [
     },
     type: 'acm.resource/route',
   } as EncodedExtension<ResourceRoute>,
+
+  {
+    properties: {
+      component: {
+        $codeRef: 'Checkups',
+      },
+      path: [
+        '/k8s/all-clusters/all-namespaces/checkups',
+        '/k8s/cluster/:cluster/all-namespaces/checkups',
+        '/k8s/cluster/:cluster/ns/:ns/checkups',
+      ],
+    },
+    type: 'console.page/route',
+  } as EncodedExtension<RoutePage>,
+  {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC'],
+    },
+    properties: {
+      component: {
+        $codeRef: 'CheckupsSelfValidationForm',
+      },
+      path: ['/k8s/cluster/:cluster/ns/:ns/checkups/self-validation/form'],
+    },
+    type: 'console.page/route',
+  } as EncodedExtension<RoutePage>,
+  {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC'],
+    },
+    properties: {
+      component: {
+        $codeRef: 'CheckupsSelfValidationDetailsPage',
+      },
+      path: ['/k8s/cluster/:cluster/ns/:ns/checkups/self-validation/:checkupName'],
+    },
+    type: 'console.page/route',
+  } as EncodedExtension<RoutePage>,
   {
     properties: {
       handler: { $codeRef: 'urls.getFleetClusterResourceRoute' },

--- a/src/utils/components/ClusterProjectDropdown/ClusterProjectDropdown.tsx
+++ b/src/utils/components/ClusterProjectDropdown/ClusterProjectDropdown.tsx
@@ -10,6 +10,7 @@ import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useActiveClusterParam from '@multicluster/hooks/useActiveClusterParam';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
@@ -24,7 +25,7 @@ type ClusterProjectDropdownProps = {
 
 const ClusterProjectDropdown: FC<ClusterProjectDropdownProps> = memo(
   ({
-    includeAllClusters,
+    includeAllClusters = true,
     includeAllProjects,
     showClusterDropdown = true,
     showProjectDropdown = true,
@@ -32,6 +33,7 @@ const ClusterProjectDropdown: FC<ClusterProjectDropdownProps> = memo(
     const { t } = useKubevirtTranslation();
     const isACMPage = useIsACMPage();
     const cluster = useActiveClusterParam();
+    const selectedCluster = useClusterParam();
     const namespace = useNamespaceParam();
     const navigate = useNavigate();
     const location = useLocation();
@@ -69,19 +71,19 @@ const ClusterProjectDropdown: FC<ClusterProjectDropdownProps> = memo(
     );
 
     useEffect(() => {
-      if (!includeAllClusters && isEmpty(cluster) && hubClusterNameLoaded) {
+      if (!isACMPage) return;
+      if (includeAllClusters) return;
+
+      if (isEmpty(selectedCluster) && hubClusterNameLoaded) {
         onClusterChange(hubClusterName);
       }
     }, [cluster, hubClusterName, hubClusterNameLoaded, includeAllClusters, onClusterChange]);
 
     useEffect(() => {
-      if (
-        !includeAllProjects &&
-        cluster &&
-        isEmpty(namespace) &&
-        projectLoaded &&
-        showProjectDropdown
-      ) {
+      if (!isACMPage) return;
+      if (includeAllProjects) return;
+
+      if (cluster && isEmpty(namespace) && projectLoaded && showProjectDropdown) {
         const defaultProject = projects?.find((project) => project === DEFAULT_NAMESPACE);
         const selectedProject = defaultProject || projects?.[0] || ALL_PROJECTS;
         if (selectedProject) {

--- a/src/utils/resources/checkups/urls.ts
+++ b/src/utils/resources/checkups/urls.ts
@@ -1,0 +1,19 @@
+import { CHECKUP_URLS } from '../../../views/checkups/utils/constants';
+
+export const getNetworkCheckupURL = (name: string, namespace: string, cluster?: string) => {
+  return cluster
+    ? `/k8s/cluster/${cluster}/ns/${namespace}/checkups/${CHECKUP_URLS.NETWORK}/${name}`
+    : `/k8s/ns/${namespace}/checkups/${CHECKUP_URLS.NETWORK}/${name}`;
+};
+
+export const getStorageCheckupURL = (name: string, namespace: string, cluster?: string) => {
+  return cluster
+    ? `/k8s/cluster/${cluster}/ns/${namespace}/checkups/${CHECKUP_URLS.STORAGE}/${name}`
+    : `/k8s/ns/${namespace}/checkups/${CHECKUP_URLS.STORAGE}/${name}`;
+};
+
+export const getSelfValidationCheckupURL = (name: string, namespace: string, cluster?: string) => {
+  return cluster
+    ? `/k8s/cluster/${cluster}/ns/${namespace}/checkups/${CHECKUP_URLS.SELF_VALIDATION}/${name}`
+    : `/k8s/ns/${namespace}/checkups/${CHECKUP_URLS.SELF_VALIDATION}/${name}`;
+};

--- a/src/views/checkups/Checkups.tsx
+++ b/src/views/checkups/Checkups.tsx
@@ -1,8 +1,10 @@
 import React, { FC, useEffect, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
+import ClusterProjectDropdown from '@kubevirt-utils/components/ClusterProjectDropdown/ClusterProjectDropdown';
 import { PageTitles } from '@kubevirt-utils/constants/page-constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useIsACMPage from '@multicluster/useIsACMPage';
 import {
   DocumentTitle,
   HorizontalNav,
@@ -18,11 +20,14 @@ const CheckupsList: FC = () => {
   const { t } = useKubevirtTranslation();
   const location = useLocation();
   const navigate = useNavigate();
+  const isACMpage = useIsACMPage();
 
   const pages = useMemo(() => getCheckUpTabs(t), [t]);
 
   // Redirect to default tab if URL is just /checkups
   useEffect(() => {
+    if (isACMpage) return;
+
     const normalizedPath = location.pathname.endsWith('/')
       ? location.pathname.slice(0, -1)
       : location.pathname;
@@ -33,11 +38,12 @@ const CheckupsList: FC = () => {
         navigate(`${normalizedPath}/${defaultTab.href}`, { replace: true });
       }
     }
-  }, [location.pathname, pages, navigate]);
+  }, [location.pathname, pages, navigate, isACMpage]);
 
   return (
     <>
       <DocumentTitle>{PageTitles.Checkups}</DocumentTitle>
+      <ClusterProjectDropdown includeAllClusters={false} includeAllProjects={false} />
       <ListPageHeader title={PageTitles.Checkups}>
         <CheckupsRunButton />
       </ListPageHeader>

--- a/src/views/checkups/components/CheckupsDetailsPageBreadcrumb.tsx
+++ b/src/views/checkups/components/CheckupsDetailsPageBreadcrumb.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { Breadcrumb, BreadcrumbItem, Button, ButtonVariant } from '@patternfly/react-core';
 
 import { CHECKUP_URLS } from '../utils/constants';
@@ -18,11 +18,7 @@ const CheckupsDetailsPageBreadcrumb: FC<CheckupsDetailsPageBreadcrumbProps> = ({
   parentLabel,
 }) => {
   const navigate = useNavigate();
-  const [namespace] = useActiveNamespace();
-
-  if (!namespace) {
-    return null;
-  }
+  const namespace = useActiveNamespace();
 
   return (
     <Breadcrumb>

--- a/src/views/checkups/network/components/form/CheckupsNetworkFormNADS.tsx
+++ b/src/views/checkups/network/components/form/CheckupsNetworkFormNADS.tsx
@@ -2,8 +2,9 @@ import React, { Dispatch, FC, MouseEvent, SetStateAction } from 'react';
 
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import useNADsData from '@kubevirt-utils/components/NetworkInterfaceModal/components/hooks/useNADsData';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { FormGroup, SelectOption } from '@patternfly/react-core';
 
 type CheckupsNetworkFormNADSProps = {
@@ -15,8 +16,9 @@ const CheckupsNetworkFormNADS: FC<CheckupsNetworkFormNADSProps> = ({
   setSelectedNAD,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [namespace] = useActiveNamespace();
-  const { nads } = useNADsData(namespace);
+  const namespace = useActiveNamespace();
+  const cluster = useClusterParam();
+  const { nads } = useNADsData(namespace, cluster);
 
   const nadsItems = (nads || [])
     ?.filter((nad) => nad?.metadata?.namespace === namespace)

--- a/src/views/checkups/network/hooks/useCheckupsNetworkListColumns.ts
+++ b/src/views/checkups/network/hooks/useCheckupsNetworkListColumns.ts
@@ -1,8 +1,12 @@
+import { useMemo } from 'react';
+
 import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettingsTableColumns from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns';
-import { TableColumn, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import useIsACMPage from '@multicluster/useIsACMPage';
+import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 
 import {
@@ -26,89 +30,103 @@ const useCheckupsNetworkCheckupsListColumns = (): [
   TableColumn<IoK8sApiCoreV1ConfigMap>[],
   boolean,
 ] => {
-  const [namespace] = useActiveNamespace();
+  const namespace = useActiveNamespace();
   const { t } = useKubevirtTranslation();
+  const isACMPage = useIsACMPage();
 
-  const columns: TableColumn<IoK8sApiCoreV1ConfigMap>[] = [
-    {
-      id: 'name',
-      sort: 'metadata.name',
-      title: t('Name'),
-      transforms: [sortable],
-    },
-    ...(namespace === ALL_NAMESPACES_SESSION_KEY
-      ? [
-          {
-            id: 'namespace',
-            sort: 'metadata.namespace',
-            title: t('Namespace'),
-            transforms: [sortable],
-          },
-        ]
-      : []),
-    {
-      id: 'nad',
-      sort: (data, sortDirection) => columnsSorting(data, sortDirection, CONFIG_PARAM_NAD_NAME),
-      title: t('NetworkAttachmentDefinition'),
-      transforms: [sortable],
-    },
-    {
-      id: 'status',
-      sort: (data, sortDirection) => columnsSorting(data, sortDirection, STATUS_SUCCEEDED),
-      title: t('Status'),
-      transforms: [sortable],
-    },
-    {
-      id: 'latency',
-      sort: (data, sortDirection) => columnsSorting(data, sortDirection, STATUS_MAX_LATENCY_NANO),
-      title: t('Latency'),
-      transforms: [sortable],
-    },
-    {
-      additional: true,
-      id: 'duration',
-      sort: (data, sortDirection) =>
-        columnsSorting(data, sortDirection, CONFIG_PARAM_SAMPLE_DURATION),
-      title: t('Duration'),
-      transforms: [sortable],
-    },
-    {
-      additional: true,
-      id: 'source-node',
-      sort: (data, sortDirection) =>
-        columnsSorting(data, sortDirection, STATUS_SOURCE_NODE, CONFIG_PARAM_SOURCE_NODE),
-      title: t('Source node'),
-      transforms: [sortable],
-    },
-    {
-      additional: true,
-      id: 'target-node',
-      sort: (data, sortDirection) =>
-        columnsSorting(data, sortDirection, STATUS_TARGET_NODE, CONFIG_PARAM_TARGET_NODE),
-      title: t('Target node'),
-      transforms: [sortable],
-    },
-    {
-      additional: true,
-      id: 'start-time',
-      sort: (data, sortDirection) => columnsSorting(data, sortDirection, STATUS_START_TIME_STAMP),
-      title: t('Start time'),
-      transforms: [sortable],
-    },
-    {
-      additional: true,
-      id: 'complete-time',
-      sort: (data, sortDirection) =>
-        columnsSorting(data, sortDirection, STATUS_COMPLETION_TIME_STAMP),
-      title: t('Complete time'),
-      transforms: [sortable],
-    },
-    {
-      id: '',
-      props: { className: 'pf-v6-c-table__action' },
-      title: '',
-    },
-  ];
+  const columns: TableColumn<IoK8sApiCoreV1ConfigMap>[] = useMemo(
+    () => [
+      {
+        id: 'name',
+        sort: 'metadata.name',
+        title: t('Name'),
+        transforms: [sortable],
+      },
+      ...(isACMPage
+        ? [
+            {
+              id: 'cluster',
+              sort: 'cluster',
+              title: t('Cluster'),
+              transforms: [sortable],
+            },
+          ]
+        : []),
+      ...(namespace === ALL_NAMESPACES_SESSION_KEY
+        ? [
+            {
+              id: 'namespace',
+              sort: 'metadata.namespace',
+              title: t('Namespace'),
+              transforms: [sortable],
+            },
+          ]
+        : []),
+      {
+        id: 'nad',
+        sort: (data, sortDirection) => columnsSorting(data, sortDirection, CONFIG_PARAM_NAD_NAME),
+        title: t('NetworkAttachmentDefinition'),
+        transforms: [sortable],
+      },
+      {
+        id: 'status',
+        sort: (data, sortDirection) => columnsSorting(data, sortDirection, STATUS_SUCCEEDED),
+        title: t('Status'),
+        transforms: [sortable],
+      },
+      {
+        id: 'latency',
+        sort: (data, sortDirection) => columnsSorting(data, sortDirection, STATUS_MAX_LATENCY_NANO),
+        title: t('Latency'),
+        transforms: [sortable],
+      },
+      {
+        additional: true,
+        id: 'duration',
+        sort: (data, sortDirection) =>
+          columnsSorting(data, sortDirection, CONFIG_PARAM_SAMPLE_DURATION),
+        title: t('Duration'),
+        transforms: [sortable],
+      },
+      {
+        additional: true,
+        id: 'source-node',
+        sort: (data, sortDirection) =>
+          columnsSorting(data, sortDirection, STATUS_SOURCE_NODE, CONFIG_PARAM_SOURCE_NODE),
+        title: t('Source node'),
+        transforms: [sortable],
+      },
+      {
+        additional: true,
+        id: 'target-node',
+        sort: (data, sortDirection) =>
+          columnsSorting(data, sortDirection, STATUS_TARGET_NODE, CONFIG_PARAM_TARGET_NODE),
+        title: t('Target node'),
+        transforms: [sortable],
+      },
+      {
+        additional: true,
+        id: 'start-time',
+        sort: (data, sortDirection) => columnsSorting(data, sortDirection, STATUS_START_TIME_STAMP),
+        title: t('Start time'),
+        transforms: [sortable],
+      },
+      {
+        additional: true,
+        id: 'complete-time',
+        sort: (data, sortDirection) =>
+          columnsSorting(data, sortDirection, STATUS_COMPLETION_TIME_STAMP),
+        title: t('Complete time'),
+        transforms: [sortable],
+      },
+      {
+        id: '',
+        props: { className: 'pf-v6-c-table__action' },
+        title: '',
+      },
+    ],
+    [t, isACMPage, namespace],
+  );
 
   const [activeColumns, , loadedColumns] =
     useKubevirtUserSettingsTableColumns<IoK8sApiCoreV1ConfigMap>({

--- a/src/views/checkups/network/list/CheckupsNetworkList.tsx
+++ b/src/views/checkups/network/list/CheckupsNetworkList.tsx
@@ -3,15 +3,14 @@ import React from 'react';
 import { IoK8sApiBatchV1Job, IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import ListPageFilter from '@kubevirt-utils/components/ListPageFilter/ListPageFilter';
 import useNADsData from '@kubevirt-utils/components/NetworkInterfaceModal/components/hooks/useNADsData';
+import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import usePagination from '@kubevirt-utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@kubevirt-utils/hooks/usePagination/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import {
-  ListPageBody,
-  useActiveNamespace,
-  VirtualizedTable,
-} from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import { ListPageBody, VirtualizedTable } from '@openshift-console/dynamic-plugin-sdk';
 import { Pagination } from '@patternfly/react-core';
 
 import { getJobByName } from '../../utils/utils';
@@ -28,9 +27,11 @@ import '@kubevirt-utils/styles/list-managment-group.scss';
 const CheckupsNetworkList = () => {
   const { t } = useKubevirtTranslation();
   const [columns, activeColumns, loadedColumns] = useCheckupsNetworkCheckupsListColumns();
-  const [namespace] = useActiveNamespace();
+  const namespace = useActiveNamespace();
+  const validNamespace = namespace === ALL_NAMESPACES_SESSION_KEY ? null : namespace;
+  const cluster = useClusterParam();
 
-  const { nads } = useNADsData(namespace);
+  const { nads } = useNADsData(validNamespace, cluster);
   const { isPermitted, loading: loadingPermissions } = useCheckupsNetworkPermissions();
   const { configMaps, error, jobs, loaded } = useCheckupsNetworkData();
 

--- a/src/views/checkups/network/list/CheckupsNetworkListEmptyState.tsx
+++ b/src/views/checkups/network/list/CheckupsNetworkListEmptyState.tsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react';
 
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import {
   Button,
   ButtonVariant,
@@ -21,7 +22,8 @@ import './checkups-network-list-empty-state.scss';
 
 const CheckupsNetworkListEmptyState = ({ isPermitted, nadsInNamespace }) => {
   const { t } = useKubevirtTranslation();
-  const [namespace] = useActiveNamespace();
+  const namespace = useActiveNamespace();
+  const cluster = useClusterParam();
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   return (
@@ -42,7 +44,7 @@ const CheckupsNetworkListEmptyState = ({ isPermitted, nadsInNamespace }) => {
           <Button
             onClick={async () => {
               setIsLoading(true);
-              await installOrRemoveCheckupsNetworkPermissions(namespace, isPermitted);
+              await installOrRemoveCheckupsNetworkPermissions(namespace, cluster, isPermitted);
               setIsLoading(false);
             }}
             isDisabled={!nadsInNamespace || isLoading}

--- a/src/views/checkups/network/list/CheckupsNetworkListRow.tsx
+++ b/src/views/checkups/network/list/CheckupsNetworkListRow.tsx
@@ -3,14 +3,15 @@ import { Link } from 'react-router-dom-v5-compat';
 
 import { modelToGroupVersionKind, NamespaceModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiBatchV1Job, IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { getNetworkCheckupURL } from '@kubevirt-utils/resources/checkups/urls';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
-import {
-  ResourceLink,
-  RowProps,
-  TableData,
-  Timestamp,
-} from '@openshift-console/dynamic-plugin-sdk';
-import { createURL } from '@virtualmachines/details/tabs/overview/utils/utils';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
+import { ManagedClusterModel } from '@multicluster/constants';
+import { getCluster } from '@multicluster/helpers/selectors';
+import useIsACMPage from '@multicluster/useIsACMPage';
+import { RowProps, TableData, Timestamp } from '@openshift-console/dynamic-plugin-sdk';
+import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import CheckupsStatusIcon from '../../CheckupsStatusIcon';
 import { STATUS_COMPLETION_TIME_STAMP, STATUS_START_TIME_STAMP } from '../../utils/utils';
@@ -37,25 +38,32 @@ const CheckupsNetworkListRow: FC<CheckupsNetworkListRowProps> = ({
   obj: configMap,
   rowData: { getJobByName },
 }) => {
+  const isACMPage = useIsACMPage();
+  const [hubClusterName] = useHubClusterName();
+  const cluster = getCluster(configMap) || hubClusterName;
+  const namespace = getNamespace(configMap);
+  const name = getName(configMap);
   const jobs = getJobByName(configMap?.metadata?.name);
   const job = jobs?.[0];
 
   return (
     <>
       <TableData activeColumnIDs={activeColumnIDs} id="name">
-        <Link
-          to={createURL(
-            `network/${configMap?.metadata?.name}`,
-            `/k8s/ns/${configMap?.metadata?.namespace}/checkups`,
-          )}
-        >
-          {configMap?.metadata?.name}
+        <Link to={getNetworkCheckupURL(name, namespace, isACMPage ? cluster : undefined)}>
+          {name}
         </Link>
       </TableData>
+      <TableData activeColumnIDs={activeColumnIDs} id="cluster">
+        <MulticlusterResourceLink
+          groupVersionKind={modelToGroupVersionKind(ManagedClusterModel)}
+          name={cluster}
+        />
+      </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="namespace">
-        <ResourceLink
+        <MulticlusterResourceLink
+          cluster={cluster}
           groupVersionKind={modelToGroupVersionKind(NamespaceModel)}
-          name={configMap?.metadata?.namespace}
+          name={namespace}
         />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="nad">

--- a/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActionFactory.tsx
+++ b/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActionFactory.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 import { IoK8sApiBatchV1Job, IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
+import { trimLastHistoryPath } from '@kubevirt-utils/components/HorizontalNavbar/utils/utils';
 import { ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 
 import DeleteCheckupModal from '../../../components/DeleteCheckupModal';
-import { CHECKUP_URLS } from '../../../utils/constants';
 import { deleteSelfValidationCheckup } from '../../utils';
 
 import { getConfigMapInfo } from './CheckupsSelfValidationActionsUtils';
@@ -39,7 +39,10 @@ export const CheckupsSelfValidationActionFactory = {
       deleteSelfValidationCheckup(configMap, jobs).catch((err) => {
         kubevirtConsole.error('Failed to delete self-validation checkup:', err);
       });
-      navigate(`/k8s/ns/${getNamespace(configMap)}/checkups/${CHECKUP_URLS.SELF_VALIDATION}`);
+
+      const newPath = trimLastHistoryPath(location.pathname, [getName(configMap)]);
+
+      navigate(newPath);
     };
 
     return {

--- a/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActions.tsx
+++ b/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActions.tsx
@@ -4,6 +4,9 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import { IoK8sApiBatchV1Job, IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import ActionsDropdown from '@kubevirt-utils/components/ActionsDropdown/ActionsDropdown';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
+import { getName } from '@kubevirt-utils/resources/shared';
+import { getCluster } from '@multicluster/helpers/selectors';
 
 import { isJobRunning } from '../../utils';
 import { useAllRunningSelfValidationJobs } from '../hooks/useAllRunningSelfValidationJobs';
@@ -26,12 +29,16 @@ const CheckupsSelfValidationActions: FC<CheckupsSelfValidationActionsProps> = ({
   const [clusterRunningJobs] = useAllRunningSelfValidationJobs();
 
   const thisCheckupJobNames = useMemo(
-    () => new Set(jobs.map((job) => job?.metadata?.name)),
+    () => new Set(jobs.map((job) => `${getCluster(job) || SINGLE_CLUSTER_KEY}-${getName(job)}`)),
     [jobs],
   );
 
   const otherRunningJobs = useMemo(
-    () => (clusterRunningJobs || []).filter((job) => !thisCheckupJobNames.has(job?.metadata?.name)),
+    () =>
+      (clusterRunningJobs || []).filter(
+        (job) =>
+          !thisCheckupJobNames.has(`${getCluster(job) || SINGLE_CLUSTER_KEY}-${getName(job)}`),
+      ),
     [clusterRunningJobs, thisCheckupJobNames],
   );
 

--- a/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActionsUtils.ts
+++ b/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActionsUtils.ts
@@ -11,7 +11,7 @@ export type SelfValidationActionMode =
   typeof SELF_VALIDATION_ACTION_MODE[keyof typeof SELF_VALIDATION_ACTION_MODE];
 
 export type ActionState = {
-  configMapInfo: { name: string; namespace: string } | null;
+  configMapInfo: { cluster: string; name: string; namespace: string } | null;
   isEnabled: boolean;
   showWarning: boolean;
 };

--- a/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationSharedActionFactory.tsx
+++ b/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationSharedActionFactory.tsx
@@ -1,11 +1,10 @@
 import React, { ReactNode } from 'react';
-import { CHECKUP_URLS } from 'src/views/checkups/utils/constants';
 
 import { IoK8sApiBatchV1Job, IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
 import { ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { getSelfValidationCheckupURL } from '@kubevirt-utils/resources/checkups/urls';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
-import { createURL } from '@virtualmachines/details/tabs/overview/utils/utils';
 
 import RerunCheckupModal from '../../../components/RerunCheckupModal';
 import { isJobRunning, rerunSelfValidationCheckup } from '../../utils';
@@ -106,15 +105,17 @@ export const createGoToRunningCheckupAction = ({
   }
 
   const handleGoToRunningCheckup = () => {
-    const path = createURL(
-      `${CHECKUP_URLS.SELF_VALIDATION}/${configMapInfo.name}`,
-      `/k8s/ns/${configMapInfo.namespace}/checkups`,
+    const path = getSelfValidationCheckupURL(
+      configMapInfo.name,
+      configMapInfo.namespace,
+      configMapInfo.cluster,
     );
     navigate(path);
   };
 
   const description = (
     <RunningCheckupWarningDescription
+      configMapCluster={configMapInfo.cluster}
       configMapName={configMapInfo.name}
       configMapNamespace={configMapInfo.namespace}
       maxWidth="150px"

--- a/src/views/checkups/self-validation/components/actions/RunningCheckupWarningDescription.tsx
+++ b/src/views/checkups/self-validation/components/actions/RunningCheckupWarningDescription.tsx
@@ -1,14 +1,14 @@
 import React, { FC } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
-import { CHECKUP_URLS } from 'src/views/checkups/utils/constants';
 
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getSelfValidationCheckupURL } from '@kubevirt-utils/resources/checkups/urls';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { createURL } from '@virtualmachines/details/tabs/overview/utils/utils';
 
 import './running-checkup-warning-description.scss';
 
 type RunningCheckupWarningDescriptionProps = {
+  configMapCluster: string;
   configMapName: string;
   configMapNamespace: string;
   maxWidth?: string;
@@ -17,16 +17,14 @@ type RunningCheckupWarningDescriptionProps = {
 };
 
 const RunningCheckupWarningDescription: FC<RunningCheckupWarningDescriptionProps> = ({
+  configMapCluster,
   configMapName,
   configMapNamespace,
   maxWidth = '50px',
   preventLink = false,
   showTitle = true,
 }) => {
-  const linkTo = createURL(
-    `${CHECKUP_URLS.SELF_VALIDATION}/${configMapName}`,
-    `/k8s/ns/${configMapNamespace}/checkups`,
-  );
+  const linkTo = getSelfValidationCheckupURL(configMapName, configMapNamespace, configMapCluster);
 
   return (
     <span className="running-checkup-warning">

--- a/src/views/checkups/self-validation/components/form/CheckupsSelfValidationForm.tsx
+++ b/src/views/checkups/self-validation/components/form/CheckupsSelfValidationForm.tsx
@@ -3,6 +3,7 @@ import CheckupImageField from 'src/views/checkups/components/CheckupImageField';
 
 import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import CheckboxSelect from '@kubevirt-utils/components/CheckboxSelect/CheckboxSelect';
+import ClusterProjectDropdown from '@kubevirt-utils/components/ClusterProjectDropdown/ClusterProjectDropdown';
 import { getDefaultStorageClass } from '@kubevirt-utils/components/DiskModal/components/StorageClassAndPreallocation/utils/helpers';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useRelatedImage from '@kubevirt-utils/hooks/useRelatedImage';
@@ -125,80 +126,83 @@ const CheckupsSelfValidationForm = () => {
   }, [selectedTestSuites, t]);
 
   return (
-    <Grid>
-      <GridItem span={6}>
-        <Form className={'CheckupsSelfValidationForm--main'}>
-          <FormSection title={t('Run self validation checkup')} titleElement="h1">
-            <Alert
-              isInline
-              title={t('WARNING: This checkup may put the cluster under stress')}
-              variant={AlertVariant.warning}
-            >
-              {t(
-                'This checkup can take up to 3 hours to complete. It should not be used in production environments as it may impact cluster performance.',
+    <>
+      <ClusterProjectDropdown includeAllClusters={false} includeAllProjects={false} />
+      <Grid>
+        <GridItem span={6}>
+          <Form className={'CheckupsSelfValidationForm--main'}>
+            <FormSection title={t('Run self validation checkup')} titleElement="h1">
+              <Alert
+                isInline
+                title={t('WARNING: This checkup may put the cluster under stress')}
+                variant={AlertVariant.warning}
+              >
+                {t(
+                  'This checkup can take up to 3 hours to complete. It should not be used in production environments as it may impact cluster performance.',
+                )}
+              </Alert>
+
+              <FormGroup fieldId="name" isRequired label={t('Name')}>
+                <TextInput
+                  id="name"
+                  isRequired
+                  name="name"
+                  onChange={(_event, value) => setName(value)}
+                  value={name}
+                />
+              </FormGroup>
+
+              {checkupImageLoadError && (
+                <CheckupImageField
+                  checkupImage={checkupImage}
+                  checkupImageLoaded={checkupImageLoaded}
+                  checkupImageLoadError={checkupImageLoadError}
+                />
               )}
-            </Alert>
 
-            <FormGroup fieldId="name" isRequired label={t('Name')}>
-              <TextInput
-                id="name"
-                isRequired
-                name="name"
-                onChange={(_event, value) => setName(value)}
-                value={name}
+              <FormGroup fieldId="test-suites" isRequired label={t('Test suites')}>
+                <CheckboxSelect
+                  options={TEST_SUITE_OPTIONS.map((option) => ({
+                    children: option.label,
+                    isSelected: selectedTestSuites.includes(option.value),
+                    value: option.value,
+                  }))}
+                  onSelect={handleTestSuiteSelect}
+                  selectedValues={selectedTestSuites}
+                  toggleTitle={testSuitesToggleTitle}
+                />
+              </FormGroup>
+              <AdvancedSettings
+                defaultSC={defaultSC}
+                handleStorageCapabilitySelect={handleStorageCapabilitySelect}
+                isDryRun={isDryRun}
+                pvcSize={pvcSize}
+                setIsDryRun={setIsDryRun}
+                setPvcSize={setPvcSize}
+                setStorageClass={setStorageClass}
+                setTestSkips={setTestSkips}
+                storageCapabilities={storageCapabilities}
+                storageClass={storageClass}
+                storageClasses={storageClasses}
+                storageClassesLoaded={storageClassesLoaded}
+                testSkips={testSkips}
               />
-            </FormGroup>
 
-            {checkupImageLoadError && (
-              <CheckupImageField
+              <CheckupsSelfValidationFormActions
                 checkupImage={checkupImage}
-                checkupImageLoaded={checkupImageLoaded}
-                checkupImageLoadError={checkupImageLoadError}
+                isDryRun={isDryRun}
+                name={name}
+                pvcSize={pvcSize}
+                selectedTestSuites={selectedTestSuites}
+                storageCapabilities={storageCapabilities}
+                storageClass={storageClass || defaultSC?.metadata?.name}
+                testSkips={testSkips}
               />
-            )}
-
-            <FormGroup fieldId="test-suites" isRequired label={t('Test suites')}>
-              <CheckboxSelect
-                options={TEST_SUITE_OPTIONS.map((option) => ({
-                  children: option.label,
-                  isSelected: selectedTestSuites.includes(option.value),
-                  value: option.value,
-                }))}
-                onSelect={handleTestSuiteSelect}
-                selectedValues={selectedTestSuites}
-                toggleTitle={testSuitesToggleTitle}
-              />
-            </FormGroup>
-            <AdvancedSettings
-              defaultSC={defaultSC}
-              handleStorageCapabilitySelect={handleStorageCapabilitySelect}
-              isDryRun={isDryRun}
-              pvcSize={pvcSize}
-              setIsDryRun={setIsDryRun}
-              setPvcSize={setPvcSize}
-              setStorageClass={setStorageClass}
-              setTestSkips={setTestSkips}
-              storageCapabilities={storageCapabilities}
-              storageClass={storageClass}
-              storageClasses={storageClasses}
-              storageClassesLoaded={storageClassesLoaded}
-              testSkips={testSkips}
-            />
-
-            <CheckupsSelfValidationFormActions
-              checkupImage={checkupImage}
-              isDryRun={isDryRun}
-              name={name}
-              pvcSize={pvcSize}
-              selectedTestSuites={selectedTestSuites}
-              storageCapabilities={storageCapabilities}
-              storageClass={storageClass || defaultSC?.metadata?.name}
-              testSkips={testSkips}
-            />
-          </FormSection>
-        </Form>
-      </GridItem>
-    </Grid>
+            </FormSection>
+          </Form>
+        </GridItem>
+      </Grid>
+    </>
   );
 };
 

--- a/src/views/checkups/self-validation/components/hooks/useAllRunningSelfValidationJobs.ts
+++ b/src/views/checkups/self-validation/components/hooks/useAllRunningSelfValidationJobs.ts
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 
 import { IoK8sApiBatchV1Job } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { Operator, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import { Operator } from '@openshift-console/dynamic-plugin-sdk';
 
 import { createJobWatchConfig } from '../../../utils/utils';
 import {
@@ -19,18 +21,20 @@ export const useAllRunningSelfValidationJobs = (): [
   loaded: boolean,
   error: Error,
 ] => {
+  const cluster = useClusterParam();
+
   const jobWatchConfig = useMemo(
     () =>
-      createJobWatchConfig(SELF_VALIDATION_LABEL_VALUE, undefined, [
+      createJobWatchConfig(SELF_VALIDATION_LABEL_VALUE, undefined, cluster, [
         {
           key: SELF_VALIDATION_RESULTS_ONLY_LABEL,
           operator: Operator.DoesNotExist,
         },
       ]),
-    [],
+    [cluster],
   );
 
-  const [jobs, loaded, error] = useK8sWatchResource<IoK8sApiBatchV1Job[]>(jobWatchConfig);
+  const [jobs, loaded, error] = useKubevirtWatchResource<IoK8sApiBatchV1Job[]>(jobWatchConfig);
 
   const runningJobs = useMemo(() => {
     if (!jobs || !Array.isArray(jobs)) {

--- a/src/views/checkups/self-validation/components/hooks/useCheckupsSelfValidationListColumns.ts
+++ b/src/views/checkups/self-validation/components/hooks/useCheckupsSelfValidationListColumns.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { IoK8sApiBatchV1Job, IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettingsTableColumns from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns';
+import useIsACMPage from '@multicluster/useIsACMPage';
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable, SortByDirection } from '@patternfly/react-table';
 
@@ -19,6 +20,7 @@ const useCheckupsSelfValidationListColumns = (
   jobs: IoK8sApiBatchV1Job[],
 ): [TableColumn<IoK8sApiCoreV1ConfigMap>[], TableColumn<IoK8sApiCoreV1ConfigMap>[], boolean] => {
   const { t } = useKubevirtTranslation();
+  const isACMPage = useIsACMPage();
 
   const jobsByConfigMapName = useMemo(() => groupJobsByConfigMapName(jobs), [jobs]);
 
@@ -30,6 +32,16 @@ const useCheckupsSelfValidationListColumns = (
         title: t('Name'),
         transforms: [sortable],
       },
+      ...(isACMPage
+        ? [
+            {
+              id: 'cluster',
+              sort: 'cluster',
+              title: t('Cluster'),
+              transforms: [sortable],
+            },
+          ]
+        : []),
       {
         id: 'namespace',
         sort: 'metadata.namespace',

--- a/src/views/checkups/self-validation/components/hooks/useCheckupsSelfValidationListFilters.ts
+++ b/src/views/checkups/self-validation/components/hooks/useCheckupsSelfValidationListFilters.ts
@@ -19,7 +19,9 @@ type UseCheckupsSelfValidationFilters = (
 
 const useCheckupsSelfValidationListFilters: UseCheckupsSelfValidationFilters = (data) => {
   const { t } = useKubevirtTranslation();
+
   const filters = getCheckupsSelfValidationListFilters(t);
+
   const [unfilteredData, filteredData, onFilterChange] = useListPageFilter<
     IoK8sApiCoreV1ConfigMap,
     IoK8sApiCoreV1ConfigMap

--- a/src/views/checkups/self-validation/details/components/progress/hooks/useProgressTracking.ts
+++ b/src/views/checkups/self-validation/details/components/progress/hooks/useProgressTracking.ts
@@ -8,6 +8,7 @@ import { getOverallProgress } from '../utils/progressTracker';
 import type { OverallProgress } from '../utils/types';
 
 type UseProgressTrackingProps = {
+  cluster: string;
   enabled: boolean;
   job: IoK8sApiBatchV1Job;
   namespace: string;
@@ -23,6 +24,7 @@ type UseProgressTrackingResult = {
  * Hook to track real-time progress of test suites using watch instead of polling
  */
 export const useProgressTracking = ({
+  cluster,
   enabled,
   job,
   namespace,
@@ -34,13 +36,14 @@ export const useProgressTracking = ({
     () =>
       enabled && jobName
         ? {
+            cluster,
             groupVersionKind: modelToGroupVersionKind(JobModel),
             isList: false,
             name: jobName,
             namespace,
           }
         : null,
-    [enabled, jobName, namespace],
+    [enabled, jobName, namespace, cluster],
   );
 
   // Only watch when resource is valid - useK8sWatchData handles null by returning [undefined, true, undefined]

--- a/src/views/checkups/self-validation/details/tabs/details/CheckupsSelfValidationDetailsTab.tsx
+++ b/src/views/checkups/self-validation/details/tabs/details/CheckupsSelfValidationDetailsTab.tsx
@@ -2,6 +2,8 @@ import React, { FC, useCallback } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 
 import { IoK8sApiBatchV1Job } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { getCluster } from '@multicluster/helpers/selectors';
 import { Divider, PageSection } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 
@@ -27,8 +29,9 @@ const CheckupsSelfValidationDetailsTab: FC = () => {
     isLoading: isLoadingResults,
     results,
   } = useJobResults({
+    cluster: getCluster(configMap),
     job: currentJob,
-    namespace: configMap?.metadata?.namespace || '',
+    namespace: getNamespace(configMap) || '',
   });
 
   const isJobRunning = currentJob && !currentJob.status?.succeeded && !currentJob.status?.failed;
@@ -42,9 +45,10 @@ const CheckupsSelfValidationDetailsTab: FC = () => {
     loading: isProgressLoading,
     progress,
   } = useProgressTracking({
+    cluster: getCluster(configMap),
     enabled: isJobRunning,
     job: currentJob,
-    namespace: configMap?.metadata?.namespace || '',
+    namespace: getNamespace(configMap) || '',
   });
 
   const renderCustomActions = useCallback(

--- a/src/views/checkups/self-validation/list/CheckupsSelfValidationList.tsx
+++ b/src/views/checkups/self-validation/list/CheckupsSelfValidationList.tsx
@@ -1,15 +1,12 @@
 import React, { FC, useCallback, useMemo } from 'react';
 
 import { IoK8sApiBatchV1Job, IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import ListPageFilter from '@kubevirt-utils/components/ListPageFilter/ListPageFilter';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import usePagination from '@kubevirt-utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@kubevirt-utils/hooks/usePagination/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import {
-  ListPageBody,
-  ListPageFilter,
-  VirtualizedTable,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { ListPageBody, VirtualizedTable } from '@openshift-console/dynamic-plugin-sdk';
 import { Pagination } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 

--- a/src/views/checkups/self-validation/list/CheckupsSelfValidationListEmptyState.tsx
+++ b/src/views/checkups/self-validation/list/CheckupsSelfValidationListEmptyState.tsx
@@ -4,8 +4,9 @@ import { IoK8sApiRbacV1ClusterRoleBinding } from '@kubevirt-ui/kubevirt-api/kube
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import {
   Alert,
   AlertVariant,
@@ -39,7 +40,8 @@ const CheckupsSelfValidationListEmptyState: FC<CheckupsSelfValidationListEmptySt
   loadingPermissions,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [namespace] = useActiveNamespace();
+  const namespace = useActiveNamespace();
+  const cluster = useClusterParam();
   const [isLoading, setIsLoading] = useState<boolean>();
   const [error, setError] = useState<null | string>(null);
   const [runningSelfValidationJobs] = useAllRunningSelfValidationJobs();
@@ -93,8 +95,8 @@ const CheckupsSelfValidationListEmptyState: FC<CheckupsSelfValidationListEmptySt
               setError(null);
               setIsLoading(true);
               const result = isPermitted
-                ? await removeSelfValidationPermissions(namespace, t)
-                : await installSelfValidationPermissions(namespace, t);
+                ? await removeSelfValidationPermissions(namespace, cluster, t)
+                : await installSelfValidationPermissions(namespace, cluster, t);
               if (!result.success && result.error) {
                 setError(result.error);
               }

--- a/src/views/checkups/self-validation/utils/constants.ts
+++ b/src/views/checkups/self-validation/utils/constants.ts
@@ -236,6 +236,7 @@ export type JobResults = {
 export type ValidatedJobParameters = {
   baseName: string;
   checkupImage: string;
+  cluster: string;
   isDryRun: boolean;
   namespace: string;
   originalJobName: string;

--- a/src/views/checkups/self-validation/utils/selfValidationJob/helpers.ts
+++ b/src/views/checkups/self-validation/utils/selfValidationJob/helpers.ts
@@ -1,5 +1,6 @@
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
-import { K8sModel, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
+import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
+import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
 /**
  * Generates a timestamp string in format YYYYMMDD-HHMMSS
@@ -28,6 +29,7 @@ export const addOwnerReference = async (
   model: K8sModel,
   resourceName: string,
   namespace: string,
+  cluster: string,
   owner: {
     apiVersion: string;
     kind: string;
@@ -36,7 +38,8 @@ export const addOwnerReference = async (
   },
 ): Promise<void> => {
   try {
-    await k8sPatch({
+    await kubevirtK8sPatch({
+      cluster,
       data: [
         {
           op: 'add',

--- a/src/views/checkups/self-validation/utils/selfValidationJob/resultsResources.ts
+++ b/src/views/checkups/self-validation/utils/selfValidationJob/resultsResources.ts
@@ -1,6 +1,6 @@
 import { JobModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiBatchV1Job } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { k8sCreate, k8sGet } from '@openshift-console/dynamic-plugin-sdk';
+import { kubevirtK8sCreate, kubevirtK8sGet } from '@multicluster/k8sRequests';
 
 import { type ValidatedJobParameters } from '../constants';
 
@@ -19,6 +19,7 @@ export const createResultsResourcesJob = async (
   const {
     baseName,
     checkupImage,
+    cluster,
     isDryRun,
     namespace,
     pvcName,
@@ -49,7 +50,8 @@ export const createResultsResourcesJob = async (
   // Create the job (no PVC creation needed - reusing existing one)
   // Handle idempotency: if job already exists (409), fetch and return it
   try {
-    const job = await k8sCreate<IoK8sApiBatchV1Job>({
+    const job = await kubevirtK8sCreate<IoK8sApiBatchV1Job>({
+      cluster,
       data: jobData,
       model: JobModel,
     });
@@ -57,7 +59,8 @@ export const createResultsResourcesJob = async (
   } catch (error: any) {
     // If job already exists (409), fetch and return the existing job
     if (error?.response?.status === 409 || error?.code === 409) {
-      const existingJob = await k8sGet<IoK8sApiBatchV1Job>({
+      const existingJob = await kubevirtK8sGet<IoK8sApiBatchV1Job>({
+        cluster,
         model: JobModel,
         name: resultsJobName,
         ns: namespace,

--- a/src/views/checkups/self-validation/utils/selfValidationMessages.tsx
+++ b/src/views/checkups/self-validation/utils/selfValidationMessages.tsx
@@ -3,7 +3,9 @@ import { Link } from 'react-router-dom-v5-compat';
 import { extractConfigMapName } from 'src/views/checkups/utils/utils';
 
 import { IoK8sApiBatchV1Job } from '@kubevirt-ui/kubevirt-api/kubernetes';
-import { createURL } from '@virtualmachines/details/tabs/overview/utils/utils';
+import { getSelfValidationCheckupURL } from '@kubevirt-utils/resources/checkups/urls';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getCluster } from '@multicluster/helpers/selectors';
 
 export const getRunningCheckupErrorMessage = (
   t: (key: string) => string,
@@ -12,17 +14,14 @@ export const getRunningCheckupErrorMessage = (
 ): ReactElement => {
   const jobLinks = runningJobs.flatMap((job, index) => {
     const configMapInfo = extractConfigMapName(job);
-    const jobName = job?.metadata?.name || t('Unknown');
-    const key = job?.metadata?.name ?? `job-${index}`;
+
+    const jobName = getName(job) || t('Unknown');
+    const key = getName(job) ?? `job-${index}`;
+    const cluster = getCluster(job);
+    const url = getSelfValidationCheckupURL(getName(job), getNamespace(job), cluster);
+
     const linkElement = configMapInfo ? (
-      <Link
-        to={createURL(
-          `self-validation/${configMapInfo.name}`,
-          `/k8s/ns/${configMapInfo.namespace}/checkups`,
-        )}
-        key={key}
-        onClick={() => onClose?.()}
-      >
+      <Link key={key} onClick={() => onClose?.()} to={url}>
         <strong>{configMapInfo.name}</strong>
       </Link>
     ) : (

--- a/src/views/checkups/storage/components/form/CheckupsStorageFormActions.tsx
+++ b/src/views/checkups/storage/components/form/CheckupsStorageFormActions.tsx
@@ -1,9 +1,10 @@
 import React, { FC, useState } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { ActionGroup, Alert, AlertVariant, Button, ButtonVariant } from '@patternfly/react-core';
 
 import { CHECKUP_URLS } from '../../../utils/constants';
@@ -22,7 +23,8 @@ const CheckupsStorageFormActions: FC<CheckupsStorageFormActionsProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
-  const [namespace] = useActiveNamespace();
+  const namespace = useActiveNamespace();
+  const cluster = useClusterParam();
   const [error, setError] = useState<string>(null);
 
   return (
@@ -32,7 +34,7 @@ const CheckupsStorageFormActions: FC<CheckupsStorageFormActionsProps> = ({
           onClick={async () => {
             setError(null);
             try {
-              await createStorageCheckup(namespace, timeOut, name, checkupImage);
+              await createStorageCheckup(namespace, cluster, timeOut, name, checkupImage);
               navigate(`/k8s/ns/${namespace}/checkups/${CHECKUP_URLS.STORAGE}`);
             } catch (e) {
               kubevirtConsole.log(e);

--- a/src/views/checkups/storage/components/hooks/useCheckupsStorageData.ts
+++ b/src/views/checkups/storage/components/hooks/useCheckupsStorageData.ts
@@ -4,15 +4,19 @@ import { createJobWatchConfig, KUBEVIRT_VM_LATENCY_LABEL } from 'src/views/check
 import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiBatchV1Job, IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
-import { useActiveNamespace, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 
 import { KUBEVIRT_STORAGE_LABEL_VALUE } from '../../utils/utils';
 
 const useCheckupsStorageData = () => {
-  const [namespace] = useActiveNamespace();
+  const namespace = useActiveNamespace();
+  const cluster = useClusterParam();
 
   const configMapWatchConfig = useMemo(
     () => ({
+      cluster,
       groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
       isList: true,
       ...(namespace !== ALL_NAMESPACES_SESSION_KEY && { namespace, namespaced: true }),
@@ -22,19 +26,20 @@ const useCheckupsStorageData = () => {
         },
       },
     }),
-    [namespace],
+    [namespace, cluster],
   );
 
   const jobWatchConfig = useMemo(
-    () => createJobWatchConfig(KUBEVIRT_STORAGE_LABEL_VALUE, namespace),
-    [namespace],
+    () => createJobWatchConfig(KUBEVIRT_STORAGE_LABEL_VALUE, namespace, cluster),
+    [namespace, cluster],
   );
 
   const [configMaps, configMapsLoaded, loadErrorConfigMaps] =
-    useK8sWatchResource<IoK8sApiCoreV1ConfigMap[]>(configMapWatchConfig);
+    useKubevirtWatchResource<IoK8sApiCoreV1ConfigMap[]>(configMapWatchConfig);
 
   const [jobs, jobsLoaded, loadErrorJobs] =
-    useK8sWatchResource<IoK8sApiBatchV1Job[]>(jobWatchConfig);
+    useKubevirtWatchResource<IoK8sApiBatchV1Job[]>(jobWatchConfig);
+
   return {
     configMaps,
     error: loadErrorConfigMaps || loadErrorJobs,

--- a/src/views/checkups/storage/components/hooks/useCheckupsStorageListColumns.ts
+++ b/src/views/checkups/storage/components/hooks/useCheckupsStorageListColumns.ts
@@ -1,8 +1,12 @@
+import { useMemo } from 'react';
+
 import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettingsTableColumns from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns';
-import { TableColumn, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import useIsACMPage from '@multicluster/useIsACMPage';
+import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable, SortByDirection } from '@patternfly/react-table';
 
 import {
@@ -18,60 +22,74 @@ const useCheckupsStorageListColumns = (): [
   TableColumn<IoK8sApiCoreV1ConfigMap>[],
   boolean,
 ] => {
-  const [namespace] = useActiveNamespace();
+  const namespace = useActiveNamespace();
   const { t } = useKubevirtTranslation();
+  const isACMPage = useIsACMPage();
 
-  const columns: TableColumn<IoK8sApiCoreV1ConfigMap>[] = [
-    {
-      id: 'name',
-      sort: 'metadata.name',
-      title: t('Name'),
-      transforms: [sortable],
-    },
-    ...(namespace === ALL_NAMESPACES_SESSION_KEY
-      ? [
-          {
-            id: 'namespace',
-            sort: 'metadata.namespace',
-            title: t('Namespace'),
-            transforms: [sortable],
-          },
-        ]
-      : []),
-    {
-      id: 'status',
-      sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
-        columnsSorting(data, sortDirection, STATUS_SUCCEEDED),
-      title: t('Status'),
-      transforms: [sortable],
-    },
-    {
-      id: 'failure',
-      sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
-        columnsSorting(data, sortDirection, STATUS_FAILURE_REASON),
-      title: t('Failure reason'),
-      transforms: [sortable],
-    },
-    {
-      id: 'start-time',
-      sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
-        columnsSorting(data, sortDirection, STATUS_START_TIME_STAMP),
-      title: t('Start time'),
-      transforms: [sortable],
-    },
-    {
-      id: 'complete-time',
-      sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
-        columnsSorting(data, sortDirection, STATUS_COMPLETION_TIME_STAMP),
-      title: t('Completion time'),
-      transforms: [sortable],
-    },
-    {
-      id: '',
-      props: { className: 'pf-v6-c-table__action' },
-      title: '',
-    },
-  ];
+  const columns: TableColumn<IoK8sApiCoreV1ConfigMap>[] = useMemo(
+    () => [
+      {
+        id: 'name',
+        sort: 'metadata.name',
+        title: t('Name'),
+        transforms: [sortable],
+      },
+      ...(isACMPage
+        ? [
+            {
+              id: 'cluster',
+              sort: 'cluster',
+              title: t('Cluster'),
+              transforms: [sortable],
+            },
+          ]
+        : []),
+      ...(namespace === ALL_NAMESPACES_SESSION_KEY
+        ? [
+            {
+              id: 'namespace',
+              sort: 'metadata.namespace',
+              title: t('Namespace'),
+              transforms: [sortable],
+            },
+          ]
+        : []),
+      {
+        id: 'status',
+        sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
+          columnsSorting(data, sortDirection, STATUS_SUCCEEDED),
+        title: t('Status'),
+        transforms: [sortable],
+      },
+      {
+        id: 'failure',
+        sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
+          columnsSorting(data, sortDirection, STATUS_FAILURE_REASON),
+        title: t('Failure reason'),
+        transforms: [sortable],
+      },
+      {
+        id: 'start-time',
+        sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
+          columnsSorting(data, sortDirection, STATUS_START_TIME_STAMP),
+        title: t('Start time'),
+        transforms: [sortable],
+      },
+      {
+        id: 'complete-time',
+        sort: (data: IoK8sApiCoreV1ConfigMap[], sortDirection: SortByDirection) =>
+          columnsSorting(data, sortDirection, STATUS_COMPLETION_TIME_STAMP),
+        title: t('Completion time'),
+        transforms: [sortable],
+      },
+      {
+        id: '',
+        props: { className: 'pf-v6-c-table__action' },
+        title: '',
+      },
+    ],
+    [t, isACMPage, namespace],
+  );
 
   const [activeColumns, , loadedColumns] =
     useKubevirtUserSettingsTableColumns<IoK8sApiCoreV1ConfigMap>({

--- a/src/views/checkups/storage/list/CheckupsStorageListEmptyState.tsx
+++ b/src/views/checkups/storage/list/CheckupsStorageListEmptyState.tsx
@@ -4,8 +4,9 @@ import { IoK8sApiRbacV1ClusterRoleBinding } from '@kubevirt-ui/kubevirt-api/kube
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import {
   Button,
   ButtonVariant,
@@ -35,7 +36,8 @@ const CheckupsStorageListEmptyState: FC<CheckupsStorageListEmptyStateProps> = ({
   loadingPermissions,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [namespace] = useActiveNamespace();
+  const namespace = useActiveNamespace();
+  const cluster = useClusterParam();
   const [isLoading, setIsLoading] = useState<boolean>();
 
   return (
@@ -64,6 +66,7 @@ const CheckupsStorageListEmptyState: FC<CheckupsStorageListEmptyStateProps> = ({
               try {
                 await installOrRemoveCheckupsStoragePermissions(
                   namespace,
+                  cluster,
                   isPermitted,
                   clusterRoleBinding,
                 );

--- a/src/views/instancetypes/list/hooks/useUserInstancetypeListColumns.ts
+++ b/src/views/instancetypes/list/hooks/useUserInstancetypeListColumns.ts
@@ -3,13 +3,14 @@ import { useCallback } from 'react';
 import { VirtualMachineInstancetypeModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1VirtualMachineInstancetype } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettingsTableColumns from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns';
 import { PaginationState } from '@kubevirt-utils/hooks/usePagination/utils/types';
 import { columnSorting } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useIsACMPage from '@multicluster/useIsACMPage';
-import { TableColumn, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 
 import { sortInstanceTypeByMemory } from './utils';
@@ -29,7 +30,7 @@ const useUserInstancetypeListColumns: UseUserInstancetypeListColumns = (paginati
   const { t } = useKubevirtTranslation();
   const isACMPage = useIsACMPage();
   const cluster = useClusterParam();
-  const [activeNamespace] = useActiveNamespace();
+  const activeNamespace = useActiveNamespace();
 
   const sorting = useCallback(
     (direction, path) => columnSorting(data, direction, pagination, path),

--- a/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/MigrationPolicyCreateForm.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/MigrationPolicyCreateForm.tsx
@@ -35,7 +35,9 @@ const MigrationPolicyCreateForm: FC = (): JSX.Element => {
   return (
     <div className="migration-policy__form kv-m-pane__form">
       <DocumentTitle>{t('Create MigrationPolicy')}</DocumentTitle>
-      {isACMPage && <ClusterProjectDropdown showProjectDropdown={false} />}
+      {isACMPage && (
+        <ClusterProjectDropdown includeAllClusters={false} showProjectDropdown={false} />
+      )}
       <MigrationPolicyCreateFormHeader />
       <Form className="migration-policy__form-body">
         <FormGroup fieldId="create-description">

--- a/src/views/preferences/list/hooks/useUserPreferenceListColumns.ts
+++ b/src/views/preferences/list/hooks/useUserPreferenceListColumns.ts
@@ -3,11 +3,12 @@ import { useCallback, useMemo } from 'react';
 import { VirtualMachinePreferenceModelRef } from '@kubevirt-ui/kubevirt-api/console';
 import { V1beta1VirtualMachinePreference } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettingsTableColumns from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns';
 import { PaginationState } from '@kubevirt-utils/hooks/usePagination/utils/types';
 import { columnSorting } from '@kubevirt-utils/utils/utils';
-import { TableColumn, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 
 type UseUserPreferenceListColumnsValues = [
@@ -23,7 +24,7 @@ type UseUserPreferenceListColumns = (
 
 const useUserPreferenceListColumns: UseUserPreferenceListColumns = (pagination, data) => {
   const { t } = useKubevirtTranslation();
-  const [activeNamespace] = useActiveNamespace();
+  const activeNamespace = useActiveNamespace();
   const sorting = useCallback(
     (direction, path) => columnSorting(data, direction, pagination, path),
     [data, pagination],


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

list with multicluster filters

In the following prs i'll address the multicluster creation form and details page

Missing storage and network creation form and details page. Following pr 

## 🎥 Demo

> Please add a video or an image of the behavior/changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster-aware navigation and pages for Checkups (Network, Storage, Self‑Validation) with cluster/project selector for ACM workflows.
  * Self‑Validation form: name, test-suite selection, advanced storage settings, and improved run/tooltip behavior.

* **Improvements**
  * Full multicluster support: cluster-scoped URLs, routing, job/results handling, and permission flows.
  * List/table enhancements: conditional Cluster column on ACM pages and ACM-aware Run buttons and action links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->