### PR TITLE
CNV-90088: show permission tooltip on disabled action menu items

### DIFF
--- a/src/utils/components/LazyActionMenu/ActionMenuItem.tsx
+++ b/src/utils/components/LazyActionMenu/ActionMenuItem.tsx
@@ -54,7 +54,17 @@ const ActionItem: FC<ActionMenuItemProps & { isAllowed: boolean }> = ({
     ...(external ? { isExternalLink: external, to: href } : {}),
   };
 
-  return <MenuItem {...props}>{label}</MenuItem>;
+  const menuItem = <MenuItem {...props}>{label}</MenuItem>;
+
+  if (isDisabled && action.disabledTooltip && !action.tooltip) {
+    return (
+      <Tooltip content={action.disabledTooltip} position="left">
+        <div>{menuItem}</div>
+      </Tooltip>
+    );
+  }
+
+  return menuItem;
 };
 
 const AccessReviewActionItem = connect(impersonateStateToProps)(
@@ -81,13 +91,7 @@ const ActionMenuItem: FC<ActionMenuItemProps & { checkAccess: CheckAccess }> = (
     );
   }
 
-  return action.disabled && action.disabledTooltip ? (
-    <Tooltip content={action.disabledTooltip} position="left">
-      <div>{item}</div>
-    </Tooltip>
-  ) : (
-    item
-  );
+  return item;
 };
 
 export default ActionMenuItem;


### PR DESCRIPTION
## Summary
- The kebab menu items were greyed out for unprivileged users but showed no tooltip because the tooltip logic lived in a component that didn't know about the permission check result.
- Moved the tooltip into the component that knows the full disabled state, so "You don't have permission to perform this action" now appears on hover.

## Test plan
- [ ] Log in as an unprivileged user (without `create` permission on `virtualmachineinstancemigrations`)
- [ ] Navigate to a running VM's kebab menu → Migration → Compute
- [ ] Verify the item is greyed out and hovering shows "You don't have permission to perform this action"
- [ ] Repeat for Migration → Storage
- [ ] Verify that tooltips still show for other disabled reasons (VM not running, VM not live migratable)
- [ ] Verify that enabled actions still work normally


New
<img width="2304" height="1069" alt="nopermission5" src="https://github.com/user-attachments/assets/3aa85a21-1130-4e13-9800-4d6347315458" />
<img width="2308" height="1074" alt="nopermissions4" src="https://github.com/user-attachments/assets/47737385-a7b3-4c1b-8b22-1402daf878a9" />
<img width="2306" height="1075" alt="nopremissiosn3" src="https://github.com/user-attachments/assets/16bfb8ff-8628-423a-b16a-a8639a10e137" />
<img width="2309" height="1072" alt="Nopermissions-2" src="https://github.com/user-attachments/assets/d6afd5af-7a2d-416c-84a5-ef883960c6d2" />
<img width="2313" height="1065" alt="Permissions-No1" src="https://github.com/user-attachments/assets/1a12474e-c3bd-490e-bbde-02bd44ca9e90" />
<img width="2306" height="1075" alt="nopermission6" src="https://github.com/user-attachments/assets/8d5c08f6-e5e1-4111-8c06-69379180101e" />







Made with [Cursor](https://cursor.com)