### PR TITLE
Fix perspective resetting to "Core platform" by switchProject in cypress

### DIFF
--- a/cypress/support/project.ts
+++ b/cypress/support/project.ts
@@ -1,4 +1,4 @@
-import { ALL_PROJ_NS, TEST_NS } from '../utils/const/index';
+import { ALL_PROJ_NS, SECOND, TEST_NS } from '../utils/const/index';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -33,30 +33,23 @@ Cypress.Commands.add('selectTestProject', () => {
 // Switches project by rewriting the URL namespace segment, preserving the current resource type.
 // Only the first resource path segment is kept (e.g. /k8s/ns/<ns>/<resource>);
 // deeper sub-paths (VM detail pages, tabs) are dropped intentionally.
-Cypress.Commands.add('switchProjectUsingTreeView', (projectName: string) => {
-  cy.url().then((currentUrl) => {
-    const url = new URL(currentUrl);
-    const path = url.pathname;
-    const nsSegment = projectName === ALL_PROJ_NS ? 'all-namespaces' : `ns/${projectName}`;
+const buildProjectPath = (currentUrl: string, projectName: string): string => {
+  const url = new URL(currentUrl);
+  const path = url.pathname;
+  const nsSegment = projectName === ALL_PROJ_NS ? 'all-namespaces' : `ns/${projectName}`;
 
-    let resource: string;
-    if (path.includes('/fleet-virtualization/')) {
-      const match = path.match(/\/fleet-virtualization\/([^/]+)/);
-      resource = match?.[1] ?? 'kubevirt.io~v1~VirtualMachine';
-    } else {
-      // Standard pattern: /k8s/ns/<ns>/<resource>/... or /k8s/all-namespaces/<resource>/...
-      const match = path.match(/\/k8s\/(?:ns\/[^/]+|all-namespaces)\/([^/]+)/);
-      resource = match?.[1] ?? 'kubevirt.io~v1~VirtualMachine';
-    }
-    const newPath = `/k8s/${nsSegment}/${resource}`;
+  let resource: string;
+  if (path.includes('/fleet-virtualization/')) {
+    const match = path.match(/\/fleet-virtualization\/([^/]+)/);
+    resource = match?.[1] ?? 'kubevirt.io~v1~VirtualMachine';
+  } else {
+    // Standard pattern: /k8s/ns/<ns>/<resource>/... or /k8s/all-namespaces/<resource>/...
+    const match = path.match(/\/k8s\/(?:ns\/[^/]+|all-namespaces)\/([^/]+)/);
+    resource = match?.[1] ?? 'kubevirt.io~v1~VirtualMachine';
+  }
 
-    cy.visit(newPath + url.search + url.hash, {
-      onBeforeLoad(win) {
-        win.localStorage.setItem('showEmptyProjects', 'show');
-      },
-    });
-  });
-});
+  return `/k8s/${nsSegment}/${resource}${url.search}${url.hash}`;
+};
 
 Cypress.Commands.add('switchProject', (projectName: string) => {
   if (projectName == null || (typeof projectName === 'string' && !projectName.trim())) {
@@ -65,5 +58,18 @@ Cypress.Commands.add('switchProject', (projectName: string) => {
     );
   }
   const name = typeof projectName === 'string' ? projectName : String(projectName);
-  cy.switchProjectUsingTreeView(name);
+
+  cy.url().then((currentUrl) => {
+    const newPath = buildProjectPath(currentUrl, name);
+
+    // Uses client-side navigation (pushState + popstate) so the SPA
+    // re-renders without a full page reload, preserving the active perspective.
+    cy.window().then((win) => {
+      win.localStorage.setItem('showEmptyProjects', 'show');
+      win.history.pushState(null, '', newPath);
+      win.dispatchEvent(new PopStateEvent('popstate'));
+    });
+
+    cy.wait(2 * SECOND);
+  });
 });


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes perspective resetting to "Core platform" by `switchProject` in cypress.

Fixed by not using `cy.visit` causing a full page reload - removing the perspective information

## 🎥 Demo

Bug:

https://github.com/user-attachments/assets/791da1b2-b519-4727-a75c-85031c1235d7




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized test infrastructure by refactoring project switching logic to improve test execution efficiency.
  * Removed deprecated test command in favor of streamlined project switching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->