### PR TITLE
CNV-73375: add NIC info to default disk in boot order

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1,4 +1,5 @@
 {
+  " (NIC)": " (NIC)",
   " {{sockets}} sockets, {{threads}} threads, and {{cores}} cores.": " {{sockets}} sockets, {{threads}} threads, and {{cores}} cores.",
   " Adding hot plugged disk": " Adding hot plugged disk",
   " in namespace <2>{{objNamespace}}</2>?": " in namespace <2>{{objNamespace}}</2>?",
@@ -1580,6 +1581,7 @@
   "This field is required": "This field is required",
   "This interface is currently hot-unplugged until the VirtualMachine is migrated": "This interface is currently hot-unplugged until the VirtualMachine is migrated",
   "This is a CD-ROM boot source": "This is a CD-ROM boot source",
+  "This is a network interface (NIC)": "This is a network interface (NIC)",
   "This is an ISO file": "This is an ISO file",
   "This key will override the SSH key secret set on the template": "This key will override the SSH key secret set on the template",
   "This Persistent Volume Claim will be created using a DataVolume through Containerized Data Importer (CDI)": "This Persistent Volume Claim will be created using a DataVolume through Containerized Data Importer (CDI)",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1,4 +1,5 @@
 {
+  " (NIC)": " (NIC)",
   " {{sockets}} sockets, {{threads}} threads, and {{cores}} cores.": " {{sockets}} sockets, {{threads}} hilos y {{cores}} núcleos.",
   " Adding hot plugged disk": " Agregar disco conectado en caliente",
   " in namespace <2>{{objNamespace}}</2>?": " en el espacio de nombre <2>{{objNamespace}}</2>?",
@@ -1588,6 +1589,7 @@
   "This field is required": "Este campo es obligatorio",
   "This interface is currently hot-unplugged until the VirtualMachine is migrated": "Esta interfaz está actualmente desconectada en caliente hasta que se migre la VirtualMachine.",
   "This is a CD-ROM boot source": "Esta es una fuente de arranque en CD-ROM.",
+  "This is a network interface (NIC)": "This is a network interface (NIC)",
   "This is an ISO file": "Este es un archivo ISO.",
   "This key will override the SSH key secret set on the template": "Esta clave anulará el secreto de la clave SSH establecido en la plantilla.",
   "This Persistent Volume Claim will be created using a DataVolume through Containerized Data Importer (CDI)": "Esta reclamación de volumen persistente se creará utilizando un volumen de datos a través del importador de datos en contenedores (CDI).",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1,4 +1,5 @@
 {
+  " (NIC)": " (NIC)",
   " {{sockets}} sockets, {{threads}} threads, and {{cores}} cores.": " {{sockets}} sockets, {{threads}} fils de discussion, et {{cores}} noyaux.",
   " Adding hot plugged disk": " Ajout d'un disque connecté à chaud",
   " in namespace <2>{{objNamespace}}</2>?": " dans l’espace de nommage <2>{{objNamespace}}</2>?",
@@ -1588,6 +1589,7 @@
   "This field is required": "Ce champ est obligatoire",
   "This interface is currently hot-unplugged until the VirtualMachine is migrated": "Cette interface est actuellement débranchée à chaud jusqu'à ce que la machine virtuelle soit migrée.",
   "This is a CD-ROM boot source": "Il s’agit d’une source de démarrage sur CD-ROM",
+  "This is a network interface (NIC)": "This is a network interface (NIC)",
   "This is an ISO file": "Ceci est un fichier ISO",
   "This key will override the SSH key secret set on the template": "Cette clé remplacera le secret de la clé SSH défini sur le modèle",
   "This Persistent Volume Claim will be created using a DataVolume through Containerized Data Importer (CDI)": "Cette revendication de volume persistant sera créée à l’aide d’un volume de données via un importateur de données conteneurisées (CDI).",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1,4 +1,5 @@
 {
+  " (NIC)": " (NIC)",
   " {{sockets}} sockets, {{threads}} threads, and {{cores}} cores.": " {{sockets}} ソケット、{{threads}} スレッド、{{cores}} コア。",
   " Adding hot plugged disk": " ホットプラグディスクの追加",
   " in namespace <2>{{objNamespace}}</2>?": " namespace <2>{{objNamespace}}</2> にありますか?",
@@ -1580,6 +1581,7 @@
   "This field is required": "このフィールドは必須です",
   "This interface is currently hot-unplugged until the VirtualMachine is migrated": "このインターフェイスは、VirtualMachine が移行されるまでホットアンプラグされています",
   "This is a CD-ROM boot source": "これは CD-ROM ブートソースです",
+  "This is a network interface (NIC)": "This is a network interface (NIC)",
   "This is an ISO file": "これは ISO ファイルです",
   "This key will override the SSH key secret set on the template": "このキーはテンプレートに設定された SSH キーシークレットをオーバーライドします",
   "This Persistent Volume Claim will be created using a DataVolume through Containerized Data Importer (CDI)": "この永続ボリューム要求は、Containerized Data Importer (CDI) で DataVolume を使用して作成されます",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1,4 +1,5 @@
 {
+  " (NIC)": " (NIC)",
   " {{sockets}} sockets, {{threads}} threads, and {{cores}} cores.": " {{sockets}} 소켓, {{threads}} 스레드 및 {{cores}} 코어.",
   " Adding hot plugged disk": " 핫 플러그 디스크 추가",
   " in namespace <2>{{objNamespace}}</2>?": " 네임스페이스 <2>{{objNamespace}}</2>에 있습니까?",
@@ -1580,6 +1581,7 @@
   "This field is required": "이 필드는 필수입니다",
   "This interface is currently hot-unplugged until the VirtualMachine is migrated": "이 인터페이스는 VirtualMachine가 마이그레이션될 때까지 현재 핫 언플러그 상태입니다.",
   "This is a CD-ROM boot source": "CD-ROM 부팅 소스입니다",
+  "This is a network interface (NIC)": "This is a network interface (NIC)",
   "This is an ISO file": "ISO 파일입니다",
   "This key will override the SSH key secret set on the template": "이 키는 템플릿에 설정된 SSH 키 시크릿을 재정의합니다.",
   "This Persistent Volume Claim will be created using a DataVolume through Containerized Data Importer (CDI)": "이 영구 볼륨 클레임은 CDI (Containerized Data Importer)를 통해 DataVolume을 사용하여 생성됩니다.",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1,4 +1,5 @@
 {
+  " (NIC)": " (NIC)",
   " {{sockets}} sockets, {{threads}} threads, and {{cores}} cores.": " {{sockets}} 套接字、{{threads}} 线程和 {{cores}} 内核。",
   " Adding hot plugged disk": " 添加热插磁盘",
   " in namespace <2>{{objNamespace}}</2>?": " 在命名空间 <2>{{objNamespace}}</2> 中？",
@@ -1580,6 +1581,7 @@
   "This field is required": "这个字段是必需的",
   "This interface is currently hot-unplugged until the VirtualMachine is migrated": "这个接口当前是热拔的，直到 VirtualMachine 被迁移为止",
   "This is a CD-ROM boot source": "这是一个 CD-ROM 引导源",
+  "This is a network interface (NIC)": "This is a network interface (NIC)",
   "This is an ISO file": "这是一个 ISO 文件",
   "This key will override the SSH key secret set on the template": "此密钥将覆盖模板上设置的 SSH 密钥 secret",
   "This Persistent Volume Claim will be created using a DataVolume through Containerized Data Importer (CDI)": "此持久性卷声明将使用一个 DataVolume 通过 Containerized Data Importer（CDI）创建",

--- a/src/utils/components/BootOrder/BootableDevicesList.tsx
+++ b/src/utils/components/BootOrder/BootableDevicesList.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import TemplateValue from '@kubevirt-utils/components/TemplateValue/TemplateValue';
 import { List, ListComponent, ListItem, OrderType } from '@patternfly/react-core';
 
-import { BootableDeviceType } from '../../resources/vm/utils/boot-order/bootOrder';
+import { BootableDeviceType, DeviceType } from '../../resources/vm/utils/boot-order/bootOrder';
 
 type BootableDevicesListProps = {
   devices: BootableDeviceType[];
@@ -13,7 +13,7 @@ const BootableDevicesList: React.FC<BootableDevicesListProps> = ({ devices }) =>
   <List component={ListComponent.ol} type={OrderType.number}>
     {devices?.map((device) => (
       <ListItem key={`${device?.value?.name}-${device?.value?.bootOrder}`}>
-        <TemplateValue value={device?.value?.name} />
+        <TemplateValue isNIC={device?.type === DeviceType.NIC} value={device?.value?.name} />
       </ListItem>
     ))}
   </List>

--- a/src/utils/components/BootOrderModal/BootOrderModalBody.tsx
+++ b/src/utils/components/BootOrderModal/BootOrderModalBody.tsx
@@ -109,7 +109,7 @@ export const BootOrderModalBody: React.FC<{
                               <Split>
                                 <SplitItem isFilled>
                                   <span id={value.name}>{value.name}</span>
-
+                                  {type === DeviceType.NIC && <span>{t(' (NIC)')}</span>}
                                   <span className="pf-v6-u-ml-sm">
                                     <DeviceTypeIcon type={type as DeviceType} />
                                   </span>

--- a/src/utils/components/BootOrderModal/DeviceTypeIcon.tsx
+++ b/src/utils/components/BootOrderModal/DeviceTypeIcon.tsx
@@ -1,21 +1,26 @@
 import React from 'react';
 
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { DeviceType } from '@kubevirt-utils/resources/vm/utils/boot-order/bootOrder';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { NetworkIcon, VolumeIcon } from '@patternfly/react-icons';
 
 type DeviceTypeIconProps = {
   type: DeviceType;
 };
 
-const DeviceTypeIconMapping = {
-  DISK: VolumeIcon,
-  NIC: NetworkIcon,
-} as const;
-
 const DeviceTypeIcon: React.FC<DeviceTypeIconProps> = ({ type }) => {
-  const Icon = DeviceTypeIconMapping[type];
+  const { t } = useKubevirtTranslation();
 
-  return Icon ? <Icon /> : <VolumeIcon />;
+  if (type === DeviceType.NIC) {
+    return (
+      <Tooltip content={t('This is a network interface (NIC)')} position={TooltipPosition.bottom}>
+        <NetworkIcon />
+      </Tooltip>
+    );
+  }
+
+  return <VolumeIcon />;
 };
 
 export default DeviceTypeIcon;

--- a/src/utils/components/TemplateValue/TemplateValue.tsx
+++ b/src/utils/components/TemplateValue/TemplateValue.tsx
@@ -6,14 +6,20 @@ import { isTemplateParameter } from '@kubevirt-utils/utils/utils';
 import './template-value.scss';
 
 type TemplateNameTableDataProps = {
+  isNIC?: boolean;
   value: string;
 };
 
-const TemplateNameTableData: React.FC<TemplateNameTableDataProps> = ({ children, value }) => {
+const TemplateNameTableData: React.FC<TemplateNameTableDataProps> = ({
+  children,
+  isNIC,
+  value,
+}) => {
   const { t } = useKubevirtTranslation();
   return (
     <span className="template-value">
       {children || value}
+      {isNIC && t(' (NIC)')}
       {isTemplateParameter(value) && (
         <div className="template-parameter">{t('Template parameter')}</div>
       )}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- adds NIC info to `default` disk (which is a network interface) in boot order

## 🎥 Demo

Before:

<img width="214" height="102" alt="Screenshot 2025-12-01 at 11 21 23" src="https://github.com/user-attachments/assets/228f02cc-ab0e-43f4-9841-4941246c1f51" />
<img width="590" height="321" alt="Screenshot 2025-12-01 at 11 21 34" src="https://github.com/user-attachments/assets/5e004016-3d51-49c0-aaf0-d20042c132b8" />


After:
<img width="214" height="102" alt="Screenshot 2025-12-01 at 11 14 22" src="https://github.com/user-attachments/assets/9166841f-f767-4ccb-99c5-90b6de1fc820" />
<img width="600" height="316" alt="Screenshot 2025-12-01 at 12 51 05" src="https://github.com/user-attachments/assets/9c4af229-6900-42ab-9d6b-58d0d774b661" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show NIC devices in boot order with a "(NIC)" label and a network-specific icon with informational tooltip.
  * Added NIC-related translations for English, Spanish, French, Japanese, Korean, and Chinese.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->