### PR TITLE
CNV-84556: Guided tour and welcome modal flash briefly when switching to Fleet Virtualization perspective

### DIFF
--- a/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
+++ b/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
@@ -8,6 +8,7 @@ import VMsTabOnboardingPopover from '@kubevirt-utils/components/OnboardingPopove
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VirtualMachineModelRef } from '@kubevirt-utils/models';
 import { FLEET_VIRTUAL_MACHINES_PATH } from '@multicluster/constants';
+import { isACMPath } from '@multicluster/urls';
 import { OnFilterChange } from '@openshift-console/dynamic-plugin-sdk';
 import { Divider, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
@@ -36,6 +37,8 @@ const VirtualMachineNavigator: FC = () => {
   const { activeTabKey, handleTabSelect } = useNavigatorTabs();
 
   const { cluster, ns: namespace } = useParams<{ cluster?: string; ns: string }>();
+
+  const isFleetPage = isACMPath(location.pathname);
 
   const isACMVMListPage =
     matchPath(`${FLEET_VIRTUAL_MACHINES_PATH}/all-clusters/all-namespaces`, location.pathname) ||
@@ -73,8 +76,8 @@ const VirtualMachineNavigator: FC = () => {
       <SettingsClusterProvider cluster={cluster}>
         <VirtualizationFeaturesContextProvider>
           <VirtualMachineTreeView onFilterChange={onFilterChange} {...treeProps}>
-            <GuidedTour />
-            <WelcomeModal />
+            {!isFleetPage && <GuidedTour />}
+            {!isFleetPage && <WelcomeModal />}
             <CatalogOnboardingPopover />
             {isVirtualMachineListPage ? (
               <Tabs


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-84556](https://redhat.atlassian.net/browse/CNV-84556)

Guided tour and welcome modal flash briefly when switching to Fleet Virtualization perspective

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/1fc4468a-0184-4bc0-9ebc-132a81295683


After (it doesn't happen). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Guided Tour and Welcome Modal appearing on the Fleet page. These components now correctly respect the current navigation context and are properly hidden when viewing Fleet-related pages for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->