### PR TITLE
CNV-89351: Fix folder selection in Create VM Wizard

### DIFF
--- a/src/utils/components/FolderSelect/hooks/useFolderOptions.tsx
+++ b/src/utils/components/FolderSelect/hooks/useFolderOptions.tsx
@@ -24,7 +24,10 @@ const useFolderOptions: UseFolderOptions = (namespace, cluster) => {
   });
 
   useEffect(() => {
-    if (isEmpty(vms)) return;
+    if (isEmpty(vms)) {
+      setFolders([]);
+      return;
+    }
 
     const folderOptions = vms.reduce((uniqueValues, vm) => {
       const folderLabel = getLabel(vm, VM_FOLDER_LABEL);

--- a/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
+++ b/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
@@ -43,11 +43,9 @@ const VMCreationWizard: FC = () => {
   const { t } = useKubevirtTranslation();
   const {
     creationMethod,
+    initializeVMCreationWizardValues,
     markStepVisited,
-    project,
     resetWizardState,
-    setCluster,
-    setProject,
     setTemplatesDrawerIsOpen,
   } = useVMWizardStore();
   const syncDescription = useSyncDescription();
@@ -63,29 +61,20 @@ const VMCreationWizard: FC = () => {
 
   useEffect(() => {
     if (!hasInitialized.current) {
-      const currentProject = project; // capture before resetWizardState clears it
-      resetWizardState();
       setTemplatesDrawerIsOpen(false);
-
-      setCluster(clusterParam);
-      // Non-admin: always use the active namespace.
-      // Admin: keep their previously selected project if set, otherwise use the active namespace.
-      setProject(!isAdmin ? namespace : currentProject || namespace);
+      initializeVMCreationWizardValues({ cluster: clusterParam, isAdmin, namespace });
       hasInitialized.current = true;
     }
+
+    return () => resetWizardState();
   }, [
     clusterParam,
     isAdmin,
     namespace,
-    project,
     resetWizardState,
-    setCluster,
-    setProject,
     setTemplatesDrawerIsOpen,
+    initializeVMCreationWizardValues,
   ]);
-
-  // Reset wizard state only on unmount (separate from init to avoid wiping user selections when store values in the dep array change).
-  useEffect(() => () => resetWizardState(), []);
 
   const isInstanceTypeMethod = isInstanceTypeCreationMethod(creationMethod);
   const isCloneMethod = isCloneCreationMethod(creationMethod);

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore.ts
@@ -4,12 +4,34 @@ import { Template } from '@kubevirt-utils/resources/template';
 import { clearCustomizeInstanceType } from '@kubevirt-utils/store/customizeInstanceType';
 import useInstanceTypeVMStore from '@virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore';
 import { initialVMWizardState } from '@virtualmachines/creation-wizard/state/vm-wizard-store/utils/state';
-import { VMWizardStore } from '@virtualmachines/creation-wizard/state/vm-wizard-store/utils/types';
+import {
+  InitializeVMCreateWizardValues,
+  VMWizardStore,
+} from '@virtualmachines/creation-wizard/state/vm-wizard-store/utils/types';
 import { VMCreationMethod, VMWizardStep } from '@virtualmachines/creation-wizard/utils/constants';
+
+const clearWizardRelatedStores = (): void => {
+  clearCustomizeInstanceType();
+  useInstanceTypeVMStore.getState().resetInstanceTypeVMState();
+};
 
 const useVMWizardStore = create<VMWizardStore>()((set) => {
   return {
     ...initialVMWizardState,
+    initializeVMCreationWizardValues: ({
+      cluster,
+      isAdmin,
+      namespace,
+    }: InitializeVMCreateWizardValues) => {
+      clearWizardRelatedStores();
+      set(({ project: previousProject }) => ({
+        ...initialVMWizardState,
+        cluster,
+        // Non-admin: always use the active namespace.
+        // Admin: keep their previously selected project if set, otherwise use the active namespace.
+        project: !isAdmin ? namespace : previousProject || namespace,
+      }));
+    },
     markStepVisited: (stepId: string) =>
       set((state) => {
         if (state.visitedSteps.has(stepId)) return state;
@@ -18,8 +40,7 @@ const useVMWizardStore = create<VMWizardStore>()((set) => {
         return { visitedSteps: next };
       }),
     resetWizardState: () => {
-      clearCustomizeInstanceType();
-      useInstanceTypeVMStore.getState().resetInstanceTypeVMState();
+      clearWizardRelatedStores();
       set({ ...initialVMWizardState, visitedSteps: new Set([VMWizardStep.DEPLOYMENT_DETAILS]) });
     },
     setCluster: (cluster: string) => set({ cluster }),

--- a/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/types.ts
+++ b/src/views/virtualmachines/creation-wizard/state/vm-wizard-store/utils/types.ts
@@ -15,7 +15,13 @@ export type VMWizardState = {
   vmName: string | undefined;
 };
 
+export type InitializeVMCreateWizardValues = Partial<VMWizardState> & {
+  isAdmin: boolean;
+  namespace: string;
+};
+
 export type VMWizardActions = {
+  initializeVMCreationWizardValues: (values: InitializeVMCreateWizardValues) => void;
   markStepVisited: (stepId: string) => void;
   resetWizardState: () => void;
   setCluster: (cluster: string) => void;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes a bug where folder options from the previous project stayed visible after switching to a project with no VMs.
Also moves wizard init logic into the store and uses a single useEffect for setup and cleanup on close.

## 🔗 Links

> [Jira ticket: [CNV-89351](https://redhat.atlassian.net/browse/CNV-89351)](https://redhat.atlassian.net/browse/CNV-89351)

## 🎥 Demo

before:
https://github.com/user-attachments/assets/2d2c964d-7f5d-4a09-8968-7ec8ec282783



after:
https://github.com/user-attachments/assets/ac19ccfd-7bd7-459d-8474-984242d31a0d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Folder selection now correctly shows an empty list when no virtual machines are available.

* **Refactor**
  * VM creation wizard initialization and teardown improved for more reliable state handling.
  * Admin users now retain previously selected projects when available; non-admins consistently use the current namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->