### PR TITLE
CNV-74966: Update overview tab to support multi-cluster requests

### DIFF
--- a/__mocks__/multicluster-sdk.ts
+++ b/__mocks__/multicluster-sdk.ts
@@ -3,7 +3,10 @@ const multiclusterSDK = require('@stolostron/multicluster-sdk');
 module.exports = {
   FleetWatchK8sResource: multiclusterSDK.FleetWatchK8sResource,
   getFleetK8sAPIPath: () => Promise.resolve('/k8s/kubernetes'),
+  useFleetClusterNames: () => [['cluster1', 'cluster2'], true, undefined],
   useFleetK8sAPIPath: () => ['/k8s/kubernetes', true, undefined],
   useFleetK8sWatchResource: () => [undefined, true, undefined],
+  useFleetPrometheusPoll: () => [undefined, true, undefined],
+  useFleetSearchPoll: () => [undefined, true, undefined, jest.fn()],
   useHubClusterName: () => ['hub', true, undefined],
 };

--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1144,6 +1144,7 @@
   "Not supported with primary user-defined networks": "Not supported with primary user-defined networks",
   "Note that for Node field expressions, entering a full path is required in the \"Key\" field (e.g. \"metadata.name: value\").": "Note that for Node field expressions, entering a full path is required in the \"Key\" field (e.g. \"metadata.name: value\").",
   "O series": "O series",
+  "Observability is disabled for this cluster": "Observability is disabled for this cluster",
   "Off": "Off",
   "OFF": "OFF",
   "Okay, got it!": "Okay, got it!",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1155,6 +1155,7 @@
   "Not supported with primary user-defined networks": "Not supported with primary user-defined networks",
   "Note that for Node field expressions, entering a full path is required in the \"Key\" field (e.g. \"metadata.name: value\").": "Tenga en cuenta que, en las expresiones del campo Nodo, es necesario ingresar una ruta completa en el campo \"Clave\" (p.\u00a0ej., \"metadata.name: value\").",
   "O series": "Serie O",
+  "Observability is disabled for this cluster": "Observability is disabled for this cluster",
   "Off": "Apagado",
   "OFF": "APAGADO",
   "Okay, got it!": "¡De acuerdo, entendido!",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1155,6 +1155,7 @@
   "Not supported with primary user-defined networks": "Not supported with primary user-defined networks",
   "Note that for Node field expressions, entering a full path is required in the \"Key\" field (e.g. \"metadata.name: value\").": "Notez que pour les expressions de champ Node, la saisie d'un chemin complet est requise dans le champ «\u00a0Clé\u00a0» (par exemple «\u00a0metadata.name\u00a0: valeur\u00a0»).",
   "O series": "Série O",
+  "Observability is disabled for this cluster": "Observability is disabled for this cluster",
   "Off": "Désactivé",
   "OFF": "DÉSACTIVÉ",
   "Okay, got it!": "J’ai compris.",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1140,6 +1140,7 @@
   "Not supported with primary user-defined networks": "Not supported with primary user-defined networks",
   "Note that for Node field expressions, entering a full path is required in the \"Key\" field (e.g. \"metadata.name: value\").": "ノードフィールド式の場合、\"キー\" フィールドにフルパスを入力する必要があることに注意してください (例: \"metadata.name: value\")。",
   "O series": "O シリーズ",
+  "Observability is disabled for this cluster": "Observability is disabled for this cluster",
   "Off": "オフ",
   "OFF": "無効",
   "Okay, got it!": "了解しました!",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1140,6 +1140,7 @@
   "Not supported with primary user-defined networks": "Not supported with primary user-defined networks",
   "Note that for Node field expressions, entering a full path is required in the \"Key\" field (e.g. \"metadata.name: value\").": "노드 필드 표현식의 경우 \"Key\" 필드에 전체 경로를 입력해야 합니다. (예: \"metadata.name: value\")",
   "O series": "O 시리즈",
+  "Observability is disabled for this cluster": "Observability is disabled for this cluster",
   "Off": "OFF",
   "OFF": "OFF",
   "Okay, got it!": "알겠습니다!",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1140,6 +1140,7 @@
   "Not supported with primary user-defined networks": "Not supported with primary user-defined networks",
   "Note that for Node field expressions, entering a full path is required in the \"Key\" field (e.g. \"metadata.name: value\").": "请注意，对于 Node 字段表达式，在 Key 字段中输入完整路径（如 \"metadata.name: value\"）。",
   "O series": "O 系列",
+  "Observability is disabled for this cluster": "Observability is disabled for this cluster",
   "Off": "Off",
   "OFF": "OFF",
   "Okay, got it!": "好，知道了！",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@patternfly/react-tokens": "^6.2.2",
     "@patternfly/react-topology": "^6.2.0",
     "@preact/signals-react": "^2.0.1",
-    "@stolostron/multicluster-sdk": "^0.7.5",
+    "@stolostron/multicluster-sdk": "^0.8.0",
     "@xterm/addon-clipboard": "^0.1.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",

--- a/src/multicluster/components/MulticlusterYAMLCreation/MulticlusterYAMLCreation.tsx
+++ b/src/multicluster/components/MulticlusterYAMLCreation/MulticlusterYAMLCreation.tsx
@@ -11,6 +11,7 @@ import { getName } from '@kubevirt-utils/resources/shared';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { kubevirtK8sCreate } from '@multicluster/k8sRequests';
 import { getFleetResourceRoute, getMulticlusterSearchURL } from '@multicluster/urls';
