### PR TITLE
CNV-88827: Centralize K8s resource condition selectors and replace inline property chains

### DIFF
--- a/.cursor/commands/review.md
+++ b/.cursor/commands/review.md
@@ -1,6 +1,6 @@
 # /review -- Full Team Review Command
 
-Run **all five review agents in parallel** on the current changes and present a unified summary.
+Run **all six review agents in parallel** on the current changes and present a unified summary.
 
 Agent types, i18n compliance rules, code standards, and severity levels are defined in `.cursor/rules/team-review.mdc` (the single source of truth). This command file only covers scope detection, launch orchestration, output format, and post-review actions.
 
@@ -21,26 +21,29 @@ Read all changed files so you can pass their content to the agents.
 
 ## 2. Agent Execution
 
-Launch **all five agents in parallel** using the Task tool. Use the agent types from `team-review.mdc` Section 2 (Developer, UX, QE, Security, KubeVirt Expert).
+Launch **all six agents in parallel** using the Task tool. Use the agent types from `team-review.mdc` Section 2 (Developer, UX, QE, Security, KubeVirt Expert, Selector Reviewer).
 
 Each agent receives:
 
 - The **full content** of every changed file
 - The **diff** showing what changed
 - The agent's **specific focus areas** (from its rule file in `.cursor/rules/agents/`)
-- Instruction to check **i18n compliance** and **code standards** per `team-review.mdc` Section 2
+- Instruction to check **i18n compliance** and **code standards** per `team-review.mdc` Section 2 (Developer agent); selector checks are handled by Task 6
 
 ### Launch Pattern
 
 ```text
-Use the Task tool five times in a single message:
+Use the Task tool six times in a single message:
 
 Task 1: subagent_type="developer", prompt includes developer focus + i18n + code standards
 Task 2: subagent_type="ux-reviewer", prompt includes UX focus
 Task 3: subagent_type="qe-agent", prompt includes QE focus
 Task 4: subagent_type="security-reviewer", prompt includes security focus
 Task 5: subagent_type="kubevirt-expert", prompt includes KubeVirt focus
+Task 6: subagent_type="generalPurpose", prompt includes selector-reviewer focus from `.cursor/rules/agents/selector-reviewer.mdc`
 ```
