### PR TITLE
CNV-81278: show "Make persistent" action for hotplug non-CDROM disks

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
@@ -85,7 +85,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
     const mounted = isMountedVolume(vol);
 
     return {
-      isCDROMMountedState: mounted,
+      isCDROMMountedState: isCDROM && mounted,
       volume: vol,
     };
   }, [vm, vmi, isVMRunning, diskName, isCDROM]);
@@ -208,7 +208,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
         <DropdownItem key="disk-delete" onClick={() => onModalOpen(createDeleteDiskModal)}>
           {deleteBtnText}
         </DropdownItem>
-        {isHotplug && !isCDROMMountedState && (
+        {isHotplug && !isCDROM && (
           <DropdownItem
             description={t('Will make disk persistent on next reboot')}
             key="make-persistent"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Issue: "Make persistent" action was not showing up for hotplug disks. 

The issue was in `isHotplug && !isCDROMMountedState` check to show the action. `isCDROMMountedState` was checking mounted state of **any** disk, not just CDROM

Fix: 
- update `isCDROMMountedState` variable to check also that `isCDROM` is true
- update condition to `isHotplug && !isCDROM` to hide "Make persistent" action for every CDROM disk

## 🎥 Demo

Before:
<img width="1909" height="1238" alt="Screenshot 2026-03-05 at 16 15 44" src="https://github.com/user-attachments/assets/29886fc6-8cf8-4062-8669-924ea68ad26b" />



After:
<img width="1909" height="1238" alt="Screenshot 2026-03-05 at 16 13 21" src="https://github.com/user-attachments/assets/0cd9f394-98e0-4aaf-ace1-83cf976002fa" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CDROM mounting state detection for virtual machine disks to more accurately reflect actual mount conditions.
  * Refined visibility of the "Make persistent" option to prevent display when a CDROM is mounted, ensuring options are only shown when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->