### PR TITLE
CNV-71356: Fixing the virtual machine status summery to display vm's status by current namespace

### DIFF
--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -46,7 +46,6 @@ import {
   paginationInitialState,
 } from '@kubevirt-utils/hooks/usePagination/utils/constants';
 import useQuery from '@kubevirt-utils/hooks/useQuery';
-import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   DocumentTitle,
@@ -74,6 +73,7 @@ import useFiltersFromURL from './hooks/useFiltersFromURL';
 import useVirtualMachineColumns from './hooks/useVirtualMachineColumns';
 import { useVMListFilters } from './hooks/useVMListFilters/useVMListFilters';
 import useVMMetrics from './hooks/useVMMetrics';
+import { filterVMsByNamespace } from './utils/utils';
 import { getListPageBodySize, ListPageBodySize } from './listPageBodySize';
 
 import '@kubevirt-utils/styles/list-managment-group.scss';
@@ -237,11 +237,12 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
   const existingSelectedVMs = useExistingSelectedVMs(filteredVMs);
   const isAllVMsSelected = filteredVMs?.length === existingSelectedVMs.length;
 
-  const allVMs = vmsSignal?.value;
-
-  const hasNoVMs = isEmpty(
-    namespace ? allVMs?.filter((resource) => getNamespace(resource) === namespace) : allVMs,
+  const allVMs = useMemo(
+    () => filterVMsByNamespace(vmsSignal.value, namespace),
+    [vmsSignal.value, namespace],
   );
+
+  const hasNoVMs = isEmpty(allVMs);
 
   return (
     /* All of this table and components should be replaced to our own fitted components */

--- a/src/views/virtualmachines/list/utils/utils.ts
+++ b/src/views/virtualmachines/list/utils/utils.ts
@@ -1,0 +1,11 @@
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+
+export const filterVMsByNamespace = (vms: V1VirtualMachine[], namespace: string) =>
+  vms.filter((vm) => {
+    const vmNamespace = getNamespace(vm);
+
+    if (namespace && namespace !== vmNamespace) return false;
+
+    return true;
+  });


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

in the virtual machine status summery all vm's status was displayed regardless of the current namespace, adding a utility to filter status by namespace.

## 🎥 Demo
Before:
<img width="1763" height="651" alt="image" src="https://github.com/user-attachments/assets/0c44eb87-b6dc-4d3e-90f9-b9d7c3329069" />

After:
<img width="1699" height="617" alt="image" src="https://github.com/user-attachments/assets/27aa90c3-b253-4f8f-96aa-9adc665636bd" />
