### PR TITLE
CNV-87452: Fix Jira clone workflow failures on issue create

### DIFF
--- a/.github/scripts/src/clone-tickets.ts
+++ b/.github/scripts/src/clone-tickets.ts
@@ -1,6 +1,7 @@
 import { JiraClient } from './jira-client.js';
 import { buildClonePayload } from './jira-clone-builder.js';
-import type { ClonedTicket, JiraIssue } from './types/index.js';
+import { jiraErrorMessage } from './utils.js';
+import type { ClonedTicket, JiraCreateIssuePayload, JiraIssue } from './types/index.js';
 
 /** Clone all Jira tickets for a release branch, linking and commenting on each original. */
 export const cloneAllTickets = async (
@@ -23,17 +24,24 @@ export const cloneAllTickets = async (
     try {
       originalIssue = await jira.getIssue(originalKey);
     } catch (err) {
-      console.warn(`Warning: could not fetch ${originalKey}, skipping: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      console.warn(`Warning: could not fetch ${originalKey}, skipping: ${jiraErrorMessage(err)}`);
       continue;
     }
 
-    const clonePayload = buildClonePayload(originalIssue, matchedVersion, discoveredFields);
+    let clonePayload: JiraCreateIssuePayload;
+    try {
+      clonePayload = buildClonePayload(originalIssue, matchedVersion, discoveredFields);
+    } catch (err) {
+      console.warn(`Warning: could not clone ${originalKey}: ${jiraErrorMessage(err)}`);
+      continue;
+    }
+
     let clonedIssue: JiraIssue;
 
     try {
       clonedIssue = await jira.createIssue(clonePayload);
     } catch (err) {
-      console.warn(`Warning: could not clone ${originalKey}: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      console.warn(`Warning: could not clone ${originalKey}: ${jiraErrorMessage(err)}`);
       continue;
     }
 
@@ -43,7 +51,7 @@ export const cloneAllTickets = async (
     try {
       await jira.createIssueLink(clonedIssue.key, originalKey, 'Cloners');
     } catch (err) {
-      console.warn(`Warning: could not link ${clonedIssue.key}: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      console.warn(`Warning: could not link ${clonedIssue.key}: ${jiraErrorMessage(err)}`);
     }
 
     try {
@@ -52,7 +60,7 @@ export const cloneAllTickets = async (
         `Cloned to ${clonedIssue.key} for ${targetBranch} via PR #${prNumber} (${repoFullName})`,
       );
     } catch (err) {
-      console.warn(`Warning: could not comment on ${originalKey}: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      console.warn(`Warning: could not comment on ${originalKey}: ${jiraErrorMessage(err)}`);
     }
   }
 

--- a/.github/scripts/src/jira-adf-utils.ts
+++ b/.github/scripts/src/jira-adf-utils.ts
@@ -1,0 +1,58 @@
+type AdfNode = {
+  type: string;
+  content?: AdfNode[];
+  [key: string]: unknown;
+};
+
+type AdfDoc = {
+  type: string;
+  version: number;
+  content: AdfNode[];
+};
+
+/** ADF node types that reference issue-specific assets and cannot be reused on create. */
+const UNSUPPORTED_CLONE_NODES = new Set(['media', 'mediaSingle', 'mediaGroup', 'inlineCard']);
+
+const sanitizeAdfNode = (node: AdfNode): AdfNode | null => {
+  if (UNSUPPORTED_CLONE_NODES.has(node.type)) {
+    return null;
+  }
+
+  if (!node.content) {
+    return node;
+  }
+
+  const content = node.content
+    .map(sanitizeAdfNode)
+    .filter((child): child is AdfNode => child !== null);
+
+  if (content.length === 0 && (node.type === 'paragraph' || node.type === 'heading')) {
+    return null;
+  }
+
+  return { ...node, content };
+};
+
+/** Remove embedded media and other issue-bound nodes from an ADF description before cloning. */
+export const sanitizeDescriptionForClone = (description: unknown): unknown | undefined => {
+  if (description == null) {
+    return undefined;
+  }
+
+  if (typeof description !== 'object') {
+    return description;
+  }
+
+  const doc = description as AdfDoc;
+  if (doc.type !== 'doc' || !Array.isArray(doc.content)) {
+    return description;
+  }
+
+  const content = doc.content.map(sanitizeAdfNode).filter((node): node is AdfNode => node !== null);
+
+  if (content.length === 0) {
+    return undefined;
+  }
+
+  return { ...doc, content };
+};

--- a/.github/scripts/src/jira-clone-builder.ts
+++ b/.github/scripts/src/jira-clone-builder.ts
@@ -1,9 +1,16 @@
+import { sanitizeDescriptionForClone } from './jira-adf-utils.js';
 import type {
   DiscoveredFields,
   JiraCreateIssuePayload,
   JiraIssue,
   JiraVersion,
 } from './types/index.js';
+
+const isCustomFieldOption = (value: unknown): value is { id: string } =>
+  typeof value === 'object' &&
+  value !== null &&
+  'id' in value &&
+  typeof (value as { id: unknown }).id === 'string';
 
 /** Build a Jira create-issue payload that clones an original ticket with a new fix version. */
 export const buildClonePayload = (
@@ -12,19 +19,24 @@ export const buildClonePayload = (
   discoveredFields: DiscoveredFields,
 ): JiraCreateIssuePayload => {
   const { fields } = original;
+  const description = sanitizeDescriptionForClone(fields.description);
+  if (description == null) {
+    throw new Error(
+      `Cannot clone ${original.key}: description is missing or empty after sanitization`,
+    );
+  }
 
   const payload: JiraCreateIssuePayload = {
     fields: {
       project: { key: 'CNV' },
       issuetype: { id: fields.issuetype.id },
       summary: fields.summary,
-      description: fields.description,
+      description,
       labels: [...fields.labels],
       components: fields.components.map((c) => ({ id: c.id })),
       fixVersions: [{ id: targetFixVersion.id }],
     },
   };
-
   if (fields.assignee) {
     payload.fields.assignee = { accountId: fields.assignee.accountId };
   }
@@ -39,10 +51,12 @@ export const buildClonePayload = (
     }
   }
 
-  if (discoveredFields.productTypeFieldId) {
-    const ptValue = fields[discoveredFields.productTypeFieldId as `customfield_${string}`];
-    if (ptValue != null) {
-      payload.fields[discoveredFields.productTypeFieldId as `customfield_${string}`] = ptValue;
+  if (discoveredFields.activityTypeFieldId) {
+    const atValue = fields[discoveredFields.activityTypeFieldId as `customfield_${string}`];
+    if (isCustomFieldOption(atValue)) {
+      payload.fields[discoveredFields.activityTypeFieldId as `customfield_${string}`] = {
+        id: atValue.id,
+      };
     }
   }
 

--- a/.github/scripts/src/utils.ts
+++ b/.github/scripts/src/utils.ts
@@ -13,3 +13,17 @@ export const safeErrorMessage = (err: unknown): string => {
   if (err instanceof Error) return err.message;
   return 'Unknown error';
 };
+
+/** Format a Jira API error, including the response body when present. */
+export const jiraErrorMessage = (err: unknown): string => {
+  if (!(err instanceof Error)) {
+    return 'Unknown error';
+  }
+
+  const cause = err.cause;
+  if (typeof cause === 'string' && cause.length > 0) {
+    return `${err.message}: ${cause}`;
+  }
+
+  return err.message;
+};


### PR DESCRIPTION
## Summary
- Strip embedded media and inline cards from cloned Jira descriptions before `POST /issue`, fixing 400 errors on tickets with attachments in the description (e.g. [CNV-87979](https://redhat.atlassian.net/browse/CNV-87979))
- Copy Activity Type custom field correctly (was referencing non-existent `productTypeFieldId`)
- Include Jira API response body in clone workflow error logs for easier debugging

## Test plan
- [ ] Merge to `main`
- [ ] Re-run `/clone release-4.22` on a PR whose Jira ticket has an embedded video in the description
- [ ] Verify clone is created, linked to original via Cloners, and cherry-pick PR opens
- [ ] Verify cloned ticket has text description, Activity Type, and fix version set; media remains on original only


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, consistently formatted error messages for ticket cloning failures to aid troubleshooting.

* **Improvements**
  * Descriptions are sanitized during cloning to remove unsupported or empty content for more reliable transfers.
  * Custom field values are validated and mapped more safely during cloning to prevent incorrect or malformed field copies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->