### PR TITLE
CNV-89824:[release-4.14] Bump Axios to 1.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@patternfly/react-icons": "^4.82.8",
     "@patternfly/react-table": "^4.100.8",
     "@types/byte-size": "^8.1.0",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "byte-size": "^8.1.0",
     "classnames": "^2.3.1",
     "date-fns": "^2.28.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2109,10 +2109,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
-  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
+axios@1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.2.tgz#eb8fb6d30349abace6ade5b4cb4d9e8a0dc23e5b"
+  integrity sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==
   dependencies:
     follow-redirects "^1.15.11"
     form-data "^4.0.5"


### PR DESCRIPTION
This PR is a fix for [CVE-2026-44495](https://access.redhat.com/security/cve/cve-2026-44495)