### PR TITLE
CNV-84964: Cannot install permissions for Self validation in managed cluster from Fleet Virtualization

### DIFF
--- a/src/views/checkups/self-validation/utils/selfValidationPermissions.ts
+++ b/src/views/checkups/self-validation/utils/selfValidationPermissions.ts
@@ -106,7 +106,7 @@ const handleDeleteError = (
  * @returns Error message if creation fails, null if successful
  */
 const getOrCreateResource = async (
-  getOptions: { model: K8sModel; name: string; ns?: string },
+  getOptions: { cluster?: string; model: K8sModel; name: string; ns?: string },
   createOptions: { cluster: string; data: K8sResourceCommon; model: K8sModel },
   resourceKind: string,
   t: TFunction,
@@ -120,6 +120,9 @@ const getOrCreateResource = async (
         await kubevirtK8sCreate(createOptions);
         return null;
       } catch (createError) {
+        if (isErrorStatusCode(createError, 409)) {
+          return null;
+        }
         const errorMessage = getFailedToModifyMessage(t, resourceKind);
         kubevirtConsole.error(`Failed to create ${resourceKind}:`, createError);
         return errorMessage;
@@ -203,6 +206,7 @@ export const installPermissions = async (
   const [serviceAccountError, roleError, roleBindingError] = await Promise.all([
     getOrCreateResource(
       {
+        cluster,
         model: ServiceAccountModel,
         name: SELF_VALIDATION_SA,
         ns: namespace,
@@ -217,6 +221,7 @@ export const installPermissions = async (
     ),
     getOrCreateResource(
       {
+        cluster,
         model: RoleModel,
         name: SELF_VALIDATION_ROLE,
         ns: namespace,
@@ -231,6 +236,7 @@ export const installPermissions = async (
     ),
     getOrCreateResource(
       {
+        cluster,
         model: RoleBindingModel,
         name: SELF_VALIDATION_ROLE,
         ns: namespace,


### PR DESCRIPTION
## 📝 Description

While trying to install permissions for Self validation in the managed cluster from the Fleet virtualization view, nothing happens.

## 🔗 Links

Jira ticket: [CNV-84964](https://redhat.atlassian.net/browse/CNV-84964)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/344d4b0d-3690-4ca1-a113-166068a20c10


After:

https://github.com/user-attachments/assets/9fad7b25-3ea4-401e-bc89-06029ad7182a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for resource conflicts during cluster permissions setup—conflicts are now managed gracefully.
  * Improved cluster-specific configuration support when provisioning permissions resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->