### PR TITLE
CNV-90113: fix useVMTemplateFeatureFlag to allow non-priv to create vm from template

### DIFF
--- a/src/utils/hooks/useVMTemplateFeatureFlag/useIsVMTemplateFeatureEnabled.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/useIsVMTemplateFeatureEnabled.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+
+import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+
+import { TEMPLATE_FEATURE_GATE } from './constants';
+
+type UseIsVMTemplateFeatureEnabled = (clusterOverride?: string) => {
+  featureEnabled: boolean;
+  loading: boolean;
+};
+
+const useIsVMTemplateFeatureEnabled: UseIsVMTemplateFeatureEnabled = (clusterOverride) => {
+  const clusterParam = useClusterParam();
+  const cluster = clusterOverride || clusterParam;
+
+  const { featureGates, hcLoaded } = useKubevirtHyperconvergeConfiguration(cluster);
+
+  const featureEnabled = useMemo(
+    () => featureGates?.includes(TEMPLATE_FEATURE_GATE) ?? false,
+    [featureGates],
+  );
+
+  return { featureEnabled, loading: !hcLoaded };
+};
+
+export default useIsVMTemplateFeatureEnabled;

--- a/src/utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag.ts
@@ -1,39 +1,33 @@
-import { useMemo } from 'react';
-
 import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { K8S_OPS } from '@kubevirt-utils/constants/constants';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
-import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
 import { getAnnotations } from '@kubevirt-utils/resources/shared';
 import { escapeJsonPointerToken, isEmpty } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
 import { Patch } from '@openshift-console/dynamic-plugin-sdk';
 
