### PR TITLE
[release-4.22] CNV-90048: Clone VM creation wizard fixes.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -23,5 +23,4 @@ reviewers:
   - lkladnit
   - gouyang
   - batyana
-  - aviavissar
   - Pedro-S-Abreu

--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1573,6 +1573,7 @@
   "Project name to clone the template to": "Project name to clone the template to",
   "Project root": "Project root",
   "Project-scoped": "Project-scoped",
+  "Project: {{project}}": "Project: {{project}}",
   "Projects": "Projects",
   "Provider": "Provider",
   "Provisioning": "Provisioning",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1590,6 +1590,7 @@
   "Project name to clone the template to": "Nombre del proyecto para clonar la plantilla en",
   "Project root": "Root del proyecto",
   "Project-scoped": "Delimitado por el alcance del proyecto",
+  "Project: {{project}}": "Project: {{project}}",
   "Projects": "Proyectos",
   "Provider": "Proveedor",
   "Provisioning": "Aprovisionamiento",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1590,6 +1590,7 @@
   "Project name to clone the template to": "Nom du projet vers lequel cloner le modèle",
   "Project root": "Racine du projet",
   "Project-scoped": "Sous le périmètre du projet",
+  "Project: {{project}}": "Project: {{project}}",
   "Projects": "Projets",
   "Provider": "Fournisseur",
   "Provisioning": "Provisionnement",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1573,6 +1573,7 @@
   "Project name to clone the template to": "テンプレートのクローン作成先のプロジェクト名",
   "Project root": "プロジェクトのルート",
   "Project-scoped": "プロジェクトスコープの",
+  "Project: {{project}}": "Project: {{project}}",
   "Projects": "プロジェクト",
   "Provider": "プロバイダー",
   "Provisioning": "Provisioning",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1573,6 +1573,7 @@
   "Project name to clone the template to": "템플릿을 복제할 프로젝트 이름",
   "Project root": "프로젝트 루트",
   "Project-scoped": "프로젝트 범위",
+  "Project: {{project}}": "Project: {{project}}",
   "Projects": "프로젝트",
   "Provider": "공급자",
   "Provisioning": "프로비저닝",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1573,6 +1573,7 @@
   "Project name to clone the template to": "将模板克隆到的项目名称",
   "Project root": "项目根",
   "Project-scoped": "项目范围的",
+  "Project: {{project}}": "Project: {{project}}",
   "Projects": "项目",
   "Provider": "供应商",
   "Provisioning": "置备",

