### PR TITLE
CNV-69216: make watches multicluster part 2

### DIFF
--- a/src/multicluster/hooks/useKubevirtWatchResources.ts
+++ b/src/multicluster/hooks/useKubevirtWatchResources.ts
@@ -1,0 +1,33 @@
+import {
+  useK8sWatchResources,
+  WatchK8sResource,
+  WatchK8sResources,
+} from '@openshift-console/dynamic-plugin-sdk';
+import {
+  FleetResourcesObject,
+  FleetWatchK8sResource,
+  FleetWatchK8sResources,
+  FleetWatchK8sResults,
+  useFleetK8sWatchResources,
+  useHubClusterName,
+} from '@stolostron/multicluster-sdk';
+
+const useKubevirtWatchResources = <R extends FleetResourcesObject>(
+  resources: FleetWatchK8sResources<R>,
+): FleetWatchK8sResults<R> => {
+  const [hubClusterName] = useHubClusterName();
+
+  const useFleet = Object.values(resources).some(
+    (resource: FleetWatchK8sResource | WatchK8sResource) =>
+      'cluster' in resource && resource?.cluster && resource?.cluster !== hubClusterName,
+  );
+
+  const fleetData = useFleetK8sWatchResources(
+    (useFleet ? resources : {}) as FleetWatchK8sResources<R>,
+  );
+  const k8sData = useK8sWatchResources((useFleet ? {} : resources) as WatchK8sResources<R>);
+
+  return useFleet ? fleetData : k8sData;
+};
+
+export default useKubevirtWatchResources;

--- a/src/utils/components/SysprepModal/hooks/useConfigMaps.ts
+++ b/src/utils/components/SysprepModal/hooks/useConfigMaps.ts
@@ -1,17 +1,24 @@
 import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useK8sWatchResource, WatchK8sResult } from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { WatchK8sResult } from '@openshift-console/dynamic-plugin-sdk';
 
 import { AUTOUNATTEND, UNATTEND } from '../sysprep-utils';
 
 const checkEqualCaseInsensitive = (a: string, b: string) =>
   a.localeCompare(b, 'en', { sensitivity: 'base' }) === 0; // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
 
