### PR TITLE
CNV-71596: fix showing empty Node icon in VM table row

### DIFF
--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
@@ -7,7 +7,8 @@ import {
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, NodeModel } from '@kubevirt-utils/models';
-import { getVMIIPAddressesWithName } from '@kubevirt-utils/resources/vmi';
+import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
+import { getVMIIPAddressesWithName, getVMINodeName } from '@kubevirt-utils/resources/vmi';
 import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { RowProps } from '@openshift-console/dynamic-plugin-sdk';
@@ -31,18 +32,21 @@ const VirtualMachineRunningRow: FC<
   const { t } = useKubevirtTranslation();
 
   const ipAddresses = getVMIIPAddressesWithName(vmi);
+  const nodeName = getVMINodeName(vmi);
 
   return (
     <VirtualMachineRowLayout
       rowData={{
         ips: <FirstItemListPopover headerContent={t('IP addresses')} items={ipAddresses} />,
-        node: (
+        node: nodeName ? (
           <MulticlusterResourceLink
             cluster={getCluster(obj)}
             groupVersionKind={modelToGroupVersionKind(NodeModel)}
-            name={vmi?.status?.nodeName}
+            name={nodeName}
             truncate
           />
+        ) : (
+          NO_DATA_DASH
         ),
         pvcMapper,
         status,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- use no data dash instead of empty Node icon in VirtualMachine table

## 🎥 Demo

Before:
<img width="1705" height="955" alt="Screenshot 2025-11-11 at 15 01 06" src="https://github.com/user-attachments/assets/8e9133fa-3ef5-423c-a02d-f2a314776d7c" />

After:
<img width="1705" height="955" alt="Screenshot 2025-11-11 at 15 01 27" src="https://github.com/user-attachments/assets/3e212c49-07c9-4b63-ab4d-0444b7e26de3" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced virtual machine row display with improved node information handling, including proper placeholders when node data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->