### PR TITLE
CNV-74265: IBM Cloud cluster setup workflows (bootstrap)

### DIFF
--- a/.github/workflows/ibmc-cluster-auto-teardown.yml
+++ b/.github/workflows/ibmc-cluster-auto-teardown.yml
@@ -1,0 +1,25 @@
+name: IBM Cloud Hot Cluster Auto-Teardown
+
+on:
+  schedule:
+    # Runs daily at 02:00 UTC (safety net for forgotten clusters)
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      cluster_name:
+        description: 'Cluster name to tear down'
+        required: true
+        default: 'kubevirt-plugin-ci'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  auto-teardown:
+    name: Auto-Teardown Hot Cluster
+    uses: ./.github/workflows/ibmc-cluster-teardown.yml
+    with:
+      cluster_name: ${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}
+    secrets:
+      IC_KEY: ${{ secrets.IC_KEY }}

--- a/.github/workflows/ibmc-cluster-setup.yml
+++ b/.github/workflows/ibmc-cluster-setup.yml
@@ -1,0 +1,239 @@
+name: IBM Cloud Hot Cluster Setup
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster_name:
+        description: 'Cluster name'
+        required: true
+        default: 'kubevirt-plugin-ci'
+        type: string
+      zone:
+        description: 'IBM Cloud classic infrastructure zone (e.g., dal10, wdc04, fra02)'
+        required: true
+        default: 'wdc04'
+        type: string
+      openshift_version:
+        description: 'OpenShift version'
+        required: true
+        default: '4.20_openshift'
+        type: string
+      worker_flavor:
+        description: 'Worker node flavor (bare metal: mb4c.4x32, mb4c.20x64; vpc: m3c.4x16, m3c.8x64)'
+        required: true
+        default: 'm3c.8x64'
+        type: string
+      worker_count:
+        description: 'Number of worker nodes (at least 2 so ingress is happy)'
+        required: true
+        default: '2'
+        type: string
+      kvm_emulation:
+        description: 'KVM emulation (true for vpc, false for bare metal)'
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  CLUSTER_NAME: ${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}
+
+jobs:
+  provision-cluster:
+    name: Provision OpenShift Cluster
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup IBM Cloud CLI
+        uses: IBM/actions-ibmcloud-cli@953e229550655a880eda6ecfb01fbbdf12f119a5
+        with:
+          api_key: ${{ secrets.IC_KEY }}
+          region: eu-de
+          group: cnv-ui
+          plugins: kubernetes-service, container-registry
+
+      - name: Check for existing cluster
+        id: check_cluster
+        run: |
+          if ibmcloud oc cluster get --cluster "${CLUSTER_NAME}" &>/dev/null; then
+            echo "Cluster '${CLUSTER_NAME}' already exists"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Cluster '${CLUSTER_NAME}' does not exist, will create"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify zone and flavor
+        if: steps.check_cluster.outputs.exists == 'false'
+        env:
+          ZONE: ${{ inputs.zone }}
+          FLAVOR: ${{ inputs.worker_flavor }}
+        run: |
+          echo "Fetching classic infrastructure locations and flavors..."
+          LOCATIONS_JSON=$(
+            ibmcloud oc locations --provider classic --show-flavors --output json |\
+            jq '[.[] | select(.kind=="dc")]'
+          )
+
+          echo "Checking zone '${ZONE}' exists..."
+          ZONE_EXISTS=$(
+            echo "${LOCATIONS_JSON}" |\
+            jq -r --arg z "${ZONE}" \
+              '[.[] | select(.id == $z)] | length'
+          )
+          if [[ "${ZONE_EXISTS}" -ne 1 ]]; then
+            echo "ERROR: Zone '${ZONE}' not found in classic infrastructure locations."
+            echo ""
+            echo "Available zones:"
+            echo "${LOCATIONS_JSON}" | jq -r '.[].id' | sort
+            exit 1
+          fi
+          echo "Zone '${ZONE}' exists"
+
+          echo "Checking flavor '${FLAVOR}' is available in zone '${ZONE}'..."
+          FLAVOR_EXISTS=$(
+            echo "${LOCATIONS_JSON}" |\
+            jq -r --arg z "${ZONE}" --arg f "${FLAVOR}" \
+              '.[] | select(.id == $z) | .flavors | split(",") | any(index($f))'
+          )
+          if [[ "${FLAVOR_EXISTS}" == "false" ]]; then
+            echo "ERROR: Flavor '${FLAVOR}' is not available in zone '${ZONE}'."
+            echo ""
+            echo "Available flavors in '${ZONE}':"
+            echo "${LOCATIONS_JSON}" | jq -r --arg z "${ZONE}" '.[] | select(.id == $z) | .flavors | split(",")[]' | sort
+            exit 2
+          fi
+          echo "Flavor '${FLAVOR}' is available in zone '${ZONE}'"
+
+      - name: Create ROKS cluster
+        if: steps.check_cluster.outputs.exists == 'false'
+        env:
+          ZONE: ${{ inputs.zone }}
+          OPENSHIFT_VERSION: ${{ inputs.openshift_version }}
+          WORKER_FLAVOR: ${{ inputs.worker_flavor }}
+          WORKER_COUNT: ${{ inputs.worker_count }}
+        run: |
+          echo "Looking up existing VLANs in zone '${ZONE}'..."
+          VLAN_JSON=$(ibmcloud oc vlan ls --zone "${ZONE}" --output json 2>/dev/null || echo "[]")
+          PRIVATE_VLAN=$(echo "${VLAN_JSON}" | jq -r '[.[] | select(.type == "private")] | first | .id // empty')
+          PUBLIC_VLAN=$(echo "${VLAN_JSON}" | jq -r '[.[] | select(.type == "public")] | first | .id // empty')
+
+          if [[ -n "${PRIVATE_VLAN}" ]]; then
+            echo "Reusing existing private VLAN: ${PRIVATE_VLAN}"
+            echo "Reusing existing public VLAN: ${PUBLIC_VLAN:-'(none)'}"
+          else
+            echo "No existing VLANs in zone, new VLANs will be created"
+          fi
+
+          echo "Creating cluster '${CLUSTER_NAME}' with ${WORKER_COUNT}x ${WORKER_FLAVOR} workers in zone ${ZONE}..."
+          VLAN_ARGS=()
+          if [[ -n "${PRIVATE_VLAN}" ]]; then
+            VLAN_ARGS+=(--private-vlan "${PRIVATE_VLAN}")
+          fi
+          if [[ -n "${PUBLIC_VLAN}" ]]; then
+            VLAN_ARGS+=(--public-vlan "${PUBLIC_VLAN}")
+          fi
+          ibmcloud oc cluster create classic \
+            --name "${CLUSTER_NAME}" \
+            --version "${OPENSHIFT_VERSION}" \
+            --flavor "${WORKER_FLAVOR}" \
+            --workers "${WORKER_COUNT}" \
+            --zone "${ZONE}" \
+            "${VLAN_ARGS[@]}"
+
+      - name: Wait for cluster to be ready to use
+        run: |
+          ./ci-scripts/check-roks-cluster-state.sh
+
+      - name: Install oc client from cluster version
+        run: |
+          CLUSTER_JSON="$(ibmcloud oc cluster get --cluster "${CLUSTER_NAME}" --output json)"
+          export CLUSTER_JSON
+          bash ./ci-scripts/install-oc-client.sh
+
+      - name: Configure kubeconfig
+        run: |
+          ibmcloud oc cluster config --cluster "${CLUSTER_NAME}" --admin
+          oc cluster-info
+          oc get nodes -o wide
+
+      - name: Install HCO
+        env:
+          KVM_EMULATION: ${{ inputs.kvm_emulation }}
+        run: |
+          ./ci-scripts/install-hco.sh
+
+      - name: Verify ARC secrets
+        run: |
+          HAS_APP=$([ -n "${{ secrets.ARC_GITHUB_APP_ID }}" ] && [ -n "${{ secrets.ARC_GITHUB_APP_INSTALL_ID }}" ] && [ -n "${{ secrets.ARC_GITHUB_APP_PRIVATE_KEY }}" ] && echo "yes" || echo "no")
+          HAS_PAT=$([ -n "${{ secrets.ARC_GITHUB_PAT }}" ] && echo "yes" || echo "no")
+          if [[ "$HAS_APP" != "yes" && "$HAS_PAT" != "yes" ]]; then
+            echo "::error::ARC authentication secrets are missing or empty."
+            echo "Configure either:"
+            echo "  - ARC_GITHUB_APP_ID, ARC_GITHUB_APP_INSTALL_ID, ARC_GITHUB_APP_PRIVATE_KEY (GitHub App), or"
+            echo "  - ARC_GITHUB_PAT (Personal Access Token)"
+            echo "in Settings → Secrets and variables → Actions for this repository (or its organization)."
+            exit 1
+          fi
+          echo "ARC secrets are present."
+
+      - name: Setup ARC runner image
+        id: build_runner
+        env:
+          OC_VERSION: '4.20'
+        run: |
+          IMAGE_REF=$(./ci-scripts/images/setup-arc-runner-image.sh | grep '^IMAGE_REF=' | cut -d= -f2-)
+          echo "image_ref=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Install ARC
+        env:
+          ARC_CONFIG_URL: 'https://github.com/${{ github.repository }}'
+          ARC_APP_ID: ${{ secrets.ARC_GITHUB_APP_ID }}
+          ARC_APP_INSTALL_ID: ${{ secrets.ARC_GITHUB_APP_INSTALL_ID }}
+          ARC_APP_PRIVATE_KEY: ${{ secrets.ARC_GITHUB_APP_PRIVATE_KEY }}
+          ARC_PAT: ${{ secrets.ARC_GITHUB_PAT }}
+          ARC_RUNNER_IMAGE: ${{ steps.build_runner.outputs.image_ref }}
+          # Pin with script default (0.14.0); set to "latest" in the workflow to float OCI tags.
+          ARC_VERSION: '0.14.0'
+        run: |
+          ./ci-scripts/arc/install-arc-controller.sh
+          ./ci-scripts/arc/install-runner-scale-set.sh
+
+      - name: Verify cluster health
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          ./ci-scripts/check-cluster-health.sh
+
+      - name: Setup summary
+        if: always()
+        env:
+          INPUT_ZONE: ${{ inputs.zone }}
+          INPUT_VERSION: ${{ inputs.openshift_version }}
+          INPUT_FLAVOR: ${{ inputs.worker_flavor }}
+          INPUT_WORKERS: ${{ inputs.worker_count }}
+          INPUT_KVM: ${{ inputs.kvm_emulation }}
+        run: |
+          echo "## Hot Cluster Setup Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Parameter | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Cluster | \`${CLUSTER_NAME}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Zone | \`${INPUT_ZONE}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| OpenShift | \`${INPUT_VERSION}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Worker Flavor | \`${INPUT_FLAVOR}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Workers | \`${INPUT_WORKERS}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| KVM Emulation | \`${INPUT_KVM}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if oc cluster-info &>/dev/null; then
+            echo "Cluster is **healthy** and ready for CI." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Cluster setup **may have issues**. Check the logs." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/ibmc-cluster-teardown.yml
+++ b/.github/workflows/ibmc-cluster-teardown.yml
@@ -1,0 +1,151 @@
+name: IBM Cloud Hot Cluster Teardown
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster_name:
+        description: 'Cluster name to tear down'
+        required: true
+        default: 'kubevirt-plugin-ci'
+        type: string
+  workflow_call:
+    inputs:
+      cluster_name:
+        description: 'Cluster name to tear down'
+        required: false
+        default: 'kubevirt-plugin-ci'
+        type: string
+    secrets:
+      IC_KEY:
+        required: true
+      BOT_PAT:
+        required: false
+
+permissions:
+  contents: read
+
+env:
+  CLUSTER_NAME: ${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}
+
+jobs:
+  teardown:
+    name: Tear Down Hot Cluster
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    steps:
+      - name: Setup IBM Cloud CLI
+        uses: IBM/actions-ibmcloud-cli@953e229550655a880eda6ecfb01fbbdf12f119a5
+        with:
+          api_key: ${{ secrets.IC_KEY }}
+          region: eu-de
+          group: cnv-ui
+          plugins: kubernetes-service
+
+      - name: Check cluster exists
+        id: check_cluster
+        run: |
+          OUTPUT=$(ibmcloud oc cluster get --cluster "${CLUSTER_NAME}" --output json 2>&1) && EXIT=0 || EXIT=$?
+
+          if [[ ${EXIT} -eq 0 ]]; then
+            echo "Cluster '${CLUSTER_NAME}' found"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+
+            ibmcloud oc cluster config --cluster "${CLUSTER_NAME}" --admin || true
+          elif grep -qE 'G0004|could not be found' <<< "${OUTPUT}"; then
+            echo "Cluster '${CLUSTER_NAME}' not found, nothing to tear down"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ERROR: Failed to check cluster '${CLUSTER_NAME}':"
+            echo "${OUTPUT}"
+            exit 1
+          fi
+
+      - name: Setup Helm
+        if: steps.check_cluster.outputs.exists == 'true'
+        uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
+        with:
+          version: '3.19.0'
+
+      - name: Deregister ARC runners
+        if: steps.check_cluster.outputs.exists == 'true'
+        continue-on-error: true
+        run: |
+          echo "Uninstalling ARC runner scale set..."
+          helm uninstall kubevirt-plugin-ci --namespace arc-runners --wait --timeout 5m 2>/dev/null || echo "Runner scale set not found or already removed"
+
+          echo "Uninstalling ARC controller..."
+          helm uninstall arc --namespace arc-systems --wait --timeout 5m 2>/dev/null || echo "ARC controller not found or already removed"
+
+      - name: Delete cluster
+        if: steps.check_cluster.outputs.exists == 'true'
+        run: |
+          echo "Deleting cluster '${CLUSTER_NAME}'..."
+          ibmcloud oc cluster rm --cluster "${CLUSTER_NAME}" -f --force-delete-storage
+          echo "Cluster deletion initiated"
+
+          echo "Waiting for cluster to be fully removed..."
+          MAX_WAIT=7200  # 2 hours
+          INTERVAL=30
+          ELAPSED=0
+
+          while [[ ${ELAPSED} -lt ${MAX_WAIT} ]]; do
+            OUTPUT=$(ibmcloud oc cluster get --cluster "${CLUSTER_NAME}" --output json 2>&1) && EXIT=0 || EXIT=$?
+
+            if [[ ${EXIT} -eq 0 ]]; then
+              echo "[$(date '+%H:%M:%S')] Cluster still being deleted... (${ELAPSED}s elapsed)"
+              sleep ${INTERVAL}
+              ELAPSED=$((ELAPSED + INTERVAL))
+            elif grep -qE 'G0004|could not be found' <<< "${OUTPUT}"; then
+              echo "Cluster has been removed"
+              break
+            else
+              echo "[$(date '+%H:%M:%S')] WARNING: Failed to check cluster status (will retry):"
+              echo "${OUTPUT}"
+              sleep ${INTERVAL}
+              ELAPSED=$((ELAPSED + INTERVAL))
+            fi
+          done
+
+          OUTPUT=$(ibmcloud oc cluster get --cluster "${CLUSTER_NAME}" --output json 2>&1) && EXIT=0 || EXIT=$?
+          if [[ ${EXIT} -eq 0 ]]; then
+            echo "::error::Timed out waiting for cluster deletion"
+            exit 1
+          elif grep -qE 'G0004|could not be found' <<< "${OUTPUT}"; then
+            echo "Cluster deletion confirmed"
+          else
+            echo "ERROR: Failed to verify cluster deletion for '${CLUSTER_NAME}':"
+            echo "${OUTPUT}"
+            exit 1
+          fi
+
+      # TODO: Followup about how to manually delete "Runner scale sets" from ARC
+      - name: Clean up ghost runners
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+        run: |
+          echo "Checking for offline self-hosted runners..."
+          RUNNERS=$(gh api "/repos/${{ github.repository }}/actions/runners" \
+            --jq '.runners[] | select(.status == "offline") | select(.labels[].name == env.CLUSTER_NAME) | .id' \
+            2>/dev/null || true)
+
+          if [[ -z "${RUNNERS}" ]]; then
+            echo "No offline '${CLUSTER_NAME}' runners found"
+          else
+            for runner_id in ${RUNNERS}; do
+              echo "Deleting offline runner ${runner_id}..."
+              gh api -X DELETE "/repos/${{ github.repository }}/actions/runners/${runner_id}" || echo "Failed to delete runner ${runner_id}"
+            done
+            echo "Ghost runner cleanup complete"
+          fi
+
+      - name: Teardown summary
+        if: always()
+        run: |
+          echo "## Hot Cluster Teardown Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Parameter | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Cluster | \`${CLUSTER_NAME}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Cluster Found | \`${{ steps.check_cluster.outputs.exists }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ibmc-cluster-teardown.yml
+++ b/.github/workflows/ibmc-cluster-teardown.yml
@@ -18,8 +18,6 @@ on:
     secrets:
       IC_KEY:
         required: true
