### PR TITLE
feat: initial commit with changes aimed at making the plugin compatible with vanilla k8s.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest AS policy
-
-RUN update-crypto-policies --set DEFAULT:PQ
-# NOTE: Since the `:latest` tag can have npm version changes, we are using
-#       a specific version tag. Container build errors have come up when
-#       the `:latest` is updated.
-#
-# Image info: https://catalog.redhat.com/en/software/containers/ubi9/nodejs-22/66431d1785c5c3a31edd24f1
-FROM registry.access.redhat.com/ubi9/nodejs-22:9.7-1776701988 AS builder
+FROM node:22@sha256:1031993481795705055273f2eef0c24597abdcb277d6e058c82f78cbbdef92a6 AS builder
 USER root
 
 COPY . /opt/app-root/src
@@ -17,11 +9,13 @@ RUN npm config set fetch-timeout 1200000
 RUN npm ci --ignore-scripts
 RUN npm run build
 
-# Image info: https://catalog.redhat.com/en/software/containers/ubi9/nginx-124/657b066b6c1bc124a1d7ff39
-FROM registry.access.redhat.com/ubi9/nginx-124:9.7-1776735087
+FROM nginx:stable-alpine@sha256:5f979dcfed4ce6461873f087e8c980d6e29b084b9e8776d9704a7e989b5f4898
 
-COPY --from=policy /etc/crypto-policies /etc/crypto-policies
 COPY --from=builder /opt/app-root/src/dist /usr/share/nginx/html
-COPY default.conf /opt/app-root/etc/nginx.d/default.conf
-USER 1001
-CMD /usr/libexec/s2i/run
+COPY default.conf /etc/nginx/conf.d/default.conf
+
+WORKDIR /usr/share/nginx/html
+
+USER nginx
+
+EXPOSE 8080 9443

--- a/src/multicluster/components/CrossClusterMigration/hooks/useClustersAndProjects.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useClustersAndProjects.ts
@@ -3,7 +3,8 @@ import { useCallback, useMemo } from 'react';
 import { V1beta1Provider } from '@kubev2v/types';
 import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-utils/models';
+import { modelToGroupVersionKind } from '@kubevirt-utils/models';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { ManagedClusterModel } from '@multicluster/constants';
 import { useFleetClusterNames } from '@stolostron/multicluster-sdk';
@@ -46,7 +47,8 @@ const useClustersAndProjects: UseClustersAndProjects = (sourceCluster, selectedC
   );
 
   const [projects, projectsLoaded, projectsError] = useProjects(selectedClusterTarget);
