### PR TITLE
CNV-72446: use single VM actions for bulk if only 1 VM is selected

### DIFF
--- a/src/utils/resources/shared.ts
+++ b/src/utils/resources/shared.ts
@@ -501,3 +501,19 @@ export const getCreationTimestamp = (entity: K8sResourceCommon): string =>
 export const getLongestNameLength = (resources: K8sResourceCommon[]): number => {
   return Math.max(...(resources || []).map((resource) => getName(resource)?.length ?? 0));
 };
+
+export const haveSameNamespace = (resources: K8sResourceCommon[]) =>
+  haveSamePropValue(resources, getNamespace);
+
+export const haveSameCluster = (resources: K8sResourceCommon[]) =>
+  haveSamePropValue(resources, getCluster);
+
+export const haveSamePropValue = (
+  resources: K8sResourceCommon[],
+  getPropValue: (resource: K8sResourceCommon) => string,
+) => {
+  if (resources.length <= 1) return true;
+
+  const value = getPropValue(resources[0]);
+  return resources.every((resource) => getPropValue(resource) === value);
+};

--- a/src/views/virtualmachines/actions/BulkVirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/BulkVirtualMachineActionFactory.tsx
@@ -10,7 +10,12 @@ import MoveBulkVMToFolderModal from '@kubevirt-utils/components/MoveVMToFolderMo
 import BulkSnapshotModal from '@kubevirt-utils/components/SnapshotModal/BulkSnapshotModal';
 import SnapshotModal from '@kubevirt-utils/components/SnapshotModal/SnapshotModal';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getLabels, getNamespace } from '@kubevirt-utils/resources/shared';
+import {
+  getLabels,
+  getNamespace,
+  haveSameCluster,
+  haveSameNamespace,
+} from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import CrossClusterMigration from '@multicluster/components/CrossClusterMigration/CrossClusterMigration';
 import { CROSS_CLUSTER_MIGRATION_ACTION_ID } from '@multicluster/constants';
@@ -33,7 +38,7 @@ import {
   stopVM,
   unpauseVM,
 } from './actions';
-import { getCommonLabels, getLabelsDiffPatch, isSameCluster, isSameNamespace } from './utils';
+import { getCommonLabels, getLabelsDiffPatch } from './utils';
 
 const { Stopped } = printableVMStatus;
 
@@ -189,7 +194,7 @@ export const BulkVirtualMachineActionFactory = {
           vms={vms}
         />
       )),
-    disabled: !isSameCluster(vms) || !isSameNamespace(vms) || isEmpty(vms),
+    disabled: !haveSameCluster(vms) || !haveSameNamespace(vms) || isEmpty(vms),
     id: ACTIONS_ID.MOVE_TO_FOLDER,
     label: t('Move to folder'),
   }),

--- a/src/views/virtualmachines/actions/utils.ts
+++ b/src/views/virtualmachines/actions/utils.ts
@@ -1,10 +1,9 @@
 import { DataVolumeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { getAnnotation, getLabels, getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getAnnotation, getLabels, getName } from '@kubevirt-utils/resources/shared';
 import { getDataVolumeTemplates, getVolumes } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { getCluster } from '@multicluster/helpers/selectors';
 import { k8sDelete, Patch } from '@openshift-console/dynamic-plugin-sdk';
 import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
 
@@ -167,18 +166,4 @@ export const getLabelsDiffPatch = (
   patchArray.push(...labelsPatchDelete);
 
   return patchArray;
-};
-
-export const isSameNamespace = (vms: V1VirtualMachine[]) => {
-  if (vms.length <= 1) return true;
-
-  const namespace = getNamespace(vms?.[0]);
-  return vms.every((vm) => getNamespace(vm) === namespace);
-};
-
-export const isSameCluster = (vms: V1VirtualMachine[]) => {
-  if (vms.length <= 1) return true;
-
-  const cluster = getCluster(vms?.[0]);
-  return vms.every((vm) => getCluster(vm) === cluster);
 };

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/DefaultRightClickActionMenu.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/DefaultRightClickActionMenu.tsx
@@ -26,12 +26,14 @@ const DefaultRightClickActionMenu: FC<DefaultRightClickActionMenuProps> = ({
   const vms = getVMsTrigger(triggerElement);
   const [vmims] = useVirtualMachineInstanceMigrations(cluster, namespace);
   const vmimMapper = useVirtualMachineInstanceMigrationMapper(vmims);
-  const actions = useMultipleVirtualMachineActions(vms, vmimMapper);
+  const baseActions = useMultipleVirtualMachineActions(vms, vmimMapper);
 
   const navigate = useNavigate();
 
-  if (prefix === PROJECT_SELECTOR_PREFIX)
-    actions.unshift(getCreateVMAction(navigate, namespace, cluster));
+  const actions =
+    prefix === PROJECT_SELECTOR_PREFIX
+      ? [getCreateVMAction(navigate, namespace, cluster), ...baseActions]
+      : baseActions;
 
   const getNestedLevel = () => {
     if (prefix === FOLDER_SELECTOR_PREFIX) {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- uses actions for a single VirtualMachine (`useVirtualMachineActionsProvider`) if only 1 VM is selected for bulk actions
- refactor `isSameNamespace` to a general function to compare any prop on a list of objects

## 🎥 Demo

After:

<img width="1884" height="971" alt="Screenshot 2026-01-21 at 16 42 28" src="https://github.com/user-attachments/assets/d473cfc2-606a-4a27-ad8f-542a5a674c2d" />

