### PR TITLE
CNV-85902: fix creating vm for non-priv users

### DIFF
--- a/src/utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag.ts
@@ -33,7 +33,7 @@ const useVMTemplateFeatureFlag = (clusterOverride?: string) => {
   return {
     canEdit: isAdmin,
     featureEnabled,
-    loading: !hcLoaded || !hcConfigLoaded || !hyperConvergeConfiguration,
+    loading: !hcLoaded || !hcConfigLoaded,
     toggleFeature: (isChecked: boolean) => {
       if (!hyperConvergeConfiguration) {
         return Promise.reject(new Error('HyperConverged configuration is not loaded'));

--- a/src/utils/resources/template/hooks/useVMTemplateGeneratedParams.ts
+++ b/src/utils/resources/template/hooks/useVMTemplateGeneratedParams.ts
@@ -15,10 +15,12 @@ import { generateParamsWithPrettyName } from './../utils/helpers';
 
 const useVMTemplateGeneratedParams = (
   template: Template,
+  namespaceOverride?: string,
 ): [template: Template, loading: boolean, error: Error] => {
   const cluster = useClusterParam();
   const [error, setError] = useState<Error>();
-  const { ns: namespace = DEFAULT_NAMESPACE } = useParams<{ ns: string }>();
+  const { ns: nsFromParams = DEFAULT_NAMESPACE } = useParams<{ ns: string }>();
+  const namespace = namespaceOverride || nsFromParams;
   const [templateWithGeneratedValues, setTemplateWithGeneratedValues] = useState<Template>();
   const [loading, setLoading] = useState<boolean>(false);
 

--- a/src/utils/resources/template/hooks/useVmTemplates.ts
+++ b/src/utils/resources/template/hooks/useVmTemplates.ts
@@ -20,20 +20,24 @@ export const useVmTemplates = (namespace?: string, cluster?: string): useVmTempl
   const { allowedTemplates, allowedTemplatesError, allowedTemplatesloaded } =
     useWatchNonAdminTemplates();
 
-  const [allTemplates, allTemplatesLoaded, allTemplatesError] = useK8sWatchData<V1Template[]>({
-    cluster,
-    groupVersionKind: TemplateModelGroupVersionKind,
-    isList: true,
-    selector: {
-      matchExpressions: [
-        {
-          key: TEMPLATE_TYPE_LABEL,
-          operator: Operator.In,
-          values: [TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_VM],
-        },
-      ],
-    },
-  });
+  const [allTemplates, allTemplatesLoaded, allTemplatesError] = useK8sWatchData<V1Template[]>(
+    isAdmin
+      ? {
+          cluster,
+          groupVersionKind: TemplateModelGroupVersionKind,
+          isList: true,
+          selector: {
+            matchExpressions: [
+              {
+                key: TEMPLATE_TYPE_LABEL,
+                operator: Operator.In,
+                values: [TEMPLATE_TYPE_BASE, TEMPLATE_TYPE_VM],
+              },
+            ],
+          },
+        }
+      : null,
+  );
 
   const templates = useMemo(
     () => (isAdmin ? allTemplates : allowedTemplates),

--- a/src/utils/resources/template/hooks/useWatchNonAdminTemplates.ts
+++ b/src/utils/resources/template/hooks/useWatchNonAdminTemplates.ts
@@ -32,10 +32,11 @@ const useWatchNonAdminTemplates = () => {
     namespaced: false,
   });
 
-  const projectNames = projects?.map((proj) => getName(proj));
-  if (projectNames && !projectNames.includes(OPENSHIFT_NAMESPACE)) {
-    projectNames.push(OPENSHIFT_NAMESPACE);
-  }
+  const projectNames = useMemo(() => {
+    const names = new Set(projects?.map((proj) => getName(proj)) ?? []);
+    names.add(OPENSHIFT_NAMESPACE);
+    return [...names];
+  }, [projects]);
 
   // user has limited access, so we can only get templates from allowed namespaces
   const allowedResources = useK8sWatchResources<{ [key: string]: V1Template[] }>(
@@ -74,6 +75,12 @@ const useWatchNonAdminTemplates = () => {
       if (errorKey) {
         setAllowedTemplatesError(allowedResources[errorKey].loadError);
       }
+
+      if (loaded && isEmpty(Object.keys(allowedResources))) {
+        setAllowedTemplatesLoaded(true);
+        return;
+      }
+
       if (
         Object.keys(allowedResources).length > 0 &&
         Object.keys(allowedResources).every((key) => {
@@ -84,7 +91,7 @@ const useWatchNonAdminTemplates = () => {
         setAllowedTemplatesLoaded(true);
       }
     }
-  }, [allowedResources, isAdmin]);
+  }, [allowedResources, isAdmin, loaded]);
 
   return useMemo(
     () => ({

--- a/src/views/templates/list/hooks/useOpenShiftTemplates.ts
+++ b/src/views/templates/list/hooks/useOpenShiftTemplates.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { V1Template } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { OPENSHIFT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import useListClusters from '@kubevirt-utils/hooks/useListClusters';
 import useListMulticlusterFilters from '@kubevirt-utils/hooks/useListMulticlusterFilters';
 import {
@@ -30,6 +31,11 @@ export const useOpenShiftTemplates: UseOpenShiftTemplates = ({
   const multiclusterFilters = useListMulticlusterFilters();
   const clusters = useListClusters();
   const cluster = clusters?.length === 1 ? clusters[0] : undefined;
+
+  const templateWatchNamespaces = useMemo(
+    () => (namespace ? [OPENSHIFT_NAMESPACE, namespace] : [OPENSHIFT_NAMESPACE]),
+    [namespace],
+  );
 
   const templateMulticlusterFilters = useMemo(
     () => [
@@ -66,6 +72,7 @@ export const useOpenShiftTemplates: UseOpenShiftTemplates = ({
         },
       ],
     },
+    watchNamespaces: templateWatchNamespaces,
   });
 
   return {

--- a/src/views/templates/list/hooks/useVirtualMachineTemplates.ts
+++ b/src/views/templates/list/hooks/useVirtualMachineTemplates.ts
@@ -1,5 +1,6 @@
 import { VirtualMachineTemplateModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1alpha1VirtualMachineTemplate } from '@kubevirt-ui-ext/kubevirt-api/virt-template';
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useListClusters from '@kubevirt-utils/hooks/useListClusters';
 import { getGroupVersionKindForModel } from '@openshift-console/dynamic-plugin-sdk';
@@ -16,11 +17,14 @@ type UseVirtualMachineTemplates = (
 const useVirtualMachineTemplates: UseVirtualMachineTemplates = (namespace, enabled = true) => {
   const clusters = useListClusters();
   const cluster = clusters?.length === 1 ? clusters[0] : undefined;
+  const isAdmin = useIsAdmin();
+
+  const shouldWatch = enabled && (isAdmin || Boolean(namespace));
 
   const [vmTemplates, loaded, loadError] = useKubevirtWatchResource<
     V1alpha1VirtualMachineTemplate[]
   >(
-    enabled
+    shouldWatch
       ? {
           cluster,
           groupVersionKind: getGroupVersionKindForModel(VirtualMachineTemplateModel),
@@ -33,7 +37,7 @@ const useVirtualMachineTemplates: UseVirtualMachineTemplates = (namespace, enabl
 
   return {
     error: loadError,
-    loaded,
+    loaded: shouldWatch ? loaded : true,
     vmTemplates: vmTemplates ?? [],
   };
 };

--- a/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
+++ b/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect, useRef } from 'react';
 import classnames from 'classnames';
 
 import { FLAG_LIGHTSPEED_PLUGIN } from '@kubevirt-utils/flags/consts';
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import { getValidNamespace, isEmpty } from '@kubevirt-utils/utils/utils';
@@ -50,22 +51,27 @@ const VMCreationWizard: FC = () => {
   const clusterParam = useClusterParam();
   const hasInitialized = useRef(false);
   const closeWizard = useCloseWizard();
+  const isAdmin = useIsAdmin();
   const [activeNamespace] = useActiveNamespace();
   const namespace = getValidNamespace(activeNamespace);
 
   useEffect(() => {
     if (!hasInitialized.current) {
+      const currentProject = project; // capture before resetWizardState clears it
       resetWizardState();
       setTemplatesDrawerIsOpen(false);
 
       setCluster(clusterParam);
-      setProject(Boolean(project) ? project : namespace);
+      // Non-admin: always use the active namespace.
+      // Admin: keep their previously selected project if set, otherwise use the active namespace.
+      setProject(!isAdmin ? namespace : currentProject || namespace);
       hasInitialized.current = true;
     }
   }, [
     clusterParam,
-    project,
+    isAdmin,
     namespace,
+    project,
     resetWizardState,
     setCluster,
     setProject,

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/BootSourceStep.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/BootSourceStep.tsx
@@ -1,9 +1,11 @@
 import React, { FC } from 'react';
 
+import { ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
 import useInstanceTypesAndPreferences from '@kubevirt-utils/hooks/useInstanceTypesAndPreferences';
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useBootableVolumes from '@kubevirt-utils/resources/bootableresources/hooks/useBootableVolumes';
-import { getValidNamespace } from '@kubevirt-utils/utils/utils';
+import { getValidNamespace, OS_IMAGES_NS } from '@kubevirt-utils/utils/utils';
 import {
   Radio,
   Split,
@@ -21,13 +23,20 @@ import AddBootableVolumeButton from './components/AddBootableVolumeButton';
 
 const BootSourceStep: FC = () => {
   const { t } = useKubevirtTranslation();
-  const { setUseBootSource, useBootSource } = useInstanceTypeVMStore();
+  const isAdmin = useIsAdmin();
+  const { setUseBootSource, useBootSource, volumeListNamespace } = useInstanceTypeVMStore();
   const { project } = useVMWizardStore();
   const instanceTypesAndPreferencesData = useInstanceTypesAndPreferences(
     getValidNamespace(project),
   );
-  const { volumeListNamespace } = useInstanceTypeVMStore();
-  const bootableVolumesData = useBootableVolumes(volumeListNamespace);
+
+  // For non-admin users with no explicit selection, always scope to the OS images
+  // namespace — they cannot do cluster-wide watches. Respect any explicit selection.
+  const effectiveNamespace =
+    isAdmin || (volumeListNamespace && volumeListNamespace !== ALL_PROJECTS)
+      ? volumeListNamespace
+      : OS_IMAGES_NS;
+  const bootableVolumesData = useBootableVolumes(effectiveNamespace);
 
   return (
     <Stack hasGutter>

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/BootableVolumeList.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/BootableVolumeList.tsx
@@ -1,20 +1,14 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 
 import ListPageFilter from '@kubevirt-utils/components/ListPageFilter/ListPageFilter';
 import ProjectDropdown from '@kubevirt-utils/components/ProjectDropdown/ProjectDropdown';
-import {
-  KUBEVIRT_HYPERCONVERGED,
-  KUBEVIRT_OS_IMAGES_NS,
-  OPENSHIFT_OS_IMAGES_NS,
-} from '@kubevirt-utils/constants/constants';
 import { ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useHideDeprecatedBootableVolumes from '@kubevirt-utils/resources/bootableresources/hooks/useHideDeprecatedBootableVolumes';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { getName } from '@kubevirt-utils/resources/shared';
-import { operatorNamespaceSignal } from '@kubevirt-utils/store/operatorNamespace';
-import { isEmpty, OS_IMAGES_NS } from '@kubevirt-utils/utils/utils';
+import { OS_IMAGES_NS } from '@kubevirt-utils/utils/utils';
 import { Card, FormGroup, Skeleton, Split, SplitItem } from '@patternfly/react-core';
 import useInstanceTypeVMStore from '@virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore';
 import usePreferencesData from '@virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/usePreferencesData';
@@ -43,7 +37,6 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const isAdmin = useIsAdmin();
-  const operatorNamespace = operatorNamespaceSignal.value;
   const {
     dvSource,
     onSelectCreatedVolume,
@@ -53,9 +46,16 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
     volumeListNamespace,
     volumeSnapshotSource,
   } = useInstanceTypeVMStore();
+
+  // Non-admin users cannot list across all projects — default to the OS images
+  // namespace where system bootable volumes live. If they explicitly pick a
+  // different project via the dropdown, respect that choice.
+  const isNamespaceUnset = !volumeListNamespace || volumeListNamespace === ALL_PROJECTS;
+  const effectiveNamespace = !isAdmin && isNamespaceUnset ? OS_IMAGES_NS : volumeListNamespace;
+
   const { preferences: preferencesData } = instanceTypesAndPreferencesData;
   const { preferencesMap, userPreferencesData, userPreferencesLoaded, userPreferencesMap } =
-    usePreferencesData(volumeListNamespace, preferencesData);
+    usePreferencesData(effectiveNamespace, preferencesData);
 
   const { loaded } = bootableVolumesData;
 
@@ -78,29 +78,13 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
     sortedPaginatedData,
     unfilteredData,
   } = useBootableVolumesTableData(
-    volumeListNamespace,
+    effectiveNamespace,
     displayShowAllButton,
     preferencesMap,
     userPreferencesMap,
   );
 
   useHideDeprecatedBootableVolumes(onFilterChange);
-
-  useEffect(() => {
-    if (isAdmin || volumeListNamespace !== ALL_PROJECTS) return;
-
-    if (isEmpty(operatorNamespace)) {
-      setVolumeListNamespace(OS_IMAGES_NS);
-      return;
-    }
-
-    const osImagesNamespace =
-      operatorNamespace === KUBEVIRT_HYPERCONVERGED
-        ? KUBEVIRT_OS_IMAGES_NS
-        : OPENSHIFT_OS_IMAGES_NS;
-
-    setVolumeListNamespace(osImagesNamespace);
-  }, [isAdmin, volumeListNamespace, setVolumeListNamespace, operatorNamespace]);
 
   const isVolumesLoaded = loaded && loadedColumns && userPreferencesLoaded;
   const displayVolumes = isVolumesLoaded && !isEmptyVolumes && !isPreferenceFilterEmpty;
@@ -127,7 +111,7 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
               <ProjectDropdown
                 includeAllProjects={isAdmin}
                 onChange={setVolumeListNamespace}
-                selectedProject={volumeListNamespace}
+                selectedProject={effectiveNamespace}
               />
             </FormGroup>
           </SplitItem>

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/hooks/useDrawerContext.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/hooks/useDrawerContext.tsx
@@ -5,6 +5,7 @@ import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getTemplateVirtualMachineObject, Template } from '@kubevirt-utils/resources/template';
 import { useVMTemplateSource } from '@kubevirt-utils/resources/template';
 import useVMTemplateGeneratedParams from '@kubevirt-utils/resources/template/hooks/useVMTemplateGeneratedParams';
+import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
 
 export type DrawerContext = {
   setTemplate: Updater<Template>;
@@ -16,8 +17,11 @@ export type DrawerContext = {
 
 const useDrawer = (initialTemplate: Template) => {
   const [template, setTemplate] = useImmer(initialTemplate);
-  const [templateWithGeneratedParams, loading, error] =
-    useVMTemplateGeneratedParams(initialTemplate);
+  const { project } = useVMWizardStore();
+  const [templateWithGeneratedParams, loading, error] = useVMTemplateGeneratedParams(
+    initialTemplate,
+    project || undefined,
+  );
   const { loaded: bootSourceLoaded } = useVMTemplateSource(initialTemplate);
 
   // reset drawer template state when selected template changes

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/hooks/useCreateVMFromTemplate.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/hooks/useCreateVMFromTemplate.ts
@@ -6,6 +6,10 @@ import {
   CUSTOMIZE_VM_FAILED,
 } from '@kubevirt-utils/extensions/telemetry/utils/constants';
 import { getLabels } from '@kubevirt-utils/resources/shared';
+import {
+  LABEL_USED_TEMPLATE_NAME,
+  LABEL_USED_TEMPLATE_NAMESPACE,
+} from '@kubevirt-utils/resources/template';
 import { getDefaultRunningStrategy } from '@kubevirt-utils/resources/vm';
 import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
@@ -30,7 +34,12 @@ const useCreateVMFromTemplate: UseCreateVMFromTemplate = () => {
       const vmObject = await resolveVMFromTemplate(selectedTemplate, namespace, cluster);
 
       vmObject.metadata.namespace = namespace;
-      if (folder) vmObject.metadata.labels = { ...getLabels(vmObject), [VM_FOLDER_LABEL]: folder };
+      vmObject.metadata.labels = {
+        ...getLabels(vmObject),
+        [LABEL_USED_TEMPLATE_NAME]: selectedTemplate.metadata.name,
+        [LABEL_USED_TEMPLATE_NAMESPACE]: selectedTemplate.metadata.namespace,
+        ...(folder ? { [VM_FOLDER_LABEL]: folder } : {}),
+      };
       vmObject.spec.runStrategy = getDefaultRunningStrategy();
 
       vmSignal.value = vmObject;

--- a/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
+++ b/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
@@ -4,6 +4,7 @@ import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { KubevirtDataPodFilters } from '@kubevirt-utils/hooks/useKubevirtDataPod/useKubevirtDataPodFilters';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
+import { isSystemNamespace } from '@kubevirt-utils/resources/namespace/helper';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useIsACMPage from '@multicluster/useIsACMPage';
@@ -22,8 +23,10 @@ type UseAccessibleResourcesArgs = {
   filterOptions?: KubevirtDataPodFilters;
   groupVersionKind: K8sGroupVersionKind;
   namespace?: string;
+  onlyUserProjects?: boolean;
   searchQueries?: AdvancedSearchFilter;
   selector?: Selector;
+  watchNamespaces?: string[];
 };
 
 type UseAccessibleResources = <T extends K8sResourceCommon>(
@@ -40,13 +43,21 @@ export const useAccessibleResources: UseAccessibleResources = <T>({
   filterOptions,
   groupVersionKind,
   namespace,
+  onlyUserProjects,
   searchQueries,
   selector,
+  watchNamespaces,
 }) => {
   const isAdmin = useIsAdmin();
   const isACMPage = useIsACMPage();
   const cluster = useClusterParam();
   const [projectNames, projectNamesLoaded, projectNamesError] = useProjects();
+
+  const namespacesToWatch = useMemo(() => {
+    if (watchNamespaces) return watchNamespaces;
+    if (!onlyUserProjects || !projectNames) return projectNames;
+    return projectNames.filter((ns) => !isSystemNamespace(ns));
+  }, [onlyUserProjects, projectNames, watchNamespaces]);
 
   const loadPerNamespace = !isACMPage && projectNamesLoaded && !isAdmin;
 
@@ -71,12 +82,14 @@ export const useAccessibleResources: UseAccessibleResources = <T>({
   const allowedResources = useK8sWatchResources<{ [key: string]: T[] }>(
     Object.fromEntries(
       loadPerNamespace
-        ? (projectNames || []).map((ns) => [
+        ? (namespacesToWatch || []).map((ns) => [
             ns,
             {
+              fieldSelector,
               groupVersionKind,
               isList: true,
               namespace: ns,
+              selector,
             },
           ])
         : [],


### PR DESCRIPTION

## 📝 Description

This PR fixes several regressions that prevented non-privileged users from creating VMs through the new creation wizard.

Template catalog (non-admin users)

Skip cluster-wide Template watch for non-admin users; use per-namespace watches instead to avoid 403 floods
Fix useVMTemplateFeatureFlag stuck loading when HyperConverged CR is inaccessible
Fix processedtemplates API calls using the correct namespace (wizard's selected project)
Restrict OpenShift template watches to openshift + user namespace via watchNamespaces
VM provisioning (CDI smart clone)

Add vm.kubevirt.io/template and vm.kubevirt.io/template.namespace labels to VMs created from templates. Without these labels, virt-api cannot generate a CDI clone token, forcing host-assisted clone which fails for non-admin users due to cross-namespace RBAC and causes ResourceQuota exhaustion from orphaned PVCs
Boot source (instance type flow)

Non-admin users now default to openshift-virtualization-os-images (or kubevirt-os-images upstream) instead of a blank cluster-wide watch that returns 403. Users can still switch to another project via the dropdown
Wizard namespace

Wizard initializes with the correct project: non-admin users always get their active namespace; admin users keep their previously selected project (falling back to active namespace)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/a2d1e1d7-17ea-4ef2-8c7d-668111d87ae7


After:


https://github.com/user-attachments/assets/ac7aad3c-a15f-462f-b055-ba75ed2fb791



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable role-based template visibility and access for admins vs non-admins.
  * VM creation wizard preserves/initializes project selection correctly for non-admins and admins.
  * Loading state reporting improved for template-related actions.

* **Refactor**
  * Boot source and bootable volume lists scoped correctly by effective namespace based on role/selection.
  * Template watching and namespace handling optimized to reduce unnecessary watches and improve load signaling.
  * Generated VMs always include stable template identity labels.

* **New Features**
  * Template generation and resource-watching accept explicit namespace overrides and watch-list options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->