### PR TITLE
[release-4.22] CNV-90047: Remove favorites column from VM wizard Boot Source step

### DIFF
--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/BootableVolumeList.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/BootableVolumeList.tsx
@@ -65,7 +65,6 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
     activeColumns,
     columnLayout,
     data,
-    favorites,
     filters,
     getSortType,
     isEmptyVolumes,
@@ -149,7 +148,6 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
               {displayShowAllButton && (
                 <ShowAllBootableVolumesButton
                   bootableVolumesData={bootableVolumesData}
-                  favorites={favorites}
                   onSelect={onModalBootableVolumeSelect}
                   preferencesData={instanceTypesAndPreferencesData}
                   userPreferencesData={userPreferencesData}
@@ -159,18 +157,15 @@ const BootableVolumeList: FC<BootableVolumeListProps> = ({
           )}
         </Split>
         {displayVolumes && (
-          <>
-            <BootableVolumeTable
-              activeColumns={activeColumns}
-              bootableVolumesData={bootableVolumesData}
-              favorites={favorites}
-              getSortType={getSortType}
-              preferencesMap={preferencesMap}
-              selectedBootableVolumeState={[selectedBootableVolume, onSelectCreatedVolume]}
-              sortedPaginatedData={sortedPaginatedData}
-              userPreferencesMap={userPreferencesMap}
-            />
-          </>
+          <BootableVolumeTable
+            activeColumns={activeColumns}
+            bootableVolumesData={bootableVolumesData}
+            getSortType={getSortType}
+            preferencesMap={preferencesMap}
+            selectedBootableVolumeState={[selectedBootableVolume, onSelectCreatedVolume]}
+            sortedPaginatedData={sortedPaginatedData}
+            userPreferencesMap={userPreferencesMap}
+          />
         )}
         {isVolumesLoaded && isEmptyVolumes && <BootableVolumeEmptyState />}
         {isVolumesLoaded && isPreferenceFilterEmpty && (

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeListModal/BootableVolumeListModal.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeListModal/BootableVolumeListModal.tsx
@@ -3,7 +3,6 @@ import React, { FC } from 'react';
 import { V1beta1VirtualMachinePreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { UserSettingFavorites } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
 import useBootableVolumes from '@kubevirt-utils/resources/bootableresources/hooks/useBootableVolumes';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { ModalVariant } from '@patternfly/react-core';
@@ -17,7 +16,6 @@ import BootableVolumeList from '../../BootableVolumeList';
 
 type BootableVolumeListModalProps = {
   bootableVolumesData: UseBootableVolumesValues;
-  favorites: UserSettingFavorites;
   isOpen: boolean;
   onClose: () => void;
   onSelect: (selectedBootableVolume: BootableVolume) => void;

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
@@ -1,4 +1,4 @@
-import React, { FC, MouseEvent } from 'react';
+import React, { FC } from 'react';
 
 import {
   V1beta1DataImportCron,
@@ -53,7 +53,6 @@ type BootableVolumeRowProps = {
     bootableVolumeSelectedState: [BootableVolume, InstanceTypeVMStore['onSelectCreatedVolume']];
     dataImportCron: V1beta1DataImportCron;
     dvSource: V1beta1DataVolume;
-    favorites: [isFavorite: boolean, updaterFavorites: (val: boolean) => void];
     preference: VirtualMachinePreference;
     pvcSource: IoK8sApiCoreV1PersistentVolumeClaim;
     volumeSnapshotSource: VolumeSnapshotKind;
@@ -67,7 +66,6 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
     bootableVolumeSelectedState: [selectedBootableVolume, setSelectedBootableVolume],
     dataImportCron,
     dvSource,
-    favorites,
     preference,
     pvcSource,
     volumeSnapshotSource,
@@ -79,8 +77,6 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
   const bootVolumeNamespace = getNamespace(bootableVolume);
   const sizeData = getHumanizedSize(getDiskSize(dvSource, pvcSource, volumeSnapshotSource)).string;
   const icon = getVolumeNameOSIcon(bootVolumeName) || getTemplateOSIcon(preference);
-
-  const [isFavorite, addOrRemoveFavorite] = favorites;
 
   const handleOnClick = () => {
     setSelectedBootableVolume(bootableVolume, pvcSource, volumeSnapshotSource, dvSource);
@@ -103,18 +99,6 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
       isSelectable
       onClick={() => handleOnClick()}
     >
-      <TableData
-        favorites={{
-          isFavorited: isFavorite,
-          onFavorite: (e: MouseEvent, isFavoring: boolean) => {
-            e.stopPropagation();
-            addOrRemoveFavorite(isFavoring);
-          },
-        }}
-        activeColumnIDs={activeColumnIDs}
-        id="favorites"
-        modifier="fitContent"
-      />
       <TableData activeColumnIDs={activeColumnIDs} id="name" width={15}>
         <Flex alignItems={{ default: 'alignItemsCenter' }} columnGap={{ default: 'columnGapXs' }}>
           <img alt="os-icon" className="bootable-volume-row-icon" src={icon} />

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeTable/BootableVolumeTable.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeTable/BootableVolumeTable.tsx
@@ -5,7 +5,6 @@ import {
   V1beta1VirtualMachineClusterPreference,
   V1beta1VirtualMachinePreference,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { UserSettingFavorites } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
 import {
   getBootableVolumePVCSource,
   getDataImportCronFromDataSource,
@@ -20,13 +19,11 @@ import { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/ba
 import { InstanceTypeVMStore } from '@virtualmachines/creation-wizard/state/instance-type-vm-store/utils/types';
 import { UseBootableVolumesValues } from '@virtualmachines/creation-wizard/utils/types';
 
-import { FAVORITES_COLUMN_ID } from '../../utils/constants';
 import BootableVolumeRow from '../BootableVolumeRow/BootableVolumeRow';
 
 type BootableVolumeTableProps = {
   activeColumns: TableColumn<BootableVolume>[];
   bootableVolumesData: UseBootableVolumesValues;
-  favorites: UserSettingFavorites;
   getSortType: (columnIndex: number) => ThSortType;
   preferencesMap: ResourceMap<V1beta1VirtualMachineClusterPreference>;
   selectedBootableVolumeState?: [BootableVolume, InstanceTypeVMStore['onSelectCreatedVolume']];
@@ -37,14 +34,12 @@ type BootableVolumeTableProps = {
 const BootableVolumeTable: FC<BootableVolumeTableProps> = ({
   activeColumns,
   bootableVolumesData,
-  favorites,
   getSortType,
   preferencesMap,
   selectedBootableVolumeState,
   sortedPaginatedData,
   userPreferencesMap,
 }) => {
-  const [volumeFavorites, updateFavorites] = favorites;
   const { dataImportCrons, dvSources, pvcSources, volumeSnapshotSources } = bootableVolumesData;
 
   return (
@@ -52,15 +47,7 @@ const BootableVolumeTable: FC<BootableVolumeTableProps> = ({
       <Thead>
         <Tr>
           {activeColumns.map((col, columnIndex) => (
-            <Th
-              sort={
-                col.id === FAVORITES_COLUMN_ID
-                  ? { ...getSortType(columnIndex), isFavorites: true }
-                  : getSortType(columnIndex)
-              }
-              id={col?.id}
-              key={col?.id}
-            >
+            <Th id={col?.id} key={col?.id} sort={getSortType(columnIndex)}>
               {col?.title}
             </Th>
           ))}
@@ -80,15 +67,6 @@ const BootableVolumeTable: FC<BootableVolumeTableProps> = ({
                   bootSource as V1beta1DataSource,
                 ),
                 dvSource: getDataVolumeForPVC(pvcSource, dvSources),
-                favorites: [
-                  volumeFavorites?.includes(bootSourceName),
-                  (addTofavorites: boolean) =>
-                    updateFavorites(
-                      addTofavorites
-                        ? [...volumeFavorites, bootSourceName]
-                        : volumeFavorites.filter((fav: string) => fav !== bootSourceName),
-                    ),
-                ],
                 preference: getPreference(bootSource, preferencesMap, userPreferencesMap),
                 pvcSource,
                 volumeSnapshotSource: volumeSnapshotSources?.[bootSourceName],

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/ShowAllBootableVolumesButton/ShowAllBootableVolumesButton.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/ShowAllBootableVolumesButton/ShowAllBootableVolumesButton.tsx
@@ -2,7 +2,6 @@ import React, { FC, useState } from 'react';
 
 import { V1beta1VirtualMachinePreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { UserSettingFavorites } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { Button, ButtonVariant, SplitItem } from '@patternfly/react-core';
 import {
@@ -14,7 +13,6 @@ import BootableVolumeListModal from '../BootableVolumeListModal/BootableVolumeLi
 
 type ShowAllBootableVolumesButtonProps = {
   bootableVolumesData: UseBootableVolumesValues;
-  favorites: UserSettingFavorites;
   onSelect: (selectedBootableVolume: BootableVolume) => void;
   preferencesData: UseInstanceTypeAndPreferencesValues;
   userPreferencesData: V1beta1VirtualMachinePreference[];

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootVolumeColumns.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootVolumeColumns.ts
@@ -8,7 +8,6 @@ import { ColumnLayout } from '@openshift-console/dynamic-plugin-sdk-internal/lib
 
 import {
   DESCRIPTION_COLUMN_ID,
-  FAVORITES_COLUMN_ID,
   NAME_COLUMN_ID,
   NAMESPACE_COLUMN_ID,
   OPERATING_SYSTEM_COLUMN_ID,
@@ -30,10 +29,6 @@ const useBootVolumeColumns: UseBootVolumesColumns = (volumeListNamespace, isModa
   const { t } = useKubevirtTranslation();
 
   const columns: TableColumn<BootableVolume>[] = [
-    {
-      id: FAVORITES_COLUMN_ID,
-      title: '',
-    },
     {
       id: NAME_COLUMN_ID,
       title: t('Volume name'),

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
@@ -29,7 +29,6 @@ import { getDiskSize } from '@virtualmachines/creation-wizard/utils/utils';
 
 type UseBootVolumeSortColumns = (
   unsortedData: BootableVolume[],
-  volumeFavorites: string[],
   clusterPreferencesMap: ResourceMap<V1beta1VirtualMachineClusterPreference>,
   userPreferencesMap: NamespacedResourceMap<V1beta1VirtualMachinePreference>,
   pvcSources: ClusterNamespacedResourceMap<IoK8sApiCoreV1PersistentVolumeClaim>,
@@ -47,7 +46,6 @@ type UseBootVolumeSortColumns = (
 
 const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
   unsortedData = [],
-  volumeFavorites,
   clusterPreferencesMap,
   userPreferencesMap,
   pvcSources,
@@ -76,9 +74,8 @@ const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
   };
 
   const sortVolumes = (a: BootableVolume, b: BootableVolume): number => {
-    //favorites is column 0, so we need to decrease index by 1
-    const aValue = getSortableRowValues(a)[activeSortIndex - 1];
-    const bValue = getSortableRowValues(b)[activeSortIndex - 1];
+    const aValue = getSortableRowValues(a)[activeSortIndex];
+    const bValue = getSortableRowValues(b)[activeSortIndex];
 
     if (activeSortDirection === 'asc') {
       return aValue?.localeCompare(bValue, undefined, { numeric: true, sensitivity: 'base' });
@@ -99,26 +96,7 @@ const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
     },
   });
 
-  // will try to keep the same sorting for other fields such as name and only arrange the favorites to be first
-  const arrangeFavorites = (
-    acc: [favorites: BootableVolume[], notFavorites: BootableVolume[]],
-    volume: BootableVolume,
-  ): [BootableVolume[], BootableVolume[]] => {
-    if (activeSortIndex === 0) {
-      const isASC = activeSortDirection === 'asc';
-      if (volumeFavorites?.includes(volume?.metadata?.name)) {
-        acc[isASC ? 0 : 1].push(volume);
-      } else {
-        acc[isASC ? 1 : 0].push(volume);
-      }
-      return acc;
-    }
-    acc[0].push(volume);
-    return acc;
-  };
-
-  const sortedData = [...unsortedData].sort(sortVolumes).reduce(arrangeFavorites, [[], []]).flat();
-
+  const sortedData = [...unsortedData].sort(sortVolumes);
   const sortedPaginatedData = sortedData.slice(pagination.startIndex, pagination.endIndex);
 
   return { getSortType, sortedData, sortedPaginatedData };

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
@@ -57,47 +57,66 @@ const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
   const [activeSortIndex, setActiveSortIndex] = useState<null | number>(0);
   const [activeSortDirection, setActiveSortDirection] = useState<'asc' | 'desc' | null>('asc');
 
-  const getSortableRowValues = (bootableVolume: BootableVolume): string[] => {
-    const pvcSource = getBootableVolumePVCSource(bootableVolume, pvcSources);
-    const dvSource = getDataVolumeForPVC(pvcSource, dvSources);
-    const volumeSnapshotSource = volumeSnapshotSources?.[bootableVolume?.metadata?.name];
+  const getSortableRowValues = useCallback(
+    (bootableVolume: BootableVolume): string[] => {
+      const pvcSource = getBootableVolumePVCSource(bootableVolume, pvcSources);
+      const dvSource = getDataVolumeForPVC(pvcSource, dvSources);
+      const volumeSnapshotSource = volumeSnapshotSources?.[bootableVolume?.metadata?.name];
 
-    return [
-      getName(bootableVolume),
-      getArchitecture(bootableVolume),
-      ...(includeNamespaceColumn ? [getNamespace(bootableVolume)] : []),
-      getOSFromDefaultPreference(bootableVolume, clusterPreferencesMap, userPreferencesMap),
-      pvcSource?.spec?.storageClassName || getVolumeSnapshotStorageClass(volumeSnapshotSource),
-      getDiskSize(dvSource, pvcSource, volumeSnapshotSource),
-      bootableVolume?.metadata?.annotations?.[DESCRIPTION_ANNOTATION],
-    ];
-  };
-
-  const sortVolumes = (a: BootableVolume, b: BootableVolume): number => {
-    const aValue = getSortableRowValues(a)[activeSortIndex];
-    const bValue = getSortableRowValues(b)[activeSortIndex];
-
-    if (activeSortDirection === 'asc') {
-      return aValue?.localeCompare(bValue, undefined, { numeric: true, sensitivity: 'base' });
-    }
-    return bValue?.localeCompare(aValue, undefined, { numeric: true, sensitivity: 'base' });
-  };
-
-  const getSortType = (columnIndex: number): ThSortType => ({
-    columnIndex,
-    onSort: (_event, index, direction) => {
-      setActiveSortIndex(index);
-      setActiveSortDirection(direction);
+      return [
+        getName(bootableVolume),
+        getArchitecture(bootableVolume),
+        ...(includeNamespaceColumn ? [getNamespace(bootableVolume)] : []),
+        getOSFromDefaultPreference(bootableVolume, clusterPreferencesMap, userPreferencesMap),
+        pvcSource?.spec?.storageClassName || getVolumeSnapshotStorageClass(volumeSnapshotSource),
+        getDiskSize(dvSource, pvcSource, volumeSnapshotSource),
+        bootableVolume?.metadata?.annotations?.[DESCRIPTION_ANNOTATION],
+      ];
     },
-    sortBy: {
-      defaultDirection: 'asc',
-      direction: activeSortDirection,
-      index: activeSortIndex,
-    },
-  });
+    [
+      clusterPreferencesMap,
+      dvSources,
+      includeNamespaceColumn,
+      pvcSources,
+      userPreferencesMap,
+      volumeSnapshotSources,
+    ],
+  );
 
-  const sortedData = [...unsortedData].sort(sortVolumes);
-  const sortedPaginatedData = sortedData.slice(pagination.startIndex, pagination.endIndex);
+  const sortedData = useMemo(() => {
+    const sortVolumes = (a: BootableVolume, b: BootableVolume): number => {
+      const aValue = getSortableRowValues(a)[activeSortIndex];
+      const bValue = getSortableRowValues(b)[activeSortIndex];
+
+      if (activeSortDirection === 'asc') {
+        return aValue?.localeCompare(bValue, undefined, { numeric: true, sensitivity: 'base' });
+      }
+      return bValue?.localeCompare(aValue, undefined, { numeric: true, sensitivity: 'base' });
+    };
+
+    return unsortedData?.sort(sortVolumes);
+  }, [activeSortDirection, activeSortIndex, getSortableRowValues, unsortedData]);
+
+  const sortedPaginatedData = useMemo(
+    () => sortedData.slice(pagination.startIndex, pagination.endIndex),
+    [pagination.endIndex, pagination.startIndex, sortedData],
+  );
+
+  const getSortType = useCallback(
+    (columnIndex: number): ThSortType => ({
+      columnIndex,
+      onSort: (_event, index, direction) => {
+        setActiveSortIndex(index);
+        setActiveSortDirection(direction);
+      },
+      sortBy: {
+        defaultDirection: 'asc',
+        direction: activeSortDirection,
+        index: activeSortIndex,
+      },
+    }),
+    [activeSortDirection, activeSortIndex],
+  );
 
   return { getSortType, sortedData, sortedPaginatedData };
 };

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootableVolumesTableData.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootableVolumesTableData.ts
@@ -5,8 +5,6 @@ import {
   V1beta1VirtualMachinePreference,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
-import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
-import { UserSettingFavorites } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/types';
 import { PaginationState } from '@kubevirt-utils/hooks/usePagination/utils/types';
 import useBootableVolumes from '@kubevirt-utils/resources/bootableresources/hooks/useBootableVolumes';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
@@ -21,7 +19,6 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base/types';
 import useInstanceTypeVMStore from '@virtualmachines/creation-wizard/state/instance-type-vm-store/useInstanceTypeVMStore';
-import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
 import useBootVolumeColumns from '@virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootVolumeColumns';
 import useBootVolumeFilters from '@virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootVolumeFilters';
 import useBootVolumeSortColumns from '@virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootVolumeSortColumns';
@@ -43,7 +40,6 @@ type UseBootableVolumesTableData = (
   activeColumns: TableColumn<BootableVolume>[];
   columnLayout: ColumnLayout;
   data: BootableVolume[];
-  favorites: UserSettingFavorites;
   filters: RowFilter<BootableVolume>[];
   getSortType: (columnIndex: number) => ThSortType;
   isEmptyVolumes: boolean;
@@ -65,7 +61,6 @@ const useBootableVolumesTableData: UseBootableVolumesTableData = (
   preferencesMap,
   userPreferencesMap,
 ) => {
-  const { cluster } = useVMWizardStore();
   const { preference } = useInstanceTypeVMStore();
   const bootableVolumesData = useBootableVolumes(volumeListNamespace);
   const { bootableVolumes, dvSources, pvcSources, volumeSnapshotSources } = bootableVolumesData;
@@ -77,10 +72,6 @@ const useBootableVolumesTableData: UseBootableVolumesTableData = (
 
   const isPreferenceFilterEmpty =
     !!preference && !isEmpty(bootableVolumes) && isEmpty(preferenceFilteredVolumes);
-
-  const favoritesData = useKubevirtUserSettings('favoriteBootableVolumes', cluster);
-  const [favorites = [], updaterFavorites] = favoritesData;
-  const volumeFavorites = favorites as [];
 
   const allFilters = useBootVolumeFilters(preferenceFilteredVolumes, !displayShowAllButton);
 
@@ -105,7 +96,6 @@ const useBootableVolumesTableData: UseBootableVolumesTableData = (
 
   const { getSortType, sortedData, sortedPaginatedData } = useBootVolumeSortColumns(
     data,
-    volumeFavorites,
     preferencesMap,
     userPreferencesMap,
     pvcSources,
@@ -124,7 +114,6 @@ const useBootableVolumesTableData: UseBootableVolumesTableData = (
     activeColumns,
     columnLayout,
     data,
-    favorites: [favorites as [], updaterFavorites],
     filters,
     getSortType,
     isEmptyVolumes: isEmpty(bootableVolumes),

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/utils/constants.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/utils/constants.ts
@@ -30,7 +30,6 @@ export const WINDOWS_BOOTSOURCE_PIPELINE = 'windows-bootsource-pipeline';
 
 export const NAME_COLUMN_ID = 'name';
 export const NAMESPACE_COLUMN_ID = 'namespace';
-export const FAVORITES_COLUMN_ID = 'favorites';
 export const OPERATING_SYSTEM_COLUMN_ID = 'operating-system';
 export const STORAGE_CLASS_COLUMN_ID = 'storage-class';
 export const SIZE_COLUMN_ID = 'size';


### PR DESCRIPTION
https://redhat.atlassian.net/browse/CNV-90047

Cherry-pick of #4002 to release-4.22.

Remove the favorites column (star icon) from the Boot Source step in the VM creation wizard. The bootable volumes table no longer shows star/favorite controls or sorts volumes by favorites first.

Additional changes for release-4.22 compatibility:
- Removed favorites prop from ShowAllBootableVolumesButton and BootableVolumeListModal (components that don't exist on main)

Made with [Cursor](https://cursor.com)