### PR TITLE
CNV-89127: Fleet virtualization templates page fails with 404 when selecting a spoke cluster

### DIFF
--- a/src/views/templates/list/hooks/isResourceNotFoundError.ts
+++ b/src/views/templates/list/hooks/isResourceNotFoundError.ts
@@ -1,0 +1,11 @@
+type K8sResourceLoadError = {
+  code?: number;
+  response?: { status?: number };
+};
+
+const isResourceNotFoundError = (error: unknown): boolean => {
+  const loadError = error as K8sResourceLoadError;
+  return loadError?.code === 404 || loadError?.response?.status === 404;
+};
+
+export default isResourceNotFoundError;

--- a/src/views/templates/list/hooks/useVirtualMachineTemplateRequests.ts
+++ b/src/views/templates/list/hooks/useVirtualMachineTemplateRequests.ts
@@ -4,6 +4,8 @@ import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchReso
 import useListClusters from '@kubevirt-utils/hooks/useListClusters';
 import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
+import isResourceNotFoundError from './isResourceNotFoundError';
+
 type UseVirtualMachineTemplateRequests = (
   namespace?: string,
   enabled?: boolean,
@@ -38,9 +40,11 @@ const useVirtualMachineTemplateRequests: UseVirtualMachineTemplateRequests = (
       : null,
   );
 
+  const is404 = isResourceNotFoundError(loadError);
+
   return {
-    error: loadError,
-    loaded: shouldWatch ? loaded : true,
+    error: is404 ? undefined : loadError,
+    loaded: shouldWatch ? loaded || !!loadError : true,
     vmTemplateRequests: vmTemplateRequests ?? [],
   };
 };

--- a/src/views/templates/list/hooks/useVirtualMachineTemplates.ts
+++ b/src/views/templates/list/hooks/useVirtualMachineTemplates.ts
@@ -5,6 +5,8 @@ import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchReso
 import useListClusters from '@kubevirt-utils/hooks/useListClusters';
 import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
+import isResourceNotFoundError from './isResourceNotFoundError';
+
 type UseVirtualMachineTemplates = (
   namespace?: string,
   enabled?: boolean,
@@ -37,9 +39,11 @@ const useVirtualMachineTemplates: UseVirtualMachineTemplates = (namespace, enabl
       : null,
   );
 
+  const is404 = isResourceNotFoundError(loadError);
+
   return {
-    error: loadError,
-    loaded: shouldWatch ? loaded : true,
+    error: is404 ? undefined : loadError,
+    loaded: shouldWatch ? loaded || !!loadError : true,
     vmTemplates: vmTemplates ?? [],
   };
 };


### PR DESCRIPTION
## 📝 Description

On the Fleet Virtualization templates page, selecting a spoke cluster causes the page to fail with a 404 Not Found error.

## 🔗 Links

Jira ticket: [CNV-89127](https://redhat.atlassian.net/browse/CNV-89127)

## 🎥 Demo

Before: 

https://github.com/user-attachments/assets/08d31e03-350f-4294-b5fe-827c4f6e65e1


After:

https://github.com/user-attachments/assets/4edb0c3b-23fe-4184-8ca4-33c8003d6fb0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced virtual machine template loading to gracefully handle 404 not-found errors without displaying error messages, and improved loading state tracking when monitoring resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->