### PR TITLE
CNV-81330: Inconsistent casing in OCP/ACM perspective titles

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -890,6 +890,7 @@
   "Find settings": "Find settings",
   "Finish": "Finish",
   "Flavor": "Flavor",
+  "Fleet virtualization": "Fleet virtualization",
   "Folder": "Folder",
   "Folder (optional)": "Folder (optional)",
   "Folder name can't end with": "Folder name can't end with",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -903,6 +903,7 @@
   "Find settings": "Find settings",
   "Finish": "Finalizar",
   "Flavor": "Sabor",
+  "Fleet virtualization": "Fleet virtualization",
   "Folder": "Carpeta",
   "Folder (optional)": "Folder (optional)",
   "Folder name can't end with": "El nombre de la carpeta no puede terminar con",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -903,6 +903,7 @@
   "Find settings": "Find settings",
   "Finish": "Terminer",
   "Flavor": "Saveur",
+  "Fleet virtualization": "Fleet virtualization",
   "Folder": "Dossier",
   "Folder (optional)": "Folder (optional)",
   "Folder name can't end with": "Le nom du dossier ne peut pas se terminer par",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -887,6 +887,7 @@
   "Find settings": "Find settings",
   "Finish": "終了",
   "Flavor": "フレーバー",
+  "Fleet virtualization": "Fleet virtualization",
   "Folder": "フォルダー",
   "Folder (optional)": "Folder (optional)",
   "Folder name can't end with": "フォルダー名の末尾を以下にすることはできません",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -887,6 +887,7 @@
   "Find settings": "Find settings",
   "Finish": "종료",
   "Flavor": "플레이버",
+  "Fleet virtualization": "Fleet virtualization",
   "Folder": "폴더",
   "Folder (optional)": "Folder (optional)",
   "Folder name can't end with": "폴더 이름은 다음으로 끝날 수 없습니다.",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -887,6 +887,7 @@
   "Find settings": "Find settings",
   "Finish": "完成",
   "Flavor": "类型（Flavor）",
+  "Fleet virtualization": "Fleet virtualization",
   "Folder": "文件夹",
   "Folder (optional)": "Folder (optional)",
   "Folder name can't end with": "文件夹名称不能以其结尾",

--- a/src/multicluster/extensions.ts
+++ b/src/multicluster/extensions.ts
@@ -44,7 +44,7 @@ export const extensions: EncodedExtension[] = [
       id: PERSPECTIVES.FLEET_VIRTUALIZATION,
       importRedirectURL: { $codeRef: 'perspective.getACMLandingPageURL' },
       landingPageURL: { $codeRef: 'perspective.getACMLandingPageURL' },
-      name: '%plugin__console-virt-perspective-plugin~Fleet Virtualization%',
+      name: '%plugin__kubevirt-plugin~Fleet virtualization%',
     },
     type: 'console.perspective',
   },

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -55,6 +55,7 @@
 // t('plugin__kubevirt-plugin~Storage migrations')
 // t('plugin__kubevirt-plugin~Storage MigrationPlans')
 // t('plugin__kubevirt-plugin~Cross cluster migration')
+// t('plugin__kubevirt-plugin~Fleet virtualization')
 
 // SSH service type titles - used in SSHAccess/constants.ts via t(serviceTypeTitles[type])
 // t('SSH over LoadBalancer')


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-81330](https://redhat.atlassian.net/browse/CNV-81330)

Inconsistent casing in OCP/ACM perspective titles


## 🎥 Demo

Before:
<img width="350" height="190" alt="Before" src="https://github.com/user-attachments/assets/4fa28fce-241c-4838-b4be-a7a1360cac40" />

After:
<img width="331" height="319" alt="After" src="https://github.com/user-attachments/assets/0c42c04a-29c6-4880-9aae-b83584ae5c17" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected capitalization in the Fleet virtualization perspective label for improved consistency with interface standards.
* **Documentation**
  * Registered a translation/catalog entry for the updated Fleet virtualization label to ensure it appears correctly in localized interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->