### PR TITLE
CNV-72538: Limit preview features to admins

### DIFF
--- a/src/views/clusteroverview/ClusterOverviewPage.tsx
+++ b/src/views/clusteroverview/ClusterOverviewPage.tsx
@@ -75,6 +75,12 @@ const ClusterOverviewPage: FC = () => {
         isHidden: true,
         name: 'settings/features',
       },
+      {
+        component: SettingsTab,
+        href: 'settings/*',
+        isHidden: true,
+        name: 'settings/*',
+      },
     ];
   }, [isAdmin, t]);
 

--- a/src/views/clusteroverview/SettingsTab/tabs.ts
+++ b/src/views/clusteroverview/SettingsTab/tabs.ts
@@ -1,3 +1,4 @@
+import { FC } from 'react';
 import { TFunction } from 'react-i18next';
 
 import ClusterTab from './ClusterTab/ClusterTab';
@@ -14,26 +15,33 @@ export type SettingsTab = typeof SETTINGS_TABS[keyof typeof SETTINGS_TABS];
 
 export const SETTINGS_TABS_ARRAY: SettingsTab[] = Object.values(SETTINGS_TABS);
 
-export const getTabs = (isAdmin: boolean, t: TFunction) => [
-  ...(isAdmin
-    ? [
-        {
-          Component: ClusterTab,
-          dataTest: 'cluster-settings',
-          name: SETTINGS_TABS.CLUSTER,
-          title: t('Cluster'),
-        },
-      ]
-    : []),
+export type SettingsTabConfig = {
+  Component: FC;
+  dataTest: string;
+  isEnabled: boolean;
+  name: SettingsTab;
+  title: string;
+};
+
+export const getTabs = (isAdmin: boolean, t: TFunction): SettingsTabConfig[] => [
+  {
+    Component: ClusterTab,
+    dataTest: 'cluster-settings',
+    isEnabled: isAdmin,
+    name: SETTINGS_TABS.CLUSTER,
+    title: t('Cluster'),
+  },
   {
     Component: UserTab,
     dataTest: 'user-settings',
+    isEnabled: true,
     name: SETTINGS_TABS.USER,
     title: t('User'),
   },
   {
     Component: PreviewFeaturesTab,
     dataTest: 'preview-features',
+    isEnabled: isAdmin,
     name: SETTINGS_TABS.FEATURES,
     title: t('Preview features'),
   },


### PR DESCRIPTION
## 📝 Description

Only admins should be able to access the preview features tab in settings.

In addition, refactored `useSettingsTab.ts` in order to properly show the correct URL after navigating to the settings tab and also handle navigating to a tab that doesn't exist. 

Jira Ticket:  [CNV-72538](https://issues.redhat.com/browse/CNV-72538)

## 🎥 Demo

Original issue: 

Before: 

https://github.com/user-attachments/assets/1f5b50ae-c13e-4d1f-8ffd-47505506c893


After:


https://github.com/user-attachments/assets/1afe66fd-0a2d-42f0-be49-d58aae652edd

refactoring `useSettingsTab.ts`:

Before:

https://github.com/user-attachments/assets/3955178b-9da6-4641-8ec7-7f4a50044c8f


After:

https://github.com/user-attachments/assets/63dd9527-4f7f-4aac-beb8-c7c48cd7ddd5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabs now carry explicit enable/disable settings so only enabled tabs are shown.
  * Added a hidden settings navigation entry to support deep linking into settings.

* **Bug Fixes**
  * Preview features tab is now visible only to admin users.

* **Behavior Changes**
  * Active-tab resolution and redirects simplified: URL-derived tab is preferred; missing/invalid or base /settings paths redirect to the first enabled tab.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->