### PR TITLE
CNV-70979: Update node version from 18 to 22

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'yarn'
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Check i18n
         shell: bash
@@ -39,14 +39,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'yarn'
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Lint
         run: yarn lint:fix
@@ -62,14 +62,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Yarn
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'yarn'
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Run Unit Tests
         run: yarn test-cov

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 #       a specific version tag. Container build errors have come up when
 #       the `:latest` is updated.
 #
-# Image info: https://catalog.redhat.com/software/containers/ubi9/nodejs-18/62e8e7ed22d1d3c2dfe2ca01
-FROM registry.access.redhat.com/ubi9/nodejs-18:9.6-1749709214 AS builder
+# Image info: https://catalog.redhat.com/en/software/containers/ubi9/nodejs-22/66431d1785c5c3a31edd24f1
+FROM registry.access.redhat.com/ubi9/nodejs-22:9.7-1764636141 AS builder
 USER root
 RUN command -v yarn || npm i -g yarn
 
@@ -12,9 +12,10 @@ WORKDIR /opt/app-root/src
 ENV NODE_OPTIONS=--max-old-space-size=8192
 ENV YARN_NETWORK_TIMEOUT 1200000
 ENV HUSKY=0
-RUN yarn install --frozen-lockfile && yarn build
+RUN yarn install --frozen-lockfile --ignore-scripts  && yarn build
 
-FROM registry.access.redhat.com/ubi8/nginx-120
+# Image info: https://catalog.redhat.com/en/software/containers/ubi9/nginx-124/657b066b6c1bc124a1d7ff39
+FROM registry.access.redhat.com/ubi9/nginx-124:9.7-1764620487
 
 COPY --from=builder /opt/app-root/src/dist /usr/share/nginx/html
 USER 1001

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@testing-library/react-hooks": "^7.0.2",
     "@testing-library/user-event": "^13.5.0",
     "@types/js-yaml": "^4.0.5",
-    "@types/node": "^18.x",
+    "@types/node": "^22.x",
     "@types/react": "^17.0.40",
     "@types/react-dom": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^8.33.0",
@@ -128,8 +128,8 @@
     "yarn": "^1.22.18"
   },
   "engines": {
-    "node": ">=18.20.5",
-    "npm": "^9.5.0 || >=10.5.2"
+    "npm": ">=10.9.4",
+    "node": ">=22.0.0"
   },
   "lint-staged": {
     "src/**/*.{js,ts,tsx,jsx,json}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2119,12 +2119,12 @@
   dependencies:
     undici-types "~6.20.0"
 
-"@types/node@^18.x":
-  version "18.19.111"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.111.tgz#e95b89efc24cc625834b43bcd70bd5591a5dfba5"
-  integrity sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==
+"@types/node@^22.x":
+  version "22.19.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.1.tgz#1188f1ddc9f46b4cc3aec76749050b4e1f459b7b"
+  integrity sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==
   dependencies:
-    undici-types "~5.26.4"
+    undici-types "~6.21.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -10953,15 +10953,15 @@ underscore.string@~3.3.4:
     sprintf-js "^1.1.1"
     util-deprecate "^1.0.2"
 
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
-
 undici-types@~6.20.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 unique-names-generator@^4.6.0:
   version "4.7.1"


### PR DESCRIPTION
## 📝 Description

Library updates from : https://github.com/kubevirt-ui/kubevirt-plugin/pull/3209

Updates:
1. the Node version from v18 to v22 (currently the newest version
       supported by e2e test runners is 22.14)
2. actions/setup-node from v4 to v6
3. unify actions/checkout to v5
4. docker image - use the current v22 image (the previously used v18 is
   marked as deprecated)
5. docker - update from ubi8/nginx-120 to ubi9/nginx-124
    
Reference-Url: https://catalog.redhat.com/en/software/containers/ubi9/nginx-124/657b066b6c1bc124a1d7ff39
Reference-Url: https://catalog.redhat.com/en/software/containers/ubi9/nodejs-22/66431d1785c5c3a31edd24f1
Reference-Url: https://catalog.redhat.com/en/software/containers/ubi9/nodejs-18/62e8e7ed22d1d3c2dfe2ca01


## 🎥 Demo

no changes in the UI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Node.js requirement to v22, minimum npm to 10.9.4, and dev tooling types aligned to Node 22.
* **Build / CI**
  * CI workflows and install steps updated to use newer action versions and stricter install flags for more reproducible builds.
* **Deployment**
  * Base/container images and startup behavior refreshed to match the Node 22 build output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->