### PR TITLE
CNV-85829: auto-select default size when switching Compute Resource series

### DIFF
--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/RedHatProvidedInstanceTypesSection/components/RedHatInstanceTypeSeriesGallery/components/RedHatSeriesMenuCard/RedHatSeriesMenuCard.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/RedHatProvidedInstanceTypesSection/components/RedHatInstanceTypeSeriesGallery/components/RedHatSeriesMenuCard/RedHatSeriesMenuCard.tsx
@@ -37,6 +37,10 @@ const RedHatSeriesMenuCard: FC<RedHatSeriesMenuCardProps> = ({ rhSeriesItem }) =
   const defaultSeriesLabel = useMemo(() => getSeriesLabel(seriesName, t), [seriesName, t]);
 
   const handleSeriesClick = () => {
+    if (seriesName === selectedSeries) {
+      return;
+    }
+
     const standardSizes = seriesHasHugepagesVariant(seriesName)
       ? sizes?.filter((s) => !is1GiInstanceType(s.sizeLabel))
       : sizes;

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/RedHatProvidedInstanceTypesSection/components/RedHatInstanceTypeSeriesGallery/components/RedHatSeriesMenuCard/RedHatSeriesMenuCard.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/RedHatProvidedInstanceTypesSection/components/RedHatInstanceTypeSeriesGallery/components/RedHatSeriesMenuCard/RedHatSeriesMenuCard.tsx
@@ -6,6 +6,8 @@ import { RedHatInstanceTypeSeries } from '@kubevirt-utils/components/AddBootable
 import {
   getSeriesLabel,
   getSeriesSymbol,
+  is1GiInstanceType,
+  seriesHasHugepagesVariant,
 } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Card, CardBody, CardHeader, Flex, Tooltip } from '@patternfly/react-core';
@@ -21,9 +23,9 @@ type RedHatSeriesMenuCardProps = {
 const RedHatSeriesMenuCard: FC<RedHatSeriesMenuCardProps> = ({ rhSeriesItem }) => {
   const { t } = useKubevirtTranslation();
 
-  const { selectedSeries, setSelectedSeries } = useInstanceTypeVMStore();
+  const { selectedSeries, setSelectedSeries, setSelectedSize } = useInstanceTypeVMStore();
 
-  const { classDisplayNameAnnotation, descriptionAnnotation, seriesName } = rhSeriesItem;
+  const { classDisplayNameAnnotation, descriptionAnnotation, seriesName, sizes } = rhSeriesItem;
 
   const { Icon, seriesLabel } = instanceTypeSeriesNameMapper[seriesName] || {};
 
@@ -35,7 +37,12 @@ const RedHatSeriesMenuCard: FC<RedHatSeriesMenuCardProps> = ({ rhSeriesItem }) =
   const defaultSeriesLabel = useMemo(() => getSeriesLabel(seriesName, t), [seriesName, t]);
 
   const handleSeriesClick = () => {
+    const standardSizes = seriesHasHugepagesVariant(seriesName)
+      ? sizes?.filter((s) => !is1GiInstanceType(s.sizeLabel))
+      : sizes;
+    const defaultSize = (standardSizes?.[0] ?? sizes?.[0])?.sizeLabel;
     setSelectedSeries(seriesName);
+    setSelectedSize(defaultSize);
   };
 
   const card = (


### PR DESCRIPTION
## Summary
- Fixes a bug where switching to a different instance type series (e.g., from General Purpose to Compute Exclusive) in the VM Wizard Compute Resources step left the size dropdown blank and the Next button disabled
- Default size is now selected at the point of user interaction in `RedHatSeriesMenuCard`: the first standard (non-hugepages) size for the chosen series is set immediately when the series card is clicked

## Root cause
`setSelectedSeries` resets `selectedSize` to `''` but nothing re-populated it when the user picked a new series. The initial "General Purpose" selection had a size pre-filled from the boot volume's instance type annotation — switching series lost that.

## Changes
- `RedHatSeriesMenuCard.tsx`: `handleSeriesClick` now computes the first standard size from `rhSeriesItem.sizes` and calls `setSelectedSize` right after `setSelectedSeries`


### Demo

**BEFORE**

https://github.com/user-attachments/assets/f82ea9df-145f-4d24-93fd-9b8e75cd6ec8


**AFTER**

https://github.com/user-attachments/assets/3b63e5e4-b4ed-41e6-ad4f-5354b1295028





Jira: https://issues.redhat.com/browse/CNV-85829

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * When selecting an instance type series in the virtual machine creation wizard, a default size is now automatically selected, streamlining the configuration process.
  * Selecting an already-selected series is now handled more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->