+
+For Task 6, read `.cursor/rules/agents/selector-reviewer.mdc` and apply its checklist to every changed file (excluding selector definition files and tests per the agent's exceptions).
 
 ---
 
@@ -73,6 +76,10 @@ After all agents complete, present a unified summary:
 [findings with severity icons]
 
 ### KubeVirt Expert
+
+[findings with severity icons]
+
+### Selector Usage
 
 [findings with severity icons]
 

--- a/.cursor/rules/agents/selector-reviewer.mdc
+++ b/.cursor/rules/agents/selector-reviewer.mdc
@@ -1,0 +1,119 @@
+---
+description: Selector Reviewer agent - enforce K8s resource field access via selectors
+alwaysApply: false
+---
+
+# Selector Reviewer Agent
+
+Invoke with: _"review:selectors"_, _"as selector reviewer"_, _"selector review"_, _"check selectors"_
+
+## Your Role
+
+You are a **KubeVirt plugin maintainer** focused on consistent resource field access patterns. You ensure that K8s custom resource fields are read through **selectors** (pure `get*` / `is*` / `has*` functions) rather than inline property chains scattered across the codebase.
+
+Your approach:
+
+- Flag direct property access that bypasses existing selectors
+- Recommend the correct selector import path
+- Acknowledge when new selectors are added and used correctly
+- Do not flag selector definition files or test assertions
+
+---
+
+## Focus Areas
+
+### 1. Generic Selectors (`@kubevirt-utils/resources/shared`)
+
+| Direct access | Use instead |
+|---------------|-------------|
+| `entity?.status?.conditions` | `getStatusConditions(entity)` |
+| `entity?.status?.conditions?.find(...)` | `getStatusConditionsByType(entity, type)` |
+| `condition?.status === 'True'` checks by type | `isStatusConditionTrue(entity, type)` |
+| `entity?.metadata?.labels` | `getLabels(entity)` |
+| `entity?.metadata?.labels?.[key]` | `getLabel(entity, key)` |
+| `entity?.metadata?.annotations` | `getAnnotations(entity)` |
+| `entity?.metadata?.annotations?.[key]` | `getAnnotation(entity, key)` |
+| `entity?.metadata?.name` | `getName(entity)` |
+| `entity?.metadata?.namespace` | `getNamespace(entity)` |
+| `entity?.metadata?.uid` | `getUID(entity)` |
+| `entity?.metadata?.creationTimestamp` | `getCreationTimestamp(entity)` |
+| `entity?.status?.phase` | `getStatusPhase(entity)` |
+
+Derived condition helpers in `shared.ts`:
+
+- `getStatusConditionMessage(entity, type)`
+- `getStatusConditionReason(entity, type)`
+
+### 2. Resource-Specific Selectors
+
+| Resource | Import path | Examples |
+|----------|-------------|----------|
+| VM | `@kubevirt-utils/resources/vm` | `getDisks`, `getInterfaces`, `getNetworks`, `getStatusConditions`, `getStatusConditionByType` |
+| VMI | `@kubevirt-utils/resources/vmi` | `getVMIVolumes`, `getVMIStatusConditions`, `getVMIStatusConditionByType` |
+| Template | `@kubevirt-utils/resources/template` | `getTemplateVirtualMachineObject`, `getTemplateNetworks`, `getTemplateInterfaces`, `getTemplateDisks` |
+| Node | `@kubevirt-utils/resources/node` | `getNodeConditions` |
+| Bootable volumes | `@kubevirt-utils/resources/bootableresources` | `getDataSourcePVCSource`, `getDataSourcePVCName`, `getPVCStorageClassName`, `getDataVolumeSize` |
+
+Common VM direct-access patterns to flag:
+
+- `vm?.spec?.template?.spec?.domain?.devices?.interfaces` → `getInterfaces(vm)`
+- `vm?.spec?.template?.spec?.domain?.devices?.disks` → `getDisks(vm)`
+- `vm?.spec?.template?.spec?.networks` → `getNetworks(vm)`
+- `vm?.status?.printableStatus` → `getVMStatus(vm)` from shared
+
+### 3. Selector Authoring Rules
+
+When a PR **adds** new field access:
+
+- **SUGGESTION**: New inline property chain when an existing selector covers the same field
+- **BLOCKER**: New selector that duplicates logic already in `shared.ts` instead of composing with it
+- **SUGGESTION**: New inline access for a field with no selector yet — recommend adding a selector in the resource's `selectors.ts` file
+- **GOOD**: Resource-specific selector composes with generic selectors from `shared.ts` (e.g. VM `getStatusConditions` wrapping `getResourceStatusConditions`)
+
+### 4. Exceptions (Do NOT Flag)
+
+- Files named `**/selectors.ts` or `shared.ts` (selector definitions)
+- Test files (`*.test.ts`, `*.test.tsx`, `__tests__/`, `tests/`)
+- Type definition files (`types.ts`, `*.d.ts`)
+- Mock/fixture data setup
+- Comment-only references
+
+---
+
+## Severity Mapping
+
+| Finding | Severity |
+|---------|----------|
+| Direct `status?.conditions` when selector exists | 🟡 SUGGESTION |
+| Direct `metadata?.name` / `metadata?.namespace` | 🟢 NITPICK |
+| New selector duplicates `shared.ts` instead of composing | 🔴 BLOCKER |
+| New inline access without adding a selector | 🟡 SUGGESTION |
+| Correct selector usage in changed code | ✅ GOOD |
+| New selector added and used in the same PR | ✅ GOOD |
+
+---
+
+## Review Approach
+
+1. **Scan changed files** for direct K8s resource property access patterns
+2. **Cross-reference** with existing selectors in `src/utils/resources/**/selectors.ts` and `shared.ts`
+3. **Verify imports**: changed code should import selectors from barrel paths (`@kubevirt-utils/resources/vm`, not deep paths unless necessary)
+4. **Check composition**: new selectors should delegate to generic ones where applicable
+5. **Skip exceptions** listed above
+
+---
+
+## Output Format
+
+```
+🔴 BLOCKER: [issue]
+   Why: [explanation of impact]
+   Fix: [suggest selector import and function]
+
+🟡 SUGGESTION: [issue]
+   Consider: [recommendation with selector name and import path]
+
+🟢 NITPICK: [minor improvement]
+
+✅ GOOD: [acknowledge correct selector usage]
+```

--- a/.cursor/rules/team-review.mdc
+++ b/.cursor/rules/team-review.mdc
@@ -18,7 +18,7 @@ When reviewing code or implementing features, automatically consider all team pe
 Do NOT wait for user confirmation to start - begin immediately upon receiving a ticket.
 
 ### /review Command
-Use *"/review"* to run **all five review agents in parallel** on the current changes. This follows the workflow defined in `.cursor/commands/review.md`. It detects changed files, launches all agents simultaneously, and returns a unified summary.
+Use *"/review"* to run **all six review agents in parallel** on the current changes. This follows the workflow defined in `.cursor/commands/review.md`. It detects changed files, launches all agents simultaneously, and returns a unified summary.
 
 ### Quick vs Deep Reviews
 - **Quick Review** (default): High-level feedback from all perspectives
@@ -106,6 +106,10 @@ Use *"/review"* to run **all five review agents in parallel** on the current cha
 ### 🔒 Security
 ✅ [Security looks good]
 
+### 🔍 Selector Usage
+🟡 [Direct property access instead of selector]
+✅ [Selectors used correctly]
+
 ### 🌐 i18n Compliance
 🔴 [Untranslated string / wrong TFunction type]
 ✅ [All strings properly translated]
@@ -128,6 +132,7 @@ For thorough analysis from a single perspective, invoke a specific agent:
 | *"as qe"* | QE Agent | Testing, edge cases, error scenarios |
 | *"as security"* | Security Agent | Vulnerabilities, input validation, auth |
 | *"as kubevirt expert"* | KubeVirt Expert | K8s patterns, VM lifecycle, API usage |
+| *"review:selectors"* | Selector Reviewer | Selector usage, field access patterns |
 
 ---
 
@@ -144,6 +149,8 @@ For thorough analysis from a single perspective, invoke a specific agent:
 - [ ] **UX**: Accessibility, states, consistency
 - [ ] **QE**: Edge cases, tests, async issues
 - [ ] **Security**: Input validation, auth, XSS
+- [ ] **KubeVirt**: K8s patterns, VM lifecycle, API usage
+- [ ] **Selectors**: Field access via selectors, no unnecessary inline property chains
 - [ ] **i18n**: All strings translated, `TFunction` from `i18next`, no concatenation
 - [ ] **Standards**: One component per file, filename matches, files under 150 lines
 

--- a/src/utils/resources/shared.ts
+++ b/src/utils/resources/shared.ts
@@ -141,13 +141,20 @@ export const getConditionReason = (condition: V1beta1Condition): string => condi
 export const isConditionStatusTrue = (condition: V1beta1Condition): boolean =>
   condition?.status === 'True';
 
+export type ResourceWithConditions<C = K8sResourceCondition> = {
+  status?: {
+    conditions?: C[];
+  };
+};
+
 /**
  * A selector for a resource's conditions
  * @param entity - entity to get condition from
  * @returns array of conditions
  */
-export const getStatusConditions = (entity): K8sResourceCondition[] =>
-  entity?.status?.conditions ?? [];
+export const getStatusConditions = <C = K8sResourceCondition>(
+  entity: ResourceWithConditions<C>,
+): C[] => entity?.status?.conditions ?? [];
 
 /**
  * A selector for a resource's conditions based on type
@@ -155,8 +162,49 @@ export const getStatusConditions = (entity): K8sResourceCondition[] =>
  * @param type - type of the condition
  * @returns condition based on type
  */
-export const getStatusConditionsByType = (entity, type: string): K8sResourceCondition =>
-  getStatusConditions(entity)?.find((condition) => condition?.type === type);
+export const getStatusConditionsByType = <C extends { type?: string } = K8sResourceCondition>(
+  entity: ResourceWithConditions<C>,
+  type: string,
+): C | undefined => getStatusConditions<C>(entity)?.find((condition) => condition?.type === type);
+
+/**
+ * A selector that checks whether a resource has a condition of the given type with status True
+ * @param entity - entity to get condition from
+ * @param type - type of the condition
+ * @returns true if the condition exists and its status is True
+ */
+export const isStatusConditionTrue = <
+  C extends { status?: string; type?: string } = K8sResourceCondition,
+>(
+  entity: ResourceWithConditions<C>,
+  type: string,
+): boolean => getStatusConditionsByType(entity, type)?.status === 'True';
+
+/**
+ * A selector for a resource's condition message by type
+ * @param entity - entity to get condition from
+ * @param type - type of the condition
+ * @returns the condition message, if present
+ */
+export const getStatusConditionMessage = <
+  C extends { message?: string; type?: string } = K8sResourceCondition,
+>(
+  entity: ResourceWithConditions<C>,
+  type: string,
+): string | undefined => getStatusConditionsByType(entity, type)?.message;
+
+/**
+ * A selector for a resource's condition reason by type
+ * @param entity - entity to get condition from
+ * @param type - type of the condition
+ * @returns the condition reason, if present
+ */
+export const getStatusConditionReason = <
+  C extends { reason?: string; type?: string } = K8sResourceCondition,
+>(
+  entity: ResourceWithConditions<C>,
+  type: string,
+): string | undefined => getStatusConditionsByType(entity, type)?.reason;
 
 /**
  * function for creating a resource's owner reference from a resource
@@ -476,8 +524,7 @@ export const getAvailableDataSources = (dataSources: V1beta1DataSource[]): V1bet
   dataSources?.filter((dataSource) => isDataSourceReady(dataSource));
 
 export const isDataImportCronProgressing = (dataImportCron: V1beta1DataImportCron): boolean =>
-  dataImportCron?.status?.conditions?.find((condition) => condition.type === 'UpToDate')?.reason ===
-  'ImportProgressing';
+  getStatusConditionReason(dataImportCron, 'UpToDate') === 'ImportProgressing';
 
 /**
  * function to get all V1beta1DataSource objects with condition type 'Ready'and status 'True'

--- a/src/utils/resources/vm/utils/selectors.ts
+++ b/src/utils/resources/vm/utils/selectors.ts
@@ -18,7 +18,13 @@ import {
 import { DYNAMIC_CREDENTIALS_SUPPORT } from '@kubevirt-utils/components/DynamicSSHKeyInjection/constants/constants';
 import { ROOTDISK } from '@kubevirt-utils/constants/constants';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
-import { getAnnotation, getLabel, getLabels } from '@kubevirt-utils/resources/shared';
+import {
+  getAnnotation,
+  getLabel,
+  getLabels,
+  getStatusConditions as getResourceStatusConditions,
+  getStatusConditionsByType as getResourceStatusConditionsByType,
+} from '@kubevirt-utils/resources/shared';
 import { WORKLOADS } from '@kubevirt-utils/resources/template';
 import { isVM } from '@kubevirt-utils/utils/typeGuards';
 import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
@@ -356,13 +362,13 @@ export const getPreferenceMatcher = (vm: V1VirtualMachine): V1PreferenceMatcher 
  * @returns {V1VirtualMachineCondition[]} the VM's status conditions
  */
 export const getStatusConditions = (vm: V1VirtualMachine): V1VirtualMachineCondition[] =>
-  vm?.status?.conditions;
+  getResourceStatusConditions<V1VirtualMachineCondition>(vm);
 
 export const getStatusConditionByType = (
   vm: V1VirtualMachine,
   conditionType: VirtualMachineStatusConditionTypes,
-): V1VirtualMachineCondition =>
-  vm?.status?.conditions?.find((condition) => condition.type === conditionType);
+): undefined | V1VirtualMachineCondition =>
+  getResourceStatusConditionsByType<V1VirtualMachineCondition>(vm, conditionType);
 
 export const getUpdateStrategy = (vm: V1VirtualMachine): UPDATE_STRATEGIES =>
   vm?.spec?.updateVolumesStrategy as UPDATE_STRATEGIES;

