### PR TITLE
[release-4.22] Backport Jira GitHub Actions workflows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,9 @@
 Thanks for creating a Pull Request 💖!
 
 Please read the following before submitting:
+- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
+  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
+  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
 - PRs that adds new external dependencies might take a while to review.
 - Keep your PR as small as possible.
 - Limit your PR to one type (feature, refactoring, ci, or bugfix)
@@ -10,6 +13,10 @@ Please read the following before submitting:
 ## 📝 Description
 
 > Add a brief description
+
+## 🔗 Links
+
+> Add JIRA, Docs, and other PR/Issue links
 
 ## 🎥 Demo
 

--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -1,0 +1,775 @@
+{
+  "name": "kubevirt-plugin-gh-scripts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kubevirt-plugin-gh-scripts",
+      "dependencies": {
+        "@octokit/rest": "^21.1.1",
+        "tsx": "^4.19.4"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.17",
+        "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
+      "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.2.2",
+        "@octokit/request": "^9.2.3",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
+      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
+      "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^10.1.4",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
+      "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^6.1.4",
+        "@octokit/plugin-paginate-rest": "^11.4.2",
+        "@octokit/plugin-request-log": "^5.3.1",
+        "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
+      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "name": "kubevirt-plugin-gh-scripts",
+  "type": "module",
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "dependencies": {
+    "@octokit/rest": "^21.1.1",
+    "tsx": "^4.19.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.17",
+    "typescript": "^5.8.3"
+  }
+}

--- a/.github/scripts/src/cherry-pick.ts
+++ b/.github/scripts/src/cherry-pick.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from 'node:child_process';
+import { Octokit } from '@octokit/rest';
+
+import { addLabel } from './github-comments.js';
+import { createPullRequest } from './github-repo.js';
+import { CONFLICT_LABEL, JIRA_BASE_URL } from './types/index.js';
+import type { CherryPickResult, ClonedTicket, JiraVersion } from './types/index.js';
+
+/** Run a git command via execFileSync, returning trimmed stdout. */
+const git = (...args: string[]): string =>
+  execFileSync('git', args, {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+
+/** Run a git command, returning empty string on failure. */
+const gitSafe = (...args: string[]): string => {
+  try {
+    return git(...args);
+  } catch {
+    return '';
+  }
+};
+
+/** Cherry-pick a commit onto a target branch; aborts cleanly on conflicts. */
+export const performCherryPick = (
+  targetBranch: string,
+  commitSha: string,
+  branchName: string,
+): CherryPickResult => {
+  let cherryPickClean = true;
+  let conflictDetails = '';
+
+  git('fetch', 'origin', targetBranch);
+  git('checkout', '-b', branchName, `origin/${targetBranch}`);
+
+  try {
+    git('cherry-pick', commitSha, '-m', '1', '--allow-empty');
+  } catch {
+    cherryPickClean = false;
+    conflictDetails = gitSafe('diff', '--name-only', '--diff-filter=U');
+    git('cherry-pick', '--abort');
+    git('commit', '--allow-empty', '-m',
+      `[CONFLICTS] Cherry-pick ${commitSha} to ${targetBranch} - manual resolution required`);
+  }
+
+  git('push', 'origin', branchName);
+
+  return { cherryPickClean, conflictDetails, cherryPickBranch: branchName };
+};
+
+/** Open a cherry-pick PR with ticket mapping table; marks as draft if conflicts. */
+export const openCherryPickPR = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  params: {
+    prTitle: string;
+    originalPrNumber: number;
+    targetBranch: string;
+    cherryPickBranch: string;
+    cherryPickClean: boolean;
+    conflictDetails: string;
+    clonedTickets: ClonedTicket[];
+    matchedVersion: JiraVersion;
+  },
+): Promise<{ number: number; html_url: string }> => {
+  const { originalPrNumber, targetBranch, matchedVersion, clonedTickets } = params;
+
+  const ticketMappingLines = clonedTickets.map((ct) =>
+    `| [${ct.originalKey}](${JIRA_BASE_URL}/browse/${ct.originalKey}) | [${ct.clonedKey}](${JIRA_BASE_URL}/browse/${ct.clonedKey}) |`,
+  );
+
+  const prBody = [
+    `## Cherry-pick of #${originalPrNumber} to \`${targetBranch}\``,
+    '',
+    `**Original PR**: #${originalPrNumber}`,
+    `**Fix version**: ${matchedVersion.name}`,
+    '',
+    '### Cloned tickets',
+    '| Original | Clone |',
+    '|----------|-------|',
+    ...ticketMappingLines,
+    '',
+    params.cherryPickClean
+      ? ':white_check_mark: Cherry-pick applied cleanly.'
+      : `:warning: **Cherry-pick had conflicts.** Files needing resolution:\n\`\`\`\n${params.conflictDetails}\n\`\`\``,
+  ].join('\n');
+
+  const newPr = await createPullRequest(octokit, owner, repo, {
+    title: params.prTitle,
+    body: prBody,
+    head: params.cherryPickBranch,
+    base: targetBranch,
+    draft: !params.cherryPickClean,
+  });
+
+  if (!params.cherryPickClean) {
+    await addLabel(octokit, owner, repo, newPr.number, CONFLICT_LABEL);
+  }
+
+  return newPr;
+};

--- a/.github/scripts/src/cherry-pick.ts
+++ b/.github/scripts/src/cherry-pick.ts
@@ -3,6 +3,7 @@ import { Octokit } from '@octokit/rest';
 
 import { addLabel } from './github-comments.js';
 import { createPullRequest } from './github-repo.js';
+import { rewriteJiraKeysInText, stripOriginalJiraKeys } from './version-utils.js';
 import { CONFLICT_LABEL, JIRA_BASE_URL } from './types/index.js';
 import type { CherryPickResult, ClonedTicket, JiraVersion } from './types/index.js';
 
@@ -22,11 +23,21 @@ const gitSafe = (...args: string[]): string => {
   }
 };
 
+/** Amend the latest commit message, preserving multi-line bodies. */
+const amendCommitMessage = (message: string): void => {
+  execFileSync('git', ['commit', '--amend', '-F', '-'], {
+    encoding: 'utf-8',
+    input: message,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+};
+
 /** Cherry-pick a commit onto a target branch; aborts cleanly on conflicts. */
 export const performCherryPick = (
   targetBranch: string,
   commitSha: string,
   branchName: string,
+  clonedTickets: ClonedTicket[],
 ): CherryPickResult => {
   let cherryPickClean = true;
   let conflictDetails = '';
@@ -36,12 +47,24 @@ export const performCherryPick = (
 
   try {
     git('cherry-pick', commitSha, '-m', '1', '--allow-empty');
+
+    if (clonedTickets.length > 0) {
+      const originalMessage = git('log', '-1', '--format=%B');
+      const rewrittenMessage = rewriteJiraKeysInText(originalMessage, clonedTickets);
+      if (rewrittenMessage !== originalMessage) {
+        amendCommitMessage(rewrittenMessage);
+      }
+    }
   } catch {
     cherryPickClean = false;
     conflictDetails = gitSafe('diff', '--name-only', '--diff-filter=U');
     git('cherry-pick', '--abort');
-    git('commit', '--allow-empty', '-m',
-      `[CONFLICTS] Cherry-pick ${commitSha} to ${targetBranch} - manual resolution required`);
+    git(
+      'commit',
+      '--allow-empty',
+      '-m',
+      `[CONFLICTS] Cherry-pick ${commitSha} to ${targetBranch} - manual resolution required`,
+    );
   }
 
   git('push', 'origin', branchName);
@@ -49,7 +72,42 @@ export const performCherryPick = (
   return { cherryPickClean, conflictDetails, cherryPickBranch: branchName };
 };
 
-/** Open a cherry-pick PR with ticket mapping table; marks as draft if conflicts. */
+/** Build PR body with clone ticket references only (no original Jira keys). */
+export const buildCherryPickPrBody = (params: {
+  originalPrNumber: number;
+  targetBranch: string;
+  matchedVersion: JiraVersion;
+  clonedTickets: ClonedTicket[];
+  cherryPickClean: boolean;
+  conflictDetails: string;
+}): string => {
+  const { originalPrNumber, targetBranch, matchedVersion, clonedTickets, cherryPickClean, conflictDetails } =
+    params;
+
+  const jiraLines = clonedTickets.map(
+    (ct) => `- [${ct.clonedKey}](${JIRA_BASE_URL}/browse/${ct.clonedKey})`,
+  );
+
+  const statusLine = cherryPickClean
+    ? ':white_check_mark: Cherry-pick applied cleanly.'
+    : `:warning: **Cherry-pick had conflicts.** Files needing resolution:\n\`\`\`\n${conflictDetails}\n\`\`\``;
+
+  const body = [
+    `## Cherry-pick to \`${targetBranch}\``,
+    '',
+    `**Source PR**: #${originalPrNumber}`,
+    `**Fix version**: ${matchedVersion.name}`,
+    '',
+    '### Jira',
+    ...jiraLines,
+    '',
+    statusLine,
+  ].join('\n');
+
+  return stripOriginalJiraKeys(body, clonedTickets);
+};
+
+/** Open a cherry-pick PR referencing only clone tickets; marks as draft if conflicts. */
 export const openCherryPickPR = async (
   octokit: Octokit,
   owner: string,
@@ -65,33 +123,13 @@ export const openCherryPickPR = async (
     matchedVersion: JiraVersion;
   },
 ): Promise<{ number: number; html_url: string }> => {
-  const { originalPrNumber, targetBranch, matchedVersion, clonedTickets } = params;
-
-  const ticketMappingLines = clonedTickets.map((ct) =>
-    `| [${ct.originalKey}](${JIRA_BASE_URL}/browse/${ct.originalKey}) | [${ct.clonedKey}](${JIRA_BASE_URL}/browse/${ct.clonedKey}) |`,
-  );
-
-  const prBody = [
-    `## Cherry-pick of #${originalPrNumber} to \`${targetBranch}\``,
-    '',
-    `**Original PR**: #${originalPrNumber}`,
-    `**Fix version**: ${matchedVersion.name}`,
-    '',
-    '### Cloned tickets',
-    '| Original | Clone |',
-    '|----------|-------|',
-    ...ticketMappingLines,
-    '',
-    params.cherryPickClean
-      ? ':white_check_mark: Cherry-pick applied cleanly.'
-      : `:warning: **Cherry-pick had conflicts.** Files needing resolution:\n\`\`\`\n${params.conflictDetails}\n\`\`\``,
-  ].join('\n');
+  const prBody = buildCherryPickPrBody(params);
 
   const newPr = await createPullRequest(octokit, owner, repo, {
     title: params.prTitle,
     body: prBody,
     head: params.cherryPickBranch,
-    base: targetBranch,
+    base: params.targetBranch,
     draft: !params.cherryPickClean,
   });
 

--- a/.github/scripts/src/clone-pr.ts
+++ b/.github/scripts/src/clone-pr.ts
@@ -120,7 +120,7 @@ const main = async (): Promise<void> => {
 
   let result: Awaited<ReturnType<typeof performCherryPick>>;
   try {
-    result = performCherryPick(targetBranch, commitSha, cherryPickBranch);
+    result = performCherryPick(targetBranch, commitSha, cherryPickBranch, clonedTickets);
   } catch (err) {
     const keys = clonedTickets
       .map((ct) => `[${ct.clonedKey}](${JIRA_BASE_URL}/browse/${ct.clonedKey})`)

--- a/.github/scripts/src/clone-pr.ts
+++ b/.github/scripts/src/clone-pr.ts
@@ -1,0 +1,183 @@
+import { JiraClient } from './jira-client.js';
+import { createOctokit, branchExists } from './github-repo.js';
+import { upsertComment } from './github-comments.js';
+import {
+  extractTicketIds,
+  extractVersionFromBranch,
+  findMatchingFixVersion,
+} from './version-utils.js';
+import { cloneAllTickets } from './clone-tickets.js';
+import { performCherryPick, openCherryPickPR } from './cherry-pick.js';
+import { requireEnv } from './utils.js';
+import { CLONE_COMMENT_MARKER, JIRA_BASE_URL, JIRA_PROJECT_KEY } from './types/index.js';
+import type { GitHubConfig } from './types/index.js';
+
+const ALLOWED_ASSOCIATIONS = new Set(['MEMBER', 'OWNER', 'COLLABORATOR']);
+const CLONE_CMD_REGEX = /^\/clone\s+(release-\d+\.\d+)\s*$/m;
+
+/** Post a clone failure message as an idempotent PR comment. */
+const postError = async (
+  octokit: ReturnType<typeof createOctokit>,
+  ghConfig: GitHubConfig,
+  prNumber: number,
+  message: string,
+): Promise<void> => {
+  await upsertComment(
+    octokit,
+    ghConfig.owner,
+    ghConfig.repo,
+    prNumber,
+    CLONE_COMMENT_MARKER,
+    `:x: **Clone failed**\n\n${message}`,
+  );
+};
+
+/** Entrypoint: parse /clone command, clone Jira tickets, cherry-pick, and open a new PR. */
+const main = async (): Promise<void> => {
+  const ghConfig: GitHubConfig = {
+    token: requireEnv('GITHUB_TOKEN'),
+    owner: requireEnv('REPO_OWNER'),
+    repo: requireEnv('REPO_NAME'),
+  };
+
+  const prNumber = parseInt(requireEnv('PR_NUMBER'), 10);
+  const prTitle = requireEnv('PR_TITLE');
+  const headSha = requireEnv('HEAD_SHA');
+  const mergeCommitSha = process.env['MERGE_COMMIT_SHA'] || '';
+  const commentBody = requireEnv('COMMENT_BODY');
+  const commentAuthorAssociation = requireEnv('COMMENT_AUTHOR_ASSOCIATION');
+  const octokit = createOctokit(ghConfig);
+
+  if (!ALLOWED_ASSOCIATIONS.has(commentAuthorAssociation)) {
+    await postError(octokit, ghConfig, prNumber, 'You do not have write access to use `/clone`.');
+    process.exit(1);
+  }
+
+  const cmdMatch = commentBody.match(CLONE_CMD_REGEX);
+  if (!cmdMatch) return;
+
+  const targetBranch = cmdMatch[1]!;
+  const targetVersion = extractVersionFromBranch(targetBranch);
+  if (!targetVersion) {
+    await postError(octokit, ghConfig, prNumber, `Invalid branch: \`${targetBranch}\``);
+    process.exit(1);
+  }
+
+  if (!(await branchExists(octokit, ghConfig.owner, ghConfig.repo, targetBranch))) {
+    await postError(octokit, ghConfig, prNumber, `Branch \`${targetBranch}\` does not exist.`);
+    process.exit(1);
+  }
+
+  const ticketIds = extractTicketIds(prTitle);
+  if (ticketIds.length === 0) {
+    await postError(octokit, ghConfig, prNumber, 'No `CNV-XXXXX` found in title.');
+    process.exit(1);
+  }
+
+  const jira = new JiraClient({
+    baseUrl: JIRA_BASE_URL,
+    token: requireEnv('JIRA_TOKEN'),
+    projectKey: JIRA_PROJECT_KEY,
+  });
+  const projectVersions = await jira.getProjectVersions(JIRA_PROJECT_KEY);
+  const matchedVersion = findMatchingFixVersion(projectVersions, targetVersion);
+  if (!matchedVersion) {
+    const available = projectVersions
+      .filter((v) => !v.archived)
+      .map((v) => v.name)
+      .join(', ');
+    await postError(
+      octokit,
+      ghConfig,
+      prNumber,
+      `No fix version for \`${targetVersion}\`.\n\nAvailable: ${available}`,
+    );
+    process.exit(1);
+  }
+
+  const repoFullName = `${ghConfig.owner}/${ghConfig.repo}`;
+  const clonedTickets = await cloneAllTickets(
+    jira,
+    ticketIds,
+    matchedVersion.id,
+    targetBranch,
+    prNumber,
+    repoFullName,
+  );
+  if (clonedTickets.length === 0) {
+    await postError(
+      octokit,
+      ghConfig,
+      prNumber,
+      `Failed to clone any tickets: ${ticketIds.join(', ')}`,
+    );
+    process.exit(1);
+  }
+
+  const primaryClone = clonedTickets[0]!;
+  const cherryPickBranch = `cherry-pick-${primaryClone.clonedKey.toLowerCase()}-to-${targetBranch}`;
+  const commitSha = mergeCommitSha || headSha;
+
+  let result: Awaited<ReturnType<typeof performCherryPick>>;
+  try {
+    result = performCherryPick(targetBranch, commitSha, cherryPickBranch);
+  } catch (err) {
+    const keys = clonedTickets
+      .map((ct) => `[${ct.clonedKey}](${JIRA_BASE_URL}/browse/${ct.clonedKey})`)
+      .join(', ');
+    await postError(octokit, ghConfig, prNumber, `Cherry-pick failed.\n\nCloned tickets: ${keys}`);
+    process.exit(1);
+  }
+
+  const originalSummary = prTitle.replace(/^(?:\[.*?\]\s*)?(?:CNV-\d+\s*)+:\s*/i, '').trim();
+  const newPrTitle = `[${targetBranch}] ${clonedTickets
+    .map((ct) => ct.clonedKey)
+    .join(' ')}: ${originalSummary}`;
+
+  const newPr = await openCherryPickPR(octokit, ghConfig.owner, ghConfig.repo, {
+    prTitle: newPrTitle,
+    originalPrNumber: prNumber,
+    targetBranch,
+    cherryPickBranch: result.cherryPickBranch,
+    cherryPickClean: result.cherryPickClean,
+    conflictDetails: result.conflictDetails,
+    clonedTickets,
+    matchedVersion,
+  });
+
+  const statusIcon = result.cherryPickClean ? ':white_check_mark:' : ':warning:';
+  const draftNote = result.cherryPickClean ? '' : ' (opened as **draft**)';
+  const rows = clonedTickets.map(
+    (ct) =>
+      `| ${ct.originalKey} → ${ct.clonedKey} | [${ct.clonedKey}](${JIRA_BASE_URL}/browse/${ct.clonedKey}) |`,
+  );
+
+  const comment = [
+    `${statusIcon} **Clone to \`${targetBranch}\` complete**${draftNote}`,
+    '',
+    '| Ticket mapping | Link |',
+    '|----------------|------|',
+    ...rows,
+    '',
+    '| | |',
+    '|---|---|',
+    `| **Fix version** | ${matchedVersion.name} |`,
+    `| **New PR** | #${newPr.number} |`,
+    `| **Cherry-pick** | ${result.cherryPickClean ? 'Clean' : 'Conflicts (see PR)'} |`,
+  ].join('\n');
+
+  await upsertComment(
+    octokit,
+    ghConfig.owner,
+    ghConfig.repo,
+    prNumber,
+    `<!-- jira-clone:${targetBranch} -->`,
+    comment,
+  );
+  console.log(`Done. New PR: ${newPr.html_url}`);
+};
+
+main().catch((err) => {
+  console.error('Unexpected error:', err instanceof Error ? err.message : 'Unknown error');
+  process.exit(1);
+});

--- a/.github/scripts/src/clone-tickets.ts
+++ b/.github/scripts/src/clone-tickets.ts
@@ -1,0 +1,68 @@
+import { JiraClient } from './jira-client.js';
+import { buildClonePayload } from './jira-clone-builder.js';
+import { jiraErrorMessage } from './utils.js';
+import type { ClonedTicket, JiraCreateIssuePayload, JiraIssue } from './types/index.js';
+
+/** Clone all Jira tickets for a release branch, linking and commenting on each original. */
+export const cloneAllTickets = async (
+  jira: JiraClient,
+  ticketIds: string[],
+  matchedVersionId: string,
+  targetBranch: string,
+  prNumber: number,
+  repoFullName: string,
+): Promise<ClonedTicket[]> => {
+  const discoveredFields = await jira.discoverCustomFields();
+  const projectVersions = await jira.getProjectVersions('CNV');
+  const matchedVersion = projectVersions.find((v) => v.id === matchedVersionId);
+  if (!matchedVersion) throw new Error(`Fix version ID ${matchedVersionId} not found`);
+
+  const clonedTickets: ClonedTicket[] = [];
+
+  for (const originalKey of ticketIds) {
+    let originalIssue: JiraIssue;
+    try {
+      originalIssue = await jira.getIssue(originalKey);
+    } catch (err) {
+      console.warn(`Warning: could not fetch ${originalKey}, skipping: ${jiraErrorMessage(err)}`);
+      continue;
+    }
+
+    let clonePayload: JiraCreateIssuePayload;
+    try {
+      clonePayload = buildClonePayload(originalIssue, matchedVersion, discoveredFields);
+    } catch (err) {
+      console.warn(`Warning: could not clone ${originalKey}: ${jiraErrorMessage(err)}`);
+      continue;
+    }
+
+    let clonedIssue: JiraIssue;
+
+    try {
+      clonedIssue = await jira.createIssue(clonePayload);
+    } catch (err) {
+      console.warn(`Warning: could not clone ${originalKey}: ${jiraErrorMessage(err)}`);
+      continue;
+    }
+
+    console.log(`Cloned: ${originalKey} → ${clonedIssue.key}`);
+    clonedTickets.push({ originalKey, clonedKey: clonedIssue.key });
+
+    try {
+      await jira.createIssueLink(clonedIssue.key, originalKey, 'Cloners');
+    } catch (err) {
+      console.warn(`Warning: could not link ${clonedIssue.key}: ${jiraErrorMessage(err)}`);
+    }
+
+    try {
+      await jira.addComment(
+        originalKey,
+        `Cloned to ${clonedIssue.key} for ${targetBranch} via PR #${prNumber} (${repoFullName})`,
+      );
+    } catch (err) {
+      console.warn(`Warning: could not comment on ${originalKey}: ${jiraErrorMessage(err)}`);
+    }
+  }
+
+  return clonedTickets;
+};

--- a/.github/scripts/src/github-comments.ts
+++ b/.github/scripts/src/github-comments.ts
@@ -1,0 +1,116 @@
+import { Octokit } from '@octokit/rest';
+
+import { BLOCK_LABEL, VALIDATION_COMMENT_MARKER } from './types/index.js';
+
+/** Post or update an idempotent comment identified by a hidden HTML marker. */
+export const upsertComment = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  marker: string,
+  body: string,
+): Promise<void> => {
+  const markedBody = `${marker}\n${body}`;
+
+  const comments = await octokit.paginate(octokit.issues.listComments, {
+    owner, repo, issue_number: issueNumber, per_page: 100,
+  });
+
+  const existing = comments.find((c) => c.body?.includes(marker));
+
+  if (existing) {
+    await octokit.issues.updateComment({ owner, repo, comment_id: existing.id, body: markedBody });
+  } else {
+    await octokit.issues.createComment({ owner, repo, issue_number: issueNumber, body: markedBody });
+  }
+};
+
+/** Add a label to a PR, auto-creating the label if it doesn't exist. */
+export const addLabel = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  label: string,
+): Promise<void> => {
+  try {
+    await octokit.issues.getLabel({ owner, repo, name: label });
+  } catch (err: unknown) {
+    const status = (err as { status?: number }).status;
+    if (status === 404) {
+      await octokit.issues.createLabel({
+        owner, repo, name: label, color: 'e11d48',
+        description: 'Automated label for Jira integration',
+      });
+    }
+  }
+
+  await octokit.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: [label] });
+};
+
+/** Remove a label from a PR (no-op if the label is not present). */
+export const removeLabel = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  label: string,
+): Promise<void> => {
+  try {
+    await octokit.issues.removeLabel({ owner, repo, issue_number: issueNumber, name: label });
+  } catch {
+    // Label not present
+  }
+};
+
+/** Check whether a specific label is present on a PR. */
+export const hasLabel = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  label: string,
+): Promise<boolean> => {
+  const { data: labels } = await octokit.issues.listLabelsOnIssue({
+    owner, repo, issue_number: issueNumber, per_page: 100,
+  });
+  return labels.some((l) => l.name === label);
+};
+
+/** Create or update a GitHub commit status for the jira-validation check. */
+export const setCommitStatus = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  sha: string,
+  state: 'pending' | 'success' | 'failure' | 'error',
+  description: string,
+): Promise<void> => {
+  await octokit.repos.createCommitStatus({
+    owner,
+    repo,
+    sha,
+    state,
+    context: 'jira-validation',
+    description: description.slice(0, 140),
+  });
+};
+
+/** Update the validation comment and add/remove the block label based on result. */
+export const reportValidation = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  passed: boolean,
+  commentBody: string,
+): Promise<void> => {
+  await upsertComment(octokit, owner, repo, prNumber, VALIDATION_COMMENT_MARKER, commentBody);
+
+  if (passed) {
+    await removeLabel(octokit, owner, repo, prNumber, BLOCK_LABEL);
+  } else {
+    await addLabel(octokit, owner, repo, prNumber, BLOCK_LABEL);
+  }
+};

