### PR TITLE
[release-4.21] CNV-83147: Fix VMI mapper lookup for hub cluster VMs in fleet view

### DIFF
--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -38,7 +38,6 @@ import useVirtualMachineInstanceMigrations from '@kubevirt-utils/resources/vmim/
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { getCatalogURL } from '@multicluster/urls';
-import useIsACMPage from '@multicluster/useIsACMPage';
 import {
   DocumentTitle,
   K8sResourceCommon,
@@ -48,7 +47,6 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { Flex, PageSection, Pagination } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
-import { useHubClusterName } from '@stolostron/multicluster-sdk';
 import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
 import useVMSearchQueries from '@virtualmachines/search/hooks/useVMSearchQueries';
 import VirtualMachineFilterToolbar from '@virtualmachines/search/VirtualMachineFilterToolbar';
@@ -87,9 +85,6 @@ type VirtualMachinesListProps = {
 const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref) => {
   const { t } = useKubevirtTranslation();
   const { allVMsLoaded, cluster, isSearchResultsPage = false, kind, namespace } = props;
-
-  const isACMPage = useIsACMPage();
-  const [hubClusterName] = useHubClusterName();
 
   const searchQueries = useVMSearchQueries();
 
@@ -152,10 +147,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
   );
 
   const filteredVMIs = useMemo(
-    () =>
-      filteredVMs
-        ?.map((vm) => getVMIFromMapper(vmiMapper, vm, isACMPage ? hubClusterName : undefined))
-        .filter(Boolean),
+    () => filteredVMs?.map((vm) => getVMIFromMapper(vmiMapper, vm)).filter(Boolean),
     [filteredVMs, vmiMapper],
   );
 
@@ -287,8 +279,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
                   <div className="pf-v6-u-text-align-center">{t('No VirtualMachines found')}</div>
                 )}
                 rowData={{
-                  getVmi: (vm: V1VirtualMachine) =>
-                    getVMIFromMapper(vmiMapper, vm, isACMPage ? hubClusterName : undefined),
+                  getVmi: (vm: V1VirtualMachine) => getVMIFromMapper(vmiMapper, vm),
                   getVmim: (vm: V1VirtualMachine) =>
                     getVMIMFromMapper(vmimMapper, getName(vm), getNamespace(vm), getCluster(vm)),
                   kind,

--- a/src/views/virtualmachines/utils/mappers.ts
+++ b/src/views/virtualmachines/utils/mappers.ts
@@ -23,14 +23,8 @@ export type VMIMMapper = {
   };
 };
 
-export const getVMIFromMapper = (
-  VMIMapper: VMIMapper,
-  vm: V1VirtualMachine,
-  hubClusterName?: string,
-) =>
-  VMIMapper?.mapper?.[getCluster(vm) || hubClusterName || SINGLE_CLUSTER_KEY]?.[getNamespace(vm)]?.[
-    getName(vm)
-  ];
+export const getVMIFromMapper = (VMIMapper: VMIMapper, vm: V1VirtualMachine) =>
+  VMIMapper?.mapper?.[getCluster(vm) || SINGLE_CLUSTER_KEY]?.[getNamespace(vm)]?.[getName(vm)];
 
 export const getVMIMFromMapper = (
   VMIMMapper: VMIMMapper,


### PR DESCRIPTION
## 📝 Description

Backport of #3690 to `release-4.21`.

Fixes the VM list showing "-" for Memory, CPU, and Network columns for all running VMs in the Fleet Virtualization perspective when the hub cluster is selected.

**Root cause:** The VMI mapper stores hub cluster VMIs under `SINGLE_CLUSTER_KEY` (since hub VMIs don't have a `cluster` property set), but `getVMIFromMapper` was looking them up under `hubClusterName` (e.g., `"local-cluster"`). This key mismatch meant VMIs were never found for hub VMs on the ACM page, so Memory and CPU had no VMI data for their denominators.

**Fix:** Remove the `hubClusterName` fallback from `getVMIFromMapper` so the lookup key matches the storage key: `getCluster(vm) || SINGLE_CLUSTER_KEY`.


Made with [Cursor](https://cursor.com)