### PR TITLE
CNV-82389: display correct cancel option in menu depending on migration type

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -351,6 +351,7 @@
   "Cancel compute migration": "Cancel compute migration",
   "Cancel error": "Cancel error",
   "Cancel migration": "Cancel migration",
+  "Cancel storage migration": "Cancel storage migration",
   "Cancel upload": "Cancel upload",
   "Cancel Upload": "Cancel Upload",
   "Canceled": "Canceled",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -361,6 +361,7 @@
   "Cancel compute migration": "Cancelar migración de cálculo",
   "Cancel error": "Error al momento de cancelar",
   "Cancel migration": "Cancelar migración",
+  "Cancel storage migration": "Cancel storage migration",
   "Cancel upload": "Cancelar carga",
   "Cancel Upload": "Cancelar carga",
   "Canceled": "Cancelado",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -361,6 +361,7 @@
   "Cancel compute migration": "Annuler la migration du calcul",
   "Cancel error": "Erreur lors de l’annulation",
   "Cancel migration": "Annuler la migration",
+  "Cancel storage migration": "Cancel storage migration",
   "Cancel upload": "Annuler le téléchargement",
   "Cancel Upload": "Annuler le téléchargement",
   "Canceled": "Annulé",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -348,6 +348,7 @@
   "Cancel compute migration": "コンピュート移行のキャンセル",
   "Cancel error": "キャンセルエラー",
   "Cancel migration": "移行のキャンセル",
+  "Cancel storage migration": "Cancel storage migration",
   "Cancel upload": "アップロードのキャンセル",
   "Cancel Upload": "アップロードのキャンセル",
   "Canceled": "キャンセルしました",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -348,6 +348,7 @@
   "Cancel compute migration": "컴퓨팅 마이그레이션 취소",
   "Cancel error": "취소 오류",
   "Cancel migration": "마이그레이션 취소",
+  "Cancel storage migration": "Cancel storage migration",
   "Cancel upload": "업로드 취소",
   "Cancel Upload": "업로드 취소",
   "Canceled": "취소됨",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -348,6 +348,7 @@
   "Cancel compute migration": "取消计算迁移",
   "Cancel error": "取消错误",
   "Cancel migration": "取消迁移",
+  "Cancel storage migration": "Cancel storage migration",
   "Cancel upload": "取消上传",
   "Cancel Upload": "取消上传",
   "Canceled": "取消",

--- a/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
@@ -25,6 +25,7 @@ import {
   VirtualMachineInstanceSubresourcesModel,
   VirtualMachineSubresourcesModel,
 } from '@kubevirt-utils/models';
+import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
 import { asAccessReview, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getVMSSHSecretName } from '@kubevirt-utils/resources/vm';
 import {
@@ -58,6 +59,7 @@ import DeleteVMModal from './components/DeleteVMModal/DeleteVMModal';
 import { ACTIONS_ID } from './hooks/constants';
 import {
   cancelMigration,
+  cancelStorageMigrationPlan,
   pauseVM,
   resetVM,
   restartVM,
@@ -96,6 +98,26 @@ export const createVirtualMachineActionFactory = (t: TFunction) => ({
       disabled: !vmim || !!vmim?.metadata?.deletionTimestamp,
       id: 'vm-action-cancel-migrate',
       label: t('Cancel compute migration'),
+    };
+  },
+  cancelStorageMigration: (
+    vm: V1VirtualMachine,
+    storageMigrationPlan: MultiNamespaceVirtualMachineStorageMigrationPlan,
+  ): ActionDropdownItemType => {
+    return {
+      accessReview: {
+        cluster: getCluster(vm),
+        group: MultiNamespaceVirtualMachineStorageMigrationPlanModel.apiGroup,
+        namespace: getNamespace(vm),
+        resource: MultiNamespaceVirtualMachineStorageMigrationPlanModel.plural,
+        verb: 'delete',
+      },
+      cta: () => cancelStorageMigrationPlan(vm, storageMigrationPlan),
+      description:
+        !!storageMigrationPlan?.metadata?.deletionTimestamp && t('Canceling ongoing migration'),
+      disabled: !storageMigrationPlan || !!storageMigrationPlan?.metadata?.deletionTimestamp,
+      id: 'vm-action-cancel-storage-migrate',
+      label: t('Cancel storage migration'),
     };
   },
   clone: (

--- a/src/views/virtualmachines/actions/actions.ts
+++ b/src/views/virtualmachines/actions/actions.ts
@@ -8,6 +8,8 @@ import {
   V1VirtualMachine,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { MultiNamespaceVirtualMachineStorageMigrationPlanModel } from '@kubevirt-utils/models';
+import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
 import { getRandomChars, kubevirtConsole, truncateToK8sName } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import {
@@ -110,6 +112,17 @@ export const cancelMigration = async (vmim: V1VirtualMachineInstanceMigration) =
     cluster: vmim?.cluster,
     model: VirtualMachineInstanceMigrationModel,
     resource: vmim,
+  });
+};
+
+export const cancelStorageMigrationPlan = async (
+  vm: V1VirtualMachine,
+  plan: MultiNamespaceVirtualMachineStorageMigrationPlan,
+) => {
+  await kubevirtK8sDelete({
+    cluster: getCluster(vm),
+    model: MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+    resource: plan,
   });
 };
 

--- a/src/views/virtualmachines/actions/hooks/useActiveVMStorageMigrationPlan.ts
+++ b/src/views/virtualmachines/actions/hooks/useActiveVMStorageMigrationPlan.ts
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+
+import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  modelToGroupVersionKind,
+  MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+} from '@kubevirt-utils/models';
+import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
+import { isMigrationCompleted } from '@kubevirt-utils/resources/migrations/utils';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getCluster } from '@multicluster/helpers/selectors';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+
+const useActiveVMStorageMigrationPlan = (
+  vm: V1VirtualMachine,
+): MultiNamespaceVirtualMachineStorageMigrationPlan | null => {
+  const namespace = getNamespace(vm);
+  const vmName = getName(vm);
+
+  const [storageMigPlans] = useK8sWatchData<MultiNamespaceVirtualMachineStorageMigrationPlan[]>(
+    vm && {
+      cluster: getCluster(vm),
+      groupVersionKind: modelToGroupVersionKind(
+        MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+      ),
+      isList: true,
+      namespace,
+      namespaced: true,
+    },
+  );
+
+  return useMemo(() => {
+    if (!storageMigPlans || !vmName) return null;
+
+    return (
+      storageMigPlans.find((plan) => {
+        if (plan?.metadata?.deletionTimestamp) return false;
+        if (isMigrationCompleted(plan)) return false;
+
+        return plan?.spec?.namespaces?.some(
+          (ns) =>
+            ns?.name === namespace &&
+            ns?.virtualMachines?.some((vmSpec) => vmSpec?.name === vmName),
+        );
+      }) ?? null
+    );
+  }, [storageMigPlans, vmName, namespace]);
+};
+
+export default useActiveVMStorageMigrationPlan;

