### PR TITLE
CNV-74885: Allow display of vm with undefined cloud-init disk

### DIFF
--- a/src/utils/resources/vm/hooks/disk/utils.ts
+++ b/src/utils/resources/vm/hooks/disk/utils.ts
@@ -66,7 +66,7 @@ export const getPVCAndDVWatches = (vm: V1VirtualMachine) => {
 };
 
 export const getEjectedCDROMDrives = (diskDevices: DiskRawData[], vmDisks: V1Disk[]) => {
-  const diskDevicesSet = new Set(diskDevices.map((obj) => obj.disk.name));
+  const diskDevicesSet = new Set(diskDevices.map((obj) => obj.disk?.name).filter(Boolean));
   const ejectedCDROMDrives = (vmDisks || []).filter((obj) => !diskDevicesSet.has(obj.name));
   const mappedEjectedCDROMDrives = ejectedCDROMDrives.map((disk) => ({
     disk,

--- a/src/utils/resources/vm/utils/disk/rowData.ts
+++ b/src/utils/resources/vm/utils/disk/rowData.ts
@@ -38,10 +38,13 @@ export const getDiskRowDataLayout = (
     // eslint-disable-next-line require-jsdoc
     const volumeSource = Object.keys(volume).find((key) => key !== 'name');
 
+    const isDiskConfigured = disk && (disk.disk || disk.cdrom || disk.lun);
+
     const diskRowDataObject: DiskRowDataLayout = {
-      drive: isEmpty(disk) ? NO_DATA_DASH : getPrintableDiskDrive(disk),
+      drive: isEmpty(disk) || !isDiskConfigured ? NO_DATA_DASH : getPrintableDiskDrive(disk),
       hasDataVolume: Boolean(dataVolume),
-      interface: isEmpty(disk) ? NO_DATA_DASH : getPrintableDiskInterface(disk),
+      interface:
+        isEmpty(disk) || !isDiskConfigured ? NO_DATA_DASH : getPrintableDiskInterface(disk),
       isBootDisk: disk?.name === bootDisk?.name,
       isEnvDisk: !!volume?.configMap || !!volume?.secret || !!volume?.serviceAccount,
       metadata: { name: volume?.name },
@@ -70,6 +73,10 @@ export const getDiskRowDataLayout = (
 
     if (volumeSource === VolumeTypes.CONTAINER_DISK) {
       diskRowDataObject.source = CONTAINER_EPHERMAL;
+      diskRowDataObject.size = DYNAMIC;
+    }
+
+    if (volume.cloudInitNoCloud || volume.cloudInitConfigDrive) {
       diskRowDataObject.size = DYNAMIC;
     }
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

vm details don't load in the ui for vms with cloudinit volumes without disk, even though the vm is running, I added checks to handle and display incomplete disk objects.

## 🎥 Demo

Before:
<img width="2921" height="403" alt="image" src="https://github.com/user-attachments/assets/37499bc6-e9ba-4839-a4c5-c3fc88e1c309" />

After:

https://github.com/user-attachments/assets/a480e0bf-a043-4e9e-a266-fe6fd3b0c0b9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional disk configurations to prevent potential runtime errors.
  * Corrected display of unconfigured drives and interfaces to show consistent placeholder values.
  
* **New Features**
  * Added dynamic disk sizing support for cloud-init configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->