### PR TITLE
CNV-84132: Show instance type in VM clone dialog

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -994,6 +994,7 @@
   "Increment": "Increment",
   "Indicates the current completion percentage of the ongoing live migration operation.": "Indicates the current completion percentage of the ongoing live migration operation.",
   "Indications": "Indications",
+  "Inferred from volume {{volumeName}}": "Inferred from volume {{volumeName}}",
   "Info": "Info",
   "Ingresses": "Ingresses",
   "Initial run": "Initial run",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1008,6 +1008,7 @@
   "Increment": "Incremento",
   "Indicates the current completion percentage of the ongoing live migration operation.": "Indica el porcentaje de finalización actual de la operación de migración en vivo en curso.",
   "Indications": "Indicaciones",
+  "Inferred from volume {{volumeName}}": "Inferred from volume {{volumeName}}",
   "Info": "Información",
   "Ingresses": "Ingresos",
   "Initial run": "Ejecución inicial",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1008,6 +1008,7 @@
   "Increment": "Incrémenter",
   "Indicates the current completion percentage of the ongoing live migration operation.": "Indique le pourcentage d'achèvement actuel de l'opération de migration en direct en cours.",
   "Indications": "Indications",
+  "Inferred from volume {{volumeName}}": "Inferred from volume {{volumeName}}",
   "Info": "Info",
   "Ingresses": "Entrées",
   "Initial run": "Première exécution",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -991,6 +991,7 @@
   "Increment": "インクリメント",
   "Indicates the current completion percentage of the ongoing live migration operation.": "進行中のライブマイグレーション操作の現在の完了率を示します。",
   "Indications": "表示",
+  "Inferred from volume {{volumeName}}": "Inferred from volume {{volumeName}}",
   "Info": "情報",
   "Ingresses": "Ingresses",
   "Initial run": "初回実行",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -991,6 +991,7 @@
   "Increment": "증가",
   "Indicates the current completion percentage of the ongoing live migration operation.": "진행 중인 실시간 마이그레이션 작업의 현재 완료 비율을 표시합니다.",
   "Indications": "표시",
+  "Inferred from volume {{volumeName}}": "Inferred from volume {{volumeName}}",
   "Info": "정보",
   "Ingresses": "Ingress",
   "Initial run": "초기 실행",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -991,6 +991,7 @@
   "Increment": "增量",
   "Indicates the current completion percentage of the ongoing live migration operation.": "代表正在进行实时迁移操作的当前完成百分比。",
   "Indications": "表示",
+  "Inferred from volume {{volumeName}}": "Inferred from volume {{volumeName}}",
   "Info": "信息",
   "Ingresses": "Ingresses",
   "Initial run": "初始运行",

--- a/src/utils/components/CloneVMModal/components/InstanceTypeConfiguration.tsx
+++ b/src/utils/components/CloneVMModal/components/InstanceTypeConfiguration.tsx
@@ -1,16 +1,10 @@
 import React, { FC } from 'react';
 
