### PR TITLE
CNV-76259: Revert "CNV-75956: VNC console element has 0px height"

### DIFF
--- a/src/utils/components/Consoles/components/vnc-console/vnc-console.scss
+++ b/src/utils/components/Consoles/components/vnc-console/vnc-console.scss
@@ -11,7 +11,6 @@
   }
   canvas {
     margin: 0 !important;
-    min-height: 400px;
   }
 }
 


### PR DESCRIPTION
## 📝 Description
Reverts  #3325 -  commit 8270287a6a43f1efa58e546bdd7b91e1074f5278.      
                                                                        
Forced min height interacts with auto-scaling based                     
on the parent container size. The fix delivered in #3324                
prevents the original bug.                                              
                                                                        
See also previous regressions in this area: #2496 and #2393.            
                                                                        
Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/3324 
Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/3325 
Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/2496 
Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/2393 

## 🎥 Demo

### Before

<img width="1119" height="978" alt="Screenshot From 2026-01-09 14-03-52" src="https://github.com/user-attachments/assets/0f351781-b1f5-4538-ae1e-92c470aa5e8c" />
<img width="780" height="531" alt="Screenshot From 2026-01-09 14-03-29" src="https://github.com/user-attachments/assets/11d31fbe-1b0d-4418-af0e-cad4c531c7be" />

### After
<img width="780" height="531" alt="Screenshot From 2026-01-09 14-01-37" src="https://github.com/user-attachments/assets/4e00a7c0-3565-4c63-85ba-1fd8818609c2" />
<img width="1024" height="1029" alt="Screenshot From 2026-01-09 14-00-35" src="https://github.com/user-attachments/assets/33afd614-8405-4bd7-aa09-8a3d5a2185aa" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed fixed minimum height constraint on the VNC console canvas, allowing flexible sizing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->