### PR TITLE
CNV-71648: hide system namespaces in ssh modal

### DIFF
--- a/src/utils/components/SSHSecretModal/components/SSHOptionUseExisting/SSHOptionUseExisting.tsx
+++ b/src/utils/components/SSHSecretModal/components/SSHOptionUseExisting/SSHOptionUseExisting.tsx
@@ -58,15 +58,15 @@ const SSHOptionUseExisting: FC<SSHOptionUseExistingProps> = ({
   const [selectedProject, setSelectedProject] = useState<string>(
     localNSProject || namespace || sshDetails?.sshSecretNamespace,
   );
-  const [projects] = useProjects(cluster);
+  const [userProjects] = useProjects(cluster, true);
 
   useEffect(
     () =>
       !selectedProject &&
       setSelectedProject(
-        localNSProject || namespace || sshDetails?.sshSecretNamespace || projects?.[0],
+        localNSProject || namespace || sshDetails?.sshSecretNamespace || userProjects?.[0],
       ),
-    [namespace, localNSProject, projects, selectedProject, sshDetails?.sshSecretNamespace],
+    [namespace, localNSProject, userProjects, selectedProject, sshDetails?.sshSecretNamespace],
   );
 
   const onSelectProject = useCallback(
@@ -101,7 +101,7 @@ const SSHOptionUseExisting: FC<SSHOptionUseExistingProps> = ({
     ? selectedProject !== namespace
     : selectedProject !== sshDetails?.sshSecretNamespace;
 
-  if (isEmpty(projects)) return <Bullseye>{t('No SSH keys found')}</Bullseye>;
+  if (isEmpty(userProjects)) return <Bullseye>{t('No SSH keys found')}</Bullseye>;
 
   return (
     <>
@@ -116,7 +116,7 @@ const SSHOptionUseExisting: FC<SSHOptionUseExistingProps> = ({
         <GridItem span={6}>
           <FormGroup fieldId="project" label={t('Project')}>
             <InlineFilterSelect
-              options={projects.map((project) => ({
+              options={userProjects.map((project) => ({
                 children: project,
                 groupVersionKind: modelToGroupVersionKind(ProjectModel),
                 value: project,

--- a/src/utils/hooks/useProjects.ts
+++ b/src/utils/hooks/useProjects.ts
@@ -1,25 +1,33 @@
 import { useMemo } from 'react';
 
 import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui/kubevirt-api/console';
+import { isSystemNamespace } from '@kubevirt-utils/resources/namespace/helper';
 import { getName } from '@kubevirt-utils/resources/shared';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
-type UseProjects = (cluster?: string) => [string[], boolean, any];
+type UseProjects = (cluster?: string, onlyUserProjects?: boolean) => [string[], boolean, any];
 
-const useProjects: UseProjects = (cluster) => {
+const useProjects: UseProjects = (cluster, onlyUserProjects = false) => {
   const [projectsData, loaded, error] = useK8sWatchData<K8sResourceCommon[]>({
     cluster,
     groupVersionKind: modelToGroupVersionKind(ProjectModel),
     isList: true,
   });
 
-  const projectsNames = useMemo(
-    () => projectsData?.map(getName).sort((a, b) => a.localeCompare(b)),
-    [projectsData],
-  );
+  const projectsNames = useMemo(() => projectsData?.map(getName), [projectsData]);
 
-  return [projectsNames, loaded, error];
+  const filteredProjectsData = useMemo(() => {
+    return onlyUserProjects
+      ? projectsNames?.filter((project) => !isSystemNamespace(project))
+      : projectsNames;
+  }, [projectsNames, onlyUserProjects]);
+
+  const sortedProjectsNames = useMemo(() => {
+    return filteredProjectsData?.sort((a, b) => a.localeCompare(b));
+  }, [filteredProjectsData]);
+
+  return [sortedProjectsNames, loaded, error];
 };
 
 export default useProjects;

--- a/src/utils/resources/namespace/constants.ts
+++ b/src/utils/resources/namespace/constants.ts
@@ -1,0 +1,2 @@
+export const SYSTEM_NAMESPACES_PREFIX = ['kube-', 'openshift-', 'kubernetes-'];
+export const SYSTEM_NAMESPACES = ['default', 'openshift'];

--- a/src/utils/resources/namespace/helper.ts
+++ b/src/utils/resources/namespace/helper.ts
@@ -1,0 +1,8 @@
+import { SYSTEM_NAMESPACES, SYSTEM_NAMESPACES_PREFIX } from './constants';
+
+export const isSystemNamespace = (projectName: string) => {
+  const startsWithNamespace = SYSTEM_NAMESPACES_PREFIX.some((ns) => projectName.startsWith(ns));
+  const isNamespace = SYSTEM_NAMESPACES.includes(projectName);
+
+  return startsWithNamespace || isNamespace;
+};

--- a/src/views/virtualmachines/tree/hooks/useFilteredTreeView.ts
+++ b/src/views/virtualmachines/tree/hooks/useFilteredTreeView.ts
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 
 import useLocalStorage from '@kubevirt-utils/hooks/useLocalStorage';
+import { isSystemNamespace } from '@kubevirt-utils/resources/namespace/helper';
 import { TreeViewDataItem } from '@patternfly/react-core';
 
 import { HIDE, PROJECT_SELECTOR_PREFIX, SHOW, SHOW_EMPTY_PROJECTS_KEY } from '../utils/constants';
-import { filterNamespaceItems, isSystemNamespace } from '../utils/utils';
+import { filterNamespaceItems } from '../utils/utils';
 
 type UseFilteredTreeView = (treeData: TreeViewDataItem[]) => TreeViewDataItem[];
 

--- a/src/views/virtualmachines/tree/utils/constants.ts
+++ b/src/views/virtualmachines/tree/utils/constants.ts
@@ -9,8 +9,6 @@ export const OPEN_DRAWER_SIZE = '400px';
 export const CLOSED_DRAWER_SIZE = '30px';
 export const PANEL_WIDTH_PROPERTY = '--pf-v6-c-drawer__panel--md--FlexBasis';
 
-export const SYSTEM_NAMESPACES_PREFIX = ['kube-', 'openshift-', 'kubernetes-'];
-export const SYSTEM_NAMESPACES = ['default', 'openshift'];
 export const SHOW_EMPTY_PROJECTS_KEY = 'showEmptyProjects';
 export const TREE_VIEW_LAST_WIDTH = 'treeViewLastWidth';
 export const SHOW_TREE_VIEW = 'showTreeView';

--- a/src/views/virtualmachines/tree/utils/utils.tsx
+++ b/src/views/virtualmachines/tree/utils/utils.tsx
@@ -8,6 +8,7 @@ import {
 } from '@kubevirt-utils/components/GuidedTour/utils/constants';
 import { ALL_NAMESPACES_SESSION_KEY, ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
 import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
+import { isSystemNamespace } from '@kubevirt-utils/resources/namespace/helper';
 import { getLabel, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { universalComparator } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -35,8 +36,6 @@ import {
   CLUSTER_SELECTOR_PREFIX,
   FOLDER_SELECTOR_PREFIX,
   PROJECT_SELECTOR_PREFIX,
-  SYSTEM_NAMESPACES,
-  SYSTEM_NAMESPACES_PREFIX,
   VM_FOLDER_LABEL,
 } from './constants';
 
@@ -401,13 +400,6 @@ export const filterNamespaceItems = (
         .length > 0
     );
   }
-};
-
-export const isSystemNamespace = (projectName: string) => {
-  const startsWithNamespace = SYSTEM_NAMESPACES_PREFIX.some((ns) => projectName.startsWith(ns));
-  const isNamespace = SYSTEM_NAMESPACES.includes(projectName);
-
-  return startsWithNamespace || isNamespace;
 };
 
 export const getAllTreeViewItems = (treeData: TreeViewDataItem[]) => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

We discussed with yifat matan and ronen and ended up deciding that do not make sense in the ssh modal to show all the projects. Lets show only the user namespaces


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project lists can be requested with an option to exclude system namespaces so views that opt in show only user namespaces.
  * Default project selection now prefers user namespaces when available.

* **Refactor**
  * Namespace-identification logic consolidated into a shared utility and internal usages updated for consistency across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->