--- a/.github/scripts/src/github-repo.ts
+++ b/.github/scripts/src/github-repo.ts
@@ -1,0 +1,66 @@
+import { Octokit } from '@octokit/rest';
+
+import type { GitHubConfig } from './types/index.js';
+
+/** Create an authenticated Octokit instance. */
+export const createOctokit = (config: GitHubConfig): Octokit =>
+  new Octokit({ auth: config.token });
+
+/** Fetch all branch names matching "release-*" from the repo. */
+export const getReleaseBranches = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+): Promise<string[]> => {
+  const branches: string[] = [];
+  let page = 1;
+
+  while (true) {
+    const { data } = await octokit.repos.listBranches({ owner, repo, per_page: 100, page });
+
+    if (data.length === 0) break;
+
+    for (const branch of data) {
+      if (branch.name.startsWith('release-')) {
+        branches.push(branch.name);
+      }
+    }
+
+    if (data.length < 100) break;
+    page++;
+  }
+
+  return branches;
+};
+
+/** Check if a branch exists in the repo. */
+export const branchExists = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  branch: string,
+): Promise<boolean> => {
+  try {
+    await octokit.repos.getBranch({ owner, repo, branch });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** Create a pull request and return its number and URL. */
+export const createPullRequest = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  params: {
+    title: string;
+    body: string;
+    head: string;
+    base: string;
+    draft?: boolean;
+  },
+): Promise<{ number: number; html_url: string }> => {
+  const { data } = await octokit.pulls.create({ owner, repo, ...params });
+  return { number: data.number, html_url: data.html_url };
+};

--- a/.github/scripts/src/jira-adf-utils.ts
+++ b/.github/scripts/src/jira-adf-utils.ts
@@ -1,0 +1,58 @@
+type AdfNode = {
+  type: string;
+  content?: AdfNode[];
+  [key: string]: unknown;
+};
+
+type AdfDoc = {
+  type: string;
+  version: number;
+  content: AdfNode[];
+};
+
+/** ADF node types that reference issue-specific assets and cannot be reused on create. */
+const UNSUPPORTED_CLONE_NODES = new Set(['media', 'mediaSingle', 'mediaGroup', 'inlineCard']);
+
+const sanitizeAdfNode = (node: AdfNode): AdfNode | null => {
+  if (UNSUPPORTED_CLONE_NODES.has(node.type)) {
+    return null;
+  }
+
+  if (!node.content) {
+    return node;
+  }
+
+  const content = node.content
+    .map(sanitizeAdfNode)
+    .filter((child): child is AdfNode => child !== null);
+
+  if (content.length === 0 && (node.type === 'paragraph' || node.type === 'heading')) {
+    return null;
+  }
+
+  return { ...node, content };
+};
+
+/** Remove embedded media and other issue-bound nodes from an ADF description before cloning. */
+export const sanitizeDescriptionForClone = (description: unknown): unknown | undefined => {
+  if (description == null) {
+    return undefined;
+  }
+
+  if (typeof description !== 'object') {
+    return description;
+  }
+
+  const doc = description as AdfDoc;
+  if (doc.type !== 'doc' || !Array.isArray(doc.content)) {
+    return description;
+  }
+
+  const content = doc.content.map(sanitizeAdfNode).filter((node): node is AdfNode => node !== null);
+
+  if (content.length === 0) {
+    return undefined;
+  }
+
+  return { ...doc, content };
+};

--- a/.github/scripts/src/jira-client.ts
+++ b/.github/scripts/src/jira-client.ts
@@ -1,0 +1,130 @@
+import type {
+  DiscoveredFields,
+  JiraConfig,
+  JiraCreateIssuePayload,
+  JiraFieldMeta,
+  JiraIssue,
+  JiraVersion,
+} from './types/index.js';
+
+type RequestOptions = {
+  method?: string;
+  body?: unknown;
+  params?: Record<string, string>;
+};
+
+/** Typed Jira Cloud REST API client with Basic auth. */
+export class JiraClient {
+  private baseUrl: string;
+  private authHeader: string;
+  private fieldCache: DiscoveredFields | null = null;
+
+  constructor(config: JiraConfig) {
+    this.baseUrl = config.baseUrl.replace(/\/$/, '');
+    this.authHeader = `Basic ${config.token}`;
+  }
+
+  private request = async <T>(path: string, options: RequestOptions = {}): Promise<T> => {
+    const { method = 'GET', body, params } = options;
+    let url = `${this.baseUrl}/rest/api/3${path}`;
+
+    if (params) {
+      const searchParams = new URLSearchParams(params);
+      url += `?${searchParams.toString()}`;
+    }
+
+    const response = await fetch(url, {
+      method,
+      headers: {
+        Authorization: this.authHeader,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(
+        `Jira API ${method} ${path} failed with status ${response.status}`,
+        { cause: text },
+      );
+    }
+
+    if (response.status === 204 || response.headers.get('content-length') === '0') {
+      return undefined as T;
+    }
+
+    return response.json() as Promise<T>;
+  };
+
+  /** Fetch a single Jira issue by key. */
+  getIssue = async (issueKey: string): Promise<JiraIssue> =>
+    this.request<JiraIssue>(`/issue/${issueKey}`);
+
+  /** Fetch all versions (fix versions) for a Jira project. */
+  getProjectVersions = async (projectKey: string): Promise<JiraVersion[]> =>
+    this.request<JiraVersion[]>(`/project/${projectKey}/versions`);
+
+  getAllFields = async (): Promise<JiraFieldMeta[]> =>
+    this.request<JiraFieldMeta[]>('/field');
+
+  /** Auto-discover custom field IDs for "Story Points" and "Activity Type" (cached). */
+  discoverCustomFields = async (): Promise<DiscoveredFields> => {
+    if (this.fieldCache) return this.fieldCache;
+
+    const fields = await this.getAllFields();
+    let storyPointsFieldId: string | null = null;
+    let activityTypeFieldId: string | null = null;
+
+    for (const field of fields) {
+      const nameLower = field.name.toLowerCase();
+      if (!storyPointsFieldId && nameLower === 'story points') {
+        storyPointsFieldId = field.id;
+      }
+      if (!activityTypeFieldId && nameLower === 'activity type') {
+        activityTypeFieldId = field.id;
+      }
+      if (storyPointsFieldId && activityTypeFieldId) break;
+    }
+
+    this.fieldCache = { storyPointsFieldId, activityTypeFieldId };
+    return this.fieldCache;
+  };
+
+  /** Create a new Jira issue. */
+  createIssue = async (payload: JiraCreateIssuePayload): Promise<JiraIssue> =>
+    this.request<JiraIssue>('/issue', { method: 'POST', body: payload });
+
+  /** Link two issues (e.g., "Cloners" link type). */
+  createIssueLink = async (
+    inwardIssueKey: string,
+    outwardIssueKey: string,
+    linkTypeName: string = 'Cloners',
+  ): Promise<void> => {
+    await this.request<void>('/issueLink', {
+      method: 'POST',
+      body: {
+        type: { name: linkTypeName },
+        inwardIssue: { key: inwardIssueKey },
+        outwardIssue: { key: outwardIssueKey },
+      },
+    });
+  };
+
+  /** Add a text comment to a Jira issue using ADF format. */
+  addComment = async (issueKey: string, bodyText: string): Promise<void> => {
+    await this.request<unknown>(`/issue/${issueKey}/comment`, {
+      method: 'POST',
+      body: {
+        body: {
+          type: 'doc',
+          version: 1,
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: bodyText }] },
+          ],
+        },
+      },
+    });
+  };
+}

