### PR TITLE
CNV-87979: Fix user instance type delete from list kebab menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@kubev2v/types": "^0.0.22",
-        "@kubevirt-ui-ext/kubevirt-api": "1.7.0",
+        "@kubevirt-ui-ext/kubevirt-api": "1.8.1",
         "@kubevirt-ui-ext/vnc-keymaps": "1.0.4",
         "@novnc/novnc": "1.5.0",
         "@patternfly/quickstarts": "~6.4.0",
@@ -3611,9 +3611,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@kubevirt-ui-ext/kubevirt-api": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@kubevirt-ui-ext/kubevirt-api/-/kubevirt-api-1.7.0.tgz",
-      "integrity": "sha512-FG/kkL5fR3relVUoWimvqYqiSMuW95L4hor8HW7TVUPbUnxgvkh9L1RxNEMN6cgnQ+I7LlrPZhsSSUxt8+vd/g==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@kubevirt-ui-ext/kubevirt-api/-/kubevirt-api-1.8.1.tgz",
+      "integrity": "sha512-sCqwHPrF29hpvV5ggNowon+LOEabkmnOwEc9RhvtNOqF5i3rEblt5+zktNuftW9YnB7S1V2L7d4tCHz3QaFe1A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@kubev2v/types": "^0.0.22",
-    "@kubevirt-ui-ext/kubevirt-api": "1.7.0",
+    "@kubevirt-ui-ext/kubevirt-api": "1.8.1",
     "@kubevirt-ui-ext/vnc-keymaps": "1.0.4",
     "@novnc/novnc": "1.5.0",
     "@patternfly/quickstarts": "~6.4.0",

--- a/src/views/instancetypes/actions/hooks/useUserInstancetypeActionsProvider.tsx
+++ b/src/views/instancetypes/actions/hooks/useUserInstancetypeActionsProvider.tsx
@@ -1,12 +1,15 @@
 import React, { useMemo } from 'react';
 
