### PR TITLE
CNV-89141: VM creation wizard: Back button missing on first step; entered VM name persists after leaving wizard

### DIFF
--- a/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
+++ b/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
@@ -73,6 +73,8 @@ const VMCreationWizard: FC = () => {
       setProject(!isAdmin ? namespace : currentProject || namespace);
       hasInitialized.current = true;
     }
+
+    return () => resetWizardState();
   }, [
     clusterParam,
     isAdmin,

--- a/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/DeploymentDetailsStepFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/DeploymentDetailsStepFooter.tsx
@@ -23,12 +23,17 @@ const DeploymentDetailsStepFooter: FC = () => {
   const { creationMethod } = useVMWizardStore();
   const isCloneMethod = isCloneCreationMethod(creationMethod);
   const closeWizard = useCloseWizard();
-  const { cancelButtonText, nextButtonText } = useWizardFooterProps();
+  const { backButtonText, cancelButtonText, nextButtonText } = useWizardFooterProps();
 
   return (
     <WizardFooterWrapper>
       <ActionList>
         <ActionListGroup>
+          <ActionListItem>
+            <Button isDisabled variant="secondary">
+              {backButtonText}
+            </Button>
+          </ActionListItem>
           <ActionListItem>
             {isCloneMethod ? (
               <Button onClick={goToNextStep} variant="primary">


### PR DESCRIPTION
## 📝 Description

Two issues in the Create VirtualMachine wizard:

1. First-step footer does not match PatternFly wizard guidelines. Per PatternFly guidelines, "The Back button is disabled on the first page of the wizard."
2.  Wizard input is not cleared when leaving without Cancel. 

## 🔗 Links

Jira ticket: [CNV-89141](https://redhat.atlassian.net/browse/CNV-89141)


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/816bb891-c3e1-40c3-8597-e35b95d6aa59

After:


https://github.com/user-attachments/assets/d6298c2c-953f-4d12-981c-f0c00d762ae9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when exiting the VM creation wizard to ensure wizard state is reset and resources are managed properly.

* **New Features**
  * Added a visible back button to the deployment details step in the VM creation wizard (rendered disabled where not applicable) to improve navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->