### PR TITLE
CNV-84735: Empty state checks VM create permission instead of project create permission for "Don't have a project yet?" hint

### DIFF
--- a/src/views/virtualmachines/list/components/VirtualMachineEmptyState/VirtualMachineEmptyState.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineEmptyState/VirtualMachineEmptyState.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { Trans } from 'react-i18next';
 
-import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { ProjectRequestModel, VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ListPageBody, useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
@@ -27,12 +27,20 @@ const VirtualMachineEmptyState: FC<VirtualMachineEmptyStateProps> = ({ namespace
   const { t } = useKubevirtTranslation();
   const selectedNamespace = namespace || DEFAULT_NAMESPACE;
 
-  const [canCreateVM, loading] = useAccessReview({
+  const [canCreateVM, loadingVM] = useAccessReview({
     group: VirtualMachineModel.apiGroup,
     namespace: selectedNamespace,
     resource: VirtualMachineModel.plural,
     verb: 'create',
   });
+
+  const [canCreateProject, loadingProject] = useAccessReview({
+    group: ProjectRequestModel.apiGroup,
+    resource: ProjectRequestModel.plural,
+    verb: 'create',
+  });
+
+  const loading = loadingVM || loadingProject;
 
   return (
     <ListPageBody>
@@ -58,7 +66,7 @@ const VirtualMachineEmptyState: FC<VirtualMachineEmptyStateProps> = ({ namespace
               ) : (
                 <div>{t('To create a virtual machine, contact an administrator.')}</div>
               )}
-              {canCreateVM && (
+              {canCreateProject && (
                 <div className="pf-v6-u-mt-md">
                   <Trans ns="plugin__kubevirt-plugin" t={t}>
                     <b>Don&apos;t have a project yet?</b> Right-click a cluster in the navigation


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-84735](https://redhat.atlassian.net/browse/CNV-84735)

The VirtualMachine list empty state shows a hint: "Don't have a project yet? Right-click a cluster in the navigation tree to create your first one."

This message is gated on canCreateVM (create permission for virtualmachines.kubevirt.io), but it should check whether the user can create a project (projectrequests.project.openshift.io).

A user who cannot create VMs but can create projects never sees this hint.

## 🎥 Demo

Before:
<img width="1661" height="944" alt="Before" src="https://github.com/user-attachments/assets/ee191cff-6bc6-4bb5-af7f-b6c8d0006855" />

After:
<img width="1629" height="891" alt="After" src="https://github.com/user-attachments/assets/f6b45eb1-d71a-4d2c-87a5-e5eb8cba5012" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission validation for project creation functionality. The empty state now correctly checks whether users have permission to create projects, in addition to existing virtual machine creation checks. Loading states now properly wait for both permission validations to complete before displaying UI content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->