### PR TITLE
CNV-69216: fix migration policy URLs

### DIFF
--- a/src/multicluster/urls.ts
+++ b/src/multicluster/urls.ts
@@ -135,7 +135,7 @@ export const getFleetResourceRoute: GetFleetResourceRouteProps = ({
         namespace,
         resource: null,
       })
-    : getFleetClusterResourceRoute({ cluster, model: extensionModel, name, resource: null });
+    : getFleetClusterResourceRoute({ cluster, model: extensionModel, name });
 };
 
 export const getFleetNamespacedResourceRoute: ResourceRouteHandler = ({
@@ -149,8 +149,26 @@ export const getFleetNamespacedResourceRoute: ResourceRouteHandler = ({
   return `/k8s/cluster/${cluster}/ns/${namespace}/${group}~${version}~${kind}/${name}`;
 };
 
-export const getFleetClusterResourceRoute: ResourceRouteHandler = ({ cluster, model, name }) => {
+type GetClusterResourceRouteProps = (input: {
+  cluster?: string;
+  model: ExtensionK8sModel;
+  name: string;
+}) => string;
+
+export const getFleetClusterResourceRoute: GetClusterResourceRouteProps = ({
+  cluster,
+  model,
+  name,
+}) => {
   const { group, kind, version } = model;
 
   return `/k8s/cluster/${cluster}/${group}~${version}~${kind}/${name}`;
+};
+
+export const getClusterResourceRoute: GetClusterResourceRouteProps = ({ cluster, model, name }) => {
+  const { group, kind, version } = model;
+
+  return cluster
+    ? getFleetClusterResourceRoute({ cluster, model, name })
+    : `/k8s/cluster/${group}~${version}~${kind}/${name}`;
 };

--- a/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -7,12 +7,11 @@ import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useCDIUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
 import { UPLOAD_STATUS } from '@kubevirt-utils/hooks/useCDIUpload/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useListClusters from '@kubevirt-utils/hooks/useListClusters';
+import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
 import { getValidNamespace, kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { Form, PopoverPosition, Title } from '@patternfly/react-core';
-import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import SchedulingSettings from './components/SchedulingSettings';
 import SourceTypeSelection from './components/SourceTypeSelection/SourceTypeSelection';
@@ -43,13 +42,12 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
   const { t } = useKubevirtTranslation();
   const [activeNamespace] = useActiveNamespace();
   const namespace = getValidNamespace(activeNamespace);
-  const clusters = useListClusters();
-  const [hubClusterName] = useHubClusterName();
   const isACMPage = useIsACMPage();
+  const selectedCluster = useSelectedCluster();
 
   const [bootableVolume, setBootableVolume] = useState<AddBootableVolumeState>({
     ...initialBootableVolumeState,
-    bootableVolumeCluster: clusters?.[0] || hubClusterName,
+    bootableVolumeCluster: selectedCluster,
     bootableVolumeNamespace: namespace,
   });
 

--- a/src/utils/hooks/useSelectedCluster.ts
+++ b/src/utils/hooks/useSelectedCluster.ts
@@ -1,0 +1,17 @@
+import useIsACMPage from '@multicluster/useIsACMPage';
+import { useHubClusterName } from '@stolostron/multicluster-sdk';
+
+import useListClusters from './useListClusters';
+
+/**
+ * Returns a cluster name that a user has selected or the hub cluster if none have been selected yet.
+ * @returns a cluster name if the page is an ACM page, otherwise null
+ */
+const useSelectedCluster = () => {
+  const isACMPage = useIsACMPage();
+  const clusters = useListClusters();
+  const [hubClusterName] = useHubClusterName();
+  return isACMPage ? clusters?.[0] || hubClusterName : null;
+};
+
+export default useSelectedCluster;

--- a/src/utils/resources/bootableresources/hooks/useCanCreateBootableVolume.ts
+++ b/src/utils/resources/bootableresources/hooks/useCanCreateBootableVolume.ts
@@ -5,10 +5,10 @@ import {
 import { DataImportCronModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { DataSourceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineClusterPreferenceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import useListClusters from '@kubevirt-utils/hooks/useListClusters';
 import useListNamespaces from '@kubevirt-utils/hooks/useListNamespaces';
+import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
 import { K8sVerb } from '@openshift-console/dynamic-plugin-sdk';
-import { useFleetAccessReview, useHubClusterName } from '@stolostron/multicluster-sdk';
+import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
 
 type UseCanCreateBootableVolume = (namespace: string) => {
   canCreateDS: boolean;
@@ -19,11 +19,9 @@ type UseCanCreateBootableVolume = (namespace: string) => {
 };
 
 const useCanCreateBootableVolume: UseCanCreateBootableVolume = (namespace) => {
-  const selectedClusters = useListClusters();
   const selectedNamespaces = useListNamespaces();
-  const [hubClusterName] = useHubClusterName();
 
-  const clusterToVerifyAccess = selectedClusters?.[0] || hubClusterName;
+  const clusterToVerifyAccess = useSelectedCluster();
   const namespaceToVerifyAccess = selectedNamespaces?.[0] || namespace;
 
   const [canCreatePVC, loadingPVC] = useFleetAccessReview({

--- a/src/views/bootablevolumes/list/components/BootableVolumeAddButton.tsx
+++ b/src/views/bootablevolumes/list/components/BootableVolumeAddButton.tsx
@@ -6,11 +6,10 @@ import AddBootableVolumeModal from '@kubevirt-utils/components/AddBootableVolume
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useListClusters from '@kubevirt-utils/hooks/useListClusters';
+import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
 import useCanCreateBootableVolume from '@kubevirt-utils/resources/bootableresources/hooks/useCanCreateBootableVolume';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { ListPageCreateDropdown } from '@openshift-console/dynamic-plugin-sdk';
-import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 type BootableVolumeAddButtonProps = {
   buttonText?: string;
@@ -22,9 +21,7 @@ const BootableVolumeAddButton: FC<BootableVolumeAddButtonProps> = ({ buttonText,
   const { createModal } = useModal();
   const navigate = useNavigate();
   const isACMPage = useIsACMPage();
-  const clusters = useListClusters();
-  const [hubClusterName] = useHubClusterName();
-  const selectedCluster = clusters?.[0] || hubClusterName;
+  const selectedCluster = useSelectedCluster();
   const selectedNamespace = namespace || DEFAULT_NAMESPACE;
 
   const { canCreateDS, canCreatePVC, canListInstanceTypesPreference } =

--- a/src/views/checkups/network/hooks/useCheckupsNetworkPermissions.ts
+++ b/src/views/checkups/network/hooks/useCheckupsNetworkPermissions.ts
@@ -13,8 +13,7 @@ import {
 } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
-import useListClusters from '@kubevirt-utils/hooks/useListClusters';
-import { useHubClusterName } from '@stolostron/multicluster-sdk';
+import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
 
 import { findObjectByName } from '../../utils/utils';
 import {
@@ -25,9 +24,7 @@ import {
 
 const useCheckupsNetworkPermissions = (): { isPermitted: boolean; loading: boolean } => {
   const namespace = useActiveNamespace();
-  const selectedClusters = useListClusters();
-  const [hubClusterName] = useHubClusterName();
-  const cluster = selectedClusters?.[0] || hubClusterName;
+  const cluster = useSelectedCluster();
 
   const [serviceAccounts, serviceAccountsLoaded] = useKubevirtWatchResource<
     IoK8sApiCoreV1ServiceAccount[]

--- a/src/views/checkups/self-validation/components/hooks/useCheckupsSelfValidationPermissions.ts
+++ b/src/views/checkups/self-validation/components/hooks/useCheckupsSelfValidationPermissions.ts
@@ -8,8 +8,7 @@ import {
 import { IoK8sApiRbacV1ClusterRoleBinding } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
-import useListClusters from '@kubevirt-utils/hooks/useListClusters';
-import { useHubClusterName } from '@stolostron/multicluster-sdk';
+import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
 import { checkAccess } from '@stolostron/multicluster-sdk/lib/internal/checkAccess';
 
 import { SELF_VALIDATION_CLUSTER_ROLE_BINDING, SELF_VALIDATION_SA } from '../../utils';
@@ -18,9 +17,7 @@ const useCheckupsSelfValidationPermissions = () => {
   const namespace = useActiveNamespace();
   const [canCreateClusterRoleBinding, setCanCreateClusterRoleBinding] = useState<boolean>(false);
   const [checkingPermissions, setCheckingPermissions] = useState<boolean>(true);
-  const selectedClusters = useListClusters();
-  const [hubClusterName] = useHubClusterName();
-  const cluster = selectedClusters?.[0] || hubClusterName;
+  const cluster = useSelectedCluster();
 
   const [clusterRoleBindings, loadedClusterRoleBinding] = useKubevirtWatchResource<
     IoK8sApiRbacV1ClusterRoleBinding[]

--- a/src/views/checkups/storage/components/hooks/useCheckupsStoragePermissions.ts
+++ b/src/views/checkups/storage/components/hooks/useCheckupsStoragePermissions.ts
@@ -17,9 +17,8 @@ import {
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
-import useListClusters from '@kubevirt-utils/hooks/useListClusters';
+import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import {
   STORAGE_CHECKUP_ROLE,
@@ -29,9 +28,7 @@ import {
 
 export const useCheckupsStoragePermissions = () => {
   const namespace = useActiveNamespace();
-  const selectedClusters = useListClusters();
-  const [hubClusterName] = useHubClusterName();
-  const cluster = selectedClusters?.[0] || hubClusterName;
+  const cluster = useSelectedCluster();
   const isAllNamespace = namespace === ALL_NAMESPACES_SESSION_KEY;
 
   const [serviceAccounts, serviceAccountsLoaded] = useKubevirtWatchResource<

--- a/src/views/migrationpolicies/components/MigrationPolicyEditModal/MigrationPolicyEditModal.tsx
+++ b/src/views/migrationpolicies/components/MigrationPolicyEditModal/MigrationPolicyEditModal.tsx
@@ -6,11 +6,13 @@ import { V1alpha1MigrationPolicy } from '@kubevirt-ui-ext/kubevirt-api/kubevirt'
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getName } from '@kubevirt-utils/resources/shared';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { kubevirtK8sCreate, kubevirtK8sDelete, kubevirtK8sUpdate } from '@multicluster/k8sRequests';
 import { FormGroup, TextInput } from '@patternfly/react-core';
 
-import { useMigrationPoliciesPageBaseURL } from '../../hooks/useMigrationPoliciesPageBaseURL';
+import { useMigrationPoliciesListURL } from '../../hooks/useMigrationPoliciesListURL';
+import { getMigrationPolicyURL } from '../../utils/utils';
 import MigrationPolicyConfigurations from '../MigrationPolicyConfigurations/MigrationPolicyConfigurations';
 
 import { EditMigrationPolicyInitialState } from './utils/constants';
@@ -30,7 +32,7 @@ const MigrationPolicyEditModal: FC<MigrationPolicyEditModalProps> = ({ isOpen, m
   const navigate = useNavigate();
   const location = useLocation();
   const cluster = useClusterParam();
-  const migrationPoliciesBaseURL = useMigrationPoliciesPageBaseURL();
+  const migrationPoliciesBaseURL = useMigrationPoliciesListURL();
   const [state, setState] = useState<EditMigrationPolicyInitialState>(
     extractEditMigrationPolicyInitialValues(mp),
   );
@@ -59,7 +61,7 @@ const MigrationPolicyEditModal: FC<MigrationPolicyEditModalProps> = ({ isOpen, m
             () => {
               if (lastPolicyPathElement === mp?.metadata?.name) {
                 // if we were on MigrationPolicy details page, stay there and just update the data
-                navigate(`${migrationPoliciesBaseURL}/${updatedMP?.metadata?.name}`);
+                navigate(getMigrationPolicyURL(getName(updatedMP), cluster));
               } else {
                 navigate(migrationPoliciesBaseURL); // MigrationPolicies list
               }

--- a/src/views/migrationpolicies/details/components/MigrationPolicyBreadcrumb/MigrationPolicyBreadcrumb.tsx
+++ b/src/views/migrationpolicies/details/components/MigrationPolicyBreadcrumb/MigrationPolicyBreadcrumb.tsx
@@ -1,21 +1,20 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
+import { useMigrationPoliciesListURL } from 'src/views/migrationpolicies/hooks/useMigrationPoliciesListURL';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
-
-import { useMigrationPoliciesPageBaseURL } from '../../../hooks/useMigrationPoliciesPageBaseURL';
 
 import './MigrationPolicyBreadcrumb.scss';
 
 export const MigrationPolicyBreadcrumb: React.FC = () => {
   const { t } = useKubevirtTranslation();
-  const migrationPoliciesBaseURL = useMigrationPoliciesPageBaseURL();
+  const migrationPoliciesClusterListPage = useMigrationPoliciesListURL();
 
   return (
     <Breadcrumb>
       <BreadcrumbItem>
-        <Link to={migrationPoliciesBaseURL}>{t('MigrationPolicies')}</Link>
+        <Link to={migrationPoliciesClusterListPage}>{t('MigrationPolicies')}</Link>
       </BreadcrumbItem>
       <BreadcrumbItem>{t('MigrationPolicy details')}</BreadcrumbItem>
     </Breadcrumb>

--- a/src/views/migrationpolicies/hooks/useMigrationPoliciesListURL.ts
+++ b/src/views/migrationpolicies/hooks/useMigrationPoliciesListURL.ts
@@ -1,15 +1,14 @@
-import useListClusters from '@kubevirt-utils/hooks/useListClusters';
 import { MigrationPolicyModelRef } from '@kubevirt-utils/models';
 import { CLUSTER_LIST_FILTER_PARAM } from '@kubevirt-utils/utils/constants';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
-export const useMigrationPoliciesPageBaseURL = () => {
-  const clusters = useListClusters();
+export const useMigrationPoliciesListURL = () => {
   const isACMPage = useIsACMPage();
   const [hubClusterName] = useHubClusterName();
-
-  const cluster = clusters?.[0] || hubClusterName;
+  const clusterParam = useClusterParam();
+  const cluster = clusterParam || hubClusterName;
 
   if (isACMPage) {
     return `/k8s/all-clusters/${MigrationPolicyModelRef}?${CLUSTER_LIST_FILTER_PARAM}=${cluster}`;

--- a/src/views/migrationpolicies/list/components/MigrationPoliciesCreateButton/MigrationPoliciesCreateButton.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPoliciesCreateButton/MigrationPoliciesCreateButton.tsx
@@ -1,26 +1,21 @@
 import React, { FC } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
+import { getMigrationPolicyURL } from 'src/views/migrationpolicies/utils/utils';
 
 import { MigrationPolicyModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { MigrationPolicyModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useListClusters from '@kubevirt-utils/hooks/useListClusters';
+import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
 import { K8sVerb, ListPageCreateDropdown } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, Tooltip } from '@patternfly/react-core';
-import { useFleetAccessReview, useHubClusterName } from '@stolostron/multicluster-sdk';
+import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
 
-import { useMigrationPoliciesPageBaseURL } from '../../../hooks/useMigrationPoliciesPageBaseURL';
 import { createItems } from '../../utils/constants';
 
 const MigrationPoliciesCreateButton: FC = () => {
   const { t } = useKubevirtTranslation();
-  const clusters = useListClusters();
-  const [hubClusterName] = useHubClusterName();
+  const selectedCluster = useSelectedCluster();
   const navigate = useNavigate();
-
-  const selectedCluster = clusters?.[0] || hubClusterName;
-
-  const migrationPoliciesBaseURL = useMigrationPoliciesPageBaseURL();
 
   const [canCreateMigrationPolicy] = useFleetAccessReview({
     cluster: selectedCluster,
@@ -30,9 +25,7 @@ const MigrationPoliciesCreateButton: FC = () => {
   });
 
   const onCreate = (type: string) => {
-    return type === 'form'
-      ? navigate(`${migrationPoliciesBaseURL}/form`)
-      : navigate(`${migrationPoliciesBaseURL}/~new`);
+    return navigate(getMigrationPolicyURL(type === 'form' ? 'form' : '~new', selectedCluster));
   };
 
   if (!canCreateMigrationPolicy) {

--- a/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/copmonents/MigrationPolicyCreateFormHeader/MigrationPolicyCreateFormHeader.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/copmonents/MigrationPolicyCreateFormHeader/MigrationPolicyCreateFormHeader.tsx
@@ -1,18 +1,22 @@
 import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
-import { useMigrationPoliciesPageBaseURL } from 'src/views/migrationpolicies/hooks/useMigrationPoliciesPageBaseURL';
+import { getMigrationPolicyURL } from 'src/views/migrationpolicies/utils/utils';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
 import { Title } from '@patternfly/react-core';
 
 const MigrationPolicyCreateFormHeader: React.FC = () => {
   const { t } = useKubevirtTranslation();
-  const migrationPoliciesBaseURL = useMigrationPoliciesPageBaseURL();
+  const selectedCluster = useSelectedCluster();
 
   return (
     <Title className="migration-policy__form-header" headingLevel="h1">
       <div>{t('Create MigrationPolicy')}</div>
-      <Link className="migration-policy__form-header-link" to={`${migrationPoliciesBaseURL}/~new`}>
+      <Link
+        className="migration-policy__form-header-link"
+        to={getMigrationPolicyURL('~new', selectedCluster)}
+      >
         {t('Edit YAML')}
       </Link>
     </Title>

--- a/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/copmonents/MigrationPolicyFormFooter/MigrationPolicyFormFooter.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/copmonents/MigrationPolicyFormFooter/MigrationPolicyFormFooter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { useMigrationPoliciesPageBaseURL } from 'src/views/migrationpolicies/hooks/useMigrationPoliciesPageBaseURL';
+import { getMigrationPolicyURL } from 'src/views/migrationpolicies/utils/utils';
 
 import { MigrationPolicyModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1alpha1MigrationPolicy } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
@@ -29,8 +29,6 @@ const MigrationPolicyFormFooter: React.FC<MigrationPolicyFormFooterProps> = ({
   const navigate = useNavigate();
   const cluster = useClusterParam();
 
-  const migrationPoliciesBaseURL = useMigrationPoliciesPageBaseURL();
-
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState(undefined);
   const migrationPolicyName = migrationPolicy?.metadata?.name;
@@ -41,7 +39,7 @@ const MigrationPolicyFormFooter: React.FC<MigrationPolicyFormFooterProps> = ({
     setError(undefined);
 
     kubevirtK8sCreate({ cluster, data: migrationPolicy, model: MigrationPolicyModel })
-      .then(() => navigate(`${migrationPoliciesBaseURL}/${migrationPolicyName}`))
+      .then(() => navigate(getMigrationPolicyURL(migrationPolicyName, cluster)))
       .catch(setError)
       .finally(() => setIsSubmitting(false));
   };

--- a/src/views/migrationpolicies/utils/utils.ts
+++ b/src/views/migrationpolicies/utils/utils.ts
@@ -1,8 +1,11 @@
 import { MigrationPolicyModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1alpha1MigrationPolicy } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { modelToGroupVersionKind } from '@kubevirt-utils/models';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
+import { getClusterResourceRoute } from '@multicluster/urls';
+import { ExtensionK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
 export const getBooleanText = (value: boolean): string => (value ? t('Yes') : t('No'));
 
@@ -20,3 +23,10 @@ export const getEmptyMigrationPolicy = (): V1alpha1MigrationPolicy => ({
   metadata: { annotations: {} },
   spec: { selectors: {} },
 });
+
+export const getMigrationPolicyURL = (name: string, cluster?: string) =>
+  getClusterResourceRoute({
+    cluster,
+    model: modelToGroupVersionKind(MigrationPolicyModel) as ExtensionK8sModel,
+    name,
+  });

--- a/src/views/templates/list/components/VirtualMachineTemplatesCreateButton/VirtualMachineTemplatesCreateButton.tsx
+++ b/src/views/templates/list/components/VirtualMachineTemplatesCreateButton/VirtualMachineTemplatesCreateButton.tsx
@@ -4,19 +4,18 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import { TemplateModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useListClusters from '@kubevirt-utils/hooks/useListClusters';
 import useListNamespaces from '@kubevirt-utils/hooks/useListNamespaces';
+import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { Button } from '@patternfly/react-core';
-import { useFleetAccessReview, useHubClusterName } from '@stolostron/multicluster-sdk';
+import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
 
 const VirtualMachineTemplatesCreateButton: FC = () => {
   const { t } = useKubevirtTranslation();
-  const [hubClusterName] = useHubClusterName();
-  const selectedClusters = useListClusters();
+  const selectedCluster = useSelectedCluster();
   const selectedNamespaces = useListNamespaces();
   const navigate = useNavigate();
-  const cluster = selectedClusters?.[0] || hubClusterName;
+  const cluster = selectedCluster;
   const namespace = selectedNamespaces?.[0] || DEFAULT_NAMESPACE;
   const isACMPage = useIsACMPage();
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Make sure non-acm migrationpolicy do not goes into acm paths  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized cluster selection across the app so UI flows, create/edit dialogs, and permission checks use a single selected-cluster source for consistent behavior.
  * Create/navigation components now derive active namespace/cluster consistently for more predictable navigation.

* **New Features**
  * Added a URL helper to generate consistent cluster-scoped links for Migration Policy pages and post-create/rename redirects.
  * Bootable volume permission checks expanded to expose separate checks (PVCs, snapshots, instance-type prefs) and a loading state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->