### PR TITLE
CNV-86879: show full templates info in ACM VM creation wizard

### DIFF
--- a/src/multicluster/hooks/useK8sWatchData.ts
+++ b/src/multicluster/hooks/useK8sWatchData.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useIsACMPage from '@multicluster/useIsACMPage';
+import { enrichFleetData } from '@multicluster/utils';
 import { useK8sWatchResource, WatchK8sResult } from '@openshift-console/dynamic-plugin-sdk';
 import {
   FleetWatchK8sResource,
@@ -24,6 +25,11 @@ const useK8sWatchData = <T>(resource: FleetWatchK8sResource | null): WatchK8sRes
     useFleet && !waitingForHubName ? requestWithNoLimit : null,
   );
 
+  const normalizedFleetData = useMemo(
+    () => enrichFleetData(fleetData, resource?.groupVersionKind),
+    [fleetData, resource?.groupVersionKind],
+  );
+
   const [k8sWatchData, k8sWatchLoaded, k8sWatchError] = useK8sWatchResource<T>(
     !useFleet ? resource : null,
   );
@@ -39,7 +45,7 @@ const useK8sWatchData = <T>(resource: FleetWatchK8sResource | null): WatchK8sRes
   if (waitingForHubName) return [defaultData, false, undefined];
 
   return useFleet
-    ? [isEmpty(fleetData) ? defaultData : fleetData, fleetLoaded, fleetError]
+    ? [isEmpty(normalizedFleetData) ? defaultData : normalizedFleetData, fleetLoaded, fleetError]
     : [isEmpty(k8sWatchData) ? defaultData : k8sWatchData, k8sWatchLoaded, k8sWatchError];
 };
 

--- a/src/multicluster/utils.ts
+++ b/src/multicluster/utils.ts
@@ -1,0 +1,21 @@
+import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
+
+/**
+ * useFleetK8sWatchResource does not inject apiVersion/kind into list items
+ * (unlike fleetK8sList which does). This normalizes fleet data so that
+ * getGroupVersionKindForResource and kind-based type guards work correctly.
+ */
+export const enrichFleetData = <T>(data: T, gvk: K8sGroupVersionKind): T => {
+  if (!data || !gvk?.kind || !gvk?.version) return data;
+
+  const apiVersion = gvk.group ? `${gvk.group}/${gvk.version}` : gvk.version;
+
+  const enrichResource = (resource: K8sResourceCommon) =>
+    resource.apiVersion && resource.kind ? resource : { apiVersion, kind: gvk.kind, ...resource };
+
+  if (Array.isArray(data)) {
+    return data.map((item: K8sResourceCommon) => enrichResource(item)) as T;
+  }
+
+  return enrichResource(data) as T;
+};

--- a/src/views/templates/list/hooks/useOpenShiftTemplates.ts
+++ b/src/views/templates/list/hooks/useOpenShiftTemplates.ts
@@ -30,7 +30,6 @@ export const useOpenShiftTemplates: UseOpenShiftTemplates = ({
 }) => {
   const multiclusterFilters = useListMulticlusterFilters();
   const clusters = useListClusters();
-  const cluster = clusters?.length === 1 ? clusters[0] : undefined;
 
   const templateWatchNamespaces = useMemo(
     () => (namespace ? [OPENSHIFT_NAMESPACE, namespace] : [OPENSHIFT_NAMESPACE]),
@@ -56,7 +55,7 @@ export const useOpenShiftTemplates: UseOpenShiftTemplates = ({
     loadError,
     resources: templates,
   } = useAccessibleResources<V1Template>({
-    clusters: cluster ? [cluster] : undefined,
+    clusters,
     fieldSelector,
     groupVersionKind: TemplateModelGroupVersionKind,
     namespace,

--- a/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
+++ b/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
@@ -29,15 +29,13 @@ type UseAccessibleResourcesArgs = {
   watchNamespaces?: string[];
 };
 
-type UseAccessibleResources = <T extends K8sResourceCommon>(
-  args: UseAccessibleResourcesArgs,
-) => {
+type UseAccessibleResourcesReturn<T> = {
   loaded: boolean;
   loadError?: any;
   resources: T[];
 };
 
-export const useAccessibleResources: UseAccessibleResources = <T>({
+export const useAccessibleResources = <T>({
   clusters,
   fieldSelector,
   filterOptions,
@@ -47,11 +45,16 @@ export const useAccessibleResources: UseAccessibleResources = <T>({
   searchQueries,
   selector,
   watchNamespaces,
-}) => {
+}: UseAccessibleResourcesArgs): UseAccessibleResourcesReturn<T> => {
   const isAdmin = useIsAdmin();
   const isACMPage = useIsACMPage();
   const cluster = useClusterParam();
   const [projectNames, projectNamesLoaded, projectNamesError] = useProjects();
+
+  const clusterToWatch = useMemo(() => {
+    if (clusters?.length === 1) return clusters[0];
+    return clusters ? undefined : cluster;
+  }, [clusters, cluster]);
 
   const namespacesToWatch = useMemo(() => {
     if (watchNamespaces) return watchNamespaces;
@@ -65,7 +68,7 @@ export const useAccessibleResources: UseAccessibleResources = <T>({
   const [allResources, allResourcesLoaded] = useKubevirtWatchResource<T[]>(
     shouldFetchClusterWide
       ? {
-          cluster: clusters ? undefined : cluster,
+          cluster: clusterToWatch,
           fieldSelector,
           groupVersionKind,
           isList: true,


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Show full templates info in ACM VM creation wizard

Fix:
- load templates from `useFleetK8sWatchResource` and not from multi-search `useFleetSearchPoll` (which contains only partial spec of the resources)

This fix would cause a bug, where Template names are not loaded in the Templates list page:
- fixed by enriching data from `useFleetK8sWatchResource` with `kind` and `apiVersion`

## 🎥 Demo
Before:

https://github.com/user-attachments/assets/331177fa-bd8d-4c53-bb37-443b1273c1e0




After:

https://github.com/user-attachments/assets/3a4d3ba5-ad71-4345-ba6d-0676e8d990b5





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a utility for enriching and normalizing Kubernetes resource data with automatic API version and kind injection.

* **Refactor**
  * Improved resource accessibility handling across single and multi-cluster environments.
  * Enhanced cluster resource watching logic to better support varying cluster configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->