### PR TITLE
CNV-74367: backporting fix to cpu and memory metrics from pull #2944

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1105,7 +1105,7 @@
   "Removing Resources": "Removing Resources",
   "Request sent": "Request sent",
   "Requested": "Requested",
-  "Requested of ": "Requested of ",
+  "Requested of {{cpuRequested}}": "Requested of {{cpuRequested}}",
   "Required": "Required",
   "Required parameters": "Required parameters",
   "Required when automatic update is enabled": "Required when automatic update is enabled",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1109,7 +1109,7 @@
   "Removing Resources": "Eliminando recursos",
   "Request sent": "Solicitud enviada",
   "Requested": "Solicitado",
-  "Requested of ": "Solicitado de",
+  "Requested of {{cpuRequested}}": "Requested of {{cpuRequested}}",
   "Required": "Requerido",
   "Required parameters": "Parámetros requeridos",
   "Required when automatic update is enabled": "Se requiere cuando la actualización automática está habilitada.",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1109,7 +1109,7 @@
   "Removing Resources": "Suppression des ressources",
   "Request sent": "Demande envoyée",
   "Requested": "Demandé",
-  "Requested of ": "Demandé de ",
+  "Requested of {{cpuRequested}}": "Requested of {{cpuRequested}}",
   "Required": "Requis",
   "Required parameters": "Paramètres requis",
   "Required when automatic update is enabled": "Obligatoire lorsque la mise à jour automatique est activée",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1105,7 +1105,7 @@
   "Removing Resources": "リソースの削除",
   "Request sent": "送信済みリクエスト",
   "Requested": "要求済み",
-  "Requested of ": "要求済み / ",
+  "Requested of {{cpuRequested}}": "Requested of {{cpuRequested}}",
   "Required": "必須",
   "Required parameters": "必須パラメーター",
   "Required when automatic update is enabled": "自動更新が有効な場合に必須",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1105,7 +1105,7 @@
   "Removing Resources": "리소스 제거 중",
   "Request sent": "요청 전송됨",
   "Requested": "요청됨",
-  "Requested of ": "요청됨",
+  "Requested of {{cpuRequested}}": "Requested of {{cpuRequested}}",
   "Required": "필수 항목",
   "Required parameters": "필수 매개 변수",
   "Required when automatic update is enabled": "자동 업데이트가 활성화된 경우 필수 사항",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1105,7 +1105,7 @@
   "Removing Resources": "删除资源",
   "Request sent": "请求发生",
   "Requested": "请求的",
-  "Requested of ": "请求的",
+  "Requested of {{cpuRequested}}": "Requested of {{cpuRequested}}",
   "Required": "必需",
   "Required parameters": "所需的参数",
   "Required when automatic update is enabled": "在启用自动更新时需要",

