### PR TITLE
CNV-75833: useClusterObservabilityDisabled should only be used in ACM

### DIFF
--- a/src/utils/hooks/useAlerts/useAlerts.ts
+++ b/src/utils/hooks/useAlerts/useAlerts.ts
@@ -103,7 +103,7 @@ const useAlerts: UseAlerts = () => {
   return {
     alerts: allAlerts,
     error: observabilityError || (isACMPage ? metricError : singleClusterAlerts.error),
-    loaded: isACMPage ? metricLoaded : singleClusterAlerts.loaded,
+    loaded: isACMPage ? metricLoaded && observabilityLoaded : singleClusterAlerts.loaded,
   };
 };
 

--- a/src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData.ts
+++ b/src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData.ts
@@ -119,7 +119,7 @@ const useMigrationCardDataAndFilters: UseMigrationCardDataAndFilters = (duration
 
   return {
     filters,
-    loaded: vmimsLoaded && vmisLoaded,
+    loaded: vmimsLoaded && vmisLoaded && observabilityLoaded,
     loadErrors: observabilityError || vmimsErrors || vmisErrors,
     migrationsTableFilteredData: data,
     migrationsTableUnfilteredData: unfilteredData,

--- a/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusesCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusesCard.tsx
@@ -68,6 +68,7 @@ const VMStatusesCard: FC = () => {
   const { otherStatuses, otherStatusesCount, primaryStatuses } = getVMStatuses(vms || []);
 
   const displayError = observabilityError || error;
+  const isLoaded = loaded && observabilityLoaded;
 
   return (
     <Card className="vm-statuses-card" data-test-id="vm-statuses-card">
@@ -79,12 +80,12 @@ const VMStatusesCard: FC = () => {
           <ErrorAlert error={displayError} />
         </CardBody>
       )}
-      {!loaded && !displayError && (
+      {!isLoaded && !displayError && (
         <CardBody>
           <LoadingEmptyState />
         </CardBody>
       )}
-      {loaded && (
+      {isLoaded && (
         <>
           <div className="vm-statuses-card__body">
             <Grid hasGutter>


### PR DESCRIPTION
## 📝 Description

`useClusterObservabilityDisabled` should only used in ACM - if used in non ACM envs it returns an error. 

Jira ticket: [CNV-75833](https://issues.redhat.com/browse/CNV-75833)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/4f1a0446-f8ee-4df6-9425-ddaf36a4d245


After:


https://github.com/user-attachments/assets/f5036f4f-731f-4298-aa16-5ff6c71bf8a9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated loading conditions across alerts, cluster overview, migrations, and VM status displays to ensure data is fully prepared before showing content.
  * Loading states will persist longer until all required data dependencies are satisfied, improving consistency and completeness of displayed information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->