### PR TITLE
CNV-85842: [relase-4.14]  DOMPurify: Cross-Site Scripting (XSS) via inconsistent tag sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,9 @@
   "name": "kubevirt-plugin",
   "private": true,
   "resolutions": {
+    "@openshift-console/dynamic-plugin-sdk-internal/@patternfly/quickstarts/dompurify": "3.4.0",
     "@openshift-console/dynamic-plugin-sdk-internal/immutable": "^3.8.3",
+    "@openshift-console/dynamic-plugin-sdk/@patternfly/quickstarts/dompurify": "3.4.0",
     "@openshift-console/dynamic-plugin-sdk/immutable": "^3.8.3",
     "@types/react": "17.0.40",
     "webpack": "^5.68.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,6 +1574,11 @@
   dependencies:
     "@types/jest" "*"
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/ws@^8.5.1":
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
@@ -3457,10 +3462,12 @@ domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^2.2.6:
-  version "2.5.8"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.8.tgz#2809d89d7e528dc7a071dea440d7376df676f824"
-  integrity sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==
+dompurify@3.4.0, dompurify@^2.2.6:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.0.tgz#b1fc33ebdadb373241621e0a30e4ad81573dfd0b"
+  integrity sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Fix raised to bump vulnerable dompurify package to patched version