### PR TITLE
CNV-72907: fix showing 2 default NICs on customizing VM from template

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1589,6 +1589,7 @@
   "This user is not allowed to edit this boot source": "This user is not allowed to edit this boot source",
   "This VirtualMachine has": "This VirtualMachine has",
   "This VirtualMachine is down. Please start it to access its console.": "This VirtualMachine is down. Please start it to access its console.",
+  "This VM is using auto attached Pod Network. To disable it, set spec.template.spec.domain.devices.autoattachPodInterface to false.": "This VM is using auto attached Pod Network. To disable it, set spec.template.spec.domain.devices.autoattachPodInterface to false.",
   "This will create a cloned copy of the Volume in the destination project.": "This will create a cloned copy of the Volume in the destination project.",
   "Threads": "Threads",
   "Thresholds signify the distance from the average node utilization (formatted as below:above). An Asymmetric deviation threshold will force all nodes below the average to be considered as underutilized to help rebalancing overutilized outliers.": "Thresholds signify the distance from the average node utilization (formatted as below:above). An Asymmetric deviation threshold will force all nodes below the average to be considered as underutilized to help rebalancing overutilized outliers.",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1597,6 +1597,7 @@
   "This user is not allowed to edit this boot source": "Este usuario no tiene permiso para editar esta fuente de arranque.",
   "This VirtualMachine has": "Esta VirtualMachine tiene",
   "This VirtualMachine is down. Please start it to access its console.": "Esta VirtualMachine está inactiva. Iníciela para acceder a su consola.",
+  "This VM is using auto attached Pod Network. To disable it, set spec.template.spec.domain.devices.autoattachPodInterface to false.": "This VM is using auto attached Pod Network. To disable it, set spec.template.spec.domain.devices.autoattachPodInterface to false.",
   "This will create a cloned copy of the Volume in the destination project.": "Esto creará una copia clonada del volumen en el proyecto de destino.",
   "Threads": "Hilos",
   "Thresholds signify the distance from the average node utilization (formatted as below:above). An Asymmetric deviation threshold will force all nodes below the average to be considered as underutilized to help rebalancing overutilized outliers.": "Thresholds signify the distance from the average node utilization (formatted as below:above). An Asymmetric deviation threshold will force all nodes below the average to be considered as underutilized to help rebalancing overutilized outliers.",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1597,6 +1597,7 @@
   "This user is not allowed to edit this boot source": "Cet utilisateur n'est pas autorisé à modifier cette source de démarrage",
   "This VirtualMachine has": "Cette machine virtuelle a",
   "This VirtualMachine is down. Please start it to access its console.": "Cette machine virtuelle est en panne. Veuillez la démarrer pour accéder à sa console.",
+  "This VM is using auto attached Pod Network. To disable it, set spec.template.spec.domain.devices.autoattachPodInterface to false.": "This VM is using auto attached Pod Network. To disable it, set spec.template.spec.domain.devices.autoattachPodInterface to false.",
   "This will create a cloned copy of the Volume in the destination project.": "Cela créera une copie clonée du volume dans le projet de destination.",
   "Threads": "Fils de discussion",
   "Thresholds signify the distance from the average node utilization (formatted as below:above). An Asymmetric deviation threshold will force all nodes below the average to be considered as underutilized to help rebalancing overutilized outliers.": "Thresholds signify the distance from the average node utilization (formatted as below:above). An Asymmetric deviation threshold will force all nodes below the average to be considered as underutilized to help rebalancing overutilized outliers.",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1589,6 +1589,7 @@
   "This user is not allowed to edit this boot source": "このユーザーはこのブートソースを編集できません",
   "This VirtualMachine has": "この VirtualMachine には以下があります",
   "This VirtualMachine is down. Please start it to access its console.": "この VirtualMachine はダウンしています。コンソールにアクセスするには起動してください。",
+  "This VM is using auto attached Pod Network. To disable it, set spec.template.spec.domain.devices.autoattachPodInterface to false.": "This VM is using auto attached Pod Network. To disable it, set spec.template.spec.domain.devices.autoattachPodInterface to false.",
   "This will create a cloned copy of the Volume in the destination project.": "これにより、移行先プロジェクトにボリュームのクローンコピーが作成されます。",
   "Threads": "スレッド",
   "Thresholds signify the distance from the average node utilization (formatted as below:above). An Asymmetric deviation threshold will force all nodes below the average to be considered as underutilized to help rebalancing overutilized outliers.": "Thresholds signify the distance from the average node utilization (formatted as below:above). An Asymmetric deviation threshold will force all nodes below the average to be considered as underutilized to help rebalancing overutilized outliers.",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1589,6 +1589,7 @@
   "This user is not allowed to edit this boot source": "이 사용자는 이 부팅 소스를 편집할 수 없습니다",
   "This VirtualMachine has": "이 VirtualMachine에는 다음이 있습니다",
   "This VirtualMachine is down. Please start it to access its console.": "이 VirtualMachine은 중지 상태입니다. 콘솔에 액세스하려면 시작합니다.",
