### PR TITLE
CNV-71166: Current network is not displayed in modal

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/NetworkInterfaceModal.tsx
+++ b/src/utils/components/NetworkInterfaceModal/NetworkInterfaceModal.tsx
@@ -139,6 +139,7 @@ const NetworkInterfaceModal: FC<NetworkInterfaceModalProps> = ({
         setInterfaceModel={setInterfaceModel}
       />
       <NetworkInterfaceNetworkSelect
+        editInitValueNetworkName={getNetworkName(network) ?? undefined}
         isEditing={Boolean(network) && Boolean(iface)}
         namespace={namespace || getNamespace(vm)}
         networkName={networkName}

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
@@ -11,9 +11,7 @@ import React, {
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
-import SelectTypeahead, {
-  SelectTypeaheadOptionProps,
-} from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
+import SelectTypeahead from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
 import useIsIPv6SingleStackCluster from '@kubevirt-utils/hooks/useIPStackType/useIsIPv6SingleStackCluster';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
@@ -25,22 +23,24 @@ import {
 } from '@kubevirt-utils/resources/vm';
 import { interfaceTypesProxy } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
-import { FormGroup, Label, ValidatedOptions } from '@patternfly/react-core';
+import { FormGroup, ValidatedOptions } from '@patternfly/react-core';
 
 import {
   getNadFullName,
-  getNadType,
   getNameAndNs,
   isNadFullName,
-  isNADUsedInVM,
   isOvnOverlayNad,
-  isPodNetworkName,
   podNetworkExists,
 } from '../../utils/helpers';
 import useNADsData from '../hooks/useNADsData';
 
 import NetworkSelectHelperPopover from './components/NetworkSelectHelperPopover';
+import { buildNetworkSelectOptions, getShowPodNetworkingOption } from './editNetworkSelectUtils';
+import { NetworkSelectTypeaheadOptionProps } from './types';
+import useEditNetworkSelect from './useEditNetworkSelect';
 import { createNewNetworkOption, getCreateNetworkOption, validateNADNamespace } from './utils';
+
+export type { NetworkSelectTypeaheadOptionProps } from './types';
 
 type NetworkInterfaceNetworkSelectProps = {
   editInitValueNetworkName?: string | undefined;
@@ -51,10 +51,6 @@ type NetworkInterfaceNetworkSelectProps = {
   setNetworkName: Dispatch<SetStateAction<string>>;
   setSubmitDisabled: Dispatch<SetStateAction<boolean>>;
   vm: V1VirtualMachine;
-};
-
-export type NetworkSelectTypeaheadOptionProps = SelectTypeaheadOptionProps & {
-  type: string;
 };
 
 const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
@@ -69,13 +65,12 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const isIPv6SingleStack = useIsIPv6SingleStackCluster(getCluster(vm));
-  const vmiNamespace = vm?.metadata?.namespace || namespace;
+  const vmiNamespace = getNamespace(vm) || namespace;
   const { loaded, loadError, nads, primaryNADs } = useNADsData(vmiNamespace, getCluster(vm));
   const [isNamespaceManagedByUDN] = useNamespaceUDN(vmiNamespace);
   const podNetworkType = isNamespaceManagedByUDN
     ? interfaceTypesProxy.l2bridge
     : interfaceTypesProxy.masquerade;
-  const [selectedFirstOnLoad, setSelectedFirstOnLoad] = useState(false);
   const [createdNetworkOptions, setCreatedNetworkOptions] = useState<
     NetworkSelectTypeaheadOptionProps[]
   >([]);
@@ -91,9 +86,21 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
     [vm],
   );
 
-  const filteredNADs = nads?.filter((nad) => {
-    const isNADInUse = isNADUsedInVM(nad, currentlyUsedNADFullNames);
-    return !isNADInUse || !isOvnOverlayNad(nad);
+  const {
+    filteredNADs,
+    selectedFirstOnLoad,
+    selectNetworkName,
+    selectTypeaheadKey,
+    setSelectedFirstOnLoad,
+  } = useEditNetworkSelect({
+    currentlyUsedNADFullNames,
+    editInitValueNetworkName,
+    isEditing,
+    loaded,
+    nads,
+    networkName,
+    setSubmitDisabled,
+    vmiNamespace,
   });
 
   const ovnNADFullNames =
@@ -114,9 +121,12 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
 
   const hasPodNetwork = useMemo(() => podNetworkExists(vm), [vm]);
   const hasNads = useMemo(() => filteredNADs?.length > 0, [filteredNADs]);
-  const showPodNetworkingOption = isIPv6SingleStack
-    ? false
-    : !hasPodNetwork || (isEditing && isPodNetworkName(editInitValueNetworkName));
+  const showPodNetworkingOption = getShowPodNetworkingOption({
+    editInitValueNetworkName,
+    hasPodNetwork,
+    isEditing,
+    isIPv6SingleStack,
+  });
 
   const canCreateNetworkInterface = useMemo(
     () => hasNads || !hasPodNetwork,
@@ -125,57 +135,31 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
 
   const podNetworkingText = useMemo(() => t('Pod networking'), [t]);
 
-  const networkOptions: NetworkSelectTypeaheadOptionProps[] = useMemo(() => {
-    const options = filteredNADs?.map((nad) => {
-      const { name, namespace: nadNamespace } = nad?.metadata;
-      const type = getNadType(nad);
-      const displayedValue = `${nadNamespace}/${name}`;
-      const value = nadNamespace === vmiNamespace ? name : displayedValue;
-      return {
-        label: displayedValue,
-        optionProps: {
-          children: (
-            <>
-              {displayedValue} <Label isCompact>{getNadType(nad)} Binding</Label>
-            </>
-          ),
-          key: value,
-        },
-        type,
-        value,
-      };
-    });
-
-    if (showPodNetworkingOption) {
-      options.unshift({
-        label: podNetworkingText,
-        optionProps: {
-          children: (
-            <>
-              {podNetworkingText} <Label isCompact>{podNetworkType} Binding</Label>
-            </>
-          ),
-          key: POD_NETWORK,
-        },
-        type: podNetworkType,
-        value: POD_NETWORK,
-      });
-    }
-
-    return [
-      ...options,
-      ...createdNetworkOptions.filter(({ value }) =>
-        options.every((option) => option.value !== value),
-      ),
-    ];
-  }, [
-    showPodNetworkingOption,
-    filteredNADs,
-    podNetworkingText,
-    vmiNamespace,
-    createdNetworkOptions,
-    podNetworkType,
-  ]);
+  const networkOptions = useMemo(
+    () =>
+      buildNetworkSelectOptions({
+        createdNetworkOptions,
+        editInitValueNetworkName,
+        filteredNADs,
+        isEditing,
+        podNetworkingText,
+        podNetworkType,
+        selectNetworkName,
+        showPodNetworkingOption,
+        vmiNamespace,
+      }),
+    [
+      showPodNetworkingOption,
+      filteredNADs,
+      podNetworkingText,
+      vmiNamespace,
+      createdNetworkOptions,
+      podNetworkType,
+      isEditing,
+      editInitValueNetworkName,
+      selectNetworkName,
+    ],
+  );
 
   const validated =
     canCreateNetworkInterface || isEditing ? ValidatedOptions.default : ValidatedOptions.error;
@@ -192,15 +176,11 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
     [setNetworkName, setInterfaceType, networkOptions, podNetworkType],
   );
 
-  // This useEffect is to handle the submit button and init value
   useEffect(() => {
-    // if networkName exists, we have the option to create a NIC either with pod networking or by existing NAD
-    if (networkName) {
-      setSubmitDisabled(false);
+    if (networkName || isEditing) {
       return;
     }
 
-    // if networkName is empty, we can create a NIC with existing NAD if there is one
     if (loaded && !loadError && !selectedFirstOnLoad) {
       setSelectedFirstOnLoad(true);
       const networkToPreselect = networkOptions?.[0]?.value;
@@ -210,22 +190,27 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
       return;
     }
 
-    // if no nads and pod network already exists, we can't create a NIC
     if (loaded && (loadError || !canCreateNetworkInterface)) {
       setSubmitDisabled(true);
-      return;
     }
   }, [
     loadError,
     canCreateNetworkInterface,
+    isEditing,
     loaded,
     networkName,
     networkOptions,
     selectedFirstOnLoad,
-    setNetworkName,
+    setSelectedFirstOnLoad,
     setSubmitDisabled,
     handleChange,
   ]);
+
+  useEffect(() => {
+    if (networkName && !isEditing) {
+      setSubmitDisabled(false);
+    }
+  }, [isEditing, networkName, setSubmitDisabled]);
 
   return (
     <FormGroup
@@ -253,10 +238,10 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
           dataTestId="select-nad"
           getCreateAction={getCreateNetworkOption(validators)}
           isFullWidth
-          key={selectedFirstOnLoad ? 'select-nad-with-preselect' : 'select-nad-without-preselect'}
+          key={selectTypeaheadKey}
           options={networkOptions}
           placeholder={t('Select a NetworkAttachmentDefinition')}
-          selectedValue={networkName}
+          selectedValue={selectNetworkName}
           setSelectedValue={handleChange}
         />
       </div>

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/editNetworkSelectUtils.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/editNetworkSelectUtils.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+
+import { POD_NETWORK } from '@kubevirt-utils/resources/vm';
+import { interfaceTypesProxy } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { Label } from '@patternfly/react-core';
+
+import {
+  getNadType,
+  isNadFullName,
+  isNADUsedInVM,
+  isOvnOverlayNad,
+  isPodNetworkName,
+} from '../../utils/helpers';
+import { NetworkAttachmentDefinition } from '../hooks/types';
+
+import type {
+  BuildNetworkSelectOptionsArgs,
+  FilterNADsForSelectArgs,
+  GetEditingNetworkOptionIfMissingArgs,
+  GetSelectTypeaheadKeyArgs,
+  GetShowPodNetworkingOptionArgs,
+  NetworkSelectTypeaheadOptionProps,
+} from './types';
+
+export const getNadOptionValue = (
+  nad: NetworkAttachmentDefinition,
+  vmiNamespace: string,
+): string => {
+  const { name, namespace: nadNamespace } = nad.metadata;
+  const fullName = `${nadNamespace}/${name}`;
+  return nadNamespace === vmiNamespace ? name : fullName;
+};
+
+export const nadMatchesNetworkName = (
+  nad: NetworkAttachmentDefinition,
+  networkName: string,
+  vmiNamespace: string,
+): boolean => {
+  if (!networkName) {
+    return false;
+  }
+
+  const { name, namespace: nadNamespace } = nad.metadata;
+  const fullName = `${nadNamespace}/${name}`;
+  const optionValue = getNadOptionValue(nad, vmiNamespace);
+
+  return (
+    networkName === optionValue ||
+    networkName === fullName ||
+    (networkName === name && nadNamespace === vmiNamespace)
+  );
+};
+
+export const getSelectNetworkName = (
+  networkName: string,
+  nads: NetworkAttachmentDefinition[],
+  vmiNamespace: string,
+): string => {
+  if (!networkName) {
+    return networkName;
+  }
+
+  const matchingNad = nads?.find((nad) => nadMatchesNetworkName(nad, networkName, vmiNamespace));
+  if (matchingNad) {
+    return getNadOptionValue(matchingNad, vmiNamespace);
+  }
+
+  if (isNadFullName(networkName)) {
+    const [ns, name] = networkName.split('/');
+    if (ns === vmiNamespace) {
+      return name;
+    }
+  }
+
+  return networkName;
+};
+
+const getNetworkOptionLabel = (networkName: string, vmiNamespace: string): string =>
+  isNadFullName(networkName) ? networkName : `${vmiNamespace}/${networkName}`;
+
+export const filterNADsForSelect = ({
+  currentlyUsedNADFullNames,
+  editInitValueNetworkName,
+  isEditing,
+  nads,
+  vmiNamespace,
+}: FilterNADsForSelectArgs): NetworkAttachmentDefinition[] =>
+  nads?.filter((nad) => {
+    if (
+      isEditing &&
+      editInitValueNetworkName &&
+      nadMatchesNetworkName(nad, editInitValueNetworkName, vmiNamespace)
+    ) {
+      return true;
+    }
+
+    const isNADInUse = isNADUsedInVM(nad, currentlyUsedNADFullNames);
+    return !isNADInUse || !isOvnOverlayNad(nad);
+  }) ?? [];
+
+export const getShowPodNetworkingOption = ({
+  editInitValueNetworkName,
+  hasPodNetwork,
+  isEditing,
+  isIPv6SingleStack,
+}: GetShowPodNetworkingOptionArgs): boolean => {
+  if (isIPv6SingleStack) {
+    return false;
+  }
+
+  return !hasPodNetwork || (isEditing && isPodNetworkName(editInitValueNetworkName));
+};
+
+export const getSelectTypeaheadKey = ({
+  isEditing,
+  loaded,
+  selectedFirstOnLoad,
+}: GetSelectTypeaheadKeyArgs): string =>
+  selectedFirstOnLoad || (isEditing && loaded)
+    ? 'select-nad-with-preselect'
+    : 'select-nad-without-preselect';
+
+export const getEditingNetworkOptionIfMissing = ({
+  editInitValueNetworkName,
+  isEditing,
+  options,
+  selectNetworkName,
+  vmiNamespace,
+}: GetEditingNetworkOptionIfMissingArgs): NetworkSelectTypeaheadOptionProps | undefined => {
+  if (
+    !isEditing ||
+    !editInitValueNetworkName ||
+    !selectNetworkName ||
+    isPodNetworkName(editInitValueNetworkName) ||
+    options.some((option) => option.value === selectNetworkName)
+  ) {
+    return undefined;
+  }
+
+  const label = getNetworkOptionLabel(editInitValueNetworkName, vmiNamespace);
+
+  return {
+    label,
+    optionProps: {
+      children: (
+        <>
+          {label} <Label isCompact>{interfaceTypesProxy.bridge} Binding</Label>
+        </>
+      ),
+      key: selectNetworkName,
+    },
+    type: interfaceTypesProxy.bridge,
+    value: selectNetworkName,
+  };
+};
+
+export const buildNetworkSelectOptions = ({
+  createdNetworkOptions,
+  editInitValueNetworkName,
+  filteredNADs,
+  isEditing,
+  podNetworkingText,
+  podNetworkType,
+  selectNetworkName,
+  showPodNetworkingOption,
+  vmiNamespace,
+}: BuildNetworkSelectOptionsArgs): NetworkSelectTypeaheadOptionProps[] => {
+  const options: NetworkSelectTypeaheadOptionProps[] = filteredNADs.map((nad) => {
+    const { name, namespace: nadNamespace } = nad.metadata;
+    const type = getNadType(nad);
+    const displayedValue = `${nadNamespace}/${name}`;
+    const value = getNadOptionValue(nad, vmiNamespace);
+
+    return {
+      label: displayedValue,
+      optionProps: {
+        children: (
+          <>
+            {displayedValue} <Label isCompact>{getNadType(nad)} Binding</Label>
+          </>
+        ),
+        key: value,
+      },
+      type,
+      value,
+    };
+  });
+
+  if (showPodNetworkingOption) {
+    options.unshift({
+      label: podNetworkingText,
+      optionProps: {
+        children: (
+          <>
+            {podNetworkingText} <Label isCompact>{podNetworkType} Binding</Label>
+          </>
+        ),
+        key: POD_NETWORK,
+      },
+      type: podNetworkType,
+      value: POD_NETWORK,
+    });
+  }
+
+  const editingNetworkOption = getEditingNetworkOptionIfMissing({
+    editInitValueNetworkName,
+    isEditing,
+    options,
+    selectNetworkName,
+    vmiNamespace,
+  });
+
+  if (editingNetworkOption) {
+    options.push(editingNetworkOption);
+  }
+
+  return [
+    ...options,
+    ...createdNetworkOptions.filter(({ value }) =>
+      options.every((option) => option.value !== value),
+    ),
+  ];
+};

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/types.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/types.ts
@@ -1,0 +1,48 @@
+import { SelectTypeaheadOptionProps } from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
+
+import { NetworkAttachmentDefinition } from '../hooks/types';
+
+export type NetworkSelectTypeaheadOptionProps = SelectTypeaheadOptionProps & {
+  type: string;
+};
+
+export type GetShowPodNetworkingOptionArgs = {
+  editInitValueNetworkName?: string;
+  hasPodNetwork: boolean;
+  isEditing?: boolean;
+  isIPv6SingleStack: boolean;
+};
+
+export type FilterNADsForSelectArgs = {
+  currentlyUsedNADFullNames: string[];
+  editInitValueNetworkName?: string;
+  isEditing?: boolean;
+  nads: NetworkAttachmentDefinition[];
+  vmiNamespace: string;
+};
+
+export type GetSelectTypeaheadKeyArgs = {
+  isEditing?: boolean;
+  loaded: boolean;
+  selectedFirstOnLoad: boolean;
+};
+
+export type GetEditingNetworkOptionIfMissingArgs = {
+  editInitValueNetworkName?: string;
+  isEditing?: boolean;
+  options: NetworkSelectTypeaheadOptionProps[];
+  selectNetworkName: string;
+  vmiNamespace: string;
+};
+
+export type BuildNetworkSelectOptionsArgs = {
+  createdNetworkOptions: NetworkSelectTypeaheadOptionProps[];
+  editInitValueNetworkName?: string;
+  filteredNADs: NetworkAttachmentDefinition[];
+  isEditing?: boolean;
+  podNetworkingText: string;
+  podNetworkType: string;
+  selectNetworkName: string;
+  showPodNetworkingOption: boolean;
+  vmiNamespace: string;
+};

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useEditNetworkSelect.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useEditNetworkSelect.ts
@@ -1,0 +1,70 @@
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
+
+import { NetworkAttachmentDefinition } from '../hooks/types';
+
+import {
+  filterNADsForSelect,
+  getSelectNetworkName,
+  getSelectTypeaheadKey,
+} from './editNetworkSelectUtils';
+
+type UseEditNetworkSelectArgs = {
+  currentlyUsedNADFullNames: string[];
+  editInitValueNetworkName?: string;
+  isEditing?: boolean;
+  loaded: boolean;
+  nads: NetworkAttachmentDefinition[];
+  networkName: string;
+  setSubmitDisabled: Dispatch<SetStateAction<boolean>>;
+  vmiNamespace: string;
+};
+
+const useEditNetworkSelect = ({
+  currentlyUsedNADFullNames,
+  editInitValueNetworkName,
+  isEditing,
+  loaded,
+  nads,
+  networkName,
+  setSubmitDisabled,
+  vmiNamespace,
+}: UseEditNetworkSelectArgs) => {
+  const [selectedFirstOnLoad, setSelectedFirstOnLoad] = useState(Boolean(isEditing));
+
+  const filteredNADs = useMemo(
+    () =>
+      filterNADsForSelect({
+        currentlyUsedNADFullNames,
+        editInitValueNetworkName,
+        isEditing,
+        nads,
+        vmiNamespace,
+      }),
+    [currentlyUsedNADFullNames, editInitValueNetworkName, isEditing, nads, vmiNamespace],
+  );
+
+  const selectNetworkName = useMemo(
+    () => getSelectNetworkName(networkName, nads, vmiNamespace),
+    [networkName, nads, vmiNamespace],
+  );
+
+  const selectTypeaheadKey = getSelectTypeaheadKey({ isEditing, loaded, selectedFirstOnLoad });
+
+  useEffect(() => {
+    if (!isEditing) {
+      return;
+    }
+
+    setSubmitDisabled(!networkName);
+  }, [isEditing, networkName, setSubmitDisabled]);
+
+  return {
+    filteredNADs,
+    selectedFirstOnLoad,
+    selectNetworkName,
+    selectTypeaheadKey,
+    setSelectedFirstOnLoad,
+  };
+};
+
+export default useEditNetworkSelect;

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/utils.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/utils.tsx
@@ -10,7 +10,7 @@ import { InfoIcon } from '@patternfly/react-icons';
 import { isNadFullName } from '../../utils/helpers';
 
 import InvalidNADNamespace from './components/InvalidNADNamespace';
-import { NetworkSelectTypeaheadOptionProps } from './NetworkInterfaceNetworkSelect';
+import { NetworkSelectTypeaheadOptionProps } from './types';
 
 export const createNewNetworkOption = (value): NetworkSelectTypeaheadOptionProps => ({
   optionProps: {


### PR DESCRIPTION
## 📝 Description

In "Edit network interface" modal the "Network" selector is not updated.

## 🔗 Links

Jira ticket: [CNV-71166](https://redhat.atlassian.net/browse/CNV-71166)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/9cdf7907-368b-440d-8293-ff2248ef5f4a


After:

https://github.com/user-attachments/assets/91e4fc4d-6b8e-4a44-b957-d3efbdd9adcc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserve and respect an initial edited network name when opening the Network Interface modal, ensuring the correct option is preselected even if missing.

* **Refactor**
  * Improved network selection: smarter option ordering, inclusion of synthesized editing option, and more reliable preselection behavior.
  * Pod-networking option visibility now respects IPv6/single‑stack and edit state.
  * More predictable submit enable/disable behavior during edit and load scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->