--- a/src/utils/components/Charts/utils/queries.ts
+++ b/src/utils/components/Charts/utils/queries.ts
@@ -1,7 +1,6 @@
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 enum VMQueries {
-  CPU_REQUESTED = 'CPU_REQUESTED',
   CPU_USAGE = 'CPU_USAGE',
   FILESYSTEM_READ_USAGE = 'FILESYSTEM_READ_USAGE',
   FILESYSTEM_USAGE_TOTAL = 'FILESYSTEM_TOTAL_USAGE',
@@ -24,23 +23,17 @@ enum VMQueries {
 
 type UtilizationQueriesArgs = {
   duration?: string;
-  launcherPodName?: string;
   nic?: string;
   obj: K8sResourceCommon;
 };
 
-type GetUtilizationQueries = ({ duration, launcherPodName, nic, obj }: UtilizationQueriesArgs) => {
+type GetUtilizationQueries = ({ duration, nic, obj }: UtilizationQueriesArgs) => {
   [key in VMQueries]: string;
 };
 
-export const getUtilizationQueries: GetUtilizationQueries = ({
-  duration,
-  launcherPodName,
-  obj,
-}) => {
+export const getUtilizationQueries: GetUtilizationQueries = ({ duration, obj }) => {
   const { name, namespace } = obj?.metadata || {};
   return {
-    [VMQueries.CPU_REQUESTED]: `sum(kube_pod_resource_request{resource='cpu',pod='${launcherPodName}',namespace='${namespace}'}) BY (name, namespace)`,
     [VMQueries.CPU_USAGE]: `sum(rate(kubevirt_vmi_cpu_usage_seconds_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
     [VMQueries.FILESYSTEM_READ_USAGE]: `sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,
     [VMQueries.FILESYSTEM_USAGE_TOTAL]: `sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total{name='${name}',namespace='${namespace}'}[${duration}]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,

--- a/src/utils/resources/vm/utils/utils.ts
+++ b/src/utils/resources/vm/utils/utils.ts
@@ -1,5 +1,9 @@
 import { VirtualMachineModelRef } from '@kubevirt-ui/kubevirt-api/console';
+import { V1CPU } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getNamespacePathSegment, isEmpty } from '@kubevirt-utils/utils/utils';
+
+export const getVCPUCount = (cpu: V1CPU) =>
+  (cpu?.sockets || 1) * (cpu?.cores || 1) * (cpu?.threads || 1);
 
 export const getVMListPath = (namespace: string, params: string) => {
   const namespaceSegment = getNamespacePathSegment(namespace);

--- a/src/views/virtualmachines/details/tabs/metrics/UtilizationCharts/UtilizationCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/UtilizationCharts/UtilizationCharts.tsx
@@ -4,15 +4,13 @@ import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import CPUThresholdChart from '@kubevirt-utils/components/Charts/CPUUtil/CPUThresholdChart';
 import MemoryThresholdChart from '@kubevirt-utils/components/Charts/MemoryUtil/MemoryThresholdChart';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { Card, CardBody, CardTitle, Grid, GridItem } from '@patternfly/react-core';
 
 type UtilizationChartsProps = {
-  pods: K8sResourceCommon[];
   vmi: V1VirtualMachineInstance;
 };
 
-const UtilizationCharts: FC<UtilizationChartsProps> = ({ pods, vmi }) => {
+const UtilizationCharts: FC<UtilizationChartsProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
 
   return (
@@ -29,7 +27,7 @@ const UtilizationCharts: FC<UtilizationChartsProps> = ({ pods, vmi }) => {
         <Card>
           <CardTitle>{t('CPU')}</CardTitle>
           <CardBody>
-            <CPUThresholdChart pods={pods} vmi={vmi} />
+            <CPUThresholdChart vmi={vmi} />
           </CardBody>
         </Card>
       </GridItem>

--- a/src/views/virtualmachines/details/tabs/overview/VirtualMachinesOverviewTab.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/VirtualMachinesOverviewTab.tsx
@@ -46,7 +46,7 @@ const VirtualMachinesOverviewTab: FC<NavPageComponentProps> = ({
               />
             </GridItem>
             <GridItem>
-              <VirtualMachinesOverviewTabUtilization pods={pods} vm={vm} vmi={vmi} />
+              <VirtualMachinesOverviewTabUtilization vm={vm} vmi={vmi} />
             </GridItem>
           </Grid>
         </GridItem>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/VirtualMachinesOverviewTabUtilization.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/VirtualMachinesOverviewTabUtilization.tsx
@@ -4,7 +4,6 @@ import { Trans } from 'react-i18next';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ComponentReady from '@kubevirt-utils/components/Charts/ComponentReady/ComponentReady';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Card,
   CardBody,
@@ -28,13 +27,11 @@ import UtilizationThresholdCharts from './components/UtilizationThresholdCharts'
 import './virtual-machines-overview-tab-utilization.scss';
 
 type VirtualMachinesOverviewTabUtilizationProps = {
-  pods: K8sResourceCommon[];
   vm: V1VirtualMachine;
   vmi: V1VirtualMachineInstance;
 };
 
 const VirtualMachinesOverviewTabUtilization: FC<VirtualMachinesOverviewTabUtilizationProps> = ({
-  pods,
   vm,
   vmi,
 }) => {
@@ -66,7 +63,7 @@ const VirtualMachinesOverviewTabUtilization: FC<VirtualMachinesOverviewTabUtiliz
         <ComponentReady isReady={isRunning(vm)} text={t('VirtualMachine is not running')}>
           <Grid>
             <GridItem span={3}>
-              <CPUUtil pods={pods} vmi={vmi} />
+              <CPUUtil vmi={vmi} />
             </GridItem>
             <GridItem span={3}>
               <MemoryUtil vmi={vmi} />
@@ -77,7 +74,7 @@ const VirtualMachinesOverviewTabUtilization: FC<VirtualMachinesOverviewTabUtiliz
             <GridItem span={3}>
               <NetworkUtil vmi={vmi} />
             </GridItem>
-            <UtilizationThresholdCharts pods={pods} vmi={vmi} />
+            <UtilizationThresholdCharts vmi={vmi} />
           </Grid>
         </ComponentReady>
       </CardBody>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/UtilizationThresholdCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/UtilizationThresholdCharts.tsx
@@ -1,27 +1,25 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import CPUThresholdChart from '@kubevirt-utils/components/Charts/CPUUtil/CPUThresholdChart';
 import MemoryThresholdChart from '@kubevirt-utils/components/Charts/MemoryUtil/MemoryThresholdChart';
 import NetworkThresholdChart from '@kubevirt-utils/components/Charts/NetworkUtil/NetworkThresholdChart';
 import StorageTotalReadWriteThresholdChart from '@kubevirt-utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { GridItem } from '@patternfly/react-core';
 
 import TimeDropdown from './TimeDropdown';
 
 type UtilizationThresholdChartsProps = {
-  pods: K8sResourceCommon[];
   vmi: V1VirtualMachineInstance;
 };
-const UtilizationThresholdCharts: React.FC<UtilizationThresholdChartsProps> = ({ pods, vmi }) => {
+const UtilizationThresholdCharts: FC<UtilizationThresholdChartsProps> = ({ vmi }) => {
   return (
     <>
       <GridItem span={12}>
         <TimeDropdown />
       </GridItem>
       <GridItem span={3}>
-        <CPUThresholdChart pods={pods} vmi={vmi} />
+        <CPUThresholdChart vmi={vmi} />
       </GridItem>
       <GridItem span={3}>
         <MemoryThresholdChart vmi={vmi} />

--- a/src/views/virtualmachines/list/components/VirtualMachineListSummary/VirtualMachineListSummary.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineListSummary/VirtualMachineListSummary.tsx
@@ -44,7 +44,7 @@ const VirtualMachineListSummary: FC<VirtualMachineListSummaryProps> = ({
   const { primaryStatuses } = getVMStatuses(vms || []);
 
   const { cpuRequested, cpuUsage, memoryCapacity, memoryUsage, storageCapacity, storageUsage } =
-    useVMTotalsMetrics(vms, vmis);
+    useVMTotalsMetrics(vmis);
 
   const onStatusChange = (status: 'Error' | VM_STATUS) => () =>
     onFilterChange(VirtualMachineRowFilterType.Status, { selected: [status] });

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
@@ -7,10 +7,12 @@ import {
 } from '@kubevirt-ui/kubevirt-api/console';
 import {
   V1VirtualMachine,
+  V1VirtualMachineInstance,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getCPU, getMemory } from '@kubevirt-utils/resources/vm';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
@@ -38,16 +40,11 @@ const VirtualMachineRowLayout: FC<
       node: ReactNode | string;
       pvcMapper: PVCMapper;
       status: ReactNode;
+      vmi?: V1VirtualMachineInstance;
       vmim: V1VirtualMachineInstanceMigration;
-      vmiMemory?: string;
     }
   >
-> = ({
-  activeColumnIDs,
-  index,
-  obj,
-  rowData: { ips, node, pvcMapper, status, vmim, vmiMemory },
-}) => {
+> = ({ activeColumnIDs, index, obj, rowData: { ips, node, pvcMapper, status, vmi, vmim } }) => {
   // TODO: investigate using the index prop
   index;
   const selected = isVMSelected(obj);
@@ -96,10 +93,10 @@ const VirtualMachineRowLayout: FC<
         {ips}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="memory-usage">
-        <MemoryPercentage vm={obj} vmiMemory={vmiMemory} />
+        <MemoryPercentage vm={obj} vmiMemory={getMemory(vmi)} />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="cpu-usage">
-        <CPUPercentage vm={obj} />
+        <CPUPercentage vm={obj} vmiCPU={getCPU(vmi)} />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="network-usage">
         <NetworkUsage vm={obj} />

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
@@ -7,7 +7,6 @@ import {
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, NodeModel } from '@kubevirt-utils/models';
-import { getMemory } from '@kubevirt-utils/resources/vm';
 import { getVMIIPAddressesWithName } from '@kubevirt-utils/resources/vmi';
 import { ResourceLink, RowProps } from '@openshift-console/dynamic-plugin-sdk';
 import { PVCMapper } from '@virtualmachines/utils/mappers';
@@ -43,8 +42,8 @@ const VirtualMachineRunningRow: FC<
         ),
         pvcMapper,
         status,
+        vmi,
         vmim,
-        vmiMemory: getMemory(vmi),
       }}
       activeColumnIDs={activeColumnIDs}
       index={index}

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/components/CPUPercentage.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/components/CPUPercentage.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1CPU, V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -9,10 +9,11 @@ import { isRunning } from '@virtualmachines/utils';
 
 type CPUPercentageProps = {
   vm: V1VirtualMachine;
+  vmiCPU: V1CPU;
 };
 
-const CPUPercentage: FC<CPUPercentageProps> = ({ vm }) => {
-  const cpuUsagePercentage = getCPUUsagePercentage(getName(vm), getNamespace(vm));
+const CPUPercentage: FC<CPUPercentageProps> = ({ vm, vmiCPU }) => {
+  const cpuUsagePercentage = getCPUUsagePercentage(getName(vm), getNamespace(vm), vmiCPU);
 
   if (isEmpty(cpuUsagePercentage) || !isRunning(vm)) return <span>{NO_DATA_DASH}</span>;
 

--- a/src/views/virtualmachines/list/hooks/constants.ts
+++ b/src/views/virtualmachines/list/hooks/constants.ts
@@ -4,7 +4,6 @@ export const TEXT_FILTER_NAME_ID = 'name';
 export const TEXT_FILTER_LABELS_ID = 'labels';
 
 export const VMListQueries = {
-  CPU_REQUESTED: 'CPU_REQUESTED',
   CPU_USAGE: 'CPU_USAGE',
   MEMORY_USAGE: 'MEMORY_USAGE',
   NETWORK_TOTAL_USAGE: 'NETWORK_TOTAL_USAGE',
@@ -15,7 +14,6 @@ export const getVMListQueries = (namespace: string) => {
     namespace === ALL_NAMESPACES_SESSION_KEY ? '' : `namespace='${namespace}'`;
 
   return {
-    [VMListQueries.CPU_REQUESTED]: `kube_pod_resource_request{resource='cpu',${namespaceFilter}}`,
     [VMListQueries.CPU_USAGE]: `rate(kubevirt_vmi_cpu_usage_seconds_total{${namespaceFilter}}[30s])`,
     [VMListQueries.MEMORY_USAGE]: `kubevirt_vmi_memory_used_bytes{${namespaceFilter}}`,
     [VMListQueries.NETWORK_TOTAL_USAGE]: `rate(kubevirt_vmi_network_transmit_bytes_total{${namespaceFilter}}[30s]) + rate(kubevirt_vmi_network_receive_bytes_total{${namespaceFilter}}[30s])`,

--- a/src/views/virtualmachines/list/hooks/sortColumns.ts
+++ b/src/views/virtualmachines/list/hooks/sortColumns.ts
@@ -1,6 +1,6 @@
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { getMemory } from '@kubevirt-utils/resources/vm';
+import { getCPU, getMemory } from '@kubevirt-utils/resources/vm';
 import { columnSortingCompare, isEmpty } from '@kubevirt-utils/utils/utils';
 import { SortByDirection } from '@patternfly/react-table';
 import { getDeletionProtectionPrintableStatus } from '@virtualmachines/details/tabs/configuration/details/components/DeletionProtection/utils/utils';
@@ -39,10 +39,14 @@ export const sortByCPUUsage = (
   data: V1VirtualMachine[],
   direction: SortByDirection,
   pagination: { [key: string]: any },
+  vmiMapper: VMIMapper,
 ) => {
   const compareCPUUsage = (a: V1VirtualMachine, b: V1VirtualMachine): number => {
-    const cpuUsageA = getCPUUsagePercentage(getName(a), getNamespace(a));
-    const cpuUsageB = getCPUUsagePercentage(getName(b), getNamespace(b));
+    const aCPU = getCPU(getVMIFromMapper(vmiMapper, a));
+    const bCPU = getCPU(getVMIFromMapper(vmiMapper, b));
+
+    const cpuUsageA = getCPUUsagePercentage(getName(a), getNamespace(a), aCPU);
+    const cpuUsageB = getCPUUsagePercentage(getName(b), getNamespace(b), bCPU);
 
     if (isEmpty(cpuUsageA)) return -1;
     if (isEmpty(cpuUsageB)) return 1;

--- a/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
+++ b/src/views/virtualmachines/list/hooks/useVirtualMachineColumns.ts
@@ -123,7 +123,7 @@ const useVirtualMachineColumns = (
       {
         additional: true,
         id: 'cpu-usage',
-        sort: (_, direction) => sortingUsingFunction(direction, sortByCPUUsage),
+        sort: (_, direction) => sortingUsingFunctionWithMapper(direction, sortByCPUUsage),
         title: t('CPU'),
         transforms: [sortable],
       },

--- a/src/views/virtualmachines/list/metrics.ts
+++ b/src/views/virtualmachines/list/metrics.ts
@@ -1,12 +1,13 @@
 import xbytes from 'xbytes';
 
+import { V1CPU } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
+import { getVCPUCount } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { signal } from '@preact/signals-core';
 
 export type MetricsType = {
   [key in string]: {
-    cpuRequested?: number;
     cpuUsage?: number;
     memoryRequested?: number;
     memoryUsage?: number;
@@ -40,18 +41,14 @@ export const setVMCPUUsage = (vmName: string, vmNamespace: string, cpuUsage: num
   vmMetrics.cpuUsage = cpuUsage;
 };
 
-export const setVMCPURequested = (vmName: string, vmNamespace: string, cpuRequested: number) => {
-  const vmMetrics = getVMMetrics(vmName, vmNamespace);
-  vmMetrics.cpuRequested = cpuRequested;
-};
+export const getCPUUsagePercentage = (vmName: string, vmNamespace: string, vmiCPU: V1CPU) => {
+  const { cpuUsage } = getVMMetrics(vmName, vmNamespace);
 
-export const getCPUUsagePercentage = (vmName: string, vmNamespace: string) => {
-  const { cpuRequested, cpuUsage } = getVMMetrics(vmName, vmNamespace);
+  if (isEmpty(cpuUsage)) return;
 
-  if (isEmpty(cpuRequested) || isEmpty(cpuUsage)) return;
+  const cpuRequested = getVCPUCount(vmiCPU);
 
-  const percentage = (cpuUsage * 100) / cpuRequested;
-  return percentage;
+  return (cpuUsage * 100) / cpuRequested;
 };
 
 export const getMemoryUsagePercentage = (

--- a/src/views/virtualmachines/list/utils/processVMTotalsMetrics.ts
+++ b/src/views/virtualmachines/list/utils/processVMTotalsMetrics.ts
@@ -2,8 +2,9 @@ import xbytes from 'xbytes';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
-import { getMemory } from '@kubevirt-utils/resources/vm';
+import { getCPU, getMemory, getVCPUCount } from '@kubevirt-utils/resources/vm';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
+import { humanizeCpuCores } from '@kubevirt-utils/utils/humanize.js';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
 import { METRICS } from '@overview/OverviewTab/metric-charts-card/utils/constants';
 import {
@@ -44,4 +45,10 @@ export const getMemoryCapacityText = (vmis: V1VirtualMachineInstance[]) => {
 export const getMetricText = (response: PrometheusResponse, metric: string) => {
   const bytes = getRawNumber(response);
   return getValueWithUnitText(bytes, metric);
+};
+
+export const getCpuRequestedText = (vmis: V1VirtualMachineInstance[]) => {
+  const totalCPU = vmis.map((vmi) => getCPU(vmi)).reduce((acc, cpu) => acc + getVCPUCount(cpu), 0);
+
+  return humanizeCpuCores(totalCPU).string;
 };

--- a/src/views/virtualmachines/list/utils/totalsQueries.ts
+++ b/src/views/virtualmachines/list/utils/totalsQueries.ts
@@ -1,26 +1,21 @@
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 
 export const VMTotalsQueries = {
-  TOTAL_CPU_REQUESTED: 'TOTAL_CPU_REQUESTED',
   TOTAL_CPU_USAGE: 'TOTAL_CPU_USAGE',
   TOTAL_MEMORY_USAGE: 'TOTAL_MEMORY_USAGE',
   TOTAL_STORAGE_CAPACITY: 'TOTAL_STORAGE_CAPACITY',
   TOTAL_STORAGE_USAGE: 'TOTAL_STORAGE_USAGE',
 };
 
-export const getVMTotalsQueries = (namespace: string, namespacesList: string[]) => {
+export const getVMTotalsQueries = (namespace: string) => {
   const isAllNamespaces = namespace === ALL_NAMESPACES_SESSION_KEY;
 
   const sumByNamespace = isAllNamespaces ? 'sum' : 'sum by (namespace)';
   const filterByNamespace = isAllNamespaces ? '' : `{namespace='${namespace}'}`;
-  const filterCpuRequestedByNamespace = isAllNamespaces
-    ? `namespace=~'${namespacesList.join('|')}'`
-    : `namespace='${namespace}'`;
 
   return {
-    [VMTotalsQueries.TOTAL_CPU_REQUESTED]: `${sumByNamespace}(kube_pod_resource_request{resource='cpu',${filterCpuRequestedByNamespace}})`,
     [VMTotalsQueries.TOTAL_CPU_USAGE]: `${sumByNamespace}(rate(kubevirt_vmi_cpu_usage_seconds_total${filterByNamespace}[30s]))`,
-    [VMTotalsQueries.TOTAL_MEMORY_USAGE]: `${sumByNamespace}(kubevirt_vmi_memory_available_bytes${filterByNamespace} - kubevirt_vmi_memory_usable_bytes${filterByNamespace})`,
+    [VMTotalsQueries.TOTAL_MEMORY_USAGE]: `${sumByNamespace}(kubevirt_vmi_memory_used_bytes${filterByNamespace})`,
     [VMTotalsQueries.TOTAL_STORAGE_CAPACITY]: `${sumByNamespace}(max(kubevirt_vmi_filesystem_capacity_bytes${filterByNamespace}) by (namespace, name, disk_name))`,
     [VMTotalsQueries.TOTAL_STORAGE_USAGE]: `${sumByNamespace}(max(kubevirt_vmi_filesystem_used_bytes${filterByNamespace}) by (namespace, name, disk_name))`,
   };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

backporting https://github.com/kubevirt-ui/kubevirt-plugin/pull/2944 changes to cpu and memory metrics. 
For CPU requested metric we don't have to fetch it from prometheus using `kube_pod_resource_request`
We need to take it from the VMI. `kube_pod_resource_request` is not directly related to the VMI CPU requested, but it's scaled using HCO configuration.

For memory we often use `kubevirt_vmi_memory_available_bytes `- `kubevirt_vmi_memory_usable_bytes` but the right metric is `kubevirt_vmi_memory_used_bytes`