--- a/.github/scripts/src/jira-clone-builder.ts
+++ b/.github/scripts/src/jira-clone-builder.ts
@@ -1,0 +1,64 @@
+import { sanitizeDescriptionForClone } from './jira-adf-utils.js';
+import type {
+  DiscoveredFields,
+  JiraCreateIssuePayload,
+  JiraIssue,
+  JiraVersion,
+} from './types/index.js';
+
+const isCustomFieldOption = (value: unknown): value is { id: string } =>
+  typeof value === 'object' &&
+  value !== null &&
+  'id' in value &&
+  typeof (value as { id: unknown }).id === 'string';
+
+/** Build a Jira create-issue payload that clones an original ticket with a new fix version. */
+export const buildClonePayload = (
+  original: JiraIssue,
+  targetFixVersion: JiraVersion,
+  discoveredFields: DiscoveredFields,
+): JiraCreateIssuePayload => {
+  const { fields } = original;
+  const description = sanitizeDescriptionForClone(fields.description);
+  if (description == null) {
+    throw new Error(
+      `Cannot clone ${original.key}: description is missing or empty after sanitization`,
+    );
+  }
+
+  const payload: JiraCreateIssuePayload = {
+    fields: {
+      project: { key: 'CNV' },
+      issuetype: { id: fields.issuetype.id },
+      summary: fields.summary,
+      description,
+      labels: [...fields.labels],
+      components: fields.components.map((c) => ({ id: c.id })),
+      fixVersions: [{ id: targetFixVersion.id }],
+    },
+  };
+  if (fields.assignee) {
+    payload.fields.assignee = { accountId: fields.assignee.accountId };
+  }
+  if (fields.priority) {
+    payload.fields.priority = { id: fields.priority.id };
+  }
+
+  if (discoveredFields.storyPointsFieldId) {
+    const spValue = fields[discoveredFields.storyPointsFieldId as `customfield_${string}`];
+    if (spValue != null) {
+      payload.fields[discoveredFields.storyPointsFieldId as `customfield_${string}`] = spValue;
+    }
+  }
+
+  if (discoveredFields.activityTypeFieldId) {
+    const atValue = fields[discoveredFields.activityTypeFieldId as `customfield_${string}`];
+    if (isCustomFieldOption(atValue)) {
+      payload.fields[discoveredFields.activityTypeFieldId as `customfield_${string}`] = {
+        id: atValue.id,
+      };
+    }
+  }
+
+  return payload;
+};