-      BOT_PAT:
-        required: false
 
 permissions:
   contents: read
@@ -60,6 +58,12 @@ jobs:
             exit 1
           fi
 
+      - name: Checkout
+        if: steps.check_cluster.outputs.exists == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
       - name: Setup Helm
         if: steps.check_cluster.outputs.exists == 'true'
         uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
@@ -70,11 +74,7 @@ jobs:
         if: steps.check_cluster.outputs.exists == 'true'
         continue-on-error: true
         run: |
-          echo "Uninstalling ARC runner scale set..."
-          helm uninstall kubevirt-plugin-ci --namespace arc-runners --wait --timeout 5m 2>/dev/null || echo "Runner scale set not found or already removed"
-
-          echo "Uninstalling ARC controller..."
-          helm uninstall arc --namespace arc-systems --wait --timeout 5m 2>/dev/null || echo "ARC controller not found or already removed"
+          ./ci-scripts/arc/uninstall-arc.sh
 
       - name: Delete cluster
         if: steps.check_cluster.outputs.exists == 'true'
@@ -116,27 +116,6 @@ jobs:
             echo "ERROR: Failed to verify cluster deletion for '${CLUSTER_NAME}':"
             echo "${OUTPUT}"
             exit 1
-          fi
-
-      # TODO: Followup about how to manually delete "Runner scale sets" from ARC
-      - name: Clean up ghost runners
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.BOT_PAT }}
-        run: |
-          echo "Checking for offline self-hosted runners..."
-          RUNNERS=$(gh api "/repos/${{ github.repository }}/actions/runners" \
-            --jq '.runners[] | select(.status == "offline") | select(.labels[].name == env.CLUSTER_NAME) | .id' \
-            2>/dev/null || true)
-
-          if [[ -z "${RUNNERS}" ]]; then
-            echo "No offline '${CLUSTER_NAME}' runners found"
-          else
-            for runner_id in ${RUNNERS}; do
-              echo "Deleting offline runner ${runner_id}..."
-              gh api -X DELETE "/repos/${{ github.repository }}/actions/runners/${runner_id}" || echo "Failed to delete runner ${runner_id}"
-            done
-            echo "Ghost runner cleanup complete"
           fi
 
       - name: Teardown summary

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ scripts/ca.crt
 scripts/console-client-secret
 *.json-*
 *.env
+ci-scripts/_
+ci-scripts/_ci_tools
+ci-scripts/generated/
 
 # Personal Cursor rules (not shared with team)
 .cursor/rules/personal-*.mdc

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,7 @@ i18n-scripts/
 cypress/gui-test-screenshots
 cypress/cypress-a11y-report.json
 /locales
+
+# Helm templates contain Go template syntax that Prettier cannot parse
+ci-scripts/**/helm/**/templates/
+ci-scripts/images/**/helm/**/templates/

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -25,7 +25,8 @@ Workers can be **bare metal** (real KVM) or **VPC / shared** flavors with **KVM 
 GitHub Actions
   │
   ├── ibmc-cluster-setup.yml          → "IBM Cloud Hot Cluster Setup"
