### PR TITLE
CNV-69165: Use preserveSession flag for VNC connections - part 2

### DIFF
--- a/src/utils/components/Consoles/components/utils/ConsoleConsts.ts
+++ b/src/utils/components/Consoles/components/utils/ConsoleConsts.ts
@@ -16,6 +16,8 @@ export enum ConsoleState {
 
 export const WS = 'ws';
 export const WSS = 'wss';
+export const HTTP = 'http';
+export const HTTPS = 'https';
 export const SERIAL_CONSOLE_TYPE = 'Serial console';
 export const VNC_CONSOLE_TYPE = 'VNC console';
 export const DESKTOP_VIEWER_CONSOLE_TYPE = 'Desktop viewer';

--- a/src/utils/components/Consoles/components/vnc-console/utils/util.ts
+++ b/src/utils/components/Consoles/components/vnc-console/utils/util.ts
@@ -10,8 +10,11 @@ export const HORIZONTAL_TAB = 9;
 export const LATIN_1_FIRST_CHAR = 0x20;
 export const LATIN_1_LAST_CHAR = 0xff;
 
-// TODO implement based on the error returned from the backend
-export const isSessionAlreadyInUse = (_arg) => false;
+const VNC_IN_USE_ERROR_TEXT = 'Active VNC connection. Request denied.';
+
+export const isSessionAlreadyInUse = (error: Error): boolean => {
+  return error?.message?.includes?.(VNC_IN_USE_ERROR_TEXT) ?? false;
+};
 
 export const isConnectableState = (state: ConsoleState) =>
   [


### PR DESCRIPTION
## 📝 Description

Follow up to https://github.com/kubevirt-ui/kubevirt-plugin/pull/3085

Detect VNC-in-use error state

noVNC provides no direct access the error code returned by
socket.on("close") callback. As a workaround the original callback is
replaced by a custom proxy.

The backend returns the message introduced in #15267 for HTTP requests.
For the websocket requests we receive error 1006 (abnormal disconnect).
As a workaround an additional dedicated HTTP request is triggered to
retrieve the error.

Reference-Url: https://github.com/kubevirt/kubevirt/pull/15267
Reference-Url: https://github.com/kubevirt/kubevirt/blob/46aa1b24982cd6fcfd37c950825c8d3acd3dbaf3/pkg/virt-handler/rest/console.go#L163
Reference-Url: https://github.com/novnc/noVNC/blob/d44f7e04fc456844836c7c5ac911d0f4e8dd06e6/core/rfb.js#L662
Reference-Url: https://datatracker.ietf.org/doc/html/rfc6455#section-7.4
Signed-off-by: Radoslaw Szwajkowski <rszwajko@redhat.com>

## 🎥 Demo


https://github.com/user-attachments/assets/12646308-79cd-43a6-a833-43d849517df5




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP and HTTPS constants to the public API for consistent protocol handling.

* **Bug Fixes**
  * Improved VNC console disconnect flow to detect abnormal disconnects and perform an HTTP verification before cleanup.
  * Replaced a placeholder session check with real detection logic to determine if a VNC session is already in use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->