### PR TITLE
CNV-81682: gate Virtualization navigation on manual role aggregation RBAC

### DIFF
--- a/plugin-extensions.ts
+++ b/plugin-extensions.ts
@@ -81,6 +81,9 @@ const extensions: EncodedExtension[] = [
 
   // Hardware Devices (compute section, not virtualization)
   {
+    flags: {
+      required: ['KUBEVIRT_VIRTUALIZATION_NAV'],
+    },
     properties: {
       href: '/hardwaredevices',
       id: 'hardwaredevices',

--- a/plugin-extensions.ts
+++ b/plugin-extensions.ts
@@ -5,6 +5,7 @@ import { extensions as MulticlusterExtensions } from './src/multicluster/extensi
 import { extensions as VirtualizationPerspectiveExtensions } from './src/perspective/extensions';
 import { extensions as YamlTemplatesExtensions } from './src/templates/extensions';
 import { extensions as utilsExtensions } from './src/utils/extension';
+import { FLAG_KUBEVIRT_VIRTUALIZATION_NAV } from './src/utils/flags/consts';
 import { extensions as BootableVolumesExtensions } from './src/views/bootablevolumes/extensions';
 import { extensions as CatalogExtensions } from './src/views/catalog/extensions';
 import { extensions as CDIUploadProviderExtensions } from './src/views/cdi-upload-provider/extensions';
@@ -82,7 +83,7 @@ const extensions: EncodedExtension[] = [
   // Hardware Devices (compute section, not virtualization)
   {
     flags: {
-      required: ['KUBEVIRT_VIRTUALIZATION_NAV'],
+      required: [FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
     },
     properties: {
       href: '/hardwaredevices',

--- a/src/multicluster/extensions.ts
+++ b/src/multicluster/extensions.ts
@@ -39,7 +39,7 @@ export const extensions: EncodedExtension[] = [
   {
     flags: {
       disallowed: ['KUBEVIRT_DISALLOW_DYNAMIC_ACM'],
-      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+      required: [FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
     },
     properties: {
       icon: { $codeRef: 'perspective.icon' },
@@ -60,9 +60,6 @@ export const extensions: EncodedExtension[] = [
   // MigrationPolicies
   // Checkups
   {
-    flags: {
-      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
-    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-virtualmachines',
@@ -77,9 +74,6 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
   {
-    flags: {
-      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
-    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-templates',
@@ -95,9 +89,6 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
   {
-    flags: {
-      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
-    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-bootablevolumes',
@@ -113,9 +104,6 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
   {
-    flags: {
-      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
-    },
     properties: {
       id: 'acm-separator-1',
       insertAfter: 'bootablevolumes-virt-perspective',
@@ -126,9 +114,6 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/separator',
   } as EncodedExtension<Separator>,
   {
-    flags: {
-      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
-    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-instancetype',
@@ -144,9 +129,6 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
   {
-    flags: {
-      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
-    },
     properties: {
       id: 'acm-separator-2',
       insertAfter: 'instancetype-virt-perspective',
@@ -157,9 +139,6 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/separator',
   } as EncodedExtension<Separator>,
   {
-    flags: {
-      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
-    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-migrationpolicies',
@@ -175,9 +154,6 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
   {
-    flags: {
-      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
-    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-checkups',
@@ -193,9 +169,6 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
   {
-    flags: {
-      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
-    },
     properties: {
       component: { $codeRef: 'ConsoleStandAlone' },
       exact: false,
@@ -204,9 +177,6 @@ export const extensions: EncodedExtension[] = [
     type: 'console.page/route/standalone',
   } as EncodedExtension<StandaloneRoutePage>,
   {
-    flags: {
-      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
-    },
     properties: {
       component: {
         $codeRef: 'Navigator',
@@ -222,9 +192,6 @@ export const extensions: EncodedExtension[] = [
     type: 'console.page/route',
   } as EncodedExtension<RoutePage>,
   {
-    flags: {
-      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
-    },
     properties: {
       component: {
         $codeRef: 'InstanceTypePage',
@@ -307,7 +274,7 @@ export const extensions: EncodedExtension[] = [
   } as EncodedExtension<RoutePage>,
   {
     flags: {
-      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+      required: ['KUBEVIRT_DYNAMIC_ACM'],
     },
     properties: {
       component: {

--- a/src/multicluster/extensions.ts
+++ b/src/multicluster/extensions.ts
@@ -11,6 +11,7 @@ import type { ConsolePluginBuildMetadata } from '@openshift-console/dynamic-plug
 import { ResourceRoute } from '@stolostron/multicluster-sdk';
 
 import { PERSPECTIVES } from '../utils/constants/constants';
+import { FLAG_KUBEVIRT_VIRTUALIZATION_NAV } from '../utils/flags/consts';
 
 import {
   CROSS_CLUSTER_MIGRATION_ACTION_ID,
@@ -38,6 +39,7 @@ export const extensions: EncodedExtension[] = [
   {
     flags: {
       disallowed: ['KUBEVIRT_DISALLOW_DYNAMIC_ACM'],
+      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
     },
     properties: {
       icon: { $codeRef: 'perspective.icon' },
@@ -58,6 +60,9 @@ export const extensions: EncodedExtension[] = [
   // MigrationPolicies
   // Checkups
   {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-virtualmachines',
@@ -72,6 +77,9 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
   {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-templates',
@@ -87,6 +95,9 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
   {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-bootablevolumes',
@@ -102,6 +113,9 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
   {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+    },
     properties: {
       id: 'acm-separator-1',
       insertAfter: 'bootablevolumes-virt-perspective',
@@ -112,6 +126,9 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/separator',
   } as EncodedExtension<Separator>,
   {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-instancetype',
@@ -127,6 +144,9 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
   {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+    },
     properties: {
       id: 'acm-separator-2',
       insertAfter: 'instancetype-virt-perspective',
@@ -137,6 +157,9 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/separator',
   } as EncodedExtension<Separator>,
   {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-migrationpolicies',
@@ -152,6 +175,9 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
   {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-checkups',
@@ -167,6 +193,9 @@ export const extensions: EncodedExtension[] = [
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
   {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+    },
     properties: {
       component: { $codeRef: 'ConsoleStandAlone' },
       exact: false,
@@ -175,6 +204,9 @@ export const extensions: EncodedExtension[] = [
     type: 'console.page/route/standalone',
   } as EncodedExtension<StandaloneRoutePage>,
   {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+    },
     properties: {
       component: {
         $codeRef: 'Navigator',
@@ -190,6 +222,9 @@ export const extensions: EncodedExtension[] = [
     type: 'console.page/route',
   } as EncodedExtension<RoutePage>,
   {
+    flags: {
+      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+    },
     properties: {
       component: {
         $codeRef: 'InstanceTypePage',
@@ -272,7 +307,7 @@ export const extensions: EncodedExtension[] = [
   } as EncodedExtension<RoutePage>,
   {
     flags: {
-      required: ['KUBEVIRT_DYNAMIC_ACM'],
+      required: ['KUBEVIRT_DYNAMIC_ACM', FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
     },
     properties: {
       component: {

--- a/src/perspective/extensions.ts
+++ b/src/perspective/extensions.ts
@@ -19,6 +19,7 @@ export const extensions: EncodedExtension[] = [
   {
     flags: {
       disallowed: ['KUBEVIRT_DYNAMIC_ACM'],
+      required: ['KUBEVIRT_VIRTUALIZATION_NAV'],
     },
     properties: {
       icon: { $codeRef: 'perspective.icon' },

--- a/src/perspective/extensions.ts
+++ b/src/perspective/extensions.ts
@@ -3,6 +3,7 @@ import { Perspective } from '@openshift-console/dynamic-plugin-sdk';
 import type { ConsolePluginBuildMetadata } from '@openshift-console/dynamic-plugin-sdk-webpack';
 
 import { PERSPECTIVES } from '../utils/constants/constants';
+import { FLAG_KUBEVIRT_VIRTUALIZATION_NAV } from '../utils/flags/consts';
 
 import { clusterSection } from './navigation/clusterSection';
 import { computeSection } from './navigation/computeSection';
@@ -19,7 +20,7 @@ export const extensions: EncodedExtension[] = [
   {
     flags: {
       disallowed: ['KUBEVIRT_DYNAMIC_ACM'],
-      required: ['KUBEVIRT_VIRTUALIZATION_NAV'],
+      required: [FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
     },
     properties: {
       icon: { $codeRef: 'perspective.icon' },

--- a/src/utils/components/HardwareDevices/hooks/useHCPermittedHostDevices.ts
+++ b/src/utils/components/HardwareDevices/hooks/useHCPermittedHostDevices.ts
@@ -3,6 +3,7 @@ import {
   V1PermittedHostDevices,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
+import { getHyperconvergedConfiguration } from '@kubevirt-utils/resources/hyperconverged/selectors';
 
 type UseHCPermittedHostDevicesType = () => {
   hcError: Error;
@@ -13,7 +14,8 @@ type UseHCPermittedHostDevicesType = () => {
 const useHCPermittedHostDevices: UseHCPermittedHostDevicesType = () => {
   const { hcConfig, hcError, hcLoaded } = useKubevirtHyperconvergeConfiguration();
 
-  const { permittedHostDevices }: V1KubeVirtConfiguration = hcConfig?.spec?.configuration || {};
+  const { permittedHostDevices }: V1KubeVirtConfiguration =
+    getHyperconvergedConfiguration(hcConfig) || {};
 
   return { hcError, hcLoaded, permittedHostDevices };
 };

--- a/src/utils/components/HardwareDevices/hooks/useHCPermittedHostDevices.ts
+++ b/src/utils/components/HardwareDevices/hooks/useHCPermittedHostDevices.ts
@@ -2,7 +2,9 @@ import {
   V1KubeVirtConfiguration,
   V1PermittedHostDevices,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
+import useKubevirtHyperconvergeConfiguration, {
+  selectHyperconvergedConfiguration,
+} from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
 
 type UseHCPermittedHostDevicesType = () => {
   hcError: Error;
@@ -13,7 +15,8 @@ type UseHCPermittedHostDevicesType = () => {
 const useHCPermittedHostDevices: UseHCPermittedHostDevicesType = () => {
   const { hcConfig, hcError, hcLoaded } = useKubevirtHyperconvergeConfiguration();
 
-  const { permittedHostDevices }: V1KubeVirtConfiguration = hcConfig?.spec?.configuration || {};
+  const { permittedHostDevices }: V1KubeVirtConfiguration =
+    selectHyperconvergedConfiguration(hcConfig) || {};
 
   return { hcError, hcLoaded, permittedHostDevices };
 };

--- a/src/utils/components/HardwareDevices/hooks/useHCPermittedHostDevices.ts
+++ b/src/utils/components/HardwareDevices/hooks/useHCPermittedHostDevices.ts
@@ -2,9 +2,7 @@ import {
   V1KubeVirtConfiguration,
   V1PermittedHostDevices,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import useKubevirtHyperconvergeConfiguration, {
-  selectHyperconvergedConfiguration,
-} from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
+import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
 
 type UseHCPermittedHostDevicesType = () => {
   hcError: Error;
@@ -15,8 +13,7 @@ type UseHCPermittedHostDevicesType = () => {
 const useHCPermittedHostDevices: UseHCPermittedHostDevicesType = () => {
   const { hcConfig, hcError, hcLoaded } = useKubevirtHyperconvergeConfiguration();
 
-  const { permittedHostDevices }: V1KubeVirtConfiguration =
-    selectHyperconvergedConfiguration(hcConfig) || {};
+  const { permittedHostDevices }: V1KubeVirtConfiguration = hcConfig?.spec?.configuration || {};
 
   return { hcError, hcLoaded, permittedHostDevices };
 };

--- a/src/utils/extension.ts
+++ b/src/utils/extension.ts
@@ -37,7 +37,10 @@ export const extensions: EncodedExtension[] = [
     properties: { handler: { $codeRef: 'kubevirtFlags.useEnableKubevirtMenuFlags' } },
     type: 'console.flag/hookProvider',
   } as EncodedExtension<FeatureFlagHookProvider>,
-
+  {
+    properties: { handler: { $codeRef: 'kubevirtFlags.useVirtualizationNavVisibilityFlag' } },
+    type: 'console.flag/hookProvider',
+  } as EncodedExtension<FeatureFlagHookProvider>,
   {
     properties: {
       description: '%plugin__kubevirt-plugin~Create a Virtual Machine from a template%',

--- a/src/utils/flags/consts.ts
+++ b/src/utils/flags/consts.ts
@@ -10,7 +10,7 @@ export const FLAG_SHOW_MIGRATION_SECTION = 'SHOW_MIGRATION_SECTION';
 export const FLAG_NMSTATE_DYNAMIC = 'NMSTATE_DYNAMIC';
 export const FLAG_LIGHTSPEED_PLUGIN = 'LIGHTSPEED_PLUGIN';
 
-/** When true, show Virtualization nav, perspective switcher entry, and related ACM nav (CNV-81682). */
+/** When true, show the Virtualization perspective and admin Virtualization nav section (CNV-81682). */
 export const FLAG_KUBEVIRT_VIRTUALIZATION_NAV = 'KUBEVIRT_VIRTUALIZATION_NAV';
 
 export const MIGRATION_SECTION_ID = 'migration';

--- a/src/utils/flags/consts.ts
+++ b/src/utils/flags/consts.ts
@@ -10,5 +10,8 @@ export const FLAG_SHOW_MIGRATION_SECTION = 'SHOW_MIGRATION_SECTION';
 export const FLAG_NMSTATE_DYNAMIC = 'NMSTATE_DYNAMIC';
 export const FLAG_LIGHTSPEED_PLUGIN = 'LIGHTSPEED_PLUGIN';
 
+/** When true, show Virtualization nav, perspective switcher entry, and related ACM nav (CNV-81682). */
+export const FLAG_KUBEVIRT_VIRTUALIZATION_NAV = 'KUBEVIRT_VIRTUALIZATION_NAV';
+
 export const MIGRATION_SECTION_ID = 'migration';
 export const KUBEVIRT_PLUGIN_NAME = 'kubevirt-plugin';

--- a/src/utils/flags/consts.ts
+++ b/src/utils/flags/consts.ts
@@ -10,8 +10,11 @@ export const FLAG_SHOW_MIGRATION_SECTION = 'SHOW_MIGRATION_SECTION';
 export const FLAG_NMSTATE_DYNAMIC = 'NMSTATE_DYNAMIC';
 export const FLAG_LIGHTSPEED_PLUGIN = 'LIGHTSPEED_PLUGIN';
 
-/** When true, show the Virtualization perspective and admin Virtualization nav section (CNV-81682). */
+/** When true, show the Virtualization perspective and admin Virtualization nav section. */
 export const FLAG_KUBEVIRT_VIRTUALIZATION_NAV = 'KUBEVIRT_VIRTUALIZATION_NAV';
+
+/** HyperConverged `roleAggregationStrategy` value for manual RBAC aggregation. */
+export const HCO_MANUAL_ROLE_AGGREGATION_STRATEGY = 'Manual';
 
 export const MIGRATION_SECTION_ID = 'migration';
 export const KUBEVIRT_PLUGIN_NAME = 'kubevirt-plugin';

--- a/src/utils/flags/index.ts
+++ b/src/utils/flags/index.ts
@@ -1,3 +1,4 @@
 export { enableKubevirtDynamicFlag } from './enableKubevirtDynamicFlag';
 export { default as useEnableKubevirtMenuFlags } from './useEnableKubevirtMenuFlags';
 export { default as useShowMigrationSectionFLag } from './useShowMigrationSectionFlag';
+export { default as useVirtualizationNavVisibilityFlag } from './useVirtualizationNavVisibilityFlag';

--- a/src/utils/flags/useVirtualizationNavVisibilityFlag.ts
+++ b/src/utils/flags/useVirtualizationNavVisibilityFlag.ts
@@ -7,7 +7,7 @@ import {
   VirtualMachineModel,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
 import useKubevirtHyperconvergeConfiguration, {
-  KubevirtHyperconverged,
+  selectHyperconvergedConfiguration,
 } from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -18,12 +18,7 @@ import {
   useK8sWatchResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 
-import { FLAG_KUBEVIRT_VIRTUALIZATION_NAV } from './consts';
-
-const MANUAL_ROLE_AGGREGATION = 'Manual';
-
-const getRoleAggregationStrategy = (hcConfig: KubevirtHyperconverged): string | undefined =>
-  hcConfig?.spec?.configuration?.roleAggregationStrategy;
+import { FLAG_KUBEVIRT_VIRTUALIZATION_NAV, HCO_MANUAL_ROLE_AGGREGATION_STRATEGY } from './consts';
 
 const useVirtualizationNavVisibilityFlag = (setFeatureFlag: SetFeatureFlag) => {
   const { hcConfig, hcError, hcLoaded } = useKubevirtHyperconvergeConfiguration();
@@ -34,9 +29,12 @@ const useVirtualizationNavVisibilityFlag = (setFeatureFlag: SetFeatureFlag) => {
     namespaced: false,
   });
 
-  const strategy = getRoleAggregationStrategy(hcConfig);
+  const strategy = selectHyperconvergedConfiguration(hcConfig)?.roleAggregationStrategy;
 
-  const isManualRoleAggregation = useMemo(() => strategy === MANUAL_ROLE_AGGREGATION, [strategy]);
+  const isManualRoleAggregation = useMemo(
+    () => strategy === HCO_MANUAL_ROLE_AGGREGATION_STRATEGY,
+    [strategy],
+  );
 
   const fetchAccessReview = hcLoaded && projectsLoaded && isManualRoleAggregation;
 
@@ -49,16 +47,20 @@ const useVirtualizationNavVisibilityFlag = (setFeatureFlag: SetFeatureFlag) => {
     [projects],
   );
 
-  const [allowed, accessReviewsLoading] = useMultipleAccessReviews(
-    fetchAccessReview
-      ? projectNames.map((name) => ({
-          group: VirtualMachineModel.apiGroup,
-          namespace: name,
-          resource: VirtualMachineModel.plural,
-          verb: 'list' as K8sVerb,
-        }))
-      : [],
+  const accessReviewAttributes = useMemo(
+    () =>
+      fetchAccessReview
+        ? projectNames.map((name) => ({
+            group: VirtualMachineModel.apiGroup,
+            namespace: name,
+            resource: VirtualMachineModel.plural,
+            verb: 'list' as K8sVerb,
+          }))
+        : [],
+    [fetchAccessReview, projectNames],
   );
+
+  const [allowed, accessReviewsLoading] = useMultipleAccessReviews(accessReviewAttributes);
 
   const isAllowed = useMemo(() => allowed.some((accessReview) => accessReview.allowed), [allowed]);
 

--- a/src/utils/flags/useVirtualizationNavVisibilityFlag.ts
+++ b/src/utils/flags/useVirtualizationNavVisibilityFlag.ts
@@ -6,9 +6,8 @@ import {
   ProjectModel,
   VirtualMachineModel,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
-import useKubevirtHyperconvergeConfiguration, {
-  selectHyperconvergedConfiguration,
-} from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
+import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
+import { getHyperconvergedRoleAggregationStrategy } from '@kubevirt-utils/resources/hyperconverged/selectors';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
@@ -29,7 +28,7 @@ const useVirtualizationNavVisibilityFlag = (setFeatureFlag: SetFeatureFlag) => {
     namespaced: false,
   });
 
-  const strategy = selectHyperconvergedConfiguration(hcConfig)?.roleAggregationStrategy;
+  const strategy = getHyperconvergedRoleAggregationStrategy(hcConfig);
 
   const isManualRoleAggregation = useMemo(
     () => strategy === HCO_MANUAL_ROLE_AGGREGATION_STRATEGY,

--- a/src/utils/flags/useVirtualizationNavVisibilityFlag.ts
+++ b/src/utils/flags/useVirtualizationNavVisibilityFlag.ts
@@ -1,0 +1,92 @@
+import { useEffect, useMemo } from 'react';
+import useMultipleAccessReviews from 'src/views/cdi-upload-provider/hooks/useMultipleAccessReviews';
+
+import {
+  modelToGroupVersionKind,
+  ProjectModel,
+  VirtualMachineModel,
+} from '@kubevirt-ui-ext/kubevirt-api/console';
+import useKubevirtHyperconvergeConfiguration, {
+  KubevirtHyperconverged,
+} from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
+import { getName } from '@kubevirt-utils/resources/shared';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import {
+  K8sResourceCommon,
+  K8sVerb,
+  SetFeatureFlag,
+  useK8sWatchResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+
+import { FLAG_KUBEVIRT_VIRTUALIZATION_NAV } from './consts';
+
+const MANUAL_ROLE_AGGREGATION = 'Manual';
+
+const getRoleAggregationStrategy = (hcConfig: KubevirtHyperconverged): string | undefined =>
+  hcConfig?.spec?.configuration?.roleAggregationStrategy;
+
+const useVirtualizationNavVisibilityFlag = (setFeatureFlag: SetFeatureFlag) => {
+  const { hcConfig, hcError, hcLoaded } = useKubevirtHyperconvergeConfiguration();
+
+  const [projects, projectsLoaded] = useK8sWatchResource<K8sResourceCommon[]>({
+    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+    isList: true,
+    namespaced: false,
+  });
+
+  const strategy = getRoleAggregationStrategy(hcConfig);
+
+  const isManualRoleAggregation = useMemo(() => strategy === MANUAL_ROLE_AGGREGATION, [strategy]);
+
+  const fetchAccessReview = hcLoaded && projectsLoaded && isManualRoleAggregation;
+
+  const projectNames = useMemo(
+    () =>
+      (projects ?? [])
+        .map((p) => getName(p))
+        .filter((n) => !isEmpty(n))
+        .sort((a, b) => a.localeCompare(b)),
+    [projects],
+  );
+
+  const [allowed, accessReviewsLoading] = useMultipleAccessReviews(
+    fetchAccessReview
+      ? projectNames.map((name) => ({
+          group: VirtualMachineModel.apiGroup,
+          namespace: name,
+          resource: VirtualMachineModel.plural,
+          verb: 'list' as K8sVerb,
+        }))
+      : [],
+  );
+
+  const isAllowed = useMemo(() => allowed.some((accessReview) => accessReview.allowed), [allowed]);
+
+  useEffect(() => {
+    if (hcError) {
+      setFeatureFlag(FLAG_KUBEVIRT_VIRTUALIZATION_NAV, true);
+      return;
+    }
+
+    if (!hcLoaded) return;
+
+    if (!isManualRoleAggregation) {
+      setFeatureFlag(FLAG_KUBEVIRT_VIRTUALIZATION_NAV, true);
+      return;
+    }
+
+    if (isAllowed) {
+      setFeatureFlag(FLAG_KUBEVIRT_VIRTUALIZATION_NAV, true);
+      return;
+    }
+
+    if (accessReviewsLoading && !isAllowed) {
+      setFeatureFlag(FLAG_KUBEVIRT_VIRTUALIZATION_NAV, false);
+      return;
+    }
+
+    setFeatureFlag(FLAG_KUBEVIRT_VIRTUALIZATION_NAV, false);
+  }, [setFeatureFlag, isAllowed, isManualRoleAggregation, hcLoaded, hcError, accessReviewsLoading]);
+};
+
+export default useVirtualizationNavVisibilityFlag;

--- a/src/utils/hooks/useKubevirtHyperconvergeConfiguration/index.ts
+++ b/src/utils/hooks/useKubevirtHyperconvergeConfiguration/index.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { V1KubeVirtConfiguration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getHyperconvergedConfiguration } from '@kubevirt-utils/resources/hyperconverged/selectors';
 import { operatorNamespaceSignal } from '@kubevirt-utils/store/operatorNamespace';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
@@ -36,7 +37,7 @@ const useKubevirtHyperconvergeConfiguration = (
   const hcLoaded = _hcLoaded && !isEmpty(operatorNamespace);
 
   const featureGates = useMemo(() => {
-    return hcConfig?.spec?.configuration?.developerConfiguration?.featureGates;
+    return getHyperconvergedConfiguration(hcConfig)?.developerConfiguration?.featureGates;
   }, [hcConfig]);
 
   return { featureGates, hcConfig, hcError, hcLoaded };

--- a/src/utils/hooks/useKubevirtHyperconvergeConfiguration/index.ts
+++ b/src/utils/hooks/useKubevirtHyperconvergeConfiguration/index.ts
@@ -14,6 +14,10 @@ export type KubevirtHyperconverged = K8sResourceCommon & {
   };
 };
 
+export const selectHyperconvergedConfiguration = (
+  hc: KubevirtHyperconverged | undefined,
+): undefined | V1KubeVirtConfiguration => hc?.spec?.configuration;
+
 const useKubevirtHyperconvergeConfiguration = (
   cluster?: string,
 ): {
@@ -36,7 +40,7 @@ const useKubevirtHyperconvergeConfiguration = (
   const hcLoaded = _hcLoaded && !isEmpty(operatorNamespace);
 
   const featureGates = useMemo(() => {
-    return hcConfig?.spec?.configuration?.developerConfiguration?.featureGates;
+    return selectHyperconvergedConfiguration(hcConfig)?.developerConfiguration?.featureGates;
   }, [hcConfig]);
 
   return { featureGates, hcConfig, hcError, hcLoaded };

--- a/src/utils/hooks/useKubevirtHyperconvergeConfiguration/index.ts
+++ b/src/utils/hooks/useKubevirtHyperconvergeConfiguration/index.ts
@@ -14,10 +14,6 @@ export type KubevirtHyperconverged = K8sResourceCommon & {
   };
 };
 
-export const selectHyperconvergedConfiguration = (
-  hc: KubevirtHyperconverged | undefined,
-): undefined | V1KubeVirtConfiguration => hc?.spec?.configuration;
-
 const useKubevirtHyperconvergeConfiguration = (
   cluster?: string,
 ): {
@@ -40,7 +36,7 @@ const useKubevirtHyperconvergeConfiguration = (
   const hcLoaded = _hcLoaded && !isEmpty(operatorNamespace);
 
   const featureGates = useMemo(() => {
-    return selectHyperconvergedConfiguration(hcConfig)?.developerConfiguration?.featureGates;
+    return hcConfig?.spec?.configuration?.developerConfiguration?.featureGates;
   }, [hcConfig]);
 
   return { featureGates, hcConfig, hcError, hcLoaded };

--- a/src/utils/hooks/usePasstFeatureFlag.ts
+++ b/src/utils/hooks/usePasstFeatureFlag.ts
@@ -4,6 +4,7 @@ import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
+import { getHyperconvergedConfiguration } from '@kubevirt-utils/resources/hyperconverged/selectors';
 import { getAnnotations } from '@kubevirt-utils/resources/shared';
 import {
   PASS_IP_STACK_MIGRATION_GATE,
@@ -23,7 +24,7 @@ const usePasstFeatureFlag = (clusterOverride?: string) => {
   const isAdmin = useIsAdmin();
 
   const featureEnabled = useMemo(
-    () => Boolean(hcConfig?.spec?.configuration?.network?.binding?.[PASST_BINDING_NAME]),
+    () => Boolean(getHyperconvergedConfiguration(hcConfig)?.network?.binding?.[PASST_BINDING_NAME]),
     [hcConfig],
   );
 

--- a/src/utils/hooks/usePasstFeatureFlag.ts
+++ b/src/utils/hooks/usePasstFeatureFlag.ts
@@ -3,9 +3,7 @@ import { useMemo } from 'react';
 import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
-import useKubevirtHyperconvergeConfiguration, {
-  selectHyperconvergedConfiguration,
-} from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
+import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
 import { getAnnotations } from '@kubevirt-utils/resources/shared';
 import {
   PASS_IP_STACK_MIGRATION_GATE,
@@ -25,8 +23,7 @@ const usePasstFeatureFlag = (clusterOverride?: string) => {
   const isAdmin = useIsAdmin();
 
   const featureEnabled = useMemo(
-    () =>
-      Boolean(selectHyperconvergedConfiguration(hcConfig)?.network?.binding?.[PASST_BINDING_NAME]),
+    () => Boolean(hcConfig?.spec?.configuration?.network?.binding?.[PASST_BINDING_NAME]),
     [hcConfig],
   );
 

--- a/src/utils/hooks/usePasstFeatureFlag.ts
+++ b/src/utils/hooks/usePasstFeatureFlag.ts
@@ -3,7 +3,9 @@ import { useMemo } from 'react';
 import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
-import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
+import useKubevirtHyperconvergeConfiguration, {
+  selectHyperconvergedConfiguration,
+} from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
 import { getAnnotations } from '@kubevirt-utils/resources/shared';
 import {
   PASS_IP_STACK_MIGRATION_GATE,
@@ -23,7 +25,8 @@ const usePasstFeatureFlag = (clusterOverride?: string) => {
   const isAdmin = useIsAdmin();
 
   const featureEnabled = useMemo(
-    () => Boolean(hcConfig?.spec?.configuration?.network?.binding?.[PASST_BINDING_NAME]),
+    () =>
+      Boolean(selectHyperconvergedConfiguration(hcConfig)?.network?.binding?.[PASST_BINDING_NAME]),
     [hcConfig],
   );
 

--- a/src/utils/resources/hyperconverged/selectors.ts
+++ b/src/utils/resources/hyperconverged/selectors.ts
@@ -1,6 +1,11 @@
 import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import type { KubevirtHyperconverged } from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
 
 import { CalculationMethod } from '../quotas/types';
 
 export const getAAQCalculationMethod = (hyperConverge: HyperConverged): CalculationMethod =>
   hyperConverge?.spec?.applicationAwareConfig?.vmiCalcConfigName;
+
+export const getHyperconvergedRoleAggregationStrategy = (
+  hc: KubevirtHyperconverged | undefined,
+): string | undefined => hc?.spec?.configuration?.roleAggregationStrategy;

--- a/src/utils/resources/hyperconverged/selectors.ts
+++ b/src/utils/resources/hyperconverged/selectors.ts
@@ -1,3 +1,4 @@
+import { V1KubeVirtConfiguration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import type { KubevirtHyperconverged } from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
 
@@ -6,6 +7,10 @@ import { CalculationMethod } from '../quotas/types';
 export const getAAQCalculationMethod = (hyperConverge: HyperConverged): CalculationMethod =>
   hyperConverge?.spec?.applicationAwareConfig?.vmiCalcConfigName;
 
+export const getHyperconvergedConfiguration = (
+  hc: KubevirtHyperconverged | undefined,
+): undefined | V1KubeVirtConfiguration => hc?.spec?.configuration;
+
 export const getHyperconvergedRoleAggregationStrategy = (
   hc: KubevirtHyperconverged | undefined,
-): string | undefined => hc?.spec?.configuration?.roleAggregationStrategy;
+): string | undefined => getHyperconvergedConfiguration(hc)?.roleAggregationStrategy;


### PR DESCRIPTION
## Description

Introduces the `KUBEVIRT_VIRTUALIZATION_NAV` feature flag, set by a new console flag hook. When HyperConverged `roleAggregationStrategy` is `Manual`, the flag is enabled only if the user can list VirtualMachines in at least one project (via self-SAR). Otherwise the Virtualization admin nav section, Virtualization perspective, and fleet ACM extensions stay hidden. Non-manual strategies and HCO read errors keep the nav visible (fail-open for errors).

Also switches project watching in the hook to `useK8sWatchResource` so core plugin code does not depend on the multicluster hook.

## Links

- https://issues.redhat.com/browse/CNV-81682

## Testing

- `npm run lint` (warnings only, pre-existing)
- Local `npm run check-types` was not clean in this workspace (dependency resolution); CI should run the full suite on the PR branch.

## Notes for reviewers

- Fleet extensions now require `KUBEVIRT_VIRTUALIZATION_NAV` in addition to `KUBEVIRT_DYNAMIC_ACM` so ACM UI stays aligned with single-cluster nav visibility.

Fixes: [CNV-81682](https://redhat.atlassian.net/browse/CNV-81682)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented dynamic feature-gating for virtualization navigation components. Hardware Devices console navigation and Fleet Virtualization perspective now have conditional visibility determined at runtime based on cluster configuration settings and user access permissions, with support for flexible role management strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->