### PR TITLE
CNV-85664: Cluster selection should only be available in ACM view for bootable volumes

### DIFF
--- a/src/views/bootablevolumes/list/hooks/useBootableVolumesFilters.ts
+++ b/src/views/bootablevolumes/list/hooks/useBootableVolumesFilters.ts
@@ -23,6 +23,7 @@ import {
   getArchitecture,
 } from '@kubevirt-utils/utils/architecture';
 import { getItemNameWithOther, includeFilter } from '@kubevirt-utils/utils/utils';
+import useIsACMPage from '@multicluster/useIsACMPage';
 import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 
 import { BootableResource } from '../../utils/types';
@@ -37,6 +38,7 @@ const useBootableVolumesFilters = (
   rowFilters: RowFilter<BootableResource>[];
 } => {
   const { t } = useKubevirtTranslation();
+  const isACMPage = useIsACMPage();
   const clusterFilter = useClusterFilter();
   const projectFilter = useProjectFilter();
 
@@ -55,8 +57,8 @@ const useBootableVolumesFilters = (
   );
 
   const filtersWithSelect = useMemo(
-    () => [clusterFilter, projectFilter],
-    [clusterFilter, projectFilter],
+    () => (isACMPage ? [clusterFilter, projectFilter] : [projectFilter]),
+    [isACMPage, clusterFilter, projectFilter],
   );
 
   const rowFilters = useMemo(


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-85664](https://redhat.atlassian.net/browse/CNV-85664)

Remove cluster dropdown from bootable volumes page in core platform. 

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/23b555c9-1a46-4e65-9afb-4e531273a683


After:

https://github.com/user-attachments/assets/847953f9-6141-4c22-b63d-5bca5ad003b1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bootable volumes filtering is now context-aware and adaptive. Filter options automatically adjust to match your cluster management environment: managed cluster pages display both cluster and project filtering options, while standard deployments show only the project filter, ensuring you see the most relevant options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->