### PR TITLE
CNV-74672: improve tooltip of "Select threshold" in Load balance feature

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -800,6 +800,7 @@
   "Info": "Info",
   "Initial run": "Initial run",
   "Install FAR.": "Install FAR.",
+  "Install load balance feature first to select a threshold.": "Install load balance feature first to select a threshold.",
   "Install NHC.": "Install NHC.",
   "Install permissions": "Install permissions",
   "installation iso of Microsoft Windows 10 ": "installation iso of Microsoft Windows 10 ",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -810,6 +810,7 @@
   "Info": "Información",
   "Initial run": "Ejecución inicial",
   "Install FAR.": "Instalar FAR.",
+  "Install load balance feature first to select a threshold.": "Install load balance feature first to select a threshold.",
   "Install NHC.": "Instalar NHC.",
   "Install permissions": "Permisos de instalación",
   "installation iso of Microsoft Windows 10 ": "ISO de instalación de Microsoft Windows 10 ",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -810,6 +810,7 @@
   "Info": "Info",
   "Initial run": "Première exécution",
   "Install FAR.": "Installez FAR.",
+  "Install load balance feature first to select a threshold.": "Install load balance feature first to select a threshold.",
   "Install NHC.": "Installer NHC.",
   "Install permissions": "Installer les autorisations",
   "installation iso of Microsoft Windows 10 ": "installation iso de Microsoft Windows 10 ",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -796,6 +796,7 @@
   "Info": "情報",
   "Initial run": "初回実行",
   "Install FAR.": "FAR をインストールします。",
+  "Install load balance feature first to select a threshold.": "Install load balance feature first to select a threshold.",
   "Install NHC.": "NHC をインストールします。",
   "Install permissions": "インストール権限",
   "installation iso of Microsoft Windows 10 ": "Microsoft Windows 10 のインストール ISO ",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -796,6 +796,7 @@
   "Info": "정보",
   "Initial run": "초기 실행",
   "Install FAR.": "FAR을 설치합니다.",
+  "Install load balance feature first to select a threshold.": "Install load balance feature first to select a threshold.",
   "Install NHC.": "NHC를 설치합니다.",
   "Install permissions": "설치 권한",
   "installation iso of Microsoft Windows 10 ": "Microsoft Windows 10 설치 ISO ",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -796,6 +796,7 @@
   "Info": "信息",
   "Initial run": "初始运行",
   "Install FAR.": "安装 FAR。",
+  "Install load balance feature first to select a threshold.": "Install load balance feature first to select a threshold.",
   "Install NHC.": "安装 NHC。",
   "Install permissions": "安装权限",
   "installation iso of Microsoft Windows 10 ": "Microsoft Windows 10 的安装 iso ",

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/LoadBalanceSection/LoadBalanceSection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/LoadBalanceSection/LoadBalanceSection.tsx
@@ -49,7 +49,7 @@ const LoadBalanceSection: FC = () => {
       isIndented
       toggleContent={t('Load balance')}
     >
-      <DeschedulerSection />
+      <DeschedulerSection isOperatorInstalled={isOperatorInstalled} />
     </ExpandSectionWithCustomToggle>
   );
 };

--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/LoadBalanceConfigurationSection/LoadBalanceConfigurationSection.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/LoadBalanceConfigurationSection/LoadBalanceConfigurationSection.tsx
@@ -4,6 +4,9 @@ import ExpandSectionWithCustomToggle from '@kubevirt-utils/components/ExpandSect
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import LightspeedSimplePopoverContent from '@lightspeed/components/LightspeedSimplePopoverContent';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
+import { DESCHEDULER_OPERATOR_NAME } from '@overview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/utils/constants';
+import { isInstalled } from '@overview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/utils/utils';
+import { useVirtualizationFeaturesContext } from '@overview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/utils/VirtualizationFeaturesContext/VirtualizationFeaturesContext';
 import DeschedulerSection from '@overview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/LoadBalanceSection/components/DeschedulerSection';
 import LoadBalanceToggleContent from '@overview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/LoadBalanceConfigurationSection/components/LoadBalanceToggleContent/LoadBalanceToggleContent';
 import HelpTextTooltipContent from '@overview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/HelpTextTooltipContent/HelpTextTooltipContent';
@@ -16,6 +19,10 @@ import './LoadBalanceConfigurationSection.scss';
 const LoadBalanceConfigurationSection: FC = () => {
   const { t } = useKubevirtTranslation();
   const [alternativeChecked, setAlternativeChecked] = useState<boolean>(false);
+
+  const { operatorDetailsMap } = useVirtualizationFeaturesContext();
+  const { installState } = operatorDetailsMap?.[DESCHEDULER_OPERATOR_NAME] || {};
+  const isOperatorInstalled = isInstalled(installState);
 
   return (
     <ExpandSectionWithCustomToggle
@@ -48,7 +55,7 @@ const LoadBalanceConfigurationSection: FC = () => {
           />
         </StackItem>
         <StackItem>
-          <DeschedulerSection />
+          <DeschedulerSection isOperatorInstalled={isOperatorInstalled} />
         </StackItem>
       </Stack>
     </ExpandSectionWithCustomToggle>


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- In Settings -> Virtualization features, when the "Load balance" fetaure (Kube Descheduler Operator) is not installed yet, then we will show a tooltip for the "Select threshold" to install the Load balance feature first

## 🎥 Demo

After:

https://github.com/user-attachments/assets/06b19768-900a-4400-99c3-5797da6fe2d3




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Descheduler option now reflects operator installation status and shows contextual guidance when prerequisites aren't met.
  * New user-facing message "Install load balance feature first to select a threshold." added to English, Spanish, French, Japanese, Korean, and Chinese locales to guide setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->