-import {
-  ADD_TEMPLATE_FEATURE_GATE_PATCH,
-  KUBEVIRT_JSONPATCH_ANNOTATION,
-  TEMPLATE_FEATURE_GATE,
-} from './constants';
+import { ADD_TEMPLATE_FEATURE_GATE_PATCH, KUBEVIRT_JSONPATCH_ANNOTATION } from './constants';
+import useIsVMTemplateFeatureEnabled from './useIsVMTemplateFeatureEnabled';
 import { isTemplatePatch, parseJsonPatchAnnotation } from './utils';
 
 const useVMTemplateFeatureFlag = (clusterOverride?: string) => {
   const clusterParam = useClusterParam();
   const cluster = clusterOverride || clusterParam;
-  const { featureGates, hcLoaded } = useKubevirtHyperconvergeConfiguration(cluster);
-  const [hyperConvergeConfiguration, hcConfigLoaded] = useHyperConvergeConfiguration(cluster);
-  const isAdmin = useIsAdmin();
 
-  const featureEnabled = useMemo(
-    () => featureGates?.includes(TEMPLATE_FEATURE_GATE) ?? false,
-    [featureGates],
-  );
+  const { featureEnabled, loading: featureEnabledLoading } = useIsVMTemplateFeatureEnabled(cluster);
+
+  const [hyperConvergeConfiguration, hcConfigLoaded, hcConfigError] =
+    useHyperConvergeConfiguration(cluster);
+
+  const isAdmin = useIsAdmin();
 
   return {
     canEdit: isAdmin,
+    error: hcConfigError,
     featureEnabled,
-    loading: !hcLoaded || !hcConfigLoaded,
+    loading: featureEnabledLoading || !hcConfigLoaded,
     toggleFeature: (isChecked: boolean) => {
       if (!hyperConvergeConfiguration) {
         return Promise.reject(new Error('HyperConverged configuration is not loaded'));

--- a/src/views/templates/list/filters/useTypeFilter.tsx
+++ b/src/views/templates/list/filters/useTypeFilter.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 
 import { ExtendedRowFilterItem } from '@kubevirt-utils/components/ListPageFilter/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useVMTemplateFeatureFlag from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag';
+import useIsVMTemplateFeatureEnabled from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useIsVMTemplateFeatureEnabled';
 import { isOpenShiftTemplate, TemplateOrRequest } from '@kubevirt-utils/resources/template';
 import {
   TemplateModelGroupVersionKind,
@@ -27,7 +27,7 @@ const getTemplateType = (obj: TemplateOrRequest): string => {
 
 const useTypeFilter = (): null | RowFilter<TemplateOrRequest> => {
   const { t } = useKubevirtTranslation();
-  const { featureEnabled: vmTemplatesEnabled } = useVMTemplateFeatureFlag();
+  const { featureEnabled: vmTemplatesEnabled } = useIsVMTemplateFeatureEnabled();
 
   return useMemo(() => {
     if (!vmTemplatesEnabled) return null;

--- a/src/views/templates/list/hooks/useAllTemplateResources.ts
+++ b/src/views/templates/list/hooks/useAllTemplateResources.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import useVMTemplateFeatureFlag from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag';
+import useIsVMTemplateFeatureEnabled from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useIsVMTemplateFeatureEnabled';
 import {
   sortTemplates,
   Template,
@@ -32,7 +32,7 @@ const useAllTemplateResources: UseAllTemplateResources = ({
   selector,
 }) => {
   const { featureEnabled: vmTemplatesEnabled, loading: vmTemplatesFeatureLoading } =
-    useVMTemplateFeatureFlag();
+    useIsVMTemplateFeatureEnabled();
 
   const {
     error: templatesError,

--- a/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
+++ b/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
@@ -10,7 +10,7 @@ import { getConsoleVirtctlCommand } from '@kubevirt-utils/components/SSHAccess/u
 import { CONFIRM_VM_ACTIONS, TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useVMTemplateFeatureFlag from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag';
+import useIsVMTemplateFeatureEnabled from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useIsVMTemplateFeatureEnabled';
 import { VirtualMachineModelRef } from '@kubevirt-utils/models';
 import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
 import { CROSS_CLUSTER_MIGRATION_ACTION_ID } from '@multicluster/constants';
@@ -53,7 +53,7 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, 
 
   const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
   const { featureEnabled: vmTemplatesEnabled, loading: vmTemplatesLoading } =
-    useVMTemplateFeatureFlag(effectiveCluster);
+    useIsVMTemplateFeatureEnabled(effectiveCluster);
 
   const VirtualMachineActionFactory = useMemo(() => createVirtualMachineActionFactory(t), [t]);
 

--- a/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useTemplates.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useTemplates.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import useVMTemplateFeatureFlag from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag';
+import useIsVMTemplateFeatureEnabled from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useIsVMTemplateFeatureEnabled';
 import { Template } from '@kubevirt-utils/resources/template';
 import { useOpenShiftTemplates } from '@templates/list/hooks/useOpenShiftTemplates';
 import useVirtualMachineTemplates from '@templates/list/hooks/useVirtualMachineTemplates';
@@ -13,7 +13,7 @@ type UseTemplates = (namespace?: string) => {
 
 const useTemplates: UseTemplates = (namespace) => {
   const { featureEnabled: vmTemplatesEnabled, loading: vmTemplatesFeatureLoading } =
-    useVMTemplateFeatureFlag();
+    useIsVMTemplateFeatureEnabled();
 
   const {
     error: templatesError,


### PR DESCRIPTION


## 📝 Description

`useK8sWatchResource` never sets loaded: true on error, so `useVMTemplateFeatureFlag` blocks the template catalog indefinitely. Handles failed watches (403) by treating errors as a terminal loaded state.

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-90113

## 🎥 Demo

Before:
<img width="2936" height="1126" alt="image" src="https://github.com/user-attachments/assets/2a5f3efe-9730-431b-a409-28eb56dcf7d1" />

After:
<img width="3110" height="1025" alt="Screenshot at Jun 15 17-48-52" src="https://github.com/user-attachments/assets/88f81509-7089-4922-9816-498be5c9fef5" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the “VM templates” enablement check, including more accurate loading behavior and better surfaced error handling when template configuration can’t be retrieved.
* **Refactor**
  * Updated template-related feature gating to use a dedicated enablement hook across filters, template resource loading, and virtual machine actions/wizard flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->