### PR TITLE
CNV-84105: adjust the create vm wizard footer padding

### DIFF
--- a/src/views/catalog/wizard/Wizard.scss
+++ b/src/views/catalog/wizard/Wizard.scss
@@ -19,6 +19,12 @@
   z-index: 1000;
 }
 
+.vm-creation-wizard {
+  .pf-v6-c-wizard__footer .pf-v6-c-action-list {
+    justify-content: flex-start;
+  }
+}
+
 .wizard-header {
   .pf-l-split {
     justify-content: space-between;

--- a/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
+++ b/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
@@ -1,12 +1,10 @@
 import React, { FC, useEffect, useRef } from 'react';
-import classnames from 'classnames';
 
-import { FLAG_LIGHTSPEED_PLUGIN } from '@kubevirt-utils/flags/consts';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getValidNamespace } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
-import { useActiveNamespace, useFlag } from '@openshift-console/dynamic-plugin-sdk';
+import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { Wizard, WizardHeader, WizardStep } from '@patternfly/react-core';
 import DefaultWizardFooter from '@virtualmachines/creation-wizard/components/DefaultWizardFooter';
 import useCloseWizard from '@virtualmachines/creation-wizard/hooks/useCloseWizard';
@@ -33,9 +31,10 @@ import {
 import TemplatesDrawerWrapper from './components/TemplatesDrawerWrapper';
 import DeploymentDetailsStep from './steps/DeploymentDetailsStep/DeploymentDetailsStep';
 
+import '@catalog/wizard/Wizard.scss';
+
 const VMCreationWizard: FC = () => {
   const { t } = useKubevirtTranslation();
-  const hasOLSConsole = useFlag(FLAG_LIGHTSPEED_PLUGIN);
   const {
     creationMethod,
     markStepVisited,
@@ -81,8 +80,6 @@ const VMCreationWizard: FC = () => {
   const isCloneMethod = isCloneCreationMethod(creationMethod);
   const isTemplateMethod = isTemplateCreationMethod(creationMethod);
 
-  const cancelButtonProps = { className: classnames({ 'pf-v6-u-mr-4xl': hasOLSConsole }) };
-
   return (
     <TemplatesDrawerWrapper>
       <Wizard
@@ -104,7 +101,6 @@ const VMCreationWizard: FC = () => {
         </WizardStep>
         <WizardStep
           footer={{
-            cancelButtonProps,
             isNextDisabled: isNextDisabledForStep(VMWizardStep.GUEST_OS),
           }}
           id={VMWizardStep.GUEST_OS}
@@ -115,7 +111,6 @@ const VMCreationWizard: FC = () => {
         </WizardStep>
         <WizardStep
           footer={{
-            cancelButtonProps,
             isNextDisabled: isNextDisabledForStep(VMWizardStep.BOOT_SOURCE),
           }}
           id={VMWizardStep.BOOT_SOURCE}
@@ -156,7 +151,6 @@ const VMCreationWizard: FC = () => {
         </WizardStep>
         <WizardStep
           footer={{
-            cancelButtonProps,
             isNextDisabled: isNextDisabledForStep(VMWizardStep.CLONE),
           }}
           id={VMWizardStep.CLONE}

--- a/src/views/virtualmachines/creation-wizard/components/DefaultWizardFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard/components/DefaultWizardFooter.tsx
@@ -1,8 +1,5 @@
 import React, { FC } from 'react';
-import classnames from 'classnames';
 
-import { FLAG_LIGHTSPEED_PLUGIN } from '@kubevirt-utils/flags/consts';
-import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { useWizardContext, WizardFooter } from '@patternfly/react-core';
 import useCloseWizard from '@virtualmachines/creation-wizard/hooks/useCloseWizard';
 
@@ -13,12 +10,10 @@ type DefaultWizardFooterProps = {
 const DefaultWizardFooter: FC<DefaultWizardFooterProps> = ({ isNextDisabled }) => {
   const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
   const closeWizard = useCloseWizard();
-  const hasOLSConsole = useFlag(FLAG_LIGHTSPEED_PLUGIN);
 
   return (
     <WizardFooter
       activeStep={activeStep}
-      cancelButtonProps={{ className: classnames({ 'pf-v6-u-mr-4xl': hasOLSConsole }) }}
       isBackDisabled={activeStep.index === 1}
       isNextDisabled={isNextDisabled}
       onBack={goToPrevStep}

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/ComputeResourcesStepFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/ComputeResourcesStepFooter.tsx
@@ -1,8 +1,5 @@
 import React, { FC } from 'react';
-import classnames from 'classnames';
 
-import { FLAG_LIGHTSPEED_PLUGIN } from '@kubevirt-utils/flags/consts';
-import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { useWizardContext, WizardFooter } from '@patternfly/react-core';
 import useCloseWizard from '@virtualmachines/creation-wizard/hooks/useCloseWizard';
 import useWizardStepValidation from '@virtualmachines/creation-wizard/hooks/useWizardStepValidation';
@@ -10,7 +7,6 @@ import useCreateVMFromInstanceType from '@virtualmachines/creation-wizard/steps/
 import { VMWizardStep } from '@virtualmachines/creation-wizard/utils/constants';
 
 const ComputeResourcesStepFooter: FC = () => {
-  const hasOLSConsole = useFlag(FLAG_LIGHTSPEED_PLUGIN);
   const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
   const handleCreateVM = useCreateVMFromInstanceType();
   const closeWizard = useCloseWizard();
@@ -24,7 +20,6 @@ const ComputeResourcesStepFooter: FC = () => {
   return (
     <WizardFooter
       activeStep={activeStep}
-      cancelButtonProps={{ className: classnames({ 'pf-v6-u-mr-4xl': hasOLSConsole }) }}
       isBackDisabled={activeStep.index === 1}
       isNextDisabled={isNextDisabledForStep(VMWizardStep.COMPUTE_RESOURCES)}
       onBack={goToPrevStep}

--- a/src/views/virtualmachines/creation-wizard/steps/ReviewAndCreateStep/components/ReviewAndCreateStepFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/ReviewAndCreateStep/components/ReviewAndCreateStepFooter.tsx
@@ -1,9 +1,6 @@
 import React, { FC } from 'react';
-import classnames from 'classnames';
 
-import { FLAG_LIGHTSPEED_PLUGIN } from '@kubevirt-utils/flags/consts';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { useWizardContext, WizardFooter } from '@patternfly/react-core';
 import useCloseWizard from '@virtualmachines/creation-wizard/hooks/useCloseWizard';
 import useCreateVM from '@virtualmachines/creation-wizard/hooks/useCreateVM';
@@ -11,7 +8,6 @@ import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-s
 import { isCloneCreationMethod } from '@virtualmachines/creation-wizard/utils/utils';
 
 const ReviewAndCreateStepFooter: FC = () => {
-  const hasOLSConsole = useFlag(FLAG_LIGHTSPEED_PLUGIN);
   const { activeStep, goToPrevStep } = useWizardContext();
   const { creationMethod, isVMNameValid } = useVMWizardStore();
   const isCloneMethod = isCloneCreationMethod(creationMethod);
@@ -21,7 +17,6 @@ const ReviewAndCreateStepFooter: FC = () => {
   return (
     <WizardFooter
       activeStep={activeStep}
-      cancelButtonProps={{ className: classnames({ 'pf-v6-u-mr-4xl': hasOLSConsole }) }}
       isNextDisabled={!isVMNameValid}
       nextButtonText={isCloneMethod ? t('Clone VirtualMachine') : t('Create VirtualMachine')}
       onBack={goToPrevStep}

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplateStepFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplateStepFooter.tsx
@@ -1,8 +1,5 @@
 import React, { FC } from 'react';
-import classnames from 'classnames';
 
-import { FLAG_LIGHTSPEED_PLUGIN } from '@kubevirt-utils/flags/consts';
-import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { useWizardContext, WizardFooter } from '@patternfly/react-core';
 import useCloseWizard from '@virtualmachines/creation-wizard/hooks/useCloseWizard';
 import useWizardStepValidation from '@virtualmachines/creation-wizard/hooks/useWizardStepValidation';
@@ -11,7 +8,6 @@ import useCreateVMFromTemplate from '@virtualmachines/creation-wizard/steps/Temp
 import { VMWizardStep } from '@virtualmachines/creation-wizard/utils/constants';
 
 const TemplateStepFooter: FC = () => {
-  const hasOLSConsole = useFlag(FLAG_LIGHTSPEED_PLUGIN);
   const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
   const { createVMFromTemplate } = useCreateVMFromTemplate();
   const closeWizard = useCloseWizard();
@@ -27,7 +23,6 @@ const TemplateStepFooter: FC = () => {
   return (
     <WizardFooter
       activeStep={activeStep}
-      cancelButtonProps={{ className: classnames({ 'pf-v6-u-mr-4xl': hasOLSConsole }) }}
       isBackDisabled={activeStep.index === 1}
       isNextDisabled={isNextDisabledForStep(VMWizardStep.TEMPLATE)}
       onBack={goToPrevStep}


### PR DESCRIPTION

## 📝 Description

The cancel button in the create vm wizard was hidden by lightspeed icon when enabled. The Console's QuickStartDrawer.scss applies `justify-content: space-between` to all `.pf-v6-c-action-list` elements, pushing the Cancel button away from Back/Next in the VM creation wizard footer. This overrides it with `flex-start `to keep the buttons grouped together according to [PF guidelines](https://www.patternfly.org/components/wizard/react-deprecated/#wizard-in-modal). 

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-84105

## 🎥 Demo

Before:
<img width="1457" height="1110" alt="image" src="https://github.com/user-attachments/assets/86b8c8b7-8b9a-40db-91d7-ada9fb6e088a" />

After:
<img width="1550" height="1208" alt="image" src="https://github.com/user-attachments/assets/ac2ed87f-0bca-47d8-ba67-117e8c9ee774" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified and improved alignment of actions in the VM creation wizard footer for consistent button spacing and layout across all steps.
* **Chores**
  * Removed conditional spacing behavior so cancel/next buttons render consistently throughout the wizard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->