### PR TITLE
CNV-84565: Metrics tab network interface dropdown navigates away from fleet virtualization view

### DIFF
--- a/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
+++ b/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
@@ -109,7 +109,10 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
           })}
         </ul>
       </nav>
-      <div className={classNames('horizontal-navbar__routes', routesClassName)}>
+      <div
+        className={classNames('horizontal-navbar__routes', routesClassName)}
+        id="horizontal-navbar-routes"
+      >
         <Routes>{RoutesComponents}</Routes>
       </div>
     </>

--- a/src/views/virtualmachines/details/tabs/metrics/NetworkCharts/NetworkCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/NetworkCharts/NetworkCharts.tsx
@@ -1,11 +1,9 @@
 import React, { FC, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
-import { VirtualMachineModelRef } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { Grid, GridItem, SelectOption, Title } from '@patternfly/react-core';
 
 import useQuery from '../../../../../../utils/hooks/useQuery';
@@ -23,6 +21,7 @@ type NetworkChartsProps = {
 
 const NetworkCharts: FC<NetworkChartsProps> = ({ prometheusUnavailable, vmi }) => {
   const { t } = useKubevirtTranslation();
+  const { pathname } = useLocation();
   const navigate = useNavigate();
 
   const interfacesNames = useMemo(() => {
@@ -65,11 +64,7 @@ const NetworkCharts: FC<NetworkChartsProps> = ({ prometheusUnavailable, vmi }) =
         {interfacesNames?.map((nic) => (
           <SelectOption
             onClick={() => {
-              navigate(
-                `/k8s/ns/${getNamespace(vmi)}/${VirtualMachineModelRef}/${getName(
-                  vmi,
-                )}/metrics?network=${nic}`,
-              );
+              navigate({ pathname, search: `?network=${nic}` }, { replace: true });
             }}
             key={nic}
             value={nic}

--- a/src/views/virtualmachines/details/tabs/metrics/VirtualMachineMetricsTab.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/VirtualMachineMetricsTab.tsx
@@ -45,7 +45,15 @@ const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
       const focusedSectionId = Object.values(MetricsTabExpendedSections).find((focusedSection) =>
         location?.search?.includes(focusedSection),
       );
-      document.getElementById(focusedSectionId)?.scrollIntoView();
+      const element = focusedSectionId ? document.getElementById(focusedSectionId) : null;
+      const scrollContainer = document.getElementById('horizontal-navbar-routes');
+
+      if (element && scrollContainer) {
+        scrollContainer.scrollTo({
+          behavior: 'smooth',
+          top: element.offsetTop - scrollContainer.offsetTop,
+        });
+      }
     }
   }, [location?.search, vmiLoaded]);
 


### PR DESCRIPTION
## 📝 Description

Jira Ticket: [CNV-84565](https://redhat.atlassian.net/browse/CNV-84565)

Metrics tab network interface dropdown navigates away from fleet virtualization view

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/12acb996-b2fe-4769-8124-9580eb4c29af


After:

https://github.com/user-attachments/assets/63e78dc0-3641-46d1-a45a-e7e7eb75a5c5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network selection now preserves the current page location and updates only the URL query, replacing the current browser history entry.
  * Metric-section navigation uses a safer, container-aware smooth scroll for more accurate positioning.
  * Horizontal navbar routes container gains a stable DOM identifier to improve scroll targeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->