### PR TITLE
CNV-72943: Revert "CNV-46447: do not add securty context"

### DIFF
--- a/src/utils/components/ExportModal/utils.ts
+++ b/src/utils/components/ExportModal/utils.ts
@@ -109,6 +109,10 @@ export const createUploaderPod: CreateUploaderPodType = ({
                 memory: '3Gi',
               },
             },
+            securityContext: {
+              allowPrivilegeEscalation: false,
+              capabilities: { drop: ['ALL'] },
+            },
             volumeMounts: [
               {
                 mountPath: '/tmp',
@@ -118,6 +122,12 @@ export const createUploaderPod: CreateUploaderPodType = ({
           },
         ],
         restartPolicy: 'Never',
+        securityContext: {
+          runAsNonRoot: true,
+          seccompProfile: {
+            type: 'RuntimeDefault',
+          },
+        },
         serviceAccountName: 'kubevirt-disk-uploader',
         volumes: [
           {


### PR DESCRIPTION
Reverts kubevirt-ui/kubevirt-plugin#2264

The security context is not required for this container so there is no necessity on doing do


This change is required to fix this bug: https://issues.redhat.com/browse/CNV-72943


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container security configurations with additional isolation and access control measures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->