### PR TITLE
CNV-75949: make VM YAML editor take up full height

### DIFF
--- a/src/utils/components/HorizontalNavbar/HorizontalNavbar.scss
+++ b/src/utils/components/HorizontalNavbar/HorizontalNavbar.scss
@@ -1,0 +1,4 @@
+.horizontal-navbar__routes {
+  // Needed for YAML editor to take up full height
+  height: 100%;
+}

--- a/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
+++ b/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
@@ -12,6 +12,8 @@ import StateHandler from '../StateHandler/StateHandler';
 import useDynamicPages from './utils/useDynamicPages';
 import { NavPageKubevirt, trimLastHistoryPath } from './utils/utils';
 
+import './HorizontalNavbar.scss';
+
 type HorizontalNavbarProps = {
   basePath?: string;
   error?: any;
@@ -107,7 +109,7 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
           })}
         </ul>
       </nav>
-      <div className={routesClassName || 'horizontal-navbar__routes'}>
+      <div className={classNames('horizontal-navbar__routes', routesClassName)}>
         <Routes>{RoutesComponents}</Routes>
       </div>
     </>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- make VM YAML editor take up full height
- the `horizontal-navbar__routes` class with `height: 100%` will always be added to prevent similar bugs if a custom `routesClassName` is applied

## 🎥 Demo
Before:
<img width="1700" height="1265" alt="Screenshot 2026-01-06 at 10 59 01" src="https://github.com/user-attachments/assets/8d07d126-db1f-466a-a03c-4f3cd843e0ba" />


After:
<img width="1700" height="1265" alt="Screenshot 2026-01-06 at 10 43 51" src="https://github.com/user-attachments/assets/12f0f9a8-382b-41b1-ae20-ea542dcc027e" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved horizontal navbar styling to ensure routes section occupies full height
  * Enhanced class name handling for better component styling consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->