### PR TITLE
CNV-72407: Fix typo in selector name

### DIFF
--- a/src/views/catalog/utils/quick-create-vm.ts
+++ b/src/views/catalog/utils/quick-create-vm.ts
@@ -2,7 +2,7 @@ import produce from 'immer';
 
 import { ProcessedTemplatesModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
-import { V1Devices, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { updateCloudInitRHELSubscription } from '@kubevirt-utils/components/CloudinitModal/utils/cloudinit-utils';
 import { applyCloudDriveCloudInitVolume } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
@@ -12,7 +12,7 @@ import {
   LABEL_USED_TEMPLATE_NAMESPACE,
   replaceTemplateVM,
 } from '@kubevirt-utils/resources/template';
-import { getBootDisk, getDisks, getInterfaces } from '@kubevirt-utils/resources/vm';
+import { getBootDisk, getDevices, getInterfaces } from '@kubevirt-utils/resources/vm';
 import {
   DEFAULT_NETWORK_INTERFACE,
   UDN_BINDING_NAME,
@@ -76,9 +76,7 @@ export const quickCreateVM: QuickCreateVMType = async ({
     draftVM.metadata.labels[LABEL_USED_TEMPLATE_NAMESPACE] = template.metadata.namespace;
 
     if (isDisabledGuestSystemLogs) {
-      const devices = (<unknown>getDisks(draftVM)) as V1Devices & {
-        logSerialConsole: boolean;
-      };
+      const devices = getDevices(draftVM);
       devices.logSerialConsole = false;
       draftVM.spec.template.spec.domain.devices = devices;
     }


### PR DESCRIPTION
## 📝 Description
Regression after: https://github.com/kubevirt-ui/kubevirt-plugin/pull/3051

Due to typo `getDisks()` selector was used instead of `getDevices()`.

## 🎥 Demo

no visual changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code improvements and refactoring to VM utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->