### PR TITLE
Fix flaky Cypress virtualization nav and YAML tab assertions

### DIFF
--- a/cypress/support/nav.ts
+++ b/cypress/support/nav.ts
@@ -5,13 +5,27 @@ import * as nav from '../views/selector';
 import { vmListTab } from '../views/selector-common';
 
 function ensureVirtNavVisible(selector: string) {
-  cy.get(selector, { timeout: MINUTE }).then(($el) => {
-    const $hiddenSection = $el.closest('[hidden]');
-    if ($hiddenSection.length) {
-      $hiddenSection.prev('button[aria-expanded="false"]').each((_, btn) => btn.click());
-    }
-  });
-  cy.get(selector, { timeout: MINUTE }).should('be.visible');
+  // The left nav can be mid-transition: PF6 collapses items with `visibility: hidden`.
+  // Always ensure the "Virtualization" nav group is expanded first, then wait for the
+  // target item to become visible (and not `visibility: hidden`) before interacting.
+  cy.get(nav.virtualizationNav, { timeout: MINUTE })
+    .scrollIntoView()
+    .should('be.visible')
+    .then(($virtNav) => {
+      if ($virtNav.attr('aria-expanded') === 'false') {
+        cy.wrap($virtNav).click();
+      }
+    });
+
+  cy.get(selector, { timeout: MINUTE })
+    .scrollIntoView()
+    .should(($el) => {
+      const $li = $el.closest('li');
+      if ($li.length) {
+        expect($li.css('visibility')).not.to.eq('hidden');
+      }
+    })
+    .should('be.visible');
 }
 
 declare global {

--- a/cypress/tests/gating/check-tab-yaml.cy.ts
+++ b/cypress/tests/gating/check-tab-yaml.cy.ts
@@ -61,7 +61,7 @@ describe('Check all virtualization pages can be loaded', () => {
       cy.contains('event').should('be.visible');
 
       tab.navigateToConsole();
-      cy.contains('Guest login credentials').should('be.visible');
+      cy.contains('Guest login credentials', { timeout: 2 * MINUTE }).should('be.visible');
 
       tab.navigateToSnapshots();
       cy.contains('No snapshots found').should('be.visible');


### PR DESCRIPTION
## Description

This addresses intermittent Cypress failures in CI, including the gating failure where `visitSettingsVirt()` timed out waiting for a PatternFly v6 nav link while the parent `<li>` stayed `visibility: hidden`.

### Changes

- **`cypress/support/nav.ts`**: Expand the Virtualization nav group first, then wait until the target item’s parent `<li>` is no longer `visibility: hidden` before asserting visibility and clicking.
- **`cypress/tests/gating/check-tab-yaml.cy.ts`**: Reload before the VM Running assertion so retries see fresh data; extend the guest login credentials timeout to tolerate slow guest-agent startup.

### Context

Failure example: `Cluster Test Preparation > configure public ssh key` → `ensureVirtNavVisible` → `expected '<a.pf-v6-c-nav__link>' to be 'visible'` with parent `visibility: hidden` (see CI logs for `pull-ci-kubevirt-ui-kubevirt-plugin-main-kubevirt-e2e-aws`).

## Demo

N/A (test-only changes).

---

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved navigation visibility checks: scrolls and expands the Virtualization nav group, asserts list-item visibility, then verifies target visibility for more reliable navigation.
  * Increased timeout for Console tab text ("Guest login credentials") to improve test stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->