### PR TITLE
CNV-69216: convert k8sGet into multicluster

### DIFF
--- a/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
@@ -10,6 +10,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { getLabel } from '@kubevirt-utils/resources/shared';
 import { getCPU, getMemory, VM_TEMPLATE_ANNOTATION } from '@kubevirt-utils/resources/vm';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import {
   Alert,
   AlertVariant,
@@ -45,6 +46,7 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
   vm,
 }) => {
   const { t } = useKubevirtTranslation();
+  const cluster = useClusterParam();
 
   const [updateInProcess, setUpdateInProcess] = useState<boolean>(false);
   const [updateError, setUpdateError] = useState<string>();
@@ -61,6 +63,7 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
   } = useTemplateDefaultCpuMemory(
     vm?.metadata?.labels?.['vm.kubevirt.io/template'],
     vm?.metadata?.labels?.['vm.kubevirt.io/template.namespace'] || templateNamespace,
+    cluster,
   );
   const { defaultCpu, defaultMemory } = templateDefaultsData || {};
 

--- a/src/utils/components/CPUMemoryModal/hooks/useTemplateDefaultCpuMemory.ts
+++ b/src/utils/components/CPUMemoryModal/hooks/useTemplateDefaultCpuMemory.ts
@@ -4,13 +4,14 @@ import { TemplateModel, V1Template } from '@kubevirt-ui-ext/kubevirt-api/console
 import { V1CPU } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { getCPU, getMemory } from '@kubevirt-utils/resources/vm';
