### PR TITLE
CNV-87303: add /recheck-jira comment trigger to Jira PR validation workflow

### DIFF
--- a/.github/scripts/src/jira-client.ts
+++ b/.github/scripts/src/jira-client.ts
@@ -69,26 +69,26 @@ export class JiraClient {
   getAllFields = async (): Promise<JiraFieldMeta[]> =>
     this.request<JiraFieldMeta[]>('/field');
 
-  /** Auto-discover custom field IDs for "Story Points" and "Product Type" (cached). */
+  /** Auto-discover custom field IDs for "Story Points" and "Activity Type" (cached). */
   discoverCustomFields = async (): Promise<DiscoveredFields> => {
     if (this.fieldCache) return this.fieldCache;
 
     const fields = await this.getAllFields();
     let storyPointsFieldId: string | null = null;
-    let productTypeFieldId: string | null = null;
+    let activityTypeFieldId: string | null = null;
 
     for (const field of fields) {
       const nameLower = field.name.toLowerCase();
       if (!storyPointsFieldId && nameLower === 'story points') {
         storyPointsFieldId = field.id;
       }
-      if (!productTypeFieldId && nameLower === 'product type') {
-        productTypeFieldId = field.id;
+      if (!activityTypeFieldId && nameLower === 'activity type') {
+        activityTypeFieldId = field.id;
       }
-      if (storyPointsFieldId && productTypeFieldId) break;
+      if (storyPointsFieldId && activityTypeFieldId) break;
     }
 
-    this.fieldCache = { storyPointsFieldId, productTypeFieldId };
+    this.fieldCache = { storyPointsFieldId, activityTypeFieldId };
     return this.fieldCache;
   };
 

--- a/.github/scripts/src/types/jira.ts
+++ b/.github/scripts/src/types/jira.ts
@@ -90,5 +90,5 @@ export type JiraCreateIssuePayload = {
 
 export type DiscoveredFields = {
   storyPointsFieldId: string | null;
-  productTypeFieldId: string | null;
+  activityTypeFieldId: string | null;
 };

--- a/.github/scripts/src/validation-checks.ts
+++ b/.github/scripts/src/validation-checks.ts
@@ -7,7 +7,7 @@ import {
 import { JIRA_BASE_URL, MIN_STORY_POINTS, REQUIRED_COMPONENT } from './types/index.js';
 import type { JiraIssue, ValidationCheck } from './types/index.js';
 
-/** Validate story points, fix version, component, and product type on a Jira ticket. */
+/** Validate story points, fix version, component, and activity type on a Jira ticket. */
 export const validateTicket = async (
   jira: JiraClient,
   issue: JiraIssue,
@@ -71,17 +71,17 @@ export const validateTicket = async (
       : `Component "${REQUIRED_COMPONENT}" is not set (found: ${issue.fields.components.map((c) => c.name).join(', ') || 'none'})`,
   });
 
-  const ptFieldId = discoveredFields.productTypeFieldId;
-  let productTypeSet = false;
-  if (ptFieldId) {
-    const raw = issue.fields[ptFieldId as `customfield_${string}`];
-    productTypeSet = raw != null && raw !== '';
+  const atFieldId = discoveredFields.activityTypeFieldId;
+  let activityTypeSet = false;
+  if (atFieldId) {
+    const raw = issue.fields[atFieldId as `customfield_${string}`];
+    activityTypeSet = raw != null && raw !== '';
   }
   checks.push({
-    name: 'Product Type', passed: productTypeSet,
-    message: productTypeSet
-      ? 'Product Type is set'
-      : ptFieldId ? 'Product Type is not set on the ticket' : 'Could not discover "Product Type" custom field',
+    name: 'Activity Type', passed: activityTypeSet,
+    message: activityTypeSet
+      ? 'Activity Type is set'
+      : atFieldId ? 'Activity Type is not set on the ticket' : 'Could not discover "Activity Type" custom field',
   });
 
   return checks;

--- a/.github/workflows/jira_pr_check.yml
+++ b/.github/workflows/jira_pr_check.yml
@@ -11,14 +11,13 @@ permissions:
   issues: write
   statuses: write
 
-concurrency:
-  group: jira-check-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   jira-validation:
     name: jira-validation
     runs-on: ubuntu-latest
+    concurrency:
+      group: jira-check-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
     if: >
       github.event_name == 'pull_request_target' ||
       (github.event_name == 'issue_comment' &&

--- a/.github/workflows/jira_pr_check.yml
+++ b/.github/workflows/jira_pr_check.yml
@@ -3,6 +3,8 @@ name: Jira PR Validation
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+  issue_comment:
+    types: [created]
 
 permissions:
   pull-requests: write
@@ -10,18 +12,37 @@ permissions:
   statuses: write
 
 concurrency:
-  group: jira-check-${{ github.event.pull_request.number }}
+  group: jira-check-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
   jira-validation:
     name: jira-validation
     runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '/recheck-jira'))
     steps:
+      - name: Get PR info (comment trigger)
+        if: github.event_name == 'issue_comment'
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('title', pr.title);
+            core.setOutput('base_ref', pr.base.ref);
+
       - name: Checkout base branch scripts
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.base.ref || steps.pr-info.outputs.base_ref }}
           sparse-checkout: .github/scripts
 
       - name: Setup Node
@@ -38,9 +59,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PR_TITLE: ${{ github.event.pull_request.title || steps.pr-info.outputs.title }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref || steps.pr-info.outputs.base_ref }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
         run: npx tsx src/validate-pr.ts


### PR DESCRIPTION
## 📝 Description

Add an `issue_comment` trigger to the `jira_pr_check.yml` workflow so contributors can manually re-run the Jira PR validation by posting `/recheck-jira` as a comment on a pull request.

Previously the check could only be triggered by PR events (open, edit, sync, reopen, label). Now it can also be triggered on demand via a PR comment.

**How it works:**
- A new `issue_comment: [created]` trigger is added alongside the existing `pull_request_target`
- The job only runs when the comment is on a PR (not a regular issue) and the body contains `/recheck-jira`
- A `github-script` step fetches PR title and base branch from the API when triggered by comment (since `issue_comment` events don't carry full PR context)
- All env vars are unified with `||` fallbacks so both trigger paths produce identical inputs to the validation script

## 🔗 Links

https://issues.redhat.com/browse/CNV-87303

## 🎥 Demo

N/A — CI workflow change only

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflow: allow validation to be re-triggered via PR comments with "/recheck-jira", unify concurrency so comment-triggered rechecks share cancel-in-progress behavior with PR runs, and ensure checkout/validation use the correct PR or comment-associated branch and metadata.
* **Bug Fixes**
  * Validation: switched checks and messaging from "Product Type" to "Activity Type" and updated related type information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->