### PR TITLE
CNV-74667: Fix wrong display of high availability status

### DIFF
--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/VirtualizationFeaturesSection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/VirtualizationFeaturesSection.tsx
@@ -10,7 +10,6 @@ import {
   CLUSTER_OBSERVABILITY_OPERATOR_NAME,
   NETOBSERV_OPERATOR_NAME,
   NMSTATE_OPERATOR_NAME,
-  NODE_HEALTH_OPERATOR_NAME,
 } from '../utils/constants';
 import {
   useVirtualizationFeaturesContext,
@@ -19,6 +18,7 @@ import {
 import VirtualizationFeaturesWizard from '../VirtualizationFeaturesWizard/VirtualizationFeaturesWizard';
 
 import FeaturedOperatorItem from './components/FeaturedOperatorItem';
+import HighAvailabilitySection from './components/HighAvailabilitySection/HighAvailabilitySection';
 import LoadBalanceSection from './components/LoadBalanceSection/LoadBalanceSection';
 
 import './VirtualizationFeaturesSection.scss';
@@ -80,10 +80,7 @@ const VirtualizationFeaturesSection: FC = () => {
           />
         </StackItem>
         <StackItem isFilled>
-          <FeaturedOperatorItem
-            operatorName={NODE_HEALTH_OPERATOR_NAME}
-            title={t('High availability')}
-          />
+          <HighAvailabilitySection />
         </StackItem>
         <StackItem isFilled>
           <LoadBalanceSection />

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/HighAvailabilitySection/HighAvailabilitySection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/HighAvailabilitySection/HighAvailabilitySection.tsx
@@ -1,0 +1,48 @@
+import React, { FC } from 'react';
+import { useNavigate } from 'react-router-dom-v5-compat';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import {
+  FENCE_AGENTS_OPERATOR_NAME,
+  NODE_HEALTH_OPERATOR_NAME,
+} from '@overview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/utils/constants';
+import { getInstallStateIcon } from '@overview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/utils/utils';
+import { useVirtualizationFeaturesContext } from '@overview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/utils/VirtualizationFeaturesContext/VirtualizationFeaturesContext';
+import { getHighAvailabilityInstallState } from '@overview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/SummaryStep/components/HighAvailabilitySection/utils/utils';
+import { Button, Split, SplitItem } from '@patternfly/react-core';
+
+import IconSkeleton from '../icons/IconSkeleton/IconSkeleton';
+
+import '../FeaturedOperatorItem.scss';
+
+const HighAvailabilitySection: FC = () => {
+  const { t } = useKubevirtTranslation();
+  const navigate = useNavigate();
+  const { operatorDetailsMap, operatorResourcesLoaded } = useVirtualizationFeaturesContext();
+
+  const { installState: nhcInstallState, operatorHubURL } =
+    operatorDetailsMap?.[NODE_HEALTH_OPERATOR_NAME] || {};
+  const { installState: farInstallState } = operatorDetailsMap?.[FENCE_AGENTS_OPERATOR_NAME] || {};
+
+  const jointInstallState = getHighAvailabilityInstallState(nhcInstallState, farInstallState);
+  const Icon = getInstallStateIcon(jointInstallState);
+
+  return (
+    <Split className="featured-operator-item" hasGutter>
+      <SplitItem>
+        <Button
+          className="featured-operator-item__link-button"
+          onClick={() => navigate(operatorHubURL)}
+          variant="link"
+        >
+          {t('High availability')}
+        </Button>
+      </SplitItem>
+      <SplitItem className="featured-operator-item__icon-container">
+        {operatorResourcesLoaded ? <Icon /> : <IconSkeleton />}
+      </SplitItem>
+    </Split>
+  );
+};
+
+export default HighAvailabilitySection;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

in virtualization features high availability would show the wrong status of "installed" if at least one operator was installed (nhc / far) while this feature requires both to be installed. added HighAvailabilitySection that checks install state of both operators (previously only checked nhc state)

## 🎥 Demo
Before:

https://github.com/user-attachments/assets/ff8bec1f-e085-4983-b4ed-a3b4975e7f8b


After:

https://github.com/user-attachments/assets/1ca0cc21-74bb-4c35-943a-3db26d5fd4b8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization of the High Availability feature in cluster settings. Restructured the display logic into a dedicated component for better maintainability and code clarity. All existing functionality and user experience remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->