### PR TITLE
CNV-83348: Use bulk actions for single VM in tree view namespace/folder right-click

### DIFF
--- a/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.tsx
+++ b/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.tsx
@@ -55,7 +55,7 @@ const useMultipleVirtualMachineActions: UseMultipleVirtualMachineActions = (
   );
 
   return useMemo(() => {
-    if (vms.length === 1) {
+    if (vms.length === 1 && !isTreeViewMenu) {
       return singleVMActions;
     }
 
@@ -116,6 +116,7 @@ const useMultipleVirtualMachineActions: UseMultipleVirtualMachineActions = (
   }, [
     confirmVMActionsEnabled,
     createModal,
+    isTreeViewMenu,
     mtvInstalled,
     provider,
     providerLoaded,


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

**Bug:** Right-clicking a namespace (or folder) in tree view which contains 1 VM shows the actions for that VM. This is confusing to users, who might expect actions on that namespace.

**Fix:** When right-clicking a namespace or folder in the tree view that contains only one VM, show the bulk actions instead of showing single VM actions.

## 🎥 Demo

Before (initially):
<img width="1432" height="940" alt="Screenshot 2026-04-15 at 6 37 00" src="https://github.com/user-attachments/assets/948bafbe-debf-4717-b2b0-f73f6dd4090b" />


Before (after merging https://github.com/kubevirt-ui/kubevirt-plugin/pull/3777):
<img width="1432" height="940" alt="Screenshot 2026-04-15 at 6 32 36" src="https://github.com/user-attachments/assets/f4e6de4c-4e03-44cf-96eb-a602c0c6d945" />



AFTER:

<img width="1432" height="940" alt="Screenshot 2026-04-15 at 6 36 36" src="https://github.com/user-attachments/assets/a25f8831-7419-444c-af9f-1e39ad8c8fd3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed virtual machine action availability in tree view context—single instances now properly display migration, folder move, label editing, and deletion options based on view type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->