### PR TITLE
CNV-86103: remove the project filter from the create from clone in create wizard

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1566,6 +1566,7 @@
   "Project name to clone the template to": "Project name to clone the template to",
   "Project root": "Project root",
   "Project-scoped": "Project-scoped",
+  "Project: {{project}}": "Project: {{project}}",
   "Projects": "Projects",
   "Provider": "Provider",
   "Provisioning": "Provisioning",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1583,6 +1583,7 @@
   "Project name to clone the template to": "Nombre del proyecto para clonar la plantilla en",
   "Project root": "Root del proyecto",
   "Project-scoped": "Delimitado por el alcance del proyecto",
+  "Project: {{project}}": "Project: {{project}}",
   "Projects": "Proyectos",
   "Provider": "Proveedor",
   "Provisioning": "Aprovisionamiento",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1583,6 +1583,7 @@
   "Project name to clone the template to": "Nom du projet vers lequel cloner le modèle",
   "Project root": "Racine du projet",
   "Project-scoped": "Sous le périmètre du projet",
+  "Project: {{project}}": "Project: {{project}}",
   "Projects": "Projets",
   "Provider": "Fournisseur",
   "Provisioning": "Provisionnement",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1566,6 +1566,7 @@
   "Project name to clone the template to": "テンプレートのクローン作成先のプロジェクト名",
   "Project root": "プロジェクトのルート",
   "Project-scoped": "プロジェクトスコープの",
+  "Project: {{project}}": "Project: {{project}}",
   "Projects": "プロジェクト",
   "Provider": "プロバイダー",
   "Provisioning": "Provisioning",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1566,6 +1566,7 @@
   "Project name to clone the template to": "템플릿을 복제할 프로젝트 이름",
   "Project root": "프로젝트 루트",
   "Project-scoped": "프로젝트 범위",
+  "Project: {{project}}": "Project: {{project}}",
   "Projects": "프로젝트",
   "Provider": "공급자",
   "Provisioning": "프로비저닝",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1566,6 +1566,7 @@
   "Project name to clone the template to": "将模板克隆到的项目名称",
   "Project root": "项目根",
   "Project-scoped": "项目范围的",
+  "Project: {{project}}": "Project: {{project}}",
   "Projects": "项目",
   "Provider": "供应商",
   "Provisioning": "置备",

--- a/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
@@ -14,7 +14,6 @@ import {
 } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { buildColumnLayout } from '@kubevirt-utils/components/KubevirtTable/utils';
-import { useQueryParamsMethods } from '@kubevirt-utils/components/ListPageFilter/hooks/useQueryParamsMethods';
 import ListPageFilter from '@kubevirt-utils/components/ListPageFilter/ListPageFilter';
 import useContainerWidth from '@kubevirt-utils/hooks/useContainerWidth';
 import { KUBEVIRT_APISERVER_PROXY } from '@kubevirt-utils/hooks/useFeatures/constants';
@@ -27,18 +26,16 @@ import {
   paginationInitialState,
 } from '@kubevirt-utils/hooks/usePagination/utils/constants';
 import { usePVCMapper } from '@kubevirt-utils/hooks/usePVCMapper';
