### PR TITLE
CNV-85421: Fix create vm wizard customization flow so vm doesn't start by default when checkbox isn't checked

### DIFF
--- a/src/utils/components/RunStrategyModal/useRunStrategyToggle.ts
+++ b/src/utils/components/RunStrategyModal/useRunStrategyToggle.ts
@@ -21,7 +21,7 @@ export const useRunStrategyToggle = (
   const runStrategy =
     typeof vmOrRunStrategy === 'string'
       ? vmOrRunStrategy
-      : getEffectiveRunStrategy(vmOrRunStrategy);
+      : getEffectiveRunStrategy(vmOrRunStrategy) ?? getDefaultRunningStrategy();
 
   const isManual = isRunStrategyManual(runStrategy);
   const isActive = isRunStrategyNotHalted(runStrategy);

--- a/src/utils/components/RunStrategyModal/utils.ts
+++ b/src/utils/components/RunStrategyModal/utils.ts
@@ -85,6 +85,8 @@ export const getRunStrategyDisplayValue = (t: TFunction, vm: V1VirtualMachine): 
 export const getStartAfterCreationLabel = (t: TFunction): string =>
   t('Start this VirtualMachine after creation');
 
+export const START_AFTER_CREATION_CHECKBOX_ID = 'start-after-create-checkbox';
+
 export const getRunStrategyHelpText = (t: TFunction): string =>
   t('Controls how the VM behaves after a failure, shutdown, or restart.');
 

--- a/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
+++ b/src/views/catalog/CreateFromInstanceTypes/components/CreateVMFooter/CreateVMFooter.tsx
@@ -9,7 +9,10 @@ import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernete
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useRunStrategyToggle } from '@kubevirt-utils/components/RunStrategyModal/useRunStrategyToggle';
-import { getStartAfterCreationLabel } from '@kubevirt-utils/components/RunStrategyModal/utils';
+import {
+  getStartAfterCreationLabel,
+  START_AFTER_CREATION_CHECKBOX_ID,
+} from '@kubevirt-utils/components/RunStrategyModal/utils';
 import { SecretSelectionOption } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
 import {
   AUTOUNATTEND,
@@ -165,7 +168,7 @@ const CreateVMFooter: FC = () => {
               const { newStrategy } = onToggle(checked);
               setRunStrategy(newStrategy);
             }}
-            id="start-after-create-checkbox"
+            id={START_AFTER_CREATION_CHECKBOX_ID}
             isChecked={isStartChecked}
             label={getStartAfterCreationLabel(t)}
           />

--- a/src/views/catalog/CustomizeInstanceType/components/CustomizeITVMFooter.tsx
+++ b/src/views/catalog/CustomizeInstanceType/components/CustomizeITVMFooter.tsx
@@ -5,7 +5,10 @@ import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/u
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import { useRunStrategyToggle } from '@kubevirt-utils/components/RunStrategyModal/useRunStrategyToggle';
-import { getStartAfterCreationLabel } from '@kubevirt-utils/components/RunStrategyModal/utils';
+import {
+  getStartAfterCreationLabel,
+  START_AFTER_CREATION_CHECKBOX_ID,
+} from '@kubevirt-utils/components/RunStrategyModal/utils';
 import { SecretSelectionOption } from '@kubevirt-utils/components/SSHSecretModal/utils/types';
 import { logITFlowEvent } from '@kubevirt-utils/extensions/telemetry/telemetry';
 import {
@@ -79,7 +82,7 @@ const CustomizeITVMFooter: FC = () => {
                 },
               ]);
             }}
-            id="start-after-create-checkbox"
+            id={START_AFTER_CREATION_CHECKBOX_ID}
             isChecked={isStartChecked}
             label={getStartAfterCreationLabel(t)}
           />

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/TemplatesCatalogDrawerCreateForm.tsx
@@ -4,7 +4,10 @@ import { DRAWER_FORM_ID } from '@catalog/templatescatalog/utils/consts';
 import { getNotSupportedVMError } from '@catalog/utils/constants';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import FolderSelect from '@kubevirt-utils/components/FolderSelect/FolderSelect';
-import { getStartAfterCreationLabel } from '@kubevirt-utils/components/RunStrategyModal/utils';
+import {
+  getStartAfterCreationLabel,
+  START_AFTER_CREATION_CHECKBOX_ID,
+} from '@kubevirt-utils/components/RunStrategyModal/utils';
 import { validateVMName } from '@kubevirt-utils/components/VMNameValidationHelperText/utils/utils';
 import VMNameValidationHelperText from '@kubevirt-utils/components/VMNameValidationHelperText/VMNameValidationHelperText';
 import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
@@ -129,7 +132,7 @@ export const TemplatesCatalogDrawerCreateForm: FC<TemplatesCatalogDrawerCreateFo
           </StackItem>
           <StackItem>
             <Checkbox
