### PR TITLE
CNV-89402: Fix incorrect disabled add cd-rom to vm for users 4.21

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskList.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskList.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 
-import { useInstanceTypeVMStore } from '@catalog/CreateFromInstanceTypes/state/useInstanceTypeVMStore';
-import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { DataVolumeModel, VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DiskListTitle from '@kubevirt-utils/components/DiskListTitle/DiskListTitle';
 import DiskSourceSelect from '@kubevirt-utils/components/DiskModal/components/DiskSourceSelect/DiskSourceSelect';
@@ -9,7 +8,7 @@ import DiskModal from '@kubevirt-utils/components/DiskModal/DiskModal';
 import { SourceTypes } from '@kubevirt-utils/components/DiskModal/utils/types';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import WindowsDrivers from '@kubevirt-utils/components/WindowsDrivers/WindowsDrivers';
-import { asAccessReview } from '@kubevirt-utils/resources/shared';
+import { asAccessReview, getNamespace } from '@kubevirt-utils/resources/shared';
 import useDisksTableData from '@kubevirt-utils/resources/vm/hooks/disk/useDisksTableData';
 import useProvisioningPercentage from '@kubevirt-utils/resources/vm/hooks/useProvisioningPercentage';
 import { K8sVerb, useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
@@ -40,7 +39,6 @@ const DiskList: FC<DiskListProps> = ({ customize = false, onDiskUpdate, vm, vmi 
   const { createModal } = useModal();
   const columns = useDiskColumns();
   const [disks, sourcesLoaded, loadError] = useDisksTableData(vm, vmi);
-  const instanceTypeVMStore = useInstanceTypeVMStore();
   const filters = useDisksFilters();
   const [data, filteredData, onFilterChange] = useListPageFilter(disks, filters);
 
@@ -48,9 +46,9 @@ const DiskList: FC<DiskListProps> = ({ customize = false, onDiskUpdate, vm, vmi 
   const [canUpdate] = useFleetAccessReview(accessReview || {});
 
   const [canCreateDataVolume] = useAccessReview({
-    group: VirtualMachineModel.apiGroup,
-    namespace: instanceTypeVMStore?.vmNamespaceTarget,
-    resource: VirtualMachineModel.plural,
+    group: DataVolumeModel.apiGroup,
+    namespace: getNamespace(vm),
+    resource: DataVolumeModel.plural,
     verb: 'create' as K8sVerb,
   });
 


### PR DESCRIPTION
## :memo: Description

fixed CD-ROM button RBAC check to verify DataVolume create permission instead of VirtualMachine create permission in the Storage tab backported to 4.21

## :link: Links

Jira ticket for this BP: https://redhat.atlassian.net/browse/CNV-89402
original Jira: https://redhat.atlassian.net/browse/CNV-88892
PR merged: https://github.com/kubevirt-ui/kubevirt-plugin/pull/4029

## :movie_camera: Demo

Before:
<img width="1142" height="914" alt="602907965-e69d5301-38d2-4a6a-a0d9-b39adc710fee" src="https://github.com/user-attachments/assets/9820fd66-fad9-4d8d-8291-9e1813f5b291" />

After:
<img width="1839" height="723" alt="602907744-de66224e-40ac-4986-96dc-18eb7fd4f72f" src="https://github.com/user-attachments/assets/87c1ab92-e1d1-4110-ac7e-5037b18503de" />
<img width="1241" height="1047" alt="602907733-3f856328-6f79-4c39-a279-b069a259b476" src="https://github.com/user-attachments/assets/db0210c6-761d-421a-a7d3-88c0780cd3ed" />