### PR TITLE
fix(cypress): fix e2e test failures (onboarding popovers, tree view)

### DIFF
--- a/cypress/support/nav.ts
+++ b/cypress/support/nav.ts
@@ -63,7 +63,7 @@ Cypress.Commands.add('visitNAD', () => {
   cy.get('[data-quickstart-id="qs-nav-networking"]', { timeout: MINUTE }).scrollIntoView();
   cy.contains('Networking').should('be.visible');
   cy.clickNavLink(['Networking', 'NetworkAttachmentDefinitions']);
-  cy.byButtonText('Create').should('be.visible');
+  cy.contains('h1', 'NetworkAttachmentDefinitions', { timeout: MINUTE }).should('be.visible');
 });
 
 Cypress.Commands.add('visitTemplates', () => {
@@ -72,6 +72,7 @@ Cypress.Commands.add('visitTemplates', () => {
 
 Cypress.Commands.add('visitTemplatesVirt', () => {
   cy.get(nav.templateNav, { timeout: 5 * MINUTE }).click();
+  cy.contains('h1', 'Templates', { timeout: MINUTE }).should('be.visible');
 });
 
 Cypress.Commands.add('visitITs', () => {
@@ -136,4 +137,5 @@ Cypress.Commands.add('visitStorageclass', () => {
   cy.get('[data-quickstart-id="qs-nav-storage"]', { timeout: MINUTE }).scrollIntoView();
   cy.containsExactMatch('Storage').should('be.visible');
   cy.clickNavLink(['Storage', 'StorageClasses']);
+  cy.contains('h1', 'StorageClasses', { timeout: MINUTE }).should('be.visible');
 });

--- a/cypress/support/project.ts
+++ b/cypress/support/project.ts
@@ -1,4 +1,4 @@
-import { TEST_NS, TREEVIEW_ROOT_ID } from '../utils/const/index';
+import { ALL_PROJ_NS, TEST_NS, TREEVIEW_ROOT_ID } from '../utils/const/index';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -37,7 +37,7 @@ Cypress.Commands.add('switchProjectUsingTreeView', (projectName: string) => {
       cy.get('.vms-tree-view__toolbar-switch input').uncheck({ force: true });
     }
   });
-  cy.get(projectSelector, { timeout: 10000 }).click();
+  cy.get(projectSelector, { timeout: 30000 }).click();
 });
 
 Cypress.Commands.add('switchProject', (projectName: string) => {
@@ -52,7 +52,7 @@ Cypress.Commands.add('switchProject', (projectName: string) => {
     .should('exist')
     .then(() => {
       cy.get('body').then(($body) => {
-        if ($body.find(TREEVIEW_ROOT_ID).length) {
+        if (name !== ALL_PROJ_NS && $body.find(`${TREEVIEW_ROOT_ID}:visible`).length) {
           cy.switchProjectUsingTreeView(name);
         } else {
           cy.byLegacyTestID('namespace-bar-dropdown').contains('Project:').click();

--- a/cypress/support/project.ts
+++ b/cypress/support/project.ts
@@ -31,7 +31,13 @@ Cypress.Commands.add('selectTestProject', () => {
 });
 
 Cypress.Commands.add('switchProjectUsingTreeView', (projectName: string) => {
-  cy.get(`li#projectSelector/${projectName}`).click();
+  const projectSelector = `li[id="projectSelector/#single-cluster#/${projectName}"]`;
+  cy.get('body').then(($body) => {
+    if (!$body.find(projectSelector).length) {
+      cy.get('.vms-tree-view__toolbar-switch input').uncheck({ force: true });
+    }
+  });
+  cy.get(projectSelector, { timeout: 10000 }).click();
 });
 
 Cypress.Commands.add('switchProject', (projectName: string) => {
@@ -41,14 +47,18 @@ Cypress.Commands.add('switchProject', (projectName: string) => {
     );
   }
   const name = typeof projectName === 'string' ? projectName : String(projectName);
-  cy.get('body').then(($body) => {
-    if ($body.find(TREEVIEW_ROOT_ID).length) {
-      cy.switchProjectUsingTreeView(name);
-      return;
-    }
-
-    cy.byLegacyTestID('namespace-bar-dropdown').contains('Project:').click();
-    cy.byTestID('showSystemSwitch').check();
-    cy.byTestID('dropdown-menu-item-link').contains(name).click();
-  });
+  const namespaceBarSelector = '[data-test-id="namespace-bar-dropdown"]';
+  cy.get(`${namespaceBarSelector}, ${TREEVIEW_ROOT_ID}`, { timeout: 30000 })
+    .should('exist')
+    .then(() => {
+      cy.get('body').then(($body) => {
+        if ($body.find(TREEVIEW_ROOT_ID).length) {
+          cy.switchProjectUsingTreeView(name);
+        } else {
+          cy.byLegacyTestID('namespace-bar-dropdown').contains('Project:').click();
+          cy.byTestID('showSystemSwitch').check();
+          cy.byTestID('dropdown-menu-item-link').contains(name).click();
+        }
+      });
+    });
 });

--- a/cypress/tests/gating/set-default-sc.cy.ts
+++ b/cypress/tests/gating/set-default-sc.cy.ts
@@ -1,7 +1,10 @@
 import { dsIT } from '../../utils/const/index';
-import { getRow, kebabBtn } from '../../views/actions';
+import { kebabBtn } from '../../views/actions';
 
 const cluster_default_sc = 'ocs-storagecluster-ceph-rbd-virtualization';
+
+const getScRow = (name: string, within: VoidFunction) =>
+  cy.byLegacyTestID(name).parents('tr').within(within);
 
 describe('Set default storageclass', () => {
   before(() => {
@@ -13,16 +16,16 @@ describe('Set default storageclass', () => {
     cy.exec('oc get sc -o custom-columns=NAME:metadata.name --no-headers | head -n 1').then(
       (result) => {
         cy.task('log', result);
-        getRow(result.stdout, () => cy.get(kebabBtn).click());
+        getScRow(result.stdout, () => cy.get(kebabBtn).click());
         cy.get('[data-test-action="Set as default"]').click();
-        getRow(result.stdout, () => cy.contains('Default').should('exist'));
+        getScRow(result.stdout, () => cy.contains('Default').should('exist'));
       },
     );
   });
 
   dsIT('restore storageclass to cluster default', () => {
-    getRow(cluster_default_sc, () => cy.get(kebabBtn).click());
+    getScRow(cluster_default_sc, () => cy.get(kebabBtn).click());
     cy.get('[data-test-action="Set as default"]').click();
-    getRow(cluster_default_sc, () => cy.contains('Default').should('exist'));
+    getScRow(cluster_default_sc, () => cy.contains('Default').should('exist'));
   });
 });

--- a/cypress/views/nad.ts
+++ b/cypress/views/nad.ts
@@ -14,7 +14,7 @@ export const bridgeMTU = 'input[name="ovn-k8s-cni-overlay-localnet.mtu"]';
 export const kebabBtn = '[data-test-id="kebab-button"]';
 export const deleteAction = '[data-test-action=" Network Attachment Definition"]';
 export const confirmBtn = '[data-test="confirm-action"]';
-export const heading = '[data-test-section-heading="Network Attachment Definition details"]';
+export const heading = '[data-test-section-heading="NetworkAttachmentDefinition details"]';
 export const createBtn = '#save-changes';
 export const macSpoofCHK = 'input[id="bridge.macspoofchk"]';
 export const ovnSubnet = 'input[name="ovn-k8s-cni-overlay.subnets"]';

--- a/test-cypress.sh
+++ b/test-cypress.sh
@@ -27,17 +27,13 @@ do
 done
 
 # Run tests.
-npm_script_args=""
-
 if [ -n "${gui-}" ]; then
-  npm_script_args="test-cypress"
+  npm run test-cypress
+elif [ -n "${spec-}" ]; then
+  npm run test-cypress-headless -- --spec $spec
+else
+  npm run test-cypress-headless
 fi
-
-if [ -n "${spec-}" ]; then
-  npm_script_args="$npm_script_args --spec '$spec'"
-fi
-
-npm run test-cypress-headless -- $npm_script_args
 
 # Generate Cypress report.
 npm run cypress-postreport

--- a/test-setup.sh
+++ b/test-setup.sh
@@ -5,8 +5,8 @@ set -ex
 # create test namespace
 oc get namespace ${CYPRESS_TEST_NS} || oc new-project ${CYPRESS_TEST_NS}
 
-# close welcome modal
-oc patch configmap -n ${CYPRESS_CNV_NS} kubevirt-user-settings --type=merge --patch '{"data": {"kube-admin": "{\"quickStart\":{\"dontShowWelcomeModal\":true}}"}}'
+# dismiss welcome modal and onboarding popovers
+oc patch configmap -n ${CYPRESS_CNV_NS} kubevirt-user-settings --type=merge --patch '{"data": {"kube-admin": "{\"quickStart\":{\"dontShowWelcomeModal\":true},\"onboardingPopoversHidden\":{\"vmsTab\":true,\"catalog\":true,\"createProject\":true}}"}}'
 oc patch configmap -n ${CYPRESS_CNV_NS} kubevirt-ui-features --type=merge --patch '{"data": {"advancedSearch": "true", "treeViewFolders": "true"}}'
 
 # create secret


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
fix e2e test failures

- Dismiss onboarding popovers via ConfigMap patch in test-setup.sh
- Fix switchProject to wait for either the tree view or namespace bar to load
- Toggle "Show only projects with VirtualMachines" switch when the target project is not visible in the tree view
- Fix attribute selector for tree view project items
- Fix test-cypress.sh GUI mode


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved project-switching reliability with more robust detection, fallback behavior, and longer wait handling
  * Updated navigation checks to assert page headings for select pages
  * Scoped storage-class test interactions to row-level with a focused local helper
  * Expanded test setup to suppress onboarding popovers and the welcome dialog
  * Adjusted NAD detail verification to match updated page heading selector

* **Chores**
  * Simplified test runner script to choose GUI vs. headless execution more explicitly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->