--- a/src/utils/resources/vmi/utils/guest-agent.ts
+++ b/src/utils/resources/vmi/utils/guest-agent.ts
@@ -3,16 +3,12 @@ import {
   V1VirtualMachineInstance,
   V1VirtualMachineInstanceGuestAgentInfo,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { getVMStatus } from '@kubevirt-utils/resources/shared';
+import { getVMStatus, isStatusConditionTrue } from '@kubevirt-utils/resources/shared';
+import { VirtualMachineStatusConditionTypes } from '@kubevirt-utils/resources/vm/utils/constants';
 import { VM_STATUS } from '@kubevirt-utils/resources/vm/utils/vmStatus';
 
-const AGENT_CONNECTED = 'AgentConnected';
-
-const hasAgentConnectedCondition = (conditions?: { status?: string; type?: string }[]): boolean =>
-  conditions?.some((c) => c?.type === AGENT_CONNECTED && c?.status === 'True') ?? false;
-
 export const isGuestAgentConnected = (vmi: V1VirtualMachineInstance): boolean =>
-  hasAgentConnectedCondition(vmi?.status?.conditions);
+  isStatusConditionTrue(vmi, VirtualMachineStatusConditionTypes.AgentConnected);
 
 /**
  * Check whether the guest agent is connected by looking at the VM's own conditions.
@@ -21,7 +17,7 @@ export const isGuestAgentConnected = (vmi: V1VirtualMachineInstance): boolean =>
  * @param vm - the virtual machine to check
  */
 export const isVMGuestAgentConnected = (vm: V1VirtualMachine): boolean =>
-  hasAgentConnectedCondition(vm?.status?.conditions);
+  isStatusConditionTrue(vm, VirtualMachineStatusConditionTypes.AgentConnected);
 
 export const getOSNameFromGuestAgent = (
   guestAgentData: V1VirtualMachineInstanceGuestAgentInfo,

--- a/src/utils/resources/vmi/utils/selectors.ts
+++ b/src/utils/resources/vmi/utils/selectors.ts
@@ -1,9 +1,15 @@
 import {
   V1Bootloader,
   V1Devices,
+  V1VirtualMachineCondition,
   V1VirtualMachineInstance,
   V1VirtualMachineInstanceNetworkInterface,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  getStatusConditions as getResourceStatusConditions,
+  getStatusConditionsByType as getResourceStatusConditionsByType,
+} from '@kubevirt-utils/resources/shared';
+
 /**
  * A selector for the virtual machine instance's volumes
  * @param {V1VirtualMachineInstance} vmi the virtual machine instance
@@ -72,3 +78,24 @@ export const getVMIArchitecture = (vmi: V1VirtualMachineInstance): string =>
   vmi?.spec?.architecture;
 
 export const getVMIDisks = (vmi: V1VirtualMachineInstance) => vmi?.spec?.domain?.devices?.disks;
+
+/**
+ * A selector that returns the VMI's status conditions
+ * @param {V1VirtualMachineInstance} vmi the virtual machine instance
+ * @returns {V1VirtualMachineCondition[]} the VMI's status conditions
+ */
+export const getVMIStatusConditions = (
+  vmi: V1VirtualMachineInstance,
+): V1VirtualMachineCondition[] => getResourceStatusConditions<V1VirtualMachineCondition>(vmi);
+
+/**
+ * A selector that returns a VMI status condition by type
+ * @param {V1VirtualMachineInstance} vmi the virtual machine instance
+ * @param conditionType - type of the condition
+ * @returns the matching condition, if present
+ */
+export const getVMIStatusConditionByType = (
+  vmi: V1VirtualMachineInstance,
+  conditionType: string,
+): undefined | V1VirtualMachineCondition =>
+  getResourceStatusConditionsByType<V1VirtualMachineCondition>(vmi, conditionType);

--- a/src/views/virtualmachinesinstance/list/virtualMachinesInstancesDefinition.tsx
+++ b/src/views/virtualmachinesinstance/list/virtualMachinesInstancesDefinition.tsx
@@ -8,7 +8,13 @@ import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt
 import { getK8sRowId } from '@kubevirt-utils/components/KubevirtTable/utils';
 import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { ACTIONS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import {
+  getCreationTimestamp,
+  getName,
+  getNamespace,
+  getStatusPhase,
+} from '@kubevirt-utils/resources/shared';
+import { getVMINodeName, getVMIStatusConditions } from '@kubevirt-utils/resources/vmi';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import { GlobeAmericasIcon } from '@patternfly/react-icons';
 
@@ -54,10 +60,10 @@ export const getVMIColumns = (
 
   columns.push(
     {
-      getValue: (row) => row?.status?.phase ?? '',
+      getValue: (row) => getStatusPhase(row) ?? '',
       key: VMI_COLUMN_KEYS.status,
       label: t('Status'),
-      renderCell: (row) => <VirtualMachinesInstancesStatus status={row?.status?.phase} />,
+      renderCell: (row) => <VirtualMachinesInstancesStatus status={getStatusPhase(row)} />,
       sortable: true,
     },
     {
@@ -65,15 +71,17 @@ export const getVMIColumns = (
       key: VMI_COLUMN_KEYS.conditions,
       label: t('Conditions'),
       renderCell: (row) => (
-        <VMStatusConditionLabelList conditions={row?.status?.conditions?.filter((c) => c.reason)} />
+        <VMStatusConditionLabelList
+          conditions={getVMIStatusConditions(row).filter((c) => c.reason)}
+        />
       ),
     },
     {
-      getValue: (row) => row?.metadata?.creationTimestamp ?? '',
+      getValue: (row) => getCreationTimestamp(row) ?? '',
       key: VMI_COLUMN_KEYS.created,
       label: t('Created'),
       renderCell: (row) => {
-        const creationTimestamp = row?.metadata?.creationTimestamp;
+        const creationTimestamp = getCreationTimestamp(row);
         if (!creationTimestamp) return null;
         return (
           <>
@@ -84,11 +92,11 @@ export const getVMIColumns = (
       sortable: true,
     },
     {
-      getValue: (row) => row?.status?.nodeName ?? '',
+      getValue: (row) => getVMINodeName(row) ?? '',
       key: VMI_COLUMN_KEYS.node,
       label: t('Node'),
       renderCell: (row) => {
-        const nodeName = row?.status?.nodeName;
+        const nodeName = getVMINodeName(row);
         if (!nodeName) return null;
         return <ResourceLink kind={NodeModel.kind} name={nodeName} />;
       },


### PR DESCRIPTION
## 📝 Description

- Added some missing selectors
- Created a selectors reviewer which can be invoked manually or using `/review` custom command
- 
## 🔗 Links

Jira ticket: [CNV-88827](https://redhat.atlassian.net/browse/CNV-88827)

## 🎥 Demo

No UI changes. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team review command now runs six parallel agents and includes a new "Selector Usage" section in review output.
  * Added a dedicated "Selector Reviewer" workflow to flag selector-based field-access issues.

* **Refactor**
  * Introduced shared, generic condition/selectors helpers for more consistent status/condition handling.
  * VM/VMI list and status displays updated to use shared helpers for more reliable Status, Conditions, Node and Created columns.
* **Chores**
  * Exported additional selector helpers for VMI/VM condition access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->