### PR TITLE
CNV-76522: fix showing YAML in Create VM in ACM

### DIFF
--- a/src/multicluster/components/MulticlusterYAMLCreation/hooks/useYAMLTemplateExtension.ts
+++ b/src/multicluster/components/MulticlusterYAMLCreation/hooks/useYAMLTemplateExtension.ts
@@ -1,5 +1,3 @@
-import { load } from 'js-yaml';
-
 import {
   isYAMLTemplate,
   K8sModel,
@@ -7,21 +5,20 @@ import {
   YAMLTemplate,
 } from '@openshift-console/dynamic-plugin-sdk';
 
+import { ResourceYAMLTemplate } from '../types';
+import { convertResourceYAMLTemplate } from '../utils';
+
 const useYAMLTemplateExtension = (model: K8sModel) => {
   const [yamlExtensions, yamlExtensionsResolved] =
     useResolvedExtensions<YAMLTemplate>(isYAMLTemplate);
 
   const resourceYAMLTemplate = yamlExtensions?.find(
     (ext) => ext.properties.model.kind === model?.kind,
-  )?.properties?.template as (() => string) | string;
+  )?.properties?.template as ResourceYAMLTemplate;
 
   return {
     resourceYAMLTemplate: resourceYAMLTemplate
-      ? load(
-          typeof resourceYAMLTemplate === 'function'
-            ? resourceYAMLTemplate()
-            : resourceYAMLTemplate,
-        )
+      ? convertResourceYAMLTemplate(resourceYAMLTemplate)
       : undefined,
     yamlExtensionsResolved,
   };

--- a/src/multicluster/components/MulticlusterYAMLCreation/types.ts
+++ b/src/multicluster/components/MulticlusterYAMLCreation/types.ts
@@ -1,0 +1,1 @@
+export type ResourceYAMLTemplate = (() => object) | (() => string) | string;

--- a/src/multicluster/components/MulticlusterYAMLCreation/utils.ts
+++ b/src/multicluster/components/MulticlusterYAMLCreation/utils.ts
@@ -1,0 +1,15 @@
+import { load } from 'js-yaml';
+
+import { ResourceYAMLTemplate } from './types';
+
+export const convertResourceYAMLTemplate = (resourceYAMLTemplate: ResourceYAMLTemplate): object => {
+  if (typeof resourceYAMLTemplate === 'function') {
+    const result = resourceYAMLTemplate();
+    if (typeof result === 'string') {
+      return load(result) as object;
+    }
+    return result;
+  }
+
+  return load(resourceYAMLTemplate) as object;
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes YAML editor showing `object Object` in Create VirtualMachine with YAML page in ACM

- the resourceYAMLTemplate variable obtained from `useResolvedExtensions<YAMLTemplate>` was of type `() => object` not `() => string`. This PR adds handling of various different types

## 🎥 Demo


Before:
<img width="1722" height="1028" alt="Screenshot 2026-01-14 at 14 14 29" src="https://github.com/user-attachments/assets/88174c39-8e6c-4b75-ae3c-a16c3478c059" />


After:
<img width="1722" height="1028" alt="Screenshot 2026-01-14 at 14 17 02" src="https://github.com/user-attachments/assets/a90b3199-bdd0-4678-86cf-0766d32b4c7c" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized how YAML resource templates are handled and normalized across the multicluster YAML creation flow. Internal conversion is now more consistent and robust (supports strings, objects, or provider functions). No visible behavior or API changes for end users; existing integrations continue to work the same.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->