### PR TITLE
CNV-89140: Storage checkup Rerun fails or leaves multiple running jobs in History

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -2105,6 +2105,7 @@
   "This project is also governed by a ResourceQuota. Review to ensure accurate and consistent resource enforcement.": "This project is also governed by a ResourceQuota. Review to ensure accurate and consistent resource enforcement.",
   "This quota contains advanced settings (such as pod limits) that cannot be displayed in this simplified form. These configurations remain active and can be viewed or edited in the YAML view.": "This quota contains advanced settings (such as pod limits) that cannot be displayed in this simplified form. These configurations remain active and can be viewed or edited in the YAML view.",
   "This self validation checkup is currently running. If you rerun the checkup, the running job will be deleted.": "This self validation checkup is currently running. If you rerun the checkup, the running job will be deleted.",
+  "This storage checkup is currently running. If you rerun the checkup, the running job will be deleted.": "This storage checkup is currently running. If you rerun the checkup, the running job will be deleted.",
   "This suite was skipped.": "This suite was skipped.",
   "This user is not allowed to edit this boot source": "This user is not allowed to edit this boot source",
   "This VirtualMachine has": "This VirtualMachine has",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -2125,6 +2125,7 @@
   "This project is also governed by a ResourceQuota. Review to ensure accurate and consistent resource enforcement.": "Este proyecto también se rige por una cuota de recursos. Revísela para garantizar una aplicación precisa y coherente de los mismos.",
   "This quota contains advanced settings (such as pod limits) that cannot be displayed in this simplified form. These configurations remain active and can be viewed or edited in the YAML view.": "Esta cuota contiene ajustes avanzados (como límites de pods) que no se pueden mostrar en este formato simplificado. Estas configuraciones permanecen activas y se pueden ver o editar en la vista YAML.",
   "This self validation checkup is currently running. If you rerun the checkup, the running job will be deleted.": "Este control de autovalidación está en ejecución. Si lo vuelve a ejecutar, se eliminará el trabajo en ejecución.",
+  "This storage checkup is currently running. If you rerun the checkup, the running job will be deleted.": "This storage checkup is currently running. If you rerun the checkup, the running job will be deleted.",
   "This suite was skipped.": "Se omitió esta suite.",
   "This user is not allowed to edit this boot source": "Este usuario no tiene permiso para editar esta fuente de arranque.",
   "This VirtualMachine has": "Esta VirtualMachine tiene",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -2125,6 +2125,7 @@
   "This project is also governed by a ResourceQuota. Review to ensure accurate and consistent resource enforcement.": "Ce projet est également soumis à un quota de ressources. Un examen est nécessaire pour garantir une application précise et cohérente des ressources.",
   "This quota contains advanced settings (such as pod limits) that cannot be displayed in this simplified form. These configurations remain active and can be viewed or edited in the YAML view.": "Ce quota contient des paramètres avancés (tels que les limites de pods) qui ne peuvent pas être affichés sous cette forme simplifiée. Ces configurations restent actives et peuvent être consultées ou modifiées dans la vue YAML.",
   "This self validation checkup is currently running. If you rerun the checkup, the running job will be deleted.": "Cette vérification d'autovalidation est en cours. Si vous la relancez, la tâche en cours sera supprimée.",
+  "This storage checkup is currently running. If you rerun the checkup, the running job will be deleted.": "This storage checkup is currently running. If you rerun the checkup, the running job will be deleted.",
   "This suite was skipped.": "Cette suite a été ignorée.",
   "This user is not allowed to edit this boot source": "Cet utilisateur n'est pas autorisé à modifier cette source de démarrage",
   "This VirtualMachine has": "Cette machine virtuelle a",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -2105,6 +2105,7 @@
   "This project is also governed by a ResourceQuota. Review to ensure accurate and consistent resource enforcement.": "このプロジェクトは ResourceQuota によっても管理されています。リソースが正確かつ一貫して強制されるよう、内容を確認してください。",
   "This quota contains advanced settings (such as pod limits) that cannot be displayed in this simplified form. These configurations remain active and can be viewed or edited in the YAML view.": "このクォータには、この簡略化された形式では表示できない高度な設定 (Pod 制限など) が含まれています。これらの設定は有効なままであり、YAML ビューで表示または編集できます。",
   "This self validation checkup is currently running. If you rerun the checkup, the running job will be deleted.": "この自己検証チェックアップは現在実行中です。チェックアップを再実行すると、実行中のジョブが削除されます。",