--- a/.github/scripts/src/types/config.ts
+++ b/.github/scripts/src/types/config.ts
@@ -1,0 +1,38 @@
+export type ValidationCheck = {
+  name: string;
+  passed: boolean;
+  message: string;
+};
+
+export type JiraConfig = {
+  baseUrl: string;
+  token: string;
+  projectKey: string;
+};
+
+export type GitHubConfig = {
+  token: string;
+  owner: string;
+  repo: string;
+};
+
+export type ClonedTicket = {
+  originalKey: string;
+  clonedKey: string;
+};
+
+export type CherryPickResult = {
+  cherryPickClean: boolean;
+  conflictDetails: string;
+  cherryPickBranch: string;
+};
+
+export const JIRA_BASE_URL = 'https://redhat.atlassian.net';
+export const JIRA_PROJECT_KEY = 'CNV';
+export const REQUIRED_COMPONENT = 'CNV User Interface';
+export const VALIDATION_COMMENT_MARKER = '<!-- jira-validation -->';
+export const CLONE_COMMENT_MARKER = '<!-- jira-clone-result -->';
+export const BLOCK_LABEL = 'do-not-merge/jira-invalid';
+export const SKIP_LABEL = 'skip-jira-check';
+export const CONFLICT_LABEL = 'do-not-merge/has-conflicts';
+export const MIN_STORY_POINTS = 2;

