### PR TITLE
CNV-85825: fix health popup status mismatch - filter alerts by operator_health_impact=critical and display by severity

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1123,6 +1123,7 @@
   "Loading": "Loading",
   "Loading ...": "Loading ...",
   "Loading checkup image": "Loading checkup image",
+  "Loading contents": "Loading contents",
   "Loading guest login credentials": "Loading guest login credentials",
   "Loading results": "Loading results",
   "Loading searches": "Loading searches",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1137,6 +1137,7 @@
   "Loading": "Cargando",
   "Loading ...": "Cargando ...",
   "Loading checkup image": "Cargando imagen de control",
+  "Loading contents": "Loading contents",
   "Loading guest login credentials": "Cargando credenciales de inicio de sesión del huésped",
   "Loading results": "Cargando resultados",
   "Loading searches": "Cargando búsquedas",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1137,6 +1137,7 @@
   "Loading": "Chargement",
   "Loading ...": "Chargement...",
   "Loading checkup image": "Chargement de l'image de contrôle",
+  "Loading contents": "Loading contents",
   "Loading guest login credentials": "Chargement des informations de connexion des invités",
   "Loading results": "Chargement des résultats",
   "Loading searches": "Chargement des recherches",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1123,6 +1123,7 @@
   "Loading": "読み込み中",
   "Loading ...": "ロード中 ...",
   "Loading checkup image": "チェックアップイメージのロード中",
+  "Loading contents": "Loading contents",
   "Loading guest login credentials": "ゲストログイン認証情報のロード中",
   "Loading results": "結果のロード中",
   "Loading searches": "検索のロード中",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1123,6 +1123,7 @@
   "Loading": "로딩 중 ...",
   "Loading ...": "로딩 중 ...",
   "Loading checkup image": "검사 이미지 로딩 중",
+  "Loading contents": "Loading contents",
   "Loading guest login credentials": "게스트 로그인 인증 정보 로딩 중",
   "Loading results": "결과 로딩 중",
   "Loading searches": "검색 로딩 중",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1123,6 +1123,7 @@
   "Loading": "加载",
   "Loading ...": "载入......",
   "Loading checkup image": "加载检查镜像",
+  "Loading contents": "Loading contents",
   "Loading guest login credentials": "加载客户机登录凭证",
   "Loading results": "加载结果",
   "Loading searches": "加载搜索",

