### PR TITLE
CNV-75365: Prometheus queries for Usage summary don't work in multicluster for hub cluster

### DIFF
--- a/src/views/virtualmachines/list/hooks/useVMTotalsMetrics.ts
+++ b/src/views/virtualmachines/list/hooks/useVMTotalsMetrics.ts
@@ -8,7 +8,7 @@ import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useIsAllClustersPage from '@multicluster/hooks/useIsAllClustersPage';
 import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
 import { METRICS } from '@overview/OverviewTab/metric-charts-card/utils/constants';
-import { useFleetPrometheusPoll } from '@stolostron/multicluster-sdk';
+import { useFleetPrometheusPoll, useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import {
   getCpuRequestedText,
@@ -23,14 +23,15 @@ const useVMTotalsMetrics = (vmis: V1VirtualMachineInstance[]) => {
   const namespace = useNamespaceParam();
   const clusters = useListClusters();
   const namespaces = useListNamespaces();
+  const [hubClusterName] = useHubClusterName();
 
   const isAllClustersPage = useIsAllClustersPage();
 
   const currentTime = useMemo<number>(() => Date.now(), []);
 
   const queries = useMemo(
-    () => getVMTotalsQueries(namespaces, clusters, isAllClustersPage),
-    [namespaces, clusters, isAllClustersPage],
+    () => getVMTotalsQueries(namespaces, clusters, isAllClustersPage, hubClusterName),
+    [namespaces, clusters, isAllClustersPage, hubClusterName],
   );
 
   const prometheusPollProps = {

--- a/src/views/virtualmachines/list/utils/totalsQueries.ts
+++ b/src/views/virtualmachines/list/utils/totalsQueries.ts
@@ -12,10 +12,12 @@ export const getVMTotalsQueries = (
   namespaces: string[],
   clusters?: string[],
   allClusters = false,
+  hubClusterName?: string,
 ) => {
   const isAllNamespaces = isEmpty(namespaces);
 
-  const clusterFilter = isEmpty(clusters) ? '' : `cluster=~'${clusters.join('|')}'`;
+  const filteredClusters = clusters?.filter((c) => c !== hubClusterName);
+  const clusterFilter = isEmpty(filteredClusters) ? '' : `cluster=~'${filteredClusters.join('|')}'`;
 
   const filters = isAllNamespaces
     ? `{${clusterFilter}}`


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-75365](https://issues.redhat.com/browse/CNV-75365)

Prometheus queries for Usage summary don't work in multi-cluster for hub cluster

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/a74ce9d1-cf63-4c8d-bd8a-3d279bd91e88

After:


https://github.com/user-attachments/assets/1f48d4bf-b720-4a7b-9e2a-54453b7e7447



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Virtual machine metrics calculations have been improved to properly account for hub cluster context. Hub cluster data is now appropriately excluded from managed cluster-specific metrics aggregations and calculations, ensuring accurate and reliable performance visibility. This enhancement provides clearer insights into the health and operational status of individual managed clusters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->