### PR TITLE
CNV-75956: VNC console element has 0px height

### DIFF
--- a/src/utils/components/Consoles/components/vnc-console/vnc-console.scss
+++ b/src/utils/components/Consoles/components/vnc-console/vnc-console.scss
@@ -11,6 +11,7 @@
   }
   canvas {
     margin: 0 !important;
+    min-height: 400px;
   }
 }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

vnc console was having a 0px inline height which basically made it hidden, adding min-height to fix it.

## 🎥 Demo

#### Before

<img width="1182" height="659" alt="vnc-no-height" src="https://github.com/user-attachments/assets/8c3984c3-ca88-4de0-b7d6-2193e98f6983" />

#### After

<img width="1454" height="821" alt="vnc-min-height" src="https://github.com/user-attachments/assets/c17b7c9d-14ab-4169-a0e2-15c194ab1892" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the VNC console layout to maintain a minimum height, ensuring consistent visual appearance across different screen configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->