### PR TITLE
CNV-75945: Overview page does not load properly when MCO is not installed

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1012,6 +1012,7 @@
   "Move to folder": "Move to folder",
   "MP": "MP",
   "MTV": "MTV",
+  "Multicluster observability is not installed on the hub cluster": "Multicluster observability is not installed on the hub cluster",
   "my-storage-claim": "my-storage-claim",
   "N series": "N series",
   "N Series": "N Series",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1022,6 +1022,7 @@
   "Move to folder": "Mover a la carpeta",
   "MP": "MP",
   "MTV": "MTV",
+  "Multicluster observability is not installed on the hub cluster": "Multicluster observability is not installed on the hub cluster",
   "my-storage-claim": "my-storage-claim",
   "N series": "Serie N",
   "N Series": "Serie N",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1022,6 +1022,7 @@
   "Move to folder": "Déplacer vers le dossier",
   "MP": "MP",
   "MTV": "MTV",
+  "Multicluster observability is not installed on the hub cluster": "Multicluster observability is not installed on the hub cluster",
   "my-storage-claim": "my-storage-claim",
   "N series": "Série N",
   "N Series": "Séries N",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1008,6 +1008,7 @@
   "Move to folder": "フォルダーに移動",
   "MP": "MP",
   "MTV": "MTV",
+  "Multicluster observability is not installed on the hub cluster": "Multicluster observability is not installed on the hub cluster",
   "my-storage-claim": "my-storage-claim",
   "N series": "N シリーズ",
   "N Series": "N シリーズ",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1008,6 +1008,7 @@
   "Move to folder": "폴더로 이동",
   "MP": "MP",
   "MTV": "MTV",
+  "Multicluster observability is not installed on the hub cluster": "Multicluster observability is not installed on the hub cluster",
   "my-storage-claim": "my-storage-claim",
   "N series": "N 시리즈",
   "N Series": "N 시리즈",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1008,6 +1008,7 @@
   "Move to folder": "移到文件夹",
   "MP": "MP",
   "MTV": "MTV",
+  "Multicluster observability is not installed on the hub cluster": "Multicluster observability is not installed on the hub cluster",
   "my-storage-claim": "my-storage-claim",
   "N series": "N 系列",
   "N Series": "N 系列",

