### PR TITLE
CNV-72270: remove resource limit in the resource fetch for multicluster

### DIFF
--- a/src/multicluster/hooks/useK8sWatchData.ts
+++ b/src/multicluster/hooks/useK8sWatchData.ts
@@ -11,10 +11,13 @@ import {
 const useK8sWatchData = <T>(resource: FleetWatchK8sResource | null): WatchK8sResult<T> => {
   const [hubClusterName] = useHubClusterName();
 
+  // multicluster sdk doesn't support limit as console sdk does
+  const requestWithNoLimit = resource ? { ...resource, limit: undefined } : null;
+
   const useFleet = resource?.cluster && resource?.cluster !== hubClusterName;
 
   const [fleetData, fleetLoaded, fleetError] = useFleetK8sWatchResource<T>(
-    useFleet ? resource : null,
+    useFleet ? requestWithNoLimit : null,
   );
 
   const [k8sWatchData, k8sWatchLoaded, k8sWatchError] = useK8sWatchResource<T>(

--- a/src/multicluster/hooks/useKubevirtSearchPoll.ts
+++ b/src/multicluster/hooks/useKubevirtSearchPoll.ts
@@ -1,0 +1,18 @@
+import { WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  AdvancedSearchFilter,
+  SearchResult,
+  useFleetSearchPoll,
+} from '@stolostron/multicluster-sdk';
+
+const useKubevirtSearchPoll = <T extends K8sResourceCommon | K8sResourceCommon[]>(
+  watchOptions: WatchK8sResource,
+  advancedSearchFilters?: AdvancedSearchFilter,
+  pollInterval?: false | number,
+): [SearchResult<T>, boolean, Error, () => void] => {
+  const requestWithNoLimit = watchOptions ? { ...watchOptions, limit: undefined } : {};
+
+  return useFleetSearchPoll<T>(requestWithNoLimit, advancedSearchFilters, pollInterval);
+};
+
+export default useKubevirtSearchPoll;

--- a/src/multicluster/hooks/useMulticlusterNamespaces.ts
+++ b/src/multicluster/hooks/useMulticlusterNamespaces.ts
@@ -3,7 +3,8 @@ import { useMemo } from 'react';
 import { modelToGroupVersionKind, NamespaceModel } from '@kubevirt-utils/models';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useIsACMPage from '@multicluster/useIsACMPage';
-import { useFleetSearchPoll } from '@stolostron/multicluster-sdk';
+
+import useKubevirtSearchPoll from './useKubevirtSearchPoll';
 
 export type UseMulticlusterNamespacesReturn = {
   allNamespaces: K8sResourceCommon[];
@@ -17,7 +18,9 @@ const useMulticlusterNamespaces = (
 ): UseMulticlusterNamespacesReturn => {
   const isACMTreeView = useIsACMPage();
 
-  const [namespaces, namespacesLoaded, namespacesError] = useFleetSearchPoll<K8sResourceCommon[]>(
+  const [namespaces, namespacesLoaded, namespacesError] = useKubevirtSearchPoll<
+    K8sResourceCommon[]
+  >(
     isACMTreeView
       ? {
           groupVersionKind: modelToGroupVersionKind(NamespaceModel),

--- a/src/utils/hooks/useKubevirtWatchResource/useRedirectWatchHooks.ts
+++ b/src/utils/hooks/useKubevirtWatchResource/useRedirectWatchHooks.ts
@@ -2,9 +2,10 @@ import { useMemo } from 'react';
 
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import useKubevirtSearchPoll from '@multicluster/hooks/useKubevirtSearchPoll';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
-import { AdvancedSearchFilter, useFleetSearchPoll } from '@stolostron/multicluster-sdk';
+import { AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
 
 import useKubevirtDataPod from '../useKubevirtDataPod/useKubevirtDataPod';
 
@@ -23,7 +24,7 @@ const useRedirectWatchHooks = <T extends K8sResourceCommon | K8sResourceCommon[]
   const usePod = shouldUseProxyPod && !isACMTreeView;
 
   const k8sWatch = useK8sWatchData<T>(!usePod && !useMulticlusterSearch ? watchOptions : null);
-  const [multiSearchData, multiSearchLoaded, multiSearchError] = useFleetSearchPoll<T>(
+  const [multiSearchData, multiSearchLoaded, multiSearchError] = useKubevirtSearchPoll<T>(
     !usePod && useMulticlusterSearch && watchOptions,
     searchQueries,
   );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

multicluster sdk and search api have a different concept of LIMIT in the request. 

For console sdk `useK8sWatchResource` hook, the limit is PER REQUEST. This means that if we have more than 10k vms we'll continue to fetch the other 10 001 vms using the `continue` token in the first response.

Multicluster sdk and search api do not have this mechanism so the user will just see 10k vms in their acm view even tho can be more vms 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved fleet cluster data queries by removing limit restrictions to ensure complete data retrieval.
  * Introduced optimized search polling mechanism for enhanced data fetching efficiency.
  * Updated internal hooks to use consolidated search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->