### PR TITLE
CNV-87480: hide Windows OS options on s390x architecture

### DIFF
--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeEmptyState/BootableVolumeOSIcons.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeEmptyState/BootableVolumeOSIcons.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
 import { LINUX, OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
 import { Split, SplitItem } from '@patternfly/react-core';
 import { getIconByOSName } from '@virtualmachines/creation-wizard/utils/os-icons/os-icons';
@@ -11,6 +12,8 @@ type BootableVolumeOSIconsProps = {
 };
 
 const BootableVolumeOSIcons: FC<BootableVolumeOSIconsProps> = ({ osName }) => {
+  const isWindowsSupported = useIsWindowsSupportedArchitecture();
+
   if (osName) {
     const icon = getIconByOSName(osName);
     if (icon) {
@@ -27,7 +30,7 @@ const BootableVolumeOSIcons: FC<BootableVolumeOSIconsProps> = ({ osName }) => {
   const osIcons = [
     getIconByOSName(LINUX),
     getIconByOSName(OS_NAME_TYPES.rhel),
-    getIconByOSName(OS_NAME_TYPES.windows),
+    ...(isWindowsSupported ? [getIconByOSName(OS_NAME_TYPES.windows)] : []),
   ];
 
   return (

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/GuestOSStep/components/OperatingSystemTileGroup/OperatingSystemTileGroup.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/GuestOSStep/components/OperatingSystemTileGroup/OperatingSystemTileGroup.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
 import { Split, SplitItem } from '@patternfly/react-core';
 import useInstanceTypeVMStore from '@virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore';
 import { OperatingSystemType } from '@virtualmachines/creation-wizard/steps/InstanceTypesSteps/GuestOSStep/utils/constants';
@@ -8,20 +9,25 @@ import OperatingSystemTile from './components/OperatingSystemTile/OperatingSyste
 
 const OperatingSystemTileGroup: FC = () => {
   const { operatingSystemType, setOperatingSystemType } = useInstanceTypeVMStore();
+  const isWindowsSupported = useIsWindowsSupportedArchitecture();
+
+  const osTypes = [
+    OperatingSystemType.RHEL,
+    ...(isWindowsSupported ? [OperatingSystemType.WINDOWS] : []),
+    OperatingSystemType.OTHER_LINUX,
+  ];
 
   return (
     <Split hasGutter>
-      {[OperatingSystemType.RHEL, OperatingSystemType.WINDOWS, OperatingSystemType.OTHER_LINUX].map(
-        (osType) => (
-          <SplitItem key={osType}>
-            <OperatingSystemTile
-              isSelected={operatingSystemType === osType}
-              onClick={() => setOperatingSystemType(osType)}
-              operatingSystem={osType}
-            />
-          </SplitItem>
-        ),
-      )}
+      {osTypes.map((osType) => (
+        <SplitItem key={osType}>
+          <OperatingSystemTile
+            isSelected={operatingSystemType === osType}
+            onClick={() => setOperatingSystemType(osType)}
+            operatingSystem={osType}
+          />
+        </SplitItem>
+      ))}
     </Split>
   );
 };

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/TemplatesCatalog.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/TemplatesCatalog.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 
 import { V1Template } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { useApplyFiltersWithQuery } from '@kubevirt-utils/components/ListPageFilter/hooks/useApplyFiltersWithQuery';
@@ -7,7 +7,9 @@ import { TemplatesFilterVariant } from '@kubevirt-utils/components/TemplatesFilt
 import { logTemplateFlowEvent } from '@kubevirt-utils/extensions/telemetry/telemetry';
 import { TEMPLATE_SELECTED } from '@kubevirt-utils/extensions/telemetry/utils/constants';
 import useFiltersFromURL from '@kubevirt-utils/hooks/useFiltersFromURL';
-import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
+import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
+import { getTemplateVirtualMachineObject, OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
+import { getTemplateOS } from '@kubevirt-utils/resources/template/utils/selectors';
 import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useListPageFilter } from '@openshift-console/dynamic-plugin-sdk';
@@ -31,10 +33,20 @@ const TemplatesCatalog: FC = () => {
   const { availableDataSources, availableTemplatesUID, bootSourcesLoaded, loaded, templates } =
     useTemplatesWithAvailableSource({ namespace });
 
-  const { filters } = useVirtualMachineTemplatesFilters(templates);
+  const isWindowsSupported = useIsWindowsSupportedArchitecture();
+
+  const supportedTemplates = useMemo(
+    () =>
+      isWindowsSupported
+        ? templates
+        : templates.filter((t) => getTemplateOS(t) !== OS_NAME_TYPES.windows),
+    [templates, isWindowsSupported],
+  );
+
+  const { filters } = useVirtualMachineTemplatesFilters(supportedTemplates);
   const filtersFromURL = useFiltersFromURL(filters);
   const [, filteredTemplates, onFilterChange] = useListPageFilter(
-    templates,
+    supportedTemplates,
     filters,
     filtersFromURL,
   );


### PR DESCRIPTION
## 📝 Description

On s390x (IBM Z) clusters, Windows is not a supported guest OS. This PR hides Windows-related UI elements in the VM creation wizard when the cluster only supports s390x workloads.

**Changes:**
- `OperatingSystemTileGroup`: Skip the Windows tile in the Guest OS step when `useIsWindowsSupportedArchitecture()` returns `false`
- `BootableVolumeOSIcons`: Skip the Windows icon in the boot volume empty state when Windows is not supported

The existing `useIsWindowsSupportedArchitecture` hook reads `workloadsArchitectures` from the HyperConverged CR status (falling back to `SERVER_FLAGS.nodeArchitectures`). On s390x-only clusters neither `amd64` nor `arm64` is present, so the hook returns `false`.

## 🔗 Links

- https://issues.redhat.com/browse/CNV-87480

## 🎥 Demo


**BEFORE**
<img width="1874" height="1068" alt="Screenshot 2026-05-18 at 09 33 50" src="https://github.com/user-attachments/assets/d251c137-d87e-4864-a6a0-50a1e5bc53a6" />

<img width="1904" height="1049" alt="Screenshot 2026-05-18 at 10 23 54" src="https://github.com/user-attachments/assets/c30121fa-d3f9-4871-8e5f-79ced2035898" />

**AFTER**

<img width="1874" height="1068" alt="Screenshot 2026-05-18 at 09 34 21" src="https://github.com/user-attachments/assets/566fc54a-a70e-49bf-a48e-71bc4ae3e321" />

<img width="1904" height="1049" alt="Screenshot 2026-05-18 at 10 29 41" src="https://github.com/user-attachments/assets/d969b438-34df-4cd3-9894-91d47a2ca244" />



Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows support is now conditional based on system architecture. Windows options are displayed only when supported for the current architecture; unsupported architectures no longer show Windows as an available choice in OS selection, bootable volumes, and template catalogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
