### PR TITLE
CNV-88330: prefer new storage migration API over MTC when both are available

### DIFF
--- a/src/views/virtualmachines/actions/hooks/useIsMTCInstalled.ts
+++ b/src/views/virtualmachines/actions/hooks/useIsMTCInstalled.ts
@@ -1,6 +1,19 @@
 import { FLAG_STORAGE_MIGRATION_ENABLED } from '@kubevirt-utils/flags/consts';
-import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
+import { VirtualMachineStorageMigrationPlanModel } from '@kubevirt-utils/models';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import {
+  getGroupVersionKindForModel,
+  useFlag,
+  useK8sModel,
+} from '@openshift-console/dynamic-plugin-sdk';
 
-const useIsMTCInstalled = () => useFlag(FLAG_STORAGE_MIGRATION_ENABLED);
+const useIsMTCInstalled = () => {
+  const mtcInstalled = useFlag(FLAG_STORAGE_MIGRATION_ENABLED);
+  const [vmsmpModel] = useK8sModel(
+    getGroupVersionKindForModel(VirtualMachineStorageMigrationPlanModel),
+  );
+
+  return mtcInstalled && isEmpty(vmsmpModel);
+};
 
 export default useIsMTCInstalled;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

When the VirtualMachineStorageMigrationPlan CRD is registered on the
cluster, use the new migrations.kubevirt.io API instead of falling back
to MTC MigPlan resources.

## 🔗 Links

> Add JIRA, Docs, and other PR/Issue links

## 🎥 Demo

> Please add a video or an image of the behavior/changes
