### PR TITLE
CNV-88330: [SCMIG][UI] Storage Migration not working via UI on 4.20.15 version if MTC installed

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,5 @@ yarn.lock
 /gui-test-screenshots
 cypress/gui-test-screenshots
 cypress/cypress-a11y-report.json
+playwright/
+playwright/test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ console-extensions.md
 scripts/ca.crt
 scripts/console-client-secret
 *.json-*
+/playwright
+.env.local
+local.env

--- a/src/views/storagemigrations/list/hooks/useStorageMigrationResources.ts
+++ b/src/views/storagemigrations/list/hooks/useStorageMigrationResources.ts
@@ -10,7 +10,7 @@ import {
   MigPlanModel,
 } from '@kubevirt-utils/resources/migrations/migrationsMtcConstants';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
-import useIsMTCInstalled from '@virtualmachines/actions/hooks/useIsMTCInstalled';
+import useShouldUseMtcMigration from '@virtualmachines/actions/hooks/useShouldUseMtcMigration';
 
 const adaptMigPlanToVmsmp = (
   migPlan: MigPlan,
@@ -57,7 +57,7 @@ type UseStorageMigrationResources = () => {
 
 const useStorageMigrationResources: UseStorageMigrationResources = () => {
   const namespace = useNamespaceParam();
-  const mtcInstalled = useIsMTCInstalled();
+  const shouldUseMtcMigration = useShouldUseMtcMigration();
 
   const [vmsmpPlans, vmsmpLoaded, vmsmpError] = useK8sWatchData<
     MultiNamespaceVirtualMachineStorageMigrationPlan[]
@@ -76,7 +76,7 @@ const useStorageMigrationResources: UseStorageMigrationResources = () => {
     namespace: DEFAULT_MIGRATION_NAMESPACE,
   });
 
-  if (mtcInstalled) {
+  if (shouldUseMtcMigration) {
     const adaptedPlans = (migPlans || []).map(adaptMigPlanToVmsmp);
     const filteredPlans = namespace
       ? adaptedPlans.filter((plan) => plan.spec?.namespaces?.some((ns) => ns.name === namespace))

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationModal.tsx
@@ -10,7 +10,7 @@ import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { Modal, ModalBody, Wizard, WizardHeader, WizardStep } from '@patternfly/react-core';
-import useIsMTCInstalled from '@virtualmachines/actions/hooks/useIsMTCInstalled';
+import useShouldUseMtcMigration from '@virtualmachines/actions/hooks/useShouldUseMtcMigration';
 
 import useMigrationNamespacesPVCs from './hooks/useMigrationNamespacesPVCs';
 import useMigrationState from './hooks/useMigrationState';
@@ -37,7 +37,7 @@ const VirtualMachineMigrateModal: FC<VirtualMachineMigrateModalProps> = ({
   vms,
 }) => {
   const { t } = useKubevirtTranslation();
-  const mtcInstalled = useIsMTCInstalled();
+  const shouldUseMtcMigration = useShouldUseMtcMigration();
 
   const cluster = getCluster(vms?.[0]);
   const [selectedStorageClass, setSelectedStorageClass] = useState('');
@@ -85,7 +85,7 @@ const VirtualMachineMigrateModal: FC<VirtualMachineMigrateModalProps> = ({
     destinationStorageClass,
   );
 
-  const { migrationError, migrationLoading, migrationStarted, onSubmit } = mtcInstalled
+  const { migrationError, migrationLoading, migrationStarted, onSubmit } = shouldUseMtcMigration
     ? mtcState
     : vmsmpState;
 
@@ -112,14 +112,14 @@ const VirtualMachineMigrateModal: FC<VirtualMachineMigrateModalProps> = ({
           hasData
           loaded={migrationNamespacesPVCsLoaded && selectedMigrations !== null}
         >
-          {migrationStarted && mtcInstalled && (
+          {migrationStarted && shouldUseMtcMigration && (
             <VirtualMachineMigrationStatusMtc
               migMigration={mtcState.migMigration}
               onClose={onClose}
               vmNamespace={getNamespace(vms?.[0])}
             />
           )}
-          {migrationStarted && !mtcInstalled && (
+          {migrationStarted && !shouldUseMtcMigration && (
             <VirtualMachineMigrationStatus
               onClose={onClose}
               storageMigrationPlan={vmsmpState.migrationPlan}

--- a/src/views/virtualmachines/actions/hooks/useShouldUseMtcMigration.ts
+++ b/src/views/virtualmachines/actions/hooks/useShouldUseMtcMigration.ts
@@ -1,0 +1,18 @@
+import { MultiNamespaceVirtualMachineStorageMigrationPlanModel } from '@kubevirt-utils/models';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { getGroupVersionKindForModel, useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+
+import useIsMTCInstalled from './useIsMTCInstalled';
+
+const useShouldUseMtcMigration = (): boolean => {
+  const mtcInstalled = useIsMTCInstalled();
+  const [vmsmpModel] = useK8sModel(
+    getGroupVersionKindForModel(MultiNamespaceVirtualMachineStorageMigrationPlanModel),
+  );
+
+  const nativeCRDAvailable = !isEmpty(vmsmpModel);
+
+  return mtcInstalled && !nativeCRDAvailable;
+};
+
+export default useShouldUseMtcMigration;


### PR DESCRIPTION
## 📝 Description

On clusters with both MTC and the native `migrations.kubevirt.io` CRDs, storage migration via the UI incorrectly used the `MTC` MigPlan path instead of the native KubeVirt API.

## 🔗 Links

Jira ticket: [CNV-88330](https://redhat.atlassian.net/browse/CNV-88330)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/932def0d-ed43-4183-a24d-a71216f6396b


After:


https://github.com/user-attachments/assets/e4f4bb35-bf98-42c5-8958-6455d389d505

<details>
<summary>Validation script</summary>

```
#
# Validate storage migration backend selection (native vs MTC).
#
# Use on a cluster where BOTH are installed:
#   - migrations.kubevirt.io (MultiNamespaceVirtualMachineStorageMigrationPlan)
#   - MTC (MigPlan in openshift-migration)
#
# Expected WITH the fix (useShouldUseMtcMigration):
#   UI creates native plans/migrations in the VM namespace — NOT new MigPlan/MigMigration in openshift-migration.
#
# Expected WITHOUT the fix (useIsMTCInstalled only):
#   UI creates MigPlan + MigMigration in openshift-migration.
#
# Usage:
#   ./scripts/validate-storage-migration-backend.sh check
#   ./scripts/validate-storage-migration-backend.sh before <vm-namespace>
#   # Run storage migration in the console UI
#   ./scripts/validate-storage-migration-backend.sh after <vm-namespace>
#   ./scripts/validate-storage-migration-backend.sh compare <vm-namespace>
#
# Optional env:
#   STATE_DIR   Directory for snapshots (default: /tmp/kubevirt-storage-migration-validation)
#   MTC_NS      MTC namespace (default: openshift-migration)

set -euo pipefail

MTC_NS="${MTC_NS:-openshift-migration}"
STATE_DIR="${STATE_DIR:-/tmp/kubevirt-storage-migration-validation}"

RED='\033[0;31m'
GREEN='\033[0;32m'
YELLOW='\033[1;33m'
BLUE='\033[0;34m'
NC='\033[0m'

info() { echo -e "${BLUE}==>${NC} $*"; }
ok() { echo -e "${GREEN}PASS:${NC} $*"; }
warn() { echo -e "${YELLOW}WARN:${NC} $*"; }
fail() { echo -e "${RED}FAIL:${NC} $*"; }

usage() {
  sed -n '2,22p' "$0" | sed 's/^# \?//'
  exit "${1:-0}"
}

require_kubectl() {
  if ! command -v kubectl &>/dev/null; then
    fail "kubectl not found in PATH"
    exit 1
  fi
  if ! kubectl cluster-info &>/dev/null; then
    fail "kubectl cannot reach the cluster (check context: $(kubectl config current-context 2>/dev/null || echo 'unknown'))"
    exit 1
  fi
}

require_jq() {
  if ! command -v jq &>/dev/null; then
    fail "jq is required to scope MTC MigPlans by spec.namespaces"
    exit 1
  fi
}

snapshot_file() {
  local vm_ns="$1"
  echo "${STATE_DIR}/${vm_ns}/snapshot.tsv"
}

ensure_state_dir() {
  local vm_ns="$1"
  mkdir -p "${STATE_DIR}/${vm_ns}"
}

# Writes one TSV line per resource: KIND<TAB>NS<TAB>NAME<TAB>CREATION_TIMESTAMP
# MTC resources are scoped to plans/migrations that target vm_ns (spec.namespaces), not all of openshift-migration.
collect_resources() {
  local vm_ns="$1"

  kubectl get multinamespacevirtualmachinestoragemigrationplans -n "$vm_ns" \
    -o custom-columns=KIND:.kind,NS:.metadata.namespace,NAME:.metadata.name,CREATED:.metadata.creationTimestamp \
    --no-headers 2>/dev/null | while read -r kind ns name created; do
    [[ -n "${name:-}" ]] && printf 'NativePlan\t%s\t%s\t%s\n' "$ns" "$name" "$created"
  done

  kubectl get multinamespacevirtualmachinestoragemigrations -n "$vm_ns" \
    -o custom-columns=KIND:.kind,NS:.metadata.namespace,NAME:.metadata.name,CREATED:.metadata.creationTimestamp \
    --no-headers 2>/dev/null | while read -r kind ns name created; do
    [[ -n "${name:-}" ]] && printf 'NativeMigration\t%s\t%s\t%s\n' "$ns" "$name" "$created"
  done

  if ! kubectl get migplans -n "$MTC_NS" &>/dev/null; then
    return 0
  fi

  # Only MigPlans that include this VM namespace in spec.namespaces
  kubectl get migplans -n "$MTC_NS" -o json 2>/dev/null | jq -r --arg vmns "$vm_ns" '
    .items[]
    | select([.spec.namespaces[]?] | index($vmns))
    | ["MtcMigPlan", .metadata.namespace, .metadata.name, .metadata.creationTimestamp] | @tsv
  ' | while IFS=$'\t' read -r kind ns name created; do
    [[ -n "${name:-}" ]] && printf '%s\t%s\t%s\t%s\n' "$kind" "$ns" "$name" "$created"
  done

  # MigMigrations whose migPlanRef points at a MigPlan scoped to vm_ns
  local plan_names
  plan_names=$(kubectl get migplans -n "$MTC_NS" -o json 2>/dev/null | jq -r --arg vmns "$vm_ns" '
    .items[]
    | select([.spec.namespaces[]?] | index($vmns))
    | .metadata.name
  ')

  if [[ -z "$plan_names" ]]; then
    return 0
  fi

  kubectl get migmigrations -n "$MTC_NS" -o json 2>/dev/null | jq -r --arg plans "$plan_names" '
    ($plans | split("\n")) as $planList
    | .items[]
    | select(.spec.migPlanRef.name as $n | $planList | index($n))
    | ["MtcMigMigration", .metadata.namespace, .metadata.name, .metadata.creationTimestamp] | @tsv
  ' | while IFS=$'\t' read -r kind ns name created; do
    [[ -n "${name:-}" ]] && printf '%s\t%s\t%s\t%s\n' "$kind" "$ns" "$name" "$created"
  done
}

cmd_check() {
  info "Cluster: $(kubectl config current-context)"
  if ver=$(kubectl get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null); then
    info "OpenShift version: ${ver}"
  fi
  echo

  local native_crd=0 mtc_crd=0 mtc_controller=0

  if kubectl get crd multinamespacevirtualmachinestoragemigrationplans.migrations.kubevirt.io &>/dev/null; then
    native_crd=1
    ok "Native CRD: multinamespacevirtualmachinestoragemigrationplans.migrations.kubevirt.io"
  else
    fail "Native CRD not found — this script targets clusters with migrations.kubevirt.io"
  fi

  if kubectl get crd migplans.migration.openshift.io &>/dev/null; then
    mtc_crd=1
    ok "MTC CRD: migplans.migration.openshift.io"
  else
    warn "MTC MigPlan CRD not found — only native-path validation applies"
  fi

  if kubectl get migrationcontrollers -n "$MTC_NS" &>/dev/null 2>&1; then
    local count
    count=$(kubectl get migrationcontrollers -n "$MTC_NS" --no-headers 2>/dev/null | wc -l | tr -d ' ')
    if [[ "$count" -gt 0 ]]; then
      mtc_controller=1
      ok "MTC MigrationController in ${MTC_NS} (${count})"
    fi
  else
    warn "No MigrationController in ${MTC_NS}"
  fi

  echo
  if [[ "$native_crd" -eq 1 && "$mtc_crd" -eq 1 && "$mtc_controller" -eq 1 ]]; then
    ok "Cluster matches CNV-88330 scenario (native CRD + MTC both present)"
    echo
    echo "  With fix:    expect NEW NativePlan/NativeMigration in VM namespace after UI migration"
    echo "  Without fix: expect NEW MtcMigPlan/MtcMigMigration in ${MTC_NS} after UI migration"
  elif [[ "$native_crd" -eq 1 ]]; then
    info "Native-only cluster — UI should always use migrations.kubevirt.io"
  elif [[ "$mtc_crd" -eq 1 ]]; then
    info "MTC-only cluster — UI should use MigPlan in ${MTC_NS}"
  fi

  echo
  info "Running VMs (candidates for storage migration — must be Running):"
  kubectl get vm -A --no-headers 2>/dev/null | awk '$4 == "Running" {printf "  - %s/%s\n", $1, $2}' | head -10 || warn "No VMs or unable to list"
}

cmd_before() {
  local vm_ns="$1"
  ensure_state_dir "$vm_ns"
  local outfile
  outfile=$(snapshot_file "$vm_ns")

  info "Saving BEFORE snapshot for namespace: ${vm_ns}"
  collect_resources "$vm_ns" | sort >"$outfile"

  echo
  info "Snapshot written: ${outfile}"
  echo "--- Current resources (summary) ---"
  if [[ ! -s "$outfile" ]]; then
    echo "(empty — no migration resources yet)"
  else
    column -t -s $'\t' <"$outfile" 2>/dev/null || cat "$outfile"
  fi
  echo
  info "Next: run storage migration in the console for a VM in namespace '${vm_ns}', then:"
  echo "  $0 after ${vm_ns}"
}

cmd_after() {
  local vm_ns="$1"
  ensure_state_dir "$vm_ns"
  local before after
  before=$(snapshot_file "$vm_ns")
  after="${STATE_DIR}/${vm_ns}/snapshot-after.tsv"

  if [[ ! -f "$before" ]]; then
    fail "No BEFORE snapshot at ${before}. Run: $0 before ${vm_ns}"
    exit 1
  fi

  info "Saving AFTER snapshot for namespace: ${vm_ns}"
  collect_resources "$vm_ns" | sort >"$after"

  echo
  "$0" compare "$vm_ns"
}

cmd_compare() {
  local vm_ns="$1"
  local before after
  before=$(snapshot_file "$vm_ns")
  after="${STATE_DIR}/${vm_ns}/snapshot-after.tsv"

  if [[ ! -f "$before" ]]; then
    fail "Missing BEFORE snapshot: ${before}"
    exit 1
  fi
  if [[ ! -f "$after" ]]; then
    fail "Missing AFTER snapshot: ${after}. Run: $0 after ${vm_ns}"
    exit 1
  fi

  info "Comparing snapshots for namespace: ${vm_ns}"
  echo "  BEFORE: ${before}"
  echo "  AFTER:  ${after}"
  echo "  (MTC rows only include MigPlans with spec.namespaces containing '${vm_ns}')"
  echo

  local new_native_plans new_native_migs new_mtc_plans new_mtc_migs
  new_native_plans=$(comm -13 <(grep '^NativePlan' "$before" | sort) <(grep '^NativePlan' "$after" | sort) || true)
  new_native_migs=$(comm -13 <(grep '^NativeMigration' "$before" | sort) <(grep '^NativeMigration' "$after" | sort) || true)
  new_mtc_plans=$(comm -13 <(grep '^MtcMigPlan' "$before" | sort) <(grep '^MtcMigPlan' "$after" | sort) || true)
  new_mtc_migs=$(comm -13 <(grep '^MtcMigMigration' "$before" | sort) <(grep '^MtcMigMigration' "$after" | sort) || true)

  echo "--- New since BEFORE ---"
  if [[ -z "$new_native_plans" && -z "$new_native_migs" && -z "$new_mtc_plans" && -z "$new_mtc_migs" ]]; then
    warn "No new migration resources detected. Did the UI migration complete?"
  else
    [[ -n "$new_native_plans" ]] && { echo "Native plans (migrations.kubevirt.io):"; echo "$new_native_plans" | column -t -s $'\t'; echo; }
    [[ -n "$new_native_migs" ]] && { echo "Native migrations:"; echo "$new_native_migs" | column -t -s $'\t'; echo; }
    [[ -n "$new_mtc_plans" ]] && { echo "MTC MigPlans (${MTC_NS}):"; echo "$new_mtc_plans" | column -t -s $'\t'; echo; }
    [[ -n "$new_mtc_migs" ]] && { echo "MTC MigMigrations (${MTC_NS}):"; echo "$new_mtc_migs" | column -t -s $'\t'; echo; }
  fi

  if [[ -n "$new_native_plans" && -z "$new_mtc_plans" ]]; then
    local recent_other
    recent_other=$(kubectl get migplans -n "$MTC_NS" -o json 2>/dev/null | jq -r --arg vmns "$vm_ns" '
      .items[]
      | select([.spec.namespaces[]?] | index($vmns) | not)
      | "  \(.metadata.name) -> namespaces: \(.spec.namespaces | join(", ")) (created \(.metadata.creationTimestamp))"
    ')
    if [[ -n "$recent_other" ]]; then
      echo "--- Other MTC MigPlans on cluster (ignored for '${vm_ns}') ---"
      echo "$recent_other"
      echo
    fi
  fi

  echo "--- Verdict ---"
  local fix_pass=0 fix_fail=0 legacy_pass=0 legacy_fail=0

  if [[ -n "$new_native_plans" || -n "$new_native_migs" ]]; then
    ok "Native API used: new resources in namespace '${vm_ns}' (migrations.kubevirt.io)"
    fix_pass=1
  else
    fail "No new native plan/migration in '${vm_ns}' — fix may not be active or migration did not run"
    fix_fail=1
  fi

  if [[ -n "$new_mtc_plans" || -n "$new_mtc_migs" ]]; then
    fail "MTC API used: new MigPlan/MigMigration in '${MTC_NS}' (pre-fix behavior when MTC is installed)"
    fix_fail=1
    legacy_pass=1
  else
    ok "No new MTC MigPlan/MigMigration in '${MTC_NS}'"
    if [[ "$fix_pass" -eq 1 ]]; then
      ok "Matches expected behavior WITH useShouldUseMtcMigration fix"
    fi
  fi

  echo
  if [[ "$fix_pass" -eq 1 && "$fix_fail" -eq 0 ]]; then
    echo -e "${GREEN}Overall: VALIDATION PASSED (native path)${NC}"
    exit 0
  elif [[ "$legacy_pass" -eq 1 ]]; then
    echo -e "${YELLOW}Overall: Pre-fix / MTC path detected — rebuild plugin WITH fix and retry${NC}"
    exit 2
  else
    echo -e "${RED}Overall: INCONCLUSIVE — check UI migration completed and namespace is correct${NC}"
    exit 3
  fi
}

cmd_cleanup() {
  local vm_ns="${1:-}"
  if [[ -z "$vm_ns" ]]; then
    rm -rf "$STATE_DIR"
    ok "Removed all snapshots under ${STATE_DIR}"
  else
    rm -rf "${STATE_DIR}/${vm_ns}"
    ok "Removed snapshots for ${vm_ns}"
  fi
}

main() {
  local cmd="${1:-}"
  shift || true

  case "$cmd" in
    check) require_kubectl; cmd_check ;;
    before)
      require_kubectl
      require_jq
      [[ -n "${1:-}" ]] || { fail "Usage: $0 before <vm-namespace>"; exit 1; }
      cmd_before "$1"
      ;;
    after)
      require_kubectl
      require_jq
      [[ -n "${1:-}" ]] || { fail "Usage: $0 after <vm-namespace>"; exit 1; }
      cmd_after "$1"
      ;;
    compare)
      require_kubectl
      require_jq
      [[ -n "${1:-}" ]] || { fail "Usage: $0 compare <vm-namespace>"; exit 1; }
      cmd_compare "$1"
      ;;
    cleanup)
      cmd_cleanup "${1:-}"
      ;;
    -h|--help|help|'') usage ;;
    *)
      fail "Unknown command: $cmd"
      usage 1
      ;;
  esac
}

main "$@"

```
</details>


