### PR TITLE
CNV-74670: installed features in High availability are checked

### DIFF
--- a/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/HighAvailabilityConfigurationSection/components/HighAvailabilityContent/HighAvailabilityFeatureItem/HighAvailabilityFeatureItem.tsx
+++ b/src/views/clusteroverview/SettingsTab/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/HighAvailabilityConfigurationSection/components/HighAvailabilityContent/HighAvailabilityFeatureItem/HighAvailabilityFeatureItem.tsx
@@ -46,7 +46,7 @@ const HighAvailabilityFeatureItem: FC<HighAvailabilityFeatureItemProps> = ({
             <Checkbox
               className="high-availability-feature-item__checkbox"
               id={`${operatorName}-checkbox`}
-              isChecked={operatorsToInstall?.[operatorName]}
+              isChecked={operatorsToInstall?.[operatorName] || installed}
               isDisabled={alternativeChecked || installed}
               label={checkboxLabel}
               onChange={(_, checked) => updateInstallRequests({ [operatorName]: checked })}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Installed features in Settings -> Configure features modal -> High availability are now checked.

(We can't make the checkboxes enabled, because the modal can't uninstall the features.)

## 🎥 Demo

After:
<img width="1171" height="948" alt="Screenshot 2026-01-05 at 14 02 10" src="https://github.com/user-attachments/assets/d031eef7-dca7-47e6-ba72-b64b2fb6c9f4" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed high availability feature configuration display to correctly show the checked state when virtualization operators are already installed on the cluster, regardless of their current selection status. This ensures accurate visual feedback during cluster configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->