### PR TITLE
CNV-89814: Warn user when navigating away while uploads are in progress

### DIFF
--- a/src/utils/hooks/useUploadProgressToast/UploadNavigationGuard/useUploadBeforeUnload.test.ts
+++ b/src/utils/hooks/useUploadProgressToast/UploadNavigationGuard/useUploadBeforeUnload.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useUploadProgressStore } from '../uploadProgressStore';
+import { UPLOAD_PROGRESS_STATUS } from '../utils/constants';
+
+import useUploadBeforeUnload from './useUploadBeforeUnload';
+
+const UPLOAD_KEY = 'test-upload-key';
+const FILE_IMAGE_ISO = 'image.iso';
+
+const resetStore = (): void => {
+  useUploadProgressStore.setState({ uploads: {} });
+};
+
+describe('useUploadBeforeUnload', () => {
+  let addEventListenerSpy: jest.SpyInstance;
+  let removeEventListenerSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetStore();
+    addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    act(() => {
+      resetStore();
+    });
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it('should not register beforeunload listener when no uploads are active', () => {
+    renderHook(() => useUploadBeforeUnload());
+
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+
+  it('should register beforeunload listener when an upload is in progress', () => {
+    const { rerender } = renderHook(() => useUploadBeforeUnload());
+
+    act(() => {
+      useUploadProgressStore.getState().startUpload(UPLOAD_KEY, { fileName: FILE_IMAGE_ISO });
+    });
+    rerender();
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+
+  it('should remove beforeunload listener when upload completes', () => {
+    const { rerender } = renderHook(() => useUploadBeforeUnload());
+
+    act(() => {
+      useUploadProgressStore.getState().startUpload(UPLOAD_KEY, { fileName: FILE_IMAGE_ISO });
+    });
+    rerender();
+
+    const handler = addEventListenerSpy.mock.calls.find(
+      ([eventName]) => eventName === 'beforeunload',
+    )?.[1] as EventListener;
+
+    act(() => {
+      useUploadProgressStore.getState().completeUpload(UPLOAD_KEY);
+    });
+    rerender();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('beforeunload', handler);
+  });
+
+  it('should call preventDefault on beforeunload when uploads are active', () => {
+    const { rerender } = renderHook(() => useUploadBeforeUnload());
+
+    act(() => {
+      useUploadProgressStore.getState().startUpload(UPLOAD_KEY, { fileName: FILE_IMAGE_ISO });
+    });
+    rerender();
+
+    const handler = addEventListenerSpy.mock.calls.find(
+      ([eventName]) => eventName === 'beforeunload',
+    )?.[1] as (event: BeforeUnloadEvent) => void;
+
+    const event = {
+      preventDefault: jest.fn(),
+      returnValue: 'initial',
+    } as unknown as BeforeUnloadEvent;
+
+    handler(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.returnValue).toBe('');
+  });
+
+  it('should not register listener for terminal upload statuses', () => {
+    act(() => {
+      useUploadProgressStore.getState().startUpload(UPLOAD_KEY, { fileName: FILE_IMAGE_ISO });
+      useUploadProgressStore.setState({
+        uploads: {
+          [UPLOAD_KEY]: {
+            fileName: FILE_IMAGE_ISO,
+            progress: 100,
+            status: UPLOAD_PROGRESS_STATUS.SUCCESS,
+          },
+        },
+      });
+    });
+
+    renderHook(() => useUploadBeforeUnload());
+
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith('beforeunload', expect.any(Function));
+  });
+});

--- a/src/utils/hooks/useUploadProgressToast/UploadNavigationGuard/useUploadBeforeUnload.ts
+++ b/src/utils/hooks/useUploadProgressToast/UploadNavigationGuard/useUploadBeforeUnload.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+import { useUploadProgressStore } from '../uploadProgressStore';
+import { UPLOAD_PROGRESS_STATUS } from '../utils/constants';
+
+const useUploadBeforeUnload = (): void => {
+  const hasActiveUploads = useUploadProgressStore((state) =>
+    Object.values(state.uploads).some((entry) => entry.status === UPLOAD_PROGRESS_STATUS.UPLOADING),
+  );
+
+  useEffect(() => {
+    if (!hasActiveUploads) {
+      return;
+    }
+
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [hasActiveUploads]);
+};
+
+export default useUploadBeforeUnload;

--- a/src/utils/hooks/useUploadProgressToast/UploadProgressToastProvider.tsx
+++ b/src/utils/hooks/useUploadProgressToast/UploadProgressToastProvider.tsx
@@ -1,16 +1,21 @@
 import React, { FC, ReactNode } from 'react';
 
+import useUploadBeforeUnload from './UploadNavigationGuard/useUploadBeforeUnload';
 import UploadProgressToastListener from './UploadProgressToastListener';
 
 type UploadProgressToastProviderProps = {
   children?: ReactNode;
 };
 
-const UploadProgressToastProvider: FC<UploadProgressToastProviderProps> = ({ children }) => (
-  <>
-    <UploadProgressToastListener />
-    {children}
-  </>
-);
+const UploadProgressToastProvider: FC<UploadProgressToastProviderProps> = ({ children }) => {
+  useUploadBeforeUnload();
+
+  return (
+    <>
+      <UploadProgressToastListener />
+      {children}
+    </>
+  );
+};
 
 export default UploadProgressToastProvider;


### PR DESCRIPTION
## 📝 Description

When one or more file uploads are running (CD-ROM ISO, disk, or bootable volume), the user should be warned before navigating away from the current page.

This prevents accidental loss of in-progress uploads that would leave orphaned DataVolumes in the cluster.


## 🔗 Links

Jira ticket: [CNV-89814](https://redhat.atlassian.net/browse/CNV-89814)


## 🎥 Demo


https://github.com/user-attachments/assets/4ecdc6d6-a47d-4e76-a3ed-1d3596654cd2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added page navigation protection to prevent accidental leaving when file uploads are in progress, reducing the risk of losing unfinished uploads.

## Tests
* Added coverage for upload navigation protection, verifying that the `beforeunload` listener is correctly registered/removed based on upload state and that the handler blocks navigation during active uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->