--- a/.github/scripts/src/types/index.ts
+++ b/.github/scripts/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './jira.js';
+export * from './config.js';

--- a/.github/scripts/src/types/jira.ts
+++ b/.github/scripts/src/types/jira.ts
@@ -1,0 +1,94 @@
+export type JiraUser = {
+  accountId: string;
+  displayName: string;
+  emailAddress?: string;
+  active: boolean;
+};
+
+export type JiraVersion = {
+  id: string;
+  name: string;
+  archived: boolean;
+  released: boolean;
+  description?: string;
+};
+
+export type JiraComponent = {
+  id: string;
+  name: string;
+  description?: string;
+};
+
+export type JiraPriority = {
+  id: string;
+  name: string;
+};
+
+export type JiraIssueType = {
+  id: string;
+  name: string;
+  subtask: boolean;
+};
+
+export type JiraStatus = {
+  id: string;
+  name: string;
+  statusCategory: { key: string; name: string };
+};
+
+export type JiraIssueLink = {
+  id: string;
+  type: { id: string; name: string; inward: string; outward: string };
+  inwardIssue?: { key: string };
+  outwardIssue?: { key: string };
+};
+
+export type JiraIssueFields = {
+  summary: string;
+  description: unknown;
+  issuetype: JiraIssueType;
+  status: JiraStatus;
+  priority: JiraPriority;
+  assignee: JiraUser | null;
+  reporter: JiraUser | null;
+  labels: string[];
+  components: JiraComponent[];
+  fixVersions: JiraVersion[];
+  issuelinks: JiraIssueLink[];
+  [customField: `customfield_${string}`]: unknown;
+};
+
+export type JiraIssue = {
+  id: string;
+  key: string;
+  self: string;
+  fields: JiraIssueFields;
+};
+
+export type JiraFieldMeta = {
+  id: string;
+  key: string;
+  name: string;
+  custom: boolean;
+  schema?: { type: string; custom?: string };
+};
+
+export type JiraCreateIssuePayload = {
+  fields: {
+    project: { key: string };
+    issuetype: { id: string };
+    summary: string;
+    description?: unknown;
+    labels?: string[];
+    components?: Array<{ id: string }>;
+    assignee?: { accountId: string } | null;
+    priority?: { id: string };
+    fixVersions?: Array<{ id: string }>;
+    [customField: `customfield_${string}`]: unknown;
+  };
+};
+
+export type DiscoveredFields = {
+  storyPointsFieldId: string | null;
+  activityTypeFieldId: string | null;
+};

