### PR TITLE
CNV-89938: VM Wizard - Folder selection issues

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -781,6 +781,7 @@
   "Enable persistent reservation": "Enable persistent reservation",
   "Enable preallocation": "Enable preallocation",
   "Enable predictive analytics": "Enable predictive analytics",
+  "Enable the \"Enable folders in VirtualMachines tree view\" preview feature in Settings > Preview features to use folders.": "Enable the \"Enable folders in VirtualMachines tree view\" preview feature in Settings > Preview features to use folders.",
   "Enable the creation of LoadBalancer services for SSH connections to VirtualMachines. A load balancer must be configured": "Enable the creation of LoadBalancer services for SSH connections to VirtualMachines. A load balancer must be configured",
   "Enable Windows Server 2022 golden image creation and testing. Requires accepting the Windows End User License Agreement (EULA).": "Enable Windows Server 2022 golden image creation and testing. Requires accepting the Windows End User License Agreement (EULA).",
   "Enabled": "Enabled",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -794,6 +794,7 @@
   "Enable persistent reservation": "Habilitar la reserva persistente",
   "Enable preallocation": "Habilitar preasignación",
   "Enable predictive analytics": "Habilitar el análisis predictivo",
+  "Enable the \"Enable folders in VirtualMachines tree view\" preview feature in Settings > Preview features to use folders.": "Enable the \"Enable folders in VirtualMachines tree view\" preview feature in Settings > Preview features to use folders.",
   "Enable the creation of LoadBalancer services for SSH connections to VirtualMachines. A load balancer must be configured": "Habilite la creación de servicios de LoadBalancer para conexiones SSH a VirtualMachines. Se debe configurar un equilibrador de carga.",
   "Enable Windows Server 2022 golden image creation and testing. Requires accepting the Windows End User License Agreement (EULA).": "Enable Windows Server 2022 golden image creation and testing. Requires accepting the Windows End User License Agreement (EULA).",
   "Enabled": "Activado",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -794,6 +794,7 @@
   "Enable persistent reservation": "Activer la réservation persistante",
   "Enable preallocation": "Activer la préallocation",
   "Enable predictive analytics": "Activer l'analyse prédictive",
+  "Enable the \"Enable folders in VirtualMachines tree view\" preview feature in Settings > Preview features to use folders.": "Enable the \"Enable folders in VirtualMachines tree view\" preview feature in Settings > Preview features to use folders.",
   "Enable the creation of LoadBalancer services for SSH connections to VirtualMachines. A load balancer must be configured": "Activez la création de services LoadBalancer pour les connexions SSH aux machines virtuelles. Un équilibreur de charge doit être configuré.",
   "Enable Windows Server 2022 golden image creation and testing. Requires accepting the Windows End User License Agreement (EULA).": "Enable Windows Server 2022 golden image creation and testing. Requires accepting the Windows End User License Agreement (EULA).",
   "Enabled": "Activé",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -780,6 +780,7 @@
   "Enable persistent reservation": "永続的予約を有効にする",
   "Enable preallocation": "事前割り当てを有効にする",
   "Enable predictive analytics": "予測分析を有効にする",
+  "Enable the \"Enable folders in VirtualMachines tree view\" preview feature in Settings > Preview features to use folders.": "Enable the \"Enable folders in VirtualMachines tree view\" preview feature in Settings > Preview features to use folders.",
   "Enable the creation of LoadBalancer services for SSH connections to VirtualMachines. A load balancer must be configured": "VirtualMachine に SSH 接続するための LoadBalancer サービスの作成を有効にします。ロードバランサーを設定する必要があります",
   "Enable Windows Server 2022 golden image creation and testing. Requires accepting the Windows End User License Agreement (EULA).": "Enable Windows Server 2022 golden image creation and testing. Requires accepting the Windows End User License Agreement (EULA).",
   "Enabled": "有効",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -780,6 +780,7 @@
   "Enable persistent reservation": "영구 예약 활성화",
   "Enable preallocation": "사전 할당 활성화",
   "Enable predictive analytics": "예측 분석 활성화",
