### PR TITLE
CNV-87452: Preserve reporter and add release prefix in Jira clone

### DIFF
--- a/.github/scripts/src/jira-clone-builder.ts
+++ b/.github/scripts/src/jira-clone-builder.ts
@@ -1,4 +1,5 @@
 import { sanitizeDescriptionForClone } from './jira-adf-utils.js';
+import { buildClonedIssueSummary } from './version-utils.js';
 import type {
   DiscoveredFields,
   JiraCreateIssuePayload,
@@ -30,7 +31,7 @@ export const buildClonePayload = (
     fields: {
       project: { key: 'CNV' },
       issuetype: { id: fields.issuetype.id },
-      summary: fields.summary,
+      summary: buildClonedIssueSummary(fields.summary, targetFixVersion.name),
       description,
       labels: [...fields.labels],
       components: fields.components.map((c) => ({ id: c.id })),
@@ -39,6 +40,9 @@ export const buildClonePayload = (
   };
   if (fields.assignee) {
     payload.fields.assignee = { accountId: fields.assignee.accountId };
+  }
+  if (fields.reporter) {
+    payload.fields.reporter = { accountId: fields.reporter.accountId };
   }
   if (fields.priority) {
     payload.fields.priority = { id: fields.priority.id };

--- a/.github/scripts/src/types/jira.ts
+++ b/.github/scripts/src/types/jira.ts
@@ -82,6 +82,7 @@ export type JiraCreateIssuePayload = {
     labels?: string[];
     components?: Array<{ id: string }>;
     assignee?: { accountId: string } | null;
+    reporter?: { accountId: string } | null;
     priority?: { id: string };
     fixVersions?: Array<{ id: string }>;
     [customField: `customfield_${string}`]: unknown;

--- a/.github/scripts/src/version-utils.ts
+++ b/.github/scripts/src/version-utils.ts
@@ -104,6 +104,23 @@ export const suggestBranchForFixVersion = (fixVersionName: string): string | nul
   return `release-${version}`;
 };
 
+const RELEASE_SUMMARY_PREFIX_REGEX = /^\[release-\d+\.\d+\]\s*/i;
+
+/** Strip an existing [release-X.YY] prefix from a Jira summary. */
+export const stripReleaseSummaryPrefix = (summary: string): string =>
+  summary.replace(RELEASE_SUMMARY_PREFIX_REGEX, '').trim();
+
+/** Prefix a Jira summary with [release-X.YY] derived from a fix version name (e.g., "CNV v4.21.z"). */
+export const buildClonedIssueSummary = (
+  originalSummary: string,
+  fixVersionName: string,
+): string => {
+  const releaseBranch = suggestBranchForFixVersion(fixVersionName);
+  const baseSummary = stripReleaseSummaryPrefix(originalSummary);
+  if (!releaseBranch) return baseSummary;
+  return `[${releaseBranch}] ${baseSummary}`;
+};
+
 /** Extract all CNV-XXXXX ticket IDs from a PR title. */
 export const extractTicketIds = (title: string): string[] => {
   const matches = title.match(/CNV-\d+/gi);


### PR DESCRIPTION
## Summary
- Copy the original Jira reporter when cloning tickets via `/clone`, instead of defaulting to the API token owner
- Prefix cloned ticket summaries with `[release-X.XX]` derived from the target fix version (e.g. `CNV v4.21.z` → `[release-4.21]`)
- Strip any existing release prefix before applying the new one to avoid duplicate prefixes on re-clones

## Test plan
- [ ] Run `/clone release-X.XX` on a PR and verify the cloned Jira ticket keeps the original reporter
- [ ] Verify the cloned ticket summary is prefixed with `[release-X.XX]` matching the target fix version
- [ ] Verify cloning a ticket that already has a `[release-X.XX]` prefix replaces it with the new release prefix

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Jira issue cloning now automatically includes release version prefixes in cloned issue summaries
  * Reporter information is now preserved when cloning Jira issues
  * Enhanced issue metadata handling during the cloning workflow for improved consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->