### PR TITLE
CNV-86873: standalone web console fails to open for spoke cluster VMs

### DIFF
--- a/src/multicluster/constants.ts
+++ b/src/multicluster/constants.ts
@@ -8,6 +8,10 @@ import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
 export const BASE_K8S_API_PATH = '/api/kubernetes';
 
+/** Proxy path prefix used by the multicluster SDK to reach spoke-cluster K8s APIs. */
+export const FLEET_SPOKE_PROXY_BASE_PATH =
+  '/api/proxy/plugin/mce/console/multicloud/managedclusterproxy';
+
 export const FLEET_BASE_PATH = '/fleet-virtualization';
 
 export const FLEET_VIRTUAL_MACHINES_PATH = `${FLEET_BASE_PATH}/${VirtualMachineModelRef}`;

--- a/src/multicluster/hooks/useK8sBaseAPIPath.ts
+++ b/src/multicluster/hooks/useK8sBaseAPIPath.ts
@@ -1,10 +1,17 @@
-import { BASE_K8S_API_PATH } from '@multicluster/constants';
+import { BASE_K8S_API_PATH, FLEET_SPOKE_PROXY_BASE_PATH } from '@multicluster/constants';
 import { useFleetK8sAPIPath } from '@stolostron/multicluster-sdk';
 
 const useK8sBaseAPIPath = (cluster?: string): [string, boolean] => {
-  const [apiPath, apiPathLoaded] = useFleetK8sAPIPath(cluster);
+  const [apiPath, apiPathLoaded, apiPathError] = useFleetK8sAPIPath(cluster);
 
   if (!cluster) return [BASE_K8S_API_PATH, true];
+
+  // When the fleet SDK is unavailable (e.g. RHACM not yet initialised in a
+  // standalone window), fall back to constructing the spoke-cluster proxy path
+  // directly so the VNC console is not permanently blocked.
+  if (!apiPathLoaded && apiPathError) {
+    return [`${FLEET_SPOKE_PROXY_BASE_PATH}/${cluster}`, true];
+  }
 
   return [apiPath, apiPathLoaded];
 };

--- a/src/utils/components/Consoles/ConsoleStandAlone.tsx
+++ b/src/utils/components/Consoles/ConsoleStandAlone.tsx
@@ -10,6 +10,7 @@ import { isWindows } from '@kubevirt-utils/resources/vm/utils/operation-system/o
 import useK8sBaseAPIPath from '@multicluster/hooks/useK8sBaseAPIPath';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { Bullseye, Spinner } from '@patternfly/react-core';
+import { useIsFleetAvailable } from '@stolostron/multicluster-sdk';
 
 import ErrorAlert from '../ErrorAlert/ErrorAlert';
 import { ModalProvider, useModalValue } from '../ModalProvider/ModalProvider';
@@ -28,16 +29,19 @@ const ConsoleStandAlone: FC = () => {
     name,
     namespace: ns,
   });
-  const { vmi, vmiLoaded, vmiLoadError } = useVMI(name, ns, cluster);
+  const { vmi, vmiLoadError } = useVMI(name, ns, cluster);
+  const isFleetAvailable = useIsFleetAvailable();
   const value = useModalValue();
 
-  if (!vmi && vmiLoadError) {
+  // For local/no-cluster flows show errors immediately; for fleet/spoke flows wait
+  // until the fleet SDK is initialised to avoid false positives during startup.
+  if (!vmi && vmiLoadError && (!cluster || isFleetAvailable)) {
     return <ErrorAlert error={vmiLoadError} />;
   }
 
   const waitingForVm = !vmLoaded && !vmLoadError;
 
-  if (!apiPathLoaded || !vmiLoaded || waitingForVm)
+  if (!apiPathLoaded || waitingForVm)
     return (
       <Bullseye>
         <Spinner />


### PR DESCRIPTION
## 📝 Description

Jira Ticket: [CNV-86873](https://redhat.atlassian.net/browse/CNV-86873)

When opening the standalone web console (via "Open web console" button or direct URL) for a VM on a spoke cluster in the fleet-virtualization perspective, the page shows an error as a result of "A version of RHACM that is compatible with the multicluster SDK is not available" error. 

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/ef9712bd-87ad-4d26-a05c-6b12a5f77468

After:


https://github.com/user-attachments/assets/711f309e-bd93-418c-b5a6-fc39c727864c




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and added a fallback proxy path for managed cluster APIs so functionality continues when the fleet integration fails to load.

* **Refactor**
  * Strengthened fleet integration and availability checks, and adjusted console loading/error behavior to present more reliable UI state for standalone consoles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->