### PR TITLE
CNV-74439: Improve checkups RBAC logic

### DIFF
--- a/src/views/checkups/components/CheckupsEmptyState/CheckupsEmptyState.tsx
+++ b/src/views/checkups/components/CheckupsEmptyState/CheckupsEmptyState.tsx
@@ -47,7 +47,7 @@ const CheckupsEmptyState: FC<CheckupsEmptyState> = ({
 
   const bodyText = useMemo(
     () => getBodyText(checkupType, isAllNamespaces, isPermitted, t),
-    [isAllNamespaces, isPermitted, t],
+    [checkupType, isAllNamespaces, isPermitted, t],
   );
 
   const { isDisabled, onClick } = permissionsButtonProps;
@@ -76,7 +76,7 @@ const CheckupsEmptyState: FC<CheckupsEmptyState> = ({
                   onClick={onClick}
                   variant={isLoading ? ButtonVariant.plain : ButtonVariant.secondary}
                 >
-                  {!isLoading && isPermitted ? t('Remove permissions') : t('Install permissions')}
+                  {isPermitted ? t('Remove permissions') : t('Install permissions')}
                 </Button>
               </StackItem>
               {isDisabled && !isLoading && (

--- a/src/views/checkups/self-validation/components/hooks/useCheckupsSelfValidationPermissions.ts
+++ b/src/views/checkups/self-validation/components/hooks/useCheckupsSelfValidationPermissions.ts
@@ -1,78 +1,129 @@
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
+import { findObjectByName } from 'src/views/checkups/utils/utils';
 
 import {
   ClusterRoleBindingModel,
   modelToGroupVersionKind,
+  RoleBindingModel,
+  RoleModel,
   ServiceAccountModel,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiRbacV1ClusterRoleBinding } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import {
+  IoK8sApiCoreV1ServiceAccount,
+  IoK8sApiRbacV1ClusterRoleBinding,
+  IoK8sApiRbacV1Role,
+  IoK8sApiRbacV1RoleBinding,
+} from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
-import { checkAccess } from '@stolostron/multicluster-sdk/lib/internal/checkAccess';
+import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
 
-import { SELF_VALIDATION_CLUSTER_ROLE_BINDING, SELF_VALIDATION_SA } from '../../utils';
+import {
+  SELF_VALIDATION_CLUSTER_ROLE_BINDING,
+  SELF_VALIDATION_ROLE,
+  SELF_VALIDATION_SA,
+} from '../../utils';
 
 const useCheckupsSelfValidationPermissions = () => {
   const namespace = useActiveNamespace();
-  const [canCreateClusterRoleBinding, setCanCreateClusterRoleBinding] = useState<boolean>(false);
-  const [checkingPermissions, setCheckingPermissions] = useState<boolean>(true);
   const cluster = useSelectedCluster();
+  const isAllNamespace = namespace === ALL_NAMESPACES_SESSION_KEY;
 
-  const [clusterRoleBindings, loadedClusterRoleBinding, loadedClusterRoleBindingError] =
-    useKubevirtWatchResource<IoK8sApiRbacV1ClusterRoleBinding[]>({
+  // Use the public useFleetAccessReview hook to check ClusterRoleBinding create permission.
+  // Passes cluster so the SAR targets the correct managed cluster.
+  const [canCreateClusterRoleBinding, checkingPermissions] = useFleetAccessReview({
+    cluster,
+    group: ClusterRoleBindingModel.apiGroup,
+    resource: ClusterRoleBindingModel.plural,
+    verb: 'create',
+  });
+
+  const [serviceAccounts, serviceAccountsLoaded, serviceAccountsError] = useKubevirtWatchResource<
+    IoK8sApiCoreV1ServiceAccount[]
+  >(
+    !isAllNamespace && {
       cluster,
-      groupVersionKind: modelToGroupVersionKind(ClusterRoleBindingModel),
+      groupVersionKind: modelToGroupVersionKind(ServiceAccountModel),
       isList: true,
-    });
-
-  const clusterRoleBinding = clusterRoleBindings?.find(
-    (crb) => crb.metadata.name === SELF_VALIDATION_CLUSTER_ROLE_BINDING,
+      namespace,
+    },
   );
 
-  const isPermitted = clusterRoleBinding?.subjects?.some(
-    (subject) =>
-      subject?.kind === ServiceAccountModel.kind &&
-      subject?.name === SELF_VALIDATION_SA &&
-      subject?.namespace === namespace,
-  );
-
-  // Check if user has cluster-admin permissions (can create ClusterRoleBindings)
-  useEffect(() => {
-    setCheckingPermissions(true);
-    checkAccess(
-      ClusterRoleBindingModel.apiGroup,
-      ClusterRoleBindingModel.plural,
-      null,
-      'create',
-      null,
-      null,
+  const [roles, rolesLoaded, rolesError] = useKubevirtWatchResource<IoK8sApiRbacV1Role[]>(
+    !isAllNamespace && {
       cluster,
-    )
-      .then((result) => {
-        setCanCreateClusterRoleBinding(Boolean(result?.status?.allowed));
-      })
-      .catch(() => {
-        // If checkAccess fails (e.g., API unavailable, network error), default to true
-        // to allow the user to attempt installation. Kubernetes will enforce permissions
-        // when they actually try to create the ClusterRoleBinding, and installPermissions
-        // will handle any permission errors gracefully.
-        setCanCreateClusterRoleBinding(true);
-      })
-      .finally(() => {
-        setCheckingPermissions(false);
-      });
-  }, [cluster]);
+      groupVersionKind: modelToGroupVersionKind(RoleModel),
+      isList: true,
+      namespace,
+    },
+  );
 
-  // Only allow installation if user has cluster-admin permissions (can create ClusterRoleBindings)
-  // The checkup requires cluster-admin access according to the documentation
-  const isPermittedToInstall = canCreateClusterRoleBinding;
+  const [roleBindings, roleBindingsLoaded, roleBindingsError] = useKubevirtWatchResource<
+    IoK8sApiRbacV1RoleBinding[]
+  >(
+    !isAllNamespace && {
+      cluster,
+      groupVersionKind: modelToGroupVersionKind(RoleBindingModel),
+      isList: true,
+      namespace,
+    },
+  );
+
+  const [clusterRoleBindings, clusterRoleBindingsLoaded, clusterRoleBindingsError] =
+    useKubevirtWatchResource<IoK8sApiRbacV1ClusterRoleBinding[]>(
+      !isAllNamespace && {
+        cluster,
+        groupVersionKind: modelToGroupVersionKind(ClusterRoleBindingModel),
+        isList: true,
+      },
+    );
+
+  const clusterRoleBinding = useMemo(() => {
+    const crb = findObjectByName(clusterRoleBindings, SELF_VALIDATION_CLUSTER_ROLE_BINDING);
+    const hasSubjectForNamespace = crb?.subjects?.some(
+      (subject) =>
+        subject?.kind === ServiceAccountModel.kind &&
+        subject?.name === SELF_VALIDATION_SA &&
+        subject?.namespace === namespace,
+    );
+    return hasSubjectForNamespace ? crb : undefined;
+  }, [clusterRoleBindings, namespace]);
+
+  const isServiceAccount = useMemo(
+    () => findObjectByName(serviceAccounts, SELF_VALIDATION_SA),
+    [serviceAccounts],
+  );
+
+  const isRole = useMemo(() => findObjectByName(roles, SELF_VALIDATION_ROLE), [roles]);
+
+  // Validate that the RoleBinding both targets the expected Role and includes the expected SA.
+  const isRoleBinding = useMemo(() => {
+    const rb = findObjectByName(roleBindings, SELF_VALIDATION_ROLE);
+    const bindsExpectedRole =
+      rb?.roleRef?.kind === RoleModel.kind && rb?.roleRef?.name === SELF_VALIDATION_ROLE;
+    const bindsExpectedSA = rb?.subjects?.some(
+      (subject) =>
+        subject?.kind === ServiceAccountModel.kind &&
+        subject?.name === SELF_VALIDATION_SA &&
+        subject?.namespace === namespace,
+    );
+    return bindsExpectedRole && bindsExpectedSA ? rb : undefined;
+  }, [roleBindings, namespace]);
 
   return {
     clusterRoleBinding,
-    isPermitted: !!isPermitted,
-    isPermittedToInstall,
-    loading: (!loadedClusterRoleBinding && !loadedClusterRoleBindingError) || checkingPermissions,
+    isPermitted: Boolean(isServiceAccount && isRole && isRoleBinding && clusterRoleBinding),
+    isPermittedToInstall: !isAllNamespace && canCreateClusterRoleBinding,
+    loadError:
+      serviceAccountsError || rolesError || roleBindingsError || clusterRoleBindingsError || null,
+    loading:
+      checkingPermissions ||
+      !serviceAccountsLoaded ||
+      !rolesLoaded ||
+      !roleBindingsLoaded ||
+      !clusterRoleBindingsLoaded,
   };
 };
 

--- a/src/views/checkups/self-validation/list/CheckupsSelfValidationList.tsx
+++ b/src/views/checkups/self-validation/list/CheckupsSelfValidationList.tsx
@@ -41,9 +41,11 @@ const CheckupsSelfValidationList: FC = () => {
     clusterRoleBinding,
     isPermitted,
     isPermittedToInstall,
+    loadError: permissionsError,
     loading: loadingPermissions,
   } = useCheckupsSelfValidationPermissions();
-  const { configMaps, error, jobs, loaded } = useCheckupsSelfValidationData();
+  const { configMaps, error: dataError, jobs, loaded } = useCheckupsSelfValidationData();
+  const error = dataError || permissionsError;
 
   const [unfilteredData, filteredData, onFilterChange, filters] =
     useCheckupsSelfValidationListFilters(configMaps || []);

--- a/src/views/checkups/self-validation/utils/selfValidationPermissions.ts
+++ b/src/views/checkups/self-validation/utils/selfValidationPermissions.ts
@@ -15,7 +15,8 @@ import {
   kubevirtK8sGet,
   kubevirtK8sPatch,
 } from '@multicluster/k8sRequests';
-import { checkAccess, K8sModel, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { K8sModel, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { checkAccess } from '@stolostron/multicluster-sdk/lib/internal/checkAccess';
 
 import {
   SELF_VALIDATION_CLUSTER_ROLE_BINDING,
@@ -34,24 +35,31 @@ export type PermissionOperationResult = {
   success: boolean;
 };
 
+type K8sError = {
+  code?: number;
+  json?: { code?: number };
+  response?: { status?: number };
+};
+
 /**
  * Extracts HTTP status code from k8s SDK error
  * Checks multiple possible error properties as the SDK may structure errors differently
  * @param error - The error object from k8s SDK
  * @returns The HTTP status code or undefined if not found
  */
-const getErrorStatusCode = (error: any): number | undefined => {
+const getErrorStatusCode = (error: unknown): number | undefined => {
+  const err = error as K8sError | null | undefined;
   // Check error.response.status (standard HTTP error structure)
-  if (error?.response?.status) {
-    return error.response.status;
+  if (err?.response?.status) {
+    return err.response.status;
   }
   // Check error.code (some SDK versions use this)
-  if (typeof error?.code === 'number') {
-    return error.code;
+  if (typeof err?.code === 'number') {
+    return err.code;
   }
   // Check error.json.code (some SDK versions nest the code)
-  if (typeof error?.json?.code === 'number') {
-    return error.json.code;
+  if (typeof err?.json?.code === 'number') {
+    return err.json.code;
   }
   return undefined;
 };
@@ -62,7 +70,7 @@ const getErrorStatusCode = (error: any): number | undefined => {
  * @param statusCode - The HTTP status code to check for
  * @returns True if the error matches the status code
  */
-const isErrorStatusCode = (error: any, statusCode: number): boolean => {
+const isErrorStatusCode = (error: unknown, statusCode: number): boolean => {
   return getErrorStatusCode(error) === statusCode;
 };
 
@@ -75,7 +83,7 @@ const isErrorStatusCode = (error: any, statusCode: number): boolean => {
  * @returns Error result if error is not 404, null if 404 (can be ignored)
  */
 const handleDeleteError = (
-  error: any,
+  error: unknown,
   resourceKind: string,
   t: TFunction,
 ): null | PermissionOperationResult => {
@@ -105,10 +113,8 @@ const getOrCreateResource = async (
 ): Promise<null | string> => {
   try {
     await kubevirtK8sGet(getOptions);
-    // Resource exists, no need to create
     return null;
   } catch (error) {
-    // Only create if resource doesn't exist (404)
     if (isErrorStatusCode(error, 404)) {
       try {
         await kubevirtK8sCreate(createOptions);
@@ -119,7 +125,6 @@ const getOrCreateResource = async (
         return errorMessage;
       }
     }
-    // Re-throw non-404 errors (permission errors, etc.)
     const errorMessage = getFailedToModifyMessage(t, resourceKind);
     kubevirtConsole.error(`Failed to get ${resourceKind}:`, error);
     return errorMessage;
@@ -171,6 +176,29 @@ export const installPermissions = async (
   cluster: string,
   t: TFunction,
 ): Promise<PermissionOperationResult> => {
+  // Check cluster-admin permission first to avoid creating partial namespaced RBAC state
+  // when the user lacks permission to bind to cluster-admin.
+  try {
+    const accessReview = await checkAccess(
+      ClusterRoleBindingModel.apiGroup,
+      ClusterRoleBindingModel.plural,
+      null,
+      'create',
+      null,
+      null,
+      cluster,
+    );
+
+    if (!accessReview?.status?.allowed) {
+      const errorMessage = getPermissionDeniedMessage(t);
+      kubevirtConsole.error('Permission check failed:', errorMessage);
+      return { error: errorMessage, success: false };
+    }
+  } catch (checkAccessError) {
+    // If checkAccess itself fails, proceed and let Kubernetes enforce permissions on the target cluster
+    kubevirtConsole.warn('checkAccess for ClusterRoleBinding failed:', checkAccessError);
+  }
+
   // Create ServiceAccount, Role, and RoleBinding if they don't exist
   const [serviceAccountError, roleError, roleBindingError] = await Promise.all([
     getOrCreateResource(
@@ -217,37 +245,15 @@ export const installPermissions = async (
     ),
   ]);
 
-  // Check if any operation failed
   const error = serviceAccountError || roleError || roleBindingError;
   if (error) {
     return { error, success: false };
   }
 
-  // Check if user has permission to create ClusterRoleBinding
-  // Note: Kubernetes will enforce binding permissions when we try to bind to cluster-admin
-  try {
-    const accessReview = await checkAccess({
-      group: 'rbac.authorization.k8s.io',
-      resource: ClusterRoleBindingModel.plural,
-      verb: 'create',
-    });
-
-    if (!accessReview?.status?.allowed) {
-      const errorMessage = getPermissionDeniedMessage(t);
-      kubevirtConsole.error('Permission check failed:', errorMessage);
-      return {
-        error: errorMessage,
-        success: false,
-      };
-    }
-  } catch (checkAccessError) {
-    // If checkAccess itself fails, we'll still try to create and let Kubernetes enforce permissions
-    // This allows the operation to proceed if checkAccess is unavailable, but Kubernetes will still enforce permissions
-  }
-
   // Create or update ClusterRoleBinding
   try {
     const existingClusterRoleBinding = await kubevirtK8sGet({
+      cluster,
       model: ClusterRoleBindingModel,
       name: SELF_VALIDATION_CLUSTER_ROLE_BINDING,
     });


### PR DESCRIPTION
## 📝 Description

Jira ticket: [CNV-74439](https://redhat.atlassian.net/browse/CNV-74439)

Checkups should integrate `useAccessReview` and use `impersonate` in order to be aligned with other similar parts of the codebase. 

https://github.com/kubevirt-ui/kubevirt-plugin/pull/3235#discussion_r2585109266


## 🎥 Demo

No ui changes. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permission status display and button label so install/remove actions reflect actual permission state (no longer gated by transient loading).
  * Consolidated error reporting so load errors surface correctly from both permissions and data sources.

* **Improvements**
  * Strengthened permission validation with cross-checked resource existence and namespace-scoped checks.
  * Loading and error states now reflect combined access-review and resource watcher results; install action disabled for "all namespaces".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->