### PR TITLE
CNV-88903: Lock-in the bootable volume in the custom configuration fl…

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -278,6 +278,7 @@
   "Automatically collapse the side navigation when managing your virtual machines to maximize your workspace": "Automatically collapse the side navigation when managing your virtual machines to maximize your workspace",
   "Automatically pull updates from the RHEL repository. Activation key and Organization ID are mandatory to enable this.": "Automatically pull updates from the RHEL repository. Activation key and Organization ID are mandatory to enable this.",
   "Automatically selected Node": "Automatically selected Node",
+  "Automatically set by the VM Guest OS selection.": "Automatically set by the VM Guest OS selection.",
   "Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.": "Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.",
   "Autounattend.xml": "Autounattend.xml",
   "Autounattend.xml answer file": "Autounattend.xml answer file",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -288,6 +288,7 @@
   "Automatically collapse the side navigation when managing your virtual machines to maximize your workspace": "Automatically collapse the side navigation when managing your virtual machines to maximize your workspace",
   "Automatically pull updates from the RHEL repository. Activation key and Organization ID are mandatory to enable this.": "Obtenga actualizaciones automáticamente del repositorio RHEL. Para ello, se requieren la clave de activación y el ID de la organización.",
   "Automatically selected Node": "Nodo seleccionado automáticamente",
+  "Automatically set by the VM Guest OS selection.": "Automatically set by the VM Guest OS selection.",
   "Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.": "Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.",
   "Autounattend.xml": "Autounattend.xml",
   "Autounattend.xml answer file": "Archivo de respuesta Autounattend.xml",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -288,6 +288,7 @@
   "Automatically collapse the side navigation when managing your virtual machines to maximize your workspace": "Automatically collapse the side navigation when managing your virtual machines to maximize your workspace",
   "Automatically pull updates from the RHEL repository. Activation key and Organization ID are mandatory to enable this.": "Extraire automatiquement les mises à jour du référentiel RHEL. La clé d'activation et l'identifiant de l'organisation sont obligatoires pour activer cette option.",
   "Automatically selected Node": "Nœud sélectionné automatiquement",
+  "Automatically set by the VM Guest OS selection.": "Automatically set by the VM Guest OS selection.",
   "Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.": "Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.",
   "Autounattend.xml": "Autounattend.xml",
   "Autounattend.xml answer file": "Fichier de réponses Autounattend.xml",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -278,6 +278,7 @@
   "Automatically collapse the side navigation when managing your virtual machines to maximize your workspace": "Automatically collapse the side navigation when managing your virtual machines to maximize your workspace",
   "Automatically pull updates from the RHEL repository. Activation key and Organization ID are mandatory to enable this.": "RHEL リポジトリーから更新を自動的にプルします。この機能を有効にするには、アクティベーションキーと組織 ID が必要です。",
   "Automatically selected Node": "自動的に選択されたノード",
+  "Automatically set by the VM Guest OS selection.": "Automatically set by the VM Guest OS selection.",
   "Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.": "Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.",
   "Autounattend.xml": "Autounattend.xml",
   "Autounattend.xml answer file": "Autounattend.xml アンサーファイル",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -278,6 +278,7 @@
   "Automatically collapse the side navigation when managing your virtual machines to maximize your workspace": "Automatically collapse the side navigation when managing your virtual machines to maximize your workspace",
   "Automatically pull updates from the RHEL repository. Activation key and Organization ID are mandatory to enable this.": "RHEL 리포지토리에서 자동으로 업데이트를 가져옵니다. 이 기능을 사용하려면 활성화 키와 조직 ID가 필수입니다.",
   "Automatically selected Node": "자동으로 선택된 노드",
+  "Automatically set by the VM Guest OS selection.": "Automatically set by the VM Guest OS selection.",
   "Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.": "Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.",
   "Autounattend.xml": "Autounattend.xml",
   "Autounattend.xml answer file": "Autounattend.xml 응답 파일",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -278,6 +278,7 @@
   "Automatically collapse the side navigation when managing your virtual machines to maximize your workspace": "Automatically collapse the side navigation when managing your virtual machines to maximize your workspace",
   "Automatically pull updates from the RHEL repository. Activation key and Organization ID are mandatory to enable this.": "从 RHEL 仓库自动拉取更新。需要激活码和机构 ID 才能启用此功能。",
   "Automatically selected Node": "自动选择的节点",
+  "Automatically set by the VM Guest OS selection.": "Automatically set by the VM Guest OS selection.",
   "Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.": "Autounattend will be picked up automatically during windows installation. it can be used with destructive actions such as disk formatting. Autounattend will only be used once during installation.",
   "Autounattend.xml": "Autounattend.xml",
   "Autounattend.xml answer file": "Autounattend.xml 应答文件",