--- a/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
+++ b/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
@@ -21,6 +21,7 @@ import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 import { printableVMStatus } from '../../utils';
 import { createVirtualMachineActionFactory } from '../VirtualMachineActionFactory';
 
+import useActiveVMStorageMigrationPlan from './useActiveVMStorageMigrationPlan';
 import useIsMTVInstalled from './useIsMTVInstalled';
 
 type UseVirtualMachineActionsProvider = (
@@ -36,6 +37,8 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, 
   const virtctlCommand = getConsoleVirtctlCommand(vm);
 
   const [mtvInstalled] = useIsMTVInstalled();
+
+  const activeStorageMigrationPlan = useActiveVMStorageMigrationPlan(vm);
 
   const acmActions = useACMExtensionActions(vm);
 
@@ -63,7 +66,9 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, 
     const currentMigrationExist =
       vmim && ![vmimStatuses.Failed, vmimStatuses.Succeeded].includes(vmim?.status?.phase);
 
-    const isComputeMigration = printableStatus === Migrating || currentMigrationExist;
+    const isStorageMigration = !!activeStorageMigrationPlan;
+    const isComputeMigration =
+      !isStorageMigration && (printableStatus === Migrating || !!currentMigrationExist);
 
     const startOrStop = ((printableStatusMachine) => {
       const map = {
@@ -85,9 +90,14 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, 
       startMigrationActions.unshift(crossClusterMigration);
     }
 
-    const migrationActions = isComputeMigration
-      ? [VirtualMachineActionFactory.cancelComputeMigration(vm, vmim)]
-      : startMigrationActions;
+    let migrationActions = startMigrationActions;
+    if (isComputeMigration) {
+      migrationActions = [VirtualMachineActionFactory.cancelComputeMigration(vm, vmim)];
+    } else if (isStorageMigration) {
+      migrationActions = [
+        VirtualMachineActionFactory.cancelStorageMigration(vm, activeStorageMigrationPlan),
+      ];
+    }
 
     const pauseOrUnpause =
       printableStatus === Paused
@@ -118,6 +128,7 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, 
   }, [
     vm,
     vmim,
+    activeStorageMigrationPlan,
     createModal,
     confirmVMActionsEnabled,
     virtctlCommand,


### PR DESCRIPTION

## 📝 Description

Fixes [CNV-82389](https://redhat.atlassian.net/browse/CNV-82389) — when a storage migration was in progress, the Migration submenu incorrectly showed "Cancel compute migration" instead of "Cancel storage migration".

Root cause: isComputeMigration was evaluated as `printableStatus === Migrating || currentMigrationExist`. Storage migrations set `printableStatus` to `Migrating` but do not create a `VirtualMachineInstanceMigration` object, so the condition was always true regardless of migration type.

Added a `useActiveVMStorageMigrationPlan` hook and a `cancelStorageMigration` action, then updated `useVirtualMachineActionsProvider` to show "Cancel storage migration" when a storage migration is active, and "Cancel compute migration" when it's not.

## 🎥 Demo
Before:

https://github.com/user-attachments/assets/187ae407-a694-4aca-96ec-f4da5c18bb8a


After:

https://github.com/user-attachments/assets/4e2b3f77-f05d-435c-9f7f-e28e422c952d




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Users can now cancel storage migrations for virtual machines. A new storage migration cancellation action has been added to the virtual machine interface, enabling users to stop ongoing storage migration operations. The system now distinguishes between storage and compute migrations, automatically presenting the appropriate cancellation action based on the active migration type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->