### PR TITLE
CNV-84006: Fix missing subdomain on template-created VMs causing FQDN NXDOMAIN

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useCreateDrawerForm.tsx
@@ -184,8 +184,10 @@ const useCreateDrawerForm = (
 
           if (!getLabels(vmObject.spec.template)) vmObject.spec.template.metadata.labels = {};
 
-          if (!isUDNManagedNamespace)
+          if (!isUDNManagedNamespace) {
             vmObject.spec.template.metadata.labels[HEADLESS_SERVICE_LABEL] = HEADLESS_SERVICE_NAME;
+            vmObject.spec.template.spec.subdomain = HEADLESS_SERVICE_NAME;
+          }
 
           const modifiedTemplateObjects = template?.objects?.map((obj) =>
             obj.kind === VirtualMachineModel.kind ? vmObject : obj,

--- a/src/views/catalog/utils/useWizardVMCreate.ts
+++ b/src/views/catalog/utils/useWizardVMCreate.ts
@@ -79,8 +79,10 @@ export const useWizardVMCreate = (): UseWizardVMCreateValues => {
 
         if (!getLabels(vmDraft.spec.template)) vmDraft.spec.template.metadata.labels = {};
 
-        if (!isUDNManagedNamespace)
+        if (!isUDNManagedNamespace) {
           vmDraft.spec.template.metadata.labels[HEADLESS_SERVICE_LABEL] = HEADLESS_SERVICE_NAME;
+          vmDraft.spec.template.spec.subdomain = HEADLESS_SERVICE_NAME;
+        }
 
         if (addRegistrySecret)
           vmDraft.spec.dataVolumeTemplates[0].spec.source.registry.secretRef = imageSecretName;

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/utils/quick-create-vm.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/utils/quick-create-vm.ts
@@ -18,8 +18,12 @@ import {
   UDN_BINDING_NAME,
 } from '@kubevirt-utils/resources/vm/utils/constants';
 import { getArchitecture } from '@kubevirt-utils/utils/architecture';
-import { createHeadlessService } from '@kubevirt-utils/utils/headless-service';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
+import {
+  createHeadlessService,
+  HEADLESS_SERVICE_LABEL,
+  HEADLESS_SERVICE_NAME,
+} from '@kubevirt-utils/utils/headless-service';
+import { ensurePath, isEmpty } from '@kubevirt-utils/utils/utils';
 import { kubevirtK8sCreate } from '@multicluster/k8sRequests';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -103,6 +107,12 @@ export const quickCreateVM: QuickCreateVMType = async ({
     const bootDisk = getBootDisk(draftVM);
     if (bootDisk && !bootDisk.bootOrder) {
       bootDisk.bootOrder = 1;
+    }
+
+    if (!isUDNManagedNamespace) {
+      ensurePath(draftVM, 'spec.template.metadata.labels');
+      draftVM.spec.template.metadata.labels[HEADLESS_SERVICE_LABEL] = HEADLESS_SERVICE_NAME;
+      draftVM.spec.template.spec.subdomain = HEADLESS_SERVICE_NAME;
     }
   });
 


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fix missing subdomain on template-created VMs causing FQDN NXDOMAIN

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/b102594b-d8cf-4b48-a9d7-797d294bfe30

After:


https://github.com/user-attachments/assets/56847563-2e34-4184-bcd8-00fd7f4af09e





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VM template configuration to properly set subdomain values for headless services in non-UDN-managed namespaces across VM creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->