+import useIsACMPage from '@multicluster/useIsACMPage';
 import { ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
 
 import useModelFromParam from './hooks/useModelFromParam';
@@ -19,7 +20,7 @@ import useYAMLTemplateExtension from './hooks/useYAMLTemplateExtension';
 const MulticlusterYAMLCreation: FC = () => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
-
+  const isACMPage = useIsACMPage();
   const [model, loading] = useModelFromParam();
   const { resourceYAMLTemplate, yamlExtensionsResolved } = useYAMLTemplateExtension(model);
 
@@ -59,7 +60,12 @@ const MulticlusterYAMLCreation: FC = () => {
 
   return (
     <>
-      <ClusterProjectDropdown includeAllClusters={false} showProjectDropdown={model?.namespaced} />
+      {isACMPage && (
+        <ClusterProjectDropdown
+          includeAllClusters={false}
+          showProjectDropdown={model?.namespaced}
+        />
+      )}
       <ResourceYAMLEditor
         create
         header={t('Create {{kind}}', { kind: model.kind })}

--- a/src/multicluster/extensions.ts
+++ b/src/multicluster/extensions.ts
@@ -48,6 +48,22 @@ export const extensions: EncodedExtension[] = [
       dataAttributes: {
         'data-border': 'no-border',
         'data-class': 'kv-plugin-virt-perspective-element',
+        'data-quickstart-id': 'qs-nav-virtualization-overview',
+        'data-test-id': 'virtualization-overview-nav-item',
+      },
+      href: '/k8s/all-clusters/all-namespaces/virtualization-overview',
+      id: 'overview-virt-perspective',
+      insertBefore: 'virtualization-catalog-virt-perspective',
+      name: '%plugin__kubevirt-plugin~Overview%',
+      perspective: 'fleet-virtualization-perspective',
+    },
+    type: 'console.navigation/href',
+  } as EncodedExtension<HrefNavItem>,
+  {
+    properties: {
+      dataAttributes: {
+        'data-border': 'no-border',
+        'data-class': 'kv-plugin-virt-perspective-element',
         'data-quickstart-id': 'qs-nav-virtualization-catalog',
         'data-test-id': 'virtualization-catalog-nav-item',
       },
@@ -252,6 +268,22 @@ export const extensions: EncodedExtension[] = [
     },
     type: 'acm.virtualmachine/action',
   } as EncodedExtension<ACMVirtualMachineAction>,
+  {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC_ACM'],
+    },
+    properties: {
+      component: {
+        $codeRef: 'ClusterOverviewPage',
+      },
+      path: [
+        '/k8s/all-clusters/all-namespaces/virtualization-overview',
+        '/k8s/cluster/:cluster/ns/:ns/virtualization-overview',
+        '/k8s/cluster/:cluster/all-namespaces/virtualization-overview',
+      ],
+    },
+    type: 'console.page/route',
+  } as EncodedExtension<RoutePage>,
   {
     properties: {
       component: {

--- a/src/multicluster/urls.ts
+++ b/src/multicluster/urls.ts
@@ -1,6 +1,10 @@
 import { matchPath } from 'react-router-dom-v5-compat';
 
-import { ALL_NAMESPACES } from '@kubevirt-utils/hooks/constants';
+import {
+  ALL_CLUSTERS_KEY,
+  ALL_NAMESPACES,
+  ALL_NAMESPACES_SESSION_KEY,
+} from '@kubevirt-utils/hooks/constants';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
 import { isAllNamespaces } from '@kubevirt-utils/utils/utils';
 import { ExtensionK8sModel, K8sModel } from '@openshift-console/dynamic-plugin-sdk';
@@ -22,15 +26,20 @@ export const getACMVMURL = (cluster: string, namespace: string, name: string): s
   `/k8s/cluster/${cluster}/ns/${namespace}/${KUBEVIRT_VM_PATH}/${name}`;
 
 export const getACMVMListURL = (cluster?: string, namespace?: string): string => {
-  if (namespace) return getACMVMListNamespacesURL(cluster, namespace);
+  if (namespace && namespace !== ALL_NAMESPACES_SESSION_KEY) {
+    if (!cluster || cluster === ALL_CLUSTERS_KEY) {
+      return `/k8s/${ALL_CLUSTERS_KEY}/ns/${namespace}/${KUBEVIRT_VM_PATH}`;
+    }
+    return getACMVMListNamespacesURL(cluster, namespace);
+  }
 
-  return cluster
-    ? `/k8s/cluster/${cluster}/all-namespaces/${KUBEVIRT_VM_PATH}`
-    : `/k8s/all-clusters/all-namespaces/${KUBEVIRT_VM_PATH}`;
+  return cluster && cluster !== ALL_CLUSTERS_KEY
+    ? `/k8s/cluster/${cluster}/${ALL_NAMESPACES}/${KUBEVIRT_VM_PATH}`
+    : `/k8s/${ALL_CLUSTERS_KEY}/${ALL_NAMESPACES}/${KUBEVIRT_VM_PATH}`;
 };
 
 export const getACMVMSearchURL = (): string =>
-  `/k8s/all-clusters/all-namespaces/${KUBEVIRT_VM_PATH}/search`;
+  `/k8s/${ALL_CLUSTERS_KEY}/${ALL_NAMESPACES}/${KUBEVIRT_VM_PATH}/search`;
 
 export const getACMVMListNamespacesURL = (cluster: string, namespace: string): string =>
   `/k8s/cluster/${cluster}/ns/${namespace}/${KUBEVIRT_VM_PATH}`;
@@ -38,7 +47,7 @@ export const getACMVMListNamespacesURL = (cluster: string, namespace: string): s
 // based on dns1123LabelRegexp
 const catalogWithNs = new RegExp('/ns/[-a-z0-9]+/catalog');
 
-export const isCatalogURL = (path: string = '') =>
+export const isCatalogURL = (path: string = ''): boolean =>
   path.includes(`${ALL_NAMESPACES}/catalog`) || catalogWithNs.test(path);
 
 export const getCatalogURL = (cluster: string, namespace?: string): string => {
@@ -68,7 +77,7 @@ export const getVMURL = (cluster: string, namespace: string, name: string): stri
         resource: { metadata: { name, namespace } },
       });
 
-export const getVMListURL = (cluster?: string, namespace?: string) =>
+export const getVMListURL = (cluster?: string, namespace?: string): string =>
   cluster
     ? getACMVMListURL(cluster, namespace)
     : getResourceUrl({

--- a/src/perspective/perspective.ts
+++ b/src/perspective/perspective.ts
@@ -1,3 +1,4 @@
+import { ALL_CLUSTERS_KEY, ALL_NAMESPACES } from '@kubevirt-utils/hooks/constants';
 import { Perspective, ResolvedExtension } from '@openshift-console/dynamic-plugin-sdk';
 
 import virtualizationIcon from './virtualization-icon';
@@ -9,7 +10,7 @@ export const icon: ResolvedExtension<Perspective>['properties']['icon'] = {
 };
 
 export const getLandingPageURL: ResolvedExtension<Perspective>['properties']['landingPageURL'] =
-  () => `/k8s/all-namespaces/virtualization-overview`;
+  () => `/k8s/${ALL_NAMESPACES}/virtualization-overview`;
 
 export const getVirtualizationLandingPageURL: ResolvedExtension<Perspective>['properties']['landingPageURL'] =
   () => `/k8s/virtualization-landing`;
@@ -18,4 +19,4 @@ export const getImportRedirectURL: ResolvedExtension<Perspective>['properties'][
   (namespace: string) => `/k8s/ns/${namespace}/virtualization-overview`;
 
 export const getACMLandingPageURL: ResolvedExtension<Perspective>['properties']['landingPageURL'] =
-  () => `/k8s/all-clusters/all-namespaces/kubevirt.io~v1~VirtualMachine`;
+  () => `/k8s/${ALL_CLUSTERS_KEY}/${ALL_NAMESPACES}/virtualization-overview`;

--- a/src/utils/components/AlertsCard/AlertStatusItem.tsx
+++ b/src/utils/components/AlertsCard/AlertStatusItem.tsx
@@ -5,6 +5,7 @@ import { AlertType, SimplifiedAlert } from '@kubevirt-utils/components/AlertsCar
 import { alertIcon } from '@kubevirt-utils/components/AlertsCard/utils/utils';
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useIsACMPage from '@multicluster/useIsACMPage';
 
 import './AlertStatusItem.scss';
 
@@ -15,6 +16,7 @@ type AlertStatusItemProps = {
 
 const AlertStatusItem: React.FC<AlertStatusItemProps> = ({ alertDetails, alertType }) => {
   const { t } = useKubevirtTranslation();
+  const isACMPage = useIsACMPage();
   const { alertName, description, isVMAlert, link, time } = alertDetails;
   const Icon = alertIcon[alertType];
 
@@ -35,7 +37,9 @@ const AlertStatusItem: React.FC<AlertStatusItemProps> = ({ alertDetails, alertTy
                   {t('VM')}
                 </span>
               )}
-              <Timestamp className="alert-item__timestamp" hideIcon timestamp={time} />
+              {!isACMPage && (
+                <Timestamp className="alert-item__timestamp" hideIcon timestamp={time} />
+              )}
             </span>
           </div>
           <div className="alert-name">{alertName}</div>

--- a/src/utils/components/ClusterProjectDropdown/ClusterDropdown.tsx
+++ b/src/utils/components/ClusterProjectDropdown/ClusterDropdown.tsx
@@ -11,7 +11,10 @@ import { useFleetClusterNames } from '@stolostron/multicluster-sdk';
 type ClusterDropdownProps = {
   bookmarkCluster?: string;
   disabled?: boolean;
+  disabledClusters?: string[];
+  disabledItemTooltip?: string;
   includeAllClusters?: boolean;
+  omittedClusters?: string[];
   onChange: (cluster: string) => void;
   selectedCluster: string;
 };
@@ -19,13 +22,24 @@ type ClusterDropdownProps = {
 const ClusterDropdown: FC<ClusterDropdownProps> = ({
   bookmarkCluster,
   disabled = false,
+  disabledClusters,
+  disabledItemTooltip,
   includeAllClusters = true,
+  omittedClusters,
   onChange,
   selectedCluster,
 }): JSX.Element => {
   const { t } = useKubevirtTranslation();
   const [clusterNames, clustersLoaded] = useFleetClusterNames();
   const [bookmarks, updateBookmarks, bookmarksLoaded] = useConsoleClusterBookmarks(bookmarkCluster);
+
+  const isItemDisabled = useMemo(() => {
+    if (!disabledClusters || disabledClusters.length === 0) {
+      return undefined;
+    }
+    const disabledSet = new Set(disabledClusters);
+    return (key: string) => disabledSet.has(key);
+  }, [disabledClusters]);
 
   const config: DropdownConfig = useMemo(
     () => ({
@@ -59,11 +73,14 @@ const ClusterDropdown: FC<ClusterDropdownProps> = ({
       }}
       config={config}
       disabled={disabled}
+      disabledItemTooltip={disabledItemTooltip}
       extractKey={(name) => name}
       extractTitle={(name) => name}
       includeAllItems={includeAllClusters}
+      isItemDisabled={isItemDisabled}
       items={clusterNames || null}
       itemsLoaded={clustersLoaded}
+      omittedItems={omittedClusters}
       onChange={onChange}
       selectedItem={selectedCluster}
     />

--- a/src/utils/components/ClusterProjectDropdown/Dropdown/DropdownGroup.tsx
+++ b/src/utils/components/ClusterProjectDropdown/Dropdown/DropdownGroup.tsx
@@ -1,7 +1,7 @@
 import React, { FC, JSX } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Divider, MenuGroup, MenuItem, MenuList } from '@patternfly/react-core';
+import { Divider, MenuGroup, MenuItem, MenuList, TooltipPosition } from '@patternfly/react-core';
 
 import { DropdownConfig, DropdownOption } from './types';
 
@@ -32,8 +32,21 @@ const DropdownGroup: FC<DropdownGroupProps> = ({
         <MenuList>
           {options.map((option) => {
             const isFavorite = !!favorites?.[option.key];
+            // Use isAriaDisabled instead of isDisabled when tooltip is present
+            // This allows tooltips to work on disabled items (isDisabled sets pointer-events: none)
+            const hasTooltip = !!option.tooltip;
             return (
               <MenuItem
+                tooltipProps={
+                  option.tooltip
+                    ? {
+                        content: option.tooltip,
+                        position: TooltipPosition.left,
+                      }
+                    : undefined
+                }
+                isAriaDisabled={option.disabled && hasTooltip}
+                isDisabled={option.disabled && !hasTooltip}
                 isFavorited={isFavorite}
                 isSelected={selectedKey === option.key}
                 itemId={option.key}

--- a/src/utils/components/ClusterProjectDropdown/Dropdown/types.ts
+++ b/src/utils/components/ClusterProjectDropdown/Dropdown/types.ts
@@ -1,6 +1,8 @@
 export type DropdownOption = {
+  disabled?: boolean;
   key: string;
   title: string;
+  tooltip?: string;
 };
 
 export type DropdownBookmarks = {

--- a/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
+++ b/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
@@ -18,6 +18,7 @@ type HorizontalNavbarProps = {
   instanceTypeExpandedSpec?: V1VirtualMachine;
   loaded: boolean;
   pages: NavPageKubevirt[];
+  routesClassName?: string;
   vm?: V1VirtualMachine;
 };
 
@@ -27,6 +28,7 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
   instanceTypeExpandedSpec,
   loaded,
   pages,
+  routesClassName,
   vm,
 }) => {
   const location = useLocation();
@@ -105,7 +107,9 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
           })}
         </ul>
       </nav>
-      <Routes>{RoutesComponents}</Routes>
+      <div className={routesClassName || 'horizontal-navbar__routes'}>
+        <Routes>{RoutesComponents}</Routes>
+      </div>
     </>
   );
 };

--- a/src/utils/hooks/useAlerts/useAlerts.ts
+++ b/src/utils/hooks/useAlerts/useAlerts.ts
@@ -1,34 +1,110 @@
 import { useMemo } from 'react';
 
-import { SUCCESS } from '@kubevirt-utils/hooks/useAlerts/utils/constants';
-import {
-  getAlertsAndRules,
-  silenceFiringAlerts,
-} from '@kubevirt-utils/hooks/useAlerts/utils/utils';
-import useSilences from '@kubevirt-utils/hooks/useSilences/useSilences';
-import { PrometheusRulesResponse } from '@kubevirt-utils/types/prometheus';
+import { ALL_CLUSTERS_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveClusterParam from '@multicluster/hooks/useActiveClusterParam';
+import useIsACMPage from '@multicluster/useIsACMPage';
 import {
   Alert,
   PrometheusEndpoint,
-  usePrometheusPoll,
+  PrometheusResponse,
 } from '@openshift-console/dynamic-plugin-sdk';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 
-type UseAlerts = () => { alerts: Alert[]; loaded: boolean };
+import useSilences from '../useSilences/useSilences';
+
+import { buildAlertsQuery } from './utils/alertQueries';
+import { convertMetricResultsToAlerts } from './utils/metricToAlerts';
+import { useClusterObservabilityDisabled } from './utils/useClusterObservabilityDisabled';
+import { silenceFiringAlerts } from './utils/utils';
+import useSingleClusterAlerts from './useSingleClusterAlerts';
+
+type UseAlerts = () => {
+  alerts: Alert[];
+  error: Error | unknown;
+  loaded: boolean;
+};
 
 const useAlerts: UseAlerts = () => {
+  const cluster = useActiveClusterParam();
+  const [hubClusterName] = useHubClusterName();
+  const isACMPage = useIsACMPage();
+  const {
+    enabledClusters,
+    error: observabilityError,
+    loaded: observabilityLoaded,
+  } = useClusterObservabilityDisabled(true);
+
+  // For non-ACM pages, use the single cluster alerts hook
+  const singleClusterAlerts = useSingleClusterAlerts();
+
+  // Automatically filter by enabled clusters when querying all clusters
+  const selectedClusters = useMemo(() => {
+    if (cluster === ALL_CLUSTERS_KEY && observabilityLoaded && enabledClusters.length > 0) {
+      return enabledClusters;
+    }
+    return undefined;
+  }, [cluster, observabilityLoaded, enabledClusters]);
+
+  // Determine if we should query all clusters or specific clusters
+  const isAllClusters = cluster === ALL_CLUSTERS_KEY;
+  const hasSelectedClusters = selectedClusters && selectedClusters.length > 0;
+
+  // Build query for all kubevirt alerts (no operator_health_impact filter to get all)
+  // When selectedClusters is provided, use it instead of the single cluster parameter
+  const query = useMemo(() => {
+    if (!isACMPage) {
+      return undefined; // Don't build query for non-ACM pages (we use RULES endpoint)
+    }
+
+    // When selectedClusters is provided, don't pass single cluster/hubClusterName
+    // The buildAlertsQuery function will use selectedClusters for filtering
+    let clusterParam: string | undefined = undefined;
+    let hubClusterNameParam: string | undefined = undefined;
+
+    if (!hasSelectedClusters) {
+      if (!isAllClusters) {
+        clusterParam = cluster;
+        hubClusterNameParam = hubClusterName;
+      }
+    }
+
+    return buildAlertsQuery(
+      clusterParam,
+      hubClusterNameParam,
+      undefined,
+      undefined,
+      selectedClusters,
+    );
+  }, [isACMPage, cluster, hubClusterName, isAllClusters, selectedClusters, hasSelectedClusters]);
+
+  // For ACM pages, use QUERY endpoint with ALERTS metric for multicluster support
   const { silences } = useSilences();
-  const [response] = usePrometheusPoll({
-    endpoint: PrometheusEndpoint?.RULES,
+  const [metricResponse, metricLoaded, metricError] = useFleetPrometheusPoll({
+    endpoint: PrometheusEndpoint.QUERY,
+    query: isACMPage && query ? query : undefined, // Only query for ACM pages with valid query
+    ...(isACMPage && (isAllClusters || hasSelectedClusters) ? { allClusters: true } : {}),
+    ...(isACMPage && !isAllClusters && !hasSelectedClusters && cluster ? { cluster } : {}),
   });
-  const pollingStatus = (response as PrometheusRulesResponse)?.status;
 
   const allAlerts = useMemo(() => {
-    const { alerts } = getAlertsAndRules((response as PrometheusRulesResponse)?.data);
+    if (isACMPage) {
+      // For ACM pages, use ALERTS metric query results
+      if (!metricResponse || metricError) {
+        return [];
+      }
+      const alerts = convertMetricResultsToAlerts(metricResponse as PrometheusResponse);
+      return silenceFiringAlerts(alerts, silences);
+    } else {
+      // For non-ACM pages, use single cluster alerts hook
+      return singleClusterAlerts.alerts;
+    }
+  }, [isACMPage, metricResponse, metricError, silences, singleClusterAlerts.alerts]);
 
-    return silenceFiringAlerts(alerts, silences);
-  }, [response, silences]);
-
-  return { alerts: allAlerts || [], loaded: pollingStatus === SUCCESS };
+  return {
+    alerts: allAlerts,
+    error: observabilityError || (isACMPage ? metricError : singleClusterAlerts.error),
+    loaded: isACMPage ? metricLoaded : singleClusterAlerts.loaded,
+  };
 };
 
 export default useAlerts;

--- a/src/utils/hooks/useAlerts/useSingleClusterAlerts.ts
+++ b/src/utils/hooks/useAlerts/useSingleClusterAlerts.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+
+import { PrometheusRulesResponse } from '@kubevirt-utils/types/prometheus';
+import {
+  Alert,
+  PrometheusEndpoint,
+  usePrometheusPoll,
+} from '@openshift-console/dynamic-plugin-sdk';
+
+import useSilences from '../useSilences/useSilences';
+
+import { convertRulesToAlerts } from './utils/metricToAlerts';
+import { silenceFiringAlerts } from './utils/utils';
+
+type UseSingleClusterAlerts = () => {
+  alerts: Alert[];
+  error: Error | unknown;
+  loaded: boolean;
+};
+
+/**
+ * Hook for fetching alerts in non-ACM (single cluster) environments.
+ * Uses the Prometheus RULES endpoint to get full alert information including timestamps and descriptions.
+ */
+const useSingleClusterAlerts: UseSingleClusterAlerts = () => {
+  const { silences } = useSilences();
+
+  const [rulesResponse, rulesLoaded, rulesError] = usePrometheusPoll({
+    endpoint: PrometheusEndpoint.RULES,
+  });
+
+  const alerts = useMemo(() => {
+    if (!rulesResponse || rulesError) {
+      return [];
+    }
+    const convertedAlerts = convertRulesToAlerts(rulesResponse as PrometheusRulesResponse);
+    return silenceFiringAlerts(convertedAlerts, silences);
+  }, [rulesResponse, rulesError, silences]);
+
+  return {
+    alerts,
+    error: rulesError,
+    loaded: rulesLoaded,
+  };
+};
+
+export default useSingleClusterAlerts;

--- a/src/utils/hooks/useAlerts/utils/alertQueries.ts
+++ b/src/utils/hooks/useAlerts/utils/alertQueries.ts
@@ -1,0 +1,46 @@
+import { KUBEVIRT } from '@kubevirt-utils/constants/constants';
+import { OPERATOR_LABEL_KEY } from '@kubevirt-utils/constants/prometheus';
+import { ALL_CLUSTERS_KEY } from '@kubevirt-utils/hooks/constants';
+import { OPERATOR_HEALTH_IMPACT_LABEL } from '@kubevirt-utils/hooks/useInfrastructureAlerts/utils/constants';
+import { escapePromLabelValue, escapePromRegexValue } from '@kubevirt-utils/utils/prometheus';
+import { AlertStates } from '@openshift-console/dynamic-plugin-sdk';
+
+import { OPERATOR_HEALTH_IMPACT } from './constants';
+
+type OperatorHealthImpact =
+  | typeof OPERATOR_HEALTH_IMPACT.NONE
+  | typeof OPERATOR_HEALTH_IMPACT.NOT_NONE;
+
+export const buildAlertsQuery = (
+  cluster?: string,
+  hubClusterName?: string,
+  operatorHealthImpact?: OperatorHealthImpact,
+  severity?: string,
+  selectedClusters?: string[],
+): string => {
+  const filters: string[] = [
+    `alertstate="${AlertStates.Firing}"`,
+    `${OPERATOR_LABEL_KEY}="${KUBEVIRT}"`,
+  ];
+
+  if (operatorHealthImpact === OPERATOR_HEALTH_IMPACT.NOT_NONE) {
+    filters.push(`${OPERATOR_HEALTH_IMPACT_LABEL}!="${OPERATOR_HEALTH_IMPACT.NONE}"`);
+  } else if (operatorHealthImpact === OPERATOR_HEALTH_IMPACT.NONE) {
+    filters.push(`${OPERATOR_HEALTH_IMPACT_LABEL}="${OPERATOR_HEALTH_IMPACT.NONE}"`);
+  }
+
+  if (severity) {
+    filters.push(`severity="${escapePromLabelValue(severity)}"`);
+  }
+
+  // Handle multiple selected clusters using regex match
+  if (selectedClusters && selectedClusters.length > 0) {
+    // Escape special regex characters and join with |
+    const escapedClusters = selectedClusters.map(escapePromRegexValue).join('|');
+    filters.push(`cluster=~"${escapedClusters}"`);
+  } else if (cluster && cluster !== ALL_CLUSTERS_KEY && cluster !== hubClusterName) {
+    filters.push(`cluster="${escapePromLabelValue(cluster)}"`);
+  }
+
+  return `ALERTS{${filters.join(',')}}`;
+};

--- a/src/utils/hooks/useAlerts/utils/constants.ts
+++ b/src/utils/hooks/useAlerts/utils/constants.ts
@@ -1,1 +1,6 @@
 export const SUCCESS = 'success';
+
+export const OPERATOR_HEALTH_IMPACT = {
+  NONE: 'none',
+  NOT_NONE: 'not-none',
+} as const;

--- a/src/utils/hooks/useAlerts/utils/metricToAlerts.ts
+++ b/src/utils/hooks/useAlerts/utils/metricToAlerts.ts
@@ -1,0 +1,136 @@
+import { KUBEVIRT } from '@kubevirt-utils/constants/constants';
+import { SECONDS_TO_MILLISECONDS_MULTIPLIER } from '@kubevirt-utils/resources/vm/utils/constants';
+import { PrometheusRulesResponse } from '@kubevirt-utils/types/prometheus';
+import {
+  Alert,
+  AlertSeverity,
+  AlertStates,
+  PrometheusAlert,
+  PrometheusRule,
+  Rule,
+  RuleStates,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
+
+import { addAlertIdToRule } from './utils';
+
+/**
+ * Convert ALERTS metric query results to Alert objects
+ * The ALERTS metric returns time series with labels that represent alerts
+ * @param response - Prometheus response containing ALERTS metric query results
+ */
+export const convertMetricResultsToAlerts = (response: null | PrometheusResponse): Alert[] => {
+  if (!response?.data?.result) {
+    return [];
+  }
+
+  const alerts: Alert[] = [];
+
+  response.data.result.forEach((result) => {
+    const labels = result.metric || {};
+    const { alertname, alertstate, severity = AlertSeverity.Warning } = labels;
+
+    if (!alertname) {
+      return;
+    }
+
+    // Skip non-firing alerts
+    if (alertstate !== AlertStates.Firing) {
+      return;
+    }
+
+    // Create a minimal PrometheusAlert from metric labels
+    // ALERTS metric has value [timestamp, 1] when active
+    const timestamp = result.value?.[0]
+      ? new Date(Number(result.value[0]) * SECONDS_TO_MILLISECONDS_MULTIPLIER).toISOString()
+      : new Date().toISOString();
+
+    const prometheusAlert: PrometheusAlert = {
+      activeAt: timestamp,
+      annotations: {
+        description: labels.description || labels.message || '',
+        summary: labels.summary || labels.message || '',
+      },
+      labels: {
+        ...labels,
+        alertname,
+        alertstate,
+        severity,
+      },
+      state: alertstate as AlertStates,
+      value: result.value?.[1] || '1',
+    };
+
+    const prometheusRule: PrometheusRule = {
+      alerts: [],
+      annotations: {
+        description: labels.description || labels.message || '',
+        summary: labels.summary || labels.message || '',
+      },
+      duration: 0,
+      labels: {
+        ...labels,
+        alertname,
+        severity,
+      },
+      name: alertname,
+      query: '',
+      state: RuleStates.Firing,
+      type: 'alerting',
+    };
+
+    // Generate unique ID and create Rule
+    const rule: Rule = {
+      ...addAlertIdToRule({ file: labels.file || '', name: alertname, rules: [] }, prometheusRule),
+      alerts: [prometheusAlert],
+    };
+
+    // Create Alert object combining rule and alert
+    const alert: Alert = {
+      ...prometheusAlert,
+      rule,
+    };
+
+    alerts.push(alert);
+  });
+
+  return alerts;
+};
+
+/**
+ * Convert Prometheus Rules API response to Alert objects
+ * The RULES endpoint returns full alert information including timestamps and descriptions
+ * @param response - Prometheus response containing rules with alerts
+ */
+export const convertRulesToAlerts = (response: null | PrometheusRulesResponse): Alert[] => {
+  if (!response?.data?.groups) {
+    return [];
+  }
+
+  const alerts: Alert[] = [];
+
+  response.data.groups.forEach((ruleGroup) => {
+    ruleGroup.rules?.forEach((rule) => {
+      // Only process firing rules for KubeVirt operator
+      if (
+        rule?.state === RuleStates.Firing &&
+        rule?.labels?.kubernetes_operator_part_of === KUBEVIRT
+      ) {
+        rule.alerts?.forEach((prometheusAlert) => {
+          // Create Rule object with ID
+          const ruleWithId: Rule = addAlertIdToRule(ruleGroup, rule);
+
+          // Create Alert object combining rule and alert
+          const alert: Alert = {
+            ...prometheusAlert,
+            rule: ruleWithId,
+          };
+
+          alerts.push(alert);
+        });
+      }
+    });
+  });
+
+  return alerts;
+};

--- a/src/utils/hooks/useAlerts/utils/useClusterCNVInstalled.ts
+++ b/src/utils/hooks/useAlerts/utils/useClusterCNVInstalled.ts
@@ -1,0 +1,65 @@
+import { useMemo } from 'react';
+
+import { SubscriptionModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console/models/SubscriptionModel';
+import { KUBEVIRT_HYPERCONVERGED } from '@kubevirt-utils/constants/constants';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
+import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
+import { SubscriptionKind } from '@overview/utils/types';
+import { useFleetClusterNames } from '@stolostron/multicluster-sdk';
+
+export const useClusterCNVInstalled = (): {
+  cnvInstalledClusters: string[];
+  cnvNotInstalledClusters: string[];
+  loaded: boolean;
+} => {
+  const [clusterNames, clustersLoaded] = useFleetClusterNames();
+
+  const [allSubscriptions, subscriptionsLoaded] = useKubevirtWatchResource<SubscriptionKind[]>({
+    groupVersionKind: SubscriptionModelGroupVersionKind,
+    isList: true,
+    namespace: DEFAULT_OPERATOR_NAMESPACE,
+  });
+
+  const { cnvInstalledClusters, cnvNotInstalledClusters } = useMemo(() => {
+    if (!clusterNames || !allSubscriptions) {
+      return { cnvInstalledClusters: [], cnvNotInstalledClusters: [] };
+    }
+
+    const installed: string[] = [];
+    const notInstalled: string[] = [];
+    const subscriptionsByCluster = new Map<string, SubscriptionKind[]>();
+    const subscriptions = Array.isArray(allSubscriptions) ? allSubscriptions : [];
+
+    subscriptions.forEach((sub: SubscriptionKind & { cluster?: string }) => {
+      const cluster = sub?.cluster;
+      if (cluster) {
+        if (!subscriptionsByCluster.has(cluster)) {
+          subscriptionsByCluster.set(cluster, []);
+        }
+        subscriptionsByCluster.get(cluster)?.push(sub);
+      }
+    });
+
+    clusterNames.forEach((clusterName) => {
+      const clusterSubs = subscriptionsByCluster.get(clusterName) || [];
+      const hasCNV = clusterSubs.some((sub) => sub?.spec?.name?.endsWith(KUBEVIRT_HYPERCONVERGED));
+
+      if (hasCNV) {
+        installed.push(clusterName);
+      } else {
+        notInstalled.push(clusterName);
+      }
+    });
+
+    return {
+      cnvInstalledClusters: installed,
+      cnvNotInstalledClusters: notInstalled,
+    };
+  }, [clusterNames, allSubscriptions]);
+
+  return {
+    cnvInstalledClusters,
+    cnvNotInstalledClusters,
+    loaded: clustersLoaded && subscriptionsLoaded,
+  };
+};

--- a/src/utils/hooks/useAlerts/utils/useClusterObservabilityDisabled.ts
+++ b/src/utils/hooks/useAlerts/utils/useClusterObservabilityDisabled.ts
@@ -1,0 +1,97 @@
+import { useMemo } from 'react';
+
+import { modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
+import { getLabel, getName } from '@kubevirt-utils/resources/shared';
+import { ManagedClusterModel } from '@multicluster/constants';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { useHubClusterName } from '@stolostron/multicluster-sdk';
+
+import { useClusterCNVInstalled } from './useClusterCNVInstalled';
+
+type K8sResourceList = K8sResourceCommon & {
+  items: K8sResourceCommon[];
+};
+
+const isK8sResourceList = (
+  data: K8sResourceCommon | K8sResourceCommon[] | undefined,
+): data is K8sResourceList => {
+  return (
+    data !== undefined &&
+    typeof data === 'object' &&
+    !Array.isArray(data) &&
+    'items' in data &&
+    Array.isArray((data as K8sResourceList).items)
+  );
+};
+
+export const useClusterObservabilityDisabled = (
+  onlyCNVClusters = false,
+): {
+  disabledClusters: string[];
+  enabledClusters: string[];
+  error: Error | unknown;
+  loaded: boolean;
+} => {
+  const [hubClusterName] = useHubClusterName();
+
+  const [managedClusterData, loaded, loadError] = useKubevirtWatchResource<
+    K8sResourceCommon | K8sResourceCommon[]
+  >({
+    cluster: hubClusterName,
+    groupVersionKind: modelToGroupVersionKind(ManagedClusterModel),
+    isList: true,
+  });
+
+  const { cnvInstalledClusters, loaded: cnvLoaded } = useClusterCNVInstalled();
+
+  const { disabledClusters, enabledClusters: rawEnabledClusters } = useMemo(() => {
+    if (!managedClusterData) {
+      return { disabledClusters: [], enabledClusters: [] };
+    }
+
+    let clusters: K8sResourceCommon[];
+    if (Array.isArray(managedClusterData)) {
+      clusters = managedClusterData;
+    } else if (isK8sResourceList(managedClusterData)) {
+      clusters = managedClusterData.items;
+    } else {
+      clusters = [];
+    }
+
+    if (clusters.length === 0) {
+      return { disabledClusters: [], enabledClusters: [] };
+    }
+
+    const disabled: string[] = [];
+    const enabled: string[] = [];
+
+    clusters.forEach((mc) => {
+      const clusterName = getName(mc);
+      if (!clusterName) return;
+
+      const observabilityDisabled = getLabel(mc, 'observability') === 'disabled';
+      if (observabilityDisabled) {
+        disabled.push(clusterName);
+      } else {
+        enabled.push(clusterName);
+      }
+    });
+
+    return { disabledClusters: disabled, enabledClusters: enabled };
+  }, [managedClusterData]);
+
+  const enabledClusters = useMemo(() => {
+    if (!onlyCNVClusters || !cnvLoaded) {
+      return rawEnabledClusters;
+    }
+    return rawEnabledClusters.filter((clusterName) => cnvInstalledClusters.includes(clusterName));
+  }, [onlyCNVClusters, cnvLoaded, rawEnabledClusters, cnvInstalledClusters]);
+
+  return {
+    disabledClusters,
+    enabledClusters,
+    error: loadError,
+    loaded: onlyCNVClusters ? loaded && cnvLoaded : loaded,
+  };
+};

--- a/src/utils/hooks/useKubevirtAlerts.ts
+++ b/src/utils/hooks/useKubevirtAlerts.ts
@@ -1,16 +1,16 @@
 import { useMemo } from 'react';
 
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import useAlerts from '@kubevirt-utils/hooks/useAlerts/useAlerts';
 import { inNamespace, isKubeVirtAlert } from '@kubevirt-utils/utils/prometheus';
 import { Alert } from '@openshift-console/dynamic-plugin-sdk';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 
-export type UseKubevirtAlerts = () => [Alert[], boolean];
+export type UseKubevirtAlerts = () => [Alert[], boolean, Error | unknown];
 
 const useKubevirtAlerts: UseKubevirtAlerts = () => {
-  const [activeNamespace] = useActiveNamespace();
-  const { alerts, loaded } = useAlerts();
+  const activeNamespace = useActiveNamespace();
+  const { alerts, error, loaded } = useAlerts();
   const filteredAlerts: Alert[] = useMemo(() => {
     if (activeNamespace && activeNamespace !== ALL_NAMESPACES_SESSION_KEY) {
       return alerts?.filter(
@@ -21,7 +21,7 @@ const useKubevirtAlerts: UseKubevirtAlerts = () => {
     return alerts?.filter((alert) => isKubeVirtAlert(alert));
   }, [activeNamespace, alerts]);
 
-  return [filteredAlerts, loaded];
+  return [filteredAlerts, loaded, error];
 };
 
 export default useKubevirtAlerts;

--- a/src/utils/resources/vm/utils/constants.ts
+++ b/src/utils/resources/vm/utils/constants.ts
@@ -2,7 +2,7 @@ import { V1Interface, V1Network } from '@kubevirt-ui/kubevirt-api/kubevirt';
 
 export const NO_DATA_DASH = '-';
 
-export const MILLISECONDS_TO_SECONDS_MULTIPLIER = 1000;
+export const SECONDS_TO_MILLISECONDS_MULTIPLIER = 1000;
 
 export const PATHS_TO_HIGHLIGHT = {
   DEFAULT: ['spec.template.spec.domain.devices.disks', 'spec.template.spec.volumes'],
@@ -26,7 +26,7 @@ export const PATHS_TO_HIGHLIGHT = {
   SCRIPTS_TAB: ['spec.template.spec.volumes', 'spec.template.spec.accessCredentials'],
 };
 
-export const MIGRATION__PROMETHEUS_DELAY = 15 * MILLISECONDS_TO_SECONDS_MULTIPLIER;
+export const MIGRATION__PROMETHEUS_DELAY = 15 * SECONDS_TO_MILLISECONDS_MULTIPLIER;
 
 export const DEFAULT_NETWORK_INTERFACE: V1Interface = { masquerade: {}, name: 'default' };
 

--- a/src/utils/utils/prometheus.ts
+++ b/src/utils/utils/prometheus.ts
@@ -5,6 +5,32 @@ import { MONITORING_SALT, OPERATOR_LABEL_KEY } from '@kubevirt-utils/constants/p
 import { Group } from '@kubevirt-utils/types/prometheus';
 import { Alert, PrometheusLabels, PrometheusRule } from '@openshift-console/dynamic-plugin-sdk';
 
+/**
+ * Escapes special characters in PromQL label values for use in exact match filters.
+ * Escapes backslashes and double quotes to prevent PromQL injection issues.
+ *
+ * @param v - The label value to escape
+ * @returns The escaped label value safe for use in PromQL queries like `label="${escapedValue}"`
+ */
+export const escapePromLabelValue = (v: string): string =>
+  v.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+/**
+ * Regex pattern matching all special regex characters that need to be escaped in PromQL regex patterns.
+ * Matches: . * + ? ^ $ { } ( ) | [ ] \
+ */
+const PROMQL_REGEX_SPECIAL_CHARS_PATTERN = /[.*+?^${}()|[\]\\]/g;
+
+/**
+ * Escapes special regex characters in PromQL label values for use in regex match filters.
+ * Escapes characters like . * + ? ^ $ { } ( ) | [ ] \ to prevent regex injection issues.
+ *
+ * @param v - The label value to escape
+ * @returns The escaped label value safe for use in PromQL regex queries like `label=~"${escapedValue}"`
+ */
+export const escapePromRegexValue = (v: string): string =>
+  v.replace(PROMQL_REGEX_SPECIAL_CHARS_PATTERN, '\\$&');
+
 export const generateAlertId = (group: Group, rule: PrometheusRule): string => {
   const key = [
     group?.file,

--- a/src/views/catalog/Catalog.tsx
+++ b/src/views/catalog/Catalog.tsx
@@ -17,7 +17,13 @@ const Catalog: FC = (): JSX.Element => {
   return (
     <WizardVMContextProvider>
       <DocumentTitle>{PageTitles.Catalog}</DocumentTitle>
-      {isACMPage && <ClusterProjectDropdown includeAllClusters={false} includeAllProjects={true} />}
+      {isACMPage && (
+        <ClusterProjectDropdown
+          includeAllClusters={false}
+          includeAllProjects={true}
+          onlyCNVClusters={true}
+        />
+      )}
       <Routes>
         <Route Component={Wizard} path={'template/review/*'} />
         <Route Component={CustomizeInstanceTypeVirtualMachine} path={`review/*`} />

--- a/src/views/clusteroverview/ClusterOverviewPage.scss
+++ b/src/views/clusteroverview/ClusterOverviewPage.scss
@@ -1,0 +1,27 @@
+.cluster-overview-page {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - var(--pf-v6-c-page__main-section--PaddingTop, 0px));
+  overflow: hidden;
+
+  &__header {
+    flex-shrink: 0;
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  &__routes {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+}

--- a/src/views/clusteroverview/MigrationsTab/MigrationsTab.tsx
+++ b/src/views/clusteroverview/MigrationsTab/MigrationsTab.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import DurationDropdown from '@kubevirt-utils/components/DurationOption/DurationDropdown';
 import DurationOption from '@kubevirt-utils/components/DurationOption/DurationOption';
+import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
+import LoadingEmptyState from '@kubevirt-utils/components/LoadingEmptyState/LoadingEmptyState';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useLocalStorage from '@kubevirt-utils/hooks/useLocalStorage';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -37,9 +39,9 @@ const MigrationsTab: React.FC = () => {
 
   const migrationCardDataAndFilters = useMigrationCardDataAndFilters(duration);
 
-  const { onFilterChange, vmims } = migrationCardDataAndFilters || {};
+  const { loaded, loadErrors, onFilterChange, vmims } = migrationCardDataAndFilters || {};
 
-  const filteredVMIMS = getFilteredDurationVMIMS(vmims, duration);
+  const filteredVMIMS = getFilteredDurationVMIMS(vmims ?? [], duration);
 
   const onDurationSelect = (value: string) =>
     setDuration(DurationOption.fromDropdownLabel(value)?.toString());
@@ -64,7 +66,13 @@ const MigrationsTab: React.FC = () => {
           <CardTitle>{t('VirtualMachineInstanceMigrations information')} </CardTitle>
         </CardHeader>
         <CardBody className="kv-monitoring-card__body">
-          {!isEmpty(filteredVMIMS) ? (
+          {loadErrors && <ErrorAlert error={loadErrors} />}
+          {!loaded && !loadErrors && (
+            <Bullseye>
+              <LoadingEmptyState />
+            </Bullseye>
+          )}
+          {loaded && !loadErrors && !isEmpty(filteredVMIMS) && (
             <Grid>
               <GridItem className="kv-monitoring-card__graph-separator" span={6}>
                 <CardHeader
@@ -93,7 +101,8 @@ const MigrationsTab: React.FC = () => {
                 <MigrationTable tableData={migrationCardDataAndFilters} />
               </GridItem>
             </Grid>
-          ) : (
+          )}
+          {loaded && !loadErrors && isEmpty(filteredVMIMS) && (
             <Bullseye>
               <MigrationEmptyState />
             </Bullseye>

--- a/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/BandwidthConsumptionCharts.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/BandwidthConsumptionCharts.tsx
@@ -3,9 +3,11 @@ import xbytes from 'xbytes';
 
 import useResponsiveCharts from '@kubevirt-utils/components/Charts/hooks/useResponsiveCharts';
 import DurationOption from '@kubevirt-utils/components/DurationOption/DurationOption';
+import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
+import LoadingEmptyState from '@kubevirt-utils/components/LoadingEmptyState/LoadingEmptyState';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { Divider, Grid } from '@patternfly/react-core';
+import { Bullseye, Divider, Grid } from '@patternfly/react-core';
 
 import MigrationsTimeAxis from './components/MigrationsTimeAxis';
 import MigrationsUtilizationChart from './components/MigrationsUtilizationChart';
@@ -24,8 +26,35 @@ const BandwidthConsumptionCharts: React.FC<BandwidthConsumptionChartsProps> = ({
   const domainX: [number, number] = [currentTime - timespan, currentTime];
   const { ref } = useResponsiveCharts();
 
-  const { bandwidthConsumed, maxBandwidthConsumed, maxMigrationCount, migrationsCount } =
-    useMigrationChartsData(duration, currentTime, timespan);
+  const {
+    bandwidthConsumed,
+    bandwidthLoaded,
+    countLoaded,
+    errorBandwidth,
+    errorCount,
+    maxBandwidthConsumed,
+    maxMigrationCount,
+    migrationsCount,
+  } = useMigrationChartsData(duration, currentTime, timespan);
+
+  const isLoading = !bandwidthLoaded || !countLoaded;
+  const hasError = !!errorBandwidth || !!errorCount;
+
+  if (isLoading && !hasError) {
+    return (
+      <Bullseye>
+        <LoadingEmptyState />
+      </Bullseye>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <Bullseye>
+        <ErrorAlert error={errorBandwidth || errorCount} />
+      </Bullseye>
+    );
+  }
 
   return (
     <Grid ref={ref}>

--- a/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/useMigrationChartsData.ts
+++ b/src/views/clusteroverview/MigrationsTab/components/BandwidthConsumptionCharts/useMigrationChartsData.ts
@@ -1,9 +1,12 @@
 import { useMemo } from 'react';
 
 import { getPrometheusData } from '@kubevirt-utils/components/Charts/utils/utils';
+import { ALL_CLUSTERS_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import useActiveClusterParam from '@multicluster/hooks/useActiveClusterParam';
+import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import { ChartDataObject } from './constants';
 import { getBaseQuery, mapPrometheusValues } from './utils';
@@ -14,6 +17,10 @@ type UseMigrationChartsData = (
   timespan: number,
 ) => {
   bandwidthConsumed: ChartDataObject[];
+  bandwidthLoaded: boolean;
+  countLoaded: boolean;
+  errorBandwidth: Error | unknown;
+  errorCount: Error | unknown;
   maxBandwidthConsumed: number;
   maxMigrationCount: number;
   migrationsCount: ChartDataObject[];
@@ -21,39 +28,57 @@ type UseMigrationChartsData = (
 
 export const useMigrationChartsData: UseMigrationChartsData = (duration, currentTime, timespan) => {
   const { t } = useKubevirtTranslation();
-  const [activeNamespace] = useActiveNamespace();
+  const activeNamespace = useActiveNamespace();
+  const cluster = useActiveClusterParam();
+  const [hubClusterName] = useHubClusterName();
   const baseQuery = useMemo(
-    () => getBaseQuery(duration, activeNamespace),
-    [activeNamespace, duration],
+    () =>
+      getBaseQuery(
+        duration,
+        activeNamespace,
+        cluster === ALL_CLUSTERS_KEY ? undefined : cluster,
+        cluster === ALL_CLUSTERS_KEY ? undefined : hubClusterName,
+      ),
+    [activeNamespace, cluster, duration, hubClusterName],
   );
 
-  const [migrationsBandwidthConsumed] = usePrometheusPoll({
+  const [migrationsBandwidthConsumed, bandwidthLoaded, errorBandwidth] = useFleetPrometheusPoll({
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     query: `sum${baseQuery}`,
     timespan,
+    ...(cluster === ALL_CLUSTERS_KEY ? { allClusters: true } : { cluster }),
   });
-  const [proccessedMigrationsCount] = usePrometheusPoll({
+  const [processedMigrationsCount, countLoaded, errorCount] = useFleetPrometheusPoll({
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
     endTime: currentTime,
     query: `count${baseQuery}`,
     timespan,
+    ...(cluster === ALL_CLUSTERS_KEY ? { allClusters: true } : { cluster }),
   });
 
-  const bandwidthConsumed = mapPrometheusValues(
-    getPrometheusData(migrationsBandwidthConsumed),
-    t('Bandwidth consumption'),
+  const bandwidthConsumed = useMemo(
+    () =>
+      mapPrometheusValues(
+        getPrometheusData(migrationsBandwidthConsumed),
+        t('Bandwidth consumption'),
+      ),
+    [migrationsBandwidthConsumed, t],
   );
 
-  const migrationsCount = mapPrometheusValues(
-    getPrometheusData(proccessedMigrationsCount),
-    t('Running migrations'),
+  const migrationsCount = useMemo(
+    () => mapPrometheusValues(getPrometheusData(processedMigrationsCount), t('Running migrations')),
+    [processedMigrationsCount, t],
   );
 
   return {
     bandwidthConsumed,
-    maxBandwidthConsumed: Math.max(...(bandwidthConsumed || []).map((o) => o.y)),
-    maxMigrationCount: Math.max(...(migrationsCount || []).map((o) => o.y)),
+    bandwidthLoaded,
+    countLoaded,
+    errorBandwidth,
+    errorCount,
+    maxBandwidthConsumed: Math.max(...(bandwidthConsumed || []).map((o) => o.y), 0),
+    maxMigrationCount: Math.max(...(migrationsCount || []).map((o) => o.y), 0),
     migrationsCount,
   };
 };

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/hooks/useVirtualMachineInstanceMigrationsColumns.ts
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/hooks/useVirtualMachineInstanceMigrationsColumns.ts
@@ -3,14 +3,10 @@ import {
   VirtualMachineInstanceMigrationModelRef,
 } from '@kubevirt-ui/kubevirt-api/console';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettingsTableColumns from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns';
-import {
-  K8sVerb,
-  TableColumn,
-  useAccessReview,
-  useActiveNamespace,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { K8sVerb, TableColumn, useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 
 import { MigrationTableDataLayout } from '../utils/utils';
@@ -20,7 +16,7 @@ const useVirtualMachineInstanceMigrationsColumns = (): [
   TableColumn<MigrationTableDataLayout>[],
 ] => {
   const { t } = useKubevirtTranslation();
-  const [activeNamespace] = useActiveNamespace();
+  const activeNamespace = useActiveNamespace();
   const [canGetNode] = useAccessReview({
     resource: NodeModel.plural,
     verb: 'get' as K8sVerb,

--- a/src/views/clusteroverview/OverviewTab/alerts-card/OverviewAlertsCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/alerts-card/OverviewAlertsCard.tsx
@@ -1,15 +1,39 @@
 import * as React from 'react';
 
 import AlertsCard from '@kubevirt-utils/components/AlertsCard/AlertsCard';
+import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { Bullseye, Card, CardBody, CardHeader, CardTitle, Spinner } from '@patternfly/react-core';
 
 import useSimplifiedAlerts from './hooks/useSimplifiedAlerts';
 
 import './OverviewAlertsCard.scss';
 
 const OverviewAlertsCard = () => {
-  const alerts = useSimplifiedAlerts();
+  const { alerts: simplifiedAlerts, error, loaded } = useSimplifiedAlerts();
+  const { t } = useKubevirtTranslation();
+  if (!loaded || error) {
+    return (
+      <Card className="overview-alerts-card">
+        <CardHeader>
+          <CardTitle> {t('Alerts ({{alertsQuantity}})', { alertsQuantity: 0 })}</CardTitle>
+        </CardHeader>
+        <CardBody>
+          {error ? (
+            <ErrorAlert error={error} />
+          ) : (
+            <Bullseye>
+              <Spinner />
+            </Bullseye>
+          )}
+        </CardBody>
+      </Card>
+    );
+  }
 
-  return <AlertsCard className="overview-alerts-card" isOverviewPage sortedAlerts={alerts} />;
+  return (
+    <AlertsCard className="overview-alerts-card" isOverviewPage sortedAlerts={simplifiedAlerts} />
+  );
 };
 
 export default OverviewAlertsCard;

--- a/src/views/clusteroverview/OverviewTab/alerts-card/hooks/useSimplifiedAlerts.ts
+++ b/src/views/clusteroverview/OverviewTab/alerts-card/hooks/useSimplifiedAlerts.ts
@@ -8,15 +8,19 @@ import { Alert } from '@openshift-console/dynamic-plugin-sdk';
 
 import { AlertResource } from '../../status-card/utils/utils';
 
-type UseSimplifiedAlerts = () => SimplifiedAlerts;
+type UseSimplifiedAlerts = () => {
+  alerts: SimplifiedAlerts;
+  error: Error | unknown;
+  loaded: boolean;
+};
 
 const getAlertURL = (alert: Alert) =>
   `${AlertResource.plural}/${alert?.rule?.id}?${labelsToParams(alert.labels)}`;
 
 const useSimplifiedAlerts: UseSimplifiedAlerts = () => {
-  const [alerts] = useKubevirtAlerts();
+  const [alerts, loaded, error] = useKubevirtAlerts();
 
-  return React.useMemo(() => {
+  const simplifiedAlerts = React.useMemo(() => {
     // eslint-disable-next-line perfectionist/sort-objects
     const data = { critical: [], warning: [], info: [] };
     return (
@@ -36,6 +40,8 @@ const useSimplifiedAlerts: UseSimplifiedAlerts = () => {
       }, data) || data
     );
   }, [alerts]);
+
+  return { alerts: simplifiedAlerts, error, loaded };
 };
 
 export default useSimplifiedAlerts;

--- a/src/views/clusteroverview/OverviewTab/metric-charts-card/components/ChartCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/metric-charts-card/components/ChartCard.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 
+import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
+import LoadingEmptyState from '@kubevirt-utils/components/LoadingEmptyState/LoadingEmptyState';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { Bullseye, Card, Grid, GridItem } from '@patternfly/react-core';
+import { Bullseye, Card, CardBody, Grid, GridItem } from '@patternfly/react-core';
 
 import useMetricChartData from '../utils/hooks/useMetricChartData';
 import { ChartCardProps } from '../utils/types';
@@ -16,7 +18,7 @@ import './ChartCard.scss';
 const ChartCard: React.FC<ChartCardProps> = ({ metric }) => {
   const { t } = useKubevirtTranslation();
   const metricChartData = useMetricChartData(metric);
-  const { chartData, isReady, numberOfTicks, unit } = metricChartData;
+  const { chartData, error, isReady, loaded, numberOfTicks, unit } = metricChartData;
   const currentValue = getCurrentValue(chartData);
   const chartLabel = t("Last {{numOfDays}} days' trend", { numOfDays: numberOfTicks });
   const metricLabel = unit && isReady ? `${metric} (${unit})` : metric;
@@ -24,36 +26,40 @@ const ChartCard: React.FC<ChartCardProps> = ({ metric }) => {
 
   return (
     <Card className="metric-chart-card">
-      <Grid className="metric-chart-card__content">
-        <GridItem className="metric-chart-card__header">
-          <div className="metric-chart-card__header--current-value">
-            <span className="metric-chart-card__header--value">{metricValue}</span>
-          </div>
-          <div className="metric-chart-card__header--metric">{metricLabel}</div>
-        </GridItem>
-        <GridItem className="metric-chart-card__chart">
-          {isReady ? (
-            <span>
-              <div className="metric-chart-card__chart--label">{chartLabel}</div>
-              <div className="metric-chart-card__chart--chart">
-                <MetricChart metric={metric} metricChartData={metricChartData} />
-              </div>
-            </span>
-          ) : (
-            <Bullseye>
-              <MutedTextSpan
-                text={
-                  isEmpty(chartData)
-                    ? t('No data available')
-                    : t(
-                        'VMs in this namespace are new, therefore not enough data is collected to display a graph.',
-                      )
-                }
-              />
-            </Bullseye>
-          )}
-        </GridItem>
-      </Grid>
+      {!loaded ? (
+        <CardBody>{error ? <ErrorAlert error={error} /> : <LoadingEmptyState />}</CardBody>
+      ) : (
+        <Grid className="metric-chart-card__content">
+          <GridItem className="metric-chart-card__header">
+            <div className="metric-chart-card__header--current-value">
+              <span className="metric-chart-card__header--value">{metricValue}</span>
+            </div>
+            <div className="metric-chart-card__header--metric">{metricLabel}</div>
+          </GridItem>
+          <GridItem className="metric-chart-card__chart">
+            {isReady ? (
+              <>
+                <div className="metric-chart-card__chart--label">{chartLabel}</div>
+                <div className="metric-chart-card__chart--chart">
+                  <MetricChart metric={metric} metricChartData={metricChartData} />
+                </div>
+              </>
+            ) : (
+              <Bullseye>
+                <MutedTextSpan
+                  text={
+                    isEmpty(chartData)
+                      ? t('No data available')
+                      : t(
+                          'VMs in this namespace are new, therefore not enough data is collected to display a graph.',
+                        )
+                  }
+                />
+              </Bullseye>
+            )}
+          </GridItem>
+        </Grid>
+      )}
     </Card>
   );
 };

--- a/src/views/clusteroverview/OverviewTab/metric-charts-card/utils/metricQueries.ts
+++ b/src/views/clusteroverview/OverviewTab/metric-charts-card/utils/metricQueries.ts
@@ -3,26 +3,61 @@ import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { METRICS } from './constants';
 
 const metricQueriesForNamespace = {
-  [METRICS.MEMORY]: (namespace) =>
-    `sum by (namespace)(kubevirt_vmi_memory_used_bytes{namespace="${namespace}"})`,
-  [METRICS.STORAGE]: (namespace) =>
-    `sum by (namespace)(max(kubevirt_vmi_filesystem_used_bytes{namespace="${namespace}"}) by (namespace, name, disk_name))`,
-  [METRICS.VCPU_USAGE]: (namespace) =>
-    `count(kubevirt_vmi_vcpu_wait_seconds_total{namespace="${namespace}"})`,
-  [METRICS.VM]: (namespace) =>
-    `sum by (namespace)(count by (name,namespace)(kubevirt_vm_error_status_last_transition_timestamp_seconds{namespace="${namespace}"} + kubevirt_vm_migrating_status_last_transition_timestamp_seconds{namespace="${namespace}"} + kubevirt_vm_non_running_status_last_transition_timestamp_seconds{namespace="${namespace}"} + kubevirt_vm_running_status_last_transition_timestamp_seconds{namespace="${namespace}"} + kubevirt_vm_starting_status_last_transition_timestamp_seconds{namespace="${namespace}"}))`,
+  [METRICS.MEMORY]: (filters: string) =>
+    `sum by (namespace)(kubevirt_vmi_memory_used_bytes{${filters}})`,
+  [METRICS.STORAGE]: (filters: string) =>
+    `sum by (namespace)(max(kubevirt_vmi_filesystem_used_bytes{${filters}}) by (namespace, name, disk_name))`,
+  [METRICS.VCPU_USAGE]: (filters: string) =>
+    `count(kubevirt_vmi_vcpu_wait_seconds_total{${filters}})`,
+  [METRICS.VM]: (filters: string) =>
+    `sum by (namespace)(count by (name,namespace)(kubevirt_vm_error_status_last_transition_timestamp_seconds{${filters}} + kubevirt_vm_migrating_status_last_transition_timestamp_seconds{${filters}} + kubevirt_vm_non_running_status_last_transition_timestamp_seconds{${filters}} + kubevirt_vm_running_status_last_transition_timestamp_seconds{${filters}} + kubevirt_vm_starting_status_last_transition_timestamp_seconds{${filters}}))`,
 };
 
 const metricQueriesForAllNamespaces = {
-  [METRICS.MEMORY]: () => `sum(kubevirt_vmi_memory_used_bytes)`,
-  [METRICS.STORAGE]: () =>
-    `sum(max(kubevirt_vmi_filesystem_used_bytes) by (namespace, name, disk_name))`,
-  [METRICS.VCPU_USAGE]: () => `count(kubevirt_vmi_vcpu_wait_seconds_total)`,
-  [METRICS.VM]: () =>
-    `sum(count by (name,namespace)(kubevirt_vm_error_status_last_transition_timestamp_seconds + kubevirt_vm_migrating_status_last_transition_timestamp_seconds + kubevirt_vm_non_running_status_last_transition_timestamp_seconds + kubevirt_vm_running_status_last_transition_timestamp_seconds + kubevirt_vm_starting_status_last_transition_timestamp_seconds))`,
+  [METRICS.MEMORY]: (clusterFilter: string) =>
+    `sum(kubevirt_vmi_memory_used_bytes${clusterFilter ? `{${clusterFilter}}` : ''})`,
+  [METRICS.STORAGE]: (clusterFilter: string) =>
+    `sum(max(kubevirt_vmi_filesystem_used_bytes${
+      clusterFilter ? `{${clusterFilter}}` : ''
+    }) by (namespace, name, disk_name))`,
+  [METRICS.VCPU_USAGE]: (clusterFilter: string) =>
+    `count(kubevirt_vmi_vcpu_wait_seconds_total${clusterFilter ? `{${clusterFilter}}` : ''})`,
+  [METRICS.VM]: (clusterFilter: string) =>
+    `sum(count by (name,namespace)(kubevirt_vm_error_status_last_transition_timestamp_seconds${
+      clusterFilter ? `{${clusterFilter}}` : ''
+    } + kubevirt_vm_migrating_status_last_transition_timestamp_seconds${
+      clusterFilter ? `{${clusterFilter}}` : ''
+    } + kubevirt_vm_non_running_status_last_transition_timestamp_seconds${
+      clusterFilter ? `{${clusterFilter}}` : ''
+    } + kubevirt_vm_running_status_last_transition_timestamp_seconds${
+      clusterFilter ? `{${clusterFilter}}` : ''
+    } + kubevirt_vm_starting_status_last_transition_timestamp_seconds${
+      clusterFilter ? `{${clusterFilter}}` : ''
+    }))`,
 };
 
-export const getMetricQuery = (metric: string, namespace: string) =>
-  namespace === ALL_NAMESPACES_SESSION_KEY
-    ? metricQueriesForAllNamespaces[metric]()
-    : metricQueriesForNamespace?.[metric]?.(namespace);
+export const getMetricQuery = (
+  metric: string,
+  namespace: string,
+  cluster?: string,
+  hubClusterName?: string,
+): string | undefined => {
+  const escapeLabelValue = (v: string): string => v.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+
+  // Add cluster filter only for non-hub clusters (per useFleetPrometheusPoll documentation)
+  const clusterFilter =
+    cluster && cluster.trim() !== '' && cluster !== hubClusterName
+      ? `cluster="${escapeLabelValue(cluster)}"`
+      : '';
+  const namespaceFilter =
+    namespace !== ALL_NAMESPACES_SESSION_KEY ? `namespace="${escapeLabelValue(namespace)}"` : '';
+
+  if (namespace === ALL_NAMESPACES_SESSION_KEY) {
+    return metricQueriesForAllNamespaces[metric]?.(clusterFilter);
+  }
+
+  const filters = [namespaceFilter, clusterFilter]
+    .filter((filter) => Boolean(filter?.trim()))
+    .join(',');
+  return metricQueriesForNamespace?.[metric]?.(filters);
+};

--- a/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusesCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusesCard.tsx
@@ -1,17 +1,23 @@
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 
 import { VirtualMachineModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
+import LoadingEmptyState from '@kubevirt-utils/components/LoadingEmptyState/LoadingEmptyState';
+import { ALL_CLUSTERS_KEY, ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
+import { useClusterObservabilityDisabled } from '@kubevirt-utils/hooks/useAlerts/utils/useClusterObservabilityDisabled';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import { VM_STATUS } from '@kubevirt-utils/resources/vm/utils/vmStatus';
-import { useActiveNamespace, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useActiveClusterParam from '@multicluster/hooks/useActiveClusterParam';
 import { ERROR, OTHER } from '@overview/OverviewTab/vm-statuses-card/utils/constants';
 import {
   getOtherStatuses,
   getVMStatuses,
 } from '@overview/OverviewTab/vm-statuses-card/utils/utils';
-import { Card, CardHeader, CardTitle, Divider, Grid } from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, CardTitle, Divider, Grid } from '@patternfly/react-core';
+import { AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
 
 import VMAdditionalStatuses from './VMAdditionalStatuses';
 import VMStatusItem from './VMStatusItem';
@@ -19,63 +25,103 @@ import VMStatusItem from './VMStatusItem';
 import './VMStatusesCard.scss';
 
 const VMStatusesCard: FC = () => {
-  const [activeNamespace] = useActiveNamespace();
-  const namespace = React.useMemo(
-    () => (activeNamespace === ALL_NAMESPACES_SESSION_KEY ? null : activeNamespace),
+  const activeNamespace = useActiveNamespace();
+  const cluster = useActiveClusterParam();
+  const namespace = useMemo(
+    () => (activeNamespace === ALL_NAMESPACES_SESSION_KEY ? undefined : activeNamespace),
     [activeNamespace],
   );
 
   const { t } = useKubevirtTranslation();
   const OTHER_STATUSES = getOtherStatuses();
 
-  const [vms] = useK8sWatchResource<V1VirtualMachine[]>({
-    groupVersionKind: VirtualMachineModelGroupVersionKind,
-    isList: true,
-    namespace: namespace,
-    namespaced: Boolean(namespace),
-  });
+  const {
+    enabledClusters,
+    error: observabilityError,
+    loaded: observabilityLoaded,
+  } = useClusterObservabilityDisabled(true);
+
+  const normalizedCluster = cluster === ALL_CLUSTERS_KEY ? undefined : cluster;
+
+  const searchQueries = useMemo<AdvancedSearchFilter | undefined>(() => {
+    if (cluster === ALL_CLUSTERS_KEY && observabilityLoaded) {
+      return [{ property: 'cluster', values: enabledClusters }];
+    }
+    return undefined;
+  }, [cluster, enabledClusters, observabilityLoaded]);
+
+  const [vms, loaded, error] = useKubevirtWatchResource<V1VirtualMachine[]>(
+    useMemo(
+      () => ({
+        cluster: normalizedCluster,
+        groupVersionKind: VirtualMachineModelGroupVersionKind,
+        isList: true,
+        namespace: namespace,
+        namespaced: Boolean(namespace),
+      }),
+      [normalizedCluster, namespace],
+    ),
+    undefined,
+    searchQueries,
+  );
 
   const { otherStatuses, otherStatusesCount, primaryStatuses } = getVMStatuses(vms || []);
+
+  const displayError = observabilityError || error;
 
   return (
     <Card className="vm-statuses-card" data-test-id="vm-statuses-card">
       <CardHeader className="vm-statuses-card__header">
         <CardTitle>{t('VirtualMachine statuses')}</CardTitle>
       </CardHeader>
-      <div className="vm-statuses-card__body">
-        <Grid hasGutter>
-          <VMStatusItem
-            count={primaryStatuses.Error}
-            namespace={activeNamespace}
-            statusArray={[ERROR]}
-            statusLabel={ERROR}
+      {displayError && (
+        <CardBody>
+          <ErrorAlert error={displayError} />
+        </CardBody>
+      )}
+      {!loaded && !displayError && (
+        <CardBody>
+          <LoadingEmptyState />
+        </CardBody>
+      )}
+      {loaded && (
+        <>
+          <div className="vm-statuses-card__body">
+            <Grid hasGutter>
+              <VMStatusItem
+                count={primaryStatuses.Error}
+                namespace={activeNamespace}
+                statusArray={[ERROR]}
+                statusLabel={ERROR}
+              />
+              <VMStatusItem
+                count={primaryStatuses.Running}
+                namespace={activeNamespace}
+                statusArray={[VM_STATUS.Running]}
+                statusLabel={VM_STATUS.Running}
+              />
+              <VMStatusItem
+                count={primaryStatuses.Stopped}
+                namespace={activeNamespace}
+                statusArray={[VM_STATUS.Stopped]}
+                statusLabel={VM_STATUS.Stopped}
+              />
+              <VMStatusItem
+                count={otherStatusesCount}
+                namespace={activeNamespace}
+                statusArray={OTHER_STATUSES}
+                statusLabel={t(OTHER)}
+              />
+            </Grid>
+          </div>
+          <Divider />
+          <VMAdditionalStatuses
+            activeNamespace={activeNamespace}
+            otherStatuses={otherStatuses}
+            otherStatusesCount={otherStatusesCount}
           />
-          <VMStatusItem
-            count={primaryStatuses.Running}
-            namespace={activeNamespace}
-            statusArray={[VM_STATUS.Running]}
-            statusLabel={VM_STATUS.Running}
-          />
-          <VMStatusItem
-            count={primaryStatuses.Stopped}
-            namespace={activeNamespace}
-            statusArray={[VM_STATUS.Stopped]}
-            statusLabel={VM_STATUS.Stopped}
-          />
-          <VMStatusItem
-            count={otherStatusesCount}
-            namespace={activeNamespace}
-            statusArray={OTHER_STATUSES}
-            statusLabel={t(OTHER)}
-          />
-        </Grid>
-      </div>
-      <Divider />
-      <VMAdditionalStatuses
-        activeNamespace={activeNamespace}
-        otherStatuses={otherStatuses}
-        otherStatusesCount={otherStatusesCount}
-      />
+        </>
+      )}
     </Card>
   );
 };

--- a/src/views/clusteroverview/OverviewTab/vms-per-resource-card/RunningVMsChartLegendLabel.tsx
+++ b/src/views/clusteroverview/OverviewTab/vms-per-resource-card/RunningVMsChartLegendLabel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 
 import { getInstanceTypeSeriesLabel, getLinkPath } from './utils/utils';
 
@@ -23,7 +23,7 @@ type RunningVMsChartLegendLabelProps = {
 };
 
 const RunningVMsChartLegendLabel: React.FC<RunningVMsChartLegendLabelProps> = ({ item }) => {
-  const [activeNamespace] = useActiveNamespace();
+  const activeNamespace = useActiveNamespace();
   const iconStyle = { color: item.color };
   const linkPath = getLinkPath(item, activeNamespace);
   const linkText = item?.isInstanceType ? getInstanceTypeSeriesLabel(item.name) : item?.name;

--- a/src/views/clusteroverview/OverviewTab/vms-per-resource-card/hooks/useVMsPerResource.ts
+++ b/src/views/clusteroverview/OverviewTab/vms-per-resource-card/hooks/useVMsPerResource.ts
@@ -2,9 +2,10 @@ import { useMemo } from 'react';
 
 import { VirtualMachineModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import { ALL_CLUSTERS_KEY, ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
+import useActiveClusterParam from '@multicluster/hooks/useActiveClusterParam';
 
 type UseVMsPerResource = () => {
   loaded: boolean;
@@ -13,18 +14,27 @@ type UseVMsPerResource = () => {
 };
 
 const useVMsPerResource: UseVMsPerResource = () => {
-  const [activeNamespace] = useActiveNamespace();
+  const activeNamespace = useActiveNamespace();
+  const cluster = useActiveClusterParam();
   const namespace = useMemo(
-    () => (activeNamespace === ALL_NAMESPACES_SESSION_KEY ? null : activeNamespace),
+    () => (activeNamespace === ALL_NAMESPACES_SESSION_KEY ? undefined : activeNamespace),
     [activeNamespace],
   );
 
-  const [vms, loaded, loadedError] = useK8sWatchResource<V1VirtualMachine[]>({
-    groupVersionKind: VirtualMachineModelGroupVersionKind,
-    isList: true,
-    namespace,
-    namespaced: !!namespace,
-  });
+  const normalizedCluster = cluster === ALL_CLUSTERS_KEY ? undefined : cluster;
+
+  const watchResource = useMemo(
+    () => ({
+      cluster: normalizedCluster,
+      groupVersionKind: VirtualMachineModelGroupVersionKind,
+      isList: true,
+      namespace,
+      namespaced: !!namespace,
+    }),
+    [normalizedCluster, namespace],
+  );
+
+  const [vms, loaded, loadedError] = useKubevirtWatchResource<V1VirtualMachine[]>(watchResource);
 
   return {
     loaded,

--- a/src/views/clusteroverview/TopConsumersTab/utils/TopConsumerCard.tsx
+++ b/src/views/clusteroverview/TopConsumersTab/utils/TopConsumerCard.tsx
@@ -2,12 +2,12 @@ import React, { FC, useMemo } from 'react';
 
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   SetTopConsumerData,
   TopConsumersData,
 } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { SelectOption } from '@patternfly/react-core';
 
 import { TopConsumerMetric } from './topConsumerMetric';
@@ -28,7 +28,7 @@ const TopConsumerCard: FC<TopConsumersMetricCard> = ({
   setLocalStorageData,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [activeNamespace] = useActiveNamespace();
+  const activeNamespace = useActiveNamespace();
   const isAllNamespaces = activeNamespace === ALL_NAMESPACES_SESSION_KEY;
 
   const metricKey = useMemo(

--- a/src/views/clusteroverview/TopConsumersTab/utils/queries.ts
+++ b/src/views/clusteroverview/TopConsumersTab/utils/queries.ts
@@ -1,10 +1,19 @@
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import { escapePromLabelValue } from '@kubevirt-utils/utils/prometheus';
 
 import { TopConsumerMetric as Metric } from './topConsumerMetric';
 import { TopConsumerScope as Scope } from './topConsumerScope';
 
-const getNamespaceFilter = (namespace: string) =>
-  namespace && namespace !== ALL_NAMESPACES_SESSION_KEY ? `{namespace="${namespace}"}` : '';
+const getNamespaceFilter = (namespace: string, clusterFilter: string): string => {
+  const namespacePart =
+    namespace && namespace !== ALL_NAMESPACES_SESSION_KEY
+      ? `namespace="${escapePromLabelValue(namespace)}"`
+      : '';
+  const filters = [namespacePart, clusterFilter]
+    .filter((filter) => Boolean(filter?.trim()))
+    .join(',');
+  return filters ? `{${filters}}` : '';
+};
 
 const topConsumerQueries = {
   [Scope.NODE.getValue()]: {
@@ -26,22 +35,22 @@ const topConsumerQueries = {
       `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_vcpu_wait_seconds_total${namespaceFilter}[${duration}])) by (node))) > 0`,
   },
   [Scope.PROJECT.getValue()]: {
-    [Metric.CPU.getValue()]: (numItemsToShow, duration, _namespace) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_cpu_usage_seconds_total[${duration}])) by (namespace))) > 0`,
-    [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow, _duration, _namespace) =>
-      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_swap_in_traffic_bytes + kubevirt_vmi_memory_swap_out_traffic_bytes) by (namespace))) > 0`,
-    [Metric.MEMORY.getValue()]: (numItemsToShow, _duration, _namespace) =>
-      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_used_bytes) by (namespace))) > 0`,
-    [Metric.STORAGE_IOPS.getValue()]: (numItemsToShow, duration, _namespace) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_iops_read_total[${duration}]) + rate(kubevirt_vmi_storage_iops_write_total[${duration}])) by (namespace))) > 0`,
-    [Metric.STORAGE_READ_LATENCY.getValue()]: (numItemsToShow, duration, _namespace) =>
-      `sort_desc(topk(${numItemsToShow}, sum by (namespace)(rate(kubevirt_vmi_storage_read_times_seconds_total[${duration}]) / sum by (namespace)(rate(kubevirt_vmi_storage_iops_read_total[${duration}]) > 0))))`,
-    [Metric.STORAGE_THROUGHPUT.getValue()]: (numItemsToShow, duration, _namespace) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total[${duration}]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total[${duration}])) by (namespace))) > 0`,
-    [Metric.STORAGE_WRITE_LATENCY.getValue()]: (numItemsToShow, duration, _namespace) =>
-      `sort_desc(topk(${numItemsToShow}, sum by (namespace)(rate(kubevirt_vmi_storage_write_times_seconds_total[${duration}]) / sum by (namespace)(rate(kubevirt_vmi_storage_iops_write_total[${duration}]) > 0))))`,
-    [Metric.VCPU_WAIT.getValue()]: (numItemsToShow, duration, _namespace) =>
-      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_vcpu_wait_seconds_total[${duration}])) by (namespace))) > 0`,
+    [Metric.CPU.getValue()]: (numItemsToShow, duration, clusterFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_cpu_usage_seconds_total${clusterFilter}[${duration}])) by (namespace))) > 0`,
+    [Metric.MEMORY_SWAP_TRAFFIC.getValue()]: (numItemsToShow, _duration, clusterFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_swap_in_traffic_bytes${clusterFilter} + kubevirt_vmi_memory_swap_out_traffic_bytes${clusterFilter}) by (namespace))) > 0`,
+    [Metric.MEMORY.getValue()]: (numItemsToShow, _duration, clusterFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(kubevirt_vmi_memory_used_bytes${clusterFilter}) by (namespace))) > 0`,
+    [Metric.STORAGE_IOPS.getValue()]: (numItemsToShow, duration, clusterFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_iops_read_total${clusterFilter}[${duration}]) + rate(kubevirt_vmi_storage_iops_write_total${clusterFilter}[${duration}])) by (namespace))) > 0`,
+    [Metric.STORAGE_READ_LATENCY.getValue()]: (numItemsToShow, duration, clusterFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum by (namespace)(rate(kubevirt_vmi_storage_read_times_seconds_total${clusterFilter}[${duration}]) / sum by (namespace)(rate(kubevirt_vmi_storage_iops_read_total${clusterFilter}[${duration}]) > 0))))`,
+    [Metric.STORAGE_THROUGHPUT.getValue()]: (numItemsToShow, duration, clusterFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_storage_read_traffic_bytes_total${clusterFilter}[${duration}]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total${clusterFilter}[${duration}])) by (namespace))) > 0`,
+    [Metric.STORAGE_WRITE_LATENCY.getValue()]: (numItemsToShow, duration, clusterFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum by (namespace)(rate(kubevirt_vmi_storage_write_times_seconds_total${clusterFilter}[${duration}]) / sum by (namespace)(rate(kubevirt_vmi_storage_iops_write_total${clusterFilter}[${duration}]) > 0))))`,
+    [Metric.VCPU_WAIT.getValue()]: (numItemsToShow, duration, clusterFilter) =>
+      `sort_desc(topk(${numItemsToShow}, sum(rate(kubevirt_vmi_vcpu_wait_seconds_total${clusterFilter}[${duration}])) by (namespace))) > 0`,
   },
   [Scope.VM.getValue()]: {
     [Metric.CPU.getValue()]: (numItemsToShow, duration, namespaceFilter) =>
@@ -64,13 +73,26 @@ const topConsumerQueries = {
 };
 
 export const getTopConsumerQuery = (
-  metric,
-  scope,
+  metric: string,
+  scope: string,
   numItemsToShow = 5,
   duration = '5m',
   namespace?: string,
-) => {
-  const namespaceFilter = getNamespaceFilter(namespace);
+  cluster?: string,
+  hubClusterName?: string,
+): string | undefined => {
+  // Add cluster filter only for non-hub clusters (per useFleetPrometheusPoll documentation)
+  const trimmedCluster = typeof cluster === 'string' ? cluster.trim() : '';
+  const clusterFilter =
+    trimmedCluster !== '' && trimmedCluster !== hubClusterName
+      ? `cluster="${escapePromLabelValue(trimmedCluster)}"`
+      : '';
+  const clusterFilterString = clusterFilter ? `{${clusterFilter}}` : '';
+  const namespaceFilter = getNamespaceFilter(namespace || '', clusterFilter);
 
-  return topConsumerQueries?.[scope]?.[metric]?.(numItemsToShow, duration, namespaceFilter);
+  // PROJECT scope aggregates by namespace, so it uses clusterFilter directly
+  // NODE and VM scopes use namespaceFilter which includes both namespace and cluster
+  return scope === Scope.PROJECT.getValue()
+    ? topConsumerQueries?.[scope]?.[metric]?.(numItemsToShow, duration, clusterFilterString)
+    : topConsumerQueries?.[scope]?.[metric]?.(numItemsToShow, duration, namespaceFilter);
 };

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabActiveUser/ActiveUserListRowVm.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabActiveUser/ActiveUserListRowVm.tsx
@@ -4,15 +4,15 @@ import { V1VirtualMachineInstanceGuestOSUser } from '@kubevirt-ui/kubevirt-api/k
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
 import { fromNow } from '@kubevirt-utils/components/Timestamp/utils/datetime';
 import {
-  MILLISECONDS_TO_SECONDS_MULTIPLIER,
   NO_DATA_DASH,
+  SECONDS_TO_MILLISECONDS_MULTIPLIER,
 } from '@kubevirt-utils/resources/vm/utils/constants';
 import { RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 
 type ActiveUserListRowProps = RowProps<V1VirtualMachineInstanceGuestOSUser, { kind: string }>;
 
 const ActiveUserListRowVm: React.FC<ActiveUserListRowProps> = ({ activeColumnIDs, obj }) => {
-  const time = obj?.loginTime * MILLISECONDS_TO_SECONDS_MULTIPLIER;
+  const time = obj?.loginTime * SECONDS_TO_MILLISECONDS_MULTIPLIER;
   return (
     <>
       <TableData activeColumnIDs={activeColumnIDs} id="userName">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1535,10 +1535,10 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@stolostron/multicluster-sdk@^0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@stolostron/multicluster-sdk/-/multicluster-sdk-0.7.5.tgz#50c49459bd03409f0d01dd804aada6780ea2a22d"
-  integrity sha512-1UzPKpQvFXic2iTPl+3UDKUi7z3g2AuzIBC/kERqsKu/+5grTwxqNHznNs5x3vXqm/3qkj1E1qE/LOQRPt01dQ==
+"@stolostron/multicluster-sdk@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@stolostron/multicluster-sdk/-/multicluster-sdk-0.8.0.tgz#a983d40eeac31144480b1a0dda13fa5b7e036773"
+  integrity sha512-5eAC1E4BNWZ53r0BUn8rjUJQI+YDfErFCtSoeM/mmKKZxzDn0cae5azwbTZRM0My6CTQx6+VE6ILZYDv499wPQ==
   dependencies:
     "@apollo/client" "3.10.8"
     "@patternfly/react-component-groups" "^6.2.1"


### PR DESCRIPTION
## 📝 Description

Add overview tab to Fleet Vitrtualization:

1. Create new alert query utilities (`alertQueries.ts`, `metricToAlerts.ts`) and observability hooks (`useClusterCNVInstalled`, `useClusterObservabilityDisabled`) to build Prometheus alert queries with cluster filtering and detect clusters with observability disabled.

2. Implement `useClusterObservabilityDisabled` hook that checks for `observability=disabled` label on ManagedCluster resources and filters out clusters without observability when querying metrics.

3. Update all overview tab metrics (VM Count, vCPU Usage, Memory, Storage), VM Statuses Card, VMs Per Resource Card, Top Consumers Tab, and Migrations Tab to support observability-aware cluster filtering.

Jira ticket: [CNV-74966](https://issues.redhat.com/browse/CNV-74966)
Main Jira ticket: [CNV-69178](https://issues.redhat.com/browse/CNV-69178)

## 🎥 Demo

https://github.com/user-attachments/assets/27e6f14e-d598-4c4e-be77-22c023ee94d4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-cluster observability: ACM-aware pages, fleet Prometheus polling, and CNV-aware cluster filtering.

* **Improvements**
  * Added loading/error states across alerts and metric charts, safer/escaped multi-cluster queries, enhanced cluster/project dropdown with per-item disable/tooltips/omissions and adaptive redirects, new navigation route for virtualization overview.

* **Documentation**
  * Added translations for "Observability is disabled for this cluster" (en, es, fr, ja, ko, zh).

* **Chores**
  * Updated multicluster SDK dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->