### PR TITLE
CNV-73282: Support bulk actions contributed from other plugins

### DIFF
--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1357,7 +1357,7 @@
   "Select different Node": "Seleccionar un nodo diferente",
   "Select InstanceType": "Seleccionar InstanceType",
   "Select ISO": "Seleccionar ISO",
-  "Select multiple VirtualMachines to perform an action for all of them": "Seleccione varias VirtualMachines a fin de realizar una acción para todas ellas.",
+  "Select multiple VirtualMachines to perform an action for all of them": "Select multiple VirtualMachines to perform an action for all of them",
   "Select NetwrokAttachmentDefinition": "Seleccionar NetworkAttachmentDefinition",
   "Select node": "Seleccionar nodo",
   "Select nodes": "Seleccionar nodos",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1357,7 +1357,7 @@
   "Select different Node": "Sélectionnez un nœud différent",
   "Select InstanceType": "Sélectionner le type d'instance",
   "Select ISO": "Sélectionnez ISO",
-  "Select multiple VirtualMachines to perform an action for all of them": "Sélectionnez plusieurs machines virtuelles pour effectuer une action pour chacune d'elles",
+  "Select multiple VirtualMachines to perform an action for all of them": "Select multiple VirtualMachines to perform an action for all of them",
   "Select NetwrokAttachmentDefinition": "Sélectionner NetworkAttachmentDefinition",
   "Select node": "Sélectionner un nœud",
   "Select nodes": "Sélectionner des nœuds",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1348,7 +1348,7 @@
   "Select different Node": "別のノードの選択",
   "Select InstanceType": "InstanceType の選択",
   "Select ISO": "ISO の選択",
-  "Select multiple VirtualMachines to perform an action for all of them": "複数の VirtualMachine を選択して、それらすべてに対してアクションを実行する",
+  "Select multiple VirtualMachines to perform an action for all of them": "Select multiple VirtualMachines to perform an action for all of them",
   "Select NetwrokAttachmentDefinition": "NetwrokAttachmentDefinition の選択",
   "Select node": "ノードの選択",
   "Select nodes": "ノードの選択",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1348,7 +1348,7 @@
   "Select different Node": "다른 노드 선택",
   "Select InstanceType": "InstanceType 선택",
   "Select ISO": "ISO 선택",
-  "Select multiple VirtualMachines to perform an action for all of them": "모든 작업에 대해 작업을 수행하려면 여러 VirtualMachines를 선택합니다.",
+  "Select multiple VirtualMachines to perform an action for all of them": "Select multiple VirtualMachines to perform an action for all of them",
   "Select NetwrokAttachmentDefinition": "NetwrokAttachmentDefinition 선택",
   "Select node": "노드 선택",
   "Select nodes": "노드 선택",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1348,7 +1348,7 @@
   "Select different Node": "选择不同的节点",
   "Select InstanceType": "选择 InstanceType",
   "Select ISO": "选择 ISO",
-  "Select multiple VirtualMachines to perform an action for all of them": "选择多个 VirtualMachines 来对它们执行操作",
+  "Select multiple VirtualMachines to perform an action for all of them": "Select multiple VirtualMachines to perform an action for all of them",
   "Select NetwrokAttachmentDefinition": "选择 NetwrokAttachmentDefinition",
   "Select node": "选择节点",
   "Select nodes": "选择节点",

--- a/src/utils/components/LazyActionMenu/LazyActionMenu.tsx
+++ b/src/utils/components/LazyActionMenu/LazyActionMenu.tsx
@@ -24,7 +24,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk/lib/api/internal-types';
 import { impersonateStateToProps } from '@openshift-console/dynamic-plugin-sdk/lib/app/core/reducers/coreSelectors';
 import { ImpersonateKind } from '@openshift-console/dynamic-plugin-sdk/lib/app/redux-types';
-import { MenuList, MenuToggle, Select, SelectPopperProps } from '@patternfly/react-core';
+import { MenuList, MenuToggle, Select, SelectPopperProps, Tooltip } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 
 import ActionMenuContent from './ActionMenuContent';
@@ -34,6 +34,7 @@ export type CheckAccess = typeof defaultCheckAccess;
 
 export type ExtendedLazyActionMenuProps = LazyActionMenuProps & {
   checkAccessDelegate?: CheckAccess;
+  disabledTooltip?: string;
   localOptions?: MenuOption[];
 };
 
