### PR TITLE
CNV-56029:Virtualization overview page shows the alerts with incorrec…

### DIFF
--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -14,13 +14,16 @@ export const ROOTDISK = 'rootdisk';
 export const CLOUDINITDISK = 'cloudinitdisk';
 
 export const KUBEVIRT_HYPERCONVERGED = 'kubevirt-hyperconverged';
+
 export const OPENSHIFT_CNV = 'openshift-cnv';
+export const CNV_OBSERVABILITY = 'cnv-observability';
 
 export const RUNSTRATEGY_ALWAYS = 'Always';
 export const RUNSTRATEGY_HALTED = 'Halted';
 export const RUNSTRATEGY_MANUAL = 'Manual';
 export const RUNSTRATEGY_RERUNONFAILURE = 'RerunOnFailure';
 
+export const NONE = 'NONE';
 export const SPACE_SYMBOL = ' ';
 
 export enum K8S_OPS {

--- a/src/utils/utils/prometheus.ts
+++ b/src/utils/utils/prometheus.ts
@@ -1,6 +1,6 @@
 import { murmur3 } from 'murmurhash-js';
 
-import { KUBEVIRT } from '@kubevirt-utils/constants/constants';
+import { CNV_OBSERVABILITY, KUBEVIRT, NONE } from '@kubevirt-utils/constants/constants';
 import { MONITORING_SALT, OPERATOR_LABEL_KEY } from '@kubevirt-utils/constants/prometheus';
 import { Group } from '@kubevirt-utils/types/prometheus';
 import { Alert, PrometheusLabels, PrometheusRule } from '@openshift-console/dynamic-plugin-sdk';
@@ -24,7 +24,9 @@ export const labelsToParams = (labels: PrometheusLabels): string => {
 };
 
 export const isKubeVirtAlert = (alert: Alert): boolean =>
-  alert?.labels?.[OPERATOR_LABEL_KEY] === KUBEVIRT;
+  alert?.labels?.[OPERATOR_LABEL_KEY] === KUBEVIRT &&
+  alert?.labels?.operator_health_impact !== NONE &&
+  alert?.labels?.kubernetes_operator_component !== CNV_OBSERVABILITY;
 
 export const inNamespace = (namespace: string, alert: Alert): boolean =>
   alert?.labels?.namespace === namespace;


### PR DESCRIPTION
#JIRA   https://issues.redhat.com/browse/CNV-56029?filter=-1


## 📝 Description
When we filter by Show virtualization health alerts I see the **PersistentVolumeFillingUp** in the warning alerts for 2 reasons:

Its has this label **operator_health_impact=none** . Value none should not be included when we filter by health alerts, only warning or critical
We need to filter out alerts with this label: **kubernetes_operator_component=cnv-observability** , its alerts that are not reflecting the CNV operator health.    
<img width="1671" height="771" alt="Screenshot From 2025-12-01 13-24-18 (2)" src="https://github.com/user-attachments/assets/c5883e42-aa2d-49e9-a529-3f6cd24f3868" />



## 🎥 Demo
## before 
<img width="1671" height="771" alt="Screenshot From 2025-12-01 13-24-28" src="https://github.com/user-attachments/assets/cf0a8006-7db5-46c0-af6d-10d90dfc6951" />
## after
<img width="1604" height="746" alt="image" src="https://github.com/user-attachments/assets/50c83654-0477-45a7-8fef-05c96b097436" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined alert filtering to reduce false positives and ensure only actionable alerts surface in monitoring.

* **Chores**
  * Added internal constants to support observability-related filtering and handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->