### PR TITLE
CNV-83806: Surface Succeeded compute migrations in overview widget

### DIFF
--- a/src/utils/resources/vmim/utils.test.ts
+++ b/src/utils/resources/vmim/utils.test.ts
@@ -1,0 +1,43 @@
+import { V1VirtualMachineInstanceMigration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+
+import { vmimStatuses } from './statuses';
+import { getMigrationStatusCounts } from './utils';
+
+const vmimWithPhase = (phase: string): V1VirtualMachineInstanceMigration =>
+  ({
+    status: { phase },
+  } as V1VirtualMachineInstanceMigration);
+
+describe('getMigrationStatusCounts', () => {
+  it('counts Succeeded separately from other', () => {
+    const counts = getMigrationStatusCounts([
+      vmimWithPhase(vmimStatuses.Succeeded),
+      vmimWithPhase(vmimStatuses.Pending),
+    ]);
+
+    expect(counts).toEqual({
+      failed: 0,
+      other: 1,
+      running: 0,
+      scheduled: 0,
+      succeeded: 1,
+    });
+  });
+
+  it('aggregates known phases', () => {
+    expect(
+      getMigrationStatusCounts([
+        vmimWithPhase(vmimStatuses.Failed),
+        vmimWithPhase(vmimStatuses.Running),
+        vmimWithPhase(vmimStatuses.Scheduled),
+        vmimWithPhase(vmimStatuses.Scheduling),
+      ]),
+    ).toEqual({
+      failed: 1,
+      other: 0,
+      running: 1,
+      scheduled: 2,
+      succeeded: 0,
+    });
+  });
+});

--- a/src/utils/resources/vmim/utils.ts
+++ b/src/utils/resources/vmim/utils.ts
@@ -10,7 +10,7 @@ export type MigrationStatusCounts = {
   succeeded: number;
 };
 
-const emptyMigrationStatusCounts = (): MigrationStatusCounts => ({
+const getEmptyMigrationStatusCounts = (): MigrationStatusCounts => ({
   failed: 0,
   other: 0,
   running: 0,
@@ -21,7 +21,7 @@ const emptyMigrationStatusCounts = (): MigrationStatusCounts => ({
 /**
  * Counts migration statuses from a list of VMIMs.
  * Phases that are not Failed, Running, Scheduled, Scheduling, or Succeeded are counted as "other".
- * @param vmims
+ * @param vmims VMIM resources to aggregate by status phase.
  */
 export const getMigrationStatusCounts = (
   vmims: V1VirtualMachineInstanceMigration[],
@@ -40,5 +40,5 @@ export const getMigrationStatusCounts = (
       acc.other++;
     }
     return acc;
-  }, emptyMigrationStatusCounts());
+  }, getEmptyMigrationStatusCounts());
 };

--- a/src/utils/resources/vmim/utils.ts
+++ b/src/utils/resources/vmim/utils.ts
@@ -2,35 +2,43 @@ import { V1VirtualMachineInstanceMigration } from '@kubevirt-ui-ext/kubevirt-api
 
 import { vmimStatuses } from './statuses';
 
-type MigrationStatusCounts = {
+export type MigrationStatusCounts = {
   failed: number;
   other: number;
   running: number;
   scheduled: number;
+  succeeded: number;
 };
+
+const emptyMigrationStatusCounts = (): MigrationStatusCounts => ({
+  failed: 0,
+  other: 0,
+  running: 0,
+  scheduled: 0,
+  succeeded: 0,
+});
 
 /**
  * Counts migration statuses from a list of VMIMs.
- * Phases that are not Failed, Running, Scheduled, or Scheduling are counted as "other".
+ * Phases that are not Failed, Running, Scheduled, Scheduling, or Succeeded are counted as "other".
  * @param vmims
  */
 export const getMigrationStatusCounts = (
   vmims: V1VirtualMachineInstanceMigration[],
 ): MigrationStatusCounts => {
-  return (vmims || []).reduce(
-    (acc, vmim) => {
-      const phase = vmim?.status?.phase;
-      if (phase === vmimStatuses.Failed) {
-        acc.failed++;
-      } else if (phase === vmimStatuses.Running) {
-        acc.running++;
-      } else if ([vmimStatuses.Scheduled, vmimStatuses.Scheduling].includes(phase)) {
-        acc.scheduled++;
-      } else if (phase) {
-        acc.other++;
-      }
-      return acc;
-    },
-    { failed: 0, other: 0, running: 0, scheduled: 0 },
-  );
+  return (vmims || []).reduce((acc, vmim) => {
+    const phase = vmim?.status?.phase;
+    if (phase === vmimStatuses.Failed) {
+      acc.failed++;
+    } else if (phase === vmimStatuses.Running) {
+      acc.running++;
+    } else if ([vmimStatuses.Scheduled, vmimStatuses.Scheduling].includes(phase)) {
+      acc.scheduled++;
+    } else if (phase === vmimStatuses.Succeeded) {
+      acc.succeeded++;
+    } else if (phase) {
+      acc.other++;
+    }
+    return acc;
+  }, emptyMigrationStatusCounts());
 };

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/MigrationsWidget.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/MigrationsWidget.tsx
@@ -3,6 +3,7 @@ import React, { FC, useMemo } from 'react';
 import { V1VirtualMachineInstanceMigration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getMigrationStatusCounts } from '@kubevirt-utils/resources/vmim/utils';
+import { GreenCheckCircleIcon } from '@openshift-console/dynamic-plugin-sdk';
 import { vmStatusIcon } from '@overview/OverviewTab/vm-statuses-card/utils/utils';
 import { Card, CardBody, CardHeader, CardTitle, Content, Grid } from '@patternfly/react-core';
 
@@ -16,6 +17,7 @@ import {
   OTHER_STATUSES,
   RUNNING_STATUSES,
   SCHEDULED_STATUSES,
+  SUCCEEDED_STATUSES,
 } from './utils/migrationStatusConstants';
 
 import './MigrationsWidget.scss';
@@ -56,6 +58,7 @@ const MigrationsWidget: FC<MigrationsWidgetProps> = ({
       other: buildStatusFilterPath(basePath, OTHER_STATUSES),
       running: buildStatusFilterPath(basePath, RUNNING_STATUSES),
       scheduled: buildStatusFilterPath(basePath, SCHEDULED_STATUSES),
+      succeeded: buildStatusFilterPath(basePath, SUCCEEDED_STATUSES),
     };
   }, [basePath]);
 
@@ -88,26 +91,37 @@ const MigrationsWidget: FC<MigrationsWidgetProps> = ({
               icon: <vmStatusIcon.Error />,
               key: 'failed',
               label: t('Failed'),
+              span: 4 as const,
             },
             {
               count: statusCounts.running,
               icon: <vmStatusIcon.Running />,
               key: 'running',
               label: t('Running'),
+              span: 4 as const,
             },
             {
               count: statusCounts.scheduled,
               icon: <vmStatusIcon.Scheduled />,
               key: 'scheduled',
               label: t('Scheduled'),
+              span: 4 as const,
+            },
+            {
+              count: statusCounts.succeeded,
+              icon: <GreenCheckCircleIcon />,
+              key: 'succeeded',
+              label: t('Succeeded'),
+              span: 6 as const,
             },
             {
               count: statusCounts.other,
               icon: <vmStatusIcon.Other />,
               key: 'other',
               label: t('Other'),
+              span: 6 as const,
             },
-          ].map(({ count, icon, key, label }) => (
+          ].map(({ count, icon, key, label, span }) => (
             <StatusCountItem
               {...getLinkProps(statusLinks[key], isExternal)}
               count={count}
@@ -115,7 +129,7 @@ const MigrationsWidget: FC<MigrationsWidgetProps> = ({
               isLoading={isLoading}
               key={key}
               label={label}
-              span={3}
+              span={span}
             />
           ))}
         </Grid>

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/MigrationsWidget.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/MigrationsWidget.tsx
@@ -2,7 +2,10 @@ import React, { FC, useMemo } from 'react';
 
 import { V1VirtualMachineInstanceMigration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getMigrationStatusCounts } from '@kubevirt-utils/resources/vmim/utils';
+import {
+  type MigrationStatusCounts,
+  getMigrationStatusCounts,
+} from '@kubevirt-utils/resources/vmim/utils';
 import { GreenCheckCircleIcon } from '@openshift-console/dynamic-plugin-sdk';
 import { vmStatusIcon } from '@overview/OverviewTab/vm-statuses-card/utils/utils';
 import { Card, CardBody, CardHeader, CardTitle, Content, Grid } from '@patternfly/react-core';
@@ -13,7 +16,6 @@ import ViewAllLink from '../shared/ViewAllLink';
 import {
   buildStatusFilterPath,
   FAILED_STATUSES,
-  MigrationStatusCounts,
   OTHER_STATUSES,
   RUNNING_STATUSES,
   SCHEDULED_STATUSES,
@@ -91,37 +93,32 @@ const MigrationsWidget: FC<MigrationsWidgetProps> = ({
               icon: <vmStatusIcon.Error />,
               key: 'failed',
               label: t('Failed'),
-              span: 4 as const,
             },
             {
               count: statusCounts.running,
               icon: <vmStatusIcon.Running />,
               key: 'running',
               label: t('Running'),
-              span: 4 as const,
             },
             {
               count: statusCounts.scheduled,
               icon: <vmStatusIcon.Scheduled />,
               key: 'scheduled',
               label: t('Scheduled'),
-              span: 4 as const,
             },
             {
               count: statusCounts.succeeded,
               icon: <GreenCheckCircleIcon />,
               key: 'succeeded',
               label: t('Succeeded'),
-              span: 6 as const,
             },
             {
               count: statusCounts.other,
               icon: <vmStatusIcon.Other />,
               key: 'other',
               label: t('Other'),
-              span: 6 as const,
             },
-          ].map(({ count, icon, key, label, span }) => (
+          ].map(({ count, icon, key, label }) => (
             <StatusCountItem
               {...getLinkProps(statusLinks[key], isExternal)}
               count={count}
@@ -129,7 +126,6 @@ const MigrationsWidget: FC<MigrationsWidgetProps> = ({
               isLoading={isLoading}
               key={key}
               label={label}
-              span={span}
             />
           ))}
         </Grid>

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/utils/migrationStatusConstants.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/utils/migrationStatusConstants.ts
@@ -1,22 +1,18 @@
 import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
+import type { MigrationStatusCounts } from '@kubevirt-utils/resources/vmim/utils';
 import { STATUS_LIST_FILTER_PARAM } from '@virtualmachines/utils/constants';
 
 import { buildFilterPath } from '../../shared/urlUtils';
 
-export type MigrationStatusCounts = {
-  failed: number;
-  other: number;
-  running: number;
-  scheduled: number;
-};
+export type { MigrationStatusCounts };
 
 export const FAILED_STATUSES = [vmimStatuses.Failed];
 export const RUNNING_STATUSES = [vmimStatuses.Running];
 export const SCHEDULED_STATUSES = [vmimStatuses.Scheduled, vmimStatuses.Scheduling];
+export const SUCCEEDED_STATUSES = [vmimStatuses.Succeeded];
 export const OTHER_STATUSES = [
   'Unset',
   vmimStatuses.TargetReady,
-  vmimStatuses.Succeeded,
   vmimStatuses.PreparingTarget,
   vmimStatuses.Pending,
   vmimStatuses.Paused,

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/utils/migrationStatusConstants.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/utils/migrationStatusConstants.ts
@@ -1,10 +1,7 @@
 import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
-import type { MigrationStatusCounts } from '@kubevirt-utils/resources/vmim/utils';
 import { STATUS_LIST_FILTER_PARAM } from '@virtualmachines/utils/constants';
 
 import { buildFilterPath } from '../../shared/urlUtils';
-
-export type { MigrationStatusCounts };
 
 export const FAILED_STATUSES = [vmimStatuses.Failed];
 export const RUNNING_STATUSES = [vmimStatuses.Running];


### PR DESCRIPTION
## Description

Completed compute migrations (`VirtualMachineInstanceMigration` phase **Succeeded**) were grouped under **Other** on the **Virtualization → Virtual Machines → Overview** compute migrations card. They are now counted and shown in a dedicated **Succeeded** column with a filter link to the migrations list, and **Other** only covers remaining non-terminal phases.

**Jira:** https://issues.redhat.com/browse/CNV-83806

### Changes
- `getMigrationStatusCounts`: add `succeeded`; exclude **Succeeded** from `other`.
- `migrationStatusConstants`: `SUCCEEDED_STATUSES`; remove **Succeeded** from `OTHER_STATUSES`.
- `MigrationsWidget`: new **Succeeded** tile (green check icon); two-row grid layout.
- Unit tests for `getMigrationStatusCounts`.

## Demo

**BEFORE**
<img width="1574" height="734" alt="Screenshot 2026-04-10 at 15 55 17" src="https://github.com/user-attachments/assets/a8ae4643-3414-4d25-a0d1-dc118d6b6947" />


**AFTER**
<img width="1574" height="734" alt="Screenshot 2026-04-10 at 15 53 45" src="https://github.com/user-attachments/assets/548853f6-159b-4a30-88fd-6dc11f0b3d8d" />

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a distinct "Succeeded" migration status with its own green indicator and dedicated count, removed it from the "Other" group, and updated status tile sizing/layout for clearer display.

* **Tests**
  * Added tests verifying migration status counting, including the new succeeded category and aggregation across known phases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->