### PR TITLE
CNV-87319: guard VMT/VMTR watches until models are  available

### DIFF
--- a/src/views/templates/list/hooks/useVirtualMachineTemplateRequests.ts
+++ b/src/views/templates/list/hooks/useVirtualMachineTemplateRequests.ts
@@ -1,8 +1,8 @@
-import { VirtualMachineTemplateRequestModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { VirtualMachineTemplateRequestModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1alpha1VirtualMachineTemplateRequest } from '@kubevirt-ui-ext/kubevirt-api/virt-template';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useListClusters from '@kubevirt-utils/hooks/useListClusters';
-import { getGroupVersionKindForModel } from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
 type UseVirtualMachineTemplateRequests = (
   namespace?: string,
@@ -19,14 +19,18 @@ const useVirtualMachineTemplateRequests: UseVirtualMachineTemplateRequests = (
 ) => {
   const clusters = useListClusters();
   const cluster = clusters?.length === 1 ? clusters[0] : undefined;
+  const [model, inFlight] = useK8sModel(VirtualMachineTemplateRequestModelGroupVersionKind);
+
+  const modelAvailable = !!model && !inFlight;
+  const shouldWatch = enabled && modelAvailable;
 
   const [vmTemplateRequests, loaded, loadError] = useKubevirtWatchResource<
     V1alpha1VirtualMachineTemplateRequest[]
   >(
-    enabled
+    shouldWatch
       ? {
           cluster,
-          groupVersionKind: getGroupVersionKindForModel(VirtualMachineTemplateRequestModel),
+          groupVersionKind: VirtualMachineTemplateRequestModelGroupVersionKind,
           isList: true,
           namespace,
           namespaced: true,
@@ -36,7 +40,7 @@ const useVirtualMachineTemplateRequests: UseVirtualMachineTemplateRequests = (
 
   return {
     error: loadError,
-    loaded,
+    loaded: shouldWatch ? loaded : true,
     vmTemplateRequests: vmTemplateRequests ?? [],
   };
 };

--- a/src/views/templates/list/hooks/useVirtualMachineTemplates.ts
+++ b/src/views/templates/list/hooks/useVirtualMachineTemplates.ts
@@ -1,9 +1,9 @@
-import { VirtualMachineTemplateModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { VirtualMachineTemplateModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1alpha1VirtualMachineTemplate } from '@kubevirt-ui-ext/kubevirt-api/virt-template';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useListClusters from '@kubevirt-utils/hooks/useListClusters';
-import { getGroupVersionKindForModel } from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
 type UseVirtualMachineTemplates = (
   namespace?: string,
@@ -18,8 +18,10 @@ const useVirtualMachineTemplates: UseVirtualMachineTemplates = (namespace, enabl
   const clusters = useListClusters();
   const cluster = clusters?.length === 1 ? clusters[0] : undefined;
   const isAdmin = useIsAdmin();
+  const [model, inFlight] = useK8sModel(VirtualMachineTemplateModelGroupVersionKind);
 
-  const shouldWatch = enabled && (isAdmin || Boolean(namespace));
+  const modelAvailable = !!model && !inFlight;
+  const shouldWatch = enabled && modelAvailable && (isAdmin || Boolean(namespace));
 
   const [vmTemplates, loaded, loadError] = useKubevirtWatchResource<
     V1alpha1VirtualMachineTemplate[]
@@ -27,7 +29,7 @@ const useVirtualMachineTemplates: UseVirtualMachineTemplates = (namespace, enabl
     shouldWatch
       ? {
           cluster,
-          groupVersionKind: getGroupVersionKindForModel(VirtualMachineTemplateModel),
+          groupVersionKind: VirtualMachineTemplateModelGroupVersionKind,
           isList: true,
           namespace,
           namespaced: true,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes showing `Error: Model does not exist` in the Templates page, after enabling VirtualMachineTemplates feature in settings.

- guard `VirtualMachineTemplate` and `VirtualMachineTemplateRequest` watches until models are available

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-87319

## 🎥 Demo
Before:

https://github.com/user-attachments/assets/b75bc06c-3e83-460b-b694-64ce527844aa



After:


https://github.com/user-attachments/assets/3df9ce71-d672-4519-ab6b-8de2afe7d8e2




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of Virtual Machine Template and Template Request resource loading by ensuring Kubernetes models are fully initialized before monitoring for resource changes. This prevents potential loading failures when models are not yet available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->