### PR TITLE
CNV-88647 installed version widget shows infinite skeleton when MCO is not installed

### DIFF
--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/OpenShiftVirtualizationWidget/OpenShiftVirtualizationWidget.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/OpenShiftVirtualizationWidget/OpenShiftVirtualizationWidget.tsx
@@ -57,11 +57,11 @@ const OpenShiftVirtualizationWidget: FC<OpenShiftVirtualizationWidgetProps> = ({
     if (isAllClustersPage) {
       return NBSP;
     }
-    if (isLoading) {
+    if (!csvLoaded) {
       return <Skeleton width="50%" />;
     }
     return t('Installed version {{version}}', { version: version || t('Unknown') });
-  }, [isAllClustersPage, isLoading, version, t]);
+  }, [isAllClustersPage, csvLoaded, version, t]);
 
   return (
     <Card


### PR DESCRIPTION
## 📝 Description

Fix infinite loading skeleton in the OpenShift Virtualization widget for installed versions when MCO is not installed.

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-88647

## 🎥 Demo

Before: 
<img width="1906" height="921" alt="image" src="https://github.com/user-attachments/assets/07468907-f3ce-44e7-a573-df6f00c08a94" />

After:

<img width="1918" height="927" alt="image" src="https://github.com/user-attachments/assets/1843b719-c4e6-414f-ac50-e495222c7e56" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the loading state display for the OpenShift Virtualization widget subtitle. A skeleton placeholder now appears while data is loading, and the installed version information displays once the data is ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->