### PR TITLE
CNV-87321: fix Search by name filter

### DIFF
--- a/src/utils/components/ListPageFilter/hooks/useApplyFiltersWithQuery.ts
+++ b/src/utils/components/ListPageFilter/hooks/useApplyFiltersWithQuery.ts
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
+import useQuery from '@kubevirt-utils/hooks/useQuery';
 import { OnFilterChange } from '@openshift-console/dynamic-plugin-sdk';
 import { getRowFilterQueryKey } from '@search/utils/query';
 
@@ -10,12 +11,32 @@ import { useQueryParamsMethods } from './useQueryParamsMethods';
 
 export const useApplyFiltersWithQuery = (applyFilters: OnFilterChange) => {
   const { setOrRemoveQueryArgument } = useQueryParamsMethods();
+  const queryParams = useQuery();
+  const nameParamClearedRef = useRef(false);
+
+  // Handles removing the 'name' param from the URL
+  useEffect(() => {
+    if (!nameParamClearedRef.current) return;
+
+    if (!queryParams.has(STATIC_SEARCH_FILTERS.name)) {
+      nameParamClearedRef.current = false;
+      applyFilters(STATIC_SEARCH_FILTERS.name, { selected: [] });
+    }
+  }, [queryParams, applyFilters]);
 
   const applyFiltersWithQuery = useCallback<ApplyTextFilters>(
     (type, value) => {
       const valueIsArray = Array.isArray(value);
 
       setOrRemoveQueryArgument(getRowFilterQueryKey(type), valueIsArray ? value.join(',') : value);
+
+      // For 'name' param, don't call applyFilters — let the URL update first.
+      // The console's useListPageFilter internal useEffect handles filtering based on updates to 'name' param.
+      // We need to handle removing the 'name' param in our own effect - this is not handled by the console's useEffect.
+      if (type === STATIC_SEARCH_FILTERS.name) {
+        nameParamClearedRef.current = !value;
+        return;
+      }
 
       const values = valueIsArray ? value : [value];
       const selectedValues = value ? values : [];


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes the "Search by name" filter in various list pages.

### Problem

Clearing the name filter on list pages (e.g. Templates) did not work — the filter would revert back to its previous value. This happened both when removing the toolbar chip and when backspacing the search input to empty.

### Root cause

The Console SDK's `useListPageFilter` hook ([filter-hook.ts](https://github.com/openshift/console/blob/master/frontend/public/components/factory/ListPage/filter-hook.ts)) has an internal `useEffect` that syncs the `?name=` URL param into its filter state:

```ts
useEffect(() => {
  const params = new URLSearchParams(location.search);
  const name = params.get('name');
  if (!_.isNil(name) && name !== filter?.name?.selected?.[0]) {
    setFilter((state) => ({ ...state, name: { selected: [name] } }));
  }
}, [filter, location]);
```

Our `useApplyFiltersWithQuery` hook was calling both `navigate()` (to update the URL) and `applyFilters()` (to update the SDK's filter state) in the same synchronous callback. In React 18, React Router wraps `navigate()` in `startTransition` (low priority), while `applyFilters` triggers a regular-priority `setState`. React processes the higher-priority update first, so:

1. `applyFilters('name', { selected: [] })` commits — filter is cleared
2. SDK's effect fires because `filter` changed, reads `location.search` — **still has `?name=rhel`** (navigate hasn't committed yet)
3. `'rhel' !== undefined` → SDK **reverts** the clear: `{ name: { selected: ['rhel'] } }`
4. Navigate finally commits — `name` param is gone — but the SDK's effect only *sets* from URL, never *clears* (`!_.isNil(null)` is false → no-op)

The filter is permanently stuck.

### Fix

For the `name` filter type, don't call `applyFilters` directly in the callback. Instead, only update the URL and let the committed URL drive the filter state:

- **Setting a value** (e.g. typing "rhel"): the SDK's own effect handles it — once the URL commits with `?name=rhel`, the effect reads it and sets the filter.
- **Clearing** (chip removal or empty input): a new `useEffect` watches `queryParams` and calls `applyFilters('name', { selected: [] })` after the URL has committed without the `name` param — filling the gap the SDK's effect doesn't cover.

A `nameParamClearedRef` guards the effect so it only fires when we explicitly initiated a clear, avoiding unnecessary re-renders on unrelated URL changes.


## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-87321

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/ab899b1f-15fb-4294-8e9a-a947935cfdce



After:


https://github.com/user-attachments/assets/7b772284-a9d0-4e2d-9f99-9840176d1efc





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced filter synchronization with URL parameters to ensure filter selections persist correctly when navigating and reloading pages.
  * Improved filter removal logic to properly align with URL parameter lifecycle changes.
  * Fixed instances where filter state would become inconsistent during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->