### PR TITLE
CNV-83804: The notification on overview page should be stretched to the full width of the screen

### DIFF
--- a/src/views/virtualmachines/list/components/OverviewTab/components/MCONotInstalledAlert.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/components/MCONotInstalledAlert.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useState } from 'react';
 
+import { getMCONotInstalledTooltip } from '@kubevirt-utils/hooks/useAlerts/utils/useMCOInstalled';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Alert, AlertActionCloseButton, AlertVariant } from '@patternfly/react-core';
 
@@ -13,11 +14,9 @@ const MCONotInstalledAlert: FC = () => {
 
   return (
     <Alert
-      title={t(
-        'Multicluster observability is not available. Install it on the hub cluster to enable monitoring across clusters.',
-      )}
       actionClose={<AlertActionCloseButton onClose={() => setDismissed(true)} />}
       isInline
+      title={getMCONotInstalledTooltip(t)}
       variant={AlertVariant.warning}
     />
   );

--- a/src/views/virtualmachines/list/components/OverviewTab/components/OverviewAlerts.scss
+++ b/src/views/virtualmachines/list/components/OverviewTab/components/OverviewAlerts.scss
@@ -1,5 +1,0 @@
-.overview-alerts {
-  &__item {
-    max-width: 60%;
-  }
-}

--- a/src/views/virtualmachines/list/components/OverviewTab/components/OverviewAlerts.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/components/OverviewAlerts.tsx
@@ -1,15 +1,12 @@
 import React, { FC } from 'react';
 
 import useIsACMPage from '@multicluster/useIsACMPage';
-import { StackItem } from '@patternfly/react-core';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import MCONotInstalledAlert from './MCONotInstalledAlert';
 import NoVMsAlert from './NoVMsAlert';
 import ObservabilityDisabledAlert from './ObservabilityDisabledAlert';
 import { getIsSpokeCluster, getShowMCOWarning, getShowObservabilityWarning } from './utils';
-
-import './OverviewAlerts.scss';
 
 type OverviewAlertsProps = {
   cluster?: string;
@@ -70,21 +67,11 @@ const OverviewAlerts: FC<OverviewAlertsProps> = ({
 
   return (
     <>
-      {showMCOWarning && (
-        <StackItem className="overview-alerts__item">
-          <MCONotInstalledAlert />
-        </StackItem>
-      )}
+      {showMCOWarning && <MCONotInstalledAlert />}
       {!showMCOWarning && showObservabilityWarning && (
-        <StackItem className="overview-alerts__item">
-          <ObservabilityDisabledAlert disabledClusters={alertClusters} />
-        </StackItem>
+        <ObservabilityDisabledAlert disabledClusters={alertClusters} />
       )}
-      {hasNoVMs && (
-        <StackItem className="overview-alerts__item">
-          <NoVMsAlert namespace={namespace} />
-        </StackItem>
-      )}
+      {hasNoVMs && <NoVMsAlert namespace={namespace} />}
     </>
   );
 };


### PR DESCRIPTION
## 📝 Description

Jira Ticket: [CNV-83804](https://redhat.atlassian.net/browse/CNV-83804)

Warnings / notifications for VM overview tab should fill the entire width of the section. 


## 🎥 Demo

Before:

<img width="1682" height="415" alt="Screenshot 2026-04-14 at 11 09 29 AM" src="https://github.com/user-attachments/assets/18ef97c1-6cbb-4057-8773-bc7d625f98fc" />


After:

https://github.com/user-attachments/assets/4a0afce6-388b-4fa0-9228-7f6502fa4629



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated alert layout and styling for improved display in virtual machine overview.

* **Refactor**
  * Simplified alert title computation and component structure for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->