### PR TITLE
CNV-67892: Show disk driver/bus in UI when set by VMI at runtime

### DIFF
--- a/src/utils/resources/vm/hooks/disk/tests/utils.test.ts
+++ b/src/utils/resources/vm/hooks/disk/tests/utils.test.ts
@@ -1,0 +1,68 @@
+import { V1Disk } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { createDisk, createVMI } from '@kubevirt-utils/resources/vm/utils/disk/tests/mocks';
+
+import { enrichDisksWithVMIBusInfo } from '../utils';
+
+describe('enrichDisksWithVMIBusInfo', () => {
+  it('should add bus from VMI when VM disk has no bus', () => {
+    const vmDisks: V1Disk[] = [{ disk: {}, name: 'rootdisk' }];
+    const vmi = createVMI([{ disk: { bus: 'scsi' }, name: 'rootdisk' }]);
+
+    const result = enrichDisksWithVMIBusInfo(vmDisks, vmi);
+
+    expect(result[0].disk.bus).toBe('scsi');
+  });
+
+  it('should not override existing VM disk bus', () => {
+    const vmDisks: V1Disk[] = [{ disk: { bus: 'virtio' }, name: 'rootdisk' }];
+    const vmi = createVMI([{ disk: { bus: 'scsi' }, name: 'rootdisk' }]);
+
+    const result = enrichDisksWithVMIBusInfo(vmDisks, vmi);
+
+    expect(result[0].disk.bus).toBe('virtio');
+  });
+
+  it('should handle VMI without matching disk', () => {
+    const vmDisks: V1Disk[] = [{ disk: {}, name: 'rootdisk' }];
+    const vmi = createVMI([{ disk: { bus: 'scsi' }, name: 'other-disk' }]);
+
+    const result = enrichDisksWithVMIBusInfo(vmDisks, vmi);
+
+    expect(result[0].disk.bus).toBeUndefined();
+  });
+
+  it('should handle multiple disks with mixed bus states', () => {
+    const vmDisks: V1Disk[] = [
+      { disk: { bus: 'virtio' }, name: 'disk-with-bus' },
+      { disk: {}, name: 'disk-without-bus' },
+      { cdrom: {}, name: 'cdrom-without-bus' },
+    ];
+    const vmi = createVMI([
+      { disk: { bus: 'virtio' }, name: 'disk-with-bus' },
+      { disk: { bus: 'scsi' }, name: 'disk-without-bus' },
+      { cdrom: { bus: 'sata' }, name: 'cdrom-without-bus' },
+    ]);
+
+    const result = enrichDisksWithVMIBusInfo(vmDisks, vmi);
+
+    expect(result[0].disk.bus).toBe('virtio');
+    expect(result[1].disk.bus).toBe('scsi');
+    expect(result[2].cdrom.bus).toBe('sata');
+  });
+
+  it('should handle null VMI', () => {
+    const vmDisks: V1Disk[] = [createDisk({ disk: {} })];
+
+    const result = enrichDisksWithVMIBusInfo(vmDisks, null);
+
+    expect(result[0].disk.bus).toBeUndefined();
+  });
+
+  it('should handle empty disk lists', () => {
+    const vmi = createVMI([{ disk: { bus: 'scsi' }, name: 'rootdisk' }]);
+
+    const result = enrichDisksWithVMIBusInfo([], vmi);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
+++ b/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
@@ -13,7 +13,7 @@ import { getBootDisk, getDataVolumeTemplates, getDisks, getVolumes } from '../..
 import { getDiskRowDataLayout } from '../../utils/disk/rowData';
 
 import useDisksSources from './useDisksSources';
-import { getEjectedCDROMDrives, isStorageVolume } from './utils';
+import { enrichDisksWithVMIBusInfo, getEjectedCDROMDrives, isStorageVolume } from './utils';
 
 type UseDisksTableDisks = (
   vm: V1VirtualMachine,
@@ -30,13 +30,15 @@ const useDisksTableData: UseDisksTableDisks = (vm, vmi) => {
   const { dvs, loaded, loadingError, pvcs } = useDisksSources(vm);
   const isVMRunning = isRunning(vm);
 
-  const vmDisks = useMemo(
-    () =>
-      !isVMRunning
-        ? getDisks(vm)
-        : [...(getDisks(vm) || []), ...getRunningVMMissingDisksFromVMI(getDisks(vm) || [], vmi)],
-    [vm, vmi, isVMRunning],
-  );
+  const vmDisks = useMemo(() => {
+    const vmDiskList = getDisks(vm) || [];
+    if (!isVMRunning) return vmDiskList;
+
+    const enrichedDisks = vmi ? enrichDisksWithVMIBusInfo(vmDiskList, vmi) : vmDiskList;
+    const missingDisks = getRunningVMMissingDisksFromVMI(vmDiskList, vmi);
+
+    return [...enrichedDisks, ...missingDisks];
+  }, [vm, vmi, isVMRunning]);
 
   const vmVolumes = useMemo(() => {
     const detectedVolumes = !isVMRunning

--- a/src/utils/resources/vm/hooks/disk/utils.ts
+++ b/src/utils/resources/vm/hooks/disk/utils.ts
@@ -13,6 +13,7 @@ import {
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { DiskRawData } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import { getDiskDrive } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
+import { getVMIDisks } from '@kubevirt-utils/resources/vmi/utils/selectors';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 
@@ -92,14 +93,14 @@ export const isStorageVolume = (volume: V1Volume) => {
  * KubeVirt may set the disk bus via admission webhooks or preferences,
  * meaning the VMI has bus info that the VM template spec does not.
  * This merges VMI bus info into VM disks that are missing it.
- * @param vmDiskList
- * @param vmi
+ * @param vmDiskList disks from the VM template spec
+ * @param vmi optional running VMI; when null/undefined, disks are returned unchanged
  */
 export const enrichDisksWithVMIBusInfo = (
   vmDiskList: V1Disk[],
-  vmi: V1VirtualMachineInstance,
+  vmi?: null | V1VirtualMachineInstance,
 ): V1Disk[] => {
-  const vmiDisks = vmi?.spec?.domain?.devices?.disks || [];
+  const vmiDisks = getVMIDisks(vmi) || [];
 
   return vmDiskList.map((vmDisk) => {
     const driveType = getDiskDrive(vmDisk);

--- a/src/utils/resources/vm/hooks/disk/utils.ts
+++ b/src/utils/resources/vm/hooks/disk/utils.ts
@@ -2,6 +2,7 @@ import {
   V1beta1DataVolumeSourcePVC,
   V1Disk,
   V1VirtualMachine,
+  V1VirtualMachineInstance,
   V1Volume,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
@@ -11,6 +12,7 @@ import {
 } from '@kubevirt-utils/models';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { DiskRawData } from '@kubevirt-utils/resources/vm/utils/disk/constants';
+import { getDiskDrive } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 
@@ -84,4 +86,35 @@ export const isStorageVolume = (volume: V1Volume) => {
       volume.cloudInitNoCloud ||
       volume.cloudInitConfigDrive,
   );
+};
+
+/**
+ * KubeVirt may set the disk bus via admission webhooks or preferences,
+ * meaning the VMI has bus info that the VM template spec does not.
+ * This merges VMI bus info into VM disks that are missing it.
+ * @param vmDiskList
+ * @param vmi
+ */
+export const enrichDisksWithVMIBusInfo = (
+  vmDiskList: V1Disk[],
+  vmi: V1VirtualMachineInstance,
+): V1Disk[] => {
+  const vmiDisks = vmi?.spec?.domain?.devices?.disks || [];
+
+  return vmDiskList.map((vmDisk) => {
+    const driveType = getDiskDrive(vmDisk);
+    if (vmDisk[driveType]?.bus) return vmDisk;
+
+    const vmiDisk = vmiDisks.find(({ name }) => name === vmDisk.name);
+    if (!vmiDisk) return vmDisk;
+
+    const vmiDriveType = getDiskDrive(vmiDisk);
+    const vmiBus = vmiDisk[vmiDriveType]?.bus;
+    if (!vmiBus) return vmDisk;
+
+    return {
+      ...vmDisk,
+      [driveType]: { ...vmDisk[driveType], bus: vmiBus },
+    };
+  });
 };

--- a/src/utils/resources/vm/utils/disk/rowData.ts
+++ b/src/utils/resources/vm/utils/disk/rowData.ts
@@ -44,7 +44,9 @@ export const getDiskRowDataLayout = (
       drive: isEmpty(disk) || !isDiskConfigured ? NO_DATA_DASH : getPrintableDiskDrive(disk),
       hasDataVolume: Boolean(dataVolume),
       interface:
-        isEmpty(disk) || !isDiskConfigured ? NO_DATA_DASH : getPrintableDiskInterface(disk),
+        isEmpty(disk) || !isDiskConfigured
+          ? NO_DATA_DASH
+          : getPrintableDiskInterface(disk) || NO_DATA_DASH,
       isBootDisk: disk?.name === bootDisk?.name,
       isEnvDisk: !!volume?.configMap || !!volume?.secret || !!volume?.serviceAccount,
       metadata: { name: volume?.name },

--- a/src/utils/resources/vm/utils/disk/selectors.ts
+++ b/src/utils/resources/vm/utils/disk/selectors.ts
@@ -12,6 +12,8 @@ import { getDisks, getVolumes } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { isRunning } from '@virtualmachines/utils';
 
+import { NO_DATA_DASH } from '../constants';
+
 import { DiskType, diskTypes, diskTypesLabels } from './constants';
 
 /**
@@ -46,10 +48,12 @@ export const getDiskInterface = (disk: V1Disk): string => disk?.[getDiskDrive(di
  */
 export const getPrintableDiskInterface = (disk: V1Disk): string => {
   const diskInterface = getDiskInterface(disk);
+  if (!diskInterface) return NO_DATA_DASH;
+
   if (diskInterface === InterfaceTypes.SCSI || diskInterface === InterfaceTypes.SATA) {
     return diskInterface.toUpperCase();
   }
-  return diskInterface ?? '';
+  return diskInterface ?? NO_DATA_DASH;
 };
 
 export const isCDROMDisk = (disk: V1Disk): boolean => {

--- a/src/utils/resources/vm/utils/disk/tests/selectors.test.ts
+++ b/src/utils/resources/vm/utils/disk/tests/selectors.test.ts
@@ -1,4 +1,5 @@
 import { V1Disk } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 
 import {
   getDiskDrive,
@@ -65,9 +66,9 @@ describe('disk selectors', () => {
     it.each([
       [{ disk: {} }, 'missing bus'],
       [null, 'null disk'],
-    ])('should return empty string for %s', (diskInput, _description) => {
+    ])('should return NO_DATA_DASH for %s', (diskInput, _description) => {
       const disk = diskInput ? createDisk(diskInput) : null;
-      expect(getPrintableDiskInterface(disk as V1Disk)).toBe('');
+      expect(getPrintableDiskInterface(disk as V1Disk)).toBe(NO_DATA_DASH);
     });
   });
 });

--- a/src/views/catalog/wizard/tabs/disks/wizardDisksTableDefinition.tsx
+++ b/src/views/catalog/wizard/tabs/disks/wizardDisksTableDefinition.tsx
@@ -44,10 +44,10 @@ export const getWizardDiskColumns = (t: TFunction): ColumnConfig<DiskRowDataLayo
     sortable: true,
   },
   {
-    getValue: (row) => row?.interface ?? '',
+    getValue: (row) => row?.interface || NO_DATA_DASH,
     key: 'interface',
     label: t('Interface'),
-    renderCell: (row) => <>{row?.interface ?? NO_DATA_DASH}</>,
+    renderCell: (row) => <>{row?.interface || NO_DATA_DASH}</>,
     sortable: true,
   },
   {


### PR DESCRIPTION
## 📝 Description

Fixes [CNV-67892](https://issues.redhat.com/browse/CNV-67892): The disk driver/bus (e.g., SCSI) is not reflected in the UI dashboard.

When VMs are created without an explicit disk bus (e.g., via Packer), KubeVirt admission webhooks or preferences set the bus on the VMI at runtime. The UI was only reading disk info from the VM template spec, missing these runtime-resolved values and showing an empty **Interface** column while the CLI correctly showed the bus type.

### Root Cause

1. `useDisksTableData` reads disks from the VM template spec, which may not have `bus` set
2. `getPrintableDiskInterface` returns `''` (empty string) when `bus` is `undefined`
3. Table cells use `??` (nullish coalescing) which doesn't catch empty strings — only `null`/`undefined`

### Changes

- **Enrich VM disks with VMI bus info** (`utils.ts`): New `enrichDisksWithVMIBusInfo()` function that merges VMI disk bus information into VM disks when the bus is missing from the VM template spec. Only runs when the VM is running and VMI data is available. Preserves explicit VM bus values.
- **Update disk data hook** (`useDisksTableData.ts`): Call the enrichment function in the `vmDisks` memo when VM is running.
- **Safety net for empty strings** (`rowData.ts`): Use `|| NO_DATA_DASH` fallback so empty strings from `getPrintableDiskInterface` render as `—` instead of a blank cell.
- **Unit tests** (`utils.test.ts`): 6 test cases covering bus enrichment from VMI, no-override of existing bus, no-match scenarios, mixed disk types (disk/cdrom), null VMI, and empty lists.

## 🎥 Demo

**Before**: Interface column shows empty for SCSI disks created via Packer
**After**: Interface column correctly shows `SCSI` (or other bus types) by reading runtime values from VMI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Running VMs: disk listings are now enriched with bus info from the live instance and include any missing disks detected at runtime.

* **Bug Fixes**
  * Disk interface display now shows a consistent "no data" placeholder when interface info is absent.

* **Tests**
  * Added thorough tests for disk enrichment behavior, covering null/empty inputs, multiple disks, and preservation of existing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->