### PR TITLE
CNV-76532: fix hiding the Cluster/Project select in ACM VM Create with YAML

### DIFF
--- a/src/multicluster/components/MulticlusterYAMLCreation/MulticlusterYAMLCreation.tsx
+++ b/src/multicluster/components/MulticlusterYAMLCreation/MulticlusterYAMLCreation.tsx
@@ -63,6 +63,7 @@ const MulticlusterYAMLCreation: FC = () => {
       {isACMPage && (
         <ClusterProjectDropdown
           includeAllClusters={false}
+          includeAllProjects={false}
           showProjectDropdown={model?.namespaced}
         />
       )}

--- a/src/utils/components/ClusterProjectDropdown/ClusterProjectDropdown.tsx
+++ b/src/utils/components/ClusterProjectDropdown/ClusterProjectDropdown.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import ClusterDropdown from '@kubevirt-utils/components/ClusterProjectDropdown/ClusterDropdown';
 import NamespaceDropdown from '@kubevirt-utils/components/ClusterProjectDropdown/NamespaceDropdown';
+import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { ALL_CLUSTERS_KEY, ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
 import { useClusterCNVInstalled } from '@kubevirt-utils/hooks/useAlerts/utils/useClusterCNVInstalled';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -59,9 +60,12 @@ const ClusterProjectDropdown: FC<ClusterProjectDropdownProps> = memo(
           .replace(`/cluster/${cluster}/`, clusterReplaceKey)
           .replace('/all-clusters/', clusterReplaceKey);
 
-        // Reset project to "all projects" when cluster changes
+        // Reset project to "all projects" or default project when cluster changes
         if (namespace) {
-          newPathname = newPathname.replace(`/ns/${namespace}/`, '/all-namespaces/');
+          newPathname = newPathname.replace(
+            `/ns/${namespace}/`,
+            includeAllProjects ? '/all-namespaces/' : `/ns/${DEFAULT_NAMESPACE}/`,
+          );
         }
 
         navigate(newPathname);


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes hiding the Cluster/Project select in ACM VM Create with YAML

- hide the "All projects" option
- redirect to default project on Cluster change instead of "All projects", if the "All projects" option is not there

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/8dee832e-39dd-4fb1-aca6-c749a1496b1b



After:

https://github.com/user-attachments/assets/3444e07b-1be2-45aa-ba12-d16e97f55040





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The cluster project dropdown on ACM pages has been updated to restrict the "all projects" option, requiring users to explicitly select specific projects for their operations.
  * Modified default namespace handling when switching between clusters in ACM environments to provide more appropriate and consistent defaults based on page configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->