### PR TITLE
CNV-72903: show "Cancel compute migration" action when migrating VM

### DIFF
--- a/src/views/virtualmachines/utils/mappers.ts
+++ b/src/views/virtualmachines/utils/mappers.ts
@@ -31,7 +31,7 @@ export const getVMIMFromMapper = (
   name: string,
   namespace: string,
   cluster?: string,
-) => VMIMMapper?.mapper?.[cluster || SINGLE_CLUSTER_KEY]?.[namespace]?.[name];
+) => VMIMMapper?.[cluster || SINGLE_CLUSTER_KEY]?.[namespace]?.[name];
 
 export type PVCMapper = {
   [cluster in string]: {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- `VMIMMapper` object had an incorrect prop access
- fixes showing "Cancel compute migration" action in list and tree view when migrating VM


## 🎥 Demo

Before:


https://github.com/user-attachments/assets/d3885dc0-384b-4297-ae8e-8730361dfc4c



After:


https://github.com/user-attachments/assets/d23d2481-f3dc-48e5-8636-53da45063d11




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected virtual machine instance migration data retrieval to ensure accurate access and handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->