### PR TITLE
CNV-86227: Use radios for specific node in compute migration

### DIFF
--- a/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/ComputeMigrationModal.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/ComputeMigrationModal.tsx
@@ -44,7 +44,7 @@ const ComputeMigrationModal: FC<ComputeMigrationModalProps> = ({ isOpen, onClose
   const [error, setError] = useState<Error>(null);
 
   const handleNodeSelection = (changedNode: string) => {
-    changedNode === selectedNode ? setSelectedNode('') : setSelectedNode(changedNode);
+    setSelectedNode(changedNode);
   };
 
   const initiateMigration = async () => {

--- a/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/components/NodesTable/nodesTableDefinition.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/components/NodesTable/nodesTableDefinition.tsx
@@ -5,7 +5,7 @@ import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { humanizeBinaryBytes } from '@kubevirt-utils/utils/humanize.js';
 import Status from '@openshift-console/dynamic-plugin-sdk/lib/app/components/status/Status';
-import { Checkbox } from '@patternfly/react-core';
+import { Radio } from '@patternfly/react-core';
 
 import { NodeData } from '../../utils/types';
 
@@ -23,10 +23,12 @@ const SelectionCell: FC<SelectionCellProps> = ({ callbacks, row }) => {
   const { t } = useKubevirtTranslation();
   const { handleNodeSelection, selectedNode } = callbacks;
   return (
-    <Checkbox
+    <Radio
       aria-label={t('Select node {{name}}', { name: row.name })}
       id={`select-${row.name}`}
       isChecked={selectedNode === row.name}
+      label=""
+      name="compute-migration-node-selection"
       onChange={() => handleNodeSelection(row.name)}
     />
   );


### PR DESCRIPTION
https://redhat.atlassian.net/browse/CNV-86227
Made-with: Cursor

## 📝 Description
Replace row checkboxes with radio buttons in the migrate-compute nodes table so manual node selection reads as single-select. Selection no longer toggles off when clicking the same row again.

## 🎥 Demo
Before
<img width="1788" height="933" alt="image" src="https://github.com/user-attachments/assets/8b1065e1-ecb1-4fbd-8a90-c82c355e9be7" />

After
<img width="1784" height="930" alt="image" src="https://github.com/user-attachments/assets/92c3d98d-606a-48d2-83ad-58045204e26a" />