### PR TITLE
chore: enforce Playwright tests for Epics/Stories via CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,7 +17,7 @@ reviews:
   # The check also instructs CodeRabbit to apply do-not-merge/no-tests-added.
   pre_merge_checks:
     custom_checks:
-      - name: 'Playwright tests required for Epics/Stories'
+      - name: 'Tests required for Epics/Stories'
         mode: 'error'
         instructions: |
           Perform the following steps to determine PASS or FAIL:
@@ -49,24 +49,35 @@ reviews:
           Only continue to Step 5 when the Epic/Story clearly describes a
           new user-facing feature or enhancement.
 
-          Step 5 - Check for actual Playwright test or page-object files.
-          Inspect the PR diff for files under playwright/tests/** or playwright/pages/**.
-          Do NOT count playwright/fixtures/**, playwright/utils/**, playwright/types/**,
-          or playwright/tsconfig.json — those are pure helpers with no test logic.
-          - At least one file added or modified under playwright/tests/ or
-            playwright/pages/ -> PASS.
-          - Only fixture/util/type files changed, or no playwright/ files at all ->
+          Step 5 - Check for test files.
+          Inspect the PR diff for any file that qualifies as a test. A file qualifies if
+          it matches ANY of the following patterns:
+          - playwright/tests/**/*.ts or playwright/tests/**/*.spec.ts (Playwright tests)
+          - playwright/pages/**/*.ts (Playwright page-object models)
+          - **/*.test.ts or **/*.test.tsx (unit/integration tests)
+          - **/*.spec.ts or **/*.spec.tsx (unit/integration spec files)
+
+          Do NOT count these as tests:
+          - playwright/fixtures/**, playwright/utils/**, playwright/types/**,
+            playwright/tsconfig.json — these are pure helpers with no test logic.
+
+          - At least one qualifying test file added or modified -> PASS.
+          - No qualifying test file found ->
             FAIL and apply the label "do-not-merge/no-tests-added" with this message:
-            "This PR is linked to a Jira Epic/Story for a new feature but no
-            Playwright test or page-object files were added under playwright/tests/
-            or playwright/pages/. Please add or update those files, or ask a
-            maintainer to remove the do-not-merge/no-tests-added label."
+            "This PR is linked to a Jira Epic/Story for a new feature but no test
+            files were added or modified. Please either:
+            • Add or update Playwright tests under playwright/tests/ or page-object
+              models under playwright/pages/
+            • Add or update unit/integration tests (*.test.ts, *.test.tsx,
+              *.spec.ts, *.spec.tsx)
+            • Or ask a maintainer to remove the do-not-merge/no-tests-added label
+              if tests are not applicable for this change."
 
 knowledge_base:
   code_guidelines:
     enabled: true
     filePatterns:
-      - '**​/CODING_STANDARDS.md'
+      - '**/CODING_STANDARDS.md'
   jira:
     usage: enabled
     project_keys:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,9 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 reviews:
   profile: chill
   high_level_summary: true
+  # required for pre_merge_checks with mode:error to actually block the PR
+  request_changes_workflow: true
   auto_review:
     auto_incremental_review: true
     enabled: true
@@ -10,12 +13,64 @@ reviews:
   path_filters:
     - '!locales/**'
   collapse_walkthrough: true
