### PR TITLE
CNV-72183: fix ssh modal crash on error

### DIFF
--- a/src/utils/components/SSHSecretModal/components/SSHSecretModalBody/SSHSecretModalBody.tsx
+++ b/src/utils/components/SSHSecretModal/components/SSHSecretModalBody/SSHSecretModalBody.tsx
@@ -1,5 +1,6 @@
 import React, { Dispatch, FC, SetStateAction, useState } from 'react';
 
+import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import SecretSelectionRadioGroup from '@kubevirt-utils/components/SSHSecretModal/components/SecretSelectionRadioGroup';
 import SSHKeyUpload from '@kubevirt-utils/components/SSHSecretModal/components/SSHKeyUpload/SSHKeyUpload';
 import {
@@ -9,7 +10,7 @@ import {
 } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { Alert, AlertVariant, Checkbox, Grid, GridItem } from '@patternfly/react-core';
+import { Checkbox, Grid, GridItem } from '@patternfly/react-core';
 
 import SSHOptionUseExisting from '../SSHOptionUseExisting/SSHOptionUseExisting';
 
@@ -94,11 +95,7 @@ const SSHSecretModalBody: FC<SSHSecretModalBodyProps> = ({
           isDisabled={isUserTab}
         />
       )}
-      {secretsLoadError && (
-        <Alert title={t('Error')} variant={AlertVariant.danger}>
-          {secretsLoadError}
-        </Alert>
-      )}
+      {secretsLoadError && <ErrorAlert error={secretsLoadError} />}
     </Grid>
   );
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description


When there is an error, here is crashing as `secretsLoadError` is an object and cannot be rendered directly in react. We have to show `secretsLoadError.message` that its a string. `ErrorAlert` already do that 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated error alert component in SSH secret modal for improved consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->