### PR TITLE
CNV-86641: close tree view menu on clicking anywhere outside

### DIFF
--- a/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
+++ b/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
@@ -7,15 +7,6 @@
     position: relative;
   }
 
-  .right-click-action-menu-background {
-    bottom: 0;
-    left: 0;
-    position: fixed;
-    right: 0;
-    top: 0;
-    z-index: 100;
-  }
-
   &__toolbar-section {
     width: 100%;
   }

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/TreeViewRightClickActionMenu.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/TreeViewRightClickActionMenu.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import useDismissMenu from './hooks/useDismissMenu';
 import { getActionMenuComponent } from './utils';
 
 type TreeViewRightClickActionMenuProps = {
@@ -11,20 +12,13 @@ const TreeViewRightClickActionMenu: FC<TreeViewRightClickActionMenuProps> = ({
   hideMenu,
   triggerElement,
 }) => {
+  useDismissMenu(hideMenu, !!triggerElement);
+
   if (!triggerElement) return null;
 
   const ActionMenu = getActionMenuComponent(triggerElement);
 
-  return (
-    <>
-      <ActionMenu hideMenu={hideMenu} triggerElement={triggerElement} />
-      <div
-        className="right-click-action-menu-background"
-        data-test="right-click-backdrop"
-        onClick={hideMenu}
-      />
-    </>
-  );
+  return <ActionMenu hideMenu={hideMenu} triggerElement={triggerElement} />;
 };
 
 export default TreeViewRightClickActionMenu;

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/hooks/useDismissMenu.ts
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/hooks/useDismissMenu.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect } from 'react';
+
+import { CLICK, ESCAPE, KEYDOWN } from '@kubevirt-utils/hooks/useClickOutside/constants';
+
+const useDismissMenu = (hideMenu: () => void, isOpen: boolean): void => {
+  const handleClick = useCallback(
+    (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (target.closest('.right-click-action-menu')) return;
+      hideMenu();
+    },
+    [hideMenu],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === ESCAPE) hideMenu();
+    },
+    [hideMenu],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    document.addEventListener(CLICK, handleClick, true);
+    document.addEventListener(KEYDOWN, handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener(CLICK, handleClick, true);
+      document.removeEventListener(KEYDOWN, handleKeyDown, true);
+    };
+  }, [isOpen, handleClick, handleKeyDown]);
+};
+
+export default useDismissMenu;

--- a/src/views/virtualmachines/tree/hooks/useTreeViewItemActions.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewItemActions.ts
@@ -40,6 +40,7 @@ const useTreeViewItemActions: UseTreeViewItemActions = (treeData) => {
     const handler = (event) => {
       event.preventDefault();
       event.stopPropagation();
+      document.body.click();
       setTriggerElement(element);
     };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Close tree view menu on clicking anywhere outside

- Fixed the tree view right-click context menu not closing when clicking outside the tree panel
  - Previously, dismissal relied on a backdrop div rendered inside the drawer panel, which couldn't intercept clicks on elements outside the panel's DOM/stacking context.
    - Replaced it with a global click event listener on document that closes the menu on any outside click.
- Fixed other menus (e.g., kebab menus in the VM list) staying open when opening the right-click context menu. A synthetic `document.body.click()` is now dispatched before opening the context menu, causing any open PatternFly dropdowns to dismiss themselves.
- Added Escape key support to close the right-click context menu.


## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-86641

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/b5c276e4-30ad-4605-91ab-524bceccc6b6




After:

https://github.com/user-attachments/assets/b34944b8-ae46-4e67-90a6-25da4c337ced




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved right-click context menu behavior and dismissal handling for virtual machine tree view interactions. The menu now responds more reliably to outside clicks and keyboard shortcuts (Escape key).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->