### PR TITLE
CNV-89656: fix advanced search for non-priv users to search by label

### DIFF
--- a/src/views/search/components/AdvancedSearchModal/AdvancedSearchModal.tsx
+++ b/src/views/search/components/AdvancedSearchModal/AdvancedSearchModal.tsx
@@ -4,7 +4,6 @@ import { VirtualMachineModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/c
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { ModalComponentProps } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import {
   Button,
@@ -16,7 +15,7 @@ import {
   ModalFooter,
   ModalHeader,
 } from '@patternfly/react-core';
-import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils/constants';
+import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
 
 import { AdvancedSearchInputs, AdvancedSearchQueryInputs } from '../../utils/types';
 
@@ -55,12 +54,9 @@ const AdvancedSearchModal: FC<AdvancedSearchModalProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
 
-  const [vms] = useKubevirtWatchResource<V1VirtualMachine[]>({
-    groupVersionKind: VirtualMachineModelGroupVersionKind,
-    isList: true,
-    limit: OBJECTS_FETCHING_LIMIT,
-    namespaced: true,
-  });
+  const { resources: vms } = useAccessibleResources<V1VirtualMachine>(
+    VirtualMachineModelGroupVersionKind,
+  );
 
   const isACMPage = useIsACMPage();
 

--- a/src/views/search/components/AdvancedSearchModal/store/useAdvancedSearchStore.ts
+++ b/src/views/search/components/AdvancedSearchModal/store/useAdvancedSearchStore.ts
@@ -1,4 +1,5 @@
 import produce from 'immer';
+import isEqual from 'lodash/isEqual';
 import { create } from 'zustand';
 
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
@@ -66,6 +67,18 @@ const getInitialState = (prefillInputs: AdvancedSearchInputs = {}): AdvancedSear
   return baseState;
 };
 
+const isStateEmpty = (state: AdvancedSearchState): boolean => {
+  const initialState = getInitialState();
+  const { dateOption, isValidDate, labelInputText, ...currentQueryInputs } = state;
+  const {
+    dateOption: dateOptionInit,
+    isValidDate: isValidDateInit,
+    labelInputText: labelInputTextInit,
+    ...initialQueryInputs
+  } = initialState;
+  return isEqual(currentQueryInputs, initialQueryInputs);
+};
+
 const useAdvancedSearchStore = create<AdvancedSearchStore>()((set, get) => ({
   actions: {
     getSearchQueryInputs: () => {
@@ -110,4 +123,4 @@ export const useAdvancedSearchField = <K extends keyof AdvancedSearchState>(fiel
   });
 
 export const useIsSearchDisabled = () =>
-  useAdvancedSearchStore((store) => !store.state.isValidDate);
+  useAdvancedSearchStore((store) => !store.state.isValidDate || isStateEmpty(store.state));


### PR DESCRIPTION


## 📝 Description

non-priv users weren't able to apply advanced search and receive suggested labels. Manually backported fix that switches `AdvancedSearchModal` from`useKubevirtWatchResource` to `useAccessibleResources`. also backported the `isStateEmpty` guard that disables the Search button until the user selects a filter value.

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-89656
fix in 4.21: https://github.com/kubevirt-ui/kubevirt-plugin/pull/3322

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/8e6e3d6d-2d8b-4af7-9ccb-5f31b58776bb


After:

https://github.com/user-attachments/assets/a79cc5fc-61fc-4f6f-824e-5239f83d91cb