--- a/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
@@ -34,11 +34,11 @@ import useVirtualMachineInstanceMigrations from '@kubevirt-utils/resources/vmim/
 import { clearCustomizeInstanceType, vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import { PROJECT_LIST_FILTER_PARAM } from '@kubevirt-utils/utils/constants';
 import { isVM } from '@kubevirt-utils/utils/typeGuards';
-import { isEmpty, truncateToK8sName } from '@kubevirt-utils/utils/utils';
+import { truncateToK8sName } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useIsAllClustersPage from '@multicluster/hooks/useIsAllClustersPage';
-import { K8sVerb, ListPageBody, useListPageFilter } from '@openshift-console/dynamic-plugin-sdk';
-import { Bullseye, Pagination, Split, SplitItem } from '@patternfly/react-core';
+import { K8sVerb, useListPageFilter } from '@openshift-console/dynamic-plugin-sdk';
+import { Label, Pagination, Split, SplitItem } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
 import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
 import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
@@ -46,7 +46,6 @@ import { useVirtualMachineInstanceMapper } from '@virtualmachines/list/hooks/use
 import useVMMetrics from '@virtualmachines/list/hooks/useVMMetrics';
 import { getListPageBodySize, ListPageBodySize } from '@virtualmachines/list/listPageBodySize';
 import { VM_FILTER_OPTIONS } from '@virtualmachines/list/utils/constants';
-import { filterVMsByClusterAndNamespace } from '@virtualmachines/list/utils/utils';
 import {
   getVMColumns,
   VM_COLUMN_KEYS,
@@ -54,7 +53,6 @@ import {
 } from '@virtualmachines/list/virtualMachinesDefinition';
 import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
 import useVMSearchQueries from '@virtualmachines/search/hooks/useVMSearchQueries';
-import { vmsSignal } from '@virtualmachines/tree/utils/signals';
 import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils';
 import { getVMIFromMapper, getVMIMFromMapper } from '@virtualmachines/utils/mappers';
 
@@ -213,13 +211,6 @@ const VirtualMachinesList = forwardRef(({}, ref) => {
 
   const loaded = vmsLoaded && vmisLoaded && vmimsLoaded && !loadingFeatureProxy && loadedColumns;
 
-  const allVMsInNamespace = useMemo(
-    () => filterVMsByClusterAndNamespace(vmsSignal.value, undefined, cluster),
-    [cluster],
-  );
-
-  const hasNoVMs = useMemo(() => isEmpty(allVMsInNamespace), [allVMsInNamespace]);
-
   const callbacks: VMCallbacks = useMemo(
     () => ({
       getVmi: (vm: V1VirtualMachine) => getVMIFromMapper(vmiMapper, vm),
@@ -252,64 +243,58 @@ const VirtualMachinesList = forwardRef(({}, ref) => {
   };
 
   return (
-    <>
-      <ListPageBody>
-        <div className="vm-listpagebody" ref={listPageBodyRef}>
-          <>
-            <Split hasGutter>
-              <SplitItem>
-                <ListPageFilter
-                  onFilterChange={(...args) => {
-                    onFilterChange(...args);
-                    setPagination((prevPagination) => ({
-                      ...prevPagination,
-                      endIndex: prevPagination?.perPage,
-                      page: 1,
-                      startIndex: 0,
-                    }));
-                  }}
-                  columnLayout={columnLayout}
-                  data={unfilteredData}
-                  filtersWithSelect={filtersWithSelect}
-                  loaded={loaded}
-                  rowFilters={rowFilters}
-                />
-              </SplitItem>
-              <SplitItem isFilled />
-              <SplitItem>
-                <Pagination
-                  onPerPageSelect={(_e, perPage, page, startIndex, endIndex) =>
-                    onPageChange({ endIndex, page, perPage, startIndex })
-                  }
-                  onSetPage={(_e, page, perPage, startIndex, endIndex) =>
-                    onPageChange({ endIndex, page, perPage, startIndex })
-                  }
-                  className="list-managment-group__pagination"
-                  isCompact={listPageBodySize !== ListPageBodySize.lg}
-                  isLastFullPageShown
-                  itemCount={filteredVMs?.length}
-                  page={pagination?.page}
-                  perPage={pagination?.perPage}
-                  perPageOptions={paginationDefaultValues}
-                />
-              </SplitItem>
-            </Split>
-            {vmsLoaded && hasNoVMs ? (
-              <Bullseye>{t('No VirtualMachines found')}</Bullseye>
-            ) : (
-              <VirtualMachineTable
-                callbacks={callbacks}
-                columns={activeTableColumns}
-                data={paginatedData}
-                loaded={loaded}
-                loadError={vmsLoadError}
-                selectedVMState={[vmSignal.value, setVM]}
-              />
-            )}
-          </>
-        </div>
-      </ListPageBody>
-    </>
+    <div className="pf-v6-u-mt-sm" ref={listPageBodyRef}>
+      {targetNamespace && (
+        <Label className="pf-v6-u-mb-sm" data-test="clone-source-project-label">
+          {t('Project: {{project}}', { project: targetNamespace })}
+        </Label>
+      )}
+      <Split className="pf-v6-u-mb-sm" hasGutter>
+        <SplitItem>
+          <ListPageFilter
+            onFilterChange={(...args) => {
+              onFilterChange(...args);
+              setPagination((prevPagination) => ({
+                ...prevPagination,
+                endIndex: prevPagination?.perPage,
+                page: 1,
+                startIndex: 0,
+              }));
+            }}
+            columnLayout={columnLayout}
+            data={unfilteredData}
+            loaded
+            rowFilters={rowFilters}
+          />
+        </SplitItem>
+        <SplitItem isFilled />
+        <SplitItem>
+          <Pagination
+            onPerPageSelect={(_e, perPage, page, startIndex, endIndex) =>
+              onPageChange({ endIndex, page, perPage, startIndex })
+            }
+            onSetPage={(_e, page, perPage, startIndex, endIndex) =>
+              onPageChange({ endIndex, page, perPage, startIndex })
+            }
+            className="list-managment-group__pagination"
+            isCompact={listPageBodySize !== ListPageBodySize.lg}
+            isLastFullPageShown
+            itemCount={filteredVMs?.length}
+            page={pagination?.page}
+            perPage={pagination?.perPage}
+            perPageOptions={paginationDefaultValues}
+          />
+        </SplitItem>
+      </Split>
+      <VirtualMachineTable
+        callbacks={callbacks}
+        columns={activeTableColumns}
+        data={paginatedData}
+        loaded={loaded}
+        loadError={vmsLoadError}
+        selectedVMState={[vmSignal.value, setVM]}
+      />
+    </div>
   );
 });
 

--- a/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/components/VirtualMachineRow.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/components/VirtualMachineRow.tsx
@@ -4,6 +4,7 @@ import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
+import { Radio } from '@patternfly/react-core';
 import { Td, Tr } from '@patternfly/react-table';
 import { VMCallbacks } from '@virtualmachines/list/virtualMachinesDefinition';
 
@@ -38,9 +39,18 @@ const VirtualMachineRow: FC<VirtualMachineRowProps> = ({
   const handleOnClick = () => {
     setSelectedVM(vm);
   };
+  const rowId = `${vmCluster}-${vmNamespace}-${vmName}`;
 
   return (
-    <Tr isClickable isRowSelected={isRowSelected} isSelectable onClick={handleOnClick}>
+    <Tr isRowSelected={isRowSelected} onClick={handleOnClick}>
+      <Td className="pf-v6-u-pl-sm">
+        <Radio
+          id={`select-vm-${rowId}`}
+          isChecked={isRowSelected}
+          name="clone-source-vm"
+          onChange={handleOnClick}
+        />
+      </Td>
       {columns.map((col) => (
         <Td key={col.key} {...col.props}>
           {col.renderCell(vm, callbacks)}

--- a/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/components/VirtualMachineTable.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/components/VirtualMachineTable.tsx
@@ -1,12 +1,12 @@
 import React, { FC } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import ListSkeleton from '@kubevirt-utils/components/StateHandler/ListSkeleton';
 import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { Table, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 import useVMWizardStore from '@virtualmachines/creation-wizard/state/vm-wizard-store/useVMWizardStore';
-import LoadingSkeleton from '@virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/TwoColumnCard/LoadingSkeleton';
 import { VMCallbacks } from '@virtualmachines/list/virtualMachinesDefinition';
 
 import VirtualMachineRow from './VirtualMachineRow';
@@ -40,7 +40,7 @@ const VirtualMachineTable: FC<VirtualMachineTableProps> = ({
   }
 
   if (!loaded) {
-    return <LoadingSkeleton />;
+    return <ListSkeleton />;
   }
 
   if (!data || data.length === 0) {
@@ -50,9 +50,10 @@ const VirtualMachineTable: FC<VirtualMachineTableProps> = ({
   }
 
   return (
-    <Table className="VirtualMachineList-table" variant={TableVariant.compact}>
+    <Table variant={TableVariant.compact}>
       <Thead>
         <Tr>
+          <Th aria-label={t('Select')} />
           {columns.map((col) => (
             <Th id={col?.key} key={col?.key}>
               {col?.label}

--- a/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/VMCreationLocationForm.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/DeploymentDetailsStep/components/VMCreationLocationForm.tsx
@@ -37,6 +37,7 @@ const VMCreationLocationForm: FC = () => {
             setFolder('');
           }}
           cluster={cluster}
+          includeAllProjects={false}
           selectedProject={project || DEFAULT_NAMESPACE}
         />
       </FormGroup>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/CNV-90048

Cherry-pick of #3948 to release-4.22.

Clone VM creation wizard fixes:
- Source VMs table uses radio buttons instead of checkboxes (per design doc)
- Search by name no longer remounts on every keystroke
- "All projects" is no longer selectable as project location
- Project label added to clone source step

Made with [Cursor](https://cursor.com)