### PR TITLE
CNV-76121: fix showing all VMs when clicked on cluster

### DIFF
--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -116,7 +116,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
     loaded: accessibleVMsLoaded,
     loadError: accessibleVMsError,
     resources: accessibleVMs,
-  } = useAccessibleResources<V1VirtualMachine>(VirtualMachineModelGroupVersionKind);
+  } = useAccessibleResources<V1VirtualMachine>(VirtualMachineModelGroupVersionKind, cluster);
 
   const vms = namespace ? namespacedVMs : accessibleVMs;
   const vmsLoaded = namespace ? namespacedVMsLoaded : accessibleVMsLoaded;

--- a/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
+++ b/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
@@ -16,6 +16,7 @@ type UseAccessibleResources<T> = {
 
 export const useAccessibleResources = <T>(
   groupVersionKind: K8sGroupVersionKind,
+  cluster?: string,
 ): UseAccessibleResources<T> => {
   const isAdmin = useIsAdmin();
   const isACMPage = useIsACMPage();
@@ -27,6 +28,7 @@ export const useAccessibleResources = <T>(
   const [allResources, allResourcesLoaded] = useKubevirtWatchResource<T[]>(
     shouldFetchClusterWide
       ? {
+          cluster,
           groupVersionKind,
           isList: true,
           limit: OBJECTS_FETCHING_LIMIT,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes a bug that all VMs from all clusters were shown if we click on a specific cluster in the tree view.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/f9f03940-7b91-4758-9a12-c2ddc9165e57



After:

https://github.com/user-attachments/assets/b1492dd9-371f-4e9c-afed-95f27d230f90





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced virtual machine resource fetching with cluster-aware capabilities. The accessible resources query now supports cluster-specific context, enabling more precise retrieval of virtual machine data based on cluster selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->