### PR TITLE
CNV-87480: [release-4.22] hide Windows OS options on s390x architecture (backport to release-4.22)

### DIFF
--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeEmptyState/BootableVolumeOSIcons.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeEmptyState/BootableVolumeOSIcons.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
 import { LINUX, OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
 import { Split, SplitItem } from '@patternfly/react-core';
 import { getIconByOSName } from '@virtualmachines/creation-wizard/utils/os-icons/os-icons';
@@ -11,6 +12,8 @@ type BootableVolumeOSIconsProps = {
 };
 
 const BootableVolumeOSIcons: FC<BootableVolumeOSIconsProps> = ({ osName }) => {
+  const isWindowsSupported = useIsWindowsSupportedArchitecture();
+
   if (osName) {
     const icon = getIconByOSName(osName);
     if (icon) {
@@ -27,7 +30,7 @@ const BootableVolumeOSIcons: FC<BootableVolumeOSIconsProps> = ({ osName }) => {
   const osIcons = [
     getIconByOSName(LINUX),
     getIconByOSName(OS_NAME_TYPES.rhel),
-    getIconByOSName(OS_NAME_TYPES.windows),
+    ...(isWindowsSupported ? [getIconByOSName(OS_NAME_TYPES.windows)] : []),
   ];
 
   return (

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/GuestOSStep/components/OperatingSystemTileGroup/OperatingSystemTileGroup.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/GuestOSStep/components/OperatingSystemTileGroup/OperatingSystemTileGroup.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
 import { Split, SplitItem } from '@patternfly/react-core';
 import useInstanceTypeVMStore from '@virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore';
 import { OperatingSystemType } from '@virtualmachines/creation-wizard/steps/InstanceTypesSteps/GuestOSStep/utils/constants';
@@ -8,20 +9,25 @@ import OperatingSystemTile from './components/OperatingSystemTile/OperatingSyste
 
 const OperatingSystemTileGroup: FC = () => {
   const { operatingSystemType, setOperatingSystemType } = useInstanceTypeVMStore();
+  const isWindowsSupported = useIsWindowsSupportedArchitecture();
+
+  const osTypes = [
+    OperatingSystemType.RHEL,
+    ...(isWindowsSupported ? [OperatingSystemType.WINDOWS] : []),
+    OperatingSystemType.OTHER_LINUX,
+  ];
 
   return (
     <Split hasGutter>
-      {[OperatingSystemType.RHEL, OperatingSystemType.WINDOWS, OperatingSystemType.OTHER_LINUX].map(
-        (osType) => (
-          <SplitItem key={osType}>
-            <OperatingSystemTile
-              isSelected={operatingSystemType === osType}
-              onClick={() => setOperatingSystemType(osType)}
-              operatingSystem={osType}
-            />
-          </SplitItem>
-        ),
-      )}
+      {osTypes.map((osType) => (
+        <SplitItem key={osType}>
+          <OperatingSystemTile
+            isSelected={operatingSystemType === osType}
+            onClick={() => setOperatingSystemType(osType)}
+            operatingSystem={osType}
+          />
+        </SplitItem>
+      ))}
     </Split>
   );
 };

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/TemplatesCatalog.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/TemplatesCatalog.tsx
@@ -3,7 +3,9 @@ import React, { FC, useMemo } from 'react';
 import { V1Template } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { logTemplateFlowEvent } from '@kubevirt-utils/extensions/telemetry/telemetry';
 import { TEMPLATE_SELECTED } from '@kubevirt-utils/extensions/telemetry/utils/constants';
-import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
+import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
+import { getTemplateVirtualMachineObject, OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
+import { getTemplateOS } from '@kubevirt-utils/resources/template/utils/selectors';
 import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { PageSection, Stack } from '@patternfly/react-core';
@@ -33,9 +35,19 @@ const TemplatesCatalog: FC = () => {
       onlyDefault: filters.onlyDefault,
     });
 
+  const isWindowsSupported = useIsWindowsSupportedArchitecture();
+
+  const supportedTemplates = useMemo(
+    () =>
+      isWindowsSupported
+        ? templates
+        : templates.filter((t) => getTemplateOS(t) !== OS_NAME_TYPES.windows),
+    [templates, isWindowsSupported],
+  );
+
   const filteredTemplates = useMemo(
-    () => filterTemplates(templates, filters),
-    [templates, filters],
+    () => filterTemplates(supportedTemplates, filters),
+    [supportedTemplates, filters],
   );
 
   useHideDeprecatedTemplateTiles(onFilterChange);

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesToolbar/components/TemplatesCatalogFilters/TemplatesCatalogFilters.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesToolbar/components/TemplatesCatalogFilters/TemplatesCatalogFilters.tsx
@@ -2,7 +2,9 @@ import React, { FC, memo, useMemo } from 'react';
 
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import useHcoWorkloadArchitectures from '@kubevirt-utils/hooks/useHcoWorkloadArchitectures';
+import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
 import {
   HIDE_DEPRECATED_TEMPLATES_KEY,
   OS_NAMES,
@@ -25,6 +27,13 @@ export const TemplatesCatalogFilters: FC<{
   onFilterChange: (type: CATALOG_FILTERS, value: boolean | string) => void;
 }> = memo(({ filters, onFilterChange }) => {
   const { t } = useKubevirtTranslation();
+  const isWindowsSupported = useIsWindowsSupportedArchitecture();
+
+  const osNames = useMemo(
+    () =>
+      isWindowsSupported ? OS_NAMES : OS_NAMES.filter((item) => item.id !== OS_NAME_TYPES.windows),
+    [isWindowsSupported],
+  );
 
   const workloadsArchitectures = useHcoWorkloadArchitectures();
   const workloadsArchitecturesItems = useMemo(
@@ -73,7 +82,7 @@ export const TemplatesCatalogFilters: FC<{
     }
 
     // Handle OS name filters
-    if (OS_NAMES.some((item) => item.id === value)) {
+    if (osNames.some((item) => item.id === value)) {
       onFilterChange(CATALOG_FILTERS.OS_NAME, value);
       return;
     }
@@ -140,7 +149,7 @@ export const TemplatesCatalogFilters: FC<{
       </SelectGroup>
 
       <SelectGroup label={t('Operating system')}>
-        {OS_NAMES.map((item) => (
+        {osNames.map((item) => (
           <SelectOption
             data-test-row-filter={item.id}
             hasCheckbox


### PR DESCRIPTION
## Summary

Backport of #3956 to `release-4.22`.

On s390x (IBM Z) clusters, Windows is not a supported guest OS. This PR hides Windows-related UI elements in the VM creation wizard when the cluster only supports s390x workloads.

**Changes:**
- `OperatingSystemTileGroup`: Skip the Windows tile in the Guest OS step when `useIsWindowsSupportedArchitecture()` returns `false`
- `BootableVolumeOSIcons`: Skip the Windows icon in the boot volume empty state when Windows is not supported
- `TemplatesCatalog`: Filter out Windows templates from the template catalog when Windows is not supported
- `TemplatesCatalogFilters`: Hide Windows from the OS filter dropdown on release-4.22 (adaptation for the release branch catalog filter implementation)

## Links

- https://issues.redhat.com/browse/CNV-87480
- Original PR: https://github.com/kubevirt-ui/kubevirt-plugin/pull/3956

## Test plan

- [ ] On an s390x-only cluster, verify Windows tile is hidden in Guest OS step
- [ ] On an s390x-only cluster, verify Windows icon is hidden in boot volume empty state
- [ ] On an s390x-only cluster, verify Windows templates are hidden in template catalog
- [ ] On an s390x-only cluster, verify Windows is not shown in OS filter dropdown
- [ ] On amd64/arm64 clusters, verify Windows options remain visible


Made with [Cursor](https://cursor.com)