### PR TITLE
CNV-72450: fixing vm inconsistency in delete and cross cluster migration actions

### DIFF
--- a/src/multicluster/hooks/useACMExtensionActions/useACMExtensionActions.ts
+++ b/src/multicluster/hooks/useACMExtensionActions/useACMExtensionActions.ts
@@ -11,6 +11,7 @@ import { getCluster } from '@multicluster/helpers/selectors';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { useResolvedExtensions } from '@openshift-console/dynamic-plugin-sdk';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
+import { isRunning } from '@virtualmachines/utils';
 
 import { ACMVirtualMachineActionExtension } from './constants';
 import {
@@ -40,6 +41,10 @@ const useACMExtensionActions = (vm): ActionDropdownItemType[] => {
         crossClusterMigration.properties.description = t(
           'Cross-cluster migration is not supported on this cluster.',
         );
+      }
+      if (!isRunning(vm)) {
+        crossClusterMigration.properties.isDisabled = true;
+        crossClusterMigration.properties.description = t('The VirtualMachine is not running');
       }
     });
 

--- a/src/views/virtualmachines/actions/BulkVirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/BulkVirtualMachineActionFactory.tsx
@@ -37,6 +37,7 @@ export const BulkVirtualMachineActionFactory = {
   delete: (
     vms: V1VirtualMachine[],
     createModal: (modal: ModalComponent) => void,
+    isDisabled: boolean,
   ): ActionDropdownItemType => ({
     cta: () =>
       createModal(({ isOpen, onClose }) => (
@@ -48,7 +49,7 @@ export const BulkVirtualMachineActionFactory = {
           vms={vms}
         />
       )),
-    disabled: isEmpty(vms),
+    disabled: isEmpty(vms) || isDisabled,
     id: ACTIONS_ID.DELETE,
     label: t('Delete'),
   }),

--- a/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.tsx
+++ b/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.tsx
@@ -10,6 +10,7 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useProviderByClusterName from '@multicluster/components/CrossClusterMigration/hooks/useProviderByClusterName';
 import { FEATURE_KUBEVIRT_CROSS_CLUSTER_MIGRATION } from '@multicluster/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
+import { isDeletionProtectionEnabled } from '@virtualmachines/details/tabs/configuration/details/components/DeletionProtection/utils/utils';
 import { isPaused, isRunning, isStopped } from '@virtualmachines/utils';
 
 import { BulkVirtualMachineActionFactory } from '../BulkVirtualMachineActionFactory';
@@ -55,6 +56,10 @@ const useMultipleVirtualMachineActions: UseMultipleVirtualMachineActions = (vms)
       migrationActions.push(BulkVirtualMachineActionFactory.migrateStorage(vms, createModal));
     }
 
+    const hasRunningVM = vms?.some(isRunning);
+    const hasProtectedVM = vms?.some(isDeletionProtectionEnabled);
+    const isDeleteDisabled = hasRunningVM || hasProtectedVM;
+
     const actions: ActionDropdownItemType[] = [
       BulkVirtualMachineActionFactory.start(vms),
       BulkVirtualMachineActionFactory.stop(vms, createModal, confirmVMActionsEnabled),
@@ -68,7 +73,7 @@ const useMultipleVirtualMachineActions: UseMultipleVirtualMachineActions = (vms)
         ? [BulkVirtualMachineActionFactory.moveToFolder(vms, createModal)]
         : []),
       BulkVirtualMachineActionFactory.editLabels(vms, createModal),
-      BulkVirtualMachineActionFactory.delete(vms, createModal),
+      BulkVirtualMachineActionFactory.delete(vms, createModal, isDeleteDisabled),
     ];
 
     if (vms.every(isStopped)) {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

disabling the delete option for the bulk action menu in the virtual machine list when at least one running vm is selected. disabling the cross cluster migration option from action menu when vm isn't running

## 🎥 Demo
Before:
<img width="2467" height="782" alt="image" src="https://github.com/user-attachments/assets/37cc8eb1-7813-40d9-8355-0c39b7844f85" />

After:
<img width="2466" height="836" alt="image" src="https://github.com/user-attachments/assets/85f1646d-36d0-455f-999a-9a290ceb7de5" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cross-cluster Migration action is now disabled when a VirtualMachine is not running.
  * VM deletion is now restricted when the VirtualMachine is running or has deletion protection enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->