--- a/src/utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts.ts
+++ b/src/utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts.ts
@@ -22,7 +22,7 @@ type UseInfrastructureAlerts = () => {
 const useInfrastructureAlerts: UseInfrastructureAlerts = () => {
   const { alerts, loaded } = useAlerts();
 
-  const alertsBySeverity = useMemo(() => {
+  const alertsBySeverity = useMemo((): AlertsBySeverity => {
     const filteredAlerts = alerts?.filter(
       (alert) =>
         isKubeVirtAlert(alert) &&

--- a/src/utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts.ts
+++ b/src/utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts.ts
@@ -1,19 +1,20 @@
 import { useMemo } from 'react';
 
+import { AlertType } from '@kubevirt-utils/components/AlertsCard/utils/types';
 import useAlerts from '@kubevirt-utils/hooks/useAlerts/useAlerts';
 import {
   getNumberOfAlerts,
+  isCriticalHealthImpactAlert,
   isFiringOrSilencedAlert,
-  isImportantInfrastructureAlert,
-  sortAlertsByHealthImpact,
+  sortAlertsBySeverity,
 } from '@kubevirt-utils/hooks/useInfrastructureAlerts/utils/utils';
 import { isKubeVirtAlert } from '@kubevirt-utils/utils/prometheus';
 import { Alert } from '@openshift-console/dynamic-plugin-sdk';
 
-export type AlertsByHealthImpact = { critical: Alert[]; none: Alert[]; warning: Alert[] };
+export type AlertsBySeverity = { [key in AlertType]: Alert[] };
 
 type UseInfrastructureAlerts = () => {
-  alerts: AlertsByHealthImpact;
+  alerts: AlertsBySeverity;
   loaded: boolean;
   numberOfAlerts: number;
 };
@@ -21,21 +22,21 @@ type UseInfrastructureAlerts = () => {
 const useInfrastructureAlerts: UseInfrastructureAlerts = () => {
   const { alerts, loaded } = useAlerts();
 
-  const alertsByHealthImpact = useMemo(() => {
+  const alertsBySeverity = useMemo(() => {
     const filteredAlerts = alerts?.filter(
       (alert) =>
         isKubeVirtAlert(alert) &&
         isFiringOrSilencedAlert(alert) &&
-        isImportantInfrastructureAlert(alert),
+        isCriticalHealthImpactAlert(alert),
     );
 
-    return sortAlertsByHealthImpact(filteredAlerts);
+    return sortAlertsBySeverity(filteredAlerts);
   }, [alerts]);
 
   return {
-    alerts: alertsByHealthImpact,
+    alerts: alertsBySeverity,
     loaded,
-    numberOfAlerts: getNumberOfAlerts(alertsByHealthImpact) || 0,
+    numberOfAlerts: getNumberOfAlerts(alertsBySeverity) || 0,
   };
 };
 

--- a/src/utils/hooks/useInfrastructureAlerts/utils/utils.ts
+++ b/src/utils/hooks/useInfrastructureAlerts/utils/utils.ts
@@ -1,4 +1,5 @@
-import { AlertsByHealthImpact } from '@kubevirt-utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts';
+import { AlertType } from '@kubevirt-utils/components/AlertsCard/utils/types';
+import { AlertsBySeverity } from '@kubevirt-utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts';
 import { OPERATOR_HEALTH_IMPACT_LABEL } from '@kubevirt-utils/hooks/useInfrastructureAlerts/utils/constants';
 import { Alert, AlertStates } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -9,6 +10,9 @@ export const isFiringOrSilencedAlert = (alert: Alert): boolean =>
 
 const getHealthImpact = (alert: Alert) => alert?.labels?.[OPERATOR_HEALTH_IMPACT_LABEL];
 
+export const isCriticalHealthImpactAlert = (alert: Alert): boolean =>
+  getHealthImpact(alert) === HealthImpactLevel.critical;
+
 export const isImportantInfrastructureAlert = (alert: Alert) => {
   const healthImpact = getHealthImpact(alert);
   return (
@@ -17,19 +21,18 @@ export const isImportantInfrastructureAlert = (alert: Alert) => {
   );
 };
 
-export const sortAlertsByHealthImpact = (alerts: Alert[]) =>
+export const sortAlertsBySeverity = (alerts: Alert[]): AlertsBySeverity =>
   alerts?.reduce(
     (acc, alert) => {
-      const healthImpact = getHealthImpact(alert);
-
-      if (healthImpact) acc[healthImpact]?.push(alert);
+      const severity = alert?.labels?.severity as AlertType;
+      if (severity && acc[severity]) acc[severity].push(alert);
       return acc;
     },
-    { critical: [], none: [], warning: [] },
-  );
+    { [AlertType.critical]: [], [AlertType.info]: [], [AlertType.warning]: [] } as AlertsBySeverity,
+  ) ?? { [AlertType.critical]: [], [AlertType.info]: [], [AlertType.warning]: [] };
 
-export const getNumberOfAlerts = (alerts: AlertsByHealthImpact) =>
-  Object.values(alerts)?.reduce((acc, alertsForImpactLevel) => {
-    acc += alertsForImpactLevel?.length || 0;
+export const getNumberOfAlerts = (alerts: AlertsBySeverity) =>
+  Object.values(alerts)?.reduce((acc, alertsForLevel) => {
+    acc += alertsForLevel?.length || 0;
     return acc;
   }, 0);

--- a/src/utils/hooks/useInfrastructureAlerts/utils/utils.ts
+++ b/src/utils/hooks/useInfrastructureAlerts/utils/utils.ts
@@ -13,14 +13,6 @@ const getHealthImpact = (alert: Alert) => alert?.labels?.[OPERATOR_HEALTH_IMPACT
 export const isCriticalHealthImpactAlert = (alert: Alert): boolean =>
   getHealthImpact(alert) === HealthImpactLevel.critical;
 
-export const isImportantInfrastructureAlert = (alert: Alert) => {
-  const healthImpact = getHealthImpact(alert);
-  return (
-    healthImpact &&
-    (healthImpact === HealthImpactLevel.warning || healthImpact === HealthImpactLevel.critical)
-  );
-};
-
 export const sortAlertsBySeverity = (alerts: Alert[]): AlertsBySeverity =>
   alerts?.reduce(
     (acc, alert) => {
@@ -31,7 +23,7 @@ export const sortAlertsBySeverity = (alerts: Alert[]): AlertsBySeverity =>
     { [AlertType.critical]: [], [AlertType.info]: [], [AlertType.warning]: [] } as AlertsBySeverity,
   ) ?? { [AlertType.critical]: [], [AlertType.info]: [], [AlertType.warning]: [] };
 
-export const getNumberOfAlerts = (alerts: AlertsBySeverity) =>
+export const getNumberOfAlerts = (alerts: AlertsBySeverity): number =>
   Object.values(alerts)?.reduce((acc, alertsForLevel) => {
     acc += alertsForLevel?.length || 0;
     return acc;

--- a/src/views/dashboard-extensions/KubevirtHealthPopup/KubevirtHealthPopup.tsx
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/KubevirtHealthPopup.tsx
@@ -16,7 +16,6 @@ import { Divider, Grid, GridItem, Stack, StackItem } from '@patternfly/react-cor
 
 import Conditions from './components/Conditions/Conditions';
 import HealthPopupChart from './components/HealthPopupChart';
-import { HealthImpactLevel } from './utils/types';
 import { HEALTH_ALERTS_URL_PARAMS } from './utils/utils';
 
 import './KubevirtHealthPopup.scss';
@@ -30,7 +29,7 @@ const KubevirtHealthPopup: FC = () => {
     'You can host and manage virtualized workloads on the same platform as container-based workloads.',
   );
 
-  const numCriticalAlerts = alerts?.[HealthImpactLevel.critical]?.length;
+  const numCriticalAlerts = alerts?.[AlertType.critical]?.length;
   const numWarningAlerts = alerts?.[AlertType.warning]?.length;
   const healthAlertsURLBasePath = getAlertsPath(perspective, null, HEALTH_ALERTS_URL_PARAMS);
 
@@ -49,7 +48,7 @@ const KubevirtHealthPopup: FC = () => {
               <StackItem>
                 <div className="kv-health-popup__alerts-count">
                   <RedExclamationCircleIcon className="kv-health-popup__alerts-count--icon" />
-                  <Link to={`${healthAlertsURLBasePath}${HealthImpactLevel.critical}`}>
+                  <Link to={`${healthAlertsURLBasePath}${AlertType.critical}`}>
                     {numCriticalAlerts} {t('Critical')}
                   </Link>
                 </div>
@@ -59,7 +58,7 @@ const KubevirtHealthPopup: FC = () => {
               <StackItem>
                 <div className="kv-health-popup__alerts-count">
                   <YellowExclamationTriangleIcon className="kv-health-popup__alerts-count--icon" />{' '}
-                  <Link to={`${healthAlertsURLBasePath}${HealthImpactLevel.warning}`}>
+                  <Link to={`${healthAlertsURLBasePath}${AlertType.warning}`}>
                     {numWarningAlerts} {t('Warning')}
                   </Link>
                 </div>

--- a/src/views/dashboard-extensions/KubevirtHealthPopup/components/Conditions/Conditions.tsx
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/components/Conditions/Conditions.tsx
@@ -20,7 +20,7 @@ const Conditions: FC = () => {
   if (!loaded || !hyperLoaded)
     return (
       <StackItem>
-        <Skeleton screenreaderText="Loading contents" />
+        <Skeleton screenreaderText={t('Loading contents')} />
       </StackItem>
     );
 

--- a/src/views/dashboard-extensions/KubevirtHealthPopup/components/Conditions/Conditions.tsx
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/components/Conditions/Conditions.tsx
@@ -2,26 +2,20 @@ import React, { FC } from 'react';
 import { Link } from 'react-router';
 
 import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { AlertType } from '@kubevirt-utils/components/AlertsCard/utils/types';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import useInfrastructureAlerts from '@kubevirt-utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { PrometheusEndpoint, usePrometheusPoll } from '@openshift-console/dynamic-plugin-sdk';
 import { Skeleton, StackItem } from '@patternfly/react-core';
 
 import ConditionIcon from './ConditionIcon';
-import { HCO_HEALTH_METRIC, VALUE_TO_LABEL } from './constants';
+import { SEVERITY_TO_CONDITION_VALUE, VALUE_TO_LABEL } from './constants';
 
 const Conditions: FC = () => {
   const { t } = useKubevirtTranslation();
   const [hyperConverge, hyperLoaded] = useHyperConvergeConfiguration();
-
-  const [queryData, loaded] = usePrometheusPoll({
-    endpoint: PrometheusEndpoint.QUERY,
-    query: HCO_HEALTH_METRIC,
-  });
-
-  const condition = queryData?.data?.result?.[0]?.value?.[1];
+  const { alerts, loaded } = useInfrastructureAlerts();
 
   if (!loaded || !hyperLoaded)
     return (
@@ -30,9 +24,16 @@ const Conditions: FC = () => {
       </StackItem>
     );
 
-  if (isEmpty(condition)) return null;
+  const getConditionValue = (): number => {
+    if (alerts?.[AlertType.critical]?.length)
+      return SEVERITY_TO_CONDITION_VALUE[AlertType.critical];
+    if (alerts?.[AlertType.warning]?.length) return SEVERITY_TO_CONDITION_VALUE[AlertType.warning];
+    return SEVERITY_TO_CONDITION_VALUE.none;
+  };
 
-  const label = VALUE_TO_LABEL[condition] ? t(VALUE_TO_LABEL[condition]) : condition;
+  const condition = getConditionValue();
+
+  const label = t(VALUE_TO_LABEL[condition]);
 
   return (
     <>

--- a/src/views/dashboard-extensions/KubevirtHealthPopup/components/Conditions/constants.ts
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/components/Conditions/constants.ts
@@ -8,7 +8,7 @@ export const SEVERITY_TO_CONDITION_VALUE: Record<'none' | AlertType, number> = {
 };
 
 export const VALUE_TO_LABEL: Record<number, string> = {
-  0: 'Healthy',
-  1: 'Warning',
-  2: 'Error',
+  0: 'Healthy', // t('Healthy')
+  1: 'Warning', // t('Warning')
+  2: 'Degraded', // t('Degraded')
 };

--- a/src/views/dashboard-extensions/KubevirtHealthPopup/components/Conditions/constants.ts
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/components/Conditions/constants.ts
@@ -1,6 +1,13 @@
-export const HCO_HEALTH_METRIC = 'kubevirt_hco_system_health_status';
+import { AlertType } from '@kubevirt-utils/components/AlertsCard/utils/types';
 
-export const VALUE_TO_LABEL = {
+export const SEVERITY_TO_CONDITION_VALUE: Record<'none' | AlertType, number> = {
+  [AlertType.critical]: 2,
+  [AlertType.info]: 0,
+  [AlertType.warning]: 1,
+  none: 0,
+};
+
+export const VALUE_TO_LABEL: Record<number, string> = {
   0: 'Healthy',
   1: 'Warning',
   2: 'Error',

--- a/src/views/dashboard-extensions/KubevirtHealthPopup/components/HealthPopupChart.tsx
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/components/HealthPopupChart.tsx
@@ -2,7 +2,7 @@ import React, { FC, useMemo } from 'react';
 
 import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/SubTitleChartLabel';
 import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
-import { AlertsByHealthImpact } from '@kubevirt-utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts';
+import { AlertsBySeverity } from '@kubevirt-utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ChartDonut } from '@patternfly/react-charts/victory';
@@ -12,7 +12,7 @@ import { alertTypeToColorMap } from '../utils/utils';
 import EmptyStateNoAlerts from './EmptyStateNoAlerts';
 
 type HealthPopupChartProps = {
-  alerts: AlertsByHealthImpact;
+  alerts: AlertsBySeverity;
   numberOfAlerts?: number;
 };
 


### PR DESCRIPTION
## 📝 Description

Fix a mismatch in the OpenShift Virtualization health popup where:
- The **Conditions** section showed **Healthy** while the overview icon showed a danger/error state
- Alert counts in the popup showed severity based on `operator_health_impact` label (e.g. "1 Critical") but the actual alert severity was different (e.g. "Warning"), causing confusion when clicking through to the alert details

### Root cause

`useInfrastructureAlerts` grouped alerts by `operator_health_impact` (`critical`/`warning`). This caused alerts like `HPPOperatorDown` (which has `operator_health_impact=critical` but `severity=warning`) to appear as "Critical" in the popup, mismatching what users see in the alert detail view.

The Conditions section also used an independent Prometheus metric (`kubevirt_hco_system_health_status`) that could diverge from the overview icon metric (`kubevirt_hyperconverged_operator_health_status`).

### Fix

- **Filter** infrastructure alerts to only those with `operator_health_impact=critical` (these are the alerts that drive the danger icon)
- **Group by `severity` label** instead of `operator_health_impact` for display — so "1 Warning" means the alert's actual severity is Warning, consistent with what users see when clicking through
- **Remove Prometheus query from Conditions** — derive the condition state from the highest alert severity among the filtered alerts (`critical`→Error, `warning`→Warning, none→Healthy). This keeps the Conditions icon/text consistent with the Alerts section and the overview icon

## 🔗 Links

- https://issues.redhat.com/browse/CNV-85825

## 🎥 Demo

**BEFORE**
The alerts are shown as 'critical' because we use the `operator_health_impact` to show it. 


**AFTER**

alerts are shownd only if they have `operator_health_impact` `critical` and then use the `severity` to show `critical` or `warning`. 

If there is an error in  the health, we show the `Degraded` label instead of `Error` 


<img width="353" height="360" alt="Screenshot 2026-05-18 at 11 42 50" src="https://github.com/user-attachments/assets/4eac6692-60b6-43b8-b5f7-71716437fdd3" />
<img width="353" height="360" alt="Screenshot 2026-05-18 at 11 44 33" src="https://github.com/user-attachments/assets/2fdf55a8-d86f-44c2-a819-31e806b97935" />

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Infrastructure alerts are now grouped and surfaced by severity (critical, warning, info/none).

* **Bug Fixes**
  * Health condition labeling updated—“Error” renamed to “Degraded” for clearer status.
  * Alert counts, filtering, and links corrected to reflect severity-based grouping.

* **Improvements**
  * Health popup and condition displays now use the unified alerts source and show a localized loading state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->