### PR TITLE
CNV-89737: [release-4.12] DOMPurify: Cross-Site Scripting (XSS) via inconsistent tag sanitization 

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,8 @@
     "@types/react": "17.0.40",
     "dompurify": "^2.5.8",
     "@openshift-console/dynamic-plugin-sdk-internal/immutable": "^3.8.3",
-    "@openshift-console/dynamic-plugin-sdk/immutable": "^3.8.3"
+    "@openshift-console/dynamic-plugin-sdk/immutable": "^3.8.3",
+    "@openshift-console/dynamic-plugin-sdk/@patternfly/quickstarts/dompurify": "3.4.0",
+    "@openshift-console/dynamic-plugin-sdk-internal/@patternfly/quickstarts/dompurify": "3.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,6 +1499,11 @@
   dependencies:
     "@types/jest" "*"
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/ws@^8.5.1":
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
@@ -3267,6 +3272,13 @@ domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
     domelementtype "^2.3.0"
+
+dompurify@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.0.tgz#b1fc33ebdadb373241621e0a30e4ad81573dfd0b"
+  integrity sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 dompurify@^2.2.6, dompurify@^2.5.8:
   version "2.5.8"


### PR DESCRIPTION
Fix raised to bump vulnerable dompurify package to patched version 