-import { VirtualMachineInstancetypeModelRef } from '@kubevirt-ui-ext/kubevirt-api/console';
+import {
+  VirtualMachineInstancetypeModel,
+  VirtualMachineInstancetypeModelRef,
+} from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1beta1VirtualMachineInstancetype } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import CloneResourceModal from '@kubevirt-utils/components/CloneResourceModal/CloneResourceModal';
 import DeleteModal from '@kubevirt-utils/components/DeleteModal/DeleteModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { asAccessReview, getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { asAccessReview } from '@kubevirt-utils/resources/shared';
 import { kubevirtK8sDelete } from '@multicluster/k8sRequests';
 import { Action, useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -20,17 +23,17 @@ const useUserInstancetypeActionsProvider: UseUserInstancetypeActionsProvider = (
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
 
-  const [model, inFlight] = useK8sModel(VirtualMachineInstancetypeModelRef);
+  const [, inFlight] = useK8sModel(VirtualMachineInstancetypeModelRef);
   const actions: Action[] = useMemo(() => {
     return [
       {
-        accessReview: asAccessReview(model, instanceType, 'create'),
+        accessReview: asAccessReview(VirtualMachineInstancetypeModel, instanceType, 'create'),
         cta: () =>
           createModal((modalProps) => {
             return (
               <CloneResourceModal
                 {...modalProps}
-                model={model}
+                model={VirtualMachineInstancetypeModel}
                 namespace={instanceType?.metadata?.namespace}
                 object={instanceType}
               />
@@ -41,7 +44,7 @@ const useUserInstancetypeActionsProvider: UseUserInstancetypeActionsProvider = (
         label: t('Clone'),
       },
       {
-        accessReview: asAccessReview(model, instanceType, 'delete'),
+        accessReview: asAccessReview(VirtualMachineInstancetypeModel, instanceType, 'delete'),
         cta: () =>
           createModal(({ isOpen, onClose }) => {
             return (
@@ -49,9 +52,7 @@ const useUserInstancetypeActionsProvider: UseUserInstancetypeActionsProvider = (
                 onDeleteSubmit={() =>
                   kubevirtK8sDelete({
                     cluster: instanceType?.cluster,
-                    model,
-                    name: getName(instanceType),
-                    ns: getNamespace(instanceType),
+                    model: VirtualMachineInstancetypeModel,
                     resource: instanceType,
                   })
                 }

--- a/src/views/instancetypes/actions/hooks/useUserInstancetypeActionsProvider.tsx
+++ b/src/views/instancetypes/actions/hooks/useUserInstancetypeActionsProvider.tsx
@@ -1,13 +1,12 @@
 import React, { useMemo } from 'react';
 
 import { VirtualMachineInstancetypeModelRef } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { VirtualMachineInstancetypeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1beta1VirtualMachineInstancetype } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import CloneResourceModal from '@kubevirt-utils/components/CloneResourceModal/CloneResourceModal';
 import DeleteModal from '@kubevirt-utils/components/DeleteModal/DeleteModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { asAccessReview } from '@kubevirt-utils/resources/shared';
+import { asAccessReview, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { kubevirtK8sDelete } from '@multicluster/k8sRequests';
 import { Action, useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -21,17 +20,17 @@ const useUserInstancetypeActionsProvider: UseUserInstancetypeActionsProvider = (
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
 
-  const [, inFlight] = useK8sModel(VirtualMachineInstancetypeModelRef);
+  const [model, inFlight] = useK8sModel(VirtualMachineInstancetypeModelRef);
   const actions: Action[] = useMemo(() => {
     return [
       {
-        accessReview: asAccessReview(VirtualMachineInstancetypeModel, instanceType, 'create'),
+        accessReview: asAccessReview(model, instanceType, 'create'),
         cta: () =>
           createModal((modalProps) => {
             return (
               <CloneResourceModal
                 {...modalProps}
-                model={VirtualMachineInstancetypeModel}
+                model={model}
                 namespace={instanceType?.metadata?.namespace}
                 object={instanceType}
               />
@@ -42,7 +41,7 @@ const useUserInstancetypeActionsProvider: UseUserInstancetypeActionsProvider = (
         label: t('Clone'),
       },
       {
-        accessReview: asAccessReview(VirtualMachineInstancetypeModel, instanceType, 'delete'),
+        accessReview: asAccessReview(model, instanceType, 'delete'),
         cta: () =>
           createModal(({ isOpen, onClose }) => {
             return (
@@ -50,7 +49,9 @@ const useUserInstancetypeActionsProvider: UseUserInstancetypeActionsProvider = (
                 onDeleteSubmit={() =>
                   kubevirtK8sDelete({
                     cluster: instanceType?.cluster,
-                    model: VirtualMachineInstancetypeModel,
+                    model,
+                    name: getName(instanceType),
+                    ns: getNamespace(instanceType),
                     resource: instanceType,
                   })
                 }


### PR DESCRIPTION
## 📝 Description

Fixes deletion of user-defined `VirtualMachineInstancetype` resources from the list kebab menu.

The delete action was calling `kubevirtK8sDelete` with a model that was incorrectly marked as cluster-scoped in `@kubevirt-ui-ext/kubevirt-api` 1.7.0, so the request was sent to a cluster-scoped URL and returned 404:

```
DELETE .../virtualmachineinstancetypes/example
```

This PR upgrades `@kubevirt-ui-ext/kubevirt-api` to **1.8.1**, where `VirtualMachineInstancetypeModel` is correctly namespaced, and uses that model for access review, clone, and delete actions. Delete now passes the full `resource` to `kubevirtK8sDelete`, which targets the correct endpoint:

```
DELETE .../namespaces/<namespace>/virtualmachineinstancetypes/example
```

## 🔗 Links

- https://issues.redhat.com/browse/CNV-87979

## 🎥 Demo

**BEFORE**

https://github.com/user-attachments/assets/0ecdb941-4121-486d-94ee-c177d12ffde2

**AFTER**

https://github.com/user-attachments/assets/5cda154e-8b50-471f-9212-641be6ec1999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->