### PR TITLE
CNV-85812: CNV-85822: Fix VM name validation and Tab requirement in creation wizard

### DIFF
--- a/src/utils/components/CloneVMModal/CloneVMModal.tsx
+++ b/src/utils/components/CloneVMModal/CloneVMModal.tsx
@@ -41,7 +41,7 @@ const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, sour
     truncateToK8sName(isVM(source) ? `${name}-clone` : name),
   );
 
-  const [vmNameConfirmed, setVmNameConfirmed] = useState(false);
+  const [isVMNameValid, setIsVMNameValid] = useState(false);
 
   const [cloneDescription, setCloneDescription] = useState('');
 
@@ -82,7 +82,7 @@ const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, sour
     <TabModal
       closeOnSubmit={false}
       headerText={headerText ?? t('Clone {{sourceKind}}', { sourceKind: source.kind })}
-      isDisabled={Boolean(initialCloneRequest) || !vmNameConfirmed}
+      isDisabled={Boolean(initialCloneRequest) || !isVMNameValid}
       isHorizontal
       isLoading={Boolean(initialCloneRequest)}
       isOpen={isOpen}
@@ -93,12 +93,7 @@ const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, sour
       shouldWrapInForm
       submitBtnText={isVM(source) ? t('Clone') : t('Create')}
     >
-      <NameInput
-        autoFocus
-        name={cloneName}
-        onConfirm={() => setVmNameConfirmed(true)}
-        setName={onNameChange}
-      />
+      <NameInput autoFocus name={cloneName} setIsValid={setIsVMNameValid} setName={onNameChange} />
       <DescriptionInput
         placeholder={
           isVM(source)

--- a/src/utils/components/CloneVMModal/components/NameInput.tsx
+++ b/src/utils/components/CloneVMModal/components/NameInput.tsx
@@ -3,15 +3,16 @@ import { Trans } from 'react-i18next';
 
 import TabToConfirmTextInput from '@kubevirt-utils/components/TabToConfirmTextInput/TabToConfirmTextInput';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getDNS1123LabelError } from '@kubevirt-utils/utils/validation';
 
 type NameInputProps = {
   autoFocus?: boolean;
   name: string;
-  onConfirm: () => void;
+  setIsValid: (valid: boolean) => void;
   setName: Dispatch<SetStateAction<string>>;
 };
 
