### PR TITLE
CNV-74669: Virtualization features list — no catalog links, add help

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -2251,7 +2251,6 @@
   "View diagnostic": "View diagnostic",
   "View documentation": "View documentation",
   "View events": "View events",
-  "View in Operator hub": "View in Operator hub",
   "View installation documentation": "View installation documentation",
   "View matching {{matchingNodeText}}": "View matching {{matchingNodeText}}",
   "View matching {{matchingProjectText}}": "View matching {{matchingProjectText}}",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -2271,7 +2271,6 @@
   "View diagnostic": "Ver diagnóstico",
   "View documentation": "Ver documentación",
   "View events": "Ver eventos",
-  "View in Operator hub": "Ver en el centro del operador",
   "View installation documentation": "View installation documentation",
   "View matching {{matchingNodeText}}": "Ver {{matchingNodeText}} coincidente",
   "View matching {{matchingProjectText}}": "Ver {{matchingProjectText}} coincidente",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -2271,7 +2271,6 @@
   "View diagnostic": "Voir le diagnostic",
   "View documentation": "Afficher la documentation",
   "View events": "Afficher les événements",
-  "View in Operator hub": "Afficher dans le hub de l'opérateur",
   "View installation documentation": "View installation documentation",
   "View matching {{matchingNodeText}}": "Voir la correspondance {{matchingNodeText}}",
   "View matching {{matchingProjectText}}": "Voir la correspondance {{matchingProjectText}}",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -2247,7 +2247,6 @@
   "View diagnostic": "診断の表示",
   "View documentation": "ドキュメントの表示",
   "View events": "イベントの表示",
-  "View in Operator hub": "Operator Hub で表示",
   "View installation documentation": "View installation documentation",
   "View matching {{matchingNodeText}}": "一致する {{matchingNodeText}} の表示",
   "View matching {{matchingProjectText}}": "一致する {{matchingProjectText}} の表示",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -2247,7 +2247,6 @@
   "View diagnostic": "진단 보기",
   "View documentation": "문서 보기",
   "View events": "이벤트보기",
-  "View in Operator hub": "Operator 허브에서 보기",
   "View installation documentation": "View installation documentation",
   "View matching {{matchingNodeText}}": "{{matchingNodeText}}개의 일치 항목 보기",
   "View matching {{matchingProjectText}}": "{{matchingProjectText}}개의 일치 항목 보기",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -2247,7 +2247,6 @@
   "View diagnostic": "查看诊断",
   "View documentation": "查看文档",
   "View events": "查看事件",
