### PR TITLE
CNV-68721 and CNV-68721 Cherry picking

### DIFF
--- a/src/utils/components/BootOrder/BootOrderSummary.tsx
+++ b/src/utils/components/BootOrder/BootOrderSummary.tsx
@@ -1,36 +1,18 @@
-import React, { useMemo } from 'react';
+import React, { FC, useMemo } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import BootableDevicesList from '@kubevirt-utils/components/BootOrder/BootableDevicesList';
-import { getDisks, getInterfaces } from '@kubevirt-utils/resources/vm';
-import { transformDevices } from '@kubevirt-utils/resources/vm/utils/boot-order/bootOrder';
+import { getSortedBootableDevices } from '@kubevirt-utils/resources/vm/utils/boot-order/bootOrder';
 
 type BootOrderSummaryProps = {
+  instanceTypeVM: V1VirtualMachine;
   vm: V1VirtualMachine;
 };
 
-const BootOrderSummary: React.FC<BootOrderSummaryProps> = ({ vm }) => {
-  const disks = getDisks(vm);
-  const interfaces = getInterfaces(vm);
-
+const BootOrderSummary: FC<BootOrderSummaryProps> = ({ instanceTypeVM, vm }) => {
   const transformedDevices = useMemo(
-    () =>
-      transformDevices(disks, interfaces)?.sort((a, b) => {
-        if (a.value.bootOrder && b.value.bootOrder) {
-          return a.value.bootOrder - b.value.bootOrder;
-        }
-
-        if (a.value.bootOrder) {
-          return -1;
-        }
-
-        if (b.value.bootOrder) {
-          return 1;
-        }
-
-        return 0;
-      }),
-    [disks, interfaces],
+    () => getSortedBootableDevices({ instanceTypeVM, vm }),
+    [vm, instanceTypeVM],
   );
 
   return <BootableDevicesList devices={transformedDevices} />;

--- a/src/utils/components/BootOrderModal/BootOrderModal.tsx
+++ b/src/utils/components/BootOrderModal/BootOrderModal.tsx
@@ -4,11 +4,10 @@ import produce from 'immer';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ModalPendingChangesAlert from '@kubevirt-utils/components/PendingChanges/ModalPendingChangesAlert/ModalPendingChangesAlert';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getDisks, getInterfaces } from '@kubevirt-utils/resources/vm';
 import {
   BootableDeviceType,
   DeviceType,
-  transformDevices,
+  getSortedBootableDevices,
 } from '@kubevirt-utils/resources/vm/utils/boot-order/bootOrder';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 
@@ -19,20 +18,19 @@ import { BootOrderModalBody } from './BootOrderModalBody';
 import './boot-order.scss';
 
 const BootOrderModal: FC<{
+  instanceTypeVM: V1VirtualMachine;
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine>;
   vm: V1VirtualMachine;
   vmi?: V1VirtualMachineInstance;
-}> = ({ isOpen, onClose, onSubmit, vm, vmi }) => {
+}> = ({ instanceTypeVM, isOpen, onClose, onSubmit, vm, vmi }) => {
   const { t } = useKubevirtTranslation();
-  const transformedDevices = transformDevices(getDisks(vm), getInterfaces(vm));
+  const sortedBootableDevices = getSortedBootableDevices({ instanceTypeVM, vm });
 
-  const [devices, setDevices] = useState<BootableDeviceType[]>(
-    transformedDevices.sort((a, b) => a.value.bootOrder - b.value.bootOrder),
-  );
+  const [devices, setDevices] = useState<BootableDeviceType[]>(sortedBootableDevices);
   const [isEditMode, setIsEditMode] = useState(
-    transformedDevices.some((device) => !!device.value.bootOrder),
+    sortedBootableDevices.some((device) => !!device.value.bootOrder),
   );
 
   const updatedVirtualMachine = produce<V1VirtualMachine>(vm, (draftVM) => {

--- a/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
+++ b/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
@@ -69,6 +69,7 @@ import { PendingChange } from '../utils/types';
 export const usePendingChanges = (
   vm: V1VirtualMachine,
   vmi: V1VirtualMachineInstance,
+  instanceTypeExpandedSpec: V1VirtualMachine,
 ): PendingChange[] => {
   const { t } = useKubevirtTranslation();
 
@@ -167,7 +168,14 @@ export const usePendingChanges = (
       handleAction: () => {
         navigate(getTabURL(vm, VirtualMachineDetailsTab.Details));
         createModal(({ isOpen, onClose }) => (
-          <BootOrderModal isOpen={isOpen} onClose={onClose} onSubmit={onSubmit} vm={vm} vmi={vmi} />
+          <BootOrderModal
+            instanceTypeVM={instanceTypeExpandedSpec}
+            isOpen={isOpen}
+            onClose={onClose}
+            onSubmit={onSubmit}
+            vm={vm}
+            vmi={vmi}
+          />
         ));
       },
       hasPendingChange: bootOrderChanged,

--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -10,6 +10,7 @@ export const OPENSHIFT_MULTUS_NS = 'openshift-multus';
 export const VENDOR_LABEL = 'instancetype.kubevirt.io/vendor';
 
 export const ROOTDISK = 'rootdisk';
+export const CLOUDINITDISK = 'cloudinitdisk';
 
 export const KUBEVIRT_HYPERCONVERGED = 'kubevirt-hyperconverged';
 export const OPENSHIFT_CNV = 'openshift-cnv';

--- a/src/utils/store/customizeInstanceType.test.ts
+++ b/src/utils/store/customizeInstanceType.test.ts
@@ -1,0 +1,367 @@
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+
+import {
+  clearCustomizeInstanceType,
+  updateCustomizeInstanceType,
+  updateVMCustomizeIT,
+  vmSignal,
+} from './customizeInstanceType';
+
+// Mock the utils functions
+jest.mock('./customizeInstanceType/utils/utils', () => ({
+  ...jest.requireActual('./customizeInstanceType/utils/utils'),
+  getCustomizeInstanceTypeSessionStorage: jest.fn(),
+  saveCustomizeInstanceTypeSessionStorage: jest.fn(),
+}));
+
+// Mock the effect to prevent it from running during tests
+jest.mock('@preact/signals-react', () => ({
+  effect: jest.fn(),
+  signal: jest.fn(() => {
+    const mockSignal = { value: null };
+    return mockSignal;
+  }),
+}));
+
+describe('customizeInstanceType', () => {
+  const mockVM: V1VirtualMachine = {
+    apiVersion: 'kubevirt.io/v1',
+    kind: 'VirtualMachine',
+    metadata: {
+      name: 'test-vm',
+      namespace: 'default',
+    },
+    spec: {
+      template: {
+        spec: {
+          domain: {
+            devices: {
+              disks: [
+                {
+                  disk: { bus: 'virtio' },
+                  name: 'rootdisk',
+                },
+              ],
+              interfaces: [
+                {
+                  masquerade: {},
+                  name: 'default',
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    // Reset the signal value before each test
+    vmSignal.value = null;
+    jest.clearAllMocks();
+  });
+
+  describe('updateCustomizeInstanceType', () => {
+    it('should replace the entire VM object when path is empty', () => {
+      vmSignal.value = mockVM;
+      const newVM = { ...mockVM, metadata: { ...mockVM.metadata, name: 'new-vm' } };
+
+      const result = updateCustomizeInstanceType([{ data: newVM }]);
+
+      expect(result).toEqual(newVM);
+      expect(vmSignal.value).toEqual(newVM);
+    });
+
+    it('should update a simple property using string path', () => {
+      vmSignal.value = mockVM;
+
+      const result = updateCustomizeInstanceType([{ data: 'new-name', path: 'metadata.name' }]);
+
+      expect(result.metadata.name).toBe('new-name');
+      expect(result.spec).toEqual(mockVM.spec);
+    });
+
+    it('should update a nested property using string path', () => {
+      vmSignal.value = mockVM;
+
+      const result = updateCustomizeInstanceType([
+        { data: 'sata', path: 'spec.template.spec.domain.devices.disks.0.disk.bus' },
+      ]);
+
+      expect(result.spec.template.spec.domain.devices.disks[0].disk.bus).toBe('sata');
+    });
+
+    it('should update a property using array path', () => {
+      vmSignal.value = mockVM;
+
+      const result = updateCustomizeInstanceType([
+        { data: 'new-namespace', path: ['metadata', 'namespace'] },
+      ]);
+
+      expect(result.metadata.namespace).toBe('new-namespace');
+    });
+
+    it('should create nested objects when they do not exist', () => {
+      vmSignal.value = {
+        ...mockVM,
+        spec: {
+          template: {
+            spec: {
+              domain: {
+                devices: {
+                  disks: [],
+                  interfaces: [],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const result = updateCustomizeInstanceType([
+        { data: 'virtio', path: 'spec.template.spec.domain.devices.disks.0.disk.bus' },
+      ]);
+
+      expect(result.spec.template.spec.domain.devices.disks[0].disk.bus).toBe('virtio');
+    });
+
+    it('should merge data when merge is true', () => {
+      vmSignal.value = mockVM;
+
+      const result = updateCustomizeInstanceType([
+        {
+          data: { newLabel: 'new-value' },
+          merge: true,
+          path: 'metadata.labels',
+        },
+      ]);
+
+      expect(result.metadata.labels).toEqual({
+        ...mockVM.metadata.labels,
+        newLabel: 'new-value',
+      });
+    });
+
+    it('should handle multiple updates in sequence', () => {
+      vmSignal.value = mockVM;
+
+      const result = updateCustomizeInstanceType([
+        { data: 'updated-name', path: 'metadata.name' },
+        { data: 'updated-namespace', path: 'metadata.namespace' },
+        { data: 'virtio', path: 'spec.template.spec.domain.devices.disks.0.disk.bus' },
+      ]);
+
+      expect(result.metadata.name).toBe('updated-name');
+      expect(result.metadata.namespace).toBe('updated-namespace');
+      expect(result.spec.template.spec.domain.devices.disks[0].disk.bus).toBe('virtio');
+    });
+
+    it('should filter out empty string parts from path', () => {
+      vmSignal.value = mockVM;
+
+      const result = updateCustomizeInstanceType([
+        { data: 'updated-name', path: 'metadata..name' },
+      ]);
+
+      expect(result.metadata.name).toBe('updated-name');
+    });
+
+    it('should skip update when path is empty string', () => {
+      vmSignal.value = mockVM;
+      const originalVM = { ...mockVM };
+
+      const result = updateCustomizeInstanceType([{ data: 'should-not-change', path: '' }]);
+
+      expect(result).toEqual(originalVM);
+    });
+
+    it('should skip update when all path parts are empty strings', () => {
+      vmSignal.value = mockVM;
+      const originalVM = { ...mockVM };
+
+      const result = updateCustomizeInstanceType([
+        { data: 'should-not-change', path: ['', '', ''] },
+      ]);
+
+      expect(result).toEqual(originalVM);
+    });
+
+    it('should handle array updates correctly', () => {
+      vmSignal.value = mockVM;
+
+      const newDisks = [
+        { disk: { bus: 'virtio' }, name: 'disk1' },
+        { disk: { bus: 'sata' }, name: 'disk2' },
+      ];
+
+      const result = updateCustomizeInstanceType([
+        { data: newDisks, path: 'spec.template.spec.domain.devices.disks' },
+      ]);
+
+      expect(result.spec.template.spec.domain.devices.disks).toEqual(newDisks);
+    });
+
+    it('should create a deep copy and not mutate the original signal value', () => {
+      vmSignal.value = mockVM;
+      const originalSignalValue = vmSignal.value;
+
+      updateCustomizeInstanceType([{ data: 'updated-name', path: 'metadata.name' }]);
+
+      // The original signal value should be unchanged
+      expect(originalSignalValue.metadata.name).toBe('test-vm');
+      // But the signal should have the updated value
+      expect(vmSignal.value.metadata.name).toBe('updated-name');
+    });
+
+    it('should handle complex nested object updates', () => {
+      vmSignal.value = mockVM;
+
+      const newInterface = {
+        bridge: {},
+        model: 'virtio',
+        name: 'new-interface',
+      };
+
+      const result = updateCustomizeInstanceType([
+        { data: newInterface, path: 'spec.template.spec.domain.devices.interfaces.1' },
+      ]);
+
+      expect(result.spec.template.spec.domain.devices.interfaces[1]).toEqual(newInterface);
+      expect(result.spec.template.spec.domain.devices.interfaces[0]).toEqual(
+        mockVM.spec.template.spec.domain.devices.interfaces[0],
+      );
+    });
+  });
+
+  describe('clearCustomizeInstanceType', () => {
+    it('should clear the signal value and save to session storage', () => {
+      vmSignal.value = mockVM;
+
+      clearCustomizeInstanceType();
+
+      expect(vmSignal.value).toBeNull();
+    });
+  });
+
+  describe('updateVMCustomizeIT', () => {
+    it('should return a promise that resolves with the updated VM', async () => {
+      vmSignal.value = mockVM;
+      const newVM = { ...mockVM, metadata: { ...mockVM.metadata, name: 'promise-vm' } };
+
+      const result = await updateVMCustomizeIT(newVM);
+
+      expect(result).toEqual(newVM);
+      expect(vmSignal.value).toEqual(newVM);
+    });
+  });
+
+  describe('edge cases and error handling', () => {
+    it('should handle null/undefined signal value', () => {
+      vmSignal.value = null;
+
+      const result = updateCustomizeInstanceType([{ data: 'test', path: 'metadata.name' }]);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle undefined data', () => {
+      vmSignal.value = mockVM;
+
+      const result = updateCustomizeInstanceType([{ data: undefined, path: 'metadata.name' }]);
+
+      expect(result.metadata.name).toBeUndefined();
+    });
+
+    it('should handle null data', () => {
+      vmSignal.value = mockVM;
+
+      const result = updateCustomizeInstanceType([{ data: null, path: 'metadata.name' }]);
+
+      expect(result.metadata.name).toBeNull();
+    });
+
+    it('should handle empty updateValues array', () => {
+      vmSignal.value = mockVM;
+      const originalVM = { ...mockVM };
+
+      const result = updateCustomizeInstanceType([]);
+
+      expect(result).toEqual(originalVM);
+    });
+
+    it('should handle deeply nested paths', () => {
+      vmSignal.value = mockVM;
+
+      const result = updateCustomizeInstanceType([
+        {
+          data: 'deep-value',
+          path: 'spec.template.spec.domain.devices.disks.0.disk.bus',
+        },
+      ]);
+
+      expect(result.spec.template.spec.domain.devices.disks[0].disk.bus).toBe('deep-value');
+    });
+
+    it('should handle array index paths', () => {
+      vmSignal.value = mockVM;
+
+      const result = updateCustomizeInstanceType([
+        { data: 'new-interface', path: 'spec.template.spec.domain.devices.interfaces.0.name' },
+      ]);
+
+      expect(result.spec.template.spec.domain.devices.interfaces[0].name).toBe('new-interface');
+    });
+  });
+
+  describe('object corruption prevention', () => {
+    it('should not create empty string keys', () => {
+      vmSignal.value = mockVM;
+
+      const result = updateCustomizeInstanceType([
+        { data: 'test', path: 'metadata.name' },
+        { data: 'test2', path: '' }, // This should be ignored
+        { data: 'test3', path: 'metadata.namespace' },
+      ]);
+
+      expect(result).not.toHaveProperty('');
+      expect(result.metadata.name).toBe('test');
+      expect(result.metadata.namespace).toBe('test3');
+    });
+
+    it('should not create corrupted nested structures', () => {
+      vmSignal.value = mockVM;
+
+      const result = updateCustomizeInstanceType([
+        { data: 'test', path: 'spec.template.spec.domain.devices.disks.0.name' },
+        { data: 'test2', path: 'spec.template.spec.domain.devices.disks.0.disk.bus' },
+      ]);
+
+      expect(result.spec.template.spec.domain.devices.disks[0].name).toBe('test');
+      expect(result.spec.template.spec.domain.devices.disks[0].disk.bus).toBe('test2');
+      expect(result).not.toHaveProperty('');
+    });
+
+    it('should maintain object structure integrity with multiple updates', () => {
+      vmSignal.value = mockVM;
+
+      const result = updateCustomizeInstanceType([
+        { data: 'updated-vm', path: 'metadata.name' },
+        { data: 'updated-ns', path: 'metadata.namespace' },
+        { data: 'virtio', path: 'spec.template.spec.domain.devices.disks.0.disk.bus' },
+        { data: 'rootdisk', path: 'spec.template.spec.domain.devices.disks.0.name' },
+      ]);
+
+      // Verify the structure is intact
+      expect(result.apiVersion).toBe('kubevirt.io/v1');
+      expect(result.kind).toBe('VirtualMachine');
+      expect(result.metadata.name).toBe('updated-vm');
+      expect(result.metadata.namespace).toBe('updated-ns');
+      expect(result.spec.template.spec.domain.devices.disks[0].name).toBe('rootdisk');
+      expect(result.spec.template.spec.domain.devices.disks[0].disk.bus).toBe('virtio');
+
+      // Verify no corruption
+      expect(result).not.toHaveProperty('');
+      expect(Object.keys(result)).toEqual(['apiVersion', 'kind', 'metadata', 'spec']);
+    });
+  });
+});

--- a/src/utils/store/customizeInstanceType/utils/utils.ts
+++ b/src/utils/store/customizeInstanceType/utils/utils.ts
@@ -14,14 +14,38 @@ export const getCustomizeInstanceTypeSessionStorage = (): V1VirtualMachine => {
       const vm = JSON.parse(vmString);
       return vm;
     } catch (error) {
-      kubevirtConsole.log('Error parsing vm session storage');
+      kubevirtConsole.log('Error parsing vm session storage:', error);
     }
   }
   return null;
 };
 
 export const mergeData = (seedData, appendData) => {
-  return Array.isArray(seedData) || Array.isArray(appendData)
-    ? [...(seedData || []), ...(appendData || [])]
-    : { ...(seedData || {}), ...(appendData || {}) };
+  // Handle null/undefined cases
+  if (seedData == null && appendData == null) {
+    return {};
+  }
+
+  if (seedData == null) {
+    return appendData;
+  }
+
+  if (appendData == null) {
+    return seedData;
+  }
+
+  // Handle array merging
+  if (Array.isArray(seedData) || Array.isArray(appendData)) {
+    const seedArray = Array.isArray(seedData) ? seedData : [];
+    const appendArray = Array.isArray(appendData) ? appendData : [];
+    return [...seedArray, ...appendArray];
+  }
+
+  // Handle object merging
+  if (typeof seedData === 'object' && typeof appendData === 'object') {
+    return { ...seedData, ...appendData };
+  }
+
+  // For primitive values, return the appendData
+  return appendData;
 };

--- a/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/utils/utils.ts
@@ -17,8 +17,11 @@ import { InterfaceTypes } from '@kubevirt-utils/components/DiskModal/utils/types
 import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
 import { addSecretToVM } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import { sysprepDisk, sysprepVolume } from '@kubevirt-utils/components/SysprepModal/sysprep-utils';
-import { ROOTDISK } from '@kubevirt-utils/constants/constants';
-import { RUNSTRATEGY_ALWAYS, RUNSTRATEGY_HALTED } from '@kubevirt-utils/constants/constants';
+import {
+  ROOTDISK,
+  RUNSTRATEGY_ALWAYS,
+  RUNSTRATEGY_HALTED,
+} from '@kubevirt-utils/constants/constants';
 import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
 import {
   isBootableVolumeISO,
@@ -256,7 +259,22 @@ export const generateVM: GenerateVMCallback = ({
     emptyVM = addSecretToVM(emptyVM, sshSecretName, isDynamic);
   }
 
+  emptyVM = addRootDiskToVM(emptyVM);
+
   return emptyVM;
+};
+
+export const addRootDiskToVM = (vm: V1VirtualMachine) => {
+  return produce(vm, (vmDraft) => {
+    const disks = vmDraft.spec.template.spec.domain.devices.disks;
+
+    if (disks.length === 0) {
+      vmDraft.spec.template.spec.domain.devices.disks.push({
+        bootOrder: 1,
+        name: ROOTDISK,
+      });
+    }
+  });
 };
 
 export const addISOFlowToVM = (vm: V1VirtualMachine, storageClassName: string) => {

--- a/src/views/catalog/utils/quick-create-vm.ts
+++ b/src/views/catalog/utils/quick-create-vm.ts
@@ -2,7 +2,7 @@ import produce from 'immer';
 
 import { ProcessedTemplatesModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
-import { V1Devices, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { updateCloudInitRHELSubscription } from '@kubevirt-utils/components/CloudinitModal/utils/cloudinit-utils';
 import { applyCloudDriveCloudInitVolume } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
@@ -12,7 +12,7 @@ import {
   LABEL_USED_TEMPLATE_NAMESPACE,
   replaceTemplateVM,
 } from '@kubevirt-utils/resources/template';
-import { getInterfaces } from '@kubevirt-utils/resources/vm';
+import { getBootDisk, getDevices, getInterfaces } from '@kubevirt-utils/resources/vm';
 import {
   DEFAULT_NETWORK_INTERFACE,
   UDN_BINDING_NAME,
@@ -68,9 +68,7 @@ export const quickCreateVM: QuickCreateVMType = async ({
     draftVM.metadata.labels[LABEL_USED_TEMPLATE_NAMESPACE] = template.metadata.namespace;
 
     if (isDisabledGuestSystemLogs) {
-      const devices = (<unknown>draftVM.spec.template.spec.domain.devices) as V1Devices & {
-        logSerialConsole: boolean;
-      };
+      const devices = getDevices(draftVM);
       devices.logSerialConsole = false;
       draftVM.spec.template.spec.domain.devices = devices;
     }
@@ -87,6 +85,11 @@ export const quickCreateVM: QuickCreateVMType = async ({
     if (isUDNManagedNamespace && defaultInterface) {
       delete defaultInterface.masquerade;
       defaultInterface.binding = { name: UDN_BINDING_NAME };
+    }
+
+    const bootDisk = getBootDisk(draftVM);
+    if (bootDisk && !bootDisk.bootOrder) {
+      bootDisk.bootOrder = 1;
     }
   });
 

--- a/src/views/topology/components/vm/VMDetailsPanel/TopologyVMDetailsPanel.tsx
+++ b/src/views/topology/components/vm/VMDetailsPanel/TopologyVMDetailsPanel.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import useInstanceTypeExpandSpec from '@kubevirt-utils/resources/vm/hooks/useInstanceTypeExpandSpec';
 import { Grid, GridItem } from '@patternfly/react-core';
 import { observer } from '@patternfly/react-topology';
 import { VMNode } from '@topology/utils/types/types';
@@ -16,7 +17,7 @@ const TopologyVMDetailsPanel: FC<TopologyVMDetailsPanelProps> = observer(({ vmNo
   const vmData = vmNode.getData();
   const vm = vmData.resource as V1VirtualMachine;
   const { vmi } = vmData?.data;
-
+  const [instanceTypeExpandedSpec] = useInstanceTypeExpandSpec(vm);
   return (
     <div className="overview__sidebar-pane-body resource-overview__body">
       <Grid hasGutter>
@@ -24,7 +25,7 @@ const TopologyVMDetailsPanel: FC<TopologyVMDetailsPanelProps> = observer(({ vmNo
           <VMDetailsPanelLeftColumn vm={vm} vmi={vmi} />
         </GridItem>
         <GridItem span={6}>
-          <VMDetailsPanelRightColumn vm={vm} vmi={vmi} />
+          <VMDetailsPanelRightColumn instanceTypeVM={instanceTypeExpandedSpec} vm={vm} vmi={vmi} />
         </GridItem>
       </Grid>
     </div>

--- a/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/VMDetailsPanelRightColumn.tsx
+++ b/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/VMDetailsPanelRightColumn.tsx
@@ -20,11 +20,12 @@ import VMUserCredentialsDetailsItem from './components/VMUserCredentialsDetailsI
 import VMWorkloadProfileDetailsItem from './components/VMWorkloadProfileDetailsItem';
 
 export type VMResourceListProps = {
+  instanceTypeVM?: V1VirtualMachine;
   vm?: V1VirtualMachine;
   vmi?: V1VirtualMachineInstance;
 };
 
-const VMDetailsPanelRightColumn: FC<VMResourceListProps> = ({ vm, vmi }) => {
+const VMDetailsPanelRightColumn: FC<VMResourceListProps> = ({ instanceTypeVM, vm, vmi }) => {
   const { pods } = useVMIAndPodsForVM(getName(vm), getNamespace(vm));
   const launcherPod = getVMIPod(vmi, pods);
 
@@ -35,7 +36,7 @@ const VMDetailsPanelRightColumn: FC<VMResourceListProps> = ({ vm, vmi }) => {
     >
       <VMStatusDetailsItem vm={vm} vmi={vmi} />
       <VMPodDetailsItem pods={pods} vmi={vmi} />
-      <VMBootOrderDetailsItem vm={vm} vmi={vmi} />
+      <VMBootOrderDetailsItem instanceTypeVM={instanceTypeVM} vm={vm} vmi={vmi} />
       <VMIPAddressesDetailsItem launcherPod={launcherPod} vmi={vmi} />
       <VMHostnameDetailsItem vm={vm} vmi={vmi} />
       <VMTimezoneDetailsItem vmi={vmi} />

--- a/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/components/VMBootOrderDetailsItem.tsx
+++ b/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/components/VMBootOrderDetailsItem.tsx
@@ -12,11 +12,12 @@ import { updateBootOrder } from '@virtualmachines/details/tabs/configuration/det
 import '../../../TopologyVMDetailsPanel.scss';
 
 type VMBootOrderDetailsItemProps = {
+  instanceTypeVM: V1VirtualMachine;
   vm: V1VirtualMachine;
   vmi: V1VirtualMachineInstance;
 };
 
-const VMBootOrderDetailsItem: FC<VMBootOrderDetailsItemProps> = ({ vm, vmi }) => {
+const VMBootOrderDetailsItem: FC<VMBootOrderDetailsItemProps> = ({ instanceTypeVM, vm, vmi }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
 
@@ -26,6 +27,7 @@ const VMBootOrderDetailsItem: FC<VMBootOrderDetailsItemProps> = ({ vm, vmi }) =>
         createModal((props) => (
           <BootOrderModal
             {...props}
+            instanceTypeVM={instanceTypeVM}
             onSubmit={(updatedVM: V1VirtualMachine) => updateBootOrder(updatedVM)}
             vm={vm}
             vmi={vmi}
@@ -34,7 +36,7 @@ const VMBootOrderDetailsItem: FC<VMBootOrderDetailsItemProps> = ({ vm, vmi }) =>
       }
       className="topology-vm-details-panel__item"
       data-test-id={`${getName(vm)}-boot-order`}
-      descriptionData={<BootOrderSummary vm={vm} />}
+      descriptionData={<BootOrderSummary instanceTypeVM={instanceTypeVM} vm={vm} />}
       descriptionHeader={t('Boot order')}
       isEdit
     />

--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/VirtualMachinePendingChangesAlert.tsx
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/VirtualMachinePendingChangesAlert.tsx
@@ -20,10 +20,11 @@ type VirtualMachinePendingChangesAlertProps = {
 };
 
 const VirtualMachinePendingChangesAlert: FC<VirtualMachinePendingChangesAlertProps> = ({
+  instanceTypeExpandedSpec,
   vm,
   vmi,
 }) => {
-  const pendingChanges = usePendingChanges(vm, vmi);
+  const pendingChanges = usePendingChanges(vm, vmi, instanceTypeExpandedSpec);
 
   const hasPendingChanges = pendingChanges?.some((change) => change?.hasPendingChange);
 

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
@@ -106,6 +106,7 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({
                     )
                   : updateBootOrder(updatedVM)
               }
+              instanceTypeVM={instanceTypeVM}
               vm={vm}
               vmi={vmi}
             />
@@ -113,7 +114,7 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({
         }
         className="DetailsSection-margin__bottom"
         data-test-id={`${vmName}-boot-order`}
-        descriptionData={<BootOrderSummary vm={vm} />}
+        descriptionData={<BootOrderSummary instanceTypeVM={instanceTypeVM} vm={vm} />}
         descriptionHeader={<SearchItem id="boot-order">{t('Boot order')}</SearchItem>}
         isEdit
       />

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Details/BootOrder/BootOrder.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Details/BootOrder/BootOrder.tsx
@@ -1,28 +1,20 @@
-import * as React from 'react';
+import React, { FC, useMemo } from 'react';
 
 import { V1Disk, V1Interface } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import BootableDevicesList from '@kubevirt-utils/components/BootOrder/BootableDevicesList';
-import { transformDevices } from '@kubevirt-utils/resources/vm/utils/boot-order/bootOrder';
+import {
+  sortBootOrder,
+  transformDevices,
+} from '@kubevirt-utils/resources/vm/utils/boot-order/bootOrder';
 
 type BootOrderProps = {
   disks: V1Disk[];
   interfaces: V1Interface[];
 };
 
-const BootOrder: React.FC<BootOrderProps> = ({ disks, interfaces }) => {
-  const transformedDevices = React.useMemo(
-    () =>
-      transformDevices(disks, interfaces)?.sort((a, b) => {
-        if (a.value.bootOrder && b.value.bootOrder) {
-          return a.value.bootOrder - b.value.bootOrder;
-        } else if (a.value.bootOrder) {
-          return -1;
-        } else if (b.value.bootOrder) {
-          return 1;
-        } else {
-          return 0;
-        }
-      }),
+const BootOrder: FC<BootOrderProps> = ({ disks, interfaces }) => {
+  const transformedDevices = useMemo(
+    () => transformDevices(disks, interfaces)?.toSorted(sortBootOrder),
     [disks, interfaces],
   );
 


### PR DESCRIPTION
## 📝 Description

Cherry picking 
[CNV-70171](https://issues.redhat.com//browse/CNV-70171): Prevent YAML corruption when changing boot order while customizing a new vm
[CNV-68721](https://issues.redhat.com//browse/CNV-68721): Adding a second disk changes the boot order

Jira Tickets: 
[CNV-70233](https://issues.redhat.com/browse/CNV-70233)
[CNV-68721](https://issues.redhat.com/browse/CNV-68721)
[CNV-72407](https://issues.redhat.com/browse/CNV-72407)

https://github.com/kubevirt-ui/kubevirt-plugin/pull/3060
https://github.com/kubevirt-ui/kubevirt-plugin/pull/3051
https://github.com/kubevirt-ui/kubevirt-plugin/pull/3244
