### PR TITLE
CNV-76066: show pvc size, or dv size, or datavolumeTemplate size

### DIFF
--- a/src/utils/resources/vm/utils/disk/rowData.ts
+++ b/src/utils/resources/vm/utils/disk/rowData.ts
@@ -52,10 +52,11 @@ export const getDiskRowDataLayout = (
       storageClass: dataVolumeTemplate?.spec?.storage?.storageClassName || NO_DATA_DASH,
     };
 
-    const dataSourceSize = getPVCSize(pvc) || getDataVolumeSize(dataVolume);
-    const dataVolumeCustomSize = dataVolumeTemplate?.spec?.storage?.resources?.requests?.storage;
+    const pvcSize = getPVCSize(pvc);
+    const dataVolumeSize = getDataVolumeSize(dataVolume);
+    const dataVolumeTemplateSize = dataVolumeTemplate?.spec?.storage?.resources?.requests?.storage;
 
-    const size = getHumanizedSize(dataVolumeCustomSize || dataSourceSize);
+    const size = getHumanizedSize(pvcSize || dataVolumeSize || dataVolumeTemplateSize);
 
     diskRowDataObject.size = size.value === 0 ? NO_DATA_DASH : size.string;
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Show PVC size first. This is the real size. if we have only DV, show DV size, if we dont' have DV (not created vm) , show the dataVolumeTemplate size. 


If user resize the size, it will see the new size. 

DV cannot be edited so we have to show the PVC size to let the user know that there is a difference now


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved disk size calculation logic for enhanced code clarity and maintainability. The internal sizing mechanism has been restructured to be more explicit and easier to maintain, with no impact on user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->