### PR TITLE
CNV-87868: Add local development script for Lightspeed plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "start-console": "./start-console.sh",
     "start-console-with-monitoring": "./start-console.sh monitoring-plugin",
     "start-console-with-networking": "./start-console.sh networking-console-plugin",
+    "start-console-with-lightspeed": "./start-console.sh lightspeed-console-plugin",
     "start-console-with-nmstate": "./start-console.sh nmstate-console-plugin",
     "test": "jest",
     "test-cov": "jest --coverage",

--- a/start-console.sh
+++ b/start-console.sh
@@ -8,6 +8,7 @@ plugins="
 monitoring-plugin=https://github.com/openshift/monitoring-plugin.git
 networking-console-plugin=https://github.com/openshift/networking-console-plugin.git
 nmstate-console-plugin=https://github.com/openshift/nmstate-console-plugin.git
+lightspeed-console-plugin=https://github.com/openshift/lightspeed-console.git
 "
 
 # Plugin URLs per container runtime
@@ -22,6 +23,9 @@ get_plugin_url() {
     done
 }
 
+OLS_PORT=${OLS_PORT:-8080}
+LIGHTSPEED_ENABLED=false
+
 INITIAL_PORT=9002
 BASE_DIR=$(pwd)
 
@@ -33,14 +37,28 @@ for arg in "$@"; do
         exit 1
     fi
 
-    if [ ! -d "../$arg" ]; then
-        echo "Creating folder $arg ..."
+    # Lightspeed needs special handling: source helper and start OLS backend
+    if [ "$arg" = "lightspeed-console-plugin" ]; then
+        LIGHTSPEED_ENABLED=true
+        . ./start-lightspeed.sh
+        start_lightspeed_service
+    fi
+
+    # The git repo name differs from the plugin name for lightspeed
+    if [ "$arg" = "lightspeed-console-plugin" ]; then
+        repo_dir="lightspeed-console"
+    else
+        repo_dir="$arg"
+    fi
+
+    if [ ! -d "../$repo_dir" ]; then
+        echo "Creating folder $repo_dir ..."
         cd ..
         echo "Cloning $plugin_url ..."
         git clone "$plugin_url"
-        cd "$arg"
+        cd "$repo_dir"
     else
-        cd "../$arg"
+        cd "../$repo_dir"
     fi
 
     git pull
@@ -52,13 +70,22 @@ for arg in "$@"; do
         cd web 
     fi
 
+    # Build env vars for the plugin dev server
+    plugin_env="PORT=$INITIAL_PORT"
+    if [ "$arg" = "lightspeed-console-plugin" ]; then
+        plugin_env="$plugin_env OLS_API_BASE_URL=http://127.0.0.1:${OLS_PORT}"
+    fi
+
     if [ -f yarn.lock ]; then
         echo "Detected yarn.lock → using yarn to run $arg"
         yarn install
-        PORT=$INITIAL_PORT yarn start --port="$INITIAL_PORT" &
+        env $plugin_env yarn start --port="$INITIAL_PORT" &
+    elif [ "$arg" = "lightspeed-console-plugin" ]; then
+        npm ci
+        env $plugin_env npx ts-node -O '{"module":"commonjs"}' node_modules/.bin/webpack serve --port="$INITIAL_PORT" &
     else
         npm ci
-        PORT=$INITIAL_PORT npm run start -- --port="$INITIAL_PORT" &
+        env $plugin_env npm run start -- --port="$INITIAL_PORT" &
     fi
 
     running_podman_linux="$running_podman_linux,$arg=http://localhost:$INITIAL_PORT"
@@ -86,9 +113,17 @@ BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
 BRIDGE_USER_SETTINGS_LOCATION="localstorage"
 BRIDGE_I18N_NAMESPACES="plugin__kubevirt-plugin"
 
+if [ "$LIGHTSPEED_ENABLED" = "true" ]; then
+    configure_lightspeed_proxy
+fi
+
 echo "API Server: $BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT"
 echo "Console Image: $CONSOLE_IMAGE"
 echo "Console URL: http://localhost:${CONSOLE_PORT}"
+
+if [ "$LIGHTSPEED_ENABLED" = "true" ]; then
+    launch_chrome_insecure
+fi
 
 # Build --env args dynamically
 env_args=""

