### PR TITLE
CNV-70577: check migcontroller to enable storage migration

### DIFF
--- a/src/utils/flags/useStorageMigrationEnabled.ts
+++ b/src/utils/flags/useStorageMigrationEnabled.ts
@@ -1,8 +1,11 @@
+import { modelToGroupVersionKind } from '@kubevirt-utils/models';
 import {
   DEFAULT_MIGRATION_NAMESPACE,
   MigPlanModel,
+  MigrationControllerModel,
 } from '@kubevirt-utils/resources/migrations/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import {
   getGroupVersionKindForModel,
   SetFeatureFlag,
@@ -21,7 +24,18 @@ const useStorageMigrationEnabled = (setFeatureFlag: SetFeatureFlag) => {
     verb: 'list',
   });
 
-  setFeatureFlag(FLAG_STORAGE_MIGRATION_ENABLED, !isEmpty(model) && haveAccessToMigrationNamespace);
+  const [migController, loaded] = useK8sWatchData({
+    groupVersionKind: modelToGroupVersionKind(MigrationControllerModel),
+    isList: true,
+    namespace: DEFAULT_MIGRATION_NAMESPACE,
+  });
+
+  const migControllerInstalled = !isEmpty(migController) && loaded;
+
+  setFeatureFlag(
+    FLAG_STORAGE_MIGRATION_ENABLED,
+    !isEmpty(model) && haveAccessToMigrationNamespace && migControllerInstalled,
+  );
 };
 
 export default useStorageMigrationEnabled;

--- a/src/utils/resources/migrations/constants.ts
+++ b/src/utils/resources/migrations/constants.ts
@@ -53,6 +53,18 @@ export const MigPlanModel: K8sModel = {
   plural: 'migplans',
 };
 
+export const MigrationControllerModel: K8sModel = {
+  abbr: 'MC',
+  apiGroup: 'migration.openshift.io',
+  apiVersion: 'v1alpha1',
+  crd: true,
+  kind: 'MigrationController',
+  label: 'MigrationController',
+  labelPlural: 'MigrationControllers',
+  namespaced: true,
+  plural: 'migrationcontrollers',
+};
+
 export type MigMigration = K8sResourceCommon & {
   spec: {
     canceled?: boolean;

--- a/src/views/virtualmachines/actions/hooks/useIsMTCInstalled.ts
+++ b/src/views/virtualmachines/actions/hooks/useIsMTCInstalled.ts
@@ -1,12 +1,8 @@
-import { modelToGroupVersionKind } from '@kubevirt-utils/models';
-import { MigPlanModel } from '@kubevirt-utils/resources/migrations/constants';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { FLAG_STORAGE_MIGRATION_ENABLED } from '@kubevirt-utils/flags/consts';
+import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 
 const useIsMTCInstalled = () => {
-  const [migPlan] = useK8sModel(modelToGroupVersionKind(MigPlanModel));
-
-  return !isEmpty(migPlan);
+  return useFlag(FLAG_STORAGE_MIGRATION_ENABLED);
 };
 
 export default useIsMTCInstalled;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

make sure to check the migcontroller is created to enable the storage migration.
We'll backport this 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Storage migration feature is now available and requires MigrationController installation to be active.

* **Refactor**
  * Improved feature detection logic for storage migration capabilities, now relying on a centralized feature flag that validates required controller installation rather than indirect checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->