### PR TITLE
CNV-85422: Show VirtualMachineTemplates in the creation wizard catalog by default

### DIFF
--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useTemplatesWithAvailableSource.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useTemplatesWithAvailableSource.ts
@@ -4,6 +4,7 @@ import { V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-d
 import { getUID } from '@kubevirt-utils/resources/shared';
 import { isDefaultVariantTemplate, Template } from '@kubevirt-utils/resources/template';
 import { useSingleClusterAvailableSources } from '@kubevirt-utils/resources/template/hooks/useSingleClusterAvailableSources';
+import { isVirtualMachineTemplate } from '@kubevirt-utils/resources/template/utils/types';
 import useAvailableTemplates from '@virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useAvailableTemplates';
 import useTemplates from '@virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useTemplates';
 
@@ -41,8 +42,9 @@ const useTemplatesWithAvailableSource: UseTemplatesWithAvailableSource = ({
   );
 
   const filteredTemplates = useMemo(() => {
-    return (onlyAvailable ? availableTemplates : templates).filter((template) =>
-      onlyDefault ? isDefaultVariantTemplate(template) : true,
+    return (onlyAvailable ? availableTemplates : templates).filter(
+      (template) =>
+        !onlyDefault || isDefaultVariantTemplate(template) || isVirtualMachineTemplate(template),
     );
   }, [availableTemplates, onlyAvailable, onlyDefault, templates]);
 

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/utils/utils.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/utils/utils.ts
@@ -11,6 +11,7 @@ import {
   getTemplateOS,
   getTemplateWorkload,
 } from '@kubevirt-utils/resources/template/utils/selectors';
+import { isVirtualMachineTemplate } from '@kubevirt-utils/resources/template/utils/types';
 import { getArchitecture } from '@kubevirt-utils/utils/architecture';
 
 import { TemplateFilters } from './types';
@@ -32,7 +33,8 @@ export const filterTemplates = (templates: Template[], filters: TemplateFilters)
 
         const defaultVariantFilter =
           (!filters?.onlyDefault && !hasNoDefaultUserAllFilters(filters)) ||
-          isDefaultVariantTemplate(tmp);
+          isDefaultVariantTemplate(tmp) ||
+          isVirtualMachineTemplate(tmp);
 
         const userFilter = !filters.onlyUser || isUserTemplate(tmp);
 


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Improve visibility of `VirtualMachineTemplates` in the Template catalog in Create VirtualMachine wizard

- VirtualMachineTemplates were filtered out by the "default variant" filter, which only applies to classic OpenShift templates
- They now bypass this filter so they always appear in the catalog alongside default templates

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/370b717b-9950-4909-80c1-54bae2bea349



After:

https://github.com/user-attachments/assets/8845a567-1e28-4c6a-830f-9984eecf1f9d


**NOTE:**
- this is just a current workaround, the whole template filter will be reworked to look like this in next version:
<img width="1480" height="1163" alt="Select a template-Filter outside" src="https://github.com/user-attachments/assets/208dcf8a-4a47-439c-b580-487f1855ccc4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template filtering logic in the virtual machine creation wizard to ensure additional templates are properly included when applying filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->