### PR TITLE
[release-4.20] CNV-82198: cluster-wide VM list when namespace unset 

### DIFF
--- a/src/multicluster/hooks/useK8sWatchData.ts
+++ b/src/multicluster/hooks/useK8sWatchData.ts
@@ -24,7 +24,10 @@ const useK8sWatchData = <T>(resource: FleetWatchK8sResource | null): WatchK8sRes
     useFleet ? null : resource,
   );
 
-  const defaultData: T = useMemo(() => (resource?.isList ? ([] as T) : undefined), [resource]);
+  const defaultData: T = useMemo(
+    () => (resource?.isList ? ([] as T) : undefined),
+    [resource?.isList],
+  );
 
   if (!resource || isEmpty(resource) || isEmpty(resource?.groupVersionKind))
     return [undefined, true, undefined];

--- a/src/multicluster/hooks/useKubevirtSearchPoll.ts
+++ b/src/multicluster/hooks/useKubevirtSearchPoll.ts
@@ -1,4 +1,4 @@
-import { WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
+import { K8sResourceCommon, WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
 import {
   AdvancedSearchFilter,
   SearchResult,
@@ -6,7 +6,7 @@ import {
 } from '@stolostron/multicluster-sdk';
 
 const useKubevirtSearchPoll = <T extends K8sResourceCommon | K8sResourceCommon[]>(
-  watchOptions: WatchK8sResource,
+  watchOptions: null | WatchK8sResource,
   advancedSearchFilters?: AdvancedSearchFilter,
   pollInterval?: false | number,
 ): [SearchResult<T>, boolean, Error, () => void] => {

--- a/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPod.ts
+++ b/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPod.ts
@@ -19,14 +19,14 @@ import {
 import useKubevirtDataPodFilters from './useKubevirtDataPodFilters';
 
 type UseKubevirtDataPod = <T extends K8sResourceCommon | K8sResourceCommon[]>(
-  watchOptions: WatchK8sResource,
+  watchOptions: null | WatchK8sResource,
   filterOptions?: { [key: string]: string },
 ) => [T, boolean, Error];
 
 const nullResponse: [undefined, boolean, Error] = [undefined, false, null];
 
 const useKubevirtDataPod: UseKubevirtDataPod = <T extends K8sResourceCommon | K8sResourceCommon[]>(
-  watchOptions: WatchK8sResource,
+  watchOptions: null | WatchK8sResource,
   filterOptions?: { [key: string]: string },
 ) => {
   const [data, setData] = useState<T>((<unknown>[]) as T);
@@ -34,9 +34,10 @@ const useKubevirtDataPod: UseKubevirtDataPod = <T extends K8sResourceCommon | K8
   const [error, setError] = useState<Error>(null);
   const [resourceVersion, setResourceVersion] = useState<string>(null);
   const query = useKubevirtDataPodFilters(filterOptions);
-  const watchOptionsMemoized = useDeepCompareMemoize<WatchK8sResource>(watchOptions, true);
+  const watchOptionsMemoized = useDeepCompareMemoize<null | WatchK8sResource>(watchOptions, true);
   const url = useMemo(
-    () => constructURL(watchOptionsMemoized, query),
+    () =>
+      watchOptionsMemoized?.groupVersionKind?.kind ? constructURL(watchOptionsMemoized, query) : '',
     [query, watchOptionsMemoized],
   );
   const [shouldConnect, setShouldConnect] = useState<boolean>(false);
@@ -54,10 +55,14 @@ const useKubevirtDataPod: UseKubevirtDataPod = <T extends K8sResourceCommon | K8
       },
       share: true,
     },
-    shouldConnect && Boolean(resourceVersion),
+    shouldConnect &&
+      Boolean(resourceVersion) &&
+      Boolean(watchOptionsMemoized?.groupVersionKind?.kind),
   );
   useEffect(() => {
     const fetch = async () => {
+      if (!watchOptionsMemoized?.groupVersionKind?.kind) return;
+
       setLoaded(false);
       try {
         const response = await consoleFetch(url);

--- a/src/utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource.ts
+++ b/src/utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource.ts
@@ -17,7 +17,7 @@ export type Result<R extends K8sResourceCommon | K8sResourceCommon[]> = [
 ];
 
 const useKubevirtWatchResource = <T extends K8sResourceCommon | K8sResourceCommon[]>(
-  watchOptions: WatchK8sResource & { cluster?: string },
+  watchOptions: null | (WatchK8sResource & { cluster?: string }),
   filterOptions?: { [key: string]: string },
   searchQueries?: AdvancedSearchFilter,
 ): Result<T> => {

--- a/src/utils/hooks/useKubevirtWatchResource/useRedirectWatchHooks.ts
+++ b/src/utils/hooks/useKubevirtWatchResource/useRedirectWatchHooks.ts
@@ -1,10 +1,9 @@
 import { useMemo } from 'react';
 
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import useKubevirtSearchPoll from '@multicluster/hooks/useKubevirtSearchPoll';
 import useIsACMPage from '@multicluster/useIsACMPage';
-import { WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
+import { K8sResourceCommon, WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
 import { AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
 
 import useKubevirtDataPod from '../useKubevirtDataPod/useKubevirtDataPod';
@@ -12,24 +11,33 @@ import useKubevirtDataPod from '../useKubevirtDataPod/useKubevirtDataPod';
 import { Result } from './useKubevirtWatchResource';
 
 const useRedirectWatchHooks = <T extends K8sResourceCommon | K8sResourceCommon[]>(
-  watchOptions: WatchK8sResource & { cluster?: string },
+  watchOptions: null | (WatchK8sResource & { cluster?: string }),
   filterOptions?: { [key: string]: string },
   searchQueries?: AdvancedSearchFilter,
   shouldUseProxyPod?: boolean,
 ): Result<T> => {
   const isACMTreeView = useIsACMPage();
 
-  const useMulticlusterSearch = isACMTreeView && isEmpty(watchOptions?.cluster);
+  const useMulticlusterSearch = useMemo(() => {
+    if (!isACMTreeView || !watchOptions) return false;
+    const cluster = watchOptions.cluster;
+    return cluster === undefined || cluster === '';
+  }, [isACMTreeView, watchOptions]);
 
   const usePod = shouldUseProxyPod && !isACMTreeView;
 
+  const multiSearchWatchOptions = useMemo(
+    () => (!usePod && useMulticlusterSearch ? watchOptions : null),
+    [usePod, useMulticlusterSearch, watchOptions],
+  );
+
   const k8sWatch = useK8sWatchData<T>(!usePod && !useMulticlusterSearch ? watchOptions : null);
   const [multiSearchData, multiSearchLoaded, multiSearchError] = useKubevirtSearchPoll<T>(
-    !usePod && useMulticlusterSearch && watchOptions,
+    multiSearchWatchOptions,
     searchQueries,
   );
 
-  const kubevirtPodWatch = useKubevirtDataPod<T>(usePod ? watchOptions : {}, filterOptions);
+  const kubevirtPodWatch = useKubevirtDataPod<T>(usePod ? watchOptions : null, filterOptions);
 
   return useMemo(() => {
     const defaultData: T = watchOptions?.isList ? ([] as T) : undefined;

--- a/src/utils/hooks/usePVCMapper.ts
+++ b/src/utils/hooks/usePVCMapper.ts
@@ -10,7 +10,7 @@ import { convertIntoPVCMapper } from '@virtualmachines/utils/mappers';
 
 import useKubevirtWatchResource from './useKubevirtWatchResource/useKubevirtWatchResource';
 
-export const usePVCMapper = (namespace: string, cluster?: string) => {
+export const usePVCMapper = (namespace: string | undefined, cluster?: string) => {
   const [pvcs] = useKubevirtWatchResource<IoK8sApiCoreV1PersistentVolumeClaim[]>({
     cluster,
     groupVersionKind: modelToGroupVersionKind(PersistentVolumeClaimModel),

--- a/src/utils/resources/vmim/hooks/useVirtualMachineInstanceMigrations.ts
+++ b/src/utils/resources/vmim/hooks/useVirtualMachineInstanceMigrations.ts
@@ -1,0 +1,37 @@
+import { VirtualMachineInstanceMigrationModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import { V1VirtualMachineInstanceMigration } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
+import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
+import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils/constants';
+
+const useVirtualMachineInstanceMigrations = (cluster?: string, namespace?: string) => {
+  const [namespacedVMIMs, namespacedVMIMsLoaded, namespacedVMIMsLoadError] =
+    useKubevirtWatchResource<V1VirtualMachineInstanceMigration[]>(
+      namespace
+        ? {
+            cluster,
+            groupVersionKind: VirtualMachineInstanceMigrationModelGroupVersionKind,
+            isList: true,
+            limit: OBJECTS_FETCHING_LIMIT,
+            namespace,
+            namespaced: true,
+          }
+        : null,
+    );
+
+  const {
+    loaded: accessibleVMIMsLoaded,
+    loadError: accessibleVMIMsError,
+    resources: accessibleVMIMs,
+  } = useAccessibleResources<V1VirtualMachineInstanceMigration>(
+    VirtualMachineInstanceMigrationModelGroupVersionKind,
+  );
+
+  const vmims = namespace ? namespacedVMIMs : accessibleVMIMs;
+  const loaded = namespace ? namespacedVMIMsLoaded : accessibleVMIMsLoaded;
+  const loadError = namespace ? namespacedVMIMsLoadError : accessibleVMIMsError;
+
+  return [vmims || [], loaded, loadError] as const;
+};
+
+export default useVirtualMachineInstanceMigrations;

--- a/src/utils/resources/vmim/hooks/useVirtualMachineInstanceMigrations.ts
+++ b/src/utils/resources/vmim/hooks/useVirtualMachineInstanceMigrations.ts
@@ -25,6 +25,7 @@ const useVirtualMachineInstanceMigrations = (cluster?: string, namespace?: strin
     resources: accessibleVMIMs,
   } = useAccessibleResources<V1VirtualMachineInstanceMigration>(
     VirtualMachineInstanceMigrationModelGroupVersionKind,
+    { cluster },
   );
 
   const vmims = namespace ? namespacedVMIMs : accessibleVMIMs;

--- a/src/views/search/components/AdvancedSearchModal/formFields/NodesField.tsx
+++ b/src/views/search/components/AdvancedSearchModal/formFields/NodesField.tsx
@@ -13,7 +13,7 @@ const NodesField: FC = () => {
   const { t } = useKubevirtTranslation();
   const { setValue, value } = useAdvancedSearchField(VirtualMachineRowFilterType.Node);
 
-  const vmiMapper = useVirtualMachineInstanceMapper();
+  const { vmiMapper } = useVirtualMachineInstanceMapper();
   const nodesFilter = useNodesFilter(vmiMapper);
 
   const allNodes = nodesFilter.items.map((node) => node.id);

--- a/src/views/search/components/SearchBar.tsx
+++ b/src/views/search/components/SearchBar.tsx
@@ -31,12 +31,10 @@ import SaveSearchModal from './SaveSearchModal';
 import './search-bar.scss';
 
 type SearchBarProps = {
-  cluster?: string;
-  namespace?: null | string;
   onFilterChange: OnFilterChange;
 };
 
-const SearchBar: FC<SearchBarProps> = ({ cluster, namespace = null, onFilterChange }) => {
+const SearchBar: FC<SearchBarProps> = ({ onFilterChange }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
 
@@ -46,10 +44,7 @@ const SearchBar: FC<SearchBarProps> = ({ cluster, namespace = null, onFilterChan
   const searchInputRef = useRef<HTMLInputElement>();
   const searchSuggestBoxRef = useRef<HTMLDivElement>();
 
-  const { vmis, vmisLoaded, vms, vmsLoaded } = useVirtualMachineSearchSuggestionResources({
-    cluster,
-    namespace: namespace ?? null,
-  });
+  const { vmis, vmisLoaded, vms, vmsLoaded } = useVirtualMachineSearchSuggestionResources();
 
   const [vmSuggestions, vmSuggestionsLoaded] = useVirtualMachineSearchSuggestions({
     searchQuery,

--- a/src/views/search/components/SearchBar.tsx
+++ b/src/views/search/components/SearchBar.tsx
@@ -16,6 +16,7 @@ import {
 } from '@patternfly/react-core';
 import SlidersHIcon from '@patternfly/react-icons/dist/esm/icons/sliders-h-icon';
 import { SearchSuggestResult } from '@search/utils/types';
+import { useVirtualMachineSearchSuggestionResources } from '@virtualmachines/search/hooks/useVirtualMachineSearchSuggestionResources';
 import { useVirtualMachineSearchSuggestions } from '@virtualmachines/search/hooks/useVirtualMachineSearchSuggestions';
 
 import { useNavigateToSearchResults } from '../hooks/useNavigateToSearchResults';
@@ -30,10 +31,12 @@ import SaveSearchModal from './SaveSearchModal';
 import './search-bar.scss';
 
 type SearchBarProps = {
+  cluster?: string;
+  namespace?: null | string;
   onFilterChange: OnFilterChange;
 };
 
-const SearchBar: FC<SearchBarProps> = ({ onFilterChange }) => {
+const SearchBar: FC<SearchBarProps> = ({ cluster, namespace = null, onFilterChange }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
 
@@ -43,7 +46,18 @@ const SearchBar: FC<SearchBarProps> = ({ onFilterChange }) => {
   const searchInputRef = useRef<HTMLInputElement>();
   const searchSuggestBoxRef = useRef<HTMLDivElement>();
 
-  const [vmSuggestions, vmSuggestionsLoaded] = useVirtualMachineSearchSuggestions(searchQuery);
+  const { vmis, vmisLoaded, vms, vmsLoaded } = useVirtualMachineSearchSuggestionResources({
+    cluster,
+    namespace: namespace ?? null,
+  });
+
+  const [vmSuggestions, vmSuggestionsLoaded] = useVirtualMachineSearchSuggestions({
+    searchQuery,
+    vmis,
+    vmisLoaded,
+    vms,
+    vmsLoaded,
+  });
   const navigateToSearchResults = useNavigateToSearchResults(onFilterChange);
   const { saveSearch, urlSearchQuery } = useSavedSearchData();
 

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -115,10 +115,10 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
     loaded: accessibleVMsLoaded,
     loadError: accessibleVMsLoadError,
     resources: accessibleVMs,
-  } = useAccessibleResources<V1VirtualMachine>(
-    VirtualMachineModelGroupVersionKind,
-    VM_FILTER_OPTIONS,
-  );
+  } = useAccessibleResources<V1VirtualMachine>(VirtualMachineModelGroupVersionKind, {
+    cluster,
+    filterOptions: VM_FILTER_OPTIONS,
+  });
 
   const vms = namespace ? namespacedVMs : accessibleVMs;
   const vmsLoaded = namespace ? namespacedVMsLoaded : accessibleVMsLoaded;
@@ -133,6 +133,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
   const { filtersWithSelect, hiddenFilters, vmiMapper, vmimMapper, vmisLoaded } = useVMListFilters(
     vmims,
     pvcMapper,
+    cluster,
   );
 
   const vmisForSummary = useMemo(

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -10,16 +10,10 @@ import React, {
 } from 'react';
 
 import {
-  VirtualMachineInstanceMigrationModelGroupVersionKind,
-  VirtualMachineInstanceModelGroupVersionKind,
   VirtualMachineModelGroupVersionKind,
   VirtualMachineModelRef,
 } from '@kubevirt-ui/kubevirt-api/console';
-import {
-  V1VirtualMachine,
-  V1VirtualMachineInstance,
-  V1VirtualMachineInstanceMigration,
-} from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import ColumnManagement from '@kubevirt-utils/components/ColumnManagementModal/ColumnManagement';
 import { tourGuideVM } from '@kubevirt-utils/components/GuidedTour/utils/constants';
 import { runningTourSignal } from '@kubevirt-utils/components/GuidedTour/utils/guidedTourSignals';
@@ -39,6 +33,7 @@ import { usePVCMapper } from '@kubevirt-utils/hooks/usePVCMapper';
 import useQuery from '@kubevirt-utils/hooks/useQuery';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getName } from '@kubevirt-utils/resources/shared';
+import useVirtualMachineInstanceMigrations from '@kubevirt-utils/resources/vmim/hooks/useVirtualMachineInstanceMigrations';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { getCatalogURL } from '@multicluster/urls';
@@ -51,6 +46,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { Flex, Pagination } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
+import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
 import { VMSearchQueries } from '@virtualmachines/search/hooks/useVMSearchQueries';
 import VirtualMachineFilterToolbar from '@virtualmachines/search/VirtualMachineFilterToolbar';
 import { vmsSignal } from '@virtualmachines/tree/utils/signals';
@@ -69,6 +65,7 @@ import useFiltersFromURL from './hooks/useFiltersFromURL';
 import useVirtualMachineColumns from './hooks/useVirtualMachineColumns';
 import { useVMListFilters } from './hooks/useVMListFilters/useVMListFilters';
 import useVMMetrics from './hooks/useVMMetrics';
+import { VM_FILTER_OPTIONS } from './utils/constants';
 import { filterVMsByClusterAndNamespace } from './utils/utils';
 import { getListPageBodySize, ListPageBodySize } from './listPageBodySize';
 import { deselectAllVMs } from './selectedVMs';
@@ -80,7 +77,7 @@ type VirtualMachinesListProps = {
   allVMsLoaded?: boolean;
   cluster?: string;
   kind: string;
-  namespace: string;
+  namespace: null | string;
   searchQueries?: VMSearchQueries;
 } & RefAttributes<ExposedFilterFunctions | null>;
 
@@ -97,56 +94,50 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
 
   const query = useQuery();
 
-  const [vms, vmsLoaded, loadError] = useKubevirtWatchResource<V1VirtualMachine[]>(
-    {
-      cluster,
-      groupVersionKind: VirtualMachineModelGroupVersionKind,
-      isList: true,
-      limit: OBJECTS_FETCHING_LIMIT,
-      namespace,
-      namespaced: true,
-    },
-    {
-      labels: 'metadata.labels',
-      name: 'metadata.name',
-      'rowFilter-os': 'spec.template.metadata.annotations.vm\\.kubevirt\\.io/os',
-      'rowFilter-status': 'status.printableStatus',
-    },
+  const [namespacedVMs, namespacedVMsLoaded, namespacedVMsLoadError] = useKubevirtWatchResource<
+    V1VirtualMachine[]
+  >(
+    namespace
+      ? {
+          cluster,
+          groupVersionKind: VirtualMachineModelGroupVersionKind,
+          isList: true,
+          limit: OBJECTS_FETCHING_LIMIT,
+          namespace,
+          namespaced: true,
+        }
+      : null,
+    VM_FILTER_OPTIONS,
     searchQueries?.vmQueries,
   );
 
-  const vmsToShow = useMemo(() => (runningTourSignal.value ? [tourGuideVM] : vms), [vms]);
-
-  const [vmis, vmisLoaded] = useKubevirtWatchResource<V1VirtualMachineInstance[]>(
-    {
-      cluster,
-      groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
-      isList: true,
-      limit: OBJECTS_FETCHING_LIMIT,
-      namespace,
-      namespaced: true,
-    },
-    {
-      ip: 'status.interfaces',
-      'rowFilter-node': 'status.nodeName',
-    },
-    searchQueries?.vmiQueries,
+  const {
+    loaded: accessibleVMsLoaded,
+    loadError: accessibleVMsLoadError,
+    resources: accessibleVMs,
+  } = useAccessibleResources<V1VirtualMachine>(
+    VirtualMachineModelGroupVersionKind,
+    VM_FILTER_OPTIONS,
   );
 
-  const pvcMapper = usePVCMapper(namespace, cluster);
+  const vms = namespace ? namespacedVMs : accessibleVMs;
+  const vmsLoaded = namespace ? namespacedVMsLoaded : accessibleVMsLoaded;
+  const vmsLoadError = namespace ? namespacedVMsLoadError : accessibleVMsLoadError;
 
-  const [vmims, vmimsLoaded] = useKubevirtWatchResource<V1VirtualMachineInstanceMigration[]>({
-    cluster,
-    groupVersionKind: VirtualMachineInstanceMigrationModelGroupVersionKind,
-    isList: true,
-    limit: OBJECTS_FETCHING_LIMIT,
-    namespace,
-    namespaced: true,
-  });
+  const vmsToShow = useMemo(() => (runningTourSignal.value ? [tourGuideVM] : vms), [vms]);
 
-  const { filtersWithSelect, hiddenFilters, vmiMapper, vmimMapper } = useVMListFilters(
+  const pvcMapper = usePVCMapper(namespace ?? undefined, cluster);
+
+  const [vmims, vmimsLoaded] = useVirtualMachineInstanceMigrations(cluster, namespace || undefined);
+
+  const { filtersWithSelect, hiddenFilters, vmiMapper, vmimMapper, vmisLoaded } = useVMListFilters(
     vmims,
     pvcMapper,
+  );
+
+  const vmisForSummary = useMemo(
+    () => (vmsToShow || []).map((vm) => getVMIFromMapper(vmiMapper, vm)).filter(Boolean),
+    [vmsToShow, vmiMapper],
   );
 
   const filtersFromURL = useFiltersFromURL([...filtersWithSelect, ...hiddenFilters]);
@@ -196,7 +187,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
   };
 
   const [columns, activeColumns, loadedColumns] = useVirtualMachineColumns(
-    namespace,
+    namespace ?? '',
     pagination,
     filteredVMs,
     vmiMapper,
@@ -222,9 +213,9 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
       <DocumentTitle>{PageTitles.VirtualMachines}</DocumentTitle>
       {!isSearchResultsPage && (
         <VirtualMachineListSummary
-          namespace={namespace}
+          namespace={namespace ?? ''}
           onFilterChange={onFilterChange}
-          vmis={vmis}
+          vmis={vmisForSummary}
           vms={allVMs}
         />
       )}
@@ -301,7 +292,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = forwardRef((props, ref
                 columns={activeColumns}
                 data={paginatedVMs}
                 loaded={loaded}
-                loadError={loadError}
+                loadError={vmsLoadError}
                 Row={VirtualMachineRow}
                 unfilteredData={vmsToShow}
               />

--- a/src/views/virtualmachines/list/hooks/useVMListFilters/useVMListFilters.ts
+++ b/src/views/virtualmachines/list/hooks/useVMListFilters/useVMListFilters.ts
@@ -36,8 +36,9 @@ export const useVMListFilters = (
   hiddenFilters: RowFilter<V1VirtualMachine>[];
   vmiMapper: VMIMapper;
   vmimMapper: VMIMMapper;
+  vmisLoaded: boolean;
 } => {
-  const vmiMapper = useVirtualMachineInstanceMapper();
+  const { vmiMapper, vmisLoaded } = useVirtualMachineInstanceMapper();
 
   const vmimMapper: VMIMMapper = useMemo(() => getLatestMigrationForEachVM(vmims), [vmims]);
 
@@ -86,5 +87,6 @@ export const useVMListFilters = (
     ],
     vmiMapper,
     vmimMapper,
+    vmisLoaded,
   };
 };

--- a/src/views/virtualmachines/list/hooks/useVMListFilters/useVMListFilters.ts
+++ b/src/views/virtualmachines/list/hooks/useVMListFilters/useVMListFilters.ts
@@ -31,6 +31,7 @@ import { useStorageClassFilter } from './useStorageClassFilter';
 export const useVMListFilters = (
   vmims: V1VirtualMachineInstanceMigration[],
   pvcMapper: PVCMapper,
+  cluster?: string,
 ): {
   filtersWithSelect: RowFilter<V1VirtualMachine>[];
   hiddenFilters: RowFilter<V1VirtualMachine>[];
@@ -38,7 +39,7 @@ export const useVMListFilters = (
   vmimMapper: VMIMMapper;
   vmisLoaded: boolean;
 } => {
-  const { vmiMapper, vmisLoaded } = useVirtualMachineInstanceMapper();
+  const { vmiMapper, vmisLoaded } = useVirtualMachineInstanceMapper(cluster);
 
   const vmimMapper: VMIMMapper = useMemo(() => getLatestMigrationForEachVM(vmims), [vmims]);
 

--- a/src/views/virtualmachines/list/hooks/useVirtualMachineInstanceMapper.ts
+++ b/src/views/virtualmachines/list/hooks/useVirtualMachineInstanceMapper.ts
@@ -7,9 +7,10 @@ import { getCluster } from '@multicluster/helpers/selectors';
 import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
 import { VMIMapper } from '@virtualmachines/utils/mappers';
 
-export const useVirtualMachineInstanceMapper = () => {
+export const useVirtualMachineInstanceMapper = (clusterScope?: string) => {
   const { loaded: vmisLoaded, resources: vmis } = useAccessibleResources<V1VirtualMachineInstance>(
     VirtualMachineInstanceModelGroupVersionKind,
+    { cluster: clusterScope },
   );
 
   const vmiMapper: VMIMapper = useMemo(() => {
@@ -17,14 +18,14 @@ export const useVirtualMachineInstanceMapper = () => {
       (acc, vmi) => {
         const name = vmi?.metadata?.name;
         const namespace = vmi?.metadata?.namespace;
-        const cluster = getCluster(vmi) || SINGLE_CLUSTER_KEY;
-        if (!acc.mapper[cluster]) {
-          acc.mapper[cluster] = {};
+        const vmiCluster = getCluster(vmi) || SINGLE_CLUSTER_KEY;
+        if (!acc.mapper[vmiCluster]) {
+          acc.mapper[vmiCluster] = {};
         }
-        if (!acc.mapper[cluster][namespace]) {
-          acc.mapper[cluster][namespace] = {};
+        if (!acc.mapper[vmiCluster][namespace]) {
+          acc.mapper[vmiCluster][namespace] = {};
         }
-        acc.mapper[cluster][namespace][name] = vmi;
+        acc.mapper[vmiCluster][namespace][name] = vmi;
         const nodeName = vmi?.status?.nodeName;
         if (nodeName && !acc?.nodeNames?.[nodeName]) {
           acc.nodeNames[nodeName] = {

--- a/src/views/virtualmachines/list/hooks/useVirtualMachineInstanceMapper.ts
+++ b/src/views/virtualmachines/list/hooks/useVirtualMachineInstanceMapper.ts
@@ -2,16 +2,15 @@ import { useMemo } from 'react';
 
 import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt/models';
-import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
+import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
 import { VMIMapper } from '@virtualmachines/utils/mappers';
 
 export const useVirtualMachineInstanceMapper = () => {
-  const [vmis] = useKubevirtWatchResource<V1VirtualMachineInstance[]>({
-    groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
-    isList: true,
-  });
+  const { loaded: vmisLoaded, resources: vmis } = useAccessibleResources<V1VirtualMachineInstance>(
+    VirtualMachineInstanceModelGroupVersionKind,
+  );
 
   const vmiMapper: VMIMapper = useMemo(() => {
     return (Array.isArray(vmis) ? vmis : [])?.reduce(
@@ -39,5 +38,5 @@ export const useVirtualMachineInstanceMapper = () => {
     );
   }, [vmis]);
 
-  return vmiMapper;
+  return { vmiMapper, vmis, vmisLoaded };
 };

--- a/src/views/virtualmachines/list/utils/constants.ts
+++ b/src/views/virtualmachines/list/utils/constants.ts
@@ -1,0 +1,11 @@
+export const VM_FILTER_OPTIONS = {
+  labels: 'metadata.labels',
+  name: 'metadata.name',
+  'rowFilter-os': 'spec.template.metadata.annotations.vm\\.kubevirt\\.io/os',
+  'rowFilter-status': 'status.printableStatus',
+};
+
+export const VMI_FILTER_OPTIONS = {
+  ip: 'status.interfaces',
+  'rowFilter-node': 'status.nodeName',
+};

--- a/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
+++ b/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
@@ -48,11 +48,7 @@ const VirtualMachineNavigator: FC = () => {
       ) : (
         <>
           <ListPageHeader title={t('VirtualMachines')}>
-            <SearchBar
-              cluster={cluster}
-              namespace={namespace ?? null}
-              onFilterChange={onFilterChange}
-            />
+            <SearchBar onFilterChange={onFilterChange} />
             <div>
               <VirtualMachinesCreateButton namespace={namespace} />
             </div>

--- a/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
+++ b/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
@@ -48,7 +48,11 @@ const VirtualMachineNavigator: FC = () => {
       ) : (
         <>
           <ListPageHeader title={t('VirtualMachines')}>
-            <SearchBar onFilterChange={onFilterChange} />
+            <SearchBar
+              cluster={cluster}
+              namespace={namespace ?? null}
+              onFilterChange={onFilterChange}
+            />
             <div>
               <VirtualMachinesCreateButton namespace={namespace} />
             </div>

--- a/src/views/virtualmachines/search/VirtualMachineSearchResults.tsx
+++ b/src/views/virtualmachines/search/VirtualMachineSearchResults.tsx
@@ -42,7 +42,7 @@ const VirtualMachineSearchResults: FC = () => {
     () => (
       <>
         <ListPageHeader title={t('VirtualMachines')}>
-          <SearchBar cluster={cluster} namespace={namespace} onFilterChange={onFilterChange} />
+          <SearchBar onFilterChange={onFilterChange} />
           <div>
             <VirtualMachinesCreateButton namespace={namespace} />
           </div>

--- a/src/views/virtualmachines/search/VirtualMachineSearchResults.tsx
+++ b/src/views/virtualmachines/search/VirtualMachineSearchResults.tsx
@@ -5,6 +5,7 @@ import { ExposedFilterFunctions } from '@kubevirt-utils/components/ListPageFilte
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VirtualMachineModelRef } from '@kubevirt-utils/models';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import {
   ListPageHeader,
   OnFilterChange,
@@ -24,7 +25,9 @@ const VirtualMachineSearchResults: FC = () => {
 
   const vmSearchQueries = useVMSearchQueries();
 
-  const { cluster } = useParams<{ cluster?: string }>();
+  const { cluster: clusterParam } = useParams<{ cluster?: string }>();
+  const clusterFromHook = useClusterParam();
+  const cluster = clusterParam ?? clusterFromHook;
   const namespace = activeNamespace === ALL_NAMESPACES_SESSION_KEY ? null : activeNamespace;
 
   useHideNamespaceBar();
@@ -39,7 +42,7 @@ const VirtualMachineSearchResults: FC = () => {
     () => (
       <>
         <ListPageHeader title={t('VirtualMachines')}>
-          <SearchBar onFilterChange={onFilterChange} />
+          <SearchBar cluster={cluster} namespace={namespace} onFilterChange={onFilterChange} />
           <div>
             <VirtualMachinesCreateButton namespace={namespace} />
           </div>

--- a/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
+++ b/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
@@ -4,7 +4,6 @@ import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import {
   K8sGroupVersionKind,
@@ -15,10 +14,22 @@ import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils/constants';
 
 type FilterOptions = { [key: string]: string };
 
+export type UseAccessibleResourcesOptions = {
+  /**
+   * Managed cluster to scope the watch. Pass `undefined` for fleet-wide / all-clusters multicluster
+   * search (callers e.g. search UI decide when that applies). This hook does not read the URL.
+   */
+  cluster?: string;
+  filterOptions?: FilterOptions;
+  /**
+   * When non-empty, fleet search uses these cluster names and the watch `cluster` field stays unset.
+   */
+  fleetClusterNames?: string[];
+};
+
 type UseAccessibleResources = <T extends K8sResourceCommon>(
   groupVersionKind: K8sGroupVersionKind,
-  filterOptions?: FilterOptions,
-  clusters?: string[],
+  options?: UseAccessibleResourcesOptions,
 ) => {
   loaded: boolean;
   loadError?: unknown;
@@ -27,28 +38,31 @@ type UseAccessibleResources = <T extends K8sResourceCommon>(
 
 export const useAccessibleResources: UseAccessibleResources = <T extends K8sResourceCommon>(
   groupVersionKind: K8sGroupVersionKind,
-  filterOptions?: FilterOptions,
-  clusters?: string[],
+  options?: UseAccessibleResourcesOptions,
 ) => {
+  const { cluster: clusterScope, filterOptions, fleetClusterNames } = options ?? {};
+
   const isAdmin = useIsAdmin();
   const isACMPage = useIsACMPage();
-  const cluster = useClusterParam();
   const [projectNames, projectNamesLoaded, projectNamesError] = useProjects();
 
   const loadPerNamespace = !isACMPage && projectNamesLoaded && !isAdmin;
 
   const shouldFetchClusterWide = isAdmin || isACMPage;
+  const hasFleetFilter = Boolean(fleetClusterNames?.length);
+  const watchCluster = hasFleetFilter ? undefined : clusterScope;
+
   const [allResources, allResourcesLoaded] = useKubevirtWatchResource<T[]>(
     shouldFetchClusterWide
       ? {
-          cluster: clusters ? undefined : cluster,
+          cluster: watchCluster,
           groupVersionKind,
           isList: true,
           limit: OBJECTS_FETCHING_LIMIT,
         }
       : null,
     filterOptions,
-    clusters ? [{ property: 'cluster', values: clusters }] : null,
+    hasFleetFilter ? [{ property: 'cluster', values: fleetClusterNames }] : null,
   );
 
   const allowedResources = useK8sWatchResources<{ [key: string]: T[] }>(

--- a/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
+++ b/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
@@ -12,6 +12,8 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils/constants';
 
+import useClustersRowFilters from './useClustersRowFilters';
+
 type FilterOptions = { [key: string]: string };
 
 export type UseAccessibleResourcesOptions = {
@@ -21,10 +23,6 @@ export type UseAccessibleResourcesOptions = {
    */
   cluster?: string;
   filterOptions?: FilterOptions;
-  /**
-   * When non-empty, fleet search uses these cluster names and the watch `cluster` field stays unset.
-   */
-  fleetClusterNames?: string[];
 };
 
 type UseAccessibleResources = <T extends K8sResourceCommon>(
@@ -40,7 +38,7 @@ export const useAccessibleResources: UseAccessibleResources = <T extends K8sReso
   groupVersionKind: K8sGroupVersionKind,
   options?: UseAccessibleResourcesOptions,
 ) => {
-  const { cluster: clusterScope, filterOptions, fleetClusterNames } = options ?? {};
+  const { cluster: clusterScope, filterOptions } = options ?? {};
 
   const isAdmin = useIsAdmin();
   const isACMPage = useIsACMPage();
@@ -48,8 +46,9 @@ export const useAccessibleResources: UseAccessibleResources = <T extends K8sReso
 
   const loadPerNamespace = !isACMPage && projectNamesLoaded && !isAdmin;
 
+  const fleetClusterNames = useClustersRowFilters();
   const shouldFetchClusterWide = isAdmin || isACMPage;
-  const hasFleetFilter = Boolean(fleetClusterNames?.length);
+  const hasFleetFilter = Boolean(fleetClusterNames.length);
   const watchCluster = hasFleetFilter ? undefined : clusterScope;
 
   const [allResources, allResourcesLoaded] = useKubevirtWatchResource<T[]>(

--- a/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
+++ b/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
@@ -1,0 +1,84 @@
+import { useMemo } from 'react';
+
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
+import useProjects from '@kubevirt-utils/hooks/useProjects';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import useIsACMPage from '@multicluster/useIsACMPage';
+import {
+  K8sGroupVersionKind,
+  K8sResourceCommon,
+  useK8sWatchResources,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils/constants';
+
+type FilterOptions = { [key: string]: string };
+
+type UseAccessibleResources = <T extends K8sResourceCommon>(
+  groupVersionKind: K8sGroupVersionKind,
+  filterOptions?: FilterOptions,
+  clusters?: string[],
+) => {
+  loaded: boolean;
+  loadError?: unknown;
+  resources: T[];
+};
+
+export const useAccessibleResources: UseAccessibleResources = <T extends K8sResourceCommon>(
+  groupVersionKind: K8sGroupVersionKind,
+  filterOptions?: FilterOptions,
+  clusters?: string[],
+) => {
+  const isAdmin = useIsAdmin();
+  const isACMPage = useIsACMPage();
+  const cluster = useClusterParam();
+  const [projectNames, projectNamesLoaded, projectNamesError] = useProjects();
+
+  const loadPerNamespace = !isACMPage && projectNamesLoaded && !isAdmin;
+
+  const shouldFetchClusterWide = isAdmin || isACMPage;
+  const [allResources, allResourcesLoaded] = useKubevirtWatchResource<T[]>(
+    shouldFetchClusterWide
+      ? {
+          cluster: clusters ? undefined : cluster,
+          groupVersionKind,
+          isList: true,
+          limit: OBJECTS_FETCHING_LIMIT,
+        }
+      : null,
+    filterOptions,
+    clusters ? [{ property: 'cluster', values: clusters }] : null,
+  );
+
+  const allowedResources = useK8sWatchResources<{ [key: string]: T[] }>(
+    Object.fromEntries(
+      loadPerNamespace
+        ? (projectNames || []).map((ns) => [
+            ns,
+            {
+              groupVersionKind,
+              isList: true,
+              namespace: ns,
+            },
+          ])
+        : [],
+    ),
+  );
+
+  const resources = useMemo(() => {
+    const aggregated = loadPerNamespace
+      ? Object.values(allowedResources).flatMap((resource) => resource.data || [])
+      : allResources;
+    return aggregated || [];
+  }, [allResources, allowedResources, loadPerNamespace]);
+
+  const loaded =
+    projectNamesLoaded &&
+    (loadPerNamespace
+      ? isEmpty(allowedResources) ||
+        Object.values(allowedResources).some((resource) => resource.loaded || resource.loadError)
+      : allResourcesLoaded);
+
+  return { loaded, loadError: projectNamesError, resources };
+};

--- a/src/views/virtualmachines/search/hooks/useClustersRowFilters.ts
+++ b/src/views/virtualmachines/search/hooks/useClustersRowFilters.ts
@@ -1,0 +1,13 @@
+import { useSearchParams } from 'react-router-dom-v5-compat';
+
+import { getRowFilterQueryKey } from '@search/utils/query';
+import { VirtualMachineRowFilterType } from '@virtualmachines/utils/constants';
+
+const useClustersRowFilters = () => {
+  const [searchParams] = useSearchParams();
+  const clusters = searchParams.getAll(getRowFilterQueryKey(VirtualMachineRowFilterType.Cluster));
+
+  return clusters;
+};
+
+export default useClustersRowFilters;

--- a/src/views/virtualmachines/search/hooks/useVirtualMachineSearchSuggestionResources.ts
+++ b/src/views/virtualmachines/search/hooks/useVirtualMachineSearchSuggestionResources.ts
@@ -1,0 +1,75 @@
+import {
+  VirtualMachineInstanceModelGroupVersionKind,
+  VirtualMachineModelGroupVersionKind,
+} from '@kubevirt-ui/kubevirt-api/console';
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
+import { VM_FILTER_OPTIONS } from '@virtualmachines/list/utils/constants';
+import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils';
+
+import { useAccessibleResources } from './useAccessibleResources';
+
+type UseVirtualMachineSearchSuggestionResources = (args: {
+  cluster?: string;
+  namespace: null | string;
+}) => {
+  vmis: V1VirtualMachineInstance[];
+  vmisLoaded: boolean;
+  vms: V1VirtualMachine[];
+  vmsLoaded: boolean;
+};
+
+/**
+ * Loads VMs and VMIs for search suggestions using the same scope rules as VirtualMachinesList:
+ * namespaced watch when a namespace is selected; otherwise cluster-wide data via useAccessibleResources
+ * (per-namespace aggregation for non-admins). Avoids cluster-wide namespaced list watches that never
+ * resolve loaded for users who cannot list all namespaces.
+ */
+export const useVirtualMachineSearchSuggestionResources: UseVirtualMachineSearchSuggestionResources =
+  ({ cluster, namespace }) => {
+    const [namespacedVMs, namespacedVMsLoaded] = useKubevirtWatchResource<V1VirtualMachine[]>(
+      namespace
+        ? {
+            cluster,
+            groupVersionKind: VirtualMachineModelGroupVersionKind,
+            isList: true,
+            limit: OBJECTS_FETCHING_LIMIT,
+            namespace,
+            namespaced: true,
+          }
+        : null,
+      VM_FILTER_OPTIONS,
+    );
+
+    const { loaded: accessibleVMsLoaded, resources: accessibleVMs } =
+      useAccessibleResources<V1VirtualMachine>(
+        VirtualMachineModelGroupVersionKind,
+        VM_FILTER_OPTIONS,
+      );
+
+    const vms = namespace ? namespacedVMs : accessibleVMs;
+    const vmsLoaded = namespace ? namespacedVMsLoaded : accessibleVMsLoaded;
+
+    const [namespacedVMIs, namespacedVMIsLoaded] = useKubevirtWatchResource<
+      V1VirtualMachineInstance[]
+    >(
+      namespace
+        ? {
+            cluster,
+            groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
+            isList: true,
+            limit: OBJECTS_FETCHING_LIMIT,
+            namespace,
+            namespaced: true,
+          }
+        : null,
+    );
+
+    const { loaded: accessibleVMIsLoaded, resources: accessibleVMIs } =
+      useAccessibleResources<V1VirtualMachineInstance>(VirtualMachineInstanceModelGroupVersionKind);
+
+    const vmis = namespace ? namespacedVMIs : accessibleVMIs;
+    const vmisLoaded = namespace ? namespacedVMIsLoaded : accessibleVMIsLoaded;
+
+    return { vmis, vmisLoaded, vms, vmsLoaded };
+  };

--- a/src/views/virtualmachines/search/hooks/useVirtualMachineSearchSuggestionResources.ts
+++ b/src/views/virtualmachines/search/hooks/useVirtualMachineSearchSuggestionResources.ts
@@ -3,16 +3,13 @@ import {
   VirtualMachineModelGroupVersionKind,
 } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import useIsACMPage from '@multicluster/useIsACMPage';
 import { VM_FILTER_OPTIONS } from '@virtualmachines/list/utils/constants';
-import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils';
 
 import { useAccessibleResources } from './useAccessibleResources';
 
-type UseVirtualMachineSearchSuggestionResources = (args: {
-  cluster?: string;
-  namespace: null | string;
-}) => {
+type UseVirtualMachineSearchSuggestionResources = () => {
   vmis: V1VirtualMachineInstance[];
   vmisLoaded: boolean;
   vms: V1VirtualMachine[];
@@ -20,56 +17,34 @@ type UseVirtualMachineSearchSuggestionResources = (args: {
 };
 
 /**
- * Loads VMs and VMIs for search suggestions using the same scope rules as VirtualMachinesList:
- * namespaced watch when a namespace is selected; otherwise cluster-wide data via useAccessibleResources
- * (per-namespace aggregation for non-admins). Avoids cluster-wide namespaced list watches that never
- * resolve loaded for users who cannot list all namespaces.
+ * VM search suggestions load accessible VMs/VMIs across namespaces (per-namespace for non-admins on
+ * single-cluster console). On ACM, passes `cluster: undefined` so fleet search includes all managed
+ * clusters; otherwise passes the cluster from the route.
  */
 export const useVirtualMachineSearchSuggestionResources: UseVirtualMachineSearchSuggestionResources =
-  ({ cluster, namespace }) => {
-    const [namespacedVMs, namespacedVMsLoaded] = useKubevirtWatchResource<V1VirtualMachine[]>(
-      namespace
-        ? {
-            cluster,
-            groupVersionKind: VirtualMachineModelGroupVersionKind,
-            isList: true,
-            limit: OBJECTS_FETCHING_LIMIT,
-            namespace,
-            namespaced: true,
-          }
-        : null,
-      VM_FILTER_OPTIONS,
-    );
+  () => {
+    const isACMPage = useIsACMPage();
+    const clusterFromRoute = useClusterParam();
+    const searchCluster = isACMPage ? undefined : clusterFromRoute;
 
     const { loaded: accessibleVMsLoaded, resources: accessibleVMs } =
-      useAccessibleResources<V1VirtualMachine>(
-        VirtualMachineModelGroupVersionKind,
-        VM_FILTER_OPTIONS,
-      );
-
-    const vms = namespace ? namespacedVMs : accessibleVMs;
-    const vmsLoaded = namespace ? namespacedVMsLoaded : accessibleVMsLoaded;
-
-    const [namespacedVMIs, namespacedVMIsLoaded] = useKubevirtWatchResource<
-      V1VirtualMachineInstance[]
-    >(
-      namespace
-        ? {
-            cluster,
-            groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
-            isList: true,
-            limit: OBJECTS_FETCHING_LIMIT,
-            namespace,
-            namespaced: true,
-          }
-        : null,
-    );
+      useAccessibleResources<V1VirtualMachine>(VirtualMachineModelGroupVersionKind, {
+        cluster: searchCluster,
+        filterOptions: VM_FILTER_OPTIONS,
+      });
 
     const { loaded: accessibleVMIsLoaded, resources: accessibleVMIs } =
-      useAccessibleResources<V1VirtualMachineInstance>(VirtualMachineInstanceModelGroupVersionKind);
+      useAccessibleResources<V1VirtualMachineInstance>(
+        VirtualMachineInstanceModelGroupVersionKind,
+        {
+          cluster: searchCluster,
+        },
+      );
 
-    const vmis = namespace ? namespacedVMIs : accessibleVMIs;
-    const vmisLoaded = namespace ? namespacedVMIsLoaded : accessibleVMIsLoaded;
-
-    return { vmis, vmisLoaded, vms, vmsLoaded };
+    return {
+      vmis: accessibleVMIs,
+      vmisLoaded: accessibleVMIsLoaded,
+      vms: accessibleVMs,
+      vmsLoaded: accessibleVMsLoaded,
+    };
   };

--- a/src/views/virtualmachines/search/hooks/useVirtualMachineSearchSuggestions.ts
+++ b/src/views/virtualmachines/search/hooks/useVirtualMachineSearchSuggestions.ts
@@ -1,38 +1,33 @@
 import { useMemo } from 'react';
 
-import {
-  VirtualMachineInstanceModelGroupVersionKind,
-  VirtualMachineModelGroupVersionKind,
-} from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import { getAnnotation, getLabels, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getVMIIPAddresses } from '@kubevirt-utils/resources/vmi/utils/ips';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { SearchSuggestResult } from '@search/utils/types';
-import { compareCIDR, OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils';
+import { compareCIDR } from '@virtualmachines/utils';
 
-type UseVirtualMachineSearchSuggestions = (
-  searchQuery: string,
-) => [result: SearchSuggestResult, loaded: boolean];
-
-export const useVirtualMachineSearchSuggestions: UseVirtualMachineSearchSuggestions = (
+type UseVirtualMachineSearchSuggestions = ({
   searchQuery,
-) => {
-  const [vms, vmsLoaded] = useKubevirtWatchResource<V1VirtualMachine[]>({
-    groupVersionKind: VirtualMachineModelGroupVersionKind,
-    isList: true,
-    limit: OBJECTS_FETCHING_LIMIT,
-    namespaced: true,
-  });
+  vmis,
+  vmisLoaded,
+  vms,
+  vmsLoaded,
+}: {
+  searchQuery: string;
+  vmis: V1VirtualMachineInstance[];
+  vmisLoaded: boolean;
+  vms: V1VirtualMachine[];
+  vmsLoaded: boolean;
+}) => [result: SearchSuggestResult, loaded: boolean];
 
-  const [vmis, vmisLoaded] = useKubevirtWatchResource<V1VirtualMachineInstance[]>({
-    groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
-    isList: true,
-    limit: OBJECTS_FETCHING_LIMIT,
-    namespaced: true,
-  });
-
+export const useVirtualMachineSearchSuggestions: UseVirtualMachineSearchSuggestions = ({
+  searchQuery,
+  vmis,
+  vmisLoaded,
+  vms,
+  vmsLoaded,
+}) => {
   const vmsToSuggest = useMemo<V1VirtualMachine[]>(
     () =>
       vmsLoaded


### PR DESCRIPTION
## Description

Backport of the main-branch Virtual Machines list behavior for **all-namespaces** and **RBAC**-correct loading on **release-4.20**.

When `namespace` is unset (e.g. advanced search / all projects), the list no longer issues invalid namespaced watches. VMs and VM instance migrations load via `useAccessibleResources` (cluster-wide for admin/ACM, per-project watches for non-admin). VMI data for the list summary is derived from visible VMs and the shared VMI mapper.

Also aligns watch/proxy helpers with main: nullable `useKubevirtWatchResource` options, safer `useKubevirtDataPod` / multicluster search wiring, and `usePVCMapper` accepting `namespace | undefined`.

**Jira:** https://issues.redhat.com/browse/CNV-82198

## Demo

DEMO

https://github.com/user-attachments/assets/0711ec81-4b95-4672-b9cb-e3e05d586ccd


---

Thanks for creating a Pull Request.

- PRs that add new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)

Made with [Cursor](https://cursor.com)