### PR TITLE
CNV-84035: Align Create network button behavior with empty state

### DIFF
--- a/src/views/vmnetworks/hooks/useCanCreateVMNetwork.ts
+++ b/src/views/vmnetworks/hooks/useCanCreateVMNetwork.ts
@@ -1,0 +1,26 @@
+import { ClusterUserDefinedNetworkModel } from '@kubevirt-utils/models';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
+
+import usePhysicalNetworkOptions from './usePhysicalNetworkOptions';
+
+type UseCanCreateVMNetwork = () => {
+  canCreate: boolean;
+  showNoPhysicalNetworkAlert: boolean;
+};
+
+const useCanCreateVMNetwork: UseCanCreateVMNetwork = () => {
+  const [physicalNetworkOptions, , loaded, error] = usePhysicalNetworkOptions();
+  const [canCreateRBAC] = useAccessReview({
+    group: ClusterUserDefinedNetworkModel.apiGroup,
+    resource: ClusterUserDefinedNetworkModel.plural,
+    verb: 'create',
+  });
+
+  const canCreate = loaded && !error && canCreateRBAC && !isEmpty(physicalNetworkOptions);
+  const showNoPhysicalNetworkAlert = loaded && !error && isEmpty(physicalNetworkOptions);
+
+  return { canCreate, showNoPhysicalNetworkAlert };
+};
+
+export default useCanCreateVMNetwork;

--- a/src/views/vmnetworks/list/VMNetworksPage.tsx
+++ b/src/views/vmnetworks/list/VMNetworksPage.tsx
@@ -3,16 +3,14 @@ import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import {
-  ClusterUserDefinedNetworkModelGroupVersionKind,
-  NetworkAttachmentDefinitionModel,
-} from '@kubevirt-utils/models';
+import { NetworkAttachmentDefinitionModel } from '@kubevirt-utils/models';
 import PopoverContentWithLightspeedButton from '@lightspeed/components/PopoverContentWithLightspeedButton/PopoverContentWithLightspeedButton';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import { ListPageCreateButton, ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, PopoverPosition, Stack, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 
 import { VM_NETWORKS_PATH } from '../constants';
+import useCanCreateVMNetwork from '../hooks/useCanCreateVMNetwork';
 
 import { NADS_LIST_PATH, PATH_BY_TAB_INDEX, TAB_INDEX_BY_PATH, TAB_INDEXES } from './constants';
 import VMNetworkList from './VMNetworkList';
@@ -22,6 +20,7 @@ const VMNetworksPage: FC = () => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
   const location = useLocation();
+  const { canCreate } = useCanCreateVMNetwork();
 
   const locationTabKey = TAB_INDEX_BY_PATH[location?.pathname];
 
@@ -32,12 +31,7 @@ const VMNetworksPage: FC = () => {
   return (
     <>
       <ListPageHeader title={t('Virtual machine networks')}>
-        <ListPageCreateButton
-          createAccessReview={{
-            groupVersionKind: ClusterUserDefinedNetworkModelGroupVersionKind,
-          }}
-          onClick={onCreate}
-        >
+        <ListPageCreateButton isDisabled={!canCreate} onClick={onCreate}>
           {t('Create network')}
         </ListPageCreateButton>
       </ListPageHeader>

--- a/src/views/vmnetworks/list/components/LocalnetEmptyState/LocalnetEmptyState.tsx
+++ b/src/views/vmnetworks/list/components/LocalnetEmptyState/LocalnetEmptyState.tsx
@@ -1,11 +1,10 @@
 import React, { FC } from 'react';
 import { Trans } from 'react-i18next';
-import usePhysicalNetworkOptions from 'src/views/vmnetworks/hooks/usePhysicalNetworkOptions';
+import useCanCreateVMNetwork from 'src/views/vmnetworks/hooks/useCanCreateVMNetwork';
 
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   Button,
   EmptyState,
@@ -27,9 +26,7 @@ const LocalnetEmptyState: FC<LocalnetEmptyStateProps> = ({ onCreate }) => {
   const kind = t('OVN localnet network');
   const createButtonText = t('Create network');
 
-  const [physicalNetworkOptions] = usePhysicalNetworkOptions();
-
-  const canCreate = !isEmpty(physicalNetworkOptions);
+  const { canCreate, showNoPhysicalNetworkAlert } = useCanCreateVMNetwork();
 
   return (
     <EmptyState
@@ -38,12 +35,12 @@ const LocalnetEmptyState: FC<LocalnetEmptyStateProps> = ({ onCreate }) => {
       titleText={t('No {{kind}} found', { kind })}
     >
       <EmptyStateBody>
-        {canCreate ? (
+        {showNoPhysicalNetworkAlert ? (
+          <NoPhysicalNetworkAlert />
+        ) : (
           <Trans t={t}>
             Click <b>{{ createButtonText }}</b> to create your first {{ kind }}
           </Trans>
-        ) : (
-          <NoPhysicalNetworkAlert />
         )}
       </EmptyStateBody>
       <EmptyStateFooter>


### PR DESCRIPTION

## 📝 Description

Align **Create network** button behavior with empty state on the Virtual machine networks page.

- extract `useCanCreateVMNetwork` hook to share disabled logic and RBAC access review between the page header and empty state create buttons
- create button is now disabled when physical networks have not loaded, failed to load, are absent, or the user lacks create permissions

## 🎥 Demo

Before:
<img width="1811" height="867" alt="Screenshot 2026-04-13 at 10 46 29" src="https://github.com/user-attachments/assets/d6ad8848-9e7b-4801-8add-fd749738613e" />

After:
<img width="1811" height="867" alt="Screenshot 2026-04-13 at 10 36 51" src="https://github.com/user-attachments/assets/2c9e3abb-52cd-4b75-898c-4f14e153c590" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM Network creation button behavior to properly disable when physical networks are unavailable.
  * Enhanced empty state messaging to clearly indicate when physical networks are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->