### PR TITLE
CNV-76450: Make compute migration multicluster

### DIFF
--- a/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesData.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesData.ts
@@ -4,7 +4,8 @@ import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { isNodeSchedulable, nodeStatus } from '@kubevirt-utils/resources/node/utils/utils';
 import { getName } from '@kubevirt-utils/resources/shared';
 import useNode from '@kubevirt-utils/resources/vm/hooks/useNode';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { getCluster } from '@multicluster/helpers/selectors';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import useNodesMetrics from '@virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/useNodesMetrics';
 import { NodeData } from '@virtualmachines/actions/components/VirtualMachineComputeMigration/utils/types';
 
@@ -15,14 +16,16 @@ type UseNodesData = (vm: V1VirtualMachine) => {
 };
 
 const useNodesData: UseNodesData = (vm) => {
-  const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
+  const cluster = getCluster(vm);
+  const [nodes, nodesLoaded] = useK8sWatchData<IoK8sApiCoreV1Node[]>({
+    cluster,
     groupVersionKind: modelToGroupVersionKind(NodeModel),
     isList: true,
     selector: {
       matchLabels: { 'node-role.kubernetes.io/worker': '' },
     },
   });
-  const { metricsData, metricsLoaded } = useNodesMetrics();
+  const { metricsData, metricsLoaded } = useNodesMetrics(cluster);
   const vmiNodeName = useNode(vm);
 
   const filteredNodes = nodes?.filter(

--- a/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/useNodesMetrics.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/useNodesMetrics.ts
@@ -1,26 +1,34 @@
-import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
+import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
+import { useFleetPrometheusPoll } from '@stolostron/multicluster-sdk';
 import { MetricsDataByNode } from '@virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/utils/types';
 import { getDataByNode } from '@virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/utils/utils';
 
-type UseNodesMetrics = () => { metricsData: MetricsDataByNode; metricsLoaded: boolean };
+type UseNodesMetrics = (cluster?: string) => {
+  metricsData: MetricsDataByNode;
+  metricsLoaded: boolean;
+};
 
-const useNodesMetrics: UseNodesMetrics = () => {
-  const [usedMemoryResult, usedMemoryLoaded] = usePrometheusPoll({
+const useNodesMetrics: UseNodesMetrics = (cluster) => {
+  const [usedMemoryResult, usedMemoryLoaded] = useFleetPrometheusPoll({
+    cluster,
     endpoint: PrometheusEndpoint.QUERY,
     query: 'sum by (instance) (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes)',
   });
 
-  const [totalMemoryResult, totalMemoryLoaded] = usePrometheusPoll({
+  const [totalMemoryResult, totalMemoryLoaded] = useFleetPrometheusPoll({
+    cluster,
     endpoint: PrometheusEndpoint.QUERY,
     query: 'sum by (instance) (node_memory_MemTotal_bytes)',
   });
 
-  const [usedCPUResult, usedCPULoaded] = usePrometheusPoll({
+  const [usedCPUResult, usedCPULoaded] = useFleetPrometheusPoll({
+    cluster,
     endpoint: PrometheusEndpoint.QUERY,
     query: 'sum by(instance) (instance:node_cpu:rate:sum)',
   });
 
-  const [totalCPUResult, totalCPULoaded] = usePrometheusPoll({
+  const [totalCPUResult, totalCPULoaded] = useFleetPrometheusPoll({
+    cluster,
     endpoint: PrometheusEndpoint.QUERY,
     query: 'sum by(instance) (instance:node_num_cpu:sum)',
   });


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Compute migration was not showing vm cluster nodes but hub cluster nodes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Virtual machine compute migration now scopes node and resource metrics to the cluster that hosts the VM, improving accuracy of resource availability and migration planning in multi-cluster environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->