### PR TITLE
CNV-84432: prevent both popovers and guided tour from both appearing and render them conditionally

### DIFF
--- a/src/utils/components/GuidedTour/GuidedTour.tsx
+++ b/src/utils/components/GuidedTour/GuidedTour.tsx
@@ -3,13 +3,14 @@ import Joyride, { ACTIONS, CallBackProps, EVENTS, TooltipRenderProps } from 'rea
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useSignals } from '@preact/signals-react/runtime';
 
 import TourPopover from './components/TourPopover/TourPopover';
 import useTour from './hooks/useTour';
 import { getTourSteps } from './utils/constants';
-import { runningTourSignal, stepIndexSignal } from './utils/guidedTourSignals';
+import { runningTourSignal, stepIndexSignal, tourStepsSeenSignal } from './utils/guidedTourSignals';
 import { handleClose, handleNext, handlePrev } from './utils/utils';
 
 const GuidedTour: FC = () => {
@@ -20,6 +21,7 @@ const GuidedTour: FC = () => {
   const navigate = useNavigate();
 
   const { resetTour } = useTour();
+  const [quickStarts, setQuickStarts] = useKubevirtUserSettings('quickStart');
 
   const steps = useMemo(() => getTourSteps(t), [t]);
 
@@ -33,16 +35,35 @@ const GuidedTour: FC = () => {
           document.querySelector(step.target)?.scrollIntoView({ block: 'nearest' });
         }
 
-        if (!isEmpty(route) && location.pathname !== route && runningTourSignal.value) {
-          navigate(route);
-        }
+        const markStepSeen = (stepIndex: number) => {
+          const mergedSeen = Array.from(
+            new Set([
+              ...(quickStarts?.tourStepsSeen || []),
+              ...tourStepsSeenSignal.value,
+              stepIndex,
+            ]),
+          );
+          if (mergedSeen.length !== (quickStarts?.tourStepsSeen || []).length) {
+            setQuickStarts?.({ ...quickStarts, tourStepsSeen: mergedSeen });
+          }
+          if (mergedSeen.length !== tourStepsSeenSignal.value.length) {
+            tourStepsSeenSignal.value = mergedSeen;
+          }
+        };
 
         if (action === ACTIONS.CLOSE) {
+          markStepSeen(index);
           handleClose(resetTour);
           return;
         }
 
+        if (!isEmpty(route) && location.pathname !== route && runningTourSignal.value) {
+          navigate(route);
+        }
+
         if (type === EVENTS.STEP_AFTER) {
+          markStepSeen(index);
+
           if (index !== stepIndexSignal.value) return;
 
           const currentIndex = stepIndexSignal.value;

--- a/src/utils/components/GuidedTour/hooks/useTour.ts
+++ b/src/utils/components/GuidedTour/hooks/useTour.ts
@@ -11,22 +11,20 @@ const useTour = () => {
   const navigate = useNavigate();
   const namespace = useNamespaceParam();
 
-  const resetNamespace = () => {
-    if (location.pathname.includes(ALL_NAMESPACES) && namespaceSignal.value) {
-      const newPath = location.pathname.replace(ALL_NAMESPACES, `ns/${namespaceSignal.value}`);
-      navigate(newPath, { replace: true });
-    }
-  };
-
   const startTour = () => {
     if (stepIndexSignal.value >= TOUR_STEPS_COUNT) stepIndexSignal.value = 0;
-    runningTourSignal.value = true;
     namespaceSignal.value = namespace;
+    runningTourSignal.value = true;
   };
 
   const stopTour = () => {
     runningTourSignal.value = false;
-    resetNamespace();
+    // Navigate back to the user's namespace URL if the tour moved them to all-namespaces
+    if (location.pathname.includes(ALL_NAMESPACES) && namespaceSignal.value) {
+      navigate(location.pathname.replace(ALL_NAMESPACES, `ns/${namespaceSignal.value}`), {
+        replace: true,
+      });
+    }
   };
 
   const resetTour = () => {

--- a/src/utils/components/GuidedTour/utils/guidedTourSignals.ts
+++ b/src/utils/components/GuidedTour/utils/guidedTourSignals.ts
@@ -4,6 +4,8 @@ export const runningTourSignal = signal(false);
 export const stepIndexSignal = signal(0);
 export const namespaceSignal = signal<string | undefined>(undefined);
 export const tourContextMenuTriggerSignal = signal<HTMLElement | null>(null);
+export const welcomeModalDismissedSignal = signal(false);
+export const tourStepsSeenSignal = signal<number[]>([]);
 
 export const nextStep = () => {
   stepIndexSignal.value++;

--- a/src/utils/components/OnboardingPopover/OnboardingPopover.tsx
+++ b/src/utils/components/OnboardingPopover/OnboardingPopover.tsx
@@ -1,81 +1,103 @@
-import React, { FC, ReactNode, useRef, useState } from 'react';
+import React, { FC, ReactNode, useCallback, useEffect } from 'react';
 
+import {
+  runningTourSignal,
+  tourStepsSeenSignal,
+  welcomeModalDismissedSignal,
+} from '@kubevirt-utils/components/GuidedTour/utils/guidedTourSignals';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
 import { Button, ButtonVariant, Popover, PopoverPosition } from '@patternfly/react-core';
+import { useSignals } from '@preact/signals-react/runtime';
 
 import { ONBOARDING_POPOVER_CHAIN } from './constants';
+import { dismissedPopoverKeysSignal } from './onboardingSignals';
 import { OnboardingPopoverKey } from './types';
 
 type OnboardingPopoverProps = {
   bodyContent: ReactNode;
+  coveredByTourSteps?: number[];
   headerContent: ReactNode;
   hideOnTriggerClick?: boolean;
   popoverKey: OnboardingPopoverKey;
-  triggerElement?: HTMLElement;
+  triggerElement: HTMLElement | null;
 };
 
 const OnboardingPopover: FC<OnboardingPopoverProps> = ({
   bodyContent,
-  children,
+  coveredByTourSteps,
   headerContent,
   hideOnTriggerClick = false,
   popoverKey,
   triggerElement,
 }) => {
+  useSignals();
   const { t } = useKubevirtTranslation();
-  const [onboardingPopoversHidden, setOnboardingPopoversHidden, userSettingsLoaded] =
-    useKubevirtUserSettings('onboardingPopoversHidden');
-  const [isHidden, setIsHidden] = useState(false);
-  const spanRef = useRef<HTMLSpanElement>(null);
-
-  const triggerRef = triggerElement ? () => triggerElement : spanRef;
-
+  const [userSettings, setUserSettings, userSettingsLoaded] = useKubevirtUserSettings();
+  const onboardingPopoversHidden = userSettings?.onboardingPopoversHidden;
+  const quickStarts = userSettings?.quickStart;
   const chainIndex = ONBOARDING_POPOVER_CHAIN.indexOf(popoverKey);
-  const predecessorsDismissed = ONBOARDING_POPOVER_CHAIN.slice(0, chainIndex).every(
-    (key) => onboardingPopoversHidden?.[key],
-  );
+  const predecessorsDismissed =
+    chainIndex === -1 ||
+    ONBOARDING_POPOVER_CHAIN.slice(0, chainIndex).every(
+      (key) => onboardingPopoversHidden?.[key] || dismissedPopoverKeysSignal.value.has(key),
+    );
+
+  const tourStepsSeen = [...(quickStarts?.tourStepsSeen || []), ...tourStepsSeenSignal.value];
+  const coveredByTour = coveredByTourSteps?.some((step) => tourStepsSeen.includes(step)) ?? false;
+
+  const hide = useCallback(() => {
+    dismissedPopoverKeysSignal.value = new Set([...dismissedPopoverKeysSignal.value, popoverKey]);
+    setUserSettings({
+      ...userSettings,
+      onboardingPopoversHidden: { ...onboardingPopoversHidden, [popoverKey]: true },
+    });
+  }, [onboardingPopoversHidden, popoverKey, setUserSettings, userSettings]);
+
+  useEffect(() => {
+    if (coveredByTour && !dismissedPopoverKeysSignal.value.has(popoverKey)) {
+      hide();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [coveredByTour]);
+
+  const welcomeExperienceDone =
+    welcomeModalDismissedSignal.value || !!quickStarts?.dontShowWelcomeModal;
 
   const isVisible =
     userSettingsLoaded &&
-    !isHidden &&
+    !dismissedPopoverKeysSignal.value.has(popoverKey) &&
     !onboardingPopoversHidden?.[popoverKey] &&
     predecessorsDismissed &&
-    triggerElement !== null;
-
-  const hide = () => {
-    setIsHidden(true);
-    setOnboardingPopoversHidden({ ...onboardingPopoversHidden, [popoverKey]: true });
-  };
+    !coveredByTour &&
+    !runningTourSignal.value &&
+    welcomeExperienceDone &&
+    !!triggerElement;
 
   const handleClose = (event: KeyboardEvent | MouseEvent) => {
     // if user clicks the trigger element, don't hide the popover (unless hideOnTriggerClick is true)
     if (!hideOnTriggerClick && event instanceof MouseEvent) {
-      const trigger = triggerElement ?? spanRef.current;
-      if (trigger?.contains(event.target as Node)) return;
+      if (triggerElement?.contains(event.target as Node)) return;
     }
     hide();
   };
 
   return (
-    <>
-      {!triggerElement && <span ref={spanRef}>{children}</span>}
-      <Popover
-        footerContent={
-          <Button onClick={hide} variant={ButtonVariant.link}>
-            {t('Got it')}
-          </Button>
-        }
-        bodyContent={bodyContent}
-        headerContent={headerContent}
-        hideOnOutsideClick={false}
-        isVisible={isVisible}
-        position={PopoverPosition.right}
-        shouldClose={handleClose}
-        showClose
-        triggerRef={triggerRef}
-      />
-    </>
+    <Popover
+      footerContent={
+        <Button onClick={hide} variant={ButtonVariant.link}>
+          {t('Got it')}
+        </Button>
+      }
+      bodyContent={bodyContent}
+      headerContent={headerContent}
+      hideOnOutsideClick={false}
+      isVisible={isVisible}
+      position={PopoverPosition.right}
+      shouldClose={handleClose}
+      showClose
+      triggerRef={() => triggerElement as HTMLElement}
+    />
   );
 };
 

--- a/src/utils/components/OnboardingPopover/components/CreateProjectOnboardingPopover.tsx
+++ b/src/utils/components/OnboardingPopover/components/CreateProjectOnboardingPopover.tsx
@@ -19,6 +19,7 @@ const CreateProjectOnboardingPopover: FC<CreateProjectOnboardingPopoverProps> = 
       bodyContent={t(
         'Right-click a cluster in the navigation tree to create a new project and start organizing your workspace.',
       )}
+      coveredByTourSteps={[0]}
       headerContent={t('Create a new project')}
       popoverKey={OnboardingPopoverKey.CreateProject}
       triggerElement={triggerElement}

--- a/src/utils/components/OnboardingPopover/components/VMsTabOnboardingPopover.tsx
+++ b/src/utils/components/OnboardingPopover/components/VMsTabOnboardingPopover.tsx
@@ -6,8 +6,10 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import OnboardingPopover from '../OnboardingPopover';
 import { OnboardingPopoverKey } from '../types';
 
-const VMsTabOnboardingPopover: FC = ({ children }) => {
+const VMsTabOnboardingPopover: FC = () => {
   const { t } = useKubevirtTranslation();
+
+  const triggerElement = document.querySelector<HTMLElement>('[data-test="vm-list-tab"]');
 
   return (
     <OnboardingPopover
@@ -19,12 +21,12 @@ const VMsTabOnboardingPopover: FC = ({ children }) => {
           high-level summary of your current view, including health and alerts.
         </Trans>
       }
+      coveredByTourSteps={[2, 3]}
       headerContent={t('Looking for your VMs?')}
       hideOnTriggerClick
       popoverKey={OnboardingPopoverKey.VMsTab}
-    >
-      {children}
-    </OnboardingPopover>
+      triggerElement={triggerElement}
+    />
   );
 };
 

--- a/src/utils/components/OnboardingPopover/onboardingSignals.ts
+++ b/src/utils/components/OnboardingPopover/onboardingSignals.ts
@@ -1,0 +1,8 @@
+import { signal } from '@preact/signals-react';
+
+import { OnboardingPopoverKey } from './types';
+
+// Tracks dismissed popover keys synchronously within the session so the chain
+// can advance immediately without waiting for ConfigMap propagation.
+// Note: .value must be reassigned (not mutated) to trigger signal reactivity.
+export const dismissedPopoverKeysSignal = signal<Set<OnboardingPopoverKey>>(new Set());

--- a/src/utils/hooks/useKubevirtUserSettings/utils/userSettingsInitialState.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/utils/userSettingsInitialState.ts
@@ -21,7 +21,8 @@ type ColumnsUserSettings = {
 };
 
 type QuickStartUserSettings = {
-  [guideName: string]: boolean;
+  dontShowWelcomeModal?: boolean;
+  tourStepsSeen?: number[];
 };
 
 type CardsUserSettings = {

--- a/src/views/virtualmachines/list/components/OverviewTab/OverviewTab.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/OverviewTab.tsx
@@ -7,9 +7,11 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useIsAllClustersPage from '@multicluster/hooks/useIsAllClustersPage';
 import useIsACMPage from '@multicluster/useIsACMPage';
+import { WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, Bullseye, PageSection, Spinner, Stack } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
 import { AdvancedSearchFilter, useHubClusterName } from '@stolostron/multicluster-sdk';
+import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
 import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils';
 
 import OverviewAlerts from './components/OverviewAlerts';
@@ -42,20 +44,34 @@ const OverviewTab: FC<OverviewTabProps> = ({ cluster, namespace }) => {
 
   const watchEnabled = !isACMPage || !cluster || hubClusterLoaded;
 
-  const [vms, vmsLoaded, vmsError] = useKubevirtWatchResource<V1VirtualMachine[]>(
-    watchEnabled
+  const [watchedVms, watchedVmsLoaded, watchedVmsError] = useKubevirtWatchResource<
+    V1VirtualMachine[]
+  >(
+    (watchEnabled && !!namespace
       ? {
           cluster: isManagedClusterFetch ? undefined : cluster,
           groupVersionKind: VirtualMachineModelGroupVersionKind,
           isList: true,
           limit: OBJECTS_FETCHING_LIMIT,
           namespace,
-          namespaced: !!namespace,
+          namespaced: true,
         }
-      : null,
+      : null) as WatchK8sResource,
     undefined,
     searchQueries,
   );
+  const {
+    loaded: accessibleVmsLoaded,
+    loadError: accessibleVmsError,
+    resources: accessibleVms,
+  } = useAccessibleResources<V1VirtualMachine>({
+    groupVersionKind: VirtualMachineModelGroupVersionKind,
+    namespace: namespace || undefined,
+  });
+
+  const vms = namespace ? watchedVms : accessibleVms;
+  const vmsLoaded = namespace ? watchedVmsLoaded : accessibleVmsLoaded;
+  const vmsError = namespace ? watchedVmsError : accessibleVmsError;
 
   const { filteredVMs, vmNames } = useFolderFilter(vms);
 

--- a/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
+++ b/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
@@ -81,6 +81,7 @@ const VirtualMachineNavigator: FC = () => {
             {!isFleetPage && <GuidedTour />}
             {!isFleetPage && <WelcomeModal />}
             <CatalogOnboardingPopover />
+            <VMsTabOnboardingPopover />
             {isVirtualMachineListPage ? (
               <Tabs
                 activeKey={activeTabKey}
@@ -97,9 +98,7 @@ const VirtualMachineNavigator: FC = () => {
                 </Tab>
                 <Tab
                   title={
-                    <VMsTabOnboardingPopover>
-                      <TabTitleText data-test="vm-list-tab">{t('Virtual machines')}</TabTitleText>
-                    </VMsTabOnboardingPopover>
+                    <TabTitleText data-test="vm-list-tab">{t('Virtual machines')}</TabTitleText>
                   }
                   eventKey={VM_LIST_TAB_INDEX}
                 >

--- a/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
@@ -18,9 +18,10 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
 import { getName } from '@kubevirt-utils/resources/shared';
-import { universalComparator } from '@kubevirt-utils/utils/utils';
+import { isEmpty, universalComparator } from '@kubevirt-utils/utils/utils';
 import useMulticlusterNamespaces from '@multicluster/hooks/useMulticlusterNamespaces';
 import useIsACMPage from '@multicluster/useIsACMPage';
+import { WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
 import { useK8sWatchResources } from '@openshift-console/dynamic-plugin-sdk';
 import { TreeViewDataItem } from '@patternfly/react-core';
 import { useFleetClusterNames } from '@stolostron/multicluster-sdk';
@@ -56,11 +57,15 @@ export const useTreeViewData = (): UseTreeViewData => {
 
   const loadVMsPerNamespace = !isACMTreeView && projectNamesLoaded && !isAdmin;
 
-  const [allVMs, allVMsLoaded] = useKubevirtWatchResource<V1VirtualMachine[]>({
-    groupVersionKind: VirtualMachineModelGroupVersionKind,
-    isList: true,
-    limit: OBJECTS_FETCHING_LIMIT,
-  });
+  const [allVMs, allVMsLoaded] = useKubevirtWatchResource<V1VirtualMachine[]>(
+    (isAdmin || isACMTreeView
+      ? {
+          groupVersionKind: VirtualMachineModelGroupVersionKind,
+          isList: true,
+          limit: OBJECTS_FETCHING_LIMIT,
+        }
+      : null) as WatchK8sResource,
+  );
 
   // user has limited access, so we can only get vms from allowed namespaces
   const allowedResources = useK8sWatchResources<{ [key: string]: V1VirtualMachine[] }>(
@@ -78,11 +83,15 @@ export const useTreeViewData = (): UseTreeViewData => {
     ),
   );
 
-  const [allVMIM] = useKubevirtWatchResource<V1VirtualMachineInstanceMigration[]>({
-    groupVersionKind: VirtualMachineInstanceMigrationModelGroupVersionKind,
-    isList: true,
-    limit: OBJECTS_FETCHING_LIMIT,
-  });
+  const [allVMIM] = useKubevirtWatchResource<V1VirtualMachineInstanceMigration[]>(
+    (isAdmin || isACMTreeView
+      ? {
+          groupVersionKind: VirtualMachineInstanceMigrationModelGroupVersionKind,
+          isList: true,
+          limit: OBJECTS_FETCHING_LIMIT,
+        }
+      : null) as WatchK8sResource,
+  );
 
   const allowedVMIMResources = useK8sWatchResources<{
     [key: string]: V1VirtualMachineInstanceMigration[];
@@ -127,7 +136,8 @@ export const useTreeViewData = (): UseTreeViewData => {
   const loaded =
     projectsLoaded &&
     (loadVMsPerNamespace
-      ? Object.values(allowedResources).some((resource) => resource.loaded)
+      ? isEmpty(allowedResources) ||
+        Object.values(allowedResources).every((resource) => resource.loaded || resource.loadError)
       : allVMsLoaded);
 
   const treeData = useMemo(() => {

--- a/src/views/welcome/WelcomeModal.tsx
+++ b/src/views/welcome/WelcomeModal.tsx
@@ -1,7 +1,10 @@
-import React, { FC, useCallback, useState } from 'react';
+import React, { FC, useCallback, useEffect, useState } from 'react';
 import openCulture from 'images/openCulture.svg';
 
-import { runningTourSignal } from '@kubevirt-utils/components/GuidedTour/utils/guidedTourSignals';
+import {
+  runningTourSignal,
+  welcomeModalDismissedSignal,
+} from '@kubevirt-utils/components/GuidedTour/utils/guidedTourSignals';
 import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
@@ -17,18 +20,27 @@ import {
   Stack,
   Title,
 } from '@patternfly/react-core';
+import { useSignals } from '@preact/signals-react/runtime';
 
 import WelcomeButtons from './components/WelcomeButtons';
 
 import './WelcomeModal.scss';
 
 const WelcomeModal: FC = () => {
+  useSignals();
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState<boolean>(true);
   const [quickStarts, setQuickStarts, loaded] = useKubevirtUserSettings('quickStart');
   const isWindowsSupported = useIsWindowsSupportedArchitecture();
 
-  const onClose = useCallback(() => setIsOpen(false), []);
+  useEffect(() => {
+    welcomeModalDismissedSignal.value = false;
+  }, []);
+
+  const onClose = useCallback(() => {
+    setIsOpen(false);
+    welcomeModalDismissedSignal.value = true;
+  }, []);
 
   if (runningTourSignal.value || !loaded || quickStarts?.dontShowWelcomeModal) return null;
 


### PR DESCRIPTION

## 📝 Description

Implements a guided tour, welcome modal, and sequential onboarding popover chain for first-time users.

- **Guided tour**: 6-step tour navigates within the user's actual namespace; records seen steps to suppress redundant onboarding hints
- **Welcome modal**: tracks dismissal via signal so onboarding popovers don't appear while it's on screen; hidden on Fleet/ACM pages
- **Onboarding popover chain** (VMsTab → Catalog → CreateProject): each popover waits for its predecessor; popovers whose content was covered by the tour are auto-skipped
- **Non-privileged users**: `useForceProjectSelection` redirects users away from all-namespaces to their first available namespace to fix a non-related existing bug


## 🎥 Demo

After:

https://github.com/user-attachments/assets/528c0fa4-c2c6-408e-a123-4be7b522a333


https://github.com/user-attachments/assets/821776c6-99e7-4fe2-b811-5057dc1b9dfb


https://github.com/user-attachments/assets/0b91c015-b31e-4f63-9d2e-966c7953eec3


https://github.com/user-attachments/assets/a38e6e31-f9bc-44d2-b7da-758d8d2dd613




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guided tour now records which steps you’ve seen and respects that across sessions; welcome modal dismissal is tracked.
  * Onboarding popovers coordinate with tours (auto-hide when a tour covers them), persist dismissal, and improve VM-tab trigger behavior.

* **Behavior Changes**
  * VM list/tree and overview use namespace-aware sources and conditionally enable watches for more accurate loading and error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->