### PR TITLE
CNV-89390: VM creation wizard: changing project in location form resets wizard state

### DIFF
--- a/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
+++ b/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
@@ -73,8 +73,6 @@ const VMCreationWizard: FC = () => {
       setProject(!isAdmin ? namespace : currentProject || namespace);
       hasInitialized.current = true;
     }
-
-    return () => resetWizardState();
   }, [
     clusterParam,
     isAdmin,
@@ -85,6 +83,9 @@ const VMCreationWizard: FC = () => {
     setProject,
     setTemplatesDrawerIsOpen,
   ]);
+
+  // Reset wizard state only on unmount (separate from init to avoid wiping user selections when store values in the dep array change).
+  useEffect(() => () => resetWizardState(), []);
 
   const isInstanceTypeMethod = isInstanceTypeCreationMethod(creationMethod);
   const isCloneMethod = isCloneCreationMethod(creationMethod);


### PR DESCRIPTION
## 📝 Description

Changing the project in the VM creation wizard's location form immediately resets the selection back to the default. The user cannot select a different project.

## 🔗 Links

Jira ticket: [CNV-89390](https://redhat.atlassian.net/browse/CNV-89390)


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/d84ba2e1-f71b-485c-9fab-d415392176a2


After:

https://github.com/user-attachments/assets/dc43617b-7a54-4d43-871a-9ce4827191dd



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VM Creation Wizard state reset behavior to properly manage cleanup when the wizard is closed, preventing unexpected state resets during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->