--- a/start-lightspeed.sh
+++ b/start-lightspeed.sh
@@ -1,0 +1,154 @@
+#!/bin/sh
+# Helper script to set up and start the Lightspeed backend service (OLS) for local development.
+# Sourced by start-console.sh when lightspeed-console-plugin is requested.
+#
+# Prerequisites: ollama must be installed (https://ollama.com/)
+#
+# Environment variables (set by caller):
+#   OLS_PORT  - Port for lightspeed-service (default: 8080)
+#   BASE_DIR  - Caller's working directory (required)
+#
+# Provides:
+#   start_lightspeed_service  - Clone, configure, and start the OLS backend
+#   configure_lightspeed_proxy - Add OLS proxy entry to BRIDGE_PLUGIN_PROXY
+#   launch_chrome_insecure     - Open Chrome with --disable-web-security
+OLS_PORT=${OLS_PORT:-8080}
+LIGHTSPEED_SERVICE_DIR="../lightspeed-service"
+
+: "${BASE_DIR:?BASE_DIR must be set by the caller}"
+
+start_lightspeed_service() {
+    # ── Clone lightspeed-service if needed ──────────────────────────
+    if [ ! -d "$LIGHTSPEED_SERVICE_DIR" ]; then
+        echo "Cloning lightspeed-service..."
+        git clone https://github.com/openshift/lightspeed-service.git "$LIGHTSPEED_SERVICE_DIR"
+    fi
+
+    # ── Ollama: start server + pull model ──────────────────────────
+    if command -v ollama >/dev/null; then
+        if ! pgrep -x "ollama" >/dev/null 2>&1; then
+            echo "Starting ollama server..."
+            ollama serve &
+            sleep 2
+        else
+            echo "ollama is already running."
+        fi
+
+        if ! ollama list 2>/dev/null | grep -q "llama3.1:latest"; then
+            echo "Pulling llama3.1:latest model (this may take a while on first run)..."
+            ollama pull llama3.1:latest
+        fi
+    else
+        echo "================================================================"
+        echo "ERROR: ollama is not installed."
+        echo "  Install it from https://ollama.com/ then run:"
+        echo "    ollama pull llama3.1:latest"
+        echo "================================================================"
+        echo "The lightspeed service will start but will not work without an LLM backend."
+    fi
+
+    # ── Generate default config if missing ─────────────────────────
+    if [ ! -f "$LIGHTSPEED_SERVICE_DIR/olsconfig.yaml" ]; then
+        echo "Creating default olsconfig.yaml for local ollama..."
+        cat > "$LIGHTSPEED_SERVICE_DIR/olsconfig.yaml" << 'OLSCFG'
+llm_providers:
+  - name: ollama
+    type: openai
+    url: "http://localhost:11434/v1/"
+    models:
+      - name: 'llama3.1:latest'
+ols_config:
+  reference_content:
+  conversation_cache:
+    type: memory
+    memory:
+      max_entries: 1000
+  logging_config:
+    app_log_level: info
+    lib_log_level: warning
+    uvicorn_log_level: info
+  default_provider: ollama
+  default_model: 'llama3.1:latest'
+  user_data_collection:
+    feedback_disabled: false
+    feedback_storage: "/tmp/data/feedback"
+    transcripts_disabled: false
+    transcripts_storage: "/tmp/data/transcripts"
+dev_config:
+  enable_dev_ui: true
+  disable_auth: true
+  disable_tls: true
+OLSCFG
+    fi
+
+    # ── Create Python venv if needed ───────────────────────────────
+    if [ ! -d "$LIGHTSPEED_SERVICE_DIR/.venv" ]; then
+        echo "Creating Python virtual environment for lightspeed-service..."
+        python3 -m venv "$LIGHTSPEED_SERVICE_DIR/.venv"
+    fi
+
+    # ── Start lightspeed-service in a subshell ─────────────────────
+    echo "Starting lightspeed-service on port $OLS_PORT..."
+    (
+        cd "$LIGHTSPEED_SERVICE_DIR"
+        # shellcheck disable=SC1091
+        . .venv/bin/activate
+        OPENAI_API_KEY="${OPENAI_API_KEY:-IGNORED}" make install-deps && \
+        OPENAI_API_KEY="${OPENAI_API_KEY:-IGNORED}" make run
+    ) &
+
+    # ── Wait for readiness ─────────────────────────────────────────
+    echo "Waiting for lightspeed-service to be ready..."
+    for i in $(seq 1 60); do
+        if curl -s "http://127.0.0.1:$OLS_PORT/readiness" >/dev/null 2>&1; then
+            echo "lightspeed-service is ready."
+            break
+        fi
+        if [ "$i" = "60" ]; then
+            echo "Warning: lightspeed-service may not be ready yet. Continuing anyway."
+        fi
+        sleep 2
+    done
+}
+
+configure_lightspeed_proxy() {
+    ols_endpoint_linux="http://localhost:${OLS_PORT}"
+    ols_endpoint_container="http://host.containers.internal:${OLS_PORT}"
+    ols_endpoint_docker="http://host.docker.internal:${OLS_PORT}"
+
+    if command -v podman >/dev/null; then
+        if [ "$(uname -s)" = "Linux" ]; then
+            ols_endpoint="$ols_endpoint_linux"
+        else
+            ols_endpoint="$ols_endpoint_container"
+        fi
+    else
+        ols_endpoint="$ols_endpoint_docker"
+    fi
+
+    BRIDGE_PLUGIN_PROXY=${BRIDGE_PLUGIN_PROXY:-'{"services":[]}'}
+    BRIDGE_PLUGIN_PROXY=$(echo "$BRIDGE_PLUGIN_PROXY" | jq -c \
+        --arg endpoint "$ols_endpoint" \
+        '.services += [{"consoleAPIPath":"/api/proxy/plugin/lightspeed-console-plugin/ols/","endpoint":$endpoint,"authorize":true}]')
+    export BRIDGE_PLUGIN_PROXY
+    echo "OLS PROXY: $(echo "${BRIDGE_PLUGIN_PROXY}" | jq .)"
+}
+
+launch_chrome_insecure() {
+    CHROME_DATA_DIR="${HOME}/chrome-dev-data-dir"
+    CHROME_URL="http://localhost:${CONSOLE_PORT}"
+    echo "Launching Chrome with disabled web security..."
+
+    if [ "$(uname -s)" = "Darwin" ]; then
+        open -a "Google Chrome" --args --disable-web-security --user-data-dir="$CHROME_DATA_DIR" "$CHROME_URL" &
+    elif command -v google-chrome >/dev/null; then
+        google-chrome --disable-web-security --user-data-dir="$CHROME_DATA_DIR" "$CHROME_URL" &
+    elif command -v google-chrome-stable >/dev/null; then
+        google-chrome-stable --disable-web-security --user-data-dir="$CHROME_DATA_DIR" "$CHROME_URL" &
+    elif command -v chromium-browser >/dev/null; then
+        chromium-browser --disable-web-security --user-data-dir="$CHROME_DATA_DIR" "$CHROME_URL" &
+    else
+        echo "Warning: Could not find Chrome. Please open Chrome manually with:"
+        echo "  google-chrome --disable-web-security --user-data-dir=\"$CHROME_DATA_DIR\" $CHROME_URL"
+    fi
+}


