### PR TITLE
[release-4.20] CNV-84270: Use VM cluster for disk modal PVC watches

### DIFF
--- a/src/utils/components/DiskModal/DiskModal.tsx
+++ b/src/utils/components/DiskModal/DiskModal.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getDataVolumeTemplates, getVolumes } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { getCluster } from '@multicluster/helpers/selectors';
 
 import usePVCDiskSource from './hooks/usePVCDiskSource';
 import { getDiskModalBySource } from './utils/getDiskModalBySource';
@@ -26,7 +27,7 @@ const DiskModal: FC<V1DiskModalProps> = ({
   );
 
   const namespace = getNamespace(vm);
-  const [pvc] = usePVCDiskSource(createdPVCName, namespace);
+  const [pvc] = usePVCDiskSource(createdPVCName, namespace, getCluster(vm));
 
   const editDiskSource = getSourceFromVolume(diskVolume, dataVolumeTemplate);
 

--- a/src/utils/components/DiskModal/hooks/usePVCDiskSource.tsx
+++ b/src/utils/components/DiskModal/hooks/usePVCDiskSource.tsx
@@ -3,8 +3,10 @@ import { modelToGroupVersionKind, PersistentVolumeClaimModel } from '@kubevirt-u
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-const usePVCDiskSource = (pvcName: string, pvcNamespace: string) => {
-  const cluster = useClusterParam();
+// Prefer VM.cluster on ACM so the PVC watch targets the spoke (CNV-84270).
+const usePVCDiskSource = (pvcName: string, pvcNamespace: string, vmCluster?: string) => {
+  const clusterParam = useClusterParam();
+  const cluster = vmCluster ?? clusterParam;
 
   return useK8sWatchData<IoK8sApiCoreV1PersistentVolumeClaim>(
     pvcName


### PR DESCRIPTION
This is a manual cherry-pick of #3776 (backport of #3835 for release-4.21).

On ACM VM details routes, `useClusterParam()` can be unset when the URL
does not include the fleet cluster segment. Use `getCluster(vm)` and
`diskState.cluster` so PVC watches target the managed cluster and
capacity/resize UI can load the PersistentVolumeClaim.

/assign upalatucci

Made with [Cursor](https://cursor.com)