--- a/.github/scripts/src/utils.ts
+++ b/.github/scripts/src/utils.ts
@@ -1,0 +1,29 @@
+/** Read a required environment variable or exit with an error. */
+export const requireEnv = (name: string): string => {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required environment variable: ${name}`);
+    process.exit(1);
+  }
+  return value;
+};
+
+/** Extract a safe error message without leaking headers or response bodies. */
+export const safeErrorMessage = (err: unknown): string => {
+  if (err instanceof Error) return err.message;
+  return 'Unknown error';
+};
+
+/** Format a Jira API error, including the response body when present. */
+export const jiraErrorMessage = (err: unknown): string => {
+  if (!(err instanceof Error)) {
+    return 'Unknown error';
+  }
+
+  const cause = err.cause;
+  if (typeof cause === 'string' && cause.length > 0) {
+    return `${err.message}: ${cause}`;
+  }
+
+  return err.message;
+};

--- a/.github/scripts/src/validate-pr.ts
+++ b/.github/scripts/src/validate-pr.ts
@@ -1,0 +1,126 @@
+import { JiraClient } from './jira-client.js';
+import { createOctokit, getReleaseBranches } from './github-repo.js';
+import { hasLabel, reportValidation, setCommitStatus } from './github-comments.js';
+import { extractTicketIds, getExpectedVersionForBranch } from './version-utils.js';
+import { validateTicket, formatValidationComment } from './validation-checks.js';
+import { requireEnv, safeErrorMessage } from './utils.js';
+import { JIRA_BASE_URL, SKIP_LABEL } from './types/index.js';
+import type { GitHubConfig, JiraIssue, ValidationCheck } from './types/index.js';
+
+/** Entrypoint: extract ticket IDs from PR title and validate each against Jira. */
+const main = async (): Promise<void> => {
+  const ghConfig: GitHubConfig = {
+    token: requireEnv('GITHUB_TOKEN'),
+    owner: requireEnv('REPO_OWNER'),
+    repo: requireEnv('REPO_NAME'),
+  };
+
+  const prNumber = parseInt(requireEnv('PR_NUMBER'), 10);
+  const prTitle = requireEnv('PR_TITLE');
+  const baseBranch = requireEnv('BASE_BRANCH');
+  const headSha = process.env.PR_HEAD_SHA;
+  const octokit = createOctokit(ghConfig);
+
+  if (headSha) {
+    await setCommitStatus(octokit, ghConfig.owner, ghConfig.repo, headSha, 'pending', 'Jira validation in progress…');
+  }
+
+  const shouldSkip = await hasLabel(octokit, ghConfig.owner, ghConfig.repo, prNumber, SKIP_LABEL);
+  if (shouldSkip) {
+    console.log(`Label "${SKIP_LABEL}" found, skipping Jira validation.`);
+    await reportValidation(
+      octokit, ghConfig.owner, ghConfig.repo, prNumber, true,
+      `:white_check_mark: **Jira Validation Skipped** — \`${SKIP_LABEL}\` label is present.`,
+    );
+    if (headSha) {
+      await setCommitStatus(octokit, ghConfig.owner, ghConfig.repo, headSha, 'success', 'Jira validation skipped');
+    }
+    return;
+  }
+
+  const ticketIds = extractTicketIds(prTitle);
+  if (ticketIds.length === 0) {
+    const msg =
+      ':x: **Jira Validation Failed**\n\n' +
+      'No `CNV-XXXXX` ticket ID found in the PR title.\n\n' +
+      'PR titles must start with a Jira ticket ID, e.g.:\n' +
+      '- `CNV-12345: Fix the login button`\n' +
+      '- `[release-4.21] CNV-12345: Backport fix`\n\n' +
+      '> Edit your PR title to include a valid Jira ticket ID.';
+
+    await reportValidation(octokit, ghConfig.owner, ghConfig.repo, prNumber, false, msg);
+    if (headSha) {
+      await setCommitStatus(octokit, ghConfig.owner, ghConfig.repo, headSha, 'failure', 'No CNV ticket ID found in PR title');
+    }
+    process.exit(1);
+  }
+
+  const releaseBranches = await getReleaseBranches(octokit, ghConfig.owner, ghConfig.repo);
+  const expectedVersion = getExpectedVersionForBranch(baseBranch, releaseBranches);
+
+  const jira = new JiraClient({
+    baseUrl: JIRA_BASE_URL,
+    token: requireEnv('JIRA_TOKEN'),
+    projectKey: 'CNV',
+  });
+
+  const allChecks = new Map<string, ValidationCheck[]>();
+  let allPassed = true;
+
+  for (const ticketKey of ticketIds) {
+    let issue: JiraIssue;
+    try {
+      issue = await jira.getIssue(ticketKey);
+    } catch (err) {
+      allChecks.set(ticketKey, [
+        { name: 'Ticket Exists', passed: false, message: `Could not fetch ticket: ${safeErrorMessage(err)}` },
+      ]);
+      allPassed = false;
+      continue;
+    }
+
+    const checks = await validateTicket(jira, issue, expectedVersion, baseBranch);
+    allChecks.set(ticketKey, checks);
+
+    if (checks.some((c) => !c.passed)) {
+      allPassed = false;
+    }
+  }
+
+  const commentBody = formatValidationComment(ticketIds, allChecks, allPassed);
+  await reportValidation(octokit, ghConfig.owner, ghConfig.repo, prNumber, allPassed, commentBody);
+
+  if (headSha) {
+    await setCommitStatus(
+      octokit, ghConfig.owner, ghConfig.repo, headSha,
+      allPassed ? 'success' : 'failure',
+      allPassed ? 'All Jira checks passed' : 'One or more Jira checks failed',
+    );
+  }
+
+  if (!allPassed) {
+    console.error('Jira validation failed. See PR comment for details.');
+    process.exit(1);
+  }
+
+  console.log('Jira validation passed.');
+};
+
+main().catch(async (err) => {
+  console.error('Unexpected error:', safeErrorMessage(err));
+  const headSha = process.env.PR_HEAD_SHA;
+  if (headSha) {
+    try {
+      const ghConfig: GitHubConfig = {
+        token: process.env.GITHUB_TOKEN ?? '',
+        owner: process.env.REPO_OWNER ?? '',
+        repo: process.env.REPO_NAME ?? '',
+      };
+      const octokit = createOctokit(ghConfig);
+      await setCommitStatus(octokit, ghConfig.owner, ghConfig.repo, headSha, 'error', 'Jira validation encountered an unexpected error');
+    } catch {
+      // best-effort
+    }
+  }
+  process.exit(1);
+});

--- a/.github/scripts/src/validation-checks.ts
+++ b/.github/scripts/src/validation-checks.ts
@@ -1,0 +1,116 @@
+import { JiraClient } from './jira-client.js';
+import {
+  extractVersionNumber,
+  fixVersionMatchesBranch,
+  suggestBranchForFixVersion,
+} from './version-utils.js';
+import { JIRA_BASE_URL, MIN_STORY_POINTS, REQUIRED_COMPONENT } from './types/index.js';
+import type { JiraIssue, ValidationCheck } from './types/index.js';
+
+/** Validate story points, fix version, component, and activity type on a Jira ticket. */
+export const validateTicket = async (
+  jira: JiraClient,
+  issue: JiraIssue,
+  expectedVersion: string | null,
+  baseBranch: string,
+): Promise<ValidationCheck[]> => {
+  const checks: ValidationCheck[] = [];
+  const discoveredFields = await jira.discoverCustomFields();
+
+  const spFieldId = discoveredFields.storyPointsFieldId;
+  let storyPoints: number | null = null;
+  if (spFieldId) {
+    const raw = issue.fields[spFieldId as `customfield_${string}`];
+    storyPoints = typeof raw === 'number' ? raw : null;
+  }
+  checks.push({
+    name: 'Story Points',
+    passed: storyPoints !== null && storyPoints >= MIN_STORY_POINTS,
+    message:
+      storyPoints === null
+        ? 'Story points are not set on the ticket'
+        : storyPoints < MIN_STORY_POINTS
+          ? `Story points must be greater than 1 (current: ${storyPoints})`
+          : `Story points: ${storyPoints}`,
+  });
+
+  const fixVersions = issue.fields.fixVersions;
+  if (fixVersions.length === 0) {
+    checks.push({ name: 'Fix Version', passed: false, message: 'No fix version is set on the ticket' });
+  } else if (expectedVersion) {
+    const hasMatch = fixVersions.some((fv) => fixVersionMatchesBranch(fv, expectedVersion));
+    if (hasMatch) {
+      checks.push({
+        name: 'Fix Version', passed: true,
+        message: `Fix version matches target branch \`${baseBranch}\` (expected: ${expectedVersion})`,
+      });
+    } else {
+      const fvNames = fixVersions.map((fv) => fv.name).join(', ');
+      const fvVersion = extractVersionNumber(fixVersions[0]!.name);
+      const suggestedBranch = fixVersions[0] ? suggestBranchForFixVersion(fixVersions[0].name) : null;
+      const suggestion = suggestedBranch ? `. Did you mean to target \`${suggestedBranch}\` instead?` : '';
+      checks.push({
+        name: 'Fix Version', passed: false,
+        message: `Fix version "${fvNames}" (version ${fvVersion}) does not match PR target branch \`${baseBranch}\` (expected: ${expectedVersion})${suggestion}`,
+      });
+    }
+  } else {
+    checks.push({
+      name: 'Fix Version', passed: true,
+      message: `Fix version set: ${fixVersions.map((fv) => fv.name).join(', ')} (branch alignment check skipped for \`${baseBranch}\`)`,
+    });
+  }
+
+  const hasComponent = issue.fields.components.some(
+    (c) => c.name.toLowerCase() === REQUIRED_COMPONENT.toLowerCase(),
+  );
+  checks.push({
+    name: 'Component', passed: hasComponent,
+    message: hasComponent
+      ? `Component "${REQUIRED_COMPONENT}" is set`
+      : `Component "${REQUIRED_COMPONENT}" is not set (found: ${issue.fields.components.map((c) => c.name).join(', ') || 'none'})`,
+  });
+
+  const atFieldId = discoveredFields.activityTypeFieldId;
+  let activityTypeSet = false;
+  if (atFieldId) {
+    const raw = issue.fields[atFieldId as `customfield_${string}`];
+    activityTypeSet = raw != null && raw !== '';
+  }
+  checks.push({
+    name: 'Activity Type', passed: activityTypeSet,
+    message: activityTypeSet
+      ? 'Activity Type is set'
+      : atFieldId ? 'Activity Type is not set on the ticket' : 'Could not discover "Activity Type" custom field',
+  });
+
+  return checks;
+};
+
+/** Format validation results as a markdown table for the PR comment. */
+export const formatValidationComment = (
+  ticketIds: string[],
+  allChecks: Map<string, ValidationCheck[]>,
+  allPassed: boolean,
+): string => {
+  const icon = allPassed ? ':white_check_mark:' : ':x:';
+  const title = allPassed ? `${icon} **Jira Validation Passed**` : `${icon} **Jira Validation Failed**`;
+  const lines: string[] = [title, ''];
+
+  for (const [ticketKey, checks] of allChecks) {
+    lines.push(`### [${ticketKey}](${JIRA_BASE_URL}/browse/${ticketKey})`, '');
+    lines.push('| Check | Status | Details |', '|-------|--------|---------|');
+    for (const check of checks) {
+      const statusIcon = check.passed ? ':white_check_mark:' : ':x:';
+      lines.push(`| ${check.name} | ${statusIcon} | ${check.message} |`);
+    }
+    lines.push('');
+  }
+
+  if (!allPassed) {
+    lines.push('---');
+    lines.push('> Fix the issues above in Jira, then push a new commit or re-edit the PR title to re-run validation.');
+  }
+
+  return lines.join('\n');
+};

