### PR TITLE
CNV-83731: Update Template tiles to PF selectable cards and Template drawer to PF drawer

### DIFF
--- a/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
+++ b/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
@@ -18,18 +18,20 @@ import GuestOSStep from '@virtualmachines/creation-wizard/steps/InstanceTypesSte
 import ReviewAndCreateStep from '@virtualmachines/creation-wizard/steps/ReviewAndCreateStep/ReviewAndCreateStep';
 import TemplateStepFooter from '@virtualmachines/creation-wizard/steps/TemplateStep/components/TemplateStepFooter';
 import TemplateStep from '@virtualmachines/creation-wizard/steps/TemplateStep/TemplateStep';
+import { VMWizardStep } from '@virtualmachines/creation-wizard/utils/constants';
 import {
   isCloneCreationMethod,
   isInstanceTypeCreationMethod,
   isTemplateCreationMethod,
 } from '@virtualmachines/creation-wizard/utils/utils';
 
+import TemplatesDrawerWrapper from './components/TemplatesDrawerWrapper';
 import DeploymentDetailsStep from './steps/DeploymentDetailsStep/DeploymentDetailsStep';
 
 const VMCreationWizard: FC = () => {
   const { t } = useKubevirtTranslation();
   useSignals();
-  const { creationMethod, setCluster, setProject } = useVMWizardStore();
+  const { creationMethod, setCluster, setProject, setTemplatesDrawerIsOpen } = useVMWizardStore();
   const clusterParam = useClusterParam();
   const { ns } = useParams<{ ns: string }>();
   const hasInitialized = useRef(false);
@@ -49,79 +51,84 @@ const VMCreationWizard: FC = () => {
   const isTemplateMethod = isTemplateCreationMethod(creationMethod);
 
   return (
-    <Wizard
-      className="vm-creation-wizard"
-      header={<WizardHeader isCloseHidden title={t('Create VirtualMachine')} />}
-      onClose={closeWizard}
-      title={t('Create VirtualMachine')}
-    >
-      <WizardStep
-        footer={<DefaultWizardFooter />}
-        id="vm-creation-deployment-details-step"
-        name={t('Deployment details')}
-      >
-        <DeploymentDetailsStep />
-      </WizardStep>
-      <WizardStep
-        footer={<DefaultWizardFooter />}
-        id="vm-creation-guest-os-step"
-        isHidden={!isInstanceTypeMethod}
-        name={t('Guest OS')}
-      >
-        <GuestOSStep />
-      </WizardStep>
-      <WizardStep
-        footer={<DefaultWizardFooter />}
-        id="vm-creation-boot-source-step"
-        isHidden={!isInstanceTypeMethod}
-        name={t('Boot source')}
-      >
-        <BootSourceStep />
-      </WizardStep>
-      <WizardStep
-        footer={<ComputeResourcesStepFooter />}
-        id="vm-creation-compute-resources-step"
-        isHidden={!isInstanceTypeMethod}
-        name={t('Compute resources')}
-      >
-        <ComputeResourcesStep />
-      </WizardStep>
-
-      <WizardStep
-        footer={<TemplateStepFooter />}
-        id="vm-creation-template-step"
-        isHidden={!isTemplateMethod}
-        name={t('Template')}
-      >
-        <TemplateStep />
-      </WizardStep>
-      <WizardStep
-        footer={<DefaultWizardFooter />}
-        id="vm-creation-customization-step"
-        isHidden={isCloneMethod}
-        name={t('Customization')}
-      >
-        <CustomizationStep />
-      </WizardStep>
-      <WizardStep
-        footer={<DefaultWizardFooter />}
-        id="vm-creation-clone-step"
-        isHidden={!isCloneMethod}
-        name={t('Source')}
-      >
-        <CloneSourceStep />
-      </WizardStep>
-      <WizardStep
-        footer={{
-          nextButtonText: isCloneMethod ? t('Clone VirtualMachine') : t('Create VirtualMachine'),
-          onNext: createVM,
+    <TemplatesDrawerWrapper>
+      <Wizard
+        onStepChange={(_, currentStep) => {
+          if (currentStep?.id !== VMWizardStep.TEMPLATE) setTemplatesDrawerIsOpen(false);
         }}
-        id="vm-creation-review-and-create-step"
-        name={t('Review and create')}
+        className="vm-creation-wizard"
+        header={<WizardHeader isCloseHidden title={t('Create VirtualMachine')} />}
+        onClose={closeWizard}
+        title={t('Create VirtualMachine')}
       >
-        <ReviewAndCreateStep />
-      </WizardStep>
-    </Wizard>
+        <WizardStep
+          footer={<DefaultWizardFooter />}
+          id={VMWizardStep.DEPLOYMENT_DETAILS}
+          name={t('Deployment details')}
+        >
+          <DeploymentDetailsStep />
+        </WizardStep>
+        <WizardStep
+          footer={<DefaultWizardFooter />}
+          id={VMWizardStep.GUEST_OS}
+          isHidden={!isInstanceTypeMethod}
+          name={t('Guest OS')}
+        >
+          <GuestOSStep />
+        </WizardStep>
+        <WizardStep
+          footer={<DefaultWizardFooter />}
+          id={VMWizardStep.BOOT_SOURCE}
+          isHidden={!isInstanceTypeMethod}
+          name={t('Boot source')}
+        >
+          <BootSourceStep />
+        </WizardStep>
+        <WizardStep
+          footer={<ComputeResourcesStepFooter />}
+          id={VMWizardStep.COMPUTE_RESOURCES}
+          isHidden={!isInstanceTypeMethod}
+          name={t('Compute resources')}
+        >
+          <ComputeResourcesStep />
+        </WizardStep>
+
+        <WizardStep
+          footer={<TemplateStepFooter />}
+          id={VMWizardStep.TEMPLATE}
+          isHidden={!isTemplateMethod}
+          name={t('Template')}
+        >
+          <TemplateStep />
+        </WizardStep>
+        <WizardStep
+          footer={<DefaultWizardFooter />}
+          id={VMWizardStep.CUSTOMIZATION}
+          isHidden={isCloneMethod}
+          name={t('Customization')}
+        >
+          <CustomizationStep />
+        </WizardStep>
+        <WizardStep
+          footer={<DefaultWizardFooter />}
+          id={VMWizardStep.CLONE}
+          isHidden={!isCloneMethod}
+          name={t('Source')}
+        >
+          <CloneSourceStep />
+        </WizardStep>
+        <WizardStep
+          footer={{
+            nextButtonText: isCloneMethod ? t('Clone VirtualMachine') : t('Create VirtualMachine'),
+            onNext: createVM,
+          }}
+          id={VMWizardStep.REVIEW_AND_CREATE}
+          name={t('Review and create')}
+        >
+          <ReviewAndCreateStep />
+        </WizardStep>
+      </Wizard>
+    </TemplatesDrawerWrapper>
   );
 };
 

--- a/src/views/virtualmachines/creation-wizard/components/TemplatesDrawerWrapper.tsx
+++ b/src/views/virtualmachines/creation-wizard/components/TemplatesDrawerWrapper.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from 'react';
+
+import { Drawer, DrawerContent, DrawerContentBody } from '@patternfly/react-core';
+import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
+
+import { TemplatesCatalogDrawer } from '../steps/TemplateStep/components/TemplatesCatalogDrawer/TemplatesCatalogDrawer';
+
+const TemplatesDrawerWrapper: FC = ({ children }) => {
+  const { selectedTemplate, setTemplatesDrawerIsOpen, templatesDrawerIsOpen } = useVMWizardStore();
+
+  const handleDrawerClose = () => {
+    setTemplatesDrawerIsOpen(false);
+  };
+
+  return (
+    <Drawer isExpanded={templatesDrawerIsOpen && !!selectedTemplate} position="end">
+      <DrawerContent
+        panelContent={
+          <TemplatesCatalogDrawer onClose={handleDrawerClose} template={selectedTemplate} />
+        }
+      >
+        <DrawerContentBody>{children}</DrawerContentBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default TemplatesDrawerWrapper;

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore.ts
@@ -16,6 +16,8 @@ const useVMWizardStore = create<VMWizardStore>()((set) => {
     setProject: (project: string) => set({ project }),
     setSelectedTemplate: (selectedTemplate: V1Template) => set(() => ({ selectedTemplate })),
     setStartVM: (startVM: boolean) => set({ startVM }),
+    setTemplatesDrawerIsOpen: (templatesDrawerIsOpen: boolean) =>
+      set(() => ({ templatesDrawerIsOpen })),
   };
 });
 

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/state.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/state.ts
@@ -10,4 +10,5 @@ export const initialVMWizardState: VMWizardState = {
   project: '',
   selectedTemplate: null,
   startVM: false,
+  templatesDrawerIsOpen: false,
 };

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/types.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/types.ts
@@ -10,6 +10,7 @@ export type VMWizardState = {
   project: string;
   selectedTemplate: V1Template;
   startVM: boolean;
+  templatesDrawerIsOpen: boolean;
 };
 
 export type VMWizardActions = {
@@ -22,6 +23,7 @@ export type VMWizardActions = {
   setProject: (project: string) => void;
   setSelectedTemplate: (template: V1Template) => void;
   setStartVM: (startVM: boolean) => void;
+  setTemplatesDrawerIsOpen: (templatesDrawerIsOpen: boolean) => void;
 };
 
 export type VMWizardStore = VMWizardState & VMWizardActions;

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplateStepFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplateStepFooter.tsx
@@ -2,15 +2,18 @@ import React, { FC } from 'react';
 
 import { useWizardContext, WizardFooter } from '@patternfly/react-core';
 import useCloseWizard from '@virtualmachines/creation-wizard/hooks/useCloseWizard';
+import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
 import useCreateVMFromTemplate from '@virtualmachines/creation-wizard/steps/TemplateStep/hooks/useCreateVMFromTemplate';
 
 const TemplateStepFooter: FC = ({}) => {
   const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
   const { createVMFromTemplate } = useCreateVMFromTemplate();
   const closeWizard = useCloseWizard();
+  const { setTemplatesDrawerIsOpen } = useVMWizardStore();
 
   const handleGoToNextStep = async () => {
     await createVMFromTemplate();
+    setTemplatesDrawerIsOpen(false);
     goToNextStep();
   };
 

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/TemplatesCatalog.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/TemplatesCatalog.tsx
@@ -1,8 +1,6 @@
-import React, { FC, useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom-v5-compat';
+import React, { FC, useMemo } from 'react';
 
 import { V1Template } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { logTemplateFlowEvent } from '@kubevirt-utils/extensions/telemetry/telemetry';
 import { TEMPLATE_SELECTED } from '@kubevirt-utils/extensions/telemetry/utils/constants';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
@@ -18,14 +16,11 @@ import useHideDeprecatedTemplateTiles from '@virtualmachines/creation-wizard/ste
 import { useTemplatesWithAvailableSource } from '@virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useTemplatesWithAvailableSource';
 import { useTemplatesFilters } from '@virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useVMTemplatesFilters';
 import { filterTemplates } from '@virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/utils/utils';
-import { TemplatesCatalogDrawer } from '@virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/TemplatesCatalogDrawer';
 
 import './TemplateCatalog.scss';
 
 const TemplatesCatalog: FC = () => {
-  const { ns: namespace } = useParams<{ ns: string }>();
-  const { selectedTemplate, setSelectedTemplate } = useVMWizardStore();
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const { selectedTemplate, setSelectedTemplate, setTemplatesDrawerIsOpen } = useVMWizardStore();
 
   const [filters, onFilterChange, clearAll] = useTemplatesFilters();
   const { availableDataSources, availableTemplatesUID, bootSourcesLoaded, loaded, templates } =
@@ -47,11 +42,7 @@ const TemplatesCatalog: FC = () => {
     const vm = getTemplateVirtualMachineObject(template);
     vmSignal.value = vm;
     logTemplateFlowEvent(TEMPLATE_SELECTED, template);
-    setIsDrawerOpen(true);
-  };
-
-  const handleDrawerClose = () => {
-    setIsDrawerOpen(false);
+    setTemplatesDrawerIsOpen(true);
   };
 
   return (
@@ -83,12 +74,6 @@ const TemplatesCatalog: FC = () => {
       ) : (
         <CatalogSkeleton />
       )}
-      <TemplatesCatalogDrawer
-        isOpen={isDrawerOpen && !!selectedTemplate}
-        namespace={namespace ?? DEFAULT_NAMESPACE}
-        onClose={handleDrawerClose}
-        template={selectedTemplate}
-      />
     </PageSection>
   );
 };

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesCatalogItems/components/TemplatesCatalogTile.scss
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesCatalogItems/components/TemplatesCatalogTile.scss
@@ -1,10 +1,3 @@
-.template-catalog-tile-wrapper {
-  &--selected {
-    .template-catalog-tile {
-      --pf-v6-c-card--BorderColor: var(--pf-t--global--color--brand--default);
-      --pf-v6-c-card--BorderWidth: var(--pf-t--global--border--width--action--default);
-
-      box-shadow: var(--pf-t--global--box-shadow--md);
-    }
-  }
+.templates-catalog-tile .pf-v6-c-card__actions {
+  padding-left: 0;
 }

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesCatalogItems/components/TemplatesCatalogTile.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesCatalogItems/components/TemplatesCatalogTile.tsx
@@ -5,6 +5,7 @@ import { V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-d
 import ArchitectureLabel from '@kubevirt-utils/components/ArchitectureLabel/ArchitectureLabel';
 import DeprecatedBadge from '@kubevirt-utils/components/badges/DeprecatedBadge/DeprecatedBadge';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getAnnotations, getName, getNamespace, getUID } from '@kubevirt-utils/resources/shared';
 import {
   getTemplateFlavorData,
   isDeprecatedTemplate,
@@ -18,8 +19,17 @@ import {
 import { getVMBootSourceLabel } from '@kubevirt-utils/resources/vm/utils/source';
 import { ARCHITECTURE_TITLE, getArchitecture } from '@kubevirt-utils/utils/architecture';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
-import { CatalogTile } from '@patternfly/react-catalog-view-extension';
-import { Badge, Skeleton, Stack, StackItem } from '@patternfly/react-core';
+import {
+  Badge,
+  Card,
+  CardBody,
+  CardHeader,
+  Skeleton,
+  Split,
+  SplitItem,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 import { getTemplateOSIcon } from '@virtualmachines/creation-wizard/utils/os-icons/os-icons';
 
 import './TemplatesCatalogTile.scss';
@@ -46,6 +56,8 @@ const TemplatesCatalogTile: FC<TemplatesCatalogTileProps> = memo(
 
     const isDeprecated = isDeprecatedTemplate(template);
     const workload = getTemplateWorkload(template);
+    const templateID = getUID(template);
+    const templateName = getName(template);
     const displayName = getTemplateName(template);
     const bootSource = getTemplateBootSourceType(template);
     const isBootSourceAvailable = availableTemplatesUID.has(template.metadata.uid);
@@ -58,50 +70,62 @@ const TemplatesCatalogTile: FC<TemplatesCatalogTileProps> = memo(
     const icon = useMemo(() => {
       return getTemplateOSIcon(template);
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [template?.metadata?.annotations?.iconClass]);
+    }, [getAnnotations(template)?.iconClass]);
 
     return (
-      <div
-        className={`template-catalog-tile-wrapper ${
-          isSelected ? 'template-catalog-tile-wrapper--selected' : ''
-        }`}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') onClick(template);
-        }}
+      <Card
+        className="templates-catalog-tile"
+        data-test-id={templateName}
+        id={templateID}
+        isSelectable
+        isSelected={isSelected}
         onClick={() => onClick(template)}
-        role="button"
-        tabIndex={0}
       >
-        <CatalogTile
-          badges={[
-            <Stack className="badge-stack" key="badge-stack">
-              {bootSourcesLoaded
-                ? isBootSourceAvailable && [
-                    <Badge key="available-boot">{t('Source available')}</Badge>,
-                  ]
-                : [
-                    <Skeleton
-                      className="badgeload"
-                      height="18px"
-                      key="loading-sources"
-                      width="105px"
-                    />,
-                  ]}
-              {isDeprecated ? <DeprecatedBadge className="deprecated-template" /> : null}
-            </Stack>,
-          ]}
-          title={
-            <Stack>
-              <StackItem>
-                <b>{displayName}</b>
-              </StackItem>
-              <StackItem className="pf-v6-u-text-color-subtle">{template.metadata.name}</StackItem>
-            </Stack>
-          }
-          className="template-catalog-tile"
-          data-test-id={template.metadata.name}
-          iconImg={icon}
+        <CardHeader
+          selectableActions={{
+            isHidden: true,
+            name: 'template-catalog-tile',
+            onChange: () => onClick(template),
+            selectableActionAriaLabelledby: `template-catalog-tile-${templateName}`,
+            selectableActionId: templateID,
+            variant: 'single',
+          }}
         >
+          <Stack>
+            <StackItem>
+              <Split>
+                {icon && (
+                  <SplitItem>
+                    <img alt={`${templateName} icon`} className="catalog-tile-pf-icon" src={icon} />
+                  </SplitItem>
+                )}
+                <SplitItem isFilled />
+                <SplitItem>
+                  <Stack className="badge-stack" key="badge-stack">
+                    {bootSourcesLoaded
+                      ? isBootSourceAvailable && [
+                          <Badge key="available-boot">{t('Source available')}</Badge>,
+                        ]
+                      : [
+                          <Skeleton
+                            className="badgeload"
+                            height="1.125rem" // 18px
+                            key="loading-sources"
+                            width="6.563rem" // 105px
+                          />,
+                        ]}
+                    {isDeprecated ? <DeprecatedBadge className="deprecated-template" /> : null}
+                  </Stack>
+                </SplitItem>
+              </Split>
+            </StackItem>
+            <StackItem>
+              <b>{displayName}</b>
+            </StackItem>
+            <StackItem className="pf-v6-u-text-color-subtle">{templateName}</StackItem>
+          </Stack>
+        </CardHeader>
+        <CardBody>
           <Stack hasGutter>
             <StackItem>
               <Stack>
@@ -110,7 +134,7 @@ const TemplatesCatalogTile: FC<TemplatesCatalogTileProps> = memo(
                   <ArchitectureLabel architecture={getArchitecture(template)} />
                 </StackItem>
                 <StackItem>
-                  <b>{t('Project')}</b> {template.metadata.namespace}
+                  <b>{t('Project')}</b> {getNamespace(template)}
                 </StackItem>
                 <StackItem>
                   <b>{t('Boot source')}</b> {getVMBootSourceLabel(bootSource?.type, dataSource)}
@@ -131,8 +155,8 @@ const TemplatesCatalogTile: FC<TemplatesCatalogTileProps> = memo(
               </Stack>
             </StackItem>
           </Stack>
-        </CatalogTile>
-      </div>
+        </CardBody>
+      </Card>
     );
   },
 );

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/TemplateCatalogDrawer.scss
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/TemplateCatalogDrawer.scss
@@ -1,15 +1,4 @@
 .template-catalog-drawer {
-  .pf-v6-c-modal-box__footer {
-    padding: 0;
-
-    .template-catalog-drawer-footer-section {
-      padding: var(--pf-v6-c-modal-box__footer--PaddingBlockStart) var(--pf-t--global--spacer--xl)
-        var(--pf-t--global--spacer--xl);
-      border-top: var(--pf-t--global--border--width--regular) solid
-        var(--pf-t--global--border--color--default);
-    }
-  }
-
   .field-group {
     margin-bottom: var(--pf-t--global--spacer--md);
   }

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/TemplatesCatalogDrawer.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/TemplatesCatalogDrawer.tsx
@@ -3,7 +3,13 @@ import React, { FC } from 'react';
 import { V1Template } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { getTemplateName } from '@kubevirt-utils/resources/template/utils/selectors';
 import { CatalogItemHeader } from '@patternfly/react-catalog-view-extension';
-import { Modal, ModalBody, ModalHeader } from '@patternfly/react-core';
+import {
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerHead,
+  DrawerPanelBody,
+  DrawerPanelContent,
+} from '@patternfly/react-core';
 import { getTemplateOSIcon } from '@virtualmachines/creation-wizard/utils/os-icons/os-icons';
 
 import TemplatesCatalogDrawerPanel from './components/TemplatesCatalogDrawerPanel/TemplatesCatalogDrawerPanel';
@@ -12,43 +18,34 @@ import { DrawerContextProvider } from './hooks/useDrawerContext';
 import './TemplateCatalogDrawer.scss';
 
 type TemplatesCatalogDrawerProps = {
-  isOpen: boolean;
-  namespace: string;
   onClose: () => void;
   template: undefined | V1Template;
 };
 
-export const TemplatesCatalogDrawer: FC<TemplatesCatalogDrawerProps> = ({
-  isOpen,
-  onClose,
-  template,
-}) => {
+export const TemplatesCatalogDrawer: FC<TemplatesCatalogDrawerProps> = ({ onClose, template }) => {
+  if (!template) return null;
+
   const templateName = getTemplateName(template);
   const osIcon = getTemplateOSIcon(template);
 
-  if (!isOpen || !template) return null;
-
   return (
     <DrawerContextProvider template={template}>
-      <Modal
-        aria-label="Template drawer"
-        className="ocs-modal co-catalog-page__overlay co-catalog-page__overlay--right template-catalog-drawer"
-        disableFocusTrap
-        isOpen={isOpen}
-        onClose={onClose}
-      >
-        <ModalHeader>
+      <DrawerPanelContent className="template-catalog-drawer" maxSize="37.5rem" minSize="37.5rem">
+        <DrawerHead>
           <CatalogItemHeader
             className="co-catalog-page__overlay-header"
             iconImg={osIcon}
             title={templateName}
             vendor={template?.metadata?.name}
           />
-        </ModalHeader>
-        <ModalBody>
+          <DrawerActions>
+            <DrawerCloseButton onClick={onClose} />
+          </DrawerActions>
+        </DrawerHead>
+        <DrawerPanelBody>
           <TemplatesCatalogDrawerPanel />
-        </ModalBody>
-      </Modal>
+        </DrawerPanelBody>
+      </DrawerPanelContent>
     </DrawerContextProvider>
   );
 };

--- a/src/views/virtualmachines/creation-wizard/utils/constants.ts
+++ b/src/views/virtualmachines/creation-wizard/utils/constants.ts
@@ -3,3 +3,14 @@ export enum VMCreationMethod {
   INSTANCE_TYPE = 'instance-type',
   TEMPLATE = 'template',
 }
+
+export enum VMWizardStep {
+  BOOT_SOURCE = 'vm-creation-boot-source-step',
+  CLONE = 'vm-creation-clone-step',
+  COMPUTE_RESOURCES = 'vm-creation-compute-resources-step',
+  CUSTOMIZATION = 'vm-creation-customization-step',
+  DEPLOYMENT_DETAILS = 'vm-creation-deployment-details-step',
+  GUEST_OS = 'vm-creation-guest-os-step',
+  REVIEW_AND_CREATE = 'vm-creation-review-and-create-step',
+  TEMPLATE = 'vm-creation-template-step',
+}


### PR DESCRIPTION
## 📝 Description

This PR updates the Template catalog tiles to be PF selectable cards and the Template details drawer to use the PF drawer component instead of the modal-based drawer component. This allows the the wizard buttons to be used even when the drawer is displayed.

Jira: https://redhat.atlassian.net/browse/CNV-83731

## 🎥 Demo

https://github.com/user-attachments/assets/69ecf448-762b-4846-8cfd-9d227f2f7a2c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dockable templates drawer alongside the VM creation wizard.
  * Added wizard state to track and control the templates drawer open/closed state.

* **Improvements**
  * Templates catalog converted from modal to drawer and redesigned with updated card layout and selection behavior.
  * Drawer auto-closes when navigating away from the template step.
  * Cleaner styling and layout adjustments for template tiles and drawer content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->