### PR TITLE
CNV-89378: Storage migrations page lists only MultiNamespaceVirtualMachineStorageMigrationPlan

### DIFF
--- a/src/perspective/navigation/migrationSection.ts
+++ b/src/perspective/navigation/migrationSection.ts
@@ -1,4 +1,4 @@
-import { NavSection, ResourceNSNavItem } from '@openshift-console/dynamic-plugin-sdk';
+import { HrefNavItem, NavSection } from '@openshift-console/dynamic-plugin-sdk';
 import { EncodedExtension } from '@openshift-console/dynamic-plugin-sdk-webpack';
 
 import { PERSPECTIVES } from '../../utils/constants/constants';
@@ -21,21 +21,21 @@ export const migrationSection: EncodedExtension[] = [
     type: 'console.navigation/section',
   } as EncodedExtension<NavSection>,
   {
+    flags: {
+      required: ['SHOW_MIGRATION_SECTION'],
+    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-storagemigrations-virt-perspective',
         'data-test-id': 'storagemigrations-virt-perspective-nav-item',
       },
+      href: 'storagemigrations',
       id: 'storagemigrations-virt-perspective',
-      model: {
-        group: 'migration.openshift.io',
-        kind: 'MigPlan',
-        version: 'v1alpha1',
-      },
       name: '%plugin__kubevirt-plugin~Storage migrations%',
       perspective: PERSPECTIVES.VIRTUALIZATION,
+      prefixNamespaced: true,
       section: 'migration-virt-perspective',
     },
-    type: 'console.navigation/resource-ns',
-  } as EncodedExtension<ResourceNSNavItem>,
+    type: 'console.navigation/href',
+  } as EncodedExtension<HrefNavItem>,
 ];

