### PR TITLE
CNV-75220: Set correct perspective for fleet-virtualization pages

### DIFF
--- a/src/multicluster/useIsACMPage.ts
+++ b/src/multicluster/useIsACMPage.ts
@@ -1,12 +1,31 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
+
+import { PERSPECTIVES } from '@kubevirt-utils/constants/constants';
+import { useActivePerspective } from '@openshift-console/dynamic-plugin-sdk';
 
 import { isACMPath } from './urls';
 
-const useIsACMPage = () => {
-  const location = useLocation();
+type UseIsACMPageOptions = {
+  activePerspectiveSync?: boolean;
+};
 
-  return useMemo(() => isACMPath(location.pathname), [location.pathname]);
+const useIsACMPage = ({ activePerspectiveSync = true }: UseIsACMPageOptions = {}) => {
+  const location = useLocation();
+  const [activePerspective, setActivePerspective] = useActivePerspective();
+  const isACMPathResult = useMemo(() => isACMPath(location.pathname), [location.pathname]);
+
+  useEffect(() => {
+    if (
+      activePerspectiveSync &&
+      isACMPathResult &&
+      activePerspective !== PERSPECTIVES.FLEET_VIRTUALIZATION
+    ) {
+      setActivePerspective(PERSPECTIVES.FLEET_VIRTUALIZATION);
+    }
+  }, [activePerspectiveSync, isACMPathResult, activePerspective, setActivePerspective]);
+
+  return isACMPathResult;
 };
 
 export default useIsACMPage;

--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -36,6 +36,7 @@ export enum PERSPECTIVES {
   ACM = 'acm',
   ADMIN = 'admin',
   DEVELOPER = 'dev',
+  FLEET_VIRTUALIZATION = 'fleet-virtualization-perspective',
   VIRTUALIZATION = 'virtualization-perspective',
 }
 

--- a/src/views/virtualmachines/actions/tests/useVirtualMachineActionsProvider.test.tsx
+++ b/src/views/virtualmachines/actions/tests/useVirtualMachineActionsProvider.test.tsx
@@ -10,6 +10,7 @@ import { exampleRunningVirtualMachine } from './mocks';
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   getGroupVersionKindForModel: jest.fn(() => ({})),
   k8sPatch: jest.fn(() => ({})),
+  useActivePerspective: jest.fn(() => ['', jest.fn()]),
   useFlag: jest.fn(() => true),
   useK8sModel: jest.fn(() => [[], true]),
   useK8sWatchResource: jest.fn(() => [[], true]),


### PR DESCRIPTION
## 📝 Description

Use `setActivePerspective` hook to set the correct `activePerspective` on ACM pages.

~This PR needs to be rebased on https://github.com/kubevirt-ui/kubevirt-plugin/pull/3279 once it is merged.~

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/7b6a1dbf-b77c-41c0-8890-0ed8b63ef61b

After:

https://github.com/user-attachments/assets/4db770ca-c6cc-40ce-b060-bd2493fa1fd5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Fleet Virtualization perspective to expand viewing options in multi-cluster environments.
  * Implemented automatic perspective switching when navigating to ACM pages, with ability to disable if needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->