### PR TITLE
CNV-84552: Fix metrics and utilization display issues for spoke cluster VMs without MCO

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -2161,6 +2161,7 @@
   "Type to create folder": "Type to create folder",
   "UEFI": "UEFI",
   "UEFI (secure)": "UEFI (secure)",
+  "Unable to verify multicluster observability status. Metrics may not be available.": "Unable to verify multicluster observability status. Metrics may not be available.",
   "Unattend.xml answer file": "Unattend.xml answer file",
   "Unavailable": "Unavailable",
   "Unique name of the MigrationPolicy": "Unique name of the MigrationPolicy",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -2181,6 +2181,7 @@
   "Type to create folder": "Tipo para crear carpeta",
   "UEFI": "UEFI",
   "UEFI (secure)": "UEFI (segura)",
+  "Unable to verify multicluster observability status. Metrics may not be available.": "Unable to verify multicluster observability status. Metrics may not be available.",
   "Unattend.xml answer file": "Archivo de respuesta Unattend.xml",
   "Unavailable": "No disponible",
   "Unique name of the MigrationPolicy": "Nombre único de la MigrationPolicy",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -2181,6 +2181,7 @@
   "Type to create folder": "Tapez pour créer un dossier",
   "UEFI": "UEFI",
   "UEFI (secure)": "UEFI (sécurisé)",
+  "Unable to verify multicluster observability status. Metrics may not be available.": "Unable to verify multicluster observability status. Metrics may not be available.",
   "Unattend.xml answer file": "Fichier de réponses Unattend.xml",
   "Unavailable": "Non disponible",
   "Unique name of the MigrationPolicy": "Nom unique de la MigrationPolicy",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -2157,6 +2157,7 @@
   "Type to create folder": "入力してフォルダーを作成",
   "UEFI": "UEFI",
   "UEFI (secure)": "UEFI (セキュア)",
+  "Unable to verify multicluster observability status. Metrics may not be available.": "Unable to verify multicluster observability status. Metrics may not be available.",
   "Unattend.xml answer file": "Unattend.xml アンサーファイル",
   "Unavailable": "利用不可",
   "Unique name of the MigrationPolicy": "MigrationPolicy の一意の名前",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -2157,6 +2157,7 @@
   "Type to create folder": "폴더를 생성하려면 입력하세요",
   "UEFI": "UEFI",
   "UEFI (secure)": "UEFI (보안)",
+  "Unable to verify multicluster observability status. Metrics may not be available.": "Unable to verify multicluster observability status. Metrics may not be available.",
   "Unattend.xml answer file": "Unattend.xml 응답 파일",
   "Unavailable": "사용할 수 없음",
   "Unique name of the MigrationPolicy": "MigrationPolicy의 고유 이름",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -2157,6 +2157,7 @@
   "Type to create folder": "输入来创建文件夹",
   "UEFI": "UEFI",
   "UEFI (secure)": "UEFI （安全）",
+  "Unable to verify multicluster observability status. Metrics may not be available.": "Unable to verify multicluster observability status. Metrics may not be available.",
   "Unattend.xml answer file": "Unattend.xml 应答文件",
   "Unavailable": "不可用",
   "Unique name of the MigrationPolicy": "MigrationPolicy 的唯一名称",

--- a/src/utils/hooks/useAlerts/utils/useMCOInstalled.ts
+++ b/src/utils/hooks/useAlerts/utils/useMCOInstalled.ts
@@ -12,6 +12,9 @@ export const getMCONotInstalledTooltip = (t: TFunction): string =>
     'Multicluster observability is not available. Install it on the hub cluster to enable monitoring across clusters.',
   );
 
