### PR TITLE
CNV-87999: Mount ISO upload does not show DV source until upload completes (unlike Add CD-ROM)

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -39,6 +39,7 @@
   "{{count}} Volumes_other": "{{count}} Volumes",
   "{{cpu}} CPU | {{memory}} Memory": "{{cpu}} CPU | {{memory}} Memory",
   "{{cpus}} CPUs, {{memory}} Memory": "{{cpus}} CPUs, {{memory}} Memory",
+  "{{diskName}}: upload in progress": "{{diskName}}: upload in progress",
   "{{gpusCount}} GPU devices": "{{gpusCount}} GPU devices",
   "{{hostDevicesCount}} Host devices": "{{hostDevicesCount}} Host devices",
   "{{hours}}h {{minutes}}m {{seconds}}s": "{{hours}}h {{minutes}}m {{seconds}}s",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -49,6 +49,7 @@
   "{{count}} Volumes_other": "{{count}} volúmenes_other",
   "{{cpu}} CPU | {{memory}} Memory": "{{cpu}} CPU | {{memory}} Memoria",
   "{{cpus}} CPUs, {{memory}} Memory": "{{cpus}} CPU, {{memory}} Memoria",
+  "{{diskName}}: upload in progress": "{{diskName}}: upload in progress",
   "{{gpusCount}} GPU devices": "{{gpusCount}} Dispositivos GPU",
   "{{hostDevicesCount}} Host devices": "{{hostDevicesCount}} dispositivos host",
   "{{hours}}h {{minutes}}m {{seconds}}s": "{{hours}} h{{minutes}} m {{seconds}} s",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -49,6 +49,7 @@
   "{{count}} Volumes_other": "{{count}} Volumes_autres",
   "{{cpu}} CPU | {{memory}} Memory": "{{cpu}}: {{memory}} processeurs |  de mémoire",
   "{{cpus}} CPUs, {{memory}} Memory": "{{cpus}} processeurs,{{memory}} mémoire",
+  "{{diskName}}: upload in progress": "{{diskName}}: upload in progress",
   "{{gpusCount}} GPU devices": "{{gpusCount}} périphériquesGPU",
   "{{hostDevicesCount}} Host devices": "{{hostDevicesCount}} périphériques hôtes",
   "{{hours}}h {{minutes}}m {{seconds}}s": "{{hours}}h{{minutes}} m{{seconds}} s",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -39,6 +39,7 @@
   "{{count}} Volumes_other": "{{count}} 台のボリューム",
   "{{cpu}} CPU | {{memory}} Memory": "{{cpu}} CPU | {{memory}} メモリー",
   "{{cpus}} CPUs, {{memory}} Memory": "{{cpus}} CPU、{{memory}} メモリー",
+  "{{diskName}}: upload in progress": "{{diskName}}: upload in progress",
   "{{gpusCount}} GPU devices": "{{gpusCount}} 台の GPU デバイス",
   "{{hostDevicesCount}} Host devices": "{{hostDevicesCount}} 台のホストデバイス",
   "{{hours}}h {{minutes}}m {{seconds}}s": "{{hours}}h {{minutes}}m {{seconds}}s",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -39,6 +39,7 @@
   "{{count}} Volumes_other": "{{count}} 볼륨",
   "{{cpu}} CPU | {{memory}} Memory": "{{cpu}} CPU |{{memory}} 메모리",
   "{{cpus}} CPUs, {{memory}} Memory": "{{cpus}} CPU, {{memory}} 메모리",
+  "{{diskName}}: upload in progress": "{{diskName}}: upload in progress",
   "{{gpusCount}} GPU devices": "{{gpusCount}} GPU 장치",
   "{{hostDevicesCount}} Host devices": "{{hostDevicesCount}} 호스트 장치",
   "{{hours}}h {{minutes}}m {{seconds}}s": "{{hours}}h {{minutes}}m {{seconds}}s",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -39,6 +39,7 @@
   "{{count}} Volumes_other": "{{count}} 个卷_other",
   "{{cpu}} CPU | {{memory}} Memory": "{{cpu}} CPU | {{memory}} 内存",
   "{{cpus}} CPUs, {{memory}} Memory": "{{cpus}} CPU, {{memory}} 内存",
+  "{{diskName}}: upload in progress": "{{diskName}}: upload in progress",
   "{{gpusCount}} GPU devices": "{{gpusCount}} GPU 设备",
   "{{hostDevicesCount}} Host devices": "{{hostDevicesCount}} 主机设备",
   "{{hours}}h {{minutes}}m {{seconds}}s": "{{hours}}h {{minutes}}m {{seconds}}s",

