### PR TITLE
CNV-73890: Fix memory density appearance

### DIFF
--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralSettings/MemoryDensity/MemoryDensity.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralSettings/MemoryDensity/MemoryDensity.tsx
@@ -44,15 +44,15 @@ const MemoryDensity: FC<MemoryDensityProps> = ({ hyperConvergeConfiguration, new
 
   const currentOvercommit = getCurrentOvercommit(hyperConverge);
 
-  const { appliedRatio, isLoading: isLoadingRatio } = useAppliedOvercommitRatio();
+  useEffect(() => {
+    setIsSwitchOn(currentOvercommit > MEMORY_OVERCOMMIT_STARTING_VALUE);
+  }, [currentOvercommit]);
+
+  const { appliedRatio, isLoading: isLoadingRatio } = useAppliedOvercommitRatio(isSwitchOn);
   const { hasChanged, inputValue, isLoading, onSave, onSliderChange } = useMemoryDensityValue({
     currentOvercommit,
     hyperConverge,
   });
-
-  useEffect(() => {
-    setIsSwitchOn(currentOvercommit > MEMORY_OVERCOMMIT_STARTING_VALUE);
-  }, [currentOvercommit]);
 
   const handleToggleSwitch = (checked: boolean) => {
     if (checked) {

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralSettings/MemoryDensity/components/CurrentMemoryDensity.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralSettings/MemoryDensity/components/CurrentMemoryDensity.tsx
@@ -1,10 +1,10 @@
-import React, { FC, useState } from 'react';
+import React, { FC, ReactNode, useState } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ExpandableSection } from '@patternfly/react-core';
 
 type CurrentMemoryDensityProps = {
-  children: React.ReactNode;
+  children: ReactNode;
   currentOvercommit: number;
   isLoading: boolean;
 };
@@ -25,7 +25,7 @@ const CurrentMemoryDensity: FC<CurrentMemoryDensityProps> = ({
       onToggle={(_event, expanded) => !isLoading && setIsExpanded(expanded)}
       toggleText={t('Current memory density: {{percentage}}%', { percentage: currentOvercommit })}
     >
-      {children}
+      {isExpanded && children}
     </ExpandableSection>
   );
 };

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralSettings/MemoryDensity/components/MemoryDensitySlider.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralSettings/MemoryDensity/components/MemoryDensitySlider.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { Dispatch, FC, SetStateAction } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Button, Content, ContentVariants, Slider, StackItem } from '@patternfly/react-core';
@@ -31,7 +31,7 @@ const MemoryDensitySlider: FC<MemoryDensitySliderProps> = ({
     _event,
     value: number,
     sliderInputValue?: number,
-    setLocalInputValue?: React.Dispatch<React.SetStateAction<number>>,
+    setLocalInputValue?: Dispatch<SetStateAction<number>>,
   ) => {
     if (sliderInputValue === undefined) {
       onSliderChange(value);

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralSettings/MemoryDensity/hooks/useAppliedOvercommitRatio.ts
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/GeneralSettings/MemoryDensity/hooks/useAppliedOvercommitRatio.ts
@@ -3,8 +3,10 @@ import { useMemo } from 'react';
 import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
 import { SETTINGS_TAB_QUERIES } from '@overview/SettingsTab/utils/queries';
 
-const useAppliedOvercommitRatio = (): { appliedRatio: null | number; isLoading: boolean } => {
-  const query = SETTINGS_TAB_QUERIES.MEMORY_DENSITY_APPLIED_RATIO;
+const useAppliedOvercommitRatio = (
+  enabled: boolean = true,
+): { appliedRatio: null | number; isLoading: boolean } => {
+  const query = enabled ? SETTINGS_TAB_QUERIES.MEMORY_DENSITY_APPLIED_RATIO : null;
 
   const [data, loaded] = usePrometheusPoll({
     endpoint: PrometheusEndpoint.QUERY,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

fixed the slowness in memory density section appearing due to loading of applied ratio, running the Prometheus query only when the feature is enabled and eliminated gap by conditionally rendering content only when expanded.

## 🎥 Demo
Before:
<img width="1858" height="1045" alt="image" src="https://github.com/user-attachments/assets/9d1ad2e9-7d89-419d-b384-43b9b1db96cf" />


After:

https://github.com/user-attachments/assets/3556e346-a4a9-4ae4-8ee2-555a2c5c7118




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state initialization and management for memory density settings functionality.
  * Optimized content rendering to display conditionally based on expansion state, enhancing resource efficiency.
  * Refined data fetching logic with conditional query execution for applied memory density ratios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->