### PR TITLE
CNV-76310: Selecting a VM Resource within the ACM Virtualization Over…

### DIFF
--- a/src/utils/resources/vm/utils/utils.ts
+++ b/src/utils/resources/vm/utils/utils.ts
@@ -23,7 +23,8 @@ const getRowFiltersString = (rowFilters: Record<string, string>) =>
 export const getVMListPathWithRowFilters = (
   namespace: string,
   rowFilters: Record<string, string>,
-) => `${getVMListURL(null, namespace)}?${getRowFiltersString(rowFilters)}`;
+  cluster?: string,
+) => `${getVMListURL(cluster, namespace)}?${getRowFiltersString(rowFilters)}`;
 
 export const getACMMListPathWithRowFilters = (
   cluster: string,

--- a/src/views/clusteroverview/OverviewTab/inventory-card/utils/vm-status-section/VMStatusInventoryItem.tsx
+++ b/src/views/clusteroverview/OverviewTab/inventory-card/utils/vm-status-section/VMStatusInventoryItem.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom-v5-compat';
 
 import { ALL_NAMESPACES } from '@kubevirt-utils/hooks/constants';
 import { getVMListPathWithRowFilters } from '@kubevirt-utils/resources/vm/utils/utils';
+import useActiveClusterParam from '@multicluster/hooks/useActiveClusterParam';
 
 import { getVMStatusIcon } from '../utils';
 
@@ -14,8 +15,9 @@ export type VMStatusInventoryItemProps = {
 };
 
 const VMStatusInventoryItem: React.FC<VMStatusInventoryItemProps> = ({ count, status }) => {
+  const cluster = useActiveClusterParam();
   const Icon = getVMStatusIcon(status);
-  const to = getVMListPathWithRowFilters(ALL_NAMESPACES, { status });
+  const to = getVMListPathWithRowFilters(ALL_NAMESPACES, { status }, cluster);
 
   return (
     <div className="co-inventory-card__status">

--- a/src/views/clusteroverview/OverviewTab/vms-per-resource-card/RunningVMsChartLegendLabel.tsx
+++ b/src/views/clusteroverview/OverviewTab/vms-per-resource-card/RunningVMsChartLegendLabel.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
 import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
+import useActiveClusterParam from '@multicluster/hooks/useActiveClusterParam';
 
 import { getInstanceTypeSeriesLabel, getLinkPath } from './utils/utils';
 
@@ -24,8 +25,9 @@ type RunningVMsChartLegendLabelProps = {
 
 const RunningVMsChartLegendLabel: React.FC<RunningVMsChartLegendLabelProps> = ({ item }) => {
   const activeNamespace = useActiveNamespace();
+  const cluster = useActiveClusterParam();
   const iconStyle = { color: item.color };
-  const linkPath = getLinkPath(item, activeNamespace);
+  const linkPath = getLinkPath(item, activeNamespace, cluster);
   const linkText = item?.isInstanceType ? getInstanceTypeSeriesLabel(item.name) : item?.name;
 
   return (

--- a/src/views/clusteroverview/OverviewTab/vms-per-resource-card/utils/utils.ts
+++ b/src/views/clusteroverview/OverviewTab/vms-per-resource-card/utils/utils.ts
@@ -111,12 +111,16 @@ export const getFilterKey = (resourceItem: RunningVMsChartLegendLabelItem) => {
   return resourceItem.isInstanceType ? INSTANCETYPE_FILTER_KEY : TEMPLATE_FILTER_KEY;
 };
 
-export const getLinkPath = (resourceItem: RunningVMsChartLegendLabelItem, namespace: string) => {
+export const getLinkPath = (
+  resourceItem: RunningVMsChartLegendLabelItem,
+  namespace: string,
+  cluster?: string,
+) => {
   const filterKey = getFilterKey(resourceItem);
   const filters =
     resourceItem?.type === UNCATEGORIZED_VM
       ? { instanceType: 'No+InstanceType', template: 'None' }
       : { [filterKey]: getInstanceTypePrefix(resourceItem.name) };
 
-  return getVMListPathWithRowFilters(namespace, filters);
+  return getVMListPathWithRowFilters(namespace, filters, cluster);
 };

--- a/src/views/virtualmachines/tree/hooks/useAutoSelectTreeViewItem.ts
+++ b/src/views/virtualmachines/tree/hooks/useAutoSelectTreeViewItem.ts
@@ -13,6 +13,11 @@ import useIsACMPage from '@multicluster/useIsACMPage';
 import { OnFilterChange } from '@openshift-console/dynamic-plugin-sdk';
 import { useLastNamespace } from '@openshift-console/dynamic-plugin-sdk-internal';
 
+import {
+  ALL_CLUSTERS_ID,
+  CLUSTER_SELECTOR_PREFIX,
+  PROJECT_SELECTOR_PREFIX,
+} from '../utils/constants';
 import { getVMTreeViewItemID, TreeViewDataItemWithHref } from '../utils/utils';
 import { getVMInfoFromPathname } from '../utils/utils';
 
@@ -47,6 +52,32 @@ const useAutoSelectTreeViewItem = ({ dataMap, onFilterChange }: UseAutoSelectTre
       setSelected(dataMap?.[getVMTreeViewItemID(vmName, vmNamespace, vmCluster)]);
     }
   }, [location.pathname, dataMap, setSelected]);
+
+  // Select cluster or project tree view item when on ACM page (only when not viewing a specific VM)
+  useEffect(() => {
+    if (!isACMPage) return;
+
+    const { vmName, vmNamespace } = getVMInfoFromPathname(location.pathname);
+    if (vmName && vmNamespace) return;
+
+    // If filtering by a specific project, select the project tree item
+    if (ns && cluster) {
+      const projectTreeItemId = `${PROJECT_SELECTOR_PREFIX}/${cluster}/${ns}`;
+      const projectTreeItem = dataMap?.[projectTreeItemId];
+      if (projectTreeItem && selected?.id !== projectTreeItemId) {
+        setSelected(projectTreeItem);
+      }
+      return;
+    }
+
+    // Otherwise, select the cluster tree item
+    const clusterTreeItemId = cluster ? `${CLUSTER_SELECTOR_PREFIX}/${cluster}` : ALL_CLUSTERS_ID;
+
+    const clusterTreeItem = dataMap?.[clusterTreeItemId];
+    if (clusterTreeItem && selected?.id !== clusterTreeItemId) {
+      setSelected(clusterTreeItem);
+    }
+  }, [cluster, dataMap, isACMPage, location.pathname, ns, selected?.id, setSelected]);
 
   // Select namespace based on privileges
   useEffect(() => {

--- a/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
@@ -9,9 +9,11 @@ import {
   V1VirtualMachine,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { ALL_CLUSTERS } from '@kubevirt-utils/hooks/constants';
 import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
 import { getName } from '@kubevirt-utils/resources/shared';
@@ -33,6 +35,7 @@ export type UseTreeViewData = {
 };
 
 export const useTreeViewData = (): UseTreeViewData => {
+  const { t } = useKubevirtTranslation();
   const isAdmin = useIsAdmin();
   const location = useLocation();
 
@@ -133,6 +136,7 @@ export const useTreeViewData = (): UseTreeViewData => {
         location.pathname,
         treeViewFoldersEnabled,
         namespacesByCluster,
+        t(ALL_CLUSTERS),
         location.search,
         clusterNames,
       );
@@ -155,6 +159,7 @@ export const useTreeViewData = (): UseTreeViewData => {
     clusterNames,
     namespacesByCluster,
     location.search,
+    t,
   ]);
 
   return useMemo(

--- a/src/views/virtualmachines/tree/utils/utils.tsx
+++ b/src/views/virtualmachines/tree/utils/utils.tsx
@@ -276,6 +276,7 @@ export const createMultiClusterTreeViewData = (
   pathname: string,
   foldersEnabled: boolean,
   projectsByClusters: UseMulticlusterNamespacesReturn['namespacesByCluster'],
+  allClustersLabel: string,
   queryParams?: string,
   clusterNames?: string[],
 ): TreeViewDataItem[] => {
@@ -334,21 +335,20 @@ export const createMultiClusterTreeViewData = (
       return clusterTreeItem;
     });
 
+  const allClustersTreeItem: TreeViewDataItemWithHref = {
+    children: treeWithClusters,
+    defaultExpanded: true,
+    hasBadge: false,
+    href: getACMVMListURL(),
+    icon: <ClusterIcon />,
+    id: ALL_CLUSTERS_ID,
+    name: allClustersLabel,
+  };
+
+  treeViewDataMap[ALL_CLUSTERS_ID] = allClustersTreeItem;
   treeDataMap.value = treeViewDataMap;
 
-  const clusterTreeItem: TreeViewDataItemWithHref[] = [
-    {
-      children: treeWithClusters,
-      defaultExpanded: true,
-      hasBadge: false,
-      href: getACMVMListURL(),
-      icon: <ClusterIcon />,
-      id: ALL_CLUSTERS_ID,
-      name: 'All clusters',
-    },
-  ];
-
-  return clusterTreeItem;
+  return [allClustersTreeItem];
 };
 
 // searches for clusters, projects and folders


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-76310](https://issues.redhat.com/browse/CNV-76310)

Selecting a VM Resource within the ACM (Advanced Cluster Management) "VirtualMachines per resource" view incorrectly redirects the user to the standard (non-ACM) VirtualMachines tree.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/119a6544-dfef-460a-ac0c-99eebfff19a8

After:

https://github.com/user-attachments/assets/460ed0b4-58ba-4557-a794-18ad5bdb6292

Updated demo with tree selection:


https://github.com/user-attachments/assets/3d3a189c-de79-4825-a6f1-e0d11ecb88c5





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation and VM lists are cluster-aware across overview cards and charts.
  * Tree view auto-selects the current cluster/project on multi-cluster pages when no specific VM is selected.
  * "All clusters" node now uses localized label text.

* **Bug Fixes**
  * VM list links consistently preserve the active cluster context when navigating from overview and chart elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->