### PR TITLE
CNV-76116: Fix delete modal in checkup to appear at top of screen

### DIFF
--- a/src/views/checkups/components/DeleteCheckupModal.tsx
+++ b/src/views/checkups/components/DeleteCheckupModal.tsx
@@ -29,7 +29,7 @@ const DeleteCheckupModal: FC<DeleteCheckupModalProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   return (
-    <Modal isOpen={isOpen} onClose={onClose} variant={ModalVariant.medium}>
+    <Modal isOpen={isOpen} onClose={onClose} position="top" variant={ModalVariant.medium}>
       <ModalHeader title={t('Delete checkup')} titleIconVariant="warning" />
       <ModalBody>
         <ConfirmActionMessage obj={{ metadata: { name, namespace } }} />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

position delete modal on top to match other delete modals 

## 🎥 Demo

Before:
<img width="2799" height="1020" alt="image" src="https://github.com/user-attachments/assets/74a52b80-0714-4cfa-a06f-8cc8e6317c67" />

After:
<img width="2684" height="634" alt="image" src="https://github.com/user-attachments/assets/3546bcf3-2df6-45c0-8c98-2e2a820989ee" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the positioning of the delete checkup confirmation modal to appear at the top of the screen.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->