### PR TITLE
CNV-84694: Fleet VM create button uses managed cluster RBAC

### DIFF
--- a/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
@@ -8,7 +8,6 @@ import { getVMListPath } from '@kubevirt-utils/resources/vm';
 import useCluster from '@multicluster/hooks/useCluster';
 import { getACMVMListURL, getVMWizardURL } from '@multicluster/urls';
 import useIsACMPage from '@multicluster/useIsACMPage';
-import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
   Dropdown,
@@ -18,6 +17,7 @@ import {
   MenuToggleAction,
   MenuToggleElement,
 } from '@patternfly/react-core';
+import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
 
 type VirtualMachinesCreateButtonProps = {
   buttonText?: string;
@@ -38,7 +38,8 @@ const VirtualMachinesCreateButton: FC<VirtualMachinesCreateButtonProps> = ({
   const cluster = useCluster();
   const selectedNamespace = namespace || DEFAULT_NAMESPACE;
 
-  const [canCreateVM] = useAccessReview({
+  const [canCreateVM] = useFleetAccessReview({
+    cluster,
     group: VirtualMachineModel.apiGroup,
     namespace: selectedNamespace,
     resource: VirtualMachineModel.plural,


### PR DESCRIPTION
## Jira
https://issues.redhat.com/browse/CNV-84694

## Problem
On fleet virtualization, the Create VirtualMachine button used `useAccessReview`, which evaluates permissions on the ACM hub (local-cluster) instead of the selected managed cluster.

## Solution
Use `useFleetAccessReview` with the same `cluster` from `useCluster()` that is already used for wizard and YAML URLs, so subject access review runs against the correct cluster.

## Changes
- `VirtualMachinesCreateButton.tsx`: replace `useAccessReview` with `useFleetAccessReview` and pass `cluster`.

Co-authored with Cursor AI on the initial investigation; final shape uses `useCluster` + single fleet access review hook.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal permission validation systems for virtual machine creation without changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->