### PR TITLE
CNV-72740: Add a safe-guard for URL.canParse

### DIFF
--- a/src/utils/resources/template/utils/helpers.ts
+++ b/src/utils/resources/template/utils/helpers.ts
@@ -77,6 +77,18 @@ export const bootDiskSourceIsRegistry = (template: V1Template) => {
   return vmBootDiskSourceIsRegistry(vmObject);
 };
 
+const canParseUrl = (url: string): boolean => {
+  if (URL?.canParse) {
+    return URL.canParse(url);
+  }
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 export const isValidTemplateIconUrl = (url: string): boolean => {
   if (!url) return false;
 
@@ -85,8 +97,8 @@ export const isValidTemplateIconUrl = (url: string): boolean => {
     return true;
   }
 
-  // For absolute URLs, validate using URL.canParse and check protocol
-  if (URL.canParse(url)) {
+  // For absolute URLs, validate using canParseUrl helper and check protocol
+  if (canParseUrl(url)) {
     try {
       const parsedUrl = new URL(url);
       // Only allow http, https protocols (block javascript:, data:, vbscript:, etc.)


### PR DESCRIPTION
## 📝 Description

Fixing an issue where `URL.canParse`is not defined - added a fallback to address it. 

Original Jira ticket: [CNV-72740](https://issues.redhat.com/browse/CNV-72740)

## 🎥 Demo

Issue: 
[parse_error_ui.webm](https://github.com/user-attachments/assets/d3055a7f-7027-467b-bde6-19889fbe2839)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved URL validation reliability with enhanced fallback handling for better compatibility across different environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->