### PR TITLE
CNV-71548: Fix manual node selection during migration

### DIFF
--- a/src/utils/resources/node/utils/utils.ts
+++ b/src/utils/resources/node/utils/utils.ts
@@ -12,3 +12,7 @@ export const isNodeReady = (node: IoK8sApiCoreV1Node): boolean => {
 };
 
 export const nodeStatus = (node: IoK8sApiCoreV1Node) => (isNodeReady(node) ? 'Ready' : 'Not Ready');
+
+export const isNodeSchedulable = (node: IoK8sApiCoreV1Node): boolean => {
+  return !node?.spec?.unschedulable;
+};

--- a/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesData.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesData.ts
@@ -1,7 +1,7 @@
 import { modelToGroupVersionKind, NodeModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { nodeStatus } from '@kubevirt-utils/resources/node/utils/utils';
+import { isNodeSchedulable, nodeStatus } from '@kubevirt-utils/resources/node/utils/utils';
 import { getName } from '@kubevirt-utils/resources/shared';
 import useNode from '@kubevirt-utils/resources/vm/hooks/useNode';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
@@ -25,7 +25,9 @@ const useNodesData: UseNodesData = (vm) => {
   const { metricsData, metricsLoaded } = useNodesMetrics();
   const vmiNodeName = useNode(vm);
 
-  const filteredNodes = nodes?.filter((node) => getName(node) !== vmiNodeName);
+  const filteredNodes = nodes?.filter(
+    (node) => getName(node) !== vmiNodeName && isNodeSchedulable(node),
+  );
 
   const nodesData = (filteredNodes || [])?.reduce((acc, node) => {
     const nodeName = getName(node);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

the manual node selector when migrating a vm was ignored, I passed selected node to migrateVM function in compute migration to fix the issue and filtered out Scheduling Disabled nodes. 

## 🎥 Demo


https://github.com/user-attachments/assets/48205105-9b54-48dc-9fa5-b83c7c29bb6c




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added manual target node selection for virtual machine migration; only schedulable nodes are available
  * Migration errors now display in the modal
  * Added loading feedback during migration operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->