### PR TITLE
CNV-74917: rebuild node_modules and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@kubev2v/types": "^0.0.22",
         "@kubevirt-ui-ext/kubevirt-api": "1.5.1",
         "@kubevirt-ui-ext/vnc-keymaps": "1.0.4",
-        "@novnc/novnc": "1.4.0",
+        "@novnc/novnc": "1.5.0",
         "@patternfly/quickstarts": "6.1.0",
         "@patternfly/react-catalog-view-extension": "^6.1.0",
         "@patternfly/react-charts": "^8.2.2",
@@ -2224,9 +2224,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
-      "integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-ryJnSmj4UhrGLZZPJ6PKVb4wNPAIkW6iyLy+0TRwazd3L1u0wzMe8RfqevAh2HbcSkoeLiSYnOVDOys4JSGYyg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2236,9 +2236,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.0.tgz",
+      "integrity": "sha512-Z82FDl1ByxqPEPrAYYeTQVlx2FSHPe1qwX465c+96IRS3fTdSYRoJcRxg3g2fEG5I69z1dSEWQlNRRr0/677mg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2730,9 +2730,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5111,9 +5111,9 @@
       }
     },
     "node_modules/@novnc/novnc": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.4.0.tgz",
-      "integrity": "sha512-kW6ALMc5BuH08e/ond/I1naYcfjc19JYMN1EdtmgjjjzPGCjW8fMtVM3MwM6q7YLRjPlQ3orEvoKMgSS7RkEVQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.5.0.tgz",
+      "integrity": "sha512-4yGHOtUCnEJUCsgEt/L78eeJu00kthurLBWXFiaXfonNx0pzbs6R/3gJb1byZe6iAE8V9MF0syQb0xIL8MSOtQ==",
       "license": "MPL-2.0"
     },
     "node_modules/@openshift-console/dynamic-plugin-sdk": {
@@ -6816,9 +6816,9 @@
       }
     },
     "node_modules/@types/jest/node_modules/@sinclair/typebox": {
-      "version": "0.34.45",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.45.tgz",
-      "integrity": "sha512-qJcFVfCa5jxBFSuv7S5WYbA8XdeCPmhnaVVfX/2Y6L8WYg8sk3XY2+6W0zH+3mq1Cz+YC7Ki66HfqX6IHAwnkg==",
+      "version": "0.34.46",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.46.tgz",
+      "integrity": "sha512-kiW7CtS/NkdvTUjkjUJo7d5JsFfbJ14YjdhDk9KoEgK6nFjKNXZPrX0jfLA8ZlET4cFLHxOZ/0vFKOP+bOxIOQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -13052,9 +13052,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -17542,9 +17542,9 @@
       }
     },
     "node_modules/jest-diff/node_modules/@sinclair/typebox": {
-      "version": "0.34.45",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.45.tgz",
-      "integrity": "sha512-qJcFVfCa5jxBFSuv7S5WYbA8XdeCPmhnaVVfX/2Y6L8WYg8sk3XY2+6W0zH+3mq1Cz+YC7Ki66HfqX6IHAwnkg==",
+      "version": "0.34.46",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.46.tgz",
+      "integrity": "sha512-kiW7CtS/NkdvTUjkjUJo7d5JsFfbJ14YjdhDk9KoEgK6nFjKNXZPrX0jfLA8ZlET4cFLHxOZ/0vFKOP+bOxIOQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -18355,9 +18355,9 @@
       }
     },
     "node_modules/jest-matcher-utils/node_modules/@sinclair/typebox": {
-      "version": "0.34.45",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.45.tgz",
-      "integrity": "sha512-qJcFVfCa5jxBFSuv7S5WYbA8XdeCPmhnaVVfX/2Y6L8WYg8sk3XY2+6W0zH+3mq1Cz+YC7Ki66HfqX6IHAwnkg==",
+      "version": "0.34.46",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.46.tgz",
+      "integrity": "sha512-kiW7CtS/NkdvTUjkjUJo7d5JsFfbJ14YjdhDk9KoEgK6nFjKNXZPrX0jfLA8ZlET4cFLHxOZ/0vFKOP+bOxIOQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -18526,9 +18526,9 @@
       }
     },
     "node_modules/jest-message-util/node_modules/@sinclair/typebox": {
-      "version": "0.34.45",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.45.tgz",
-      "integrity": "sha512-qJcFVfCa5jxBFSuv7S5WYbA8XdeCPmhnaVVfX/2Y6L8WYg8sk3XY2+6W0zH+3mq1Cz+YC7Ki66HfqX6IHAwnkg==",
+      "version": "0.34.46",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.46.tgz",
+      "integrity": "sha512-kiW7CtS/NkdvTUjkjUJo7d5JsFfbJ14YjdhDk9KoEgK6nFjKNXZPrX0jfLA8ZlET4cFLHxOZ/0vFKOP+bOxIOQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -18701,9 +18701,9 @@
       }
     },
     "node_modules/jest-mock/node_modules/@sinclair/typebox": {
-      "version": "0.34.45",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.45.tgz",
-      "integrity": "sha512-qJcFVfCa5jxBFSuv7S5WYbA8XdeCPmhnaVVfX/2Y6L8WYg8sk3XY2+6W0zH+3mq1Cz+YC7Ki66HfqX6IHAwnkg==",
+      "version": "0.34.46",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.46.tgz",
+      "integrity": "sha512-kiW7CtS/NkdvTUjkjUJo7d5JsFfbJ14YjdhDk9KoEgK6nFjKNXZPrX0jfLA8ZlET4cFLHxOZ/0vFKOP+bOxIOQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -19734,9 +19734,9 @@
       }
     },
     "node_modules/jest-util/node_modules/@sinclair/typebox": {
-      "version": "0.34.45",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.45.tgz",
-      "integrity": "sha512-qJcFVfCa5jxBFSuv7S5WYbA8XdeCPmhnaVVfX/2Y6L8WYg8sk3XY2+6W0zH+3mq1Cz+YC7Ki66HfqX6IHAwnkg==",
+      "version": "0.34.46",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.46.tgz",
+      "integrity": "sha512-kiW7CtS/NkdvTUjkjUJo7d5JsFfbJ14YjdhDk9KoEgK6nFjKNXZPrX0jfLA8ZlET4cFLHxOZ/0vFKOP+bOxIOQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -24164,9 +24164,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.69.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.69.0.tgz",
-      "integrity": "sha512-yt6ZGME9f4F6WHwevrvpAjh42HMvocuSnSIHUGycBqXIJdhqGSPQzTpGF+1NLREk/58IdPxEMfPcFCjlMhclGw==",
+      "version": "7.70.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.70.0.tgz",
+      "integrity": "sha512-COOMajS4FI3Wuwrs3GPpi/Jeef/5W1DRR84Yl5/ShlT3dKVFUfoGiEZ/QE6Uw8P4T2/CLJdcTVYKvWBMQTEpvw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -26425,9 +26425,9 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.3.0.tgz",
-      "integrity": "sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -26961,9 +26961,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.3.0.tgz",
-      "integrity": "sha512-6eg3Y9SF7SsAvGzRHQvvc1skDAhwI4YQ32ui1scxD1Ccr0G5qIIbUBT3pFTKX8kmWIQClHobtUdNuaBgwdfdWg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@kubev2v/types": "^0.0.22",
     "@kubevirt-ui-ext/kubevirt-api": "1.5.1",
     "@kubevirt-ui-ext/vnc-keymaps": "1.0.4",
-    "@novnc/novnc": "1.4.0",
+    "@novnc/novnc": "1.5.0",
     "@patternfly/quickstarts": "6.1.0",
     "@patternfly/react-catalog-view-extension": "^6.1.0",
     "@patternfly/react-charts": "^8.2.2",

--- a/src/utils/components/Consoles/components/utils/types.ts
+++ b/src/utils/components/Consoles/components/utils/types.ts
@@ -2,7 +2,7 @@ import { AccessConsolesActions } from '../AccessConsoles/utils/accessConsoles';
 
 import { ConsoleState, ConsoleTypes } from './ConsoleConsts';
 
-export type ConsoleType = typeof ConsoleTypes[number];
+export type ConsoleType = (typeof ConsoleTypes)[number];
 
 export type ConsoleComponentState = {
   actions: AccessConsolesActions;

--- a/src/utils/components/Consoles/components/vnc-console/utils/util.ts
+++ b/src/utils/components/Consoles/components/vnc-console/utils/util.ts
@@ -42,7 +42,7 @@ export const SCAN_CODE_NAMES = [
   F11,
   F12,
 ] as const;
-export type ScanCodeName = typeof SCAN_CODE_NAMES[number];
+export type ScanCodeName = (typeof SCAN_CODE_NAMES)[number];
 
 const VNC_IN_USE_ERROR_TEXT = 'Active VNC connection. Request denied.';
 

--- a/src/utils/components/NetworkIcons/utils.ts
+++ b/src/utils/components/NetworkIcons/utils.ts
@@ -18,7 +18,7 @@ export const interfaceStateIcons = {
 
 export const getNetworkInterfaceStateIcon = (
   interfaceState: NetworkInterfaceState,
-): typeof interfaceStateIcons[keyof typeof interfaceStateIcons] =>
+): (typeof interfaceStateIcons)[keyof typeof interfaceStateIcons] =>
   interfaceStateIcons[interfaceState] ?? LinkStateNoDataIcon;
 
 export const describeNetworkState = (t: TFunction, state: NetworkInterfaceState) => {

--- a/src/utils/resources/instancetype/types.ts
+++ b/src/utils/resources/instancetype/types.ts
@@ -22,7 +22,7 @@ export const InstanceTypeSizes = [
   '8xlarge1gi',
 ] as const;
 
-export type InstanceTypeSize = typeof InstanceTypeSizes[number];
+export type InstanceTypeSize = (typeof InstanceTypeSizes)[number];
 
 export type InstanceTypeSeries =
   | 'cx1'

--- a/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActionsUtils.ts
+++ b/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActionsUtils.ts
@@ -8,7 +8,7 @@ export const SELF_VALIDATION_ACTION_MODE = {
 } as const;
 
 export type SelfValidationActionMode =
-  typeof SELF_VALIDATION_ACTION_MODE[keyof typeof SELF_VALIDATION_ACTION_MODE];
+  (typeof SELF_VALIDATION_ACTION_MODE)[keyof typeof SELF_VALIDATION_ACTION_MODE];
 
 export type ActionState = {
   configMapInfo: { cluster: string; name: string; namespace: string } | null;

--- a/src/views/checkups/self-validation/utils/index.ts
+++ b/src/views/checkups/self-validation/utils/index.ts
@@ -8,6 +8,10 @@ export type {
   ValidatedJobParameters,
 } from './constants';
 export * from './constants';
+export { downloadResults, getDefaultErrorMessage, validateDownloadInputs } from './downloadResults';
+
+// Download results utilities
+export type { DownloadInputValidationResult, DownloadResultsReturn } from './downloadResults';
 
 // Job lifecycle and helpers
 export {
@@ -30,17 +34,15 @@ export {
   selfValidationJob,
   selfValidationPVC,
 } from './selfValidationJob';
-
 // Messages and UI helpers
 export { getRunningCheckupErrorMessage } from './selfValidationMessages';
-
-// RBAC permissions
-export type { PermissionOperationResult } from './selfValidationPermissions';
 export {
   installPermissions as installSelfValidationPermissions,
   uninstallPermissions as removeSelfValidationPermissions,
 } from './selfValidationPermissions';
 
+// RBAC permissions
+export type { PermissionOperationResult } from './selfValidationPermissions';
 // Results parsing and status
 export {
   formatGoDuration,
@@ -54,7 +56,3 @@ export {
   parseFailedTest,
   parseResults,
 } from './selfValidationResults';
-
-// Download results utilities
-export type { DownloadInputValidationResult, DownloadResultsReturn } from './downloadResults';
-export { downloadResults, getDefaultErrorMessage, validateDownloadInputs } from './downloadResults';

--- a/src/views/checkups/utils/types.ts
+++ b/src/views/checkups/utils/types.ts
@@ -8,4 +8,4 @@ export type TabConfig = {
   name: string;
 };
 
-export type CheckupType = typeof CHECKUP_URLS[keyof typeof CHECKUP_URLS];
+export type CheckupType = (typeof CHECKUP_URLS)[keyof typeof CHECKUP_URLS];

--- a/src/views/clusteroverview/SettingsTab/tabs.ts
+++ b/src/views/clusteroverview/SettingsTab/tabs.ts
@@ -11,7 +11,7 @@ export const SETTINGS_TABS = {
   USER: 'user',
 } as const;
 
-export type SettingsTab = typeof SETTINGS_TABS[keyof typeof SETTINGS_TABS];
+export type SettingsTab = (typeof SETTINGS_TABS)[keyof typeof SETTINGS_TABS];
 
 export const SETTINGS_TABS_ARRAY: SettingsTab[] = Object.values(SETTINGS_TABS);
 


### PR DESCRIPTION
## 📝 Description

https://issues.redhat.com/browse/CNV-74917 

This PR is rebuilding the package-lock.json + node_modules/ files from scratch to upgrade our midstream to use node 22 instead of node 20 as it blocks the builds.
After regenerating the package-lock.json + node_modules and building, I had an error with `@novnc/novnc` package.
version 1.6.0 of `@novnc/novnc` introduces a top-level await (await outside of a function) which is forbidden by webpack 5 for commonJS. for mor info on this known issue from novnc: https://github.com/novnc/noVNC/issues/1943
The workaround for that error was pinning the `@novnc/novnc` package to 1.5.0 which we already used instead of letting npm to upgrade to 1.6.0

## 🎥 Demo

> Please add a video or an image of the behavior/changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned a third‑party library to an exact version for stability.
  * Clarified and standardized many type declarations across the codebase to improve type correctness and consistency (purely syntactic; no runtime changes).
  * Consolidated and cleaned up public exports and re-exports to remove duplicates and better organize exposed APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->