### PR TITLE
CNV-85192: Fix vm name display to load immediatly with badge

### DIFF
--- a/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
@@ -56,7 +56,7 @@ const VirtualMachineNavPage: FC = () => {
       <SidebarEditorProvider>
         <div className="VirtualMachineNavPage">
           <DocumentTitle>
-            {getResourceDetailsTitle(getName(vmToShow), 'VirtualMachine')}
+            {getResourceDetailsTitle(getName(vmToShow) || name, 'VirtualMachine')}
           </DocumentTitle>
 
           <VirtualMachineNavPageTitle

--- a/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { useLocation } from 'react-router';
+import { useLocation, useParams } from 'react-router';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DetailsPageTitle from '@kubevirt-utils/components/DetailsPageTitle/DetailsPageTitle';
@@ -37,9 +37,10 @@ const VirtualMachineNavPageTitle: FC<VirtualMachineNavPageTitleProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const location = useLocation();
+  const params = useParams<{ name: string; ns: string }>();
 
-  const name = getName(vm);
-  const namespace = getNamespace(vm);
+  const name = getName(vm) ?? params.name;
+  const namespace = getNamespace(vm) ?? params.ns;
   const cluster = useClusterParam();
 
   const { vmi } = useVMI(name, namespace, cluster, isRunning(vm));


### PR DESCRIPTION

## 📝 Description

The VM name was missing from the title while the resource loaded, even though it's already in the URL. Pass `name/namespace` from URL params as a fallback so the heading renders immediately. Status and actions still wait for the full resource.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/1140b171-dcad-47d2-ae23-1debb0c758a7


After:


https://github.com/user-attachments/assets/b37c9741-5e97-41ba-a7c5-b6659361a003



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Virtual Machine details page title stability: when VM data is missing or incomplete, the page now falls back to URL parameters (name and namespace) so a meaningful title is shown consistently during load or error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->