### PR TITLE
CNV-72887: fix redirect after deleting storage migration plan

### DIFF
--- a/src/views/storagemigrations/actions/useStorageMigrationActions.tsx
+++ b/src/views/storagemigrations/actions/useStorageMigrationActions.tsx
@@ -92,6 +92,7 @@ const useStorageMigrationActions: ExtensionHook<Action[], MigPlan> = (migPlan) =
               obj={migPlan}
               onClose={onClose}
               onDeleteSubmit={deleteMigPlan}
+              redirectUrl="/k8s/storagemigrations"
             />
           )),
         disabled: false,

--- a/src/views/storagemigrations/extensions.ts
+++ b/src/views/storagemigrations/extensions.ts
@@ -3,12 +3,14 @@ import {
   FeatureFlagHookProvider,
   HrefNavItem,
   NavSection,
+  ResourceActionProvider,
   RoutePage,
 } from '@openshift-console/dynamic-plugin-sdk';
 import type { ConsolePluginBuildMetadata } from '@openshift-console/dynamic-plugin-sdk-webpack';
 
 export const exposedModules: ConsolePluginBuildMetadata['exposedModules'] = {
   StorageMigrationList: './views/storagemigrations/list/StorageMigrationList.tsx',
+  useStorageMigrationActions: './views/storagemigrations/actions/useStorageMigrationActions.tsx',
 };
 
 export const extensions: EncodedExtension[] = [
@@ -48,6 +50,22 @@ export const extensions: EncodedExtension[] = [
     },
     type: 'console.navigation/section',
   } as EncodedExtension<NavSection>,
+  {
+    flags: {
+      required: ['STORAGE_MIGRATION_ENABLED'],
+    },
+    properties: {
+      model: {
+        group: 'migration.openshift.io',
+        kind: 'MigPlan',
+        version: 'v1alpha1',
+      },
+      provider: {
+        $codeRef: 'useStorageMigrationActions',
+      },
+    },
+    type: 'console.action/resource-provider',
+  } as EncodedExtension<ResourceActionProvider>,
   {
     flags: {
       required: ['STORAGE_MIGRATION_ENABLED'],


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

i registered the same custom actions for the detail page as the list page and added redirect url so when deleting a storage migration plan it now redirects to the correct storage migration plans list page.


## 🎥 Demo


https://github.com/user-attachments/assets/c2ffbc37-6f18-488e-aff4-9d23d8b15d9e


