### PR TITLE
CNV-86642: tooltip doesn't appear in treeview right click menu

### DIFF
--- a/src/utils/components/ActionDropdownItem/ActionDropdownItem.tsx
+++ b/src/utils/components/ActionDropdownItem/ActionDropdownItem.tsx
@@ -1,6 +1,13 @@
 import React, { Dispatch, FC, SetStateAction } from 'react';
 
-import { Menu, MenuContent, MenuItem, MenuList, TooltipPosition } from '@patternfly/react-core';
+import {
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuList,
+  Tooltip,
+  TooltipPosition,
+} from '@patternfly/react-core';
 import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
 
 import { ActionDropdownItemType } from '../ActionsDropdown/constants';
@@ -10,14 +17,21 @@ import './ActionDropdownItem.scss';
 type ActionDropdownItemProps = {
   action: ActionDropdownItemType;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
+  tooltipPosition?: TooltipPosition;
+  tooltipZIndex?: number;
 };
 
-const ActionDropdownItem: FC<ActionDropdownItemProps> = ({ action, setIsOpen }) => {
+const ActionDropdownItem: FC<ActionDropdownItemProps> = ({
+  action,
+  setIsOpen,
+  tooltipPosition,
+  tooltipZIndex,
+}) => {
   const [accessReview] = useFleetAccessReview(action?.accessReview || {});
 
   const actionAllowed = accessReview || action?.accessReview === undefined;
   const isDisabled = !actionAllowed || action?.disabled;
-  const displayDisabledTooltip = isDisabled && action?.disabledTooltip;
+  const showTooltip = isDisabled && action?.disabledTooltip;
 
   const handleClick = () => {
     if (typeof action?.cta === 'function') {
@@ -26,14 +40,7 @@ const ActionDropdownItem: FC<ActionDropdownItemProps> = ({ action, setIsOpen }) 
     }
   };
 
-  const tooltipProps = displayDisabledTooltip
-    ? {
-        content: action?.disabledTooltip,
-        position: TooltipPosition.left,
-      }
-    : null;
-
-  return (
+  const menuItem = (
     <MenuItem
       flyoutMenu={
         action?.options && (
@@ -41,7 +48,13 @@ const ActionDropdownItem: FC<ActionDropdownItemProps> = ({ action, setIsOpen }) 
             <MenuContent>
               <MenuList>
                 {action?.options?.map((option) => (
-                  <ActionDropdownItem action={option} key={option.id} setIsOpen={setIsOpen} />
+                  <ActionDropdownItem
+                    action={option}
+                    key={option.id}
+                    setIsOpen={setIsOpen}
+                    tooltipPosition={tooltipPosition}
+                    tooltipZIndex={tooltipZIndex}
+                  />
                 ))}
               </MenuList>
             </MenuContent>
@@ -50,10 +63,9 @@ const ActionDropdownItem: FC<ActionDropdownItemProps> = ({ action, setIsOpen }) 
       }
       data-test-id={`${action?.id}`}
       description={action?.description}
-      isDisabled={isDisabled}
+      isAriaDisabled={isDisabled}
       key={action?.id}
       onClick={handleClick}
-      tooltipProps={tooltipProps}
     >
       {action?.label}
       {action?.icon && (
@@ -64,6 +76,20 @@ const ActionDropdownItem: FC<ActionDropdownItemProps> = ({ action, setIsOpen }) 
       )}
     </MenuItem>
   );
+
+  if (showTooltip) {
+    return (
+      <Tooltip
+        content={action.disabledTooltip}
+        position={tooltipPosition ?? TooltipPosition.left}
+        {...(tooltipZIndex && { zIndex: tooltipZIndex })}
+      >
+        <div>{menuItem}</div>
+      </Tooltip>
+    );
+  }
+
+  return menuItem;
 };
 
 export default ActionDropdownItem;

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/GroupedRightClickActionMenu.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/GroupedRightClickActionMenu.tsx
@@ -3,9 +3,10 @@ import React, { FC } from 'react';
 import ActionDropdownItem from '@kubevirt-utils/components/ActionDropdownItem/ActionDropdownItem';
 import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Divider, MenuGroup, MenuList } from '@patternfly/react-core';
+import { Divider, MenuGroup, MenuList, TooltipPosition } from '@patternfly/react-core';
 
 import useGroupedActions from './hooks/useGroupedActions';
+import { RIGHT_CLICK_MENU_Z_INDEX } from './constants';
 import { RightClickActionMenuProps } from './RightClickActionMenu';
 import RightClickMenuWrapper from './RightClickMenuWrapper';
 
@@ -33,6 +34,8 @@ const GroupedRightClickActionMenu: FC<GroupedRightClickActionMenuProps> = ({
                 action={createVMAction}
                 key={createVMAction.id}
                 setIsOpen={hideMenu}
+                tooltipPosition={TooltipPosition.right}
+                tooltipZIndex={RIGHT_CLICK_MENU_Z_INDEX + 1}
               />
             </MenuList>
           </MenuGroup>
@@ -42,7 +45,13 @@ const GroupedRightClickActionMenu: FC<GroupedRightClickActionMenuProps> = ({
       <MenuGroup label={t('Manage all VMs')}>
         <MenuList>
           {manageVMsActions.map((action) => (
-            <ActionDropdownItem action={action} key={action.id} setIsOpen={hideMenu} />
+            <ActionDropdownItem
+              action={action}
+              key={action.id}
+              setIsOpen={hideMenu}
+              tooltipPosition={TooltipPosition.right}
+              tooltipZIndex={RIGHT_CLICK_MENU_Z_INDEX + 1}
+            />
           ))}
         </MenuList>
       </MenuGroup>
@@ -50,7 +59,13 @@ const GroupedRightClickActionMenu: FC<GroupedRightClickActionMenuProps> = ({
       <MenuGroup>
         <MenuList>
           {bottomActions.map((action) => (
-            <ActionDropdownItem action={action} key={action.id} setIsOpen={hideMenu} />
+            <ActionDropdownItem
+              action={action}
+              key={action.id}
+              setIsOpen={hideMenu}
+              tooltipPosition={TooltipPosition.right}
+              tooltipZIndex={RIGHT_CLICK_MENU_Z_INDEX + 1}
+            />
           ))}
         </MenuList>
       </MenuGroup>

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/RightClickActionMenu.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/RightClickActionMenu.tsx
@@ -2,8 +2,9 @@ import React, { FC } from 'react';
 
 import ActionDropdownItem from '@kubevirt-utils/components/ActionDropdownItem/ActionDropdownItem';
 import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
-import { MenuList } from '@patternfly/react-core';
+import { MenuList, TooltipPosition } from '@patternfly/react-core';
 
+import { RIGHT_CLICK_MENU_Z_INDEX } from './constants';
 import RightClickMenuWrapper from './RightClickMenuWrapper';
 
 export type RightClickActionMenuProps = {
@@ -22,7 +23,13 @@ const RightClickActionMenu: FC<RightClickActionMenuProps> = ({
   <RightClickMenuWrapper nestedLevel={nestedLevel} triggerRef={triggerRef}>
     <MenuList>
       {actions?.map((action) => (
-        <ActionDropdownItem action={action} key={action.id} setIsOpen={hideMenu} />
+        <ActionDropdownItem
+          action={action}
+          key={action.id}
+          setIsOpen={hideMenu}
+          tooltipPosition={TooltipPosition.right}
+          tooltipZIndex={RIGHT_CLICK_MENU_Z_INDEX + 1}
+        />
       ))}
     </MenuList>
   </RightClickMenuWrapper>


### PR DESCRIPTION

## 📝 Description

Disabled "Migrate Compute" and "Migrate Storage" actions in the tree view right-click menu were not showing tooltips explaining why they are disabled, unlike the kebab menu and Actions dropdown which do. The root cause was PatternFly's `MenuItem` setting `pointer-events: none` on disabled items, blocking all hover events. Fixed by using `isAriaDisabled` instead of `isDisabled` and wrapping disabled items with an explicit Tooltip component. Tooltip position is set to right in the tree view context to avoid overlapping the menu.


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/89cb0301-e033-47e1-aaef-8d1551ccace9

After:

https://github.com/user-attachments/assets/98c4951c-d813-4c65-a72a-29c40cd0a468







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Tooltips for dropdown and right-click menus now consistently appear on the right and respect z-index for proper layering.
  * Submenu items inherit tooltip positioning for consistent behavior.

* **Bug Fixes**
  * Disabled menu items now display explanatory tooltips via conditional wrapping, improving discoverability while preserving accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->