--- a/.github/scripts/src/version-utils.ts
+++ b/.github/scripts/src/version-utils.ts
@@ -1,4 +1,5 @@
-import type { JiraVersion } from './types/index.js';
+import { JIRA_BASE_URL } from './types/index.js';
+import type { ClonedTicket, JiraVersion } from './types/index.js';
 
 const RELEASE_BRANCH_REGEX = /^release-(\d+\.\d+)$/;
 const VERSION_NUMBER_REGEX = /(\d+\.\d+)/;
@@ -46,9 +47,10 @@ export const computeNextVersion = (highestReleaseVersion: string): string => {
   const major = parts[0];
   const minorStr = parts[1]!;
   const nextMinor = parseInt(minorStr, 10) + 1;
-  const padded = minorStr.length > 1 && minorStr.startsWith('0')
-    ? String(nextMinor).padStart(minorStr.length, '0')
-    : String(nextMinor);
+  const padded =
+    minorStr.length > 1 && minorStr.startsWith('0')
+      ? String(nextMinor).padStart(minorStr.length, '0')
+      : String(nextMinor);
   return `${major}.${padded}`;
 };
 
@@ -70,7 +72,10 @@ export const getExpectedVersionForBranch = (
 };
 
 /** Check if a Jira fix version's embedded number matches an expected version. */
-export const fixVersionMatchesBranch = (fixVersion: JiraVersion, expectedVersion: string): boolean => {
+export const fixVersionMatchesBranch = (
+  fixVersion: JiraVersion,
+  expectedVersion: string,
+): boolean => {
   const fvVersion = extractVersionNumber(fixVersion.name);
   return fvVersion === expectedVersion;
 };
@@ -104,6 +109,97 @@ export const extractTicketIds = (title: string): string[] => {
   const matches = title.match(/CNV-\d+/gi);
   if (!matches) return [];
   return [...new Set(matches.map((m) => m.toUpperCase()))];
+};
+
+const JIRA_ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9]+-\d+$/;
+
+/** Validate Jira issue keys before using them in string operations. */
+export const isValidJiraIssueKey = (key: string): boolean => JIRA_ISSUE_KEY_PATTERN.test(key);
+
+/** Linear-time case-insensitive literal replacement (avoids dynamic RegExp / ReDoS). */
+export const replaceLiteralCaseInsensitive = (
+  text: string,
+  search: string,
+  replacement: string,
+): string => {
+  if (!search) return text;
+
+  const searchLower = search.toLowerCase();
+  let result = '';
+  let index = 0;
+
+  while (index < text.length) {
+    const candidate = text.slice(index, index + search.length);
+    if (candidate.length === search.length && candidate.toLowerCase() === searchLower) {
+      result += replacement;
+      index += search.length;
+    } else {
+      result += text[index];
+      index += 1;
+    }
+  }
+
+  return result;
+};
+
+const isJiraKeyChar = (char: string | undefined): boolean =>
+  char !== undefined && /[A-Z0-9]/i.test(char);
+
+/** Remove whole Jira key occurrences using literal matching (avoids dynamic RegExp / ReDoS). */
+export const removeJiraKeyOccurrences = (text: string, key: string): string => {
+  if (!isValidJiraIssueKey(key)) return text;
+
+  const keyLower = key.toLowerCase();
+  let result = '';
+  let index = 0;
+
+  while (index < text.length) {
+    const candidate = text.slice(index, index + key.length);
+    const before = index > 0 ? text[index - 1] : undefined;
+    const after = text[index + key.length];
+
+    if (
+      candidate.length === key.length &&
+      candidate.toLowerCase() === keyLower &&
+      !isJiraKeyChar(before) &&
+      !isJiraKeyChar(after)
+    ) {
+      index += key.length;
+    } else {
+      result += text[index];
+      index += 1;
+    }
+  }
+
+  return result;
+};
+
+/** Replace original Jira keys with clone keys (e.g. in cherry-picked commit messages). */
+export const rewriteJiraKeysInText = (text: string, clonedTickets: ClonedTicket[]): string => {
+  let result = text;
+  for (const { originalKey, clonedKey } of clonedTickets) {
+    if (!isValidJiraIssueKey(originalKey) || !isValidJiraIssueKey(clonedKey)) {
+      continue;
+    }
+    result = replaceLiteralCaseInsensitive(result, originalKey, clonedKey);
+  }
+  return result;
+};
+
+/** Remove original Jira keys from text so Prow does not update the source ticket. */
+export const stripOriginalJiraKeys = (text: string, clonedTickets: ClonedTicket[]): string => {
+  let result = text;
+  for (const { originalKey } of clonedTickets) {
+    if (!isValidJiraIssueKey(originalKey)) {
+      continue;
+    }
+
+    const markdownLink = `[${originalKey}](${JIRA_BASE_URL}/browse/${originalKey})`;
+    result = replaceLiteralCaseInsensitive(result, markdownLink, '');
+    result = replaceLiteralCaseInsensitive(result, `${JIRA_BASE_URL}/browse/${originalKey}`, '');
+    result = removeJiraKeyOccurrences(result, originalKey);
+  }
+  return result.replace(/\n{3,}/g, '\n\n').trim();
 };
 
 /** Check if a branch name matches the release-X.YY pattern. */