-const NameInput: FC<NameInputProps> = ({ autoFocus, name, onConfirm, setName }) => {
+const NameInput: FC<NameInputProps> = ({ autoFocus, name, setIsValid, setName }) => {
   const { t } = useKubevirtTranslation();
   return (
     <TabToConfirmTextInput
@@ -26,7 +27,8 @@ const NameInput: FC<NameInputProps> = ({ autoFocus, name, onConfirm, setName }) 
       isRequired
       label={t('Name')}
       onChange={setName}
-      onConfirm={onConfirm}
+      setIsValid={setIsValid}
+      validator={getDNS1123LabelError}
       value={name}
     />
   );

--- a/src/utils/components/TabToConfirmTextInput/TabToConfirmTextInput.tsx
+++ b/src/utils/components/TabToConfirmTextInput/TabToConfirmTextInput.tsx
@@ -1,4 +1,5 @@
 import React, { FC, FormEvent, KeyboardEvent, ReactNode, useEffect, useRef, useState } from 'react';
+import { TFunction } from 'i18next';
 
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import { TAB } from '@kubevirt-utils/hooks/useClickOutside/constants';
@@ -10,34 +11,55 @@ import './TabToConfirmTextInput.scss';
 type TabToConfirmTextInputProps = {
   autoFocus?: boolean;
   className?: string;
+  defaultInteracted?: boolean;
   fieldId: string;
   helperText?: ReactNode;
   isRequired?: boolean;
   label?: string;
   onChange?: (value: string) => void;
-  onConfirm: () => void;
   placeholder?: string;
-  validated?: ValidatedOptions;
+  setIsValid: (valid: boolean) => void;
+  validator?: (value: string) => (t: TFunction) => string;
   value?: string;
 };
 
 const TabToConfirmTextInput: FC<TabToConfirmTextInputProps> = ({
   autoFocus = false,
   className,
+  defaultInteracted = false,
   fieldId,
   helperText,
   isRequired = false,
   label,
   onChange,
-  onConfirm,
   placeholder,
-  validated = ValidatedOptions.default,
+  setIsValid,
+  validator,
   value = '',
 }) => {
   const { t } = useKubevirtTranslation();
   const [isFocused, setIsFocused] = useState<boolean>(false);
-  const [isConfirmed, setIsConfirmed] = useState<boolean>(false);
+  const [hasInteracted, setHasInteracted] = useState<boolean>(defaultInteracted);
+  const [errorText, setErrorText] = useState<string>();
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const validate = (nameValue: string): void => {
+    if (validator) {
+      const error = validator(nameValue);
+      if (error) {
+        setErrorText(error(t));
+        setIsValid(false);
+        return;
+      }
+    }
+    setErrorText(undefined);
+    setIsValid(true);
+  };
+
+  useEffect(() => {
+    if (defaultInteracted) validate(value);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     if (!autoFocus || !inputRef.current) return;
@@ -73,10 +95,10 @@ const TabToConfirmTextInput: FC<TabToConfirmTextInputProps> = ({
   }, [autoFocus]);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
-    if (event.key === TAB && isFocused && !isConfirmed) {
+    if (event.key === TAB && isFocused && !hasInteracted) {
       event.preventDefault();
-      setIsConfirmed(true);
-      onConfirm();
+      setHasInteracted(true);
+      validate(value);
     }
   };
 
@@ -89,7 +111,9 @@ const TabToConfirmTextInput: FC<TabToConfirmTextInputProps> = ({
   };
 
   const handleChange = (_event: FormEvent<HTMLInputElement>, newValue: string): void => {
+    if (!hasInteracted) setHasInteracted(true);
     onChange?.(newValue);
+    validate(newValue);
   };
 
   return (
@@ -105,16 +129,19 @@ const TabToConfirmTextInput: FC<TabToConfirmTextInputProps> = ({
           placeholder={placeholder}
           ref={inputRef}
           type="text"
-          validated={validated}
+          validated={errorText ? ValidatedOptions.error : ValidatedOptions.default}
           value={value}
         />
-        {isFocused && !isConfirmed && (
+        {isFocused && !hasInteracted && (
           <Label className="tab-to-confirm-text-input__badge" isCompact>
             {t('Tab')}
           </Label>
         )}
       </div>
-      {helperText && <FormGroupHelperText validated={validated}>{helperText}</FormGroupHelperText>}
+      {!hasInteracted && helperText && <FormGroupHelperText>{helperText}</FormGroupHelperText>}
+      {errorText && (
+        <FormGroupHelperText validated={ValidatedOptions.error}>{errorText}</FormGroupHelperText>
+      )}
     </FormGroup>
   );
 };

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore.ts
@@ -20,12 +20,13 @@ const useVMWizardStore = create<VMWizardStore>()((set) => {
     setCluster: (cluster: string) => set({ cluster }),
     setCreationMethod: (creationMethod: VMCreationMethod) => set({ creationMethod }),
     setFolder: (folder: string) => set({ folder }),
+    setIsVMNameValid: (isVMNameValid: boolean) => set({ isVMNameValid }),
     setProject: (project: string) => set({ project }),
     setSelectedTemplate: (selectedTemplate: Template) => set(() => ({ selectedTemplate })),
     setStartVM: (startVM: boolean) => set({ startVM }),
     setTemplatesDrawerIsOpen: (templatesDrawerIsOpen: boolean) =>
       set(() => ({ templatesDrawerIsOpen })),
-    setVMNameConfirmed: (vmNameConfirmed: boolean) => set({ vmNameConfirmed }),
+    setVMNameInteracted: (vmNameInteracted: boolean) => set({ vmNameInteracted }),
   };
 });
 

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/state.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/state.ts
@@ -7,9 +7,10 @@ export const initialVMWizardState: VMWizardState = {
   cluster: '',
   creationMethod: VMCreationMethod.INSTANCE_TYPE,
   folder: '',
+  isVMNameValid: false,
   project: '',
   selectedTemplate: null,
   startVM: false,
   templatesDrawerIsOpen: false,
-  vmNameConfirmed: false,
+  vmNameInteracted: false,
 };

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/types.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/types.ts
@@ -7,11 +7,12 @@ export type VMWizardState = {
   cluster: string;
   creationMethod: VMCreationMethod;
   folder: string;
+  isVMNameValid: boolean;
   project: string;
   selectedTemplate: Template;
   startVM: boolean;
   templatesDrawerIsOpen: boolean;
-  vmNameConfirmed: boolean;
+  vmNameInteracted: boolean;
 };
 
 export type VMWizardActions = {
@@ -21,11 +22,12 @@ export type VMWizardActions = {
   setCluster: (cluster: string) => void;
   setCreationMethod: (creationMethod: VMCreationMethod) => void;
   setFolder: (folder: string) => void;
+  setIsVMNameValid: (isVMNameValid: boolean) => void;
   setProject: (project: string) => void;
   setSelectedTemplate: (template: Template) => void;
   setStartVM: (startVM: boolean) => void;
   setTemplatesDrawerIsOpen: (templatesDrawerIsOpen: boolean) => void;
-  setVMNameConfirmed: (vmNameConfirmed: boolean) => void;
+  setVMNameInteracted: (vmNameInteracted: boolean) => void;
 };
 
 export type VMWizardStore = VMWizardState & VMWizardActions;

--- a/src/views/virtualmachines/creation-wizard/steps/ReviewAndCreateStep/components/NameAndDescriptionForm.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/ReviewAndCreateStep/components/NameAndDescriptionForm.tsx
@@ -1,11 +1,12 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 import { Trans } from 'react-i18next';
 
 import TabToConfirmTextInput from '@kubevirt-utils/components/TabToConfirmTextInput/TabToConfirmTextInput';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getDescription, getName } from '@kubevirt-utils/resources/shared';
 import { updateCustomizeInstanceType, vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
-import { Form, FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
+import { getDNS1123LabelError } from '@kubevirt-utils/utils/validation';
+import { Form, FormGroup, TextInput } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
 import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
 import { isCloneCreationMethod } from '@virtualmachines/creation-wizard/utils/utils';
@@ -20,22 +21,23 @@ const NameAndDescriptionForm: FC = () => {
     creationMethod,
     setCloneVMDescription,
     setCloneVMName,
-    setVMNameConfirmed,
+    setIsVMNameValid,
+    setVMNameInteracted,
+    vmNameInteracted,
   } = useVMWizardStore();
   const isCloneMethod = isCloneCreationMethod(creationMethod);
 
-  const [nameValidated, setNameValidated] = useState<ValidatedOptions>(ValidatedOptions.default);
-  const [descriptionValidated, setDescriptionValidated] = useState<ValidatedOptions>(
-    ValidatedOptions.default,
-  );
   useSignals();
   const vm = vmSignal.value;
+
+  const handleSetIsValid = (valid: boolean) => {
+    setIsVMNameValid(valid);
+    if (!vmNameInteracted) setVMNameInteracted(true);
+  };
 
   const onNameChange = (name: string) => {
     if (isCloneMethod) setCloneVMName(name);
     else updateCustomizeInstanceType([{ data: name, path: 'metadata.name' }]);
-
-    setNameValidated(ValidatedOptions.success);
   };
 
   const onDescriptionChange = (description: string) => {
@@ -44,8 +46,6 @@ const NameAndDescriptionForm: FC = () => {
       updateCustomizeInstanceType([
         { data: description, path: 'metadata.annotations.description' },
       ]);
-
-    setDescriptionValidated(ValidatedOptions.success);
   };
 
   return (
@@ -58,19 +58,19 @@ const NameAndDescriptionForm: FC = () => {
         }
         autoFocus
         className="name-and-description-form__input"
+        defaultInteracted={vmNameInteracted}
         fieldId="vm name"
         isRequired
         label={t('Name')}
         onChange={onNameChange}
-        onConfirm={() => setVMNameConfirmed(true)}
-        validated={nameValidated}
+        setIsValid={handleSetIsValid}
+        validator={getDNS1123LabelError}
         value={isCloneMethod ? cloneVMName : getName(vm)}
       />
       <FormGroup className="name-and-description-form__input" label={t('Description')}>
         <TextInput
           onChange={(_event, value: string) => onDescriptionChange(value)}
           type="text"
-          validated={descriptionValidated}
           value={isCloneMethod ? cloneVMDescription : getDescription(vm)}
         />
       </FormGroup>

--- a/src/views/virtualmachines/creation-wizard/steps/ReviewAndCreateStep/components/ReviewAndCreateStepFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/ReviewAndCreateStep/components/ReviewAndCreateStepFooter.tsx
@@ -13,7 +13,7 @@ import { isCloneCreationMethod } from '@virtualmachines/creation-wizard/utils/ut
 const ReviewAndCreateStepFooter: FC = () => {
   const hasOLSConsole = useFlag(FLAG_LIGHTSPEED_PLUGIN);
   const { activeStep, goToPrevStep } = useWizardContext();
-  const { creationMethod, vmNameConfirmed } = useVMWizardStore();
+  const { creationMethod, isVMNameValid } = useVMWizardStore();
   const isCloneMethod = isCloneCreationMethod(creationMethod);
   const createVM = useCreateVM();
   const closeWizard = useCloseWizard();
@@ -22,7 +22,7 @@ const ReviewAndCreateStepFooter: FC = () => {
     <WizardFooter
       activeStep={activeStep}
       cancelButtonProps={{ className: classnames({ 'pf-v6-u-mr-4xl': hasOLSConsole }) }}
-      isNextDisabled={!vmNameConfirmed}
+      isNextDisabled={!isVMNameValid}
       nextButtonText={isCloneMethod ? t('Clone VirtualMachine') : t('Create VirtualMachine')}
       onBack={goToPrevStep}
       onClose={closeWizard}


### PR DESCRIPTION
## Summary

- **[CNV-85812](https://redhat.atlassian.net/browse/CNV-85812)**: Remove the mandatory Tab press when the user manually types a custom VM name. Typing a valid name now enables the Create button immediately; Tab remains as a shortcut to accept the auto-generated suggestion.
- **[CNV-85822](https://redhat.atlassian.net/browse/CNV-85822)**: Add RFC 1123 validation to the VM name input. Invalid names (uppercase, special characters, too long, empty) show an inline error message and disable the Create button. Previously no validation error was shown and the button silently failed.
- Helper text (Press Tab to accept...) is now shown only before first interaction with the field, then replaced by validation feedback.

Fixes: https://issues.redhat.com/browse/CNV-85812, https://issues.redhat.com/browse/CNV-85822

## Test plan

- [ ] Create a VM via the wizard, reach the Review step
- [ ] Verify the helper text shows initially
- [ ] Type a valid custom name - helper text disappears, Create button enables without pressing Tab
- [ ] Type an invalid name (e.g. uppercase, special chars) - error message appears, Create button is disabled
- [ ] Clear the name field - Name is required error appears
- [ ] Press Tab on the auto-generated name - name is confirmed, Create button enables
- [ ] Clone VM flow: same validation behavior applies

Made with [Cursor](https://cursor.com)

# Demo:

After:

https://github.com/user-attachments/assets/7a9d3114-51bb-4493-b944-531f2910d59b




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inputs now manage interaction and validation internally, including TAB-to-confirm behavior.
  * Validation callbacks report validity to the surrounding flow to enable/disable actions.
  * Helper text and a “Tab” badge are shown only before user interaction; errors display after interaction.

* **Bug Fixes**
  * Name validation tightened (DNS‑1123) with clearer error messaging.
  * Submission and navigation controls now reliably prevent invalid names from proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->