### PR TITLE
CNV-85661: Services Pod Selector Link Breaks Fleet Context

### DIFF
--- a/src/multicluster/urls.ts
+++ b/src/multicluster/urls.ts
@@ -123,6 +123,11 @@ export const getVMListNamespacesURL = (cluster: string, namespace: string): stri
         model: VirtualMachineModel,
       });
 
+export const getACMTextSearchURL = (textSearch: string): string => {
+  const encodedTextFilter = encodeURIComponent(textSearch);
+  return `/multicloud/search?filters={"textsearch":"${encodedTextFilter}"}`;
+};
+
 export const getMulticlusterSearchURL = (
   model: K8sModel,
   name: string,

--- a/src/utils/components/Labels/utils.ts
+++ b/src/utils/components/Labels/utils.ts
@@ -1,3 +1,5 @@
+import { getACMTextSearchURL } from '@multicluster/urls';
+
 export const getSearchLabelHREF = (
   kind: string,
   labelKey: string,
@@ -5,10 +7,7 @@ export const getSearchLabelHREF = (
   cluster?: string,
 ) => {
   if (cluster) {
-    const encodedTextFilter = encodeURIComponent(
-      `cluster:${cluster} kind:${kind} label:${labelKey}=${labelValue}`,
-    );
-    return `/multicloud/search?filters={"textsearch":"${encodedTextFilter}"}`;
+    return getACMTextSearchURL(`cluster:${cluster} kind:${kind} label:${labelKey}=${labelValue}`);
   }
 
   return `/search?kind=${kind}&q=${encodeURIComponent(`${labelKey}=${labelValue}`)}`;

--- a/src/utils/components/ServicesList/Selector/Selector.tsx
+++ b/src/utils/components/ServicesList/Selector/Selector.tsx
@@ -3,31 +3,41 @@ import { Link } from 'react-router';
 import { isEmpty } from 'lodash';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useIsACMPage from '@multicluster/useIsACMPage';
 import { Selector as SelectorKind } from '@openshift-console/dynamic-plugin-sdk';
 import { SearchIcon } from '@patternfly/react-icons';
+import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
-import { selectorToString } from './utils';
+import { getSelectorSearchURL, selectorToString } from './utils';
 
 type RequirementProps = {
+  cluster?: string;
   kind: string;
   namespace?: string;
   requirements: SelectorKind;
 };
 
 type SelectorProps = {
+  cluster?: string;
   kind?: string;
   namespace?: string;
   selector: SelectorKind;
 };
 
-const Requirement: FC<RequirementProps> = ({ kind, namespace = '', requirements }) => {
+const Requirement: FC<RequirementProps> = ({ cluster, kind, namespace = '', requirements }) => {
+  const isACMPage = useIsACMPage({ activePerspectiveSync: false });
+  const [hubClusterName] = useHubClusterName();
   // Strip off any trailing '=' characters for valueless selectors
   const requirementAsString = selectorToString(requirements).replace(/=,/g, ',').replace(/=$/g, '');
-  const requirementAsUrlEncodedString = encodeURIComponent(requirementAsString);
 
-  const to = namespace
-    ? `/search/ns/${namespace}?kind=${kind}&q=${requirementAsUrlEncodedString}`
-    : `/search/all-namespaces?kind=${kind}&q=${requirementAsUrlEncodedString}`;
+  const to = getSelectorSearchURL(
+    requirementAsString,
+    kind,
+    namespace,
+    isACMPage,
+    cluster,
+    hubClusterName,
+  );
 
   return (
     <div className="co-m-requirement">
@@ -40,6 +50,7 @@ const Requirement: FC<RequirementProps> = ({ kind, namespace = '', requirements 
 };
 
 export const Selector: FC<SelectorProps> = ({
+  cluster = undefined,
   kind = 'Pod',
   namespace = undefined,
   selector = {},
@@ -50,7 +61,7 @@ export const Selector: FC<SelectorProps> = ({
       {isEmpty(selector) ? (
         <p className="pf-v6-u-text-color-subtle">{t('No selector')}</p>
       ) : (
-        <Requirement kind={kind} namespace={namespace} requirements={selector} />
+        <Requirement cluster={cluster} kind={kind} namespace={namespace} requirements={selector} />
       )}
     </div>
   );

--- a/src/utils/components/ServicesList/Selector/utils.ts
+++ b/src/utils/components/ServicesList/Selector/utils.ts
@@ -1,3 +1,5 @@
+import { ALL_CLUSTERS_KEY } from '@kubevirt-utils/hooks/constants';
+import { getACMTextSearchURL } from '@multicluster/urls';
 import { MatchExpression, Operator, Selector } from '@openshift-console/dynamic-plugin-sdk';
 
 const toArray = (value) => (Array.isArray(value) ? value : [value]);
@@ -41,4 +43,31 @@ export const toRequirements = (selector: Selector = {}) => {
 export const selectorToString = (selector: Selector): string => {
   const requirements = toRequirements(selector);
   return requirements.map(requirementToString).join(',');
+};
+
+export const getSelectorSearchURL = (
+  requirementAsString: string,
+  kind: string,
+  namespace: string,
+  isACMPage: boolean,
+  cluster?: string,
+  hubClusterName?: string,
+): string => {
+  if (cluster || isACMPage) {
+    const labelFilters = requirementAsString
+      .split(',')
+      .map((r) => `label:${r.trim()}`)
+      .join(' ');
+    const selectedCluster = cluster || hubClusterName;
+    const clusterPart =
+      selectedCluster && selectedCluster !== ALL_CLUSTERS_KEY ? `cluster:${selectedCluster} ` : '';
+    const namespacePart = namespace ? ` namespace:${namespace}` : '';
+    const textSearch = `${clusterPart}kind:${kind}${namespacePart} ${labelFilters}`;
+    return getACMTextSearchURL(textSearch);
+  }
+
+  const requirementAsUrlEncodedString = encodeURIComponent(requirementAsString);
+  return `/search/ns/${
+    namespace || 'all-namespaces'
+  }?kind=${kind}&q=${requirementAsUrlEncodedString}`;
 };

--- a/src/utils/components/ServicesList/servicesTableDefinition.tsx
+++ b/src/utils/components/ServicesList/servicesTableDefinition.tsx
@@ -58,9 +58,16 @@ const renderLabels = (service: IoK8sApiCoreV1Service): ReactNode => {
   );
 };
 
-const renderSelector = (service: IoK8sApiCoreV1Service): ReactNode => (
-  <Selector namespace={getNamespace(service)} selector={service?.spec?.selector} />
-);
+const renderSelector = (service: IoK8sApiCoreV1Service): ReactNode => {
+  const cluster = getCluster(service);
+  return (
+    <Selector
+      cluster={cluster}
+      namespace={getNamespace(service)}
+      selector={service?.spec?.selector}
+    />
+  );
+};
 
 const renderLocation = (service: IoK8sApiCoreV1Service): ReactNode => (
   <ServiceLocation service={service} />


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-85661](https://redhat.atlassian.net/browse/CNV-85661)

Services Pod Selector Link Breaks Fleet Context


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/55a31aaa-d412-4e9a-bab1-4848d1eb2078

After:

https://github.com/user-attachments/assets/dca0f06d-db1b-4bda-b587-690f3a65ca33


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Selector and label search links now use a centralized, cluster-aware URL generation for consistent multi-cluster/ACM behavior.
* **New Features**
  * Selector component accepts an optional cluster context so search links reflect the selected cluster when applicable.
* **Bug Fixes**
  * Search links now correctly include cluster/namespace info, improving search accuracy across clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->