+  "This storage checkup is currently running. If you rerun the checkup, the running job will be deleted.": "This storage checkup is currently running. If you rerun the checkup, the running job will be deleted.",
   "This suite was skipped.": "このスイートはスキップされました。",
   "This user is not allowed to edit this boot source": "このユーザーはこのブートソースを編集できません",
   "This VirtualMachine has": "この VirtualMachine には以下があります",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -2105,6 +2105,7 @@
   "This project is also governed by a ResourceQuota. Review to ensure accurate and consistent resource enforcement.": "이 프로젝트는 ResourceQuota에 의해 관리됩니다. 리소스가 정확하고 일관되게 적용되도록 검토합니다.",
   "This quota contains advanced settings (such as pod limits) that cannot be displayed in this simplified form. These configurations remain active and can be viewed or edited in the YAML view.": "이 할당량에는 이 간소화된 형식으로 표시할 수 없는 고급 설정(예: Pod 제한)이 포함되어 있습니다. 이러한 구성은 활성 상태로 유지되며 YAML 보기에서 보거나 편집할 수 있습니다.",
   "This self validation checkup is currently running. If you rerun the checkup, the running job will be deleted.": "이 자체 검증 검사가 현재 실행 중입니다. 점검을 재실행하면 실행 중인 작업이 삭제됩니다.",
+  "This storage checkup is currently running. If you rerun the checkup, the running job will be deleted.": "This storage checkup is currently running. If you rerun the checkup, the running job will be deleted.",
   "This suite was skipped.": "이 모음은 건너뛰었습니다.",
   "This user is not allowed to edit this boot source": "이 사용자는 이 부팅 소스를 편집할 수 없습니다",
   "This VirtualMachine has": "이 VirtualMachine에는 다음이 있습니다",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -2105,6 +2105,7 @@
   "This project is also governed by a ResourceQuota. Review to ensure accurate and consistent resource enforcement.": "此项目也受 ResourceQuota 管理。请检查它以确保在资源强制管理方面准确且一致。",
   "This quota contains advanced settings (such as pod limits) that cannot be displayed in this simplified form. These configurations remain active and can be viewed or edited in the YAML view.": "此配额包含无法以此简化形式显示的高级设置（如 pod 限制）。这些配置仍处于活动状态，可以在 YAML 视图中查看和编辑。",
   "This self validation checkup is currently running. If you rerun the checkup, the running job will be deleted.": "此自我验证检查当前正在运行。如果您重新运行检查，则会删除正在运行的作业。",
+  "This storage checkup is currently running. If you rerun the checkup, the running job will be deleted.": "This storage checkup is currently running. If you rerun the checkup, the running job will be deleted.",
   "This suite was skipped.": "这个套件已被跳过。",
   "This user is not allowed to edit this boot source": "不允许此用户编辑这个引导源",
   "This VirtualMachine has": "此 VirtualMachine 具有",

