### PR TITLE
CNV-85868: fix user-provided instance type selection in VM creation wizard

### DIFF
--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/ComputeResourcesStepFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/ComputeResourcesStepFooter.tsx
@@ -13,19 +13,23 @@ const ComputeResourcesStepFooter: FC = () => {
   const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
   const handleCreateVM = useCreateVMFromInstanceType();
   const closeWizard = useCloseWizard();
-  const { selectedSeries, selectedSize } = useInstanceTypeVMStore();
+  const { selectedInstanceType, selectedSeries, selectedSize } = useInstanceTypeVMStore();
 
   const handleGoToNextStep = async () => {
     await handleCreateVM();
     goToNextStep();
   };
 
+  const isRedHatProvided = Boolean(selectedSeries) && Boolean(selectedSize);
+  const isUserProvided =
+    Boolean(selectedInstanceType?.namespace) && Boolean(selectedInstanceType?.name);
+
   return (
     <WizardFooter
       activeStep={activeStep}
       cancelButtonProps={{ className: classnames({ 'pf-v6-u-mr-4xl': hasOLSConsole }) }}
       isBackDisabled={activeStep.index === 1}
-      isNextDisabled={!selectedSeries || !selectedSize}
+      isNextDisabled={!isRedHatProvided && !isUserProvided}
       onBack={goToPrevStep}
       onClose={closeWizard}
       onNext={handleGoToNextStep}

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/UserProvidedInstanceTypeList/UserProvidedInstanceTypeList.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/UserProvidedInstanceTypeList/UserProvidedInstanceTypeList.tsx
@@ -36,8 +36,7 @@ const UserProvidedInstanceTypesList: FC<UserProvidedInstanceTypesListProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const [activeNamespace] = useActiveNamespace();
-  const { selectedInstanceType, setSelectedInstanceType, setSelectedSeries, setSelectedSize } =
-    useInstanceTypeVMStore();
+  const { selectedInstanceType, setSelectedInstanceType } = useInstanceTypeVMStore();
 
   const [searchInput, setSearchInput] = useState('');
   const [pagination, setPagination] = useState(paginationInitialState);
@@ -74,8 +73,6 @@ const UserProvidedInstanceTypesList: FC<UserProvidedInstanceTypesListProps> = ({
 
   const handleRowClick = (itName: string, itNamespace: string) => {
     setSelectedInstanceType({ name: itName, namespace: itNamespace });
-    setSelectedSeries('');
-    setSelectedSize('');
   };
 
   return (


### PR DESCRIPTION
## 📝 Description

Fixes [CNV-85868](https://issues.redhat.com/browse/CNV-85868) — selecting a **User provided** instance type in the VM creation wizard was reverting to the "Red Hat provided" tab and the "Next" button remained permanently disabled.

### Root cause

In `UserProvidedInstanceTypeList`, `handleRowClick` called `setSelectedSeries('')` and `setSelectedSize('')` after `setSelectedInstanceType`. Both of those store actions overwrite `selectedInstanceType` with `{ name: '', namespace: null }`, destroying the namespace that identifies a user-provided type. This caused:

1. `SelectInstanceTypeSection`'s `useEffect` to see `namespace = null` and revert the tab to "Red Hat provided"
2. The "Next" button to stay disabled because `isNextDisabled` only checked `selectedSeries` and `selectedSize`, which are never set for user-provided selections

### Fix

- **`UserProvidedInstanceTypeList`**: removed `setSelectedSeries('')` and `setSelectedSize('')` from `handleRowClick` — these are only meaningful for Red Hat provided types and were clobbering the namespace
- **`ComputeResourcesStepFooter`**: updated `isNextDisabled` to also enable the "Next" button when a user-provided instance type (identified by a non-null namespace) is fully selected

## 🎥 Demo

> Please add a video or an image of the behavior/changes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced VM creation wizard to support flexible instance type selection: choose from Red Hat-provided options (series/size) or provide custom instance type details.

* **Bug Fixes**
  * Improved state management when selecting user-provided instance types—previously selected values are now preserved instead of being cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->