### PR TITLE
CNV-62627: after changing metric updating it to correct new metric in…

### DIFF
--- a/src/utils/components/Charts/utils/queries.ts
+++ b/src/utils/components/Charts/utils/queries.ts
@@ -50,7 +50,7 @@ export const getUtilizationQueries: GetUtilizationQueries = ({
     [VMQueries.MEMORY_USAGE]: `last_over_time(kubevirt_vmi_memory_used_bytes{name='${name}',namespace='${namespace}'}[${duration}])`,
     [VMQueries.MIGRATION_DATA_PROCESSED]: `sum(rate(kubevirt_vmi_migration_data_processed_bytes{name='${name}',namespace='${namespace}'}[${duration}]))  BY (name, namespace)`,
     [VMQueries.MIGRATION_DATA_REMAINING]: `sum(rate(kubevirt_vmi_migration_data_remaining_bytes{name='${name}',namespace='${namespace}'}[${duration}]))  BY (name, namespace)`,
-    [VMQueries.MIGRATION_DISK_TRANSFER_RATE]: `sum(sum_over_time(kubevirt_vmi_migration_disk_transfer_rate_bytes	{name='${name}',namespace='${namespace}'}[${duration}]))  BY (name, namespace)`,
+    [VMQueries.MIGRATION_DISK_TRANSFER_RATE]: `sum(sum_over_time(kubevirt_vmi_migration_memory_transfer_rate_bytes	{name='${name}',namespace='${namespace}'}[${duration}]))  BY (name, namespace)`,
     [VMQueries.MIGRATION_MEMORY_DIRTY_RATE]: `sum(rate(kubevirt_vmi_migration_dirty_memory_rate_bytes{name='${name}',namespace='${namespace}'}[${duration}]))  BY (name, namespace)`,
     [VMQueries.NETWORK_IN_BY_INTERFACE_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace, interface)`,
     [VMQueries.NETWORK_IN_USAGE]: `sum(rate(kubevirt_vmi_network_receive_bytes_total{name='${name}',namespace='${namespace}'}[${duration}])) BY (name, namespace)`,


### PR DESCRIPTION

## 📝 Description

PR https://github.com/kubevirt/kubevirt/pull/13500 updated the
`kubevirt_vmi_migration_disk_transfer_rate_bytes` metric name to
`kubevirt_vmi_migration_memory_transfer_rate_bytes`.
