### PR TITLE
CNV-61450: Variability in data causes utilization chart to re-scaled

### DIFF
--- a/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
+++ b/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
@@ -74,7 +74,7 @@ const MemoryThresholdChart: FC<MemoryThresholdChartProps> = ({ vmi }) => {
   }));
 
   const isReady = !isEmpty(chartData) || !isEmpty(thresholdLine);
-  const yMax = findMaxYValue(thresholdLine);
+  const yMax = findMaxYValue(thresholdLine) ?? 0;
 
   return (
     <ComponentReady error={error} isLoading={isLoading} isReady={isReady} linkToMetrics={queryLink}>

--- a/src/utils/components/Charts/MigrationUtil/MigrationThresholdChart.tsx
+++ b/src/utils/components/Charts/MigrationUtil/MigrationThresholdChart.tsx
@@ -26,11 +26,13 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 import { tickLabels } from '../ChartLabels/styleOverrides';
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
+import useStableYMax from '../hooks/useStableYMax';
 import {
   addTimestampToTooltip,
   findMigrationMaxYValue,
   formatMemoryYTick,
   formatMigrationThresholdTooltipData,
+  getChartYRange,
   getPrometheusData,
   MILLISECONDS_MULTIPLIER,
   queriesToLink,
@@ -105,7 +107,11 @@ const MigrationThresholdChart: React.FC<MigrationThresholdChartProps> = ({ vmi }
 
   const isReady =
     !isEmpty(chartDataProcessed) || !isEmpty(chartDataRemaining) || !isEmpty(chartDataDirtyRate);
-  const yMax = findMigrationMaxYValue(chartDataProcessed, chartDataRemaining, chartDataDirtyRate);
+  const yMax = useStableYMax(
+    findMigrationMaxYValue(chartDataProcessed, chartDataRemaining, chartDataDirtyRate),
+    `${vmi?.metadata?.uid}_${duration}`,
+  );
+  const yRange = getChartYRange(yMax);
   const linkToMetrics =
     !isACMPage &&
     queriesToLink([
@@ -131,7 +137,7 @@ const MigrationThresholdChart: React.FC<MigrationThresholdChartProps> = ({ vmi }
             }
             domain={{
               x: [currentTime - timespan, currentTime],
-              y: [0, yMax],
+              ...(yRange && { y: yRange }),
             }}
             legendData={[
               { name: t('Data Processed') },
@@ -153,8 +159,10 @@ const MigrationThresholdChart: React.FC<MigrationThresholdChartProps> = ({ vmi }
                 tickLabels,
               }}
               dependentAxis
-              tickFormat={formatMemoryYTick(yMax, 2)}
-              tickValues={[0, yMax]}
+              {...(yMax != null && {
+                tickFormat: formatMemoryYTick(yMax, 2),
+                tickValues: yRange,
+              })}
             />
             <ChartAxis
               style={{

--- a/src/utils/components/Charts/MigrationUtil/MigrationThresholdChartDiskRate.tsx
+++ b/src/utils/components/Charts/MigrationUtil/MigrationThresholdChartDiskRate.tsx
@@ -23,12 +23,14 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 import { tickLabels } from '../ChartLabels/styleOverrides';
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
+import useStableYMax from '../hooks/useStableYMax';
 import { VMQueries } from '../utils/queries';
 import {
   addTimestampToTooltip,
   findMaxYValue,
   formatMemoryYTick,
   formatMigrationThresholdDiskRateTooltipData,
+  getChartYRange,
   getPrometheusData,
   MILLISECONDS_MULTIPLIER,
   tickFormat,
@@ -64,7 +66,11 @@ const MigrationThresholdChartDiskRate: React.FC<MigrationThresholdChartDiskRateP
   });
 
   const isReady = !isEmpty(chartDataProcessed);
-  const yMax = findMaxYValue(chartDataProcessed);
+  const yMax = useStableYMax(
+    findMaxYValue(chartDataProcessed),
+    `${vmi?.metadata?.uid}_${duration}`,
+  );
+  const yRange = getChartYRange(yMax);
 
   return (
     <ComponentReady isReady={isReady} linkToMetrics={queryLink}>
@@ -79,7 +85,7 @@ const MigrationThresholdChartDiskRate: React.FC<MigrationThresholdChartDiskRateP
             }
             domain={{
               x: [currentTime - timespan, currentTime],
-              y: [0, yMax],
+              ...(yRange && { y: yRange }),
             }}
             height={height}
             padding={35}
@@ -94,8 +100,10 @@ const MigrationThresholdChartDiskRate: React.FC<MigrationThresholdChartDiskRateP
                 tickLabels,
               }}
               dependentAxis
-              tickFormat={formatMemoryYTick(yMax, 2)}
-              tickValues={[0, yMax]}
+              {...(yMax != null && {
+                tickFormat: formatMemoryYTick(yMax, 2),
+                tickValues: yRange,
+              })}
             />
             <ChartAxis
               style={{

--- a/src/utils/components/Charts/NetworkUtil/NetworkThresholdChart.tsx
+++ b/src/utils/components/Charts/NetworkUtil/NetworkThresholdChart.tsx
@@ -22,9 +22,12 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 import { tickLabels } from '../ChartLabels/styleOverrides';
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
+import useStableYMax from '../hooks/useStableYMax';
 import {
   addTimestampToTooltip,
+  findMaxYValue,
   formatNetworkThresholdTooltipData,
+  getChartYRange,
   MILLISECONDS_MULTIPLIER,
   queriesToLink,
   tickFormat,
@@ -74,6 +77,11 @@ const NetworkThresholdChart: React.FC<NetworkThresholdChartProps> = ({ vmi }) =>
   });
 
   const isReady = !isEmpty(chartDataOut) || !isEmpty(chartDataIn);
+  const yMax = useStableYMax(
+    findMaxYValue([...(chartDataIn || []), ...(chartDataOut || [])]),
+    `${vmi?.metadata?.uid}_${duration}`,
+  );
+  const yRange = getChartYRange(yMax);
 
   return (
     <ComponentReady error={error} isLoading={isLoading} isReady={isReady}>
@@ -88,6 +96,7 @@ const NetworkThresholdChart: React.FC<NetworkThresholdChartProps> = ({ vmi }) =>
             }
             domain={{
               x: [currentTime - timespan, currentTime],
+              ...(yRange && { y: yRange }),
             }}
             height={height}
             padding={35}

--- a/src/utils/components/Charts/NetworkUtil/NetworkThresholdChartSingleSource.tsx
+++ b/src/utils/components/Charts/NetworkUtil/NetworkThresholdChartSingleSource.tsx
@@ -18,11 +18,13 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 import { tickLabels } from '../ChartLabels/styleOverrides';
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
+import useStableYMax from '../hooks/useStableYMax';
 import {
   addTimestampToTooltip,
   findNetworkMaxYValue,
   formatNetworkThresholdSingleSourceTooltipData,
   formatNetworkYTick,
+  getChartYRange,
   MILLISECONDS_MULTIPLIER,
   tickFormat,
   TICKS_COUNT,
@@ -52,7 +54,8 @@ const NetworkThresholdSingleSourceChart: FC<NetworkThresholdSingleSourceChartPro
       });
     });
   const isReady = !isEmpty(chartData);
-  const Ymax = findNetworkMaxYValue(chartData);
+  const Ymax = useStableYMax(findNetworkMaxYValue(chartData), duration);
+  const yRange = getChartYRange(Ymax);
 
   const CursorVoronoiContainer = createContainer('voronoi', 'cursor');
   const legendData =
@@ -84,7 +87,7 @@ const NetworkThresholdSingleSourceChart: FC<NetworkThresholdSingleSourceChartPro
             }
             domain={{
               x: [currentTime - timespan, currentTime],
-              y: [0, Ymax + 1],
+              ...(yRange && { y: yRange }),
             }}
             height={height}
             padding={{ bottom: 60, left: 70, right: 60, top: 30 }}
@@ -101,7 +104,7 @@ const NetworkThresholdSingleSourceChart: FC<NetworkThresholdSingleSourceChartPro
               }}
               dependentAxis
               tickFormat={formatNetworkYTick}