--- a/.github/scripts/src/version-utils.ts
+++ b/.github/scripts/src/version-utils.ts
@@ -1,0 +1,111 @@
+import type { JiraVersion } from './types/index.js';
+
+const RELEASE_BRANCH_REGEX = /^release-(\d+\.\d+)$/;
+const VERSION_NUMBER_REGEX = /(\d+\.\d+)/;
+
+/** Extract "4.21" from "release-4.21". Returns null for non-release branches. */
+export const extractVersionFromBranch = (branchName: string): string | null => {
+  const match = branchName.match(RELEASE_BRANCH_REGEX);
+  return match?.[1] ?? null;
+};
+
+/** Extract the first "X.YY" version number from any string (e.g., "CNV v4.21.z" => "4.21"). */
+export const extractVersionNumber = (text: string): string | null => {
+  const match = text.match(VERSION_NUMBER_REGEX);
+  return match?.[1] ?? null;
+};
+
+/** Convert "4.21" to a comparable integer for sorting. */
+const parseVersionToNumber = (version: string): number => {
+  const [major, minor] = version.split('.').map(Number);
+  return (major ?? 0) * 100000 + (minor ?? 0);
+};
+
+/** Find the highest version among release branch names. */
+export const findHighestReleaseBranchVersion = (branchNames: string[]): string | null => {
+  let highest: string | null = null;
+  let highestNumeric = 0;
+
+  for (const name of branchNames) {
+    const version = extractVersionFromBranch(name);
+    if (!version) continue;
+
+    const numeric = parseVersionToNumber(version);
+    if (numeric > highestNumeric) {
+      highestNumeric = numeric;
+      highest = version;
+    }
+  }
+
+  return highest;
+};
+
+/** Increment minor version. Preserves zero-padding (5.03 => 5.04). */
+export const computeNextVersion = (highestReleaseVersion: string): string => {
+  const parts = highestReleaseVersion.split('.');
+  const major = parts[0];
+  const minorStr = parts[1]!;
+  const nextMinor = parseInt(minorStr, 10) + 1;
+  const padded = minorStr.length > 1 && minorStr.startsWith('0')
+    ? String(nextMinor).padStart(minorStr.length, '0')
+    : String(nextMinor);
+  return `${major}.${padded}`;
+};
+
+/** Get the expected fix version number for a branch ("main" => next version, "release-X.YY" => "X.YY"). */
+export const getExpectedVersionForBranch = (
+  baseBranch: string,
+  releaseBranches: string[],
+): string | null => {
+  const releaseVersion = extractVersionFromBranch(baseBranch);
+  if (releaseVersion) return releaseVersion;
+
+  if (baseBranch === 'main') {
+    const highest = findHighestReleaseBranchVersion(releaseBranches);
+    if (!highest) return null;
+    return computeNextVersion(highest);
+  }
+
+  return null;
+};
+
+/** Check if a Jira fix version's embedded number matches an expected version. */
+export const fixVersionMatchesBranch = (fixVersion: JiraVersion, expectedVersion: string): boolean => {
+  const fvVersion = extractVersionNumber(fixVersion.name);
+  return fvVersion === expectedVersion;
+};
+
+/** Find the best matching Jira fix version for a target version. Prefers ".z" stream versions. */
+export const findMatchingFixVersion = (
+  versions: JiraVersion[],
+  targetVersion: string,
+): JiraVersion | null => {
+  const matches = versions.filter((v) => {
+    const extracted = extractVersionNumber(v.name);
+    return extracted === targetVersion && !v.archived;
+  });
+
+  if (matches.length === 0) return null;
+  if (matches.length === 1) return matches[0]!;
+
+  const zStream = matches.find((v) => v.name.toLowerCase().includes('.z'));
+  return zStream ?? matches[0]!;
+};
+
+/** Suggest target branch for a fix version (e.g., "CNV v4.21.z" => "release-4.21"). */
+export const suggestBranchForFixVersion = (fixVersionName: string): string | null => {
+  const version = extractVersionNumber(fixVersionName);
+  if (!version) return null;
+  return `release-${version}`;
+};
+
+/** Extract all CNV-XXXXX ticket IDs from a PR title. */
+export const extractTicketIds = (title: string): string[] => {
+  const matches = title.match(/CNV-\d+/gi);
+  if (!matches) return [];
+  return [...new Set(matches.map((m) => m.toUpperCase()))];
+};
+
+/** Check if a branch name matches the release-X.YY pattern. */
+export const isReleaseBranch = (branchName: string): boolean =>
+  RELEASE_BRANCH_REGEX.test(branchName);

--- a/.github/scripts/tsconfig.json
+++ b/.github/scripts/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "noEmit": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/.github/workflows/ci_retest.yml
+++ b/.github/workflows/ci_retest.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Check for hold label
         id: hold-check
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
@@ -37,7 +37,7 @@ jobs:
       - name: Extract build URLs from comment
         if: steps.hold-check.outputs.held == 'false'
         id: extract
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const body = context.payload.comment.body;
@@ -195,7 +195,7 @@ jobs:
       - name: Count previous retests for this SHA
         if: steps.classify.outputs.is_infra == 'true'
         id: count
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({
@@ -223,7 +223,7 @@ jobs:
 
       - name: Post retest comment
         if: steps.classify.outputs.is_infra == 'true' && fromJSON(steps.count.outputs.count) < 5
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SHA_SHORT: ${{ steps.count.outputs.sha_short }}
           INFRA_JOBS: ${{ steps.classify.outputs.infra_jobs }}
@@ -266,7 +266,7 @@ jobs:
 
       - name: Post exhaustion notice
         if: steps.classify.outputs.is_infra == 'true' && fromJSON(steps.count.outputs.count) >= 5
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SHA_SHORT: ${{ steps.count.outputs.sha_short }}
           INFRA_JOBS: ${{ steps.classify.outputs.infra_jobs }}
@@ -310,7 +310,7 @@ jobs:
 
       - name: Escalate to CodeRabbit
         if: steps.classify.outputs.is_infra == 'false' && steps.extract.outputs.found == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           JOBS_JSON: ${{ steps.extract.outputs.jobs }}
         with:

--- a/.github/workflows/jira_clone.yml
+++ b/.github/workflows/jira_clone.yml
@@ -1,0 +1,76 @@
+name: Jira Clone & Cherry-Pick
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: jira-clone-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  clone-and-cherry-pick:
+    if: |
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/clone') &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('title', pr.title);
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('merge_commit_sha', pr.merge_commit_sha || '');
+            core.setOutput('base_branch', pr.base.ref);
+
+      - name: Checkout full repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install script dependencies
+        working-directory: .github/scripts
+        run: npm ci
+
+      - name: Run clone and cherry-pick
+        working-directory: .github/scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          MERGE_COMMIT_SHA: ${{ steps.pr.outputs.merge_commit_sha }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: npx tsx src/clone-pr.ts

--- a/.github/workflows/jira_pr_check.yml
+++ b/.github/workflows/jira_pr_check.yml
@@ -1,0 +1,68 @@
+name: Jira PR Validation
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  issues: write
+  statuses: write
+
+jobs:
+  jira-validation:
+    name: jira-validation
+    runs-on: ubuntu-latest
+    concurrency:
+      group: jira-check-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
+    if: >
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '/recheck-jira'))
+    steps:
+      - name: Get PR info (comment trigger)
+        if: github.event_name == 'issue_comment'
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('title', pr.title);
+            core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('head_sha', pr.head.sha);
+
+      - name: Checkout base branch scripts
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.ref || steps.pr-info.outputs.base_ref }}
+          sparse-checkout: .github/scripts
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install script dependencies
+        working-directory: .github/scripts
+        run: npm ci
+
+      - name: Run Jira PR validation
+        working-directory: .github/scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PR_TITLE: ${{ github.event.pull_request.title || steps.pr-info.outputs.title }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref || steps.pr-info.outputs.base_ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.pr-info.outputs.head_sha }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: npx tsx src/validate-pr.ts


### PR DESCRIPTION
## Summary

Backport Jira automation from `main` to `release-4.22`:

- `.github/scripts/` - TypeScript scripts for Jira PR validation and `/clone` cherry-pick
- `.github/workflows/jira_pr_check.yml` - validates PR titles and Jira ticket fields
- `.github/workflows/jira_clone.yml` - handles `/clone release-X.YY` PR comments

This fixes the `jira-validation` check failure on release branch PRs (e.g. #3990), which currently fails because the workflow checks out `.github/scripts` from the PR base branch, but that directory only exists on `main`.

Files are copied from current `main` HEAD, including follow-up fixes since #3925.

## Links

- Original feature: https://github.com/kubevirt-ui/kubevirt-plugin/pull/3925
- Related failure: https://github.com/kubevirt-ui/kubevirt-plugin/actions/runs/26593125449

## Note

This PR itself will still fail `jira-validation` until merged (bootstrap problem: scripts must exist on the base branch first). Use `/override jira-validation` if needed to merge.

## Test plan

- [ ] Merge this PR to `release-4.22`
- [ ] Re-run checks on #3990 and confirm `jira-validation` passes
- [ ] Verify `/clone release-4.22` works on merged main PRs
