### PR TITLE
[release-4.20] CNV-87481: handle persistentVolumeClaim volume type in template drawer

### DIFF
--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/SelectSource.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/SelectSource.tsx
@@ -8,7 +8,11 @@ import React, {
 } from 'react';
 
 import { useDrawerContext } from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDrawerContext';
-import { V1beta1DataVolumeSpec, V1ContainerDiskSource } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import {
+  V1beta1DataVolumeSpec,
+  V1ContainerDiskSource,
+  V1PersistentVolumeClaimVolumeSource,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
 import CapacityInput from '@kubevirt-utils/components/CapacityInput/CapacityInput';
 import { getIsMinusDisabled } from '@kubevirt-utils/components/CapacityInput/utils';
 import { DataUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
@@ -23,6 +27,7 @@ import {
   CONTAINER_DISK_SOURCE_NAME,
   DEFAULT_SOURCE,
   HTTP_SOURCE_NAME,
+  PVC_EPHEMERAL_SOURCE_NAME,
   PVC_SOURCE_NAME,
   REGISTRY_SOURCE_NAME,
   SOURCE_OPTIONS_IDS,
@@ -48,10 +53,18 @@ export type SelectSourceProps = {
   diskSource?: boolean;
   httpSourceHelperURL?: string;
   onFileSelected: (file: File | string) => void;
-  onSourceChange: (customSource: V1beta1DataVolumeSpec | V1ContainerDiskSource) => void;
+  onSourceChange: (
+    customSource:
+      | V1beta1DataVolumeSpec
+      | V1ContainerDiskSource
+      | V1PersistentVolumeClaimVolumeSource,
+  ) => void;
   registrySourceHelperText?: string;
   relevantUpload?: DataUpload;
-  selectedSource?: V1beta1DataVolumeSpec | V1ContainerDiskSource;
+  selectedSource?:
+    | V1beta1DataVolumeSpec
+    | V1ContainerDiskSource
+    | V1PersistentVolumeClaimVolumeSource;
   sourceLabel: ReactNode | string;
   sourceOptions: SOURCE_OPTIONS_IDS[];
   sourcePopOver?: ReactElement<any, JSXElementConstructor<any> | string>;
@@ -110,7 +123,8 @@ export const SelectSource: FC<SelectSourceProps> = ({
       : sourceType;
 
   const cdSourceWithSizeInput = [HTTP_SOURCE_NAME, UPLOAD_SOURCE_NAME].includes(sourceType);
-  const diskSourceWithSizeInput = sourceType !== CONTAINER_DISK_SOURCE_NAME;
+  const diskSourceWithSizeInput =
+    sourceType !== CONTAINER_DISK_SOURCE_NAME && sourceType !== PVC_EPHEMERAL_SOURCE_NAME;
 
   const showSizeInput = diskSource ? diskSourceWithSizeInput : cdSourceWithSizeInput;
 

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/utils.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/utils.ts
@@ -1,8 +1,8 @@
 import { V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import {
-  V1beta1DataVolumeSource,
   V1beta1DataVolumeSpec,
   V1ContainerDiskSource,
+  V1PersistentVolumeClaimVolumeSource,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { DEFAULT_DISK_SIZE } from '@kubevirt-utils/components/DiskModal/utils/constants';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -20,6 +20,7 @@ import {
   CONTAINER_DISK_SOURCE_NAME,
   DEFAULT_SOURCE,
   HTTP_SOURCE_NAME,
+  PVC_EPHEMERAL_SOURCE_NAME,
   PVC_SOURCE_NAME,
   REGISTRY_SOURCE_NAME,
   SOURCE_OPTIONS_IDS,
@@ -30,11 +31,13 @@ export const getQuantityFromSource = (source: V1beta1DataVolumeSpec) =>
   formatQuantityString(source?.storage?.resources?.requests?.storage);
 
 export const getSourceTypeFromDiskSource = (
-  diskSource: V1beta1DataVolumeSpec | V1ContainerDiskSource,
+  diskSource: V1beta1DataVolumeSpec | V1ContainerDiskSource | V1PersistentVolumeClaimVolumeSource,
 ): SOURCE_OPTIONS_IDS => {
   if ('image' in diskSource) return CONTAINER_DISK_SOURCE_NAME;
 
-  const dataVolumeSource = diskSource.source as V1beta1DataVolumeSource;
+  if ('claimName' in diskSource) return PVC_EPHEMERAL_SOURCE_NAME;
+
+  const dataVolumeSource = (diskSource as V1beta1DataVolumeSpec)?.source;
 
   if (isEmpty(dataVolumeSource)) return DEFAULT_SOURCE;
 

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/utils.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/utils.ts
@@ -5,6 +5,7 @@ import {
   V1beta1DataVolumeSpec,
   V1ContainerDiskSource,
   V1DataVolumeTemplateSpec,
+  V1PersistentVolumeClaimVolumeSource,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { ROOTDISK } from '@kubevirt-utils/constants/constants';
@@ -26,7 +27,11 @@ export const getRegistryHelperText = (template: V1Template) => {
 export const getDiskSource = (
   vm: V1VirtualMachine,
   diskName: string,
-): undefined | V1beta1DataVolumeSpec | V1ContainerDiskSource => {
+):
+  | undefined
+  | V1beta1DataVolumeSpec
+  | V1ContainerDiskSource
+  | V1PersistentVolumeClaimVolumeSource => {
   if (!diskName) return;
 
   const disk = getDisks(vm)?.find((d) => d.name === diskName);
@@ -36,6 +41,10 @@ export const getDiskSource = (
 
   if (volume.containerDisk) {
     return volume.containerDisk;
+  }
+
+  if (volume.persistentVolumeClaim) {
+    return volume.persistentVolumeClaim;
   }
 
   if (volume.dataVolume) {
@@ -56,11 +65,6 @@ const emptySourceDataVolume: V1DataVolumeTemplateSpec = {
   spec: {},
 };
 
-const createDataVolumeWithSource = (customSource: V1beta1DataVolumeSpec) => ({
-  ...emptySourceDataVolume,
-  spec: customSource,
-});
-
 export const overrideVirtualMachineDataVolumeSpec = (
   virtualMachine: V1VirtualMachine,
   diskName: string,
@@ -78,16 +82,20 @@ export const overrideVirtualMachineDataVolumeSpec = (
     if (isEmpty(customSource)) return;
 
     if (isEmpty(rootDataVolume)) {
-      draftVM.spec.template.spec.volumes = getVolumes(draftVM).filter((v) => v.name !== ROOTDISK);
+      draftVM.spec.template.spec.volumes = getVolumes(draftVM).filter((v) => v.name !== diskName);
       draftVM.spec.template.spec.volumes.push({
         dataVolume: {
-          name: `dv-${ROOTDISK}`,
+          name: `dv-${diskName}`,
         },
-        name: ROOTDISK,
+        name: diskName,
       });
 
       draftVM.spec.dataVolumeTemplates ??= [];
-      draftVM.spec.dataVolumeTemplates.push(createDataVolumeWithSource(customSource));
+      draftVM.spec.dataVolumeTemplates.push({
+        ...emptySourceDataVolume,
+        metadata: { ...emptySourceDataVolume.metadata, name: `dv-${diskName}` },
+        spec: customSource,
+      });
 
       return;
     }

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDefaultVMSource.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDefaultVMSource.ts
@@ -3,6 +3,7 @@ import { useCallback, useRef } from 'react';
 import {
   V1beta1DataVolumeSpec,
   V1ContainerDiskSource,
+  V1PersistentVolumeClaimVolumeSource,
   V1VirtualMachine,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
@@ -11,7 +12,9 @@ import { getBootDisk } from '@kubevirt-utils/resources/vm';
 import { getDiskSource } from '../StorageSection/utils';
 
 const useDefaultVMSource = (vm: V1VirtualMachine) => {
-  const defaultDiskSource = useRef<V1beta1DataVolumeSpec | V1ContainerDiskSource>();
+  const defaultDiskSource = useRef<
+    V1beta1DataVolumeSpec | V1ContainerDiskSource | V1PersistentVolumeClaimVolumeSource
+  >();
 
   const bootDisk = useRef(getBootDisk(vm));
   const currentDiskSource = getDiskSource(vm, bootDisk.current?.name);


### PR DESCRIPTION
## 📝 Description

Backport of #3930 to `release-4.20`.

Fixes [CNV-83098](https://redhat.atlassian.net/browse/CNV-83098) — **Blocker** bug: _Creating a VM from a template gives an error "Cannot use 'in' operator to search for 'image' in undefined"_.

The crash occurred when a VM template has a disk whose volume type is `persistentVolumeClaim` (not `containerDisk` or `dataVolume`). In that case, `getDiskSource` fell through all conditions and returned `undefined`, causing `getSourceTypeFromDiskSource(undefined)` to throw on the `'image' in undefined` check.

**Changes:**

* **`StorageSection/utils.ts`** — `getDiskSource` now handles `persistentVolumeClaim` volumes by returning `volume.persistentVolumeClaim`, preventing the `undefined` return that caused the crash.
* **`CustomizeSource/utils.ts`** — `getSourceTypeFromDiskSource` adds a `'claimName' in diskSource` discriminator (the correct unique field on `V1PersistentVolumeClaimVolumeSource`) to return `PVC_EPHEMERAL_SOURCE_NAME` for PVC volumes.
* **`CustomizeSource/SelectSource.tsx`** — Union types updated to include `V1PersistentVolumeClaimVolumeSource`; size input correctly hidden for `PVC_EPHEMERAL_SOURCE_NAME` source type.
* **`hooks/useDefaultVMSource.ts`** — Ref type updated to include `V1PersistentVolumeClaimVolumeSource`.

> Cherry-pick conflict resolved: release-4.20 uses `@kubevirt-ui/kubevirt-api/kubevirt` (not `@kubevirt-ui-ext/kubevirt-api/kubevirt` as in 4.21).

/cherry-pick-of #3930

Made with [Cursor](https://cursor.com)