### PR DESCRIPTION

## 📝 Description

## Summary
- Add `start-lightspeed.sh` helper script that automates the full local Lightspeed setup: cloning `lightspeed-service`, starting ollama, pulling the LLM model, generating `olsconfig.yaml`, creating a Python venv, installing deps, and running the OLS backend
- Integrate Lightspeed plugin support into `start-console.sh` with proper repo name mapping, OLS proxy configuration, and Chrome launch with disabled web security
- Add `start-console-with-lightspeed` npm script for convenience

## How to use

### Prerequisites

1. **Install ollama** (one-time setup):
   ```bash
   # macOS
   brew install ollama
   # or download from https://ollama.com/

That's it — the script handles everything else automatically on first run (cloning repos, pulling the LLM model, creating configs, installing Python deps).

### Running

Terminal 1 — start the kubevirt-plugin dev server as usual:
 ```bash
oc login ...
npm ci && npm run dev
```

Terminal 2 — start the console with Lightspeed:
`export BRIDGE_BRANDING=openshift && npm run start-console-with-lightspeed`

The script will:
- Clone `lightspeed-service` and `lightspeed-console` to sibling directories (if not already present)
- Start `ollama serve` (if not already running)
- Pull `llama3.1:latest` model (if not already downloaded — ~4.7GB on first run)
- Generate `olsconfig.yaml` with local ollama defaults (if not already present)
- Create a Python venv and install dependencies
- Start the OLS backend service on port 8080
- Start the Lightspeed console plugin dev server
- Configure the OLS proxy for the console
- Launch Chrome with `--disable-web-security` (required for local CORS)

### Configuration

| Variable | Default | Description |
|----------|---------|-------------|
| `OLS_PORT` | `8080` | Port for the lightspeed-service backend |
| `BRIDGE_BRANDING` | - | Set to `openshift` for OCP branding |
| `OPENAI_API_KEY` | `IGNORED` | Not needed for local ollama |

### Running with other plugins

You can combine Lightspeed with other plugins:
`export BRIDGE_BRANDING=openshift && npm run start-console lightspeed-console-plugin networking-console-plugin`

## Test plan
- [ ] Run `export BRIDGE_BRANDING=openshift && npm run start-console-with-lightspeed` and verify the Lightspeed icon appears in the console
- [ ] Verify the Lightspeed chat answers questions (requires ollama installed with `llama3.1:latest`)
- [ ] Verify other plugins still work: `npm run start-console-with-networking`
- [ ] Verify first-run experience: delete `../lightspeed-service` and `../lightspeed-console`, run the script, confirm both repos are cloned and services start
- [ ] Verify `OLS_PORT` override: `OLS_PORT=8081 npm run start-console-with-lightspeed`

Jira: https://redhat.atlassian.net/browse/CNV-87868



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added npm script to start the console with the Lightspeed plugin fully enabled for local development environments
  * Introduced Lightspeed backend service initialization with automatic LLM model retrieval, configuration generation, and continuous API readiness monitoring
  * Configured automatic proxy connection setup between console and Lightspeed backend with insecure browser launch capability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->