### PR TITLE
CNV-89945: Empty CD-ROM drive can be added on spoke cluster when Advanced CD-ROM features are disabled

### DIFF
--- a/src/utils/components/DiskModal/AddCDROMModal.tsx
+++ b/src/utils/components/DiskModal/AddCDROMModal.tsx
@@ -40,7 +40,7 @@ const AddCDROMModal: FC<V1SubDiskModalProps> = ({
   const { t } = useKubevirtTranslation();
   const { checkUploadReady, uploadData } = useCDIUpload(getCluster(vm));
   const isVMRunning = isRunning(vm);
-  const [hyperConvergeConfig] = useHyperConvergeConfiguration();
+  const [hyperConvergeConfig] = useHyperConvergeConfiguration(getCluster(vm));
   const [isSubmitting, setIsSubmitting] = useState(false);
   const vmNamespace = getNamespace(vm);
 

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/MountCDROMModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/MountCDROMModal.tsx
@@ -56,7 +56,7 @@ const MountCDROMModal: FC<MountCDROMModalProps> = ({
   const vmNamespace = getNamespace(vm);
   const cdromUploadKey = getVmCdromUploadKeyFromVm(vm, cdromName);
   const { checkUploadReady, uploadData } = useCDIUpload(getCluster(vm));
-  const { featureGates } = useKubevirtHyperconvergeConfiguration();
+  const { featureGates } = useKubevirtHyperconvergeConfiguration(getCluster(vm));
   const isHotPluggable = isHotPluggableEnabled(featureGates);
   const [isSubmitting, setIsSubmitting] = useState(false);
 

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
@@ -26,6 +26,7 @@ import {
 } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
 import { isEmptyContainerDiskImage } from '@kubevirt-utils/resources/vm/utils/disk/utils';
 import { getContentScrollableElement } from '@kubevirt-utils/utils/utils';
+import { getCluster } from '@multicluster/helpers/selectors';
 import {
   ButtonVariant,
   Dropdown,
@@ -63,7 +64,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
-  const { featureGates } = useKubevirtHyperconvergeConfiguration();
+  const { featureGates } = useKubevirtHyperconvergeConfiguration(getCluster(vm));
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const { name: diskName, source: diskSource } = obj || {};


### PR DESCRIPTION
## 📝 Description

In a multi-cluster (ACM/fleet) environment, users can add an empty CD-ROM drive to a VM on a spoke cluster even when Advanced CD-ROM features are not enabled on that spoke cluster. The UI appears to check the hub cluster's setting instead of the spoke cluster where the VM resides.

## 🔗 Links

Jira ticket: [CNV-89945](https://redhat.atlassian.net/browse/CNV-89945)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/fab275c8-7941-4965-b0d9-29b9509e06e5


After:

https://github.com/user-attachments/assets/933d6d12-4596-44de-b368-243f1e49cdbc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed virtual machine storage hot-plug/CD-ROM behavior by making hot-pluggability detection use the VM’s current cluster configuration, ensuring availability is computed correctly across different environments.
  * Updated CD-ROM mount and add flows so feature-gate–driven hot-plug flags reflect the active cluster context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->