### PR TITLE
CNV-89281: Fix wrong display of storage utilization

### DIFF
--- a/src/multicluster/hooks/useGuestAgentURL.ts
+++ b/src/multicluster/hooks/useGuestAgentURL.ts
@@ -1,20 +1,8 @@
-import VirtualMachineInstanceModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstanceModel';
 import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { getCluster } from '@multicluster/helpers/selectors';
 
-import useK8sBaseAPIPath from './useK8sBaseAPIPath';
+import useVMISubresourceURL from './useVMISubresourceURL';
 
-const useGuestAgentURL = (vmi: V1VirtualMachineInstance): [string, boolean] => {
-  const [k8sAPIPath, k8sAPIPathLoaded] = useK8sBaseAPIPath(getCluster(vmi));
-
-  const url = `${k8sAPIPath}/apis/subresources.${VirtualMachineInstanceModel.apiGroup}/${
-    VirtualMachineInstanceModel.apiVersion
-  }/namespaces/${getNamespace(vmi)}/${VirtualMachineInstanceModel.plural}/${getName(
-    vmi,
-  )}/guestosinfo`;
-
-  return [url, k8sAPIPathLoaded];
-};
+const useGuestAgentURL = (vmi: V1VirtualMachineInstance): [string, boolean] =>
+  useVMISubresourceURL(vmi, 'guestosinfo');
 
 export default useGuestAgentURL;

--- a/src/multicluster/hooks/useVMISubresourceURL.ts
+++ b/src/multicluster/hooks/useVMISubresourceURL.ts
@@ -1,0 +1,23 @@
+import VirtualMachineInstanceModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineInstanceModel';
+import { V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getCluster } from '@multicluster/helpers/selectors';
+
+import useK8sBaseAPIPath from './useK8sBaseAPIPath';
+
+const useVMISubresourceURL = (
+  vmi: V1VirtualMachineInstance,
+  subresource: string,
+): [string, boolean] => {
+  const [k8sAPIPath, k8sAPIPathLoaded] = useK8sBaseAPIPath(getCluster(vmi));
+
+  const url = `${k8sAPIPath}/apis/subresources.${VirtualMachineInstanceModel.apiGroup}/${
+    VirtualMachineInstanceModel.apiVersion
+  }/namespaces/${getNamespace(vmi)}/${VirtualMachineInstanceModel.plural}/${getName(
+    vmi,
+  )}/${subresource}`;
+
+  return [url, k8sAPIPathLoaded];
+};
+
+export default useVMISubresourceURL;

--- a/src/utils/resources/vmi/hooks/index.ts
+++ b/src/utils/resources/vmi/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useGuestOS';
+export * from './useVMIFilesystems';

--- a/src/utils/resources/vmi/hooks/useVMIFilesystems.ts
+++ b/src/utils/resources/vmi/hooks/useVMIFilesystems.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+import {
+  V1VirtualMachineInstance,
+  V1VirtualMachineInstanceFileSystem,
+} from '@kubevirt-ui/kubevirt-api/kubevirt';
+import useVMISubresourceURL from '@multicluster/hooks/useVMISubresourceURL';
+import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
+
+type UseVMIFilesystems = (
+  vmi?: V1VirtualMachineInstance,
+) => [V1VirtualMachineInstanceFileSystem[], boolean, Error];
+
+export const useVMIFilesystems: UseVMIFilesystems = (vmi) => {
+  const [loaded, setLoaded] = useState(false);
+  const [filesystems, setFilesystems] = useState<V1VirtualMachineInstanceFileSystem[]>([]);
+  const [error, setError] = useState<Error>(null);
+  const [url, urlLoaded] = useVMISubresourceURL(vmi, 'filesystemlist');
+
+  useEffect(() => {
+    if (!urlLoaded) return;
+
+    const guestOS = vmi?.status?.guestOSInfo?.id;
+
+    setError(null);
+    if (guestOS) {
+      (async () => {
+        const response = await consoleFetch(url);
+        const jsonData = await response.json();
+        setFilesystems(jsonData?.items ?? []);
+        setLoaded(true);
+      })().catch((err) => {
+        setError(err);
+        setLoaded(true);
+      });
+    }
+    (!vmi || (!guestOS && vmi?.metadata)) && setLoaded(true);
+  }, [url, loaded, vmi, urlLoaded]);
+
+  return [filesystems, loaded, error];
+};