--- a/src/utils/resources/migrations/backends/mtcBackend.ts
+++ b/src/utils/resources/migrations/backends/mtcBackend.ts
@@ -14,7 +14,6 @@ const normalizePlanForOverview = (plan: K8sResourceCommon) =>
 export const mtcBackend: StorageMigrationBackendDescriptor = {
   api: STORAGE_MIGRATION_API.MTC,
   fixedPlanNamespace: MTC_MIGRATION_NAMESPACE,
-  listConsolePathUsesResourceUrl: false,
   migrateVMs: migrateVMsMTC,
   normalizePlanForOverview,
   overviewUsesClusterScopedPlanWatch: false,

--- a/src/utils/resources/migrations/backends/multiNsBackend.ts
+++ b/src/utils/resources/migrations/backends/multiNsBackend.ts
@@ -14,7 +14,6 @@ const normalizePlanForOverview = (
 
 export const multiNsBackend: StorageMigrationBackendDescriptor = {
   api: STORAGE_MIGRATION_API.MULTI_NS,
-  listConsolePathUsesResourceUrl: true,
   migrateVMs,
   normalizePlanForOverview,
   overviewUsesClusterScopedPlanWatch: true,

--- a/src/utils/resources/migrations/backends/singleNsBackend.ts
+++ b/src/utils/resources/migrations/backends/singleNsBackend.ts
@@ -12,7 +12,6 @@ const normalizePlanForOverview = (plan: K8sResourceCommon) =>
 
 export const singleNsBackend: StorageMigrationBackendDescriptor = {
   api: STORAGE_MIGRATION_API.SINGLE_NS,
-  listConsolePathUsesResourceUrl: false,
   migrateVMs: migrateVMsSingleNs,
   normalizePlanForOverview,
   overviewUsesClusterScopedPlanWatch: false,

--- a/src/utils/resources/migrations/backends/types.ts
+++ b/src/utils/resources/migrations/backends/types.ts
@@ -33,8 +33,6 @@ export type StorageMigrationBackendDescriptor = {
   api: StorageMigrationAPI;
   /** Namespace for fleet LIST when plans are not in the VM namespace (e.g. MTC). */
   fixedPlanNamespace?: string;
-  /** When true, console list links use `getResourceUrl` for `planModel`; otherwise the custom storagemigrations route. */
-  listConsolePathUsesResourceUrl: boolean;
   migrateVMs: MigrateVMsFn;
   normalizePlanForOverview: StorageMigrationPlanOverviewNormalizer;
   /**

--- a/src/views/storagemigrations/actions/useStorageMigrationActions.tsx
+++ b/src/views/storagemigrations/actions/useStorageMigrationActions.tsx
@@ -4,10 +4,8 @@ import { useNavigate } from 'react-router';
 import DeleteModal from '@kubevirt-utils/components/DeleteModal/DeleteModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import {
-  modelToRef,
-  MultiNamespaceVirtualMachineStorageMigrationPlanModel,
-} from '@kubevirt-utils/models';
+import { modelToRef } from '@kubevirt-utils/models';
+import { getStorageMigrationPlanModelForKind } from '@kubevirt-utils/resources/migrations/backends';
 import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
 import { asAccessReview, getResourceUrl } from '@kubevirt-utils/resources/shared';
 import {
@@ -27,63 +25,46 @@ const useStorageMigrationActions: ExtensionHook<
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
 
-  const [, inFlight] = useK8sModel(
-    modelToRef(MultiNamespaceVirtualMachineStorageMigrationPlanModel),
-  );
+  const planModel = getStorageMigrationPlanModelForKind(migPlan?.kind);
+  const [, inFlight] = useK8sModel(modelToRef(planModel));
   const labelsModalLauncher = useLabelsModal(migPlan);
   const annotationsModalLauncher = useAnnotationsModal(migPlan);
   const actions = useMemo(
     () => [
       {
-        accessReview: asAccessReview(
-          MultiNamespaceVirtualMachineStorageMigrationPlanModel,
-          migPlan,
-          'patch',
-        ),
+        accessReview: asAccessReview(planModel, migPlan, 'patch'),
         cta: labelsModalLauncher,
         id: 'edit-migplan-labels',
         label: t('Edit labels'),
       },
       {
-        accessReview: asAccessReview(
-          MultiNamespaceVirtualMachineStorageMigrationPlanModel,
-          migPlan,
-          'patch',
-        ),
+        accessReview: asAccessReview(planModel, migPlan, 'patch'),
         cta: annotationsModalLauncher,
         id: 'edit-migplan-annotations',
         label: t('Edit annotations'),
       },
       {
-        accessReview: asAccessReview(
-          MultiNamespaceVirtualMachineStorageMigrationPlanModel,
-          migPlan,
-          'update',
-        ),
+        accessReview: asAccessReview(planModel, migPlan, 'update'),
         cta: () =>
           navigate(
             `${getResourceUrl({
-              model: MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+              model: planModel,
               resource: migPlan,
             })}/yaml`,
           ),
         id: 'edit-migplan-resource',
         label: t('Edit {{kind}}', {
-          kind: MultiNamespaceVirtualMachineStorageMigrationPlanModel.kind,
+          kind: planModel.kind,
         }),
       },
       {
-        accessReview: asAccessReview(
-          MultiNamespaceVirtualMachineStorageMigrationPlanModel,
-          migPlan,
-          'delete',
-        ),
+        accessReview: asAccessReview(planModel, migPlan, 'delete'),
         cta: () =>
           createModal(({ isOpen, onClose }) => (
             <DeleteModal
               onDeleteSubmit={() =>
                 k8sDelete({
-                  model: MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+                  model: planModel,
                   resource: migPlan,
                 })
               }
@@ -96,11 +77,20 @@ const useStorageMigrationActions: ExtensionHook<
         disabled: false,
         id: 'migplan-delete-action',
         label: t('Delete {{kind}}', {
-          kind: MultiNamespaceVirtualMachineStorageMigrationPlanModel.kind,
+          kind: planModel.kind,
         }),
       },
     ],
-    [annotationsModalLauncher, createModal, labelsModalLauncher, migPlan, navigate, t, inFlight],
+    [
+      annotationsModalLauncher,
+      createModal,
+      labelsModalLauncher,
+      migPlan,
+      navigate,
+      planModel,
+      t,
+      inFlight,
+    ],
   );
 
   return [actions, !inFlight, undefined];

--- a/src/views/storagemigrations/extensions.ts
+++ b/src/views/storagemigrations/extensions.ts
@@ -1,4 +1,9 @@
-import type { FeatureFlagHookProvider, NavSection } from '@openshift-console/dynamic-plugin-sdk';
+import type {
+  FeatureFlagHookProvider,
+  HrefNavItem,
+  NavSection,
+  RoutePage,
+} from '@openshift-console/dynamic-plugin-sdk';
 import type {
   ConsolePluginBuildMetadata,
   EncodedExtension,
@@ -34,38 +39,46 @@ export const extensions: EncodedExtension[] = [
   {
     properties: {
       component: { $codeRef: 'StorageMigrationList' },
-      model: {
-        group: 'migrations.kubevirt.io',
-        kind: 'MultiNamespaceVirtualMachineStorageMigrationPlan',
-        version: 'v1alpha1',
-      },
-      prefixNamespaced: true,
+      path: ['/k8s/ns/:ns/storagemigrations', '/k8s/all-namespaces/storagemigrations'],
     },
-    type: 'console.page/resource/list',
-  },
+    type: 'console.page/route',
+  } as EncodedExtension<RoutePage>,
   {
+    flags: {
+      required: ['SHOW_MIGRATION_SECTION'],
+    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-storagemigrations',
         'data-test-id': 'storagemigrations-nav-item',
       },
+      href: 'storagemigrations',
       id: 'storagemigrations',
-      model: {
-        group: 'migrations.kubevirt.io',
-        kind: 'MultiNamespaceVirtualMachineStorageMigrationPlan',
-        version: 'v1alpha1',
-      },
       name: '%plugin__kubevirt-plugin~Storage migrations%',
+      prefixNamespaced: true,
       section: 'migration',
     },
-    type: 'console.navigation/resource-ns',
-  },
+    type: 'console.navigation/href',
+  } as EncodedExtension<HrefNavItem>,
 
   {
     properties: {
       model: {
         group: 'migrations.kubevirt.io',
         kind: 'MultiNamespaceVirtualMachineStorageMigrationPlan',
+        version: 'v1alpha1',
+      },
+      provider: {
+        $codeRef: 'useStorageMigrationActionsProvider',
+      },
+    },
+    type: 'console.action/resource-provider',
+  },
+  {
+    properties: {
+      model: {
+        group: 'migrations.kubevirt.io',
+        kind: 'VirtualMachineStorageMigrationPlan',
         version: 'v1alpha1',
       },
       provider: {

--- a/src/views/storagemigrations/list/StorageMigrationCells.tsx
+++ b/src/views/storagemigrations/list/StorageMigrationCells.tsx
@@ -6,11 +6,11 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import {
   modelToGroupVersionKind,
   modelToRef,
-  MultiNamespaceVirtualMachineStorageMigrationPlanModel,
   NamespaceModel,
   StorageClassModel,
 } from '@kubevirt-utils/models';
 import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
+import { getStorageMigrationPlanSpecNamespaces } from '@kubevirt-utils/resources/migrations/selectors';
 import {
   getMigrationStartTimestamp,
   getVolumeCountFromMigPlan,
@@ -26,7 +26,7 @@ import { Timestamp } from '@openshift-console/dynamic-plugin-sdk';
 import { Progress } from '@patternfly/react-core';
 
 import { getMigrationPercentage, getStatusMigration } from './components/utils';
-import { getStorageClassesFromMigPlan } from './utils';
+import { getStorageClassesFromMigPlan, getStorageMigrationRowModel } from './utils';
 
 type CellProps = {
   row: MultiNamespaceVirtualMachineStorageMigrationPlan;
@@ -37,22 +37,21 @@ export const NameCell: FC<CellProps> = ({ row }) => {
   const clusterParam = useClusterParam();
   const cluster = getCluster(row) || clusterParam;
   const migPlanName = getName(row);
+  const planModel = getStorageMigrationRowModel(row);
 
   return (
     <span data-test={`storage-migration-name-${migPlanName}`}>
       <MulticlusterResourceLink
-        groupVersionKind={modelToGroupVersionKind(
-          MultiNamespaceVirtualMachineStorageMigrationPlanModel,
-        )}
         onClick={() =>
           navigate(
             getResourceUrl({
-              model: MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+              model: planModel,
               resource: row,
             }),
           )
         }
         cluster={cluster}
+        groupVersionKind={modelToGroupVersionKind(planModel)}
         name={migPlanName}
         namespace={getNamespace(row)}
       />
@@ -64,7 +63,7 @@ export const NamespacesCell: FC<CellProps> = ({ row }) => {
   const clusterParam = useClusterParam();
   const isACMPage = useIsACMPage();
   const cluster = getCluster(row) || clusterParam;
-  const namespaces = row?.spec?.namespaces;
+  const namespaces = getStorageMigrationPlanSpecNamespaces(row);
 
   if (isEmpty(namespaces)) {
     return <span data-test={`storage-migration-namespaces-${getName(row)}`}>{NO_DATA_DASH}</span>;
@@ -135,7 +134,6 @@ export const StatusCell: FC<CellProps> = ({ row }) => {
     </span>
   );
 };
-
 export const StartedCell: FC<CellProps> = ({ row }) => {
   const { t } = useKubevirtTranslation();
   const startTimestamp = getMigrationStartTimestamp(row);
@@ -148,7 +146,5 @@ export const StartedCell: FC<CellProps> = ({ row }) => {
 };
 
 export const ActionsCell: FC<CellProps> = ({ row }) => (
-  <LazyActionMenu
-    context={{ [modelToRef(MultiNamespaceVirtualMachineStorageMigrationPlanModel)]: row }}
-  />
+  <LazyActionMenu context={{ [modelToRef(getStorageMigrationRowModel(row))]: row }} />
 );

--- a/src/views/storagemigrations/list/hooks/useStorageMigrationResources.test.ts
+++ b/src/views/storagemigrations/list/hooks/useStorageMigrationResources.test.ts
@@ -1,0 +1,195 @@
+import {
+  modelToGroupVersionKind,
+  MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+  VirtualMachineStorageMigrationPlanModel,
+} from '@kubevirt-utils/models';
+import {
+  MultiNamespaceVirtualMachineStorageMigrationPlan,
+  VirtualMachineStorageMigrationPlan,
+} from '@kubevirt-utils/resources/migrations/constants';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { cleanup, renderHook } from '@testing-library/react';
+
+import useStorageMigrationResources from './useStorageMigrationResources';
+
+jest.mock('@kubevirt-utils/hooks/useNamespaceParam', () => ({
+  __esModule: true,
+  default: jest.fn(() => 'test-ns'),
+}));
+
+jest.mock('@multicluster/hooks/useK8sWatchData', () => ({
+  __esModule: true,
+  default: jest.fn(() => [[], true, undefined]),
+}));
+
+const multiNsGVK = modelToGroupVersionKind(MultiNamespaceVirtualMachineStorageMigrationPlanModel);
+const singleNsGVK = modelToGroupVersionKind(VirtualMachineStorageMigrationPlanModel);
+
+const multiNsPlan: MultiNamespaceVirtualMachineStorageMigrationPlan = {
+  apiVersion: 'migrations.kubevirt.io/v1alpha1',
+  kind: 'MultiNamespaceVirtualMachineStorageMigrationPlan',
+  metadata: { name: 'multi-plan-1', namespace: 'test-ns' },
+  spec: {
+    namespaces: [
+      {
+        name: 'test-ns',
+        virtualMachines: [{ name: 'vm-a', targetMigrationPVCs: [{ volumeName: 'disk0' }] }],
+      },
+    ],
+  },
+} as MultiNamespaceVirtualMachineStorageMigrationPlan;
+
+const singleNsPlan: VirtualMachineStorageMigrationPlan = {
+  apiVersion: 'migrations.kubevirt.io/v1alpha1',
+  kind: 'VirtualMachineStorageMigrationPlan',
+  metadata: { name: 'single-plan-1', namespace: 'test-ns' },
+  spec: {
+    virtualMachines: [{ name: 'vm-b', targetMigrationPVCs: [{ volumeName: 'disk1' }] }],
+  },
+} as VirtualMachineStorageMigrationPlan;
+
+afterEach(() => {
+  cleanup();
+  (useK8sWatchData as jest.Mock).mockReset();
+});
+
+describe('useStorageMigrationResources', () => {
+  it('should combine MultiNamespace and VirtualMachineStorageMigration plans', () => {
+    (useK8sWatchData as jest.Mock).mockImplementation((resource) => {
+      if (!resource) return [undefined, true, undefined];
+      const gvk = resource.groupVersionKind;
+      if (JSON.stringify(gvk) === JSON.stringify(multiNsGVK)) {
+        return [[multiNsPlan], true, undefined];
+      }
+      if (JSON.stringify(gvk) === JSON.stringify(singleNsGVK)) {
+        return [[singleNsPlan], true, undefined];
+      }
+      return [[], true, undefined];
+    });
+
+    const { result } = renderHook(() => useStorageMigrationResources());
+
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.loadError).toBeUndefined();
+    expect(result.current.storageMigPlans).toHaveLength(2);
+
+    const names = result.current.storageMigPlans.map((p) => p.metadata.name);
+    expect(names).toContain('multi-plan-1');
+    expect(names).toContain('single-plan-1');
+  });
+
+  it('should normalize VirtualMachineStorageMigrationPlan into MultiNamespace shape', () => {
+    (useK8sWatchData as jest.Mock).mockImplementation((resource) => {
+      if (!resource) return [undefined, true, undefined];
+      const gvk = resource.groupVersionKind;
+      if (JSON.stringify(gvk) === JSON.stringify(multiNsGVK)) {
+        return [[], true, undefined];
+      }
+      if (JSON.stringify(gvk) === JSON.stringify(singleNsGVK)) {
+        return [[singleNsPlan], true, undefined];
+      }
+      return [[], true, undefined];
+    });
+
+    const { result } = renderHook(() => useStorageMigrationResources());
+    const normalized = result.current.storageMigPlans[0];
+
+    expect(normalized.spec.namespaces).toHaveLength(1);
+    expect(normalized.spec.namespaces[0].name).toBe('test-ns');
+    expect(normalized.spec.namespaces[0].virtualMachines[0].name).toBe('vm-b');
+  });
+
+  it('should treat a 404 on MultiNamespace CRD as empty (not an error)', () => {
+    (useK8sWatchData as jest.Mock).mockImplementation((resource) => {
+      if (!resource) return [undefined, true, undefined];
+      const gvk = resource.groupVersionKind;
+      if (JSON.stringify(gvk) === JSON.stringify(multiNsGVK)) {
+        return [undefined, false, { code: 404 }];
+      }
+      if (JSON.stringify(gvk) === JSON.stringify(singleNsGVK)) {
+        return [[singleNsPlan], true, undefined];
+      }
+      return [[], true, undefined];
+    });
+
+    const { result } = renderHook(() => useStorageMigrationResources());
+
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.loadError).toBeUndefined();
+    expect(result.current.storageMigPlans).toHaveLength(1);
+    expect(result.current.storageMigPlans[0].metadata.name).toBe('single-plan-1');
+  });
+
+  it('should treat a 404 on VirtualMachineStorageMigration CRD as empty (not an error)', () => {
+    (useK8sWatchData as jest.Mock).mockImplementation((resource) => {
+      if (!resource) return [undefined, true, undefined];
+      const gvk = resource.groupVersionKind;
+      if (JSON.stringify(gvk) === JSON.stringify(multiNsGVK)) {
+        return [[multiNsPlan], true, undefined];
+      }
+      if (JSON.stringify(gvk) === JSON.stringify(singleNsGVK)) {
+        return [undefined, false, { code: 404 }];
+      }
+      return [[], true, undefined];
+    });
+
+    const { result } = renderHook(() => useStorageMigrationResources());
+
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.loadError).toBeUndefined();
+    expect(result.current.storageMigPlans).toHaveLength(1);
+    expect(result.current.storageMigPlans[0].metadata.name).toBe('multi-plan-1');
+  });
+
+  it('should surface non-404 errors from either watch', () => {
+    const serverError = { code: 500, message: 'Internal Server Error' };
+
+    (useK8sWatchData as jest.Mock).mockImplementation((resource) => {
+      if (!resource) return [undefined, true, undefined];
+      const gvk = resource.groupVersionKind;
+      if (JSON.stringify(gvk) === JSON.stringify(multiNsGVK)) {
+        return [undefined, false, serverError];
+      }
+      if (JSON.stringify(gvk) === JSON.stringify(singleNsGVK)) {
+        return [[singleNsPlan], true, undefined];
+      }
+      return [[], true, undefined];
+    });
+
+    const { result } = renderHook(() => useStorageMigrationResources());
+
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.loadError).toBe(serverError);
+  });
+
+  it('should report not loaded while either watch is pending', () => {
+    (useK8sWatchData as jest.Mock).mockImplementation((resource) => {
+      if (!resource) return [undefined, true, undefined];
+      const gvk = resource.groupVersionKind;
+      if (JSON.stringify(gvk) === JSON.stringify(multiNsGVK)) {
+        return [[multiNsPlan], true, undefined];
+      }
+      if (JSON.stringify(gvk) === JSON.stringify(singleNsGVK)) {
+        return [undefined, false, undefined];
+      }
+      return [[], true, undefined];
+    });
+
+    const { result } = renderHook(() => useStorageMigrationResources());
+
+    expect(result.current.loaded).toBe(false);
+  });
+
+  it('should return empty list when both watches return no data', () => {
+    (useK8sWatchData as jest.Mock).mockImplementation((resource) => {
+      if (!resource) return [undefined, true, undefined];
+      return [[], true, undefined];
+    });
+
+    const { result } = renderHook(() => useStorageMigrationResources());
+
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.loadError).toBeUndefined();
+    expect(result.current.storageMigPlans).toHaveLength(0);
+  });
+});

--- a/src/views/storagemigrations/list/hooks/useStorageMigrationResources.ts
+++ b/src/views/storagemigrations/list/hooks/useStorageMigrationResources.ts
@@ -1,20 +1,28 @@
+import { useMemo } from 'react';
+
 import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
 import {
   modelToGroupVersionKind,
   MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+  VirtualMachineStorageMigrationPlanModel,
 } from '@kubevirt-utils/models';
-import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
+import {
+  MultiNamespaceVirtualMachineStorageMigrationPlan,
+  VirtualMachineStorageMigrationPlan,
+} from '@kubevirt-utils/resources/migrations/constants';
+import { normalizeSingleNsPlan } from '@kubevirt-utils/resources/migrations/singleNs/overview';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import isResourceNotFoundError from '@templates/list/hooks/isResourceNotFoundError';
 
 type UseStorageMigrationResources = () => {
   loaded: boolean;
-  loadError: any;
+  loadError: unknown;
   storageMigPlans: MultiNamespaceVirtualMachineStorageMigrationPlan[];
 };
 
 const useStorageMigrationResources: UseStorageMigrationResources = () => {
   const namespace = useNamespaceParam();
-  const [storageMigPlans, plansLoaded, plansError] = useK8sWatchData<
+  const [multiNsPlans, multiNsLoaded, multiNsError] = useK8sWatchData<
     MultiNamespaceVirtualMachineStorageMigrationPlan[]
   >({
     groupVersionKind: modelToGroupVersionKind(
@@ -25,9 +33,35 @@ const useStorageMigrationResources: UseStorageMigrationResources = () => {
     namespaced: true,
   });
 
+  const [singleNsPlans, singleNsLoaded, singleNsError] = useK8sWatchData<
+    VirtualMachineStorageMigrationPlan[]
+  >({
+    groupVersionKind: modelToGroupVersionKind(VirtualMachineStorageMigrationPlanModel),
+    isList: true,
+    namespace,
+    namespaced: true,
+  });
+
+  const multiNsIs404 = isResourceNotFoundError(multiNsError);
+  const singleNsIs404 = isResourceNotFoundError(singleNsError);
+
+  const multiNsSettled = multiNsLoaded || !!multiNsError;
+  const singleNsSettled = singleNsLoaded || !!singleNsError;
+
+  const storageMigPlans = useMemo(
+    () => [
+      ...(multiNsPlans ?? []),
+      ...(singleNsPlans ?? []).map((plan) => normalizeSingleNsPlan(plan)).filter(Boolean),
+    ],
+    [multiNsPlans, singleNsPlans],
+  );
+
+  const effectiveMultiNsError = multiNsIs404 ? undefined : multiNsError;
+  const effectiveSingleNsError = singleNsIs404 ? undefined : singleNsError;
+
   return {
-    loaded: plansLoaded,
-    loadError: plansError,
+    loaded: multiNsSettled && singleNsSettled,
+    loadError: effectiveMultiNsError ?? effectiveSingleNsError,
     storageMigPlans,
   };
 };

--- a/src/views/storagemigrations/list/utils.test.ts
+++ b/src/views/storagemigrations/list/utils.test.ts
@@ -1,0 +1,162 @@
+import {
+  MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+  VirtualMachineStorageMigrationPlanModel,
+} from '@kubevirt-utils/models';
+import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
+
+import {
+  compareMigrationNamespaces,
+  compareMigrationStarted,
+  compareMigrationStorageClasses,
+  getStorageClassesFromMigPlan,
+  getStorageMigrationRowModel,
+} from './utils';
+
+const makePlan = (
+  overrides: Partial<MultiNamespaceVirtualMachineStorageMigrationPlan> = {},
+): MultiNamespaceVirtualMachineStorageMigrationPlan =>
+  ({
+    apiVersion: 'migrations.kubevirt.io/v1alpha1',
+    kind: 'MultiNamespaceVirtualMachineStorageMigrationPlan',
+    metadata: { name: 'plan-1', namespace: 'ns-1' },
+    spec: {
+      namespaces: [
+        {
+          name: 'ns-1',
+          virtualMachines: [
+            {
+              name: 'vm-a',
+              targetMigrationPVCs: [
+                { destinationPVC: { storageClassName: 'fast' }, volumeName: 'disk0' },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    ...overrides,
+  } as MultiNamespaceVirtualMachineStorageMigrationPlan);
+
+describe('getStorageMigrationRowModel', () => {
+  it('should return MultiNamespaceVirtualMachineStorageMigrationPlanModel for MultiNamespace kind', () => {
+    const plan = makePlan({ kind: 'MultiNamespaceVirtualMachineStorageMigrationPlan' });
+    expect(getStorageMigrationRowModel(plan)).toBe(
+      MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+    );
+  });
+
+  it('should return VirtualMachineStorageMigrationPlanModel for single-namespace kind', () => {
+    const plan = makePlan({ kind: 'VirtualMachineStorageMigrationPlan' });
+    expect(getStorageMigrationRowModel(plan)).toBe(VirtualMachineStorageMigrationPlanModel);
+  });
+
+  it('should default to MultiNamespace model when kind is undefined', () => {
+    const plan = makePlan({ kind: undefined });
+    expect(getStorageMigrationRowModel(plan)).toBe(
+      MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+    );
+  });
+});
+
+describe('getStorageClassesFromMigPlan', () => {
+  it('should extract unique storage classes from namespaces', () => {
+    const plan = makePlan({
+      spec: {
+        namespaces: [
+          {
+            name: 'ns-1',
+            virtualMachines: [
+              {
+                name: 'vm-a',
+                targetMigrationPVCs: [
+                  { destinationPVC: { storageClassName: 'fast' }, volumeName: 'disk0' },
+                  { destinationPVC: { storageClassName: 'slow' }, volumeName: 'disk1' },
+                ],
+              },
+            ],
+          },
+          {
+            name: 'ns-2',
+            virtualMachines: [
+              {
+                name: 'vm-b',
+                targetMigrationPVCs: [
+                  { destinationPVC: { storageClassName: 'fast' }, volumeName: 'disk0' },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    } as Partial<MultiNamespaceVirtualMachineStorageMigrationPlan>);
+
+    const result = getStorageClassesFromMigPlan(plan);
+    expect(result).toEqual(expect.arrayContaining(['fast', 'slow']));
+    expect(result).toHaveLength(2);
+  });
+
+  it('should handle plan with empty namespaces (normalized single-ns plan with no spec.namespaces)', () => {
+    const plan = makePlan({ spec: { namespaces: [] } });
+    expect(getStorageClassesFromMigPlan(plan)).toEqual([]);
+  });
+});
+
+describe('compareMigrationNamespaces', () => {
+  it('should compare plans by number of namespaces', () => {
+    const planA = makePlan({
+      spec: { namespaces: [{ name: 'ns-1', virtualMachines: [] }] },
+    } as Partial<MultiNamespaceVirtualMachineStorageMigrationPlan>);
+
+    const planB = makePlan({
+      spec: {
+        namespaces: [
+          { name: 'ns-1', virtualMachines: [] },
+          { name: 'ns-2', virtualMachines: [] },
+        ],
+      },
+    } as Partial<MultiNamespaceVirtualMachineStorageMigrationPlan>);
+
+    expect(compareMigrationNamespaces(planA, planB)).toBeLessThan(0);
+    expect(compareMigrationNamespaces(planB, planA)).toBeGreaterThan(0);
+    expect(compareMigrationNamespaces(planA, planA)).toBe(0);
+  });
+});
+
+describe('compareMigrationStorageClasses', () => {
+  it('should compare plans by first storage class alphabetically', () => {
+    const planA = makePlan();
+    const planB = makePlan({
+      spec: {
+        namespaces: [
+          {
+            name: 'ns-1',
+            virtualMachines: [
+              {
+                name: 'vm-a',
+                targetMigrationPVCs: [
+                  { destinationPVC: { storageClassName: 'zeta' }, volumeName: 'disk0' },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    } as Partial<MultiNamespaceVirtualMachineStorageMigrationPlan>);
+
+    expect(compareMigrationStorageClasses(planA, planB)).toBeLessThan(0);
+  });
+
+  it('should not throw when plans have no storage classes', () => {
+    const planA = makePlan({ spec: { namespaces: [] } });
+    const planB = makePlan({ spec: { namespaces: [] } });
+    expect(() => compareMigrationStorageClasses(planA, planB)).not.toThrow();
+  });
+});
+
+describe('compareMigrationStarted', () => {
+  it('should not throw when plans have no start timestamp', () => {
+    const planA = makePlan();
+    const planB = makePlan();
+    expect(() => compareMigrationStarted(planA, planB)).not.toThrow();
+  });
+});

--- a/src/views/storagemigrations/list/utils.ts
+++ b/src/views/storagemigrations/list/utils.ts
@@ -1,4 +1,6 @@
+import { getStorageMigrationPlanModelForKind } from '@kubevirt-utils/resources/migrations/backends';
 import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
+import { getStorageMigrationPlanSpecNamespaces } from '@kubevirt-utils/resources/migrations/selectors';
 import {
   getMigrationStartTimestamp,
   getVolumeCountFromMigPlan,
@@ -11,7 +13,7 @@ export const getStorageClassesFromMigPlan = (
 ): string[] =>
   Array.from(
     new Set(
-      (migrationPlan?.spec?.namespaces ?? []).flatMap((namespace) =>
+      getStorageMigrationPlanSpecNamespaces(migrationPlan).flatMap((namespace) =>
         (namespace?.virtualMachines ?? []).flatMap((vm) =>
           (vm?.targetMigrationPVCs ?? [])
             .map((pvc) => pvc.destinationPVC?.storageClassName)
@@ -20,6 +22,10 @@ export const getStorageClassesFromMigPlan = (
       ),
     ),
   );
+
+export const getStorageMigrationRowModel = (
+  row: MultiNamespaceVirtualMachineStorageMigrationPlan,
+) => getStorageMigrationPlanModelForKind(row?.kind);
 
 export const compareMigrationVolumes = (
   a: MultiNamespaceVirtualMachineStorageMigrationPlan,
@@ -35,26 +41,29 @@ export const compareMigrationNamespaces = (
   a: MultiNamespaceVirtualMachineStorageMigrationPlan,
   b: MultiNamespaceVirtualMachineStorageMigrationPlan,
 ) => {
-  return (a?.spec?.namespaces?.length || 0) - (b?.spec?.namespaces?.length || 0);
+  return (
+    getStorageMigrationPlanSpecNamespaces(a).length -
+    getStorageMigrationPlanSpecNamespaces(b).length
+  );
 };
 
 export const compareMigrationStorageClasses = (
   a: MultiNamespaceVirtualMachineStorageMigrationPlan,
   b: MultiNamespaceVirtualMachineStorageMigrationPlan,
 ) => {
-  const aStorageClasses = getStorageClassesFromMigPlan(a)?.[0];
-  const bStorageClasses = getStorageClassesFromMigPlan(b)?.[0];
+  const aStorageClasses = getStorageClassesFromMigPlan(a)?.[0] ?? '';
+  const bStorageClasses = getStorageClassesFromMigPlan(b)?.[0] ?? '';
 
-  return aStorageClasses?.localeCompare(bStorageClasses);
+  return aStorageClasses.localeCompare(bStorageClasses);
 };
 
 export const compareMigrationStarted = (
   a: MultiNamespaceVirtualMachineStorageMigrationPlan,
   b: MultiNamespaceVirtualMachineStorageMigrationPlan,
 ) => {
-  const aStarted = getMigrationStartTimestamp(a);
-  const bStarted = getMigrationStartTimestamp(b);
-  return aStarted?.localeCompare(bStarted);
+  const aStarted = getMigrationStartTimestamp(a) ?? '';
+  const bStarted = getMigrationStartTimestamp(b) ?? '';
+  return aStarted.localeCompare(bStarted);
 };
 
 export const compareMigrationStatus = (

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/backends/mtc/MtcProgress.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/backends/mtc/MtcProgress.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { useKubevirtClusterServiceVersion } from '@kubevirt-utils/hooks/useKubevirtClusterServiceVersion';
 import type { ProgressComponentProps } from '@kubevirt-utils/resources/migrations/backends/types';
 import useStorageMigrationNavigation from '@virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationNavigation';
 
@@ -9,7 +10,12 @@ import useMTCPlanPolling from './useMTCPlanPolling';
 
 const MtcProgress: FC<ProgressComponentProps> = (props) => {
   const { cluster, storageMigAPI, storageMigrationPlan } = props;
-  const { basePath, isExternal } = useStorageMigrationNavigation(cluster, storageMigAPI);
+  const { installedCSV } = useKubevirtClusterServiceVersion(cluster);
+  const { basePath, isExternal } = useStorageMigrationNavigation(
+    cluster,
+    storageMigAPI,
+    installedCSV?.spec?.version,
+  );
   const [mtcWatchedPlan, , mtcError] = useMTCPlanPolling(storageMigrationPlan);
 
   return (

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/backends/multiNs/MultiNsProgress.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/backends/multiNs/MultiNsProgress.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { useKubevirtClusterServiceVersion } from '@kubevirt-utils/hooks/useKubevirtClusterServiceVersion';
 import {
   modelToGroupVersionKind,
   MultiNamespaceVirtualMachineStorageMigrationPlanModel,
@@ -15,7 +16,12 @@ import StorageMigrationProgress from '../../components/StorageMigrationProgress'
 
 const MultiNsProgress: FC<ProgressComponentProps> = (props) => {
   const { cluster, storageMigAPI, storageMigrationPlan } = props;
-  const { basePath, isExternal } = useStorageMigrationNavigation(cluster, storageMigAPI);
+  const { installedCSV } = useKubevirtClusterServiceVersion(cluster);
+  const { basePath, isExternal } = useStorageMigrationNavigation(
+    cluster,
+    storageMigAPI,
+    installedCSV?.spec?.version,
+  );
 
   const [multiNsWatchedPlan, , multiNsError] =
     useK8sWatchData<MultiNamespaceVirtualMachineStorageMigrationPlan>(

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/backends/singleNs/SingleNsProgress.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/backends/singleNs/SingleNsProgress.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { useKubevirtClusterServiceVersion } from '@kubevirt-utils/hooks/useKubevirtClusterServiceVersion';
 import type { ProgressComponentProps } from '@kubevirt-utils/resources/migrations/backends/types';
 import useStorageMigrationNavigation from '@virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationNavigation';
 
@@ -9,7 +10,12 @@ import useSingleNsPlanPolling from './useSingleNsPlanPolling';
 
 const SingleNsProgress: FC<ProgressComponentProps> = (props) => {
   const { cluster, storageMigAPI, storageMigrationPlan } = props;
-  const { basePath, isExternal } = useStorageMigrationNavigation(cluster, storageMigAPI);
+  const { installedCSV } = useKubevirtClusterServiceVersion(cluster);
+  const { basePath, isExternal } = useStorageMigrationNavigation(
+    cluster,
+    storageMigAPI,
+    installedCSV?.spec?.version,
+  );
   const [singleNsWatchedPlan, , singleNsError] = useSingleNsPlanPolling(storageMigrationPlan);
 
   return (

--- a/src/views/virtualmachines/actions/hooks/storageMigrationApi/constants.ts
+++ b/src/views/virtualmachines/actions/hooks/storageMigrationApi/constants.ts
@@ -33,3 +33,17 @@ export const csvLoadedIndicatesMultiNsStorageMigrationApi = (
 ): boolean => csvLoaded && csvVersionMeetsMultiNsAssumeThreshold(csvVersion);
 
 export const STORAGE_MIGRATION_CSV_WAIT_AFTER_MULTI_NS_404_MS = 2500;
+
+/**
+ * OpenShift Virtualization 4.23+ → storage migrations list uses the custom route
+ * `/k8s/all-namespaces/storagemigrations` instead of the GVK resource URL.
+ * Spokes running < 4.23 do not register this custom route, so links from
+ * the hub overview to spoke consoles must fall back to the GVK resource URL.
+ */
+export const STORAGE_MIGRATION_CUSTOM_ROUTE_MIN_VERSION: VersionMajorMinor = {
+  major: 4,
+  minor: 23,
+};
+
+export const spokeSupportsCustomMigrationsRoute = (csvVersion: string | undefined): boolean =>
+  versionMeetsMajorMinorThreshold(csvVersion, STORAGE_MIGRATION_CUSTOM_ROUTE_MIN_VERSION);

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/StorageMigrationPlansWidget.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/StorageMigrationPlansWidget.tsx
@@ -31,11 +31,12 @@ type StorageMigrationPlansWidgetProps = {
 
 const StorageMigrationPlansWidget: FC<StorageMigrationPlansWidgetProps> = ({ cluster }) => {
   const { t } = useKubevirtTranslation();
-  const { loaded, loadError, storageMigAPI, storageMigPlans } =
+  const { csvVersion, loaded, loadError, storageMigAPI, storageMigPlans } =
     useStorageMigrationOverviewData(cluster);
   const { basePath, isExternal, pendingUrl, runningUrl } = useStorageMigrationNavigation(
     cluster,
     storageMigAPI,
+    csvVersion,
   );
 
   const statusCounts = useMemo(

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationNavigation.test.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationNavigation.test.ts
@@ -1,0 +1,156 @@
+import { STORAGE_MIGRATION_API } from '@kubevirt-utils/resources/migrations/constants';
+import useManagedClusterConsoleURLs from '@multicluster/hooks/useManagedClusterConsoleURLs';
+import { cleanup, renderHook } from '@testing-library/react';
+
+import useStorageMigrationNavigation from './useStorageMigrationNavigation';
+
+jest.mock('@multicluster/hooks/useManagedClusterConsoleURLs', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ spokeConsoleURL: '' })),
+}));
+
+jest.mock('@stolostron/multicluster-sdk', () => ({
+  useHubClusterName: jest.fn(() => ['hub-cluster', true, undefined]),
+}));
+
+jest.mock('@multicluster/urls', () => ({
+  buildSpokeConsoleUrl: jest.fn((base: string, path: string) => `${base}${path}`),
+}));
+
+jest.mock('@virtualmachines/actions/hooks/storageMigrationApi/constants', () => ({
+  ...jest.requireActual('@virtualmachines/actions/hooks/storageMigrationApi/constants'),
+  spokeSupportsCustomMigrationsRoute: jest.fn((version: string | undefined) => {
+    if (!version) return false;
+    const [major, minor] = version.split('.').map(Number);
+    return major > 4 || (major === 4 && minor >= 23);
+  }),
+}));
+
+const mockUseManagedClusterConsoleURLs = useManagedClusterConsoleURLs as jest.Mock;
+
+afterEach(() => {
+  cleanup();
+  mockUseManagedClusterConsoleURLs.mockReset();
+  mockUseManagedClusterConsoleURLs.mockReturnValue({ spokeConsoleURL: '' });
+});
+
+describe('useStorageMigrationNavigation', () => {
+  describe('when storageMigAPI is LOADING', () => {
+    it('should return empty paths', () => {
+      const { result } = renderHook(() =>
+        useStorageMigrationNavigation(undefined, STORAGE_MIGRATION_API.LOADING, undefined),
+      );
+
+      expect(result.current.basePath).toBe('');
+      expect(result.current.pendingUrl).toBe('');
+      expect(result.current.runningUrl).toBe('');
+      expect(result.current.isExternal).toBe(false);
+    });
+  });
+
+  describe('when storageMigAPI is NONE', () => {
+    it('should return empty paths', () => {
+      const { result } = renderHook(() =>
+        useStorageMigrationNavigation(undefined, STORAGE_MIGRATION_API.NONE, undefined),
+      );
+
+      expect(result.current.basePath).toBe('');
+      expect(result.current.pendingUrl).toBe('');
+      expect(result.current.runningUrl).toBe('');
+    });
+  });
+
+  describe('hub cluster (non-spoke)', () => {
+    it('should always use custom route regardless of CSV version', () => {
+      const { result } = renderHook(() =>
+        useStorageMigrationNavigation(undefined, STORAGE_MIGRATION_API.MULTI_NS, '4.22.0'),
+      );
+
+      expect(result.current.basePath).toBe('/k8s/all-namespaces/storagemigrations');
+      expect(result.current.isExternal).toBe(false);
+    });
+
+    it('should always use custom route even when CSV version is undefined', () => {
+      const { result } = renderHook(() =>
+        useStorageMigrationNavigation(undefined, STORAGE_MIGRATION_API.MULTI_NS, undefined),
+      );
+
+      expect(result.current.basePath).toBe('/k8s/all-namespaces/storagemigrations');
+    });
+
+    it('should always use custom route for SINGLE_NS API', () => {
+      const { result } = renderHook(() =>
+        useStorageMigrationNavigation(undefined, STORAGE_MIGRATION_API.SINGLE_NS, '4.22.0'),
+      );
+
+      expect(result.current.basePath).toBe('/k8s/all-namespaces/storagemigrations');
+    });
+
+    it('should always use custom route for MTC API', () => {
+      const { result } = renderHook(() =>
+        useStorageMigrationNavigation(undefined, STORAGE_MIGRATION_API.MTC, '4.23.0'),
+      );
+
+      expect(result.current.basePath).toBe('/k8s/all-namespaces/storagemigrations');
+    });
+  });
+
+  describe('spoke cluster', () => {
+    beforeEach(() => {
+      mockUseManagedClusterConsoleURLs.mockReturnValue({
+        spokeConsoleURL: 'https://spoke.example.com',
+      });
+    });
+
+    it('should use spoke custom route when CSV version >= 4.23', () => {
+      const { result } = renderHook(() =>
+        useStorageMigrationNavigation('spoke-cluster', STORAGE_MIGRATION_API.MULTI_NS, '4.23.0'),
+      );
+
+      expect(result.current.basePath).toContain('https://spoke.example.com');
+      expect(result.current.basePath).toContain('/k8s/all-namespaces/storagemigrations');
+      expect(result.current.isExternal).toBe(true);
+    });
+
+    it('should fall back to GVK resource URL when CSV version < 4.23', () => {
+      const { result } = renderHook(() =>
+        useStorageMigrationNavigation('spoke-cluster', STORAGE_MIGRATION_API.MULTI_NS, '4.22.0'),
+      );
+
+      expect(result.current.basePath).toContain('https://spoke.example.com');
+      expect(result.current.basePath).toContain('migrations.kubevirt.io');
+      expect(result.current.isExternal).toBe(true);
+    });
+
+    it('should fall back to GVK resource URL when CSV version is undefined', () => {
+      const { result } = renderHook(() =>
+        useStorageMigrationNavigation('spoke-cluster', STORAGE_MIGRATION_API.MULTI_NS, undefined),
+      );
+
+      expect(result.current.basePath).toContain('https://spoke.example.com');
+      expect(result.current.basePath).toContain('migrations.kubevirt.io');
+    });
+
+    it('should always use MTC GVK resource URL regardless of CSV version', () => {
+      const { result } = renderHook(() =>
+        useStorageMigrationNavigation('spoke-cluster', STORAGE_MIGRATION_API.MTC, '4.23.0'),
+      );
+
+      expect(result.current.basePath).toContain('https://spoke.example.com');
+      expect(result.current.basePath).toContain('migration.openshift.io');
+      expect(result.current.basePath).not.toContain('/k8s/all-namespaces/storagemigrations');
+    });
+  });
+
+  describe('status filter URLs', () => {
+    it('should append status filter params to pending and running URLs', () => {
+      const { result } = renderHook(() =>
+        useStorageMigrationNavigation(undefined, STORAGE_MIGRATION_API.MULTI_NS, '4.23.0'),
+      );
+
+      expect(result.current.pendingUrl).toContain('?');
+      expect(result.current.runningUrl).toContain('?');
+      expect(result.current.pendingUrl).not.toBe(result.current.runningUrl);
+    });
+  });
+});

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationNavigation.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationNavigation.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 
-import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { getStorageMigrationBackend } from '@kubevirt-utils/resources/migrations/backends';
 import {
   type StorageMigrationAPI,
@@ -11,6 +10,7 @@ import { ROW_FILTERS_PREFIX } from '@kubevirt-utils/utils/constants';
 import useManagedClusterConsoleURLs from '@multicluster/hooks/useManagedClusterConsoleURLs';
 import { buildSpokeConsoleUrl } from '@multicluster/urls';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
+import { spokeSupportsCustomMigrationsRoute } from '@virtualmachines/actions/hooks/storageMigrationApi/constants';
 
 import {
   STORAGE_MIGRATION_STATUS_FILTER_TYPE,
@@ -23,20 +23,26 @@ const STATUS_FILTER_PARAM = `${ROW_FILTERS_PREFIX}${STORAGE_MIGRATION_STATUS_FIL
 const withStatusFilter = (base: string, value: StorageMigrationStatusFilterValue): string =>
   `${base}?${STATUS_FILTER_PARAM}=${value}`;
 
-export const getStorageMigrationListConsolePath = (
-  activeNamespace: string | undefined,
+/**
+ * Resolves the console path for spoke clusters.
+ * MTC uses its own GVK resource page (our custom list doesn't show MigPlans).
+ * For other backends, use the custom route if the spoke supports it (>= 4.23),
+ * otherwise fall back to the GVK resource URL.
+ */
+const getSpokeStorageMigrationListPath = (
   storageMigAPI: StorageMigrationAPI,
+  spokeCsvVersion: string | undefined,
 ): string => {
-  const backend = getStorageMigrationBackend(storageMigAPI);
-  if (backend?.listConsolePathUsesResourceUrl) {
-    return (
-      getResourceUrl({
-        activeNamespace,
-        model: backend.planModel,
-      }) ?? ''
-    );
+  const usesCustomRoute =
+    storageMigAPI !== STORAGE_MIGRATION_API.MTC &&
+    spokeSupportsCustomMigrationsRoute(spokeCsvVersion);
+
+  if (usesCustomRoute) {
+    return ALL_NAMESPACES_STORAGE_MIGRATIONS_LIST;
   }
-  return ALL_NAMESPACES_STORAGE_MIGRATIONS_LIST;
+
+  const backend = getStorageMigrationBackend(storageMigAPI);
+  return getResourceUrl({ model: backend?.planModel }) ?? ALL_NAMESPACES_STORAGE_MIGRATIONS_LIST;
 };
 
 type StorageMigrationNavigation = {
@@ -49,16 +55,16 @@ type StorageMigrationNavigation = {
 const useStorageMigrationNavigation = (
   cluster?: string,
   storageMigAPI: StorageMigrationAPI = STORAGE_MIGRATION_API.MULTI_NS,
+  spokeCsvVersion?: string,
 ): StorageMigrationNavigation => {
-  const activeNamespace = useActiveNamespace();
   const [hubClusterName, hubClusterLoaded] = useHubClusterName();
   const { spokeConsoleURL } = useManagedClusterConsoleURLs(cluster);
 
-  const isLoading =
+  const isUnavailable =
     storageMigAPI === STORAGE_MIGRATION_API.LOADING || storageMigAPI === STORAGE_MIGRATION_API.NONE;
 
   return useMemo(() => {
-    if (isLoading) {
+    if (isUnavailable) {
       return {
         basePath: '',
         isExternal: false,
@@ -67,13 +73,17 @@ const useStorageMigrationNavigation = (
       };
     }
 
-    const listPath = getStorageMigrationListConsolePath(activeNamespace, storageMigAPI);
-
     const isManagedSpokeCluster =
       Boolean(cluster) && hubClusterLoaded && cluster !== hubClusterName;
     const useSpokeConsoleUrl = Boolean(spokeConsoleURL) && isManagedSpokeCluster;
 
-    const base = useSpokeConsoleUrl ? buildSpokeConsoleUrl(spokeConsoleURL, listPath) : listPath;
+    const consolePath = useSpokeConsoleUrl
+      ? getSpokeStorageMigrationListPath(storageMigAPI, spokeCsvVersion)
+      : ALL_NAMESPACES_STORAGE_MIGRATIONS_LIST;
+
+    const base = useSpokeConsoleUrl
+      ? buildSpokeConsoleUrl(spokeConsoleURL, consolePath)
+      : consolePath;
 
     const pendingUrl = withStatusFilter(base, StorageMigrationStatusFilterValue.Pending);
     const runningUrl = withStatusFilter(base, StorageMigrationStatusFilterValue.Running);
@@ -85,11 +95,11 @@ const useStorageMigrationNavigation = (
       runningUrl,
     };
   }, [
-    activeNamespace,
     cluster,
     hubClusterLoaded,
     hubClusterName,
-    isLoading,
+    isUnavailable,
+    spokeCsvVersion,
     spokeConsoleURL,
     storageMigAPI,
   ]);

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationOverviewData.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationOverviewData.ts
@@ -1,4 +1,7 @@
-import { modelToGroupVersionKind } from '@kubevirt-utils/models';
+import {
+  modelToGroupVersionKind,
+  VirtualMachineStorageMigrationPlanModel,
+} from '@kubevirt-utils/models';
 import { getStorageMigrationBackend } from '@kubevirt-utils/resources/migrations/backends';
 import {
   type StorageMigrationAPI,
@@ -7,6 +10,7 @@ import {
   STORAGE_MIGRATION_API,
   VirtualMachineStorageMigrationPlan,
 } from '@kubevirt-utils/resources/migrations/constants';
+import { normalizeSingleNsPlan } from '@kubevirt-utils/resources/migrations/singleNs/overview';
 import useK8sListData from '@multicluster/hooks/useK8sListData';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import useClusterStorageMigrationApiProbe from '@virtualmachines/actions/hooks/storageMigrationApi/useClusterStorageMigrationApiProbe';
@@ -14,6 +18,7 @@ import useClusterStorageMigrationApiProbe from '@virtualmachines/actions/hooks/s
 import { useKubeVirtOverviewClusterCsv } from '../../context/KubeVirtOverviewClusterCsvContext';
 
 type UseStorageMigrationOverviewData = (cluster?: string) => {
+  csvVersion: string | undefined;
   loaded: boolean;
   loadError: unknown;
   storageMigAPI: StorageMigrationAPI;
@@ -27,6 +32,7 @@ type UseStorageMigrationOverviewData = (cluster?: string) => {
  */
 const useStorageMigrationOverviewData: UseStorageMigrationOverviewData = (cluster) => {
   const { installedCSV, loaded: csvLoaded } = useKubeVirtOverviewClusterCsv();
+  const csvVersion = installedCSV?.spec?.version;
   const storageMigAPI = useClusterStorageMigrationApiProbe(cluster, {
     installedCSV,
     loaded: csvLoaded,
@@ -34,10 +40,12 @@ const useStorageMigrationOverviewData: UseStorageMigrationOverviewData = (cluste
 
   const backend = getStorageMigrationBackend(storageMigAPI);
 
+  const isMultiNs = storageMigAPI === STORAGE_MIGRATION_API.MULTI_NS;
+
   const [multiNsPlans, multiNsLoaded, multiNsError] = useK8sWatchData<
     MultiNamespaceVirtualMachineStorageMigrationPlan[]
   >(
-    storageMigAPI === STORAGE_MIGRATION_API.MULTI_NS && backend
+    isMultiNs && backend
       ? {
           cluster,
           groupVersionKind: modelToGroupVersionKind(backend.planModel),
@@ -47,7 +55,20 @@ const useStorageMigrationOverviewData: UseStorageMigrationOverviewData = (cluste
       : null,
   );
 
-  const [singleNsPlans, singleNsLoaded, singleNsError] =
+  const [singleNsPlans, singleNsLoaded, singleNsError] = useK8sWatchData<
+    VirtualMachineStorageMigrationPlan[]
+  >(
+    isMultiNs
+      ? {
+          cluster,
+          groupVersionKind: modelToGroupVersionKind(VirtualMachineStorageMigrationPlanModel),
+          isList: true,
+          namespaced: false,
+        }
+      : null,
+  );
+
+  const [singleNsOnlyPlans, singleNsOnlyLoaded, singleNsOnlyError] =
     useK8sListData<VirtualMachineStorageMigrationPlan>(
       storageMigAPI === STORAGE_MIGRATION_API.SINGLE_NS && backend
         ? {
@@ -69,6 +90,7 @@ const useStorageMigrationOverviewData: UseStorageMigrationOverviewData = (cluste
 
   if (storageMigAPI === STORAGE_MIGRATION_API.LOADING) {
     return {
+      csvVersion,
       loaded: false,
       loadError: undefined,
       storageMigAPI: STORAGE_MIGRATION_API.LOADING,
@@ -78,6 +100,7 @@ const useStorageMigrationOverviewData: UseStorageMigrationOverviewData = (cluste
 
   if (storageMigAPI === STORAGE_MIGRATION_API.NONE) {
     return {
+      csvVersion,
       loaded: true,
       loadError: undefined,
       storageMigAPI: STORAGE_MIGRATION_API.NONE,
@@ -87,6 +110,7 @@ const useStorageMigrationOverviewData: UseStorageMigrationOverviewData = (cluste
 
   if (storageMigAPI === STORAGE_MIGRATION_API.MTC && backend) {
     return {
+      csvVersion,
       loaded: mtcLoaded,
       loadError: mtcError,
       storageMigAPI: STORAGE_MIGRATION_API.MTC,
@@ -98,22 +122,25 @@ const useStorageMigrationOverviewData: UseStorageMigrationOverviewData = (cluste
 
   if (storageMigAPI === STORAGE_MIGRATION_API.SINGLE_NS && backend) {
     return {
-      loaded: singleNsLoaded,
-      loadError: singleNsError,
+      csvVersion,
+      loaded: singleNsOnlyLoaded,
+      loadError: singleNsOnlyError,
       storageMigAPI: STORAGE_MIGRATION_API.SINGLE_NS,
-      storageMigPlans: (singleNsPlans ?? [])
+      storageMigPlans: (singleNsOnlyPlans ?? [])
         .map((p) => backend.normalizePlanForOverview(p))
         .filter(Boolean),
     };
   }
 
   return {
-    loaded: multiNsLoaded,
-    loadError: multiNsError,
+    csvVersion,
+    loaded: multiNsLoaded && singleNsLoaded,
+    loadError: multiNsError ?? singleNsError,
     storageMigAPI: STORAGE_MIGRATION_API.MULTI_NS,
-    storageMigPlans: (multiNsPlans ?? [])
-      .map((p) => backend?.normalizePlanForOverview(p))
-      .filter(Boolean),
+    storageMigPlans: [
+      ...(multiNsPlans ?? []).map((p) => backend?.normalizePlanForOverview(p)).filter(Boolean),
+      ...(singleNsPlans ?? []).map((p) => normalizeSingleNsPlan(p)).filter(Boolean),
+    ],
   };
 };
 


### PR DESCRIPTION
## 📝 Description

- Use a single path (`/k8s/all-namespaces/storagemigrations`) for displaying both `MultiNamespaceVirtualMachineStorageMigrationPlan` and `VirtualMachineStorageMigration` storage migration plans. 
- Storage migrations widget aggregates both migration types in the widget. 
- View all button redirects to the correct path based on CNV version in ACM (for hub clusters we just redirect to the new path). 

## 🔗 Links

Jira ticket: [CNV-89378](https://redhat.atlassian.net/browse/CNV-89378)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/ddcbcae1-b5f1-4149-b593-5a622537add3


After:

https://github.com/user-attachments/assets/d51c501c-8869-4ac0-9d78-fda80a12f8c9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version-aware routing for storage migrations (spoke/hub-aware) with direct navigation to the Storage Migrations page; UI components now use installed service version when computing migration links.

* **Bug Fixes**
  * Improved merging/normalization of multi- and single-namespace migration plans.
  * Treats missing CRDs as “no data”; more reliable loaded/error signals and correct list/navigation URLs.

* **Tests**
  * Added unit tests for migration utilities, data hooks, and navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->