### PR TITLE
CNV-70899: VirtualMachines page is breaking words into two lines

### DIFF
--- a/src/views/search/components/search-bar.scss
+++ b/src/views/search/components/search-bar.scss
@@ -3,6 +3,11 @@
   width: 100%;
 }
 
+// Prevent the page header title from wrapping
+[data-ouia-component-id='PageHeader-title'] {
+  white-space: nowrap;
+}
+
 .saved-searches-dropdown-menu {
   max-width: 260px;
 }


### PR DESCRIPTION
## 📝 Description

Any title with more than a single word is broken into separate lines. 

Jira Ticket: [CNV-70899](https://issues.redhat.com/browse/CNV-70899)

## 🎥 Demo

Before:
<img width="558" height="391" alt="Before" src="https://github.com/user-attachments/assets/61854832-c454-44e6-b097-ff398261cf28" />

After:

<img width="1629" height="833" alt="After" src="https://github.com/user-attachments/assets/4ac13c29-3e43-4130-a43b-e9501b554cd2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated header title display to prevent line wrapping, ensuring the title remains on a single line for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->