### PR TITLE
CNV-71611: fix showing progress for already succeeded VMIM

### DIFF
--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/MigrationsRow.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/MigrationsRow.tsx
@@ -9,7 +9,6 @@ import {
 } from '@kubevirt-ui/kubevirt-api/console';
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import useMigrationPercentage from '@kubevirt-utils/resources/vm/hooks/useMigrationPercentage';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import {
   getMigrationPhase,
@@ -24,9 +23,9 @@ import {
   TableData,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { Progress, ProgressMeasureLocation, Tooltip } from '@patternfly/react-core';
-import { getMigrationProgressVariant } from '@virtualmachines/details/tabs/metrics/utils/utils';
 
 import MigrationPolicyTooltip from './components/MigrationPolicyTooltip/MigrationPolicyTooltip';
+import useMigrationProgress from './hooks/useMigrationProgress';
 import { iconMapper } from './utils/statuses';
 import { MigrationTableDataLayout } from './utils/utils';
 import MigrationActionsDropdown from './MigrationActionsDropdown';
@@ -38,8 +37,7 @@ const MigrationsRow: FC<RowProps<MigrationTableDataLayout>> = ({ activeColumnIDs
   const targetNode = getMigrationTargetNode(vmim);
   const migrationPhase = getMigrationPhase(vmim);
 
-  const { isFailed, percentage } = useMigrationPercentage(vmiObj);
-  const progressStatus = getMigrationProgressVariant(percentage, isFailed);
+  const { percentage, progressVariant } = useMigrationProgress(vmiObj, migrationPhase);
 
   const StatusIcon = iconMapper?.[migrationPhase];
 
@@ -76,7 +74,7 @@ const MigrationsRow: FC<RowProps<MigrationTableDataLayout>> = ({ activeColumnIDs
         <Progress
           measureLocation={ProgressMeasureLocation.top}
           value={percentage}
-          variant={progressStatus}
+          variant={progressVariant}
         />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="source">

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/hooks/useMigrationProgress.ts
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/hooks/useMigrationProgress.ts
@@ -1,0 +1,38 @@
+import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import useMigrationPercentage from '@kubevirt-utils/resources/vm/hooks/useMigrationPercentage';
+import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
+import { ProgressVariant } from '@patternfly/react-core';
+import { getMigrationProgressVariant } from '@virtualmachines/details/tabs/metrics/utils/utils';
+
+type UseMigrationProgress = (
+  vmi: V1VirtualMachineInstance,
+  migrationPhase: string,
+) => {
+  percentage: number;
+  progressVariant: ProgressVariant;
+};
+
+const useMigrationProgress: UseMigrationProgress = (vmi, migrationPhase) => {
+  const { isFailed, percentage } = useMigrationPercentage(vmi);
+
+  if (migrationPhase === vmimStatuses.Failed) {
+    return {
+      percentage: 0,
+      progressVariant: ProgressVariant.danger,
+    };
+  }
+
+  if (migrationPhase === vmimStatuses.Succeeded) {
+    return {
+      percentage: 100,
+      progressVariant: ProgressVariant.success,
+    };
+  }
+
+  return {
+    percentage,
+    progressVariant: getMigrationProgressVariant(percentage, isFailed),
+  };
+};
+
+export default useMigrationProgress;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes a bug that when a VMI had an active migration, all previous migrations were showing progress of the active migration

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/940bb661-1e39-46b6-9355-e3dcfd5c9c21



After:


https://github.com/user-attachments/assets/da0aa6ce-323a-4c5f-b898-7c1c841a4303





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved migration progress calculation logic by consolidating state management and variant determination into a unified approach. The migration status indicator functionality remains unchanged for end-users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->