### PR TITLE
feat(cclm): add app.kubernetes.io/created-by label to MTV resources

### DIFF
--- a/src/multicluster/components/CrossClusterMigration/constants.ts
+++ b/src/multicluster/components/CrossClusterMigration/constants.ts
@@ -1,3 +1,6 @@
 export const MTV_MIGRATION_NAMESPACE = 'mtv-integrations';
 
 export const POD_NETWORK_TYPE = 'pod';
+
+export const CCLM_LABEL_KEY = 'app.kubernetes.io/created-by';
+export const CCLM_LABEL_VALUE = 'cclm';

--- a/src/multicluster/components/CrossClusterMigration/utils.ts
+++ b/src/multicluster/components/CrossClusterMigration/utils.ts
@@ -16,13 +16,16 @@ import { getName, getNamespace, getUID } from '@kubevirt-utils/resources/shared'
 import { getNetworks, getVolumes } from '@kubevirt-utils/resources/vm';
 import { getRandomChars } from '@kubevirt-utils/utils/utils';
 
-import { MTV_MIGRATION_NAMESPACE, POD_NETWORK_TYPE } from './constants';
+import { CCLM_LABEL_KEY, CCLM_LABEL_VALUE, MTV_MIGRATION_NAMESPACE, POD_NETWORK_TYPE } from './constants';
 import { GetInitialStorageMapParams } from './types';
 
 export const getInitialMigrationPlan = (vms: V1VirtualMachine[]): V1beta1Plan => ({
   apiVersion: `${PlanModel.apiGroup}/${PlanModel.apiVersion}`,
   kind: PlanModel.kind,
   metadata: {
+    labels: {
+      [CCLM_LABEL_KEY]: CCLM_LABEL_VALUE,
+    },
     name: `cross-cluster-migration-${getRandomChars()}`,
     namespace: MTV_MIGRATION_NAMESPACE,
   },
@@ -80,6 +83,9 @@ export const getInitialNetworkMap = (
     apiVersion: `${NetworkMapModel.apiGroup}/${NetworkMapModel.apiVersion}`,
     kind: NetworkMapModel.kind,
     metadata: {
+      labels: {
+        [CCLM_LABEL_KEY]: CCLM_LABEL_VALUE,
+      },
       name: `cross-cluster-migration-${getRandomChars()}`,
       namespace: MTV_MIGRATION_NAMESPACE,
     },
@@ -159,6 +165,9 @@ export const getInitialStorageMap = ({
     apiVersion: `${StorageMapModel.apiGroup}/${StorageMapModel.apiVersion}`,
     kind: StorageMapModel.kind,
     metadata: {
+      labels: {
+        [CCLM_LABEL_KEY]: CCLM_LABEL_VALUE,
+      },
       name: `cross-cluster-migration-${getRandomChars()}`,
       namespace: MTV_MIGRATION_NAMESPACE,
     },

--- a/src/multicluster/components/CrossClusterMigration/utils.ts
+++ b/src/multicluster/components/CrossClusterMigration/utils.ts
@@ -16,7 +16,12 @@ import { getName, getNamespace, getUID } from '@kubevirt-utils/resources/shared'
 import { getNetworks, getVolumes } from '@kubevirt-utils/resources/vm';
 import { getRandomChars } from '@kubevirt-utils/utils/utils';
 
-import { CCLM_LABEL_KEY, CCLM_LABEL_VALUE, MTV_MIGRATION_NAMESPACE, POD_NETWORK_TYPE } from './constants';
+import {
+  CCLM_LABEL_KEY,
+  CCLM_LABEL_VALUE,
+  MTV_MIGRATION_NAMESPACE,
+  POD_NETWORK_TYPE,
+} from './constants';
 import { GetInitialStorageMapParams } from './types';
 
 export const getInitialMigrationPlan = (vms: V1VirtualMachine[]): V1beta1Plan => ({


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add 'app.kubernetes.io/created-by: cclm' label to the metadata of Plan, NetworkMap, and StorageMap resources created during cross-cluster migration, making them identifiable and filterable by their origin. 

## Summary
Adds a label to Plans created by CCLM so ACM can identify them and remove associated `NetworkMap` and `StorageMap` resources when a Plan is cleaned up or archived.
After a Plan is archived or deleted, `NetworkMap` and `StorageMap` objects were left behind because ACM had no reliable way to tell which maps belonged to CCLM-managed Plans. This change tags those Plans at creation time so ACM can filter on CCLM-owned Plans and delete the related maps as part of Plan cleanup/archive.
## Motivation
- NetworkMap and StorageMap leftovers remain after archiving or removing a Plan
- ACM needs a stable selector to scope cleanup to Plans created by CCLM
- Ensures map resources are removed when the parent Plan is cleaned up or archived
## Changes
- Apply `<label-key>=<label-value>` (or equivalent) when CCLM creates a Plan
- Enables ACM to list/filter CCLM Plans and trigger NetworkMap/StorageMap deletion on Plan cleanup or archive


## 🔗 Links

https://redhat.atlassian.net/browse/ACM-32316

## 🎥 Demo

> Please add a video or an image of the behavior/changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migration plans and resource maps now include standard identifying metadata for consistent identification across clusters.
  * Improves internal tracking and management of cross-cluster migration resources without changing names, namespaces, or spec behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->