### PR TITLE
CNV-88968 - fix on s390x clusters to only support IPL boot mode

### DIFF
--- a/src/utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal.tsx
+++ b/src/utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal.tsx
@@ -3,6 +3,7 @@ import React, { FC, MouseEvent, useMemo, useState } from 'react';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ModalPendingChangesAlert from '@kubevirt-utils/components/PendingChanges/ModalPendingChangesAlert/ModalPendingChangesAlert';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
+import useHcoWorkloadArchitectures from '@kubevirt-utils/hooks/useHcoWorkloadArchitectures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup, SelectOption } from '@patternfly/react-core';
 
@@ -10,7 +11,12 @@ import FormPFSelect from '../FormPFSelect/FormPFSelect';
 
 import { BootMode, BootModeTitles } from './utils/constants';
 import { BootloaderOptionValue } from './utils/types';
-import { getBootloaderFromVM, getBootloaderOptions, updatedVMBootMode } from './utils/utils';
+import {
+  getBootloaderFromVM,
+  getBootloaderOptions,
+  getClusterOnlyArchitecture,
+  updatedVMBootMode,
+} from './utils/utils';
 
 type FirmwareBootloaderModalProps = {
   isOpen: boolean;
@@ -30,10 +36,17 @@ const FirmwareBootloaderModal: FC<FirmwareBootloaderModalProps> = ({
   vmi,
 }) => {
   const { t } = useKubevirtTranslation();
+  const clusterWorkloadArchitectures = useHcoWorkloadArchitectures();
+  const clusterOnlyArchitecture = getClusterOnlyArchitecture(clusterWorkloadArchitectures);
   const [selectedFirmwareBootloader, setSelectedFirmwareBootloader] =
-    useState<BootloaderOptionValue>(getBootloaderFromVM(vm, preferredBootmode));
+    useState<BootloaderOptionValue>(
+      getBootloaderFromVM(vm, preferredBootmode, clusterOnlyArchitecture),
+    );
 
-  const bootloaderOptions = useMemo(() => getBootloaderOptions(vm), [vm]);
+  const bootloaderOptions = useMemo(
+    () => getBootloaderOptions(vm, clusterOnlyArchitecture),
+    [vm, clusterOnlyArchitecture],
+  );
 
   const handleChange = (event: MouseEvent<HTMLSelectElement>, value: BootloaderOptionValue) => {
     event.preventDefault();
@@ -41,8 +54,8 @@ const FirmwareBootloaderModal: FC<FirmwareBootloaderModalProps> = ({
   };
 
   const updatedVirtualMachine = useMemo(
-    () => updatedVMBootMode(vm, selectedFirmwareBootloader),
-    [vm, selectedFirmwareBootloader],
+    () => updatedVMBootMode(vm, selectedFirmwareBootloader, clusterOnlyArchitecture),
+    [vm, selectedFirmwareBootloader, clusterOnlyArchitecture],
   );
 
   return (

--- a/src/utils/components/FirmwareBootloaderModal/utils/utils.ts
+++ b/src/utils/components/FirmwareBootloaderModal/utils/utils.ts
@@ -20,11 +20,19 @@ import { BootloaderOption, BootloaderOptionValue } from './types';
 
 export const isObjectEmpty = (obj: object): boolean => obj && isEmpty(obj);
 
+export const getClusterOnlyArchitecture = (
+  clusterWorkloadArchitectures?: string[],
+): string | undefined => {
+  return clusterWorkloadArchitectures?.length === 1 ? clusterWorkloadArchitectures[0] : undefined;
+};
+
 export const getBootloaderFromVM = (
   vm: V1VirtualMachine,
   defaultBootmode = BootMode.bios,
+  clusterOnlyArchitecture?: string,
 ): BootloaderOptionValue => {
-  if (getArchitecture(vm) === ARCHITECTURES.S390X) {
+  const architecture = getArchitecture(vm) || clusterOnlyArchitecture;
+  if (architecture === ARCHITECTURES.S390X) {
     return BootMode.ipl;
   }
 
@@ -46,13 +54,17 @@ export const getBootloaderTitleFromVM = (
   vm: V1VirtualMachine,
   t: TFunction,
   defaultBootmode?: BootMode,
+  clusterOnlyArchitecture?: string,
 ): string => {
-  const bootloader = getBootloaderFromVM(vm, defaultBootmode);
+  const bootloader = getBootloaderFromVM(vm, defaultBootmode, clusterOnlyArchitecture);
   return t(BootModeTitles[bootloader]);
 };
 
-export const getBootloaderOptions = (vm: V1VirtualMachine): BootloaderOption[] => {
-  const architecture = getArchitecture(vm);
+export const getBootloaderOptions = (
+  vm: V1VirtualMachine,
+  clusterOnlyArchitecture?: string,
+): BootloaderOption[] => {
+  const architecture = getArchitecture(vm) || clusterOnlyArchitecture;
 
   if (architecture === ARCHITECTURES.S390X) {
     return s390xBootloaderOptions;
@@ -65,14 +77,17 @@ export const getBootloaderOptions = (vm: V1VirtualMachine): BootloaderOption[] =
  * A function to return the VirtualMachine object updated with a given boot mode
  * @param {V1VirtualMachine} vm - VirtualMachine object
  * @param {BootloaderOptionValue} firmwareBootloader - selected boot mode
+ * @param clusterOnlyArchitecture
  * @returns {V1VirtualMachine} updated VirtualMachine object
  */
 export const updatedVMBootMode = (
   vm: V1VirtualMachine,
   firmwareBootloader: BootloaderOptionValue,
+  clusterOnlyArchitecture?: string,
 ) =>
   produce<V1VirtualMachine>(vm as V1VirtualMachine, (vmDraft: V1VirtualMachine) => {
-    if (getArchitecture(vm) === ARCHITECTURES.S390X && firmwareBootloader === BootMode.ipl) {
+    const architecture = getArchitecture(vm) || clusterOnlyArchitecture;
+    if (architecture === ARCHITECTURES.S390X && firmwareBootloader === BootMode.ipl) {
       if (getBootloader(vmDraft)) {
         delete vmDraft.spec.template.spec.domain.firmware.bootloader;
       }

--- a/src/views/templates/details/tabs/details/components/BootMethod/TemplateBootloaderModal.tsx
+++ b/src/views/templates/details/tabs/details/components/BootMethod/TemplateBootloaderModal.tsx
@@ -6,10 +6,12 @@ import { BootloaderOptionValue } from '@kubevirt-utils/components/FirmwareBootlo
 import {
   getBootloaderFromVM,
   getBootloaderOptions,
+  getClusterOnlyArchitecture,
   updatedVMBootMode,
 } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/utils';
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
+import useHcoWorkloadArchitectures from '@kubevirt-utils/hooks/useHcoWorkloadArchitectures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getTemplateVirtualMachineObject, Template } from '@kubevirt-utils/resources/template';
 import { FormGroup, SelectOption } from '@patternfly/react-core';
@@ -29,10 +31,15 @@ const TemplateBootloaderModal: FC<TemplateBootloaderModalProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const vm = getTemplateVirtualMachineObject(template);
+  const clusterWorkloadArchitectures = useHcoWorkloadArchitectures();
+  const clusterOnlyArchitecture = getClusterOnlyArchitecture(clusterWorkloadArchitectures);
   const [selectedFirmwareBootloader, setSelectedFirmwareBootloader] =
-    useState<BootloaderOptionValue>(getBootloaderFromVM(vm));
+    useState<BootloaderOptionValue>(getBootloaderFromVM(vm, undefined, clusterOnlyArchitecture));
 
-  const bootloaderOptions = useMemo(() => getBootloaderOptions(vm), [vm]);
+  const bootloaderOptions = useMemo(
+    () => getBootloaderOptions(vm, clusterOnlyArchitecture),
+    [vm, clusterOnlyArchitecture],
+  );
 
   const handleChange = (event: MouseEvent<HTMLSelectElement>, value: BootloaderOptionValue) => {
     event.preventDefault();
@@ -42,11 +49,15 @@ const TemplateBootloaderModal: FC<TemplateBootloaderModalProps> = ({
   const updatedTemplate = useMemo(() => {
     return produce<Template>(template, (templateDraft: Template) => {
       const vmDraft = getTemplateVirtualMachineObject(templateDraft);
-      const updatedVM = updatedVMBootMode(vmDraft, selectedFirmwareBootloader);
+      const updatedVM = updatedVMBootMode(
+        vmDraft,
+        selectedFirmwareBootloader,
+        clusterOnlyArchitecture,
+      );
 
       vmDraft.spec.template.spec.domain = updatedVM.spec.template.spec.domain;
     });
-  }, [selectedFirmwareBootloader, template]);
+  }, [selectedFirmwareBootloader, template, clusterOnlyArchitecture]);
 
   return (
     <TabModal

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionBoot.tsx
@@ -8,9 +8,13 @@ import BootOrderModal from '@kubevirt-utils/components/BootOrderModal/BootOrderM
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import FirmwareBootloaderModal from '@kubevirt-utils/components/FirmwareBootloaderModal/FirmwareBootloaderModal';
 import { BootMode } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/constants';
-import { getBootloaderTitleFromVM } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/utils';
+import {
+  getBootloaderTitleFromVM,
+  getClusterOnlyArchitecture,
+} from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/utils';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
+import useHcoWorkloadArchitectures from '@kubevirt-utils/hooks/useHcoWorkloadArchitectures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useToggle } from '@kubevirt-utils/hooks/useToggle';
 import { getName } from '@kubevirt-utils/resources/shared';
@@ -47,7 +51,8 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({
   const [isChecked, setIsChecked] = useState<boolean>(!!vm?.spec?.template?.spec?.startStrategy);
   const [isExpanded, setIsExpanded] = useToggle('boot-management');
   const vmName = getName(vm);
-
+  const clusterWorkloadArchitectures = useHcoWorkloadArchitectures();
+  const clusterOnlyArchitecture = getClusterOnlyArchitecture(clusterWorkloadArchitectures);
   useEffect(() => {
     expandURLHash(getSearchItemsIds(getDetailsTabBootIds(vm)), location?.hash, setIsExpanded);
   }, [vm, location?.hash, setIsExpanded]);
@@ -62,7 +67,12 @@ const DetailsSectionBoot: FC<DetailsSectionBootProps> = ({
       <DescriptionItem
         descriptionData={
           <div className={classNames({ 'pf-v6-u-text-color-subtle': !canUpdateVM })}>
-            {getBootloaderTitleFromVM(instanceTypeVM || vm, t, preferredBootmode)}
+            {getBootloaderTitleFromVM(
+              instanceTypeVM || vm,
+              t,
+              preferredBootmode,
+              clusterOnlyArchitecture,
+            )}
           </div>
         }
         onEditClick={() =>


### PR DESCRIPTION
## 📝 Description
Fix for ensuring the boot mode shows only IPL when running on an s390x cluster

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-88968

## 🎥 Demo

Before:
<img width="1571" height="836" alt="image" src="https://github.com/user-attachments/assets/976b0ca3-e873-42f8-9089-ebea5413340c" />

After:

<img width="1567" height="838" alt="image" src="https://github.com/user-attachments/assets/0aba4a02-b971-49a1-a8e0-db1c720c6ae3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bootloader selection and display now properly account for cluster workload architecture, ensuring available boot modes and configuration options accurately reflect the cluster's constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->