### PR TITLE
CNV-69048: Update logic for boot order modal / summary

### DIFF
--- a/src/utils/components/BootOrderModal/BootOrderModal.tsx
+++ b/src/utils/components/BootOrderModal/BootOrderModal.tsx
@@ -35,12 +35,19 @@ const BootOrderModal: FC<{
 
   const updatedVirtualMachine = produce<V1VirtualMachine>(vm, (draftVM) => {
     ensurePath(draftVM, ['spec.template.spec.domain.devices']);
+    const updatedDevices = devices.map((device, index) => ({
+      ...device,
+      value: {
+        ...device.value,
+        bootOrder: index + 1,
+      },
+    }));
 
-    draftVM.spec.template.spec.domain.devices.disks = devices
+    draftVM.spec.template.spec.domain.devices.disks = updatedDevices
       .filter((source) => source.type === DeviceType.DISK)
       .map((source) => source.value);
 
-    draftVM.spec.template.spec.domain.devices.interfaces = devices
+    draftVM.spec.template.spec.domain.devices.interfaces = updatedDevices
       .filter((source) => source.type === DeviceType.NIC)
       .map((source) => source.value);
   });

--- a/src/utils/components/BootOrderModal/BootOrderModalBody.tsx
+++ b/src/utils/components/BootOrderModal/BootOrderModalBody.tsx
@@ -45,12 +45,7 @@ export const BootOrderModalBody: React.FC<{
 
   const onDrop = (source, dest) => {
     if (dest) {
-      const newBootableDevices = reorder(devices, source.index, dest.index).map(
-        (device, index) => ({
-          ...device,
-          value: { ...device.value, bootOrder: index + 1 },
-        }),
-      );
+      const newBootableDevices = reorder(devices, source.index, dest.index);
       onChange(newBootableDevices);
 
       return true; // Signal that this is a valid drop and not to animate the item returning home.
@@ -87,56 +82,54 @@ export const BootOrderModalBody: React.FC<{
           title={t('No resource selected')}
         />
       ) : (
-        <>
-          <DragDrop onDrop={onDrop}>
-            <Droppable hasNoWrapper>
-              <DataList aria-label="draggable data list example">
-                {devices.map(({ type, value }, index) => (
-                  <Draggable hasNoWrapper key={value.name}>
-                    <DataListItem aria-labelledby={value.name} ref={React.createRef()}>
-                      <DataListItemRow>
-                        <DataListControl>
-                          <DataListDragButton
-                            aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
-                            aria-label="Reorder"
-                            aria-labelledby={value.name}
-                            aria-pressed="false"
-                          />
-                        </DataListControl>
-                        <DataListItemCells
-                          dataListCells={[
-                            <DataListCell key={value.name}>
-                              <Split>
-                                <SplitItem isFilled>
-                                  <span id={value.name}>{value.name}</span>
-                                  {type === DeviceType.NIC && <span>{t(' (NIC)')}</span>}
-                                  <span className="pf-v6-u-ml-sm">
-                                    <DeviceTypeIcon type={type as DeviceType} />
-                                  </span>
-                                </SplitItem>
-                                <SplitItem>
-                                  {index !== devices.length - 1 && (
-                                    <Button
-                                      className="kubevirt-boot-order__delete-btn"
-                                      icon={<MinusCircleIcon />}
-                                      id={`${value.name}-delete-btn`}
-                                      onClick={() => onDelete(value.name)}
-                                      variant={ButtonVariant.link}
-                                    />
-                                  )}
-                                </SplitItem>
-                              </Split>
-                            </DataListCell>,
-                          ]}
+        <DragDrop onDrop={onDrop}>
+          <Droppable hasNoWrapper>
+            <DataList aria-label="draggable data list example">
+              {devices.map(({ type, value }, index) => (
+                <Draggable hasNoWrapper key={value.name}>
+                  <DataListItem aria-labelledby={value.name} ref={React.createRef()}>
+                    <DataListItemRow>
+                      <DataListControl>
+                        <DataListDragButton
+                          aria-describedby="Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation."
+                          aria-label="Reorder"
+                          aria-labelledby={value.name}
+                          aria-pressed="false"
                         />
-                      </DataListItemRow>
-                    </DataListItem>
-                  </Draggable>
-                ))}
-              </DataList>
-            </Droppable>
-          </DragDrop>
-        </>
+                      </DataListControl>
+                      <DataListItemCells
+                        dataListCells={[
+                          <DataListCell key={value.name}>
+                            <Split>
+                              <SplitItem isFilled>
+                                <span id={value.name}>{value.name}</span>
+
+                                <span className="pf-v6-u-ml-sm">
+                                  <DeviceTypeIcon type={type as DeviceType} />
+                                </span>
+                              </SplitItem>
+                              <SplitItem>
+                                {index !== devices.length - 1 && (
+                                  <Button
+                                    className="kubevirt-boot-order__delete-btn"
+                                    icon={<MinusCircleIcon />}
+                                    id={`${value.name}-delete-btn`}
+                                    onClick={() => onDelete(value.name)}
+                                    variant={ButtonVariant.link}
+                                  />
+                                )}
+                              </SplitItem>
+                            </Split>
+                          </DataListCell>,
+                        ]}
+                      />
+                    </DataListItemRow>
+                  </DataListItem>
+                </Draggable>
+              ))}
+            </DataList>
+          </Droppable>
+        </DragDrop>
       )}
     </>
   );


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-69048](https://issues.redhat.com/browse/CNV-69048)

- ~~Boot order summary shows only the devices with explicit `bootOrder` property.~~
- Saving the changes in the boot order modal adds the `bootOrder` property to all devices. 


## 🎥 Demo

Before:


https://github.com/user-attachments/assets/b2f7c8b6-ee06-4bd7-9b81-7eda6882f58d



After:


https://github.com/user-attachments/assets/ff1a32cf-53aa-48dd-9b6e-fe5dff0b025c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined boot order assignment logic by centralizing device ordering calculations.
  * Simplified drag-and-drop reordering interface by removing redundant boot order updates during item repositioning.
  * Restructured device list rendering for improved maintainability while preserving existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->