### PR TITLE
CNV-89616: Create VM Wizard refactor - Part 3

### DIFF
--- a/src/views/virtualmachines/creation-wizard-new/components/DescriptionInput.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/components/DescriptionInput.tsx
@@ -1,20 +1,23 @@
-import React, { FC, FormEvent } from 'react';
+import React, { FC } from 'react';
+import { Controller } from 'react-hook-form';
 
 import { Button, InputGroup, InputGroupItem, TextInput } from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+
+import { useVMWizard } from '../state/vm-wizard-context/VMWizardContext';
 
 const DescriptionInput: FC = () => {
-  const { setVMDescription, vmDescription } = useVMWizardStore();
+  const { control } = useVMWizard();
 
   return (
     <InputGroup>
       <InputGroupItem isFill>
-        <TextInput
-          id="vm-description"
-          onChange={(_event: FormEvent<HTMLInputElement>, value: string) => setVMDescription(value)}
-          type="text"
-          value={vmDescription}
+        <Controller
+          render={({ field: { ref: _, ...field } }) => (
+            <TextInput id="vm-description" type="text" {...field} />
+          )}
+          control={control}
+          name="vmData.description"
         />
       </InputGroupItem>
       <InputGroupItem style={{ visibility: 'hidden' }}>

--- a/src/views/virtualmachines/creation-wizard-new/components/NameInput.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/components/NameInput.tsx
@@ -1,4 +1,5 @@
-import React, { FC, FormEvent, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
+import { Controller, useWatch } from 'react-hook-form';
 
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -9,40 +10,46 @@ import {
 } from '@kubevirt-utils/utils/validation';
 import { InputGroup, InputGroupItem, TextInput } from '@patternfly/react-core';
 
-import useVMWizardStore from '../state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '../state/vm-wizard-context/VMWizardContext';
 
 import GenerateVMNameButton from './GenerateVMNameButton';
 
 const NameInput: FC = () => {
   const { t } = useKubevirtTranslation();
-  const { setShouldCheckVMNameProperly, setVMName, shouldCheckVMNameProperly, vmName } =
-    useVMWizardStore();
+  const { control, setValue } = useVMWizard();
+  const vmName = useWatch({ control, name: 'vmData.name' });
+  const shouldCheckVMNameProperly = useWatch({
+    control,
+    name: 'uiState.shouldCheckVMNameProperly',
+  });
   const getError = shouldCheckVMNameProperly ? getDNS1123LabelError : getDNS1123LabelErrorLenient;
   const { errorText, validated } = useNameValidation({ getError, name: vmName });
 
   const applyName = useCallback(
     (newName: string) => {
-      setShouldCheckVMNameProperly(false);
-      setVMName(newName);
+      setValue('uiState.shouldCheckVMNameProperly', false);
+      setValue('vmData.name', newName);
     },
-    [setVMName, setShouldCheckVMNameProperly],
+    [setValue],
   );
-
-  const onNameChange = (_event: FormEvent<HTMLInputElement>, name: string) => {
-    applyName(name);
-  };
 
   return (
     <>
       <InputGroup>
         <InputGroupItem isFill>
-          <TextInput
-            id="vm-name"
-            onChange={onNameChange}
-            placeholder={t('Enter a name or click the refresh icon to generate one')}
-            type="text"
-            validated={validated}
-            value={vmName}
+          <Controller
+            render={({ field: { ref: __, ...field } }) => (
+              <TextInput
+                id="vm-name"
+                {...field}
+                onChange={(_, value) => applyName(value)}
+                placeholder={t('Enter a name or click the refresh icon to generate one')}
+                type="text"
+                validated={validated}
+              />
+            )}
+            control={control}
+            name={'vmData.name'}
           />
         </InputGroupItem>
         <InputGroupItem>

--- a/src/views/virtualmachines/creation-wizard-new/components/VMNameConfirmationNextButton.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/components/VMNameConfirmationNextButton.tsx
@@ -1,10 +1,11 @@
 import React, { FC, ReactNode } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isDNS1123Label, isDNS1123LabelLenient } from '@kubevirt-utils/utils/validation';
 import { Button, Tooltip } from '@patternfly/react-core';
 
-import useVMWizardStore from '../state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '../state/vm-wizard-context/VMWizardContext';
 
 type VMNameConfirmationNextButtonProps = {
   children: ReactNode;
@@ -18,7 +19,12 @@ const VMNameConfirmationNextButton: FC<VMNameConfirmationNextButtonProps> = ({
   onClick,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { setShouldCheckVMNameProperly, shouldCheckVMNameProperly, vmName } = useVMWizardStore();
+  const { control, setValue } = useVMWizard();
+  const vmName = useWatch({ control, name: 'vmData.name' });
+  const shouldCheckVMNameProperly = useWatch({
+    control,
+    name: 'uiState.shouldCheckVMNameProperly',
+  });
 
   const isVMNameValid = isDNS1123Label(vmName);
   const isVMNameAlmostValid = isDNS1123LabelLenient(vmName);
@@ -30,7 +36,7 @@ const VMNameConfirmationNextButton: FC<VMNameConfirmationNextButtonProps> = ({
       onClick();
       return;
     }
-    setShouldCheckVMNameProperly(true);
+    setValue('uiState.shouldCheckVMNameProperly', true);
   };
 
   const nextButton = (

--- a/src/views/virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext.tsx
@@ -18,7 +18,7 @@ export const VMWizardProvider: FC<VMWizardProviderProps> = ({ children }) => {
   const [activeNamespace] = useActiveNamespace();
   const namespace = getValidNamespace(activeNamespace);
   const methods = useForm<VMWizardFormValues>({
-    defaultValues: createInitialVMWizardFormValues({ cluster: clusterParam, namespace }),
+    defaultValues: createInitialVMWizardFormValues({ cluster: clusterParam ?? '', namespace }),
   });
 
   // TODO: check if this is needed

--- a/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/DeploymentDetailsStep.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/DeploymentDetailsStep.tsx
@@ -1,8 +1,9 @@
 import React, { FC, useState } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Stack, StackItem, Title, TitleSizes } from '@patternfly/react-core';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
 import CreationMethodTileGroup from '@virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/CreationMethodTileGroup';
 import NameAndDescriptionForm from '@virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/NameAndDescriptionForm/NameAndDescriptionForm';
 import VMCreationLocationDisplay from '@virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/VMCreationLocationDisplay';
@@ -11,7 +12,8 @@ import { isCloneCreationMethod } from '@virtualmachines/creation-wizard-new/util
 
 const DeploymentDetailsStep: FC = () => {
   const { t } = useKubevirtTranslation();
-  const { creationMethod } = useVMWizardStore();
+  const { control } = useVMWizard();
+  const creationMethod = useWatch({ control, name: 'vmData.creationMethod' });
   const [editCreationLocation, setEditCreationLocation] = useState(false);
 
   const isCloneMethod = isCloneCreationMethod(creationMethod);

--- a/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/CreationMethodTileGroup.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/CreationMethodTileGroup.tsx
@@ -1,7 +1,8 @@
 import React, { FC } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { Flex, FlexItem } from '@patternfly/react-core';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
 import { VMCreationMethod } from '@virtualmachines/creation-wizard-new/utils/constants';
 
 import CreationMethodTile from './components/CreationMethodTile/CreationMethodTile';
@@ -9,7 +10,8 @@ import CreationMethodTile from './components/CreationMethodTile/CreationMethodTi
 import './CreationMethodTileGroup.scss';
 
 const CreationMethodTileGroup: FC = () => {
-  const { creationMethod, setCreationMethod } = useVMWizardStore();
+  const { control, setValue } = useVMWizard();
+  const creationMethod = useWatch({ control, name: 'vmData.creationMethod' });
 
   return (
     <Flex
@@ -22,9 +24,11 @@ const CreationMethodTileGroup: FC = () => {
         (method) => (
           <FlexItem className="vm-creation-method-tile-group__item" key={method}>
             <CreationMethodTile
+              setSelectedCreationMethod={(selectedCreationMethod) =>
+                setValue('vmData.creationMethod', selectedCreationMethod)
+              }
               creationMethod={method}
               isChecked={creationMethod === method}
-              setSelectedCreationMethod={setCreationMethod}
             />
           </FlexItem>
         ),

--- a/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/DeploymentDetailsStepFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/DeploymentDetailsStepFooter.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { useWatch } from 'react-hook-form';
 import classnames from 'classnames';
 
 import { FLAG_LIGHTSPEED_PLUGIN } from '@kubevirt-utils/flags/consts';
@@ -14,13 +15,14 @@ import {
 } from '@patternfly/react-core';
 import VMNameConfirmationNextButton from '@virtualmachines/creation-wizard-new/components/VMNameConfirmationNextButton';
 import useCloseWizard from '@virtualmachines/creation-wizard-new/hooks/useCloseWizard';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
 import { isCloneCreationMethod } from '@virtualmachines/creation-wizard-new/utils/utils';
 
 const DeploymentDetailsStepFooter: FC = () => {
   const hasOLSConsole = useFlag(FLAG_LIGHTSPEED_PLUGIN);
   const { goToNextStep } = useWizardContext();
-  const { creationMethod } = useVMWizardStore();
+  const { control } = useVMWizard();
+  const creationMethod = useWatch({ control, name: 'vmData.creationMethod' });
   const isCloneMethod = isCloneCreationMethod(creationMethod);
   const closeWizard = useCloseWizard();
   const { backButtonText, cancelButtonText, nextButtonText } = useWizardFooterProps();

--- a/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/VMCreationLocationDisplay.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/VMCreationLocationDisplay.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { useWatch } from 'react-hook-form';
 import classNames from 'classnames';
 
 import EditButton from '@kubevirt-utils/components/EditButton/EditButton';
@@ -8,7 +9,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { ButtonVariant } from '@patternfly/react-core';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
 
 import './VMCreationLocationDisplay.scss';
 
@@ -23,9 +24,15 @@ const VMCreationLocationDisplay: FC<VMCreationLocationDisplayProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const isACMPage = useIsACMPage();
+
   const { featureEnabled: treeViewFoldersEnabled, loading: treeViewFoldersLoading } =
     useFeatures(TREE_VIEW_FOLDERS);
-  const { cluster, folder, project } = useVMWizardStore();
+
+  const { control } = useVMWizard();
+  const [cluster, folder, project] = useWatch({
+    control,
+    name: ['vmData.cluster', 'vmData.folder', 'vmData.project'],
+  });
 
   return (
     <div

--- a/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/VMCreationLocationForm.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/VMCreationLocationForm.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { Controller, useWatch } from 'react-hook-form';
 
 import ClusterDropdown from '@kubevirt-utils/components/ClusterProjectDropdown/ClusterDropdown';
 import NamespaceDropdown from '@kubevirt-utils/components/ClusterProjectDropdown/NamespaceDropdown';
@@ -10,41 +11,60 @@ import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { Form, FormGroup } from '@patternfly/react-core';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
 
 import './VMCreationLocationForm.scss';
 
 const VMCreationLocationForm: FC = () => {
   const { t } = useKubevirtTranslation();
   const isACMPage = useIsACMPage();
+
   const { featureEnabled: treeViewFoldersEnabled, loading: treeViewFoldersLoading } =
     useFeatures(TREE_VIEW_FOLDERS);
-  const { cluster, folder, project, setCluster, setFolder, setProject } = useVMWizardStore();
-  const isTreeViewFoldersDisabled = treeViewFoldersLoading || !treeViewFoldersEnabled;
+
+  const { control, setValue } = useVMWizard();
+  const [cluster, folder, project] = useWatch({
+    control,
+    name: ['vmData.cluster', 'vmData.folder', 'vmData.project'],
+  });
 
   return (
     <Form className="vm-creation-location-form">
       {isACMPage && (
         <FormGroup isRequired label={t('Cluster')}>
-          <ClusterDropdown
-            onChange={(selectedCluster) => {
-              setCluster(selectedCluster);
-              setFolder('');
-              if (selectedCluster !== cluster) setProject('');
-            }}
-            selectedCluster={cluster}
+          <Controller
+            render={({ field: { ref: _, ...field } }) => (
+              <ClusterDropdown
+                {...field}
+                onChange={(selectedCluster) => {
+                  field.onChange(selectedCluster);
+                  setValue('vmData.folder', '');
+                  if (selectedCluster !== cluster) setValue('vmData.project', '');
+                }}
+                selectedCluster={field.value}
+              />
+            )}
+            control={control}
+            name="vmData.cluster"
           />
         </FormGroup>
       )}
       <FormGroup isRequired label={t('Project')}>
-        <NamespaceDropdown
-          onChange={(selectedProject) => {
-            setProject(selectedProject);
-            setFolder('');
-          }}
-          cluster={cluster}
-          includeAllProjects={false}
-          selectedProject={project || DEFAULT_NAMESPACE}
+        <Controller
+          render={({ field: { ref: _, ...field } }) => (
+            <NamespaceDropdown
+              {...field}
+              onChange={(selectedProject) => {
+                field.onChange(selectedProject);
+                setValue('vmData.folder', '');
+              }}
+              cluster={cluster}
+              includeAllProjects={false}
+              selectedProject={project || DEFAULT_NAMESPACE}
+            />
+          )}
+          control={control}
+          name="vmData.project"
         />
       </FormGroup>
       <FormGroup
@@ -61,10 +81,10 @@ const VMCreationLocationForm: FC = () => {
       >
         <FolderSelect
           cluster={cluster}
-          isDisabled={isTreeViewFoldersDisabled}
+          isDisabled={treeViewFoldersLoading || !treeViewFoldersEnabled}
           namespace={project}
           selectedFolder={folder}
-          setSelectedFolder={(newFolder) => setFolder(newFolder)}
+          setSelectedFolder={(newFolder) => setValue('vmData.folder', newFolder)}
         />
       </FormGroup>
     </Form>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Migrates the Deployment Details step of the new VM creation wizard from Zustand to react-hook-form.

* Wire creation method, VM name, description, and location fields to vmData form state via Controller / useWatch
* Update NameInput, DescriptionInput, CreationMethodTileGroup, and VMCreationLocationForm to read/write form values instead of store
* Update DeploymentDetailsStepFooter and VMNameConfirmationNextButton to use form-backed validation for the Next button
* /vm-wizard flow is unchanged

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-89616

## 🎥 Demo

no visual changes



https://github.com/user-attachments/assets/06137d41-5d94-4b3d-b535-13250a928d5f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal form state management in the virtual machine creation wizard for better code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->