### PR TITLE
CNV-87303: fix /recheck-jira to update PR check status

### DIFF
--- a/.github/scripts/src/github-comments.ts
+++ b/.github/scripts/src/github-comments.ts
@@ -78,6 +78,25 @@ export const hasLabel = async (
   return labels.some((l) => l.name === label);
 };
 
+/** Create or update a GitHub commit status for the jira-validation check. */
+export const setCommitStatus = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  sha: string,
+  state: 'pending' | 'success' | 'failure' | 'error',
+  description: string,
+): Promise<void> => {
+  await octokit.repos.createCommitStatus({
+    owner,
+    repo,
+    sha,
+    state,
+    context: 'jira-validation',
+    description: description.slice(0, 140),
+  });
+};
+
 /** Update the validation comment and add/remove the block label based on result. */
 export const reportValidation = async (
   octokit: Octokit,

--- a/.github/scripts/src/validate-pr.ts
+++ b/.github/scripts/src/validate-pr.ts
@@ -1,6 +1,6 @@
 import { JiraClient } from './jira-client.js';
 import { createOctokit, getReleaseBranches } from './github-repo.js';
-import { hasLabel, reportValidation } from './github-comments.js';
+import { hasLabel, reportValidation, setCommitStatus } from './github-comments.js';
 import { extractTicketIds, getExpectedVersionForBranch } from './version-utils.js';
 import { validateTicket, formatValidationComment } from './validation-checks.js';
 import { requireEnv, safeErrorMessage } from './utils.js';
@@ -18,7 +18,12 @@ const main = async (): Promise<void> => {
   const prNumber = parseInt(requireEnv('PR_NUMBER'), 10);
   const prTitle = requireEnv('PR_TITLE');
   const baseBranch = requireEnv('BASE_BRANCH');
+  const headSha = process.env.PR_HEAD_SHA;
   const octokit = createOctokit(ghConfig);
+
+  if (headSha) {
+    await setCommitStatus(octokit, ghConfig.owner, ghConfig.repo, headSha, 'pending', 'Jira validation in progress…');
+  }
 
   const shouldSkip = await hasLabel(octokit, ghConfig.owner, ghConfig.repo, prNumber, SKIP_LABEL);
   if (shouldSkip) {
@@ -27,6 +32,9 @@ const main = async (): Promise<void> => {
       octokit, ghConfig.owner, ghConfig.repo, prNumber, true,
       `:white_check_mark: **Jira Validation Skipped** — \`${SKIP_LABEL}\` label is present.`,
     );
+    if (headSha) {
+      await setCommitStatus(octokit, ghConfig.owner, ghConfig.repo, headSha, 'success', 'Jira validation skipped');
+    }
     return;
   }
 
@@ -41,6 +49,9 @@ const main = async (): Promise<void> => {
       '> Edit your PR title to include a valid Jira ticket ID.';
 
     await reportValidation(octokit, ghConfig.owner, ghConfig.repo, prNumber, false, msg);
+    if (headSha) {
+      await setCommitStatus(octokit, ghConfig.owner, ghConfig.repo, headSha, 'failure', 'No CNV ticket ID found in PR title');
+    }
     process.exit(1);
   }
 
@@ -79,6 +90,14 @@ const main = async (): Promise<void> => {
   const commentBody = formatValidationComment(ticketIds, allChecks, allPassed);
   await reportValidation(octokit, ghConfig.owner, ghConfig.repo, prNumber, allPassed, commentBody);
 
+  if (headSha) {
+    await setCommitStatus(
+      octokit, ghConfig.owner, ghConfig.repo, headSha,
+      allPassed ? 'success' : 'failure',
+      allPassed ? 'All Jira checks passed' : 'One or more Jira checks failed',
+    );
+  }
+
   if (!allPassed) {
     console.error('Jira validation failed. See PR comment for details.');
     process.exit(1);
@@ -87,7 +106,21 @@ const main = async (): Promise<void> => {
   console.log('Jira validation passed.');
 };
 
-main().catch((err) => {
+main().catch(async (err) => {
   console.error('Unexpected error:', safeErrorMessage(err));
+  const headSha = process.env.PR_HEAD_SHA;
+  if (headSha) {
+    try {
+      const ghConfig: GitHubConfig = {
+        token: process.env.GITHUB_TOKEN ?? '',
+        owner: process.env.REPO_OWNER ?? '',
+        repo: process.env.REPO_NAME ?? '',
+      };
+      const octokit = createOctokit(ghConfig);
+      await setCommitStatus(octokit, ghConfig.owner, ghConfig.repo, headSha, 'error', 'Jira validation encountered an unexpected error');
+    } catch {
+      // best-effort
+    }
+  }
   process.exit(1);
 });

--- a/.github/workflows/jira_pr_check.yml
+++ b/.github/workflows/jira_pr_check.yml
@@ -37,6 +37,7 @@ jobs:
             });
             core.setOutput('title', pr.title);
             core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('head_sha', pr.head.sha);
 
       - name: Checkout base branch scripts
         uses: actions/checkout@v6
@@ -61,6 +62,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PR_TITLE: ${{ github.event.pull_request.title || steps.pr-info.outputs.title }}
           BASE_BRANCH: ${{ github.event.pull_request.base.ref || steps.pr-info.outputs.base_ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.pr-info.outputs.head_sha }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
         run: npx tsx src/validate-pr.ts


### PR DESCRIPTION
## 📝 Description

Follow-up to #3927. The `/recheck-jira` comment trigger was wired up correctly but the `jira-validation` check in the PR's **Checks** tab was not being updated when triggered via comment.

**Root cause:** GitHub only auto-creates a check run when a workflow is triggered by `pull_request` / `pull_request_target`. When triggered by `issue_comment`, the workflow runs but GitHub doesn't link it to the PR's head commit, so the check status never updates in the PR UI.

**Fix:**
- `jira_pr_check.yml` — the "Get PR info" step now also outputs `head_sha`; passed as `PR_HEAD_SHA` env var to the validation script
- `github-comments.ts` — new `setCommitStatus` helper that calls `repos.createCommitStatus` (the `statuses: write` permission was already present but unused)
- `validate-pr.ts` — `setCommitStatus` called at three points: **pending** (start), **success/failure** (end), **error** (unexpected catch)

## 🔗 Links

- Jira: https://issues.redhat.com/browse/CNV-87303
- Previous PR: #3927

## 🎥 Demo

N/A — CI workflow change only

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub commit status now updates during Jira PR validation to reflect validation state (pending, success, failure, or error)
  * PR validation workflow improved to properly track and report commit status for all trigger types, including comment-based validation
  * Validation status descriptions are automatically truncated for GitHub compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->