+  # Block merging for Epics/Stories that have no Playwright tests.
+  # The check also instructs CodeRabbit to apply do-not-merge/no-tests-added.
+  pre_merge_checks:
+    custom_checks:
+      - name: 'Playwright tests required for Epics/Stories'
+        mode: 'error'
+        instructions: |
+          Perform the following steps to determine PASS or FAIL:
+
+          Step 1 - Extract Jira ticket ID.
+          Parse the PR title for a ticket ID matching CNV-<digits>.
+          If no ID is found, PASS.
+
+          Step 2 - Fetch the Jira ticket.
+          Use the Jira integration to read the issue type for that ticket ID.
+          If the ticket cannot be fetched for any reason, PASS (fail-safe).
+
+          Step 3 - Check issue type.
+          If the issue type is NOT "Epic" or "Story" (e.g. Bug, Task, Sub-task), PASS.
+
+          Step 4 - Check whether the Epic/Story is a new feature (not chore/CI).
+          Read the Jira ticket title, description, and labels. Also inspect the PR
+          title, description, and changed files for signals. PASS without enforcement if
+          any of the following are true:
+          - The Jira ticket or PR title/description uses keywords like: chore, ci,
+            refactor, cleanup, dependency, bump, upgrade, lint, config, workflow,
+            documentation, docs, i18n, translation, test-infra, tooling, release,
+            cherry-pick, revert, hotfix, infrastructure.
+          - The changed files are exclusively in: .github/, .cursor/, scripts/,
+            locales/, *.md, *.yaml, *.yml, *.json (config/lock files), or similar
+            non-feature paths.
+          - The PR title starts with "chore:", "ci:", "docs:", "refactor:",
+            "build:", "release:", or "revert:".
+          Only continue to Step 5 when the Epic/Story clearly describes a
+          new user-facing feature or enhancement.
+
+          Step 5 - Check for actual Playwright test or page-object files.
+          Inspect the PR diff for files under playwright/tests/** or playwright/pages/**.
+          Do NOT count playwright/fixtures/**, playwright/utils/**, playwright/types/**,
+          or playwright/tsconfig.json — those are pure helpers with no test logic.
+          - At least one file added or modified under playwright/tests/ or
+            playwright/pages/ -> PASS.
+          - Only fixture/util/type files changed, or no playwright/ files at all ->
+            FAIL and apply the label "do-not-merge/no-tests-added" with this message:
+            "This PR is linked to a Jira Epic/Story for a new feature but no
+            Playwright test or page-object files were added under playwright/tests/
+            or playwright/pages/. Please add or update those files, or ask a
+            maintainer to remove the do-not-merge/no-tests-added label."
 
 knowledge_base:
   code_guidelines:
     enabled: true
     filePatterns:
-      - '**/CODING_STANDARDS.md'
+      - '**​/CODING_STANDARDS.md'
+  jira:
+    usage: enabled
+    project_keys:
+      - CNV
 
 chat:
   integrations:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,7 +14,7 @@ reviews:
     - '!locales/**'
   collapse_walkthrough: true
   # Block merging for Epics/Stories that have no Playwright tests.
-  # The check also instructs CodeRabbit to apply do-not-merge/no-tests-added.
+  # The check also instructs CodeRabbit to apply do-not-merge/no-tests.
   pre_merge_checks:
     custom_checks:
       - name: 'Tests required for Epics/Stories'
@@ -63,14 +63,14 @@ reviews:
 
           - At least one qualifying test file added or modified -> PASS.
           - No qualifying test file found ->
-            FAIL and apply the label "do-not-merge/no-tests-added" with this message:
+            FAIL and apply the label "do-not-merge/no-tests" with this message:
             "This PR is linked to a Jira Epic/Story for a new feature but no test
             files were added or modified. Please either:
             • Add or update Playwright tests under playwright/tests/ or page-object
               models under playwright/pages/
             • Add or update unit/integration tests (*.test.ts, *.test.tsx,
               *.spec.ts, *.spec.tsx)
-            • Or ask a maintainer to remove the do-not-merge/no-tests-added label
+            • Or ask a maintainer to remove the do-not-merge/no-tests label
               if tests are not applicable for this change."
 
 knowledge_base:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,8 +2,6 @@
 reviews:
   profile: chill
   high_level_summary: true
-  # required for pre_merge_checks with mode:error to actually block the PR
-  request_changes_workflow: true
   auto_review:
     auto_incremental_review: true
     enabled: true
@@ -13,65 +11,38 @@ reviews:
   path_filters:
     - '!locales/**'
   collapse_walkthrough: true
