### PR TITLE
CNV-70913: fixing column width to show all table headers

### DIFF
--- a/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
@@ -112,7 +112,7 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
         id="favorites"
         modifier="fitContent"
       />
-      <TableData activeColumnIDs={activeColumnIDs} id="name" width={20}>
+      <TableData activeColumnIDs={activeColumnIDs} id="name" width={15}>
         <Flex alignItems={{ default: 'alignItemsCenter' }} columnGap={{ default: 'columnGapXs' }}>
           <img alt="os-icon" className="bootable-volume-row-icon" src={icon} />
           <FlexItem>
@@ -133,7 +133,7 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
           {bootVolumeNamespace}
         </TableData>
       )}
-      <TableData activeColumnIDs={activeColumnIDs} id="operating-system" width={20}>
+      <TableData activeColumnIDs={activeColumnIDs} id="operating-system" width={15}>
         {getAnnotation(preference, PREFERENCE_DISPLAY_NAME_KEY, NO_DATA_DASH)}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="storage-class" width={15}>
@@ -141,10 +141,10 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
           pvcSource?.spec?.storageClassName ||
           NO_DATA_DASH}
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} id="size">
+      <TableData activeColumnIDs={activeColumnIDs} id="size" width={10}>
         {sizeData}
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} id={ANNOTATIONS.description} width={30}>
+      <TableData activeColumnIDs={activeColumnIDs} id={ANNOTATIONS.description} width={20}>
         <TableText wrapModifier={WrapModifier.truncate}>
           {getAnnotation(bootableVolume, ANNOTATIONS.description, NO_DATA_DASH)}
         </TableText>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

changing the column widths in bootable volume table to allow displaying all columns and information including headers without being cut off.

## 🎥 Demo
Before:
<img width="3103" height="927" alt="image" src="https://github.com/user-attachments/assets/86781d70-7a31-48ef-ab58-9b7490a0e06a" />
<img width="1619" height="918" alt="image" src="https://github.com/user-attachments/assets/85d8930a-d4a7-4884-ab28-b844c01388e3" />

After:
<img width="3078" height="921" alt="image" src="https://github.com/user-attachments/assets/8e8d4156-ae09-40ed-8436-6ef3892ea2af" />
<img width="1603" height="806" alt="image" src="https://github.com/user-attachments/assets/c31da19d-ba50-4355-998e-2d6e48669dea" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined table column widths in the bootable volume listing interface for improved visual layout and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->