### PR TITLE
CNV-69965: allowing the use of same (non ovn) NAD in vm multiple times

### DIFF
--- a/src/utils/resources/udn/hooks/useNamespaceUDN.ts
+++ b/src/utils/resources/udn/hooks/useNamespaceUDN.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { parseNADConfig } from '@kubevirt-utils/components/NetworkInterfaceModal/utils/helpers';
 import { NetworkAttachmentDefinitionModelGroupVersionKind } from '@kubevirt-utils/models';
 import { UserDefinedNetworkRole } from '@kubevirt-utils/resources/udn/types';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -28,7 +29,7 @@ const useNamespaceUDN = (
   const udnNAD = useMemo(
     () =>
       nads?.find((nad) => {
-        const config = JSON.parse(nad?.spec?.config || '{}');
+        const config = parseNADConfig(nad);
 
         return (
           PrimaryTopologies.includes(config.topology) &&
@@ -41,7 +42,7 @@ const useNamespaceUDN = (
   const isNamespaceManagedByUDN = useMemo(() => !isEmpty(udnNAD), [udnNAD]);
 
   const vmsNotSupported = useMemo(() => {
-    const config = JSON.parse(udnNAD?.spec?.config || '{}');
+    const config = parseNADConfig(udnNAD);
     return config.topology === LAYER3_TOPOLOGY;
   }, [udnNAD]);
 

--- a/src/utils/resources/vm/utils/constants.ts
+++ b/src/utils/resources/vm/utils/constants.ts
@@ -38,6 +38,10 @@ export const BRIDGE = 'bridge';
 export const MASQUERADE = 'masquerade';
 export const SRIOV = 'sriov';
 
+// NAD config types
+export const NAD_TYPE_OVN_K8S_CNI_OVERLAY = 'ovn-k8s-cni-overlay';
+export const NAD_TYPE_CNV_BRIDGE = 'cnv-bridge';
+
 export const POD_NETWORK = 'POD_NETWORK';
 
 export enum UPDATE_STRATEGIES {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

using the same NAD in a vm multiple times was not possible through UI as we were filtering out all NADs that are already used for the vm. Fixed filtering to only filter out used ovn-k8s-cni-ovelay NAD types. 

## 🎥 Demo

Before:
<img width="2388" height="807" alt="image" src="https://github.com/user-attachments/assets/e0997bff-cb89-40ba-8749-8590c2f48b50" />


After:

https://github.com/user-attachments/assets/e9e459f5-960e-43c3-a7d7-212e42e44292




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network attachment definition filtering to better handle already-in-use network configurations.
  * Enhanced network configuration parsing for better error handling and robustness.

* **New Features**
  * Added detection for overlay network types in network selection options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->