+export const getMCOCheckErrorTooltip = (t: TFunction): string =>
+  t('Unable to verify multicluster observability status. Metrics may not be available.');
+
 type UseMCOInstalledResult = {
   error: Error | unknown;
   loaded: boolean;

--- a/src/utils/hooks/usePrometheusAvailability.ts
+++ b/src/utils/hooks/usePrometheusAvailability.ts
@@ -1,0 +1,24 @@
+import { getCluster } from '@multicluster/helpers/selectors';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { useHubClusterName } from '@stolostron/multicluster-sdk';
+
+import useMCOInstalled from './useAlerts/utils/useMCOInstalled';
+
+type UsePrometheusAvailabilityResult = {
+  mcoError: Error | unknown;
+  mcoLoaded: boolean;
+  prometheusUnavailable: boolean;
+};
+
+export const usePrometheusAvailability = (
+  resource?: K8sResourceCommon,
+): UsePrometheusAvailabilityResult => {
+  const { error: mcoError, loaded: mcoLoaded, mcoInstalled } = useMCOInstalled();
+  const [hubClusterName, hubClusterLoaded] = useHubClusterName();
+
+  const cluster = getCluster(resource);
+  const isSpoke = hubClusterLoaded && !!cluster && cluster !== hubClusterName;
+  const prometheusUnavailable = mcoLoaded && isSpoke && !mcoInstalled;
+
+  return { mcoError, mcoLoaded, prometheusUnavailable };
+};

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -172,5 +172,17 @@
 // t('Less than')
 // t('Error')
 
+// MCO status tooltips - used in useMCOInstalled.ts via getMCONotInstalledTooltip(t) and getMCOCheckErrorTooltip(t)
+// t('Multicluster observability is not available. Install it on the hub cluster to enable monitoring across clusters.')
+// t('Unable to verify multicluster observability status. Metrics may not be available.')
+
+// Storage chart titles - used in StorageCharts.tsx via STORAGE_CHART_COMPONENTS t(titleKey)
+// t('Storage total read / write')
+// t('Storage IOPS total read / write')
+// t('Storage Read Avg/Max Latency (all drives)')
+// t('Storage Write Avg/Max Latency (all drives)')
+// t('Storage Read Latency per Drive')
+// t('Storage Write Latency per Drive')
+
 //Disk size input
 // t('Dynamic')

--- a/src/views/virtualmachines/details/tabs/metrics/MigrationCharts/MigrationCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/MigrationCharts/MigrationCharts.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import MigrationThresholdChart from '@kubevirt-utils/components/Charts/MigrationUtil/MigrationThresholdChart';
@@ -18,13 +18,16 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 
+import NoDataMetricsCard from '../components/NoDataMetricsCard';
+
 import MigrationProgressStatus from './MigrationProgressStatus';
 
 type MigrationChartsProps = {
+  prometheusUnavailable?: boolean;
   vmi: V1VirtualMachineInstance;
 };
 
-const MigrationCharts: React.FC<MigrationChartsProps> = ({ vmi }) => {
+const MigrationCharts: FC<MigrationChartsProps> = ({ prometheusUnavailable, vmi }) => {
   const { t } = useKubevirtTranslation();
 
   return (
@@ -32,56 +35,64 @@ const MigrationCharts: React.FC<MigrationChartsProps> = ({ vmi }) => {
       <StackItem>
         <Grid>
           <GridItem span={6}>
-            <Card>
-              <CardTitle>
-                {t('Migration chart')}
-                <HelpTextIcon
-                  bodyContent={(hide) => (
-                    <PopoverContentWithLightspeedButton
-                      content={t(
-                        'Displays real-time metrics of the live migration process, such as memory transfer and downtime.',
-                      )}
-                      hide={hide}
-                      obj={vmi}
-                      promptType={OLSPromptType.MIGRATION_METRICS}
-                    />
-                  )}
-                  helpIconClassName="pf-v6-u-ml-xs"
-                  position={PopoverPosition.right}
-                />
-              </CardTitle>
-              <CardBody>
-                <MigrationThresholdChart vmi={vmi} />
-              </CardBody>
-            </Card>
+            {prometheusUnavailable ? (
+              <NoDataMetricsCard title={t('Migration chart')} />
+            ) : (
+              <Card>
+                <CardTitle>
+                  {t('Migration chart')}
+                  <HelpTextIcon
+                    bodyContent={(hide) => (
+                      <PopoverContentWithLightspeedButton
+                        content={t(
+                          'Displays real-time metrics of the live migration process, such as memory transfer and downtime.',
+                        )}
+                        hide={hide}
+                        obj={vmi}
+                        promptType={OLSPromptType.MIGRATION_METRICS}
+                      />
+                    )}
+                    helpIconClassName="pf-v6-u-ml-xs"
+                    position={PopoverPosition.right}
+                  />
+                </CardTitle>
+                <CardBody>
+                  <MigrationThresholdChart vmi={vmi} />
+                </CardBody>
+              </Card>
+            )}
           </GridItem>
           <GridItem span={6}>
-            <Card>
-              <CardTitle>
-                {t('KV data transfer rate')}
-                <HelpTextIcon
-                  bodyContent={(hide) => (
-                    <PopoverContentWithLightspeedButton
-                      content={t(
-                        'Shows the data throughput (MB/s) during the live migration between source and destination nodes.',
-                      )}
-                      hide={hide}
-                      obj={vmi}
-                      promptType={OLSPromptType.LIVE_MIGRATION_DATA_TRANSFER_RATE}
-                    />
-                  )}
-                  helpIconClassName="pf-v6-u-ml-xs"
-                  position={PopoverPosition.right}
-                />
-              </CardTitle>
-              <CardBody>
-                <MigrationThresholdChartDiskRate vmi={vmi} />
-              </CardBody>
-            </Card>
+            {prometheusUnavailable ? (
+              <NoDataMetricsCard title={t('KV data transfer rate')} />
+            ) : (
+              <Card>
+                <CardTitle>
+                  {t('KV data transfer rate')}
+                  <HelpTextIcon
+                    bodyContent={(hide) => (
+                      <PopoverContentWithLightspeedButton
+                        content={t(
+                          'Shows the data throughput (MB/s) during the live migration between source and destination nodes.',
+                        )}
+                        hide={hide}
+                        obj={vmi}
+                        promptType={OLSPromptType.LIVE_MIGRATION_DATA_TRANSFER_RATE}
+                      />
+                    )}
+                    helpIconClassName="pf-v6-u-ml-xs"
+                    position={PopoverPosition.right}
+                  />
+                </CardTitle>
+                <CardBody>
+                  <MigrationThresholdChartDiskRate vmi={vmi} />
+                </CardBody>
+              </Card>
+            )}
           </GridItem>
         </Grid>
       </StackItem>
-      <MigrationProgressStatus vmi={vmi} />
+      <MigrationProgressStatus prometheusUnavailable={prometheusUnavailable} vmi={vmi} />
     </Stack>
   );
 };

--- a/src/views/virtualmachines/details/tabs/metrics/MigrationCharts/MigrationProgressStatus.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/MigrationCharts/MigrationProgressStatus.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
+import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useMigrationPercentage from '@kubevirt-utils/resources/vm/hooks/useMigrationPercentage';
 import PopoverContentWithLightspeedButton from '@lightspeed/components/PopoverContentWithLightspeedButton/PopoverContentWithLightspeedButton';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import { Timestamp } from '@openshift-console/dynamic-plugin-sdk';
 import {
+  Bullseye,
   Card,
   CardBody,
   CardTitle,
@@ -21,10 +23,14 @@ import {
 import { getMigrationProgressVariant } from '../utils/utils';
 
 type MigrationProgressStatusProps = {
+  prometheusUnavailable?: boolean;
   vmi: V1VirtualMachineInstance;
 };
 
-const MigrationProgressStatus: React.FC<MigrationProgressStatusProps> = ({ vmi }) => {
+const MigrationProgressStatus: FC<MigrationProgressStatusProps> = ({
+  prometheusUnavailable,
+  vmi,
+}) => {
   const { t } = useKubevirtTranslation();
 
   const { endTimestamp, isFailed, percentage } = useMigrationPercentage(vmi);
@@ -52,27 +58,33 @@ const MigrationProgressStatus: React.FC<MigrationProgressStatusProps> = ({ vmi }
           />
         </CardTitle>
         <CardBody>
-          <Stack hasGutter>
-            <StackItem>
-              {endTimestamp && (
-                <>
-                  {t('Complete time:')}
-                  <Timestamp
-                    className="virtual-machine-metrics-tab__migration-completed-timestamp"
-                    simple
-                    timestamp={endTimestamp}
-                  />
-                </>
-              )}
-            </StackItem>
-            <StackItem>
-              <Progress
-                measureLocation={ProgressMeasureLocation.top}
-                value={percentage}
-                variant={progressStatus}
-              />
-            </StackItem>
-          </Stack>
+          {prometheusUnavailable ? (
+            <Bullseye>
+              <MutedTextSpan text={t('Not available')} />
+            </Bullseye>
+          ) : (
+            <Stack hasGutter>
+              <StackItem>
+                {endTimestamp && (
+                  <>
+                    {t('Complete time:')}
+                    <Timestamp
+                      className="virtual-machine-metrics-tab__migration-completed-timestamp"
+                      simple
+                      timestamp={endTimestamp}
+                    />
+                  </>
+                )}
+              </StackItem>
+              <StackItem>
+                <Progress
+                  measureLocation={ProgressMeasureLocation.top}
+                  value={percentage}
+                  variant={progressStatus}
+                />
+              </StackItem>
+            </Stack>
+          )}
         </CardBody>
       </Card>
     </StackItem>

--- a/src/views/virtualmachines/details/tabs/metrics/NetworkCharts/NetworkCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/NetworkCharts/NetworkCharts.tsx
@@ -6,9 +6,10 @@ import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { SelectOption, Title } from '@patternfly/react-core';
+import { Grid, GridItem, SelectOption, Title } from '@patternfly/react-core';
 
 import useQuery from '../../../../../../utils/hooks/useQuery';
+import NoDataMetricsCard from '../components/NoDataMetricsCard';
 import { ALL_NETWORKS } from '../utils/constants';
 
 import NetworkChartsByNIC from './NetworkChartsByNIC';
@@ -16,10 +17,11 @@ import NetworkChartsByNIC from './NetworkChartsByNIC';
 import '../virtual-machine-metrics-tab.scss';
 
 type NetworkChartsProps = {
+  prometheusUnavailable?: boolean;
   vmi: V1VirtualMachineInstance;
 };
 
-const NetworkCharts: FC<NetworkChartsProps> = ({ vmi }) => {
+const NetworkCharts: FC<NetworkChartsProps> = ({ prometheusUnavailable, vmi }) => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
 
@@ -33,6 +35,22 @@ const NetworkCharts: FC<NetworkChartsProps> = ({ vmi }) => {
   const [selectedNetwork, setSelectedNetwork] = useState<string>(
     query?.get('network') || ALL_NETWORKS,
   );
+
+  if (prometheusUnavailable) {
+    return (
+      <Grid>
+        <GridItem span={4}>
+          <NoDataMetricsCard title={t('Network in')} />
+        </GridItem>
+        <GridItem span={4}>
+          <NoDataMetricsCard title={t('Network out')} />
+        </GridItem>
+        <GridItem span={4}>
+          <NoDataMetricsCard title={t('Network bandwidth')} />
+        </GridItem>
+      </Grid>
+    );
+  }
 
   return (
     <div>

--- a/src/views/virtualmachines/details/tabs/metrics/StorageCharts/StorageCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/StorageCharts/StorageCharts.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import StorageIOPSTotalThresholdChart from '@kubevirt-utils/components/Charts/StorageUtil/StorageIOPSTotalThresholdChart';
@@ -10,63 +10,44 @@ import StorageWriteLatencyPerDriveChart from '@kubevirt-utils/components/Charts/
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Card, CardBody, CardTitle, Grid, GridItem } from '@patternfly/react-core';
 
+import NoDataMetricsCard from '../components/NoDataMetricsCard';
+
 type StorageChartsProps = {
+  prometheusUnavailable?: boolean;
   vmi: V1VirtualMachineInstance;
 };
 
-const StorageCharts: React.FC<StorageChartsProps> = ({ vmi }) => {
+const STORAGE_CHART_COMPONENTS = [
+  { Chart: StorageTotalReadWriteThresholdChart, titleKey: 'Storage total read / write' },
+  { Chart: StorageIOPSTotalThresholdChart, titleKey: 'Storage IOPS total read / write' },
+  { Chart: StorageReadLatencyAvgMaxChart, titleKey: 'Storage Read Avg/Max Latency (all drives)' },
+  { Chart: StorageWriteLatencyAvgMaxChart, titleKey: 'Storage Write Avg/Max Latency (all drives)' },
+  { Chart: StorageReadLatencyPerDriveChart, titleKey: 'Storage Read Latency per Drive' },
+  { Chart: StorageWriteLatencyPerDriveChart, titleKey: 'Storage Write Latency per Drive' },
+];
+
+const StorageCharts: FC<StorageChartsProps> = ({ prometheusUnavailable, vmi }) => {
   const { t } = useKubevirtTranslation();
 
   return (
     <Grid hasGutter>
-      <GridItem span={6}>
-        <Card>
-          <CardTitle>{t('Storage total read / write')}</CardTitle>
-          <CardBody>
-            <StorageTotalReadWriteThresholdChart vmi={vmi} />
-          </CardBody>
-        </Card>
-      </GridItem>
-      <GridItem span={6}>
-        <Card>
-          <CardTitle>{t('Storage IOPS total read / write')}</CardTitle>
-          <CardBody>
-            <StorageIOPSTotalThresholdChart vmi={vmi} />
-          </CardBody>
-        </Card>
-      </GridItem>
-      <GridItem span={6}>
-        <Card>
-          <CardTitle>{t('Storage Read Avg/Max Latency (all drives)')}</CardTitle>
-          <CardBody>
-            <StorageReadLatencyAvgMaxChart vmi={vmi} />
-          </CardBody>
-        </Card>
-      </GridItem>
-      <GridItem span={6}>
-        <Card>
-          <CardTitle>{t('Storage Write Avg/Max Latency (all drives)')}</CardTitle>
-          <CardBody>
-            <StorageWriteLatencyAvgMaxChart vmi={vmi} />
-          </CardBody>
-        </Card>
-      </GridItem>
-      <GridItem span={6}>
-        <Card>
-          <CardTitle>{t('Storage Read Latency per Drive')}</CardTitle>
-          <CardBody>
-            <StorageReadLatencyPerDriveChart vmi={vmi} />
-          </CardBody>
-        </Card>
-      </GridItem>
-      <GridItem span={6}>
-        <Card>
-          <CardTitle>{t('Storage Write Latency per Drive')}</CardTitle>
-          <CardBody>
-            <StorageWriteLatencyPerDriveChart vmi={vmi} />
-          </CardBody>
-        </Card>
-      </GridItem>
+      {STORAGE_CHART_COMPONENTS.map(({ Chart, titleKey }) => {
+        const title = t(titleKey);
+        return (
+          <GridItem key={titleKey} span={6}>
+            {prometheusUnavailable ? (
+              <NoDataMetricsCard title={title} />
+            ) : (
+              <Card>
+                <CardTitle>{title}</CardTitle>
+                <CardBody>
+                  <Chart vmi={vmi} />
+                </CardBody>
+              </Card>
+            )}
+          </GridItem>
+        );
+      })}
     </Grid>
   );
 };

--- a/src/views/virtualmachines/details/tabs/metrics/UtilizationCharts/UtilizationCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/UtilizationCharts/UtilizationCharts.tsx
@@ -6,30 +6,41 @@ import MemoryThresholdChart from '@kubevirt-utils/components/Charts/MemoryUtil/M
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Card, CardBody, CardTitle, Grid, GridItem } from '@patternfly/react-core';
 
+import NoDataMetricsCard from '../components/NoDataMetricsCard';
+
 type UtilizationChartsProps = {
+  prometheusUnavailable?: boolean;
   vmi: V1VirtualMachineInstance;
 };
 
-const UtilizationCharts: FC<UtilizationChartsProps> = ({ vmi }) => {
+const UtilizationCharts: FC<UtilizationChartsProps> = ({ prometheusUnavailable, vmi }) => {
   const { t } = useKubevirtTranslation();
 
   return (
     <Grid hasGutter>
       <GridItem span={6}>
-        <Card>
-          <CardTitle>{t('Memory')}</CardTitle>
-          <CardBody>
-            <MemoryThresholdChart vmi={vmi} />
-          </CardBody>
-        </Card>
+        {prometheusUnavailable ? (
+          <NoDataMetricsCard title={t('Memory')} />
+        ) : (
+          <Card>
+            <CardTitle>{t('Memory')}</CardTitle>
+            <CardBody>
+              <MemoryThresholdChart vmi={vmi} />
+            </CardBody>
+          </Card>
+        )}
       </GridItem>
       <GridItem span={6}>
-        <Card>
-          <CardTitle>{t('CPU')}</CardTitle>
-          <CardBody>
-            <CPUThresholdChart vmi={vmi} />
-          </CardBody>
-        </Card>
+        {prometheusUnavailable ? (
+          <NoDataMetricsCard title={t('CPU')} />
+        ) : (
+          <Card>
+            <CardTitle>{t('CPU')}</CardTitle>
+            <CardBody>
+              <CPUThresholdChart vmi={vmi} />
+            </CardBody>
+          </Card>
+        )}
       </GridItem>
     </Grid>
   );

--- a/src/views/virtualmachines/details/tabs/metrics/VirtualMachineMetricsTab.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/VirtualMachineMetricsTab.tsx
@@ -1,13 +1,18 @@
 import React, { FC, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
+import {
+  getMCOCheckErrorTooltip,
+  getMCONotInstalledTooltip,
+} from '@kubevirt-utils/hooks/useAlerts/utils/useMCOInstalled';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { usePrometheusAvailability } from '@kubevirt-utils/hooks/usePrometheusAvailability';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { Overview } from '@openshift-console/dynamic-plugin-sdk';
-import { ExpandableSection, Title } from '@patternfly/react-core';
+import { Alert, AlertVariant, ExpandableSection, Title } from '@patternfly/react-core';
 import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 import MigrationCharts from './MigrationCharts/MigrationCharts';
@@ -23,6 +28,7 @@ const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
   const { t } = useKubevirtTranslation();
   const location = useLocation();
   const { vmi, vmiLoaded } = useVMI(getName(vm), getNamespace(vm), getCluster(vm));
+  const { mcoError, prometheusUnavailable } = usePrometheusAvailability(vm);
 
   const [expended, setExpended] = useState<{ [key in MetricsTabExpendedSections]: boolean }>({
     [MetricsTabExpendedSections.migration]: true,
@@ -31,7 +37,7 @@ const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
     [MetricsTabExpendedSections.utilization]: true,
   });
 
-  const onToggle = (value) => () =>
+  const onToggle = (value: MetricsTabExpendedSections) => () =>
     setExpended((currentOpen) => ({ ...currentOpen, [value]: !currentOpen?.[value] }));
 
   useEffect(() => {
@@ -39,8 +45,7 @@ const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
       const focusedSectionId = Object.values(MetricsTabExpendedSections).find((focusedSection) =>
         location?.search?.includes(focusedSection),
       );
-      const focusedExpandableSection = document.getElementById(focusedSectionId);
-      focusedExpandableSection.scrollIntoView();
+      document.getElementById(focusedSectionId)?.scrollIntoView();
     }
   }, [location?.search, vmiLoaded]);
 
@@ -49,7 +54,15 @@ const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
       <Title className="title" headingLevel="h2">
         {t('Metrics')}
       </Title>
-      <TimeRange />
+      {prometheusUnavailable && (
+        <Alert
+          className="pf-v6-u-mb-md pf-v6-u-mx-md"
+          isInline
+          title={mcoError ? getMCOCheckErrorTooltip(t) : getMCONotInstalledTooltip(t)}
+          variant={AlertVariant.warning}
+        />
+      )}
+      {!prometheusUnavailable && <TimeRange />}
       <Overview className="virtual-machine-metrics-tab__charts">
         <ExpandableSection
           id={MetricsTabExpendedSections.utilization}
@@ -57,7 +70,7 @@ const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
           onToggle={onToggle(MetricsTabExpendedSections.utilization)}
           toggleText={t('Utilization')}
         >
-          <UtilizationCharts vmi={vmi} />
+          <UtilizationCharts prometheusUnavailable={prometheusUnavailable} vmi={vmi} />
         </ExpandableSection>
 
         <ExpandableSection
@@ -66,7 +79,7 @@ const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
           onToggle={onToggle(MetricsTabExpendedSections.storage)}
           toggleText={t('Storage')}
         >
-          <StorageCharts vmi={vmi} />
+          <StorageCharts prometheusUnavailable={prometheusUnavailable} vmi={vmi} />
         </ExpandableSection>
         <ExpandableSection
           id={MetricsTabExpendedSections.network}
@@ -74,7 +87,7 @@ const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
           onToggle={onToggle(MetricsTabExpendedSections.network)}
           toggleText={t('Network')}
         >
-          <NetworkCharts vmi={vmi} />
+          <NetworkCharts prometheusUnavailable={prometheusUnavailable} vmi={vmi} />
         </ExpandableSection>
         <ExpandableSection
           id={MetricsTabExpendedSections.migration}
@@ -82,7 +95,7 @@ const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
           onToggle={onToggle(MetricsTabExpendedSections.migration)}
           toggleText={t('Migration')}
         >
-          <MigrationCharts vmi={vmi} />
+          <MigrationCharts prometheusUnavailable={prometheusUnavailable} vmi={vmi} />
         </ExpandableSection>
       </Overview>
     </div>

--- a/src/views/virtualmachines/details/tabs/metrics/components/NoDataMetricsCard.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/components/NoDataMetricsCard.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from 'react';
+
+import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { Bullseye, Card, CardBody, CardTitle } from '@patternfly/react-core';
+
+type NoDataMetricsCardProps = {
+  title: string;
+};
+
+const NoDataMetricsCard: FC<NoDataMetricsCardProps> = ({ title }) => {
+  const { t } = useKubevirtTranslation();
+
+  return (
+    <Card>
+      <CardTitle>{title}</CardTitle>
+      <CardBody>
+        <Bullseye>
+          <MutedTextSpan text={t('Not available')} />
+        </Bullseye>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default NoDataMetricsCard;

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/VirtualMachinesOverviewTabUtilization.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/VirtualMachinesOverviewTabUtilization.tsx
@@ -4,10 +4,17 @@ import { Trans } from 'react-i18next';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ComponentReady from '@kubevirt-utils/components/Charts/ComponentReady/ComponentReady';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
+import {
+  getMCOCheckErrorTooltip,
+  getMCONotInstalledTooltip,
+} from '@kubevirt-utils/hooks/useAlerts/utils/useMCOInstalled';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { usePrometheusAvailability } from '@kubevirt-utils/hooks/usePrometheusAvailability';
 import PopoverContentWithLightspeedButton from '@lightspeed/components/PopoverContentWithLightspeedButton/PopoverContentWithLightspeedButton';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import {
+  Alert,
+  AlertVariant,
   Card,
   CardBody,
   CardTitle,
@@ -22,6 +29,7 @@ import { isRunning } from '@virtualmachines/utils';
 import CPUUtil from './components/CPUUtil/CPUUtil';
 import MemoryUtil from './components/MemoryUtil/MemoryUtil';
 import NetworkUtil from './components/NetworkUtil/NetworkUtil';
+import NoDataUtilizationBlock from './components/NoDataUtilizationBlock';
 import StorageUtil from './components/StorageUtil/StorageUtil';
 import TimeDropdown from './components/TimeDropdown';
 import UtilizationThresholdCharts from './components/UtilizationThresholdCharts';
@@ -38,6 +46,7 @@ const VirtualMachinesOverviewTabUtilization: FC<VirtualMachinesOverviewTabUtiliz
   vmi,
 }) => {
   const { t } = useKubevirtTranslation();
+  const { mcoError, prometheusUnavailable } = usePrometheusAvailability(vm);
 
   return (
     <Card className="VirtualMachinesOverviewTabUtilization--main">
@@ -62,28 +71,54 @@ const VirtualMachinesOverviewTabUtilization: FC<VirtualMachinesOverviewTabUtiliz
               position={PopoverPosition.right}
             />
           </div>
-          <TimeDropdown />
+          {!prometheusUnavailable && <TimeDropdown />}
         </Flex>
       </CardTitle>
       <Divider />
       <CardBody isFilled>
         <ComponentReady isReady={isRunning(vm)} text={t('VirtualMachine is not running')}>
+          {prometheusUnavailable && (
+            <Alert
+              className="pf-v6-u-mb-md"
+              isInline
+              title={mcoError ? getMCOCheckErrorTooltip(t) : getMCONotInstalledTooltip(t)}
+              variant={AlertVariant.warning}
+            />
+          )}
           <Grid>
             <GridItem span={3}>
-              <CPUUtil vmi={vmi} />
+              {prometheusUnavailable ? (
+                <NoDataUtilizationBlock dataTestId="util-summary-cpu" title={t('CPU')} />
+              ) : (
+                <CPUUtil vmi={vmi} />
+              )}
             </GridItem>
             <GridItem span={3}>
-              <MemoryUtil vmi={vmi} />
+              {prometheusUnavailable ? (
+                <NoDataUtilizationBlock dataTestId="util-summary-memory" title={t('Memory')} />
+              ) : (
+                <MemoryUtil vmi={vmi} />
+              )}
             </GridItem>
             <GridItem span={3}>
               <StorageUtil vmi={vmi} />
             </GridItem>
             <GridItem span={3}>
-              <NetworkUtil vmi={vmi} />
+              {prometheusUnavailable ? (
+                <NoDataUtilizationBlock
+                  dataTestId="util-summary-network-transfer"
+                  isNetworkUtil
+                  title={t('Network transfer')}
+                />
+              ) : (
+                <NetworkUtil vmi={vmi} />
+              )}
             </GridItem>
-            <GridItem className="pf-v6-u-pl-md" span={12}>
-              <UtilizationThresholdCharts vmi={vmi} />
-            </GridItem>
+            {!prometheusUnavailable && (
+              <GridItem className="pf-v6-u-pl-md" span={12}>
+                <UtilizationThresholdCharts vmi={vmi} />
+              </GridItem>
+            )}
           </Grid>
         </ComponentReady>
       </CardBody>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
@@ -34,12 +34,14 @@ const CPUUtil: FC<CPUUtilProps> = ({ vmi }) => {
     namespace: getNamespace(vmi),
   };
 
-  const [dataCPUUsage] = useFleetPrometheusPoll({
+  const [dataCPUUsage, loaded, error] = useFleetPrometheusPoll({
     ...prometheusProps,
     query: queries?.CPU_USAGE,
   });
 
+  const isLoading = !loaded;
   const vmCPU = getCPU(vmi);
+  const hasData = dataCPUUsage?.data?.result?.length > 0;
 
   const cpuUsage = +(dataCPUUsage?.data?.result?.[0]?.value?.[1] || 0);
   const cpuUsageHumanized = humanizeCpuCores(cpuUsage);
@@ -50,18 +52,22 @@ const CPUUtil: FC<CPUUtilProps> = ({ vmi }) => {
   const averageCPUUsageStr = ((cpuUsage / cpuRequested) * 100).toFixed(2) || 0;
   const averageCPUUsage = Number(averageCPUUsageStr);
 
-  const isReady = !Number.isNaN(cpuUsage) && !Number.isNaN(cpuRequested);
+  const isReady = loaded && hasData && !Number.isNaN(cpuRequested);
 
   return (
     <UtilizationBlock
-      usedOfTotalText={t('Requested of {{cpuRequested}}', {
-        cpuRequested: isReady ? cpuRequestedHumanized?.string : 0,
-      })}
+      usedOfTotalText={
+        isReady
+          ? t('Requested of {{cpuRequested}}', {
+              cpuRequested: cpuRequestedHumanized?.string,
+            })
+          : ''
+      }
       dataTestId="util-summary-cpu"
       title={t('CPU')}
-      usageValue={`${isReady ? cpuUsageHumanized?.string : 0}`}
+      usageValue={isReady ? cpuUsageHumanized?.string : ''}
     >
-      <ComponentReady isReady={isReady}>
+      <ComponentReady error={error} isLoading={isLoading} isReady={isReady}>
         <ChartDonutUtilization
           data={{
             x: t('CPU used'),

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
@@ -30,7 +30,7 @@ const MemoryUtil: FC<MemoryUtilProps> = ({ vmi }) => {
   const queries = useVMQueries(vmi);
   const memory = getMemorySize(getMemory(vmi));
 
-  const [data] = useFleetPrometheusPoll({
+  const [data, loaded, error] = useFleetPrometheusPoll({
     cluster: getCluster(vmi),
     endpoint: PrometheusEndpoint?.QUERY,
     endTime: currentTime,
@@ -38,19 +38,22 @@ const MemoryUtil: FC<MemoryUtilProps> = ({ vmi }) => {
     query: queries?.MEMORY_USAGE,
   });
 
+  const isLoading = !loaded;
   const memoryUsed = +data?.data?.result?.[0]?.value?.[1];
   const memoryAvailableBytes = xbytes.parseSize(`${memory?.size} ${memory?.unit}B`);
   const percentageMemoryUsed = (memoryUsed / memoryAvailableBytes) * 100;
-  const isReady = !isEmpty(memory) && !Number.isNaN(percentageMemoryUsed);
+  const isReady = loaded && !isEmpty(memory) && !Number.isNaN(percentageMemoryUsed);
 
   return (
     <UtilizationBlock
+      usedOfTotalText={
+        isReady ? t('Used of {{ total }}', { total: `${memory?.size} ${memory?.unit}B` }) : ''
+      }
       dataTestId="util-summary-memory"
       title={t('Memory')}
-      usageValue={xbytes(memoryUsed || 0, { fixed: 0, iec: true })}
-      usedOfTotalText={t('Used of {{ total }}', { total: `${memory?.size} ${memory?.unit}B` })}
+      usageValue={isReady ? xbytes(memoryUsed || 0, { fixed: 0, iec: true }) : ''}
     >
-      <ComponentReady isReady={isReady}>
+      <ComponentReady error={error} isLoading={isLoading} isReady={isReady}>
         <ChartDonutUtilization
           data={{
             x: t('Memory used'),

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/NetworkUtil/NetworkUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/NetworkUtil/NetworkUtil.tsx
@@ -35,7 +35,7 @@ const NetworkUtil: React.FC<NetworkUtilProps> = ({ vmi }) => {
     namespace: getNamespace(vmi),
   };
 
-  const [networkIn] = useFleetPrometheusPoll({
+  const [networkIn, networkInLoaded, networkInError] = useFleetPrometheusPoll({
     ...prometheusProps,
     query: queries?.NETWORK_IN_USAGE,
   });
@@ -45,29 +45,35 @@ const NetworkUtil: React.FC<NetworkUtilProps> = ({ vmi }) => {
     query: queries?.NETWORK_TOTAL_BY_INTERFACE_USAGE,
   });
 
-  const [networkOut] = useFleetPrometheusPoll({
+  const [networkOut, networkOutLoaded, networkOutError] = useFleetPrometheusPoll({
     ...prometheusProps,
     query: queries?.NETWORK_OUT_USAGE,
   });
 
-  const networkInData = +networkIn?.data?.result?.[0]?.value?.[1];
-  const networkOutData = +networkOut?.data?.result?.[0]?.value?.[1];
-  const totalTransferred = xbytes(networkInData + networkOutData || 0, {
+  const loaded = networkInLoaded && networkOutLoaded;
+  const isLoading = !loaded;
+  const error = networkInError || networkOutError;
+
+  const hasNetworkInData = !isEmpty(networkIn?.data?.result);
+  const hasNetworkOutData = !isEmpty(networkOut?.data?.result);
+  const networkInData = +(networkIn?.data?.result?.[0]?.value?.[1] ?? 0);
+  const networkOutData = +(networkOut?.data?.result?.[0]?.value?.[1] ?? 0);
+  const totalTransferred = xbytes(networkInData + networkOutData, {
     fixed: 0,
     iec: true,
   });
-  const isReady = !isEmpty(networkInData) || !isEmpty(networkOutData);
+  const isReady = loaded && (hasNetworkInData || hasNetworkOutData);
 
   return (
     <UtilizationBlock
       dataTestId="util-summary-network-transfer"
       isNetworkUtil
       title={t('Network transfer')}
-      usageValue={`${totalTransferred}ps`}
-      usedOfTotalText={t('Total')}
+      usageValue={isReady ? `${totalTransferred}ps` : ''}
+      usedOfTotalText={isReady ? t('Total') : ''}
     >
       <Stack className="pf-v6-u-pl-lg pf-v6-u-mt-xl" hasGutter>
-        <ComponentReady isReady={isReady}>
+        <ComponentReady error={error} isLoading={isLoading} isReady={isReady}>
           <div>
             <NetworkMetricsRow label={t('In')} value={networkInData} />
             <NetworkMetricsRow label={t('Out')} value={networkOutData} />

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/NoDataUtilizationBlock.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/NoDataUtilizationBlock.tsx
@@ -1,0 +1,31 @@
+import React, { FC } from 'react';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+
+import { UtilizationBlock } from './UtilizationBlock';
+
+type NoDataUtilizationBlockProps = {
+  dataTestId: string;
+  isNetworkUtil?: boolean;
+  title: string;
+};
+
+const NoDataUtilizationBlock: FC<NoDataUtilizationBlockProps> = ({
+  dataTestId,
+  isNetworkUtil = false,
+  title,
+}) => {
+  const { t } = useKubevirtTranslation();
+
+  return (
+    <UtilizationBlock
+      dataTestId={dataTestId}
+      isNetworkUtil={isNetworkUtil}
+      title={title}
+      usageValue={t('Not available')}
+      usedOfTotalText=""
+    />
+  );
+};
+
+export default NoDataUtilizationBlock;

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/StorageUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/StorageUtil.tsx
@@ -31,20 +31,25 @@ const StorageUtil: FC<StorageUtilProps> = ({ vmi }) => {
       { totalBytes: 0, usedBytes: 0 },
     ) || {};
 
-  const usedPercentage = (usedBytes / totalBytes) * 100 || 0;
+  const hasDiskData = totalBytes > 0;
+  const usedPercentage = hasDiskData ? (usedBytes / totalBytes) * 100 : 0;
 
-  const isReady = !Number.isNaN(usedPercentage) && loaded;
+  const isReady = loaded && hasDiskData;
 
   return (
     <UtilizationBlock
-      usedOfTotalText={t('Used of {{ total }}', {
-        total: xbytes(totalBytes || 0, { fixed: 2, iec: true }),
-      })}
+      usedOfTotalText={
+        isReady
+          ? t('Used of {{ total }}', {
+              total: xbytes(totalBytes || 0, { fixed: 2, iec: true }),
+            })
+          : ''
+      }
       dataTestId="util-summary-storage"
       title={t('Storage')}
-      usageValue={xbytes(usedBytes || 0, { fixed: 2, iec: true })}
+      usageValue={isReady ? xbytes(usedBytes || 0, { fixed: 2, iec: true }) : ''}
     >
-      <ComponentReady isReady={isReady}>
+      <ComponentReady isLoading={!loaded} isReady={isReady}>
         <ChartDonutUtilization
           data={{
             x: t('Storage used'),


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-84552](https://redhat.atlassian.net/browse/CNV-84552)

Fix metrics and utilization display issues for spoke cluster VMs without MCO

## 🎥 Demo


Before:

https://github.com/user-attachments/assets/a2f7be54-a12f-4a5d-9e89-ecbdaf13d440

After (MCO not installed):


https://github.com/user-attachments/assets/671f2593-3a14-4a99-bb4b-1d5abfee7c9e


After (MCO installed):

https://github.com/user-attachments/assets/97634021-5d01-468b-95bb-3800e3707e52


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics now detect Prometheus unavailability and show contextual warning alerts and translated tooltips.
  * New "No data" components replace charts, progress, and utilization panels when metrics are unavailable; time controls are hidden in that state.

* **Bug Fixes**
  * Charts and utilization blocks display clear "Not available" messaging instead of partial or misleading values.
  * Improved loading and error gating so UI only shows metric values when data is ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->