-import { k8sGet } from '@openshift-console/dynamic-plugin-sdk';
+import { kubevirtK8sGet } from '@multicluster/k8sRequests';
 
 import { getMemorySize } from '../utils/CpuMemoryUtils';
 
 type UseTemplateDefaultCpuMemory = (
   templateName: string,
   templateNamespace: string,
+  templateCluster: string,
 ) => {
   data: {
     defaultCpu: V1CPU;
@@ -23,13 +24,15 @@ type UseTemplateDefaultCpuMemory = (
 const useTemplateDefaultCpuMemory: UseTemplateDefaultCpuMemory = (
   templateName,
   templateNamespace,
+  templateCluster,
 ) => {
   const [template, setTemplate] = useState<V1Template>();
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<Error>();
 
   useEffect(() => {
-    k8sGet<V1Template>({
+    kubevirtK8sGet<V1Template>({
+      cluster: templateCluster,
       model: TemplateModel,
       name: templateName,
       ns: templateNamespace,
@@ -39,7 +42,7 @@ const useTemplateDefaultCpuMemory: UseTemplateDefaultCpuMemory = (
       .finally(() => {
         setLoaded(true);
       });
-  }, [templateName, templateNamespace]);
+  }, [templateName, templateNamespace, templateCluster]);
 
   const vmObject = getTemplateVirtualMachineObject(template);
   const defaultMemory = getMemorySize(getMemory(vmObject));

--- a/src/utils/resources/vm/utils/disk/useDriversImage.ts
+++ b/src/utils/resources/vm/utils/disk/useDriversImage.ts
@@ -2,15 +2,17 @@ import { useEffect, useState } from 'react';
 
 import { getDriversImage } from '@kubevirt-utils/resources/vm/utils/disk/drivers';
 import { driverImage, loadingDriver } from '@kubevirt-utils/store/drivers';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 
 export const useDriversImage = (): [string, boolean] => {
+  const cluster = useClusterParam();
   const [loadingDriverValue, setLoadingDriverValue] = useState(loadingDriver.value);
   const [driverImageValue, setDriverImageValue] = useState(driverImage.value);
 
   useEffect(() => {
     if (!loadingDriver.value) return;
 
-    getDriversImage()
+    getDriversImage(cluster)
       .then((image) => {
         driverImage.value = image;
         setDriverImageValue(image);
@@ -19,7 +21,7 @@ export const useDriversImage = (): [string, boolean] => {
         loadingDriver.value = false;
         setLoadingDriverValue(false);
       });
-  }, []);
+  }, [cluster]);
 
   return [driverImageValue, loadingDriverValue];
 };

--- a/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/CreateFromInstanceType.tsx
@@ -51,8 +51,8 @@ const CreateFromInstanceType: FC<CreateFromInstanceTypeProps> = ({ currentTab })
 
   useEffect(() => {
     const targetNS = getValidNamespace(namespace);
-    setVMNamespaceTarget(authorizedSSHKeys?.[targetNS], targetNS);
-  }, [authorizedSSHKeys, namespace, setVMNamespaceTarget]);
+    setVMNamespaceTarget(authorizedSSHKeys?.[targetNS], targetNS, cluster);
+  }, [authorizedSSHKeys, namespace, setVMNamespaceTarget, cluster]);
 
   const [favorites = [], updaterFavorites, loadedFavorites] = useKubevirtUserSettings(
     'favoriteBootableVolumes',

--- a/src/views/catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore.ts
@@ -23,8 +23,8 @@ import { getSSHCredentials } from './utils/utils';
 export const useInstanceTypeVMStore = create<InstanceTypeVMStore>()((set, get) => {
   return {
     ...instanceTypeVMStoreInitialState,
-    applySSHFromSettings: async (sshSecretName, targetNamespace) => {
-      const sshSecretCredentials = await getSSHCredentials(sshSecretName, targetNamespace);
+    applySSHFromSettings: async (sshSecretName, targetNamespace, cluster) => {
+      const sshSecretCredentials = await getSSHCredentials(sshSecretName, targetNamespace, cluster);
 
       set(
         produce<InstanceTypeVMStore>((currentStore) => {
@@ -95,9 +95,9 @@ export const useInstanceTypeVMStore = create<InstanceTypeVMStore>()((set, get) =
       });
       set({ vm });
     },
-    setVMNamespaceTarget: (sshSecretName, targetNamespace) => {
+    setVMNamespaceTarget: (sshSecretName, targetNamespace, cluster) => {
       get().setIsChangingNamespace();
-      get().applySSHFromSettings(sshSecretName, targetNamespace);
+      get().applySSHFromSettings(sshSecretName, targetNamespace, cluster);
     },
     setVolumeListNamespace: (namespace) => {
       set({ volumeListNamespace: namespace });

--- a/src/views/catalog/CreateFromInstanceTypes/state/utils/types.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/utils/types.ts
@@ -93,7 +93,7 @@ export type InstanceTypeVMStoreState = {
 };
 
 export type InstanceTypeVMStoreActions = {
-  applySSHFromSettings: (sshSecretName: string, targetNamespace: string) => void;
+  applySSHFromSettings: (sshSecretName: string, targetNamespace: string, cluster?: string) => void;
   onSelectCreatedVolume: (
     selectedVolume: BootableVolume,
     pvcSource?: IoK8sApiCoreV1PersistentVolumeClaim,
@@ -107,7 +107,7 @@ export type InstanceTypeVMStoreActions = {
   setSelectedStorageClass: (storageClass: string) => void;
   setStartVM: (checked: boolean) => void;
   setVM: (vm: V1VirtualMachine) => Promise<void>;
-  setVMNamespaceTarget: (sshSecretName: string, targetNamespace: string) => void;
+  setVMNamespaceTarget: (sshSecretName: string, targetNamespace: string, cluster?: string) => void;
   setVolumeListNamespace: (namespace: string) => void;
 };
 

--- a/src/views/catalog/CreateFromInstanceTypes/state/utils/utils.ts
+++ b/src/views/catalog/CreateFromInstanceTypes/state/utils/utils.ts
@@ -7,15 +7,17 @@ import {
 } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
 import { decodeSecret } from '@kubevirt-utils/resources/secret/utils';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { k8sGet } from '@openshift-console/dynamic-plugin-sdk';
+import { kubevirtK8sGet } from '@multicluster/k8sRequests';
 
 export const getSSHCredentials = (
   sshSecretName: string,
   sshSecretNamespace: string,
+  sshSecretCluster?: string,
 ): Promise<SSHSecretDetails> | SSHSecretDetails => {
   if (isEmpty(sshSecretName)) return initialSSHCredentials;
 
-  return k8sGet<IoK8sApiCoreV1Secret>({
+  return kubevirtK8sGet<IoK8sApiCoreV1Secret>({
+    cluster: sshSecretCluster,
     model: SecretModel,
     name: sshSecretName,
     ns: sshSecretNamespace,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description


Make k8sGet usage multicluster 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-cluster support added for template default configuration, disk driver image retrieval, and SSH credential management
  * Cluster context automatically propagated in virtual machine creation workflows

* **Refactor**
  * Updated internal data fetching to be cluster-aware across multiple utility modules

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->