### PR TITLE
CNV-88351: refactor user settings keys

### DIFF
--- a/src/utils/components/GuidedTour/GuidedTour.tsx
+++ b/src/utils/components/GuidedTour/GuidedTour.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useSignals } from '@preact/signals-react/runtime';
 
@@ -21,7 +22,7 @@ const GuidedTour: FC = () => {
   const navigate = useNavigate();
 
   const { resetTour } = useTour();
-  const [quickStarts, setQuickStarts] = useKubevirtUserSettings('quickStart');
+  const [quickStarts, setQuickStarts] = useKubevirtUserSettings(USER_SETTINGS_KEYS.quickStart);
 
   const steps = useMemo(() => getTourSteps(t), [t]);
 

--- a/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
+++ b/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
@@ -31,6 +31,7 @@ import useHideYamlTab from '@kubevirt-utils/hooks/useHideYamlTab';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import { isInstanceTypeVM } from '@kubevirt-utils/resources/instancetype/helper';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCPU, getGPUDevices, getHostDevices } from '@kubevirt-utils/resources/vm';
@@ -78,7 +79,9 @@ export const usePendingChanges = (
 
   const navigate = useNavigate();
   const { createModal } = useModal();
-  const [authorizedSSHKeys, updateAuthorizedSSHKeys] = useKubevirtUserSettings('ssh');
+  const [authorizedSSHKeys, updateAuthorizedSSHKeys] = useKubevirtUserSettings(
+    USER_SETTINGS_KEYS.ssh,
+  );
   const { hideYamlTab } = useHideYamlTab();
 
   const [hyperConverge, hyperLoaded, hyperLoadingError] = useHyperConvergeConfiguration(cluster);

--- a/src/utils/hooks/useKubevirtUserSettings/useKubevirtTableColumns.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/useKubevirtTableColumns.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 
-import { ACTIONS, COLUMNS } from './utils/const';
+import { ACTIONS, USER_SETTINGS_KEYS } from './utils/const';
 import useKubevirtUserSettings from './useKubevirtUserSettings';
 
 type UseKubevirtTableColumnsType = <TData, TCallbacks = undefined>(input: {
@@ -15,7 +15,7 @@ type UseKubevirtTableColumnsType = <TData, TCallbacks = undefined>(input: {
 };
 
 const useKubevirtTableColumns: UseKubevirtTableColumnsType = ({ columnManagementID, columns }) => {
-  const [userColumns, , loadedColumns, error] = useKubevirtUserSettings(COLUMNS);
+  const [userColumns, , loadedColumns, error] = useKubevirtUserSettings(USER_SETTINGS_KEYS.columns);
 
   const activeColumnKeys = useMemo(() => {
     const savedColumnKeys = userColumns?.[columnManagementID];

--- a/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns.ts
@@ -1,7 +1,7 @@
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 
-import { COLUMNS } from './utils/const';
+import { USER_SETTINGS_KEYS } from './utils/const';
 import useKubevirtUserSettings from './useKubevirtUserSettings';
 
 type UseKubevirtUserSettingsTableColumnsType = <T>(input: {
@@ -18,7 +18,9 @@ const useKubevirtUserSettingsTableColumns: UseKubevirtUserSettingsTableColumnsTy
   columnManagementID,
   columns,
 }) => {
-  const [userColumns, setUserColumns, loadedColumns, error] = useKubevirtUserSettings(COLUMNS);
+  const [userColumns, setUserColumns, loadedColumns, error] = useKubevirtUserSettings(
+    USER_SETTINGS_KEYS.columns,
+  );
 
   const setActiveColumns = (columnIds: string[]) => {
     setUserColumns?.({

--- a/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTopConsumerCards.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTopConsumerCards.ts
@@ -11,13 +11,13 @@ import {
   TOP_CONSUMERS_NUM_ITEMS_KEY,
 } from './../../../views/clusteroverview/TopConsumersTab/utils/constants';
 import { initialTopConsumerCardSettings } from './../../../views/clusteroverview/TopConsumersTab/utils/utils';
-import { TOP_CONSUMERS_CARD } from './utils/const';
+import { TOP_CONSUMERS_CARD, USER_SETTINGS_KEYS } from './utils/const';
 import { TopConsumersData, UseKubevirtUserSettingsTopConsumerCards } from './utils/types';
 import useKubevirtUserSettings from './useKubevirtUserSettings';
 
 const useKubevirtUserSettingsTopConsumerCards: UseKubevirtUserSettingsTopConsumerCards = () => {
   const updateOnceFromUserSetting = useRef(null);
-  const [cards, setCards, loaded] = useKubevirtUserSettings('cards');
+  const [cards, setCards, loaded] = useKubevirtUserSettings(USER_SETTINGS_KEYS.cards);
   const [topConsumerSettingsLocalStorage, setTopConsumerSettingsLocalStorage] =
     useLocalStorage<TopConsumersData>(TOP_CONSUMERS_CARD);
 

--- a/src/utils/hooks/useKubevirtUserSettings/utils/const.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/utils/const.ts
@@ -2,8 +2,18 @@ export const TOP_CONSUMERS_CARD = 'topConsumersCard';
 
 export const KUBEVIRT_USER_SETTINGS_CONFIG_MAP_NAME = 'kubevirt-user-settings';
 
-export const COLUMNS = 'columns';
 export const ACTIONS = 'actions';
+
+export const USER_SETTINGS_KEYS = {
+  cards: 'cards',
+  columns: 'columns',
+  favoriteBootableVolumes: 'favoriteBootableVolumes',
+  navigation: 'navigation',
+  onboardingPopoversHidden: 'onboardingPopoversHidden',
+  quickStart: 'quickStart',
+  savedSearches: 'savedSearches',
+  ssh: 'ssh',
+} as const;
 
 export const COLUMN_MANAGEMENT_IDS = {
   BOOTABLE_VOLUMES: 'bootable-volumes',

--- a/src/views/search/hooks/useSavedSearchData.ts
+++ b/src/views/search/hooks/useSavedSearchData.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import useVMSearchURL from '@multicluster/hooks/useVMSearchURL';
 import { validSearchQueryParams } from '@search/utils/constants';
 
@@ -45,7 +46,7 @@ export const useSavedSearchData: UseSavedSearchData = () => {
   }, [location.search]);
 
   const [savedSearches, setSavedSearches, searchesLoaded, searchesLoadError] =
-    useKubevirtUserSettings('savedSearches');
+    useKubevirtUserSettings(USER_SETTINGS_KEYS.savedSearches);
 
   const searchEntries = useMemo(
     () =>

--- a/src/views/settings/SettingsPage.tsx
+++ b/src/views/settings/SettingsPage.tsx
@@ -23,7 +23,7 @@ import { useSignals } from '@preact/signals-react/runtime';
 import { useFleetClusterNames, useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import { SettingsClusterProvider } from './context/SettingsClusterContext';
-import { createSettingsSearchURL, SEARCH_ITEMS } from './search/search';
+import { createSettingsSearchURL, getSearchItems } from './search/search';
 import SettingsTab from './SettingsTab';
 
 import './SettingsPage.scss';
@@ -92,7 +92,7 @@ const SettingsPage: FC = () => {
                 <ConfigurationSearch
                   createSearchURL={createSettingsSearchURL}
                   placeholder={showClusterDropdown ? t('Find in selected cluster') : undefined}
-                  searchItems={SEARCH_ITEMS}
+                  searchItems={getSearchItems(t)}
                 />
               </GridItem>
             </Grid>

--- a/src/views/settings/search/search.ts
+++ b/src/views/settings/search/search.ts
@@ -1,9 +1,9 @@
+import { TFunction } from 'i18next';
+
 import { idIsHighlighted } from '@kubevirt-utils/components/SearchItem/useIsHighlighted';
 import { VIRTUALIZATION_PATHS } from '@kubevirt-utils/constants/constants';
-import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   SearchItem,
-  SearchItemGetter,
   SearchItemWithTab,
 } from '@virtualmachines/details/tabs/configuration/utils/search';
 
@@ -14,7 +14,7 @@ import {
   USER_TAB_IDS,
 } from './constants';
 
-export const getClusterTabIds: SearchItemGetter = () => [
+export const getClusterTabIds = (t: TFunction): SearchItem[] => [
   { id: CLUSTER_TAB_IDS.virtualizationFeatures, title: t('Virtualization features') },
   { id: CLUSTER_TAB_IDS.generalSettings, title: t('General settings') },
   { id: CLUSTER_TAB_IDS.liveMigration, title: t('Live migration') },
@@ -37,7 +37,7 @@ export const getClusterTabIds: SearchItemGetter = () => [
   { id: CLUSTER_TAB_IDS.persistentReservation, title: t('Persistent reservation') },
 ];
 
-const getUserTabIds: SearchItemGetter = () => [
+const getUserTabIds = (t: TFunction): SearchItem[] => [
   { id: USER_TAB_IDS.general, title: t('General') },
   { id: USER_TAB_IDS.autoHideNav, title: t('Auto-hide navigation menu') },
   { id: USER_TAB_IDS.sshKeys, title: t('SSH keys') },
@@ -47,7 +47,7 @@ const getUserTabIds: SearchItemGetter = () => [
   { id: USER_TAB_IDS.guidedTour, title: t('Guided tour') },
 ];
 
-const getPreviewFeaturesTabIds: SearchItemGetter = () => [
+const getPreviewFeaturesTabIds = (t: TFunction): SearchItem[] => [
   { id: PREVIEW_FEATURES_TAB_IDS.previewFeatures, title: t('Preview features') },
   {
     id: PREVIEW_FEATURES_TAB_IDS.treeViewFolders,
@@ -63,16 +63,18 @@ const getPreviewFeaturesTabIds: SearchItemGetter = () => [
   },
 ];
 
-const tabsIds: { [key: string]: SearchItem[] } = {
-  cluster: getClusterTabIds(),
-  features: getPreviewFeaturesTabIds(),
-  user: getUserTabIds(),
-};
+export const getSearchItems = (t: TFunction): SearchItemWithTab[] => {
+  const tabsIds: { [key: string]: SearchItem[] } = {
+    cluster: getClusterTabIds(t),
+    features: getPreviewFeaturesTabIds(t),
+    user: getUserTabIds(t),
+  };
 
-export const SEARCH_ITEMS: SearchItemWithTab[] = Object.entries(tabsIds)
-  .map(([tab, value]) => value.map((element) => ({ element, tab })))
-  .flat()
-  .sort((a, b) => a.element.title.localeCompare(b.element.title));
+  return Object.entries(tabsIds)
+    .map(([tab, value]) => value.map((element) => ({ element, tab })))
+    .flat()
+    .sort((a, b) => a.element.title.localeCompare(b.element.title));
+};
 
 export const createSettingsSearchURL = (
   tab: string,

--- a/src/views/settings/tabs/UserTab/components/GeneralSection/GeneralSection.tsx
+++ b/src/views/settings/tabs/UserTab/components/GeneralSection/GeneralSection.tsx
@@ -4,13 +4,14 @@ import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import ExpandSection from '@settings/ExpandSection/ExpandSection';
 import { USER_TAB_IDS } from '@settings/search/constants';
 import { AUTO_HIDE_NAV_DEFAULT } from '@virtualmachines/hooks/useAutoHideNavigation/constants';
 
 const GeneralSection: FC = () => {
   const { t } = useKubevirtTranslation();
-  const [navigation, setNavigation] = useKubevirtUserSettings('navigation');
+  const [navigation, setNavigation] = useKubevirtUserSettings(USER_SETTINGS_KEYS.navigation);
 
   const isChecked = navigation?.autoHideNav ?? AUTO_HIDE_NAV_DEFAULT;
 

--- a/src/views/settings/tabs/UserTab/components/GettingStartedSection/GettingStartedSection.tsx
+++ b/src/views/settings/tabs/UserTab/components/GettingStartedSection/GettingStartedSection.tsx
@@ -6,6 +6,7 @@ import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import { Stack } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
@@ -15,7 +16,7 @@ import { USER_TAB_IDS } from '@settings/search/constants';
 const GettingStartedSection: FC = () => {
   useSignals();
   const { t } = useKubevirtTranslation();
-  const [quickStarts, setQuickStarts] = useKubevirtUserSettings('quickStart');
+  const [quickStarts, setQuickStarts] = useKubevirtUserSettings(USER_SETTINGS_KEYS.quickStart);
   const run = runningTourSignal.value;
   const { startTour, stopTour } = useTour();
 

--- a/src/views/settings/tabs/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/hooks/useSSHAuthKeys.ts
+++ b/src/views/settings/tabs/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/hooks/useSSHAuthKeys.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { SecretModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { kubevirtK8sGet } from '@multicluster/k8sRequests';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
@@ -48,7 +49,7 @@ const filterAuthRows = async (rows: AuthKeyRow[], cluster?: string) => {
 const useSSHAuthKeys: UseSSHAuthKeys = () => {
   const cluster = useSettingsCluster();
   const [authorizedSSHKeys = {}, updateAuthorizedSSHKeys, loadedSettings] = useKubevirtUserSettings(
-    'ssh',
+    USER_SETTINGS_KEYS.ssh,
     cluster,
   );
 

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootableVolumesTableData.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootableVolumesTableData.ts
@@ -6,6 +6,7 @@ import {
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import { UserSettingFavorites } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
 import { PaginationState } from '@kubevirt-utils/hooks/usePagination/utils/types';
 import useBootableVolumes from '@kubevirt-utils/resources/bootableresources/hooks/useBootableVolumes';
@@ -73,7 +74,10 @@ const useBootableVolumesTableData: UseBootableVolumesTableData = (
   const isPreferenceFilterEmpty =
     !!preference && !isEmpty(bootableVolumes) && isEmpty(preferenceFilteredVolumes);
 
-  const favoritesData = useKubevirtUserSettings('favoriteBootableVolumes', cluster);
+  const favoritesData = useKubevirtUserSettings(
+    USER_SETTINGS_KEYS.favoriteBootableVolumes,
+    cluster,
+  );
   const [favorites = [], updaterFavorites] = favoritesData;
   const volumeFavorites = favorites as [];
 

--- a/src/views/virtualmachines/details/tabs/configuration/ssh/components/SSHTabAuthorizedSSHKey.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/ssh/components/SSHTabAuthorizedSSHKey.tsx
@@ -9,6 +9,7 @@ import SecretNameLabel from '@kubevirt-utils/components/SSHSecretModal/component
 import VMSSHSecretModal from '@kubevirt-utils/components/VMSSHSecretModal/VMSSHSecretModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import { asAccessReview, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getVMSSHSecretName } from '@kubevirt-utils/resources/vm';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -36,7 +37,7 @@ const SSHTabAuthorizedSSHKey: FC<SSHTabAuthorizedSSHKeyProps> = ({
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const [authorizedSSHKeys, updateAuthorizedSSHKeys, loaded] = useKubevirtUserSettings(
-    'ssh',
+    USER_SETTINGS_KEYS.ssh,
     getCluster(vm),
   );
   const accessReview = asAccessReview(VirtualMachineModel, vm, 'update' as K8sVerb);

--- a/src/views/virtualmachines/hooks/useAutoHideNavigation/useAutoHideNavigation.ts
+++ b/src/views/virtualmachines/hooks/useAutoHideNavigation/useAutoHideNavigation.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import { useSignals } from '@preact/signals-react/runtime';
 
 import { AUTO_HIDE_NAV_DEFAULT, userExpandedNavSignal } from './constants';
@@ -14,7 +15,7 @@ import { collapseSidebar, expandSidebar, getNavToggleButton, isSidebarOpen } fro
  */
 const useAutoHideNavigation = (): boolean => {
   useSignals();
-  const [navigation, , loaded] = useKubevirtUserSettings('navigation');
+  const [navigation, , loaded] = useKubevirtUserSettings(USER_SETTINGS_KEYS.navigation);
   const [wasCollapsed, setWasCollapsed] = useState(false);
   const mountedRef = useRef(false);
 

--- a/src/views/welcome/WelcomeModal.tsx
+++ b/src/views/welcome/WelcomeModal.tsx
@@ -8,6 +8,7 @@ import {
 import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import {
   Checkbox,
   Content,
@@ -30,7 +31,9 @@ const WelcomeModal: FC = () => {
   useSignals();
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState<boolean>(true);
-  const [quickStarts, setQuickStarts, loaded] = useKubevirtUserSettings('quickStart');
+  const [quickStarts, setQuickStarts, loaded] = useKubevirtUserSettings(
+    USER_SETTINGS_KEYS.quickStart,
+  );
   const isWindowsSupported = useIsWindowsSupportedArchitecture();
 
   useEffect(() => {


### PR DESCRIPTION

## 📝 Description

Replace all raw string literals passed to useKubevirtUserSettings with a centralized USER_SETTINGS_KEYS constant object, eliminating typo risk and enabling easy refactoring
Refactor settings search-item builder functions (getClusterTabIds, getUserTabIds, getPreviewFeaturesTabIds) to accept t: TFunction as a parameter instead of importing the translation function directly, aligning with project i18n guidelines
Test plan

 TypeScript compiles with no errors (npx tsc --noEmit)

 Existing unit tests pass (npx jest)

 Settings search still works (navigate to Settings, type in search bar, results appear)

 SSH key management works (Settings > User > SSH keys)

 Guided tour launches correctly

 Auto-hide navigation setting reads/writes correctly

 Bootable volume favorites persist across page loads

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-88351



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "General" settings section with auto-hide navigation menu option for the VM view sidebar.
  * Settings search items are now dynamically translated based on your language preference.

* **Refactor**
  * Centralized user settings key definitions for improved consistency across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->