-  # Block merging for Epics/Stories that have no Playwright tests.
-  # The check also instructs CodeRabbit to apply do-not-merge/no-tests.
-  pre_merge_checks:
-    custom_checks:
-      - name: 'Tests required for Epics/Stories'
-        mode: 'error'
-        instructions: |
-          Perform the following steps to determine PASS or FAIL:
+  auto_apply_labels: true
+  labeling_instructions:
+    - label: 'do-not-merge/no-tests'
+      instructions: |
+        Apply this label when ALL of the following are true:
+        1. The PR title contains a Jira ticket ID matching CNV-<digits>.
+        2. The linked Jira ticket's issue type is "Epic" or "Story" (fetch via Jira integration).
+        3. The Epic/Story describes a new user-facing feature or enhancement — NOT chore/CI work.
+           Skip enforcement (do not apply label) if any of these signals are present:
+           - The Jira ticket or PR title/description uses keywords like: chore, ci, refactor,
+             cleanup, dependency, bump, upgrade, lint, config, workflow, documentation, docs,
+             i18n, translation, test-infra, tooling, release, cherry-pick, revert, hotfix,
+             infrastructure.
+           - The PR title starts with: chore:, ci:, docs:, refactor:, build:, release:, revert:
+           - The changed files are exclusively in non-feature paths: .github/, .cursor/,
+             scripts/, locales/, *.md, *.yaml, *.yml, *.json (config/lock files).
+        4. The PR does NOT add or modify any qualifying test file. A file qualifies as a test if
+           it matches ANY of:
+           - playwright/tests/**/*.ts or playwright/tests/**/*.spec.ts (Playwright tests)
+           - playwright/pages/**/*.ts (Playwright page-object models)
+           - **/*.test.ts or **/*.test.tsx (unit/integration tests)
+           - **/*.spec.ts or **/*.spec.tsx (unit/integration spec files)
 
