### PR TITLE
CNV-76153: Web console displays blank page when accessed from VM in spoke clusters via ACM

### DIFF
--- a/src/multicluster/useIsACMPage.ts
+++ b/src/multicluster/useIsACMPage.ts
@@ -19,7 +19,8 @@ const useIsACMPage = ({ activePerspectiveSync = true }: UseIsACMPageOptions = {}
     if (
       activePerspectiveSync &&
       isACMPathResult &&
-      activePerspective !== PERSPECTIVES.FLEET_VIRTUALIZATION
+      activePerspective !== PERSPECTIVES.FLEET_VIRTUALIZATION &&
+      setActivePerspective !== undefined
     ) {
       setActivePerspective(PERSPECTIVES.FLEET_VIRTUALIZATION);
     }


### PR DESCRIPTION
## 📝 Description

Web console displays blank page when accessed from VM in spoke clusters via ACM

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/519a183d-8ff6-4801-b410-83af1ba0e88d

After:

https://github.com/user-attachments/assets/a3321490-d2b2-4138-8c11-ad01c385bf7c




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential runtime error in the multicluster environment when perspective management is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->