### PR TITLE
CNV-90147: ACM - VM folder and confirm actions features follow hub cluster setting instead of spoke cluster

### DIFF
--- a/src/utils/hooks/useFeatures/constants.ts
+++ b/src/utils/hooks/useFeatures/constants.ts
@@ -33,8 +33,6 @@ const FEATURES_ROLE_BINDING_NAME = 'kubevirt-ui-features-reader-binding';
 export const FEATURE_PERSISTENT_RESERVATION = 'persistentReservation';
 export const FEATURE_HCO_PERSISTENT_RESERVATION = 'persistentReservationHCO';
 
-export const UI_FEATURES = [CONFIRM_VM_ACTIONS, TREE_VIEW_FOLDERS];
-
 export const FEATURES_CONFIG_MAP_INITIAL_DATA: Record<string, string> = {
   [AUTOMATIC_SUBSCRIPTION_ACTIVATION_KEY]: '',
   [AUTOMATIC_SUBSCRIPTION_ORGANIZATION_ID]: '',

--- a/src/utils/hooks/useFeatures/useFeatures.ts
+++ b/src/utils/hooks/useFeatures/useFeatures.ts
@@ -5,11 +5,7 @@ import { operatorNamespaceSignal } from '@kubevirt-utils/store/operatorNamespace
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
 
-import {
-  FEATURES_CONFIG_MAP_INITIAL_DATA,
-  FEATURES_CONFIG_MAP_NAME,
-  UI_FEATURES,
-} from './constants';
+import { FEATURES_CONFIG_MAP_INITIAL_DATA, FEATURES_CONFIG_MAP_NAME } from './constants';
 import { applyMissingFeatures, createFeaturesConfigMap } from './createFeaturesConfigMap';
 import { UseFeaturesValues } from './types';
 import useFeaturesConfigMap from './useFeaturesConfigMap';
@@ -20,9 +16,8 @@ export const useFeatures: UseFeatures = (featureName, clusterOverride) => {
   const [createError, setCreateError] = useState(null);
   const [createInProgress, setCreateInProgress] = useState(false);
 
-  const isUIFeature = UI_FEATURES.includes(featureName);
   const clusterParam = useClusterParam();
-  const configMapCluster = clusterOverride ?? (isUIFeature ? null : clusterParam);
+  const configMapCluster = clusterOverride ?? clusterParam;
   const cluster = configMapCluster ?? undefined;
   const operatorNamespace = operatorNamespaceSignal.value;
 


### PR DESCRIPTION
## 📝 Description

In ACM (multi-cluster) mode, preview feature settings for spoke clusters are incorrectly read from the hub cluster instead of the spoke cluster being viewed.

## 🔗 Links

Jira ticket: [CNV-90147](https://redhat.atlassian.net/browse/CNV-90147)

## 🎥 Demo

**Folder feature before:**

https://github.com/user-attachments/assets/4a692108-ce44-415b-9cf9-d4264d0d09b9


**Folders feature after:**

https://github.com/user-attachments/assets/2c0e8872-e180-4779-8c97-80a592be4ac5

**VM-actions before:** 

https://github.com/user-attachments/assets/ab606c9c-0a46-4a57-8aae-e74e2c2099d9


**VM-actions after:** 


https://github.com/user-attachments/assets/16603f93-c17b-48d5-8fbb-0f5a3f3b7c41



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature configuration loading so feature toggles now consistently use the selected cluster (with any explicit override still applied).
* **Refactor**
  * Removed a dedicated “UI features” constant and simplified the related configuration selection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->