@@ -89,6 +90,7 @@ const LazyFetch = connect(impersonateStateToProps)(LazyFetchInternal);
 const LazyActionMenu: FC<ExtendedLazyActionMenuProps> = ({
   checkAccessDelegate = defaultCheckAccess,
   context,
+  disabledTooltip,
   isDisabled,
   label,
   localOptions = [],
@@ -111,7 +113,7 @@ const LazyActionMenu: FC<ExtendedLazyActionMenuProps> = ({
     [localOptions, remoteOptions],
   );
 
-  return (
+  const menu = (
     <>
       {initActionLoader && (
         <LazyFetch
@@ -155,6 +157,13 @@ const LazyActionMenu: FC<ExtendedLazyActionMenuProps> = ({
         </MenuList>
       </Select>
     </>
+  );
+  return isDisabled && disabledTooltip ? (
+    <Tooltip content={disabledTooltip} position="left">
+      <div>{menu}</div>
+    </Tooltip>
+  ) : (
+    menu
   );
 };
 

--- a/src/views/virtualmachines/list/components/VirtualMachineBulkActionButton.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineBulkActionButton.tsx
@@ -1,9 +1,15 @@
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import ActionsDropdown from '@kubevirt-utils/components/ActionsDropdown/ActionsDropdown';
+import LazyActionMenu from '@kubevirt-utils/components/LazyActionMenu/LazyActionMenu';
+import {
+  checkAccessForFleet,
+  createLocalMenuOptions,
+} from '@kubevirt-utils/components/LazyActionMenu/overrides';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { VirtualMachineModelRef } from '@kubevirt-utils/models';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { ActionMenuVariant } from '@openshift-console/dynamic-plugin-sdk/lib/api/internal-types';
 import useMultipleVirtualMachineActions from '@virtualmachines/actions/hooks/useMultipleVirtualMachineActions';
 import { VMIMMapper } from '@virtualmachines/utils/mappers';
 
@@ -14,23 +20,31 @@ type VirtualMachineBulkActionButtonProps = {
   vms: V1VirtualMachine[];
 };
 
+const VirtualMachineModelRefArray = `${VirtualMachineModelRef}[]`;
+
 const VirtualMachineBulkActionButton: FC<VirtualMachineBulkActionButtonProps> = ({
   vmimMapper,
   vms,
 }) => {
   const { t } = useKubevirtTranslation();
-
   const selectedVirtualMachines = useExistingSelectedVMs(vms);
 
   const actions = useMultipleVirtualMachineActions(selectedVirtualMachines, vmimMapper);
 
+  const localOptions = useMemo(() => createLocalMenuOptions(actions), [actions]);
+  const context = useMemo(
+    () => ({ [VirtualMachineModelRefArray]: selectedVirtualMachines }),
+    [selectedVirtualMachines],
+  );
+
   return (
-    <ActionsDropdown
-      actions={actions}
-      className="vm-actions-toggle"
+    <LazyActionMenu
+      checkAccessDelegate={checkAccessForFleet}
+      context={context}
       disabledTooltip={t('Select multiple VirtualMachines to perform an action for all of them')}
       isDisabled={isEmpty(selectedVirtualMachines)}
-      variant="secondary"
+      localOptions={localOptions}
+      variant={ActionMenuVariant.DROPDOWN}
     />
   );
 };


### PR DESCRIPTION
## 📝 Description

Use extension type `console.action/provider` with contextId  `kubevirt.io~v1~VirtualMachine[]`
    
Existing actions are passed as local actions to the `LazyActionMenu`.

## 🎥 Demo

Tested with a custom action "Log VM details" from my [test-actions-plugin](https://github.com/rszwajko/test-actions-plugin). The positioning worked fine (see below). The action correctly logged the VM names to the console.

<img width="1471" height="778" alt="image" src="https://github.com/user-attachments/assets/739fbe80-7774-4025-be3b-640ba4682da8" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tooltips now display on disabled bulk action buttons to clarify why actions are unavailable.

* **Improvements**
  * Enhanced access control verification for Virtual Machine bulk operations.
  * Refined bulk action menu interface for improved usability and interaction.

* **Localization**
  * Updated localization entries across multiple supported languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->