### PR TITLE
CNV-69050: Add the option to make network devices bootable

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -2212,6 +2212,7 @@
   "Usage": "Usage",
   "Use \"{{inputValue}}\"": "Use \"{{inputValue}}\"",
   "Use an alternative": "Use an alternative",
+  "Use as boot source": "Use as boot source",
   "Use BIOS when bootloading the guest OS": "Use BIOS when bootloading the guest OS",
   "Use cron formatting to set when and how often to look for new imports.": "Use cron formatting to set when and how often to look for new imports.",
   "Use custom registration server url": "Use custom registration server url",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -2232,6 +2232,7 @@
   "Usage": "Uso",
   "Use \"{{inputValue}}\"": "Utilizar \"{{inputValue}}\"",
   "Use an alternative": "Utilice una alternativa",
+  "Use as boot source": "Use as boot source",
   "Use BIOS when bootloading the guest OS": "Utilice BIOS al momento de cargar el sistema operativo huésped.",
   "Use cron formatting to set when and how often to look for new imports.": "Utilice el formato cron para establecer cuándo y con qué frecuencia buscar nuevas importaciones.",
   "Use custom registration server url": "Utilice la URL del servidor de registro personalizado.",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -2232,6 +2232,7 @@
   "Usage": "Utilisation",
   "Use \"{{inputValue}}\"": "Utiliser \"{{inputValue}} \"",
   "Use an alternative": "Utiliser une alternative",
+  "Use as boot source": "Use as boot source",
   "Use BIOS when bootloading the guest OS": "Utiliser le BIOS lors du démarrage du système d'exploitation invité",
   "Use cron formatting to set when and how often to look for new imports.": "Utilisez le formatage cron pour définir quand et à quelle fréquence rechercher de nouvelles importations.",
   "Use custom registration server url": "Utiliser l'URL du serveur d'enregistrement personnalisé",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -2208,6 +2208,7 @@
   "Usage": "使用",
   "Use \"{{inputValue}}\"": "\"{{inputValue}}\" の使用",
   "Use an alternative": "別のものを使用する",
+  "Use as boot source": "Use as boot source",
   "Use BIOS when bootloading the guest OS": "ゲスト OS のブートロード時に BIOS を使用する",
   "Use cron formatting to set when and how often to look for new imports.": "cron 形式を使用して、新しいインポートを検索する時刻と頻度を設定します。",
   "Use custom registration server url": "カスタム登録サーバー url の使用",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -2208,6 +2208,7 @@
   "Usage": "사용량",
   "Use \"{{inputValue}}\"": "\"{{inputValue}}\" 사용",
   "Use an alternative": "대안 사용",
+  "Use as boot source": "Use as boot source",
   "Use BIOS when bootloading the guest OS": "게스트 OS를 부트로딩할 때 BIOS 사용",
   "Use cron formatting to set when and how often to look for new imports.": "cron 포맷을 사용하여 새 가져오기를 찾는 빈도와 시기를 설정합니다.",
   "Use custom registration server url": "사용자 정의 등록 서버 URL 사용",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -2208,6 +2208,7 @@
   "Usage": "使用",
   "Use \"{{inputValue}}\"": "使用 \"{{inputValue}}\"",
   "Use an alternative": "使用替代方案",
+  "Use as boot source": "Use as boot source",
   "Use BIOS when bootloading the guest OS": "在载入客户端操作系统时使用 BIOS",
   "Use cron formatting to set when and how often to look for new imports.": "使用 cron 格式设置查找新导入的时间和频率。",
   "Use custom registration server url": "使用自定义注册服务器 url",

--- a/src/utils/components/NetworkInterfaceModal/NetworkInterfaceModal.tsx
+++ b/src/utils/components/NetworkInterfaceModal/NetworkInterfaceModal.tsx
@@ -15,7 +15,7 @@ import { getNetworkInterfaceType } from '@kubevirt-utils/resources/vm/utils/netw
 import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
 import { generatePrettyName } from '@kubevirt-utils/utils/utils';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import { ExpandableSection } from '@patternfly/react-core';
