### PR TITLE
CNV-76883: Restrict non-ACM virtualization dashboard to admins

### DIFF
--- a/src/views/virtualmachines/details/tabs/metrics/TimeRange/TimeRange.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/TimeRange/TimeRange.tsx
@@ -9,6 +9,7 @@ import {
   TELEMETRY_EXTERNAL_MONITORING_TOOL,
   TELEMETRY_VM_DETAIL_TAB,
 } from '@kubevirt-utils/extensions/telemetry/utils/property-constants';
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useVirtualizationObservabilityLink } from '@kubevirt-utils/hooks/useVirtualizationObservabilityLink/useVirtualizationObservabilityLink';
 import useIsACMPage from '@multicluster/useIsACMPage';
@@ -19,6 +20,7 @@ import { MONITORING_LINK } from '../utils/constants';
 const TimeRange: FC = () => {
   const { t } = useKubevirtTranslation();
   const isACMPage = useIsACMPage();
+  const isAdmin = useIsAdmin();
   const virtualizationObservabilityLink = useVirtualizationObservabilityLink();
 
   const { duration, setDuration } = useDuration();
@@ -48,7 +50,7 @@ const TimeRange: FC = () => {
         </ExternalLink>
       )}
 
-      {!isACMPage && (
+      {!isACMPage && isAdmin && (
         <Link
           onClick={() =>
             logExternalMonitoringNavigation(

--- a/src/views/virtualmachines/details/tabs/metrics/utils/constants.ts
+++ b/src/views/virtualmachines/details/tabs/metrics/utils/constants.ts
@@ -1,3 +1,7 @@
+import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+
 export const ALL_NETWORKS = 'All networks';
 
-export const MONITORING_LINK = '/monitoring/dashboards/grafana-dashboard-kubevirt-top-consumers';
+export const MONITORING_LINK = `/monitoring/dashboards/grafana-dashboard-kubevirt-top-consumers?project-dropdown-value=${encodeURIComponent(
+  ALL_NAMESPACES_SESSION_KEY,
+)}`;


### PR DESCRIPTION
## 📝 Description

Fixes the non-ACM "Virtualization dashboard" link on the VM Metrics tab:

- Show the link only to admin users (`useIsAdmin` / `CAN_LIST_NS` flag)
- Append `?project-dropdown-value=%23ALL_NS%23` so the monitoring dashboard opens scoped to all namespaces

The ACM (Grafana) dashboard link is unchanged.

## 🔗 Links

- https://redhat.atlassian.net/browse/CNV-76883

## 🎥 Demo


**BEFORE**

<img width="3840" height="2164" alt="Screenshot 2026-06-04 at 14 57 25" src="https://github.com/user-attachments/assets/a45a7329-441c-47c1-acd3-97254e2a8707" />


**AFTER**


Notice the project dropdown on "All projects" as this dashboard do not exists on a specific project but only on all projects .


<img width="3840" height="2164" alt="Screenshot 2026-06-04 at 14 59 07" src="https://github.com/user-attachments/assets/d0b92f22-631d-4f71-bf44-666aa1345763" />


## Test plan

- [ ] Log in as a cluster admin on a non-ACM (single-cluster) console
- [ ] Open a VM → Metrics tab and confirm "Virtualization dashboard" link is visible
- [ ] Click the link and verify it opens `/monitoring/dashboards/grafana-dashboard-kubevirt-top-consumers?project-dropdown-value=%23ALL_NS%23`
- [ ] Log in as a non-admin user and confirm the link is not shown on the Metrics tab
- [ ] On an ACM/fleet page, confirm the Grafana "Virtualization dashboard" link still works for eligible users


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Virtualization dashboard link visibility now restricted to admin users
* Monitoring dashboard link updated to include all namespaces in its default configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->