--- a/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -23,23 +23,25 @@ import {
   emptyDataSource,
   SOURCE_DETAILS_SECTION_ID,
 } from './utils/constants';
-import { createBootableVolume, extractCreatedDataSources } from './utils/utils';
+import { createBootableVolume, extractCreatedDataSources, PreferenceOption } from './utils/utils';
 
 type AddBootableVolumeModalProps = {
   isOpen: boolean;
+  lockedPreference?: PreferenceOption;
   onClose: () => void;
   onCreateVolume?: (createdVolume: BootableVolume) => void;
 };
 
 const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
   isOpen,
+  lockedPreference,
   onClose,
   onCreateVolume,
 }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const { bootableVolume, setBootableVolume, setSourceType, sourceType, upload, uploadData } =
-    useAddBootableVolumeModalData();
+    useAddBootableVolumeModalData(lockedPreference);
 
   const isFormValid = useAddBootableVolumeFormValidation({
     bootableVolume,

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/PreferenceSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/PreferenceSelect.tsx
@@ -15,7 +15,7 @@ import {
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import PopoverContentWithLightspeedButton from '@lightspeed/components/PopoverContentWithLightspeedButton/PopoverContentWithLightspeedButton';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
-import { FormGroup, PopoverPosition } from '@patternfly/react-core';
+import { FormGroup, HelperText, PopoverPosition } from '@patternfly/react-core';
 
 import { getSelectedKeyByLabel } from './utils/utils';
 import PreferencePopoverContent from './PreferencePopoverContent';
@@ -44,6 +44,7 @@ const PreferenceSelect: FC<PreferenceSelectProps> = ({
 
   const handleSelect = (value: string) => {
     const selectedOption = preferenceSelectOptions.find((option) => option.value === value);
+    if (!selectedOption) return;
     setBootableVolumeField('labels', DEFAULT_PREFERENCE_LABEL)(selectedOption.label);
   };
 
@@ -60,11 +61,12 @@ const PreferenceSelect: FC<PreferenceSelectProps> = ({
   );
 
   useEffect(() => {
+    if (!preferencesLoaded || bootableVolume.lockedPreference) return;
     if (!isExistingOption) {
       deleteLabel(DEFAULT_PREFERENCE_LABEL);
       deleteLabel(DEFAULT_PREFERENCE_KIND_LABEL);
     }
-  }, [deleteLabel, isExistingOption]);
+  }, [deleteLabel, isExistingOption, bootableVolume.lockedPreference, preferencesLoaded]);
 
   if (!preferencesLoaded) return <Loading />;
 
@@ -86,12 +88,18 @@ const PreferenceSelect: FC<PreferenceSelectProps> = ({
       label={t('Preference')}
     >
       <InlineFilterSelect
+        toggleProps={{
+          isDisabled: isDisabled || !!bootableVolume.lockedPreference,
+          isFullWidth: true,
+        }}
         options={preferenceSelectOptions}
         placeholder={t('Select preference')}
         selected={selectedPreferenceKey}
         setSelected={handleSelect}
-        toggleProps={{ isDisabled, isFullWidth: true }}
       />
+      {bootableVolume.lockedPreference && (
+        <HelperText>{t('Automatically set by the VM Guest OS selection.')}</HelperText>
+      )}
     </FormGroup>
   );
 };

--- a/src/utils/components/AddBootableVolumeModal/hooks/useAddBootableVolumeModalData.ts
+++ b/src/utils/components/AddBootableVolumeModal/hooks/useAddBootableVolumeModalData.ts
@@ -5,6 +5,11 @@ import {
   DROPDOWN_FORM_SELECTION,
   initialBootableVolumeState,
 } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/constants';
+import { PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/utils';
+import {
+  DEFAULT_PREFERENCE_KIND_LABEL,
+  DEFAULT_PREFERENCE_LABEL,
+} from '@kubevirt-utils/constants/instancetypes-and-preferences';
 import {
   DataUpload,
   UploadDataProps,
@@ -14,7 +19,7 @@ import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
 import { getValidNamespace } from '@kubevirt-utils/utils/utils';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 
-type UseAddBootableVolumeModalData = () => {
+type UseAddBootableVolumeModalData = (lockedPreference?: PreferenceOption) => {
   bootableVolume: AddBootableVolumeState;
   setBootableVolume: Dispatch<SetStateAction<AddBootableVolumeState>>;
   setSourceType: Dispatch<SetStateAction<DROPDOWN_FORM_SELECTION>>;
@@ -23,7 +28,7 @@ type UseAddBootableVolumeModalData = () => {
   uploadData: ({ dataVolume, file }: UploadDataProps) => Promise<void>;
 };
 
-const useAddBootableVolumeModalData: UseAddBootableVolumeModalData = () => {
+const useAddBootableVolumeModalData: UseAddBootableVolumeModalData = (lockedPreference) => {
   const [activeNamespace] = useActiveNamespace();
   const namespace = getValidNamespace(activeNamespace);
 
@@ -33,6 +38,14 @@ const useAddBootableVolumeModalData: UseAddBootableVolumeModalData = () => {
     ...initialBootableVolumeState,
     bootableVolumeCluster: selectedCluster,
     bootableVolumeNamespace: namespace,
+    labels: lockedPreference
+      ? {
+          ...initialBootableVolumeState.labels,
+          [DEFAULT_PREFERENCE_KIND_LABEL]: lockedPreference.kind,
+          [DEFAULT_PREFERENCE_LABEL]: lockedPreference.name,
+        }
+      : { ...initialBootableVolumeState.labels },
+    lockedPreference: lockedPreference?.name,
   });
 
   const { upload, uploadData } = useCDIUpload(selectedCluster);

--- a/src/utils/components/AddBootableVolumeModal/utils/constants.ts
+++ b/src/utils/components/AddBootableVolumeModal/utils/constants.ts
@@ -51,6 +51,7 @@ export type AddBootableVolumeState = {
   cronExpression?: string;
   isIso?: boolean;
   labels?: { [key: string]: string };
+  lockedPreference?: string;
   pvcName: string;
   pvcNamespace: string;
   registryCredentials?: { password: string; username: string };

--- a/src/utils/components/AddBootableVolumeModal/utils/utils.ts
+++ b/src/utils/components/AddBootableVolumeModal/utils/utils.ts
@@ -89,6 +89,11 @@ type CreateBootableVolumeType = (input: {
   uploadData: ({ dataVolume, file }: UploadDataProps) => Promise<void>;
 }) => (dataSource: V1beta1DataSource) => Promise<V1beta1DataSource[]>;
 
+export type PreferenceOption = {
+  kind?: string;
+  name: string;
+};
+
 const getBootableVolumePromise = ({
   arch,
   bootableVolume,

--- a/src/views/virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore.ts
+++ b/src/views/virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand';
 import { V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { getInstanceTypeFromVolume } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/utils';
+import { PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/utils';
 import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { initialInstanceTypeVMState } from '@virtualmachines/creation-wizard/state/instance-type-vm-store/utils/state';
@@ -47,9 +48,9 @@ const useInstanceTypeVMStore = create<InstanceTypeVMStore>()((set) => {
       set((state) => ({
         ...state,
         operatingSystemType: osType,
-        preference: '',
+        preference: null,
       })),
-    setPreference: (preference: string) =>
+    setPreference: (preference: null | PreferenceOption) =>
       set({
         preference,
       }),

--- a/src/views/virtualmachines/creation-wizard/state/instance-type-vm-store/utils/state.ts
+++ b/src/views/virtualmachines/creation-wizard/state/instance-type-vm-store/utils/state.ts
@@ -5,7 +5,7 @@ export const initialInstanceTypeVMState: InstanceTypeVMState = {
   customDiskSize: '',
   dvSource: null,
   operatingSystemType: OperatingSystemType.RHEL,
-  preference: '',
+  preference: null,
   pvcSource: null,
   selectedBootableVolume: null,
   selectedInstanceType: null,

--- a/src/views/virtualmachines/creation-wizard/state/instance-type-vm-store/utils/types.ts
+++ b/src/views/virtualmachines/creation-wizard/state/instance-type-vm-store/utils/types.ts
@@ -1,5 +1,6 @@
 import { V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/utils';
 import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { OperatingSystemType } from '@virtualmachines/creation-wizard/steps/InstanceTypesSteps/GuestOSStep/utils/constants';
@@ -8,7 +9,7 @@ export type InstanceTypeVMState = {
   customDiskSize: string;
   dvSource: V1beta1DataVolume;
   operatingSystemType: OperatingSystemType;
-  preference: string;
+  preference: null | PreferenceOption;
   pvcSource: IoK8sApiCoreV1PersistentVolumeClaim;
   selectedBootableVolume: BootableVolume;
   selectedInstanceType: { name: string; namespace: null | string };
@@ -29,7 +30,7 @@ export type InstanceTypeVMActions = {
   resetInstanceTypeVMState: () => void;
   setDVSource: (dvSource: V1beta1DataVolume) => void;
   setOperatingSystemType: (osType: OperatingSystemType) => void;
-  setPreference: (preference: string) => void;
+  setPreference: (preference: null | PreferenceOption) => void;
   setPVCSource: (pvcSource: IoK8sApiCoreV1PersistentVolumeClaim) => void;
   setSelectedBootableVolume: (bootableVolume: BootableVolume) => void;
   setSelectedInstanceType: (instanceType: { name: string; namespace: null | string }) => void;

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/AddBootableVolumeButton.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/AddBootableVolumeButton.tsx
@@ -18,7 +18,7 @@ const AddBootableVolumeButton: FC<AddBootableVolumeButtonProps> = ({ loadError }
   const { t } = useKubevirtTranslation();
   useSignals();
   const { createModal } = useModal();
-  const { onSelectCreatedVolume, volumeListNamespace } = useInstanceTypeVMStore();
+  const { onSelectCreatedVolume, preference, volumeListNamespace } = useInstanceTypeVMStore();
 
   const { canCreateDS, canCreatePVC } = useCanCreateBootableVolume(volumeListNamespace);
   const canCreate = canCreateDS || canCreatePVC;
@@ -30,6 +30,7 @@ const AddBootableVolumeButton: FC<AddBootableVolumeButtonProps> = ({ loadError }
       onClick={() =>
         createModal((props) => (
           <AddBootableVolumeModal
+            lockedPreference={preference ?? undefined}
             onCreateVolume={(volume) => onSelectCreatedVolume(volume, null, null, null)}
             {...props}
           />

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/AddBootableVolumeLink/AddBootableVolumeLink.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/AddBootableVolumeLink/AddBootableVolumeLink.tsx
@@ -22,7 +22,7 @@ const AddBootableVolumeLink: FC<AddBootableVolumeLinkProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
-  const { onSelectCreatedVolume, volumeListNamespace } = useInstanceTypeVMStore();
+  const { onSelectCreatedVolume, preference, volumeListNamespace } = useInstanceTypeVMStore();
 
   const { canCreateDS, canCreatePVC } = useCanCreateBootableVolume(volumeListNamespace);
   const canCreate = canCreateDS || canCreatePVC;
@@ -33,6 +33,7 @@ const AddBootableVolumeLink: FC<AddBootableVolumeLinkProps> = ({
         hidePopover?.();
         createModal((props) => (
           <AddBootableVolumeModal
+            lockedPreference={preference ?? undefined}
             onCreateVolume={(volume) => onSelectCreatedVolume(volume, null, null, null)}
             {...props}
           />

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeEmptyState/BootableVolumeEmptyState.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeEmptyState/BootableVolumeEmptyState.tsx
@@ -22,7 +22,7 @@ const BootableVolumeEmptyState: FC<BootableVolumeEmptyStateProps> = ({ isPrefere
 
   const osName = preference
     ? (() => {
-        const base = preference.split('.')[0].split('-')[0];
+        const base = preference.name.split('.')[0].split('-')[0];
         return base === OS_NAME_TYPES.rhel || base === OS_NAME_TYPES.windows ? base : LINUX;
       })()
     : undefined;

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootableVolumesTableData.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootableVolumesTableData.ts
@@ -61,17 +61,17 @@ const useBootableVolumesTableData: UseBootableVolumesTableData = (
   const { bootableVolumes, dvSources, pvcSources, volumeSnapshotSources } = bootableVolumesData;
 
   const preferenceFilteredVolumes = useMemo(
-    () => filterBootableVolumesByPreference(bootableVolumes, preference),
+    () => filterBootableVolumesByPreference(bootableVolumes, preference?.name),
     [bootableVolumes, preference],
   );
 
   const isPreferenceFilterEmpty =
-    !!preference && !isEmpty(bootableVolumes) && isEmpty(preferenceFilteredVolumes);
+    !!preference?.name && !isEmpty(bootableVolumes) && isEmpty(preferenceFilteredVolumes);
 
   const allFilters = useBootVolumeFilters(preferenceFilteredVolumes);
 
   const filters = useMemo(() => {
-    if (!preference || isLinuxGenericPreference(preference)) return allFilters;
+    if (!preference?.name || isLinuxGenericPreference(preference?.name)) return allFilters;
     return allFilters.filter((f) => f.type !== 'osName');
   }, [allFilters, preference]);
 

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/PreferenceSelectMenu.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/PreferenceSelectMenu.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/utils/utils';
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup, SelectOption } from '@patternfly/react-core';
@@ -14,7 +15,7 @@ const PreferenceSelectMenu: FC = () => {
   const { cluster, project } = useVMWizardStore();
   const { operatingSystemType, preference, setPreference } = useInstanceTypeVMStore();
 
-  const { preferenceNames } = usePreferenceSelectOptions(project, cluster, operatingSystemType);
+  const { preferences } = usePreferenceSelectOptions(project, cluster, operatingSystemType);
 
   return (
     <FormGroup
@@ -23,16 +24,18 @@ const PreferenceSelectMenu: FC = () => {
       label={t('Guest operating system type')}
     >
       <FormPFSelect
+        onSelect={(_, value) => {
+          setPreference(value as PreferenceOption);
+        }}
         className="pf-v6-u-mt-md"
-        onSelect={(_, value) => setPreference(value as string)}
         placeholder={t('Select guest operating system type')}
-        selected={preference || ''}
-        selectedLabel={preference || t('Select guest operating system type')}
+        selected={preference?.name || ''}
+        selectedLabel={preference?.name || t('Select guest operating system type')}
         toggleProps={{ isFullWidth: true }}
       >
-        {preferenceNames.map((name) => (
-          <SelectOption key={name} value={name}>
-            {name}
+        {preferences.map((pref) => (
+          <SelectOption key={pref.name} value={pref}>
+            {pref.name}
           </SelectOption>
         ))}
       </FormPFSelect>

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/hooks/usePreferenceSelectOptions/usePreferenceSelectOptions.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/hooks/usePreferenceSelectOptions/usePreferenceSelectOptions.ts
@@ -10,7 +10,7 @@ type UsePreferenceSelectOptions = (
   cluster: string,
   operatingSystemType: OperatingSystemType,
 ) => {
-  preferenceNames: string[];
+  preferences: { kind: string; name: string }[];
   preferencesLoaded: boolean;
 };
 
@@ -27,13 +27,13 @@ const usePreferenceSelectOptions: UsePreferenceSelectOptions = (
     cluster,
   );
 
-  const preferenceNames = useMemo(() => {
+  const preferences = useMemo(() => {
     const allPreferences = [...(clusterPreferences || []), ...(userPreferences || [])];
     return getPreferenceNamesFilteredByOSType(allPreferences, operatingSystemType);
   }, [clusterPreferences, userPreferences, operatingSystemType]);
 
   return {
-    preferenceNames,
+    preferences,
     preferencesLoaded: clusterPreferencesLoaded && userPreferencesLoaded,
   };
 };

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/hooks/usePreferenceSelectOptions/utils/utils.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/hooks/usePreferenceSelectOptions/utils/utils.ts
@@ -10,7 +10,7 @@ import { OperatingSystemType } from '@virtualmachines/creation-wizard/steps/Inst
 export const getPreferenceNamesFilteredByOSType = (
   preferences: (V1beta1VirtualMachineClusterPreference | V1beta1VirtualMachinePreference)[],
   osType: OperatingSystemType,
-): string[] => {
+): { kind: string; name: string }[] => {
   const filteredPreferences = preferences.filter((pref) => {
     const os = pref?.spec?.annotations?.[VM_OS_ANNOTATION];
     const name = getName(pref)?.toLowerCase() || '';
@@ -27,5 +27,7 @@ export const getPreferenceNamesFilteredByOSType = (
     }
   });
 
-  return filteredPreferences.map(getName).sort((a, b) => a.localeCompare(b));
+  return filteredPreferences
+    .map((pref) => ({ kind: pref.kind, name: getName(pref) }))
+    .sort((a, b) => a.name.localeCompare(b.name));
 };


### PR DESCRIPTION
## 📝 Description
When opening the "Add volume" modal from the VM creation wizard, the preference field is now pre-filled and locked to match the Guest OS selected in the previous step.

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-88903

## 🎥 Demo

Before: 
<img width="562" height="1129" alt="image" src="https://github.com/user-attachments/assets/831c2b68-cf0a-4197-ad30-3e6857643d3f" />


After: 
<img width="559" height="1222" alt="image" src="https://github.com/user-attachments/assets/466c882f-3843-418d-9356-4b28de3b4691" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal can be opened with a locked preference so users cannot change the preference during bootable volume creation; UI shows an explanatory message and disables the selector.

* **Bug Fixes**
  * Rejects invalid/unmapped preference selections and improves preference-based filtering and empty-state behavior.

* **Refactor**
  * Preference storage changed from plain strings to typed objects and default preference cleared to null for more consistent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->