-          Step 1 - Extract Jira ticket ID.
-          Parse the PR title for a ticket ID matching CNV-<digits>.
-          If no ID is found, PASS.
+           Files that do NOT count as tests:
+           - playwright/fixtures/**, playwright/utils/**, playwright/types/**,
+             playwright/tsconfig.json
 
-          Step 2 - Fetch the Jira ticket.
-          Use the Jira integration to read the issue type for that ticket ID.
-          If the ticket cannot be fetched for any reason, PASS (fail-safe).
-
-          Step 3 - Check issue type.
-          If the issue type is NOT "Epic" or "Story" (e.g. Bug, Task, Sub-task), PASS.
-
-          Step 4 - Check whether the Epic/Story is a new feature (not chore/CI).
-          Read the Jira ticket title, description, and labels. Also inspect the PR
-          title, description, and changed files for signals. PASS without enforcement if
-          any of the following are true:
-          - The Jira ticket or PR title/description uses keywords like: chore, ci,
-            refactor, cleanup, dependency, bump, upgrade, lint, config, workflow,
-            documentation, docs, i18n, translation, test-infra, tooling, release,
-            cherry-pick, revert, hotfix, infrastructure.
-          - The changed files are exclusively in: .github/, .cursor/, scripts/,
-            locales/, *.md, *.yaml, *.yml, *.json (config/lock files), or similar
-            non-feature paths.
-          - The PR title starts with "chore:", "ci:", "docs:", "refactor:",
-            "build:", "release:", or "revert:".
-          Only continue to Step 5 when the Epic/Story clearly describes a
-          new user-facing feature or enhancement.
-
-          Step 5 - Check for test files.
-          Inspect the PR diff for any file that qualifies as a test. A file qualifies if
-          it matches ANY of the following patterns:
-          - playwright/tests/**/*.ts or playwright/tests/**/*.spec.ts (Playwright tests)
-          - playwright/pages/**/*.ts (Playwright page-object models)
-          - **/*.test.ts or **/*.test.tsx (unit/integration tests)
-          - **/*.spec.ts or **/*.spec.tsx (unit/integration spec files)
-
-          Do NOT count these as tests:
-          - playwright/fixtures/**, playwright/utils/**, playwright/types/**,
-            playwright/tsconfig.json — these are pure helpers with no test logic.
-
-          - At least one qualifying test file added or modified -> PASS.
-          - No qualifying test file found ->
-            FAIL and apply the label "do-not-merge/no-tests" with this message:
-            "This PR is linked to a Jira Epic/Story for a new feature but no test
-            files were added or modified. Please either:
-            • Add or update Playwright tests under playwright/tests/ or page-object
-              models under playwright/pages/
-            • Add or update unit/integration tests (*.test.ts, *.test.tsx,
-              *.spec.ts, *.spec.tsx)
-            • Or ask a maintainer to remove the do-not-merge/no-tests label
-              if tests are not applicable for this change."
+        Do NOT apply this label when:
+        - The Jira issue type is Bug, Task, Sub-task, or any type other than Epic/Story.
+        - At least one qualifying test file is added or modified in this PR.
+        - No Jira ticket ID is found in the PR title.
+        - The PR is clearly non-feature work (chore, ci, docs, etc.).
 
 knowledge_base:
   code_guidelines:


### PR DESCRIPTION
## 📝 Description

Adds a \`.coderabbit.yaml\` to configure CodeRabbit for this repository.

### Regular reviews — unchanged
All existing review behavior is preserved exactly:
- Profile: \`chill\`
- High-level summary, auto-incremental review, walkthrough collapse, locales excluded — all as before

### New: Playwright test enforcement for feature Epics/Stories

On every PR, CodeRabbit runs a custom pre-merge check that:

1. **Parses** the Jira ticket ID from the PR title (\`CNV-XXXXX\` format)
2. **Fetches** the ticket via the Jira integration to read the issue type
3. **Skips** if ticket type is not Epic or Story (Bug, Task, Sub-task → passes silently)
4. **Skips** if the Epic/Story is clearly non-feature work, detected via:
   - Keywords in Jira/PR title: \`chore\`, \`ci\`, \`refactor\`, \`cleanup\`, \`bump\`, \`upgrade\`, \`lint\`, \`docs\`, \`i18n\`, \`tooling\`, \`release\`, \`revert\`, etc.
   - PR title prefix: \`chore:\`, \`ci:\`, \`docs:\`, \`refactor:\`, \`build:\`, \`release:\`, \`revert:\`
   - Changed files exclusively in non-feature paths: \`.github/\`, \`.cursor/\`, \`scripts/\`, \`locales/\`, \`*.md\`, config/lock files
5. **Enforces** (when the Epic/Story is a new user-facing feature):
   - Checks for any files added/modified under \`playwright/tests/\` or \`playwright/pages/\`
   - ✅ At least one \`playwright/tests/\` or \`playwright/pages/\` file → passes
   - ❌ Only fixture/util/type helpers changed, or no playwright files at all → blocks merge (\`mode: error\`) + applies \`do-not-merge/no-tests-added\` label

**What counts as sufficient test work:**

| Path | Counts? |
|---|---|
| \`playwright/tests/**\` | ✅ Yes |
| \`playwright/pages/**\` | ✅ Yes (page-object models are test logic) |
| \`playwright/fixtures/**\` | ❌ No |
| \`playwright/utils/**\` | ❌ No |
| \`playwright/types/**\` | ❌ No |

### Other settings
- \`suggest_labels: false\` — disables CodeRabbit automatic label suggestions (e.g. \`lgtm\`)
- \`request_changes_workflow: true\` — required for \`mode: error\` to actually block PRs
- Jira integration enabled for the \`CNV\` project in both \`knowledge_base\` and \`chat\`
- Fail-safe: if no Jira ticket is in the title or the fetch fails, the check passes automatically

## 🔗 Links

- CodeRabbit docs — [Custom Pre-merge Checks](https://docs.coderabbit.ai/pr-reviews/pre-merge-checks)
- CodeRabbit docs — [Jira Integration](https://docs.coderabbit.ai/integrations/jira)

## 🎥 Demo

No UI changes — this only affects CodeRabbit automated review behaviour on new PRs.