### PR TITLE
CNV-87466: Upgrade kubevirt-api to 2.0.0 and fix ResourceQuantity types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@kubev2v/types": "^0.0.22",
-        "@kubevirt-ui-ext/kubevirt-api": "1.8.1",
+        "@kubevirt-ui-ext/kubevirt-api": "2.0.0",
         "@kubevirt-ui-ext/vnc-keymaps": "1.0.4",
         "@novnc/novnc": "1.5.0",
         "@patternfly/quickstarts": "~6.5.0",
@@ -3607,9 +3607,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@kubevirt-ui-ext/kubevirt-api": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@kubevirt-ui-ext/kubevirt-api/-/kubevirt-api-1.8.1.tgz",
-      "integrity": "sha512-sCqwHPrF29hpvV5ggNowon+LOEabkmnOwEc9RhvtNOqF5i3rEblt5+zktNuftW9YnB7S1V2L7d4tCHz3QaFe1A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@kubevirt-ui-ext/kubevirt-api/-/kubevirt-api-2.0.0.tgz",
+      "integrity": "sha512-sJgkSc1vvA1ZIbyxMCRicp5BErpU3bG8Ehdtu4td9dbGGYogCCbVfMftRnI2XqhKAApUiv8XfaV96RtjYfxulw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@kubev2v/types": "^0.0.22",
-    "@kubevirt-ui-ext/kubevirt-api": "1.8.1",
+    "@kubevirt-ui-ext/kubevirt-api": "2.0.0",
     "@kubevirt-ui-ext/vnc-keymaps": "1.0.4",
     "@novnc/novnc": "1.5.0",
     "@patternfly/quickstarts": "~6.5.0",

--- a/src/utils/components/ConditionsTable/ConditionsTable.tsx
+++ b/src/utils/components/ConditionsTable/ConditionsTable.tsx
@@ -1,27 +1,14 @@
 import React, { FC, useMemo } from 'react';
 
+import { V1Condition } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import { getConditionRowId, getConditionsColumns } from './conditionsTableDefinition';
 
-export enum K8sResourceConditionStatus {
-  False = 'False',
-  True = 'True',
-  Unknown = 'Unknown',
-}
-
-export type K8sResourceCondition = {
-  lastTransitionTime?: string;
-  message?: string;
-  reason?: string;
-  status: keyof typeof K8sResourceConditionStatus;
-  type: string;
-};
-
 export type ConditionsProps = {
-  conditions: K8sResourceCondition[];
+  conditions: V1Condition[];
 };
 
 export const ConditionsTable: FC<ConditionsProps> = ({ conditions }) => {

--- a/src/utils/components/ConditionsTable/ConditionsTable.tsx
+++ b/src/utils/components/ConditionsTable/ConditionsTable.tsx
@@ -8,10 +8,10 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getConditionRowId, getConditionsColumns } from './conditionsTableDefinition';
 
 export type ConditionsProps = {
-  conditions: V1Condition[];
+  conditions?: V1Condition[];
 };
 
