### PR TITLE
CNV-87307: "View all" link on Compute migrations widget points to wrong URL on OCP 4.21 and below

### DIFF
--- a/src/utils/version/versionUtils.test.ts
+++ b/src/utils/version/versionUtils.test.ts
@@ -1,0 +1,26 @@
+import { parseVersionMajorMinor, versionMeetsMajorMinorThreshold } from './versionUtils';
+
+describe('parseVersionMajorMinor', () => {
+  it('parses major and minor from version strings', () => {
+    expect(parseVersionMajorMinor('4.21.0')).toEqual({ major: 4, minor: 21 });
+    expect(parseVersionMajorMinor('v5.1.0')).toEqual({ major: 5, minor: 1 });
+    expect(parseVersionMajorMinor('4.21.0-rc.1')).toEqual({ major: 4, minor: 21 });
+  });
+
+  it('returns null for missing or invalid input', () => {
+    expect(parseVersionMajorMinor(undefined)).toBeNull();
+    expect(parseVersionMajorMinor('')).toBeNull();
+    expect(parseVersionMajorMinor('not-a-version')).toBeNull();
+  });
+});
+
+describe('versionMeetsMajorMinorThreshold', () => {
+  const minVersion = { major: 4, minor: 21 };
+
+  it('compares major before minor', () => {
+    expect(versionMeetsMajorMinorThreshold('4.21.0', minVersion)).toBe(true);
+    expect(versionMeetsMajorMinorThreshold('4.20.5', minVersion)).toBe(false);
+    expect(versionMeetsMajorMinorThreshold('5.1.0', minVersion)).toBe(true);
+    expect(versionMeetsMajorMinorThreshold('3.99.0', minVersion)).toBe(false);
+  });
+});

--- a/src/utils/version/versionUtils.ts
+++ b/src/utils/version/versionUtils.ts
@@ -1,0 +1,36 @@
+export type VersionMajorMinor = {
+  major: number;
+  minor: number;
+};
+
+/**
+ * Parses a version string (e.g. "4.21.0", "v5.1.0-rc.1") into major/minor components.
+ * Accepts formats: "major.minor[.patch][-prerelease]" with optional "v" prefix.
+ * @param version - version string to parse
+ */
+export const parseVersionMajorMinor = (version: string | undefined): null | VersionMajorMinor => {
+  if (!version || typeof version !== 'string') return null;
+  const match = /^v?(\d+)\.(\d+)/i.exec(version.trim());
+  if (!match) return null;
+  const major = Number.parseInt(match[1], 10);
+  const minor = Number.parseInt(match[2], 10);
+  if (!Number.isFinite(major) || !Number.isFinite(minor)) return null;
+  return { major, minor };
+};
+
+/**
+ * Returns true when the parsed version meets or exceeds the given threshold.
+ * Compares major first, then minor. Returns false for unparseable/missing input.
+ * @param version - version string to compare
+ * @param minVersion - minimum version threshold
+ */
+export const versionMeetsMajorMinorThreshold = (
+  version: string | undefined,
+  minVersion: VersionMajorMinor,
+): boolean => {
+  const parsed = parseVersionMajorMinor(version);
+  if (parsed == null) return false;
+  if (parsed.major > minVersion.major) return true;
+  if (parsed.major < minVersion.major) return false;
+  return parsed.minor >= minVersion.minor;
+};

--- a/src/views/virtualmachines/actions/hooks/storageMigrationApi/constants.test.ts
+++ b/src/views/virtualmachines/actions/hooks/storageMigrationApi/constants.test.ts
@@ -1,47 +1,37 @@
 import {
   csvLoadedIndicatesMultiNsStorageMigrationApi,
-  csvMinorMeetsMultiNsAssumeThreshold,
-  parseKubeVirtCsvMinorVersion,
-  STORAGE_MIGRATION_ASSUME_MULTI_NS_API_MIN_OPERATOR_MINOR,
+  csvVersionMeetsMultiNsAssumeThreshold,
+  STORAGE_MIGRATION_ASSUME_MULTI_NS_API_MIN_VERSION,
 } from './constants';
 