-  └── ibmc-cluster-teardown.yml       → "IBM Cloud Hot Cluster Teardown" (also workflow_call + ghost-runner cleanup)
+  ├── ibmc-cluster-teardown.yml       → "IBM Cloud Hot Cluster Teardown" (also workflow_call)
+  └── ibmc-cluster-auto-teardown.yml  → "IBM Cloud Hot Cluster Auto-Teardown" (daily cron safety net)
 ```
 
 **Hot cluster E2E** (added in PR #4099)
@@ -60,14 +61,6 @@ The API key must belong to a user or service ID with the following IAM permissio
 - **Kubernetes Service**: Administrator role (to create/delete ROKS clusters)
 - **VPC Infrastructure Services**: Editor role (if using VPC-based clusters)
 - **Classic Infrastructure**: Super User or equivalent (for bare metal provisioning)
-
-### Ghost Runner Cleanup (optional)
-
-| Secret    | Description               | How to Obtain                               |
-| --------- | ------------------------- | ------------------------------------------- |
-| `BOT_PAT` | PAT with repo admin scope | GitHub Settings → Developer Settings → PATs |
-
-The `BOT_PAT` is only needed if you want the teardown workflow to automatically delete offline "ghost" runners from GitHub. Deleting self-hosted runners requires repository admin access which `GITHUB_TOKEN` cannot provide. The PAT needs the `repo` scope (classic) or **Administration: Read and Write** (fine-grained). If not set, ghost runners can be cleaned up manually via Settings → Actions → Runners.
 
 ### ARC Authentication (choose one)
 
@@ -188,12 +181,13 @@ To turn off dind (no Docker daemon in the pod): `export CONTAINER_MODE=none` and
 
 ### Workflow file ↔ Actions UI name
 
-| File                                          | `name:` in workflow (shown in Actions tab) |
-| --------------------------------------------- | ------------------------------------------ |
-| `.github/workflows/ibmc-cluster-setup.yml`    | IBM Cloud Hot Cluster Setup                |
-| `.github/workflows/ibmc-cluster-teardown.yml` | IBM Cloud Hot Cluster Teardown             |
-| `.github/workflows/hot-cluster-e2e.yml`       | Hot Cluster E2E (PR #4099)                 |
-| `.github/workflows/hot-cluster-e2e-run.yml`   | Hot Cluster E2E Run (PR #4099)             |
+| File                                               | `name:` in workflow (shown in Actions tab) |
+| -------------------------------------------------- | ------------------------------------------ |
+| `.github/workflows/ibmc-cluster-setup.yml`         | IBM Cloud Hot Cluster Setup                |
+| `.github/workflows/ibmc-cluster-teardown.yml`      | IBM Cloud Hot Cluster Teardown             |
+| `.github/workflows/ibmc-cluster-auto-teardown.yml` | IBM Cloud Hot Cluster Auto-Teardown        |
+| `.github/workflows/hot-cluster-e2e.yml`            | Hot Cluster E2E (PR #4099)                 |
+| `.github/workflows/hot-cluster-e2e-run.yml`        | Hot Cluster E2E Run (PR #4099)             |
 
 ### Setting up the hot cluster
 
@@ -216,9 +210,9 @@ To run only the test jobs (cluster already verified): dispatch **Hot Cluster E2E
 
 **Manual:** Actions → **IBM Cloud Hot Cluster Teardown**
 
-**Teardown implementation:** Uninstalls Helm releases `kubevirt-plugin-ci` (scale set) and `arc` (controller) when possible, deletes the ROKS cluster, then optionally removes offline GitHub runners labeled with the workflow `cluster_name` input (`CLUSTER_NAME`, default `kubevirt-plugin-ci`) using `BOT_PAT`.
+**Teardown implementation:** Runs `ci-scripts/arc/uninstall-arc.sh` to cleanly deregister ARC runner scale set and controller via Helm, then deletes the ROKS cluster.
 
-> **Note:** Automatic idle teardown (`ibmc-cluster-auto-teardown.yml`) is planned in PR #4099, not in this bootstrap PR.
+**Automatic:** The `ibmc-cluster-auto-teardown.yml` workflow runs daily at 02:00 UTC as a safety net, calling the teardown workflow for the default cluster name.
 
 ## ARC on OpenShift vs [na-launch/github-arc](https://github.com/na-launch/github-arc/blob/main/README.md)
 
@@ -249,6 +243,7 @@ You do **not** need to re-apply `ci-scripts/arc/arc-openshift-scc.yaml`.
 | `images/setup-arc-runner-image.sh` | OpenShift binary build for custom ARC runner image                                |
 | `arc/install-arc-controller.sh`    | SCC + Helm `gha-runner-scale-set-controller` (once per cluster)                   |
 | `arc/install-runner-scale-set.sh`  | Helm `gha-runner-scale-set`, SCC bind, `arc-runner-rbac.yaml`                     |
+| `arc/uninstall-arc.sh`             | Reverse of install: Helm uninstall scale set + controller (same env vars)         |
 | `arc/README.md`                    | ARC on OpenShift setup guide                                                      |
 | `check-cluster-health.sh`          | Verifies cluster, HCO, ARC, storage, console; optional GitHub runner check        |
 | `check-roks-cluster-state.sh`      | Waits until ROKS cluster is usable (used by setup workflow)                       |
@@ -277,6 +272,9 @@ Key defaults:
 
 See [docs/HOT_CLUSTER_FUTURE_WORK.md](../docs/HOT_CLUSTER_FUTURE_WORK.md) for RBAC hardening, FIPS, ci-env-controller setup gap, and workflow hygiene items.
 
+- **Use `kubectl` + `_cluster-helpers.sh` to install `oc`** — Instead of downloading `oc` from `mirror.openshift.com` via `install-oc-client.sh`, use the `kubectl` binary already available on GitHub runners together with `_cluster-helpers.sh` `resolve_cli_downloads()` to fetch `oc` directly from the cluster's `ConsoleCLIDownload` resources. This avoids the external mirror dependency and ensures the binary matches the running cluster version exactly.
+- **Harden `check-cluster-health.sh`** — The health check script may need adjustments once runtime cluster configuration issues are discovered during real usage. Revisit checks and thresholds based on operational experience.
+
 Quick checklist:
 
 1. **Health check first** — Run **Hot Cluster E2E** (or health-check job only) to isolate cluster/HCO issues from test-stack issues.
@@ -294,7 +292,6 @@ Quick checklist:
 | **`ttl.sh` or ephemeral public registries**                  | Ephemeral tags, no provenance, rate/abuse limits                                                   | Internal registry + image signing, digest pinning                                     |
 | **Skip `npm audit` / `--ignore-scripts`**                    | Supply-chain and lifecycle scripts not run                                                         | Revisit for production pipelines; use lockfile + audited base images                  |
 | **Cluster-scoped mutations in `test-setup.sh`**              | Variant A may patch shared ConfigMaps                                                              | Prefer namespaced fixtures or dedicated test clusters                                 |
-| **Ghost runner cleanup via `BOT_PAT`**                       | PAT scope and rotation                                                                             | GitHub App or org-level runner management; least privilege                            |
 | **Auto-teardown idle heuristic**                             | Monitors only the two E2E test workflows; a cluster used by other workflows may be torn down early | Tie to runner job queue or explicit "last test" workflow                              |
 | **Classic ROKS only in setup workflow**                      | Not IBM Cloud VPC Gen2 path                                                                        | Add a parallel path or doc if prod standardizes on VPC                                |
 
@@ -342,7 +339,7 @@ Bare metal nodes on IBM Cloud are expensive. Tear down the cluster manually via 
 
 - Go to repository Settings → Actions → Runners
 - Manually delete any offline runners
-- Or run the teardown workflow again (it includes ghost runner cleanup)
+- Or run the teardown workflow again (Helm uninstall deregisters runners)
 
 ### ARC runner `oc` / `kubectl` permissions
 

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -1,0 +1,361 @@
+# Hot Cluster CI
+
+> **Continuation guide (CNV-74265):** [docs/HOT_CLUSTER_CI_CONTINUATION.md](../docs/HOT_CLUSTER_CI_CONTINUATION.md)  
+> **Future work backlog:** [docs/HOT_CLUSTER_FUTURE_WORK.md](../docs/HOT_CLUSTER_FUTURE_WORK.md)  
+> **Cluster lifecycle:** [docs/CLUSTER_LIFECYCLE.md](../docs/CLUSTER_LIFECYCLE.md)
+
+This directory contains scripts and documentation for the **IBM Cloud hot cluster** CI stack: an OpenShift (ROKS) cluster used for KubeVirt plugin integration testing, with **Hyperconverged Cluster Operator (HCO)** and **GitHub Actions Runner Controller (ARC)** so jobs can run on cluster-adjacent self-hosted runners (`kubevirt-plugin-ci`).
+
+Workers can be **bare metal** (real KVM) or **VPC / shared** flavors with **KVM emulation**; the setup workflow defaults favor VPC-style flavors and `kvm_emulation: true` unless you change inputs.
+
+## Why this stack (motivation)
+
+| Goal                                   | Approach                                                                                                                                                                                           |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Real KubeVirt / OpenShift behavior** | Tests run against a live cluster with HCO, virt stack, and storage—not mocks.                                                                                                                      |
+| **Console + plugin fidelity**          | Two POC paths: hit the **in-cluster** console URL, or run an **off-cluster** console container with the plugin served like the operator (TLS + nginx), matching how developers run bridge locally. |
+| **Long-running / privileged CI**       | GitHub-hosted runners are a poor fit for nested virt, heavy Playwright, and Docker-heavy flows; **ARC** on the cluster provides dind-capable runners with `oc` RBAC.                               |
+| **Cost control**                       | Bare metal and large workers are expensive; manual teardown via **IBM Cloud Hot Cluster Teardown** (auto-teardown in PR #4099).                                                                    |
+
+## Architecture
+
+**Lifecycle (IBM Cloud)**
+
+```text
+GitHub Actions
+  │
+  ├── ibmc-cluster-setup.yml          → "IBM Cloud Hot Cluster Setup"
+  └── ibmc-cluster-teardown.yml       → "IBM Cloud Hot Cluster Teardown" (also workflow_call + ghost-runner cleanup)
+```
+
+**Hot cluster E2E** (added in PR #4099)
+
+```text
+hot-cluster-e2e.yml     — "Hot Cluster E2E" (PR + manual dispatch)
+  ├── cluster-health-check (ubuntu-latest + IBM Cloud → kubeconfig)
+  │     └── ci-scripts/check-cluster-health.sh
+  └── run-e2e-tests (workflow_call → hot-cluster-e2e-run.yml)
+
+hot-cluster-e2e-run.yml — "Hot Cluster E2E Run"
+  ├── check-runner (diagnostics on ARC runner)
+  ├── build-kubevirt-plugin-image (ubuntu-latest; podman build + push)
+  └── run-gating-tests (runs-on: kubevirt-plugin-ci)
+        ├── ci-env-request → ci-env-controller → ci-test-stack (console + plugin)
+        ├── BRIDGE_BASE_ADDRESS from test stack
+        └── Playwright gating (or features project)
+```
+
+## Required GitHub Secrets
+
+These secrets must be configured in the repository settings before running the workflows.
+
+### IBM Cloud
+
+| Secret   | Description           | How to Obtain                   |
+| -------- | --------------------- | ------------------------------- |
+| `IC_KEY` | IBM Cloud IAM API key | Repository/org secret (Actions) |
+
+The API key must belong to a user or service ID with the following IAM permissions:
+
+- **Kubernetes Service**: Administrator role (to create/delete ROKS clusters)
+- **VPC Infrastructure Services**: Editor role (if using VPC-based clusters)
+- **Classic Infrastructure**: Super User or equivalent (for bare metal provisioning)
+
+### Ghost Runner Cleanup (optional)
+
+| Secret    | Description               | How to Obtain                               |
+| --------- | ------------------------- | ------------------------------------------- |
+| `BOT_PAT` | PAT with repo admin scope | GitHub Settings → Developer Settings → PATs |
+
+The `BOT_PAT` is only needed if you want the teardown workflow to automatically delete offline "ghost" runners from GitHub. Deleting self-hosted runners requires repository admin access which `GITHUB_TOKEN` cannot provide. The PAT needs the `repo` scope (classic) or **Administration: Read and Write** (fine-grained). If not set, ghost runners can be cleaned up manually via Settings → Actions → Runners.
+
+### ARC Authentication (choose one)
+
+#### Option A: GitHub App (recommended for production)
+
+| Secret                       | Description           | How to Obtain                     |
+| ---------------------------- | --------------------- | --------------------------------- |
+| `ARC_GITHUB_APP_ID`          | GitHub App ID         | See "Creating a GitHub App" below |
+| `ARC_GITHUB_APP_INSTALL_ID`  | App installation ID   | See "Creating a GitHub App" below |
+| `ARC_GITHUB_APP_PRIVATE_KEY` | App private key (PEM) | See "Creating a GitHub App" below |
+
+#### Option B: Personal Access Token (simpler, less secure)
+
+| Secret           | Description      | How to Obtain                                              |
+| ---------------- | ---------------- | ---------------------------------------------------------- |
+| `ARC_GITHUB_PAT` | Fine-grained PAT | GitHub Settings → Developer Settings → Fine-grained tokens |
+
+The PAT requires these permissions on the target repository:
+
+- **Administration**: Read and Write
+- **Metadata**: Read-only
+
+## Cluster Authentication
+
+All workflows that need cluster access use the IBM Cloud CLI to pull a kubeconfig on-demand:
+
+```yaml
+- name: Setup IBM Cloud CLI
+  uses: IBM/actions-ibmcloud-cli@953e229550655a880eda6ecfb01fbbdf12f119a5 # v1
+  with:
+    api_key: ${{ secrets.IC_KEY }}
+    region: eu-de
+    group: cnv-ui
+    plugins: kubernetes-service
+
+- name: Configure kubeconfig
+  run: |
+    ibmcloud oc cluster config --cluster "${CLUSTER_NAME}" --admin
+    oc cluster-info
+```
+
+This avoids storing kubeconfig or credentials as GitHub secrets. Any workflow or job that needs `oc`/`kubectl` access simply repeats these two steps with the shared `IC_KEY` secret.
+
+## Creating a GitHub App for ARC
+
+1. Go to your organization settings (or personal settings) → Developer settings → GitHub Apps → New GitHub App
+2. Configure the app:
+   - **Name**: `kubevirt-plugin-arc` (or any name)
+   - **Homepage URL**: Your repository URL
+   - **Webhook**: Uncheck "Active" (not needed)
+   - **Permissions**:
+     - Repository permissions → Administration: Read and Write
+     - Organization permissions → Self-hosted runners: Read and Write
+3. Create the app and note the **App ID**
+4. Generate a **Private Key** (downloads a `.pem` file)
+5. Install the app on your organization/repository and note the **Installation ID**
+   - Find it in the URL: `https://github.com/settings/installations/<INSTALL_ID>`
+6. Store the three values as GitHub secrets:
+   - `ARC_GITHUB_APP_ID` = App ID
+   - `ARC_GITHUB_APP_INSTALL_ID` = Installation ID
+   - `ARC_GITHUB_APP_PRIVATE_KEY` = Contents of the `.pem` file
+
+## Usage
+
+### ARC install scripts (OpenShift)
+
+All ARC automation lives under **`ci-scripts/arc/`**. See **[`ci-scripts/arc/README.md`](arc/README.md)** for the full walkthrough.
+
+| Script                                            | Role                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`ci-scripts/arc/setup-dind-mirror.sh`**         | Mirror **`docker:dind`** to the internal registry, write **`ci-scripts/generated/arc-dind-replace.env`** for Helm post-rendering (standard path; `SKIP_DIND_MIRROR=1` only if dind is provided another way).                                                                                                                                                                      |
+| **`ci-scripts/images/setup-arc-runner-image.sh`** | Build custom runner image (BuildConfig + `images/arc-runner/Dockerfile`); prints **`IMAGE_REF=`**.                                                                                                                                                                                                                                                                                |
+| **`ci-scripts/arc/install-arc-controller.sh`**    | Once per cluster: `arc-systems`, **`ci-scripts/arc/arc-openshift-scc.yaml`**, Helm **`gha-runner-scale-set-controller`**.                                                                                                                                                                                                                                                         |
+| **`ci-scripts/arc/install-runner-scale-set.sh`**  | Per scale set: Helm **`gha-runner-scale-set`**, optional **`ARC_RUNNER_IMAGE`**, dind post-render (**`--storage-driver=vfs`** always; optional **`docker:dind`** mirror via env file or **`ARC_DIND_INTERNAL_IMAGE`**), SCC bind, **`arc-runner-rbac.yaml`** (unless `SKIP_ARC_RUNNER_RBAC=1`). Requires **`ARC_CONFIG_URL`** + GitHub auth. Run **after** the controller script. |
+
+Hot Cluster Setup runs **`ci-scripts/images/setup-arc-runner-image.sh`**, then **`ci-scripts/arc/install-arc-controller.sh`** and **`ci-scripts/arc/install-runner-scale-set.sh`** (same env for the install steps).
+
+### Custom runner image
+
+The setup workflow builds a **custom runner image** on the cluster. The image extends the official GitHub Actions runner with Node.js 22, kubectl, oc, virtctl, and jq. Container workflows use **Docker** via the ARC **dind** sidecar (`DOCKER_HOST`).
+
+- **Dockerfile**: `ci-scripts/images/arc-runner/Dockerfile`
+- **Runner pod Helm fragment**: `ci-scripts/arc/arc-runner-scale-set.pod.yaml` — used by **`ci-scripts/arc/install-runner-scale-set.sh`**.
+- **Dind post-render**: **`ci-scripts/arc/install-runner-scale-set.sh`** always runs Helm with **`--post-renderer ci-scripts/arc/arc-dind-post-render.sh`** for **`CONTAINER_MODE=dind`** (injects **`--storage-driver=vfs`** so nested overlay does not fail on OpenShift). **`ci-scripts/arc/setup-dind-mirror.sh`** writes **`ci-scripts/generated/arc-dind-replace.env`** so the post-renderer also swaps **`docker:dind`** for the internal registry; you can set **`ARC_DIND_INTERNAL_IMAGE`** at install time instead (writes the same env file for that run).
+- **Refresh runner image only**: re-run **`ci-scripts/images/setup-arc-runner-image.sh`**, then **`ci-scripts/arc/install-runner-scale-set.sh`** with **`ARC_RUNNER_IMAGE`** set to the new ref (and the same auth env vars).
+
+Optional: `OC_VERSION`, `VIRTCTL_VERSION`, `ARC_RUNNERS_NS`, `CONTAINER_MODE` (default **dind**), `ARC_VERSION`, `ARC_SCALE_SET_LABELS`, `SKIP_ARC_RUNNER_RBAC=1`.
+
+#### ARC 0.14.0+ ([changelog](https://github.blog/changelog/2026-03-19-actions-runner-controller-release-0-14-0/))
+
+**`ci-scripts/arc/install-arc-controller.sh`** and **`ci-scripts/arc/install-runner-scale-set.sh`** use Helm chart **`0.14.0`** by default so controller and scale-set versions stay aligned and reproducible.
+
+| Feature                               | How we use it                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Multilabel scale sets**             | Optional env **`ARC_SCALE_SET_LABELS=kubevirt-plugin-ci,linux`** (comma-separated). Jobs must target **every** label, e.g. `runs-on: [kubevirt-plugin-ci, linux]`. Omit the variable to keep the previous single-label behavior (default `runs-on: kubevirt-plugin-ci`).                                                                                 |
+| **Listener on Linux nodes**           | Upstream defaults the listener pod to **`kubernetes.io/os: linux`** — helpful on mixed OS clusters without extra config.                                                                                                                                                                                                                                 |
+| **`resourceMeta` labels/annotations** | Optional: merge **`ci-scripts/examples/arc-0.14-extra-values.yaml`** (commented patterns) via **`ARC_RUNNER_EXTRA_VALUES`**.                                                                                                                                                                                                                             |
+| **Experimental charts**               | **`gha-runner-scale-set-experimental`** exposes **`runner.dind.container.image`**, so you could point dind at your internal mirror **without** the Helm post-renderer — values shape differs (`scaleset`, `auth`, …); treat as a larger migration. OCI path: `oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-experimental`. |
+
+The **stable** chart still hardcodes **`docker:dind`** in templates; this repo keeps **`ci-scripts/arc/setup-dind-mirror.sh`** + **`ci-scripts/arc/arc-dind-post-render.sh`** unless you adopt the experimental chart or cluster mirroring.
+
+#### Dind image source
+
+The stable chart embeds **`docker:dind`** (Docker Hub). This repo **mirrors by default** that image into the OpenShift internal registry via **`ci-scripts/arc/setup-dind-mirror.sh`** and rewrites rendered manifests with the Helm post-renderer so runner pods pull **arc-docker-dind** from the cluster registry (skippable via **`SKIP_DIND_MIRROR=1`** or **`ARC_DIND_INTERNAL_IMAGE`**). The approach avoids Docker Hub pull throttling / rate limiting.
+
+### Docker-in-Docker (default)
+
+**`ci-scripts/arc/install-runner-scale-set.sh`** defaults **`CONTAINER_MODE=dind`**. The ARC chart adds a privileged **`docker:dind`** sidecar and wires the main runner container with `DOCKER_HOST=unix:///var/run/docker.sock` so workflows can run:
+
+- `docker build` / `docker run` in steps
+- `container:` jobs and container actions that need a Docker daemon
+
+The custom runner image is still the **main** `runner` container; the chart merges your `template.spec.containers[runner]` with dind-specific env and volume mounts (see upstream `gha-runner-scale-set` `_helpers.tpl`).
+
+**OpenShift:** the `github-arc` SCC in `ci-scripts/arc/arc-openshift-scc.yaml` allows **privileged** containers and **RunAsAny** for UIDs so the `docker:dind` sidecar can run as root while the runner container stays at 1001/123 via Helm. This is broader than a “restricted-only” SCC; scope runner namespaces and RBAC accordingly.
+
+To turn off dind (no Docker daemon in the pod): `export CONTAINER_MODE=none` and re-run **`ci-scripts/arc/install-runner-scale-set.sh`**.
+
+### Workflow file ↔ Actions UI name
+
+| File                                          | `name:` in workflow (shown in Actions tab) |
+| --------------------------------------------- | ------------------------------------------ |
+| `.github/workflows/ibmc-cluster-setup.yml`    | IBM Cloud Hot Cluster Setup                |
+| `.github/workflows/ibmc-cluster-teardown.yml` | IBM Cloud Hot Cluster Teardown             |
+| `.github/workflows/hot-cluster-e2e.yml`       | Hot Cluster E2E (PR #4099)                 |
+| `.github/workflows/hot-cluster-e2e-run.yml`   | Hot Cluster E2E Run (PR #4099)             |
+
+### Setting up the hot cluster
+
+1. Actions → **IBM Cloud Hot Cluster Setup** → Run workflow
+2. Inputs: cluster name, **classic** zone (e.g. `wdc04`), OpenShift version, worker flavor/count, **KVM emulation** (`true` for VPC-style workers, `false` for bare metal with hardware KVM)
+3. Wait for completion (provisioning time depends on flavor; setup includes HCO, custom runner image build, ARC controller + scale set, `check-cluster-health.sh`)
+
+**Implementation notes:** Provisioning uses `ibmcloud oc cluster create classic` (not VPC workers in this workflow). Setup installs `oc` from the cluster downloads endpoint, runs `install-hco.sh`, then `images/setup-arc-runner-image.sh`, `install-arc-controller.sh`, and `install-runner-scale-set.sh`.
+
+### Running hot cluster E2E tests
+
+1. Actions → **Hot Cluster E2E** (PR trigger or manual dispatch)
+2. Inputs: Playwright project (`gating` or `features`), cluster name (default `kubevirt-plugin-ci`)
+3. Health check on `ubuntu-latest`; on success calls **Hot Cluster E2E Run**
+4. Run workflow provisions a `ci-test-stack`, runs Playwright, uploads artifacts, releases the stack
+
+To run only the test jobs (cluster already verified): dispatch **Hot Cluster E2E Run** directly.
+
+### Tearing down the cluster
+
+**Manual:** Actions → **IBM Cloud Hot Cluster Teardown**
+
+**Teardown implementation:** Uninstalls Helm releases `kubevirt-plugin-ci` (scale set) and `arc` (controller) when possible, deletes the ROKS cluster, then optionally removes offline GitHub runners labeled with the workflow `cluster_name` input (`CLUSTER_NAME`, default `kubevirt-plugin-ci`) using `BOT_PAT`.
+
+> **Note:** Automatic idle teardown (`ibmc-cluster-auto-teardown.yml`) is planned in PR #4099, not in this bootstrap PR.
+
+## ARC on OpenShift vs [na-launch/github-arc](https://github.com/na-launch/github-arc/blob/main/README.md)
+
+The [na-launch/github-arc](https://github.com/na-launch/github-arc/blob/main/README.md) README is a concise Helm + OpenShift recipe: fixed env vars for namespaces and installation names, explicit `serviceAccount.name=<install>-gha-rs-controller` on the controller chart, matching `controllerServiceAccount` on the scale set, apply SCC + ClusterRole, then `oc policy add-role-to-user system:openshift:scc:github-arc -z <runner-install>-gha-rs-no-permission`.
+
+| Topic                   | na-launch/github-arc                                               | This repo (`ci-scripts/arc/*`)                                                                                  |
+| ----------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| Controller SA name      | `${GITHUB_ARC_SYSTEM_INSTALLATION_NAME}-gha-rs-controller`         | `${ARC_CONTROLLER_INSTALL_NAME}-gha-rs-controller` (default install name `arc`)                                 |
+| Scale set → controller  | `controllerServiceAccount.name` + `.namespace`                     | Same when OpenShift is detected                                                                                 |
+| SCC + `use` ClusterRole | Separate `manifests/scc.yaml` + `cluster-role.yaml`                | Single `ci-scripts/arc/arc-openshift-scc.yaml` (equivalent)                                                     |
+| Runner policy           | `oc policy add-role-to-user ... -z <install>-gha-rs-no-permission` | Same pattern                                                                                                    |
+| Auth                    | PAT in `--set`                                                     | **GitHub App** (recommended) or PAT; App IDs forced to strings to avoid Helm float bugs                         |
+| Runner pod template     | Checked-in `values.yaml`                                           | `ci-scripts/arc/arc-runner-scale-set.pod.yaml` + optional `ARC_RUNNER_EXTRA_VALUES`                             |
+| Container jobs          | Not emphasized                                                     | **Default `CONTAINER_MODE=dind`** (privileged `docker:dind`); SCC allows privileged / RunAsAny for that sidecar |
+
+**Additional runner scale sets (same as na-launch):** Keep `ARC_CONTROLLER_NS` and `ARC_CONTROLLER_INSTALL_NAME` unchanged. **Do not** re-run **`ci-scripts/arc/install-arc-controller.sh`**. Set `ARC_RUNNERS_NS`, `RUNNER_SCALE_SET_NAME`, and `ARC_CONFIG_URL` (and auth). Run **`SKIP_ARC_RUNNER_RBAC=1` `./ci-scripts/arc/install-runner-scale-set.sh`** so the shared `ClusterRoleBinding` **arc-runner-ci** is not overwritten (it only lists one ServiceAccount). The scale-set script still binds SCC **github-arc** to the new runner SA; add **ClusterRole** access for CI:
+
+`oc adm policy add-cluster-role-to-user arc-runner-ci -z <new-RUNNER_SCALE_SET_NAME>-gha-rs-no-permission -n <new-ARC_RUNNERS_NS>`
+
+You do **not** need to re-apply `ci-scripts/arc/arc-openshift-scc.yaml`.
+
+## Scripts
+
+| Script                             | Purpose                                                                           |
+| ---------------------------------- | --------------------------------------------------------------------------------- |
+| `install-hco.sh`                   | Installs HCO operator, HPP storage, and virtctl                                   |
+| `arc/setup-dind-mirror.sh`         | Mirror `docker:dind` to internal registry; write `generated/arc-dind-replace.env` |
+| `images/setup-arc-runner-image.sh` | OpenShift binary build for custom ARC runner image                                |
+| `arc/install-arc-controller.sh`    | SCC + Helm `gha-runner-scale-set-controller` (once per cluster)                   |
+| `arc/install-runner-scale-set.sh`  | Helm `gha-runner-scale-set`, SCC bind, `arc-runner-rbac.yaml`                     |
+| `arc/README.md`                    | ARC on OpenShift setup guide                                                      |
+| `check-cluster-health.sh`          | Verifies cluster, HCO, ARC, storage, console; optional GitHub runner check        |
+| `check-roks-cluster-state.sh`      | Waits until ROKS cluster is usable (used by setup workflow)                       |
+| `resolve-console-image.sh`         | Emits `CONSOLE_IMAGE` tag **x.y** from `ClusterVersion` for off-cluster console   |
+| `start-plugin-container.sh`        | Runs plugin image with TLS + `nginx-9443.conf` (Docker dind–safe cert paths)      |
+| `start-console.sh`                 | Runs `origin-console` off-cluster; `BRIDGE_PLUGIN_PROXY` + kubevirt API route     |
+| `nginx-9443.conf`                  | Nginx config for plugin HTTPS (mounted into plugin container in POC test2)        |
+
+### Script Configuration
+
+All scripts accept configuration via environment variables. See the header comments in each script for details.
+
+Key defaults:
+
+- `KVM_EMULATION=false` (bare metal has real KVM)
+- `RUNNER_SCALE_SET_NAME=kubevirt-plugin-ci` (the `runs-on:` label)
+- `ARC_CONTROLLER_INSTALL_NAME=arc` (Helm release for controller; OpenShift SA `arc-gha-rs-controller`)
+- `MIN_RUNNERS=0`
+- `MAX_RUNNERS=5`
+- `CONTAINER_MODE=dind` (Docker-in-Docker for container jobs / `docker` in workflows)
+- `ARC_VERSION=0.14.0` (default pinned chart; `ARC_VERSION=latest` floats OCI default tag)
+- `ARC_SCALE_SET_LABELS` (optional multilabel; requires matching `runs-on` array in workflows)
+- Additional scale sets: run only **`ci-scripts/arc/install-runner-scale-set.sh`** (skip **`ci-scripts/arc/install-arc-controller.sh`**)
+
+## Follow-up work
+
+See [docs/HOT_CLUSTER_FUTURE_WORK.md](../docs/HOT_CLUSTER_FUTURE_WORK.md) for RBAC hardening, FIPS, ci-env-controller setup gap, and workflow hygiene items.
+
+Quick checklist:
+
+1. **Health check first** — Run **Hot Cluster E2E** (or health-check job only) to isolate cluster/HCO issues from test-stack issues.
+2. **ci-env-controller** — Install once on the cluster if not already present (`./dev/ci-env.sh`).
+3. **ARC on org repo** — Runners must register to `kubevirt-ui/kubevirt-plugin`, not a fork.
+4. **Auto-teardown** — Confirm idle detection watches `hot-cluster-e2e.yml` and `hot-cluster-e2e-run.yml`.
+
+## Production and hardening review (before treating POC patterns as prod)
+
+| Technique / choice                                           | Risk or limitation                                                                                 | Hardening direction                                                                   |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| **Privileged dind + broad SCC (`github-arc`)**               | High blast radius on the node; runner compromise ≈ strong cluster access                           | Narrow SCC, dedicated nodes, separate scale sets per trust zone, audit images         |
+| **`oc whoami --show-token` in `start-console.sh`**           | Long-lived bearer token injected into console container env                                        | Short-lived tokens, dedicated read-only SA, rotate; never log unmasked                |
+| **Self-signed TLS for plugin (`start-plugin-container.sh`)** | MITM within pod network if mis-scoped                                                              | Match operator-style serving certs; trust only where `InsecureSkipVerify` is explicit |
+| **`ttl.sh` or ephemeral public registries**                  | Ephemeral tags, no provenance, rate/abuse limits                                                   | Internal registry + image signing, digest pinning                                     |
+| **Skip `npm audit` / `--ignore-scripts`**                    | Supply-chain and lifecycle scripts not run                                                         | Revisit for production pipelines; use lockfile + audited base images                  |
+| **Cluster-scoped mutations in `test-setup.sh`**              | Variant A may patch shared ConfigMaps                                                              | Prefer namespaced fixtures or dedicated test clusters                                 |
+| **Ghost runner cleanup via `BOT_PAT`**                       | PAT scope and rotation                                                                             | GitHub App or org-level runner management; least privilege                            |
+| **Auto-teardown idle heuristic**                             | Monitors only the two E2E test workflows; a cluster used by other workflows may be torn down early | Tie to runner job queue or explicit "last test" workflow                              |
+| **Classic ROKS only in setup workflow**                      | Not IBM Cloud VPC Gen2 path                                                                        | Add a parallel path or doc if prod standardizes on VPC                                |
+
+## POC completion score
+
+**~55%** — **Infrastructure path is largely in place** (IBM Cloud provisioning, HCO, ARC 0.14, dind mirror, health checks, two E2E workflows, diagnostics artifacts). **Productization is incomplete**: test2 still carries registry/image shortcuts, TODOs, and a narrower Cypress entrypoint; **end-to-end “green main”** on real clusters is not yet documented as achieved. Raising the score to **~80%** means repeatable green runs on both POC variants with pinned images, no hard-coded TTL tags, and either stable full gating or an agreed minimal gate with flake budget.
+
+## Cost Control
+
+Bare metal nodes on IBM Cloud are expensive. Tear down the cluster manually via **IBM Cloud Hot Cluster Teardown** when testing is complete. Automatic idle teardown is planned in PR #4099.
+
+## Troubleshooting
+
+### Cluster setup fails during provisioning
+
+- Check IBM Cloud status page for outages
+- Verify the API key has sufficient permissions
+- Bare metal availability varies by region; try a different zone
+
+### ARC runners not registering
+
+- Check ARC controller logs: `oc logs -n arc-systems -l app.kubernetes.io/name=gha-rs-controller`
+- Verify GitHub App credentials are correct
+- Ensure the GitHub App is installed on the repository
+
+### Health check fails
+
+- Run `ci-scripts/check-cluster-health.sh` manually with `oc` configured
+- Check individual component status: `oc get pods -n kubevirt-hyperconverged`
+- Verify storage: `oc get storageclass`
+
+### `npm ci` fails in kubevirt-plugin-ci job
+
+- **"package-lock.json is out of sync"**: Run `npm install` locally and commit the updated `package-lock.json`.
+- **Node/npm version**: The workflow uses Node 22; the runner image must provide a compatible Node (or use `actions/setup-node`). Check the "Install dependencies" step log for `node -v` and `npm -v`.
+- **Network**: The runner must reach the npm registry. If the cluster restricts egress, allow `registry.npmjs.org` (and any private registries).
+- **RW Access**: The runner must have writable volumes for npm global configuration and package caching
+
+### Auto-teardown never triggers teardown
+
+- The scheduled job needs **`permissions: actions: write`** to dispatch the teardown workflow; confirm it is not overridden by org policy.
+- **`workflow_id`** in the dispatch step must match the teardown workflow filename on the default branch (**`ibmc-cluster-teardown.yml`**). A mismatch silently prevents teardown from running.
+
+### Ghost runners after failed teardown
+
+- Go to repository Settings → Actions → Runners
+- Manually delete any offline runners
+- Or run the teardown workflow again (it includes ghost runner cleanup)
+
+### ARC runner `oc` / `kubectl` permissions
+
+Jobs on `kubevirt-plugin-ci` use the ARC scale set ServiceAccount **`kubevirt-plugin-ci-gha-rs-no-permission`** in `arc-runners`, not `default`. Without RBAC, `oc` steps fail with Forbidden.
+
+**Default:** **`ci-scripts/arc/install-runner-scale-set.sh`** applies **`ci-scripts/arc/arc-runner-rbac.yaml`** after the scale set install (ClusterRole **`arc-runner-ci`** bound to **`${RUNNER_SCALE_SET_NAME}-gha-rs-no-permission`** in **`${ARC_RUNNERS_NS}`**). Set **`SKIP_ARC_RUNNER_RBAC=1`** if you manage bindings yourself.
+
+**Manual apply** (defaults only, or after skipping):
+
+```bash
+oc apply -f ci-scripts/arc/arc-runner-rbac.yaml
+```
+
+If `RUNNER_SCALE_SET_NAME` or `ARC_RUNNERS_NS` differ from defaults, edit the `subjects` block or rely on **`ci-scripts/arc/install-runner-scale-set.sh`** substitution.
+
+For a disposable or single-tenant cluster you can instead grant full cluster-admin by using the alternative ClusterRoleBinding described in the comments at the top of `ci-scripts/arc/arc-runner-rbac.yaml`.

--- a/ci-scripts/_cluster-helpers.sh
+++ b/ci-scripts/_cluster-helpers.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# Resolve CLI binary download URLs from a live OpenShift cluster.
+#
+# Source this file; do not execute it directly.
+#   source "$(dirname "${BASH_SOURCE[0]}")/_cluster-helpers.sh"
+#
+# After sourcing, call:
+#   resolve_cli_downloads           # populates OC_URL, VIRTCTL_URL, HELM_URL
+#   resolve_oc_version              # populates OC_VERSION (if not already set)
+#   resolve_internal_registry       # populates INTERNAL_REGISTRY
+#
+# The functions use ConsoleCLIDownload resources and rewrite public route URLs
+# to cluster-internal service URLs so build pods don't need to trust the
+# cluster's self-signed ingress CA.
+#
+# Requires: oc logged into OpenShift.
+# Optional: jq (URL resolution is silently skipped without it).
+
+verify_oc() {
+  if ! oc get clusterversion version &>/dev/null; then
+    echo "ERROR: OpenShift cluster required (clusterversion.version not found)."
+    exit 1
+  fi
+}
+
+# Rewrite a public https route URL to its backing cluster-internal HTTP service.
+# Arg: $1 = URL   Reads: _ALL_ROUTES_JSON (set by resolve_cli_downloads)
+_route_url_to_internal() {
+  local url="${1}"
+  [[ -z "${url}" ]] && return
+  local host path route_info ns svc svc_port
+  host=$(echo "${url}" | sed -E 's|https://([^/]+).*|\1|')
+  path=$(echo "${url}" | sed -E 's|https://[^/]+(/.*)?|\1|')
+  path="${path:-/}"
+  route_info=$(echo "${_ALL_ROUTES_JSON}" \
+    | jq -r --arg h "${host}" \
+        '.items[]? | select(.spec.host == $h) | "\(.metadata.namespace) \(.spec.to.name)"' \
+    | head -1) || true
+  if [[ -n "${route_info}" ]]; then
+    read -r ns svc <<< "${route_info}"
+    svc_port=$(oc get service "${svc}" -n "${ns}" \
+      -o jsonpath='{.spec.ports[0].port}' 2>/dev/null || echo "8080")
+    echo "http://${svc}.${ns}.svc.cluster.local:${svc_port}${path}"
+  else
+    echo "${url}"
+  fi
+}
+
+# Detect OC_VERSION from the cluster if not already set.
+# Sets OC_VERSION; defaults to 4.20 if detection fails.
+resolve_oc_version() {
+  if [[ -n "${OC_VERSION:-}" ]]; then
+    return
+  fi
+  OC_VERSION=$(oc version --output json 2>/dev/null \
+    | jq -r '.openshiftVersion | split(".") | .[0:2] | join(".") // empty') || true
+  OC_VERSION="${OC_VERSION:-4.20}"
+}
+
+# Resolve the internal image registry hostname from the cluster.
+# Sets INTERNAL_REGISTRY; defaults to the well-known service address if detection fails.
+resolve_internal_registry() {
+  INTERNAL_REGISTRY="$(oc get image.config.openshift.io/cluster \
+    -o jsonpath='{.status.internalRegistryHostname}' 2>/dev/null || true)"
+  INTERNAL_REGISTRY="${INTERNAL_REGISTRY:-image-registry.openshift-image-registry.svc:5000}"
+}
+
+# Resolve binary download URLs from ConsoleCLIDownload resources.
+# Sets: OC_URL, VIRTCTL_URL, HELM_URL (empty string if not resolved).
+# Callers can choose which variables they need; unused ones remain empty.
+resolve_cli_downloads() {
+  OC_URL=""
+  VIRTCTL_URL=""
+  HELM_URL=""
+
+  if ! command -v jq &>/dev/null; then
+    return
+  fi
+
+  local cli_json
+  cli_json=$(oc get consoleclidownload -o json 2>/dev/null || true)
+  if [[ -z "${cli_json}" ]]; then
+    return
+  fi
+
+  OC_URL=$(echo "${cli_json}" \
+    | jq -r '.items[].spec.links[] | select(.text | test("oc.*linux.*x86_64|oc.*linux.*amd64"; "i")) | .href' \
+    | head -1 || true)
+  VIRTCTL_URL=$(echo "${cli_json}" \
+    | jq -r '.items[].spec.links[] | select(.text | test("virtctl.*linux.*amd64|virtctl.*linux.*x86_64"; "i")) | .href' \
+    | head -1 || true)
+  HELM_URL=$(echo "${cli_json}" \
+    | jq -r '.items[].spec.links[] | select(.text | test("helm.*linux.*amd64|helm.*linux.*x86_64"; "i")) | .href' \
+    | head -1 || true)
+
+  _ALL_ROUTES_JSON=$(oc get route --all-namespaces -o json 2>/dev/null || true)
+  [[ -n "${OC_URL}" ]]      && OC_URL=$(_route_url_to_internal "${OC_URL}")
+  [[ -n "${VIRTCTL_URL}" ]] && VIRTCTL_URL=$(_route_url_to_internal "${VIRTCTL_URL}")
+  [[ -n "${HELM_URL}" ]]    && HELM_URL=$(_route_url_to_internal "${HELM_URL}")
+  unset _ALL_ROUTES_JSON
+}

--- a/ci-scripts/arc/README.md
+++ b/ci-scripts/arc/README.md
@@ -61,6 +61,7 @@ You do **not** need to re-apply **`arc-openshift-scc.yaml`**.
 | `arc-runner-scale-set.pod.yaml` | Helm values fragment for the runner container (volumes, securityContext)                                                     |
 | `arc-helm-helpers.sh`           | Shared Helm/auth helpers                                                                                                     |
 | `arc-dind-post-render.sh`       | Helm post-renderer: OpenShift dind `vfs` storage driver; optional `docker:dind` swap via `../generated/arc-dind-replace.env` |
+| `uninstall-arc.sh`              | Helm uninstall of scale set + controller (reverse of install; same env vars)                                                 |
 | `runner-image/Dockerfile`       | Custom runner (Node, kubectl, oc, virtctl, jq)                                                                               |
 
 Generated **`ci-scripts/generated/arc-dind-replace.env`** is gitignored; it is produced by **`setup-dind-mirror.sh`** or by **`install-runner-scale-set.sh`** when **`ARC_DIND_INTERNAL_IMAGE`** is set.

--- a/ci-scripts/arc/README.md
+++ b/ci-scripts/arc/README.md
@@ -1,0 +1,72 @@
+# GitHub Actions Runner Controller (ARC) on OpenShift
+
+Scripts in this directory install **Actions Runner Controller** with the **`gha-runner-scale-set`** chart on **OpenShift** (ROKS or other OCP clusters). They apply a custom **SecurityContextConstraints** (`github-arc`), bind it to the runner ServiceAccount, **mirror `docker:dind`** into the internal registry (the stable Helm chart hardcodes Docker Hub; we rewrite manifests to use the mirror), build a **custom runner image** in-cluster, and apply **ClusterRole** RBAC so jobs can use `oc` / KubeVirt APIs.
+
+All scripts expect **`oc login`** to an OpenShift cluster with permissions to create namespaces, SCC-related `ClusterRole`s, and Helm releases.
+
+## Order of operations
+
+Run from the **repository root** (paths below assume that).
+
+1. **`setup-dind-mirror.sh`** — `oc import-image` **`docker:dind`** → `image-registry.../arc-runners/arc-docker-dind:dind` and write **`ci-scripts/generated/arc-dind-replace.env`**. Use `SKIP_DIND_MIRROR=1` only if dind is provided via **`ImageContentSourcePolicy`** or another cluster mirror (no import from Docker Hub).
+2. **`ci-scripts/images/setup-arc-runner-image.sh`** — OpenShift `BuildConfig` binary build from [`images/arc-runner/Dockerfile`](../images/arc-runner/Dockerfile) → `arc-runner-custom:latest` in the internal registry. Prints **`IMAGE_REF=...`** for automation.
+3. **`install-arc-controller.sh`** — Once per cluster: namespace `arc-systems`, apply **`arc-openshift-scc.yaml`**, Helm **`gha-runner-scale-set-controller`**.
+4. **`install-runner-scale-set.sh`** — Per scale set: namespace `arc-runners`, Helm **`gha-runner-scale-set`** with GitHub auth, optional **`ARC_RUNNER_IMAGE`**, Helm **post-renderer** (always for dind: injects **`--storage-driver=vfs`** for OpenShift; optional **`docker:dind` → mirror** when `arc-dind-replace.env` exists or **`ARC_DIND_INTERNAL_IMAGE`** is set), **`oc policy add-role-to-user system:openshift:scc:github-arc`** on the runner SA, apply **`arc-runner-rbac.yaml`** (unless `SKIP_ARC_RUNNER_RBAC=1`).
+
+```bash
+export ARC_CONFIG_URL="https://github.com/org/repo"
+export ARC_APP_ID="..." ARC_APP_INSTALL_ID="..." ARC_APP_PRIVATE_KEY="$(cat app.pem)"
+# optional: export ARC_RUNNER_IMAGE after setup-runner-image prints IMAGE_REF=
+
+./ci-scripts/arc/setup-dind-mirror.sh
+IMAGE_REF=$(./ci-scripts/images/setup-arc-runner-image.sh | grep '^IMAGE_REF=' | cut -d= -f2-)
+export ARC_RUNNER_IMAGE="${IMAGE_REF}"
+
+./ci-scripts/arc/install-arc-controller.sh
+./ci-scripts/arc/install-runner-scale-set.sh
+```
+
+## Environment variables (summary)
+
+| Area                   | Variables                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Dind mirror**        | `ARC_RUNNERS_NS`, `SKIP_DIND_MIRROR`, `DIND_SOURCE_IMAGE`                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| **Runner image build** | `ARC_RUNNERS_NS`, `OC_VERSION`, `VIRTCTL_VERSION`, `ARC_RUNNER_IMAGE_FILE`                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| **Controller**         | `ARC_CONTROLLER_NS`, `ARC_CONTROLLER_INSTALL_NAME`, `ARC_VERSION`                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| **Scale set**          | `ARC_CONFIG_URL` (required), GitHub App (`ARC_APP_ID`, `ARC_APP_INSTALL_ID`, `ARC_APP_PRIVATE_KEY`) **or** `ARC_PAT`; `RUNNER_SCALE_SET_NAME`, `MIN_RUNNERS`, `MAX_RUNNERS`, `ARC_RUNNERS_NS`, `ARC_CONTROLLER_NS`, `ARC_CONTROLLER_INSTALL_NAME`, `ARC_VERSION`, `CONTAINER_MODE` (default `dind`; use `none` to disable), `ARC_RUNNER_IMAGE`, `ARC_DIND_INTERNAL_IMAGE` (writes replace env for this run), `ARC_USE_DIND_POST_RENDER`, `ARC_RUNNER_EXTRA_VALUES`, `ARC_SCALE_SET_LABELS`, `SKIP_ARC_RUNNER_RBAC` |
+
+Details are in each script’s header comments.
+
+## GitHub configuration
+
+- **GitHub App** (recommended): repository **Administration: Read and write**, organization **Self-hosted runners: Read and write**. Install the app on the target repo/org; use App ID, installation ID, and private key PEM.
+- **PAT**: fine-grained or classic with sufficient repo + runner permissions (see [ci-scripts/README.md](../README.md#required-github-secrets)).
+
+Workflows must use `runs-on:` labels that match **`RUNNER_SCALE_SET_NAME`** (default **`kubevirt-plugin-ci`**) or every label in **`ARC_SCALE_SET_LABELS`** if set.
+
+## Second runner scale set
+
+Do **not** re-run **`install-arc-controller.sh`**. Set `ARC_RUNNERS_NS`, `RUNNER_SCALE_SET_NAME`, and `ARC_CONFIG_URL` (and auth) for the new set. Use **`SKIP_ARC_RUNNER_RBAC=1`** so the default **`arc-runner-ci`** `ClusterRoleBinding` (single subject) is not overwritten; then bind **`arc-runner-ci`** to the new runner SA:
+
+`oc adm policy add-cluster-role-to-user arc-runner-ci -z <RUNNER_SCALE_SET_NAME>-gha-rs-no-permission -n <ARC_RUNNERS_NS>`
+
+You do **not** need to re-apply **`arc-openshift-scc.yaml`**.
+
+## Files in this directory
+
+| File                            | Purpose                                                                                                                      |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `arc-openshift-scc.yaml`        | SCC `github-arc` + `ClusterRole` to use it                                                                                   |
+| `arc-runner-rbac.yaml`          | `arc-runner-ci` ClusterRole + Binding (subject patched by install script)                                                    |
+| `arc-runner-scale-set.pod.yaml` | Helm values fragment for the runner container (volumes, securityContext)                                                     |
+| `arc-helm-helpers.sh`           | Shared Helm/auth helpers                                                                                                     |
+| `arc-dind-post-render.sh`       | Helm post-renderer: OpenShift dind `vfs` storage driver; optional `docker:dind` swap via `../generated/arc-dind-replace.env` |
+| `runner-image/Dockerfile`       | Custom runner (Node, kubectl, oc, virtctl, jq)                                                                               |
+
+Generated **`ci-scripts/generated/arc-dind-replace.env`** is gitignored; it is produced by **`setup-dind-mirror.sh`** or by **`install-runner-scale-set.sh`** when **`ARC_DIND_INTERNAL_IMAGE`** is set.
+
+## Further reading
+
+- [ci-scripts/README.md](../README.md) — secrets, dind mirror, multilabel, experimental chart notes.
+- [Red Hat: ARC on OpenShift](https://developers.redhat.com/articles/2025/02/17/how-securely-deploy-github-arc-openshift)
+- Upstream chart: `oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set`

--- a/ci-scripts/arc/arc-helm-helpers.sh
+++ b/ci-scripts/arc/arc-helm-helpers.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Shared helpers for gha-runner-scale-set Helm installs.
+#
+
+#
+# GitHub auth for scale-set chart: arc_github_config_secret_helm_auth AUTH_ARGS
+# Sets global AUTH_VALUES_FILE when authentication is used.
+#
+arc_github_config_secret_helm_auth() {
+  local -n _auth_arr="${1:?auth args array name required}"
+  _auth_arr=()
+  AUTH_VALUES_FILE=""
+  if [[ -n "${ARC_APP_ID:-}" && -n "${ARC_APP_INSTALL_ID:-}" && -n "${ARC_APP_PRIVATE_KEY:-}" ]]; then
+    echo "Using GitHub App authentication"
+    AUTH_VALUES_FILE=$(mktemp)
+    {
+      echo 'githubConfigSecret:'
+      echo "  github_app_id: \"${ARC_APP_ID}\""
+      echo "  github_app_installation_id: \"${ARC_APP_INSTALL_ID}\""
+      echo '  github_app_private_key: |'
+      echo "${ARC_APP_PRIVATE_KEY}" | sed 's/^/    /'
+    } > "${AUTH_VALUES_FILE}"
+    _auth_arr+=(--values "${AUTH_VALUES_FILE}")
+  elif [[ -n "${ARC_PAT:-}" ]]; then
+    echo "Using Personal Access Token authentication"
+    AUTH_VALUES_FILE=$(mktemp)
+    {
+      echo 'githubConfigSecret:'
+      echo "  github_token: \"${ARC_PAT}\""
+    } > "${AUTH_VALUES_FILE}"
+    _auth_arr+=(--values "${AUTH_VALUES_FILE}")
+  else
+    echo "ERROR: Set ARC_APP_ID + ARC_APP_INSTALL_ID + ARC_APP_PRIVATE_KEY, or ARC_PAT"
+    return 1
+  fi
+
+  trap '[[ -n "${AUTH_VALUES_FILE:-}" && -f "${AUTH_VALUES_FILE}" ]] && rm -f "${AUTH_VALUES_FILE}"' EXIT
+  return 0
+}

--- a/ci-scripts/arc/arc-openshift-scc.yaml
+++ b/ci-scripts/arc/arc-openshift-scc.yaml
@@ -1,0 +1,59 @@
+# OpenShift Security Context Constraint and ClusterRole for GitHub ARC runners.
+#
+# The runner container uses UID 1001 / GID 123 via Helm template.securityContext.
+# No privileged containers or privilege escalation is needed; the CI test stack
+# (console + plugin) runs as separate unprivileged pods via the ci-test-stack
+# Helm chart.
+#
+# Ref: https://developers.redhat.com/articles/2025/02/17/how-securely-deploy-github-arc-openshift
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: github-arc
+  annotations:
+    kubernetes.io/description: 'ARC runners: main container as UID 1001 (Helm), non-root, unprivileged.'
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:scc:github-arc
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - github-arc
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use

--- a/ci-scripts/arc/arc-runner-rbac.yaml
+++ b/ci-scripts/arc/arc-runner-rbac.yaml
@@ -1,0 +1,79 @@
+# Grant the ARC runner scale set ServiceAccount CI permissions.
+# gha-runner-scale-set creates: <RUNNER_SCALE_SET_NAME>-gha-rs-no-permission
+#   (default: kubevirt-plugin-ci-gha-rs-no-permission).
+#
+# Applied automatically by ci-scripts/arc/install-runner-scale-set.sh.
+# Subject name + namespace substituted for RUNNER_SCALE_SET_NAME / ARC_RUNNERS_NS.
+# Manual apply (defaults only):
+#   oc apply -f ci-scripts/arc/arc-runner-rbac.yaml
+#
+# To skip cluster RBAC (custom bindings): SKIP_ARC_RUNNER_RBAC=1
+#
+# If RUNNER_SCALE_SET_NAME differs from defaults and you apply this file by hand,
+# edit subjects or use:
+#   oc create clusterrolebinding arc-runner-ci-custom --clusterrole=arc-runner-ci \
+#     --serviceaccount=<ns>:<scale-set>-gha-rs-no-permission
+#
+# NOTE: The runner's ConfigMap access in the ci-env namespace is granted via a
+# namespaced RoleBinding created by ci-scripts/ci-env/install-ci-env-controller.sh,
+# not by this ClusterRole.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: arc-runner-ci
+  labels:
+    app.kubernetes.io/component: arc-runner-rbac
+rules:
+  # --- Cluster reads (console URL, version logging) ---
+  - apiGroups: ['']
+    resources: ['nodes']
+    verbs: ['get', 'list']
+  - apiGroups: ['config.openshift.io']
+    resources: ['consoles', 'clusterversions', 'ingresses']
+    verbs: ['get', 'list']
+
+  # --- Diagnostics (pod logs, events in test namespaces) ---
+  - apiGroups: ['']
+    resources: ['pods', 'pods/log', 'events']
+    verbs: ['get', 'list']
+
+  # --- Cypress cy.exec runs: oc patch virtualmachine ---
+  - apiGroups: ['kubevirt.io']
+    resources: ['virtualmachines']
+    verbs: ['get', 'list', 'watch', 'patch']
+
+  # --- check-runner job: HCO / operator version logging ---
+  - apiGroups: ['operators.coreos.com']
+    resources: ['clusterserviceversions']
+    verbs: ['get', 'list']
+  - apiGroups: ['kubevirt.io']
+    resources: ['kubevirts']
+    verbs: ['get', 'list']
+  - apiGroups: ['cdi.kubevirt.io']
+    resources: ['cdis']
+    verbs: ['get', 'list']
+  - apiGroups: ['ssp.kubevirt.io']
+    resources: ['ssps']
+    verbs: ['get', 'list']
+  - apiGroups: ['networkaddonsoperator.network.kubevirt.io']
+    resources: ['networkaddonsconfigs']
+    verbs: ['get', 'list']
+  - apiGroups: ['hostpathprovisioner.kubevirt.io']
+    resources: ['hostpathprovisioners']
+    verbs: ['get', 'list']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: arc-runner-ci
+  labels:
+    app.kubernetes.io/component: arc-runner-rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: arc-runner-ci
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-plugin-ci-gha-rs-no-permission
+    namespace: arc-runners

--- a/ci-scripts/arc/arc-runner-scale-set.pod.yaml
+++ b/ci-scripts/arc/arc-runner-scale-set.pod.yaml
@@ -1,0 +1,40 @@
+# gha-runner-scale-set Helm values fragment: runner pod template (OpenShift).
+# Used by ci-scripts/arc/install-runner-scale-set.sh.
+#
+# The CI test stack (console + plugin) runs as separate cluster pods via the
+# ci-test-stack Helm chart, so no Docker-in-Docker sidecar is needed.
+#
+# Default image is pinned upstream until ARC_RUNNER_IMAGE / --set overrides:
+#   --set template.spec.containers[0].image=<internal-registry>/...
+#
+# Ref: https://github.com/actions/actions-runner-controller/tree/master/charts/gha-runner-scale-set
+---
+template:
+  spec:
+    volumes:
+      - name: work
+        emptyDir: {}
+      - name: npm-cache
+        emptyDir: {}
+      - name: npm-tmp
+        emptyDir: {}
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:2.335.1
+        command:
+          - '/home/runner/run.sh'
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          runAsUser: 1001
+          runAsGroup: 123
+        volumeMounts:
+          - name: work
+            mountPath: '/home/runner/_work'
+          - name: npm-cache
+            mountPath: '/home/runner/.npm'
+          - name: npm-tmp
+            mountPath: '/home/runner/.tmp'

--- a/ci-scripts/arc/install-arc-controller.sh
+++ b/ci-scripts/arc/install-arc-controller.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Install ARC controller only (OpenShift): namespace, SCC, Helm gha-runner-scale-set-controller.
+# Pair with install-runner-scale-set.sh for the AutoscalingRunnerSet release.
+#
+# Optional environment variables:
+#   ARC_CONTROLLER_NS           (default: arc-systems)
+#   ARC_CONTROLLER_INSTALL_NAME (default: arc → SA arc-gha-rs-controller)
+#   ARC_VERSION                 Helm chart version (default: 0.14.0); set to "latest" to omit --version
+#
+# Prerequisites: oc login to OpenShift; helm
+
+set -euo pipefail
+ARC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CI_SCRIPTS_DIR="$(cd "${ARC_DIR}/.." && pwd)"
+source "${CI_SCRIPTS_DIR}/_cluster-helpers.sh"
+verify_oc
+
+ARC_CONTROLLER_NS="${ARC_CONTROLLER_NS:-arc-systems}"
+ARC_CONTROLLER_INSTALL_NAME="${ARC_CONTROLLER_INSTALL_NAME:-arc}"
+ARC_HELM_REPO="oci://ghcr.io/actions/actions-runner-controller-charts"
+ARC_VERSION="${ARC_VERSION:-0.14.0}"
+
+echo "=== ARC controller installation (OpenShift) ==="
+echo "  ARC_CONTROLLER_NS:           ${ARC_CONTROLLER_NS}"
+echo "  ARC_CONTROLLER_INSTALL_NAME: ${ARC_CONTROLLER_INSTALL_NAME}"
+echo "  ARC_HELM_REPO:               ${ARC_HELM_REPO}"
+echo "  ARC_VERSION:                 ${ARC_VERSION}"
+echo ""
+
+echo "Creating namespace ${ARC_CONTROLLER_NS}..."
+oc create namespace "${ARC_CONTROLLER_NS}" --dry-run=client -o yaml | oc apply -f -
+
+echo "Applying ARC SCC and ClusterRole (github-arc)..."
+oc apply -f "${ARC_DIR}/arc-openshift-scc.yaml"
+
+CONTROLLER_ARGS=()
+if [[ -n "${ARC_VERSION}" && "${ARC_VERSION}" != "latest" ]]; then
+  CONTROLLER_ARGS+=(--version "${ARC_VERSION}")
+fi
+
+CONTROLLER_SA_NAME="${ARC_CONTROLLER_INSTALL_NAME}-gha-rs-controller"
+CONTROLLER_ARGS+=(--set "serviceAccount.name=${CONTROLLER_SA_NAME}")
+
+echo "Installing ARC controller (Helm release: ${ARC_CONTROLLER_INSTALL_NAME})..."
+helm upgrade \
+  "${ARC_CONTROLLER_INSTALL_NAME}" \
+  "${ARC_HELM_REPO}/gha-runner-scale-set-controller" \
+  --install \
+  --namespace "${ARC_CONTROLLER_NS}" \
+  "${CONTROLLER_ARGS[@]}" \
+  --wait --timeout 5m
+
+echo ""
+echo "=== ARC controller installation complete ==="
+echo ""

--- a/ci-scripts/arc/install-runner-scale-set.sh
+++ b/ci-scripts/arc/install-runner-scale-set.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+#
+# Install gha-runner-scale-set (OpenShift): runner namespace, Helm release,
+# SCC bind, CI RBAC.
+# Requires install-arc-controller.sh (or equivalent controller + SCC) already applied.
+#
+# Required environment variables:
+#   ARC_CONFIG_URL         - Repository or org URL (e.g., https://github.com/org/repo)
+#
+# Authentication (one of):
+#   ARC_APP_ID + ARC_APP_INSTALL_ID + ARC_APP_PRIVATE_KEY  (GitHub App, recommended)
+#   ARC_PAT                                                (PAT with admin:repo)
+#
+# Optional environment variables:
+#   RUNNER_SCALE_SET_NAME       (default: kubevirt-plugin-ci)
+#   MIN_RUNNERS / MAX_RUNNERS   (default: 0 / 5)
+#   ARC_CONTROLLER_NS           (default: arc-systems) — must match controller install
+#   ARC_CONTROLLER_INSTALL_NAME (default: arc)
+#   ARC_RUNNERS_NS              (default: arc-runners)
+#   ARC_VERSION                 Helm chart version (default: 0.14.0); set to "latest" to omit --version
+#   ARC_RUNNER_IMAGE            If set, use this image for the runner container
+#   ARC_RUNNER_EXTRA_VALUES     Optional extra Helm values file (e.g. FIPS workarounds)
+#   SKIP_ARC_RUNNER_RBAC        Set to 1 to skip applying ci-scripts/arc/arc-runner-rbac.yaml
+#
+# Pod template fragment: ci-scripts/arc/arc-runner-scale-set.pod.yaml
+
+set -euo pipefail
+ARC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CI_SCRIPTS_DIR="$(cd "${ARC_DIR}/.." && pwd)"
+source "${CI_SCRIPTS_DIR}/_cluster-helpers.sh"
+verify_oc
+
+source "${ARC_DIR}/arc-helm-helpers.sh"
+
+RUNNER_POD_VALUES="${ARC_DIR}/arc-runner-scale-set.pod.yaml"
+if [[ ! -f "${RUNNER_POD_VALUES}" ]]; then
+  echo "ERROR: Missing ${RUNNER_POD_VALUES}"
+  exit 1
+fi
+
+ARC_CONFIG_URL="${ARC_CONFIG_URL:?ARC_CONFIG_URL is required}"
+ARC_CONTROLLER_NS="${ARC_CONTROLLER_NS:-arc-systems}"
+ARC_CONTROLLER_INSTALL_NAME="${ARC_CONTROLLER_INSTALL_NAME:-arc}"
+ARC_RUNNERS_NS="${ARC_RUNNERS_NS:-arc-runners}"
+ARC_HELM_REPO="oci://ghcr.io/actions/actions-runner-controller-charts"
+ARC_VERSION="${ARC_VERSION:-0.14.0}"
+RUNNER_SCALE_SET_NAME="${RUNNER_SCALE_SET_NAME:-kubevirt-plugin-ci}"
+MIN_RUNNERS="${MIN_RUNNERS:-0}"
+MAX_RUNNERS="${MAX_RUNNERS:-5}"
+if ! [[ "${MIN_RUNNERS}" =~ ^[0-9]+$ && "${MAX_RUNNERS}" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: MIN_RUNNERS and MAX_RUNNERS must be non-negative integers"
+  exit 1
+fi
+if (( MIN_RUNNERS > MAX_RUNNERS )); then
+  echo "ERROR: MIN_RUNNERS cannot be greater than MAX_RUNNERS"
+  exit 1
+fi
+CONTROLLER_SA_NAME="${ARC_CONTROLLER_INSTALL_NAME}-gha-rs-controller"
+
+echo "=== ARC runner scale set installation (OpenShift) ==="
+echo "  ARC_CONFIG_URL:              ${ARC_CONFIG_URL}"
+echo "  ARC_CONTROLLER_NS:           ${ARC_CONTROLLER_NS}"
+echo "  ARC_CONTROLLER_INSTALL_NAME: ${ARC_CONTROLLER_INSTALL_NAME}"
+echo "  ARC_RUNNERS_NS:              ${ARC_RUNNERS_NS}"
+echo "  ARC_RUNNER_IMAGE:            ${ARC_RUNNER_IMAGE:-(not set, will use default)}"
+echo "  ARC_HELM_REPO:               ${ARC_HELM_REPO}"
+echo "  ARC_VERSION:                 ${ARC_VERSION}"
+echo "  RUNNER_SCALE_SET_NAME:       ${RUNNER_SCALE_SET_NAME}"
+echo "  MIN_RUNNERS / MAX_RUNNERS:   ${MIN_RUNNERS} / ${MAX_RUNNERS}"
+echo "  Runner pod values:           ${RUNNER_POD_VALUES}"
+echo "  Controller SA name:          ${CONTROLLER_SA_NAME}"
+echo ""
+
+echo "Creating namespace ${ARC_RUNNERS_NS}..."
+oc create namespace "${ARC_RUNNERS_NS}" --dry-run=client -o yaml | oc apply -f -
+
+AUTH_ARGS=()
+if ! arc_github_config_secret_helm_auth AUTH_ARGS; then
+  exit 1
+fi
+
+RUNNER_SET_ARGS=(
+  --set "githubConfigUrl=${ARC_CONFIG_URL}"
+  --set "minRunners=${MIN_RUNNERS}"
+  --set "maxRunners=${MAX_RUNNERS}"
+  --set "controllerServiceAccount.name=${CONTROLLER_SA_NAME}"
+  --set "controllerServiceAccount.namespace=${ARC_CONTROLLER_NS}"
+  "${AUTH_ARGS[@]}"
+  --values "${RUNNER_POD_VALUES}"
+)
+if [[ -n "${ARC_RUNNER_IMAGE:-}" ]]; then
+  echo "Using runner image from ARC_RUNNER_IMAGE"
+  RUNNER_SET_ARGS+=(--set-string "template.spec.containers[0].image=${ARC_RUNNER_IMAGE}")
+fi
+if [[ -n "${ARC_RUNNER_EXTRA_VALUES:-}" ]]; then
+  if [[ ! -f "${ARC_RUNNER_EXTRA_VALUES}" ]]; then
+    echo "ERROR: ARC_RUNNER_EXTRA_VALUES file not found: ${ARC_RUNNER_EXTRA_VALUES}"
+    exit 1
+  fi
+  echo "Merging extra Helm values from ${ARC_RUNNER_EXTRA_VALUES}"
+  RUNNER_SET_ARGS+=(--values "${ARC_RUNNER_EXTRA_VALUES}")
+fi
+if [[ -n "${ARC_VERSION}" && "${ARC_VERSION}" != "latest" ]]; then
+  RUNNER_SET_ARGS+=(--version "${ARC_VERSION}")
+fi
+
+echo "Installing runner scale set '${RUNNER_SCALE_SET_NAME}'..."
+helm upgrade \
+  "${RUNNER_SCALE_SET_NAME}" \
+  "${ARC_HELM_REPO}/gha-runner-scale-set" \
+  --install \
+  --namespace "${ARC_RUNNERS_NS}" \
+  "${RUNNER_SET_ARGS[@]}" \
+  --wait --timeout 5m
+
+RUNNER_SA="${RUNNER_SCALE_SET_NAME}-gha-rs-no-permission"
+echo "Binding SCC github-arc to runner ServiceAccount ${RUNNER_SA}..."
+oc policy add-role-to-user system:openshift:scc:github-arc -z "${RUNNER_SA}" -n "${ARC_RUNNERS_NS}"
+
+RUNNER_RBAC_MANIFEST="${ARC_DIR}/arc-runner-rbac.yaml"
+if [[ "${SKIP_ARC_RUNNER_RBAC:-0}" != "1" ]]; then
+  if [[ ! -f "${RUNNER_RBAC_MANIFEST}" ]]; then
+    echo "ERROR: Missing ${RUNNER_RBAC_MANIFEST}"
+    exit 1
+  fi
+  echo "Applying runner CI RBAC (ClusterRole arc-runner-ci → ${RUNNER_SA} in ${ARC_RUNNERS_NS})..."
+  DEFAULT_RUNNER_SA='kubevirt-plugin-ci-gha-rs-no-permission'
+  DEFAULT_RUNNERS_NS='arc-runners'
+  if ! grep -qF "    name: ${DEFAULT_RUNNER_SA}" "${RUNNER_RBAC_MANIFEST}"; then
+    echo "ERROR: ${RUNNER_RBAC_MANIFEST} missing placeholder ServiceAccount '${DEFAULT_RUNNER_SA}'"
+    exit 1
+  fi
+  if ! grep -qF "    namespace: ${DEFAULT_RUNNERS_NS}" "${RUNNER_RBAC_MANIFEST}"; then
+    echo "ERROR: ${RUNNER_RBAC_MANIFEST} missing placeholder namespace '${DEFAULT_RUNNERS_NS}'"
+    exit 1
+  fi
+  RBAC_RENDERED=$(
+    sed \
+      -e "s/^    name: ${DEFAULT_RUNNER_SA}\$/    name: ${RUNNER_SA}/" \
+      -e "s/^    namespace: ${DEFAULT_RUNNERS_NS}\$/    namespace: ${ARC_RUNNERS_NS}/" \
+      "${RUNNER_RBAC_MANIFEST}"
+  )
+  if ! grep -qF "    name: ${RUNNER_SA}" <<< "${RBAC_RENDERED}"; then
+    echo "ERROR: RBAC substitution failed for ServiceAccount '${RUNNER_SA}'"
+    exit 1
+  fi
+  if ! grep -qF "    namespace: ${ARC_RUNNERS_NS}" <<< "${RBAC_RENDERED}"; then
+    echo "ERROR: RBAC substitution failed for namespace '${ARC_RUNNERS_NS}'"
+    exit 1
+  fi
+  echo "${RBAC_RENDERED}" | oc apply -f -
+  echo "  (Additional scale sets: set SKIP_ARC_RUNNER_RBAC=1 and bind arc-runner-ci per SA, e.g. oc adm policy add-cluster-role-to-user arc-runner-ci -z <sa> -n <ns>.)"
+else
+  echo "SKIP_ARC_RUNNER_RBAC=1 — not applying ${RUNNER_RBAC_MANIFEST}"
+fi
+
+echo ""
+echo "=== Runner scale set installation complete ==="
+echo "  runs-on: ${RUNNER_SCALE_SET_NAME}"
+echo "  To refresh runner image: re-run this script with ARC_RUNNER_IMAGE set (after setup-arc-runner-image.sh)."
+echo ""

--- a/ci-scripts/arc/uninstall-arc.sh
+++ b/ci-scripts/arc/uninstall-arc.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Uninstall ARC runner scale set and controller (reverse of install-runner-scale-set.sh
+# and install-arc-controller.sh). Uses the same environment variables so setup and
+# teardown stay in sync.
+#
+# Optional environment variables:
+#   RUNNER_SCALE_SET_NAME       (default: kubevirt-plugin-ci)
+#   ARC_RUNNERS_NS              (default: arc-runners)
+#   ARC_CONTROLLER_INSTALL_NAME (default: arc)
+#   ARC_CONTROLLER_NS           (default: arc-systems)
+#
+# Prerequisites: helm, oc/kubectl with cluster access
+
+set -euo pipefail
+
+RUNNER_SCALE_SET_NAME="${RUNNER_SCALE_SET_NAME:-kubevirt-plugin-ci}"
+ARC_RUNNERS_NS="${ARC_RUNNERS_NS:-arc-runners}"
+ARC_CONTROLLER_INSTALL_NAME="${ARC_CONTROLLER_INSTALL_NAME:-arc}"
+ARC_CONTROLLER_NS="${ARC_CONTROLLER_NS:-arc-systems}"
+
+echo "=== ARC uninstall ==="
+echo "  RUNNER_SCALE_SET_NAME:       ${RUNNER_SCALE_SET_NAME}"
+echo "  ARC_RUNNERS_NS:              ${ARC_RUNNERS_NS}"
+echo "  ARC_CONTROLLER_INSTALL_NAME: ${ARC_CONTROLLER_INSTALL_NAME}"
+echo "  ARC_CONTROLLER_NS:           ${ARC_CONTROLLER_NS}"
+echo ""
+
+echo "Uninstalling ARC runner scale set '${RUNNER_SCALE_SET_NAME}' from namespace '${ARC_RUNNERS_NS}'..."
+helm uninstall "${RUNNER_SCALE_SET_NAME}" \
+  --namespace "${ARC_RUNNERS_NS}" \
+  --wait --timeout 5m 2>/dev/null \
+  || echo "Runner scale set '${RUNNER_SCALE_SET_NAME}' not found or already removed"
+
+echo "Uninstalling ARC controller '${ARC_CONTROLLER_INSTALL_NAME}' from namespace '${ARC_CONTROLLER_NS}'..."
+helm uninstall "${ARC_CONTROLLER_INSTALL_NAME}" \
+  --namespace "${ARC_CONTROLLER_NS}" \
+  --wait --timeout 5m 2>/dev/null \
+  || echo "ARC controller '${ARC_CONTROLLER_INSTALL_NAME}' not found or already removed"
+
+echo ""
+echo "=== ARC uninstall complete ==="

--- a/ci-scripts/check-cluster-health.sh
+++ b/ci-scripts/check-cluster-health.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+#
+# Check the health of the hot cluster: API server, nodes, HCO, KubeVirt pods,
+# ARC runner scale set, storage, and console route.
+#
+# Returns exit code 0 if all checks pass, non-zero otherwise.
+#
+# Optional environment variables:
+#   ARC_RUNNERS_NS  - Namespace for ARC runner scale set (default: "arc-runners")
+
+set -uo pipefail
+
+ARC_RUNNERS_NS="${ARC_RUNNERS_NS:-arc-runners}"
+FAILURES=0
+
+check() {
+  local name="$1"
+  shift
+  echo -n "Checking ${name}... "
+  if "$@"; then
+    echo "✅ OK"
+  else
+    echo "❌ FAILED"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "=== Cluster Health Check ==="
+echo ""
+
+# --- API Server ---
+check "API server reachability" oc cluster-info
+
+# --- Node readiness ---
+check "node readiness" bash -c '
+  ready_nodes=$(oc get nodes --no-headers 2>/dev/null | grep -c " Ready")
+  if [[ "${ready_nodes}" -ge 1 ]]; then
+    echo "  ${ready_nodes} node(s) Ready"
+    exit 0
+  else
+    echo "  No nodes in Ready state"
+    exit 1
+  fi
+'
+
+# --- HCO Available ---
+check "HCO Available condition" \
+  oc wait -n kubevirt-hyperconverged hyperconverged kubevirt-hyperconverged \
+    --for=condition=Available --timeout=60s
+
+# --- Key KubeVirt pods ---
+check "virt-api pods" bash -c '
+  running=$(oc get pods -n kubevirt-hyperconverged -l kubevirt.io=virt-api --no-headers 2>/dev/null | grep -c "Running")
+  [[ "${running}" -ge 1 ]]
+'
+
+check "virt-controller pods" bash -c '
+  running=$(oc get pods -n kubevirt-hyperconverged -l kubevirt.io=virt-controller --no-headers 2>/dev/null | grep -c "Running")
+  [[ "${running}" -ge 1 ]]
+'
+
+check "virt-handler pods" bash -c '
+  running=$(oc get pods -n kubevirt-hyperconverged -l kubevirt.io=virt-handler --no-headers 2>/dev/null | grep -c "Running")
+  [[ "${running}" -ge 1 ]]
+'
+
+# --- ARC runner scale set ---
+# Scale sets scale to zero when idle; check the AutoscalingRunnerSet resource rather than
+# counting ephemeral runner pods (which may be 0 between jobs).
+check "ARC AutoscalingRunnerSet in ${ARC_RUNNERS_NS}" bash -c "
+  if ! oc get namespace '${ARC_RUNNERS_NS}' &>/dev/null; then
+    echo '  Namespace ${ARC_RUNNERS_NS} does not exist'
+    exit 1
+  fi
+  rs_count=\$(oc get autoscalingrunnersets -n '${ARC_RUNNERS_NS}' --no-headers 2>/dev/null | wc -l)
+  if [[ \"\${rs_count}\" -ge 1 ]]; then
+    echo \"  \${rs_count} AutoscalingRunnerSet(s) found\"
+    exit 0
+  else
+    echo '  No AutoscalingRunnerSets found in ${ARC_RUNNERS_NS}'
+    exit 1
+  fi
+"
+
+# --- ARC listener pod ---
+# The listener pod stays Running even when the scale set is idle (no ephemeral runner pods).
+# A missing or non-Running listener means the scale set cannot pick up jobs.
+check "ARC listener pod in ${ARC_RUNNERS_NS}" bash -c "
+  running=\$(oc get pods -n '${ARC_RUNNERS_NS}' -l app.kubernetes.io/component=runner-scale-set-listener --no-headers 2>/dev/null | grep -c 'Running')
+  if [[ \"\${running}\" -ge 1 ]]; then
+    echo \"  \${running} Running listener pod(s)\"
+    exit 0
+  else
+    echo '  No Running listener pod in ${ARC_RUNNERS_NS}'
+    exit 1
+  fi
+"
+
+# --- Default StorageClass ---
+check "default StorageClass" bash -c '
+  default_sc=$(oc get storageclass -o jsonpath="{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class==\"true\")].metadata.name}" 2>/dev/null)
+  if [[ -n "${default_sc}" ]]; then
+    echo "  Default StorageClass: ${default_sc}"
+    exit 0
+  else
+    echo "  No default StorageClass found"
+    exit 1
+  fi
+'
+
+# --- Console route ---
+check "console route accessible" bash -c '
+  console_url=$(oc get consoles.config.openshift.io cluster -o jsonpath="{.status.consoleURL}" 2>/dev/null)
+  if [[ -n "${console_url}" ]]; then
+    echo "  Console URL: ${console_url}"
+    exit 0
+  else
+    echo "  Console URL not found"
+    exit 1
+  fi
+'
+
+echo ""
+echo "=== Health Check Summary ==="
+if [[ ${FAILURES} -eq 0 ]]; then
+  echo "All checks passed"
+  exit 0
+else
+  echo "${FAILURES} check(s) FAILED"
+  exit 1
+fi

--- a/ci-scripts/check-roks-cluster-state.sh
+++ b/ci-scripts/check-roks-cluster-state.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+# Polls IBM Cloud until the ROKS cluster is fully available.
+# The cluster is ready when .state is "normal" AND .ingressStatus is "healthy".
+#
+# Required env:
+#   CLUSTER_NAME   - name of the cluster to check
+#
+# Optional env:
+#   MAX_WAIT       - timeout in seconds (default: 7200 = 2 hours)
+#   INTERVAL       - poll interval in seconds (default: 60)
+
+CLUSTER_NAME="${CLUSTER_NAME:?CLUSTER_NAME must be set}"
+MAX_WAIT="${MAX_WAIT:-7200}"
+INTERVAL="${INTERVAL:-60}"
+if ! [[ "${MAX_WAIT}" =~ ^[0-9]+$ && "${INTERVAL}" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: MAX_WAIT and INTERVAL must be positive integers"
+  exit 1
+fi
+if (( MAX_WAIT <= 0 || INTERVAL <= 0 )); then
+  echo "ERROR: MAX_WAIT and INTERVAL must be greater than zero"
+  exit 1
+fi
+
+echo "Waiting for cluster '${CLUSTER_NAME}' to be fully available..."
+echo "  Ready when: state=normal, ingressStatus=healthy"
+echo "  Timeout: ${MAX_WAIT}s, poll interval: ${INTERVAL}s"
+echo ""
+
+ELAPSED=0
+
+while [[ ${ELAPSED} -lt ${MAX_WAIT} ]]; do
+  if ! CLUSTER_JSON=$(ibmcloud oc cluster get --cluster "${CLUSTER_NAME}" --output json 2>&1); then
+    echo "ERROR: Failed to get cluster '${CLUSTER_NAME}':"
+    echo "${CLUSTER_JSON}"
+    exit 1
+  fi
+
+  STATE=$(echo "${CLUSTER_JSON}" | jq -r '.state // "unknown"')
+  MASTER_STATE=$(echo "${CLUSTER_JSON}" | jq -r '.masterState // "unknown"')
+  INGRESS_STATUS=$(echo "${CLUSTER_JSON}" | jq -r '.ingressStatus // "unknown"')
+
+  echo "[$(date '+%H:%M:%S')] state=${STATE}  masterState=${MASTER_STATE}  ingressStatus=${INGRESS_STATUS}  (${ELAPSED}s elapsed)"
+
+  if [[ "${STATE}" == "critical" || "${STATE}" == "delete_failed" ]]; then
+    echo "ERROR: Cluster entered '${STATE}' state"
+    exit 1
+  fi
+
+  if [[ "${STATE}" == "normal" && "${INGRESS_STATUS}" == "healthy" ]]; then
+    echo ""
+    echo "Cluster is fully available!"
+    exit 0
+  fi
+
+  sleep "${INTERVAL}"
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+echo "ERROR: Cluster did not become fully available within ${MAX_WAIT}s"
+exit 1

--- a/ci-scripts/images/arc-runner/Dockerfile
+++ b/ci-scripts/images/arc-runner/Dockerfile
@@ -1,0 +1,121 @@
+# Custom GitHub Actions runner image for kubevirt-plugin-ci CI.
+# Extends the official runner image with cli tools used in the CI pipeline (such as jq, curl,
+# envsubst, Node.js, oc, and virtctl) and system dependencies for Playwright (Chromium).
+
+#
+# https://github.com/actions/runner/blob/main/images/Dockerfile: the base image
+# The base image includes the docker CLI; with ARC containerMode.type=dind, jobs use the
+# docker:dind sidecar (DOCKER_HOST=unix:///var/run/docker.sock) for docker/container actions.
+#
+ARG RUNNER_BASE=ghcr.io/actions/actions-runner:latest
+FROM ${RUNNER_BASE}
+
+USER root
+
+# Go-based yq (mikefarah/yq) — matches the version on GitHub-hosted ubuntu-latest runners.
+# NOTE: apt's `yq` package is the Python-based yq (kislyuk), which has incompatible syntax.
+ARG YQ_VERSION=v4.52.5
+# Versions (override with build-args to match cluster)
+ARG NODE_VERSION=22
+# OpenShift client version to match cluster (e.g. 4.20)
+ARG OC_VERSION=4.20
+# KubeVirt CLI version to match HCO install (e.g. v1.4.0)
+ARG VIRTCTL_VERSION=v1.4.0
+# Helm version (e.g. 3.19.0)
+ARG HELM_VERSION=3.19.0
+
+# Direct binary download URLs resolved from ConsoleCLIDownload by setup-runner-image.sh.
+# When set, these take precedence over the static mirror/GitHub URLs above and guarantee
+# the binaries match the live cluster. Left empty to use the static fallback URLs.
+ARG OC_URL=""
+ARG VIRTCTL_URL=""
+ARG HELM_URL=""
+
+# curl and wget2 are both installed:
+#   curl  — kept for CI workflow scripts at runtime
+#   wget2 — used for all build-time HTTPS downloads
+# On Ubuntu, apt and wget2 use GnuTLS; curl and wget (1.x) use OpenSSL. On OpenShift build pods
+# where the FIPS provider .so can't load (DSO error), all OpenSSL-based HTTPS fails. wget2/GnuTLS
+# is unaffected, so every build-time binary download goes through wget2 instead.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates jq curl wget2 gettext-base \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Playwright / Chromium headless — Linux deps for Ubuntu 24.04+ (noble).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        fontconfig \
+        fonts-liberation \
+        libasound2t64 \
+        libgbm-dev \
+        libgtk-3-0t64 \
+        libnss3 \
+        libnotify-dev \
+        libxss1 \
+        libxtst6 \
+        xauth \
+        xvfb \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# yq (Go/mikefarah) — wget2/GnuTLS avoids the OpenSSL FIPS DSO loading failure on hardened clusters
+RUN wget2 -O /usr/local/bin/yq \
+    "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+    && chmod +x /usr/local/bin/yq
+
+# Node.js — the nodesource setup script internally calls curl (OpenSSL), which fails on FIPS clusters.
+# Fetch the version list from nodejs.org with wget2 (GnuTLS), pick the latest v${NODE_VERSION}.x,
+# then download and extract the pre-built binary tarball directly.
+RUN NVER=$(wget2 -qO- "https://nodejs.org/dist/index.json" \
+        | jq -r --argjson maj "${NODE_VERSION}" \
+            '[.[] | select(.version | test("^v" + ($maj|tostring) + "\\."))] | .[0].version') \
+    && wget2 -qO /tmp/node.tar.gz \
+        "https://nodejs.org/dist/${NVER}/node-${NVER}-linux-x64.tar.gz" \
+    && tar -xzf /tmp/node.tar.gz -C /usr/local --strip-components=1 \
+    && rm /tmp/node.tar.gz
+
+# OpenShift client (oc) — use console download URL if resolved, else mirror.openshift.com stable-4.x.
+# Console route serves a plain .tar; download to a temp file so GNU tar auto-detects the format.
+# Fallback uses wget2 (GnuTLS) for the external HTTPS download.
+RUN if [ -n "${OC_URL}" ]; then \
+      wget2 -qO /tmp/oc-archive "${OC_URL}" \
+      && tar -xf /tmp/oc-archive -C /usr/local/bin oc \
+      && rm /tmp/oc-archive; \
+    else \
+      wget2 -qO- "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OC_VERSION}/openshift-client-linux.tar.gz" \
+           | tar -xzf - -C /usr/local/bin; \
+    fi
+
+# virtctl (KubeVirt CLI) — use console download URL if resolved, else GitHub releases.
+# Console route serves a .tar.gz; fallback uses wget2 (GnuTLS) for the external HTTPS download.
+RUN if [ -n "${VIRTCTL_URL}" ]; then \
+      wget2 -qO /tmp/virtctl-archive "${VIRTCTL_URL}" \
+      && tar -xf /tmp/virtctl-archive -C /usr/local/bin virtctl \
+      && rm /tmp/virtctl-archive; \
+    else \
+      wget2 -qO /usr/local/bin/virtctl \
+           "https://github.com/kubevirt/kubevirt/releases/download/${VIRTCTL_VERSION}/virtctl-${VIRTCTL_VERSION}-linux-amd64"; \
+    fi \
+    && chmod +x /usr/local/bin/virtctl
+
+# Helm — use console download URL if resolved, else get.helm.sh.
+# Console route serves a .tar.gz; fallback uses wget2 (GnuTLS) for the external HTTPS download.
+RUN if [ -n "${HELM_URL}" ]; then \
+      wget2 -qO /tmp/helm-archive "${HELM_URL}" \
+      && tar -xf /tmp/helm-archive -C /usr/local/bin --strip-components=1 linux-amd64/helm \
+      && rm /tmp/helm-archive; \
+    else \
+      wget2 -qO- "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" \
+           | tar -xzf - -C /usr/local/bin --strip-components=1 linux-amd64/helm; \
+    fi \
+    && chmod +x /usr/local/bin/helm
+
+USER runner
+
+# Default npm and tmp to HOME so npm ci works in restricted containers without workflow overrides
+ENV KUBEVIRT_UI_PLUGIN_RUNNER=true \
+    HOME=/home/runner \
+    TMPDIR=/home/runner/.tmp
+
+# Keep the same entrypoint/CMD as the base image so ARC works unchanged.

--- a/ci-scripts/images/arc-runner/Dockerfile
+++ b/ci-scripts/images/arc-runner/Dockerfile
@@ -7,7 +7,7 @@
 # The base image includes the docker CLI; with ARC containerMode.type=dind, jobs use the
 # docker:dind sidecar (DOCKER_HOST=unix:///var/run/docker.sock) for docker/container actions.
 #
-ARG RUNNER_BASE=ghcr.io/actions/actions-runner:latest
+ARG RUNNER_BASE=ghcr.io/actions/actions-runner:2.335.1
 FROM ${RUNNER_BASE}
 
 USER root

--- a/ci-scripts/images/setup-arc-runner-image.sh
+++ b/ci-scripts/images/setup-arc-runner-image.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+#
+# OpenShift only: create ImageStream + BuildConfig and run a binary Docker build for the
+# custom ARC runner image (ci-scripts/images/arc-runner/Dockerfile).
+#
+# Output: prints IMAGE_REF= to stdout (and to ARC_RUNNER_IMAGE_FILE if set).
+#
+# Optional environment variables:
+#   NS               Namespace for the runner (default: arc-runners)
+#   OC_VERSION       OpenShift client version build-arg (default: detect or 4.20)
+#   HELM_VERSION     Helm version build-arg (default: 3.19.0)
+#   VIRTCTL_VERSION  (default: v1.4.0)
+#   YQ_VERSION       yq version build-arg (default: v4.52.5)
+#
+# Requires: oc logged into OpenShift; jq optional for version detection and URL resolution.
+#
+# Binary URL resolution:
+#   Uses ci-scripts/_cluster-helpers.sh to resolve cluster resources
+#
+# Namespace note: If the namespace does not match the ci-env-runner deployment namespace,
+# the running service account will need to add role "system:image-puller" so the built image
+# can be pulled.
+#
+set -euo pipefail
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+source "${REPO_ROOT}/ci-scripts/_cluster-helpers.sh"
+verify_oc
+
+NS="${NS:-arc-runners}"
+IMAGE_DIR="${SCRIPT_DIR}/arc-runner"
+IMAGE_NAME="arc-runner"
+
+resolve_oc_version
+VIRTCTL_VERSION="${VIRTCTL_VERSION:-v1.4.0}"
+HELM_VERSION="${HELM_VERSION:-3.19.0}"
+YQ_VERSION="${YQ_VERSION:-v4.52.5}"
+
+resolve_cli_downloads
+
+echo "=== Build ARC runner image (in-cluster, OpenShift) ==="
+echo "  NS:              ${NS}"
+echo "  IMAGE_DIR:       ${IMAGE_DIR}"
+echo "  IMAGE_NAME:      ${IMAGE_NAME}"
+echo "  OC_VERSION:      ${OC_VERSION}"
+echo "  VIRTCTL_VERSION: ${VIRTCTL_VERSION}"
+echo "  HELM_VERSION:    ${HELM_VERSION}"
+echo "  YQ_VERSION:      ${YQ_VERSION}"
+echo "  OC_URL:          ${OC_URL:-(fallback to mirror.openshift.com)}"
+echo "  VIRTCTL_URL:     ${VIRTCTL_URL:-(fallback to GitHub releases)}"
+echo "  HELM_URL:        ${HELM_URL:-(fallback to get.helm.sh)}"
+echo ""
+
+if [[ ! -f "${IMAGE_DIR}/Dockerfile" ]]; then
+  echo "ERROR: Dockerfile not found at ${IMAGE_DIR}/Dockerfile"
+  exit 1
+fi
+
+oc create namespace "${NS}" --dry-run=client -o yaml | oc apply -f -
+
+oc apply -f - <<EOF
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: ${IMAGE_NAME}
+  namespace: ${NS}
+spec:
+  lookupPolicy:
+    local: true
+EOF
+
+oc apply -f - <<EOF
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: ${IMAGE_NAME}-build
+  namespace: ${NS}
+spec:
+  source:
+    type: Binary
+    binary: {}
+  strategy:
+    type: Docker
+    dockerStrategy:
+      buildArgs:
+        - name: OC_VERSION
+          value: "${OC_VERSION}"
+        - name: OC_URL
+          value: "${OC_URL}"
+        - name: VIRTCTL_VERSION
+          value: "${VIRTCTL_VERSION}"
+        - name: VIRTCTL_URL
+          value: "${VIRTCTL_URL}"
+        - name: HELM_VERSION
+          value: "${HELM_VERSION}"
+        - name: HELM_URL
+          value: "${HELM_URL}"
+        - name: YQ_VERSION
+          value: "${YQ_VERSION}"
+  output:
+    to:
+      kind: ImageStreamTag
+      name: ${IMAGE_NAME}:latest
+  runPolicy: Serial
+EOF
+
+echo "Starting binary build from ${IMAGE_DIR}..."
+oc start-build -n "${NS}" "${IMAGE_NAME}-build" \
+  --from-dir="${IMAGE_DIR}" \
+  --follow
+
+resolve_internal_registry
+IMAGE_REF="${INTERNAL_REGISTRY}/${NS}/${IMAGE_NAME}:latest"
+
+echo ""
+echo "=== Build complete ==="
+echo "Image: ${IMAGE_REF}"
+echo "IMAGE_REF=${IMAGE_REF}"
+
+if [[ -n "${ARC_RUNNER_IMAGE_FILE:-}" ]]; then
+  printf '%s\n' "${IMAGE_REF}" > "${ARC_RUNNER_IMAGE_FILE}"
+  echo "Wrote ${ARC_RUNNER_IMAGE_FILE}"
+fi

--- a/ci-scripts/install-hco.sh
+++ b/ci-scripts/install-hco.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+#
+# Install HCO (HyperConverged Cluster Operator) and dependencies to the current oc
+# logged in cluster.  Based on the `deploy-kubevirt-gating.sh` script.
+#
+# Environment variables (all have defaults):
+#   KVM_EMULATION          - "true" or "false" (default: "true", only bare metal compute nodes have real KVM)
+#   HCO_IMAGE_VER          - HCO catalog image version
+#   HCO_SUBSCRIPTION_CHANNEL - OLM subscription channel
+#   HPP_VERSION            - HostPath Provisioner release branch
+#   HCO_CR_PATH            - Path to HCO CR yaml (default: cypress/fixtures/hco.yaml)
+#   SKIP_HPP               - Set to "true" to skip HPP installation
+#
+set -euo pipefail
+
+#
+# TODO: We can query details about the cluster and use that to determine the HCO version,
+#       KVM_EMULATION, and HPP_VERSION to use for the installation.  For now, we're using
+#       defaults from the prow ci configuration.
+#
+
+export KVM_EMULATION="${KVM_EMULATION:-true}"
+export HCO_IMAGE_VER="${HCO_IMAGE_VER:-1.14.0-unstable}"
+export HCO_SUBSCRIPTION_CHANNEL="${HCO_SUBSCRIPTION_CHANNEL:-candidate-v1.14}"
+export HPP_VERSION="${HPP_VERSION:-release-v0.21}"
+HCO_CR_PATH="${HCO_CR_PATH:-cypress/fixtures/hco.yaml}"
+SKIP_HPP="${SKIP_HPP:-false}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "=== HCO Installation ==="
+echo "  KVM_EMULATION:            ${KVM_EMULATION}"
+echo "  HCO_IMAGE_VER:            ${HCO_IMAGE_VER}"
+echo "  HCO_SUBSCRIPTION_CHANNEL: ${HCO_SUBSCRIPTION_CHANNEL}"
+echo "  HPP_VERSION:              ${HPP_VERSION}"
+echo "  SKIP_HPP:                 ${SKIP_HPP}"
+echo ""
+
+# --- CatalogSource ---
+echo "Creating HCO CatalogSource..."
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: hco-unstable-catalog-source
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/kubevirt/hyperconverged-cluster-index:${HCO_IMAGE_VER}
+  displayName: Kubevirt Hyperconverged Cluster Operator
+  publisher: Kubevirt Project
+EOF
+
+# --- Namespace, OperatorGroup, Subscription ---
+echo "Creating HCO Namespace, OperatorGroup, and Subscription..."
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubevirt-hyperconverged
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kubevirt-hyperconverged-group
+  namespace: kubevirt-hyperconverged
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: hco-operatorhub
+  namespace: kubevirt-hyperconverged
+spec:
+  source: hco-unstable-catalog-source
+  sourceNamespace: openshift-marketplace
+  name: community-kubevirt-hyperconverged
+  channel: "${HCO_SUBSCRIPTION_CHANNEL}"
+  config:
+    selector:
+      matchLabels:
+        name: hyperconverged-cluster-operator
+    env:
+    - name: KVM_EMULATION
+      value: "${KVM_EMULATION}"
+EOF
+
+echo "Waiting for Subscription to have an InstallPlan..."
+for i in $(seq 1 60); do
+  INSTALL_PLAN="$(oc get subscription hco-operatorhub -n kubevirt-hyperconverged \
+    -o jsonpath='{.status.installPlanRef.name}' 2>/dev/null || true)"
+  if [[ -n "${INSTALL_PLAN}" ]]; then
+    echo "InstallPlan found: ${INSTALL_PLAN}"
+    break
+  fi
+  if [[ "${i}" -eq 60 ]]; then
+    echo "ERROR: Timed out waiting for HCO InstallPlan"
+    exit 1
+  fi
+  echo "Waiting for InstallPlan... (${i}/60)"
+  sleep 5
+done
+
+# --- Wait for HCO deployments ---
+echo "Waiting for HCO deployments to become available..."
+oc wait deployments \
+  --selector="operators.coreos.com/community-kubevirt-hyperconverged.kubevirt-hyperconverged" \
+  --namespace=kubevirt-hyperconverged \
+  --for=condition=Available \
+  --timeout=10m
+
+# --- Apply HCO CR with retries ---
+echo "Creating HCO CR..."
+hco_cr_is_created="false"
+
+for i in $(seq 1 20); do
+  echo "Attempt ${i}/20"
+  if oc apply -f "${REPO_ROOT}/${HCO_CR_PATH}"; then
+    echo "HCO CR created successfully"
+    hco_cr_is_created="true"
+    break
+  fi
+  sleep 30
+done
+
+if [[ "${hco_cr_is_created}" == "false" ]]; then
+  echo "ERROR: HCO CR could not be created after 20 attempts"
+  exit 1
+fi
+
+# --- Wait for HCO to be available ---
+echo "Waiting for HCO to report Available..."
+oc wait -n kubevirt-hyperconverged hyperconverged kubevirt-hyperconverged \
+  --for=condition=Available \
+  --timeout=15m
+
+# --- HPP (optional) ---
+if [[ "${SKIP_HPP}" != "true" ]]; then
+  echo "Installing HostPath Provisioner..."
+
+  oc apply -f \
+    "https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/${HPP_VERSION}/deploy/hostpathprovisioner_cr.yaml"
+
+  oc apply -f \
+    "https://raw.githubusercontent.com/kubevirt/hostpath-provisioner-operator/${HPP_VERSION}/deploy/storageclass-wffc-csi.yaml"
+
+  oc annotate storageclasses --all storageclass.kubernetes.io/is-default-class- || true
+  oc annotate storageclass hostpath-csi storageclass.kubernetes.io/is-default-class='true'
+
+  echo "HPP installation complete"
+else
+  echo "Skipping HPP installation (SKIP_HPP=true)"
+fi
+
+echo ""
+echo "=== HCO Installation Complete ==="

--- a/ci-scripts/install-oc-client.sh
+++ b/ci-scripts/install-oc-client.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Install the OpenShift oc client from mirror.openshift.com (verified TLS).
+# Use in GitHub Actions before kubeconfig is available, or after ibmcloud cluster get.
+#
+# Environment variables:
+#   OPENSHIFT_VERSION  - Major.minor (e.g. 4.20). If unset, derived from CLUSTER_JSON.
+#   CLUSTER_JSON       - JSON from: ibmcloud oc cluster get --cluster NAME --output json
+#   OC_INSTALL_DIR     - Target directory (default: /usr/local/bin)
+#
+set -euo pipefail
+
+OC_INSTALL_DIR="${OC_INSTALL_DIR:-/usr/local/bin}"
+
+resolve_version_from_json() {
+  local json="${1:-}"
+  if [[ -z "${json}" ]]; then
+    return 1
+  fi
+  echo "${json}" | jq -r '
+    (
+      .masterKubeVersion //
+      .openshiftVersion //
+      .version //
+      ""
+    )
+    | if . == "" then empty
+      else split(".") | .[0:2] | join(".")
+      end
+  ' 2>/dev/null || true
+}
+
+if [[ -z "${OPENSHIFT_VERSION:-}" ]]; then
+  if [[ -n "${CLUSTER_JSON:-}" ]]; then
+    OPENSHIFT_VERSION="$(resolve_version_from_json "${CLUSTER_JSON}")"
+  fi
+fi
+
+OPENSHIFT_VERSION="${OPENSHIFT_VERSION:-4.20}"
+echo "Installing oc client for OpenShift ${OPENSHIFT_VERSION}..."
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+ARCHIVE="${TMP_DIR}/openshift-client-linux.tar.gz"
+URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OPENSHIFT_VERSION}/openshift-client-linux.tar.gz"
+
+if ! curl -fsSL -o "${ARCHIVE}" "${URL}"; then
+  echo "::error::Failed to download oc from ${URL}"
+  exit 1
+fi
+
+tar -xzf "${ARCHIVE}" -C "${TMP_DIR}"
+install -m 0755 "${TMP_DIR}/oc" "${OC_INSTALL_DIR}/oc"
+
+echo "Installed: $("${OC_INSTALL_DIR}/oc" version --client)"


### PR DESCRIPTION
## Summary
- Add `ibmc-cluster-setup.yml` and `ibmc-cluster-teardown.yml` (`workflow_dispatch` only — no PR/push triggers)
- Include minimal `ci-scripts/` for cluster provisioning, HCO, and ARC install
- Unblocks **IBM Cloud Hot Cluster Setup** in Actions before #4099 merges

**No impact on existing CI** (build, unit-test, Prow, Deploy, Jira). New workflows run only when manually dispatched.

Jira ticket: [CNV-74265](https://redhat.atlassian.net/browse/CNV-74265)

## Test plan
- [ ] Merge this PR
- [ ] Actions → **IBM Cloud Hotster Setup** → Run workflow from `main`
- [ ] Re-run **Hot Cluster E2E** on #4099 after cluster exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit — Release Notes

* **New Features**
  * Added manual and reusable IBM Cloud OpenShift “hot cluster” provisioning and teardown workflows.
  * Added automated deployment of HCO and Actions Runner Controller (including runner SCC/RBAC) plus an in-cluster custom runner image.
  * Added IBM Cloud cluster readiness polling and CI cluster health checks to gate execution.
* **Documentation**
  * Expanded end-to-end “hot cluster” and ARC deployment documentation, including setup, teardown, and troubleshooting.
* **Chores**
  * Updated ignore rules for generated assets and Helm templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->