### PR TITLE
CNV-86198: Fleet virtualization: 'Create VM' link in 'No data to display' alert leads to a 404 page

### DIFF
--- a/src/multicluster/urls.ts
+++ b/src/multicluster/urls.ts
@@ -78,12 +78,15 @@ export const getCatalogURL = (cluster: string, namespace?: string): string => {
     : `/k8s/${namespacePath}/catalog`;
 };
 
-export const getVMWizardURL = (cluster: string): string => {
+export const getVMWizardURL = (cluster: string, namespace?: string): string => {
   if (!cluster) return `/vm-wizard`;
 
+  const namespacePath =
+    namespace && !isAllNamespaces(namespace) ? `ns/${namespace}` : ALL_NAMESPACES;
+
   return cluster === ALL_CLUSTERS_KEY
-    ? `${FLEET_WIZARD_PATH}/${ALL_CLUSTERS_KEY}`
-    : `${FLEET_WIZARD_PATH}/cluster/${cluster}`;
+    ? `${FLEET_WIZARD_PATH}/${ALL_CLUSTERS_KEY}/${ALL_NAMESPACES}`
+    : `${FLEET_WIZARD_PATH}/cluster/${cluster}/${namespacePath}`;
 };
 
 export const getConsoleStandaloneURL = (

--- a/src/views/virtualmachines/list/components/OverviewTab/components/NoVMsAlert.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/components/NoVMsAlert.tsx
@@ -29,8 +29,8 @@ const NoVMsAlert: FC<NoVMsAlertProps> = ({ namespace }) => {
   });
 
   const vmWizardURL = useMemo(
-    () => getVMWizardURL(isACMPage ? cluster || '' : ''),
-    [isACMPage, cluster],
+    () => getVMWizardURL(isACMPage ? cluster || '' : '', namespace),
+    [isACMPage, cluster, namespace],
   );
 
   const alertMessage = getAlertMessage(canCreateVM, t);

--- a/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
@@ -47,8 +47,8 @@ const VirtualMachinesCreateButton: FC<VirtualMachinesCreateButtonProps> = ({
   });
 
   const vmWizardURL = useMemo(
-    () => getVMWizardURL(isACMPage ? cluster || '' : ''),
-    [isACMPage, cluster],
+    () => getVMWizardURL(isACMPage ? cluster || '' : '', namespace),
+    [isACMPage, cluster, namespace],
   );
 
   const yamlURL = useMemo(

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/utils.ts
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/utils.ts
@@ -29,7 +29,7 @@ export const getCreateVMAction = (
   return {
     cta: () => {
       setProject(namespace);
-      navigate(`${getVMWizardURL(cluster)}`);
+      navigate(getVMWizardURL(cluster, namespace));
     },
     id: 'create-vm',
     label: t('Create VirtualMachine'),


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-86198](https://redhat.atlassian.net/browse/CNV-86198)

In the Fleet Virtualization perspective, when no virtual machines exist in the selected namespace, an informational alert appears with a "Create VM" link. Clicking this link navigates to a URL that does not match any registered page route, resulting in a 404 error page.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/d43ec417-0329-4555-8f17-c0ce087a6d2f


After:

https://github.com/user-attachments/assets/55d561be-13f2-46e0-9e45-f60b980887d9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * VM creation wizard now includes namespace information in navigation URLs, ensuring users are directed to the correct namespace context when creating new virtual machines.

* **Updates**
  * All VM creation entry points across the application now properly pass namespace context to the wizard for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->