### PR TITLE
CNV-72265: stop proxy pod websocket on null input

### DIFF
--- a/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPod.ts
+++ b/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPod.ts
@@ -54,7 +54,7 @@ const useKubevirtDataPod: UseKubevirtDataPod = <T extends K8sResourceCommon | K8
       },
       share: true,
     },
-    shouldConnect && Boolean(resourceVersion),
+    shouldConnect && Boolean(resourceVersion) && !isEmpty(watchOptionsMemoized.groupVersionKind),
   );
   useEffect(() => {
     const fetch = async () => {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When the websocket has already started, and then we switch and do not use the hook anymore by giving empty input, the websocket continues to work and we have to stop it 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection initialization by adding validation to ensure proper configuration state before establishing connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->