### PR TITLE
[release-4.18] CNV-87187: use vCPU count from VMI spec for CPU percentage calculation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@ yarn.lock
 /gui-test-screenshots
 cypress/gui-test-screenshots
 cypress/cypress-a11y-report.json
+playwright/

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRow.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRow.tsx
@@ -38,7 +38,7 @@ const VirtualMachineRow: FC<
     <VirtualMachineRowLayout
       activeColumnIDs={activeColumnIDs}
       obj={vm}
-      rowData={{ ips: NO_DATA_DASH, node: NO_DATA_DASH, vmim: null }}
+      rowData={{ ips: NO_DATA_DASH, node: NO_DATA_DASH, vmiCPU: null, vmim: null }}
     />
   );
 };

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRowLayout.tsx
@@ -2,6 +2,7 @@ import React, { FC, ReactNode, useMemo } from 'react';
 
 import { VirtualMachineModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import {
+  V1CPU,
   V1VirtualMachine,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
@@ -28,11 +29,12 @@ const VirtualMachineRowLayout: FC<
     {
       ips: ReactNode | string;
       node: ReactNode | string;
+      vmiCPU: V1CPU;
       vmim: V1VirtualMachineInstanceMigration;
       vmiMemory?: string;
     }
   >
-> = ({ activeColumnIDs, obj, rowData: { ips, node, vmim, vmiMemory } }) => {
+> = ({ activeColumnIDs, obj, rowData: { ips, node, vmiCPU, vmim, vmiMemory } }) => {
   const selected = isVMSelected(obj);
 
   const vmName = useMemo(() => getName(obj), [obj]);
@@ -76,7 +78,7 @@ const VirtualMachineRowLayout: FC<
         <MemoryPercentage vmiMemory={vmiMemory} vmName={vmName} vmNamespace={vmNamespace} />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="cpu-usage">
-        <CPUPercentage vmName={vmName} vmNamespace={vmNamespace} />
+        <CPUPercentage vmiCPU={vmiCPU} vmName={vmName} vmNamespace={vmNamespace} />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} className="vm-column" id="network-usage">
         <NetworkUsage vmName={vmName} vmNamespace={vmNamespace} />

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/VirtualMachineRunningRow.tsx
@@ -7,7 +7,7 @@ import {
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, NodeModel } from '@kubevirt-utils/models';
-import { getMemory } from '@kubevirt-utils/resources/vm';
+import { getCPU, getMemory } from '@kubevirt-utils/resources/vm';
 import { getVMIIPAddressesWithName } from '@kubevirt-utils/resources/vmi';
 import { ResourceLink, RowProps } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -38,6 +38,7 @@ const VirtualMachineRunningRow: React.FC<
             truncate
           />
         ),
+        vmiCPU: getCPU(vmi),
         vmim,
         vmiMemory: getMemory(vmi),
       }}

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/components/CPUPercentage.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/components/CPUPercentage.tsx
@@ -1,19 +1,23 @@
 import React, { FC } from 'react';
 
+import { V1CPU } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { getVCPUCount } from '@kubevirt-utils/resources/vm';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getVMMetrics } from '@virtualmachines/list/metrics';
 
 type CPUPercentageProps = {
+  vmiCPU: V1CPU;
   vmName: string;
   vmNamespace: string;
 };
 
