### PR TITLE
CNV-85193: Fix NaN display in affinity rules weight input

### DIFF
--- a/src/utils/components/AffinityModal/components/AffinityEditModal/AffinityForm/components/PreferredAffinityWeightInput.tsx
+++ b/src/utils/components/AffinityModal/components/AffinityEditModal/AffinityForm/components/PreferredAffinityWeightInput.tsx
@@ -1,8 +1,9 @@
 import React, { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
 
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
+import NumberTextInput from '@kubevirt-utils/components/NumberTextInput/NumberTextInput';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
+import { FormGroup, ValidatedOptions } from '@patternfly/react-core';
 
 import { AffinityRowData } from '../../../../utils/types';
 
@@ -18,31 +19,25 @@ const PreferredAffinityWeightInput: FC<PreferredAffinityWeightInputProps> = ({
   setSubmitDisabled,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [validated, setValidated] = useState<ValidatedOptions>(ValidatedOptions.default);
+  const [isTouched, setIsTouched] = useState(false);
   const { weight } = focusedAffinity || {};
 
-  const onChange = (value: string) => {
-    setFocusedAffinity({ ...focusedAffinity, weight: +value });
+  const isValid = weight >= 1 && weight <= 100;
+
+  const onChange = (value: number) => {
+    setIsTouched(true);
+    setFocusedAffinity({ ...focusedAffinity, weight: value });
   };
 
   useEffect(() => {
-    if (!weight || weight < 1 || weight > 100) {
-      setValidated(ValidatedOptions.error);
-      setSubmitDisabled(true);
-    } else {
-      setValidated(ValidatedOptions.default);
-      setSubmitDisabled(false);
-    }
-  }, [weight, setSubmitDisabled]);
+    setSubmitDisabled(!isValid);
+  }, [isValid, setSubmitDisabled]);
+
+  const validated = isTouched && !isValid ? ValidatedOptions.error : ValidatedOptions.default;
 
   return (
     <FormGroup fieldId="weight" isRequired label={t('Weight')}>
-      <TextInput
-        onChange={(_event, value: string) => onChange(value)}
-        type="text"
-        validated={validated}
-        value={weight}
-      />
+      <NumberTextInput setValue={onChange} validated={validated} value={weight} />
       <FormGroupHelperText validated={validated}>
         {t('Weight must be a number between 1-100')}
       </FormGroupHelperText>


### PR DESCRIPTION
## Description
- Replace `TextInput` with a `NumberTextInput` component in the affinity rules weight input to prevent `NaN` from appearing when non-numeric characters are typed
- Don't show validation error initially when the input is empty (until the user interacts with the field)


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/03ec4faa-34b4-4460-8d46-383e5bccff03



After:

https://github.com/user-attachments/assets/7b951072-ed65-4b7a-b67b-453829c10680



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric input validation for affinity weight fields. Validation errors now display only after user interaction, and the submit button behavior is more responsive to input validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->