### PR TITLE
[release-4.21] CNV-84694: Fleet VM create button uses managed cluster RBAC

### DIFF
--- a/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
-import { VirtualMachineModelRef } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { VirtualMachineModel, VirtualMachineModelRef } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getVMListPath } from '@kubevirt-utils/resources/vm';
@@ -9,7 +9,7 @@ import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { getACMVMListURL, getCatalogURL } from '@multicluster/urls';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { ListPageCreateDropdown } from '@openshift-console/dynamic-plugin-sdk';
-import { useHubClusterName } from '@stolostron/multicluster-sdk';
+import { useFleetAccessReview, useHubClusterName } from '@stolostron/multicluster-sdk';
 
 type VirtualMachinesCreateButtonProps = {
   buttonText?: string;
@@ -27,6 +27,14 @@ const VirtualMachinesCreateButton: FC<VirtualMachinesCreateButtonProps> = ({
   const clusterParam = useClusterParam();
   const cluster = clusterParam || hubClusterName;
   const selectedNamespace = namespace || DEFAULT_NAMESPACE;
+
+  const [canCreateVM] = useFleetAccessReview({
+    cluster,
+    group: VirtualMachineModel.apiGroup,
+    namespace: selectedNamespace,
+    resource: VirtualMachineModel.plural,
+    verb: 'create',
+  });
 
   const createItems = {
     instanceType: t('From InstanceType'),
@@ -58,9 +66,13 @@ const VirtualMachinesCreateButton: FC<VirtualMachinesCreateButtonProps> = ({
     [catalogURL, navigate, namespace, cluster],
   );
 
+  if (isACMPage && !canCreateVM) return null;
+
   return (
     <ListPageCreateDropdown
-      createAccessReview={{ groupVersionKind: VirtualMachineModelRef, namespace }}
+      createAccessReview={
+        !isACMPage ? { groupVersionKind: VirtualMachineModelRef, namespace } : undefined
+      }
       items={createItems}
       onClick={onCreate}
     >


### PR DESCRIPTION
## Jira

https://issues.redhat.com/browse/CNV-84694

## Problem

On fleet virtualization, the Create VirtualMachine button used `ListPageCreateDropdown`'s `createAccessReview` prop, which evaluates permissions on the ACM hub (local-cluster) instead of the selected managed cluster.

## Solution

Add `useFleetAccessReview` with the same `cluster` from `useClusterParam`/`useHubClusterName` that is already used for wizard and YAML URLs, so subject access review runs against the correct cluster. The button is hidden on ACM pages when the user lacks create permission on the managed cluster.

## Changes

* `VirtualMachinesCreateButton.tsx`: add `useFleetAccessReview` with `cluster` to guard the button on ACM pages; remove `createAccessReview` prop on ACM pages since the fleet hook already handles it.

Backport of #3807 to release-4.21. Manual conflict resolution was required due to structural differences in the component between `main` and `release-4.21`.

Made with [Cursor](https://cursor.com)