### PR TITLE
CNV-84762: Update Add automatic CI failure triage and infrastructure retest

### DIFF
--- a/.github/workflows/ci_retest.yml
+++ b/.github/workflows/ci_retest.yml
@@ -117,6 +117,12 @@ jobs:
             "error building.*creating build container"
           )
 
+          OPERATOR_SETUP_MARKERS=(
+            "hco-unstable-catalog-source created"
+            "hco-operatorhub created"
+            "kubevirt-hyperconverged-group created"
+          )
+
           while read -r job; do
             JOB_NAME=$(echo "$job" | jq -r '.job_name')
             LOG_URL=$(echo "$job" | jq -r '.log_url')
@@ -135,6 +141,7 @@ jobs:
               continue
             fi
 
+            MATCHED="false"
             for pattern in "${INFRA_PATTERNS[@]}"; do
               MATCH=$(grep -Ei "$pattern" /tmp/build-log.txt | tail -3 || true)
               if [ -n "$MATCH" ]; then
@@ -142,9 +149,24 @@ jobs:
                 echo "$JOB_NAME" >> /tmp/infra_jobs.txt
                 echo "$MATCH" >> /tmp/infra_reasons.txt
                 echo "---" >> /tmp/infra_reasons.txt
+                MATCHED="true"
                 break
               fi
             done
+
+            if [ "$MATCHED" = "false" ] && grep -q "no matching resources found" /tmp/build-log.txt; then
+              for marker in "${OPERATOR_SETUP_MARKERS[@]}"; do
+                if grep -q "$marker" /tmp/build-log.txt; then
+                  MATCH=$(grep "no matching resources found" /tmp/build-log.txt | tail -3)
+                  echo "INFRA match: operator setup failure (no matching resources + '$marker')"
+                  echo "$JOB_NAME" >> /tmp/infra_jobs.txt
+                  echo "$MATCH" >> /tmp/infra_reasons.txt
+                  echo "---" >> /tmp/infra_reasons.txt
+                  break
+                fi
+              done
+            fi
+
             echo "::endgroup::"
           done < <(echo "$JOBS_JSON" | jq -c '.[]')
 


### PR DESCRIPTION
## 📝 Description

Jira ticket: Jira ticket: [CNV-84762](https://redhat.atlassian.net/browse/CNV-84762)


Added another use case of potential infra failure that needs to be automatically retested. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD infrastructure error detection by adding a secondary classification path that recognizes additional operator-setup indicators when standard patterns fail.
  * When such cases occur, the workflow now captures relevant log snippets and associates them with the specific job, increasing the number of failures labeled as infrastructure-related and improving reporting clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->