### PR TITLE
CNV-87452: Exclude original Jira keys from clone backport PRs

### DIFF
--- a/.github/scripts/src/cherry-pick.ts
+++ b/.github/scripts/src/cherry-pick.ts
@@ -3,6 +3,7 @@ import { Octokit } from '@octokit/rest';
 
 import { addLabel } from './github-comments.js';
 import { createPullRequest } from './github-repo.js';
+import { rewriteJiraKeysInText, stripOriginalJiraKeys } from './version-utils.js';
 import { CONFLICT_LABEL, JIRA_BASE_URL } from './types/index.js';
 import type { CherryPickResult, ClonedTicket, JiraVersion } from './types/index.js';
 
@@ -22,11 +23,21 @@ const gitSafe = (...args: string[]): string => {
   }
 };
 
+/** Amend the latest commit message, preserving multi-line bodies. */
+const amendCommitMessage = (message: string): void => {
+  execFileSync('git', ['commit', '--amend', '-F', '-'], {
+    encoding: 'utf-8',
+    input: message,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+};
+
 /** Cherry-pick a commit onto a target branch; aborts cleanly on conflicts. */
 export const performCherryPick = (
   targetBranch: string,
   commitSha: string,
   branchName: string,
+  clonedTickets: ClonedTicket[],
 ): CherryPickResult => {
   let cherryPickClean = true;
   let conflictDetails = '';
@@ -36,12 +47,24 @@ export const performCherryPick = (
 
   try {
     git('cherry-pick', commitSha, '-m', '1', '--allow-empty');
+
+    if (clonedTickets.length > 0) {
+      const originalMessage = git('log', '-1', '--format=%B');
+      const rewrittenMessage = rewriteJiraKeysInText(originalMessage, clonedTickets);
+      if (rewrittenMessage !== originalMessage) {
+        amendCommitMessage(rewrittenMessage);
+      }
+    }
   } catch {
     cherryPickClean = false;
     conflictDetails = gitSafe('diff', '--name-only', '--diff-filter=U');
     git('cherry-pick', '--abort');
-    git('commit', '--allow-empty', '-m',
-      `[CONFLICTS] Cherry-pick ${commitSha} to ${targetBranch} - manual resolution required`);
+    git(
+      'commit',
+      '--allow-empty',
+      '-m',
+      `[CONFLICTS] Cherry-pick ${commitSha} to ${targetBranch} - manual resolution required`,
+    );
   }
 
   git('push', 'origin', branchName);
@@ -49,7 +72,42 @@ export const performCherryPick = (
   return { cherryPickClean, conflictDetails, cherryPickBranch: branchName };
 };
 
-/** Open a cherry-pick PR with ticket mapping table; marks as draft if conflicts. */
+/** Build PR body with clone ticket references only (no original Jira keys). */
+export const buildCherryPickPrBody = (params: {
+  originalPrNumber: number;
+  targetBranch: string;
+  matchedVersion: JiraVersion;
+  clonedTickets: ClonedTicket[];
+  cherryPickClean: boolean;
+  conflictDetails: string;
+}): string => {
+  const { originalPrNumber, targetBranch, matchedVersion, clonedTickets, cherryPickClean, conflictDetails } =
+    params;
+
+  const jiraLines = clonedTickets.map(
+    (ct) => `- [${ct.clonedKey}](${JIRA_BASE_URL}/browse/${ct.clonedKey})`,
+  );
+
+  const statusLine = cherryPickClean
+    ? ':white_check_mark: Cherry-pick applied cleanly.'
+    : `:warning: **Cherry-pick had conflicts.** Files needing resolution:\n\`\`\`\n${conflictDetails}\n\`\`\``;
+
+  const body = [
+    `## Cherry-pick to \`${targetBranch}\``,
+    '',
+    `**Source PR**: #${originalPrNumber}`,
+    `**Fix version**: ${matchedVersion.name}`,
+    '',
+    '### Jira',
+    ...jiraLines,
+    '',
+    statusLine,
+  ].join('\n');
+
+  return stripOriginalJiraKeys(body, clonedTickets);
+};
+
+/** Open a cherry-pick PR referencing only clone tickets; marks as draft if conflicts. */
 export const openCherryPickPR = async (
   octokit: Octokit,
   owner: string,
@@ -65,33 +123,13 @@ export const openCherryPickPR = async (
     matchedVersion: JiraVersion;
   },
 ): Promise<{ number: number; html_url: string }> => {
-  const { originalPrNumber, targetBranch, matchedVersion, clonedTickets } = params;
-
-  const ticketMappingLines = clonedTickets.map((ct) =>
-    `| [${ct.originalKey}](${JIRA_BASE_URL}/browse/${ct.originalKey}) | [${ct.clonedKey}](${JIRA_BASE_URL}/browse/${ct.clonedKey}) |`,
-  );
-
-  const prBody = [
-    `## Cherry-pick of #${originalPrNumber} to \`${targetBranch}\``,
-    '',
-    `**Original PR**: #${originalPrNumber}`,
-    `**Fix version**: ${matchedVersion.name}`,
-    '',
-    '### Cloned tickets',
-    '| Original | Clone |',
-    '|----------|-------|',
-    ...ticketMappingLines,
-    '',
-    params.cherryPickClean
-      ? ':white_check_mark: Cherry-pick applied cleanly.'
-      : `:warning: **Cherry-pick had conflicts.** Files needing resolution:\n\`\`\`\n${params.conflictDetails}\n\`\`\``,
-  ].join('\n');
+  const prBody = buildCherryPickPrBody(params);
 
   const newPr = await createPullRequest(octokit, owner, repo, {
     title: params.prTitle,
     body: prBody,
     head: params.cherryPickBranch,
-    base: targetBranch,
+    base: params.targetBranch,
     draft: !params.cherryPickClean,
   });
 

--- a/.github/scripts/src/clone-pr.ts
+++ b/.github/scripts/src/clone-pr.ts
@@ -120,7 +120,7 @@ const main = async (): Promise<void> => {
 
   let result: Awaited<ReturnType<typeof performCherryPick>>;
   try {
-    result = performCherryPick(targetBranch, commitSha, cherryPickBranch);
+    result = performCherryPick(targetBranch, commitSha, cherryPickBranch, clonedTickets);
   } catch (err) {
     const keys = clonedTickets
       .map((ct) => `[${ct.clonedKey}](${JIRA_BASE_URL}/browse/${ct.clonedKey})`)

--- a/.github/scripts/src/version-utils.ts
+++ b/.github/scripts/src/version-utils.ts
@@ -1,4 +1,5 @@
-import type { JiraVersion } from './types/index.js';
+import { JIRA_BASE_URL } from './types/index.js';
+import type { ClonedTicket, JiraVersion } from './types/index.js';
 
 const RELEASE_BRANCH_REGEX = /^release-(\d+\.\d+)$/;
 const VERSION_NUMBER_REGEX = /(\d+\.\d+)/;
@@ -46,9 +47,10 @@ export const computeNextVersion = (highestReleaseVersion: string): string => {
   const major = parts[0];
   const minorStr = parts[1]!;
   const nextMinor = parseInt(minorStr, 10) + 1;
-  const padded = minorStr.length > 1 && minorStr.startsWith('0')
-    ? String(nextMinor).padStart(minorStr.length, '0')
-    : String(nextMinor);
+  const padded =
+    minorStr.length > 1 && minorStr.startsWith('0')
+      ? String(nextMinor).padStart(minorStr.length, '0')
+      : String(nextMinor);
   return `${major}.${padded}`;
 };
 
@@ -70,7 +72,10 @@ export const getExpectedVersionForBranch = (
 };
 
 /** Check if a Jira fix version's embedded number matches an expected version. */
-export const fixVersionMatchesBranch = (fixVersion: JiraVersion, expectedVersion: string): boolean => {
+export const fixVersionMatchesBranch = (
+  fixVersion: JiraVersion,
+  expectedVersion: string,
+): boolean => {
   const fvVersion = extractVersionNumber(fixVersion.name);
   return fvVersion === expectedVersion;
 };
@@ -104,6 +109,26 @@ export const extractTicketIds = (title: string): string[] => {
   const matches = title.match(/CNV-\d+/gi);
   if (!matches) return [];
   return [...new Set(matches.map((m) => m.toUpperCase()))];
+};
+
+/** Replace original Jira keys with clone keys (e.g. in cherry-picked commit messages). */
+export const rewriteJiraKeysInText = (text: string, clonedTickets: ClonedTicket[]): string => {
+  let result = text;
+  for (const { originalKey, clonedKey } of clonedTickets) {
+    result = result.replace(new RegExp(originalKey, 'gi'), clonedKey);
+  }
+  return result;
+};
+
+/** Remove original Jira keys from text so Prow does not update the source ticket. */
+export const stripOriginalJiraKeys = (text: string, clonedTickets: ClonedTicket[]): string => {
+  let result = text;
+  for (const { originalKey } of clonedTickets) {
+    result = result.replace(new RegExp(`\\[${originalKey}\\]\\([^)]*\\)`, 'gi'), '');
+    result = result.replace(new RegExp(`${JIRA_BASE_URL}/browse/${originalKey}`, 'gi'), '');
+    result = result.replace(new RegExp(`\\b${originalKey}\\b`, 'gi'), '');
+  }
+  return result.replace(/\n{3,}/g, '\n\n').trim();
 };
 
 /** Check if a branch name matches the release-X.YY pattern. */

--- a/.github/scripts/src/version-utils.ts
+++ b/.github/scripts/src/version-utils.ts
@@ -111,11 +111,77 @@ export const extractTicketIds = (title: string): string[] => {
   return [...new Set(matches.map((m) => m.toUpperCase()))];
 };
 
+const JIRA_ISSUE_KEY_PATTERN = /^[A-Z][A-Z0-9]+-\d+$/;
+
+/** Validate Jira issue keys before using them in string operations. */
+export const isValidJiraIssueKey = (key: string): boolean => JIRA_ISSUE_KEY_PATTERN.test(key);
+
+/** Linear-time case-insensitive literal replacement (avoids dynamic RegExp / ReDoS). */
+export const replaceLiteralCaseInsensitive = (
+  text: string,
+  search: string,
+  replacement: string,
+): string => {
+  if (!search) return text;
+
+  const searchLower = search.toLowerCase();
+  let result = '';
+  let index = 0;
+
+  while (index < text.length) {
+    const candidate = text.slice(index, index + search.length);
+    if (candidate.length === search.length && candidate.toLowerCase() === searchLower) {
+      result += replacement;
+      index += search.length;
+    } else {
+      result += text[index];
+      index += 1;
+    }
+  }
+
+  return result;
+};
+
+const isJiraKeyChar = (char: string | undefined): boolean =>
+  char !== undefined && /[A-Z0-9]/i.test(char);
+
+/** Remove whole Jira key occurrences using literal matching (avoids dynamic RegExp / ReDoS). */
+export const removeJiraKeyOccurrences = (text: string, key: string): string => {
+  if (!isValidJiraIssueKey(key)) return text;
+
+  const keyLower = key.toLowerCase();
+  let result = '';
+  let index = 0;
+
+  while (index < text.length) {
+    const candidate = text.slice(index, index + key.length);
+    const before = index > 0 ? text[index - 1] : undefined;
+    const after = text[index + key.length];
+
+    if (
+      candidate.length === key.length &&
+      candidate.toLowerCase() === keyLower &&
+      !isJiraKeyChar(before) &&
+      !isJiraKeyChar(after)
+    ) {
+      index += key.length;
+    } else {
+      result += text[index];
+      index += 1;
+    }
+  }
+
+  return result;
+};
+
 /** Replace original Jira keys with clone keys (e.g. in cherry-picked commit messages). */
 export const rewriteJiraKeysInText = (text: string, clonedTickets: ClonedTicket[]): string => {
   let result = text;
   for (const { originalKey, clonedKey } of clonedTickets) {
-    result = result.replace(new RegExp(originalKey, 'gi'), clonedKey);
+    if (!isValidJiraIssueKey(originalKey) || !isValidJiraIssueKey(clonedKey)) {
+      continue;
+    }
+    result = replaceLiteralCaseInsensitive(result, originalKey, clonedKey);
   }
   return result;
 };
@@ -124,9 +190,14 @@ export const rewriteJiraKeysInText = (text: string, clonedTickets: ClonedTicket[
 export const stripOriginalJiraKeys = (text: string, clonedTickets: ClonedTicket[]): string => {
   let result = text;
   for (const { originalKey } of clonedTickets) {
-    result = result.replace(new RegExp(`\\[${originalKey}\\]\\([^)]*\\)`, 'gi'), '');
-    result = result.replace(new RegExp(`${JIRA_BASE_URL}/browse/${originalKey}`, 'gi'), '');
-    result = result.replace(new RegExp(`\\b${originalKey}\\b`, 'gi'), '');
+    if (!isValidJiraIssueKey(originalKey)) {
+      continue;
+    }
+
+    const markdownLink = `[${originalKey}](${JIRA_BASE_URL}/browse/${originalKey})`;
+    result = replaceLiteralCaseInsensitive(result, markdownLink, '');
+    result = replaceLiteralCaseInsensitive(result, `${JIRA_BASE_URL}/browse/${originalKey}`, '');
+    result = removeJiraKeyOccurrences(result, originalKey);
   }
   return result.replace(/\n{3,}/g, '\n\n').trim();
 };


### PR DESCRIPTION
## Summary

When `/clone release-X.YY` creates a backport PR, Prow scans the new PR title, description, and commit messages for Jira keys. References to the **original** ticket (e.g. `CNV-87879`) were causing Prow to move that ticket back to **POST** from MODIFIED, ON_QA, or Verified.

This change ensures backport PRs only reference the **clone** ticket.


EXAMPLE: https://github.com/kubevirt-ui/kubevirt-plugin/pull/3987.
We cloned a PR and now both jira tickets (4.23 and 4.22) are in POST  status even those only 4.22 should be on post. 

## Changes

- Backport PR description lists clone ticket(s) only — no original Jira links or keys
- Cherry-picked commit messages are amended to replace original keys with clone keys
- Added `rewriteJiraKeysInText()` and `stripOriginalJiraKeys()` helpers as safeguards

## Example: backport PR description

After commenting `/clone release-4.22` on a merged PR titled `CNV-87879: Add error alert to custom configuration on create VM wizard`, users will see this on the **new backport PR**:

```markdown
## Cherry-pick to `release-4.22`

**Source PR**: #3997
**Fix version**: CNV v4.22.z

### Jira
- [CNV-89055](https://redhat.atlassian.net/browse/CNV-89055)

:white_check_mark: Cherry-pick applied cleanly.
```

**Before (problematic):** the description included an "Original | Clone" table linking to `CNV-87879`, which triggered Prow to update the source ticket.

## Example: comment on the original PR

The confirmation comment on the **source** PR still shows the ticket mapping for traceability (this does not affect the backport PR):

```markdown
:white_check_mark: **Clone to `release-4.22` complete**

| Ticket mapping | Link |
|----------------|------|
| CNV-87879 → CNV-89055 | [CNV-89055](https://redhat.atlassian.net/browse/CNV-89055) |

| | |
|---|---|
| **Fix version** | CNV v4.22.z |
| **New PR** | #4015 |
| **Cherry-pick** | Clean |
```

## Example: commit message

Cherry-picked commit message is rewritten from:

```
CNV-87879: Add error alert to custom configuration on create VM wizard
```

to:

```
CNV-89055: Add error alert to custom configuration on create VM wizard
```

## Links

https://redhat.atlassian.net/browse/CNV-87452

## Test plan

- [ ] Comment `/clone release-4.XX` on a merged PR with a Jira ticket in the title
- [ ] Verify the new backport PR description contains only the clone ticket key
- [ ] Verify the cherry-picked commit message uses the clone ticket key
- [ ] Confirm Prow does not transition the original Jira ticket to POST

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cherry-pick operations now properly handle and rewrite Jira ticket references in commit messages and pull request bodies when working with cloned tickets.
  * Pull request descriptions for cherry-picked changes automatically include cloned ticket mappings and conflict status information.
  * Enhanced Jira ticket key validation and manipulation utilities for improved ticket reference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->