### PR TITLE
CNV-88892: Fix incorrect disabled add cd-rom to vm for users

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskList.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskList.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useMemo } from 'react';
 
-import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { DataVolumeModel, VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DiskListTitle from '@kubevirt-utils/components/DiskListTitle/DiskListTitle';
 import DiskSourceSelect from '@kubevirt-utils/components/DiskModal/components/DiskSourceSelect/DiskSourceSelect';
@@ -71,9 +71,9 @@ const DiskList: FC<DiskListProps> = ({
   const canAddDisk = canUpdate || canHotplug;
 
   const [canCreateDataVolume] = useAccessReview({
-    group: VirtualMachineModel.apiGroup,
+    group: DataVolumeModel.apiGroup,
     namespace: getNamespace(vm),
-    resource: VirtualMachineModel.plural,
+    resource: DataVolumeModel.plural,
     verb: 'create' as K8sVerb,
   });
 


### PR DESCRIPTION

## 📝 Description

fixed CD-ROM button RBAC check to verify DataVolume create permission instead of VirtualMachine create permission in the Storage tab.

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-88892

## 🎥 Demo

Before:
<img width="1142" height="914" alt="image" src="https://github.com/user-attachments/assets/e69d5301-38d2-4a6a-a0d9-b39adc710fee" />


After:
<img width="1241" height="1047" alt="Screenshot at Jun 04 17-40-30" src="https://github.com/user-attachments/assets/3f856328-6f79-4c39-a279-b069a259b476" />
<img width="1839" height="723" alt="Screenshot at Jun 04 17-40-45" src="https://github.com/user-attachments/assets/de66224e-40ac-4986-96dc-18eb7fd4f72f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission validation for data volume creation in virtual machine storage configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->