### PR TITLE
CNV-84467: Fix MTV broken doc link

### DIFF
--- a/src/utils/constants/documentation.ts
+++ b/src/utils/constants/documentation.ts
@@ -39,7 +39,7 @@ export const documentationURL = {
     'https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata',
   MIGRATION_CONFIGURATION: `${KV_UG_URL}/api-reference/main/definitions.html#_v1_migrationconfiguration`,
   MIGRATION_POLICIES: `${REDHAT_DOC_URL}/html/virtualization/live-migration#live-migration-policies`,
-  MTV_OPERATOR: `${RH_DOC_URL}/migration_toolkit_for_virtualization/latest/html/installing_and_using_the_migration_toolkit_for_virtualization/index`,
+  MTV_OPERATOR: `${RH_DOC_URL}/migration_toolkit_for_virtualization`,
   NAME: `${K8_DOC_OBJ_URL}/names`,
   NAMESPACE_DOC: `${K8_DOC_OBJ_URL}/namespaces/`,
   NETWORKING: `${REDHAT_DOC_URL}/html/virtualization/networking`,


### PR DESCRIPTION
## 📝 Description

Jira Ticket: [CNV-84467](https://redhat.atlassian.net/browse/CNV-84467)

Fix broken documentation link for MTV Operator

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/279af38c-33c3-49cd-903f-bfd69a5f7172

After:

https://github.com/user-attachments/assets/eda776c1-5aca-4d03-8134-f72fdfeee6cc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Migration Toolkit for Virtualization documentation link reference to point to the base documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->