### PR TITLE
CNV-84762: Add automatic CI failure triage and infrastructure retest

### DIFF
--- a/.cursor/commands/triage.md
+++ b/.cursor/commands/triage.md
@@ -1,0 +1,18 @@
+# /triage -- CI Failure Triage Command
+
+Analyze a failing CI job, classify the failure, and optionally retest.
+
+Read `.cursor/rules/workflows/ci-triage.mdc` — it is the single source of truth for classification patterns, MCP tools, and action rules.
+
+## Input Detection
+
+Determine the PR to triage from the user's message:
+
+1. **PR number** — e.g. `/triage 3809` or `/triage PR 3809`
+2. **GitHub PR URL** — e.g. `/triage https://github.com/kubevirt-ui/kubevirt-plugin/pull/3809`
+3. **Prow build URL** — e.g. `/triage https://prow.ci.openshift.org/view/gs/...`
+4. **Current PR** — if no argument is given, detect the current branch and find its open PR
+
+## Execution
+
+Follow the steps in `.cursor/rules/workflows/ci-triage.mdc`: fetch → classify → report → act.

--- a/.cursor/rules/workflows/ci-triage.mdc
+++ b/.cursor/rules/workflows/ci-triage.mdc
@@ -1,0 +1,219 @@
+---
+description: CI failure triage - analyze Prow build failures, classify them, and retest
+alwaysApply: false
+---
+
+# CI Triage Workflow
+
+Invoked by the `/triage` command or by the babysit skill when CI fails.
+
+Analyze a failed CI job for a kubevirt-plugin PR, classify the failure, and take the appropriate action.
+
+## Input
+
+The caller provides one of:
+- A PR number
+- A Prow build URL
+- A GitHub PR URL
+- Nothing (detect from current branch)
+
+## Steps
+
+### 1. Fetch failure data
+
+Use the Prow MCP (`user-prow`) tools in parallel:
+
+- `diagnose_pr_failures` with `pr_number`, `org_repo="kubevirt-ui_kubevirt-plugin"`
+- `analyze_build_step_failures` with `job_name` and `build_id` extracted from the Prow URL or from the `diagnose_pr_failures` output
+
+If the user provided a raw build URL, extract `job_name` and `build_id` from the URL path segments.
+
+### 2. Classify the failure
+
+Match the failure output against the three categories using the patterns below:
+
+- **INFRASTRUCTURE**: Registry timeouts, image pull failures, cluster provisioning errors, network flakes, Docker build container errors. These are transient and safe to retest.
+- **CODE**: TypeScript/webpack build errors, lint failures, unit test failures, i18n drift, e2e test assertion failures. These require developer action.
+- **FLAKY_TEST**: Known intermittent test failures, timeout-only failures in test steps.
+
+When classifying:
+- Check the build step that failed (e.g. `DockerBuildFailed`, `test step failed`)
+- Look at the error message in context — a `connection refused` during cluster setup is INFRA, but during a test is FLAKY
+- If multiple patterns match, prefer the most specific one
+
+### 3. Report the result
+
+Present a structured summary to the user:
+
+```
+## CI Triage: PR #XXXX
+
+**Classification**: <one of INFRASTRUCTURE, CODE, or FLAKY_TEST>
+**Failed job(s)**: <job name(s)>
+**Root cause**: <one-line description>
+
+### Log excerpt
+<relevant 5-10 lines from the build log>
+
+### Recommended action
+<what to do next>
+```
+
+### 4. Take action (if appropriate)
+
+**Counting retests:** Use the GitHub MCP (`user-github`) `pull_request_read` (method: `get_comments`) to search for comments containing the full marker for the classification being counted (e.g. `<!-- ci-triage: INFRASTRUCTURE -->`) and the current HEAD SHA. Count ANY matching comment regardless of author — an automated GitHub Action (`ci_retest.yml`) may have already posted retest comments for this SHA. Allowed classification markers: `INFRASTRUCTURE`, `INFRASTRUCTURE_EXHAUSTED`, `FLAKY_TEST`.
+
+**For INFRASTRUCTURE failures:**
+1. If the log contains `rate limit exceeded` or `429 Too Many Requests`, classify as INFRASTRUCTURE but advise waiting at least 15 minutes before retesting.
+2. If fewer than 5 retests for this SHA, offer to post `/retest` via `add_issue_comment`
+3. Always include the classification in the comment so there's an audit trail:
+
+```
+<!-- ci-triage: INFRASTRUCTURE -->
+CI Triage: **Infrastructure failure** — <root cause summary>
+
+/retest
+```
+
+4. If 5 or more retests already exist, report that max retries are exhausted and the user should investigate further or wait
+
+**For CODE failures:**
+- Report the root cause and affected files
+- Do NOT offer to retest
+- If invoked from the babysit workflow, suggest specific fixes
+
+**For FLAKY_TEST failures:**
+1. Check if a `<!-- ci-triage: FLAKY_TEST -->` comment already exists for the current HEAD SHA
+2. If it does NOT exist, offer to post `/retest` with this tracking comment:
+
+```
+<!-- ci-triage: FLAKY_TEST -->
+CI Triage: **Flaky test detected** — <root cause summary>. Retesting once.
+
+/retest
+```
+
+3. If it DOES exist, do NOT retest. Flag it as a persistently failing test that requires investigation.
+
+## MCP Tools Reference
+
+| Tool | Server | When to use |
+|------|--------|-------------|
+| `diagnose_pr_failures` | `user-prow` | First call — broad failure analysis for a PR |
+| `analyze_build_step_failures` | `user-prow` | Second call — step-by-step breakdown of a specific build |
+| `get_build_logs` | `user-prow` | When you need raw log content for pattern matching |
+| `get_recent_job_status` | `user-prow` | To check recent job run history |
+| `pull_request_read` | `user-github` | To read PR comments (count retries, check labels) |
+| `add_issue_comment` | `user-github` | To post `/retest` + classification comment |
+
+## Repository defaults
+
+- `org_repo`: `kubevirt-ui_kubevirt-plugin`
+- Primary Prow job: `pull-ci-kubevirt-ui-kubevirt-plugin-main-kubevirt-e2e-aws`
+- When only one job context failed, use `/test <job-name>` instead of `/retest` for a targeted rerun
+
+---
+
+## Automation contract
+
+The GitHub Actions workflow `ci_retest.yml` uses the same infrastructure patterns listed below to auto-retest. Both this rule and the workflow must stay in sync — the workflow is the automated subset that handles only INFRASTRUCTURE classification. It uses the 7-character short SHA in backticks within `<!-- ci-triage: INFRASTRUCTURE -->` HTML comments for counting retests.
+
+In PR comments, prefer sentence case for classification labels (e.g. "Infrastructure failure" rather than "INFRASTRUCTURE"). Use the machine tokens only in the HTML audit markers.
+
+## Failure Classification Patterns
+
+### Infrastructure (safe to auto-retest)
+
+**Registry failures:**
+- `received unexpected HTTP status: 50[0-9]` — HTTP 5xx from container registry
+- `504 Gateway Timeout` — Gateway timeout pulling images
+- `503 Service Unavailable` — Registry temporarily unavailable
+- `registry\.access\.redhat\.com.*error` — Red Hat registry connectivity issue
+- `quay\.io.*error` — Quay registry connectivity issue
+
+**Image pull failures:**
+- `ErrImagePull` — Kubernetes failed to pull image
+- `ImagePullBackOff` — Kubernetes image pull backoff
+- `manifest unknown` — Image manifest not found (usually transient registry issue; verify the tag/digest is correct before retesting, as a wrong tag is a CODE failure)
+- `failed to resolve reference` — Image reference resolution failure
+- `creating build container: initializing source` — Build container image pull failure
+
+**Cluster provisioning failures:**
+- `could not acquire lease` — CI cluster lease unavailable
+- `cluster creation timed out` — Cluster provisioning timeout
+- `failed to create cluster` — Cluster creation failure
+- `waiting for cluster to initialize.*timed out` — Cluster init timeout
+- `infrastructure setup failed` — Generic infra setup failure
+
+**Node/resource failures:**
+- `NodeNotReady` — Kubernetes node not ready
+- `insufficient resources` — Not enough cluster resources
+- `Insufficient cpu` / `Insufficient memory` — Resource exhaustion
+
+**Network failures (during setup):**
+- `connection refused.*setup|provision|install` — Network failure during cluster setup
+- `i/o timeout.*setup|provision|install` — I/O timeout during cluster setup
+- `dial tcp.*connection refused` — TCP connection refused (infra)
+- `TLS handshake timeout` — TLS timeout during setup
+
+**GCS / CI infrastructure:**
+- `storage\.googleapis\.com.*error` — GCS storage error
+- `failed to upload.*artifact` — Artifact upload failure
+
+**Docker build (infra-related):**
+- `DockerBuildFailed.*initializing source` — Docker build failed due to image source init
+- `error building.*creating build container` — Build container creation error
+
+### Code (do NOT retest)
+
+**Dependency / Package manager:**
+- `npm ERR!` — NPM installation or script error
+- `ERESOLVE` — NPM dependency resolution conflict
+- `peer dep missing` — Missing peer dependency
+- `ETIMEDOUT` / `ECONNRESET` (during `npm install`) — Registry connectivity during install (may need lockfile update or cache clear)
+
+**TypeScript / Webpack:**
+- `TS\d{4}:` — TypeScript compiler error
+- `Module not found:` — Missing module import
+- `SyntaxError:` — JavaScript/TypeScript syntax error
+- `ERROR in .*\.tsx?` — Webpack error in TS/TSX file
+- `Cannot find module` — Missing module resolution
+- `Type '.*' is not assignable to type` — TypeScript type mismatch
+
+**Lint:**
+- `eslint.*error` — ESLint error
+- `lint:fix.*diff` — Lint autofix produced diff
+- `stylelint.*error` — Stylelint error
+- `prettier.*--check.*failed` — Prettier formatting check failure
+
+**Unit test:**
+- `FAIL\s+src/` — Jest test failure
+- `Test Suites:.*failed` — Jest suite failure summary
+- `Expected:.*Received:` — Jest assertion mismatch
+
+**i18n:**
+- `i18n files are not up to date` — i18n extraction drift
+
+**E2E assertion (test logic failure):**
+- `AssertionError:` — Assertion failure in test
+- `expect\(.*\)\.(to|not)` — Playwright/Jest expect failure
+- `Timed out.*waiting for selector` — Playwright selector timeout
+- `Error: locator\.click` — Playwright interaction failure
+- `cy\..*failed because` — Cypress command failure
+
+### Flaky Test (retest once, then flag)
+
+- `context deadline exceeded` (in test step only) — Test-level timeout
+- `SIGTERM|SIGKILL` (in test step only) — Test killed by timeout
+- `net/http: request canceled.*context deadline exceeded` — HTTP request timed out in test
+- `flaky` / `intermittent` (in test name or annotation) — Explicitly marked
+
+### Disambiguation rules
+
+- `context deadline exceeded` in a **setup/provision** step → INFRASTRUCTURE
+- `context deadline exceeded` in a **test** step → FLAKY_TEST
+- `connection refused` during **cluster setup** → INFRASTRUCTURE
+- `connection refused` during **test execution** → FLAKY_TEST (heuristic — could also be a product bug; check if the target service should be running)
+- `rate limit exceeded` or `429 Too Many Requests` → INFRASTRUCTURE, but wait at least 15 minutes before retesting (increase if the log names a specific API with a longer backoff)
+- `ETIMEDOUT` / `ECONNRESET` during **npm install** → CODE (likely needs lockfile fix); during **image pull** → INFRASTRUCTURE
+- When in doubt, look at the **build step name** to determine context