-              id="start-after-create-checkbox"
+              id={START_AFTER_CREATION_CHECKBOX_ID}
               isChecked={startVM}
               label={getStartAfterCreationLabel(t)}
               onChange={(_, checked: boolean) => onChangeStartVM(checked)}

--- a/src/views/catalog/wizard/components/WizardFooter.tsx
+++ b/src/views/catalog/wizard/components/WizardFooter.tsx
@@ -7,6 +7,7 @@ import { useRunStrategyToggle } from '@kubevirt-utils/components/RunStrategyModa
 import {
   applyRunStrategyToSpec,
   getStartAfterCreationLabel,
+  START_AFTER_CREATION_CHECKBOX_ID,
 } from '@kubevirt-utils/components/RunStrategyModal/utils';
 import { logTemplateFlowEvent } from '@kubevirt-utils/extensions/telemetry/telemetry';
 import {
@@ -96,7 +97,7 @@ export const WizardFooter: FC<{ namespace: string }> = ({ namespace }) => {
       <Stack hasGutter>
         <StackItem>
           <Checkbox
-            id="start-after-create-checkbox"
+            id={START_AFTER_CREATION_CHECKBOX_ID}
             isChecked={isStartChecked}
             isDisabled={!loaded || disableVmCreate || !isBootSourceAvailable}
             label={getStartAfterCreationLabel(t)}

--- a/src/views/virtualmachines/creation-wizard/hooks/useCloneVM.ts
+++ b/src/views/virtualmachines/creation-wizard/hooks/useCloneVM.ts
@@ -7,6 +7,7 @@ import { CLONING_STATUSES } from '@kubevirt-utils/components/CloneVMModal/utils/
 import { cloneVM, vmExists } from '@kubevirt-utils/components/CloneVMModal/utils/helpers';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { RUNSTRATEGY_HALTED } from '@kubevirt-utils/resources/vm/utils/constants';
 import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { getVMURL } from '@multicluster/urls';
@@ -17,13 +18,7 @@ type UseCloneVM = () => () => Promise<void>;
 const useCloneVM: UseCloneVM = () => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
-  const {
-    cloneVMDescription,
-    cloneVMName,
-    cluster,
-    project: targetNamespace,
-    startVM: startCloneVM,
-  } = useVMWizardStore();
+  const { cloneVMDescription, cloneVMName, cluster, project: targetNamespace } = useVMWizardStore();
 
   const source = vmSignal.value;
 
@@ -52,7 +47,7 @@ const useCloneVM: UseCloneVM = () => {
       source,
       cloneVMName,
       targetNamespace,
-      startCloneVM,
+      vmSignal.value?.spec?.runStrategy !== RUNSTRATEGY_HALTED,
       cloneVMDescription,
     );
 

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore.ts
@@ -22,7 +22,6 @@ const useVMWizardStore = create<VMWizardStore>()((set) => {
     setFolder: (folder: string) => set({ folder }),
     setProject: (project: string) => set({ project }),
     setSelectedTemplate: (selectedTemplate: Template) => set(() => ({ selectedTemplate })),
-    setStartVM: (startVM: boolean) => set({ startVM }),
     setTemplatesDrawerIsOpen: (templatesDrawerIsOpen: boolean) =>
       set(() => ({ templatesDrawerIsOpen })),
     setVMNameConfirmed: (vmNameConfirmed: boolean) => set({ vmNameConfirmed }),

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/state.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/state.ts
@@ -9,7 +9,6 @@ export const initialVMWizardState: VMWizardState = {
   folder: '',
   project: '',
   selectedTemplate: null,
-  startVM: false,
   templatesDrawerIsOpen: false,
   vmNameConfirmed: false,
 };

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/types.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/types.ts
@@ -9,7 +9,6 @@ export type VMWizardState = {
   folder: string;
   project: string;
   selectedTemplate: Template;
-  startVM: boolean;
   templatesDrawerIsOpen: boolean;
   vmNameConfirmed: boolean;
 };
@@ -23,7 +22,6 @@ export type VMWizardActions = {
   setFolder: (folder: string) => void;
   setProject: (project: string) => void;
   setSelectedTemplate: (template: Template) => void;
-  setStartVM: (startVM: boolean) => void;
   setTemplatesDrawerIsOpen: (templatesDrawerIsOpen: boolean) => void;
   setVMNameConfirmed: (vmNameConfirmed: boolean) => void;
 };

--- a/src/views/virtualmachines/creation-wizard/steps/ReviewAndCreateStep/ReviewAndCreateStep.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/ReviewAndCreateStep/ReviewAndCreateStep.tsx
@@ -1,21 +1,22 @@
 import React, { FC } from 'react';
 
-import { getStartAfterCreationLabel } from '@kubevirt-utils/components/RunStrategyModal/utils';
-import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { useRunStrategyToggle } from '@kubevirt-utils/components/RunStrategyModal/useRunStrategyToggle';
 import {
-  getDefaultRunningStrategy,
-  RUNSTRATEGY_HALTED,
-} from '@kubevirt-utils/resources/vm/utils/constants';
-import { updateCustomizeInstanceType } from '@kubevirt-utils/store/customizeInstanceType';
+  getStartAfterCreationLabel,
+  START_AFTER_CREATION_CHECKBOX_ID,
+} from '@kubevirt-utils/components/RunStrategyModal/utils';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { updateCustomizeInstanceType, vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import { Checkbox, Stack, StackItem, Title, TitleSizes } from '@patternfly/react-core';
-import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
+import { useSignals } from '@preact/signals-react/runtime';
 import ReviewGrid from '@virtualmachines/creation-wizard/steps/ReviewAndCreateStep/components/ReviewGrid/ReviewGrid';
 
 import NameAndDescriptionForm from './components/NameAndDescriptionForm';
 
 const ReviewAndCreateStep: FC = () => {
   const { t } = useKubevirtTranslation();
-  const { setStartVM, startVM } = useVMWizardStore();
+  useSignals();
+  const { isStartChecked, onToggle } = useRunStrategyToggle(vmSignal.value ?? undefined);
   return (
     <Stack hasGutter>
       <StackItem>
@@ -41,16 +42,11 @@ const ReviewAndCreateStep: FC = () => {
       <StackItem>
         <Checkbox
           onChange={(_, checked: boolean) => {
-            setStartVM(checked);
-            updateCustomizeInstanceType([
-              {
-                data: checked ? getDefaultRunningStrategy() : RUNSTRATEGY_HALTED,
-                path: 'spec.runStrategy',
-              },
-            ]);
+            const { newStrategy } = onToggle(checked);
+            updateCustomizeInstanceType([{ data: newStrategy, path: 'spec.runStrategy' }]);
           }}
-          id="start-after-create-checkbox"
-          isChecked={startVM}
+          id={START_AFTER_CREATION_CHECKBOX_ID}
+          isChecked={isStartChecked}
           label={getStartAfterCreationLabel(t)}
         />
       </StackItem>

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/hooks/useCreateVMFromTemplate.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/hooks/useCreateVMFromTemplate.ts
@@ -6,7 +6,7 @@ import {
   CUSTOMIZE_VM_FAILED,
 } from '@kubevirt-utils/extensions/telemetry/utils/constants';
 import { getLabels } from '@kubevirt-utils/resources/shared';
-import { getDefaultRunningStrategy, getRunStrategy } from '@kubevirt-utils/resources/vm';
+import { getDefaultRunningStrategy } from '@kubevirt-utils/resources/vm';
 import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
 import { resolveVMFromTemplate } from '@virtualmachines/creation-wizard/steps/TemplateStep/hooks/utils';
@@ -31,7 +31,7 @@ const useCreateVMFromTemplate: UseCreateVMFromTemplate = () => {
 
       vmObject.metadata.namespace = namespace;
       if (folder) vmObject.metadata.labels = { ...getLabels(vmObject), [VM_FOLDER_LABEL]: folder };
-      if (!getRunStrategy(vmObject)) vmObject.spec.runStrategy = getDefaultRunningStrategy();
+      vmObject.spec.runStrategy = getDefaultRunningStrategy();
 
       vmSignal.value = vmObject;
     } catch (error) {


### PR DESCRIPTION

## 📝 Description

Before: The checkbox "Start this VirtualMachine after creation" was connected to a redundant `startVM` boolean in the wizard store (defaulting to false), while the actual VM object was independently initialized with `runStrategy: RerunOnFailure`. The two were disconnected, causing the VM to auto-start regardless of the checkbox state.

Fix: Consolidates to a single source of truth (`vmSignal`) — removes the redundant `startVM` boolean from the wizard store, and wires `ReviewAndCreateStep` directly to `useRunStrategyToggle`(`vmSignal.value`). The checkbox now reflects and controls the actual VM `runStrategy`.

The `runStrategy` is unconditionally set to `getDefaultRunningStrategy()` (`RerunOnFailure`) when initializing `vmSignal` across all creation flows — including the template wizard, which previously preserved a template's own `runStrategy` (e.g. `Halted`) — ensuring the checkbox defaults to checked in all flows. Unchecking it sets `runStrategy: Halted` on the VM.

Also extracts the checkbox id to a shared constant to prevent future drift.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/0fcdde3b-fbf2-4825-87fe-9946cb9e7177



After:


https://github.com/user-attachments/assets/be202381-40fc-4f88-b7fc-8005b52afc51






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified handling of the "Start VM after creation" checkbox across VM creation flows for consistent behavior.
  * Simplified wizard state by removing redundant start-VM state and relying on a run-strategy-driven toggle.

* **Bug Fixes / Behavior**
  * Clone and template-based VM creation now derive and apply a sensible default run strategy so the start-after-creation toggle reflects actual VM intent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->