### PR TITLE
CNV-75362: select VM tree view item when in VM details page

### DIFF
--- a/src/views/virtualmachines/tree/VirtualMachineTreeView.tsx
+++ b/src/views/virtualmachines/tree/VirtualMachineTreeView.tsx
@@ -17,7 +17,7 @@ import {
 import { useHideNamespaceBar } from '../hooks/useHideNamespaceBar';
 
 import TreeViewContent from './components/TreeViewContent';
-import useSelectNamespaceBasedOnPrivileges from './hooks/useSelectNamespaceBasedOnPrivileges';
+import useAutoSelectTreeViewItem from './hooks/useAutoSelectTreeViewItem';
 import { UseTreeViewData } from './hooks/useTreeViewData';
 import {
   CLOSED_DRAWER_SIZE,
@@ -50,7 +50,7 @@ const VirtualMachineTreeView: FC<VirtualMachineTreeViewProps> = ({
   const [drawerWidth, setDrawerWidth] = useLocalStorage(TREE_VIEW_LAST_WIDTH, OPEN_DRAWER_SIZE);
   const [drawerOpen, setDrawerOpen] = useLocalStorage(SHOW_TREE_VIEW, SHOW);
 
-  const { alertMessage, onSelect, selected } = useSelectNamespaceBasedOnPrivileges({
+  const { alertMessage, onSelect, selected } = useAutoSelectTreeViewItem({
     dataMap: treeDataMap.value,
     onFilterChange,
   });

--- a/src/views/virtualmachines/tree/hooks/useAutoSelectTreeViewItem.ts
+++ b/src/views/virtualmachines/tree/hooks/useAutoSelectTreeViewItem.ts
@@ -20,21 +20,18 @@ import {
   PROJECT_SELECTOR_PREFIX,
   VM_FOLDER_LABEL,
 } from '../utils/constants';
-import { TreeViewDataItemWithHref } from '../utils/utils';
+import { getVMTreeViewItemID, TreeViewDataItemWithHref } from '../utils/utils';
 import { getVMInfoFromPathname } from '../utils/utils';
 
 import { ALL_NAMESPACES_PATH } from './constants';
 import useTreeViewSelect from './useTreeViewSelect';
 
-type UseSelectNamespaceBasedOnPrivilegesProps = {
+type UseAutoSelectTreeViewItemProps = {
   dataMap: Record<string, TreeViewDataItemWithHref>;
   onFilterChange?: OnFilterChange;
 };
 
-const useSelectNamespaceBasedOnPrivileges = ({
-  dataMap,
-  onFilterChange,
-}: UseSelectNamespaceBasedOnPrivilegesProps) => {
+const useAutoSelectTreeViewItem = ({ dataMap, onFilterChange }: UseAutoSelectTreeViewItemProps) => {
   const [selected, onSelect, setSelected] = useTreeViewSelect(onFilterChange);
 
   const { t } = useKubevirtTranslation();
@@ -51,6 +48,15 @@ const useSelectNamespaceBasedOnPrivileges = ({
   const cluster = useClusterParam();
   const { ns } = useParams<{ ns: string }>();
 
+  // Select VM tree view item based on path
+  useEffect(() => {
+    const { vmCluster, vmName, vmNamespace } = getVMInfoFromPathname(location.pathname);
+    if (vmName && vmNamespace) {
+      setSelected(dataMap?.[getVMTreeViewItemID(vmName, vmNamespace, vmCluster)]);
+    }
+  }, [location.pathname, dataMap, setSelected]);
+
+  // Select namespace based on privileges
   useEffect(() => {
     if (isACMPage || runningTourSignal.value) return;
 
@@ -167,4 +173,4 @@ const useSelectNamespaceBasedOnPrivileges = ({
   };
 };
 
-export default useSelectNamespaceBasedOnPrivileges;
+export default useAutoSelectTreeViewItem;

--- a/src/views/virtualmachines/tree/utils/utils.tsx
+++ b/src/views/virtualmachines/tree/utils/utils.tsx
@@ -43,6 +43,9 @@ export interface TreeViewDataItemWithHref extends TreeViewDataItem {
   href?: string;
 }
 
+export const getVMTreeViewItemID = (vmName: string, vmNamespace: string, vmCluster: string) =>
+  `${vmCluster || SINGLE_CLUSTER_KEY}/${vmNamespace}/${vmName}`;
+
 const buildProjectMap = (
   vms: V1VirtualMachine[],
   currentPageVMName: string,
@@ -66,7 +69,7 @@ const buildProjectMap = (
     const vmName = getName(vm);
     const vmCluster = getCluster(vm);
     const folder = foldersEnabled ? getLabel(vm, VM_FOLDER_LABEL) : null;
-    const vmTreeItemID = `${vmCluster || SINGLE_CLUSTER_KEY}/${vmNamespace}/${vmName}`;
+    const vmTreeItemID = getVMTreeViewItemID(vmName, vmNamespace, vmCluster);
     const VMStatusIcon = statusIcon[vm?.status?.printableStatus];
 
     const vmTreeItem: TreeViewDataItemWithHref = {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Select VM tree view item when user redirects to VM details page
- also renamed `useSelectNamespaceBasedOnPrivileges` as now it is used also for selecting VM item

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/29969ac1-1004-44d7-af41-1641432184f0

After:


https://github.com/user-attachments/assets/9c26ffe4-23d8-42b2-97ce-c75e9df0ffcd




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Virtual machine tree view now automatically selects the correct item based on the current URL pathname, providing improved navigation experience while maintaining existing privilege-based selection logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->