+  "Enable the \"Enable folders in VirtualMachines tree view\" preview feature in Settings > Preview features to use folders.": "Enable the \"Enable folders in VirtualMachines tree view\" preview feature in Settings > Preview features to use folders.",
   "Enable the creation of LoadBalancer services for SSH connections to VirtualMachines. A load balancer must be configured": "VirtualMachines에 대한 SSH 연결을 위해 LoadBalancer 서비스 생성을 활성화합니다. 로드 밸런서는 별도로 구성되어 있어야 합니다.",
   "Enable Windows Server 2022 golden image creation and testing. Requires accepting the Windows End User License Agreement (EULA).": "Enable Windows Server 2022 golden image creation and testing. Requires accepting the Windows End User License Agreement (EULA).",
   "Enabled": "활성화됨",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -780,6 +780,7 @@
   "Enable persistent reservation": "启用持久性保留",
   "Enable preallocation": "启用预分配",
   "Enable predictive analytics": "启用预测分析",
+  "Enable the \"Enable folders in VirtualMachines tree view\" preview feature in Settings > Preview features to use folders.": "Enable the \"Enable folders in VirtualMachines tree view\" preview feature in Settings > Preview features to use folders.",
   "Enable the creation of LoadBalancer services for SSH connections to VirtualMachines. A load balancer must be configured": "为到 VirtualMachines 的 SSH 连接启用 LoadBalancer 服务创建。必须配置一个负载均衡器",
   "Enable Windows Server 2022 golden image creation and testing. Requires accepting the Windows End User License Agreement (EULA).": "Enable Windows Server 2022 golden image creation and testing. Requires accepting the Windows End User License Agreement (EULA).",
   "Enabled": "已启用",

--- a/src/utils/components/FolderSelect/FolderSelect.tsx
+++ b/src/utils/components/FolderSelect/FolderSelect.tsx
@@ -1,15 +1,17 @@
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
 import SelectTypeahead from '../SelectTypeahead/SelectTypeahead';
 
 import useFolderOptions from './hooks/useFolderOptions';
