### PR TITLE
CNV-88780: VM tree selection is lost when switching tabs in Virtualization perspective

### DIFF
--- a/src/views/virtualmachines/tree/hooks/useAutoSelectTreeViewItem/useAutoSelectTreeViewItem.ts
+++ b/src/views/virtualmachines/tree/hooks/useAutoSelectTreeViewItem/useAutoSelectTreeViewItem.ts
@@ -99,6 +99,9 @@ const useAutoSelectTreeViewItem = ({
   useEffect(() => {
     if (isACMPage || runningTourSignal.value || !loaded) return;
 
+    const { vmName, vmNamespace } = getVMInfoFromPathname(location.pathname);
+    if (vmName && vmNamespace) return;
+
     const hasFolderFilter = searchParams.has(TEXT_FILTER_LABELS_ID);
     const isFolderSelected =
       ns && selected?.id?.startsWith(`${FOLDER_SELECTOR_PREFIX}/${SINGLE_CLUSTER_KEY}/${ns}/`);


### PR DESCRIPTION
## 📝 Description

In the Virtualization perspective, when viewing a VM and switching between detail tabs (e.g., Overview, Metrics), the VM is no longer highlighted in the left tree. The tree selection moves to the project/namespace instead of staying on the VM.

## 🔗 Links

Jira ticket: [CNV-88780](https://redhat.atlassian.net/browse/CNV-88780)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/53999438-2259-43ba-b009-e565273a25ca


After:

https://github.com/user-attachments/assets/52b0b70b-4189-4f17-a3ee-b58d45cfcb88



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tree view behavior when navigating directly to virtual machines—the tree now correctly maintains the VM-specific selection instead of reverting to namespace-level filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->