-const CPUPercentage: FC<CPUPercentageProps> = ({ vmName, vmNamespace }) => {
-  const { cpuRequested, cpuUsage } = getVMMetrics(vmName, vmNamespace);
+const CPUPercentage: FC<CPUPercentageProps> = ({ vmiCPU, vmName, vmNamespace }) => {
+  const { cpuUsage } = getVMMetrics(vmName, vmNamespace);
 
-  if (isEmpty(cpuRequested) || isEmpty(cpuUsage)) return <span>{NO_DATA_DASH}</span>;
+  if (isEmpty(cpuUsage)) return <span>{NO_DATA_DASH}</span>;
 
+  const cpuRequested = getVCPUCount(vmiCPU);
   const percentage = (cpuUsage * 100) / cpuRequested;
   return <span>{percentage.toFixed(2)}%</span>;
 };

--- a/src/views/virtualmachines/list/hooks/constants.ts
+++ b/src/views/virtualmachines/list/hooks/constants.ts
@@ -4,7 +4,6 @@ export const TEXT_FILTER_NAME_ID = 'name';
 export const TEXT_FILTER_LABELS_ID = 'labels';
 
 export const VMListQueries = {
-  CPU_REQUESTED: 'CPU_REQUESTED',
   CPU_USAGE: 'CPU_USAGE',
   MEMORY_USAGE: 'MEMORY_USAGE',
   NETWORK_TOTAL_USAGE: 'NETWORK_TOTAL_USAGE',
@@ -15,7 +14,6 @@ export const getVMListQueries = (namespace: string) => {
     namespace === ALL_NAMESPACES_SESSION_KEY ? '' : `namespace='${namespace}'`;
 
   return {
-    [VMListQueries.CPU_REQUESTED]: `kube_pod_resource_request{resource='cpu',${namespaceFilter}}`,
     [VMListQueries.CPU_USAGE]: `rate(kubevirt_vmi_cpu_usage_seconds_total{${namespaceFilter}}[5m])`,
     [VMListQueries.MEMORY_USAGE]: `kubevirt_vmi_memory_used_bytes{${namespaceFilter}}`,
     [VMListQueries.NETWORK_TOTAL_USAGE]: `rate(kubevirt_vmi_network_transmit_bytes_total{${namespaceFilter}}[5m]) + rate(kubevirt_vmi_network_receive_bytes_total{${namespaceFilter}}[5m])`,

--- a/src/views/virtualmachines/list/metrics.ts
+++ b/src/views/virtualmachines/list/metrics.ts
@@ -36,8 +36,3 @@ export const setVMCPUUsage = (vmName: string, vmNamespace: string, cpuUsage: num
   const vmMetrics = getVMMetrics(vmName, vmNamespace);
   vmMetrics.cpuUsage = cpuUsage;
 };
-
-export const setVMCPURequested = (vmName: string, vmNamespace: string, cpuRequested: number) => {
-  const vmMetrics = getVMMetrics(vmName, vmNamespace);
-  vmMetrics.cpuRequested = cpuRequested;
-};


### PR DESCRIPTION
## 📝 Description

Fix CPU usage percentage in the VM list view exceeding 100%.

BACKPORTED some changes [here](https://github.com/kubevirt-ui/kubevirt-plugin/pull/2426) that were not backported with [this pr](https://github.com/kubevirt-ui/kubevirt-plugin/pull/3510) because of some conflicts.

**Root cause:** The previous approach used `kube_pod_resource_request{resource='cpu'}` from pod metrics to get the CPU requested value, which is the Kubernetes CPU request (not the number of vCPUs). This could be unset, inaccurate, or simply a different unit than what `kubevirt_vmi_cpu_usage_seconds_total` produces.

**Fix:** Replace the pod-based CPU requested query with `getVCPUCount(vmi.spec.domain.cpu)` — computed directly from the VMI spec as `sockets × cores × threads`. This is passed as a prop through `VirtualMachineRunningRow` → `VirtualMachineRowLayout` → `CPUPercentage`, eliminating the need for the `CPU_REQUESTED` Prometheus query and the pod-watcher hook entirely.

**Changes:**
- Remove `CPU_REQUESTED` query (`kube_pod_resource_request`) from `VMListQueries`
- Remove `useK8sWatchResource` for pods and `getVMNamesFromPodsNames` from `useVMMetrics`
- Remove `setVMCPURequested` from `metrics.ts`
- Pass `vmiCPU` (from `getCPU(vmi)`) down to `CPUPercentage` and compute `cpuRequested` via `getVCPUCount`

**Bug:** <!-- Add Jira issue number here -->

## 🎥 Demo

**BEFORE**
<img width="1613" height="136" alt="Screenshot 2026-05-11 at 13 08 09" src="https://github.com/user-attachments/assets/278df284-35da-4dc5-94cd-3bacb8b87e19" />

**AFTER**
<img width="1613" height="136" alt="Screenshot 2026-05-11 at 13 08 41" src="https://github.com/user-attachments/assets/ed643277-c8e4-45a3-b7de-0326aa0fca4b" />


Made with [Cursor](https://cursor.com)