-describe('parseKubeVirtCsvMinorVersion', () => {
-  it('parses minor from CSV-style versions', () => {
-    expect(parseKubeVirtCsvMinorVersion('4.21.0')).toBe(21);
-    expect(parseKubeVirtCsvMinorVersion('v4.20.5')).toBe(20);
-    expect(parseKubeVirtCsvMinorVersion('4.21.0-rc.1')).toBe(21);
-  });
-
-  it('returns null for missing or invalid input', () => {
-    expect(parseKubeVirtCsvMinorVersion(undefined)).toBeNull();
-    expect(parseKubeVirtCsvMinorVersion('')).toBeNull();
-    expect(parseKubeVirtCsvMinorVersion('not-a-version')).toBeNull();
+describe('STORAGE_MIGRATION_ASSUME_MULTI_NS_API_MIN_VERSION', () => {
+  it('is 4.21 per storage migration API assumptions', () => {
+    expect(STORAGE_MIGRATION_ASSUME_MULTI_NS_API_MIN_VERSION).toEqual({ major: 4, minor: 21 });
   });
 });
 
-describe('STORAGE_MIGRATION_ASSUME_MULTI_NS_API_MIN_OPERATOR_MINOR', () => {
-  it('is 21 per storage migration API assumptions', () => {
-    expect(STORAGE_MIGRATION_ASSUME_MULTI_NS_API_MIN_OPERATOR_MINOR).toBe(21);
-  });
-});
-
-describe('csvMinorMeetsMultiNsAssumeThreshold', () => {
-  it('is true when minor is at or above the assume-multi-ns threshold', () => {
-    expect(csvMinorMeetsMultiNsAssumeThreshold(21)).toBe(true);
-    expect(csvMinorMeetsMultiNsAssumeThreshold(22)).toBe(true);
+describe('csvVersionMeetsMultiNsAssumeThreshold', () => {
+  it('is true when version is at or above 4.21', () => {
+    expect(csvVersionMeetsMultiNsAssumeThreshold('4.21.0')).toBe(true);
+    expect(csvVersionMeetsMultiNsAssumeThreshold('4.22.0')).toBe(true);
+    expect(csvVersionMeetsMultiNsAssumeThreshold('5.1.0')).toBe(true);
   });
 
-  it('is false when minor is below threshold or unknown', () => {
-    expect(csvMinorMeetsMultiNsAssumeThreshold(20)).toBe(false);
-    expect(csvMinorMeetsMultiNsAssumeThreshold(null)).toBe(false);
+  it('is false when version is below 4.21 or unknown', () => {
+    expect(csvVersionMeetsMultiNsAssumeThreshold('4.20.5')).toBe(false);
+    expect(csvVersionMeetsMultiNsAssumeThreshold(undefined)).toBe(false);
+  });
+
+  it('rejects high minor on lower major (regression: major.minor not minor-only)', () => {
+    expect(csvVersionMeetsMultiNsAssumeThreshold('3.99.0')).toBe(false);
   });
 });
 
 describe('csvLoadedIndicatesMultiNsStorageMigrationApi', () => {
-  it('requires csv loaded and minor meeting threshold', () => {
-    expect(csvLoadedIndicatesMultiNsStorageMigrationApi(true, 21)).toBe(true);
-    expect(csvLoadedIndicatesMultiNsStorageMigrationApi(false, 21)).toBe(false);
-    expect(csvLoadedIndicatesMultiNsStorageMigrationApi(true, 20)).toBe(false);
-    expect(csvLoadedIndicatesMultiNsStorageMigrationApi(true, null)).toBe(false);
+  it('requires csv loaded and version meeting threshold', () => {
+    expect(csvLoadedIndicatesMultiNsStorageMigrationApi(true, '4.21.0')).toBe(true);
+    expect(csvLoadedIndicatesMultiNsStorageMigrationApi(false, '4.21.0')).toBe(false);
+    expect(csvLoadedIndicatesMultiNsStorageMigrationApi(true, '4.20.5')).toBe(false);
+    expect(csvLoadedIndicatesMultiNsStorageMigrationApi(true, undefined)).toBe(false);
   });
 });

--- a/src/views/virtualmachines/actions/hooks/storageMigrationApi/constants.ts
+++ b/src/views/virtualmachines/actions/hooks/storageMigrationApi/constants.ts
@@ -1,3 +1,8 @@
+import {
+  type VersionMajorMinor,
+  versionMeetsMajorMinorThreshold,
+} from '@kubevirt-utils/version/versionUtils';
+
 export const STORAGE_MIGRATION_PROBE_PHASE_IDLE = 'idle' as const;
 
 export const STORAGE_MIGRATION_PROBE_PHASE_WAITING_CSV_AFTER_MULTI_NS_404 =
@@ -7,23 +12,24 @@ export type StorageMigrationProbeFallbackPhase =
   | typeof STORAGE_MIGRATION_PROBE_PHASE_IDLE
   | typeof STORAGE_MIGRATION_PROBE_PHASE_WAITING_CSV_AFTER_MULTI_NS_404;
 
-/** Minor >= 21 → treat multi-namespace LIST 404 as empty (skip MTC / single-namespace probes). */
-export const STORAGE_MIGRATION_ASSUME_MULTI_NS_API_MIN_OPERATOR_MINOR = 21;
+/**
+ * OpenShift Virtualization 4.21+ → treat multi-namespace LIST 404 as empty
+ * (skip MTC / single-namespace probes).
+ * This threshold corresponds to the CNV release where MultiNamespaceVirtualMachineStorageMigrationPlan
+ * became the canonical storage migration API. The version is read from the CSV (operator version),
+ * NOT the ClusterVersion (OCP platform version).
+ */
+export const STORAGE_MIGRATION_ASSUME_MULTI_NS_API_MIN_VERSION: VersionMajorMinor = {
+  major: 4,
+  minor: 21,
+};
 
-export const csvMinorMeetsMultiNsAssumeThreshold = (csvMinor: null | number): boolean =>
-  csvMinor !== null && csvMinor >= STORAGE_MIGRATION_ASSUME_MULTI_NS_API_MIN_OPERATOR_MINOR;
+export const csvVersionMeetsMultiNsAssumeThreshold = (version: string | undefined): boolean =>
+  versionMeetsMajorMinorThreshold(version, STORAGE_MIGRATION_ASSUME_MULTI_NS_API_MIN_VERSION);
 
 export const csvLoadedIndicatesMultiNsStorageMigrationApi = (
   csvLoaded: boolean,
-  csvMinor: null | number,
-): boolean => csvLoaded && csvMinorMeetsMultiNsAssumeThreshold(csvMinor);
+  csvVersion: string | undefined,
+): boolean => csvLoaded && csvVersionMeetsMultiNsAssumeThreshold(csvVersion);
 
 export const STORAGE_MIGRATION_CSV_WAIT_AFTER_MULTI_NS_404_MS = 2500;
-
-export const parseKubeVirtCsvMinorVersion = (version: string | undefined): null | number => {
-  if (!version || typeof version !== 'string') return null;
-  const match = /^v?(\d+)\.(\d+)/i.exec(version.trim());
-  if (!match) return null;
-  const minor = Number.parseInt(match[2], 10);
-  return Number.isFinite(minor) ? minor : null;
-};

--- a/src/views/virtualmachines/actions/hooks/storageMigrationApi/probeEffects.ts
+++ b/src/views/virtualmachines/actions/hooks/storageMigrationApi/probeEffects.ts
@@ -73,7 +73,7 @@ type OnMultiNs404Args = {
   canceled: () => boolean;
   cluster: string | undefined;
   csvLoaded: boolean;
-  csvMinor: null | number;
+  csvVersion: string | undefined;
   finish: FinishProbe;
   phaseRef: { current: StorageMigrationProbeFallbackPhase };
   scheduleDelayedProbe: (run: () => void) => void;
@@ -83,12 +83,12 @@ export const onMultiNamespaceStorageMigration404 = ({
   canceled,
   cluster,
   csvLoaded,
-  csvMinor,
+  csvVersion,
   finish,
   phaseRef,
   scheduleDelayedProbe,
 }: OnMultiNs404Args): void => {
-  if (csvLoadedIndicatesMultiNsStorageMigrationApi(csvLoaded, csvMinor)) {
+  if (csvLoadedIndicatesMultiNsStorageMigrationApi(csvLoaded, csvVersion)) {
     finish(STORAGE_MIGRATION_API.MULTI_NS);
     return;
   }

--- a/src/views/virtualmachines/actions/hooks/storageMigrationApi/useClusterStorageMigrationApiProbe.test.ts
+++ b/src/views/virtualmachines/actions/hooks/storageMigrationApi/useClusterStorageMigrationApiProbe.test.ts
@@ -63,6 +63,21 @@ describe('useClusterStorageMigrationApiProbe', () => {
     expect(kubevirtK8sListItems).not.toHaveBeenCalled();
   });
 
+  it('resolves MULTI_NS without LIST when CSV major is above 4 even if minor is below 21', async () => {
+    const csv = {
+      installedCSV: { spec: { version: '5.1.0' } },
+      loaded: true,
+    } as StorageMigrationProbeCsv;
+
+    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
+
+    await waitFor(() => {
+      expect(result.current).toBe(STORAGE_MIGRATION_API.MULTI_NS);
+    });
+
+    expect(kubevirtK8sListItems).not.toHaveBeenCalled();
+  });
+
   it('runs LIST probe when CSV minor is below 21', async () => {
     (kubevirtK8sListItems as jest.Mock).mockResolvedValue([]);
 

--- a/src/views/virtualmachines/actions/hooks/storageMigrationApi/useClusterStorageMigrationApiProbe.ts
+++ b/src/views/virtualmachines/actions/hooks/storageMigrationApi/useClusterStorageMigrationApiProbe.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { useKubevirtClusterServiceVersion } from '@kubevirt-utils/hooks/useKubevirtClusterServiceVersion';
 import {
@@ -11,8 +11,7 @@ import { useHubClusterName } from '@stolostron/multicluster-sdk';
 import {
   type StorageMigrationProbeFallbackPhase,
   csvLoadedIndicatesMultiNsStorageMigrationApi,
-  csvMinorMeetsMultiNsAssumeThreshold,
-  parseKubeVirtCsvMinorVersion,
+  csvVersionMeetsMultiNsAssumeThreshold,
   STORAGE_MIGRATION_CSV_WAIT_AFTER_MULTI_NS_404_MS,
   STORAGE_MIGRATION_PROBE_PHASE_IDLE,
   STORAGE_MIGRATION_PROBE_PHASE_WAITING_CSV_AFTER_MULTI_NS_404,
@@ -47,13 +46,10 @@ const useClusterStorageMigrationApiProbe = (
 
   const [, hubClusterLoaded, hubClusterError] = useHubClusterName();
   const { installedCSV, loaded: csvLoaded } = csv;
+  const csvVersion = installedCSV?.spec?.version;
 
   // Hub name must be ready before probing a named managed cluster on ACM; single-cluster skips probe.
   const probeAllowed = isACMPage && (!cluster || hubClusterLoaded || hubClusterError != null);
-  const csvMinor = useMemo(
-    () => parseKubeVirtCsvMinorVersion(installedCSV?.spec?.version),
-    [installedCSV?.spec?.version],
-  );
 
   useEffect(() => {
     phaseRef.current = STORAGE_MIGRATION_PROBE_PHASE_IDLE;
@@ -115,7 +111,7 @@ const useClusterStorageMigrationApiProbe = (
     ) {
       phaseRef.current = STORAGE_MIGRATION_PROBE_PHASE_IDLE;
       clearCsvWaitTimer();
-      if (csvMinorMeetsMultiNsAssumeThreshold(csvMinor)) {
+      if (csvVersionMeetsMultiNsAssumeThreshold(csvVersion)) {
         finish(STORAGE_MIGRATION_API.MULTI_NS);
       } else {
         probeMtcThenSingleNsOrNone(cluster, canceledFn, finish);
@@ -138,7 +134,7 @@ const useClusterStorageMigrationApiProbe = (
 
     // Fast-path: on 4.21+ the multi-namespace API is the canonical model —
     // resolve immediately without a LIST probe when CSV is already loaded.
-    if (csvLoadedIndicatesMultiNsStorageMigrationApi(csvLoaded, csvMinor)) {
+    if (csvLoadedIndicatesMultiNsStorageMigrationApi(csvLoaded, csvVersion)) {
       finish(STORAGE_MIGRATION_API.MULTI_NS);
       return () => {
         canceled = true;
@@ -153,7 +149,7 @@ const useClusterStorageMigrationApiProbe = (
         canceled: canceledFn,
         cluster,
         csvLoaded,
-        csvMinor,
+        csvVersion,
         finish,
         phaseRef,
         scheduleDelayedProbe: (run: () => void) => {
@@ -166,7 +162,7 @@ const useClusterStorageMigrationApiProbe = (
       canceled = true;
       clearCsvWaitTimer();
     };
-  }, [cluster, csvLoaded, csvMinor, probeAllowed]);
+  }, [cluster, csvLoaded, csvVersion, probeAllowed]);
 
   return result;
 };

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationStatusSection/MigrationStatusSection.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationStatusSection/MigrationStatusSection.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useMemo } from 'react';
 
 import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
+import useClusterVersion from '@kubevirt-utils/hooks/useClusterVersion/useClusterVersion';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useActiveClusterParam from '@multicluster/hooks/useActiveClusterParam';
 import useIsAllClustersPage from '@multicluster/hooks/useIsAllClustersPage';
@@ -36,6 +37,8 @@ const MigrationStatusSection: FC<OverviewSectionData> = ({
   const activeCluster = useActiveClusterParam();
   const activeNamespace = useActiveNamespace();
   const { isSpokeCluster, spokeConsoleURL } = useManagedClusterConsoleURLs(cluster);
+  const effectiveCluster = cluster ?? activeCluster ?? undefined;
+  const [clusterVersion, clusterVersionLoaded] = useClusterVersion(effectiveCluster);
 
   const overviewLevel = determineOverviewLevel(namespace, isAllClustersPage);
   const isClusterLevel = overviewLevel === OVERVIEW_LEVEL_CLUSTER;
@@ -52,13 +55,32 @@ const MigrationStatusSection: FC<OverviewSectionData> = ({
 
   const migrationsTabPath = useMemo(() => {
     if (isSpokeCluster) return undefined;
-    return getMigrationsTabPath(isACMPage, activeCluster, activeNamespace);
-  }, [isACMPage, activeCluster, activeNamespace, isSpokeCluster]);
+    return getMigrationsTabPath(
+      isACMPage,
+      activeCluster,
+      activeNamespace,
+      clusterVersion,
+      clusterVersionLoaded,
+    );
+  }, [
+    activeCluster,
+    activeNamespace,
+    clusterVersion,
+    clusterVersionLoaded,
+    isACMPage,
+    isSpokeCluster,
+  ]);
 
   const migrationsTabHref = useMemo(() => {
     if (!isSpokeCluster) return undefined;
-    return buildSpokeConsoleUrl(spokeConsoleURL, buildMigrationsSpokePath(activeNamespace));
-  }, [isSpokeCluster, spokeConsoleURL, activeNamespace]);
+    const spokePath = buildMigrationsSpokePath(
+      activeNamespace,
+      clusterVersion,
+      clusterVersionLoaded,
+    );
+    if (!spokePath) return undefined;
+    return buildSpokeConsoleUrl(spokeConsoleURL, spokePath);
+  }, [activeNamespace, clusterVersion, clusterVersionLoaded, isSpokeCluster, spokeConsoleURL]);
 
   if (isMultiClusterLevel) {
     return <MultiClusterMigrationStatusSection title={title} />;
@@ -69,7 +91,7 @@ const MigrationStatusSection: FC<OverviewSectionData> = ({
       <OverviewSectionRow gridColumns={isClusterLevel ? GRID_THREE_EQUAL : undefined}>
         <MigrationsWidget
           cardTitle={t('Compute migrations')}
-          isLoading={!migrationsLoaded}
+          isLoading={!migrationsLoaded || !clusterVersionLoaded}
           migrationsTabHref={migrationsTabHref}
           migrationsTabPath={migrationsTabPath}
           subHeader={t('Last day')}

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationStatusSection/utils.test.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationStatusSection/utils.test.ts
@@ -1,0 +1,47 @@
+import { getNamespacePathSegment } from '@kubevirt-utils/utils/utils';
+
+import {
+  getMigrationsTabPath,
+  LEGACY_MIGRATIONS_PAGE_PATH,
+  STANDALONE_MIGRATIONS_PAGE_PATH,
+} from './utils';
+
+const allNamespacesMigrationsTabPath = (pagePath: string) =>
+  `/k8s/${getNamespacePathSegment('')}/${pagePath}`;
+
+describe('getMigrationsTabPath', () => {
+  it('uses standalone migrations page on OpenShift 4.22+', () => {
+    expect(getMigrationsTabPath(false, '', '', '4.22.0', true)).toBe(
+      allNamespacesMigrationsTabPath(STANDALONE_MIGRATIONS_PAGE_PATH),
+    );
+  });
+
+  it('uses legacy overview migrations page below OpenShift 4.22', () => {
+    expect(getMigrationsTabPath(false, '', '', '4.21.5', true)).toBe(
+      allNamespacesMigrationsTabPath(LEGACY_MIGRATIONS_PAGE_PATH),
+    );
+  });
+
+  it('uses standalone migrations page on future major versions (e.g. 5.x)', () => {
+    const standalonePath = allNamespacesMigrationsTabPath(STANDALONE_MIGRATIONS_PAGE_PATH);
+    expect(getMigrationsTabPath(false, '', '', '5.1.0', true)).toBe(standalonePath);
+    expect(getMigrationsTabPath(false, '', '', '5.01.0', true)).toBe(standalonePath);
+  });
+
+  it('returns undefined while cluster version is loading', () => {
+    expect(getMigrationsTabPath(false, '', '', undefined, false)).toBeUndefined();
+    expect(getMigrationsTabPath(false, '', '', '4.22.0', false)).toBeUndefined();
+  });
+
+  it('defaults to standalone when loaded but version is missing (fetch error)', () => {
+    expect(getMigrationsTabPath(false, '', '', undefined, true)).toBe(
+      allNamespacesMigrationsTabPath(STANDALONE_MIGRATIONS_PAGE_PATH),
+    );
+  });
+
+  it('falls back to legacy when loaded but version is unparseable', () => {
+    expect(getMigrationsTabPath(false, '', '', 'not-a-version', true)).toBe(
+      allNamespacesMigrationsTabPath(LEGACY_MIGRATIONS_PAGE_PATH),
+    );
+  });
+});

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationStatusSection/utils.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationStatusSection/utils.ts
@@ -1,20 +1,48 @@
 import DurationOption from '@kubevirt-utils/components/DurationOption/DurationOption';
 import { getNamespacePathSegment } from '@kubevirt-utils/utils/utils';
+import {
+  type VersionMajorMinor,
+  versionMeetsMajorMinorThreshold,
+} from '@kubevirt-utils/version/versionUtils';
 
 export const MIGRATIONS_DURATION = DurationOption.ONE_DAY.toString();
 
-const MIGRATIONS_PAGE_PATH = 'virtualization-migrations';
+export const STANDALONE_MIGRATIONS_PAGE_PATH = 'virtualization-migrations';
+export const LEGACY_MIGRATIONS_PAGE_PATH = 'virtualization-overview/migrations';
 
-export const buildMigrationsSpokePath = (activeNamespace: string): string => {
+/**
+ * OpenShift 4.22+ uses the standalone compute migrations page.
+ * This threshold uses the ClusterVersion (OCP platform version), NOT the CSV operator version.
+ */
+const COMPUTE_MIGRATIONS_STANDALONE_MIN_VERSION: VersionMajorMinor = {
+  major: 4,
+  minor: 22,
+};
+
+const getMigrationsPagePathSegment = (clusterVersion: string | undefined): string =>
+  !clusterVersion ||
+  versionMeetsMajorMinorThreshold(clusterVersion, COMPUTE_MIGRATIONS_STANDALONE_MIN_VERSION)
+    ? STANDALONE_MIGRATIONS_PAGE_PATH
+    : LEGACY_MIGRATIONS_PAGE_PATH;
+
+export const buildMigrationsSpokePath = (
+  activeNamespace: string,
+  clusterVersion?: string,
+  clusterVersionLoaded = false,
+): string | undefined => {
+  if (!clusterVersionLoaded) return undefined;
   const nsPath = getNamespacePathSegment(activeNamespace);
-  return `/k8s/${nsPath}/${MIGRATIONS_PAGE_PATH}`;
+  return `/k8s/${nsPath}/${getMigrationsPagePathSegment(clusterVersion)}`;
 };
 
 export const getMigrationsTabPath = (
   _isACMPage: boolean,
   _cluster: string,
   activeNamespace: string,
-): string => {
+  clusterVersion?: string,
+  clusterVersionLoaded = false,
+): string | undefined => {
+  if (!clusterVersionLoaded) return undefined;
   const nsPath = getNamespacePathSegment(activeNamespace);
-  return `/k8s/${nsPath}/${MIGRATIONS_PAGE_PATH}`;
+  return `/k8s/${nsPath}/${getMigrationsPagePathSegment(clusterVersion)}`;
 };

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/MigrationsWidget.scss
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/MigrationsWidget.scss
@@ -6,4 +6,9 @@
     color: var(--pf-t--global--text--color--subtle);
     min-height: var(--pf-t--global--font--line-height--body);
   }
+
+  &__view-all-skeleton {
+    display: inline-block;
+    margin-top: var(--pf-t--global--spacer--sm);
+  }
 }

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/MigrationsWidget.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/MigrationsWidget.tsx
@@ -8,7 +8,15 @@ import {
 } from '@kubevirt-utils/resources/vmim/utils';
 import { GreenCheckCircleIcon } from '@openshift-console/dynamic-plugin-sdk';
 import { vmStatusIcon } from '@overview/OverviewTab/vm-statuses-card/utils/utils';
-import { Card, CardBody, CardHeader, CardTitle, Content, Grid } from '@patternfly/react-core';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  CardTitle,
+  Content,
+  Grid,
+  Skeleton,
+} from '@patternfly/react-core';
 
 import StatusCountItem, { getLinkProps } from '../shared/StatusCountItem';
 import ViewAllLink from '../shared/ViewAllLink';
@@ -66,13 +74,27 @@ const MigrationsWidget: FC<MigrationsWidgetProps> = ({
 
   const hasNavigation = !!migrationsTabPath || !!migrationsTabHref;
 
+  const headerActions = (() => {
+    if (hasNavigation) {
+      return <ViewAllLink href={migrationsTabHref} linkPath={migrationsTabPath} />;
+    }
+    if (isLoading) {
+      return (
+        <span className="migrations-widget__view-all-skeleton">
+          <Skeleton fontSize="sm" screenreaderText={t('Loading')} width="4.5rem" />
+        </span>
+      );
+    }
+    return null;
+  })();
+
   return (
     <Card className="migrations-widget" data-test="migrations-widget" isCompact>
       <CardHeader
         actions={
-          hasNavigation
+          headerActions
             ? {
-                actions: <ViewAllLink href={migrationsTabHref} linkPath={migrationsTabPath} />,
+                actions: headerActions,
                 hasNoOffset: false,
               }
             : undefined

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/StorageMigrationPlansWidget.scss
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/StorageMigrationPlansWidget.scss
@@ -2,6 +2,7 @@
   &__view-all-skeleton {
     display: inline-block;
     margin-top: var(--pf-t--global--spacer--sm);
+    width: 4.5rem;
   }
 
   &__body {

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/StorageMigrationPlansWidget.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/StorageMigrationPlansWidget.tsx
@@ -50,7 +50,7 @@ const StorageMigrationPlansWidget: FC<StorageMigrationPlansWidgetProps> = ({ clu
     if (!loaded && !loadError) {
       return (
         <span className="storage-migration-plans-widget__view-all-skeleton">
-          <Skeleton fontSize="sm" screenreaderText={t('Loading')} width="4.5rem" />
+          <Skeleton fontSize="sm" screenreaderText={t('Loading')} />
         </span>
       );
     }


### PR DESCRIPTION
## 📝 Description

On OCP 4.21 and below, the "View all" link on the Compute migrations widget in the Overview page navigates to /k8s/all-namespaces/virtualization-migrations (the standalone migrations page). This page does not exist on older OCP versions. On OCP 4.21 and below, the link should instead point to /k8s/all-namespaces/virtualization-overview/migrations (the migrations tab within the Virtualization Overview page).

This PR is also fixing a bug which is related to storage migrations widget where the CNV version that was parsed only took into consideration the minor version which could lead to a bug (as the major version was ignored). 

## 🔗 Links

Jira ticket: [CNV-87307](https://redhat.atlassian.net/browse/CNV-87307)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/bc36cead-f6b4-4738-a995-5922e409a998


After:


https://github.com/user-attachments/assets/fac42124-a751-4701-a5ba-e04e9b73aa62



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migrations UI now routes to standalone vs legacy pages based on cluster version.
  * Faster probe decision-making for storage migration multi-namespace API based on full version strings.
  * Improved "View all" behavior and loading handling for migrations and storage migration widgets.

* **Bug Fixes**
  * Corrected version comparison to honor major-version precedence before minor checks.

* **Tests**
  * Added tests for version parsing/thresholds and version-aware routing/probing.

* **Style**
  * Updated widget skeleton styles for consistent spacing and sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->