### PR TITLE
CNV-87879: Add error alert to custom configuration on create VM wizard

### DIFF
--- a/src/views/virtualmachines/creation-wizard/components/VMNameConfirmationNextButton.tsx
+++ b/src/views/virtualmachines/creation-wizard/components/VMNameConfirmationNextButton.tsx
@@ -8,11 +8,13 @@ import useVMWizardStore from '../state/vm-wizard-store/useVMWizardStore';
 
 type VMNameConfirmationNextButtonProps = {
   children: ReactNode;
+  isSubmitting?: boolean;
   onClick: () => void;
 };
 
 const VMNameConfirmationNextButton: FC<VMNameConfirmationNextButtonProps> = ({
   children,
+  isSubmitting = false,
   onClick,
 }) => {
   const { t } = useKubevirtTranslation();
@@ -20,7 +22,8 @@ const VMNameConfirmationNextButton: FC<VMNameConfirmationNextButtonProps> = ({
 
   const isVMNameValid = isDNS1123Label(vmName);
   const isVMNameAlmostValid = isDNS1123LabelLenient(vmName);
-  const isDisabled = shouldCheckVMNameProperly ? !isVMNameValid : !isVMNameAlmostValid;
+  const isVMNameInvalid = shouldCheckVMNameProperly ? !isVMNameValid : !isVMNameAlmostValid;
+  const isDisabled = isSubmitting || isVMNameInvalid;
 
   const handleClick = () => {
     if (isVMNameValid) {

--- a/src/views/virtualmachines/creation-wizard/hooks/useCreateVM.ts
+++ b/src/views/virtualmachines/creation-wizard/hooks/useCreateVM.ts
@@ -3,15 +3,22 @@ import useCreateCustomizedVM from '@virtualmachines/creation-wizard/hooks/useCre
 import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
 import { isCloneCreationMethod } from '@virtualmachines/creation-wizard/utils/utils';
 
-type UseCreateVM = () => () => Promise<void>;
+type UseCreateVM = () => {
+  createVM: () => Promise<void>;
+  error: Error | unknown;
+  isSubmitting: boolean;
+};
 
 const useCreateVM: UseCreateVM = () => {
   const { creationMethod } = useVMWizardStore();
   const cloneVM = useCloneVM();
-  const { createCustomizedVM } = useCreateCustomizedVM();
+  const { createCustomizedVM, error, isSubmitting } = useCreateCustomizedVM();
 
-  if (isCloneCreationMethod(creationMethod)) return cloneVM;
-  else return createCustomizedVM;
+  return {
+    createVM: isCloneCreationMethod(creationMethod) ? cloneVM : createCustomizedVM,
+    error,
+    isSubmitting,
+  };
 };
 
 export default useCreateVM;

--- a/src/views/virtualmachines/creation-wizard/steps/ReviewAndCreateStep/components/ReviewAndCreateStepFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/ReviewAndCreateStep/components/ReviewAndCreateStepFooter.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
-import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useWizardFooterProps from '@kubevirt-utils/hooks/useWizardFooterProps';
 import {
   ActionList,
@@ -10,6 +11,7 @@ import {
   useWizardContext,
   WizardFooterWrapper,
 } from '@patternfly/react-core';
+import { Stack } from '@patternfly/react-core';
 import VMNameConfirmationNextButton from '@virtualmachines/creation-wizard/components/VMNameConfirmationNextButton';
 import useCloseWizard from '@virtualmachines/creation-wizard/hooks/useCloseWizard';
 import useCreateVM from '@virtualmachines/creation-wizard/hooks/useCreateVM';
@@ -17,10 +19,11 @@ import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-s
 import { isCloneCreationMethod } from '@virtualmachines/creation-wizard/utils/utils';
 
 const ReviewAndCreateStepFooter: FC = () => {
+  const { t } = useKubevirtTranslation();
   const { goToPrevStep } = useWizardContext();
   const { creationMethod } = useVMWizardStore();
   const isCloneMethod = isCloneCreationMethod(creationMethod);
-  const createVM = useCreateVM();
+  const { createVM, error, isSubmitting } = useCreateVM();
   const closeWizard = useCloseWizard();
   const { backButtonText, cancelButtonText } = useWizardFooterProps();
 
@@ -28,27 +31,30 @@ const ReviewAndCreateStepFooter: FC = () => {
 
   return (
     <WizardFooterWrapper>
-      <ActionList>
-        <ActionListGroup>
-          <ActionListItem>
-            <Button onClick={goToPrevStep} variant="secondary">
-              {backButtonText}
-            </Button>
-          </ActionListItem>
-          <ActionListItem>
-            <VMNameConfirmationNextButton onClick={createVM}>
-              {createButtonText}
-            </VMNameConfirmationNextButton>
-          </ActionListItem>
-        </ActionListGroup>
-        <ActionListGroup>
-          <ActionListItem>
-            <Button onClick={closeWizard} variant="link">
-              {cancelButtonText}
-            </Button>
-          </ActionListItem>
-        </ActionListGroup>
-      </ActionList>
+      <Stack hasGutter>
+        {error && <ErrorAlert error={error} />}
+        <ActionList>
+          <ActionListGroup>
+            <ActionListItem>
+              <Button onClick={goToPrevStep} variant="secondary">
+                {backButtonText}
+              </Button>
+            </ActionListItem>
+            <ActionListItem>
+              <VMNameConfirmationNextButton isSubmitting={isSubmitting} onClick={createVM}>
+                {createButtonText}
+              </VMNameConfirmationNextButton>
+            </ActionListItem>
+          </ActionListGroup>
+          <ActionListGroup>
+            <ActionListItem>
+              <Button onClick={closeWizard} variant="link">
+                {cancelButtonText}
+              </Button>
+            </ActionListItem>
+          </ActionListGroup>
+        </ActionList>
+      </Stack>
     </WizardFooterWrapper>
   );
 };


### PR DESCRIPTION
## 📝 Description

When creating a VM with custom configuration failed, no error was shown to the user. This fix displays the error message in the wizard.

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-87879

## 🎥 Demo

Before: 

<img width="2559" height="1320" alt="image" src="https://github.com/user-attachments/assets/77ab28d0-8cf0-4fa0-a05d-4681c1a20302" />

After: 
<img width="2559" height="1320" alt="image" src="https://github.com/user-attachments/assets/d4a5d3fe-5d2e-46d2-bb8a-e8ec2fa92e3f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Creation flow now shows inline error alerts when VM creation encounters issues.

* **Improvements**
  * Create/confirm actions are disabled while submission is in progress to prevent duplicate submits.
  * Confirmation button behavior tightened to respect submission state and validation.
  * Footer layout adjusted to better surface errors and actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->