### PR TITLE
CNV-87305: [ACM] VM tree does not highlight selected VM in fleet virtualization list view

### DIFF
--- a/src/views/virtualmachines/tree/utils/utils.tsx
+++ b/src/views/virtualmachines/tree/utils/utils.tsx
@@ -219,8 +219,8 @@ export const getVMInfoFromPathname = (pathname: string) => {
   if (isACMTreeView) {
     const currentVMTab = splitPathname?.[8] || '';
     const vmName = splitPathname?.[7];
-    const vmNamespace = splitPathname?.[5];
-    const vmCluster = splitPathname?.[3];
+    const vmNamespace = splitPathname?.[6];
+    const vmCluster = splitPathname?.[4];
 
     return { currentVMTab, vmCluster, vmName, vmNamespace };
   }


### PR DESCRIPTION
## 📝 Description

Jira Ticket: [CNV-87305](https://redhat.atlassian.net/browse/CNV-87305)

In Advanced Cluster Management (ACM) / fleet virtualization, the Virtual Machines list tree does not show the active highlight on the VM node after selecting it. Single-cluster (non-ACM) behavior works as expected.


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/67ebc470-5f45-4289-ad8c-5f8ef311c136

After:

https://github.com/user-attachments/assets/a59824b9-7ecc-4bcf-8626-2f22392315a0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with how virtual machine URLs are parsed in the tree-view interface. The system now correctly identifies and extracts cluster and namespace information from navigation URLs, ensuring virtual machines are accurately recognized and their proper configuration details are displayed correctly across all views and navigation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->