### PR TITLE
CNV-84499, CNV-84243: Remove the header project selector from VM wizard

### DIFF
--- a/src/multicluster/constants.ts
+++ b/src/multicluster/constants.ts
@@ -18,7 +18,7 @@ export const FLEET_NS_INSTANCETYPES_PATH = `${FLEET_BASE_PATH}/${VirtualMachineI
 export const FLEET_MIGRATION_POLICIES_PATH = `${FLEET_BASE_PATH}/${MigrationPolicyModelRef}`;
 export const FLEET_CHECKUPS_PATH = `${FLEET_BASE_PATH}/checkups`;
 export const FLEET_CATALOG_PATH = `${FLEET_BASE_PATH}/catalog`;
-export const FLEET_WIZARD_PATH = `${FLEET_BASE_PATH}/vmwizard`;
+export const FLEET_WIZARD_PATH = `${FLEET_BASE_PATH}/vm-wizard`;
 
 export const FLAG_KUBEVIRT_DYNAMIC_ACM = 'KUBEVIRT_DYNAMIC_ACM';
 export const FLAG_DISALLOWED_KUBEVIRT_DYNAMIC_ACM = 'DISALLOWED_KUBEVIRT_DYNAMIC_ACM';

--- a/src/multicluster/urls.ts
+++ b/src/multicluster/urls.ts
@@ -78,15 +78,12 @@ export const getCatalogURL = (cluster: string, namespace?: string): string => {
     : `/k8s/${namespacePath}/catalog`;
 };
 
-export const getVMWizardURL = (cluster: string, namespace: string): string => {
-  const namespacePath =
-    namespace === ALL_NAMESPACES_SESSION_KEY ? ALL_NAMESPACES : `ns/${namespace}`;
-
-  if (!cluster) return `/k8s/${namespacePath}/vmwizard`;
+export const getVMWizardURL = (cluster: string): string => {
+  if (!cluster) return `/vm-wizard`;
 
   return cluster === ALL_CLUSTERS_KEY
-    ? `${FLEET_WIZARD_PATH}/${ALL_CLUSTERS_KEY}/${namespacePath}`
-    : `${FLEET_WIZARD_PATH}/cluster/${cluster}/${namespacePath}`;
+    ? `${FLEET_WIZARD_PATH}/${ALL_CLUSTERS_KEY}`
+    : `${FLEET_WIZARD_PATH}/cluster/${cluster}`;
 };
 
 export const getConsoleStandaloneURL = (

--- a/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
+++ b/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
@@ -1,8 +1,9 @@
 import React, { FC, useEffect, useRef } from 'react';
-import { useParams } from 'react-router-dom-v5-compat';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getValidNamespace } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
+import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { Wizard, WizardHeader, WizardStep } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
 import DefaultWizardFooter from '@virtualmachines/creation-wizard/components/DefaultWizardFooter';
@@ -31,20 +32,22 @@ import DeploymentDetailsStep from './steps/DeploymentDetailsStep/DeploymentDetai
 const VMCreationWizard: FC = () => {
   const { t } = useKubevirtTranslation();
   useSignals();
-  const { creationMethod, setCluster, setProject, setTemplatesDrawerIsOpen } = useVMWizardStore();
+  const { creationMethod, project, setCluster, setProject, setTemplatesDrawerIsOpen } =
+    useVMWizardStore();
   const clusterParam = useClusterParam();
-  const { ns } = useParams<{ ns: string }>();
   const hasInitialized = useRef(false);
   const createVM = useCreateVM();
   const closeWizard = useCloseWizard();
+  const [activeNamespace] = useActiveNamespace();
+  const namespace = getValidNamespace(activeNamespace);
 
   useEffect(() => {
     if (!hasInitialized.current) {
       setCluster(clusterParam);
-      setProject(ns);
+      setProject(project ?? namespace);
       hasInitialized.current = true;
     }
-  }, [clusterParam, ns, setCluster, setProject]);
+  }, [clusterParam, namespace, project, setCluster, setProject]);
 
   const isInstanceTypeMethod = isInstanceTypeCreationMethod(creationMethod);
   const isCloneMethod = isCloneCreationMethod(creationMethod);

--- a/src/views/virtualmachines/creation-wizard/extensions.ts
+++ b/src/views/virtualmachines/creation-wizard/extensions.ts
@@ -11,7 +11,7 @@ export const extensions: EncodedExtension[] = [
       component: {
         $codeRef: 'VMWizard',
       },
-      path: ['/k8s/ns/:ns/vmwizard', '/k8s/all-namespaces/vmwizard'],
+      path: ['/vm-wizard'],
     },
     type: 'console.page/route',
   } as EncodedExtension,

--- a/src/views/virtualmachines/list/components/OverviewTab/components/NoVMsAlert.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/components/NoVMsAlert.tsx
@@ -10,7 +10,9 @@ import useIsACMPage from '@multicluster/useIsACMPage';
 import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, AlertActionCloseButton, AlertVariant, Skeleton } from '@patternfly/react-core';
 
-import { getAlertMessage, NoVMsAlertProps } from './utils';
+import { getAlertMessage } from './utils';
+
+type NoVMsAlertProps = { namespace?: string };
 
 const NoVMsAlert: FC<NoVMsAlertProps> = ({ namespace }) => {
   const { t } = useKubevirtTranslation();
@@ -27,8 +29,8 @@ const NoVMsAlert: FC<NoVMsAlertProps> = ({ namespace }) => {
   });
 
   const vmWizardURL = useMemo(
-    () => getVMWizardURL(isACMPage ? cluster || '' : '', selectedNamespace),
-    [isACMPage, cluster, selectedNamespace],
+    () => getVMWizardURL(isACMPage ? cluster || '' : ''),
+    [isACMPage, cluster],
   );
 
   const alertMessage = getAlertMessage(canCreateVM, t);

--- a/src/views/virtualmachines/list/components/OverviewTab/components/utils.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/components/utils.ts
@@ -27,10 +27,6 @@ type ObservabilityWarningParams = {
   observabilityLoaded: boolean;
 };
 
-export type NoVMsAlertProps = {
-  namespace?: string;
-};
-
 export const CLUSTER_SEPARATOR = ',';
 
 export type ObservabilityDisabledAlertProps = {

--- a/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
@@ -46,8 +46,8 @@ const VirtualMachinesCreateButton: FC<VirtualMachinesCreateButtonProps> = ({
   });
 
   const vmWizardURL = useMemo(
-    () => getVMWizardURL(isACMPage ? cluster || '' : '', selectedNamespace),
-    [isACMPage, selectedNamespace, cluster],
+    () => getVMWizardURL(isACMPage ? cluster || '' : ''),
+    [isACMPage, cluster],
   );
 
   const yamlURL = useMemo(

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/DefaultRightClickActionMenu.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/DefaultRightClickActionMenu.tsx
@@ -1,10 +1,12 @@
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useVirtualMachineInstanceMigrationMapper from '@kubevirt-utils/resources/vmim/hooks/useVirtualMachineInstanceMigrationMapper';
 import useVirtualMachineInstanceMigrations from '@kubevirt-utils/resources/vmim/hooks/useVirtualMachineInstanceMigrations';
+import useIsACMPage from '@multicluster/useIsACMPage';
 import useMultipleVirtualMachineActions from '@virtualmachines/actions/hooks/useMultipleVirtualMachineActions';
+import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
 import {
   FOLDER_SELECTOR_PREFIX,
   PROJECT_SELECTOR_PREFIX,
@@ -23,19 +25,22 @@ const DefaultRightClickActionMenu: FC<DefaultRightClickActionMenuProps> = ({
   triggerElement,
 }) => {
   const { t } = useKubevirtTranslation();
+  const isACMPage = useIsACMPage();
   const { cluster, namespace, prefix } = getElementComponentsFromID(triggerElement);
 
   const vms = getVMsTrigger(triggerElement);
   const [vmims] = useVirtualMachineInstanceMigrations(cluster, namespace);
   const vmimMapper = useVirtualMachineInstanceMigrationMapper(vmims);
   const baseActions = useMultipleVirtualMachineActions(vms, vmimMapper, true);
+  const { setProject } = useVMWizardStore();
 
   const navigate = useNavigate();
 
-  const createVMAction =
-    prefix === PROJECT_SELECTOR_PREFIX
-      ? getCreateVMAction(t, navigate, namespace, cluster)
+  const createVMAction = useMemo(() => {
+    return prefix === PROJECT_SELECTOR_PREFIX
+      ? getCreateVMAction(t, navigate, namespace, setProject, isACMPage ? cluster : '')
       : undefined;
+  }, [cluster, isACMPage, namespace, navigate, prefix, setProject, t]);
 
   const getNestedLevel = () => {
     if (prefix === FOLDER_SELECTOR_PREFIX) {

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/utils.ts
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/utils.ts
@@ -6,7 +6,7 @@ import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
 import { getLabel, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
-import { getCatalogURL } from '@multicluster/urls';
+import { getVMWizardURL } from '@multicluster/urls';
 import {
   CLUSTER_SELECTOR_PREFIX,
   FOLDER_SELECTOR_PREFIX,
@@ -23,12 +23,18 @@ export const getCreateVMAction = (
   t: TFunction,
   navigate: NavigateFunction,
   namespace: string,
+  setProject: (project: string) => void,
   cluster?: string,
-): ActionDropdownItemType => ({
-  cta: () => navigate(`${getCatalogURL(cluster, namespace)}`),
-  id: 'create-vm',
-  label: t('Create VirtualMachine'),
-});
+): ActionDropdownItemType => {
+  return {
+    cta: () => {
+      setProject(namespace);
+      navigate(`${getVMWizardURL(cluster)}`);
+    },
+    id: 'create-vm',
+    label: t('Create VirtualMachine'),
+  };
+};
 
 export const getElementComponentsFromID = (
   triggerElement: HTMLElement | null,

--- a/src/views/welcome/components/WelcomeButtons.tsx
+++ b/src/views/welcome/components/WelcomeButtons.tsx
@@ -4,8 +4,6 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import CreateProjectModal from '@kubevirt-utils/components/CreateProjectModal/CreateProjectModal';
 import useTour from '@kubevirt-utils/components/GuidedTour/hooks/useTour';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
-import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
 import { getName } from '@kubevirt-utils/resources/shared';
@@ -19,7 +17,7 @@ type WelcomeButtonsProps = {
 
 const WelcomeButtons: FC<WelcomeButtonsProps> = ({ onClose }) => {
   const { t } = useKubevirtTranslation();
-  const [activeNamespace, setActiveNamespace] = useActiveNamespace();
+  const [, setActiveNamespace] = useActiveNamespace();
   const navigate = useNavigate();
   const { createModal } = useModal();
 
@@ -28,9 +26,7 @@ const WelcomeButtons: FC<WelcomeButtonsProps> = ({ onClose }) => {
   const hasNoProjects = projectsLoaded && !projectsError && (!projects || projects.length === 0);
 
   const onCreateVM = () => {
-    const wizardNamespace =
-      activeNamespace === ALL_NAMESPACES_SESSION_KEY ? DEFAULT_NAMESPACE : activeNamespace;
-    navigate(getVMWizardURL('', wizardNamespace));
+    navigate(getVMWizardURL(''));
     onClose();
   };
 


### PR DESCRIPTION
## 📝 Description

This PR:

- Removes the project selector from the top of the VM wizard page
- Fixes the "Create VirtualMachine" link in the tree right-click menu

Jira: 

- https://redhat.atlassian.net/browse/CNV-84499
- https://redhat.atlassian.net/browse/CNV-84243

## 🎥 Screenshot

<img width="1864" height="1000" alt="2026-04-17-084636_hyprshot" src="https://github.com/user-attachments/assets/e338e4d0-a9e7-4537-bf77-2fcd2a526254" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM wizard navigation flow for better reliability.

* **Refactor**
  * Updated VM creation wizard to use a cleaner URL path structure.
  * Enhanced wizard initialization to leverage OpenShift UI context for namespace determination.
  * Streamlined VM creation workflows across different cluster configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->