### PR TITLE
CNV-84543: prevent duplicate NetworkMaps/StorageMaps on multiple Migrate clicks

### DIFF
--- a/src/multicluster/components/CrossClusterMigration/hooks/useCrossClusterMigrationSubmit.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useCrossClusterMigrationSubmit.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Updater } from 'use-immer';
 
 import {
@@ -16,7 +16,7 @@ import { kubevirtK8sCreate } from '@multicluster/k8sRequests';
 
 import { MTV_MIGRATION_NAMESPACE } from '../constants';
 
-import { getCreateMigration } from './utils';
+import { cleanupPartialResources, getCreateMigration } from './utils';
 
 const useCrossClusterMigrationSubmit = (
   migrationPlan: V1beta1Plan,
@@ -28,10 +28,21 @@ const useCrossClusterMigrationSubmit = (
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
+  // Ref guard prevents duplicate submissions from rapid/concurrent clicks
+  // before the React state update re-render can disable the button.
+  const isSubmittingRef = useRef(false);
+
   const onSubmit = useCallback(async () => {
+    if (isSubmittingRef.current) return;
+    isSubmittingRef.current = true;
+
     setIsSubmitting(true);
     setError(null);
     setSuccess(false);
+
+    let createdStorageMap: undefined | V1beta1StorageMap;
+    let createdNetworkMap: undefined | V1beta1NetworkMap;
+    let createdMigrationPlan: undefined | V1beta1Plan;
 
     try {
       const finalStorageMap = {
@@ -58,11 +69,11 @@ const useCrossClusterMigrationSubmit = (
         },
       };
 
-      const createdStorageMap = await kubevirtK8sCreate({
+      createdStorageMap = await kubevirtK8sCreate({
         data: finalStorageMap,
         model: StorageMapModel,
       });
-      const createdNetworkMap = await kubevirtK8sCreate({
+      createdNetworkMap = await kubevirtK8sCreate({
         data: finalNetworkMap,
         model: NetworkMapModel,
       });
@@ -94,7 +105,7 @@ const useCrossClusterMigrationSubmit = (
         },
       };
 
-      const createdMigrationPlan = await kubevirtK8sCreate({
+      createdMigrationPlan = await kubevirtK8sCreate({
         data: finalMigrationPlan,
         model: PlanModel,
         ns: MTV_MIGRATION_NAMESPACE,
@@ -108,9 +119,11 @@ const useCrossClusterMigrationSubmit = (
       setMigrationPlan(createdMigrationPlan);
       setSuccess(true);
     } catch (apiError) {
+      cleanupPartialResources({ createdMigrationPlan, createdNetworkMap, createdStorageMap });
       setError(apiError);
     } finally {
       setIsSubmitting(false);
+      isSubmittingRef.current = false;
     }
   }, [storageMap, migrationPlan, networkMap, setMigrationPlan]);
 

--- a/src/multicluster/components/CrossClusterMigration/hooks/utils.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/utils.ts
@@ -1,9 +1,46 @@
-import { MigrationModel, V1beta1Plan } from '@kubev2v/types';
+import {
+  MigrationModel,
+  NetworkMapModel,
+  PlanModel,
+  StorageMapModel,
+  V1beta1NetworkMap,
+  V1beta1Plan,
+  V1beta1StorageMap,
+} from '@kubev2v/types';
 import { modelToGroupVersionKind } from '@kubevirt-utils/models';
 import { getName, getNamespace, getUID } from '@kubevirt-utils/resources/shared';
-import { getRandomChars, isEmpty } from '@kubevirt-utils/utils/utils';
+import { getRandomChars, isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
+import { kubevirtK8sDelete } from '@multicluster/k8sRequests';
 
 import { MTV_MIGRATION_NAMESPACE } from '../constants';
+
+export type PartialResources = {
+  createdMigrationPlan?: undefined | V1beta1Plan;
+  createdNetworkMap?: undefined | V1beta1NetworkMap;
+  createdStorageMap?: undefined | V1beta1StorageMap;
+};
+
+export const cleanupPartialResources = ({
+  createdMigrationPlan,
+  createdNetworkMap,
+  createdStorageMap,
+}: PartialResources) => {
+  if (createdStorageMap) {
+    kubevirtK8sDelete({ model: StorageMapModel, resource: createdStorageMap }).catch((e) =>
+      kubevirtConsole.error('Failed to clean up StorageMap', e),
+    );
+  }
+  if (createdNetworkMap) {
+    kubevirtK8sDelete({ model: NetworkMapModel, resource: createdNetworkMap }).catch((e) =>
+      kubevirtConsole.error('Failed to clean up NetworkMap', e),
+    );
+  }
+  if (createdMigrationPlan) {
+    kubevirtK8sDelete({ model: PlanModel, resource: createdMigrationPlan }).catch((e) =>
+      kubevirtConsole.error('Failed to clean up Plan', e),
+    );
+  }
+};
 
 export const getSelectableOptions = (
   resources: string[],


### PR DESCRIPTION
## 📝 Description

When clicking the **Migrate** button multiple times in the Cross-cluster migration wizard, each click was creating separate NetworkMap and StorageMap resources in the `mtv-integrations` namespace — even when the action failed.

Two root causes:
1. **Race condition**: React's async state update (`setIsSubmitting(true)`) doesn't prevent a second click from entering `onSubmit` before the component re-renders with the button disabled.
2. **Error-then-retry accumulation**: After a failed attempt (e.g. Plan creation fails), `isSubmitting` resets to `false` and the button re-enables — each retry created new maps on top of the orphaned ones from the previous attempt.

**Fix:**
- Added a `useRef` guard that synchronously blocks concurrent submissions before React can re-render.
- On any failure, fire-and-forget cleanup of partially created resources (StorageMap, NetworkMap, Plan) so retries always start clean.
- Extracted `cleanupPartialResources` to `hooks/utils.ts` and uses `kubevirtConsole.error` to log cleanup failures.

## 🔗 Links

- https://issues.redhat.com/browse/CNV-84543

## 👥 CC://

> @tag as needed

## 📹 Demo

> Before: clicking Migrate multiple times creates orphaned NetworkMaps and StorageMaps in `mtv-integrations`
> After: subsequent clicks are blocked by the ref guard; any partially created resources are cleaned up on failure

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cross-cluster migration reliability by automatically cleaning up any partially created resources if the migration setup process fails, ensuring no orphaned resources remain.
  * Enhanced form submission protection to prevent accidental duplicate submissions during migration setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->