### PR TITLE
CNV-82109: fixing the template redirection path

### DIFF
--- a/src/multicluster/urls.ts
+++ b/src/multicluster/urls.ts
@@ -1,6 +1,6 @@
 import { matchPath } from 'react-router-dom-v5-compat';
 
-import { VirtualMachineModelRef } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { TemplateModel, VirtualMachineModelRef } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
   ALL_CLUSTERS_KEY,
   ALL_NAMESPACES,
@@ -151,6 +151,9 @@ export const getFleetResourceRoute: GetFleetResourceRouteProps = ({
   name,
   namespace,
 }) => {
+  if (model.kind === TemplateModel.kind && model.apiGroup === TemplateModel.apiGroup) {
+    return `${getFleetTemplatesURL(cluster, namespace)}/${name}`;
+  }
   const extensionModel = {
     group: model.apiGroup,
     kind: model.kind,


### PR DESCRIPTION


## 📝 Description

`getFleetResourceRoute` was building the post-create redirect URL using the generic `group~version~kind` model ref pattern, producing `/fleet-virtualization/template.openshift.io~v1~Template/...` which has no registered route. Fixed by adding a Template-specific case in `getFleetResourceRoute` that delegates to `getFleetTemplatesURL`, producing the correct `/fleet-virtualization/templates/...` URL.

## 🎥 Demo
Before:

https://github.com/user-attachments/assets/b1594ab7-20d8-4a81-835c-01b658dd4be2



After:

https://github.com/user-attachments/assets/8f58202a-9004-44b1-a49a-168f3f151436




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-cluster resource routing so OpenShift Template resources are routed to the correct fleet template endpoints.

* **Improvements**
  * Enhanced routing logic to recognize Template resources from the template.openshift.io API group while preserving existing behavior for all other resource types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->