+import { getFolderSelectOptions } from './utils/getFolderSelectOptions';
 import { createNewFolderOption, getCreateNewFolderOption } from './utils/options';
 import { getToggleStatus } from './utils/validation';
 
 type FoldersSelectProps = {
   cluster?: string;
+  isDisabled?: boolean;
   isFullWidth?: boolean;
   namespace: string;
   selectedFolder: string;
@@ -17,6 +19,7 @@ type FoldersSelectProps = {
 };
 const FolderSelect: FC<FoldersSelectProps> = ({
   cluster,
+  isDisabled = false,
   isFullWidth = false,
   namespace,
   selectedFolder,
@@ -24,6 +27,10 @@ const FolderSelect: FC<FoldersSelectProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const [folderOptions, setFolderOptions] = useFolderOptions(namespace, cluster);
+  const options = useMemo(
+    () => getFolderSelectOptions(folderOptions, selectedFolder),
+    [folderOptions, selectedFolder],
+  );
 
   return (
     <SelectTypeahead
@@ -38,8 +45,9 @@ const FolderSelect: FC<FoldersSelectProps> = ({
       dataTestId="vm-folder-select"
       getCreateAction={getCreateNewFolderOption}
       getToggleStatus={getToggleStatus}
+      isDisabled={isDisabled}
       isFullWidth={isFullWidth}
-      options={folderOptions?.map((option) => ({ optionProps: option, value: option.value })) ?? []}
+      options={options}
       placeholder={t('Search folder')}
       selectedValue={selectedFolder}
       setSelectedValue={setSelectedFolder}

--- a/src/utils/components/FolderSelect/utils/getFolderSelectOptions.ts
+++ b/src/utils/components/FolderSelect/utils/getFolderSelectOptions.ts
@@ -1,0 +1,28 @@
+import { SelectTypeaheadOptionProps } from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
+import { SelectOptionProps } from '@patternfly/react-core';
+
+import { createNewFolderOption } from './options';
+
+/**
+ * Builds FolderSelect typeahead options from existing namespace folders.
+ * Injects the currently selected folder when it is not yet present on any VM,
+ * so newly created folder names remain visible in the dropdown.
+ * @param folderOptions
+ * @param selectedFolder
+ */
+export const getFolderSelectOptions = (
+  folderOptions: SelectOptionProps[] | undefined,
+  selectedFolder: string,
+): SelectTypeaheadOptionProps[] => {
+  const mappedOptions =
+    folderOptions?.map((option) => ({ optionProps: option, value: option.value })) ?? [];
+
+  if (selectedFolder && !mappedOptions.some((option) => option.value === selectedFolder)) {
+    return [
+      { optionProps: createNewFolderOption(selectedFolder), value: selectedFolder },
+      ...mappedOptions,
+    ];
+  }
+
+  return mappedOptions;
+};

--- a/src/utils/components/SelectTypeahead/SelectTypeahead.tsx
+++ b/src/utils/components/SelectTypeahead/SelectTypeahead.tsx
@@ -1,5 +1,14 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-import React, { FC, FormEvent, KeyboardEvent, MouseEvent, Ref, useRef, useState } from 'react';
+import React, {
+  FC,
+  FormEvent,
+  KeyboardEvent,
+  MouseEvent,
+  Ref,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { TFunction } from 'i18next';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -55,6 +64,18 @@ type SelectTypeaheadProps = {
 const getDisplayValue = (option: SelectTypeaheadOptionProps) =>
   option?.label ?? option?.value ?? '';
 
+const getSelectedDisplayValue = (
+  selectedValue: string,
+  options: SelectTypeaheadOptionProps[],
+): string => {
+  if (!selectedValue) {
+    return '';
+  }
+
+  const option = options.find((o) => o.value === selectedValue);
+  return option ? getDisplayValue(option) : selectedValue;
+};
+
 const SelectTypeahead: FC<SelectTypeaheadProps> = ({
   addOption,
   canCreate = false,
@@ -75,7 +96,17 @@ const SelectTypeahead: FC<SelectTypeaheadProps> = ({
   const selected = options.find((option) => option.value === selectedValue);
 
   const [isOpen, setIsOpen] = useState(false);
-  const [inputValue, setInputValue] = useState<string>(getDisplayValue(selected));
+  const [inputValue, setInputValue] = useState<string>(() =>
+    getSelectedDisplayValue(selectedValue, options),
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      return;
+    }
+
+    setInputValue(getSelectedDisplayValue(selectedValue, options));
+  }, [isOpen, options, selectedValue]);
 
   const [focusedItemIndex, setFocusedItemIndex] = useState<null | number>(null);
   const [activeItemId, setActiveItemId] = useState<null | string>(null);
@@ -148,10 +179,7 @@ const SelectTypeahead: FC<SelectTypeaheadProps> = ({
   };
 
   const setInputToSelected = () => {
-    const option = options.find((o) => o.value === selectedValue);
-    if (option) {
-      setInputValue(getDisplayValue(option));
-    }
+    setInputValue(getSelectedDisplayValue(selectedValue, options));
   };
 
   const selectOption = (option: SelectTypeaheadOptionProps) => {

--- a/src/utils/store/customizeInstanceType.ts
+++ b/src/utils/store/customizeInstanceType.ts
@@ -29,6 +29,22 @@ type UpdateCustomizeInstanceTypeArgs = {
   path?: string | string[];
 }[];
 
+// ensurePath joins array segments with "." and re-splits, which breaks keys that
+// contain dots (e.g. label "vm.openshift.io/folder") into nested objects.
+const ensurePathParts = (obj: object, pathParts: string[]): void => {
+  let current = obj;
+
+  for (let index = 0; index < pathParts.length - 1; index++) {
+    const part = pathParts[index];
+
+    if (!current[part]) {
+      current[part] = {};
+    }
+
+    current = current[part];
+  }
+};
+
 export type UpdateCustomizeInstanceType = (
   args: UpdateCustomizeInstanceTypeArgs,
 ) => V1VirtualMachine;
@@ -69,7 +85,13 @@ export const updateCustomizeInstanceType: UpdateCustomizeInstanceType = (
       if (validPathParts.length === 0) {
         return;
       }
-      ensurePath(vmDraft, validPathParts.join('.'));
+
+      if (typeof path === 'string') {
+        ensurePath(vmDraft, validPathParts.join('.'));
+      } else {
+        ensurePathParts(vmDraft, validPathParts);
+      }
+
       let obj = vmDraft;
       validPathParts.forEach((part, index) => {
         if (index < validPathParts.length - 1) {

--- a/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
+++ b/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
@@ -12,7 +12,7 @@ import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { Wizard, WizardHeader, WizardStep } from '@patternfly/react-core';
 import DefaultWizardFooter from '@virtualmachines/creation-wizard/components/DefaultWizardFooter';
 import useCloseWizard from '@virtualmachines/creation-wizard/hooks/useCloseWizard';
-import useSyncDescription from '@virtualmachines/creation-wizard/hooks/useSyncDescription';
+import { useSyncDeploymentDetails } from '@virtualmachines/creation-wizard/hooks/useSyncDeploymentDetails';
 import useVMGenerationNavItem from '@virtualmachines/creation-wizard/hooks/useVMGenerationNavItem';
 import useWizardStepValidation from '@virtualmachines/creation-wizard/hooks/useWizardStepValidation';
 import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
@@ -48,7 +48,7 @@ const VMCreationWizard: FC = () => {
     resetWizardState,
     setTemplatesDrawerIsOpen,
   } = useVMWizardStore();
-  const syncDescription = useSyncDescription();
+  const syncDeploymentDetails = useSyncDeploymentDetails();
   const { isNextDisabledForStep, isStepDisabled } = useWizardStepValidation();
   const { navItemWithVMGeneration } = useVMGenerationNavItem(creationMethod);
   const clusterParam = useClusterParam();
@@ -84,7 +84,7 @@ const VMCreationWizard: FC = () => {
     <TemplatesDrawerWrapper>
       <Wizard
         onStepChange={(_, currentStep, prevStep) => {
-          syncDescription(currentStep, prevStep);
+          syncDeploymentDetails(currentStep, prevStep);
           if (currentStep?.id !== VMWizardStep.TEMPLATE) setTemplatesDrawerIsOpen(false);
           if (currentStep?.id) markStepVisited(String(currentStep.id));
 

--- a/src/views/virtualmachines/creation-wizard/hooks/useSyncDeploymentDetails.ts
+++ b/src/views/virtualmachines/creation-wizard/hooks/useSyncDeploymentDetails.ts
@@ -1,21 +1,25 @@
 import { useCallback } from 'react';
 
 import { getAnnotation } from '@kubevirt-utils/resources/shared';
-import { DESCRIPTION_ANNOTATION } from '@kubevirt-utils/resources/vm';
+import { DESCRIPTION_ANNOTATION, getFolder } from '@kubevirt-utils/resources/vm';
 import { updateCustomizeInstanceType, vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import type { WizardStepType } from '@patternfly/react-core';
 import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
 import { VMWizardStep } from '@virtualmachines/creation-wizard/utils/constants';
+import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
 
-type UseSyncDescription = () => (currentStep: WizardStepType, prevStep: WizardStepType) => void;
+type UseSyncDeploymentDetails = () => (
+  currentStep: WizardStepType,
+  prevStep: WizardStepType,
+) => void;
 
 /**
- * Keeps the wizard store's vmDescription buffer in sync with vmSignal's annotation
- * across step transitions. Flushes the buffer to the signal when leaving Deployment Details,
- * and hydrates the buffer from the signal when entering Deployment Details.
+ * Keeps the wizard store's Deployment Details buffers in sync with vmSignal
+ * across step transitions. Flushes store values to the signal when leaving
+ * Deployment Details, and hydrates the store from the signal when entering it.
  */
-const useSyncDescription: UseSyncDescription = () => {
-  const { setVMDescription, vmDescription } = useVMWizardStore();
+export const useSyncDeploymentDetails: UseSyncDeploymentDetails = () => {
+  const { folder, setFolder, setVMDescription, vmDescription } = useVMWizardStore();
 
   return useCallback(
     (currentStep: WizardStepType, prevStep: WizardStepType) => {
@@ -29,15 +33,18 @@ const useSyncDescription: UseSyncDescription = () => {
             data: vmDescription || undefined,
             path: `metadata.annotations.${DESCRIPTION_ANNOTATION}`,
           },
+          {
+            data: folder || undefined,
+            path: ['metadata', 'labels', VM_FOLDER_LABEL],
+          },
         ]);
       }
 
       if (currentStep?.id === VMWizardStep.DEPLOYMENT_DETAILS) {
         setVMDescription(getAnnotation(vmSignal.value, DESCRIPTION_ANNOTATION, ''));
+        setFolder(getFolder(vmSignal.value) || '');
       }
     },
-    [setVMDescription, vmDescription],
+    [folder, setFolder, setVMDescription, vmDescription],
   );
 };
-
-export default useSyncDescription;

--- a/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/VMCreationLocationDisplay.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/VMCreationLocationDisplay.tsx
@@ -2,6 +2,8 @@ import React, { FC } from 'react';
 import classNames from 'classnames';
 
 import EditButton from '@kubevirt-utils/components/EditButton/EditButton';
+import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
+import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm';
 import useIsACMPage from '@multicluster/useIsACMPage';
@@ -21,6 +23,8 @@ const VMCreationLocationDisplay: FC<VMCreationLocationDisplayProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const isACMPage = useIsACMPage();
+  const { featureEnabled: treeViewFoldersEnabled, loading: treeViewFoldersLoading } =
+    useFeatures(TREE_VIEW_FOLDERS);
   const { cluster, folder, project } = useVMWizardStore();
 
   return (
@@ -40,9 +44,13 @@ const VMCreationLocationDisplay: FC<VMCreationLocationDisplayProps> = ({
           )}
           <span className="pf-v6-u-font-weight-bold pf-v6-u-mr-xs">{t('Project')}</span>
           {project || NO_DATA_DASH}
-          <span className="pf-v6-u-font-weight-bold pf-v6-u-mx-xs">{'>'}</span>
-          <span className="pf-v6-u-font-weight-bold pf-v6-u-mr-xs">{t('Folder')}</span>
-          {folder || NO_DATA_DASH}
+          {!treeViewFoldersLoading && treeViewFoldersEnabled && (
+            <>
+              <span className="pf-v6-u-font-weight-bold pf-v6-u-mx-xs">{'>'}</span>
+              <span className="pf-v6-u-font-weight-bold pf-v6-u-mr-xs">{t('Folder')}</span>
+              {folder || NO_DATA_DASH}
+            </>
+          )}
         </span>
       </div>
       <EditButton

--- a/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/VMCreationLocationForm.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/VMCreationLocationForm.tsx
@@ -3,7 +3,10 @@ import React, { FC } from 'react';
 import ClusterDropdown from '@kubevirt-utils/components/ClusterProjectDropdown/ClusterDropdown';
 import NamespaceDropdown from '@kubevirt-utils/components/ClusterProjectDropdown/NamespaceDropdown';
 import FolderSelect from '@kubevirt-utils/components/FolderSelect/FolderSelect';
+import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
+import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { Form, FormGroup } from '@patternfly/react-core';
@@ -14,7 +17,10 @@ import './VMCreationLocationForm.scss';
 const VMCreationLocationForm: FC = () => {
   const { t } = useKubevirtTranslation();
   const isACMPage = useIsACMPage();
+  const { featureEnabled: treeViewFoldersEnabled, loading: treeViewFoldersLoading } =
+    useFeatures(TREE_VIEW_FOLDERS);
   const { cluster, folder, project, setCluster, setFolder, setProject } = useVMWizardStore();
+  const isTreeViewFoldersDisabled = treeViewFoldersLoading || !treeViewFoldersEnabled;
 
   return (
     <Form className="vm-creation-location-form">
@@ -41,9 +47,21 @@ const VMCreationLocationForm: FC = () => {
           selectedProject={project || DEFAULT_NAMESPACE}
         />
       </FormGroup>
-      <FormGroup label={t('Folder (optional)')}>
+      <FormGroup
+        labelHelp={
+          !treeViewFoldersLoading && !treeViewFoldersEnabled ? (
+            <HelpTextIcon
+              bodyContent={t(
+                'Enable the "Enable folders in VirtualMachines tree view" preview feature in Settings > Preview features to use folders.',
+              )}
+            />
+          ) : undefined
+        }
+        label={t('Folder (optional)')}
+      >
         <FolderSelect
           cluster={cluster}
+          isDisabled={isTreeViewFoldersDisabled}
           namespace={project}
           selectedFolder={folder}
           setSelectedFolder={(newFolder) => setFolder(newFolder)}

--- a/src/views/virtualmachines/creation-wizard/steps/ReviewAndCreateStep/components/ReviewGrid/components/ReviewGridLeftColumn.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/ReviewAndCreateStep/components/ReviewGrid/components/ReviewGridLeftColumn.tsx
@@ -1,6 +1,8 @@
 import React, { FC } from 'react';
 
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
+import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
+import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getFolder, NO_DATA_DASH } from '@kubevirt-utils/resources/vm';
 import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
@@ -16,6 +18,8 @@ const ReviewGridLeftColumn: FC = () => {
   const { t } = useKubevirtTranslation();
   const vm = vmSignal.value;
   const { creationMethod, project, vmName } = useVMWizardStore();
+  const { featureEnabled: treeViewFoldersEnabled, loading: treeViewFoldersLoading } =
+    useFeatures(TREE_VIEW_FOLDERS);
 
   const isCloneMethod = isCloneCreationMethod(creationMethod);
 
@@ -38,10 +42,12 @@ const ReviewGridLeftColumn: FC = () => {
           descriptionData={project || NO_DATA_DASH}
           descriptionHeader={t('Project')}
         />
-        <DescriptionItem
-          descriptionData={getFolder(vm) || NO_DATA_DASH}
-          descriptionHeader={t('Folder')}
-        />
+        {!treeViewFoldersLoading && treeViewFoldersEnabled && (
+          <DescriptionItem
+            descriptionData={getFolder(vm) || NO_DATA_DASH}
+            descriptionHeader={t('Folder')}
+          />
+        )}
       </DescriptionList>
     </ExpandableSection>
   );


### PR DESCRIPTION
## 📝 Description

Fixes three folder selection bugs in the VM creation wizard: the edit form no longer loses the selected folder when navigating back, switching projects now correctly clears the folder in Review (by syncing the wizard store with `vmSignal` via `useSyncDeploymentDetails`), and the folder field is gated behind the `TREE_VIEW_FOLDERS` preview feature with a disabled tooltip when off. Also fixes `SelectTypeahead` to display the selected value after async options load, and corrects updateCustomizeInstanceType array-path handling so label keys containing dots (e.g. `vm.openshift.io/folder`) are not corrupted into nested objects.

## 🔗 Links

Jira ticket: [CNV-89938](https://redhat.atlassian.net/browse/CNV-89938)


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/38b1fb06-e67e-4b4f-b45e-f97c17f9171b


After: 

Folders feature **disabled**:

https://github.com/user-attachments/assets/21439572-c663-4997-97e0-329d6974f736


Folders feature **enabled**: 

https://github.com/user-attachments/assets/01f2ed96-b9ac-46a1-80ba-b4064286c722




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added folder selection during VM creation, gated by the TREE_VIEW_FOLDERS preview feature.
  * Folder selection is now persisted and synchronized with deployment details across wizard steps.
* **Refactor**
  * Improved dropdown display/value synchronization for more consistent selected text behavior.
  * Enhanced option building so the currently selected folder remains visible even when it isn’t in the default list.
  * Improved handling of nested metadata updates for array-based paths.
* **UI Updates**
  * Folder selection UI can be disabled via a component option, and folder fields are conditionally hidden while the feature flag loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->