### PR TITLE
[WIP] CNV-71773: warn when memory requests >= limits on non-guaranteed VMs

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1153,6 +1153,7 @@
   "Memory density percentage": "Memory density percentage",
   "Memory Dirty Rate": "Memory Dirty Rate",
   "Memory limits": "Memory limits",
+  "Memory limits are equal to memory requests. This can cause the virt-launcher pod to be OOM-killed during live migration. Consider increasing memory limits or enabling auto-compute resource limits.": "Memory limits are equal to memory requests. This can cause the virt-launcher pod to be OOM-killed during live migration. Consider increasing memory limits or enabling auto-compute resource limits.",
   "Memory load": "Memory load",
   "Memory requests": "Memory requests",
   "Memory swap traffic": "Memory swap traffic",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1167,6 +1167,7 @@
   "Memory density percentage": "Porcentaje de densidad de memoria",
   "Memory Dirty Rate": "Tasa sucia de memoria",
   "Memory limits": "Memory limits",
+  "Memory limits are equal to memory requests. This can cause the virt-launcher pod to be OOM-killed during live migration. Consider increasing memory limits or enabling auto-compute resource limits.": "Memory limits are equal to memory requests. This can cause the virt-launcher pod to be OOM-killed during live migration. Consider increasing memory limits or enabling auto-compute resource limits.",
   "Memory load": "Memory load",
   "Memory requests": "Memory requests",
   "Memory swap traffic": "Tráfico de intercambio de memoria",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1167,6 +1167,7 @@
   "Memory density percentage": "Pourcentage de densité de mémoire",
   "Memory Dirty Rate": "Taux de mémoire «Dirty»",
   "Memory limits": "Memory limits",
+  "Memory limits are equal to memory requests. This can cause the virt-launcher pod to be OOM-killed during live migration. Consider increasing memory limits or enabling auto-compute resource limits.": "Memory limits are equal to memory requests. This can cause the virt-launcher pod to be OOM-killed during live migration. Consider increasing memory limits or enabling auto-compute resource limits.",
   "Memory load": "Memory load",
   "Memory requests": "Memory requests",
   "Memory swap traffic": "Trafic d’échange de mémoire",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1150,6 +1150,7 @@
   "Memory density percentage": "メモリー密度のパーセンテージ",
   "Memory Dirty Rate": "メモリーダーティーレート",
   "Memory limits": "Memory limits",
+  "Memory limits are equal to memory requests. This can cause the virt-launcher pod to be OOM-killed during live migration. Consider increasing memory limits or enabling auto-compute resource limits.": "Memory limits are equal to memory requests. This can cause the virt-launcher pod to be OOM-killed during live migration. Consider increasing memory limits or enabling auto-compute resource limits.",
   "Memory load": "Memory load",
   "Memory requests": "Memory requests",
   "Memory swap traffic": "メモリースワップトラフィック",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1150,6 +1150,7 @@
   "Memory density percentage": "메모리 밀도 비율",
   "Memory Dirty Rate": "메모리 더티 비율",
   "Memory limits": "Memory limits",
+  "Memory limits are equal to memory requests. This can cause the virt-launcher pod to be OOM-killed during live migration. Consider increasing memory limits or enabling auto-compute resource limits.": "Memory limits are equal to memory requests. This can cause the virt-launcher pod to be OOM-killed during live migration. Consider increasing memory limits or enabling auto-compute resource limits.",
   "Memory load": "Memory load",
   "Memory requests": "Memory requests",
   "Memory swap traffic": "메모리 스왑 트래픽",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1150,6 +1150,7 @@
   "Memory density percentage": "内存密度百分比",
   "Memory Dirty Rate": "内存脏率",
   "Memory limits": "Memory limits",
+  "Memory limits are equal to memory requests. This can cause the virt-launcher pod to be OOM-killed during live migration. Consider increasing memory limits or enabling auto-compute resource limits.": "Memory limits are equal to memory requests. This can cause the virt-launcher pod to be OOM-killed during live migration. Consider increasing memory limits or enabling auto-compute resource limits.",
   "Memory load": "Memory load",
   "Memory requests": "Memory requests",
   "Memory swap traffic": "内存交换流量",

--- a/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
@@ -5,6 +5,7 @@ import { V1CPU, V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt'
 import CPUInput from '@kubevirt-utils/components/CPUMemoryModal/components/CPUInput/CPUInput';
 import { getCPULimitsFromVM } from '@kubevirt-utils/components/CPUMemoryModal/components/CPUInput/utils/utils';
 import MemoryInput from '@kubevirt-utils/components/CPUMemoryModal/components/MemoryInput/MemoryInput';
+import MemoryLimitsWarning from '@kubevirt-utils/components/MemoryLimitsWarning/MemoryLimitsWarning';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getLabel } from '@kubevirt-utils/resources/shared';
@@ -121,6 +122,7 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
             setMemoryUnit={setMemoryUnit}
           />
         </div>
