### PR TITLE
CNV-86658: enabling navigation through create wizard sidebar steps based on next enablement

### DIFF
--- a/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
+++ b/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
@@ -4,15 +4,14 @@ import classnames from 'classnames';
 import { FLAG_LIGHTSPEED_PLUGIN } from '@kubevirt-utils/flags/consts';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
-import { getValidNamespace, isEmpty } from '@kubevirt-utils/utils/utils';
+import { getValidNamespace } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { useActiveNamespace, useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { Wizard, WizardHeader, WizardStep } from '@patternfly/react-core';
-import { useSignals } from '@preact/signals-react/runtime';
 import DefaultWizardFooter from '@virtualmachines/creation-wizard/components/DefaultWizardFooter';
 import useCloseWizard from '@virtualmachines/creation-wizard/hooks/useCloseWizard';
-import useInstanceTypeVMStore from '@virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore';
+import useVMGenerationNavItem from '@virtualmachines/creation-wizard/hooks/useVMGenerationNavItem';
+import useWizardStepValidation from '@virtualmachines/creation-wizard/hooks/useWizardStepValidation';
 import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
 import CloneSourceStep from '@virtualmachines/creation-wizard/steps/CloneSourceStep/CloneSourceStep';
 import CustomizationStep from '@virtualmachines/creation-wizard/steps/CustomizationStep/CustomizationStep';
@@ -36,18 +35,18 @@ import DeploymentDetailsStep from './steps/DeploymentDetailsStep/DeploymentDetai
 
 const VMCreationWizard: FC = () => {
   const { t } = useKubevirtTranslation();
-  useSignals();
   const hasOLSConsole = useFlag(FLAG_LIGHTSPEED_PLUGIN);
   const {
     creationMethod,
+    markStepVisited,
     project,
     resetWizardState,
     setCluster,
     setProject,
     setTemplatesDrawerIsOpen,
   } = useVMWizardStore();
-  const { operatingSystemType, preference, selectedBootableVolume, useBootSource } =
-    useInstanceTypeVMStore();
+  const { isNextDisabledForStep, isStepDisabled } = useWizardStepValidation();
+  const { navItemWithVMGeneration } = useVMGenerationNavItem(creationMethod);
   const clusterParam = useClusterParam();
   const hasInitialized = useRef(false);
   const closeWizard = useCloseWizard();
@@ -89,10 +88,10 @@ const VMCreationWizard: FC = () => {
       <Wizard
         onStepChange={(_, currentStep) => {
           if (currentStep?.id !== VMWizardStep.TEMPLATE) setTemplatesDrawerIsOpen(false);
+          if (currentStep?.id) markStepVisited(String(currentStep.id));
         }}
         className="vm-creation-wizard"
         header={<WizardHeader isCloseHidden title={t('Create VirtualMachine')} />}
-        isVisitRequired
         onClose={closeWizard}
         title={t('Create VirtualMachine')}
       >
@@ -106,7 +105,7 @@ const VMCreationWizard: FC = () => {
         <WizardStep
           footer={{
             cancelButtonProps,
-            isNextDisabled: !operatingSystemType || !preference,
+            isNextDisabled: isNextDisabledForStep(VMWizardStep.GUEST_OS),
           }}
           id={VMWizardStep.GUEST_OS}
           isHidden={!isInstanceTypeMethod}
@@ -117,9 +116,10 @@ const VMCreationWizard: FC = () => {
         <WizardStep
           footer={{
             cancelButtonProps,
-            isNextDisabled: useBootSource && isEmpty(selectedBootableVolume),
+            isNextDisabled: isNextDisabledForStep(VMWizardStep.BOOT_SOURCE),
           }}
           id={VMWizardStep.BOOT_SOURCE}
+          isDisabled={isStepDisabled(VMWizardStep.BOOT_SOURCE)}
           isHidden={!isInstanceTypeMethod}
           name={t('Boot source')}
         >
@@ -128,6 +128,7 @@ const VMCreationWizard: FC = () => {
         <WizardStep
           footer={<ComputeResourcesStepFooter />}
           id={VMWizardStep.COMPUTE_RESOURCES}
+          isDisabled={isStepDisabled(VMWizardStep.COMPUTE_RESOURCES)}
           isHidden={!isInstanceTypeMethod}
           name={t('Compute resources')}
         >
@@ -137,6 +138,7 @@ const VMCreationWizard: FC = () => {
         <WizardStep
           footer={<TemplateStepFooter />}
           id={VMWizardStep.TEMPLATE}
+          isDisabled={isStepDisabled(VMWizardStep.TEMPLATE)}
           isHidden={!isTemplateMethod}
           name={t('Template')}
         >
@@ -145,17 +147,20 @@ const VMCreationWizard: FC = () => {
         <WizardStep
           footer={<DefaultWizardFooter />}
           id={VMWizardStep.CUSTOMIZATION}
+          isDisabled={isStepDisabled(VMWizardStep.CUSTOMIZATION)}
           isHidden={isCloneMethod}
           name={t('Customization')}
+          navItem={navItemWithVMGeneration}
         >
           <CustomizationStep />
         </WizardStep>
         <WizardStep
           footer={{
             cancelButtonProps,
-            isNextDisabled: isEmpty(vmSignal.value),
+            isNextDisabled: isNextDisabledForStep(VMWizardStep.CLONE),
           }}
           id={VMWizardStep.CLONE}
+          isDisabled={isStepDisabled(VMWizardStep.CLONE)}
           isHidden={!isCloneMethod}
           name={t('Source')}
         >
@@ -164,7 +169,9 @@ const VMCreationWizard: FC = () => {
         <WizardStep
           footer={<ReviewAndCreateStepFooter />}
           id={VMWizardStep.REVIEW_AND_CREATE}
+          isDisabled={isStepDisabled(VMWizardStep.REVIEW_AND_CREATE)}
           name={t('Review and create')}
+          navItem={navItemWithVMGeneration}
         >
           <ReviewAndCreateStep />
         </WizardStep>

--- a/src/views/virtualmachines/creation-wizard/components/DefaultWizardFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard/components/DefaultWizardFooter.tsx
@@ -6,7 +6,11 @@ import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { useWizardContext, WizardFooter } from '@patternfly/react-core';
 import useCloseWizard from '@virtualmachines/creation-wizard/hooks/useCloseWizard';
 
-const DefaultWizardFooter: FC = () => {
+type DefaultWizardFooterProps = {
+  isNextDisabled?: boolean;
+};
+
+const DefaultWizardFooter: FC<DefaultWizardFooterProps> = ({ isNextDisabled }) => {
   const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
   const closeWizard = useCloseWizard();
   const hasOLSConsole = useFlag(FLAG_LIGHTSPEED_PLUGIN);
@@ -16,6 +20,7 @@ const DefaultWizardFooter: FC = () => {
       activeStep={activeStep}
       cancelButtonProps={{ className: classnames({ 'pf-v6-u-mr-4xl': hasOLSConsole }) }}
       isBackDisabled={activeStep.index === 1}
+      isNextDisabled={isNextDisabled}
       onBack={goToPrevStep}
       onClose={closeWizard}
       onNext={goToNextStep}

--- a/src/views/virtualmachines/creation-wizard/hooks/useVMGenerationNavItem.tsx
+++ b/src/views/virtualmachines/creation-wizard/hooks/useVMGenerationNavItem.tsx
@@ -1,0 +1,64 @@
+import React, { useCallback, useState } from 'react';
+
+import { CustomWizardNavItemFunction, WizardNavItem, WizardStepType } from '@patternfly/react-core';
+import useCreateVMFromInstanceType from '@virtualmachines/creation-wizard/steps/InstanceTypesSteps/hooks/useCreateVMFromInstanceType';
+import useCreateVMFromTemplate from '@virtualmachines/creation-wizard/steps/TemplateStep/hooks/useCreateVMFromTemplate';
+import {
+  VM_GENERATION_STEPS,
+  VMCreationMethod,
+} from '@virtualmachines/creation-wizard/utils/constants';
+import {
+  isInstanceTypeCreationMethod,
+  isTemplateCreationMethod,
+} from '@virtualmachines/creation-wizard/utils/utils';
+
+const useVMGenerationNavItem = (
+  creationMethod: VMCreationMethod,
+): { isGeneratingVM: boolean; navItemWithVMGeneration: CustomWizardNavItemFunction } => {
+  const createVMFromInstanceType = useCreateVMFromInstanceType();
+  const { createVMFromTemplate } = useCreateVMFromTemplate();
+  const [isGeneratingVM, setIsGeneratingVM] = useState(false);
+
+  const isInstanceTypeMethod = isInstanceTypeCreationMethod(creationMethod);
+  const isTemplateMethod = isTemplateCreationMethod(creationMethod);
+
+  const navItemWithVMGeneration: CustomWizardNavItemFunction = useCallback(
+    (
+      step: WizardStepType,
+      activeStep: WizardStepType,
+      _steps: WizardStepType[],
+      goToStepByIndex: (index: number) => void,
+    ) => (
+      <WizardNavItem
+        onClick={async () => {
+          if (VM_GENERATION_STEPS.has(activeStep?.id)) {
+            setIsGeneratingVM(true);
+            try {
+              if (isInstanceTypeMethod) await createVMFromInstanceType();
+              if (isTemplateMethod) await createVMFromTemplate();
+            } finally {
+              setIsGeneratingVM(false);
+            }
+          }
+          goToStepByIndex(step.index);
+        }}
+        content={step.name}
+        id={step.id}
+        isCurrent={step.id === activeStep?.id}
+        isDisabled={step.isDisabled || isGeneratingVM}
+        stepIndex={step.index}
+      />
+    ),
+    [
+      createVMFromInstanceType,
+      createVMFromTemplate,
+      isGeneratingVM,
+      isInstanceTypeMethod,
+      isTemplateMethod,
+    ],
+  );
+
+  return { isGeneratingVM, navItemWithVMGeneration };
+};
+
+export default useVMGenerationNavItem;

--- a/src/views/virtualmachines/creation-wizard/hooks/useWizardStepValidation.ts
+++ b/src/views/virtualmachines/creation-wizard/hooks/useWizardStepValidation.ts
@@ -1,0 +1,85 @@
+import { useCallback, useMemo } from 'react';
+
+import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { useSignals } from '@preact/signals-react/runtime';
+import useInstanceTypeVMStore from '@virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore';
+import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
+import { VMWizardStep } from '@virtualmachines/creation-wizard/utils/constants';
+import { getActiveFlow } from '@virtualmachines/creation-wizard/utils/utils';
+
+type WizardStepValidation = {
+  isNextDisabledForStep: (stepId: VMWizardStep) => boolean;
+  isStepDisabled: (stepId: VMWizardStep) => boolean;
+};
+
+const useWizardStepValidation = (): WizardStepValidation => {
+  useSignals();
+  const { creationMethod, selectedTemplate, visitedSteps } = useVMWizardStore();
+  const {
+    operatingSystemType,
+    preference,
+    selectedBootableVolume,
+    selectedInstanceType,
+    selectedSeries,
+    selectedSize,
+    useBootSource,
+  } = useInstanceTypeVMStore();
+
+  const activeFlow = getActiveFlow(creationMethod);
+
+  const isRedHatProvided = Boolean(selectedSeries) && Boolean(selectedSize);
+  const isUserProvided =
+    Boolean(selectedInstanceType?.namespace) && Boolean(selectedInstanceType?.name);
+
+  const currentVMSignalValue = vmSignal.value;
+
+  const stepNextDisabled: Record<VMWizardStep, boolean> = useMemo(
+    () => ({
+      [VMWizardStep.BOOT_SOURCE]: useBootSource && isEmpty(selectedBootableVolume),
+      [VMWizardStep.CLONE]: isEmpty(currentVMSignalValue),
+      [VMWizardStep.COMPUTE_RESOURCES]: !isRedHatProvided && !isUserProvided,
+      [VMWizardStep.CUSTOMIZATION]: false,
+      [VMWizardStep.DEPLOYMENT_DETAILS]: false,
+      [VMWizardStep.GUEST_OS]: !operatingSystemType || !preference,
+      [VMWizardStep.REVIEW_AND_CREATE]: false,
+      [VMWizardStep.TEMPLATE]: isEmpty(selectedTemplate),
+    }),
+    [
+      currentVMSignalValue,
+      isRedHatProvided,
+      isUserProvided,
+      operatingSystemType,
+      preference,
+      selectedBootableVolume,
+      selectedTemplate,
+      useBootSource,
+    ],
+  );
+
+  const isStepDisabled = useCallback(
+    (stepId: VMWizardStep): boolean => {
+      const stepIndex = activeFlow.indexOf(stepId);
+      if (stepIndex <= 0) return false;
+
+      for (let i = 0; i < stepIndex; i++) {
+        if (stepNextDisabled[activeFlow[i]]) return true;
+      }
+
+      if (visitedSteps.has(stepId)) return false;
+
+      const previousStep = activeFlow[stepIndex - 1];
+      return !visitedSteps.has(previousStep) || stepNextDisabled[previousStep];
+    },
+    [activeFlow, stepNextDisabled, visitedSteps],
+  );
+
+  const isNextDisabledForStep = useCallback(
+    (stepId: VMWizardStep): boolean => Boolean(stepNextDisabled[stepId]),
+    [stepNextDisabled],
+  );
+
+  return { isNextDisabledForStep, isStepDisabled };
+};
+
+export default useWizardStepValidation;

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore.ts
@@ -5,15 +5,22 @@ import { clearCustomizeInstanceType } from '@kubevirt-utils/store/customizeInsta
 import useInstanceTypeVMStore from '@virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore';
 import { initialVMWizardState } from '@virtualmachines/creation-wizard/state/vm-wizard-store/utils/state';
 import { VMWizardStore } from '@virtualmachines/creation-wizard/state/vm-wizard-store/utils/types';
-import { VMCreationMethod } from '@virtualmachines/creation-wizard/utils/constants';
+import { VMCreationMethod, VMWizardStep } from '@virtualmachines/creation-wizard/utils/constants';
 
 const useVMWizardStore = create<VMWizardStore>()((set) => {
   return {
     ...initialVMWizardState,
+    markStepVisited: (stepId: string) =>
+      set((state) => {
+        if (state.visitedSteps.has(stepId)) return state;
+        const next = new Set(state.visitedSteps);
+        next.add(stepId);
+        return { visitedSteps: next };
+      }),
     resetWizardState: () => {
       clearCustomizeInstanceType();
       useInstanceTypeVMStore.getState().resetInstanceTypeVMState();
-      set({ ...initialVMWizardState });
+      set({ ...initialVMWizardState, visitedSteps: new Set([VMWizardStep.DEPLOYMENT_DETAILS]) });
     },
     setCloneVMDescription: (cloneVMDescription: string) => set({ cloneVMDescription }),
     setCloneVMName: (cloneVMName: string) => set({ cloneVMName }),

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/state.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/state.ts
@@ -1,5 +1,5 @@
 import { VMWizardState } from '@virtualmachines/creation-wizard/state/vm-wizard-store/utils/types';
-import { VMCreationMethod } from '@virtualmachines/creation-wizard/utils/constants';
+import { VMCreationMethod, VMWizardStep } from '@virtualmachines/creation-wizard/utils/constants';
 
 export const initialVMWizardState: VMWizardState = {
   cloneVMDescription: '',
@@ -11,5 +11,6 @@ export const initialVMWizardState: VMWizardState = {
   project: '',
   selectedTemplate: null,
   templatesDrawerIsOpen: false,
+  visitedSteps: new Set([VMWizardStep.DEPLOYMENT_DETAILS]),
   vmNameInteracted: false,
 };

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/types.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/types.ts
@@ -11,10 +11,12 @@ export type VMWizardState = {
   project: string;
   selectedTemplate: Template;
   templatesDrawerIsOpen: boolean;
+  visitedSteps: Set<string>;
   vmNameInteracted: boolean;
 };
 
 export type VMWizardActions = {
+  markStepVisited: (stepId: string) => void;
   resetWizardState: () => void;
   setCloneVMDescription: (cloneVMDescription: string) => void;
   setCloneVMName: (cloneVMName: string) => void;

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/ComputeResourcesStepFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/ComputeResourcesStepFooter.tsx
@@ -5,31 +5,28 @@ import { FLAG_LIGHTSPEED_PLUGIN } from '@kubevirt-utils/flags/consts';
 import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { useWizardContext, WizardFooter } from '@patternfly/react-core';
 import useCloseWizard from '@virtualmachines/creation-wizard/hooks/useCloseWizard';
-import useInstanceTypeVMStore from '@virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore';
+import useWizardStepValidation from '@virtualmachines/creation-wizard/hooks/useWizardStepValidation';
 import useCreateVMFromInstanceType from '@virtualmachines/creation-wizard/steps/InstanceTypesSteps/hooks/useCreateVMFromInstanceType';
+import { VMWizardStep } from '@virtualmachines/creation-wizard/utils/constants';
 
 const ComputeResourcesStepFooter: FC = () => {
   const hasOLSConsole = useFlag(FLAG_LIGHTSPEED_PLUGIN);
   const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
   const handleCreateVM = useCreateVMFromInstanceType();
   const closeWizard = useCloseWizard();
-  const { selectedInstanceType, selectedSeries, selectedSize } = useInstanceTypeVMStore();
+  const { isNextDisabledForStep } = useWizardStepValidation();
 
   const handleGoToNextStep = async () => {
     await handleCreateVM();
     goToNextStep();
   };
 
-  const isRedHatProvided = Boolean(selectedSeries) && Boolean(selectedSize);
-  const isUserProvided =
-    Boolean(selectedInstanceType?.namespace) && Boolean(selectedInstanceType?.name);
-
   return (
     <WizardFooter
       activeStep={activeStep}
       cancelButtonProps={{ className: classnames({ 'pf-v6-u-mr-4xl': hasOLSConsole }) }}
       isBackDisabled={activeStep.index === 1}
-      isNextDisabled={!isRedHatProvided && !isUserProvided}
+      isNextDisabled={isNextDisabledForStep(VMWizardStep.COMPUTE_RESOURCES)}
       onBack={goToPrevStep}
       onClose={closeWizard}
       onNext={handleGoToNextStep}

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplateStepFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplateStepFooter.tsx
@@ -2,19 +2,21 @@ import React, { FC } from 'react';
 import classnames from 'classnames';
 
 import { FLAG_LIGHTSPEED_PLUGIN } from '@kubevirt-utils/flags/consts';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { useWizardContext, WizardFooter } from '@patternfly/react-core';
 import useCloseWizard from '@virtualmachines/creation-wizard/hooks/useCloseWizard';
+import useWizardStepValidation from '@virtualmachines/creation-wizard/hooks/useWizardStepValidation';
 import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
 import useCreateVMFromTemplate from '@virtualmachines/creation-wizard/steps/TemplateStep/hooks/useCreateVMFromTemplate';
+import { VMWizardStep } from '@virtualmachines/creation-wizard/utils/constants';
 
-const TemplateStepFooter: FC = ({}) => {
+const TemplateStepFooter: FC = () => {
   const hasOLSConsole = useFlag(FLAG_LIGHTSPEED_PLUGIN);
   const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
   const { createVMFromTemplate } = useCreateVMFromTemplate();
   const closeWizard = useCloseWizard();
-  const { selectedTemplate, setTemplatesDrawerIsOpen } = useVMWizardStore();
+  const { setTemplatesDrawerIsOpen } = useVMWizardStore();
+  const { isNextDisabledForStep } = useWizardStepValidation();
 
   const handleGoToNextStep = async () => {
     await createVMFromTemplate();
@@ -27,7 +29,7 @@ const TemplateStepFooter: FC = ({}) => {
       activeStep={activeStep}
       cancelButtonProps={{ className: classnames({ 'pf-v6-u-mr-4xl': hasOLSConsole }) }}
       isBackDisabled={activeStep.index === 1}
-      isNextDisabled={isEmpty(selectedTemplate)}
+      isNextDisabled={isNextDisabledForStep(VMWizardStep.TEMPLATE)}
       onBack={goToPrevStep}
       onClose={closeWizard}
       onNext={handleGoToNextStep}

--- a/src/views/virtualmachines/creation-wizard/utils/constants.ts
+++ b/src/views/virtualmachines/creation-wizard/utils/constants.ts
@@ -14,3 +14,30 @@ export enum VMWizardStep {
   REVIEW_AND_CREATE = 'vm-creation-review-and-create-step',
   TEMPLATE = 'vm-creation-template-step',
 }
+
+export const INSTANCE_TYPE_FLOW: VMWizardStep[] = [
+  VMWizardStep.DEPLOYMENT_DETAILS,
+  VMWizardStep.GUEST_OS,
+  VMWizardStep.BOOT_SOURCE,
+  VMWizardStep.COMPUTE_RESOURCES,
+  VMWizardStep.CUSTOMIZATION,
+  VMWizardStep.REVIEW_AND_CREATE,
+];
+
+export const TEMPLATE_FLOW: VMWizardStep[] = [
+  VMWizardStep.DEPLOYMENT_DETAILS,
+  VMWizardStep.TEMPLATE,
+  VMWizardStep.CUSTOMIZATION,
+  VMWizardStep.REVIEW_AND_CREATE,
+];
+
+export const CLONE_FLOW: VMWizardStep[] = [
+  VMWizardStep.DEPLOYMENT_DETAILS,
+  VMWizardStep.CLONE,
+  VMWizardStep.REVIEW_AND_CREATE,
+];
+
+export const VM_GENERATION_STEPS = new Set<number | string>([
+  VMWizardStep.TEMPLATE,
+  VMWizardStep.COMPUTE_RESOURCES,
+]);

--- a/src/views/virtualmachines/creation-wizard/utils/utils.ts
+++ b/src/views/virtualmachines/creation-wizard/utils/utils.ts
@@ -11,7 +11,13 @@ import {
 import CloneIcon from '@virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/components/CreationMethodTile/components/CloneIcon';
 import { InstanceTypeIcon } from '@virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/components/CreationMethodTile/components/InstanceTypeIcon';
 import TemplateIcon from '@virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/components/CreationMethodTile/components/TemplateIcon';
-import { VMCreationMethod } from '@virtualmachines/creation-wizard/utils/constants';
+import {
+  CLONE_FLOW,
+  INSTANCE_TYPE_FLOW,
+  TEMPLATE_FLOW,
+  VMCreationMethod,
+  VMWizardStep,
+} from '@virtualmachines/creation-wizard/utils/constants';
 
 export const isCloneCreationMethod = (creationMethod: VMCreationMethod) =>
   creationMethod === VMCreationMethod.CLONE;
@@ -19,6 +25,13 @@ export const isTemplateCreationMethod = (creationMethod: VMCreationMethod) =>
   creationMethod === VMCreationMethod.TEMPLATE;
 export const isInstanceTypeCreationMethod = (creationMethod: VMCreationMethod) =>
   creationMethod === VMCreationMethod.INSTANCE_TYPE;
+
+export const getActiveFlow = (creationMethod: VMCreationMethod): VMWizardStep[] => {
+  if (isInstanceTypeCreationMethod(creationMethod)) return INSTANCE_TYPE_FLOW;
+  if (isTemplateCreationMethod(creationMethod)) return TEMPLATE_FLOW;
+  if (isCloneCreationMethod(creationMethod)) return CLONE_FLOW;
+  return INSTANCE_TYPE_FLOW;
+};
 
 export const getVMCreationMethodsDetails = (t: TFunction) => {
   return {


### PR DESCRIPTION

## 📝 Description

Sidebar steps in the VM Creation wizard were always disabled until visited, regardless of whether the "Next" button was enabled. This made direct navigation impossible even when all prerequisites were met.

Changes:

Replaced `isVisitRequired` with custom `visitedSteps` tracking and centralized validation (`useWizardStepValidation`) so sidebar steps reflect the same enabled/disabled logic as the footer "Next" button
Added `navItem` override on Customization and Review steps (`useVMGenerationNavItem`) to trigger VM generation on sidebar click, matching the existing footer "Next" behavior
Extracted step validation from individual footers into shared hook for consistency

## 🎥 Demo

After:

https://github.com/user-attachments/assets/bdc606bd-f471-42bb-a376-b1f198756538




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized validation logic for VM creation wizard steps, automatically enabling/disabling navigation based on required inputs.
  * Implemented automatic step visit tracking to improve wizard state management.

* **Improvements**
  * Enhanced wizard step navigation with smarter validation for each creation path (instance type, template, clone).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->