-              tickValues={[0, Ymax]}
+              {...(yRange && { tickValues: yRange })}
             />
             <ChartAxis
               style={{

--- a/src/utils/components/Charts/StorageUtil/StorageIOPSTotalThresholdChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageIOPSTotalThresholdChart.tsx
@@ -21,11 +21,13 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
+import useStableYMax from '../hooks/useStableYMax';
 import { VMQueries } from '../utils/queries';
 import {
   addTimestampToTooltip,
   findMaxYValue,
   formatStorageIOPSTotalThresholdTooltipData,
+  getChartYRange,
   MILLISECONDS_MULTIPLIER,
   tickFormat,
   TICKS_COUNT,
@@ -56,7 +58,8 @@ const StorageIOPSTotalThresholdChart: React.FC<StorageIOPSTotalThresholdChartPro
   const chartData = storageWriteData?.map(([x, y]) => {
     return { x: new Date(x * MILLISECONDS_MULTIPLIER), y: Number(y) };
   });
-  const yMax = findMaxYValue(chartData);
+  const yMax = useStableYMax(findMaxYValue(chartData), `${vmi?.metadata?.uid}_${duration}`);
+  const yRange = getChartYRange(yMax);
 
   return (
     <ComponentReady
@@ -76,7 +79,7 @@ const StorageIOPSTotalThresholdChart: React.FC<StorageIOPSTotalThresholdChartPro
             }
             domain={{
               x: [currentTime - timespan, currentTime],
-              y: [0, yMax],
+              ...(yRange && { y: yRange }),
             }}
             height={height}
             padding={{ bottom: 35, left: 80, right: 35, top: 35 }}
@@ -91,7 +94,7 @@ const StorageIOPSTotalThresholdChart: React.FC<StorageIOPSTotalThresholdChartPro
               }}
               dependentAxis
               tickFormat={(tick: number) => `${tick === 0 ? tick : tick?.toFixed(2)} IOPS`}
-              tickValues={[0, yMax]}
+              {...(yRange && { tickValues: yRange })}
             />
             <ChartAxis
               style={{

--- a/src/utils/components/Charts/StorageUtil/StorageReadLatencyAvgMaxChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageReadLatencyAvgMaxChart.tsx
@@ -23,12 +23,14 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
+import useStableYMax from '../hooks/useStableYMax';
 import { VMQueries } from '../utils/queries';
 import {
   addTimestampToTooltip,
   AVG_LABEL,
   findMaxYValue,
   formatStorageReadLatencyAvgMaxTooltipData,
+  getChartYRange,
   MAX_LABEL,
   MILLISECONDS_MULTIPLIER,
   tickFormat,
@@ -79,7 +81,8 @@ const StorageReadLatencyAvgMaxChart: React.FC<StorageReadLatencyAvgMaxChartProps
   });
 
   const allData = [...(avgChartData || []), ...(maxChartData || [])];
-  const yMax = findMaxYValue(allData);
+  const yMax = useStableYMax(findMaxYValue(allData), `${vmi?.metadata?.uid}_${duration}`);
+  const yRange = getChartYRange(yMax);
 
   const legendData = [
     {
@@ -110,7 +113,7 @@ const StorageReadLatencyAvgMaxChart: React.FC<StorageReadLatencyAvgMaxChartProps
             }
             domain={{
               x: [currentTime - timespan, currentTime],
-              y: [0, yMax],
+              ...(yRange && { y: yRange }),
             }}
             height={height}
             legendData={legendData}
@@ -127,7 +130,7 @@ const StorageReadLatencyAvgMaxChart: React.FC<StorageReadLatencyAvgMaxChartProps
               }}
               dependentAxis
               tickFormat={(tick: number) => `${tick === 0 ? tick : (tick * 1000)?.toFixed(2)} ms`}
-              tickValues={[0, yMax]}
+              {...(yRange && { tickValues: yRange })}
             />
             <ChartAxis
               style={{

--- a/src/utils/components/Charts/StorageUtil/StorageReadLatencyPerDriveChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageReadLatencyPerDriveChart.tsx
@@ -25,11 +25,13 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
+import useStableYMax from '../hooks/useStableYMax';
 import { VMQueries } from '../utils/queries';
 import {
   addTimestampToTooltip,
   findMaxYValue,
   formatStorageLatencyTooltipData,
+  getChartYRange,
   getDriveName,
   MILLISECONDS_MULTIPLIER,
   tickFormat,
@@ -85,7 +87,8 @@ const StorageReadLatencyPerDriveChart: React.FC<StorageReadLatencyPerDriveChartP
   });
 
   const allData = chartDataSeries.flatMap((series) => series.data);
-  const yMax = findMaxYValue(allData);
+  const yMax = useStableYMax(findMaxYValue(allData), `${vmi?.metadata?.uid}_${duration}`);
+  const yRange = getChartYRange(yMax);
 
   const legendData = chartDataSeries.map((series) => ({
     name: series.name,
@@ -110,7 +113,7 @@ const StorageReadLatencyPerDriveChart: React.FC<StorageReadLatencyPerDriveChartP
             }
             domain={{
               x: [currentTime - timespan, currentTime],
-              y: [0, yMax],
+              ...(yRange && { y: yRange }),
             }}
             height={height}
             legendData={legendData}
@@ -127,7 +130,7 @@ const StorageReadLatencyPerDriveChart: React.FC<StorageReadLatencyPerDriveChartP
               }}
               dependentAxis
               tickFormat={(tick: number) => `${tick === 0 ? tick : (tick * 1000)?.toFixed(2)} ms`}
-              tickValues={[0, yMax]}
+              {...(yRange && { tickValues: yRange })}
             />
             <ChartAxis
               style={{

--- a/src/utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageTotalReadWriteThresholdChart.tsx
@@ -25,11 +25,13 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
+import useStableYMax from '../hooks/useStableYMax';
 import { VMQueries } from '../utils/queries';
 import {
   addTimestampToTooltip,
   findMaxYValue,
   formatStorageTotalReadWriteThresholdTooltipData,
+  getChartYRange,
   getNumberOfDigitsAfterDecimalPoint,
   MILLISECONDS_MULTIPLIER,
   tickFormat,
@@ -63,11 +65,16 @@ const StorageTotalReadWriteThresholdChart: React.FC<StorageTotalReadWriteThresho
   const chartData = storageWriteData?.map(([x, y]) => {
     return { x: new Date(x * MILLISECONDS_MULTIPLIER), y: Number(y) };
   });
-  const yMax = findMaxYValue(chartData);
+  const yMax = useStableYMax(findMaxYValue(chartData), `${vmi?.metadata?.uid}_${duration}`);
+  const yRange = getChartYRange(yMax);
 
-  const thresholdData = storageWriteData?.map(([x]) => {
-    return { x: new Date(x * MILLISECONDS_MULTIPLIER), y: yMax };
-  });
+  const thresholdData =
+    yMax != null
+      ? storageWriteData?.map(([x]) => ({
+          x: new Date(x * MILLISECONDS_MULTIPLIER),
+          y: yMax,
+        }))
+      : undefined;
   return (
     <ComponentReady
       error={error}
@@ -86,7 +93,7 @@ const StorageTotalReadWriteThresholdChart: React.FC<StorageTotalReadWriteThresho
             }
             domain={{
               x: [currentTime - timespan, currentTime],
-              y: [0, yMax],
+              ...(yRange && { y: yRange }),
             }}
             height={height}
             padding={{ bottom: 35, left: 70, right: 35, top: 35 }}
@@ -101,10 +108,10 @@ const StorageTotalReadWriteThresholdChart: React.FC<StorageTotalReadWriteThresho
                 tickLabels,
               }}
               tickFormat={(tick: number) =>
-                xbytes(tick, { fixed: getNumberOfDigitsAfterDecimalPoint(yMax), iec: true })
+                xbytes(tick, { fixed: getNumberOfDigitsAfterDecimalPoint(yMax ?? 0), iec: true })
               }
               dependentAxis
-              tickValues={[0, yMax]}
+              {...(yRange && { tickValues: yRange })}
             />
             <ChartAxis
               style={{
@@ -125,15 +132,17 @@ const StorageTotalReadWriteThresholdChart: React.FC<StorageTotalReadWriteThresho
                 data={chartData}
               />
             </ChartGroup>
-            <ChartThreshold
-              style={{
-                data: {
-                  stroke: chart_color_orange_300.value,
-                  strokeDasharray: 10,
-                },
-              }}
-              data={thresholdData}
-            />
+            {thresholdData && (
+              <ChartThreshold
+                style={{
+                  data: {
+                    stroke: chart_color_orange_300.value,
+                    strokeDasharray: 10,
+                  },
+                }}
+                data={thresholdData}
+              />
+            )}
           </Chart>
         </Link>
       </div>

--- a/src/utils/components/Charts/StorageUtil/StorageWriteLatencyAvgMaxChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageWriteLatencyAvgMaxChart.tsx
@@ -23,12 +23,14 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
+import useStableYMax from '../hooks/useStableYMax';
 import { VMQueries } from '../utils/queries';
 import {
   addTimestampToTooltip,
   AVG_LABEL,
   findMaxYValue,
   formatStorageWriteLatencyAvgMaxTooltipData,
+  getChartYRange,
   MAX_LABEL,
   MILLISECONDS_MULTIPLIER,
   tickFormat,
@@ -82,7 +84,8 @@ const StorageWriteLatencyAvgMaxChart: React.FC<StorageWriteLatencyAvgMaxChartPro
   });
 
   const allData = [...(avgChartData || []), ...(maxChartData || [])];
-  const yMax = findMaxYValue(allData);
+  const yMax = useStableYMax(findMaxYValue(allData), `${vmi?.metadata?.uid}_${duration}`);
+  const yRange = getChartYRange(yMax);
 
   const legendData = [
     {
@@ -113,7 +116,7 @@ const StorageWriteLatencyAvgMaxChart: React.FC<StorageWriteLatencyAvgMaxChartPro
             }
             domain={{
               x: [currentTime - timespan, currentTime],
-              y: [0, yMax],
+              ...(yRange && { y: yRange }),
             }}
             height={height}
             legendData={legendData}
@@ -130,7 +133,7 @@ const StorageWriteLatencyAvgMaxChart: React.FC<StorageWriteLatencyAvgMaxChartPro
               }}
               dependentAxis
               tickFormat={(tick: number) => `${tick === 0 ? tick : (tick * 1000)?.toFixed(2)} ms`}
-              tickValues={[0, yMax]}
+              {...(yRange && { tickValues: yRange })}
             />
             <ChartAxis
               style={{

--- a/src/utils/components/Charts/StorageUtil/StorageWriteLatencyPerDriveChart.tsx
+++ b/src/utils/components/Charts/StorageUtil/StorageWriteLatencyPerDriveChart.tsx
@@ -25,11 +25,13 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 
 import ComponentReady from '../ComponentReady/ComponentReady';
 import useResponsiveCharts from '../hooks/useResponsiveCharts';
+import useStableYMax from '../hooks/useStableYMax';
 import { VMQueries } from '../utils/queries';
 import {
   addTimestampToTooltip,
   findMaxYValue,
   formatStorageLatencyTooltipData,
+  getChartYRange,
   getDriveName,
   MILLISECONDS_MULTIPLIER,
   tickFormat,
@@ -85,7 +87,8 @@ const StorageWriteLatencyPerDriveChart: React.FC<StorageWriteLatencyPerDriveChar
   });
 
   const allData = chartDataSeries.flatMap((series) => series.data);
-  const yMax = findMaxYValue(allData);
+  const yMax = useStableYMax(findMaxYValue(allData), `${vmi?.metadata?.uid}_${duration}`);
+  const yRange = getChartYRange(yMax);
 
   const legendData = chartDataSeries.map((series) => ({
     name: series.name,
@@ -110,7 +113,7 @@ const StorageWriteLatencyPerDriveChart: React.FC<StorageWriteLatencyPerDriveChar
             }
             domain={{
               x: [currentTime - timespan, currentTime],
-              y: [0, yMax],
+              ...(yRange && { y: yRange }),
             }}
             height={height}
             legendData={legendData}
@@ -127,7 +130,7 @@ const StorageWriteLatencyPerDriveChart: React.FC<StorageWriteLatencyPerDriveChar
               }}
               dependentAxis
               tickFormat={(tick: number) => `${tick === 0 ? tick : (tick * 1000)?.toFixed(2)} ms`}
-              tickValues={[0, yMax]}
+              {...(yRange && { tickValues: yRange })}
             />
             <ChartAxis
               style={{

--- a/src/utils/components/Charts/hooks/useStableYMax.test.ts
+++ b/src/utils/components/Charts/hooks/useStableYMax.test.ts
@@ -1,0 +1,152 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import useStableYMax from './useStableYMax';
+
+describe('useStableYMax', () => {
+  it('should return null when currentMax is null', () => {
+    const { result } = renderHook(() => useStableYMax(null));
+    expect(result.current).toBeNull();
+  });
+
+  it('should return the currentMax on first non-null value', () => {
+    const { result } = renderHook(() => useStableYMax(100));
+    expect(result.current).toBe(100);
+  });
+
+  it('should track the running maximum across re-renders', () => {
+    let currentMax = 50;
+    const { rerender, result } = renderHook(() => useStableYMax(currentMax));
+
+    expect(result.current).toBe(50);
+
+    currentMax = 200;
+    rerender();
+    expect(result.current).toBe(200);
+
+    currentMax = 100;
+    rerender();
+    expect(result.current).toBe(200);
+
+    currentMax = 250;
+    rerender();
+    expect(result.current).toBe(250);
+
+    currentMax = 50;
+    rerender();
+    expect(result.current).toBe(250);
+  });
+
+  describe('resetKey', () => {
+    it('should reset the stable max when resetKey changes', () => {
+      let currentMax = 200;
+      let resetKey = '5m';
+      const { rerender, result } = renderHook(() => useStableYMax(currentMax, resetKey));
+
+      expect(result.current).toBe(200);
+
+      currentMax = 80;
+      resetKey = '1h';
+      rerender();
+      expect(result.current).toBe(80);
+    });
+
+    it('should not reset when resetKey stays the same', () => {
+      let currentMax = 200;
+      const resetKey = '5m';
+      const { rerender, result } = renderHook(() => useStableYMax(currentMax, resetKey));
+
+      expect(result.current).toBe(200);
+
+      currentMax = 100;
+      rerender();
+      expect(result.current).toBe(200);
+    });
+
+    it('should accumulate a new maximum after reset', () => {
+      let currentMax = 200;
+      let resetKey = '5m';
+      const { rerender, result } = renderHook(() => useStableYMax(currentMax, resetKey));
+
+      expect(result.current).toBe(200);
+
+      currentMax = 50;
+      resetKey = '1h';
+      rerender();
+      expect(result.current).toBe(50);
+
+      currentMax = 120;
+      rerender();
+      expect(result.current).toBe(120);
+
+      currentMax = 80;
+      rerender();
+      expect(result.current).toBe(120);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle zero as a valid currentMax', () => {
+      const { result } = renderHook(() => useStableYMax(0));
+      expect(result.current).toBe(0);
+    });
+
+    it('should handle transition from null to a value', () => {
+      let currentMax: null | number = null;
+      const { rerender, result } = renderHook(() => useStableYMax(currentMax));
+
+      expect(result.current).toBeNull();
+
+      currentMax = 100;
+      rerender();
+      expect(result.current).toBe(100);
+    });
+
+    it('should ignore null after receiving a value', () => {
+      let currentMax: null | number = 100;
+      const { rerender, result } = renderHook(() => useStableYMax(currentMax));
+
+      expect(result.current).toBe(100);
+
+      currentMax = null;
+      rerender();
+      expect(result.current).toBe(100);
+    });
+
+    it('should ignore -Infinity', () => {
+      const { result } = renderHook(() => useStableYMax(-Infinity));
+      expect(result.current).toBeNull();
+    });
+
+    it('should ignore NaN', () => {
+      const { result } = renderHook(() => useStableYMax(NaN));
+      expect(result.current).toBeNull();
+    });
+
+    it('should not replace a finite max with -Infinity', () => {
+      let currentMax: number = 200;
+      const { rerender, result } = renderHook(() => useStableYMax(currentMax));
+
+      expect(result.current).toBe(200);
+
+      currentMax = -Infinity;
+      rerender();
+      expect(result.current).toBe(200);
+    });
+
+    it('should ignore +Infinity', () => {
+      const { result } = renderHook(() => useStableYMax(Infinity));
+      expect(result.current).toBeNull();
+    });
+
+    it('should not replace a finite max with +Infinity', () => {
+      let currentMax: number = 200;
+      const { rerender, result } = renderHook(() => useStableYMax(currentMax));
+
+      expect(result.current).toBe(200);
+
+      currentMax = Infinity;
+      rerender();
+      expect(result.current).toBe(200);
+    });
+  });
+});

--- a/src/utils/components/Charts/hooks/useStableYMax.ts
+++ b/src/utils/components/Charts/hooks/useStableYMax.ts
@@ -1,0 +1,30 @@
+import { useRef } from 'react';
+
+/**
+ * Tracks the running maximum of a chart's Y value across renders.
+ * Only allows upward changes to prevent Y-axis jitter from fluctuating data.
+ * Resets when resetKey changes (e.g. duration or VM identity change).
+ * @param currentMax
+ * @param resetKey
+ */
+const useStableYMax = (currentMax: null | number, resetKey?: unknown): null | number => {
+  const stableMax = useRef<null | number>(null);
+  const prevResetKey = useRef(resetKey);
+
+  if (prevResetKey.current !== resetKey) {
+    stableMax.current = null;
+    prevResetKey.current = resetKey;
+  }
+
+  if (
+    currentMax !== null &&
+    Number.isFinite(currentMax) &&
+    (stableMax.current === null || currentMax > stableMax.current)
+  ) {
+    stableMax.current = currentMax;
+  }
+
+  return stableMax.current;
+};
+
+export default useStableYMax;

--- a/src/utils/components/Charts/utils/utils.test.ts
+++ b/src/utils/components/Charts/utils/utils.test.ts
@@ -1,0 +1,129 @@
+import {
+  findMaxYValue,
+  findMigrationMaxYValue,
+  findNetworkMaxYValue,
+  getChartYRange,
+} from './utils';
+
+const point = (y: number) => ({ x: new Date(), y });
+
+describe('findMaxYValue', () => {
+  it('should return null for undefined input', () => {
+    expect(findMaxYValue(undefined as any)).toBeNull();
+  });
+
+  it('should return null for empty array', () => {
+    expect(findMaxYValue([])).toBeNull();
+  });
+
+  it('should return the max Y value', () => {
+    expect(findMaxYValue([point(10), point(50), point(30)])).toBe(50);
+  });
+
+  it('should handle zero as max', () => {
+    expect(findMaxYValue([point(0), point(0)])).toBe(0);
+  });
+
+  it('should handle negative values', () => {
+    expect(findMaxYValue([point(-5), point(-1), point(-10)])).toBe(-1);
+  });
+
+  it('should handle single element', () => {
+    expect(findMaxYValue([point(42)])).toBe(42);
+  });
+
+  it('should handle NaN values gracefully', () => {
+    expect(findMaxYValue([point(NaN), point(NaN)])).toBeNull();
+  });
+
+  it('should skip NaN and find finite max', () => {
+    expect(findMaxYValue([point(NaN), point(5), point(NaN)])).toBe(5);
+  });
+});
+
+describe('findMigrationMaxYValue', () => {
+  it('should return null when all series are undefined', () => {
+    expect(findMigrationMaxYValue(undefined, undefined, undefined)).toBeNull();
+  });
+
+  it('should return null when all series are empty', () => {
+    expect(findMigrationMaxYValue([], [], [])).toBeNull();
+  });
+
+  it('should find max across all three series', () => {
+    const processed = [point(10), point(20)];
+    const remaining = [point(50), point(30)];
+    const dirtyRate = [point(5), point(15)];
+    expect(findMigrationMaxYValue(processed, remaining, dirtyRate)).toBe(50);
+  });
+
+  it('should handle mixed empty and populated series', () => {
+    expect(findMigrationMaxYValue([], [point(42)], undefined)).toBe(42);
+  });
+
+  it('should return 0 when all values are zero', () => {
+    expect(findMigrationMaxYValue([point(0)], [point(0)], [point(0)])).toBe(0);
+  });
+});
+
+describe('findNetworkMaxYValue', () => {
+  const netPoint = (name: string, y: number) => ({ name, x: new Date(), y });
+
+  it('should return null for undefined input', () => {
+    expect(findNetworkMaxYValue(undefined as any)).toBeNull();
+  });
+
+  it('should return null for empty array', () => {
+    expect(findNetworkMaxYValue([])).toBeNull();
+  });
+
+  it('should find max across nested arrays', () => {
+    const data = [
+      [netPoint('eth0', 100), netPoint('eth0', 200)],
+      [netPoint('eth1', 150), netPoint('eth1', 50)],
+    ];
+    expect(findNetworkMaxYValue(data)).toBe(200);
+  });
+
+  it('should ceil non-integer values', () => {
+    const data = [[netPoint('eth0', 100.7)]];
+    expect(findNetworkMaxYValue(data)).toBe(101);
+  });
+
+  it('should ceil small fractional maxima', () => {
+    const data = [[netPoint('eth0', 100.1)]];
+    expect(findNetworkMaxYValue(data)).toBe(101);
+  });
+
+  it('should return integer values as-is', () => {
+    const data = [[netPoint('eth0', 100)]];
+    expect(findNetworkMaxYValue(data)).toBe(100);
+  });
+
+  it('should handle empty inner arrays', () => {
+    const data = [[], [netPoint('eth0', 50)]];
+    expect(findNetworkMaxYValue(data)).toBe(50);
+  });
+
+  it('should return null when all inner arrays are empty', () => {
+    expect(findNetworkMaxYValue([[], []])).toBeNull();
+  });
+});
+
+describe('getChartYRange', () => {
+  it('should return undefined for null', () => {
+    expect(getChartYRange(null)).toBeUndefined();
+  });
+
+  it('should return [0, 1] for zero', () => {
+    expect(getChartYRange(0)).toEqual([0, 1]);
+  });
+
+  it('should return [0, value] for positive values', () => {
+    expect(getChartYRange(100)).toEqual([0, 100]);
+  });
+
+  it('should return [0, value] for fractional values', () => {
+    expect(getChartYRange(0.5)).toEqual([0, 0.5]);
+  });
+});

--- a/src/utils/components/Charts/utils/utils.ts
+++ b/src/utils/components/Charts/utils/utils.ts
@@ -7,7 +7,6 @@ import {
   timestampFor,
 } from '@kubevirt-utils/components/Timestamp/utils/datetime';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   PrometheusResponse,
   PrometheusResult,
@@ -83,21 +82,25 @@ export const getPrometheusDataAllNics = (response: PrometheusResponse): Promethe
   ];
 };
 
+/**
+ * Finds the maximum Y value across nested per-NIC chart data arrays. Ceils non-integer results.
+ * @param chartData
+ */
 export const findNetworkMaxYValue = (
   chartData: { name: string; x: Date; y: number }[][],
-): number => {
-  const yValues =
-    !isEmpty(chartData) &&
-    chartData?.map((dataArray) => {
-      return Math.max(...dataArray?.map((data) => data?.y));
-    });
-  const maxY = Math.max(...(yValues || []));
+): null | number => {
+  if (!chartData?.length) return null;
 
-  if (Number.isInteger(maxY)) return maxY;
+  let max = -Infinity;
+  for (const dataArray of chartData) {
+    if (!dataArray?.length) continue;
+    for (const point of dataArray) {
+      if (point?.y > max) max = point.y;
+    }
+  }
 
-  const roundedMax = Math.round(maxY);
-
-  return isNaN(roundedMax) ? 0 : roundedMax;
+  if (!Number.isFinite(max)) return null;
+  return Number.isInteger(max) ? max : Math.ceil(max);
 };
 
 export const formatNetworkYTick = (tick: any, index: number, ticks: any[]) => {
@@ -116,18 +119,47 @@ export const formatMemoryYTick = (yMax: number, fixedDigits: number) => (tick: n
   return humanizedValue || '';
 };
 
+/**
+ * Finds the maximum Y value in a flat chart data array. Returns null when data is empty or all NaN.
+ * @param chartData
+ */
 export const findMaxYValue = (
   chartData: { name?: string; x: Date; y: number }[],
 ): null | number => {
-  const yValues = chartData?.map((point) => point?.y);
-  return yValues ? Math.max(...yValues) : 0;
+  if (!chartData?.length) return null;
+
+  let max = -Infinity;
+  for (const point of chartData) {
+    if (point?.y > max) max = point.y;
+  }
+
+  return Number.isFinite(max) ? max : null;
 };
 
-export const findMigrationMaxYValue = (processedData, remainingData, dirtyRateData) => {
-  const max = [processedData, remainingData, dirtyRateData]?.map((chartData) =>
-    findMaxYValue(chartData),
-  );
-  return Math.max(...max);
+/**
+ * Returns a [0, max] range suitable for Y-axis domain and tickValues.
+ * Returns undefined when max is null (no data), letting the chart library auto-scale.
+ * Ensures a minimum positive range to avoid degenerate [0, 0] domains.
+ * @param yMax - the maximum Y value, or null when no data is available
+ */
+export const getChartYRange = (yMax: null | number): [number, number] | undefined =>
+  yMax != null ? [0, yMax || 1] : undefined;
+
+/**
+ * Finds the overall maximum Y across the three migration metric series. Returns null when all are empty.
+ * @param processedData
+ * @param remainingData
+ * @param dirtyRateData
+ */
+export const findMigrationMaxYValue = (
+  processedData,
+  remainingData,
+  dirtyRateData,
+): null | number => {
+  const values = [processedData, remainingData, dirtyRateData]
+    .map((chartData) => findMaxYValue(chartData))
+    .filter((v): v is number => v !== null);
+  return values.length ? Math.max(...values) : null;
 };
 
 /**


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-61450](https://redhat.atlassian.net/browse/CNV-61450)

Variability in data causes utilization chart to re-scaled

## 🎥 Demo


https://github.com/user-attachments/assets/633c4b44-7574-4712-9b77-49ebd0595be6




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized chart Y-axis scaling across memory, network, migration, and storage charts to avoid jitter and handle missing data.
  * Charts now conditionally render thresholds and tick marks when meaningful data exists; tick formatting is robust when maxima are absent.

* **Tests**
  * Added comprehensive tests for Y-axis stability logic and chart utility functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->