--- a/src/utils/components/DiskModal/AddCDROMModal.tsx
+++ b/src/utils/components/DiskModal/AddCDROMModal.tsx
@@ -82,6 +82,7 @@ const AddCDROMModal: FC<V1SubDiskModalProps> = ({
   const existingISOSelected = isExistingISOMode(mountUploadMode);
 
   const uploadFile = useWatch({ control, name: FORM_FIELD_UPLOAD_FILE });
+  const diskName = useWatch({ control, name: 'disk.name' });
   const hasUploadFile = !isEmpty(uploadFile?.file);
   const hasFormErrors = !isEmpty(errors);
 
@@ -89,6 +90,7 @@ const AddCDROMModal: FC<V1SubDiskModalProps> = ({
     useCDROMUploadClose(upload, onClose);
 
   const { isUploadActive } = useCDROMUploadStore({
+    cdromDiskName: diskName ?? '',
     isUploading,
     markBackgroundUploadEnded,
     upload,

--- a/src/utils/components/DiskModal/hooks/useCDROMUploadStore.ts
+++ b/src/utils/components/DiskModal/hooks/useCDROMUploadStore.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
-  getVmUploadKeyFromVm,
+  getCdromUploadKeyFromVm,
   UPLOAD_ALERT_STATUS,
   useMountIsoUploadStore,
 } from '@kubevirt-utils/hooks/mountIsoUploadStore';
@@ -10,6 +10,7 @@ import { DataUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
 import { useSyncMountIsoUploadEnded } from '@virtualmachines/details/tabs/configuration/storage/components/hooks/useSyncMountIsoUploadEnded';
 
 type UseCDROMUploadStoreParams = {
+  cdromDiskName: string;
   isUploading: boolean;
   markBackgroundUploadEnded: () => void;
   upload: DataUpload;
@@ -17,41 +18,40 @@ type UseCDROMUploadStoreParams = {
 };
 
 type UseCDROMUploadStoreResult = {
+  cdromUploadKey: string;
   clearCancelUpload: (key: string) => void;
   clearPersistedUpload: (key: string) => void;
   isUploadActive: boolean;
-  vmUploadKey: string;
 };
 
 export const useCDROMUploadStore = ({
+  cdromDiskName,
   isUploading,
   markBackgroundUploadEnded,
   upload,
   vm,
 }: UseCDROMUploadStoreParams): UseCDROMUploadStoreResult => {
-  const vmUploadKey = getVmUploadKeyFromVm(vm);
+  const cdromUploadKey = getCdromUploadKeyFromVm(vm, cdromDiskName);
 
-  const persistedUploadStatus = useMountIsoUploadStore(
-    (state) => state.uploads[vmUploadKey]?.status,
-  );
+  const persistedUpload = useMountIsoUploadStore((state) => state.uploads[cdromUploadKey]);
   const clearPersistedUpload = useMountIsoUploadStore((state) => state.clearUpload);
   const setCancelUpload = useMountIsoUploadStore((state) => state.setCancelUpload);
   const clearCancelUpload = useMountIsoUploadStore((state) => state.clearCancelUpload);
 
-  const isUploadActive = isUploading || persistedUploadStatus === UPLOAD_ALERT_STATUS.UPLOADING;
+  const isUploadActive = isUploading || persistedUpload?.status === UPLOAD_ALERT_STATUS.UPLOADING;
 
-  useSyncMountIsoUploadEnded(vmUploadKey, markBackgroundUploadEnded);
+  useSyncMountIsoUploadEnded(cdromUploadKey, markBackgroundUploadEnded);
 
   useEffect(() => {
     if (upload?.cancelUpload) {
-      setCancelUpload(vmUploadKey, upload.cancelUpload);
+      setCancelUpload(cdromUploadKey, upload.cancelUpload);
     }
-  }, [setCancelUpload, upload?.cancelUpload, vmUploadKey]);
+  }, [cdromUploadKey, setCancelUpload, upload?.cancelUpload]);
 
   return {
+    cdromUploadKey,
     clearCancelUpload,
     clearPersistedUpload,
     isUploadActive,
-    vmUploadKey,
   };
 };

--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -339,6 +339,16 @@ export const mountISOToCDROM = async (
     } else {
       draftVM.spec.template.spec.volumes = [...volumes, newVolume];
     }
+
+    if (diskState.dataVolumeTemplate) {
+      const templates = draftVM.spec.dataVolumeTemplates || [];
+      const templateName = getName(diskState.dataVolumeTemplate);
+      const hasTemplate = templates.some((template) => getName(template) === templateName);
+
+      if (!hasTemplate) {
+        draftVM.spec.dataVolumeTemplates = [...templates, diskState.dataVolumeTemplate];
+      }
+    }
   });
 };
 

--- a/src/utils/components/DiskModal/utils/submit.ts
+++ b/src/utils/components/DiskModal/utils/submit.ts
@@ -282,8 +282,7 @@ export const submitCDROM = async (
       );
 
       const submitResult = await onSubmit(updatedVMWithEmpty);
-      const vmAfterEmptyAdd: V1VirtualMachine =
-        submitResult && typeof submitResult === 'object' ? submitResult : updatedVMWithEmpty;
+      const vmAfterEmptyAdd = submitResult || updatedVMWithEmpty;
 
       const fullPromise = uploadDataVolume(vm, uploadData, mutableData, dvName).then(
         async (uploaded) => {

--- a/src/utils/hooks/mountIsoUploadStore.ts
+++ b/src/utils/hooks/mountIsoUploadStore.ts
@@ -22,50 +22,75 @@ type CancelUploadHandler = () => Promise<unknown> | void;
 
 type MountIsoUploadStore = {
   cancelUploads: Record<string, CancelUploadHandler>;
-  clearCancelUpload: (vmKey: string) => void;
-  clearUpload: (vmKey: string) => void;
-  getCancelUpload: (vmKey: string) => CancelUploadHandler | undefined;
-  getUpload: (vmKey: string) => MountIsoUploadState | undefined;
-  setCancelUpload: (vmKey: string, cancelUpload: CancelUploadHandler) => void;
-  setUpload: (vmKey: string, state: MountIsoUploadState) => void;
+  clearCancelUpload: (uploadKey: string) => void;
+  clearUpload: (uploadKey: string) => void;
+  getCancelUpload: (uploadKey: string) => CancelUploadHandler | undefined;
+  getUpload: (uploadKey: string) => MountIsoUploadState | undefined;
+  setCancelUpload: (uploadKey: string, cancelUpload: CancelUploadHandler) => void;
+  setUpload: (uploadKey: string, state: MountIsoUploadState) => void;
   uploads: Record<string, MountIsoUploadState>;
 };
 
+/**
+ * VM scope prefix: cluster/namespace/vmName
+ * @param cluster
+ * @param namespace
+ * @param vmName
+ */
 export const getVmUploadKey = (cluster: string, namespace: string, vmName: string): string =>
   `${cluster || ''}/${namespace}/${vmName}`;
 
 export const getVmUploadKeyFromVm = (vm: {
+  cluster?: string;
   metadata?: { name?: string; namespace?: string };
 }): string => getVmUploadKey(getCluster(vm), getNamespace(vm), getName(vm));
 
+export const getCdromUploadKey = (
+  cluster: string,
+  namespace: string,
+  vmName: string,
+  cdromDiskName: string,
+): string => `${getVmUploadKey(cluster, namespace, vmName)}/${cdromDiskName}`;
+
+export const getCdromUploadKeyFromVm = (
+  vm: { cluster?: string; metadata?: { name?: string; namespace?: string } },
+  cdromDiskName: string,
+): string => getCdromUploadKey(getCluster(vm), getNamespace(vm), getName(vm), cdromDiskName);
+
+export const getUploadEntriesForVm = (
+  uploads: Record<string, MountIsoUploadState>,
+  vmKey: string,
+): [string, MountIsoUploadState][] =>
+  Object.entries(uploads).filter(([key]) => key.startsWith(`${vmKey}/`));
+
 export const useMountIsoUploadStore = create<MountIsoUploadStore>((set, get) => ({
   cancelUploads: {},
-  clearCancelUpload: (vmKey) =>
+  clearCancelUpload: (uploadKey) =>
     set((state) => {
       const nextCancelUploads = { ...state.cancelUploads };
-      delete nextCancelUploads[vmKey];
+      delete nextCancelUploads[uploadKey];
       return { cancelUploads: nextCancelUploads };
     }),
-  clearUpload: (vmKey) =>
+  clearUpload: (uploadKey) =>
     set((state) => {
       const nextUploads = { ...state.uploads };
-      delete nextUploads[vmKey];
+      delete nextUploads[uploadKey];
       return { uploads: nextUploads };
     }),
-  getCancelUpload: (vmKey) => get().cancelUploads[vmKey],
-  getUpload: (vmKey) => get().uploads[vmKey],
-  setCancelUpload: (vmKey, cancelUpload) =>
+  getCancelUpload: (uploadKey) => get().cancelUploads[uploadKey],
+  getUpload: (uploadKey) => get().uploads[uploadKey],
+  setCancelUpload: (uploadKey, cancelUpload) =>
     set((state) => ({
       cancelUploads: {
         ...state.cancelUploads,
-        [vmKey]: cancelUpload,
+        [uploadKey]: cancelUpload,
       },
     })),
-  setUpload: (vmKey, uploadState) =>
+  setUpload: (uploadKey, uploadState) =>
     set((state) => ({
       uploads: {
         ...state.uploads,
-        [vmKey]: uploadState,
+        [uploadKey]: uploadState,
       },
     })),
   uploads: {},

--- a/src/utils/resources/vm/utils/disk/constants.ts
+++ b/src/utils/resources/vm/utils/disk/constants.ts
@@ -13,6 +13,7 @@ export type DiskRawData = {
 export type DiskRowDataLayout = {
   drive: string;
   hasDataVolume?: boolean;
+  hasPVC?: boolean;
   interface: string;
   isBootDisk: boolean;
   isEnvDisk: boolean;

--- a/src/utils/resources/vm/utils/disk/rowData.ts
+++ b/src/utils/resources/vm/utils/disk/rowData.ts
@@ -15,8 +15,12 @@ import {
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { DiskRawData, DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import {
+  getDataVolumeName,
   getPrintableDiskDrive,
   getPrintableDiskInterface,
+  getPVCClaimName,
+  hasDataVolume,
+  hasPersistentVolumeClaim,
 } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
 import { getHumanizedSize } from '@kubevirt-utils/utils/units';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -43,6 +47,7 @@ export const getDiskRowDataLayout = (
     const diskRowDataObject: DiskRowDataLayout = {
       drive: isEmpty(disk) || !isDiskConfigured ? NO_DATA_DASH : getPrintableDiskDrive(disk),
       hasDataVolume: Boolean(dataVolume),
+      hasPVC: Boolean(pvc),
       interface:
         isEmpty(disk) || !isDiskConfigured
           ? NO_DATA_DASH
@@ -71,6 +76,14 @@ export const getDiskRowDataLayout = (
       diskRowDataObject.sourceStatus = getPhase(source);
       diskRowDataObject.storageClass =
         getPVCStorageClassName(pvc) || getDataVolumeStorageClassName(dataVolume);
+    } else {
+      const volumeSourceName = getPVCClaimName(volume) ?? getDataVolumeName(volume);
+
+      if (volumeSourceName) {
+        diskRowDataObject.source = volumeSourceName;
+        diskRowDataObject.hasDataVolume = hasDataVolume(volume) || Boolean(dataVolumeTemplate);
+        diskRowDataObject.hasPVC = hasPersistentVolumeClaim(volume);
+      }
     }
 
     if (volumeSource === VolumeTypes.CONTAINER_DISK) {

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/hooks/useMountIsoUploadForDisk.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/hooks/useMountIsoUploadForDisk.ts
@@ -2,41 +2,43 @@ import { useCallback } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
-  getVmUploadKeyFromVm,
+  getCdromUploadKeyFromVm,
   UPLOAD_ALERT_STATUS,
   useMountIsoUploadStore,
 } from '@kubevirt-utils/hooks/mountIsoUploadStore';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 
 type UseMountIsoUploadForDiskResult = {
-  cancelUpload: () => Promise<void>;
+  cancelUpload: () => Promise<boolean>;
   isUploadInProgress: boolean;
 };
 
 export const cancelMountIsoUpload = async (
   vm: V1VirtualMachine,
   cdromDiskName: string,
-): Promise<void> => {
-  const vmKey = getVmUploadKeyFromVm(vm);
+): Promise<boolean> => {
+  const uploadKey = getCdromUploadKeyFromVm(vm, cdromDiskName);
   const { clearCancelUpload, clearUpload, getCancelUpload, getUpload } =
     useMountIsoUploadStore.getState();
-  const upload = getUpload(vmKey);
+  const upload = getUpload(uploadKey);
 
-  if (upload?.status !== UPLOAD_ALERT_STATUS.UPLOADING || upload.cdromDiskName !== cdromDiskName) {
-    return;
+  if (upload?.status !== UPLOAD_ALERT_STATUS.UPLOADING) {
+    return false;
   }
 
-  const cancelFn = getCancelUpload(vmKey);
+  const cancelFn = getCancelUpload(uploadKey);
   if (!cancelFn) {
-    return;
+    return false;
   }
 
   try {
     await cancelFn();
-    clearUpload(vmKey);
-    clearCancelUpload(vmKey);
+    clearUpload(uploadKey);
+    clearCancelUpload(uploadKey);
+    return true;
   } catch (error) {
     kubevirtConsole.error(error);
+    return false;
   }
 };
 
@@ -44,11 +46,10 @@ export const useMountIsoUploadForDisk = (
   vm: V1VirtualMachine,
   diskName: string,
 ): UseMountIsoUploadForDiskResult => {
-  const vmKey = getVmUploadKeyFromVm(vm);
-  const upload = useMountIsoUploadStore((state) => state.uploads[vmKey]);
+  const uploadKey = getCdromUploadKeyFromVm(vm, diskName);
+  const upload = useMountIsoUploadStore((state) => state.uploads[uploadKey]);
 
-  const isUploadInProgress =
-    upload?.status === UPLOAD_ALERT_STATUS.UPLOADING && upload.cdromDiskName === diskName;
+  const isUploadInProgress = upload?.status === UPLOAD_ALERT_STATUS.UPLOADING;
 
   const cancelUpload = useCallback(() => cancelMountIsoUpload(vm, diskName), [diskName, vm]);
 

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/hooks/useSyncMountIsoUploadEnded.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/hooks/useSyncMountIsoUploadEnded.ts
@@ -7,19 +7,19 @@ import {
 } from '@kubevirt-utils/hooks/mountIsoUploadStore';
 
 export const useSyncMountIsoUploadEnded = (
-  vmUploadKey: string,
+  cdromUploadKey: string,
   markBackgroundUploadEnded: () => void,
 ): void => {
   const persistedUploadStatus = useMountIsoUploadStore(
-    (state) => state.uploads[vmUploadKey]?.status,
+    (state) => state.uploads[cdromUploadKey]?.status,
   );
   const previousStatusRef = useRef<undefined | UploadAlertStatus>(undefined);
-  const previousKeyRef = useRef(vmUploadKey);
+  const previousKeyRef = useRef(cdromUploadKey);
 
   useEffect(() => {
-    if (previousKeyRef.current !== vmUploadKey) {
+    if (previousKeyRef.current !== cdromUploadKey) {
       previousStatusRef.current = undefined;
-      previousKeyRef.current = vmUploadKey;
+      previousKeyRef.current = cdromUploadKey;
       return;
     }
 
@@ -33,5 +33,5 @@ export const useSyncMountIsoUploadEnded = (
     }
 
     previousStatusRef.current = persistedUploadStatus;
-  }, [markBackgroundUploadEnded, persistedUploadStatus, vmUploadKey]);
+  }, [cdromUploadKey, markBackgroundUploadEnded, persistedUploadStatus]);
 };

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/hooks/useUploadAlert.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/hooks/useUploadAlert.ts
@@ -1,9 +1,12 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
+  getCdromUploadKeyFromVm,
+  getUploadEntriesForVm,
   getVmUploadKeyFromVm,
   UPLOAD_ALERT_STATUS,
+  UploadAlertStatus,
   useMountIsoUploadStore,
 } from '@kubevirt-utils/hooks/mountIsoUploadStore';
 import { isUploadCanceledError } from '@kubevirt-utils/hooks/useCDIUpload/errors';
@@ -17,37 +20,61 @@ type UseUploadAlertResult = {
   uploadError: string;
 };
 
+const pickVmAlertStatus = (
+  vmUploads: [string, { alertDismissed?: boolean; status: UploadAlertStatus }][],
+): null | UploadAlertStatus => {
+  const visible = vmUploads.filter(([, upload]) => !upload.alertDismissed);
+  if (visible.some(([, upload]) => upload.status === UPLOAD_ALERT_STATUS.UPLOADING)) {
+    return UPLOAD_ALERT_STATUS.UPLOADING;
+  }
+  if (visible.some(([, upload]) => upload.status === UPLOAD_ALERT_STATUS.ERROR)) {
+    return UPLOAD_ALERT_STATUS.ERROR;
+  }
+  if (visible.some(([, upload]) => upload.status === UPLOAD_ALERT_STATUS.SUCCESS)) {
+    return UPLOAD_ALERT_STATUS.SUCCESS;
+  }
+  return null;
+};
+
 export const useUploadAlert = (vm: V1VirtualMachine): UseUploadAlertResult => {
   const vmKey = getVmUploadKeyFromVm(vm);
 
-  const persistedUpload = useMountIsoUploadStore((state) => state.uploads[vmKey]);
+  const uploads = useMountIsoUploadStore((state) => state.uploads);
   const setUpload = useMountIsoUploadStore((state) => state.setUpload);
   const getUpload = useMountIsoUploadStore((state) => state.getUpload);
   const clearUpload = useMountIsoUploadStore((state) => state.clearUpload);
   const clearCancelUpload = useMountIsoUploadStore((state) => state.clearCancelUpload);
 
-  const uploadStatus = persistedUpload?.status ?? null;
-  const uploadError = persistedUpload?.errorMessage ?? '';
+  const vmUploads = useMemo(() => getUploadEntriesForVm(uploads, vmKey), [uploads, vmKey]);
+
+  const uploadStatus = pickVmAlertStatus(vmUploads);
+  const uploadError =
+    vmUploads.find(
+      ([, upload]) => !upload.alertDismissed && upload.status === UPLOAD_ALERT_STATUS.ERROR,
+    )?.[1]?.errorMessage ?? '';
 
   const onUploadStarted = useCallback(
     (uploadPromise: Promise<unknown>, cdromDiskName?: string): void => {
-      setUpload(vmKey, {
-        cdromDiskName: cdromDiskName ?? '',
+      const diskName = cdromDiskName ?? '';
+      const uploadKey = getCdromUploadKeyFromVm(vm, diskName);
+
+      setUpload(uploadKey, {
+        cdromDiskName: diskName,
         status: UPLOAD_ALERT_STATUS.UPLOADING,
       });
 
       uploadPromise
         .then(() => {
-          setUpload(vmKey, {
-            cdromDiskName: getUpload(vmKey)?.cdromDiskName,
+          setUpload(uploadKey, {
+            cdromDiskName: getUpload(uploadKey)?.cdromDiskName ?? diskName,
             status: UPLOAD_ALERT_STATUS.SUCCESS,
           });
-          clearCancelUpload(vmKey);
+          clearCancelUpload(uploadKey);
         })
         .catch((err: unknown) => {
           if (isUploadCanceledError(err)) {
-            clearUpload(vmKey);
-            clearCancelUpload(vmKey);
+            clearUpload(uploadKey);
+            clearCancelUpload(uploadKey);
             return;
           }
 
@@ -55,29 +82,29 @@ export const useUploadAlert = (vm: V1VirtualMachine): UseUploadAlertResult => {
             (err instanceof Error ? err.message : (err as { message?: string })?.message) ||
             String(err);
 
-          setUpload(vmKey, {
-            cdromDiskName: getUpload(vmKey)?.cdromDiskName,
+          setUpload(uploadKey, {
+            cdromDiskName: getUpload(uploadKey)?.cdromDiskName ?? diskName,
             errorMessage,
             status: UPLOAD_ALERT_STATUS.ERROR,
           });
-          clearCancelUpload(vmKey);
+          clearCancelUpload(uploadKey);
         });
     },
-    [clearCancelUpload, clearUpload, getUpload, setUpload, vmKey],
+    [clearCancelUpload, clearUpload, getUpload, setUpload, vm],
   );
 
   const dismissAlert = useCallback((): void => {
-    const current = getUpload(vmKey);
-    if (!current || current.status !== UPLOAD_ALERT_STATUS.UPLOADING) {
-      clearUpload(vmKey);
-      clearCancelUpload(vmKey);
-      return;
-    }
-    setUpload(vmKey, { ...current, alertDismissed: true });
-  }, [clearCancelUpload, clearUpload, getUpload, setUpload, vmKey]);
+    vmUploads.forEach(([uploadKey, upload]) => {
+      if (upload.status === UPLOAD_ALERT_STATUS.UPLOADING) {
+        setUpload(uploadKey, { ...upload, alertDismissed: true });
+      } else {
+        clearUpload(uploadKey);
+        clearCancelUpload(uploadKey);
+      }
+    });
+  }, [clearCancelUpload, clearUpload, setUpload, vmUploads]);
 
-  const isAlertDismissed = persistedUpload?.alertDismissed ?? false;
-  const alertConfig = uploadStatus && !isAlertDismissed ? uploadAlertConfig[uploadStatus] : null;
+  const alertConfig = uploadStatus ? uploadAlertConfig[uploadStatus] : null;
 
   return { alertConfig, dismissAlert, onUploadStarted, uploadError };
 };

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/MountCDROMModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/MountCDROMModal.tsx
@@ -23,6 +23,10 @@ import { useCDIUpload } from '@kubevirt-utils/hooks/useCDIUpload/useCDIUpload';
 import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import {
+  getDataVolumeName,
+  getPVCClaimName,
+} from '@kubevirt-utils/resources/vm/utils/disk/selectors';
 import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { ButtonVariant, Stack, StackItem } from '@patternfly/react-core';
@@ -30,7 +34,7 @@ import { isRunning } from '@virtualmachines/utils';
 
 import { useISOOptions } from './hooks/useISOOptions';
 import { useMountCDROMForm } from './hooks/useMountCDROMForm';
-import { buildDiskState } from './utils';
+import { buildDiskState, produceMountUploadVolumeState } from './utils';
 
 type MountCDROMModalProps = {
   cdromName: string;
@@ -80,8 +84,9 @@ const MountCDROMModal: FC<MountCDROMModalProps> = ({
   const { handleModalClose, isUploading, markBackgroundUploadEnded, markBackgroundUploadStarted } =
     useCDROMUploadClose(upload, onClose);
 
-  const { clearCancelUpload, clearPersistedUpload, isUploadActive, vmUploadKey } =
+  const { cdromUploadKey, clearCancelUpload, clearPersistedUpload, isUploadActive } =
     useCDROMUploadStore({
+      cdromDiskName: cdromName,
       isUploading,
       markBackgroundUploadEnded,
       upload,
@@ -113,29 +118,42 @@ const MountCDROMModal: FC<MountCDROMModalProps> = ({
     if (data.uploadFile?.file) {
       markBackgroundUploadStarted();
 
-      const uploadPromise = uploadDataVolume(vm, uploadData, diskState);
+      const diskStateForMount = produceMountUploadVolumeState(
+        diskState,
+        cdromName,
+        isHotPluggable,
+        isVMRunning,
+      );
+      const dvName =
+        getName(diskState.dataVolumeTemplate) ??
+        getDataVolumeName(diskState.volume) ??
+        getPVCClaimName(diskState.volume);
+
+      let vmAfterMount: V1VirtualMachine;
+      try {
+        const vmWithMountedDv = await mountISOToCDROM(vm, diskStateForMount, isHotPluggable);
+        const submitResult = await onSubmit?.(vmWithMountedDv);
+        vmAfterMount = submitResult ?? vmWithMountedDv;
+      } catch (error) {
+        markBackgroundUploadEnded();
+        throw error;
+      }
+
+      const uploadPromise = uploadDataVolume(vmAfterMount, uploadData, diskState, dvName);
 
       const fullPromise = uploadPromise
-        .then(async (uploadedDataVolume) => {
-          diskState.volume = {
-            dataVolume: { name: getName(uploadedDataVolume) },
-            name: diskState.volume.name,
-          };
-          delete diskState.dataVolumeTemplate;
-
-          const updatedVM = await mountISOToCDROM(vm, diskState, isHotPluggable);
-          await onSubmit?.(updatedVM);
+        .then(() => {
           onClose();
         })
         .catch((error: unknown) => {
           if (isUploadCanceledError(error)) {
-            clearPersistedUpload(vmUploadKey);
+            clearPersistedUpload(cdromUploadKey);
           }
           throw error;
         })
         .finally(() => {
           markBackgroundUploadEnded();
-          clearCancelUpload(vmUploadKey);
+          clearCancelUpload(cdromUploadKey);
         });
 
       if (onUploadStarted) {

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/utils.ts
@@ -23,7 +23,7 @@ import {
 } from '@kubevirt-utils/components/DiskModal/utils/constants';
 import { InterfaceTypes, V1DiskFormState } from '@kubevirt-utils/components/DiskModal/utils/types';
 import { DEFAULT_PREFERENCE_LABEL } from '@kubevirt-utils/constants/instancetypes-and-preferences';
-import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import {
   getDataVolumeTemplates,
   getDisks,
@@ -31,6 +31,7 @@ import {
   getVolumes,
 } from '@kubevirt-utils/resources/vm';
 import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
+import { getDataVolumeName } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
 import { getVMIDevices } from '@kubevirt-utils/resources/vmi';
 import { ARCHITECTURE_LABEL } from '@kubevirt-utils/utils/architecture';
 import { ensurePath, generateUploadDiskName, isEmpty } from '@kubevirt-utils/utils/utils';
@@ -160,6 +161,45 @@ export const persistVolume = (
       await addDataVolumeToVM(draftVM, volumeToPersist?.dataVolume?.name);
 
     return draftVM;
+  });
+
+/**
+ * Aligns mount upload volume with Add CD-ROM upload so Storage tab watches resolve the source.
+ * Running hot-pluggable VMs use a dataVolume ref; stopped VMs use a PVC claim on the upload DV name.
+ */
+export const produceMountUploadVolumeState = (
+  diskState: V1DiskFormState,
+  cdromName: string,
+  isHotPluggable: boolean,
+  isVMRunning: boolean,
+): V1DiskFormState =>
+  produce(diskState, (draft) => {
+    const dvName = getName(draft.dataVolumeTemplate) ?? getDataVolumeName(draft.volume);
+
+    if (!dvName) {
+      return;
+    }
+
+    if (isVMRunning && isHotPluggable) {
+      draft.volume = {
+        dataVolume: {
+          hotpluggable: true,
+          name: dvName,
+        },
+        name: cdromName,
+      };
+      delete draft.dataVolumeTemplate;
+      return;
+    }
+
+    draft.volume = {
+      name: cdromName,
+      persistentVolumeClaim: {
+        claimName: dvName,
+        ...(isHotPluggable && { hotpluggable: true }),
+      },
+    };
+    delete draft.dataVolumeTemplate;
   });
 
 export const buildDiskState = (

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRow.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRow.tsx
@@ -26,7 +26,6 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 
-import { isPVCSource } from './utils/helpers';
 import DiskRowActions from './DiskRowActions';
 import { HotplugLabel } from './HotplugLabel';
 import ISOBadge from './ISOBadge';
@@ -62,6 +61,7 @@ const DiskRow: FC<
   const {
     drive,
     hasDataVolume,
+    hasPVC,
     interface: iface,
     isBootDisk,
     isEnvDisk,
@@ -73,8 +73,6 @@ const DiskRow: FC<
   } = obj;
 
   const provisioningPercentage = provisioningPercentages?.[source];
-
-  const hasPVC = isPVCSource(obj);
 
   const { displayName } = useMemo(() => {
     const disks = getDisks(vm) || [];
@@ -139,7 +137,7 @@ const DiskRow: FC<
 
         {!sourcesLoaded && (hasPVC || hasDataVolume) && <Skeleton width="200px" />}
 
-        {!hasPVC && getTranslatedSource(source, t)}
+        {!hasPVC && !hasDataVolume && getTranslatedSource(source, t)}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="size">
         {readableSizeUnit(size)}

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
@@ -7,6 +7,7 @@ import {
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DiskModal from '@kubevirt-utils/components/DiskModal/DiskModal';
 import {
+  ejectISOFromCDROM,
   isDeclarativeHotplugVolumesEnabled,
   produceVMDisks,
 } from '@kubevirt-utils/components/DiskModal/utils/helpers';
@@ -197,25 +198,28 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
 
   const onToggle = () => setIsDropdownOpen((prevIsOpen) => !prevIsOpen);
 
-  const handleCancelMountIsoUpload = () => {
-    cancelUpload();
+  const handleCancelMountIsoUpload = async () => {
     setIsDropdownOpen(false);
+    const wasCanceled = await cancelUpload();
+    if (wasCanceled) {
+      const ejectedVM = ejectISOFromCDROM(vm, diskName);
+      await (onDiskUpdate || updateDisks)(ejectedVM);
+    }
   };
 
-  const mountCdromItem =
-    isCDROMMountedState || !isUploadInProgress ? (
-      <DropdownItem key="cdrom" onClick={() => onModalOpen(createCDROMModal)}>
-        {isCDROMMountedState ? t('Eject') : t('Mount')}
-      </DropdownItem>
-    ) : (
-      <Tooltip content={mountIsoUploadInProgressTooltip}>
-        <span>
-          <DropdownItem isDisabled key="cdrom">
-            {t('Mount')}
-          </DropdownItem>
-        </span>
-      </Tooltip>
-    );
+  const mountCdromItem = isUploadInProgress ? (
+    <Tooltip content={mountIsoUploadInProgressTooltip}>
+      <span>
+        <DropdownItem isDisabled key="cdrom">
+          {isCDROMMountedState ? t('Eject') : t('Mount')}
+        </DropdownItem>
+      </span>
+    </Tooltip>
+  ) : (
+    <DropdownItem key="cdrom" onClick={() => onModalOpen(createCDROMModal)}>
+      {isCDROMMountedState ? t('Eject') : t('Mount')}
+    </DropdownItem>
+  );
 
   return (
     <Dropdown

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/MountIsoUploadLabel.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/MountIsoUploadLabel.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
-  getVmUploadKeyFromVm,
+  getCdromUploadKeyFromVm,
   UPLOAD_ALERT_STATUS,
   useMountIsoUploadStore,
 } from '@kubevirt-utils/hooks/mountIsoUploadStore';
@@ -16,16 +16,23 @@ type MountIsoUploadLabelProps = {
 
 const MountIsoUploadLabel: FC<MountIsoUploadLabelProps> = ({ diskName, vm }) => {
   const { t } = useKubevirtTranslation();
-  const vmKey = getVmUploadKeyFromVm(vm);
-  const upload = useMountIsoUploadStore((state) => state.uploads[vmKey]);
+  const uploadKey = getCdromUploadKeyFromVm(vm, diskName);
+  const upload = useMountIsoUploadStore((state) => state.uploads[uploadKey]);
 
-  if (upload?.status !== UPLOAD_ALERT_STATUS.UPLOADING || upload.cdromDiskName !== diskName) {
+  if (upload?.status !== UPLOAD_ALERT_STATUS.UPLOADING) {
     return null;
   }
 
+  const labelText = t('Upload in progress');
+
   return (
-    <Label color="blue" icon={<Spinner size="sm" />} variant="outline">
-      {t('Upload in progress')}
+    <Label
+      aria-label={t('{{diskName}}: upload in progress', { diskName })}
+      color="blue"
+      icon={<Spinner aria-hidden size="sm" />}
+      variant="outline"
+    >
+      {labelText}
     </Label>
   );
 };

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/cells/DiskSourceCell.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/cells/DiskSourceCell.tsx
@@ -10,8 +10,6 @@ import MulticlusterResourceLink from '@multicluster/components/MulticlusterResou
 import { getCluster } from '@multicluster/helpers/selectors';
 import { Skeleton } from '@patternfly/react-core';
 
-import { isPVCSource } from '../utils/helpers';
-
 type DiskSourceCellProps = {
   row: DiskRowDataLayout;
   sourcesLoaded?: boolean;
@@ -19,10 +17,8 @@ type DiskSourceCellProps = {
 };
 
 const DiskSourceCell: FC<DiskSourceCellProps> = ({ row, sourcesLoaded, vm }) => {
-  const { hasDataVolume, namespace, source } = row;
+  const { hasDataVolume, hasPVC, namespace, source } = row;
   const dataTestId = `disk-source-${row.name}`;
-
-  const hasPVC = isPVCSource(row);
 
   if (!sourcesLoaded && (hasPVC || hasDataVolume)) {
     return <Skeleton data-test-id={dataTestId} width="200px" />;


### PR DESCRIPTION
## 📝 Description

Fixing number of issues related to CD-ROM ISO upload:

Mount ISO — source shows "other" during upload

  1. Uploading an ISO to an existing empty CD-ROM did not show the DataVolume name or upload phase in the Storage tab until the upload finished.


2. Add/Mount CD-ROM blocked while another upload runs - Opening Add CD-ROM or Mount ISO on a different drive showed the previous drive's uploading modal state.

3. Single upload indicator per VM - Only one "Upload in progress" label and upload record applied per VM; a second concurrent upload on another drive overwrote the first.

4. Upload state not scoped by cluster/namespace - Same drive name on a different VM could share upload state.

## 🔗 Links

Jira ticket: [CNV-87999](https://redhat.atlassian.net/browse/CNV-87999)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/38609e39-cc97-48ef-8139-de90fd636464


After:

https://github.com/user-attachments/assets/645a9aab-83ab-4fa5-9b37-9f2a2d5142e8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable per‑disk CD‑ROM ISO upload tracking, cancellation, and alerting across concurrent uploads.
  * Improved mount/eject behavior and clearer upload status display (actions disabled while uploading).

* **Refactor**
  * Upload keying and persisted upload state reorganized for consistent per‑disk handling.

* **New Features**
  * Better source/PVC detection in disk rows and improved accessibility for upload labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->