### PR TITLE
CNV-89133: Replace inline required-field messages with getFieldRequiredMessage

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/VolumeDestination/VolumeDestination.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeDestination/VolumeDestination.tsx
@@ -6,6 +6,7 @@ import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/
 import ProjectDropdown from '@kubevirt-utils/components/ProjectDropdown/ProjectDropdown';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useRequiredFieldValidation } from '@kubevirt-utils/hooks/useRequiredFieldValidation';
+import { getFieldRequiredMessage } from '@kubevirt-utils/utils/validation';
 import { ExpandableSection, FormGroup, Grid, GridItem, TextInput } from '@patternfly/react-core';
 
 import { AddBootableVolumeState, SetBootableVolumeFieldType } from '../../utils/constants';
@@ -59,7 +60,7 @@ const VolumeDestination: FC<VolumeDestinationProps> = ({
         />
         {isVolumeNameInvalid && (
           <FormGroupHelperText validated={volumeNameValidated}>
-            {t('This field is required')}
+            {getFieldRequiredMessage(t)}
           </FormGroupHelperText>
         )}
       </FormGroup>

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/ContainerSource.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/ContainerSource.tsx
@@ -5,6 +5,7 @@ import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/
 import { FormPasswordInput } from '@kubevirt-utils/components/FormPasswordInput/FormPasswordInput';
 import { FormTextInput } from '@kubevirt-utils/components/FormTextInput/FormTextInput';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getFieldRequiredMessage } from '@kubevirt-utils/utils/validation';
 import { FormGroup, ValidatedOptions } from '@patternfly/react-core';
 
 type ContainerSourceProps = {
@@ -59,7 +60,7 @@ const ContainerSource: FC<ContainerSourceProps> = ({
         />
         <FormGroupHelperText validated={validated}>
           {errors?.[`${testId}-containerImage`]
-            ? t('This field is required')
+            ? getFieldRequiredMessage(t)
             : registrySourceHelperText}
         </FormGroupHelperText>
       </FormGroup>

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/HTTPSource.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/HTTPSource.tsx
@@ -10,6 +10,7 @@ import { FormTextInput } from '@kubevirt-utils/components/FormTextInput/FormText
 import { TLSCertificateSection } from '@kubevirt-utils/components/TLSCertificateSection';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useRequiredFieldValidation } from '@kubevirt-utils/hooks/useRequiredFieldValidation';
+import { getFieldRequiredMessage } from '@kubevirt-utils/utils/validation';
 import { FormGroup } from '@patternfly/react-core';
 
 type HTTPSourceProps = {
@@ -47,7 +48,7 @@ const HTTPSource: FC<HTTPSourceProps> = ({ bootableVolume, setBootableVolumeFiel
         />
         <FormGroupHelperText validated={urlValidated}>
           {isUrlInvalid ? (
-            t('This field is required')
+            getFieldRequiredMessage(t)
           ) : (
             <>
               {t('Enter URL to download. For example:')}{' '}

--- a/src/views/datasources/dataimportcron/details/DataImportCronManageModal/DataImportCronManageModal.tsx
+++ b/src/views/datasources/dataimportcron/details/DataImportCronManageModal/DataImportCronManageModal.tsx
@@ -14,6 +14,7 @@ import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpa
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getFieldRequiredMessage } from '@kubevirt-utils/utils/validation';
 import {
   Checkbox,
   Divider,
@@ -111,7 +112,7 @@ export const DataImportCronManageModal: FC<DataImportCronManageModalProps> = ({
                 validated={errors?.['url'] ? ValidatedOptions.error : ValidatedOptions.default}
               >
                 {errors?.['url']
-                  ? t('This field is required')
+                  ? getFieldRequiredMessage(t)
                   : t('Example: {{exampleURL}}', {
                       exampleURL: 'docker://quay.io/containerdisks/centos:7-2009',
                     })}
@@ -204,7 +205,7 @@ export const DataImportCronManageModal: FC<DataImportCronManageModalProps> = ({
                     }
                   >
                     {errors?.['schedule']
-                      ? t('This field is required')
+                      ? getFieldRequiredMessage(t)
                       : t('Example (At 00:00 on Tuesday): {{exampleCron}}', {
                           exampleCron: '0 0 * * 2',
                         })}

--- a/src/views/datasources/list/CreateDataSourceModal/CreateDataSourceForm.tsx
+++ b/src/views/datasources/list/CreateDataSourceModal/CreateDataSourceForm.tsx
@@ -9,6 +9,7 @@ import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getFieldRequiredMessage } from '@kubevirt-utils/utils/validation';
 import {
   Form,
   FormGroup,
@@ -52,7 +53,7 @@ export const CreateDataSourceForm: FC<CreateDataSourceFormProps> = ({
         <FormGroupHelperText
           validated={errors?.['name'] ? ValidatedOptions.error : ValidatedOptions.default}
         >
-          {errors?.['name'] && t('This field is required')}
+          {errors?.['name'] && getFieldRequiredMessage(t)}
         </FormGroupHelperText>
       </FormGroup>
       <FormGroup
@@ -73,7 +74,7 @@ export const CreateDataSourceForm: FC<CreateDataSourceFormProps> = ({
           validated={errors?.['url'] ? ValidatedOptions.error : ValidatedOptions.default}
         >
           {errors?.['url']
-            ? t('This field is required')
+            ? getFieldRequiredMessage(t)
             : t('Example: {{exampleURL}}', {
                 exampleURL: 'quay.io/containerdisks/centos:7-2009',
               })}
@@ -149,7 +150,7 @@ export const CreateDataSourceForm: FC<CreateDataSourceFormProps> = ({
           validated={errors?.['schedule'] ? ValidatedOptions.error : ValidatedOptions.default}
         >
           {errors?.['schedule']
-            ? t('This field is required')
+            ? getFieldRequiredMessage(t)
             : t('Example (At 00:00 on Tuesday): {{exampleCron}}', {
                 exampleCron: '0 0 * * 2',
               })}

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/components/FieldGroup.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/components/FieldGroup.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { TemplateParameter } from '@kubevirt-ui-ext/kubevirt-api/console';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getFieldRequiredMessage } from '@kubevirt-utils/utils/validation';
 import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
 
 type FieldGroupProps = {
@@ -51,7 +52,7 @@ const FieldGroup: FC<FieldGroupProps> = ({
         value={value}
       />
       <FormGroupHelperText validated={validated}>
-        {showError && !value ? t('This field is required') : description}
+        {showError && !value ? getFieldRequiredMessage(t) : description}
       </FormGroupHelperText>
     </FormGroup>
   );


### PR DESCRIPTION
## 📝 Description

`getFieldRequiredMessage(t)` is exported from `src/utils/utils/validation.ts` as the shared helper for required-field validation messages. Several components still inline `t('This field is required')` instead of using the utility.

## 🔗 Links

Jira ticket: [CNV-89133](https://redhat.atlassian.net/browse/CNV-89133)

## 🎥 Demo

No UI changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated form validation to use a standardized required field message format across multiple components in data source and virtual machine creation workflows, improving consistency in validation error messaging throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->