### PR TITLE
CNV-85836: VM creation wizard: keep creation method tiles visible when resizing

### DIFF
--- a/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/CreationMethodTileGroup.scss
+++ b/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/CreationMethodTileGroup.scss
@@ -1,3 +1,10 @@
 .vm-creation-method-tile-group {
-  width: 62.5rem; /* 1000px */
+  max-width: 100%;
+  width: 100%;
+
+  &__item {
+    flex: 1 1 22rem;
+    max-width: 22rem;
+    min-width: 0;
+  }
 }

--- a/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/CreationMethodTileGroup.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/CreationMethodTileGroup.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import { Split, SplitItem } from '@patternfly/react-core';
+import { Flex, FlexItem } from '@patternfly/react-core';
 import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
 import { VMCreationMethod } from '@virtualmachines/creation-wizard/utils/constants';
 
@@ -12,22 +12,24 @@ const CreationMethodTileGroup: FC = () => {
   const { creationMethod, setCreationMethod } = useVMWizardStore();
 
   return (
-    <Split
-      className="pf-v6-u-justify-content-space-between vm-creation-method-tile-group"
-      hasGutter
+    <Flex
+      className="vm-creation-method-tile-group"
+      flexWrap={{ default: 'wrap' }}
+      gap={{ default: 'gapMd' }}
+      justifyContent={{ default: 'justifyContentFlexStart' }}
     >
       {[VMCreationMethod.INSTANCE_TYPE, VMCreationMethod.TEMPLATE, VMCreationMethod.CLONE].map(
         (method) => (
-          <SplitItem key={method}>
+          <FlexItem className="vm-creation-method-tile-group__item" key={method}>
             <CreationMethodTile
               creationMethod={method}
               isChecked={creationMethod === method}
               setSelectedCreationMethod={setCreationMethod}
             />
-          </SplitItem>
+          </FlexItem>
         ),
       )}
-    </Split>
+    </Flex>
   );
 };
 

--- a/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/components/CreationMethodTile/CreationMethodTile.scss
+++ b/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/components/CreationMethodTile/CreationMethodTile.scss
@@ -1,6 +1,7 @@
 .vm-creation-method-tile {
   height: 14rem; /* 224px */
-  width: 22rem; /* 352px */
+  max-width: 22rem; /* 352px */
+  width: 100%;
 
   // Icon wrapper - set color so SVG currentColor inherits it
   &__icon {


### PR DESCRIPTION
https: //issues.redhat.com/browse/CNV-85836
Made-with: Cursor

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description
Use a wrapping Flex layout and a fluid tile group width instead of a fixed-width Split row so all three options stay reachable in narrower wizard panels and browser widths.

## 🎥 Demo
Before
<img width="1648" height="796" alt="Before resizing" src="https://github.com/user-attachments/assets/3dd62541-61ec-45f7-8d11-75582d4f274b" />

After
<img width="640" height="308" alt="Resizing create option" src="https://github.com/user-attachments/assets/43d7c859-165b-43b6-a1e7-b22c93a6a498" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced responsive layout for the virtual machine creation wizard's creation method selection, with flexible tile sizing and improved spacing that adapts across various screen resolutions and devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->