+  "This VM is using auto attached Pod Network. To disable it, set spec.template.spec.domain.devices.autoattachPodInterface to false.": "This VM is using auto attached Pod Network. To disable it, set spec.template.spec.domain.devices.autoattachPodInterface to false.",
   "This will create a cloned copy of the Volume in the destination project.": "대상 프로젝트에서 볼륨의 복제본이 생성됩니다.",
   "Threads": "스레드",
   "Thresholds signify the distance from the average node utilization (formatted as below:above). An Asymmetric deviation threshold will force all nodes below the average to be considered as underutilized to help rebalancing overutilized outliers.": "Thresholds signify the distance from the average node utilization (formatted as below:above). An Asymmetric deviation threshold will force all nodes below the average to be considered as underutilized to help rebalancing overutilized outliers.",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1589,6 +1589,7 @@
   "This user is not allowed to edit this boot source": "不允许此用户编辑这个引导源",
   "This VirtualMachine has": "此 VirtualMachine 具有",
   "This VirtualMachine is down. Please start it to access its console.": "此 VirtualMachine 已下线。请启动它以访问其控制台。",
+  "This VM is using auto attached Pod Network. To disable it, set spec.template.spec.domain.devices.autoattachPodInterface to false.": "This VM is using auto attached Pod Network. To disable it, set spec.template.spec.domain.devices.autoattachPodInterface to false.",
   "This will create a cloned copy of the Volume in the destination project.": "这将在目标项目中创建卷的克隆副本。",
   "Threads": "线程",
   "Thresholds signify the distance from the average node utilization (formatted as below:above). An Asymmetric deviation threshold will force all nodes below the average to be considered as underutilized to help rebalancing overutilized outliers.": "Thresholds signify the distance from the average node utilization (formatted as below:above). An Asymmetric deviation threshold will force all nodes below the average to be considered as underutilized to help rebalancing overutilized outliers.",

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
@@ -19,10 +19,16 @@ import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
 import { getNetworks, POD_NETWORK } from '@kubevirt-utils/resources/vm';
 import { interfaceTypesProxy } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { hasAutoAttachedPodNetwork } from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { FormGroup, Label, ValidatedOptions } from '@patternfly/react-core';
 
-import { getNadType, isPodNetworkName, podNetworkExists } from '../../utils/helpers';
+import {
+  getNadType,
+  hasExplicitlyDefinedPodNetwork,
+  isPodNetworkName,
+  podNetworkExists,
+} from '../../utils/helpers';
 import useNADsData from '../hooks/useNADsData';
 
 import NetworkSelectHelperPopover from './components/NetworkSelectHelperPopover/NetworkSelectHelperPopover';
@@ -225,6 +231,13 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
         <FormGroupHelperText validated={validated}>
           {t(
             'No NetworkAttachmentDefinitions available. Contact your system administrator for additional support.',
+          )}
+        </FormGroupHelperText>
+      )}
+      {!hasExplicitlyDefinedPodNetwork(vm) && hasAutoAttachedPodNetwork(vm) && (
+        <FormGroupHelperText validated={ValidatedOptions.warning}>
+          {t(
+            'This VM is using auto attached Pod Network. To disable it, set spec.template.spec.domain.devices.autoattachPodInterface to false.',
           )}
         </FormGroupHelperText>
       )}

--- a/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
+++ b/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
@@ -31,8 +31,11 @@ import { isStopped } from '@virtualmachines/utils';
 
 import { NetworkAttachmentDefinition } from '../components/hooks/types';
 
+export const hasExplicitlyDefinedPodNetwork = (vm: V1VirtualMachine): boolean =>
+  !!getNetworks(vm)?.find(isPodNetwork);
+
 export const podNetworkExists = (vm: V1VirtualMachine): boolean =>
-  !!vm?.spec?.template?.spec?.networks?.find(isPodNetwork) || hasAutoAttachedPodNetwork(vm);
+  hasExplicitlyDefinedPodNetwork(vm) || hasAutoAttachedPodNetwork(vm);
 
 export const isPodNetworkName = (networkName: string): boolean => networkName === POD_NETWORK;
 

--- a/src/utils/resources/vm/utils/network/rowData.ts
+++ b/src/utils/resources/vm/utils/network/rowData.ts
@@ -1,20 +1,16 @@
 import { V1Interface, V1Network } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