-export const ConditionsTable: FC<ConditionsProps> = ({ conditions }) => {
+export const ConditionsTable: FC<ConditionsProps> = ({ conditions = [] }) => {
   const { t } = useKubevirtTranslation();
 
   const columns = useMemo(() => getConditionsColumns(t), [t]);

--- a/src/utils/components/ConditionsTable/conditionsTableDefinition.tsx
+++ b/src/utils/components/ConditionsTable/conditionsTableDefinition.tsx
@@ -1,19 +1,16 @@
 import React, { ReactNode } from 'react';
 import { TFunction } from 'i18next';
 
+import { V1Condition } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
 import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 
-import { K8sResourceCondition } from './ConditionsTable';
-
-const renderTimestamp = (condition: K8sResourceCondition): ReactNode => (
+const renderTimestamp = (condition: V1Condition): ReactNode => (
   <Timestamp timestamp={condition.lastTransitionTime} />
 );
 
-export const getConditionsColumns = (
-  t: TFunction,
-): ColumnConfig<K8sResourceCondition, undefined>[] => [
+export const getConditionsColumns = (t: TFunction): ColumnConfig<V1Condition, undefined>[] => [
   {
     getValue: (r) => r.type ?? '',
     key: 'type',
@@ -49,5 +46,5 @@ export const getConditionsColumns = (
   },
 ];
 
-export const getConditionRowId = (condition: K8sResourceCondition, index: number): string =>
+export const getConditionRowId = (condition: V1Condition, index: number): string =>
   `${condition.type}-${index}`;

--- a/src/utils/components/DiskModal/components/utils/selectors.ts
+++ b/src/utils/components/DiskModal/components/utils/selectors.ts
@@ -23,4 +23,4 @@ export const getErrorSnapshotNamespace = (errors: FieldErrorsImpl<V1DiskFormStat
   errors?.dataVolumeTemplate?.spec?.source?.snapshot?.namespace;
 
 export const getDataVolumeTemplateSize = (diskState: V1DiskFormState): string =>
-  diskState.dataVolumeTemplate?.spec?.storage?.resources?.requests?.storage;
+  diskState.dataVolumeTemplate?.spec?.storage?.resources?.requests?.storage?.toString();

--- a/src/utils/resources/migrations/constants.ts
+++ b/src/utils/resources/migrations/constants.ts
@@ -1,6 +1,7 @@
 import {
   V1beta1StorageSpecAccessModesEnum,
   V1beta1StorageSpecVolumeModeEnum,
+  V1Condition,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { K8sResourceCommon, K8sResourceCondition } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -148,7 +149,7 @@ export type MigPlan = K8sResourceCommon & {
     srcMigClusterRef?: { name: string; namespace: string };
   };
   status?: {
-    conditions?: K8sResourceCondition[];
+    conditions?: V1Condition[];
     destStorageClasses?: { name: string }[];
     srcStorageClasses?: { name: string }[];
   };
@@ -165,7 +166,7 @@ export type MigMigration = K8sResourceCommon & {
     verify?: boolean;
   };
   status?: {
-    conditions?: K8sResourceCondition[];
+    conditions?: V1Condition[];
     phase?: string;
   };
 };

--- a/src/utils/resources/vm/utils/dataVolumeTemplate/selectors.ts
+++ b/src/utils/resources/vm/utils/dataVolumeTemplate/selectors.ts
@@ -15,11 +15,11 @@ export const getDataVolumePVCStorageClassName = (
 
 export const getDataVolumeStorageRequest = (
   dataVolume: V1beta1DataVolume | V1DataVolumeTemplateSpec,
-): string => dataVolume?.spec?.storage?.resources?.requests?.storage;
+): string => dataVolume?.spec?.storage?.resources?.requests?.storage?.toString();
 
 export const getDataVolumePVCStorageRequest = (
   dataVolume: V1beta1DataVolume | V1DataVolumeTemplateSpec,
-): string => dataVolume?.spec?.pvc?.resources?.requests?.storage;
+): string => dataVolume?.spec?.pvc?.resources?.requests?.storage?.toString();
 
 export const getDataVolumeSourceRef = (
   dataVolume: V1beta1DataVolume | V1DataVolumeTemplateSpec,

--- a/src/utils/resources/vm/utils/selectors.ts
+++ b/src/utils/resources/vm/utils/selectors.ts
@@ -172,7 +172,7 @@ export const getRootDiskSecretRef = (vm: V1VirtualMachine): string => {
  */
 export const getRootDiskStorageRequests = (vm: V1VirtualMachine): string => {
   const dataVolumeTemplateSpec = getRootDataVolumeTemplateSpec(vm);
-  return dataVolumeTemplateSpec?.spec?.storage?.resources?.requests?.storage;
+  return dataVolumeTemplateSpec?.spec?.storage?.resources?.requests?.storage?.toString();
 };
 
 /**
@@ -294,7 +294,8 @@ export const getDomain = <T extends Record<string, any>>(obj: T): V1DomainSpec =
   obj?.spec?.domain || obj?.spec?.template?.spec?.domain;
 
 export const getMemory = <T>(obj: T): string =>
-  getDomain(obj)?.memory?.guest || getDomain(obj)?.resources?.requests?.['memory'];
+  getDomain(obj)?.memory?.guest?.toString() ||
+  getDomain(obj)?.resources?.requests?.['memory']?.toString();
 
 export const getCPU = <T>(obj: T): V1CPU => getDomain(obj)?.cpu;
 

--- a/src/utils/utils/units.ts
+++ b/src/utils/utils/units.ts
@@ -1,3 +1,4 @@
+import { K8sIoApimachineryPkgApiResourceQuantity } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { Quantity } from '@kubevirt-utils/types/quantity.js';
 
 import {
@@ -32,8 +33,8 @@ export const addByteSuffix = (unit: QuantityUnit | string): string =>
  * @param {string} combinedStr - string containing both the value and the unit
  * @returns {string} string for displaying the value and the unit with 'B' suffix, with the space between them
  */
-export const readableSizeUnit = (combinedStr: string): string => {
-  const combinedString = combinedStr?.replace(/\s/g, ''); // remove empty spaces if there are any, to split the value and unit correctly
+export const readableSizeUnit = (combinedStr: K8sIoApimachineryPkgApiResourceQuantity): string => {
+  const combinedString = combinedStr?.toString()?.replace(/\s/g, ''); // remove empty spaces if there are any, to split the value and unit correctly
   const index = combinedString?.search(/([a-zA-Z]+)/g);
   const [value, unit] =
     index === -1
@@ -41,15 +42,15 @@ export const readableSizeUnit = (combinedStr: string): string => {
       : [combinedString?.slice(0, index), combinedString?.slice(index)];
 
   // if there isn't any specific value/size present, return the original string, for example for the dynamic disk size
-  return !value ? combinedStr : `${value} ${addByteSuffix(unit)}`;
+  return !value ? combinedStr?.toString() : `${value} ${addByteSuffix(unit)}`;
 };
 
 export const getHumanizedSize = (
-  size: string,
+  size: K8sIoApimachineryPkgApiResourceQuantity,
   bytesOption: 'withB' | 'withoutB' = 'withB',
   preferredUnit?: string,
 ) => {
-  const baseValue = convertToBaseValue(size);
+  const baseValue = convertToBaseValue(size?.toString());
 
   if (bytesOption === 'withoutB') {
     return humanizeBinaryBytesWithoutB(baseValue, null, preferredUnit);

--- a/src/views/cdi-upload-provider/utils/selectors.ts
+++ b/src/views/cdi-upload-provider/utils/selectors.ts
@@ -43,7 +43,7 @@ const getAnnotation = (
 ): string => pvc?.metadata?.annotations?.[annotationName] || defaultValue;
 
 const getStorageSize = (value: K8sIoApiCoreV1VolumeResourceRequirements): string =>
-  value?.requests.storage;
+  value?.requests.storage.toString();
 
 const getParameterValue = (obj: V1Template, name: string, defaultValue = null): string =>
   obj?.parameters?.find((parameter) => parameter.name === name)?.value || defaultValue;

--- a/src/views/cdi-upload-provider/utils/selectors.ts
+++ b/src/views/cdi-upload-provider/utils/selectors.ts
@@ -43,7 +43,7 @@ const getAnnotation = (
 ): string => pvc?.metadata?.annotations?.[annotationName] || defaultValue;
 
 const getStorageSize = (value: K8sIoApiCoreV1VolumeResourceRequirements): string =>
-  value?.requests.storage.toString();
+  value?.requests?.storage?.toString() ?? '';
 
 const getParameterValue = (obj: V1Template, name: string, defaultValue = null): string =>
   obj?.parameters?.find((parameter) => parameter.name === name)?.value || defaultValue;

--- a/src/views/clusteroverview/utils/types.ts
+++ b/src/views/clusteroverview/utils/types.ts
@@ -1,4 +1,5 @@
 import { V1Template } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { V1Condition } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { K8sResourceCommon, Selector } from '@openshift-console/dynamic-plugin-sdk';
 
 export type Descriptor<T = any> = {
@@ -143,20 +144,6 @@ export type ObjectReference = {
   uid?: string;
 };
 
-export enum K8sResourceConditionStatus {
-  False = 'False',
-  True = 'True',
-  Unknown = 'Unknown',
-}
-
-export type K8sResourceCondition = {
-  lastTransitionTime?: string;
-  message?: string;
-  reason?: string;
-  status: keyof typeof K8sResourceConditionStatus;
-  type: string;
-};
-
 export enum SubscriptionState {
   SubscriptionStateAtLatest = 'AtLatestKnown',
   SubscriptionStateFailed = 'UpgradeFailed',
@@ -182,7 +169,7 @@ export type SubscriptionKind = {
       healthy?: boolean;
       lastUpdated?: string;
     }[];
-    conditions?: K8sResourceCondition[];
+    conditions?: V1Condition[];
     currentCSV?: string;
     installedCSV?: string;
     installPlanRef?: ObjectReference;

--- a/src/views/datasources/dataimportcron/details/DataImportCronDetailsPage.tsx
+++ b/src/views/datasources/dataimportcron/details/DataImportCronDetailsPage.tsx
@@ -1,10 +1,7 @@
 import React, { FC } from 'react';
 
 import { V1beta1DataImportCron } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import {
-  ConditionsTable,
-  K8sResourceCondition,
-} from '@kubevirt-utils/components/ConditionsTable/ConditionsTable';
+import { ConditionsTable } from '@kubevirt-utils/components/ConditionsTable/ConditionsTable';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Divider, PageSection, Title } from '@patternfly/react-core';
 
@@ -30,9 +27,7 @@ const DataImportCronDetailsPage: FC<DataImportCronDetailsPageProps> = ({ obj: da
         <Title className="co-section-heading" headingLevel="h2">
           {t('Conditions')}
         </Title>
-        <ConditionsTable
-          conditions={dataImportCron?.status?.conditions as K8sResourceCondition[]}
-        />
+        <ConditionsTable conditions={dataImportCron?.status?.conditions} />
       </PageSection>
     </div>
   );

--- a/src/views/datasources/details/DataSourceDetailsPage.tsx
+++ b/src/views/datasources/details/DataSourceDetailsPage.tsx
@@ -1,10 +1,7 @@
 import React, { FC } from 'react';
 
 import { V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import {
-  ConditionsTable,
-  K8sResourceCondition,
-} from '@kubevirt-utils/components/ConditionsTable/ConditionsTable';
+import { ConditionsTable } from '@kubevirt-utils/components/ConditionsTable/ConditionsTable';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Divider, PageSection, Title } from '@patternfly/react-core';
 
@@ -33,7 +30,7 @@ const DataSourceDetailsPage: FC<DataSourceDetailsPageProps> = ({ obj: dataSource
         <Title className="co-section-heading" headingLevel="h2">
           {t('Conditions')}
         </Title>
-        <ConditionsTable conditions={dataSource?.status?.conditions as K8sResourceCondition[]} />
+        <ConditionsTable conditions={dataSource?.status?.conditions} />
       </PageSection>
     </div>
   );

--- a/src/views/migrationpolicies/components/MigrationPolicyEditModal/utils/utils.ts
+++ b/src/views/migrationpolicies/components/MigrationPolicyEditModal/utils/utils.ts
@@ -19,7 +19,9 @@ export const extractEditMigrationPolicyInitialValues = (
     initState.allowAutoConverge = mp?.spec?.allowAutoConverge;
   }
   if (migrationPolicySpecKeys.BANDWIDTH_PER_MIGRATION in mp?.spec) {
-    initState.bandwidthPerMigration = toQuantity(mp?.spec?.bandwidthPerMigration.toString());
+    if (mp?.spec?.bandwidthPerMigration != null) {
+      initState.bandwidthPerMigration = toQuantity(mp.spec.bandwidthPerMigration.toString());
+    }
   }
   if (migrationPolicySpecKeys.COMPLETION_TIMEOUT_PER_GIB in mp?.spec) {
     initState.completionTimeoutPerGiB = mp?.spec?.completionTimeoutPerGiB;

--- a/src/views/migrationpolicies/components/MigrationPolicyEditModal/utils/utils.ts
+++ b/src/views/migrationpolicies/components/MigrationPolicyEditModal/utils/utils.ts
@@ -19,7 +19,7 @@ export const extractEditMigrationPolicyInitialValues = (
     initState.allowAutoConverge = mp?.spec?.allowAutoConverge;
   }
   if (migrationPolicySpecKeys.BANDWIDTH_PER_MIGRATION in mp?.spec) {
-    initState.bandwidthPerMigration = toQuantity(mp?.spec?.bandwidthPerMigration);
+    initState.bandwidthPerMigration = toQuantity(mp?.spec?.bandwidthPerMigration.toString());
   }
   if (migrationPolicySpecKeys.COMPLETION_TIMEOUT_PER_GIB in mp?.spec) {
     initState.completionTimeoutPerGiB = mp?.spec?.completionTimeoutPerGiB;

--- a/src/views/virtualmachinesinstance/details/tabs/disks/utils/virtualMachinesInstancePageDisksTabUtils.ts
+++ b/src/views/virtualmachinesinstance/details/tabs/disks/utils/virtualMachinesInstancePageDisksTabUtils.ts
@@ -44,7 +44,7 @@ export const diskStructureCreator = (disks: DiskRaw[]): DiskPresentation[] => {
       metadata: { name: device?.name },
       name: device?.name,
       namespace: device?.pvc?.metadata?.namespace,
-      size: device?.pvc?.spec?.resources?.requests?.storage.toString(),
+      size: device?.pvc?.spec?.resources?.requests?.storage?.toString(),
       source: device?.pvc?.metadata?.name || 'Other',
       storageClass: device?.pvc?.spec?.storageClassName || '-',
     };

--- a/src/views/virtualmachinesinstance/details/tabs/disks/utils/virtualMachinesInstancePageDisksTabUtils.ts
+++ b/src/views/virtualmachinesinstance/details/tabs/disks/utils/virtualMachinesInstancePageDisksTabUtils.ts
@@ -44,7 +44,7 @@ export const diskStructureCreator = (disks: DiskRaw[]): DiskPresentation[] => {
       metadata: { name: device?.name },
       name: device?.name,
       namespace: device?.pvc?.metadata?.namespace,
-      size: device?.pvc?.spec?.resources?.requests?.storage,
+      size: device?.pvc?.spec?.resources?.requests?.storage.toString(),
       source: device?.pvc?.metadata?.name || 'Other',
       storageClass: device?.pvc?.spec?.storageClassName || '-',
     };


### PR DESCRIPTION
## 📝 Description

Upgrade `@kubevirt-ui-ext/kubevirt-api` from 1.8.1 to 2.0.0. The new version types Kubernetes resource quantities (e.g. storage, memory, bandwidth) as branded `K8sIoApimachineryPkgApiResourceQuantity` values instead of plain strings.

Update affected selectors and unit helpers to call `.toString()` where string values are required, keeping existing behavior while satisfying the stricter types.

## 🔗 Links

- https://issues.redhat.com/browse/CNV-87466

## 🎥 Demo

N/A — dependency upgrade and type compatibility fixes only.

## Test plan

- [x] `npm run check-types` passes
- [ ] Verify VM disk size display on VMI details Disks tab
- [ ] Verify disk modal storage size handling
- [ ] Verify migration policy bandwidth field loads correctly in edit modal

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Updated kubevirt API dependency to 2.0.0

* **Bug Fixes**
  * Consistent string representation for storage and memory values across disks, imports, migration policy inputs, and VM details
  * Improved handling and display of resource-quantity values for human-readable sizes
  * Simplified and more robust handling of status conditions in condition/status tables and overview pages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->