### PR TITLE
CNV-88977: GPU devices options should not be displayed on s390x clusters

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionHardware.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionHardware.tsx
@@ -8,8 +8,10 @@ import HardwareDevicesModal from '@kubevirt-utils/components/HardwareDevices/mod
 import { HARDWARE_DEVICE_TYPE } from '@kubevirt-utils/components/HardwareDevices/utils/constants';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
+import { ARCHITECTURES } from '@kubevirt-utils/constants/constants';
 import { TELEMETRY_GPU_PASSTHROUGH_TYPE } from '@kubevirt-utils/extensions/telemetry/utils/property-constants';
 import { logVMGPUAttached } from '@kubevirt-utils/extensions/telemetry/workload';
+import useHcoWorkloadArchitectures from '@kubevirt-utils/hooks/useHcoWorkloadArchitectures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useToggle } from '@kubevirt-utils/hooks/useToggle';
 import { getGPUDevices, getHostDevices } from '@kubevirt-utils/resources/vm';
@@ -34,6 +36,8 @@ const DetailsSectionHardware: FC<DetailsSectionHardwareProps> = ({
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const location = useLocation();
+  const clusterWorkloadArchitectures = useHcoWorkloadArchitectures() ?? [];
+  const clusterHasS390xArchitecture = clusterWorkloadArchitectures.includes(ARCHITECTURES.S390X);
   const [isExpanded, setIsExpanded] = useToggle('hardware-devices');
   const onSubmit = onSubmitProp || updateHardwareDevices;
   const hostDevices = getHostDevices(vm);
@@ -98,7 +102,7 @@ const DetailsSectionHardware: FC<DetailsSectionHardwareProps> = ({
       onToggle={(_event, val) => setIsExpanded(val)}
     >
       <Grid>
-        {!vmHasS390xArchitecture && (
+        {!vmHasS390xArchitecture && !clusterHasS390xArchitecture && (
           <>
             <GridItem span={5}>
               <HardwareDeviceTitle canEdit onClick={onEditGPU} title={t('GPU devices')} />
@@ -115,7 +119,7 @@ const DetailsSectionHardware: FC<DetailsSectionHardwareProps> = ({
           </>
         )}
 
-        <GridItem span={vmHasS390xArchitecture ? 11 : 5}>
+        <GridItem span={vmHasS390xArchitecture || clusterHasS390xArchitecture ? 11 : 5}>
           <HardwareDeviceTitle canEdit onClick={onEditHostDevices} title={t('Host devices')} />
           <HardwareDevicesTable devices={hostDevices} />
         </GridItem>


### PR DESCRIPTION
## 📝 Description

This fix hides GPU devices section on s390x clusters in both custom configuration and create from template flows, and expands the host devices section to fill the available width when GPU is hidden.

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-88977

## 🎥 Demo

Before: 

<img width="1905" height="905" alt="image" src="https://github.com/user-attachments/assets/02dbb39d-03bd-49f9-ae84-adcc2238f669" />


After: 
<img width="1906" height="907" alt="image" src="https://github.com/user-attachments/assets/118b0dff-9c90-4a7a-86ed-282f01b0ce78" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected virtual machine configuration details to consider cluster-level architecture alongside VM-level settings when showing host/GPU device sections.
  * GPU devices are now hidden only when both the VM and cluster use the s390x architecture.
  * Host devices layout now widens appropriately when either the VM or the cluster uses s390x, improving display and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->