-import useQuery from '@kubevirt-utils/hooks/useQuery';
 import { getDescription, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import useVirtualMachineInstanceMigrationMapper from '@kubevirt-utils/resources/vmim/hooks/useVirtualMachineInstanceMigrationMapper';
 import useVirtualMachineInstanceMigrations from '@kubevirt-utils/resources/vmim/hooks/useVirtualMachineInstanceMigrations';
 import { clearCustomizeInstanceType, vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
-import { PROJECT_LIST_FILTER_PARAM } from '@kubevirt-utils/utils/constants';
 import { isVM } from '@kubevirt-utils/utils/typeGuards';
 import { isEmpty, truncateToK8sName } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useIsAllClustersPage from '@multicluster/hooks/useIsAllClustersPage';
 import { K8sVerb, ListPageBody, useListPageFilter } from '@openshift-console/dynamic-plugin-sdk';
-import { Bullseye, Pagination, Split, SplitItem } from '@patternfly/react-core';
+import { Bullseye, Label, Pagination, Split, SplitItem } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
 import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
 import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
@@ -71,21 +68,6 @@ const VirtualMachinesList = forwardRef(({}, ref) => {
     setCloneVMDescription,
     setCloneVMName,
   } = useVMWizardStore();
-
-  // Initialize project dropdown filter to targetNamespace
-  const queryParams = useQuery();
-  const { setAllQueryArguments } = useQueryParamsMethods();
-  const hasInitializedFilter = useRef(false);
-
-  useEffect(() => {
-    if (hasInitializedFilter.current || !targetNamespace) return;
-
-    setAllQueryArguments({
-      [PROJECT_LIST_FILTER_PARAM]: targetNamespace,
-    });
-
-    hasInitializedFilter.current = true;
-  }, [targetNamespace, queryParams, setAllQueryArguments]);
 
   const isAllClustersPage = useIsAllClustersPage();
   const { loading: loadingFeatureProxy } = useFeatures(KUBEVIRT_APISERVER_PROXY);
@@ -127,14 +109,14 @@ const VirtualMachinesList = forwardRef(({}, ref) => {
   const vmimMapper = useVirtualMachineInstanceMigrationMapper(vmims);
   const pvcMapper = usePVCMapper(targetNamespace, cluster);
 
-  const { filtersWithSelect, rowFilters } = useCloneSourceVMFilters(vms, vmiMapper, pvcMapper);
+  const { rowFilters } = useCloneSourceVMFilters(vms, vmiMapper, pvcMapper);
 
   const [pagination, setPagination] = useState(paginationInitialState);
 
   const [unfilteredData, filteredVMs, onFilterChange] = useListPageFilter<
     V1VirtualMachine,
     V1VirtualMachine
-  >(vms, [...filtersWithSelect, ...rowFilters], {});
+  >(vms, rowFilters, {});
 
   // Clear selection when namespace/cluster changes
   useEffect(() => {
@@ -256,6 +238,11 @@ const VirtualMachinesList = forwardRef(({}, ref) => {
       <ListPageBody>
         <div className="vm-listpagebody" ref={listPageBodyRef}>
           <>
+            {targetNamespace && (
+              <Label className="pf-v6-u-mb-sm" data-test="clone-source-project-label">
+                {t('Project: {{project}}', { project: targetNamespace })}
+              </Label>
+            )}
             <Split hasGutter>
               <SplitItem>
                 <ListPageFilter
@@ -270,7 +257,6 @@ const VirtualMachinesList = forwardRef(({}, ref) => {
                   }}
                   columnLayout={columnLayout}
                   data={unfilteredData}
-                  filtersWithSelect={filtersWithSelect}
                   loaded={loaded}
                   rowFilters={rowFilters}
                 />

--- a/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/hooks/useCloneSourceVMFilters.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/hooks/useCloneSourceVMFilters.ts
@@ -1,6 +1,5 @@
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { useProjectFilter } from '@kubevirt-utils/hooks/useProjectFilter';
 import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 import { useNodesFilter } from '@virtualmachines/list/hooks/useVMListFilters/useNodesFilter';
 import { useStorageClassFilter } from '@virtualmachines/list/hooks/useVMListFilters/useStorageClassFilter';
@@ -17,15 +16,10 @@ export const useCloneSourceVMFilters = (
   vmiMapper: VMIMapper,
   pvcMapper: PVCMapper,
 ): {
-  filtersWithSelect: RowFilter<V1VirtualMachine>[];
   rowFilters: RowFilter<V1VirtualMachine>[];
 } => {
   const { t } = useKubevirtTranslation();
 
-  // Only project filter shown separately
-  const projectFilter = useProjectFilter<V1VirtualMachine>();
-
-  // All other filters grouped into rowFilters dropdown
   const statusFilter = getStatusFilter(t);
   const osFilters = getOSFilter(t);
   const storageClassFilter = useStorageClassFilter(vms, pvcMapper);
@@ -36,7 +30,6 @@ export const useCloneSourceVMFilters = (
   const architectureFilter = getArchitectureFilter(t, vms);
 
   return {
-    filtersWithSelect: [projectFilter],
     rowFilters: [
       statusFilter,
       osFilters,


### PR DESCRIPTION

## 📝 Description

VMs listed in the Clone source step were only fetched from the namespace selected in step 1, but the project filter dropdown allowed users to select a different project — showing no results. Removed the interactive project filter and now displays the project as a read-only label instead.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/e4a84c36-d23a-4853-ba8e-795dcfa051f6


After:

https://github.com/user-attachments/assets/19aec2e5-85fe-4918-a158-6b7e59960120




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined clone-source filtering in the VM creation wizard: project filter handling simplified and moved to an explicit "Project:" label when a target is set; dropdown filters consolidated to focus on row-based filtering for status, OS, storage, hardware, scheduling, nodes, guest agent, and architecture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->