-const useSysprepConfigMaps = (namespace: string): WatchK8sResult<IoK8sApiCoreV1ConfigMap[]> => {
-  const [configmaps, configmapsLoaded, configmapsError] = useK8sWatchResource<
+const useSysprepConfigMaps = (
+  namespace: string,
+  cluster?: string,
+): WatchK8sResult<IoK8sApiCoreV1ConfigMap[]> => {
+  const clusterParam = useClusterParam();
+  const [configmaps, configmapsLoaded, configmapsError] = useK8sWatchData<
     IoK8sApiCoreV1ConfigMap[]
   >({
+    cluster: cluster || clusterParam,
     groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
     isList: true,
     namespace,

--- a/src/utils/hooks/useDeschedulerInstalled.ts
+++ b/src/utils/hooks/useDeschedulerInstalled.ts
@@ -1,6 +1,7 @@
 import { KubeDeschedulerModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
 /**
  * A Hook that checks if Kube Descheduler operator is installed.
@@ -8,8 +9,10 @@ import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
  */
 
 // check if the Descheduler is installed
-export const useDeschedulerInstalled = (): boolean => {
-  const [resourceList] = useK8sWatchResource<any>({
+export const useDeschedulerInstalled = (cluster?: string): boolean => {
+  const clusterParam = useClusterParam();
+  const [resourceList] = useK8sWatchData<any>({
+    cluster: cluster || clusterParam,
     groupVersionKind: KubeDeschedulerModelGroupVersionKind,
     isList: false,
   });

--- a/src/utils/hooks/useDeschedulerSetting/useDeschedulerSetting.ts
+++ b/src/utils/hooks/useDeschedulerSetting/useDeschedulerSetting.ts
@@ -12,6 +12,7 @@ import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { getVMTemplateAnnotations } from '@kubevirt-utils/resources/vm';
 import { isVM } from '@kubevirt-utils/utils/typeGuards';
+import { getCluster } from '@multicluster/helpers/selectors';
 import { isLiveMigratable } from '@virtualmachines/utils';
 
 type UseDeschedulerSetting = (obj: V1Template | V1VirtualMachine) => {
@@ -24,7 +25,7 @@ const useDeschedulerSetting: UseDeschedulerSetting = (obj) => {
   const isAdmin = useIsAdmin();
   const isVMObj = isVM(obj);
   const isMigratable = isVMObj ? isLiveMigratable(obj) : true;
-  const isDeschedulerInstalled = useDeschedulerInstalled();
+  const isDeschedulerInstalled = useDeschedulerInstalled(getCluster(obj));
 
   const vm = isVM(obj) ? obj : getTemplateVirtualMachineObject(obj);
   const annotations = getVMTemplateAnnotations(vm);

--- a/src/utils/hooks/useFQDN/useFQDN.ts
+++ b/src/utils/hooks/useFQDN/useFQDN.ts
@@ -3,10 +3,13 @@ import { useMemo } from 'react';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { DNSConfigModel, modelToGroupVersionKind } from '@kubevirt-utils/models';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { K8sResourceKind, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { K8sResourceKind } from '@openshift-console/dynamic-plugin-sdk';
 
 const useFQDN = (nicName: string, vm: V1VirtualMachine): string | undefined => {
-  const [dns] = useK8sWatchResource<K8sResourceKind>({
+  const [dns] = useK8sWatchData<K8sResourceKind>({
+    cluster: getCluster(vm),
     groupVersionKind: modelToGroupVersionKind(DNSConfigModel),
     name: 'cluster',
   });

--- a/src/utils/hooks/useKubevirtHyperconvergeConfiguration.ts/index.ts
+++ b/src/utils/hooks/useKubevirtHyperconvergeConfiguration.ts/index.ts
@@ -2,7 +2,8 @@ import { useMemo } from 'react';
 
 import { V1KubeVirtConfiguration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
-import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 import { KUBEVIRT_HC_GROUP_VERSION_KIND, KUBEVIRT_HC_NAME } from './constants';
 
@@ -12,13 +13,16 @@ export type KubevirtHyperconverged = K8sResourceCommon & {
   };
 };
 
-const useKubevirtHyperconvergeConfiguration = (): {
+const useKubevirtHyperconvergeConfiguration = (
+  cluster?: string,
+): {
   featureGates: string[];
   hcConfig: KubevirtHyperconverged;
   hcError: any;
   hcLoaded: boolean;
 } => {
-  const [hcConfig, hcLoaded, hcError] = useK8sWatchResource<KubevirtHyperconverged>({
+  const [hcConfig, hcLoaded, hcError] = useK8sWatchData<KubevirtHyperconverged>({
+    cluster,
     groupVersionKind: KUBEVIRT_HC_GROUP_VERSION_KIND,
     name: KUBEVIRT_HC_NAME,
     namespace: DEFAULT_OPERATOR_NAMESPACE,

--- a/src/utils/hooks/usePods.ts
+++ b/src/utils/hooks/usePods.ts
@@ -1,22 +1,26 @@
 import { modelToGroupVersionKind, PodModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
 /**
  * @date 3/20/2022 - 8:59:40 AM
  *
  * @typedef {UsePods}
  */
-type UsePods = (namespace: string) => [K8sResourceCommon[], boolean, any];
+type UsePods = (namespace: string, cluster?: string) => [K8sResourceCommon[], boolean, any];
 
 /**
  * Get namespace pods
  * @date 3/20/2022 - 8:59:40 AM
+ * @param cluster
  *
  * @param {string} namespace - namespace
  * @returns {[K8sResourceCommon[], boolean, any]}
  */
-export const usePods: UsePods = (namespace) => {
-  const [pods, podsLoaded, podsError] = useK8sWatchResource<K8sResourceCommon[]>({
+export const usePods: UsePods = (namespace, cluster) => {
+  const clusterParam = useClusterParam();
+  const [pods, podsLoaded, podsError] = useK8sWatchData<K8sResourceCommon[]>({
+    cluster: cluster || clusterParam,
     groupVersionKind: modelToGroupVersionKind(PodModel),
     isList: true,
     namespace: namespace,

--- a/src/utils/hooks/useVMsInNamespace.ts
+++ b/src/utils/hooks/useVMsInNamespace.ts
@@ -1,9 +1,12 @@
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { VirtualMachineModelGroupVersionKind } from '@kubevirt-utils/models';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-const useVMsInNamespace = (namespace?: string) => {
-  const [vms] = useK8sWatchResource<V1VirtualMachine[]>({
+const useVMsInNamespace = (namespace?: string, cluster?: string) => {
+  const clusterParam = useClusterParam();
+  const [vms] = useK8sWatchData<V1VirtualMachine[]>({
+    cluster: cluster || clusterParam,
     groupVersionKind: VirtualMachineModelGroupVersionKind,
     isList: true,
     namespace,

--- a/src/utils/resources/descheduler/hooks/useKubeDescheduler.ts
+++ b/src/utils/resources/descheduler/hooks/useKubeDescheduler.ts
@@ -2,21 +2,23 @@ import { KubeDeschedulerModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { modelToGroupVersionKind } from '@kubevirt-utils/models';
 import { KubeDescheduler } from '@kubevirt-utils/resources/descheduler/types';
 import { defaultDescheduler } from '@kubevirt-utils/resources/descheduler/utils';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-type UseKubeDescheduler = () => {
+type UseKubeDescheduler = (cluster?: string) => {
   descheduler: KubeDescheduler;
   deschedulerLoaded: boolean;
   deschedulerLoadError: boolean;
 };
 
-const useKubeDescheduler: UseKubeDescheduler = () => {
-  const [descheduler, deschedulerLoaded, deschedulerLoadError] =
-    useK8sWatchResource<KubeDescheduler>({
-      groupVersionKind: modelToGroupVersionKind(KubeDeschedulerModel),
-      name: defaultDescheduler.metadata.name,
-      namespace: defaultDescheduler.metadata.namespace,
-    });
+const useKubeDescheduler: UseKubeDescheduler = (cluster) => {
+  const clusterParam = useClusterParam();
+  const [descheduler, deschedulerLoaded, deschedulerLoadError] = useK8sWatchData<KubeDescheduler>({
+    cluster: cluster || clusterParam,
+    groupVersionKind: modelToGroupVersionKind(KubeDeschedulerModel),
+    name: defaultDescheduler.metadata.name,
+    namespace: defaultDescheduler.metadata.namespace,
+  });
 
   return { descheduler, deschedulerLoaded, deschedulerLoadError };
 };

--- a/src/utils/resources/vm/hooks/disk/useDisksSources.ts
+++ b/src/utils/resources/vm/hooks/disk/useDisksSources.ts
@@ -4,18 +4,20 @@ import { V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-d
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useK8sWatchResources } from '@openshift-console/dynamic-plugin-sdk';
+import useKubevirtWatchResources from '@multicluster/hooks/useKubevirtWatchResources';
 
 import { getPVCAndDVWatches } from './utils';
 
 const useDisksSources = (vm: V1VirtualMachine) => {
   const { dvWatches, pvcWatches } = useMemo(() => getPVCAndDVWatches(vm), [vm]);
 
-  const pvcWatchesResult = useK8sWatchResources<{
+  const pvcWatchesResult = useKubevirtWatchResources<{
     [key: string]: IoK8sApiCoreV1PersistentVolumeClaim;
   }>(pvcWatches);
 
-  const dvWatchesResult = useK8sWatchResources<{ [key: string]: V1beta1DataVolume }>(dvWatches);
+  const dvWatchesResult = useKubevirtWatchResources<{ [key: string]: V1beta1DataVolume }>(
+    dvWatches,
+  );
 
   const dvs = useMemo(
     () =>

--- a/src/utils/resources/vm/hooks/disk/utils.ts
+++ b/src/utils/resources/vm/hooks/disk/utils.ts
@@ -12,12 +12,15 @@ import {
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { DiskRawData } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { getCluster } from '@multicluster/helpers/selectors';
 
 import { getDataVolumeTemplates, getVolumes } from '../../utils';
 
 const PersistentVolumeClaimGroupVersionKind = modelToGroupVersionKind(PersistentVolumeClaimModel);
 
 export const getPVCAndDVWatches = (vm: V1VirtualMachine) => {
+  const cluster = getCluster(vm);
+
   const pvcSources = getDataVolumeTemplates(vm)?.map((dataVolume) => ({
     name: getName(dataVolume),
     namespace: getNamespace(vm),
@@ -37,6 +40,7 @@ export const getPVCAndDVWatches = (vm: V1VirtualMachine) => {
     .filter((pvcSource) => !isEmpty(pvcSource))
     .reduce((acc, pvcSource) => {
       acc[`${pvcSource.name}-${pvcSource.namespace}`] = {
+        cluster,
         groupVersionKind: PersistentVolumeClaimGroupVersionKind,
         name: pvcSource.name,
         namespace: pvcSource.namespace,
@@ -49,6 +53,7 @@ export const getPVCAndDVWatches = (vm: V1VirtualMachine) => {
     .filter((pvcSource) => !isEmpty(pvcSource))
     .reduce((acc, pvcSource) => {
       acc[`${pvcSource.name}-${pvcSource.namespace}`] = {
+        cluster,
         groupVersionKind: DataVolumeModelGroupVersionKind,
         name: pvcSource.name,
         namespace: pvcSource.namespace,

--- a/src/views/clusteroverview/OverviewTab/resources-inventory-card/hooks/useResourcesQuantities.ts
+++ b/src/views/clusteroverview/OverviewTab/resources-inventory-card/hooks/useResourcesQuantities.ts
@@ -9,7 +9,9 @@ import {
 import { NetworkAttachmentDefinitionModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { TEMPLATE_TYPE_LABEL } from '@kubevirt-utils/resources/template';
-import { K8sResourceCommon, useK8sWatchResources } from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import useKubevirtWatchResources from '@multicluster/hooks/useKubevirtWatchResources';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 
 type UseResourcesQuantities = () => {
@@ -22,6 +24,8 @@ type UseResourcesQuantities = () => {
 
 const useResourcesQuantities: UseResourcesQuantities = () => {
   const [activeNamespace] = useActiveNamespace();
+  const cluster = useClusterParam();
+
   const namespace = React.useMemo(
     () => (activeNamespace === ALL_NAMESPACES_SESSION_KEY ? null : activeNamespace),
     [activeNamespace],
@@ -29,23 +33,27 @@ const useResourcesQuantities: UseResourcesQuantities = () => {
 
   const watchedResources = {
     nads: {
+      cluster,
       groupVersionKind: NetworkAttachmentDefinitionModelGroupVersionKind,
       isList: true,
       namespace,
       namespaced: !!namespace,
     },
     nodes: {
+      cluster,
       groupVersionKind: modelToGroupVersionKind(NodeModel),
       isList: true,
       namespaced: false,
     },
     vms: {
+      cluster,
       groupVersionKind: VirtualMachineModelGroupVersionKind,
       isList: true,
       namespace,
       namespaced: !!namespace,
     },
     vmTemplates: {
+      cluster,
       groupVersionKind: modelToGroupVersionKind(TemplateModel),
       isList: true,
       namespace,
@@ -61,7 +69,9 @@ const useResourcesQuantities: UseResourcesQuantities = () => {
     },
   };
 
-  const resources = useK8sWatchResources<{ [key: string]: K8sResourceCommon[] }>(watchedResources);
+  const resources = useKubevirtWatchResources<{ [key: string]: K8sResourceCommon[] }>(
+    watchedResources,
+  );
 
   return useMemo(() => {
     return Object.entries(resources).reduce(

--- a/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDianosticData.ts
+++ b/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDianosticData.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { useK8sWatchResources } from '@openshift-console/dynamic-plugin-sdk';
+import useKubevirtWatchResources from '@multicluster/hooks/useKubevirtWatchResources';
 
 import {
   VirtualizationDataVolumeStatus,
@@ -23,7 +23,7 @@ type UseDiagnosticData = (vm: V1VirtualMachine) => {
 };
 
 const useDiagnosticData: UseDiagnosticData = (vm) => {
-  const dataVolumesData = useK8sWatchResources<{ [name: string]: V1beta1DataVolume }>(
+  const dataVolumesData = useKubevirtWatchResources<{ [name: string]: V1beta1DataVolume }>(
     buildDataVolumeResources(vm),
   );
 

--- a/src/views/virtualmachines/details/tabs/diagnostic/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/diagnostic/utils/utils.ts
@@ -8,7 +8,8 @@ import {
   V1VolumeSnapshotStatus,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
-import { WatchK8sResults } from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import { FleetWatchK8sResults } from '@stolostron/multicluster-sdk';
 
 import {
   VirtualizationDataVolumeStatus,
@@ -61,7 +62,7 @@ export const conditionsTransformer = (
 };
 
 export const buildDVStatus = (
-  data: WatchK8sResults<{ [name: string]: V1beta1DataVolume }>,
+  data: FleetWatchK8sResults<{ [name: string]: V1beta1DataVolume }>,
 ): VirtualizationDataVolumeStatus[] => {
   const elements = Object.values(data).map((dv) => dv.data);
   return elements.map((element) => {
@@ -88,6 +89,7 @@ export const buildDataVolumeResources = (vm: V1VirtualMachine) =>
     getDataVolumesNames(vm)?.map((name) => [
       name,
       {
+        cluster: getCluster(vm),
         groupVersionKind: DataVolumeModelGroupVersionKind,
         name,
         namespace: vm?.metadata?.namespace,

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Pods/Pods.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Pods/Pods.tsx
@@ -2,22 +2,26 @@ import * as React from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { usePods } from '@kubevirt-utils/hooks/usePods';
+import { modelToGroupVersionKind, PodModel } from '@kubevirt-utils/models';
+import { getName, getNamespace, getUID } from '@kubevirt-utils/resources/shared';
 import { getVMIPod } from '@kubevirt-utils/resources/vmi';
-import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
+import { getCluster } from '@multicluster/helpers/selectors';
 
 type PodsProps = {
   vmi: V1VirtualMachineInstance;
 };
 
 const Pods: React.FC<PodsProps> = ({ vmi }) => {
-  const [pods] = usePods(vmi?.metadata?.namespace);
+  const [pods] = usePods(getNamespace(vmi), getCluster(vmi));
   const vmiPod = getVMIPod(vmi, pods);
   return vmiPod ? (
-    <ResourceLink
-      key={vmiPod?.metadata?.uid}
-      kind={vmiPod?.kind}
-      name={vmiPod?.metadata?.name}
-      namespace={vmiPod?.metadata?.namespace}
+    <MulticlusterResourceLink
+      cluster={getCluster(vmi)}
+      groupVersionKind={modelToGroupVersionKind(PodModel)}
+      key={getUID(vmiPod)}
+      name={getName(vmiPod)}
+      namespace={getNamespace(vmiPod)}
     />
   ) : (
     <>-</>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Convert other watch resources hooks into multicluster

Create `useKubevirtWatchResources` in order to convert `useK8sWatchResources` occurrences multicluster ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified multi-cluster resource watching and added cluster-aware fetching across the app.
  * Converted many data hooks to accept optional cluster context and fall back to contextual cluster resolution.
* **New Features**
  * UI now links and displays resources with cluster scope (multicluster-aware resource links).
  * Resource inventory now reports a combined "loaded" status for aggregated counts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->