### PR TITLE
CNV-80854: Fix incorrect storage utilization for VMs with snap packages

### DIFF
--- a/src/multicluster/hooks/useGuestAgentURL.ts
+++ b/src/multicluster/hooks/useGuestAgentURL.ts
@@ -1,20 +1,8 @@
-import { VirtualMachineInstanceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { getCluster } from '@multicluster/helpers/selectors';
 
-import useK8sBaseAPIPath from './useK8sBaseAPIPath';
+import useVMISubresourceURL from './useVMISubresourceURL';
 
-const useGuestAgentURL = (vmi: V1VirtualMachineInstance): [string, boolean] => {
-  const [k8sAPIPath, k8sAPIPathLoaded] = useK8sBaseAPIPath(getCluster(vmi));
-
-  const url = `${k8sAPIPath}/apis/subresources.${VirtualMachineInstanceModel.apiGroup}/${
-    VirtualMachineInstanceModel.apiVersion
-  }/namespaces/${getNamespace(vmi)}/${VirtualMachineInstanceModel.plural}/${getName(
-    vmi,
-  )}/guestosinfo`;
-
-  return [url, k8sAPIPathLoaded];
-};
+const useGuestAgentURL = (vmi: V1VirtualMachineInstance): [string, boolean] =>
+  useVMISubresourceURL(vmi, 'guestosinfo');
 
 export default useGuestAgentURL;

--- a/src/multicluster/hooks/useVMISubresourceURL.ts
+++ b/src/multicluster/hooks/useVMISubresourceURL.ts
@@ -1,0 +1,23 @@
+import { VirtualMachineInstanceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getCluster } from '@multicluster/helpers/selectors';
+
+import useK8sBaseAPIPath from './useK8sBaseAPIPath';
+
+const useVMISubresourceURL = (
+  vmi: V1VirtualMachineInstance,
+  subresource: string,
+): [string, boolean] => {
+  const [k8sAPIPath, k8sAPIPathLoaded] = useK8sBaseAPIPath(getCluster(vmi));
+
+  const url = `${k8sAPIPath}/apis/subresources.${VirtualMachineInstanceModel.apiGroup}/${
+    VirtualMachineInstanceModel.apiVersion
+  }/namespaces/${getNamespace(vmi)}/${VirtualMachineInstanceModel.plural}/${getName(
+    vmi,
+  )}/${subresource}`;
+
+  return [url, k8sAPIPathLoaded];
+};
+
+export default useVMISubresourceURL;

--- a/src/utils/resources/vmi/hooks/index.ts
+++ b/src/utils/resources/vmi/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useGuestOS';
+export * from './useVMIFilesystems';

--- a/src/utils/resources/vmi/hooks/useVMIFilesystems.ts
+++ b/src/utils/resources/vmi/hooks/useVMIFilesystems.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+import {
+  V1VirtualMachineInstance,
+  V1VirtualMachineInstanceFileSystem,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import useVMISubresourceURL from '@multicluster/hooks/useVMISubresourceURL';
+import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
+
+type UseVMIFilesystems = (
+  vmi?: V1VirtualMachineInstance,
+) => [V1VirtualMachineInstanceFileSystem[], boolean, Error];
+
+export const useVMIFilesystems: UseVMIFilesystems = (vmi) => {
+  const [loaded, setLoaded] = useState(false);
+  const [filesystems, setFilesystems] = useState<V1VirtualMachineInstanceFileSystem[]>([]);
+  const [error, setError] = useState<Error>(null);
+  const [url, urlLoaded] = useVMISubresourceURL(vmi, 'filesystemlist');
+
+  useEffect(() => {
+    if (!urlLoaded) return;
+
+    const guestOS = vmi?.status?.guestOSInfo?.id;
+
+    setError(null);
+    if (guestOS) {
+      (async () => {
+        const response = await consoleFetch(url);
+        const jsonData = await response.json();
+        setFilesystems(jsonData?.items ?? []);
+        setLoaded(true);
+      })().catch((err) => {
+        setError(err);
+        setLoaded(true);
+      });
+    }
+    (!vmi || (!guestOS && vmi?.metadata)) && setLoaded(true);
+  }, [url, loaded, vmi, urlLoaded]);
+
+  return [filesystems, loaded, error];
+};

--- a/src/utils/utils/utils.ts
+++ b/src/utils/utils/utils.ts
@@ -189,8 +189,8 @@ export const columnSortingCompare = <T>(
   return data?.sort(predicate)?.slice(startIndex, endIndex);
 };
 
-export const removeDuplicatesByName = (array: any[], nameProperty = 'name') =>
-  array?.reduce((acc, curr) => {
+export const removeDuplicatesByName = <T>(array: T[], nameProperty = 'name'): T[] =>
+  array?.reduce<T[]>((acc, curr) => {
     if (!acc.find((item) => item?.[nameProperty] === curr?.[nameProperty])) acc.push(curr);
     return acc;
   }, []);

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/StorageUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/StorageUtil.tsx
@@ -6,11 +6,13 @@ import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/Su
 import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
 import ComponentReady from '@kubevirt-utils/components/Charts/ComponentReady/ComponentReady';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { useGuestOS } from '@kubevirt-utils/resources/vmi';
+import { useVMIFilesystems } from '@kubevirt-utils/resources/vmi';
 import { removeDuplicatesByName } from '@kubevirt-utils/utils/utils';
 import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
 
 import { UtilizationBlock } from '../UtilizationBlock';
+
+import { filterWritableFilesystems } from './utils';
 
 type StorageUtilProps = {
   vmi: V1VirtualMachineInstance;
@@ -19,10 +21,10 @@ type StorageUtilProps = {
 const StorageUtil: FC<StorageUtilProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
 
-  const [guestAgentData, loaded] = useGuestOS(vmi);
+  const [filesystems, loaded] = useVMIFilesystems(vmi);
 
   const { totalBytes = 0, usedBytes = 0 } =
-    removeDuplicatesByName(guestAgentData?.fsInfo?.disks, 'diskName')?.reduce(
+    filterWritableFilesystems(removeDuplicatesByName(filesystems, 'diskName'))?.reduce(
       (acc, data) => {
         acc.totalBytes += data?.totalBytes;
         acc.usedBytes += data?.usedBytes;

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/constants.ts
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/constants.ts
@@ -1,0 +1,3 @@
+// Read-only compressed filesystems (e.g. snap loop devices on Ubuntu)
+// that should not count toward writable storage utilization.
+export const EXCLUDED_FILESYSTEM_TYPES = ['squashfs'];

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/utils.ts
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/utils.ts
@@ -1,0 +1,8 @@
+import { V1VirtualMachineInstanceFileSystem } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+
+import { EXCLUDED_FILESYSTEM_TYPES } from './constants';
+
+export const filterWritableFilesystems = (
+  filesystems: V1VirtualMachineInstanceFileSystem[],
+): V1VirtualMachineInstanceFileSystem[] =>
+  filesystems?.filter((fs) => !EXCLUDED_FILESYSTEM_TYPES.includes(fs?.fileSystemType));


### PR DESCRIPTION
## Summary

The Storage utilization donut chart (VM Overview -> Utilization -> Storage) displays incorrect values on Ubuntu VMs with snap packages installed, showing e.g. "1.05 GiB Used of 1.05 GiB" instead of the actual disk usage.

## Root cause

Two issues combine to produce this bug:

1. **10-item cap on `guestosinfo`**: The KubeVirt `guestosinfo` subresource API [caps FSInfo to a maximum of 10 items](https://kubevirt.io/user-guide/user_workloads/guest_agent_information/). On Ubuntu, each snap package creates a squashfs loop device (`/dev/loop0`, `/dev/loop1`, etc.) that the guest agent reports as a separate filesystem. When enough snaps are installed, the loop devices fill up all 10 slots and push out the real disk partitions (`vda1`, `vda15`, `vda16`).

2. **squashfs reports `totalBytes == usedBytes`**: Squashfs is a compressed read-only filesystem — it always reports 100% usage. When only squashfs entries remain (after the real disks are pushed out), the chart shows used == total, making it look like storage is completely full. The actual disk space consumed by snap images is already accounted for in the parent filesystem (`vda1`), so including squashfs entries also causes double-counting.

## Changes

- **Use `filesystemlist` API instead of `guestosinfo`**: The `filesystemlist` subresource returns all filesystem entries without the 10-item cap, ensuring real disk partitions are always included.
- **Filter out read-only squashfs filesystems**: Squashfs loop devices (snap packages) are excluded from the utilization calculation since they are not writable storage and their disk usage is already reflected in the parent filesystem.
- **Extract reusable `useVMISubresourceURL` hook**: Refactored the URL construction for VMI subresource API calls (`guestosinfo`, `filesystemlist`) into a shared hook to avoid duplication.
- **Add generic typing to `removeDuplicatesByName`**: Improved type safety of the shared utility function.

## How to reproduce

1. Create an Ubuntu 24 VM
2. Install and enable `qemu-guest-agent`
3. Install snap packages (`sudo snap install firefox htop hello-world firmware-updater snapd-desktop-integration`) until there are 10+ loop devices
4. Navigate to VM Overview -> Utilization -> Storage
5. Observe the chart shows ~100% usage with used == total

## How to verify the fix

After the fix, the Storage chart correctly shows only writable filesystem usage (e.g. "3.81 GiB Used of 31.03 GiB" for a 30 GB disk).


## 🎥 Demo

Initially the Ubuntu VM storage utilization looks fine before adding packages with `sudo snap install xyz`:
<img width="1884" height="1230" alt="Screenshot 2026-04-17 at 11 55 18" src="https://github.com/user-attachments/assets/6904e64b-df7d-469f-9ff0-bd51c03004b4" />

BUG - after installing two packages:
<img width="1884" height="1230" alt="Screenshot 2026-04-17 at 12 12 47" src="https://github.com/user-attachments/assets/4eb7cf6e-42ee-4984-bcdb-e9cb84309e19" />

BUG - after installing four packages:
<img width="1884" height="1230" alt="Screenshot 2026-04-17 at 12 25 35" src="https://github.com/user-attachments/assets/376d09ac-84ed-4dbc-b011-0093d596c161" />


FIX - after installing four packages:
<img width="1884" height="1230" alt="Screenshot 2026-04-17 at 14 37 59" src="https://github.com/user-attachments/assets/25920fff-3915-4b1a-b70c-6dcd76cd0be3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced storage utilization metrics to exclude read-only filesystem types for more accurate capacity reporting.

* **Refactor**
  * Refactored virtual machine utility hooks to improve code reusability.
  * Improved type safety in utility functions through enhanced generics handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->