### PR TITLE
CNV-70979: Add support for @kubevirt-ui scope from GitHub Packages

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -11,17 +11,23 @@ on:
 jobs:
   i18n:
     name: i18n
+    permissions:
+      packages: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'yarn'
+          registry-url: 'https://npm.pkg.github.com'
+
       - run: yarn install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check i18n
         shell: bash
@@ -39,14 +45,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'yarn'
+          registry-url: 'https://npm.pkg.github.com'
+
       - run: yarn install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
         run: yarn lint:fix
@@ -62,14 +72,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'yarn'
+          registry-url: 'https://npm.pkg.github.com'
+
       - run: yarn install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Unit Tests
         run: yarn test-cov


### PR DESCRIPTION
## 📝 Description

Usage in the CI:
1. GITHUB_TOKEN with permissions reduced to packages:read
2. create .npmrc file with actions/setup-node
3. inject the token as NODE_AUTH_TOKEN env var

Local development:
The packages under @kubevirt-ui will be public but GitHub Packages requires authentication with personal access token to install. The minimum required scope is packages:read.
One way to access the token is to use env var and amend the global .npmrc with the following 2 lines:
```
@kubevirt-ui:registry=https://npm.pkg.github.com
//npm.pkg.github.com/:_authToken=${GITHUB_READ_PACKAGES_TOKEN}
```
Updates:
1. the Node version from v18 to v22 (the currently active LTS version)
2. actions/setup-node from v4 to v6
3. unify actions/checkout to v5

Reference-Url: https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#about-scopes-and-permissions-for-package-registries

## 🎥 Demo

The change has been tested with release v0.0.1 of vnc-keymap project:
1. check the [vnc-keymaps](https://github.com/kubevirt-ui/vnc-keymaps) project page
<img width="580" height="421" alt="image" src="https://github.com/user-attachments/assets/d26bd888-f6a4-432e-9cee-ec459bf2a4b5" />
2.  check the [kubevirt-ui](https://github.com/orgs/kubevirt-ui/packages) organization on GH
<img width="1566" height="583" alt="image" src="https://github.com/user-attachments/assets/e2964ca6-51bd-45b7-abd2-9cee96b357bb" />
3. check PR #2486  that imports the released package