--- a/src/utils/utils/utils.ts
+++ b/src/utils/utils/utils.ts
@@ -159,8 +159,8 @@ export const columnSortingCompare = <T>(
   return data?.sort(predicate)?.slice(startIndex, endIndex);
 };
 
-export const removeDuplicatesByName = (array: any[], nameProperty = 'name') =>
-  array?.reduce((acc, curr) => {
+export const removeDuplicatesByName = <T>(array: T[], nameProperty = 'name'): T[] =>
+  array?.reduce<T[]>((acc, curr) => {
     if (!acc.find((item) => item?.[nameProperty] === curr?.[nameProperty])) acc.push(curr);
     return acc;
   }, []);

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/StorageUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/StorageUtil.tsx
@@ -6,9 +6,11 @@ import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/Su
 import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
 import ComponentReady from '@kubevirt-utils/components/Charts/ComponentReady/ComponentReady';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { useGuestOS } from '@kubevirt-utils/resources/vmi';
+import { useVMIFilesystems } from '@kubevirt-utils/resources/vmi';
 import { removeDuplicatesByName } from '@kubevirt-utils/utils/utils';
 import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+
+import { filterWritableFilesystems } from './utils';
 
 type StorageUtilProps = {
   vmi: V1VirtualMachineInstance;
@@ -17,10 +19,10 @@ type StorageUtilProps = {
 const StorageUtil: FC<StorageUtilProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
 
-  const [guestAgentData, loaded] = useGuestOS(vmi);
+  const [filesystems, loaded] = useVMIFilesystems(vmi);
 
   const { totalBytes = 0, usedBytes = 0 } =
-    removeDuplicatesByName(guestAgentData?.fsInfo?.disks, 'diskName')?.reduce(
+    filterWritableFilesystems(removeDuplicatesByName(filesystems, 'diskName'))?.reduce(
       (acc, data) => {
         acc.totalBytes += data?.totalBytes;
         acc.usedBytes += data?.usedBytes;

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/constants.ts
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/constants.ts
@@ -1,0 +1,3 @@
+// Read-only compressed filesystems (e.g. snap loop devices on Ubuntu)
+// that should not count toward writable storage utilization.
+export const EXCLUDED_FILESYSTEM_TYPES = ['squashfs'];

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/utils.ts
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/StorageUtil/utils.ts
@@ -1,0 +1,8 @@
+import { V1VirtualMachineInstanceFileSystem } from '@kubevirt-ui/kubevirt-api/kubevirt';
+
+import { EXCLUDED_FILESYSTEM_TYPES } from './constants';
+
+export const filterWritableFilesystems = (
+  filesystems: V1VirtualMachineInstanceFileSystem[],
+): V1VirtualMachineInstanceFileSystem[] =>
+  filesystems?.filter((fs) => !EXCLUDED_FILESYSTEM_TYPES.includes(fs?.fileSystemType));


### PR DESCRIPTION

## 📝 Description

Backport of #3808 to release-4.20. The `guestosinfo` subresource API caps filesystem entries at 10 items. On VMs with more than 10 filesystems, real partitions get silently dropped, causing the Storage utilization donut on the VM Overview tab to show incorrect values.

This switches to the `filesystemlist` subresource API which has no item cap, and filters out read-only `squashfs` filesystems that inflate the totals.

## Changes

- Use `filesystemlist` API instead of `guestosinfo` for storage utilization data
- Filter out read-only `squashfs` filesystems from the calculation
- Extract reusable `useVMISubresourceURL` hook
- Add generic typing to `removeDuplicatesByName`

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-89281
PR backported: https://github.com/kubevirt-ui/kubevirt-plugin/pull/3808

## 🎥 Demo

Before:
<img width="2105" height="1005" alt="Screenshot at Jun 17 14-17-49" src="https://github.com/user-attachments/assets/574c2df9-598d-414a-b278-8a1e960c27e3" />
<img width="1419" height="1173" alt="Screenshot at Jun 17 14-15-51" src="https://github.com/user-attachments/assets/304b18a8-e249-43a6-a500-27d710e3f95d" />

After:
<img width="601" height="806" alt="image" src="https://github.com/user-attachments/assets/fb1252e6-35d1-4f2a-8a0f-6825e98a0033" />
<img width="2139" height="1067" alt="image" src="https://github.com/user-attachments/assets/4cb6cb77-b9f1-4cd1-8e67-77ac0f949f96" />

