### PR TITLE
CNV-71976: fixing the navigation to overview tab when changing projects in top consumers

### DIFF
--- a/src/utils/hooks/usePreserveTabDisplay.ts
+++ b/src/utils/hooks/usePreserveTabDisplay.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom-v5-compat';
+
+type UsePreserveTabDisplayProps = {
+  basePath: string;
+  storageKey: string;
+};
+
+export const usePreserveTabDisplay = ({ basePath, storageKey }: UsePreserveTabDisplayProps) => {
+  const { ns: namespace } = useParams<{ ns: string }>();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const currentNsRef = useRef(namespace);
+  const currentTabRef = useRef<string>('');
+  const isInitialMount = useRef(true);
+
+  useEffect(() => {
+    const extractPathSegmentRegex = new RegExp(`${basePath}/(.+)`);
+    const match = location.pathname.match(extractPathSegmentRegex);
+    const currentTab = match?.[1] || '';
+
+    const namespaceChanged = currentNsRef.current !== namespace;
+    const prevTab = currentTabRef.current;
+
+    currentNsRef.current = namespace;
+    currentTabRef.current = currentTab;
+
+    if (currentTab) {
+      sessionStorage.setItem(storageKey, currentTab);
+    }
+
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+
+    if (!namespaceChanged || currentTab || !prevTab) return;
+
+    const storedTab = sessionStorage.getItem(storageKey);
+    if (!storedTab) return;
+
+    const newPath = namespace
+      ? `/k8s/ns/${namespace}/${basePath}/${storedTab}`
+      : `/k8s/all-namespaces/${basePath}/${storedTab}`;
+    navigate(newPath, { replace: true });
+  }, [namespace, location.pathname, basePath, storageKey, navigate]);
+};
+
+export default usePreserveTabDisplay;

--- a/src/views/clusteroverview/ClusterOverviewPage.tsx
+++ b/src/views/clusteroverview/ClusterOverviewPage.tsx
@@ -10,6 +10,7 @@ import { useSignals } from '@preact/signals-react/runtime';
 import { VIRTUALIZATION_PATHS } from '@virtualmachines/tree/utils/constants';
 
 import GuidedTour from '../../utils/components/GuidedTour/GuidedTour';
+import usePreserveTabDisplay from '../../utils/hooks/usePreserveTabDisplay';
 import WelcomeModal from '../welcome/WelcomeModal';
 
 import ClusterOverviewPageHeader from './Header/ClusterOverviewPageHeader';
@@ -25,6 +26,10 @@ const ClusterOverviewPage: FC = () => {
   useSignals();
 
   useForceProjectSelection([VIRTUALIZATION_PATHS.OVERVIEW]);
+  usePreserveTabDisplay({
+    basePath: VIRTUALIZATION_PATHS.OVERVIEW,
+    storageKey: 'lastVirtualizationOverviewTab',
+  });
 
   const overviewTabs: NavPageKubevirt[] = useMemo(() => {
     const adminPages: NavPageKubevirt[] = [


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Changing projects while on top consumers would navigate back to the overview tab. Created a hook to store the active tab and automatically restores it after changing project.

## 🎥 Demo
Before:

https://github.com/user-attachments/assets/98419b2a-4485-4be4-a212-91765264cabe

After:

https://github.com/user-attachments/assets/7f9c93e3-ea85-4868-b213-d9ac0288688c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent tab state: the cluster overview now remembers and restores the last selected tab when you navigate away and return.
  * Namespace-aware restore: the previously selected tab is preserved when switching namespaces or returning to the overview, keeping your context intact.
  * Smoother return navigation: returning to the overview restores your prior tab so you can continue work without reselecting tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->