### PR TITLE
CNV-76578: Trigger VNC force connect modal only after user actions

### DIFF
--- a/src/utils/components/Consoles/components/vnc-console/utils/constants.ts
+++ b/src/utils/components/Consoles/components/vnc-console/utils/constants.ts
@@ -1,3 +1,6 @@
+export const USER_CONNECT = 'user_connect';
+export const AUTO_CONNECT = 'auto_connect';
+
 // follow the levels used by noVNC
 // falsy value means no logging
 // https://github.com/novnc/noVNC/blob/6d0a9746657b085c11309dc5356083fcbb018526/core/util/logging.js#L32

--- a/src/utils/components/Consoles/components/vnc-console/utils/util.ts
+++ b/src/utils/components/Consoles/components/vnc-console/utils/util.ts
@@ -118,7 +118,7 @@ export const disconnect = ({
   );
   rfbRefs.current = newerSessions;
   targetAndOlderSessions.forEach(
-    ({ rfb }) => rfb._rfbConnectionState !== 'disconnected' && rfb?.disconnect(),
+    ({ rfb }) => rfb?._rfbConnectionState !== 'disconnected' && rfb?.disconnect(),
   );
   if (newerSessions.length || targetAndOlderSessions.length > 1) {
     log(
@@ -127,7 +127,7 @@ export const disconnect = ({
     // skip notification - target session already closed
     return;
   }
-  const current = targetAndOlderSessions.find((it) => it.sessionID === sessionID);
+  const current = targetAndOlderSessions.find((session) => session.sessionID === sessionID);
   const { testUrl } = current ?? {};
   if (!testUrl) {
     // synchronous cleanup


### PR DESCRIPTION
## 📝 Description

Don't show the  "VNC session already in use" modal when:
1. auto-connecting i.e. switching to a new tab
2. disconnected by other user

Instead show the regular empty state with single "Connect" button.

## 🎥 Demo

### Before


https://github.com/user-attachments/assets/020b4702-e638-45af-992c-dfe1c876ef79

### After

https://github.com/user-attachments/assets/c44331ef-1a06-4752-a00d-94d7cf7ea0f0




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable disconnect detection and handling to reduce spurious disconnect tagging and runtime errors.
  * Improved distinction between user-initiated and automatic disconnects for more accurate connection state.

* **New Features**
  * Clearer connection behavior on initial load: automatic reconnection only runs when appropriate, and explicit user-initiated connect action is exposed.

* **Refactor**
  * Improved internal connection lifecycle and logging for better traceability and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->