### PR TITLE
CNV-80334: reload YAML on VM switch (ACM tree view)

### DIFF
--- a/src/views/virtualmachines/details/tabs/yaml/VirtualMachineYAMLPage.tsx
+++ b/src/views/virtualmachines/details/tabs/yaml/VirtualMachineYAMLPage.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
 import Loading from '@kubevirt-utils/components/Loading/Loading';
+import { getUID } from '@kubevirt-utils/resources/shared';
 import { ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
 import { Bullseye } from '@patternfly/react-core';
 import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
@@ -20,7 +21,7 @@ const VirtualMachineYAMLPage: FC<NavPageComponentProps> = (props) => {
   ) : (
     <React.Suspense fallback={loading}>
       <div className="VirtualMachineYAML--main">
-        <ResourceYAMLEditor initialResource={vm} />
+        <ResourceYAMLEditor initialResource={vm} key={getUID(vm)} />
       </div>
     </React.Suspense>
   );


### PR DESCRIPTION
## Summary
- Fixes VM YAML tab not updating when switching VMs from the tree view on ACM.
- Forces the YAML editor to remount when the selected VM changes (keyed by VM UID), preventing stale YAML and the reload-info alert.

## Test plan
- Open a VM details page on ACM.
- Go to the **YAML** tab.
- Switch to a different VM via the tree view.
- Verify the YAML immediately updates to the newly selected VM and no reload alert appears.



**DEMO**


**BEFORE**

<img width="1920" height="1067" alt="Screenshot 2026-04-17 at 11 52 12" src="https://github.com/user-attachments/assets/92112ab4-7d41-41fe-ada4-440c0a4d8cc8" />

**AFTER**

<img width="1920" height="1067" alt="Screenshot 2026-04-17 at 11 51 26" src="https://github.com/user-attachments/assets/75c3c9e7-a627-4dd4-b7c3-5b82b8baea87" />



Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Virtual Machine YAML editor refresh behavior to ensure proper state synchronization when editing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->