### PR TITLE
CNV-69746: revert cd-rom size from file size to default size

### DIFF
--- a/src/utils/components/DiskModal/utils/submit.ts
+++ b/src/utils/components/DiskModal/utils/submit.ts
@@ -19,7 +19,7 @@ import { isRunning } from '@virtualmachines/utils';
 
 import { getDataVolumeTemplateSize } from '../components/utils/selectors';
 
-import { DEFAULT_DISK_SIZE, UPLOAD_SUFFIX } from './constants';
+import { DEFAULT_CDROM_DISK_SIZE, DEFAULT_DISK_SIZE, UPLOAD_SUFFIX } from './constants';
 import {
   createDataVolumeName,
   createMutableUploadData,
@@ -69,16 +69,6 @@ export const reorderBootDisk = (
   return isBootDisk ? applyDiskAsBootable(vm, diskName) : removeDiskAsBootable(vm, diskName);
 };
 
-const UPLOAD_SIZE_BUFFER_FACTOR = 1.1; // 10% buffer for filesystem overhead
-const BYTES_PER_GIB = 1024 * 1024 * 1024;
-
-const getUploadFileSizeWithBuffer = (data: V1DiskFormState): null | string => {
-  const fileSize = data?.uploadFile?.file?.size;
-  if (!fileSize) return null;
-  const sizeInGi = Math.ceil((fileSize * UPLOAD_SIZE_BUFFER_FACTOR) / BYTES_PER_GIB);
-  return `${Math.max(sizeInGi, 1)}Gi`;
-};
-
 export const uploadDataVolume = async (
   vm: V1VirtualMachine,
   uploadData: ({ dataVolume, file }: UploadDataProps) => Promise<void>,
@@ -90,8 +80,10 @@ export const uploadDataVolume = async (
 
   dataVolume.metadata.name = dvName || generateUploadDiskName(data.disk.name, UPLOAD_SUFFIX);
   dataVolume.spec.source = { upload: {} };
+  const isCDROM = Boolean(data.disk?.cdrom);
+  const defaultSize = isCDROM ? DEFAULT_CDROM_DISK_SIZE : DEFAULT_DISK_SIZE;
   dataVolume.spec.storage.resources.requests.storage =
-    getUploadFileSizeWithBuffer(data) || getDataVolumeTemplateSize(data) || DEFAULT_DISK_SIZE;
+    getDataVolumeTemplateSize(data) || defaultSize;
 
   await uploadData({ dataVolume, file });
 


### PR DESCRIPTION


## 📝 Description

In https://github.com/kubevirt-ui/kubevirt-plugin/pull/3455 we changed the uploaded DV size to be calculated from the file size (+ 10% buffer). However, this causes issues with compressed files where the compressed size is much smaller than the decompressed size. When CDI runs out of space during decompression, it fails silently without returning an error to the UI - the DV remains stuck in UploadReady with no indication of the failure.

Reverted to using a fixed default size of 10Gi for CD-ROM uploads, which should accommodate most ISO files.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified storage allocation for disk uploads: sizing now uses template-provided values or a default fallback rather than deriving size from uploaded file bytes.
  * Default fallback size now differs for CD-ROM-style disks versus regular disks to ensure appropriate initial allocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->