### PR TITLE
CNV-81682: Gate Virtualization nav section behind feature flag

### DIFF
--- a/src/views/navigation/virtualizationSection.ts
+++ b/src/views/navigation/virtualizationSection.ts
@@ -7,6 +7,8 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { EncodedExtension } from '@openshift-console/dynamic-plugin-sdk-webpack';
 
+import { FLAG_KUBEVIRT_VIRTUALIZATION_NAV } from '../../utils/flags/consts';
+
 import { NAV_ID, VIRT_SECTION_ID } from './constants';
 
 // Navigation order:
@@ -25,6 +27,9 @@ import { NAV_ID, VIRT_SECTION_ID } from './constants';
 
 export const extensions: EncodedExtension[] = [
   {
+    flags: {
+      required: [FLAG_KUBEVIRT_VIRTUALIZATION_NAV],
+    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-sec-virtualization',


### PR DESCRIPTION
## 📝 Description

Gate the Virtualization navigation section behind the `FLAG_KUBEVIRT_VIRTUALIZATION_NAV` feature flag.

The flag is controlled by `useVirtualizationNavVisibilityFlag`, which checks whether the user has permission to list `VirtualMachine` resources in at least one namespace. When the HyperConverged operator uses a manual role aggregation strategy, the Virtualization nav section will only be visible to users who have the necessary RBAC access. In all other cases (standard aggregation or HCO unavailable) the flag is set to `true` and the section remains visible.

Related: [CNV-81682](https://issues.redhat.com/browse/CNV-81682)

## 🎥 Demo

Tested with Oren and changing behind the scene the configuration.

This ƒlag was ment to hide the section from the beginning but don't know why didn't land from the start.
It was hiding everything other than the virt section. (virt perspective and fleet virt perspective)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Virtualization navigation section now requires appropriate feature flag permissions for visibility and access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->