### PR TITLE
CNV-85419: Fix create vm wizard to reset upon closing

### DIFF
--- a/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
+++ b/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 
 import { FLAG_LIGHTSPEED_PLUGIN } from '@kubevirt-utils/flags/consts';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { clearCustomizeInstanceType, vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
+import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import { getValidNamespace, isEmpty } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { useActiveNamespace, useFlag } from '@openshift-console/dynamic-plugin-sdk';
@@ -55,8 +55,6 @@ const VMCreationWizard: FC = () => {
 
   useEffect(() => {
     if (!hasInitialized.current) {
-      // clear any previous state
-      clearCustomizeInstanceType();
       resetWizardState();
       setTemplatesDrawerIsOpen(false);
 

--- a/src/views/virtualmachines/creation-wizard/hooks/useCloseWizard.ts
+++ b/src/views/virtualmachines/creation-wizard/hooks/useCloseWizard.ts
@@ -1,6 +1,5 @@
 import { useNavigate, useParams } from 'react-router';
 
-import { clearCustomizeInstanceType } from '@kubevirt-utils/store/customizeInstanceType';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { getVMListURL } from '@multicluster/urls';
 import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
@@ -16,7 +15,6 @@ const useCloseWizard: UseCloseWizard = () => {
 
   const closeWizard = () => {
     resetWizardState();
-    clearCustomizeInstanceType();
     navigate(vmListURL);
   };
 

--- a/src/views/virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore.ts
+++ b/src/views/virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore.ts
@@ -38,6 +38,7 @@ const useInstanceTypeVMStore = create<InstanceTypeVMStore>()((set) => {
           draftState.selectedSize = size;
         }),
       ),
+    resetInstanceTypeVMState: () => set({ ...initialInstanceTypeVMState }),
     setDVSource: (dvSource: V1beta1DataVolume) =>
       set({
         dvSource,

--- a/src/views/virtualmachines/creation-wizard/state/instance-type-vm-store/utils/types.ts
+++ b/src/views/virtualmachines/creation-wizard/state/instance-type-vm-store/utils/types.ts
@@ -26,6 +26,7 @@ export type InstanceTypeVMActions = {
     volumeSnapshotSource: VolumeSnapshotKind,
     dvSource: V1beta1DataVolume,
   ) => void;
+  resetInstanceTypeVMState: () => void;
   setDVSource: (dvSource: V1beta1DataVolume) => void;
   setOperatingSystemType: (osType: OperatingSystemType) => void;
   setPreference: (preference: string) => void;

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 
 import { Template } from '@kubevirt-utils/resources/template';
+import { clearCustomizeInstanceType } from '@kubevirt-utils/store/customizeInstanceType';
+import useInstanceTypeVMStore from '@virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore';
 import { initialVMWizardState } from '@virtualmachines/creation-wizard/state/vm-wizard-store/utils/state';
 import { VMWizardStore } from '@virtualmachines/creation-wizard/state/vm-wizard-store/utils/types';
 import { VMCreationMethod } from '@virtualmachines/creation-wizard/utils/constants';
@@ -8,7 +10,11 @@ import { VMCreationMethod } from '@virtualmachines/creation-wizard/utils/constan
 const useVMWizardStore = create<VMWizardStore>()((set) => {
   return {
     ...initialVMWizardState,
-    resetWizardState: () => set({ ...initialVMWizardState }),
+    resetWizardState: () => {
+      clearCustomizeInstanceType();
+      useInstanceTypeVMStore.getState().resetInstanceTypeVMState();
+      set({ ...initialVMWizardState });
+    },
     setCloneVMDescription: (cloneVMDescription: string) => set({ cloneVMDescription }),
     setCloneVMName: (cloneVMName: string) => set({ cloneVMName }),
     setCluster: (cluster: string) => set({ cluster }),


### PR DESCRIPTION

## 📝 Description
The `useInstanceTypeVMStore` (holding `operatingSystemType` and preference) was never cleared when the VM creation wizard was initialized or closed, causing the Guest OS selection to persist across wizard sessions.

Added a `resetInstanceTypeVMState` action to `useInstanceTypeVMStore` and call it both on wizard mount and on wizard close/cancel, ensuring the Guest OS step always starts fresh.


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/f336f331-213c-439d-ab57-b5f765e054a0


After:

https://github.com/user-attachments/assets/72ac1e9d-7ba0-4045-8a38-3cd3b3df1b7d




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VM Creation Wizard now reliably resets to default settings when starting or closing a session, ensuring previous customization choices do not persist and preventing stale data from appearing between uses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->