### PR TITLE
CNV-69216: fix checkup not found after creation

### DIFF
--- a/src/views/checkups/network/components/CheckupsNetworkActions.tsx
+++ b/src/views/checkups/network/components/CheckupsNetworkActions.tsx
@@ -7,7 +7,10 @@ import DropdownToggle from '@kubevirt-utils/components/toggles/DropdownToggle';
 import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getCluster } from '@multicluster/helpers/selectors';
+import useIsACMPage from '@multicluster/useIsACMPage';
 import { Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core';
+import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import DeleteCheckupModal from '../../components/DeleteCheckupModal';
 import { getCheckupImageFromNewestJob } from '../../utils/utils';
@@ -27,7 +30,10 @@ const CheckupsNetworkActions: FC<CheckupsNetworkActionsProps> = ({
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
   const { createModal } = useModal();
+  const isACMPage = useIsACMPage();
   const [isActionsOpen, setIsActionsOpen] = useState<boolean>(false);
+  const [hubClusterName] = useHubClusterName();
+  const cluster = getCluster(configMap) || hubClusterName;
 
   const checkupImage = getCheckupImageFromNewestJob(jobs);
 
@@ -39,7 +45,13 @@ const CheckupsNetworkActions: FC<CheckupsNetworkActionsProps> = ({
   const deleteCheckup = () => {
     setIsActionsOpen(false);
     deleteNetworkCheckup(configMap, jobs);
-    navigate(`/k8s/ns/${configMap?.metadata?.namespace}/checkups`);
+    const namespace = getNamespace(configMap);
+
+    navigate(
+      isACMPage
+        ? `/k8s/cluster/${cluster}/ns/${namespace}/checkups`
+        : `/k8s/ns/${namespace}/checkups`,
+    );
   };
 
   return (

--- a/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActionFactory.tsx
+++ b/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActionFactory.tsx
@@ -40,7 +40,11 @@ export const CheckupsSelfValidationActionFactory = {
         kubevirtConsole.error('Failed to delete self-validation checkup:', err);
       });
 
-      const newPath = trimLastHistoryPath(location.pathname, [getName(configMap)]);
+      const newPath = trimLastHistoryPath(location.pathname, [
+        getName(configMap),
+        `${getName(configMap)}/`,
+        `${getName(configMap)}/yaml`,
+      ]);
 
       navigate(newPath);
     };

--- a/src/views/checkups/self-validation/details/CheckupsSelfValidationDetailsPage.tsx
+++ b/src/views/checkups/self-validation/details/CheckupsSelfValidationDetailsPage.tsx
@@ -1,24 +1,18 @@
 import React from 'react';
-import { useParams } from 'react-router-dom-v5-compat';
 
 import StateHandler from '@kubevirt-utils/components/StateHandler/StateHandler';
 import { HorizontalNav } from '@openshift-console/dynamic-plugin-sdk';
 
 import CheckupsNotFound from '../../components/CheckupsNotFound';
-import { getJobByName } from '../../utils/utils';
-import useCheckupsSelfValidationData from '../components/hooks/useCheckupsSelfValidationData';
 
 import { useCheckupsSelfValidationTabs } from './hooks/useCheckupsSelfValidationTabs';
+import useWatchCheckupData from './hooks/useWatchCheckupData';
 import CheckupsSelfValidationDetailsPageHeader from './CheckupsSelfValidationDetailsPageHeader';
 
 import './checkups-self-validation-details-page.scss';
 
 const CheckupsSelfValidationDetailsPage = () => {
-  const { checkupName } = useParams<{ checkupName: string }>();
-  const { configMaps, error, jobs, loaded } = useCheckupsSelfValidationData();
-
-  const configMap = configMaps?.find((cm) => cm.metadata.name === checkupName);
-  const jobMatches = configMap ? getJobByName(jobs, configMap.metadata.name, false) : [];
+  const { configMap, error, jobMatches, loaded } = useWatchCheckupData();
 
   const pages = useCheckupsSelfValidationTabs();
   const notFound = !configMap && loaded;

--- a/src/views/checkups/self-validation/details/hooks/useWatchCheckupData.ts
+++ b/src/views/checkups/self-validation/details/hooks/useWatchCheckupData.ts
@@ -1,0 +1,60 @@
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom-v5-compat';
+
+import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { IoK8sApiBatchV1Job, IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
+import { getName } from '@kubevirt-utils/resources/shared';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import { Operator } from '@openshift-console/dynamic-plugin-sdk';
+
+import { createJobWatchConfig, getJobByName } from '../../../utils/utils';
+import { SELF_VALIDATION_LABEL_VALUE, SELF_VALIDATION_RESULTS_ONLY_LABEL } from '../../utils';
+
+type UseWatchCheckupDataResults = {
+  configMap: IoK8sApiCoreV1ConfigMap | undefined;
+  error: null | unknown;
+  jobMatches: IoK8sApiBatchV1Job[] | undefined;
+  loaded: boolean;
+};
+
+const useWatchCheckupData = (): UseWatchCheckupDataResults => {
+  const { checkupName } = useParams<{ checkupName: string }>();
+  const namespace = useActiveNamespace();
+  const cluster = useClusterParam();
+
+  const jobWatchConfig = useMemo(
+    () =>
+      createJobWatchConfig(SELF_VALIDATION_LABEL_VALUE, namespace, cluster, [
+        {
+          key: SELF_VALIDATION_RESULTS_ONLY_LABEL,
+          operator: Operator.DoesNotExist,
+        },
+      ]),
+    [namespace, cluster],
+  );
+
+  const [configMap, configMapLoaded, configMapError] =
+    useKubevirtWatchResource<IoK8sApiCoreV1ConfigMap>({
+      cluster,
+      groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
+      name: checkupName,
+      namespace,
+      namespaced: true,
+    });
+
+  const [jobs, areJobsLoaded, loadErrorJobs] =
+    useKubevirtWatchResource<IoK8sApiBatchV1Job[]>(jobWatchConfig);
+
+  const jobMatches = configMap ? getJobByName(jobs, getName(configMap), false) : [];
+
+  return {
+    configMap,
+    error: configMapError || loadErrorJobs,
+    jobMatches,
+    loaded: configMapLoaded && areJobsLoaded,
+  };
+};
+
+export default useWatchCheckupData;

--- a/src/views/checkups/self-validation/details/tabs/details/CheckupsSelfValidationDetailsTab.tsx
+++ b/src/views/checkups/self-validation/details/tabs/details/CheckupsSelfValidationDetailsTab.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useCallback } from 'react';
-import { useParams } from 'react-router-dom-v5-compat';
 
 import { IoK8sApiBatchV1Job } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
@@ -8,20 +7,16 @@ import { Divider, PageSection } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 
 import CheckupsDetailsPageHistory from '../../../../CheckupsDetailsPageHistory';
-import { getJobByName } from '../../../../utils/utils';
 import CheckupsSelfValidationHistoryActions from '../../../components/actions/CheckupsSelfValidationHistoryActions';
-import useCheckupsSelfValidationData from '../../../components/hooks/useCheckupsSelfValidationData';
 import useJobResults from '../../../components/hooks/useJobResults';
 import useProgressTracking from '../../components/progress/hooks/useProgressTracking';
 import TestProgressOverview from '../../components/progress/TestProgressOverview';
+import useWatchCheckupData from '../../hooks/useWatchCheckupData';
 
 import CheckupsSelfValidationDetailsPageSection from './CheckupsSelfValidationDetailsPageSection';
 
 const CheckupsSelfValidationDetailsTab: FC = () => {
-  const { checkupName } = useParams<{ checkupName: string }>();
-  const { configMaps, error, jobs, loaded } = useCheckupsSelfValidationData();
-  const configMap = configMaps?.find((cm) => cm.metadata.name === checkupName);
-  const jobMatches = getJobByName(jobs, configMap?.metadata?.name, false);
+  const { configMap, error, jobMatches, loaded } = useWatchCheckupData();
   const currentJob = jobMatches?.[0];
 
   const {

--- a/src/views/checkups/self-validation/details/tabs/yaml/CheckupsSelfValidationYAMLTab.tsx
+++ b/src/views/checkups/self-validation/details/tabs/yaml/CheckupsSelfValidationYAMLTab.tsx
@@ -1,17 +1,15 @@
 import React, { FC } from 'react';
-import { useParams } from 'react-router-dom-v5-compat';
 
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, AlertVariant, Bullseye } from '@patternfly/react-core';
 
-import useCheckupsSelfValidationData from '../../../components/hooks/useCheckupsSelfValidationData';
+import useWatchCheckupData from '../../hooks/useWatchCheckupData';
 
 const CheckupsSelfValidationYAMLTab: FC = () => {
   const { t } = useKubevirtTranslation();
-  const { checkupName } = useParams<{ checkupName: string }>();
-  const { configMaps, loaded } = useCheckupsSelfValidationData();
+  const { configMap, loaded } = useWatchCheckupData();
 
   if (!loaded)
     return (
@@ -19,8 +17,6 @@ const CheckupsSelfValidationYAMLTab: FC = () => {
         <Loading />
       </Bullseye>
     );
-
-  const configMap = configMaps?.find((cm) => cm?.metadata?.name === checkupName);
 
   if (!configMap) {
     return (


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

After creation the checkup was not found. Getting the checkup by name instead of searching through the namespace checkups do not have this issue and its faster. 


Note: fixing the on delete redirect by trimming the latest path part so

`k8s/ns/namespace/checkups/self-validation/checkupname/yaml` (when deleting from the yaml tab) becomes `k8s/ns/namespace/checkups/self-validation` and `k8s/ns/namespace/checkups/self-validation/checkupname/`  becomes `k8s/ns/namespace/checkups/self-validation` 

Redirecting to the list 
