### PR TITLE
CNV-81220: fix side YAML editor not taking full height in VM Configuration

### DIFF
--- a/src/utils/components/ConfigurationSearch/configuration-search.scss
+++ b/src/utils/components/ConfigurationSearch/configuration-search.scss
@@ -1,6 +1,5 @@
 .ConfigurationSearch {
   &--main {
-    margin-bottom: var(--pf-t--global--spacer--md);
     &__no-results {
       flex-direction: column;
       > * {

--- a/src/utils/components/SidebarEditor/sidebar-editor.scss
+++ b/src/utils/components/SidebarEditor/sidebar-editor.scss
@@ -1,13 +1,17 @@
 .sidebar-editor {
-  min-height: 100%;
+  height: 100%;
 
   .pf-v6-c-sidebar__panel,
   .pf-v6-c-sidebar__main {
-    min-height: 100%;
+    height: 100%;
   }
 
   .pf-v6-c-sidebar__main {
     align-items: stretch;
+  }
+
+  .pf-v6-c-sidebar__content {
+    overflow-y: auto;
   }
 
   .pf-v6-c-sidebar__panel {

--- a/src/views/settings/SettingsPage.scss
+++ b/src/views/settings/SettingsPage.scss
@@ -26,9 +26,6 @@
   &__toolbar {
     padding-block: var(--pf-t--global--spacer--xs);
     margin-top: var(--pf-t--global--spacer--md);
-    .ConfigurationSearch--main {
-      margin-bottom: 0;
-    }
   }
 
   &__cluster-selector {

--- a/src/views/virtualmachines/details/tabs/configuration/VirtualMachineConfigurationTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/VirtualMachineConfigurationTab.tsx
@@ -2,7 +2,6 @@ import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useLocation } from 'react-router-dom-v5-compat';
 
-import GuidedTour from '@kubevirt-utils/components/GuidedTour/GuidedTour';
 import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
 import useInstanceTypesAndPreferences from '@kubevirt-utils/hooks/useInstanceTypesAndPreferences';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -57,7 +56,7 @@ const VirtualMachineConfigurationTab: FC<NavPageComponentProps> = ({
   const searchItems = useMemo(() => getSearchItems(vm), [vm]);
 
   return (
-    <PageSection className="VirtualMachineConfigurationTab">
+    <PageSection className="VirtualMachineConfigurationTab" hasBodyWrapper={false}>
       <ConfigurationSearch
         createSearchURL={createConfigurationSearchURL}
         searchItems={searchItems}
@@ -85,7 +84,6 @@ const VirtualMachineConfigurationTab: FC<NavPageComponentProps> = ({
           ))}
         </Tabs>
       </div>
-      <GuidedTour />
     </PageSection>
   );
 };

--- a/src/views/virtualmachines/details/tabs/configuration/virtual-machine-configuration-tab.scss
+++ b/src/views/virtualmachines/details/tabs/configuration/virtual-machine-configuration-tab.scss
@@ -1,26 +1,27 @@
 .VirtualMachineConfigurationTab {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
   &--body > &--main {
     margin: var(--pf-t--global--spacer--sm);
-    width: fit-content;
-    min-width: max-content;
-    max-width: 100px;
+    width: max-content;
     padding-right: var(--pf-t--global--spacer--3xl);
   }
+
   &--content {
     width: 100%;
   }
+
   &--body {
+    flex: 1;
+    min-height: 0;
     display: flex;
     flex-direction: row;
-    .pf-v6-c-page__main-section {
-      background: none;
-    }
-    .pf-v6-c-expandable-section__toggle-icon {
-      display: flex;
-      align-self: center;
-    }
+
     h2 {
-      margin: var(--pf-t--global--spacer--md) 0;
+      margin-bottom: var(--pf-t--global--spacer--md);
     }
   }
 }


### PR DESCRIPTION



<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes side YAML editor not taking full height in VM Configuration

- Establish full height chain on `VirtualMachineConfigurationTab` (height: 100%, flex column, overflow: hidden) so the layout fills the available viewport space
- Change `SidebarEditor` from min-height to height and add overflow-y: auto on `SidebarContent` so the left panel scrolls independently while the YAML editor stays full height
- Remove redundant `GuidedTour` from VirtualMachineConfigurationTab causing bottom flex gap
- Clean up VirtualMachineConfigurationTab SCSS: simplify width properties, remove unused rules


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/891a9ee7-2597-436a-b45b-f7aee3db1165


After:

https://github.com/user-attachments/assets/8f5fb9b6-a2a8-4190-a3ad-72af8c4b05c9





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved sidebar editor with better height handling and vertical scrolling support
  * Refined virtual machine configuration tab layout, spacing, and component sizing
  * Updated search component margins and toolbar styling in the settings page

* **Removed Features**
  * Removed guided tour functionality from the virtual machine configuration tab

<!-- end of auto-generated comment: release notes by coderabbit.ai -->