+import { Checkbox, ExpandableSection, FormGroup } from '@patternfly/react-core';
 import {
   getConfigInterfaceStateFromVM,
   isLinkStateEditable,
@@ -36,6 +36,7 @@ export type NetworkInterfaceModalOnSubmit = {
   interfaceMACAddress: string;
   interfaceModel: string;
   interfaceType: string;
+  isBootSource?: boolean;
   isLegacyPasst: boolean;
   networkName: string;
   nicName: string;
@@ -85,6 +86,7 @@ const NetworkInterfaceModal: FC<NetworkInterfaceModalProps> = ({
     !network ? NetworkInterfaceState.UP : getConfigInterfaceStateFromVM(vm, nicName),
   );
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isBootSource, setIsBootSource] = useState<boolean>(Boolean(iface?.bootOrder));
 
   useEffect(() => {
     if (interfaceType === interfaceTypesProxy.sriov)
@@ -103,6 +105,7 @@ const NetworkInterfaceModal: FC<NetworkInterfaceModalProps> = ({
         interfaceMACAddress,
         interfaceModel,
         interfaceType,
+        isBootSource,
         isLegacyPasst,
         networkName,
         nicName,
@@ -115,6 +118,7 @@ const NetworkInterfaceModal: FC<NetworkInterfaceModalProps> = ({
     interfaceMACAddress,
     interfaceLinkState,
     interfaceType,
+    isBootSource,
     onSubmit,
     isLegacyPasst,
   ]);
@@ -143,6 +147,15 @@ const NetworkInterfaceModal: FC<NetworkInterfaceModalProps> = ({
         setSubmitDisabled={setNetworkSelectError}
         vm={vm}
       />
+      <FormGroup fieldId="nic-boot-source">
+        <Checkbox
+          data-test-id="nic-use-as-boot-source"
+          id="nic-boot-source"
+          isChecked={isBootSource}
+          label={t('Use as boot source')}
+          onChange={(_, checked) => setIsBootSource(checked)}
+        />
+      </FormGroup>
       <ExpandableSection
         className="NetworkInterfaceModal__advanced"
         isExpanded={isExpanded}

--- a/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
+++ b/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import { TFunction } from 'react-i18next';
 
-import { V1Interface, V1Network, V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  V1Disk,
+  V1Interface,
+  V1Network,
+  V1VirtualMachine,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import TechPreviewBadge from '@kubevirt-utils/components/TechPreviewBadge/TechPreviewBadge';
 import { NetworkAttachmentDefinitionConfig } from '@kubevirt-utils/resources/nad/types';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { getInterface, getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
+import { getDisks, getInterface, getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
 import {
   NAD_TYPE_OVN_K8S_CNI_OVERLAY,
   PASST_BINDING_NAME,
@@ -109,6 +114,52 @@ export const createInterface = ({
   }
 
   return createdInterface;
+};
+
+/**
+ * Returns the next available bootOrder integer, looking across ALL disks and interfaces.
+ * @param vm
+ */
+export const getNextBootOrder = (vm: V1VirtualMachine): number => {
+  const diskOrders = (getDisks(vm) || []).map((d) => d.bootOrder ?? 0);
+  const ifaceOrders = (getInterfaces(vm) || []).map((i) => i.bootOrder ?? 0);
+  return Math.max(0, ...diskOrders, ...ifaceOrders) + 1;
+};
+
+export type NICBootOrderPreparation = {
+  disksWithOrder: V1Disk[];
+  needsDiskUpdate: boolean;
+  nicBootOrder: number;
+};
+
+/**
+ * Prepares the bootOrder for a NIC being marked as a boot source.
+ * If no disks currently have a bootOrder, assigns sequential bootOrders to all disks
+ * so they retain priority over the incoming NIC in the firmware boot sequence.
+ * Disk numbering starts above any existing interface bootOrders to avoid collisions.
+ * Returns the bootOrder to assign to the NIC and whether the disks array also needs saving.
+ * @param vm
+ */
+export const prepareNICBootOrder = (vm: V1VirtualMachine): NICBootOrderPreparation => {
+  const disks = getDisks(vm) || [];
+  const anyDiskHasBootOrder = disks.some((d) => d.bootOrder != null);
+
+  if (!anyDiskHasBootOrder && disks.length > 0) {
+    // Start disk numbering above any existing interface bootOrders to avoid collisions.
+    const ifaceOrders = (getInterfaces(vm) || []).map((i) => i.bootOrder ?? 0);
+    const diskStart = Math.max(0, ...ifaceOrders) + 1;
+    return {
+      disksWithOrder: disks.map((d, index) => ({ ...d, bootOrder: diskStart + index })),
+      needsDiskUpdate: true,
+      nicBootOrder: diskStart + disks.length,
+    };
+  }
+
+  return {
+    disksWithOrder: disks,
+    needsDiskUpdate: false,
+    nicBootOrder: getNextBootOrder(vm),
+  };
 };
 
 type NADTypes = NetworkAttachmentDefinition | NetworkAttachmentDefinitionKind;

--- a/src/utils/components/PendingChanges/utils/helpers.ts
+++ b/src/utils/components/PendingChanges/utils/helpers.ts
@@ -206,7 +206,9 @@ export const getChangedNICs = (vm: V1VirtualMachine, vmi: V1VirtualMachineInstan
         // model change (virtio <-> e1000e)
         (state.config.iface?.model &&
           state.config.iface?.model !==
-            (state.runtime.iface?.model ?? getDefaultInterfaceModel(vmi))),
+            (state.runtime.iface?.model ?? getDefaultInterfaceModel(vmi))) ||
+        // boot order changed
+        state.config.iface?.bootOrder !== state.runtime.iface?.bootOrder,
     )
     .map((state) => state.runtime?.network?.name);
 

--- a/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeNetworkTab.tsx
+++ b/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeNetworkTab.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
 import NetworkInterfaceList from '@catalog/wizard/tabs/network/components/list/NetworkInterfaceList';
-import { V1Interface, V1Network, V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  V1Disk,
+  V1Interface,
+  V1Network,
+  V1VirtualMachine,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -17,19 +22,20 @@ const CustomizeInstanceTypeNetworkTab = () => {
     return <Loading />;
   }
 
-  const onAddNetworkInterface = (updatedNetworks: V1Network[], updatedInterfaces: V1Interface[]) =>
-    Promise.resolve(
-      updateCustomizeInstanceType([
-        {
-          data: updatedNetworks,
-          path: 'spec.template.spec.networks',
-        },
-        {
-          data: updatedInterfaces,
-          path: 'spec.template.spec.domain.devices.interfaces',
-        },
-      ]),
-    );
+  const onAddNetworkInterface = (
+    updatedNetworks: V1Network[],
+    updatedInterfaces: V1Interface[],
+    updatedDisks?: V1Disk[],
+  ) => {
+    const updates: Parameters<typeof updateCustomizeInstanceType>[0] = [
+      { data: updatedNetworks, path: 'spec.template.spec.networks' },
+      { data: updatedInterfaces, path: 'spec.template.spec.domain.devices.interfaces' },
+    ];
+    if (updatedDisks) {
+      updates.push({ data: updatedDisks, path: 'spec.template.spec.domain.devices.disks' });
+    }
+    return Promise.resolve(updateCustomizeInstanceType(updates));
+  };
 
   const onUpdateVM = (updatedVM: V1VirtualMachine) => {
     updateCustomizeInstanceType([{ data: updatedVM }]);

--- a/src/views/virtualmachines/creation-wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeNetworkTab.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeNetworkTab.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 
 import NetworkInterfaceList from '@catalog/wizard/tabs/network/components/list/NetworkInterfaceList';
-import { V1Interface, V1Network, V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  V1Disk,
+  V1Interface,
+  V1Network,
+  V1VirtualMachine,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -18,19 +23,20 @@ const CustomizeInstanceTypeNetworkTab = () => {
     return <Loading />;
   }
 
-  const onAddNetworkInterface = (updatedNetworks: V1Network[], updatedInterfaces: V1Interface[]) =>
-    Promise.resolve(
-      updateCustomizeInstanceType([
-        {
-          data: updatedNetworks,
-          path: 'spec.template.spec.networks',
-        },
-        {
-          data: updatedInterfaces,
-          path: 'spec.template.spec.domain.devices.interfaces',
-        },
-      ]),
-    );
+  const onAddNetworkInterface = (
+    updatedNetworks: V1Network[],
+    updatedInterfaces: V1Interface[],
+    updatedDisks?: V1Disk[],
+  ) => {
+    const updates: Parameters<typeof updateCustomizeInstanceType>[0] = [
+      { data: updatedNetworks, path: 'spec.template.spec.networks' },
+      { data: updatedInterfaces, path: 'spec.template.spec.domain.devices.interfaces' },
+    ];
+    if (updatedDisks) {
+      updates.push({ data: updatedDisks, path: 'spec.template.spec.domain.devices.disks' });
+    }
+    return Promise.resolve(updateCustomizeInstanceType(updates));
+  };
 
   const onUpdateVM = (updatedVM: V1VirtualMachine) => {
     updateCustomizeInstanceType([{ data: updatedVM }]);

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/AddNetworkInterfaceButton.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/AddNetworkInterfaceButton.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import classNames from 'classnames';
 
 import {
+  V1Disk,
   V1Interface,
   V1Network,
   V1VirtualMachine,
@@ -17,6 +18,7 @@ type AddNetworkInterfaceButtonProps = {
   onAddNetworkInterface?: (
     updatedNetworks: V1Network[],
     updatedInterfaces: V1Interface[],
+    updatedDisks?: V1Disk[],
   ) => Promise<V1VirtualMachine>;
   vm: V1VirtualMachine;
   vmi?: V1VirtualMachineInstance;

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/networkInterfaceListDefinition.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/networkInterfaceListDefinition.tsx
@@ -9,7 +9,7 @@ import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { getNetworkNameLabel } from '@kubevirt-utils/resources/vm/utils/network/network-columns';
-import { Label } from '@patternfly/react-core';
+import { Label, Stack, StackItem } from '@patternfly/react-core';
 
 import { SimpleNICPresentation } from '../../utils/types';
 import { getConfigInterfaceState, getRuntimeInterfaceState } from '../../utils/utils';
@@ -26,15 +26,26 @@ type NameCellProps = {
 };
 
 const NameCell: FC<NameCellProps> = ({ row }) => {
+  const { t } = useKubevirtTranslation();
   const { interfaceName, isInterfaceEphemeral, isPending, network } = row;
   const nicName = network?.name;
+  const isBootable = Boolean(row.config?.iface?.bootOrder);
 
   return (
-    <span data-test-id={`nic-${nicName}`}>
-      {!nicName && interfaceName ? <Label>{interfaceName}</Label> : nicName ?? NO_DATA_DASH}
-      {isPending && !isInterfaceEphemeral && <PendingBadge />}
-      {isInterfaceEphemeral && <EphemeralBadge />}
-    </span>
+    <Stack data-test-id={`nic-${nicName}`}>
+      <StackItem>
+        {!nicName && interfaceName ? <Label>{interfaceName}</Label> : nicName ?? NO_DATA_DASH}
+        {isPending && !isInterfaceEphemeral && <PendingBadge />}
+        {isInterfaceEphemeral && <EphemeralBadge />}
+      </StackItem>
+      {isBootable && (
+        <StackItem>
+          <Label color="blue" data-test-id={`nic-bootable-${nicName}`} variant="filled">
+            {t('bootable')}
+          </Label>
+        </StackItem>
+      )}
+    </Stack>
   );
 };
 

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesEditNetworkInterfaceModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesEditNetworkInterfaceModal.tsx
@@ -1,10 +1,13 @@
 import React, { FC, useCallback } from 'react';
+import produce from 'immer';
+import { VirtualMachineModel } from 'src/views/dashboard-extensions/utils';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { V1Interface, V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import NetworkInterfaceModal from '@kubevirt-utils/components/NetworkInterfaceModal/NetworkInterfaceModal';
 import {
   createInterface,
   createNetwork,
+  prepareNICBootOrder,
 } from '@kubevirt-utils/components/NetworkInterfaceModal/utils/helpers';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getInterface, getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
@@ -14,6 +17,8 @@ import {
   updateInterface,
   updateNetwork,
 } from '@kubevirt-utils/resources/vm/utils/network/patch';
+import { getCluster } from '@multicluster/helpers/selectors';
+import { kubevirtK8sUpdate } from '@multicluster/k8sRequests';
 
 type VirtualMachinesEditNetworkInterfaceModalProps = {
   isOpen: boolean;
@@ -33,6 +38,7 @@ const VirtualMachinesEditNetworkInterfaceModal: FC<
         interfaceMACAddress,
         interfaceModel,
         interfaceType,
+        isBootSource = false,
         isLegacyPasst,
         networkName,
         nicName,
@@ -53,6 +59,43 @@ const VirtualMachinesEditNetworkInterfaceModal: FC<
 
         if (!existingNetwork || !existingInterface) {
           return;
+        }
+
+        const wasBootSource = Boolean(existingInterface?.bootOrder);
+
+        if (isBootSource !== wasBootSource) {
+          const { disksWithOrder, needsDiskUpdate, nicBootOrder } = prepareNICBootOrder(vm);
+          if (isBootSource) resultInterface.bootOrder = nicBootOrder;
+
+          const newVM = produce(vm, (draftVM) => {
+            if (isBootSource && needsDiskUpdate) {
+              draftVM.spec!.template!.spec!.domain!.devices!.disks = disksWithOrder;
+            }
+            const ifaces = getInterfaces(draftVM)!;
+            const networks = getNetworks(draftVM)!;
+            const ifaceIndex = ifaces.findIndex((i) => i.name === nicName);
+            const netIndex = networks.findIndex((n) => n.name === nicName);
+            if (ifaceIndex >= 0) {
+              // Merge to preserve any extra fields not modeled by the form (mirrors updateInterface).
+              const mergedIface: V1Interface = { ...existingInterface, ...resultInterface };
+              if (!resultInterface.bridge) delete mergedIface.bridge;
+              if (!resultInterface.masquerade) delete mergedIface.masquerade;
+              if (!resultInterface.sriov) delete mergedIface.sriov;
+              if (!resultInterface.binding) delete mergedIface.binding;
+              if (!resultInterface.passtBinding) delete mergedIface.passtBinding;
+              if (!isBootSource) delete mergedIface.bootOrder;
+              ifaces[ifaceIndex] = mergedIface;
+            }
+            if (netIndex >= 0) networks[netIndex] = { ...existingNetwork, ...resultNetwork };
+          });
+
+          return kubevirtK8sUpdate({
+            cluster: getCluster(vm),
+            data: newVM,
+            model: VirtualMachineModel,
+            name: newVM.metadata?.name,
+            ns: newVM.metadata?.namespace,
+          });
         }
 
         return patchVM(vm, [

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesNetworkInterfaceModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesNetworkInterfaceModal.tsx
@@ -1,6 +1,9 @@
 import React, { FC, useCallback } from 'react';
+import produce from 'immer';
+import { VirtualMachineModel } from 'src/views/dashboard-extensions/utils';
 
 import {
+  V1Disk,
   V1Interface,
   V1Network,
   V1VirtualMachine,
@@ -10,6 +13,7 @@ import NetworkInterfaceModal from '@kubevirt-utils/components/NetworkInterfaceMo
 import {
   createInterface,
   createNetwork,
+  prepareNICBootOrder,
 } from '@kubevirt-utils/components/NetworkInterfaceModal/utils/helpers';
 import { getInterface, getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
 import {
@@ -17,13 +21,16 @@ import {
   addNetwork,
   patchVM,
 } from '@kubevirt-utils/resources/vm/utils/network/patch';
+import { getCluster } from '@multicluster/helpers/selectors';
+import { kubevirtK8sUpdate } from '@multicluster/k8sRequests';
 
 type VirtualMachinesNetworkInterfaceModalProps = {
   headerText: string;
   isOpen: boolean;
-  onAddNetworkInterface: (
+  onAddNetworkInterface?: (
     updatedNetworks: V1Network[],
     updatedInterfaces: V1Interface[],
+    updatedDisks?: V1Disk[],
   ) => Promise<V1VirtualMachine>;
   onClose: () => void;
   vm: V1VirtualMachine;
@@ -43,6 +50,7 @@ const VirtualMachinesNetworkInterfaceModal: FC<VirtualMachinesNetworkInterfaceMo
         interfaceMACAddress,
         interfaceModel,
         interfaceType,
+        isBootSource = false,
         isLegacyPasst,
         networkName,
         nicName,
@@ -64,10 +72,32 @@ const VirtualMachinesNetworkInterfaceModal: FC<VirtualMachinesNetworkInterfaceMo
           nicName,
         });
 
+        const { disksWithOrder, needsDiskUpdate, nicBootOrder } = prepareNICBootOrder(vm);
+        if (isBootSource) resultInterface.bootOrder = nicBootOrder;
+
         if (onAddNetworkInterface) {
           const updatedNetworks: V1Network[] = [...(getNetworks(vm) || []), resultNetwork];
           const updatedInterfaces: V1Interface[] = [...(getInterfaces(vm) || []), resultInterface];
-          return onAddNetworkInterface(updatedNetworks, updatedInterfaces);
+          return onAddNetworkInterface(
+            updatedNetworks,
+            updatedInterfaces,
+            isBootSource && needsDiskUpdate ? disksWithOrder : undefined,
+          );
+        }
+
+        if (isBootSource && needsDiskUpdate) {
+          const newVM = produce(vm, (draftVM) => {
+            draftVM.spec!.template!.spec!.domain!.devices!.disks = disksWithOrder;
+            getNetworks(draftVM)!.push(resultNetwork);
+            getInterfaces(draftVM)!.push(resultInterface);
+          });
+          return kubevirtK8sUpdate({
+            cluster: getCluster(vm),
+            data: newVM,
+            model: VirtualMachineModel,
+            name: newVM.metadata?.name,
+            ns: newVM.metadata?.namespace,
+          });
         }
 
         return patchVM(vm, [


### PR DESCRIPTION


## 📝 Description

Adds a "Use as boot source" checkbox to the Add/Edit network interface modal. When checked, the interface is assigned the next available `bootOrder` (max across all existing disks and interfaces + 1), placing it in the VM's boot sequence alongside disks. Users can reorder via Boot Management. Unchecking removes `bootOrder` from the interface.

"bootable" badge appears in the NIC list when an interface has a `bootOrder` set, consistent with the disk list treatment
`getChangedNICs` now detects `bootOrder` changes so toggling boot source on a running VM correctly shows a pending change indicator
Edit path uses a full VM update (`kubevirtK8sUpdate`) with a merge strategy that mirrors `updateInterface` — preserving extra interface fields while cleanly removing `bootOrder` when disabled

## 🎥 Demo


https://github.com/user-attachments/assets/44975cd9-9a99-4d6e-bd6b-e977723caf2c






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Use as boot source" option in network interface configuration to enable booting from network interfaces.
  * Added visual "bootable" badge to network interface list to highlight interfaces configured as boot sources.
  * Enhanced boot order calculation to intelligently coordinate network interface and disk boot ordering when configuring boot sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->