### PR TITLE
CNV-72264: hide "Clear all filters" button in VirtualMachines toolbar

### DIFF
--- a/src/utils/components/ListPageFilter/hooks/useAdvancedFiltersParameters.ts
+++ b/src/utils/components/ListPageFilter/hooks/useAdvancedFiltersParameters.ts
@@ -14,12 +14,10 @@ export const useAdvancedFiltersParameters = (advancedFilters: RowFilter[]) => {
       (acc, { filterGroupName, type }) => {
         const query = queryParams.get(getRowFilterQueryKey(type));
 
-        if (query) {
-          acc[type] = {
-            filterGroupName,
-            query,
-          };
-        }
+        acc[type] = {
+          filterGroupName,
+          query,
+        };
 
         return acc;
       },

--- a/src/utils/components/ListPageFilter/hooks/useNameAndLabelParameters.ts
+++ b/src/utils/components/ListPageFilter/hooks/useNameAndLabelParameters.ts
@@ -15,19 +15,15 @@ export const useNameAndLabelParameters = () => {
     const nameQuery = queryParams.get(VirtualMachineRowFilterType.Name);
     const labelsQuery = queryParams.get(VirtualMachineRowFilterType.Labels);
 
-    if (nameQuery) {
-      filters[VirtualMachineRowFilterType.Name] = {
-        filterGroupName: STATIC_SEARCH_FILTERS_LABELS.name,
-        query: nameQuery,
-      };
-    }
+    filters[VirtualMachineRowFilterType.Name] = {
+      filterGroupName: STATIC_SEARCH_FILTERS_LABELS.name,
+      query: nameQuery,
+    };
 
-    if (labelsQuery) {
-      filters[VirtualMachineRowFilterType.Labels] = {
-        filterGroupName: STATIC_SEARCH_FILTERS_LABELS.labels,
-        query: labelsQuery,
-      };
-    }
+    filters[VirtualMachineRowFilterType.Labels] = {
+      filterGroupName: STATIC_SEARCH_FILTERS_LABELS.labels,
+      query: labelsQuery,
+    };
 
     return filters;
   }, [queryParams]);

--- a/src/utils/components/ListPageFilter/types.ts
+++ b/src/utils/components/ListPageFilter/types.ts
@@ -20,5 +20,5 @@ export type ExposedFilterFunctions = {
 
 export type FilterInfo = {
   filterGroupName: string;
-  query: string;
+  query: null | string;
 };

--- a/src/utils/components/ListPageFilter/utils.ts
+++ b/src/utils/components/ListPageFilter/utils.ts
@@ -169,7 +169,10 @@ export const getSearchTextPlaceholder = (
   );
 };
 
-export const getFilterLabels = (query?: string, filterType?: VirtualMachineRowFilterType) => {
+export const getFilterLabels = (
+  query?: null | string,
+  filterType?: VirtualMachineRowFilterType,
+) => {
   if (!query) {
     return [];
   }

--- a/src/views/virtualmachines/list/VirtualMachinesList.scss
+++ b/src/views/virtualmachines/list/VirtualMachinesList.scss
@@ -23,10 +23,6 @@
     flex-wrap: nowrap;
     column-gap: var(--pf-t--global--spacer--md);
 
-    .pf-v6-c-toolbar__content-section {
-      flex-wrap: nowrap;
-    }
-
     &__toolbar {
       z-index: 0;
       flex-wrap: nowrap;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

**Incorrect behavior:**
"Clear all filters" button in VirtualMachines search results toolbar was not hiding for filter parameters from Advanced search that didn't have particular Select in the results page (e.g. Name, Description, Date created)

**Root cause:**
The issue was that the particular `ToolbarFilter` was created dynamically for each filter param based on query params. If we removed the query param, we unmounted the `ToolbarFilter`.

Inside `ToolbarFilter` PatternFly component, on each update a `this.context.updateNumberFilters` is called. Because we unmounted the `ToolbarFilter`, this call didn't happen and `numberOfFilters` from ToolbarContext was counted incorrectly.

**Fix:**
`ToolbarFilter` now exists for each Advanced search parameter statically.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/809ae4dd-3b6f-4bcc-8b68-7189a588684f


After:

https://github.com/user-attachments/assets/b9a21417-a08e-4184-9577-bf45abdd6aa7




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Filters are now always populated (may contain empty/null values) for consistent availability and simpler behavior.
  * Filter label handling updated to accept empty/null queries while preserving existing label formatting and splitting logic.

* **Style**
  * Toolbar content now allows wrapping for improved layout flexibility on narrower screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->