### PR TITLE
CNV-76123: fix redirecting to invalid namespace on Template deletion

### DIFF
--- a/src/views/templates/actions/VirtualMachineTemplatesActions.tsx
+++ b/src/views/templates/actions/VirtualMachineTemplatesActions.tsx
@@ -3,9 +3,8 @@ import React, { FC } from 'react';
 import { V1Template } from '@kubevirt-ui-ext/kubevirt-api/console';
 import ActionsDropdown from '@kubevirt-utils/components/ActionsDropdown/ActionsDropdown';
 
-import useVirtualMachineTemplatesActions, {
-  EDIT_TEMPLATE_ID,
-} from './hooks/useVirtualMachineTemplatesActions';
+import useVirtualMachineTemplatesActions from './hooks/useVirtualMachineTemplatesActions';
+import { EDIT_TEMPLATE_ID } from './constants';
 
 type VirtualMachineTemplatesActionsProps = { isKebabToggle?: boolean; template: V1Template };
 

--- a/src/views/templates/actions/constants.ts
+++ b/src/views/templates/actions/constants.ts
@@ -1,2 +1,3 @@
 export const MAXIMUM_TIMES_PVC_NOT_DELETED = 4;
 export const TIMEOUT_PVC_GETS_DELETED_INTERVAL = 1000;
+export const EDIT_TEMPLATE_ID = 'edit-template';

--- a/src/views/templates/actions/hooks/useVirtualMachineTemplatesActions.tsx
+++ b/src/views/templates/actions/hooks/useVirtualMachineTemplatesActions.tsx
@@ -11,7 +11,7 @@ import { LabelsModal } from '@kubevirt-utils/components/LabelsModal/LabelsModal'
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { useLastNamespacePath } from '@kubevirt-utils/hooks/useLastNamespacePath';
+import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
 import { asAccessReview, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import {
   getACMTemplateListURL,
@@ -31,6 +31,7 @@ import {
   NO_EDIT_TEMPLATE_PERMISSIONS,
 } from '../../utils/constants';
 import EditBootSourceModal from '../components/EditBootSourceModal';
+import { EDIT_TEMPLATE_ID } from '../constants';
 import {
   createDataVolume,
   getBootDataSource,
@@ -38,12 +39,11 @@ import {
   hasEditableBootSource,
 } from '../editBootSource';
 
-type useVirtualMachineTemplatesActionsProps = (
+type UseVirtualMachineTemplatesActions = (
   template: V1Template,
 ) => [actions: Action[], onLazyActions: () => void];
 
-export const EDIT_TEMPLATE_ID = 'edit-template';
-const useVirtualMachineTemplatesActions: useVirtualMachineTemplatesActionsProps = (
+const useVirtualMachineTemplatesActions: UseVirtualMachineTemplatesActions = (
   template: V1Template,
 ) => {
   const { t } = useKubevirtTranslation();
@@ -53,7 +53,7 @@ const useVirtualMachineTemplatesActions: useVirtualMachineTemplatesActionsProps 
   const [bootDataSource, setBootDataSource] = useState<V1beta1DataSource>();
   const [loadingBootSource, setLoadingBootSource] = useState(true);
   const editableBootSource = hasEditableBootSource(bootDataSource);
-  const lastNamespacePath = useLastNamespacePath();
+  const namespace = useNamespaceParam();
   const [hubClusterName] = useHubClusterName();
   const cluster = getCluster(template) || hubClusterName;
   const isACMPage = useIsACMPage();
@@ -109,9 +109,7 @@ const useVirtualMachineTemplatesActions: useVirtualMachineTemplatesActionsProps 
       cluster,
       model: TemplateModel,
       resource: template,
-    }).then(() =>
-      navigate(isACMPage ? getACMTemplateListURL() : getTemplateListURL(lastNamespacePath)),
-    );
+    }).then(() => navigate(isACMPage ? getACMTemplateListURL() : getTemplateListURL(namespace)));
   };
 
   const actions = [
@@ -239,6 +237,7 @@ const useVirtualMachineTemplatesActions: useVirtualMachineTemplatesActionsProps 
             obj={template}
             onClose={onClose}
             onDeleteSubmit={onDelete}
+            shouldRedirect={false}
           />
         )),
       description:


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes redirecting to invalid "all-namespaces" namespace after Template deletion.
- fixed by using `useNamespaceParam` instead of `useLastNamespacePath`
- also put `shouldRedirect={false}` to the DeleteModal, so it doesn't do redirection twice
- the rest is refactoring

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/a5307012-14ac-41cd-8d9f-f1b4140508ef




After:

https://github.com/user-attachments/assets/230875b4-b56c-46b7-aedd-0b5c7d44f201



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal constants for improved code structure and maintainability.
  * Updated navigation logic to use improved namespace resolution for virtual machine templates.
  * Enhanced delete modal behavior for better user interaction flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->