### PR TITLE
CNV-84270: Use VM cluster for disk modal PVC watches

### DIFF
--- a/src/utils/components/DiskModal/DiskModal.tsx
+++ b/src/utils/components/DiskModal/DiskModal.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getDataVolumeTemplates, getVolumes } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { getCluster } from '@multicluster/helpers/selectors';
 
 import usePVCDiskSource from './hooks/usePVCDiskSource';
 import { getDiskModalBySource } from './utils/getDiskModalBySource';
@@ -27,7 +28,7 @@ const DiskModal: FC<V1DiskModalProps> = ({
   );
 
   const namespace = getNamespace(vm);
-  const [pvc] = usePVCDiskSource(createdPVCName, namespace);
+  const [pvc] = usePVCDiskSource(createdPVCName, namespace, getCluster(vm));
 
   const editDiskSource = getSourceFromVolume(diskVolume, dataVolumeTemplate);
 

--- a/src/utils/components/DiskModal/components/DiskSizeInput/DiskSizeInput.tsx
+++ b/src/utils/components/DiskModal/components/DiskSizeInput/DiskSizeInput.tsx
@@ -30,6 +30,7 @@ const DiskSizeInput: FC<DiskSizeInputProps> = ({ isCreated, isDisabled, namespac
     getSourceRef(diskState),
     getPVCClaimName(diskState),
     namespace,
+    diskState.cluster,
   );
 
   if (isCreated) return <ExpandPVC pvc={pvc} />;

--- a/src/utils/components/DiskModal/components/DiskSizeInput/usePVCSourceSize.ts
+++ b/src/utils/components/DiskModal/components/DiskSizeInput/usePVCSourceSize.ts
@@ -16,8 +16,10 @@ const usePVCSourceSize = (
   dataSourceRef: V1beta1DataVolumeSourceRef,
   pvcClaimName: string,
   pvcClaimNamespace: string,
+  clusterFromResource?: string,
 ): [pvcSize: string, loaded: boolean, error: any] => {
-  const cluster = useClusterParam();
+  const clusterFromUrl = useClusterParam();
+  const cluster = clusterFromResource ?? clusterFromUrl;
   const [dataSource, dsLoaded, dsError] = useK8sWatchData<V1beta1DataSource>(
     dataSourceRef
       ? {

--- a/src/utils/components/DiskModal/hooks/usePVCDiskSource.tsx
+++ b/src/utils/components/DiskModal/hooks/usePVCDiskSource.tsx
@@ -3,8 +3,9 @@ import { modelToGroupVersionKind, PersistentVolumeClaimModel } from '@kubevirt-u
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-const usePVCDiskSource = (pvcName: string, pvcNamespace: string) => {
-  const cluster = useClusterParam();
+const usePVCDiskSource = (pvcName: string, pvcNamespace: string, clusterFromResource?: string) => {
+  const clusterFromUrl = useClusterParam();
+  const cluster = clusterFromResource ?? clusterFromUrl;
 
   return useK8sWatchData<IoK8sApiCoreV1PersistentVolumeClaim>(
     pvcName


### PR DESCRIPTION
## Summary

Fixes [CNV-84270](https://issues.redhat.com/browse/CNV-84270): on ACM VM details, the disk modal did not show PVC capacity / resize because `useClusterParam()` is unset when the route omits the fleet `cluster/:cluster` segment. PVC watches then targeted the wrong API context.


WHY? In the modal, we don't get the params 


## Changes

- `usePVCDiskSource`: optional cluster from resource; `DiskModal` passes `getCluster(vm)`.
- `usePVCSourceSize`: same pattern; `DiskSizeInput` passes `diskState.cluster` (aligned with `getCluster(vm)` from form defaults).

Effective cluster: `clusterFromResource ?? useClusterParam()`.

## Testing

- [ ] Edit disk backed by PVC on ACM VM details — capacity field appears and PVC watch succeeds on the managed cluster.
- [ ] Single-cluster OpenShift console — unchanged (`getCluster(vm)` typically unset, URL/local watch still used).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced cluster context resolution in disk operations. Updated how cluster information is handled and passed through disk modal components to improve consistency in resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->