### PR TITLE
CNV-73564: Fix expandable section

### DIFF
--- a/src/utils/components/ExpandSectionWithCustomToggle/ExpandSectionWithCustomToggle.tsx
+++ b/src/utils/components/ExpandSectionWithCustomToggle/ExpandSectionWithCustomToggle.tsx
@@ -93,6 +93,7 @@ const ExpandSectionWithCustomToggle: FC<ExpandSectionWithCustomToggleProps> = ({
           )}
         </Split>
       </StackItem>
+
       <StackItem>
         <ExpandableSection
           className={classNames(
@@ -106,7 +107,7 @@ const ExpandSectionWithCustomToggle: FC<ExpandSectionWithCustomToggleProps> = ({
           isIndented={isIndented}
           toggleId={toggleID}
         >
-          {children}
+          {isExpanded && children}
         </ExpandableSection>
       </StackItem>
     </Stack>

--- a/src/views/clusteroverview/SettingsTab/ExpandSection/ExpandSection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ExpandSection/ExpandSection.tsx
@@ -49,7 +49,7 @@ const ExpandSection: FC<ExpandSectionProps> = ({
       toggleContent={toggleContent}
       toggleText={toggleText}
     >
-      {children}
+      {isExpanded && children}
     </ExpandableSection>
   );
 };


### PR DESCRIPTION
## 📝 Description

Console 4.21 is using a more recent version of PatternFly React-Core package which is not properly supporting nested elements inside `ExpandableSection` component using a `{children}` renderer.

This bug is causing an extra space to appear instead of the element that is supposed to be hidden, as demonstrated in the before demo below. 

Until this bug is fixed on PF's side - for now we should handle it on our end. 

Jira ticket: [CNV-73564](https://issues.redhat.com/browse/CNV-73564)


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/e9261c16-54c1-431c-9e76-55a4576c228e


After:

https://github.com/user-attachments/assets/b6935b28-2956-4256-9e8e-5583efc18249




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Expandable sections now conditionally render their content based on the expanded state. Previously, content was rendered regardless of whether the section was expanded or collapsed. This ensures content only appears in the DOM when sections are in an expanded state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->