### PR TITLE
CNV-83862: Use CPU | Memory editor when VM has preference but no instance type

### DIFF
--- a/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
+++ b/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
@@ -31,7 +31,7 @@ import useHideYamlTab from '@kubevirt-utils/hooks/useHideYamlTab';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
-import { isExpandableSpecVM } from '@kubevirt-utils/resources/instancetype/helper';
+import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCPU, getGPUDevices, getHostDevices } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -158,7 +158,7 @@ export const usePendingChanges = (
           <CPUMemoryModal isOpen={isOpen} onClose={onClose} onSubmit={onSubmit} vm={vm} />
         )),
       ),
-      hasPendingChange: !isExpandableSpecVM(vm) && cpuMemoryChanged && restartRequired(vm),
+      hasPendingChange: !isInstanceTypeVM(vm) && cpuMemoryChanged && restartRequired(vm),
       label: t('CPU | Memory'),
     },
     {
@@ -172,7 +172,7 @@ export const usePendingChanges = (
           />
         )),
       ),
-      hasPendingChange: isExpandableSpecVM(vm) && instanceTypeChanged && restartRequired(vm),
+      hasPendingChange: isInstanceTypeVM(vm) && instanceTypeChanged && restartRequired(vm),
       label: t('InstanceType'),
     },
     {

--- a/src/utils/resources/instancetype/helper.test.ts
+++ b/src/utils/resources/instancetype/helper.test.ts
@@ -1,0 +1,136 @@
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+
+import {
+  CLUSTER_INSTANCE_TYPE_NAME_ANNOTATION,
+  CLUSTER_PREFERENCE_NAME_ANNOTATION,
+} from './constants';
+import { isExpandableSpecVM, isInstanceTypeVM } from './helper';
+
+const baseVM = (): V1VirtualMachine => ({
+  apiVersion: 'kubevirt.io/v1',
+  kind: 'VirtualMachine',
+  metadata: { name: 'vm', namespace: 'ns' },
+  spec: {
+    template: {
+      metadata: {},
+      spec: {
+        domain: {
+          devices: {},
+        },
+      },
+    },
+  },
+});
+
+const baseVMI = (): V1VirtualMachineInstance => ({
+  apiVersion: 'kubevirt.io/v1',
+  kind: 'VirtualMachineInstance',
+  metadata: { name: 'vm', namespace: 'ns' },
+  spec: { domain: { devices: {} } },
+});
+
+describe('instancetype/helper', () => {
+  describe('isExpandableSpecVM', () => {
+    it('is true when only spec.preference is set', () => {
+      const vm: V1VirtualMachine = {
+        ...baseVM(),
+        spec: {
+          ...baseVM().spec,
+          preference: {
+            kind: 'virtualmachineclusterpreference',
+            name: 'windows.2k19',
+          },
+        },
+      };
+
+      expect(isExpandableSpecVM(vm)).toBe(true);
+    });
+
+    it('is true when spec.instancetype is set', () => {
+      const vm: V1VirtualMachine = {
+        ...baseVM(),
+        spec: {
+          ...baseVM().spec,
+          instancetype: { name: 'u1.small' },
+        },
+      };
+
+      expect(isExpandableSpecVM(vm)).toBe(true);
+    });
+
+    it('is false when neither preference nor instancetype is set', () => {
+      expect(isExpandableSpecVM(baseVM())).toBe(false);
+    });
+
+    it('for VMI, is true when only preference annotation is set', () => {
+      const vmi: V1VirtualMachineInstance = {
+        ...baseVMI(),
+        metadata: {
+          ...baseVMI().metadata,
+          annotations: {
+            [CLUSTER_PREFERENCE_NAME_ANNOTATION]: 'windows.2k19',
+          },
+        },
+      };
+
+      expect(isExpandableSpecVM(vmi)).toBe(true);
+    });
+  });
+
+  describe('isInstanceTypeVM', () => {
+    it('is false when only spec.preference is set (CNV-83862)', () => {
+      const vm: V1VirtualMachine = {
+        ...baseVM(),
+        spec: {
+          ...baseVM().spec,
+          preference: {
+            kind: 'virtualmachineclusterpreference',
+            name: 'windows.2k19',
+          },
+        },
+      };
+
+      expect(isInstanceTypeVM(vm)).toBe(false);
+    });
+
+    it('is true when spec.instancetype is set', () => {
+      const vm: V1VirtualMachine = {
+        ...baseVM(),
+        spec: {
+          ...baseVM().spec,
+          instancetype: { name: 'u1.small' },
+        },
+      };
+
+      expect(isInstanceTypeVM(vm)).toBe(true);
+    });
+
+    it('for VMI, is false when only preference annotation is set', () => {
+      const vmi: V1VirtualMachineInstance = {
+        ...baseVMI(),
+        metadata: {
+          ...baseVMI().metadata,
+          annotations: {
+            [CLUSTER_PREFERENCE_NAME_ANNOTATION]: 'windows.2k19',
+          },
+        },
+      };
+
+      expect(isInstanceTypeVM(vmi)).toBe(false);
+    });
+
+    it('for VMI, is true when cluster instancetype annotation is set', () => {
+      const vmi: V1VirtualMachineInstance = {
+        ...baseVMI(),
+        metadata: {
+          ...baseVMI().metadata,
+          annotations: {
+            [CLUSTER_INSTANCE_TYPE_NAME_ANNOTATION]: 'u1.small',
+          },
+        },
+      };
+
+      expect(isInstanceTypeVM(vmi)).toBe(true);
+    });
+  });
+});

--- a/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
@@ -20,7 +20,7 @@ import WorkloadProfileModal from '@kubevirt-utils/components/WorkloadProfileModa
 import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { isExpandableSpecVM } from '@kubevirt-utils/resources/instancetype/helper';
+import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { InstanceTypeUnion } from '@kubevirt-utils/resources/instancetype/types';
 import { asAccessReview, getAnnotation, getName } from '@kubevirt-utils/resources/shared';
 import { WORKLOADS_LABELS } from '@kubevirt-utils/resources/template';
@@ -93,7 +93,7 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
 
   const cpuMemoryVM = instanceTypeVM?.metadata?.uid === vm?.metadata?.uid ? instanceTypeVM : vm;
 
-  const isExpandableSpec = isExpandableSpecVM(vm);
+  const isInstanceType = isInstanceTypeVM(vm);
   const deletionProtectionEnabled = isDeletionProtectionEnabled(vm);
 
   if (!vm) {
@@ -158,12 +158,12 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
             <DescriptionItem
               descriptionHeader={
                 <SearchItem id="cpu-memory">
-                  {isExpandableSpec ? t('InstanceType') : t('CPU | Memory')}
+                  {isInstanceType ? t('InstanceType') : t('CPU | Memory')}
                 </SearchItem>
               }
               onEditClick={() =>
                 createModal(({ isOpen, onClose }) => {
-                  return isExpandableSpec ? (
+                  return isInstanceType ? (
                     <InstanceTypeModal
                       allInstanceTypes={allInstanceTypes}
                       instanceType={instanceType}
@@ -186,7 +186,7 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
                 instanceType && getAnnotation(instanceType, INSTANCETYPE_CLASS_DISPLAY_NAME)
               }
               additionalContent={hasNUMAConfiguration(cpuMemoryVM) && <NUMABadge />}
-              bodyContent={isExpandableSpec ? null : <CPUDescription cpu={getCPU(vm)} />}
+              bodyContent={isInstanceType ? null : <CPUDescription cpu={getCPU(vm)} />}
               data-test-id={`${vmName}-cpu-memory`}
               descriptionData={<CPUMemory vm={cpuMemoryVM || vm} vmi={vmi} />}
               isEdit={canUpdateVM}


### PR DESCRIPTION
## Description

Fixes https://issues.redhat.com/browse/CNV-83862

Use `isInstanceTypeVM` for InstanceType vs CPU | Memory editor and pending changes. `isExpandableSpecVM` unchanged.

Adds helper unit tests.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed detection logic for pending CPU/Memory and instance type configuration changes in virtual machines.

* **Tests**
  * Added comprehensive test coverage for instance type detection predicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->