### PR TITLE
CNV-69868: Update logic inside addCDROMModal and MountCDROMModal

### DIFF
--- a/src/utils/components/DiskModal/AddCDROMModal.tsx
+++ b/src/utils/components/DiskModal/AddCDROMModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef } from 'react';
+import React, { FC, useEffect, useMemo } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 
 import { UPLOAD_FILENAME_FIELD } from '@kubevirt-utils/components/DiskModal/components/utils/constants';
@@ -8,16 +8,14 @@ import {
   UPLOAD_MODE_SELECT,
   UPLOAD_MODE_UPLOAD,
 } from '@kubevirt-utils/components/DiskModal/utils/constants';
-import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import { PendingChangesAlert } from '@kubevirt-utils/components/PendingChanges/PendingChangesAlert/PendingChangesAlert';
 import { useCDIUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
-import { isUploadingDisk } from '@kubevirt-utils/hooks/useCDIUpload/utils';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
-import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
-import { Content, ContentVariants, Radio, Stack, StackItem } from '@patternfly/react-core';
+import { Stack, StackItem } from '@patternfly/react-core';
 import { DECLARATIVE_HOTPLUG_VOLUMES_FEATURE_GATE } from '@settings/tabs/ClusterTab/components/GeneralSettings/AdvancedCDROMFeatures/hooks/constants';
 import { useISOOptions } from '@virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useISOOptions';
 import { useMountCDROMForm } from '@virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useMountCDROMForm';
@@ -25,8 +23,9 @@ import { isRunning } from '@virtualmachines/utils';
 
 import TabModal from '../TabModal/TabModal';
 
+import CDROMSourceOptions from './components/CDROMSourceOptions/CDROMSourceOptions';
 import DiskNameInput from './components/DiskNameInput/DiskNameInput';
-import DiskSourceUploadPVC from './components/DiskSourceSelect/components/DiskSourceUploadPVC/DiskSourceUploadPVC';
+import { useCDROMUploadClose } from './hooks/useCDROMUploadClose';
 import { getDefaultCreateValues } from './utils/form';
 import { submitCDROM } from './utils/submit';
 import { SourceTypes, V1DiskFormState, V1SubDiskModalProps } from './utils/types';
@@ -45,7 +44,6 @@ const AddCDROMModal: FC<V1SubDiskModalProps> = ({
   const [hyperConvergeConfig] = useHyperConvergeConfiguration();
   const vmNamespace = getNamespace(vm);
 
-  // Check feature gate from HyperConverged CR spec.featureGates (object with boolean values)
   const isDeclarativeHotplugEnabled = Boolean(
     hyperConvergeConfig?.spec?.featureGates?.[DECLARATIVE_HOTPLUG_VOLUMES_FEATURE_GATE],
   );
@@ -54,6 +52,7 @@ const AddCDROMModal: FC<V1SubDiskModalProps> = ({
   const { isoOptions } = useISOOptions(vmNamespace);
 
   const {
+    handleClearUpload,
     handleEmptyDriveSelection,
     handleFileUpload,
     handleISOSelection,
@@ -79,10 +78,13 @@ const AddCDROMModal: FC<V1SubDiskModalProps> = ({
   } = methods;
 
   const uploadFile = useWatch({ control, name: FORM_FIELD_UPLOAD_FILE });
-
   const hasUploadFile = !isEmpty(uploadFile?.file);
   const hasFormErrors = !isEmpty(errors);
-  const isUploading = isUploadingDisk(upload?.uploadStatus);
+
+  const { handleModalClose, isUploading, markBackgroundUploadStarted } = useCDROMUploadClose(
+    upload,
+    onClose,
+  );
 
   useEffect(() => {
     if (!uploadEnabled) {
@@ -93,29 +95,10 @@ const AddCDROMModal: FC<V1SubDiskModalProps> = ({
   const hasValidSelection = selectedISO || (uploadEnabled && hasUploadFile) || emptyDriveSelected;
   const isFormValid = Boolean(!hasFormErrors && hasValidSelection);
 
-  const isBackgroundUploadInProgress = useRef(false);
-
-  const handleModalClose = async () => {
-    const shouldCancelUpload =
-      isUploading && !isBackgroundUploadInProgress.current && upload?.cancelUpload;
-
-    if (shouldCancelUpload) {
-      try {
-        await upload.cancelUpload();
-      } catch (error) {
-        kubevirtConsole.error(error);
-      }
-    }
-    isBackgroundUploadInProgress.current = false;
-    onClose();
-  };
-
   const handleModalSubmit = async () => {
-    // For uploads, check certificate/config before proceeding
-    // This ensures the error is shown in the modal before it closes
     if (uploadEnabled && hasUploadFile) {
       await checkUploadReady();
-      isBackgroundUploadInProgress.current = true;
+      markBackgroundUploadStarted();
     }
     return submitCDROM(getValues(), {
       isHotPluggable,
@@ -128,6 +111,28 @@ const AddCDROMModal: FC<V1SubDiskModalProps> = ({
       vm,
     });
   };
+
+  const handleISOSelect = (value: string): void => {
+    handleISOSelection(value);
+    setValue(UPLOAD_FILENAME_FIELD, '');
+  };
+
+  const handleClearUploadAndFilename = (): void => {
+    handleClearUpload();
+    setValue(UPLOAD_FILENAME_FIELD, '');
+  };
+
+  const emptyDriveOption = useMemo(
+    () => ({
+      description: isEmptyDriveAllowed
+        ? t('The drive will be attached without media. You can mount an ISO later.')
+        : t('Requires enabling advanced CD-ROM features.'),
+      isAllowed: isEmptyDriveAllowed,
+      isSelected: emptyDriveSelected,
+      onSelect: handleEmptyDriveSelection,
+    }),
+    [isEmptyDriveAllowed, emptyDriveSelected, handleEmptyDriveSelection, t],
+  );
 
   return (
     <FormProvider {...methods}>
@@ -153,76 +158,19 @@ const AddCDROMModal: FC<V1SubDiskModalProps> = ({
           <StackItem>
             <DiskNameInput isDisabled={isUploading} />
           </StackItem>
-          <StackItem className="pf-v6-u-mt-md">
-            <Content component={ContentVariants.p}>{t('Select mount option')}</Content>
-          </StackItem>
-          <StackItem>
-            <Stack hasGutter>
-              <StackItem>
-                <Radio
-                  id="cdrom-source-existing"
-                  isChecked={existingISOSelected}
-                  isDisabled={isUploading}
-                  label={t('Use existing ISO')}
-                  name="cdrom-source"
-                  onChange={() => handleISOSelection('')}
-                />
-                {existingISOSelected && (
-                  <div className="pf-v6-u-ml-lg pf-v6-u-mt-sm">
-                    <InlineFilterSelect
-                      setSelected={(e) => {
-                        handleISOSelection(e);
-                        setValue(UPLOAD_FILENAME_FIELD, '');
-                      }}
-                      toggleProps={{
-                        isDisabled: isUploading,
-                        isFullWidth: true,
-                      }}
-                      options={isoOptions}
-                      placeholder={t('Select ISO file')}
-                      selected={selectedISO}
-                    />
-                  </div>
-                )}
-              </StackItem>
-              <StackItem>
-                <Radio
-                  id="cdrom-source-upload"
-                  isChecked={uploadEnabled}
-                  isDisabled={isUploading}
-                  label={t('Upload new ISO')}
-                  name="cdrom-source"
-                  onChange={handleFileUpload}
-                />
-                {uploadEnabled && (
-                  <div className="pf-v6-u-ml-lg pf-v6-u-mt-sm">
-                    <DiskSourceUploadPVC
-                      acceptedFileTypes={{
-                        'application/*': ['.iso', '.img', '.qcow2', '.gz', '.xz'],
-                      }}
-                      label=""
-                      relevantUpload={isSubmitting ? undefined : upload}
-                    />
-                  </div>
-                )}
-              </StackItem>
-              <StackItem>
-                <Radio
-                  description={
-                    isEmptyDriveAllowed
-                      ? t('The drive will be attached without media. You can mount an ISO later.')
-                      : t('Requires enabling advanced CD-ROM features.')
-                  }
-                  id="cdrom-source-empty"
-                  isChecked={emptyDriveSelected}
-                  isDisabled={isUploading || !isEmptyDriveAllowed}
-                  label={t('Leave empty drive')}
-                  name="cdrom-source"
-                  onChange={handleEmptyDriveSelection}
-                />
-              </StackItem>
-            </Stack>
-          </StackItem>
+          <CDROMSourceOptions
+            emptyDriveOption={emptyDriveOption}
+            existingISOSelected={existingISOSelected}
+            isoOptions={isoOptions}
+            isUploading={isUploading}
+            onClearUpload={handleClearUploadAndFilename}
+            onFileUpload={handleFileUpload}
+            onISOSelect={handleISOSelect}
+            radioNamePrefix="cdrom-source"
+            relevantUpload={isSubmitting ? undefined : upload}
+            selectedISO={selectedISO}
+            uploadEnabled={uploadEnabled}
+          />
         </Stack>
       </TabModal>
     </FormProvider>

--- a/src/utils/components/DiskModal/components/CDROMSourceOptions/CDROMSourceOptions.tsx
+++ b/src/utils/components/DiskModal/components/CDROMSourceOptions/CDROMSourceOptions.tsx
@@ -1,0 +1,122 @@
+import React, { FC } from 'react';
+
+import DiskSourceUploadPVC from '@kubevirt-utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceUploadPVC/DiskSourceUploadPVC';
+import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
+import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
+import { DataUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { Content, ContentVariants, Radio, Stack, StackItem } from '@patternfly/react-core';
+
+type EmptyDriveOption = {
+  description: string;
+  isAllowed: boolean;
+  isSelected: boolean;
+  onSelect: () => void;
+};
+
+type CDROMSourceOptionsProps = {
+  emptyDriveOption?: EmptyDriveOption;
+  existingISOSelected: boolean;
+  isoOptions: EnhancedSelectOptionProps[];
+  isUploading: boolean;
+  onClearUpload?: () => void;
+  onFileUpload: () => void;
+  onISOSelect: (value: string) => void;
+  radioNamePrefix: string;
+  relevantUpload?: DataUpload;
+  selectedISO: string;
+  uploadEnabled: boolean;
+};
+
+const CDROMSourceOptions: FC<CDROMSourceOptionsProps> = ({
+  emptyDriveOption,
+  existingISOSelected,
+  isoOptions,
+  isUploading,
+  onClearUpload,
+  onFileUpload,
+  onISOSelect,
+  radioNamePrefix,
+  relevantUpload,
+  selectedISO,
+  uploadEnabled,
+}) => {
+  const { t } = useKubevirtTranslation();
+  const labelId = `${radioNamePrefix}-label`;
+
+  return (
+    <>
+      <StackItem className="pf-v6-u-mt-md">
+        <Content component={ContentVariants.p} id={labelId}>
+          {t('Select mount option')}
+        </Content>
+      </StackItem>
+      <StackItem>
+        <Stack aria-labelledby={labelId} hasGutter role="radiogroup">
+          <StackItem>
+            <Radio
+              id={`${radioNamePrefix}-existing`}
+              isChecked={existingISOSelected}
+              isDisabled={isUploading}
+              label={t('Use existing ISO')}
+              name={radioNamePrefix}
+              onChange={() => onISOSelect('')}
+            />
+            {existingISOSelected && (
+              <div className="pf-v6-u-ml-lg pf-v6-u-mt-sm">
+                <InlineFilterSelect
+                  toggleProps={{
+                    isDisabled: isUploading,
+                    isFullWidth: true,
+                  }}
+                  options={isoOptions}
+                  placeholder={t('Select ISO file')}
+                  selected={selectedISO}
+                  setSelected={onISOSelect}
+                />
+              </div>
+            )}
+          </StackItem>
+          <StackItem>
+            <Radio
+              id={`${radioNamePrefix}-upload`}
+              isChecked={uploadEnabled}
+              isDisabled={isUploading}
+              label={t('Upload new ISO')}
+              name={radioNamePrefix}
+              onChange={onFileUpload}
+            />
+            {uploadEnabled && (
+              <div className="pf-v6-u-ml-lg pf-v6-u-mt-sm">
+                <DiskSourceUploadPVC
+                  acceptedFileTypes={{
+                    'application/*': ['.iso', '.img', '.qcow2', '.gz', '.xz'],
+                  }}
+                  handleClearUpload={onClearUpload}
+                  handleUpload={onFileUpload}
+                  label=""
+                  relevantUpload={relevantUpload}
+                />
+              </div>
+            )}
+          </StackItem>
+          {emptyDriveOption && (
+            <StackItem>
+              <Radio
+                description={emptyDriveOption.description}
+                id={`${radioNamePrefix}-empty`}
+                isChecked={emptyDriveOption.isSelected}
+                isDisabled={isUploading || !emptyDriveOption.isAllowed}
+                label={t('Leave empty drive')}
+                name={radioNamePrefix}
+                onChange={emptyDriveOption.onSelect}
+              />
+            </StackItem>
+          )}
+        </Stack>
+      </StackItem>
+    </>
+  );
+};
+
+export default CDROMSourceOptions;

--- a/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceUploadPVC/DiskSourceUploadPVC.tsx
+++ b/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceUploadPVC/DiskSourceUploadPVC.tsx
@@ -20,7 +20,7 @@ type DiskSourceUploadPVCProps = {
   handleUpload?: () => void;
   isRequired?: boolean;
   label?: string;
-  relevantUpload: DataUpload;
+  relevantUpload?: DataUpload;
 };
 
 const DiskSourceUploadPVC: FC<DiskSourceUploadPVCProps> = ({

--- a/src/utils/components/DiskModal/hooks/useCDROMUploadClose.ts
+++ b/src/utils/components/DiskModal/hooks/useCDROMUploadClose.ts
@@ -1,0 +1,40 @@
+import { useRef } from 'react';
+
+import { DataUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
+import { isUploadingDisk } from '@kubevirt-utils/hooks/useCDIUpload/utils';
+import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
+
+type UseCDROMUploadCloseReturn = {
+  handleModalClose: () => Promise<void>;
+  isUploading: boolean;
+  markBackgroundUploadStarted: () => void;
+};
+
+export const useCDROMUploadClose = (
+  upload: DataUpload,
+  onClose: () => void,
+): UseCDROMUploadCloseReturn => {
+  const isBackgroundUploadInProgress = useRef(false);
+  const isUploading = isUploadingDisk(upload?.uploadStatus);
+
+  const handleModalClose = async (): Promise<void> => {
+    const shouldCancelUpload =
+      isUploading && !isBackgroundUploadInProgress.current && upload?.cancelUpload;
+
+    if (shouldCancelUpload) {
+      try {
+        await upload.cancelUpload();
+      } catch (error) {
+        kubevirtConsole.error(error);
+      }
+    }
+    isBackgroundUploadInProgress.current = false;
+    onClose();
+  };
+
+  const markBackgroundUploadStarted = (): void => {
+    isBackgroundUploadInProgress.current = true;
+  };
+
+  return { handleModalClose, isUploading, markBackgroundUploadStarted };
+};

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/MountCDROMModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/MountCDROMModal.tsx
@@ -1,9 +1,10 @@
-import React, { FC, useEffect, useRef } from 'react';
+import React, { FC, useEffect } from 'react';
 import { FormProvider, useWatch } from 'react-hook-form';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import DiskSourceUploadPVC from '@kubevirt-utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceUploadPVC/DiskSourceUploadPVC';
+import CDROMSourceOptions from '@kubevirt-utils/components/DiskModal/components/CDROMSourceOptions/CDROMSourceOptions';
 import { UPLOAD_FILENAME_FIELD } from '@kubevirt-utils/components/DiskModal/components/utils/constants';
+import { useCDROMUploadClose } from '@kubevirt-utils/components/DiskModal/hooks/useCDROMUploadClose';
 import {
   FORM_FIELD_UPLOAD_FILE,
   UPLOAD_MODE_SELECT,
@@ -14,23 +15,14 @@ import {
   mountISOToCDROM,
 } from '@kubevirt-utils/components/DiskModal/utils/helpers';
 import { uploadDataVolume } from '@kubevirt-utils/components/DiskModal/utils/submit';
-import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useCDIUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
-import { isUploadingDisk } from '@kubevirt-utils/hooks/useCDIUpload/utils';
 import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
-import {
-  ButtonVariant,
-  Content,
-  ContentVariants,
-  Radio,
-  Stack,
-  StackItem,
-} from '@patternfly/react-core';
+import { ButtonVariant, Stack } from '@patternfly/react-core';
 
 import { useISOOptions } from './hooks/useISOOptions';
 import { useMountCDROMForm } from './hooks/useMountCDROMForm';
@@ -77,11 +69,13 @@ const MountCDROMModal: FC<MountCDROMModalProps> = ({
   const existingISOSelected = uploadMode === UPLOAD_MODE_SELECT || uploadMode === '';
 
   const hasUploadFile = !isEmpty(watchedUploadFile?.file);
-  const isUploading = isUploadingDisk(upload?.uploadStatus);
   const hasValidSelection = selectedISO || (uploadEnabled && hasUploadFile);
   const isFormValid = Boolean(hasValidSelection);
 
-  const isBackgroundUploadInProgress = useRef(false);
+  const { handleModalClose, isUploading, markBackgroundUploadStarted } = useCDROMUploadClose(
+    upload,
+    onClose,
+  );
 
   const { isoOptions } = useISOOptions(vmNamespace);
 
@@ -91,19 +85,14 @@ const MountCDROMModal: FC<MountCDROMModalProps> = ({
     }
   }, [uploadEnabled, clearErrors]);
 
-  const handleModalClose = async () => {
-    const shouldCancelUpload =
-      isUploading && !isBackgroundUploadInProgress.current && upload?.cancelUpload;
+  const handleISOSelect = (value: string): void => {
+    handleISOSelection(value);
+    setValue(UPLOAD_FILENAME_FIELD, '');
+  };
 
-    if (shouldCancelUpload) {
-      try {
-        await upload.cancelUpload();
-      } catch (error) {
-        kubevirtConsole.error(error);
-      }
-    }
-    isBackgroundUploadInProgress.current = false;
-    onClose();
+  const handleClearUploadAndFilename = (): void => {
+    handleClearUpload();
+    setValue(UPLOAD_FILENAME_FIELD, '');
   };
 
   const handleModalSubmit = async () => {
@@ -121,7 +110,7 @@ const MountCDROMModal: FC<MountCDROMModalProps> = ({
 
     if (data.uploadFile?.file) {
       await checkUploadReady();
-      isBackgroundUploadInProgress.current = true;
+      markBackgroundUploadStarted();
 
       const uploadPromise = uploadDataVolume(vm, uploadData, diskState);
 
@@ -161,66 +150,18 @@ const MountCDROMModal: FC<MountCDROMModalProps> = ({
         submitBtnVariant={ButtonVariant.primary}
       >
         <Stack hasGutter>
-          <StackItem className="pf-v6-u-mt-md">
-            <Content component={ContentVariants.p}>{t('Select mount option')}</Content>
-          </StackItem>
-          <StackItem>
-            <Stack hasGutter>
-              <StackItem>
-                <Radio
-                  id="mount-source-existing"
-                  isChecked={existingISOSelected}
-                  isDisabled={isUploading}
-                  label={t('Use existing ISO')}
-                  name="mount-source"
-                  onChange={() => handleISOSelection('')}
-                />
-                {existingISOSelected && (
-                  <div className="pf-v6-u-ml-lg pf-v6-u-mt-sm">
-                    <InlineFilterSelect
-                      setSelected={(e) => {
-                        handleISOSelection(e);
-                        setValue(UPLOAD_FILENAME_FIELD, '');
-                      }}
-                      toggleProps={{
-                        isDisabled: isUploading,
-                        isFullWidth: true,
-                      }}
-                      options={isoOptions}
-                      placeholder={t('Select ISO file')}
-                      selected={selectedISO}
-                    />
-                  </div>
-                )}
-              </StackItem>
-              <StackItem>
-                <Radio
-                  id="mount-source-upload"
-                  isChecked={uploadEnabled}
-                  isDisabled={isUploading}
-                  label={t('Upload new ISO')}
-                  name="mount-source"
-                  onChange={handleFileUpload}
-                />
-                {uploadEnabled && (
-                  <div className="pf-v6-u-ml-lg pf-v6-u-mt-sm">
-                    <DiskSourceUploadPVC
-                      acceptedFileTypes={{
-                        'application/*': ['.iso', '.img', '.qcow2', '.gz', '.xz'],
-                      }}
-                      handleClearUpload={() => {
-                        handleClearUpload();
-                        setValue(UPLOAD_FILENAME_FIELD, '');
-                      }}
-                      handleUpload={handleFileUpload}
-                      label=""
-                      relevantUpload={upload}
-                    />
-                  </div>
-                )}
-              </StackItem>
-            </Stack>
-          </StackItem>
+          <CDROMSourceOptions
+            existingISOSelected={existingISOSelected}
+            isoOptions={isoOptions}
+            isUploading={isUploading}
+            onClearUpload={handleClearUploadAndFilename}
+            onFileUpload={handleFileUpload}
+            onISOSelect={handleISOSelect}
+            radioNamePrefix="mount-source"
+            relevantUpload={upload}
+            selectedISO={selectedISO}
+            uploadEnabled={uploadEnabled}
+          />
         </Stack>
       </TabModal>
     </FormProvider>

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useMountCDROMForm.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useMountCDROMForm.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
 import {
@@ -34,31 +34,37 @@ export const useMountCDROMForm = () => {
   const selectedISO = useWatch({ control, name: FORM_FIELD_SELECTED_ISO });
   const uploadFile = useWatch({ control, name: FORM_FIELD_UPLOAD_FILE });
 
-  const handleISOSelection = (selectedValue: string) => {
-    setValue(FORM_FIELD_SELECTED_ISO, selectedValue);
-    setValue(FORM_FIELD_UPLOAD_MODE, UPLOAD_MODE_SELECT);
-    handleClearUpload(false);
-  };
+  const handleClearUpload = useCallback(
+    (resetMode: boolean = true) => {
+      clearErrors(FORM_FIELD_UPLOAD_FILE);
+      setValue(FORM_FIELD_UPLOAD_FILE, null);
+      setUploadFilename('');
+      if (resetMode) {
+        setValue(FORM_FIELD_UPLOAD_MODE, '');
+      }
+    },
+    [clearErrors, setValue],
+  );
 
-  const handleFileUpload = () => {
+  const handleISOSelection = useCallback(
+    (selectedValue: string) => {
+      setValue(FORM_FIELD_SELECTED_ISO, selectedValue);
+      setValue(FORM_FIELD_UPLOAD_MODE, UPLOAD_MODE_SELECT);
+      handleClearUpload(false);
+    },
+    [setValue, handleClearUpload],
+  );
+
+  const handleFileUpload = useCallback(() => {
     setValue(FORM_FIELD_UPLOAD_MODE, UPLOAD_MODE_UPLOAD);
     setValue(FORM_FIELD_SELECTED_ISO, '');
-  };
+  }, [setValue]);
 
-  const handleClearUpload = (resetMode: boolean = true) => {
-    clearErrors(FORM_FIELD_UPLOAD_FILE);
-    setValue(FORM_FIELD_UPLOAD_FILE, null);
-    setUploadFilename('');
-    if (resetMode) {
-      setValue(FORM_FIELD_UPLOAD_MODE, '');
-    }
-  };
-
-  const handleEmptyDriveSelection = () => {
+  const handleEmptyDriveSelection = useCallback(() => {
     setValue(FORM_FIELD_UPLOAD_MODE, UPLOAD_MODE_EMPTY);
     setValue(FORM_FIELD_SELECTED_ISO, '');
     handleClearUpload(false);
-  };
+  }, [setValue, handleClearUpload]);
 
   const isFormValid = Boolean(selectedISO || uploadFile?.filename);
 


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-69868](https://redhat.atlassian.net/browse/CNV-69868)

Update logic inside addCDROMModal and MountCDROMModal

## 🎥 Demo

No UI changes, just logic update. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consolidated CD-ROM source selector for choosing an existing ISO, uploading a new ISO, or leaving the drive empty.
  * Introduced improved upload-close behavior to support background uploads.

* **Bug Fixes**
  * More reliable upload cancellation and background-upload handling when closing modals.
  * Upload state and filename cleared consistently when changing ISO selection or clearing uploads.

* **Refactor**
  * Streamlined mount dialog and form handlers with memoized callbacks and centralized upload-reset logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->