--- a/src/utils/components/ClusterProjectDropdown/hooks/useDisabledClusterRedirect.ts
+++ b/src/utils/components/ClusterProjectDropdown/hooks/useDisabledClusterRedirect.ts
@@ -33,14 +33,7 @@ export const useDisabledClusterRedirect = ({
 }: UseDisabledClusterRedirectProps): void => {
   useEffect(() => {
     if (!isACMPage) return;
-    if (
-      !clustersLoaded ||
-      !clusterNames ||
-      !cluster ||
-      cluster === ALL_CLUSTERS_KEY ||
-      !disabledClusters ||
-      disabledClusters.length === 0
-    ) {
+    if (!clustersLoaded || !clusterNames || !cluster || !disabledClusters) {
       return;
     }
 
@@ -53,9 +46,17 @@ export const useDisabledClusterRedirect = ({
     const omittedSet = new Set(onlyCNVClusters && cnvLoaded ? cnvNotInstalledClusters : []);
     const disabledSet = new Set(disabledClusters);
 
-    // If includeAllClusters is true, prefer "all clusters"
-    if (includeAllClusters) {
-      onClusterChange(ALL_CLUSTERS_KEY);
+    const redirectTo = (next: string | undefined): void => {
+      if (next && next !== cluster) {
+        onClusterChange(next);
+      }
+    };
+
+    const isAllClustersDisabled = disabledSet.has(ALL_CLUSTERS_KEY);
+    const shouldRedirectToAllClusters =
+      includeAllClusters && !isAllClustersDisabled && cluster !== ALL_CLUSTERS_KEY;
+    if (shouldRedirectToAllClusters) {
+      redirectTo(ALL_CLUSTERS_KEY);
       return;
     }
 
@@ -63,12 +64,6 @@ export const useDisabledClusterRedirect = ({
     const enabledCluster = clusterNames?.find(
       (name) => !omittedSet.has(name) && !disabledSet.has(name),
     );
-
-    const redirectTo = (next: string | undefined): void => {
-      if (next && next !== cluster) {
-        onClusterChange(next);
-      }
-    };
 
     if (enabledCluster) {
       redirectTo(enabledCluster);

--- a/src/utils/hooks/useAlerts/utils/useMCOInstalled.ts
+++ b/src/utils/hooks/useAlerts/utils/useMCOInstalled.ts
@@ -1,0 +1,59 @@
+import { TFunction } from 'react-i18next';
+
+import { MultiClusterObservabilityModel } from '@kubevirt-utils/models';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import useIsACMPage from '@multicluster/useIsACMPage';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { useHubClusterName } from '@stolostron/multicluster-sdk';
+
+export const getMCONotInstalledTooltip = (t: TFunction): string =>
+  t('Multicluster observability is not installed on the hub cluster');
+
+type UseMCOInstalledResult = {
+  error: Error | unknown;
+  loaded: boolean;
+  mcoInstalled: boolean;
+};
+
+/**
+ * Hook to check if Multicluster Observability (MCO) is installed on the hub cluster.
+ * MCO is required for fleet-wide Prometheus metrics polling.
+ * When MCO is not installed, only the hub cluster should be shown and spoke clusters
+ * should be disabled with a tooltip.
+ */
+export const useMCOInstalled = (): UseMCOInstalledResult => {
+  const isACMPage = useIsACMPage();
+  const [hubClusterName] = useHubClusterName();
+
+  const [mcoResource, loaded, error] = useK8sWatchData<K8sResourceCommon[]>(
+    isACMPage
+      ? {
+          cluster: hubClusterName,
+          groupVersionKind: {
+            group: MultiClusterObservabilityModel.apiGroup,
+            kind: MultiClusterObservabilityModel.kind,
+            version: MultiClusterObservabilityModel.apiVersion,
+          },
+          isList: true,
+        }
+      : null,
+  );
+
+  if (!isACMPage) {
+    return {
+      error: undefined,
+      loaded: true,
+      mcoInstalled: true,
+    };
+  }
+  const mcoInstalled = !isEmpty(mcoResource);
+
+  return {
+    error,
+    loaded,
+    mcoInstalled,
+  };
+};
+
+export default useMCOInstalled;

--- a/src/utils/models/index.ts
+++ b/src/utils/models/index.ts
@@ -135,3 +135,15 @@ export const MultiNamespaceVirtualMachineStorageMigrationModel: K8sModel = {
   namespaced: true,
   plural: 'multinamespacevirtualmachinestoragemigrations',
 };
+
+export const MultiClusterObservabilityModel: K8sModel = {
+  abbr: 'MCO',
+  apiGroup: 'observability.open-cluster-management.io',
+  apiVersion: 'v1beta2',
+  crd: true,
+  kind: 'MultiClusterObservability',
+  label: 'MultiClusterObservability',
+  labelPlural: 'MultiClusterObservabilities',
+  namespaced: false,
+  plural: 'multiclusterobservabilities',
+};

--- a/src/views/clusteroverview/ClusterOverviewPage.tsx
+++ b/src/views/clusteroverview/ClusterOverviewPage.tsx
@@ -4,8 +4,12 @@ import { Helmet } from 'react-helmet';
 import ClusterProjectDropdown from '@kubevirt-utils/components/ClusterProjectDropdown/ClusterProjectDropdown';
 import HorizontalNavbar from '@kubevirt-utils/components/HorizontalNavbar/HorizontalNavbar';
 import { NavPageKubevirt } from '@kubevirt-utils/components/HorizontalNavbar/utils/utils';
+import LoadingEmptyState from '@kubevirt-utils/components/LoadingEmptyState/LoadingEmptyState';
 import { ALL_CLUSTERS_KEY } from '@kubevirt-utils/hooks/constants';
-import { useClusterObservabilityDisabled } from '@kubevirt-utils/hooks/useAlerts/utils/useClusterObservabilityDisabled';
+import {
+  getMCONotInstalledTooltip,
+  useClusterObservabilityDisabled,
+} from '@kubevirt-utils/hooks/useAlerts/utils/useClusterObservabilityDisabled';
 import { useForceProjectSelection } from '@kubevirt-utils/hooks/useForceProjectSelection';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -36,14 +40,31 @@ const ClusterOverviewPage: FC = () => {
     disabledClusters,
     error: observabilityError,
     loaded: observabilityLoaded,
+    mcoInstalled,
   } = useClusterObservabilityDisabled(true);
   useSignals();
+
+  // When MCO is not installed, also disable "All clusters" option
+  const disabledClustersWithAllClusters = useMemo(() => {
+    if (!observabilityLoaded || observabilityError) {
+      return undefined;
+    }
+
+    if (!mcoInstalled) {
+      // Include ALL_CLUSTERS_KEY to disable "All clusters" option when MCO is not installed
+      return [ALL_CLUSTERS_KEY, ...disabledClusters];
+    }
+
+    return disabledClusters;
+  }, [observabilityLoaded, observabilityError, mcoInstalled, disabledClusters]);
 
   useForceProjectSelection([VIRTUALIZATION_PATHS.OVERVIEW]);
   usePreserveTabDisplay({
     basePath: VIRTUALIZATION_PATHS.OVERVIEW,
     storageKey: 'lastVirtualizationOverviewTab',
   });
+
+  const isLoadingMCOCheck = isACMPage && !observabilityLoaded;
 
   const overviewTabs: NavPageKubevirt[] = useMemo(() => {
     const adminPages: NavPageKubevirt[] = [
@@ -101,14 +122,27 @@ const ClusterOverviewPage: FC = () => {
     ];
   }, [isAdmin, t, isACMPage]);
 
+  if (isLoadingMCOCheck) {
+    return (
+      <>
+        <Helmet>
+          <title>{t('Virtualization')}</title>
+        </Helmet>
+        <LoadingEmptyState />
+      </>
+    );
+  }
+
   return (
     <>
       {isACMPage && (
         <ClusterProjectDropdown
-          disabledClusters={
-            observabilityLoaded && !observabilityError ? disabledClusters : undefined
+          disabledItemTooltip={
+            !mcoInstalled
+              ? getMCONotInstalledTooltip(t)
+              : t('Observability is disabled for this cluster')
           }
-          disabledItemTooltip={t('Observability is disabled for this cluster')}
+          disabledClusters={disabledClustersWithAllClusters}
           includeAllClusters={true}
           includeAllProjects={true}
           onlyCNVClusters={true}


### PR DESCRIPTION
## 📝 Description

Jira Ticket: [CNV-75945](https://issues.redhat.com/browse/CNV-75945)

When Multi Cluster Observability plugin is not installed on the hub cluster we cannot show any data for the spoke clusters in the overview screen. 

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/ab8e7477-a901-4b9a-b819-9c4e14689b1f

After:

https://github.com/user-attachments/assets/4ff673de-e092-41a7-bf1d-b2b0ad8188da

After (MCO Installed):

https://github.com/user-attachments/assets/d8ffc6c2-428c-4676-9954-36324b0eb66d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects whether Multicluster Observability (MCO) is installed on the hub cluster and shows a loading state while checking.
  * Adds localized MCO-unavailable message entries (en, es, fr, ja, ko, zh) and a tooltip explaining MCO absence.

* **Improvements**
  * Automatically disables the "All Clusters" option when MCO is not installed and surfaces contextual tooltips.
  * Refined cluster redirect behavior to avoid selecting disabled clusters and skip unnecessary redirects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->