### PR TITLE
CNV-66290:cluster role edit cannot add network interface for the vm

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
@@ -10,7 +10,6 @@ import React, {
 
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
-import Loading from '@kubevirt-utils/components/Loading/Loading';
 import SelectTypeahead, {
   SelectTypeaheadOptionProps,
 } from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
@@ -205,27 +204,23 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
       labelHelp={<NetworkSelectHelperPopover />}
     >
       <div data-test-id="network-attachment-definition-select">
-        {hasPodNetwork && !loaded ? (
-          <Loading />
-        ) : (
-          <SelectTypeahead
-            addOption={(value) =>
-              setCreatedNetworkOptions((prev) => [
-                ...prev.filter((option) => option.value !== value),
-                createNewNetworkOption(value),
-              ])
-            }
-            canCreate
-            dataTestId="select-nad"
-            getCreateAction={getCreateNetworkOption}
-            isFullWidth
-            key={selectedFirstOnLoad ? 'select-nad-with-preselect' : 'select-nad-without-preselect'}
-            options={networkOptions}
-            placeholder={t('Select a NetworkAttachmentDefinition')}
-            selectedValue={networkName}
-            setSelectedValue={handleChange}
-          />
-        )}
+        <SelectTypeahead
+          addOption={(value) =>
+            setCreatedNetworkOptions((prev) => [
+              ...prev.filter((option) => option.value !== value),
+              createNewNetworkOption(value),
+            ])
+          }
+          canCreate
+          dataTestId="select-nad"
+          getCreateAction={getCreateNetworkOption}
+          isFullWidth
+          key={selectedFirstOnLoad ? 'select-nad-with-preselect' : 'select-nad-without-preselect'}
+          options={networkOptions}
+          placeholder={t('Select a NetworkAttachmentDefinition')}
+          selectedValue={networkName}
+          setSelectedValue={handleChange}
+        />
       </div>
       {loaded && validated === ValidatedOptions.error && (
         <FormGroupHelperText validated={validated}>

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/AddNetworkInterfaceButton.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/AddNetworkInterfaceButton.tsx
@@ -8,9 +8,7 @@ import {
   V1VirtualMachineInstance,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import WithPermissionTooltip from '@kubevirt-utils/components/WithPermissionTooltip/WithPermissionTooltip';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import usePermissions from '@kubevirt-utils/hooks/usePermissions/usePermissions';
 import { ListPageCreateButton } from '@openshift-console/dynamic-plugin-sdk';
 
 import VirtualMachinesNetworkInterfaceModal from './modal/VirtualMachinesNetworkInterfaceModal';
@@ -31,33 +29,27 @@ const AddNetworkInterfaceButton: FC<AddNetworkInterfaceButtonProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
-  const { capabilitiesData } = usePermissions();
-  const isAddNetworkDisabled = !capabilitiesData?.attacheNetworks?.allowed;
+
   const actionText = t('Add network interface');
 
   return (
-    <WithPermissionTooltip allowed={!isAddNetworkDisabled}>
-      <ListPageCreateButton
-        className={classNames('add-network-interface-button pf-v6-u-mb-md', {
-          isDisabled: isAddNetworkDisabled,
-        })}
-        onClick={() =>
-          !isAddNetworkDisabled &&
-          createModal(({ isOpen, onClose }) => (
-            <VirtualMachinesNetworkInterfaceModal
-              headerText={actionText}
-              isOpen={isOpen}
-              onAddNetworkInterface={onAddNetworkInterface}
-              onClose={onClose}
-              vm={vm}
-              vmi={vmi}
-            />
-          ))
-        }
-      >
-        {actionText}
-      </ListPageCreateButton>
-    </WithPermissionTooltip>
+    <ListPageCreateButton
+      onClick={() =>
+        createModal(({ isOpen, onClose }) => (
+          <VirtualMachinesNetworkInterfaceModal
+            headerText={actionText}
+            isOpen={isOpen}
+            onAddNetworkInterface={onAddNetworkInterface}
+            onClose={onClose}
+            vm={vm}
+            vmi={vmi}
+          />
+        ))
+      }
+      className={classNames('add-network-interface-button pf-v6-u-mb-md')}
+    >
+      {actionText}
+    </ListPageCreateButton>
   );
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## jira : 
https://issues.redhat.com/browse/CNV-66290?filter=12475298


## 📝 Description

Edit role should be able to add a new interface on the vm in the project


## before:
<img width="1410" height="806" alt="image" src="https://github.com/user-attachments/assets/398d47a4-c56c-487a-8237-238ab095595c" />


## after:

<img width="2241" height="887" alt="image" src="https://github.com/user-attachments/assets/5cf359dd-2c66-4b0e-b4f0-3cfb91fbc10a" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Network selection control now appears immediately and consistently (no intermediate loading state).
  * "Add network interface" button is always visible and clickable; it opens the interface modal without permission-based gating.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->