-import { DEFAULT_NETWORK, DEFAULT_NETWORK_INTERFACE } from '../constants';
-
 import { NetworkPresentation } from './constants';
 
 /**
  * function to get network interfaces row data from networks and interfaces
  * @param {V1Network[]} networks networks
  * @param {V1Interface[]} interfaces networks interfaces
- * @param autoattachPodInterface
  * @returns returns a network presentation array
  */
 export const getNetworkInterfaceRowData = (
   networks: V1Network[],
   interfaces: V1Interface[],
-  autoattachPodInterface?: boolean,
 ): NetworkPresentation[] => {
   const data: NetworkPresentation[] = (interfaces || []).map((iface) => {
     const network = networks?.find((net) => net.name === iface.name);
@@ -25,12 +21,5 @@ export const getNetworkInterfaceRowData = (
     };
   });
 
-  if (autoattachPodInterface)
-    data.push({
-      iface: DEFAULT_NETWORK_INTERFACE,
-      metadata: { name: DEFAULT_NETWORK.name },
-      network: DEFAULT_NETWORK,
-    } as NetworkPresentation);
-
-  return data || [];
+  return data;
 };

--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceActions.tsx
@@ -10,10 +10,6 @@ import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
 import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
-import {
-  hasAutoAttachedPodNetwork,
-  isPodNetwork,
-} from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
 import { ButtonVariant, Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core';
 import {
@@ -63,22 +59,10 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
 
   const onDelete = useCallback(() => {
     const updatedVM = produceVMNetworks(vm, (draftVM) => {
-      const vmInterfaces = getInterfaces(draftVM);
-
-      const isExistingNetwork = getNetworks(draftVM)?.find(({ name }) => name === nicName);
-      if (
-        !isExistingNetwork &&
-        hasAutoAttachedPodNetwork(draftVM) &&
-        isPodNetwork(nicPresentation?.network)
-      ) {
-        // artificial pod network added only to the table but missing in the vm
-        draftVM.spec.template.spec.domain.devices.autoattachPodInterface = false;
-      }
-
       draftVM.spec.template.spec.networks = getNetworks(draftVM)?.filter(
         ({ name }) => name !== nicName,
       );
-      draftVM.spec.template.spec.domain.devices.interfaces = vmInterfaces?.filter(
+      draftVM.spec.template.spec.domain.devices.interfaces = getInterfaces(draftVM)?.filter(
         ({ name }) => name !== nicName,
       );
     });

--- a/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceList.tsx
+++ b/src/views/catalog/wizard/tabs/network/components/list/NetworkInterfaceList.tsx
@@ -10,6 +10,7 @@ import {
   useListPageFilter,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
+import AutoAttachedNetworkEmptyState from '@virtualmachines/details/tabs/configuration/network/components/list/AutoAttachedNetworkEmptyState';
 
 import useNetworkRowFilters from '../../hooks/useNetworkRowFilters';
 
@@ -25,11 +26,8 @@ const NetworkInterfaceList: React.FC<NetworkInterfaceListProps> = ({ onUpdateVM,
   const interfaces = getInterfaces(vm);
   const filters = useNetworkRowFilters();
 
-  const networkInterfacesData = getNetworkInterfaceRowData(
-    networks,
-    interfaces,
-    hasAutoAttachedPodNetwork(vm),
-  );
+  const autoattachPodInterface = hasAutoAttachedPodNetwork(vm);
+  const networkInterfacesData = getNetworkInterfaceRowData(networks, interfaces);
   const [data, filteredData, onFilterChange] = useListPageFilter(networkInterfacesData, filters);
 
   const columns = useNetworkColumns();
@@ -39,6 +37,7 @@ const NetworkInterfaceList: React.FC<NetworkInterfaceListProps> = ({ onUpdateVM,
       <VirtualizedTable
         columns={columns}
         data={filteredData}
+        EmptyMsg={() => <AutoAttachedNetworkEmptyState isAutoAttached={autoattachPodInterface} />}
         loaded
         loadError={false}
         Row={NetworkInterfaceRow}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes showing 2 default NICs in `Catalog -> Template -> Customize VirtualMachine -> Disks`
  - the fix is in `getNetworkInterfaceRowData` - removing the part where we add an interface just for viewing purposes in case an `autoattachPodInterface` is true. I think it is misleading to show an interface which is not present in the VM YAML.
  - showing an interface which is not in YAML actually leads to more bugs, e.g. try editing that interface

- the `autoattachPodInterface` (true by default) is now represented by an empty state with an appropriate message (same as on VM details network page)

Possible improvement:
- add a checkbox to empty state to control `autoattachPodInterface: true / false` (right now configurable only from yaml)

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/1a1effeb-4e97-4356-ab7d-2d1d42301bc0



After:


https://github.com/user-attachments/assets/e144221e-fc70-4500-8b64-130020cc2302


<img width="668" height="625" alt="Screenshot 2025-12-15 at 12 41 46" src="https://github.com/user-attachments/assets/fd65d856-6951-446a-939c-be6d1f976c7c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified network interface data handling and deletion logic for more predictable behavior; removed fallback injection of a default network entry.

* **UI**
  * Updated empty-state for auto-attached networks.
  * Added a contextual warning in the network selector explaining how to enable Pod Networking when applicable.

* **Utilities**
  * Added helper to detect explicitly defined Pod networks and updated pod-network existence checks.

* **Localization**
  * Added guidance strings for Pod Networking (en, es, fr, ja, ko, zh).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->