### PR TITLE
CNV-90224: After deleting a VM from a details tab, the UI stays on the deleted VM and shows 404 Not Found

### DIFF
--- a/src/multicluster/urls.ts
+++ b/src/multicluster/urls.ts
@@ -231,8 +231,8 @@ export const getFleetMigrationPoliciesListURL = (cluster?: string): string => {
 };
 
 export const isVMDetailsPage = (pathname: string): boolean =>
-  !!matchPath(`${FLEET_VIRTUAL_MACHINES_PATH}/cluster/:cluster/ns/:ns/:name`, pathname) ||
-  !!matchPath(`/k8s/ns/:ns/${VirtualMachineModelRef}/:name`, pathname);
+  !!matchPath(`${FLEET_VIRTUAL_MACHINES_PATH}/cluster/:cluster/ns/:ns/:name/*`, pathname) ||
+  !!matchPath(`/k8s/ns/:ns/${VirtualMachineModelRef}/:name/*`, pathname);
 
 /**
  * Extract the cluster param from a fleet-virtualization URL.


### PR DESCRIPTION
## 📝 Description

After deleting a VM from a details tab, the UI stays on the deleted VM and shows 404 Not Found.

## 🔗 Links

Jira ticket: [CNV-90224](https://redhat.atlassian.net/browse/CNV-90224)


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/081dda12-b236-4e5b-94cb-3145e0b04660


After:

https://github.com/user-attachments/assets/d0e323f7-4a01-45d7-9a84-c79e3459b5cb



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing logic for VM details pages to properly recognize multiple URL patterns and variations, including additional sub-routes. This enhancement ensures consistent behavior and correct page identification when navigating through different sections within the VM details interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->