### PR TITLE
CNV-82451: Align nginx ssl_ecdh_curve with required curve list

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -3,7 +3,7 @@ server {
     ssl_certificate /var/serving-cert/tls.crt;
     ssl_certificate_key /var/serving-cert/tls.key;
     ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ecdh_curve X25519MLKEM768:SecP256r1MLKEM768:SecP384r1MLKEM1024:X25519:prime256v1:secp384r1;
+    ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;
     location / {
         root   /usr/share/nginx/html;
     }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes https://issues.redhat.com/browse/CNV-82451

Updates `default.conf` so `ssl_ecdh_curve` is **only**:

```
ssl_ecdh_curve SecP256r1MLKEM768:SecP384r1MLKEM1024:secp256r1:secp384r1;
```

This replaces the previous broader list (`X25519MLKEM768`, `X25519`, `prime256v1`, etc.).

## 🎥 Demo

N/A (config-only change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TLS/SSL elliptic curve configuration to use optimized cryptographic parameters for enhanced security and key-exchange performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->