--- a/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationSharedActionFactory.tsx
+++ b/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationSharedActionFactory.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import { TFunction } from 'i18next';
 
 import {
   IoK8sApiBatchV1Job,
@@ -10,14 +11,11 @@ import { ToastActions } from '@kubevirt-utils/hooks/useKubevirtToast';
 import { getSelfValidationCheckupURL } from '@kubevirt-utils/resources/checkups/urls';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 
-import RerunCheckupModal from '../../../components/RerunCheckupModal';
-import { showRerunToast } from '../../../utils/showRerunToast';
-import { isJobRunning, rerunSelfValidationCheckup } from '../../utils';
+import { createCheckupRerunHandler } from '../../../utils/createCheckupRerunHandler';
+import { rerunSelfValidationCheckup } from '../../utils';
 
 import { ActionState, getRerunModeState } from './CheckupsSelfValidationActionsUtils';
 import RunningCheckupWarningDescription from './RunningCheckupWarningDescription';
-
-type TranslationFunction = (key: string, options?: Record<string, unknown>) => string;
 
 type RerunActionParams = {
   configMap: IoK8sApiCoreV1ConfigMap;
@@ -28,7 +26,7 @@ type RerunActionParams = {
   jobs?: IoK8sApiBatchV1Job[];
   navigate: (path: string) => void;
   otherRunningJobs?: IoK8sApiBatchV1Job[];
-  t: TranslationFunction;
+  t: TFunction;
   toast: ToastActions;
 };
 
@@ -50,54 +48,29 @@ export const createRerunAction = ({
     otherRunningJobs,
   );
 
-  const executeRerun = async () => {
-    if (!configMap) {
-      kubevirtConsole.error('Cannot rerun checkup: configMap is missing');
-      return;
-    }
+  const handleRerunAction = createCheckupRerunHandler({
+    configMap,
+    createModal,
+    getUrl: getSelfValidationCheckupURL,
+    isKebab,
+    jobs,
+    navigate,
+    rerun: async () => {
+      if (!configMap) {
+        kubevirtConsole.error('Cannot rerun checkup: configMap is missing');
+        return;
+      }
 
-    try {
       await rerunSelfValidationCheckup(configMap, jobs, () =>
         toast.addWarningToast({ title: t('PVC may need manual cleanup') }),
       );
-      if (isKebab) {
-        showRerunToast({
-          configMap,
-          getUrl: getSelfValidationCheckupURL,
-          navigate,
-          t,
-          toast,
-        });
-      }
-    } catch (e) {
-      kubevirtConsole.error('Failed to rerun checkup:', e);
-      toast.addDangerToast({
-        content: e?.message || t('An unknown error occurred'),
-        title: t('Failed to rerun checkup'),
-      });
-    }
-  };
-
-  const handleRerunAction = () => {
-    const runningJobs = jobs.filter((job) => isJobRunning(job));
-    if (runningJobs.length > 0) {
-      createModal((props) => (
-        <RerunCheckupModal
-          {...props}
-          message={t(
-            'This self validation checkup is currently running. If you rerun the checkup, the running job will be deleted.',
-          )}
-          onConfirm={() => {
-            props.onClose();
-            executeRerun();
-          }}
-          variant="warning"
-        />
-      ));
-    } else {
-      executeRerun();
-    }
-  };
+    },
+    runningJobWarningMessage: t(
+      'This self validation checkup is currently running. If you rerun the checkup, the running job will be deleted.',
+    ),
+    t,
+    toast,
+  });
 
   return {
     cta: handleRerunAction,
@@ -111,7 +84,7 @@ export const createRerunAction = ({
 type GoToRunningCheckupActionParams = {
   configMapInfo: ActionState['configMapInfo'];
   navigate: (path: string) => void;
-  t: TranslationFunction;
+  t: TFunction;
 };
 
 export const createGoToRunningCheckupAction = ({

--- a/src/views/checkups/self-validation/utils/selfValidationJob/jobExtraction.ts
+++ b/src/views/checkups/self-validation/utils/selfValidationJob/jobExtraction.ts
@@ -3,7 +3,7 @@ import { IoK8sApiBatchV1Job } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { k8sList } from '@openshift-console/dynamic-plugin-sdk';
 
-import { getJobContainers, KUBEVIRT_VM_LATENCY_LABEL } from '../../../utils/utils';
+import { getJobContainers, isJobRunning, KUBEVIRT_VM_LATENCY_LABEL } from '../../../utils/utils';
 import {
   JOB_ENV_ACCEPT_WINDOWS_EULA,
   JOB_ENV_DRY_RUN,
@@ -67,7 +67,7 @@ export const getStorageCapabilitiesFromJob = (job: IoK8sApiBatchV1Job): string[]
 export const getCheckupImageFromJob = (job: IoK8sApiBatchV1Job): string =>
   getJobContainers(job)?.[0]?.image || '';
 
-export const isJobRunning = (job: IoK8sApiBatchV1Job): boolean => !!job?.status?.active;
+export { isJobRunning } from '../../../utils/utils';
 
 /**
  * Fetches all running self-validation jobs across the cluster

--- a/src/views/checkups/storage/components/CheckupsStorageActions.tsx
+++ b/src/views/checkups/storage/components/CheckupsStorageActions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import {
@@ -13,11 +13,10 @@ import useKubevirtToast from '@kubevirt-utils/hooks/useKubevirtToast';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getStorageCheckupURL } from '@kubevirt-utils/resources/checkups/urls';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core';
 
 import { CHECKUP_URLS } from '../../utils/constants';
-import { showRerunToast } from '../../utils/showRerunToast';
+import { createCheckupRerunHandler } from '../../utils/createCheckupRerunHandler';
 import { getCheckupImageFromNewestJob } from '../../utils/utils';
 import { deleteStorageCheckup, rerunStorageCheckup } from '../utils/utils';
 
@@ -47,6 +46,25 @@ const CheckupsStorageActions = ({
 
   const checkupName = getName(configMap);
 
+  const handleRerunAction = useMemo(
+    () =>
+      createCheckupRerunHandler({
+        configMap,
+        createModal,
+        getUrl: getStorageCheckupURL,
+        isKebab,
+        jobs,
+        navigate,
+        rerun: () => rerunStorageCheckup(configMap, checkupImage, jobs),
+        runningJobWarningMessage: t(
+          'This storage checkup is currently running. If you rerun the checkup, the running job will be deleted.',
+        ),
+        t,
+        toast,
+      }),
+    [checkupImage, configMap, createModal, isKebab, jobs, navigate, t, toast],
+  );
+
   const deleteCheckup = async (): Promise<void> => {
     setIsActionsOpen(false);
     try {
@@ -67,26 +85,9 @@ const CheckupsStorageActions = ({
     <Dropdown isOpen={isActionsOpen} onOpenChange={setIsActionsOpen} toggle={Toggle}>
       <DropdownList>
         <DropdownItem
-          onClick={async () => {
+          onClick={() => {
             setIsActionsOpen(false);
-            try {
-              await rerunStorageCheckup(configMap, checkupImage);
-              if (isKebab) {
-                showRerunToast({
-                  configMap,
-                  getUrl: getStorageCheckupURL,
-                  navigate,
-                  t,
-                  toast,
-                });
-              }
-            } catch (error) {
-              kubevirtConsole.error('Failed to rerun checkup:', error);
-              toast.addDangerToast({
-                content: error?.message || t('An unknown error occurred'),
-                title: t('Failed to rerun checkup'),
-              });
-            }
+            handleRerunAction();
           }}
           isDisabled={!checkupImage}
           key="rerun"

--- a/src/views/checkups/storage/utils/utils.ts
+++ b/src/views/checkups/storage/utils/utils.ts
@@ -14,7 +14,7 @@ import {
   IoK8sApiRbacV1ClusterRoleBinding,
 } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
+import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { kubevirtK8sCreate, kubevirtK8sDelete, kubevirtK8sPatch } from '@multicluster/k8sRequests';
 import { SimpleSelectOption } from '@patternfly/react-templates';
@@ -24,6 +24,7 @@ import {
   CONFIGMAP_NAME,
   CONFIGMAP_NAMESPACE,
   generateWithNumbers,
+  isJobRunning,
   KUBEVIRT_VM_LATENCY_LABEL,
   STATUS_COMPLETION_TIME_STAMP,
   STATUS_FAILURE_REASON,
@@ -390,41 +391,75 @@ export const deleteStorageCheckup = async (
   }
 };
 
+export const deleteStorageJob = async (job: IoK8sApiBatchV1Job): Promise<void> => {
+  await kubevirtK8sDelete({
+    cluster: getCluster(job),
+    model: JobModel,
+    resource: job,
+  });
+};
+
 export const rerunStorageCheckup = async (
   resource: IoK8sApiCoreV1ConfigMap,
   checkupImage: string,
+  jobs: IoK8sApiBatchV1Job[] = [],
 ): Promise<IoK8sApiBatchV1Job> => {
+  const runningJobs = jobs.filter(isJobRunning);
+  const deletionErrors: string[] = [];
+
+  for (const job of runningJobs) {
+    try {
+      await deleteStorageJob(job);
+      kubevirtConsole.log('Deleted running job:', getName(job));
+    } catch (error) {
+      deletionErrors.push(getName(job) || 'job');
+      kubevirtConsole.error('Failed to delete running job:', error);
+    }
+  }
+
+  if (deletionErrors.length > 0) {
+    throw new Error(
+      `Failed to delete running jobs: ${deletionErrors.join(', ')}. Cannot proceed with rerun.`,
+    );
+  }
+
   const isSucceeded = resource?.data?.[STATUS_SUCCEEDED] === 'true';
-  await kubevirtK8sPatch<IoK8sApiCoreV1ConfigMap>({
-    cluster: getCluster(resource),
-    data: [
-      { op: 'remove', path: `/data/${STATUS_COMPLETION_TIME_STAMP}` },
-      { op: 'remove', path: `/data/${STATUS_SUCCEEDED}` },
-      { op: 'remove', path: `/data/${STATUS_FAILURE_REASON}` },
-      { op: 'remove', path: `/data/${STATUS_START_TIME_STAMP}` },
-      ...(isSucceeded
-        ? [
-            { op: 'remove', path: `/data/${STORAGE_CHECKUP_DEFAULT_STORAGE_CLASS}` },
-            { op: 'remove', path: `/data/${STORAGE_CHECKUP_LIVE_MIGRATION}` },
-            { op: 'remove', path: `/data/${STORAGE_CHECKUPS_UNSET_EFS_STORAGE_CLASS}` },
-            { op: 'remove', path: `/data/${STORAGE_CHECKUPS_WITH_NON_RBD_STORAGE_CLASS}` },
-            { op: 'remove', path: `/data/${STORAGE_CHECKUPS_VM_HOT_PLUG_VOLUME}` },
-            { op: 'remove', path: `/data/${STORAGE_CHECKUPS_BOOT_GOLDEN_IMAGE}` },
-            { op: 'remove', path: `/data/${STORAGE_CHECKUPS_STORAGE_WITH_RWX}` },
-            { op: 'remove', path: `/data/${STORAGE_CHECKUPS_WITH_CLAIM_PROPERTY_SETS}` },
-            { op: 'remove', path: `/data/${STORAGE_CHECKUPS_MISSING_VOLUME_SNAP_SHOT}` },
-            { op: 'remove', path: `/data/${STORAGE_CHECKUPS_GOLDEN_IMAGE_NOT_UP_TO_DATE}` },
-            { op: 'remove', path: `/data/${STORAGE_CHECKUPS_VM_VOLUME_CLONE}` },
-          ]
-        : []),
-    ],
-    model: ConfigMapModel,
-    resource,
-  });
+  const patchOperations = [
+    STATUS_COMPLETION_TIME_STAMP,
+    STATUS_SUCCEEDED,
+    STATUS_FAILURE_REASON,
+    STATUS_START_TIME_STAMP,
+    ...(isSucceeded
+      ? [
+          STORAGE_CHECKUP_DEFAULT_STORAGE_CLASS,
+          STORAGE_CHECKUP_LIVE_MIGRATION,
+          STORAGE_CHECKUPS_UNSET_EFS_STORAGE_CLASS,
+          STORAGE_CHECKUPS_WITH_NON_RBD_STORAGE_CLASS,
+          STORAGE_CHECKUPS_VM_HOT_PLUG_VOLUME,
+          STORAGE_CHECKUPS_BOOT_GOLDEN_IMAGE,
+          STORAGE_CHECKUPS_STORAGE_WITH_RWX,
+          STORAGE_CHECKUPS_WITH_CLAIM_PROPERTY_SETS,
+          STORAGE_CHECKUPS_MISSING_VOLUME_SNAP_SHOT,
+          STORAGE_CHECKUPS_GOLDEN_IMAGE_NOT_UP_TO_DATE,
+          STORAGE_CHECKUPS_VM_VOLUME_CLONE,
+        ]
+      : []),
+  ]
+    .filter((key) => resource?.data?.[key])
+    .map((key) => ({ op: 'remove', path: `/data/${key}` }));
+
+  if (!isEmpty(patchOperations)) {
+    await kubevirtK8sPatch<IoK8sApiCoreV1ConfigMap>({
+      cluster: getCluster(resource),
+      data: patchOperations,
+      model: ConfigMapModel,
+      resource,
+    });
+  }
 
   return kubevirtK8sCreate({
     cluster: getCluster(resource),
-    data: storageCheckupJob(resource.metadata.name, resource.metadata.namespace, checkupImage),
+    data: storageCheckupJob(getName(resource), getNamespace(resource), checkupImage),
     model: JobModel,
   });
 };

--- a/src/views/checkups/utils/createCheckupRerunHandler.tsx
+++ b/src/views/checkups/utils/createCheckupRerunHandler.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { TFunction } from 'i18next';
+
+import {
+  IoK8sApiBatchV1Job,
+  IoK8sApiCoreV1ConfigMap,
+} from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { ToastActions } from '@kubevirt-utils/hooks/useKubevirtToast';
+import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
+
+import RerunCheckupModal from '../components/RerunCheckupModal';
+
+import { showRerunToast } from './showRerunToast';
+import { isJobRunning } from './utils';
+
+type CreateCheckupRerunHandlerParams = {
+  configMap: IoK8sApiCoreV1ConfigMap;
+  createModal: (modal: ModalComponent) => void;
+  getUrl: (name: string, namespace: string, cluster: string) => string;
+  isKebab?: boolean;
+  jobs: IoK8sApiBatchV1Job[];
+  navigate: (path: string) => void;
+  rerun: () => Promise<unknown>;
+  runningJobWarningMessage: string;
+  t: TFunction;
+  toast: ToastActions;
+};
+
+export const createCheckupRerunHandler = ({
+  configMap,
+  createModal,
+  getUrl,
+  isKebab = false,
+  jobs,
+  navigate,
+  rerun,
+  runningJobWarningMessage,
+  t,
+  toast,
+}: CreateCheckupRerunHandlerParams): (() => void) => {
+  const executeRerun = async () => {
+    try {
+      await rerun();
+      if (isKebab) {
+        showRerunToast({ configMap, getUrl, navigate, t, toast });
+      }
+    } catch (error) {
+      kubevirtConsole.error('Failed to rerun checkup:', error);
+      toast.addDangerToast({
+        content: error instanceof Error ? error.message : t('An unknown error occurred'),
+        title: t('Failed to rerun checkup'),
+      });
+    }
+  };
+
+  return () => {
+    const runningJobs = jobs.filter(isJobRunning);
+    if (runningJobs.length > 0) {
+      createModal((props) => (
+        <RerunCheckupModal
+          {...props}
+          onConfirm={() => {
+            props.onClose();
+            executeRerun();
+          }}
+          message={runningJobWarningMessage}
+          variant="warning"
+        />
+      ));
+    } else {
+      executeRerun();
+    }
+  };
+};

--- a/src/views/checkups/utils/showRerunToast.tsx
+++ b/src/views/checkups/utils/showRerunToast.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TFunction } from 'i18next';
 
 import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { ToastActions } from '@kubevirt-utils/hooks/useKubevirtToast';
@@ -11,7 +12,7 @@ type ShowRerunToastParams = {
   configMap: IoK8sApiCoreV1ConfigMap;
   getUrl: (name: string, namespace: string, cluster: string) => string;
   navigate: (path: string) => void;
-  t: (key: string, options?: Record<string, unknown>) => string;
+  t: TFunction;
   toast: ToastActions;
 };
 

--- a/src/views/checkups/utils/utils.ts
+++ b/src/views/checkups/utils/utils.ts
@@ -126,6 +126,9 @@ export const getJobStatus = (job?: IoK8sApiBatchV1Job): CheckupsStatus => {
   return CheckupsStatus.Pending;
 };
 
+export const isJobRunning = (job?: IoK8sApiBatchV1Job): boolean =>
+  getJobStatus(job) === CheckupsStatus.Running;
+
 const STATUS_RANK: Record<CheckupsStatus, number> = {
   [CheckupsStatus.Deleting]: 3,
   [CheckupsStatus.Done]: 5,


### PR DESCRIPTION
## 📝 Description

The Rerun action for storage checkups does not handle the case where a checkup is currently running:

1. Rerun fails when attempting to rerun a storage checkup that is currently running. It does not fail for completed or failed checkups.
2. The currently running job is not being deleted before starting a new one, resulting in multiple "Running" entries in the checkup History.
3. Unlike self-validation checkups, the storage checkup does not show a rerun confirmation dialog warning the user that the running job will be deleted.



## 🔗 Links

Jira ticket: [CNV-89140](https://redhat.atlassian.net/browse/CNV-89140)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/a46ac472-c0ac-4c3f-a618-da6e121046c4


After:

https://github.com/user-attachments/assets/458a8abd-9ddb-49db-b4a4-d549a0464deb



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Rerun flows unified across checkup types for consistent behavior.
  * Reruns now remove or skip existing running jobs before creating new ones.
  * Job-running detection improved for more accurate rerun decisions.

* **Bug Fixes**
  * Better error reporting and user-facing toasts when rerun operations fail.

* **New Features**
  * Centralized rerun handler with confirmation modal support for running jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->