### PR TITLE
CNV-88977 GPU device options should not be displayed on s390x clusters

### DIFF
--- a/src/utils/components/FirmwareBootloaderModal/utils/utils.ts
+++ b/src/utils/components/FirmwareBootloaderModal/utils/utils.ts
@@ -20,6 +20,12 @@ import { BootloaderOption, BootloaderOptionValue } from './types';
 
 export const isObjectEmpty = (obj: object): boolean => obj && isEmpty(obj);
 
+export const getClusterOnlyArchitecture = (
+  clusterWorkloadArchitectures?: string[],
+): string | undefined => {
+  return clusterWorkloadArchitectures?.length === 1 ? clusterWorkloadArchitectures[0] : undefined;
+};
+
 export const getBootloaderFromVM = (
   vm: V1VirtualMachine,
   defaultBootmode = BootMode.bios,

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionHardware.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionHardware.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect } from 'react';
 import { useLocation } from 'react-router';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getClusterOnlyArchitecture } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/utils';
 import HardwareDevicesTable from '@kubevirt-utils/components/HardwareDevices/HardwareDevicesTable';
 import HardwareDeviceTitle from '@kubevirt-utils/components/HardwareDevices/HardwareDeviceTitle';
 import HardwareDevicesModal from '@kubevirt-utils/components/HardwareDevices/modal/HardwareDevicesModal';
@@ -36,13 +37,14 @@ const DetailsSectionHardware: FC<DetailsSectionHardwareProps> = ({
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const location = useLocation();
-  const clusterWorkloadArchitectures = useHcoWorkloadArchitectures() ?? [];
-  const clusterHasS390xArchitecture = clusterWorkloadArchitectures.includes(ARCHITECTURES.S390X);
+  const clusterWorkloadArchitectures = useHcoWorkloadArchitectures();
+  const clusterOnlyArchitecture = getClusterOnlyArchitecture(clusterWorkloadArchitectures);
   const [isExpanded, setIsExpanded] = useToggle('hardware-devices');
   const onSubmit = onSubmitProp || updateHardwareDevices;
   const hostDevices = getHostDevices(vm);
   const gpus = getGPUDevices(vm);
   const vmHasS390xArchitecture = hasS390xArchitecture(vm);
+  const isClusterS390xArchitecture = clusterOnlyArchitecture === ARCHITECTURES.S390X;
 
   useEffect(() => {
     expandURLHash(getSearchItemsIds(getDetailsTabHardwareIds(vm)), location?.hash, setIsExpanded);
@@ -102,7 +104,7 @@ const DetailsSectionHardware: FC<DetailsSectionHardwareProps> = ({
       onToggle={(_event, val) => setIsExpanded(val)}
     >
       <Grid>
-        {!vmHasS390xArchitecture && !clusterHasS390xArchitecture && (
+        {!vmHasS390xArchitecture && !isClusterS390xArchitecture && (
           <>
             <GridItem span={5}>
               <HardwareDeviceTitle canEdit onClick={onEditGPU} title={t('GPU devices')} />
@@ -119,7 +121,7 @@ const DetailsSectionHardware: FC<DetailsSectionHardwareProps> = ({
           </>
         )}
 
-        <GridItem span={vmHasS390xArchitecture || clusterHasS390xArchitecture ? 11 : 5}>
+        <GridItem span={vmHasS390xArchitecture || isClusterS390xArchitecture ? 11 : 5}>
           <HardwareDeviceTitle canEdit onClick={onEditHostDevices} title={t('Host devices')} />
           <HardwareDevicesTable devices={hostDevices} />
         </GridItem>


### PR DESCRIPTION
## 📝 Description

This fix hides GPU devices section on s390x clusters in both custom configuration and create from template flows, and expands the host devices section to fill the available width when GPU is hidden.

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-88977

## 🎥 Demo

Before: 

<img width="1905" height="905" alt="image" src="https://github.com/user-attachments/assets/02dbb39d-03bd-49f9-ae84-adcc2238f669" />


After: 
<img width="1906" height="907" alt="image" src="https://github.com/user-attachments/assets/118b0dff-9c90-4a7a-86ed-282f01b0ce78" />