### PR TITLE
CNV-88899: Prefer virtualization default storage class in disk flows and bootablevolumes

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/VolumeDestination/StorageClass/StorageClassSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeDestination/StorageClass/StorageClassSelect.tsx
@@ -4,6 +4,7 @@ import { getSCSelectOptions } from '@kubevirt-utils/components/DiskModal/compone
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import useDefaultStorageClass from '@kubevirt-utils/hooks/useDefaultStorage/useDefaultStorageClass';
+import { getPreferredDefaultStorageClass } from '@kubevirt-utils/hooks/useDefaultStorage/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useReadyStorageClasses from '@kubevirt-utils/hooks/useReadyStorageClasses/useReadyStorageClasses';
 import { StorageClassModel } from '@kubevirt-utils/models';
@@ -32,10 +33,11 @@ const StorageClassSelect: FC<StorageClassSelectProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
 
-  const [{ clusterDefaultStorageClass }, defaultSCLoaded] = useDefaultStorageClass(cluster);
+  const [defaultStorageClasses, defaultSCLoaded] = useDefaultStorageClass(cluster);
   const [{ readyStorageClasses }, readySCLoaded] = useReadyStorageClasses(cluster);
 
   const loaded = defaultSCLoaded && readySCLoaded;
+  const defaultSC = getPreferredDefaultStorageClass(defaultStorageClasses);
 
   const onSelect = useCallback(
     (selection: string) => {
@@ -50,17 +52,11 @@ const StorageClassSelect: FC<StorageClassSelectProps> = ({
   );
 
   useEffect(() => {
-    if (!storageClass && loaded && !isEmpty(clusterDefaultStorageClass)) {
-      setStorageClassName(getName(clusterDefaultStorageClass));
-      setStorageClassProvisioner?.(clusterDefaultStorageClass?.provisioner);
+    if (!storageClass && loaded && !isEmpty(defaultSC)) {
+      setStorageClassName(getName(defaultSC));
+      setStorageClassProvisioner?.(defaultSC?.provisioner);
     }
-  }, [
-    clusterDefaultStorageClass,
-    setStorageClassName,
-    setStorageClassProvisioner,
-    storageClass,
-    loaded,
-  ]);
+  }, [defaultSC, setStorageClassName, setStorageClassProvisioner, storageClass, loaded]);
 
   return (
     <FormGroup fieldId="storage-class" label={t('StorageClass')}>
@@ -74,7 +70,7 @@ const StorageClassSelect: FC<StorageClassSelectProps> = ({
             options={getSCSelectOptions(readyStorageClasses)}
             placeholder={t('Select {{label}}', { label: StorageClassModel.label })}
             popperProps={{ enableFlip: true }}
-            selected={storageClass || getName(clusterDefaultStorageClass)}
+            selected={storageClass || getName(defaultSC)}
             setSelected={onSelect}
           />
         ) : (

--- a/src/utils/components/DiskModal/components/StorageClassAndPreallocation/StorageClassSelect.tsx
+++ b/src/utils/components/DiskModal/components/StorageClassAndPreallocation/StorageClassSelect.tsx
@@ -4,6 +4,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import useDefaultStorageClass from '@kubevirt-utils/hooks/useDefaultStorage/useDefaultStorageClass';
+import { getPreferredDefaultStorageClass } from '@kubevirt-utils/hooks/useDefaultStorage/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useReadyStorageClasses from '@kubevirt-utils/hooks/useReadyStorageClasses/useReadyStorageClasses';
 import { StorageClassModel } from '@kubevirt-utils/models';
@@ -37,11 +38,14 @@ const StorageClassSelect: FC<StorageClassSelectProps> = ({ checkSC, setShowSCAle
     VM_CLUSTER_FIELD,
   ]);
 
-  const [{ clusterDefaultStorageClass }, defaultSCLoaded] = useDefaultStorageClass(vmCluster);
+  const [defaultStorageClasses, defaultSCLoaded] = useDefaultStorageClass(vmCluster);
   const [{ readyStorageClasses }, readySCLoaded] = useReadyStorageClasses(vmCluster);
 
   const loaded = defaultSCLoaded && readySCLoaded;
-  const defaultSC = useMemo(() => clusterDefaultStorageClass, [clusterDefaultStorageClass]);
+  const defaultSC = useMemo(
+    () => getPreferredDefaultStorageClass(defaultStorageClasses),
+    [defaultStorageClasses],
+  );
 
   const checkAndShowAlerts = useCallback(
     (selection: string) => !blankSource && setShowSCAlert(checkSC ? checkSC(selection) : false),

--- a/src/utils/components/DiskModal/components/StorageClassAndPreallocation/utils/helpers.test.ts
+++ b/src/utils/components/DiskModal/components/StorageClassAndPreallocation/utils/helpers.test.ts
@@ -1,0 +1,39 @@
+import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import {
+  DEFAULT_STORAGE_CLASS_ANNOTATION,
+  DEFAULT_VIRT_STORAGE_CLASS_ANNOTATION,
+} from '@kubevirt-utils/hooks/useDefaultStorage/constants';
+
+import { getDefaultStorageClass } from './helpers';
+
+const createStorageClass = (
+  name: string,
+  annotations: Record<string, string> = {},
+): IoK8sApiStorageV1StorageClass => ({
+  metadata: {
+    annotations,
+    name,
+  },
+  provisioner: 'kubernetes.io/storage-provisioner',
+});
+
+describe('getDefaultStorageClass', () => {
+  it('prefers virtualization default storage class over cluster default', () => {
+    const clusterDefault = createStorageClass('cluster-default', {
+      [DEFAULT_STORAGE_CLASS_ANNOTATION]: 'true',
+    });
+    const virtDefault = createStorageClass('virt-default', {
+      [DEFAULT_VIRT_STORAGE_CLASS_ANNOTATION]: 'true',
+    });
+
+    expect(getDefaultStorageClass([clusterDefault, virtDefault])).toBe(virtDefault);
+  });
+
+  it('falls back to cluster default when no virtualization default exists', () => {
+    const clusterDefault = createStorageClass('cluster-default', {
+      [DEFAULT_STORAGE_CLASS_ANNOTATION]: 'true',
+    });
+
+    expect(getDefaultStorageClass([clusterDefault])).toBe(clusterDefault);
+  });
+});

--- a/src/utils/components/DiskModal/components/StorageClassAndPreallocation/utils/helpers.ts
+++ b/src/utils/components/DiskModal/components/StorageClassAndPreallocation/utils/helpers.ts
@@ -1,17 +1,18 @@
 import { modelToGroupVersionKind, StorageClassModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
-import { DEFAULT_STORAGE_CLASS_ANNOTATION } from '@kubevirt-utils/hooks/useDefaultStorage/constants';
+import {
+  isDefaultStorageClass,
+  isVirtDefaultStorageClass,
+} from '@kubevirt-utils/hooks/useDefaultStorage/utils';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getAnnotation, getName } from '@kubevirt-utils/resources/shared';
 import { DESCRIPTION_ANNOTATION } from '@kubevirt-utils/resources/vm';
 
-const isDefaultStorageClass = (storageClass: IoK8sApiStorageV1StorageClass): boolean =>
-  storageClass?.metadata?.annotations?.[DEFAULT_STORAGE_CLASS_ANNOTATION] === 'true';
-
 export const getDefaultStorageClass = (
   storageClasses: IoK8sApiStorageV1StorageClass[],
-): IoK8sApiStorageV1StorageClass => storageClasses?.find(isDefaultStorageClass);
+): IoK8sApiStorageV1StorageClass =>
+  storageClasses?.find(isVirtDefaultStorageClass) || storageClasses?.find(isDefaultStorageClass);
 
 export const getSCSelectOptions = (
   storageClasses: IoK8sApiStorageV1StorageClass[],

--- a/src/utils/hooks/useDefaultStorage/useDefaultStorageClass.ts
+++ b/src/utils/hooks/useDefaultStorage/useDefaultStorageClass.ts
@@ -6,10 +6,7 @@ import useClusterParam from '@multicluster/hooks/useClusterParam';
 
 import { isEmpty } from '../../utils/utils';
 
-import {
-  DEFAULT_STORAGE_CLASS_ANNOTATION,
-  DEFAULT_VIRT_STORAGE_CLASS_ANNOTATION,
-} from './constants';
+import { isDefaultStorageClass, isVirtDefaultStorageClass } from './utils';
 
 type UseDefaultStorageClass = (cluster?: string) => [
   {
@@ -29,13 +26,9 @@ const useDefaultStorageClass: UseDefaultStorageClass = (cluster) => {
     if (!loaded || isEmpty(storageClasses)) return defaultSC;
 
     return storageClasses?.reduce((acc, sc) => {
-      const annotations = sc?.metadata?.annotations;
+      if (isDefaultStorageClass(sc)) acc.clusterDefaultStorageClass = sc;
 
-      if (annotations?.[DEFAULT_STORAGE_CLASS_ANNOTATION] === 'true')
-        acc.clusterDefaultStorageClass = sc;
-
-      if (annotations?.[DEFAULT_VIRT_STORAGE_CLASS_ANNOTATION] === 'true')
-        acc.virtDefaultStorageClass = sc;
+      if (isVirtDefaultStorageClass(sc)) acc.virtDefaultStorageClass = sc;
 
       return acc;
     }, defaultSC);

--- a/src/utils/hooks/useDefaultStorage/utils.test.ts
+++ b/src/utils/hooks/useDefaultStorage/utils.test.ts
@@ -1,0 +1,75 @@
+import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+
+import {
+  DEFAULT_STORAGE_CLASS_ANNOTATION,
+  DEFAULT_VIRT_STORAGE_CLASS_ANNOTATION,
+} from './constants';
+import {
+  getPreferredDefaultStorageClass,
+  isDefaultStorageClass,
+  isVirtDefaultStorageClass,
+} from './utils';
+
+const createStorageClass = (
+  name: string,
+  annotations: Record<string, string> = {},
+): IoK8sApiStorageV1StorageClass => ({
+  metadata: {
+    annotations,
+    name,
+  },
+  provisioner: 'kubernetes.io/storage-provisioner',
+});
+
+describe('isDefaultStorageClass', () => {
+  it('returns true when cluster default annotation is set', () => {
+    const storageClass = createStorageClass('cluster-default', {
+      [DEFAULT_STORAGE_CLASS_ANNOTATION]: 'true',
+    });
+
+    expect(isDefaultStorageClass(storageClass)).toBe(true);
+  });
+
+  it('returns false when cluster default annotation is missing', () => {
+    expect(isDefaultStorageClass(createStorageClass('regular'))).toBe(false);
+  });
+});
+
+describe('isVirtDefaultStorageClass', () => {
+  it('returns true when virtualization default annotation is set', () => {
+    const storageClass = createStorageClass('virt-default', {
+      [DEFAULT_VIRT_STORAGE_CLASS_ANNOTATION]: 'true',
+    });
+
+    expect(isVirtDefaultStorageClass(storageClass)).toBe(true);
+  });
+
+  it('returns false when virtualization default annotation is missing', () => {
+    expect(isVirtDefaultStorageClass(createStorageClass('regular'))).toBe(false);
+  });
+});
+
+describe('getPreferredDefaultStorageClass', () => {
+  it('prefers virtualization default storage class over cluster default', () => {
+    const clusterDefault = createStorageClass('cluster-default');
+    const virtDefault = createStorageClass('virt-default');
+
+    expect(
+      getPreferredDefaultStorageClass({
+        clusterDefaultStorageClass: clusterDefault,
+        virtDefaultStorageClass: virtDefault,
+      }),
+    ).toBe(virtDefault);
+  });
+
+  it('falls back to cluster default when virtualization default is missing', () => {
+    const clusterDefault = createStorageClass('cluster-default');
+
+    expect(
+      getPreferredDefaultStorageClass({
+        clusterDefaultStorageClass: clusterDefault,
+        virtDefaultStorageClass: null,
+      }),
+    ).toBe(clusterDefault);
+  });
+});

--- a/src/utils/hooks/useDefaultStorage/utils.ts
+++ b/src/utils/hooks/useDefaultStorage/utils.ts
@@ -1,0 +1,23 @@
+import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+
+import {
+  DEFAULT_STORAGE_CLASS_ANNOTATION,
+  DEFAULT_VIRT_STORAGE_CLASS_ANNOTATION,
+} from './constants';
+
+type DefaultStorageClasses = {
+  clusterDefaultStorageClass: IoK8sApiStorageV1StorageClass;
+  virtDefaultStorageClass: IoK8sApiStorageV1StorageClass;
+};
+
+export const isDefaultStorageClass = (storageClass: IoK8sApiStorageV1StorageClass): boolean =>
+  storageClass?.metadata?.annotations?.[DEFAULT_STORAGE_CLASS_ANNOTATION] === 'true';
+
+export const isVirtDefaultStorageClass = (storageClass: IoK8sApiStorageV1StorageClass): boolean =>
+  storageClass?.metadata?.annotations?.[DEFAULT_VIRT_STORAGE_CLASS_ANNOTATION] === 'true';
+
+export const getPreferredDefaultStorageClass = ({
+  clusterDefaultStorageClass,
+  virtDefaultStorageClass,
+}: DefaultStorageClasses): IoK8sApiStorageV1StorageClass =>
+  virtDefaultStorageClass || clusterDefaultStorageClass;

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
@@ -5,6 +5,7 @@ import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import StateHandler from '@kubevirt-utils/components/StateHandler/StateHandler';
 import useDefaultStorageClass from '@kubevirt-utils/hooks/useDefaultStorage/useDefaultStorageClass';
+import { getPreferredDefaultStorageClass } from '@kubevirt-utils/hooks/useDefaultStorage/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useReadyStorageClasses from '@kubevirt-utils/hooks/useReadyStorageClasses/useReadyStorageClasses';
 import { getPVCStorageClassName } from '@kubevirt-utils/resources/bootableresources/selectors';
@@ -72,14 +73,14 @@ const VirtualMachineMigrateModal: FC<VirtualMachineMigrateModalProps> = ({
     selectedMigrations,
   ]);
 
-  const [{ clusterDefaultStorageClass }, defaultSCLoaded] = useDefaultStorageClass(cluster);
+  const [defaultStorageClasses, defaultSCLoaded] = useDefaultStorageClass(cluster);
   const [{ sortedStorageClasses }, readySCLoaded] = useReadyStorageClasses(cluster);
 
   const scLoaded = defaultSCLoaded && readySCLoaded;
 
   const defaultStorageClassName = useMemo(
-    () => getName(clusterDefaultStorageClass),
-    [clusterDefaultStorageClass],
+    () => getName(getPreferredDefaultStorageClass(defaultStorageClasses)),
+    [defaultStorageClasses],
   );
 
   const destinationStorageClass = useMemo(


### PR DESCRIPTION
## 📝 Description

Fixes [CNV-88899](https://redhat.atlassian.net/browse/CNV-88899).

When both a Kubernetes cluster default storage class (`storageclass.kubernetes.io/is-default-class`) and a KubeVirt virtualization default storage class (`storageclass.kubevirt.io/is-default-virt-class`) exist, the UI now pre-selects the virtualization default when creating a new virtual disk.

Changes:
- Add shared storage class helpers (`isDefaultStorageClass`, `isVirtDefaultStorageClass`, `getPreferredDefaultStorageClass`)
- Update disk creation, bootable volume, and storage migration flows to prefer the virt default
- Add unit tests for the new helpers and default selection logic

## 🔗 Links

- Jira: https://redhat.atlassian.net/browse/CNV-88899

## 🎥 Demo

N/A — default selection behavior change only.

## Test plan

- [ ] Annotate one storage class with `storageclass.kubernetes.io/is-default-class: "true"`
- [ ] Annotate a different storage class with `storageclass.kubevirt.io/is-default-virt-class: "true"`
- [ ] Create a new blank disk on a VM and verify the virtualization default storage class is pre-selected
- [ ] Verify bootable volume creation and storage migration still default to the virt storage class when annotated
- [ ] Verify fallback to cluster default when no virt default is configured

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Storage class selection now prioritizes virtualization-specific defaults over cluster defaults when available, improving resource allocation for VM operations.

* **Tests**
  * Added comprehensive test coverage for storage class selection logic and default class preference behavior.

* **Refactor**
  * Improved internal storage class selection utilities for consistent handling across modals and migration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->