### PR TITLE
CNV-85160: AlertsCard: "View warning" link is misaligned outside the alert message column

### DIFF
--- a/src/utils/components/AlertsCard/AlertStatusItem.scss
+++ b/src/utils/components/AlertsCard/AlertStatusItem.scss
@@ -3,6 +3,9 @@
   font-size: var(--pf-t--global--font--size--md);
   margin-top: var(--pf-t--global--spacer--xs);
   margin-bottom: var(--pf-t--global--spacer--xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .alert-item {
@@ -17,18 +20,19 @@
   &__message {
     display: flex;
     flex-direction: column;
+    min-width: 0;
   }
 
   &__more {
     display: flex;
     flex-shrink: 0;
-    justify-content: flex-end;
-    padding-left: var(--pf-v6-c-card--child--PaddingInlineStart);
+    justify-content: flex-start;
   }
 
   &__text {
     display: flex;
     justify-content: space-between;
+    min-width: 0;
     width: 100%;
   }
 

--- a/src/utils/components/AlertsCard/AlertStatusItem.tsx
+++ b/src/utils/components/AlertsCard/AlertStatusItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
@@ -14,7 +14,7 @@ type AlertStatusItemProps = {
   alertType: AlertType;
 };
 
-const AlertStatusItem: React.FC<AlertStatusItemProps> = ({ alertDetails, alertType }) => {
+const AlertStatusItem: FC<AlertStatusItemProps> = ({ alertDetails, alertType }) => {
   const { t } = useKubevirtTranslation();
   const { alertName, description, isVMAlert, link, time } = alertDetails;
   const Icon = alertIcon[alertType];
@@ -42,11 +42,13 @@ const AlertStatusItem: React.FC<AlertStatusItemProps> = ({ alertDetails, alertTy
               <Timestamp className="alert-item__timestamp" hideIcon timestamp={time} />
             </span>
           </div>
-          <div className="alert-name">{alertName}</div>
+          <div className="alert-name" title={alertName}>
+            {alertName}
+          </div>
           <span className="alert-item__text co-break-word">{description}</span>
-        </div>
-        <div className="alert-item__more">
-          <Link to={link}>{linkText}</Link>
+          <div className="alert-item__more">
+            <Link to={link}>{linkText}</Link>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-85160](https://redhat.atlassian.net/browse/CNV-85160)

AlertsCard: "View warning" link is misaligned outside the alert message column

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/7debba9b-86a4-4f15-9220-b0cd753b4ada


After:

https://github.com/user-attachments/assets/2b376321-4c3b-4dcd-b0bd-936f5d06972e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved alert name truncation with overflow handling and adjusted layout to prevent wrapping and clipping issues.
  * Realigned the “more” control and removed extra padding for cleaner horizontal spacing.

* **Refactor**
  * Reorganized the alert status item structure and added a hover/title tooltip so long alert names are viewable without layout breakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->