### PR TITLE
CNV-75009: Use a shared component for ack confirmation modals

### DIFF
--- a/src/utils/components/AckConfirmationModal/AckConfirmationModal.tsx
+++ b/src/utils/components/AckConfirmationModal/AckConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode, useState } from 'react';
+import React, { FC, ReactNode, useEffect, useState } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
@@ -13,24 +13,26 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 
-type ConfirmVMActionBaseModalProps = {
-  action: () => Promise<string | void>;
+export type AckConfirmationModalProps = {
+  action: () => Promise<string | void> | void;
   actionLabel: string;
-  actionType: string;
+  actionType?: string;
   checkToConfirmMessage?: string;
   children?: ReactNode;
+  className?: string;
   isOpen: boolean;
   onClose: () => void;
   severityVariant?: 'danger' | 'warning' | undefined;
   title: string;
 };
 
-const ConfirmVMActionBaseModal: FC<ConfirmVMActionBaseModalProps> = ({
+const AckConfirmationModal: FC<AckConfirmationModalProps> = ({
   action,
   actionLabel,
   actionType,
   checkToConfirmMessage,
   children,
+  className,
   isOpen,
   onClose,
   severityVariant,
@@ -38,42 +40,56 @@ const ConfirmVMActionBaseModal: FC<ConfirmVMActionBaseModalProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const [isChecked, setIsChecked] = useState<boolean>(!checkToConfirmMessage);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
-  const submitHandler = () => {
-    action();
-    onClose();
+  useEffect(() => {
+    if (!isOpen) {
+      setIsChecked(!checkToConfirmMessage);
+    }
+  }, [checkToConfirmMessage, isOpen]);
+
+  const submitHandler = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      await action();
+      onClose();
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
     <Modal
-      className="confirm-multiple-vm-actions-modal"
+      className={className}
       isOpen={isOpen}
       onClose={onClose}
       onSubmit={submitHandler}
-      variant={'small'}
+      variant="small"
     >
-      <ModalHeader title={title} titleIconVariant={severityVariant} />
+      <ModalHeader title={title} titleIconVariant={severityVariant ? 'warning' : undefined} />
       <ModalBody>
         <Stack hasGutter>
           <StackItem>{children}</StackItem>
-          <StackItem>
-            {checkToConfirmMessage && (
+          {checkToConfirmMessage && (
+            <StackItem>
               <Checkbox
-                id={`check-to-confirm-action-${actionType}`}
+                id={`ack-confirm-${actionType ?? 'action'}`}
                 isChecked={isChecked}
                 label={checkToConfirmMessage}
                 onChange={(_, checked) => setIsChecked(checked)}
               />
-            )}
-          </StackItem>
+            </StackItem>
+          )}
         </Stack>
       </ModalBody>
       <ModalFooter>
         <Button
-          isDisabled={!isChecked}
+          isDisabled={!isChecked || isSubmitting}
+          isLoading={isSubmitting}
           key="confirm"
           onClick={submitHandler}
-          variant={severityVariant}
+          variant={severityVariant === 'danger' ? ButtonVariant.danger : ButtonVariant.primary}
         >
           {actionLabel}
         </Button>
@@ -85,4 +101,4 @@ const ConfirmVMActionBaseModal: FC<ConfirmVMActionBaseModalProps> = ({
   );
 };
 
-export default ConfirmVMActionBaseModal;
+export default AckConfirmationModal;

--- a/src/views/checkups/self-validation/components/form/HeavyLoadCheckupConfirmationModal.tsx
+++ b/src/views/checkups/self-validation/components/form/HeavyLoadCheckupConfirmationModal.tsx
@@ -1,17 +1,7 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 
+import AckConfirmationModal from '@kubevirt-utils/components/AckConfirmationModal/AckConfirmationModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import {
-  Button,
-  ButtonVariant,
-  Checkbox,
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-  Stack,
-  StackItem,
-} from '@patternfly/react-core';
 
 type HeavyLoadCheckupConfirmationModalProps = {
   isOpen: boolean;
@@ -25,53 +15,24 @@ const HeavyLoadCheckupConfirmationModal: FC<HeavyLoadCheckupConfirmationModalPro
   onConfirm,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [isConfirmationChecked, setIsConfirmationChecked] = useState(false);
-
-  const handleConfirm = () => {
-    setIsConfirmationChecked(false);
-    onConfirm();
-  };
-
-  const handleClose = () => {
-    setIsConfirmationChecked(false);
-    onClose();
-  };
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} variant="small">
-      <ModalHeader title={t('Heavy load checkups')} titleIconVariant="warning" />
-      <ModalBody>
-        <Stack hasGutter>
-          <StackItem>
-            {t(
-              'You are about to run heavy self validation checkups which generate significant load and may destabilize your cluster.',
-            )}
-          </StackItem>
-          <StackItem>
-            <Checkbox
-              label={t(
-                'I confirm this is a non-production environment safe for heavy load testing.',
-              )}
-              id="confirm-non-production-checkbox"
-              isChecked={isConfirmationChecked}
-              onChange={(_, checked: boolean) => setIsConfirmationChecked(checked)}
-            />
-          </StackItem>
-        </Stack>
-      </ModalBody>
-      <ModalFooter>
-        <Button
-          isDisabled={!isConfirmationChecked}
-          onClick={handleConfirm}
-          variant={ButtonVariant.primary}
-        >
-          {t('Run checkup')}
-        </Button>
-        <Button onClick={handleClose} variant={ButtonVariant.link}>
-          {t('Cancel')}
-        </Button>
-      </ModalFooter>
-    </Modal>
+    <AckConfirmationModal
+      checkToConfirmMessage={t(
+        'I confirm this is a non-production environment safe for heavy load testing.',
+      )}
+      action={onConfirm}
+      actionLabel={t('Run checkup')}
+      actionType="heavy-load-checkup"
+      isOpen={isOpen}
+      onClose={onClose}
+      severityVariant="warning"
+      title={t('Heavy load checkups')}
+    >
+      {t(
+        'You are about to run heavy self validation checkups which generate significant load and may destabilize your cluster.',
+      )}
+    </AckConfirmationModal>
   );
 };
 

--- a/src/views/virtualmachines/actions/components/ConfirmMultipleVMActionsModal/ConfirmMultipleVMActionsModal.tsx
+++ b/src/views/virtualmachines/actions/components/ConfirmMultipleVMActionsModal/ConfirmMultipleVMActionsModal.tsx
@@ -1,12 +1,12 @@
 import React, { FC } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import AckConfirmationModal from '@kubevirt-utils/components/AckConfirmationModal/AckConfirmationModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { getVMNamesByNamespace } from '@virtualmachines/actions/components/ConfirmMultipleVMActionsModal/utils/utils';
 
-import ConfirmVMActionBaseModal from './components/ConfirmVMActionBaseModal';
 import VMsCountByNamespacePopoverLink from './components/VMsCountByNamespacePopoverLink';
 
 import './ConfirmMultipleVMActionsModal.scss';
@@ -45,12 +45,25 @@ const ConfirmMultipleVMActionsModal: FC<ConfirmMultipleVMActionsModalProps> = ({
   const numExcludedVMs = excludedVMs?.length;
   const totalSelectedVMs = numVMs + (numExcludedVMs || 0);
 
-  const actionOnVms = async () =>
-    Promise.any(
-      vms?.map((vm) => {
-        action(vm);
-      }),
+  const actionOnVms = async (): Promise<void> => {
+    const results = await Promise.allSettled(vms?.map((vm) => action(vm)) ?? []);
+    const failures = results.filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
     );
+
+    if (failures.length === 0) {
+      return;
+    }
+
+    failures.forEach((failure) =>
+      kubevirtConsole.error(`Failed to ${actionType.toLowerCase()}:`, failure.reason),
+    );
+    throw new Error(
+      `Failed to ${actionType.toLowerCase()} for ${failures.length} of ${
+        vms?.length ?? 0
+      } VirtualMachine(s)`,
+    );
+  };
 
   const defaultBody = (
     <>
@@ -82,7 +95,7 @@ const ConfirmMultipleVMActionsModal: FC<ConfirmMultipleVMActionsModalProps> = ({
     : t('{{actionType}} {{numVMs}} VirtualMachines?', { actionType, numVMs });
 
   return (
-    <ConfirmVMActionBaseModal
+    <AckConfirmationModal
       action={actionOnVms}
       actionLabel={t(actionType)}
       actionType={actionType}
@@ -93,7 +106,7 @@ const ConfirmMultipleVMActionsModal: FC<ConfirmMultipleVMActionsModalProps> = ({
       title={title}
     >
       {body}
-    </ConfirmVMActionBaseModal>
+    </AckConfirmationModal>
   );
 };
 

--- a/src/views/virtualmachines/actions/components/ConfirmVMActionModal/ConfirmVMActionModal.tsx
+++ b/src/views/virtualmachines/actions/components/ConfirmVMActionModal/ConfirmVMActionModal.tsx
@@ -1,10 +1,9 @@
 import React, { FC } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import AckConfirmationModal from '@kubevirt-utils/components/AckConfirmationModal/AckConfirmationModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-
-import ConfirmVMActionBaseModal from '../ConfirmMultipleVMActionsModal/components/ConfirmVMActionBaseModal';
 
 import { getVmActionLabels, getVmActionMessages, getVmActionTitles, VMAction } from './constants';
 
@@ -33,7 +32,7 @@ const ConfirmVMActionModal: FC<ConfirmVMActionModalProps> = ({
   const actionOnVm = async () => action(vm);
 
   return (
-    <ConfirmVMActionBaseModal
+    <AckConfirmationModal
       action={actionOnVm}
       actionLabel={getVmActionLabels[actionType](t)}
       actionType={actionType}
@@ -44,7 +43,7 @@ const ConfirmVMActionModal: FC<ConfirmVMActionModalProps> = ({
       title={getVmActionTitles[actionType](t)}
     >
       {body}
-    </ConfirmVMActionBaseModal>
+    </AckConfirmationModal>
   );
 };
 


### PR DESCRIPTION
## 📝 Description

We currently have two modals which are very similar:

HeavyLoadCheckupConfirmationModal.tsx

ConfirmVMActionBaseModal.tsx

Create a shared component and reuse it instead of having two separate components. 

## 🔗 Links

Jira ticket: [CNV-75009](https://redhat.atlassian.net/browse/CNV-75009)


## 🎥 Demo

Working as expected after the code changes:


https://github.com/user-attachments/assets/0005aedd-8c1b-4ec4-983a-25df48afca49



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated confirmation modal UI across multiple dialogs for a consistent experience.

* **New Features**
  * Optional "check to confirm" checkbox for risky actions.
  * Confirm buttons show loading/disabled state while actions run.
  * Improved warning/danger severity visuals and messaging in confirmation dialogs.

* **Bug Fixes**
  * More robust handling of bulk VM actions to reduce partial-failure surprises.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->