### PR TITLE
CNV-71576: Disable the option to create vm from snapshot when failed and displaying correct status

### DIFF
--- a/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotActionsMenu.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotActionsMenu.tsx
@@ -16,11 +16,16 @@ import { ButtonVariant, Dropdown, DropdownItem, DropdownList } from '@patternfly
 import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
 
 type SnapshotActionsMenuProps = {
+  isCloneDisabled: boolean;
   isRestoreDisabled: boolean;
   snapshot: V1beta1VirtualMachineSnapshot;
 };
 
-const SnapshotActionsMenu: FC<SnapshotActionsMenuProps> = ({ isRestoreDisabled, snapshot }) => {
+const SnapshotActionsMenu: FC<SnapshotActionsMenuProps> = ({
+  isCloneDisabled,
+  isRestoreDisabled,
+  snapshot,
+}) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -90,7 +95,7 @@ const SnapshotActionsMenu: FC<SnapshotActionsMenuProps> = ({ isRestoreDisabled, 
       <DropdownList>
         <DropdownItem
           description={t('Create a copy of the VirtualMachine from snapshot')}
-          isDisabled={!canClone}
+          isDisabled={!canClone || isCloneDisabled}
           key="snapshot-clone"
           onClick={onClone}
         >

--- a/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotRow.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotRow.tsx
@@ -24,7 +24,8 @@ const SnapshotRow: React.FC<
 > = ({ activeColumnIDs, obj: snapshot, rowData: { isVMRunning, restores } }) => {
   const relevantRestore: V1beta1VirtualMachineRestore = restores?.[snapshot?.metadata?.name];
   const isRestoreDisabled = isVMRunning || snapshot?.status?.phase !== snapshotStatuses.Succeeded;
-  const readyCondition = snapshot?.status?.conditions?.find(({ type }) => type === 'Ready');
+  const isCloneDisabled = !snapshot?.status?.readyToUse;
+  const displayPhase = snapshot?.status?.phase;
   return (
     <>
       <TableData activeColumnIDs={activeColumnIDs} id="name">
@@ -39,7 +40,7 @@ const SnapshotRow: React.FC<
         <Timestamp timestamp={snapshot?.metadata?.creationTimestamp} />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="status">
-        <SnapshotStatusIcon phase={readyCondition?.reason || readyCondition?.status} />
+        <SnapshotStatusIcon phase={displayPhase} />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="last-restored">
         <Timestamp timestamp={relevantRestore?.status?.restoreTime} />
@@ -48,7 +49,11 @@ const SnapshotRow: React.FC<
         <IndicationLabelList snapshot={snapshot} />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="pf-v6-c-table__action" id="">
-        <SnapshotActionsMenu isRestoreDisabled={isRestoreDisabled} snapshot={snapshot} />
+        <SnapshotActionsMenu
+          isCloneDisabled={isCloneDisabled}
+          isRestoreDisabled={isRestoreDisabled}
+          snapshot={snapshot}
+        />
       </TableData>
     </>
   );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
when snapshoting a vm failed it would show wrong status (not ready) and still allow trying to create vm. This fix updates the correct status for the snapshot creation and disables create vm option from action menu while snapshot status isn't ready to use.

## 🎥 Demo
Before:
<img width="2809" height="653" alt="image" src="https://github.com/user-attachments/assets/62820cc3-c998-4e31-9f4c-02acdd3ff7cf" />

After:
<img width="2847" height="700" alt="image" src="https://github.com/user-attachments/assets/43672284-a8e3-4d31-8cdb-66ec75033f86" />

