### PR TITLE
CNV-89739 fix network order in VM network dialog when adding/selecting NAD of the NIC 

### DIFF
--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/editNetworkSelectUtils.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/editNetworkSelectUtils.tsx
@@ -186,6 +186,8 @@ export const buildNetworkSelectOptions = ({
     };
   });
 
+  options.sort((a, b) => a.label.localeCompare(b.label, undefined, { numeric: true }));
+
   if (showPodNetworkingOption) {
     options.unshift({
       label: podNetworkingText,


### PR DESCRIPTION
## 📝 Description


This fix ensures networks are listed in alphabetical order in the selection dropdown.


## 🔗 Links

https://redhat.atlassian.net/browse/CNV-89739

## 🎥 Demo

Before: 

<img width="576" height="620" alt="image" src="https://github.com/user-attachments/assets/6e71c287-eb8a-42f4-a7e2-8364bab32095" />


After: 

<img width="559" height="620" alt="image" src="https://github.com/user-attachments/assets/71c3b6b9-4742-4c33-a1e1-a7c3d1473152" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network interface options are now sorted alphabetically for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->