### PR TITLE
CNV-89379 closing the storage migration with X cancels the migration instead of closing the dialog

### DIFF
--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/components/MigrationStatusShell.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/components/MigrationStatusShell.tsx
@@ -6,15 +6,10 @@ import { CloseIcon } from '@patternfly/react-icons';
 
 type MigrationStatusShellProps = {
   children: ReactNode;
-  isTerminal?: boolean;
   onHeaderClose: () => void;
 };
 
-const MigrationStatusShell: FC<MigrationStatusShellProps> = ({
-  children,
-  isTerminal,
-  onHeaderClose,
-}) => {
+const MigrationStatusShell: FC<MigrationStatusShellProps> = ({ children, onHeaderClose }) => {
   const { t } = useKubevirtTranslation();
 
   return (
@@ -22,7 +17,7 @@ const MigrationStatusShell: FC<MigrationStatusShellProps> = ({
       <div className="pf-v6-c-wizard__header">
         <div className="pf-v6-c-wizard__close">
           <Button
-            aria-label={isTerminal ? t('Close') : t('Cancel migration')}
+            aria-label={t('Close')}
             icon={<CloseIcon />}
             onClick={onHeaderClose}
             variant={ButtonVariant.plain}

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/components/StorageMigrationProgress.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/components/StorageMigrationProgress.tsx
@@ -46,13 +46,8 @@ const StorageMigrationProgress: FC<StorageMigrationProgressProps> = ({
     storageMigrationPlan,
   });
 
-  const onHeaderClose = migrationCompleted || hasFailed ? onClose : onCancelMigration;
-
   return (
-    <MigrationStatusShell
-      isTerminal={migrationCompleted || hasFailed}
-      onHeaderClose={onHeaderClose}
-    >
+    <MigrationStatusShell onHeaderClose={onClose}>
       <MigrationProgressDisplay
         basePath={basePath}
         cancelError={cancelError}


### PR DESCRIPTION
## 📝 Description

Fix X button on storage migration progress modal to dismiss the dialog without canceling the migration.

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-89379

## 🎥 Demo

Before: 

https://github.com/user-attachments/assets/80f84ed4-5ca9-4f9f-8a2e-f137798228fb

After: 

https://github.com/user-attachments/assets/0c31c193-98e6-43e1-acda-2a9d0ef762af



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the close button label in virtual machine migration dialogs to consistently display "Close" for improved user clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->