-import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getInstanceTypeModelFromMatcher } from '@kubevirt-utils/resources/instancetype/helper';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { getInstanceTypeMatcher } from '@kubevirt-utils/resources/vm';
-import useInstanceType from '@kubevirt-utils/resources/vm/hooks/useInstanceType';
-import { getCluster } from '@multicluster/helpers/selectors';
-import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
-import { Skeleton } from '@patternfly/react-core';
+
+import InstanceTypeConfigurationDescriptionData from './InstanceTypeConfigurationDescriptionData';
 
 type InstanceTypeConfigurationProps = {
   vm: V1VirtualMachine;
@@ -18,23 +12,10 @@ type InstanceTypeConfigurationProps = {
 
 const InstanceTypeConfiguration: FC<InstanceTypeConfigurationProps> = ({ vm }) => {
   const { t } = useKubevirtTranslation();
-  const itMatcher = getInstanceTypeMatcher(vm);
-  const { instanceType, instanceTypeLoaded } = useInstanceType(itMatcher, getCluster(vm));
 
   return (
     <DescriptionItem
-      descriptionData={
-        instanceTypeLoaded ? (
-          <ResourceLink
-            groupVersionKind={modelToGroupVersionKind(getInstanceTypeModelFromMatcher(itMatcher))}
-            namespace={getNamespace(instanceType)}
-          >
-            {getName(instanceType)}
-          </ResourceLink>
-        ) : (
-          <Skeleton className="pf-m-width-sm" />
-        )
-      }
+      descriptionData={<InstanceTypeConfigurationDescriptionData vm={vm} />}
       descriptionHeader={t('InstanceType')}
     />
   );

--- a/src/utils/components/CloneVMModal/components/InstanceTypeConfigurationDescriptionData.tsx
+++ b/src/utils/components/CloneVMModal/components/InstanceTypeConfigurationDescriptionData.tsx
@@ -1,0 +1,86 @@
+import React, { FC } from 'react';
+
+import {
+  ControllerRevisionModelGroupVersionKind,
+  modelToGroupVersionKind,
+} from '@kubevirt-ui-ext/kubevirt-api/console';
+import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import {
+  getInstanceTypeModelFromMatcher,
+  getInstanceTypeNameFromAnnotation,
+} from '@kubevirt-utils/resources/instancetype/helper';
+import { getInstanceTypeRevisionName } from '@kubevirt-utils/resources/instancetype/selectors';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { getInstanceTypeMatcher } from '@kubevirt-utils/resources/vm';
+import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
+import { getCluster } from '@multicluster/helpers/selectors';
+import { Stack, StackItem } from '@patternfly/react-core';
+
+type InstanceTypeConfigurationDescriptionDataProps = {
+  vm: V1VirtualMachine;
+};
+
+const InstanceTypeConfigurationDescriptionData: FC<
+  InstanceTypeConfigurationDescriptionDataProps
+> = ({ vm }) => {
+  const { t } = useKubevirtTranslation();
+  const itMatcher = getInstanceTypeMatcher(vm);
+  const cluster = getCluster(vm);
+  const inferFromVolume = itMatcher?.inferFromVolume;
+  const revisionName = getInstanceTypeRevisionName(vm);
+  const model = getInstanceTypeModelFromMatcher(itMatcher);
+  const namespacedITNamespace = model.namespaced ? getNamespace(vm) : undefined;
+
+  const revisionLinkDisplayName =
+    itMatcher?.name || getInstanceTypeNameFromAnnotation(vm) || revisionName;
+
+  if (itMatcher?.name) {
+    return (
+      <MulticlusterResourceLink
+        cluster={cluster}
+        groupVersionKind={modelToGroupVersionKind(model)}
+        name={itMatcher.name}
+        namespace={namespacedITNamespace || undefined}
+      />
+    );
+  }
+
+  if (inferFromVolume) {
+    return (
+      <Stack hasGutter>
+        <StackItem>
+          {t('Inferred from volume {{volumeName}}', { volumeName: inferFromVolume })}
+        </StackItem>
+        {revisionName && (
+          <StackItem>
+            <MulticlusterResourceLink
+              cluster={cluster}
+              displayName={revisionLinkDisplayName}
+              groupVersionKind={ControllerRevisionModelGroupVersionKind}
+              name={revisionName}
+              namespace={getNamespace(vm)}
+            />
+          </StackItem>
+        )}
+      </Stack>
+    );
+  }
+
+  if (revisionName) {
+    return (
+      <MulticlusterResourceLink
+        cluster={cluster}
+        displayName={revisionLinkDisplayName}
+        groupVersionKind={ControllerRevisionModelGroupVersionKind}
+        name={revisionName}
+        namespace={getNamespace(vm)}
+      />
+    );
+  }
+
+  return <MutedTextSpan text={t('Not available')} />;
+};
+
+export default InstanceTypeConfigurationDescriptionData;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes [CNV-84132](https://issues.redhat.com/browse/CNV-84132): when cloning a VM that uses an instance type, the clone modal now shows which instance type applies.

- **Named matcher**: `MulticlusterResourceLink` to the `VirtualMachineInstancetype` / `VirtualMachineClusterInstancetype` resource, with namespace only for namespaced instance types.
- **`inferFromVolume` (no name)**: shows the inferred-volume message and, when present, a link to the **ControllerRevision** from `vm.status.instancetypeRef` (same idea as the VM overview).
- **Revision only**: link to the controller revision when there is no matcher name and no `inferFromVolume`.
- **Otherwise**: "Not available".

Implementation: extracted `InstanceTypeConfigurationDescriptionData` so the description content is isolated from the `DescriptionItem` wrapper.

## 🎥 Demo

<img width="1919" height="1083" alt="Screenshot 2026-04-14 at 13 57 27" src="https://github.com/user-attachments/assets/d3618990-17b6-479b-975b-26ba996cb5c9" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization for instance type configuration display by separating data fetching and rendering logic into dedicated components for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->