### PR TITLE
CNV-62627: after changing metric updating it to correct new metric in queries

### DIFF
--- a/src/utils/components/Charts/utils/queries.ts
+++ b/src/utils/components/Charts/utils/queries.ts
@@ -55,7 +55,7 @@ export const getUtilizationQueries: GetUtilizationQueries = ({ duration, hubClus
     [VMQueries.MEMORY_USAGE]: `last_over_time(kubevirt_vmi_memory_used_bytes{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])`,
     [VMQueries.MIGRATION_DATA_PROCESSED]: `sum(sum_over_time(kubevirt_vmi_migration_data_processed_bytes{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}]))  BY (name, namespace${sumByCluster})`,
     [VMQueries.MIGRATION_DATA_REMAINING]: `sum(sum_over_time(kubevirt_vmi_migration_data_remaining_bytes{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}]))  BY (name, namespace${sumByCluster})`,
-    [VMQueries.MIGRATION_DISK_TRANSFER_RATE]: `sum(sum_over_time(kubevirt_vmi_migration_disk_transfer_rate_bytes	{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}]))  BY (name, namespace${sumByCluster})`,
+    [VMQueries.MIGRATION_DISK_TRANSFER_RATE]: `sum(sum_over_time(kubevirt_vmi_migration_memory_transfer_rate_bytes	{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}]))  BY (name, namespace${sumByCluster})`,
     [VMQueries.MIGRATION_MEMORY_DIRTY_RATE]: `sum(sum_over_time(kubevirt_vmi_migration_dirty_memory_rate_bytes{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}]))  BY (name, namespace${sumByCluster})`,
     [VMQueries.NETWORK_IN_BY_INTERFACE_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])) BY (name, namespace${sumByCluster}, interface)`,
     [VMQueries.NETWORK_IN_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'${clusterFilter}}[${duration}])) BY (name, namespace${sumByCluster})`,


### PR DESCRIPTION

## 📝 Description

PR https://github.com/kubevirt/kubevirt/pull/13500 updated the
`kubevirt_vmi_migration_disk_transfer_rate_bytes` metric name to 
`kubevirt_vmi_migration_memory_transfer_rate_bytes`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the metric used for migration disk transfer rate calculations during virtual machine migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->