### PR TITLE
CNV-84382: Register standalone console route without KUBEVIRT_DYNAMIC flag

### DIFF
--- a/src/utils/extension.ts
+++ b/src/utils/extension.ts
@@ -74,9 +74,6 @@ export const extensions: EncodedExtension[] = [
     type: 'console.dashboards/overview/health/prometheus',
   } as EncodedExtension<DashboardsOverviewHealthPrometheusSubsystem>,
   {
-    flags: {
-      required: ['KUBEVIRT_DYNAMIC'],
-    },
     properties: {
       component: { $codeRef: 'ConsoleStandAlone' },
       exact: false,


### PR DESCRIPTION
## Description

Removes the `KUBEVIRT_DYNAMIC` feature flag requirement from the `console.page/route/standalone` extension for the VM console standalone page (`ConsoleStandAlone`). The route is now registered whenever the plugin loads, so the standalone console URL can resolve without depending on that flag.

There is no need to have the flag on the standalone 

## Jira

https://issues.redhat.com/browse/CNV-84382

## Notes

- Keeps the change limited to the standalone console route in `src/utils/extension.ts`.
- Demo: N/A (routing / flag behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary feature flag requirement from the standalone page route, making it universally accessible.
  * Improved hub cluster detection and loading state handling in multi-cluster scenarios to prevent premature data fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->