### PR TITLE
CNV-72546: Reloading the VM catalog leads to an error

### DIFF
--- a/src/views/catalog/Catalog.tsx
+++ b/src/views/catalog/Catalog.tsx
@@ -4,7 +4,6 @@ import { Route, Routes } from 'react-router-dom-v5-compat';
 import ClusterProjectDropdown from '@kubevirt-utils/components/ClusterProjectDropdown/ClusterProjectDropdown';
 import { PageTitles } from '@kubevirt-utils/constants/page-constants';
 import { DocumentTitle } from '@openshift-console/dynamic-plugin-sdk';
-import { useSignals } from '@preact/signals-react/runtime';
 
 import CreateVMHorizontalNav from './CreateVMHorizontalNav/CreateVMHorizontalNav';
 import CustomizeInstanceTypeVirtualMachine from './CustomizeInstanceType/CustomizeInstanceTypeVirtualMachine';
@@ -12,8 +11,6 @@ import { WizardVMContextProvider } from './utils/WizardVMContext';
 import Wizard from './wizard/Wizard';
 
 const Catalog: FC = () => {
-  useSignals();
-
   return (
     <WizardVMContextProvider>
       <DocumentTitle>{PageTitles.Catalog}</DocumentTitle>

--- a/src/views/catalog/CustomizeInstanceType/CustomizeInstanceTypeVirtualMachine.tsx
+++ b/src/views/catalog/CustomizeInstanceType/CustomizeInstanceTypeVirtualMachine.tsx
@@ -4,12 +4,14 @@ import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/u
 import HorizontalNavbar from '@kubevirt-utils/components/HorizontalNavbar/HorizontalNavbar';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Stack, StackItem } from '@patternfly/react-core';
+import { useSignals } from '@preact/signals-react/runtime';
 
 import CustomizeITVMFooter from './components/CustomizeITVMFooter';
 import CustomizeITVMHeader from './components/CustomizeITVMHeader';
 import { getPages } from './utils/constants';
 
 const CustomizeInstanceTypeVirtualMachine: FC = () => {
+  useSignals();
   const { t } = useKubevirtTranslation();
   const { vm } = useInstanceTypeVMStore();
   const pages = useMemo(() => getPages(t), [t]);


### PR DESCRIPTION
## 📝 Description

Fixes an out of order effect error - caused by parent component calling `useSignals()` before the child component initialize. 

Solution: move `useSignals()` into the child component that depends on the signals. 

Jira ticket: [CNV-72546](https://issues.redhat.com/browse/CNV-72546)

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/43ca71bf-1a63-42b6-9901-03092cdb96cc


After:


https://github.com/user-attachments/assets/2ea0b08c-3e27-4a52-becd-e8e96350f3a9





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal component state management architecture to improve code organization while preserving all existing functionality and user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->