-  "View in Operator hub": "在 Operator hub 中查看",
   "View installation documentation": "View installation documentation",
   "View matching {{matchingNodeText}}": "查看匹配 {{matchingNodeText}}",
   "View matching {{matchingProjectText}}": "查看匹配 {{matchingProjectText}}",

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/VirtualizationFeaturesSection.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/VirtualizationFeaturesSection.tsx
@@ -43,6 +43,9 @@ const VirtualizationFeaturesSection: FC = () => {
       <Stack hasGutter>
         <StackItem isFilled>
           <FeaturedOperatorItem
+            helpBody={t(
+              'Delivers real-time, in-depth metrics and a fully functional Cluster Health Dashboard.',
+            )}
             isNew
             operatorName={CLUSTER_OBSERVABILITY_OPERATOR_NAME}
             title={t('Cluster observability (COO)')}
@@ -50,12 +53,16 @@ const VirtualizationFeaturesSection: FC = () => {
         </StackItem>
         <StackItem isFilled>
           <FeaturedOperatorItem
+            helpBody={t('Network flows collector and monitoring solution.')}
             operatorName={NETOBSERV_OPERATOR_NAME}
             title={t('Network observability')}
           />
         </StackItem>
         <StackItem isFilled>
           <FeaturedOperatorItem
+            helpBody={t(
+              'OpenShift Container Platform uses nmstate to report on and configure the state of the node network.',
+            )}
             operatorName={NMSTATE_OPERATOR_NAME}
             title={t('Host network management (NMState)')}
           />

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/FeaturedOperatorItem.scss
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/FeaturedOperatorItem.scss
@@ -1,6 +1,12 @@
 .featured-operator-item {
-  &__link-button {
+  &__title {
     margin-left: -0.5rem;
+  }
+
+  &__help-icon-container {
+    display: inline-flex;
+    align-items: center;
+    margin-left: var(--pf-t--global--spacer--sm);
   }
 
   &__icon-container {

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/FeaturedOperatorItem.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/FeaturedOperatorItem.tsx
@@ -1,44 +1,53 @@
 import React, { FC } from 'react';
 
+import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Label, Split, SplitItem } from '@patternfly/react-core';
-import SettingsLink from '@settings/context/SettingsLink';
+import { Label, PopoverPosition, Split, SplitItem } from '@patternfly/react-core';
 import { VirtualizationFeatureOperators } from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/types';
 import { getInstallStateIcon } from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/utils';
 import { useVirtualizationFeaturesContext } from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/VirtualizationFeaturesContext/VirtualizationFeaturesContext';
+import HelpTextTooltipContent from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/HelpTextTooltipContent/HelpTextTooltipContent';
 
 import IconSkeleton from './icons/IconSkeleton/IconSkeleton';
 
 import './FeaturedOperatorItem.scss';
 
 type FeaturedOperatorItemProps = {
+  helpBody: string;
   isNew?: boolean;
   operatorName: VirtualizationFeatureOperators;
   title: string;
 };
 
-const FeaturedOperatorItem: FC<FeaturedOperatorItemProps> = ({ isNew, operatorName, title }) => {
+const FeaturedOperatorItem: FC<FeaturedOperatorItemProps> = ({
+  helpBody,
+  isNew,
+  operatorName,
+  title,
+}) => {
   const { t } = useKubevirtTranslation();
   const { operatorDetailsMap, operatorResourcesLoaded } = useVirtualizationFeaturesContext();
-  const { installState, operatorHubURL } = operatorDetailsMap?.[operatorName] ?? {};
+  const { installState } = operatorDetailsMap?.[operatorName] ?? {};
   const Icon = getInstallStateIcon(installState);
 
   return (
     <Split className="featured-operator-item" hasGutter>
       <SplitItem>
-        <SettingsLink
-          className="featured-operator-item__link-button"
-          disabled={!operatorHubURL}
-          isInline={false}
-          to={operatorHubURL}
-        >
+        <span className="featured-operator-item__title">
           {title}
           {isNew && (
             <Label className="pf-v6-u-ml-sm" color="blue" isCompact>
               {t('New')}
             </Label>
           )}
-        </SettingsLink>
+        </span>
+      </SplitItem>
+      <SplitItem className="featured-operator-item__help-icon-container" isFilled>
+        <HelpTextIcon
+          bodyContent={<HelpTextTooltipContent bodyText={helpBody} titleText={title} />}
+          helpIconClassName="featured-operator-item__help-icon"
+          position={PopoverPosition.right}
+        />
       </SplitItem>
       <SplitItem className="featured-operator-item__icon-container">
         {operatorResourcesLoaded ? <Icon /> : <IconSkeleton />}

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/HighAvailabilitySection/HighAvailabilitySection.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/HighAvailabilitySection/HighAvailabilitySection.tsx
@@ -1,14 +1,15 @@
 import React, { FC } from 'react';
 
+import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Split, SplitItem } from '@patternfly/react-core';
-import SettingsLink from '@settings/context/SettingsLink';
+import { PopoverPosition, Split, SplitItem } from '@patternfly/react-core';
 import {
   FENCE_AGENTS_OPERATOR_NAME,
   NODE_HEALTH_OPERATOR_NAME,
 } from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/constants';
 import { getInstallStateIcon } from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/utils';
 import { useVirtualizationFeaturesContext } from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/VirtualizationFeaturesContext/VirtualizationFeaturesContext';
+import HelpTextTooltipContent from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/HelpTextTooltipContent/HelpTextTooltipContent';
 import { getHighAvailabilityInstallState } from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/SummaryStep/components/HighAvailabilitySection/utils/utils';
 
 import IconSkeleton from '../icons/IconSkeleton/IconSkeleton';
@@ -19,27 +20,32 @@ const HighAvailabilitySection: FC = () => {
   const { t } = useKubevirtTranslation();
   const { operatorDetailsMap, operatorResourcesLoaded } = useVirtualizationFeaturesContext();
 
-  const { installState: nhcInstallState, operatorHubURL } =
-    operatorDetailsMap?.[NODE_HEALTH_OPERATOR_NAME] || {};
+  const { installState: nhcInstallState } = operatorDetailsMap?.[NODE_HEALTH_OPERATOR_NAME] || {};
   const { installState: farInstallState } = operatorDetailsMap?.[FENCE_AGENTS_OPERATOR_NAME] || {};
 
   const jointInstallState = getHighAvailabilityInstallState(nhcInstallState, farInstallState);
   const Icon = getInstallStateIcon(jointInstallState);
+  const haTitle = t('High availability');
 
   return (
     <Split className="featured-operator-item" hasGutter>
       <SplitItem>
-        {operatorResourcesLoaded && operatorHubURL ? (
-          <SettingsLink
-            className="featured-operator-item__link-button"
-            isInline={false}
-            to={operatorHubURL}
-          >
-            {t('High availability')}
-          </SettingsLink>
-        ) : (
-          <span className="featured-operator-item__link-button">{t('High availability')}</span>
-        )}
+        <span className="featured-operator-item__title">{haTitle}</span>
+      </SplitItem>
+      <SplitItem className="featured-operator-item__help-icon-container" isFilled>
+        <HelpTextIcon
+          bodyContent={
+            <HelpTextTooltipContent
+              bodyText={t(
+                "The feature's availability is dependent on two required operators to be installed and enabled.",
+              )}
+              linkURL="https://access.redhat.com/articles/7057929"
+              titleText={haTitle}
+            />
+          }
+          helpIconClassName="featured-operator-item__help-icon"
+          position={PopoverPosition.right}
+        />
       </SplitItem>
       <SplitItem className="featured-operator-item__icon-container">
         {operatorResourcesLoaded ? <Icon /> : <IconSkeleton />}

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/LoadBalanceSection/LoadBalanceSection.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/LoadBalanceSection/LoadBalanceSection.tsx
@@ -13,6 +13,7 @@ import {
 } from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/utils';
 import { useVirtualizationFeaturesContext } from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/VirtualizationFeaturesContext/VirtualizationFeaturesContext';
 import DeschedulerSection from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/LoadBalanceSection/components/DeschedulerSection';
+import HelpTextTooltipContent from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/HelpTextTooltipContent/HelpTextTooltipContent';
 
 import IconSkeleton from '../icons/IconSkeleton/IconSkeleton';
 
@@ -21,19 +22,18 @@ import './LoadBalanceSection.scss';
 const LoadBalanceSection: FC = () => {
   const { t } = useKubevirtTranslation();
   const { operatorDetailsMap, operatorResourcesLoaded } = useVirtualizationFeaturesContext();
-  const { installState, operatorHubURL } = operatorDetailsMap?.[DESCHEDULER_OPERATOR_NAME] || {};
+  const { installState } = operatorDetailsMap?.[DESCHEDULER_OPERATOR_NAME] || {};
   const Icon = getInstallStateIcon(installState);
   const isOperatorInstalled = isInstalled(installState);
-  const linkURL = isOperatorInstalled ? DESCHEDULER_OPERATORS_URL : operatorHubURL;
 
   return (
     <ExpandSectionWithCustomToggle
       customContent={
         <Split className="load-balance-section__custom-content">
           <SplitItem className="load-balance-section__operator-hub-link" isFilled>
-            {linkURL && (
-              <SettingsLink showExternalIcon to={linkURL}>
-                {isOperatorInstalled ? t('View Descheduler Operator') : t('View in Operator hub')}
+            {isOperatorInstalled && (
+              <SettingsLink showExternalIcon to={DESCHEDULER_OPERATORS_URL}>
+                {t('View Descheduler Operator')}
               </SettingsLink>
             )}
           </SplitItem>
@@ -41,6 +41,14 @@ const LoadBalanceSection: FC = () => {
             {operatorResourcesLoaded ? <Icon /> : <IconSkeleton />}
           </SplitItem>
         </Split>
+      }
+      helpTextContent={
+        <HelpTextTooltipContent
+          bodyText={t(
+            'Load Aware Descheduler balances VM distribution across the cluster Nodes based on CPU utilization and Node CPU pressure',
+          )}
+          titleText={t('Load balance')}
+        />
       }
       id={CLUSTER_TAB_IDS.loadBalance}
       isIndented


### PR DESCRIPTION
## 📝 Description

Fixes [CNV-74669](https://issues.redhat.com/browse/CNV-74669).

In **Cluster** settings, **Virtualization features** rows used `SettingsLink` to the Operator Hub (Software Catalog), which was easy to mistake for navigation and confusing. This change:

- Renders feature titles (COO, Network observability, NMState, High availability) as plain text.
- Adds a help (`?`) popover per row with the same explanatory copy as the configure wizard (and the existing "Read more" link for high availability).
- For **Load balance**, adds help on the section toggle and removes **View in Operator hub** when the operator is not installed; **View Descheduler Operator** remains when installed (CSV view under `/k8s/...`, not the catalog).

`lint-staged` ran `npm run i18n`; any locale updates from that are included.

## 🎥 Demo

**BEFORE**


https://github.com/user-attachments/assets/6dd123d2-6406-4d18-baef-fe1dd9d7ca9e



**AFTER**



Made with [Cursor](https://cursor.com)

https://github.com/user-attachments/assets/8ea81e3c-78ea-471c-bffa-128dbebdd5f3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual help tooltips to operator feature items in the cluster virtualization settings section, including cluster observability, network observability, host network management, high availability, and load balance features.

* **Style**
  * Updated styling for help icon containers to ensure proper alignment and spacing in the virtualization features interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->