### PR TITLE
CNV-85175: hide Fleet Virtualization perspective when ACM is not installed

### DIFF
--- a/src/multicluster/extensions.ts
+++ b/src/multicluster/extensions.ts
@@ -15,6 +15,7 @@ import { FLAG_KUBEVIRT_VIRTUALIZATION_NAV } from '../utils/flags/consts';
 
 import {
   CROSS_CLUSTER_MIGRATION_ACTION_ID,
+  FLAG_DISALLOWED_KUBEVIRT_DYNAMIC_ACM,
   FLEET_BOOTABLE_VOLUMES_PATH,
   FLEET_CATALOG_PATH,
   FLEET_CHECKUPS_PATH,
@@ -38,7 +39,7 @@ export const exposedModules: ConsolePluginBuildMetadata['exposedModules'] = {
 export const extensions: EncodedExtension[] = [
   {
     flags: {
-      disallowed: ['KUBEVIRT_DISALLOW_DYNAMIC_ACM'],
+      disallowed: [FLAG_DISALLOWED_KUBEVIRT_DYNAMIC_ACM],
       required: [FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
     },
     properties: {


### PR DESCRIPTION
## 📝 Description

Fixes [CNV-85175](https://issues.redhat.com/browse/CNV-85175) — Fleet Virtualization navigation option was visible even when the ACM operator was not installed.

**Root cause:** The `console.perspective` extension for Fleet Virtualization used a misspelled flag string `'KUBEVIRT_DISALLOW_DYNAMIC_ACM'` in its `disallowed` guard. The actual flag set by `useKubevirtDynamicACMFlag` is `FLAG_DISALLOWED_KUBEVIRT_DYNAMIC_ACM` (`'DISALLOWED_KUBEVIRT_DYNAMIC_ACM'`). Because the flag names never matched, the guard never fired and the perspective was always shown.

**Fix:** Import and use the `FLAG_DISALLOWED_KUBEVIRT_DYNAMIC_ACM` constant from `./constants` instead of the wrong string literal.

## 🎥 Demo

See the attached video in the Jira ticket: the Fleet Virtualization option appears in the perspective switcher on clusters without ACM installed. After this fix it will only appear when ACM is present and `FLAG_DISALLOWED_KUBEVIRT_DYNAMIC_ACM` is `false`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal configuration management through code optimization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->