+        <MemoryLimitsWarning vm={vm} />
         {updateError && (
           <Alert isInline title={t('Error')} variant={AlertVariant.danger}>
             {updateError}

--- a/src/utils/components/MemoryLimitsWarning/MemoryLimitsWarning.tsx
+++ b/src/utils/components/MemoryLimitsWarning/MemoryLimitsWarning.tsx
@@ -1,0 +1,29 @@
+import React, { FC } from 'react';
+
+import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { hasRiskyMemoryLimits } from '@kubevirt-utils/resources/vm';
+import { Alert, AlertVariant } from '@patternfly/react-core';
+
+type MemoryLimitsWarningProps = {
+  isInline?: boolean;
+  vm: V1VirtualMachine;
+};
+
+const MemoryLimitsWarning: FC<MemoryLimitsWarningProps> = ({ isInline = true, vm }) => {
+  const { t } = useKubevirtTranslation();
+
+  if (!hasRiskyMemoryLimits(vm)) return null;
+
+  return (
+    <Alert
+      title={t(
+        'Memory limits are equal to memory requests. This can cause the virt-launcher pod to be OOM-killed during live migration. Consider increasing memory limits or enabling auto-compute resource limits.',
+      )}
+      isInline={isInline}
+      variant={AlertVariant.warning}
+    />
+  );
+};
+
+export default MemoryLimitsWarning;

--- a/src/utils/resources/vm/utils/selectors.ts
+++ b/src/utils/resources/vm/utils/selectors.ts
@@ -1,3 +1,5 @@
+import xbytes from 'xbytes';
+
 import {
   V1AccessCredential,
   V1Bootloader,
@@ -364,3 +366,38 @@ export const getArchitecture = (vm: V1VirtualMachine): string =>
  */
 export const getVMTemplateAnnotations = (vm: V1VirtualMachine): { [key: string]: string } =>
   vm?.spec?.template?.metadata?.annotations;
+
+const parseMemoryToBytes = (value: string): null | number => {
+  if (!value) return null;
+  try {
+    return xbytes.parseSize(`${value}B`);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Checks if a VM has memory requests >= memory limits without being a guaranteed QoS VM.
+ * This is risky because the virt-launcher pod can be OOM-killed during live migration
+ * when there's no headroom between limits and requests.
+ *
+ * Guaranteed VMs (dedicatedCpuPlacement) are exempt since limits == requests is expected.
+ *
+ * @param {V1VirtualMachine} vm the virtual machine
+ * @returns {boolean} true if memory requests >= limits and VM is not guaranteed
+ */
+export const hasRiskyMemoryLimits = (vm: V1VirtualMachine): boolean => {
+  const domain = getDomain(vm);
+  const memoryLimits = domain?.resources?.limits?.['memory'];
+  const memoryRequests = domain?.resources?.requests?.['memory'];
+
+  if (!memoryLimits || !memoryRequests) return false;
+  if (getCPU(vm)?.dedicatedCpuPlacement) return false;
+
+  const limitsBytes = parseMemoryToBytes(memoryLimits);
+  const requestsBytes = parseMemoryToBytes(memoryRequests);
+
+  if (limitsBytes === null || requestsBytes === null) return false;
+
+  return requestsBytes >= limitsBytes;
+};

--- a/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom-v5-compat';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DetailsPageTitle from '@kubevirt-utils/components/DetailsPageTitle/DetailsPageTitle';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
+import MemoryLimitsWarning from '@kubevirt-utils/components/MemoryLimitsWarning/MemoryLimitsWarning';
 import PaneHeading from '@kubevirt-utils/components/PaneHeading/PaneHeading';
 import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -85,6 +86,7 @@ const VirtualMachineNavPageTitle: FC<VirtualMachineNavPageTitleProps> = ({
           )}
         </Split>
       </PaneHeading>
+      <MemoryLimitsWarning vm={vm} />
       <VirtualMachinePendingChangesAlert
         instanceTypeExpandedSpec={instanceTypeExpandedSpec}
         vm={vm}


### PR DESCRIPTION
## 📝 Description

When memory `requests >= limits` on a non-guaranteed VM, the virt-launcher pod can be OOM-killed during live migration due to lack of memory headroom.

This PR adds a warning alert that:
- Appears **under the VM name** on the details page (before pending changes), visible on all tabs
- Appears **inside the CPU/Memory edit modal**
- Is **skipped for guaranteed VMs** (`dedicatedCpuPlacement: true`) where `limits == requests` is expected

### Changes
- **`hasRiskyMemoryLimits` selector** (`src/utils/resources/vm/utils/selectors.ts`) — detects when `requests.memory >= limits.memory` on non-guaranteed VMs, with unit-aware comparison via `xbytes`
- **`MemoryLimitsWarning` component** (`src/utils/components/MemoryLimitsWarning/`) — reusable inline warning alert
- **`VirtualMachineNavPageTitle`** — integrated warning under VM name, before pending changes
- **`CPUMemoryModal`** — integrated warning inside the modal body
- **i18n** — translation string extracted to all locales

## 🎥 Demo

> TODO: add screenshot/video

Made with [Cursor](https://cursor.com)