-  const projectOptions = getSelectableOptions(projects, modelToGroupVersionKind(ProjectModel));
+  const model = useProjectOrNamespaceModel();
+  const projectOptions = getSelectableOptions(projects, modelToGroupVersionKind(model));
 
   const getProviderFromClusterName = useCallback(
     (clusterName: string) => {

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/DiskSourcePVCSelectNamespace.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/DiskSourcePVCSelectNamespace.tsx
@@ -1,6 +1,7 @@
 import React, { Dispatch, FC, SetStateAction } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
@@ -26,6 +27,7 @@ const DiskSourcePVCSelectNamespace: FC<DiskSourcePVCSelectNamespaceProps> = ({
 
   const fieldId = 'pvc-project-select';
 
+  const model = useProjectOrNamespaceModel();
   return (
     <FormGroup
       className="pvc-selection-formgroup"
@@ -39,7 +41,7 @@ const DiskSourcePVCSelectNamespace: FC<DiskSourcePVCSelectNamespaceProps> = ({
           <InlineFilterSelect
             options={projectNames?.map((name) => ({
               children: name,
-              groupVersionKind: modelToGroupVersionKind(ProjectModel),
+              groupVersionKind: modelToGroupVersionKind(model),
               value: name,
             }))}
             toggleProps={{

--- a/src/utils/components/CloneTemplateModal/SelectProject.tsx
+++ b/src/utils/components/CloneTemplateModal/SelectProject.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
 
@@ -19,6 +20,7 @@ const SelectProject: FC<SelectProjectProps> = ({
   setSelectedProject,
 }) => {
   const { t } = useKubevirtTranslation();
+  const model = useProjectOrNamespaceModel();
 
   const [projectNames, projectsLoaded] = useProjects(cluster);
 
@@ -28,7 +30,7 @@ const SelectProject: FC<SelectProjectProps> = ({
     <InlineFilterSelect
       options={projectNames?.map((projectName) => ({
         children: projectName,
-        groupVersionKind: modelToGroupVersionKind(ProjectModel),
+        groupVersionKind: modelToGroupVersionKind(model),
         value: projectName,
       }))}
       placeholder={t('Select project')}

--- a/src/utils/components/ClusterProjectDropdown/NamespaceDropdown.tsx
+++ b/src/utils/components/ClusterProjectDropdown/NamespaceDropdown.tsx
@@ -1,6 +1,7 @@
 import React, { FC, JSX, useMemo } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import Dropdown, {
   DropdownConfig,
 } from '@kubevirt-utils/components/ClusterProjectDropdown/Dropdown/Dropdown';
@@ -30,9 +31,10 @@ const NamespaceDropdown: FC<NamespaceDropdownProps> = ({
 }): JSX.Element => {
   const { t } = useKubevirtTranslation();
 
+  const model = useProjectOrNamespaceModel();
   const [projects, projectsLoaded] = useK8sWatchData<K8sResourceCommon[]>({
     cluster,
-    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+    groupVersionKind: modelToGroupVersionKind(model),
     isList: true,
     namespaced: false,
   });

--- a/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceClonePVCSelect/DiskSourceClonePVCSelectNamespace.tsx
+++ b/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceClonePVCSelect/DiskSourceClonePVCSelectNamespace.tsx
@@ -1,7 +1,8 @@
 import React, { FC } from 'react';
 import { Controller, FieldPath, useFormContext } from 'react-hook-form';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { V1DiskFormState } from '@kubevirt-utils/components/DiskModal/utils/types';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
@@ -33,6 +34,7 @@ const DiskSourcePVCSelectNamespace: FC = () => {
 
   const error = errors?.dataVolumeTemplate?.spec?.source?.pvc?.namespace;
 
+  const model = useProjectOrNamespaceModel();
   return (
     <Controller
       render={({ field: { onChange, value } }) => (
@@ -45,7 +47,7 @@ const DiskSourcePVCSelectNamespace: FC = () => {
           <InlineFilterSelect
             options={projectNames?.map((name) => ({
               children: name,
-              groupVersionKind: modelToGroupVersionKind(ProjectModel),
+              groupVersionKind: modelToGroupVersionKind(model),
               value: name,
             }))}
             setSelected={(val) => {

--- a/src/utils/components/DynamicSSHKeyInjection/DynamicSSHKeyInjection.tsx
+++ b/src/utils/components/DynamicSSHKeyInjection/DynamicSSHKeyInjection.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect, useState } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getIsDynamicSSHInjectionEnabled } from '@kubevirt-utils/resources/vm';
 import { Switch } from '@patternfly/react-core';
 
@@ -18,6 +19,7 @@ export const DynamicSSHKeyInjection: FC<DynamicSSHKeyInjectionProps> = ({
   onSubmit,
   vm,
 }) => {
+  const { t } = useKubevirtTranslation();
   const [isChecked, setIsChecked] = useState<boolean>(
     getIsDynamicSSHInjectionEnabled(vm) || hasDynamicSSHInjectionCommand(vm),
   );
@@ -28,12 +30,13 @@ export const DynamicSSHKeyInjection: FC<DynamicSSHKeyInjectionProps> = ({
 
   return (
     <Switch
+      aria-label={t('Dynamic SSH key injection')}
+      isChecked={isChecked}
+      isDisabled={isDisabled}
       onChange={(_event, checked) => {
         setIsChecked(checked);
         onSubmit(checked);
       }}
-      isChecked={isChecked}
-      isDisabled={isDisabled}
     />
   );
 };

--- a/src/utils/components/ExpandSectionWithSwitch/ExpandSectionWithSwitch.tsx
+++ b/src/utils/components/ExpandSectionWithSwitch/ExpandSectionWithSwitch.tsx
@@ -6,6 +6,7 @@ import { Switch } from '@patternfly/react-core';
 import './ExpandSectionWithSwitch.scss';
 
 type ExpandSectionWithSwitchProps = {
+  ariaLabel?: string;
   children?: ReactNode;
   helpTextContent?: ReactNode;
   id: string;
@@ -16,6 +17,7 @@ type ExpandSectionWithSwitchProps = {
 };
 
 const ExpandSectionWithSwitch: FC<ExpandSectionWithSwitchProps> = ({
+  ariaLabel,
   children,
   helpTextContent,
   id,
@@ -28,6 +30,7 @@ const ExpandSectionWithSwitch: FC<ExpandSectionWithSwitchProps> = ({
     customContent={
       <div className="expand-section-with-switch__switch-container">
         <Switch
+          aria-label={ariaLabel}
           isChecked={switchState}
           isDisabled={isDisabled}
           onChange={(_, checked: boolean) => toggleSwitch(checked)}

--- a/src/utils/components/HardwareDevices/HardwareDevicesHeadlessMode.tsx
+++ b/src/utils/components/HardwareDevices/HardwareDevicesHeadlessMode.tsx
@@ -44,12 +44,13 @@ const HardwareDevicesHeadlessMode: FC<HardwareDevicesHeadlessModeProps> = ({ onS
           <Flex spaceItems={{ default: 'spaceItemsNone' }}>
             <FlexItem>
               <Switch
+                aria-label={t('Headless mode')}
+                id="headless-mode"
+                isChecked={isChecked}
                 onChange={(_event, checked) => {
                   setIsChecked(checked);
                   updateHeadlessMode(checked);
                 }}
-                id="headless-mode"
-                isChecked={isChecked}
               />
             </FlexItem>
           </Flex>

--- a/src/utils/components/HeadlessMode/HeadlessMode.tsx
+++ b/src/utils/components/HeadlessMode/HeadlessMode.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isHeadlessMode } from '@kubevirt-utils/resources/vm';
 import { Switch } from '@patternfly/react-core';
 
@@ -10,15 +11,17 @@ type HeadlessModeProps = {
 };
 
 const HeadlessMode: FC<HeadlessModeProps> = ({ updateHeadlessMode, vm }) => {
+  const { t } = useKubevirtTranslation();
   const [isChecked, setIsChecked] = useState<boolean>(isHeadlessMode(vm));
   return (
     <Switch
+      aria-label={t('Headless mode')}
+      id="headless-mode"
+      isChecked={isChecked}
       onChange={(_event, checked: boolean) => {
         setIsChecked(checked);
         updateHeadlessMode(checked);
       }}
-      checked={isChecked}
-      id="headless-mode"
     />
   );
 };

--- a/src/utils/components/ProjectCheckerAlert/ProjectCheckerAlert.tsx
+++ b/src/utils/components/ProjectCheckerAlert/ProjectCheckerAlert.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName } from '@kubevirt-utils/resources/shared';
@@ -27,6 +28,7 @@ const ProjectCheckerAlert: FC<ProjectCheckerAlertProps> = ({
   projectsLoaded,
   qualifiedProjects = [],
 }) => {
+  const model = useProjectOrNamespaceModel();
   const { t } = useKubevirtTranslation();
   if (!projectsLoaded) {
     return <Loading />;
@@ -62,7 +64,7 @@ const ProjectCheckerAlert: FC<ProjectCheckerAlertProps> = ({
                   <FlexItem spacer={{ default: 'spacerXs' }}>
                     <MulticlusterResourceLink
                       cluster={getCluster(project)}
-                      groupVersionKind={modelToGroupVersionKind(ProjectModel)}
+                      groupVersionKind={modelToGroupVersionKind(model)}
                       name={getName(project)}
                     />
                   </FlexItem>

--- a/src/utils/components/ProjectDropdown/ProjectDropdown.tsx
+++ b/src/utils/components/ProjectDropdown/ProjectDropdown.tsx
@@ -1,6 +1,7 @@
 import React, { FC, JSX, useMemo } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import { getProjectOptions } from '@kubevirt-utils/components/ProjectDropdown/utils/utils';
 import { ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
@@ -25,9 +26,10 @@ const ProjectDropdown: FC<ProjectDropdownProps> = ({
   selectedProject,
   useConsoleFavorites = true,
 }): JSX.Element => {
+  const model = useProjectOrNamespaceModel();
   const [projects] = useK8sWatchData<K8sResourceCommon[]>({
     cluster,
-    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+    groupVersionKind: modelToGroupVersionKind(model),
     isList: true,
     namespaced: false,
   });

--- a/src/utils/components/ProjectDropdown/utils/utils.ts
+++ b/src/utils/components/ProjectDropdown/utils/utils.ts
@@ -1,6 +1,7 @@
 import { MouseEvent } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
 import { ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
 import { getName } from '@kubevirt-utils/resources/shared';
@@ -15,6 +16,7 @@ export const getProjectOptions = (
   bookmarks: ConsoleNamespaceBookmarks = {},
   updateBookmarks?: UpdateBookmarks,
 ): EnhancedSelectOptionProps[] => {
+  const model = useProjectOrNamespaceModel();
   const favoriteOptions: EnhancedSelectOptionProps[] = [];
   const regularOptions: EnhancedSelectOptionProps[] = [];
 
@@ -24,7 +26,7 @@ export const getProjectOptions = (
     const option: EnhancedSelectOptionProps = {
       children: name,
       group: isFavorite ? 'Favorites' : undefined,
-      groupVersionKind: modelToGroupVersionKind(ProjectModel),
+      groupVersionKind: modelToGroupVersionKind(model),
       isFavorite,
       name,
       onFavorite:
@@ -59,7 +61,7 @@ export const getProjectOptions = (
     ? [
         {
           children: ALL_PROJECTS,
-          groupVersionKind: modelToGroupVersionKind(ProjectModel),
+          groupVersionKind: modelToGroupVersionKind(model),
           value: ALL_PROJECTS,
         },
       ]

--- a/src/utils/components/SSHSecretModal/components/SSHOptionUseExisting/SSHOptionUseExisting.tsx
+++ b/src/utils/components/SSHSecretModal/components/SSHOptionUseExisting/SSHOptionUseExisting.tsx
@@ -1,6 +1,7 @@
 import React, { Dispatch, FC, SetStateAction, useCallback, useEffect, useState } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { IoK8sApiCoreV1Secret } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
@@ -102,6 +103,7 @@ const SSHOptionUseExisting: FC<SSHOptionUseExistingProps> = ({
 
   if (isEmpty(userProjects)) return <Bullseye>{t('No SSH keys found')}</Bullseye>;
 
+  const model = useProjectOrNamespaceModel();
   return (
     <>
       <Alert
@@ -117,7 +119,7 @@ const SSHOptionUseExisting: FC<SSHOptionUseExistingProps> = ({
             <InlineFilterSelect
               options={userProjects.map((project) => ({
                 children: project,
-                groupVersionKind: modelToGroupVersionKind(ProjectModel),
+                groupVersionKind: modelToGroupVersionKind(model),
                 value: project,
               }))}
               className="ssh-use-existing__form-group--project"

--- a/src/utils/components/SectionWithSwitch/SectionWithSwitch.tsx
+++ b/src/utils/components/SectionWithSwitch/SectionWithSwitch.tsx
@@ -48,6 +48,7 @@ const SectionWithSwitch: FC<SectionWithSwitchProps> = ({
   title,
   turnOnSwitch,
 }) => {
+  const ariaLabel = typeof title === 'string' ? title : undefined;
   const Wrapper = inlineCheckbox ? 'div' : Split;
 
   return (
@@ -85,6 +86,7 @@ const SectionWithSwitch: FC<SectionWithSwitchProps> = ({
       <SplitItem className={classNames({ 'section-with-switch__inline': inlineCheckbox })}>
         {children}{' '}
         <Switch
+          aria-label={ariaLabel}
           className={isLoading && 'kv-cursor--loading'}
           data-test-id={dataTestID}
           isChecked={switchIsOn}

--- a/src/utils/components/SelectSnapshot/useSnapshots.ts
+++ b/src/utils/components/SelectSnapshot/useSnapshots.ts
@@ -2,9 +2,9 @@ import { useMemo } from 'react';
 
 import {
   modelToGroupVersionKind,
-  ProjectModel,
   VolumeSnapshotModel,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -19,9 +19,10 @@ type UseSnapshotsReturnType = {
 };
 
 const useSnapshots = (projectSelected: string, cluster?: string): UseSnapshotsReturnType => {
+  const model = useProjectOrNamespaceModel();
   const [projects, projectsLoaded, projectsErrors] = useK8sWatchData<K8sResourceCommon[]>({
     cluster,
-    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+    groupVersionKind: modelToGroupVersionKind(model),
     isList: true,
     namespaced: false,
   });

--- a/src/utils/flags/useVirtualizationNavVisibilityFlag.ts
+++ b/src/utils/flags/useVirtualizationNavVisibilityFlag.ts
@@ -1,11 +1,9 @@
 import { useEffect, useMemo } from 'react';
 import useMultipleAccessReviews from 'src/views/cdi-upload-provider/hooks/useMultipleAccessReviews';
 
-import {
-  modelToGroupVersionKind,
-  ProjectModel,
-  VirtualMachineModel,
-} from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind,  VirtualMachineModel,
+ } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
 import { getHyperconvergedRoleAggregationStrategy } from '@kubevirt-utils/resources/hyperconverged/selectors';
 import { getName } from '@kubevirt-utils/resources/shared';
@@ -20,10 +18,11 @@ import {
 import { FLAG_KUBEVIRT_VIRTUALIZATION_NAV, HCO_MANUAL_ROLE_AGGREGATION_STRATEGY } from './consts';
 
 const useVirtualizationNavVisibilityFlag = (setFeatureFlag: SetFeatureFlag) => {
+  const model = useProjectOrNamespaceModel();
   const { hcConfig, hcError, hcLoaded } = useKubevirtHyperconvergeConfiguration();
 
   const [projects, projectsLoaded] = useK8sWatchResource<K8sResourceCommon[]>({
-    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+        groupVersionKind: modelToGroupVersionKind(model),
     isList: true,
     namespaced: false,
   });

--- a/src/utils/hooks/useDataViewTableSort/useDataViewTableSort.ts
+++ b/src/utils/hooks/useDataViewTableSort/useDataViewTableSort.ts
@@ -47,7 +47,11 @@ export const useDataViewTableSort = <TData, TCallbacks = undefined>(
     () =>
       visibleColumns.map((col, index) => ({
         cell: col.label,
-        props: { ...col.props, sort: getSortParams(index) },
+        props: {
+          ...col.props,
+          sort: getSortParams(index),
+          ...(col.label === '' && { screenReaderText: col.key }),
+        },
       })),
     [visibleColumns, getSortParams],
   );

--- a/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings.ts
@@ -1,9 +1,7 @@
 import { useEffect, useState } from 'react';
-
 import {
   ConfigMapModel,
   modelToGroupVersionKind,
-  UserModel,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { operatorNamespaceSignal } from '@kubevirt-utils/store/operatorNamespace';
@@ -15,6 +13,38 @@ import { UseKubevirtUserSettings } from './utils/types';
 import { UserSettingsState } from './utils/userSettingsInitialState';
 import { parseNestedJSON, patchUserConfigMap } from './utils/utils';
 
+const alwaysUseLocalStorage = (window as Window & {
+  SERVER_FLAGS?: { userSettingsLocation?: 'configmap' | 'localstorage' };
+}).SERVER_FLAGS?.userSettingsLocation === 'localstorage';
+
+const getIsImpersonating = (): boolean => !!localStorage.getItem('impersonate-user');
+
+const getUserUid = (): string | null => {
+  const rawUserID = localStorage.getItem('userID');
+  if (rawUserID) {
+    try {
+      const decoded = atob(rawUserID);
+      if (decoded) return decoded;
+    } catch {
+      return rawUserID;
+    }
+  }
+  return null;
+};
+
+const getLsKey = (): string | null => {
+  const userUid = getUserUid();
+  const isImpersonating = getIsImpersonating();
+
+  if (!userUid) {
+    return null;
+  }
+
+  return alwaysUseLocalStorage && !isImpersonating
+    ? 'kubevirt-user-settings'
+    : `kubevirt-user-settings-${userUid}`;
+};
+
 const useKubevirtUserSettings: UseKubevirtUserSettings = (key, cluster) => {
   const [error, setError] = useState<Error>();
   const [userSettings, setUserSettings] = useState<UserSettingsState>();
@@ -22,44 +52,63 @@ const useKubevirtUserSettings: UseKubevirtUserSettings = (key, cluster) => {
   const [settingsInitialized, setSettingsInitialized] = useState<boolean>(false);
   const operatorNamespace = operatorNamespaceSignal.value;
 
-  const [user, loadedUser, errorUser] = useK8sWatchData<IoK8sApiCoreV1ConfigMap>({
-    cluster,
-    groupVersionKind: modelToGroupVersionKind(UserModel),
-    name: '~',
-  });
-
-  const userName = user?.metadata?.uid || user?.metadata?.name?.replace(/[^-._a-zA-Z0-9]+/g, '-');
+  const lsKey = getLsKey();
+  const isLocalStorage = alwaysUseLocalStorage || getIsImpersonating();
 
   const [userConfigMap, loadedConfigMap, configMapError] = useK8sWatchData<IoK8sApiCoreV1ConfigMap>(
-    operatorNamespace &&
-      userName && {
-        cluster,
-        groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
-        name: KUBEVIRT_USER_SETTINGS_CONFIG_MAP_NAME,
-        namespace: operatorNamespace,
-      },
+    !isLocalStorage && operatorNamespace && lsKey
+      ? {
+          cluster,
+          groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
+          name: KUBEVIRT_USER_SETTINGS_CONFIG_MAP_NAME,
+          namespace: operatorNamespace,
+        }
+      : null,
   );
 
   const loadedCM = (loadedConfigMap || !isEmpty(configMapError)) && !isEmpty(operatorNamespace);
-  const loadedUsr = loadedUser || !isEmpty(errorUser);
+  const loadedUsr = true;
+
+  const lsData = isLocalStorage
+    ? (() => {
+        try {
+          const raw = lsKey ? localStorage.getItem(lsKey) : null;
+          return raw ? JSON.parse(raw) : {};
+        } catch {
+          return {};
+        }
+      })()
+    : null;
 
   useEffect(() => {
+    if (isLocalStorage) {
+      setUserSettings(lsData as UserSettingsState);
+      setSettingsInitialized(true);
+      return;
+    }
+
     if (!loadedCM || !loadedUsr) return;
 
-    if (!isEmpty(userConfigMap) && userName) {
+    if (!isEmpty(userConfigMap) && lsKey) {
       setUserSettings(
-        (<unknown>parseNestedJSON(userConfigMap?.data?.[userName]) || {}) as UserSettingsState,
+        (<unknown>parseNestedJSON(userConfigMap?.data?.[lsKey]) || {}) as UserSettingsState,
       );
     }
 
     setSettingsInitialized(true);
-  }, [userConfigMap, userName, loadedCM, loadedUsr]);
+  }, [userConfigMap, lsKey, loadedCM, loadedUsr, lsData]);
 
   const pushUserSettingsChanges = async (data, resolve, reject) => {
     setLoading(true);
 
     try {
-      await patchUserConfigMap(userConfigMap, userName, data, cluster);
+      if (isLocalStorage) {
+        if (lsKey) {
+          localStorage.setItem(lsKey, JSON.stringify(data));
+        }
+      } else {
+        await patchUserConfigMap(userConfigMap, lsKey, data, cluster);
+      }
       resolve(key ? data[key] : data);
     } catch (apiError) {
       setError(apiError);
@@ -85,7 +134,7 @@ const useKubevirtUserSettings: UseKubevirtUserSettings = (key, cluster) => {
     key ? userSettings?.[key] : userSettings,
     userSettings && updateUserSetting,
     !loading && settingsInitialized,
-    error || errorUser || configMapError,
+    error || (!isLocalStorage ? configMapError : undefined),
   ];
 };
 

--- a/src/utils/hooks/useProjectOrNamespaceModel.ts
+++ b/src/utils/hooks/useProjectOrNamespaceModel.ts
@@ -1,0 +1,11 @@
+import { NamespaceModel, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
+
+/**
+ * Returns the appropriate model for project/namespace operations based on cluster capabilities.
+ * On OpenShift, returns ProjectModel. On vanilla Kubernetes, returns NamespaceModel.
+ */
+export const useProjectOrNamespaceModel = () => {
+  const isOpenShift = useFlag('OPENSHIFT');
+  return isOpenShift ? ProjectModel : NamespaceModel;
+};

--- a/src/utils/hooks/useProjectResources.ts
+++ b/src/utils/hooks/useProjectResources.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from './useProjectOrNamespaceModel';
 import { isSystemNamespace } from '@kubevirt-utils/resources/namespace/helper';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { universalComparator } from '@kubevirt-utils/utils/utils';
@@ -13,9 +14,10 @@ type UseProjectResources = (
 ) => [K8sResourceCommon[], boolean, Error];
 
 const useProjectResources: UseProjectResources = (cluster, onlyUserProjects = false) => {
+  const model = useProjectOrNamespaceModel();
   const [projects, loaded, error] = useK8sWatchData<K8sResourceCommon[]>({
     cluster,
-    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+    groupVersionKind: modelToGroupVersionKind(model),
     isList: true,
   });
 

--- a/src/utils/hooks/useProjects.ts
+++ b/src/utils/hooks/useProjects.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from './useProjectOrNamespaceModel';
 import { isSystemNamespace } from '@kubevirt-utils/resources/namespace/helper';
 import { getName } from '@kubevirt-utils/resources/shared';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
@@ -9,9 +10,10 @@ import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 type UseProjects = (cluster?: string, onlyUserProjects?: boolean) => [string[], boolean, any];
 
 const useProjects: UseProjects = (cluster, onlyUserProjects = false) => {
+  const model = useProjectOrNamespaceModel();
   const [projectsData, loaded, error] = useK8sWatchData<K8sResourceCommon[]>({
     cluster,
-    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+    groupVersionKind: modelToGroupVersionKind(model),
     isList: true,
   });
 

--- a/src/utils/resources/shared.ts
+++ b/src/utils/resources/shared.ts
@@ -254,7 +254,7 @@ export const getAllowedResources = (projectNames: string[], model: K8sModel) => 
     (projectNames || []).map((projName) => [
       `${projName}/${model.plural}`,
       {
-        groupVersionKind: modelToGroupVersionKind(model),
+                groupVersionKind: modelToGroupVersionKind(model),
         isList: true,
         namespace: projName,
         namespaced: true,

--- a/src/utils/resources/template/hooks/useWatchNonAdminTemplates.ts
+++ b/src/utils/resources/template/hooks/useWatchNonAdminTemplates.ts
@@ -2,7 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { OPENSHIFT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-utils/models';
+import { modelToGroupVersionKind } from '@kubevirt-utils/models';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
@@ -26,8 +27,9 @@ const useWatchNonAdminTemplates = () => {
 
   const isLocalCluster = isEmpty(cluster) || cluster === hubClusterName;
 
+  const model = useProjectOrNamespaceModel();
   const [projects, loaded] = useK8sWatchData<K8sResourceCommon[]>({
-    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+    groupVersionKind: modelToGroupVersionKind(model),
     isList: true,
     namespaced: false,
   });

--- a/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeDetailsTab.tsx
+++ b/src/views/catalog/CustomizeInstanceType/tabs/configuration/utils/tabs/CustomizeInstanceTypeDetailsTab.tsx
@@ -188,6 +188,10 @@ const CustomizeInstanceTypeDetailsTab = () => {
               )}
               descriptionData={
                 <Switch
+                  aria-label={t('Guest system log access')}
+                  id="guest-system-log-access"
+                  isChecked={isCheckedGuestSystemAccessLog}
+                  isDisabled={isGuestSystemLogsDisabled}
                   onChange={(_event, checked) => {
                     setIsCheckedGuestSystemAccessLog(checked);
                     updateCustomizeInstanceType([
@@ -197,9 +201,6 @@ const CustomizeInstanceTypeDetailsTab = () => {
                       },
                     ]);
                   }}
-                  id="guest-system-log-access"
-                  isChecked={isCheckedGuestSystemAccessLog}
-                  isDisabled={isGuestSystemLogsDisabled}
                 />
               }
               descriptionHeader={
@@ -216,6 +217,9 @@ const CustomizeInstanceTypeDetailsTab = () => {
               )}
               descriptionData={
                 <Switch
+                  aria-label={t('Deletion protection')}
+                  id="deletion-protection"
+                  isChecked={deletionProtectionEnabled}
                   onChange={(_event, checked) =>
                     createModal(({ isOpen, onClose }) => (
                       <DeletionProtectionModal
@@ -239,8 +243,6 @@ const CustomizeInstanceTypeDetailsTab = () => {
                       />
                     ))
                   }
-                  id="deletion-protection"
-                  isChecked={deletionProtectionEnabled}
                 />
               }
               descriptionHeader={

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/Sources/PersistentVolumeClaimSelect.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/Sources/PersistentVolumeClaimSelect.tsx
@@ -1,10 +1,8 @@
 import React, { FC, useCallback } from 'react';
 
-import {
-  modelToGroupVersionKind,
-  PersistentVolumeClaimModel,
-  ProjectModel,
-} from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind,
+  PersistentVolumeClaimModel, } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { V1beta1DataVolumeSpec } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
@@ -31,6 +29,7 @@ export const PersistentVolumeClaimSelect: FC<PersistentVolumeClaimSelectProps> =
   projectSelected,
   pvcNameSelected,
 }) => {
+  const model = useProjectOrNamespaceModel();
   const { t } = useKubevirtTranslation();
   const { filteredPVCNames, projectsLoaded, projectsNames, pvcMapper, pvcsLoaded } =
     useProjectsAndPVCs(projectSelected);
@@ -62,7 +61,7 @@ export const PersistentVolumeClaimSelect: FC<PersistentVolumeClaimSelectProps> =
           <InlineFilterSelect
             options={projectsNames.map((name) => ({
               children: name,
-              groupVersionKind: modelToGroupVersionKind(ProjectModel),
+              groupVersionKind: modelToGroupVersionKind(model),
               value: name,
             }))}
             placeholder={t('Select PVC project')}

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/useProjectsAndPVCs.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/StorageSection/CustomizeSource/useProjectsAndPVCs.ts
@@ -1,10 +1,8 @@
 import { useMemo } from 'react';
 
-import {
-  modelToGroupVersionKind,
-  PersistentVolumeClaimModel,
-  ProjectModel,
-} from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind,
+  PersistentVolumeClaimModel, } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { convertResourceArrayToMap } from '@kubevirt-utils/resources/shared';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
@@ -21,10 +19,11 @@ type useProjectsAndPVCsReturnType = {
 };
 
 export const useProjectsAndPVCs = (projectSelected: string): useProjectsAndPVCsReturnType => {
+  const model = useProjectOrNamespaceModel();
   const cluster = useClusterParam();
   const [projects, projectsLoaded, projectsErrors] = useK8sWatchData<K8sResourceCommon[]>({
     cluster,
-    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+    groupVersionKind: modelToGroupVersionKind(model),
     isList: true,
     namespaced: true,
   });

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogProjectsDropdown/TemplatesCatalogProjectsDropdown.tsx
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogProjectsDropdown/TemplatesCatalogProjectsDropdown.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import { ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -21,9 +22,10 @@ export const TemplatesCatalogProjectsDropdown: FC<TemplatesCatalogProjectsDropdo
   ({ onChange, selectedProject }) => {
     const { t } = useKubevirtTranslation();
     const cluster = useClusterParam();
+    const model = useProjectOrNamespaceModel();
     const [projects] = useK8sWatchData<K8sResourceCommon[]>({
       cluster,
-      groupVersionKind: modelToGroupVersionKind(ProjectModel),
+      groupVersionKind: modelToGroupVersionKind(model),
       isList: true,
       namespaced: false,
     });

--- a/src/views/catalog/wizard/tabs/overview/components/WizardOverviewGrid.tsx
+++ b/src/views/catalog/wizard/tabs/overview/components/WizardOverviewGrid.tsx
@@ -273,12 +273,13 @@ const WizardOverviewGrid: FC<WizardOverviewGridProps> = ({ tabsData, updateVM, v
           <WizardDescriptionItem
             description={
               <Switch
+                aria-label={t('Start in pause mode')}
+                id="start-in-pause-mode"
+                isChecked={isChecked}
                 onChange={(_event, checked) => {
                   setIsChecked(checked);
                   updateStartStrategy(checked);
                 }}
-                id="start-in-pause-mode"
-                isChecked={isChecked}
               />
             }
             helperPopover={{
@@ -357,6 +358,10 @@ const WizardOverviewGrid: FC<WizardOverviewGridProps> = ({ tabsData, updateVM, v
           <WizardDescriptionItem
             description={
               <Switch
+                aria-label={t('Guest system log access')}
+                id="guest-system-log-access"
+                isChecked={isCheckedGuestSystemLogAccess}
+                isDisabled={isDisabledGuestSystemLogs}
                 onChange={(_event, checked) => {
                   setIsCheckedGuestSystemLogAccess(checked);
                   updateVM((vmDraft) => {
@@ -368,9 +373,6 @@ const WizardOverviewGrid: FC<WizardOverviewGridProps> = ({ tabsData, updateVM, v
                     return vmDraft;
                   });
                 }}
-                id="guest-system-log-access"
-                isChecked={isCheckedGuestSystemLogAccess}
-                isDisabled={isDisabledGuestSystemLogs}
               />
             }
             helperPopover={{
@@ -389,6 +391,9 @@ const WizardOverviewGrid: FC<WizardOverviewGridProps> = ({ tabsData, updateVM, v
           <WizardDescriptionItem
             description={
               <Switch
+                aria-label={t('Deletion protection')}
+                id="deletion-protection"
+                isChecked={deletionProtectionEnabled}
                 onChange={(_event, checked) =>
                   createModal(({ isOpen, onClose }) => (
                     <DeletionProtectionModal
@@ -412,8 +417,6 @@ const WizardOverviewGrid: FC<WizardOverviewGridProps> = ({ tabsData, updateVM, v
                     />
                   ))
                 }
-                id="deletion-protection"
-                isChecked={deletionProtectionEnabled}
               />
             }
             helperPopover={{

--- a/src/views/catalog/wizard/tabs/scheduling/components/Descheduler.tsx
+++ b/src/views/catalog/wizard/tabs/scheduling/components/Descheduler.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useDeschedulerSetting from '@kubevirt-utils/hooks/useDeschedulerSetting/useDeschedulerSetting';
 import { Switch } from '@patternfly/react-core';
 
@@ -9,12 +10,14 @@ type DeschedulerProps = {
 };
 
 const Descheduler: FC<DeschedulerProps> = ({ vm }) => {
+  const { t } = useKubevirtTranslation();
   const { deschedulerEnabled, deschedulerSwitchDisabled, onDeschedulerChange } =
     useDeschedulerSetting(vm);
 
   return (
     <>
       <Switch
+        aria-label={t('Descheduler')}
         id="descheduler-switch"
         isChecked={deschedulerEnabled}
         isDisabled={deschedulerSwitchDisabled}

--- a/src/views/clusteroverview/OverviewTab/inventory-card/hooks/useProjectNames.ts
+++ b/src/views/clusteroverview/OverviewTab/inventory-card/hooks/useProjectNames.ts
@@ -1,10 +1,12 @@
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 export const useProjectNames = (): string[] => {
+  const model = useProjectOrNamespaceModel();
   const [projects] = useK8sWatchResource<K8sResourceCommon[]>({
-    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+    groupVersionKind: modelToGroupVersionKind(model),
     isList: true,
     namespaced: false,
   });

--- a/src/views/quotas/details/QuotaDetailsPage.tsx
+++ b/src/views/quotas/details/QuotaDetailsPage.tsx
@@ -25,7 +25,7 @@ const QuotaDetailsPage: FC = () => {
     : ApplicationAwareClusterResourceQuotaModel;
 
   const [quota, loaded] = useK8sWatchResource<ApplicationAwareQuota>({
-    groupVersionKind: modelToGroupVersionKind(model),
+        groupVersionKind: modelToGroupVersionKind(model),
     name,
     namespace,
   });

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/TemplatesAndImagesManagement.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/TemplatesAndImagesManagement.tsx
@@ -2,7 +2,8 @@ import React, { FC } from 'react';
 
 import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-utils/models';
+import { modelToGroupVersionKind } from '@kubevirt-utils/models';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { Stack, StackItem } from '@patternfly/react-core';
@@ -24,12 +25,12 @@ const TemplatesAndImagesManagement: FC<TemplatesAndImagesManagementProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const cluster = useSettingsCluster();
+  const model = useProjectOrNamespaceModel();
   const projectsData = useK8sWatchData<K8sResourceCommon[]>({
     cluster,
-    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+    groupVersionKind: modelToGroupVersionKind(model),
     isList: true,
   });
-
   return (
     <ExpandSection
       searchItemId={CLUSTER_TAB_IDS.templatesManagement}

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/shared/GeneralSettingsProjectSelector.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/shared/GeneralSettingsProjectSelector.tsx
@@ -2,7 +2,8 @@ import React, { FC } from 'react';
 
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-utils/models';
+import { modelToGroupVersionKind } from '@kubevirt-utils/models';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { Spinner } from '@patternfly/react-core';
@@ -21,12 +22,13 @@ const GeneralSettingsProjectSelector: FC<GeneralSettingsProjectSelectorProps> = 
 }) => {
   const { t } = useKubevirtTranslation();
 
+  const model = useProjectOrNamespaceModel();
   return (
     <InlineFilterSelect
       options={[
         ...projects
           ?.map((proj) => ({
-            groupVersionKind: modelToGroupVersionKind(ProjectModel),
+                        groupVersionKind: modelToGroupVersionKind(model),
             value: getName(proj),
           }))
           .sort((a, b) => a.value.localeCompare(b.value)),

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/HighAvailabilityConfigurationSection/components/HighAvailabilityToggleContent/SwitchWithTooltip.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/HighAvailabilityConfigurationSection/components/HighAvailabilityToggleContent/SwitchWithTooltip.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 import { Switch, Tooltip } from '@patternfly/react-core';
 
 type SwitchWithTooltipProps = {
+  ariaLabel?: string;
   dataTestID?: string;
   disabledTooltipContent: string;
   onSwitchChange: (newSwitchState: boolean) => void;
@@ -11,6 +12,7 @@ type SwitchWithTooltipProps = {
 };
 
 const SwitchWithTooltip: FC<SwitchWithTooltipProps> = ({
+  ariaLabel,
   dataTestID,
   disabledTooltipContent,
   onSwitchChange,
@@ -20,6 +22,7 @@ const SwitchWithTooltip: FC<SwitchWithTooltipProps> = ({
   switchIsDisabled ? (
     <Tooltip content={disabledTooltipContent}>
       <Switch
+        aria-label={ariaLabel}
         data-test-id={dataTestID}
         isChecked={switchState}
         isDisabled={switchIsDisabled}
@@ -28,6 +31,7 @@ const SwitchWithTooltip: FC<SwitchWithTooltipProps> = ({
     </Tooltip>
   ) : (
     <Switch
+      aria-label={ariaLabel}
       data-test-id={dataTestID}
       isChecked={switchState}
       onChange={(_, checked: boolean) => onSwitchChange(checked)}

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/LoadBalanceConfigurationSection/components/LoadBalanceToggleContent/LoadBalanceToggleContent.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/LoadBalanceConfigurationSection/components/LoadBalanceToggleContent/LoadBalanceToggleContent.tsx
@@ -45,6 +45,7 @@ const LoadBalanceToggleContent: FC<LoadBalanceToggleContentProps> = ({ alternati
           <InstalledIconWithTooltip />
         ) : (
           <Switch
+            aria-label={t('Load balance')}
             data-test-id="load-balance"
             isChecked={switchState}
             onChange={(_event, newSwitchState) => handleSwitchChange(newSwitchState)}

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/VirtFeatureConfigurationItem/VirtFeatureConfigurationItem.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/VirtFeatureConfigurationItem/VirtFeatureConfigurationItem.tsx
@@ -79,6 +79,7 @@ const VirtFeatureConfigurationItem: FC<VirtFeatureConfigurationItemProps> = ({
               <Icon />
             ) : (
               <Switch
+                aria-label={title}
                 data-test-id={operatorName}
                 isChecked={switchState}
                 onChange={(_, checked: boolean) => handleSwitchChange(checked)}

--- a/src/views/settings/tabs/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/components/SSHAuthKeyRow/SSHAuthKeyRow.tsx
+++ b/src/views/settings/tabs/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/components/SSHAuthKeyRow/SSHAuthKeyRow.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useCallback } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
 import {
@@ -36,6 +37,7 @@ const SSHAuthKeyRow: FC<SSHAuthKeyRowProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const cluster = useSettingsCluster();
+  const model = useProjectOrNamespaceModel();
   const { projectName, secretName } = row;
 
   const onSubmit = useCallback(
@@ -82,7 +84,7 @@ const SSHAuthKeyRow: FC<SSHAuthKeyRowProps> = ({
           <InlineFilterSelect
             options={selectableProjects?.sort().map((opt) => ({
               children: opt,
-              groupVersionKind: modelToGroupVersionKind(ProjectModel),
+              groupVersionKind: modelToGroupVersionKind(model),
               value: opt,
             }))}
             toggleProps={{

--- a/src/views/settings/tabs/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/hooks/useSSHAuthProjects.ts
+++ b/src/views/settings/tabs/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/hooks/useSSHAuthProjects.ts
@@ -1,10 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import {
-  modelToGroupVersionKind,
-  ProjectModel,
-  SecretModel,
-} from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind,  SecretModel,
+ } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
@@ -19,10 +17,11 @@ type UseSSHAuthProjects = (authKeyRows: AuthKeyRow[]) => {
 };
 
 const useSSHAuthProjects: UseSSHAuthProjects = (authKeyRows) => {
+  const model = useProjectOrNamespaceModel();
   const cluster = useSettingsCluster();
   const [projects, loaded] = useK8sWatchData<K8sResourceCommon[]>({
     cluster,
-    groupVersionKind: modelToGroupVersionKind(ProjectModel),
+    groupVersionKind: modelToGroupVersionKind(model),
     isList: true,
     namespaced: false,
   });

--- a/src/views/templates/actions/components/PersistentVolumeClaimSelect/PersistentVolumeSelectProject.tsx
+++ b/src/views/templates/actions/components/PersistentVolumeClaimSelect/PersistentVolumeSelectProject.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -23,6 +24,7 @@ export const PersistentVolumeSelectProject: FC<PersistentVolumeSelectProjectProp
 
   const validated = !selectedProject ? ValidatedOptions.error : ValidatedOptions.default;
 
+  const model = useProjectOrNamespaceModel();
   return (
     <FormGroup
       className="pvc-selection-formgroup"
@@ -34,7 +36,7 @@ export const PersistentVolumeSelectProject: FC<PersistentVolumeSelectProjectProp
       <InlineFilterSelect
         options={projectsName?.map((name) => ({
           children: name,
-          groupVersionKind: modelToGroupVersionKind(ProjectModel),
+          groupVersionKind: modelToGroupVersionKind(model),
           value: name,
         }))}
         toggleProps={{

--- a/src/views/templates/details/tabs/scheduling/components/Descheduler.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/Descheduler.tsx
@@ -33,6 +33,7 @@ const Descheduler: FC<DeschedulerProps> = ({ template }) => {
         }
         descriptionData={
           <Switch
+            aria-label={t('Descheduler')}
             id="descheduler-switch"
             isChecked={deschedulerEnabled}
             isDisabled={deschedulerSwitchDisabled}

--- a/src/views/virtualmachines/creation-wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeDetailsTab.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeDetailsTab.tsx
@@ -185,6 +185,10 @@ const CustomizeInstanceTypeDetailsTab = () => {
             )}
             descriptionData={
               <Switch
+                aria-label={t('Guest system log access')}
+                id="guest-system-log-access"
+                isChecked={isCheckedGuestSystemAccessLog}
+                isDisabled={isGuestSystemLogsDisabled}
                 onChange={(_event, checked) => {
                   setIsCheckedGuestSystemAccessLog(checked);
                   updateCustomizeInstanceType([
@@ -194,9 +198,6 @@ const CustomizeInstanceTypeDetailsTab = () => {
                     },
                   ]);
                 }}
-                id="guest-system-log-access"
-                isChecked={isCheckedGuestSystemAccessLog}
-                isDisabled={isGuestSystemLogsDisabled}
               />
             }
             descriptionHeader={
@@ -213,6 +214,9 @@ const CustomizeInstanceTypeDetailsTab = () => {
             )}
             descriptionData={
               <Switch
+                aria-label={t('Deletion protection')}
+                id="deletion-protection"
+                isChecked={deletionProtectionEnabled}
                 onChange={(_event, checked) =>
                   createModal(({ isOpen, onClose }) => (
                     <DeletionProtectionModal
@@ -236,8 +240,6 @@ const CustomizeInstanceTypeDetailsTab = () => {
                     />
                   ))
                 }
-                id="deletion-protection"
-                isChecked={deletionProtectionEnabled}
               />
             }
             descriptionHeader={

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesToolbar/components/TemplatesCatalogProjectsDropdown/TemplatesCatalogProjectsDropdown.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesToolbar/components/TemplatesCatalogProjectsDropdown/TemplatesCatalogProjectsDropdown.tsx
@@ -1,6 +1,7 @@
 import React, { FC, memo, useMemo } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import { ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
 import { getName } from '@kubevirt-utils/resources/shared';
@@ -18,9 +19,10 @@ type TemplatesCatalogProjectsDropdownProps = {
 export const TemplatesCatalogProjectsDropdown: FC<TemplatesCatalogProjectsDropdownProps> = memo(
   ({ onChange, selectedProject }) => {
     const cluster = useClusterParam();
+    const model = useProjectOrNamespaceModel();
     const [projects] = useK8sWatchData<K8sResourceCommon[]>({
       cluster,
-      groupVersionKind: modelToGroupVersionKind(ProjectModel),
+      groupVersionKind: modelToGroupVersionKind(model),
       isList: true,
       namespaced: false,
     });

--- a/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/DetailsSection.tsx
@@ -242,13 +242,14 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
               )}
               descriptionData={
                 <Switch
+                  aria-label={t('Guest system log access')}
+                  id="guest-system-log-access"
+                  isChecked={isCheckedGuestSystemAccessLog}
+                  isDisabled={isGuestSystemLogsDisabled}
                   onChange={(_event, checked) => {
                     setIsCheckedGuestSystemAccessLog(checked);
                     updateGuestSystemAccessLog(vm, checked);
                   }}
-                  id="guest-system-log-access"
-                  isChecked={isCheckedGuestSystemAccessLog}
-                  isDisabled={isGuestSystemLogsDisabled}
                 />
               }
               descriptionHeader={
@@ -265,6 +266,9 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
               )}
               descriptionData={
                 <Switch
+                  aria-label={t('Deletion protection')}
+                  id="deletion-protection"
+                  isChecked={deletionProtectionEnabled}
                   onChange={(_event, checked) =>
                     createModal(({ isOpen, onClose }) => (
                       <DeletionProtectionModal
@@ -283,8 +287,6 @@ const DetailsSection: FC<DetailsSectionProps> = ({ allInstanceTypes, instanceTyp
                       />
                     ))
                   }
-                  id="deletion-protection"
-                  isChecked={deletionProtectionEnabled}
                 />
               }
               descriptionHeader={

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
@@ -125,6 +125,9 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({
         )}
         descriptionData={
           <Switch
+            aria-label={t('Start in pause mode')}
+            id="start-in-pause-mode"
+            isChecked={isChecked}
             onChange={(_event, checked) => {
               setIsChecked(checked);
               isCustomizeInstanceType
@@ -138,8 +141,6 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({
                   )
                 : updateStartStrategy(checked, vm);
             }}
-            id="start-in-pause-mode"
-            isChecked={isChecked}
           />
         }
         descriptionHeader={

--- a/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabConditions.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabConditions.tsx
@@ -119,9 +119,10 @@ const VirtualMachineDiagnosticTabConditions: FC<VirtualMachineDiagnosticTabCondi
         <Thead>
           <Tr>
             <Th
+              aria-label={t('Expand all rows')}
               expand={{
                 areAllExpanded: expend.expended.size !== expend.ids.size,
-                collapseAllAriaLabel: '',
+                collapseAllAriaLabel: t('Collapse all rows'),
                 onToggle: (_, __, isOpen) => {
                   setExpend((expendObj) => ({
                     expended: new Set(!isOpen ? [] : expendObj.ids),

--- a/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabDataVolumeStatus.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabDataVolumeStatus.tsx
@@ -80,9 +80,10 @@ const VirtualMachineDiagnosticTabDataVolumeStatus: FC<
         <Thead>
           <Tr>
             <Th
+              aria-label={t('Expand all rows')}
               expand={{
                 areAllExpanded: expend.expended.size !== expend.ids.size,
-                collapseAllAriaLabel: '',
+                collapseAllAriaLabel: t('Collapse all rows'),
                 onToggle: (_, __, isOpen) => {
                   setExpend((expendObj) => ({
                     expended: new Set(!isOpen ? [] : expendObj.ids),

--- a/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabVolumeStatus.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabVolumeStatus.tsx
@@ -80,9 +80,10 @@ const VirtualMachineDiagnosticTabVolumeStatus: FC<VirtualMachineDiagnosticTabVol
         <Thead>
           <Tr>
             <Th
+              aria-label={t('Expand all rows')}
               expand={{
                 areAllExpanded: expend.expended.size !== expend.ids.size,
-                collapseAllAriaLabel: '',
+                collapseAllAriaLabel: t('Collapse all rows'),
                 onToggle: (_, __, isOpen) => {
                   setExpend((expendObj) => ({
                     expended: new Set(!isOpen ? [] : expendObj.ids),

--- a/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
@@ -47,6 +47,7 @@ const TreeViewToolbar: FC<TreeViewToolbarProps> = ({ onSearch }) => {
               </SplitItem>
               <SplitItem isFilled />
               <Switch
+                aria-label={t('Show only projects with VirtualMachines')}
                 checked={showEmptyProjects === HIDE}
                 className="vms-tree-view__toolbar-switch"
                 isReversed

--- a/src/views/vmnetworks/details/tabs/ConnectedProjects/ConnectedProjectsRow.tsx
+++ b/src/views/vmnetworks/details/tabs/ConnectedProjects/ConnectedProjectsRow.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-utils/models';
+import { modelToGroupVersionKind } from '@kubevirt-utils/models';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { ResourceLink, RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 
 import { ProjectWithVMCount } from '../../types';
@@ -8,13 +9,14 @@ import { ProjectWithVMCount } from '../../types';
 type ConnectedProjectsRowProps = RowProps<ProjectWithVMCount>;
 
 const ConnectedProjectsRow: FC<ConnectedProjectsRowProps> = ({ activeColumnIDs, obj }) => {
+  const model = useProjectOrNamespaceModel();
   const { projectName, vmCount } = obj;
 
   return (
     <>
       <TableData activeColumnIDs={activeColumnIDs} id="name">
         <ResourceLink
-          groupVersionKind={modelToGroupVersionKind(ProjectModel)}
+          groupVersionKind={modelToGroupVersionKind(model)}
           key={projectName}
           name={projectName}
         />

--- a/src/views/vmnetworks/details/tabs/ConnectedProjects/cells/ProjectNameCell.tsx
+++ b/src/views/vmnetworks/details/tabs/ConnectedProjects/cells/ProjectNameCell.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-utils/models';
+import { modelToGroupVersionKind } from '@kubevirt-utils/models';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -11,6 +12,7 @@ type ProjectNameCellProps = {
 };
 
 const ProjectNameCell: FC<ProjectNameCellProps> = ({ row }) => {
+  const model = useProjectOrNamespaceModel();
   const { projectName } = row;
 
   if (!projectName) {
@@ -19,7 +21,7 @@ const ProjectNameCell: FC<ProjectNameCellProps> = ({ row }) => {
 
   return (
     <span data-test={`project-name-${projectName}`}>
-      <ResourceLink groupVersionKind={modelToGroupVersionKind(ProjectModel)} name={projectName} />
+      <ResourceLink groupVersionKind={modelToGroupVersionKind(model)} name={projectName} />
     </span>
   );
 };

--- a/src/views/vmnetworks/form/components/SelectedProjects.tsx
+++ b/src/views/vmnetworks/form/components/SelectedProjects.tsx
@@ -3,7 +3,8 @@ import { useFormContext } from 'react-hook-form';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useProjectResources from '@kubevirt-utils/hooks/useProjectResources';
-import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-utils/models';
+import { modelToGroupVersionKind } from '@kubevirt-utils/models';
+import { useProjectOrNamespaceModel } from '@kubevirt-utils/hooks/useProjectOrNamespaceModel';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { ResourceIcon } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -20,6 +21,7 @@ import { getVMNetworkProjects } from '../../utils';
 import { VMNetworkForm } from '../constants';
 
 const SelectedProjects: FC = () => {
+  const model = useProjectOrNamespaceModel();
   const { t } = useKubevirtTranslation();
 
   const { watch } = useFormContext<VMNetworkForm>();
@@ -48,7 +50,7 @@ const SelectedProjects: FC = () => {
             <List>
               {matchingProjects?.map((project) => (
                 <ListItem key={getName(project)}>
-                  <ResourceIcon groupVersionKind={modelToGroupVersionKind(ProjectModel)} />
+                  <ResourceIcon groupVersionKind={modelToGroupVersionKind(model)} />
                   {getName(project)}
                 </ListItem>
               ))}


### PR DESCRIPTION
<!---

## 📝 Description

This PR makes initial changes to make the kubevirt-plugin compatible with vanilla k8s clusters. A new hook is introduced to use Projects and fallback to Namespaces model when projects api is not available the the hook is reused accross components that rely on the projects api . Also made some accessibility fixes to data tables and switch controls to silence patternfly warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-based local storage option for persistent user settings configuration as an alternative to ConfigMap-based storage

* **Bug Fixes**
  * Enhanced screen reader accessibility with aria-labels added to switch controls and expandable table components

* **Refactor**
  * Refactored resource model selection throughout the application to dynamically support both Project and Namespace models based on cluster configuration
  * Modernized Docker deployment image from UBI9 NodeJS to Alpine Linux-based nginx runtime

<!-- end of auto-generated comment: release notes by coderabbit.ai -->