--- a/.github/workflows/ci_retest.yml
+++ b/.github/workflows/ci_retest.yml
@@ -1,0 +1,287 @@
+name: Auto-retest infrastructure failures
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ci-retest-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  triage-and-retest:
+    if: |
+      github.event.issue.pull_request &&
+      github.event.comment.user.login == 'openshift-ci[bot]' &&
+      contains(github.event.comment.body, 'failed') &&
+      contains(github.event.comment.body, 'prow.ci.openshift.org')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for hold label
+        id: hold-check
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const held = labels.some(l => l.name === 'do-not-merge/hold');
+            core.setOutput('held', held.toString());
+
+      - name: Extract build URLs from comment
+        if: steps.hold-check.outputs.held == 'false'
+        id: extract
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const body = context.payload.comment.body;
+            const pr = context.issue.number;
+            const orgRepo = `${context.repo.owner}_${context.repo.repo}`;
+
+            const urlPattern = new RegExp(
+              `https://prow\\.ci\\.openshift\\.org/view/gs/test-platform-results/pr-logs/pull/${orgRepo}/(\\d+)/([^/]+)/(\\d+)`,
+              'g'
+            );
+            const matches = [...body.matchAll(urlPattern)];
+
+            if (matches.length === 0) {
+              core.info('No Prow build URLs found in comment');
+              core.setOutput('found', 'false');
+              return;
+            }
+
+            const jobNamePattern = /^[A-Za-z0-9._-]+$/;
+            const jobs = matches
+              .filter(m => jobNamePattern.test(m[2]))
+              .map(m => ({
+                job_name: m[2],
+                build_id: m[3],
+                log_url: `https://storage.googleapis.com/test-platform-results/pr-logs/pull/${orgRepo}/${m[1]}/${m[2]}/${m[3]}/build-log.txt`
+              }));
+
+            if (jobs.length === 0) {
+              core.info('No valid job names extracted');
+              core.setOutput('found', 'false');
+              return;
+            }
+
+            core.setOutput('found', 'true');
+            core.setOutput('jobs', JSON.stringify(jobs));
+
+      - name: Fetch and classify build logs
+        if: steps.extract.outputs.found == 'true'
+        id: classify
+        shell: bash
+        env:
+          JOBS_JSON: ${{ steps.extract.outputs.jobs }}
+        run: |
+          if ! echo "$JOBS_JSON" | jq empty 2>/dev/null; then
+            echo "::error::Failed to parse jobs JSON"
+            echo "is_infra=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          INFRA_PATTERNS=(
+            "received unexpected HTTP status: 50[0-9]"
+            "504 Gateway Timeout"
+            "503 Service Unavailable"
+            "registry\.access\.redhat\.com.*error"
+            "quay\.io.*error"
+            "ErrImagePull"
+            "ImagePullBackOff"
+            "manifest unknown"
+            "failed to resolve reference"
+            "creating build container: initializing source"
+            "could not acquire lease"
+            "cluster creation timed out"
+            "failed to create cluster"
+            "waiting for cluster to initialize.*timed out"
+            "infrastructure setup failed"
+            "NodeNotReady"
+            "insufficient resources"
+            "Insufficient cpu"
+            "Insufficient memory"
+            "connection refused.*(setup|provision|install)"
+            "i/o timeout.*(setup|provision|install)"
+            "dial tcp.*connection refused"
+            "TLS handshake timeout"
+            "storage\.googleapis\.com.*error"
+            "failed to upload.*artifact"
+            "DockerBuildFailed.*initializing source"
+            "error building.*creating build container"
+          )
+
+          while read -r job; do
+            JOB_NAME=$(echo "$job" | jq -r '.job_name')
+            LOG_URL=$(echo "$job" | jq -r '.log_url')
+
+            echo "::group::Analyzing $JOB_NAME"
+
+            if ! HTTP_CODE=$(curl -s -o /tmp/build-log.txt -w "%{http_code}" "$LOG_URL" --max-time 30); then
+              echo "curl failed for $JOB_NAME, skipping"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ "$HTTP_CODE" != "200" ]; then
+              echo "Failed to fetch log (HTTP $HTTP_CODE), skipping"
+              echo "::endgroup::"
+              continue
+            fi
+
+            for pattern in "${INFRA_PATTERNS[@]}"; do
+              MATCH=$(grep -Ei "$pattern" /tmp/build-log.txt | tail -3 || true)
+              if [ -n "$MATCH" ]; then
+                echo "INFRA match: $pattern"
+                echo "$JOB_NAME" >> /tmp/infra_jobs.txt
+                echo "$MATCH" >> /tmp/infra_reasons.txt
+                echo "---" >> /tmp/infra_reasons.txt
+                break
+              fi
+            done
+            echo "::endgroup::"
+          done < <(echo "$JOBS_JSON" | jq -c '.[]')
+
+          if [ -f /tmp/infra_jobs.txt ]; then
+            echo "is_infra=true" >> "$GITHUB_OUTPUT"
+            JOBS_LIST=$(sort -u /tmp/infra_jobs.txt | paste -sd ',' -)
+            echo "infra_jobs=$JOBS_LIST" >> "$GITHUB_OUTPUT"
+
+            REASONS_RAW=$(cat /tmp/infra_reasons.txt)
+            REASONS_SIZE=${#REASONS_RAW}
+            REASONS=$(head -c 1000 /tmp/infra_reasons.txt)
+            TRUNCATED="false"
+            if [ "$REASONS_SIZE" -gt 1000 ]; then
+              TRUNCATED="true"
+            fi
+            echo "truncated=$TRUNCATED" >> "$GITHUB_OUTPUT"
+
+            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "infra_reasons<<$EOF" >> "$GITHUB_OUTPUT"
+            echo "$REASONS" >> "$GITHUB_OUTPUT"
+            echo "$EOF" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_infra=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Count previous retests for this SHA
+        if: steps.classify.outputs.is_infra == 'true'
+        id: count
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const headSha = pr.head.sha.substring(0, 7);
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const retestCount = comments.filter(c =>
+              c.body.includes('<!-- ci-triage: INFRASTRUCTURE -->') &&
+              c.body.includes(headSha)
+            ).length;
+
+            core.info(`Found ${retestCount} previous auto-retests for SHA ${headSha}`);
+            core.setOutput('count', retestCount.toString());
+            core.setOutput('sha_short', headSha);
+
+      - name: Post retest comment
+        if: steps.classify.outputs.is_infra == 'true' && fromJSON(steps.count.outputs.count) < 5
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          SHA_SHORT: ${{ steps.count.outputs.sha_short }}
+          INFRA_JOBS: ${{ steps.classify.outputs.infra_jobs }}
+          INFRA_REASONS: ${{ steps.classify.outputs.infra_reasons }}
+          RETEST_COUNT: ${{ steps.count.outputs.count }}
+          TRUNCATED: ${{ steps.classify.outputs.truncated }}
+        with:
+          script: |
+            const sha = process.env.SHA_SHORT;
+            const jobs = process.env.INFRA_JOBS;
+            const reasons = process.env.INFRA_REASONS;
+            const attempt = parseInt(process.env.RETEST_COUNT, 10) + 1;
+            const truncated = process.env.TRUNCATED === 'true';
+            const truncNote = truncated ? '\n\n_(log truncated)_' : '';
+
+            const body = [
+              '<!-- ci-triage: INFRASTRUCTURE -->',
+              `**CI Triage** (auto-retest ${attempt}/5 for \`${sha}\`)`,
+              '',
+              '**Classification**: Infrastructure failure',
+              `**Failed job(s)**: ${jobs}`,
+              '',
+              '<details><summary>Log excerpt (infrastructure pattern matched)</summary>',
+              '',
+              '```',
+              reasons.trim(),
+              '```',
+              truncNote,
+              '</details>',
+              '',
+              '/retest',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body,
+            });
+
+      - name: Post exhaustion notice
+        if: steps.classify.outputs.is_infra == 'true' && fromJSON(steps.count.outputs.count) >= 5
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          SHA_SHORT: ${{ steps.count.outputs.sha_short }}
+          INFRA_JOBS: ${{ steps.classify.outputs.infra_jobs }}
+          INFRA_REASONS: ${{ steps.classify.outputs.infra_reasons }}
+          TRUNCATED: ${{ steps.classify.outputs.truncated }}
+        with:
+          script: |
+            const sha = process.env.SHA_SHORT;
+            const jobs = process.env.INFRA_JOBS;
+            const reasons = process.env.INFRA_REASONS;
+            const truncated = process.env.TRUNCATED === 'true';
+            const truncNote = truncated ? '\n\n_(log truncated)_' : '';
+
+            const body = [
+              '<!-- ci-triage: INFRASTRUCTURE_EXHAUSTED -->',
+              `**CI Triage**: Max retries exhausted for \`${sha}\``,
+              '',
+              'Infrastructure failures persisted after 5 automatic retests.',
+              `**Failed job(s)**: ${jobs}`,
+              '',
+              '<details><summary>Log excerpt (infrastructure pattern matched)</summary>',
+              '',
+              '```',
+              reasons.trim(),
+              '```',
+              truncNote,
+              '</details>',
+              '',
+              '**Next steps**:',
+              '- Check the [OpenShift CI status page](https://status.ci.openshift.org/) for ongoing outages',
+              '- Wait for infrastructure to recover and manually run `/retest`',
+              '- If the issue persists, investigate the failing job logs directly',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body,
+            });


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-84762](https://redhat.atlassian.net/browse/CNV-84762)

### Problem
Prow e2e-aws failures caused by transient infrastructure issues (registry timeouts, cluster provisioning errors, etc.) require manual /retest commands. The OpenShift CI Retester is configured but not functioning due to a platform-side caching bug (reported to DPTP).

### Solution
GitHub Actions auto-retest workflow (.github/workflows/ci_retest.yml):

Triggers on Prow failure comments, fetches build logs from GCS, classifies against infrastructure patterns

Auto-posts /retest for infra failures (up to 5 times per SHA), never retests code failures

Safety guards: respects do-not-merge/hold, includes audit trail comments, portable across repos

Cursor `/triage` command (.cursor/commands/triage.md + .cursor/rules/workflows/ci-triage.mdc):

On-demand CI failure analysis via Prow MCP — classifies failures as INFRASTRUCTURE / CODE / FLAKY_TEST

Reports root cause with log excerpts and recommended action




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New `/triage` command to analyze CI failures, infer PR context from input or branch, classify issues as infrastructure, code, or flaky test, and produce a concise report with recommended action.
  * Automated infra-failure detection with controlled auto-retest behavior, attempt counting, and exhaustion notices.

* **Documentation**
  * Added comprehensive user-facing documentation describing the triage command, classification rules, report format, and automated retest policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->