### PR TITLE
CNV-71697: Enable Custom Icons in Virtualization Template Catalog

### DIFF
--- a/src/utils/resources/template/utils/helpers.ts
+++ b/src/utils/resources/template/utils/helpers.ts
@@ -76,3 +76,25 @@ export const bootDiskSourceIsRegistry = (template: V1Template) => {
   const vmObject: V1VirtualMachine = getTemplateVirtualMachineObject(template);
   return vmBootDiskSourceIsRegistry(vmObject);
 };
+
+export const isValidTemplateIconUrl = (url: string): boolean => {
+  if (!url) return false;
+
+  // Allow relative paths starting with /
+  if (/^\/[^/]/.test(url)) {
+    return true;
+  }
+
+  // For absolute URLs, validate using URL.canParse and check protocol
+  if (URL.canParse(url)) {
+    try {
+      const parsedUrl = new URL(url);
+      // Only allow http, https protocols (block javascript:, data:, vbscript:, etc.)
+      return ['http:', 'https:'].includes(parsedUrl.protocol);
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+};

--- a/src/views/catalog/templatescatalog/utils/os-icons.tsx
+++ b/src/views/catalog/templatescatalog/utils/os-icons.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
+import { isValidTemplateIconUrl, OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 const bsd = require('./svg/bsd.svg') as string;
@@ -27,6 +27,9 @@ const iconMap = {
 
 export const getTemplateOSIcon = (template: K8sResourceCommon): string => {
   const icon = template?.metadata?.annotations?.iconClass;
+  if (isValidTemplateIconUrl(icon)) {
+    return icon;
+  }
   return iconMap[icon] || iconMap['icon-other'];
 };
 


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-71697](https://issues.redhat.com/browse/CNV-71697)

In OCP 4.20 is possible to set the custom iconClass for the templates using a URL - we need to support it on our end. 
https://github.com/openshift/console/pull/15248

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/e0b62c96-c703-4e2a-b9a3-b628ff506af6


After:


https://github.com/user-attachments/assets/4f063982-790c-4ba7-beb6-b5e32ef51b9e




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template icon handling: now validates icon URLs (including safe relative paths) and gracefully falls back to default icons for invalid or unsupported URLs, preventing broken or unsafe icon displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->