### PR TITLE
CNV-76065: use pvc spec storage and not capacity

### DIFF
--- a/src/utils/components/DiskModal/components/DiskSizeInput/ExpandPVC.tsx
+++ b/src/utils/components/DiskModal/components/DiskSizeInput/ExpandPVC.tsx
@@ -4,12 +4,13 @@ import { useFormContext } from 'react-hook-form';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import CapacityInput from '@kubevirt-utils/components/CapacityInput/CapacityInput';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getPVCSize } from '@kubevirt-utils/resources/bootableresources/selectors';
 import { formatQuantityString, quantityToString, toQuantity } from '@kubevirt-utils/utils/units';
 
 import { V1DiskFormState } from '../../utils/types';
 import { EXPAND_PVC_SIZE } from '../utils/constants';
 
-import { getMinSizes, getPVCStorageForInput } from './utils';
+import { getMinSizes } from './utils';
 
 type ExpandPVCProps = { pvc: IoK8sApiCoreV1PersistentVolumeClaim };
 
@@ -19,7 +20,7 @@ const ExpandPVC: FC<ExpandPVCProps> = ({ pvc }) => {
   const diskState = watch();
 
   const expandPVCSize = diskState.expandPVCSize;
-  const pvcStorage = formatQuantityString(getPVCStorageForInput(pvc));
+  const pvcStorage = formatQuantityString(getPVCSize(pvc));
   if (!pvcStorage) {
     return null;
   }

--- a/src/utils/components/DiskModal/components/DiskSizeInput/utils.ts
+++ b/src/utils/components/DiskModal/components/DiskSizeInput/utils.ts
@@ -1,12 +1,6 @@
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import {
-  getPVCSize,
-  getPVCStorageCapacity,
-} from '@kubevirt-utils/resources/bootableresources/selectors';
 import { convertToBaseValue, humanizeBinaryBytesWithoutB } from '@kubevirt-utils/utils/humanize.js';
 import { binaryUnitsOrdered } from '@kubevirt-utils/utils/unitConstants';
 import { BinaryUnit } from '@kubevirt-utils/utils/unitConstants';
-import { formatQuantityString } from '@kubevirt-utils/utils/units';
 
 export const getMinSizes = (pvcSize: string) => {
   const pvcSizeBytes = convertToBaseValue(pvcSize);
@@ -18,15 +12,4 @@ export const getMinSizes = (pvcSize: string) => {
   });
 
   return minSizes;
-};
-
-export const getPVCStorageForInput = (pvc: IoK8sApiCoreV1PersistentVolumeClaim) => {
-  const pvcStorageRequested = getPVCSize(pvc);
-  if (!pvcStorageRequested) return null;
-
-  const pvcStorageCapacity = getPVCStorageCapacity(pvc);
-
-  return convertToBaseValue(pvcStorageCapacity) >= convertToBaseValue(pvcStorageRequested)
-    ? pvcStorageCapacity
-    : formatQuantityString(pvcStorageRequested, false);
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Do not use PVC capacity in the disk modal as it's a different thing than the spec storage size. For some storageclasses when we request a certain amount for a PVC, it actually loads a heavier chunk under the hood so this is why we have higher capacity. But we are not interested on showing this mechanism


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal logic for disk storage size retrieval in the disk configuration modal, consolidating how storage information is handled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->