### PR TITLE
CNV-89616: Create VM Wizard refactor - Part 4

### DIFF
--- a/src/utils/utils/validation.ts
+++ b/src/utils/utils/validation.ts
@@ -17,14 +17,10 @@ const maxNameLengthErrorMsg = (t: TFunction) =>
     maxNameLength: DNS1123LabelMaxLength,
   });
 
-// IsDNS1123Label tests for a string that conforms to the definition of a label in
-// DNS (RFC 1123).
+// DNS-1123 (RFC 1123) is the Kubernetes resource naming convention.
+// The "DNS1123" prefix mirrors Kubernetes' own naming (e.g. IsDNS1123Label in apimachinery).
 export const isDNS1123Label = (value: string): boolean => !getDNS1123LabelError(value);
 
-/**
- * @deprecated Prefer `validateDNS1123Label(t, value)` which returns the error string directly.
- * @param value - the DNS label string to validate
- */
 export const getDNS1123LabelError = (value: string): ((t: TFunction) => string) | undefined => {
   if (value?.length > DNS1123LabelMaxLength) {
     return maxNameLengthErrorMsg;

--- a/src/views/virtualmachines/creation-wizard-new/VMCreationWizardContent.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/VMCreationWizardContent.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useEffect, useRef } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import {
   logVMCreationStarted,
@@ -35,19 +36,21 @@ import {
 } from '@virtualmachines/creation-wizard-new/utils/utils';
 
 import TemplatesDrawerWrapper from './components/TemplatesDrawerWrapper';
+import { useVMWizard } from './state/vm-wizard-context/VMWizardContext';
+import {
+  CREATE_VM_FORM_FIELDS_UI_STATE,
+  CREATE_VM_FORM_FIELDS_VM_DATA,
+} from './state/vm-wizard-form/consts';
 import DeploymentDetailsStep from './steps/DeploymentDetailsStep/DeploymentDetailsStep';
 
 import './Wizard.scss';
 
 const VMCreationWizardContent: FC = () => {
   const { t } = useKubevirtTranslation();
-  const {
-    creationMethod,
-    initializeVMCreationWizardValues,
-    markStepVisited,
-    resetWizardState,
-    setTemplatesDrawerIsOpen,
-  } = useVMWizardStore();
+  // TODO: get data from vm creation form fields instead of using useVMWizardStore
+  const { markStepVisited, project, resetWizardState, setCluster, setProject } = useVMWizardStore();
+  const { control, setValue } = useVMWizard();
+  const creationMethod = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.CREATION_METHOD });
   const syncDeploymentDetails = useSyncDeploymentDetails();
   const { isNextDisabledForStep, isStepDisabled } = useWizardStepValidation();
   const { navItemWithVMGeneration } = useVMGenerationNavItem(creationMethod);
@@ -59,22 +62,20 @@ const VMCreationWizardContent: FC = () => {
   const activeNamespace = useActiveNamespace();
   const namespace = getValidNamespace(activeNamespace);
 
+  // TODO: get rid of this useEffect and use the new form values instead
   useEffect(() => {
     if (!hasInitialized.current) {
-      setTemplatesDrawerIsOpen(false);
-      initializeVMCreationWizardValues({ cluster: clusterParam, isAdmin, namespace });
+      const currentProject = project;
+      resetWizardState();
+      setValue(CREATE_VM_FORM_FIELDS_UI_STATE.IS_TEMPLATES_DRAWER_OPEN, false);
+
+      setCluster(clusterParam);
+      setProject(!isAdmin ? namespace : currentProject || namespace);
       hasInitialized.current = true;
     }
 
     return () => resetWizardState();
-  }, [
-    clusterParam,
-    isAdmin,
-    namespace,
-    resetWizardState,
-    setTemplatesDrawerIsOpen,
-    initializeVMCreationWizardValues,
-  ]);
+  }, [clusterParam, isAdmin, namespace, resetWizardState, setCluster, setProject, setValue]);
 
   const isInstanceTypeMethod = isInstanceTypeCreationMethod(creationMethod);
   const isCloneMethod = isCloneCreationMethod(creationMethod);
@@ -85,7 +86,9 @@ const VMCreationWizardContent: FC = () => {
       <Wizard
         onStepChange={(_, currentStep, prevStep) => {
           syncDeploymentDetails(currentStep, prevStep);
-          if (currentStep?.id !== VMWizardStep.TEMPLATE) setTemplatesDrawerIsOpen(false);
+          if (currentStep?.id !== VMWizardStep.TEMPLATE) {
+            setValue(CREATE_VM_FORM_FIELDS_UI_STATE.IS_TEMPLATES_DRAWER_OPEN, false);
+          }
           if (currentStep?.id) markStepVisited(String(currentStep.id));
 
           const creationMethodTelemetry = mapWizardStepToCreationMethodTelemetry(

--- a/src/views/virtualmachines/creation-wizard-new/components/DescriptionInput.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/components/DescriptionInput.tsx
@@ -5,6 +5,7 @@ import { Button, InputGroup, InputGroupItem, TextInput } from '@patternfly/react
 import { SyncAltIcon } from '@patternfly/react-icons';
 
 import { useVMWizard } from '../state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '../state/vm-wizard-form/consts';
 
 const DescriptionInput: FC = () => {
   const { control } = useVMWizard();
@@ -17,7 +18,7 @@ const DescriptionInput: FC = () => {
             <TextInput id="vm-description" type="text" {...field} />
           )}
           control={control}
-          name="vmData.description"
+          name={CREATE_VM_FORM_FIELDS_VM_DATA.DESCRIPTION}
         />
       </InputGroupItem>
       <InputGroupItem style={{ visibility: 'hidden' }}>

--- a/src/views/virtualmachines/creation-wizard-new/components/NameInput.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/components/NameInput.tsx
@@ -11,24 +11,28 @@ import {
 import { InputGroup, InputGroupItem, TextInput } from '@patternfly/react-core';
 
 import { useVMWizard } from '../state/vm-wizard-context/VMWizardContext';
+import {
+  CREATE_VM_FORM_FIELDS_UI_STATE,
+  CREATE_VM_FORM_FIELDS_VM_DATA,
+} from '../state/vm-wizard-form/consts';
 
 import GenerateVMNameButton from './GenerateVMNameButton';
 
 const NameInput: FC = () => {
   const { t } = useKubevirtTranslation();
   const { control, setValue } = useVMWizard();
-  const vmName = useWatch({ control, name: 'vmData.name' });
+  const vmName = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.NAME });
   const shouldCheckVMNameProperly = useWatch({
     control,
-    name: 'uiState.shouldCheckVMNameProperly',
+    name: CREATE_VM_FORM_FIELDS_UI_STATE.SHOULD_CHECK_VM_NAME_PROPERLY,
   });
   const getError = shouldCheckVMNameProperly ? getDNS1123LabelError : getDNS1123LabelErrorLenient;
   const { errorText, validated } = useNameValidation({ getError, name: vmName });
 
   const applyName = useCallback(
     (newName: string) => {
-      setValue('uiState.shouldCheckVMNameProperly', false);
-      setValue('vmData.name', newName);
+      setValue(CREATE_VM_FORM_FIELDS_UI_STATE.SHOULD_CHECK_VM_NAME_PROPERLY, false);
+      setValue(CREATE_VM_FORM_FIELDS_VM_DATA.NAME, newName);
     },
     [setValue],
   );
@@ -49,7 +53,7 @@ const NameInput: FC = () => {
               />
             )}
             control={control}
-            name={'vmData.name'}
+            name={CREATE_VM_FORM_FIELDS_VM_DATA.NAME}
           />
         </InputGroupItem>
         <InputGroupItem>

--- a/src/views/virtualmachines/creation-wizard-new/components/TemplatesDrawerWrapper.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/components/TemplatesDrawerWrapper.tsx
@@ -1,19 +1,31 @@
 import React, { FC, ReactNode } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { Drawer, DrawerContent, DrawerContentBody } from '@patternfly/react-core';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import {
+  CREATE_VM_FORM_FIELDS_UI_STATE,
+  CREATE_VM_FORM_FIELDS_VM_DATA,
+} from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 
 import { TemplatesCatalogDrawer } from '../steps/TemplateStep/components/TemplatesCatalogDrawer/TemplatesCatalogDrawer';
 
 const TemplatesDrawerWrapper: FC<{ children?: ReactNode }> = ({ children }) => {
-  const { selectedTemplate, setTemplatesDrawerIsOpen, templatesDrawerIsOpen } = useVMWizardStore();
+  const { control, setValue } = useVMWizard();
+  const [selectedTemplate, isTemplatesDrawerOpen] = useWatch({
+    control,
+    name: [
+      CREATE_VM_FORM_FIELDS_VM_DATA.SELECTED_TEMPLATE,
+      CREATE_VM_FORM_FIELDS_UI_STATE.IS_TEMPLATES_DRAWER_OPEN,
+    ],
+  });
 
   const handleDrawerClose = () => {
-    setTemplatesDrawerIsOpen(false);
+    setValue(CREATE_VM_FORM_FIELDS_UI_STATE.IS_TEMPLATES_DRAWER_OPEN, false);
   };
 
   return (
-    <Drawer isExpanded={templatesDrawerIsOpen && !!selectedTemplate} position="end">
+    <Drawer isExpanded={isTemplatesDrawerOpen && !!selectedTemplate} position="end">
       <DrawerContent
         panelContent={
           <TemplatesCatalogDrawer onClose={handleDrawerClose} template={selectedTemplate} />

--- a/src/views/virtualmachines/creation-wizard-new/components/VMNameConfirmationNextButton.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/components/VMNameConfirmationNextButton.tsx
@@ -6,6 +6,10 @@ import { isDNS1123Label, isDNS1123LabelLenient } from '@kubevirt-utils/utils/val
 import { Button, Tooltip } from '@patternfly/react-core';
 
 import { useVMWizard } from '../state/vm-wizard-context/VMWizardContext';
+import {
+  CREATE_VM_FORM_FIELDS_UI_STATE,
+  CREATE_VM_FORM_FIELDS_VM_DATA,
+} from '../state/vm-wizard-form/consts';
 
 type VMNameConfirmationNextButtonProps = {
   children: ReactNode;
@@ -20,10 +24,10 @@ const VMNameConfirmationNextButton: FC<VMNameConfirmationNextButtonProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const { control, setValue } = useVMWizard();
-  const vmName = useWatch({ control, name: 'vmData.name' });
+  const vmName = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.NAME });
   const shouldCheckVMNameProperly = useWatch({
     control,
-    name: 'uiState.shouldCheckVMNameProperly',
+    name: CREATE_VM_FORM_FIELDS_UI_STATE.SHOULD_CHECK_VM_NAME_PROPERLY,
   });
 
   const isVMNameValid = isDNS1123Label(vmName);
@@ -36,7 +40,7 @@ const VMNameConfirmationNextButton: FC<VMNameConfirmationNextButtonProps> = ({
       onClick();
       return;
     }
-    setValue('uiState.shouldCheckVMNameProperly', true);
+    setValue(CREATE_VM_FORM_FIELDS_UI_STATE.SHOULD_CHECK_VM_NAME_PROPERLY, true);
   };
 
   const nextButton = (

--- a/src/views/virtualmachines/creation-wizard-new/hooks/useCloneVM.ts
+++ b/src/views/virtualmachines/creation-wizard-new/hooks/useCloneVM.ts
@@ -16,14 +16,15 @@ import { RUNSTRATEGY_HALTED } from '@kubevirt-utils/resources/vm/utils/constants
 import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { getVMURL } from '@multicluster/urls';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 
 type UseCloneVM = () => () => Promise<void>;
 
 const useCloneVM: UseCloneVM = () => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
-  const { cluster, project: targetNamespace, vmDescription, vmName } = useVMWizardStore();
+  const { getValues } = useVMWizard();
 
   const source = vmSignal.value;
 
@@ -36,13 +37,23 @@ const useCloneVM: UseCloneVM = () => {
   );
 
   useEffect(() => {
+    const { name: vmName, project: targetNamespace } = getValues(
+      CREATE_VM_FORM_FIELDS_VM_DATA.ROOT,
+    );
+
     if (cloneRequest?.status?.phase === CLONING_STATUSES.SUCCEEDED) {
       logVMCreated(TELEMETRY_VM_CREATION_METHOD.CLONE);
       navigate(getVMURL(cloneRequest?.cluster, targetNamespace, vmName));
     }
-  }, [cloneRequest, vmName, targetNamespace, navigate, source]);
+  }, [cloneRequest, navigate, source, getValues]);
 
   const sendCloneRequest = async () => {
+    const {
+      cluster,
+      description: vmDescription,
+      name: vmName,
+      project: targetNamespace,
+    } = getValues(CREATE_VM_FORM_FIELDS_VM_DATA.ROOT);
     try {
       const vmSameName = await vmExists(vmName, targetNamespace, getCluster(source) || cluster);
 

--- a/src/views/virtualmachines/creation-wizard-new/hooks/useSyncDeploymentDetails.ts
+++ b/src/views/virtualmachines/creation-wizard-new/hooks/useSyncDeploymentDetails.ts
@@ -1,10 +1,9 @@
-import { useCallback } from 'react';
-
 import { getAnnotation } from '@kubevirt-utils/resources/shared';
 import { DESCRIPTION_ANNOTATION, getFolder } from '@kubevirt-utils/resources/vm';
 import { updateCustomizeInstanceType, vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import type { WizardStepType } from '@patternfly/react-core';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import { VMWizardStep } from '@virtualmachines/creation-wizard-new/utils/constants';
 import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
 
@@ -14,37 +13,39 @@ type UseSyncDeploymentDetails = () => (
 ) => void;
 
 /**
- * Keeps the wizard store's Deployment Details buffers in sync with vmSignal
- * across step transitions. Flushes store values to the signal when leaving
- * Deployment Details, and hydrates the store from the signal when entering it.
+ * Keeps the form's Deployment Details buffers in sync with vmSignal's annotation
+ * across step transitions. Flushes the form value to the signal when leaving Deployment Details,
+ * and hydrates the form from the signal when entering Deployment Details.
  */
 export const useSyncDeploymentDetails: UseSyncDeploymentDetails = () => {
-  const { folder, setFolder, setVMDescription, vmDescription } = useVMWizardStore();
+  const { getValues, setValue } = useVMWizard();
 
-  return useCallback(
-    (currentStep: WizardStepType, prevStep: WizardStepType) => {
-      if (!vmSignal.value) {
-        return;
-      }
+  return (currentStep: WizardStepType, prevStep: WizardStepType) => {
+    if (!vmSignal.value) {
+      return;
+    }
 
-      if (prevStep?.id === VMWizardStep.DEPLOYMENT_DETAILS) {
-        updateCustomizeInstanceType([
-          {
-            data: vmDescription || undefined,
-            path: `metadata.annotations.${DESCRIPTION_ANNOTATION}`,
-          },
-          {
-            data: folder || undefined,
-            path: ['metadata', 'labels', VM_FOLDER_LABEL],
-          },
-        ]);
-      }
+    if (prevStep?.id === VMWizardStep.DEPLOYMENT_DETAILS) {
+      const description = getValues(CREATE_VM_FORM_FIELDS_VM_DATA.DESCRIPTION);
+      const folder = getValues(CREATE_VM_FORM_FIELDS_VM_DATA.FOLDER);
+      updateCustomizeInstanceType([
+        {
+          data: description || undefined,
+          path: `metadata.annotations.${DESCRIPTION_ANNOTATION}`,
+        },
+        {
+          data: folder || undefined,
+          path: ['metadata', 'labels', VM_FOLDER_LABEL],
+        },
+      ]);
+    }
 
-      if (currentStep?.id === VMWizardStep.DEPLOYMENT_DETAILS) {
-        setVMDescription(getAnnotation(vmSignal.value, DESCRIPTION_ANNOTATION, ''));
-        setFolder(getFolder(vmSignal.value) || '');
-      }
-    },
-    [folder, setFolder, setVMDescription, vmDescription],
-  );
+    if (currentStep?.id === VMWizardStep.DEPLOYMENT_DETAILS) {
+      setValue(
+        CREATE_VM_FORM_FIELDS_VM_DATA.DESCRIPTION,
+        getAnnotation(vmSignal.value, DESCRIPTION_ANNOTATION, ''),
+      );
+      setValue(CREATE_VM_FORM_FIELDS_VM_DATA.FOLDER, getFolder(vmSignal.value) || '');
+    }
+  };
 };

--- a/src/views/virtualmachines/creation-wizard-new/hooks/useWizardStepValidation.ts
+++ b/src/views/virtualmachines/creation-wizard-new/hooks/useWizardStepValidation.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -12,6 +13,9 @@ import {
   isCloneCreationMethod,
 } from '@virtualmachines/creation-wizard-new/utils/utils';
 
+import { useVMWizard } from '../state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '../state/vm-wizard-form/consts';
+
 type WizardStepValidation = {
   isNextDisabledForStep: (stepId: VMWizardStep) => boolean;
   isStepDisabled: (stepId: VMWizardStep) => boolean;
@@ -19,7 +23,7 @@ type WizardStepValidation = {
 
 const useWizardStepValidation = (): WizardStepValidation => {
   useSignals();
-  const { creationMethod, selectedTemplate, visitedSteps, vmName } = useVMWizardStore();
+  const { visitedSteps } = useVMWizardStore();
   const {
     operatingSystemType,
     preference,
@@ -29,6 +33,13 @@ const useWizardStepValidation = (): WizardStepValidation => {
     selectedSize,
     useBootSource,
   } = useInstanceTypeVMStore();
+  const { control } = useVMWizard();
+  const creationMethod = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.CREATION_METHOD });
+  const name = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.NAME });
+  const selectedTemplate = useWatch({
+    control,
+    name: CREATE_VM_FORM_FIELDS_VM_DATA.SELECTED_TEMPLATE,
+  });
 
   const activeFlow = getActiveFlow(creationMethod);
 
@@ -38,7 +49,7 @@ const useWizardStepValidation = (): WizardStepValidation => {
 
   const currentVMSignalValue = vmSignal.value;
 
-  const isValidVMName = isCloneCreationMethod(creationMethod) || isDNS1123Label(vmName);
+  const isValidVMName = isCloneCreationMethod(creationMethod) || isDNS1123Label(name);
 
   const stepNextDisabled: Record<VMWizardStep, boolean> = useMemo(
     () => ({

--- a/src/views/virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext.tsx
@@ -6,8 +6,8 @@ import { clearCustomizeInstanceType } from '@kubevirt-utils/store/customizeInsta
 import { getValidNamespace } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useInstanceTypeVMStore from '@virtualmachines/creation-wizard-new/state/instance-type-vm-store/useInstanceTypeVMStore';
-import { createInitialVMWizardFormValues } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/initialValues';
 import { VMWizardFormValues } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/types';
+import { createInitialVMWizardFormValues } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/utils';
 
 type VMWizardProviderProps = {
   children?: ReactNode;

--- a/src/views/virtualmachines/creation-wizard-new/state/vm-wizard-form/consts.ts
+++ b/src/views/virtualmachines/creation-wizard-new/state/vm-wizard-form/consts.ts
@@ -1,0 +1,27 @@
+import { FieldPath } from 'react-hook-form';
+
+import { VMWizardFormValues } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/types';
+
+export const CREATE_VM_FORM_FIELDS_VM_DATA: Record<string, FieldPath<VMWizardFormValues>> = {
+  CLUSTER: 'vmData.cluster',
+  CREATION_METHOD: 'vmData.creationMethod',
+  DESCRIPTION: 'vmData.description',
+  FOLDER: 'vmData.folder',
+  NAME: 'vmData.name',
+  PROJECT: 'vmData.project',
+  ROOT: 'vmData',
+  SELECTED_TEMPLATE: 'vmData.selectedTemplate',
+};
+
+export const CREATE_VM_FORM_FIELDS_UI_STATE: Record<string, FieldPath<VMWizardFormValues>> = {
+  IS_TEMPLATES_DRAWER_OPEN: 'uiState.isTemplatesDrawerOpen',
+  LAST_PROCESSED_TEMPLATE_KEY: 'uiState.lastProcessedTemplateKey',
+  SHOULD_CHECK_VM_NAME_PROPERLY: 'uiState.shouldCheckVMNameProperly',
+};
+
+export const CREATE_VM_FORM_FIELDS_STEP_NAVIGATION: Record<
+  string,
+  FieldPath<VMWizardFormValues>
+> = {
+  VISITED_STEPS: 'stepNavigation.visitedSteps',
+};

--- a/src/views/virtualmachines/creation-wizard-new/state/vm-wizard-form/types.ts
+++ b/src/views/virtualmachines/creation-wizard-new/state/vm-wizard-form/types.ts
@@ -29,3 +29,8 @@ export type VMWizardFormValues = {
   uiState: VMWizardUIState;
   vmData: VMWizardVirtualMachineData;
 };
+
+export type CreateInitialVMWizardFormValuesArgs = {
+  cluster: string;
+  namespace: string;
+};

--- a/src/views/virtualmachines/creation-wizard-new/state/vm-wizard-form/utils.ts
+++ b/src/views/virtualmachines/creation-wizard-new/state/vm-wizard-form/utils.ts
@@ -1,13 +1,9 @@
-import { VMWizardFormValues } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/types';
 import {
   VMCreationMethod,
   VMWizardStep,
 } from '@virtualmachines/creation-wizard-new/utils/constants';
 
-export type CreateInitialVMWizardFormValuesArgs = {
-  cluster: string;
-  namespace: string;
-};
+import { CreateInitialVMWizardFormValuesArgs, VMWizardFormValues } from './types';
 
 export const createInitialVMWizardFormValues = ({
   cluster,

--- a/src/views/virtualmachines/creation-wizard-new/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import {
   NodeModel,
@@ -38,7 +39,8 @@ import { K8sVerb, useListPageFilter } from '@openshift-console/dynamic-plugin-sd
 import { Label, Pagination, Split, SplitItem } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
 import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import { useVirtualMachineInstanceMapper } from '@virtualmachines/list/hooks/useVirtualMachineInstanceMapper';
 import useVMMetrics from '@virtualmachines/list/hooks/useVMMetrics';
 import { getListPageBodySize, ListPageBodySize } from '@virtualmachines/list/listPageBodySize';
@@ -60,7 +62,11 @@ const VirtualMachinesList = forwardRef(({}, ref) => {
   const { t } = useKubevirtTranslation();
   useSignals();
   useVMMetrics();
-  const { cluster, project: targetNamespace, setVMDescription, setVMName } = useVMWizardStore();
+  const { control, setValue } = useVMWizard();
+  const [cluster, targetNamespace] = useWatch({
+    control,
+    name: [CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER, CREATE_VM_FORM_FIELDS_VM_DATA.PROJECT],
+  });
 
   const isAllClustersPage = useIsAllClustersPage();
   const { loading: loadingFeatureProxy } = useFeatures(KUBEVIRT_APISERVER_PROXY);
@@ -214,8 +220,8 @@ const VirtualMachinesList = forwardRef(({}, ref) => {
   const setVM = (vm: V1VirtualMachine) => {
     const sourceVMName = getName(vm);
     const name = truncateToK8sName(isVM(vm) ? `${sourceVMName}-clone` : sourceVMName);
-    setVMName(name);
-    setVMDescription(getDescription(vm));
+    setValue(CREATE_VM_FORM_FIELDS_VM_DATA.NAME, name);
+    setValue(CREATE_VM_FORM_FIELDS_VM_DATA.DESCRIPTION, getDescription(vm) ?? '');
     vmSignal.value = vm;
   };
 
@@ -265,6 +271,7 @@ const VirtualMachinesList = forwardRef(({}, ref) => {
       </Split>
       <VirtualMachineTable
         callbacks={callbacks}
+        cluster={cluster}
         columns={activeTableColumns}
         data={paginatedData}
         loaded={loaded}

--- a/src/views/virtualmachines/creation-wizard-new/steps/CloneSourceStep/components/VirtualMachinesList/components/VirtualMachineTable.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/CloneSourceStep/components/VirtualMachinesList/components/VirtualMachineTable.tsx
@@ -6,13 +6,13 @@ import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { Table, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
 import { VMCallbacks } from '@virtualmachines/list/virtualMachinesDefinition';
 
 import VirtualMachineRow from './VirtualMachineRow';
 
 type VirtualMachineTableProps = {
   callbacks: VMCallbacks;
+  cluster: string;
   columns: ColumnConfig<V1VirtualMachine, VMCallbacks>[];
   data: V1VirtualMachine[];
   loaded: boolean;
@@ -22,6 +22,7 @@ type VirtualMachineTableProps = {
 
 const VirtualMachineTable: FC<VirtualMachineTableProps> = ({
   callbacks,
+  cluster,
   columns,
   data,
   loaded,
@@ -29,7 +30,6 @@ const VirtualMachineTable: FC<VirtualMachineTableProps> = ({
   selectedVMState,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { cluster } = useVMWizardStore();
 
   if (loadError) {
     return (

--- a/src/views/virtualmachines/creation-wizard-new/steps/CustomizationStep/CustomizationStep.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/CustomizationStep/CustomizationStep.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useEffect } from 'react';
+import { useWatch } from 'react-hook-form';
 import produce from 'immer';
 
 import useIsIPv6SingleStackCluster from '@kubevirt-utils/hooks/useIPStackType/useIsIPv6SingleStackCluster';
@@ -8,12 +9,14 @@ import { isPodNetwork } from '@kubevirt-utils/resources/vm/utils/network/selecto
 import { removePodNetworkFromVM } from '@kubevirt-utils/resources/vm/utils/network/utils';
 import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import { Stack, StackItem, Title, TitleSizes } from '@patternfly/react-core';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import CustomizeVirtualMachine from '@virtualmachines/creation-wizard-new/steps/CustomizationStep/components/CustomizeVirtualMachine/CustomizeVirtualMachine';
 
 const CustomizationStep: FC = () => {
   const { t } = useKubevirtTranslation();
-  const { cluster } = useVMWizardStore();
+  const { control } = useVMWizard();
+  const cluster = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER });
   const isIPv6SingleStack = useIsIPv6SingleStackCluster(cluster);
   const vm = vmSignal.value;
 

--- a/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/DeploymentDetailsStep.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/DeploymentDetailsStep.tsx
@@ -4,6 +4,7 @@ import { useWatch } from 'react-hook-form';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Stack, StackItem, Title, TitleSizes } from '@patternfly/react-core';
 import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import CreationMethodTileGroup from '@virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/CreationMethodTileGroup';
 import NameAndDescriptionForm from '@virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/NameAndDescriptionForm/NameAndDescriptionForm';
 import VMCreationLocationDisplay from '@virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/VMCreationLocationDisplay';
@@ -13,7 +14,7 @@ import { isCloneCreationMethod } from '@virtualmachines/creation-wizard-new/util
 const DeploymentDetailsStep: FC = () => {
   const { t } = useKubevirtTranslation();
   const { control } = useVMWizard();
-  const creationMethod = useWatch({ control, name: 'vmData.creationMethod' });
+  const creationMethod = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.CREATION_METHOD });
   const [editCreationLocation, setEditCreationLocation] = useState(false);
 
   const isCloneMethod = isCloneCreationMethod(creationMethod);

--- a/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/CreationMethodTileGroup.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/CreationMethodTileGroup.tsx
@@ -3,6 +3,7 @@ import { useWatch } from 'react-hook-form';
 
 import { Flex, FlexItem } from '@patternfly/react-core';
 import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import { VMCreationMethod } from '@virtualmachines/creation-wizard-new/utils/constants';
 
 import CreationMethodTile from './components/CreationMethodTile/CreationMethodTile';
@@ -11,7 +12,7 @@ import './CreationMethodTileGroup.scss';
 
 const CreationMethodTileGroup: FC = () => {
   const { control, setValue } = useVMWizard();
-  const creationMethod = useWatch({ control, name: 'vmData.creationMethod' });
+  const creationMethod = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.CREATION_METHOD });
 
   return (
     <Flex
@@ -25,7 +26,7 @@ const CreationMethodTileGroup: FC = () => {
           <FlexItem className="vm-creation-method-tile-group__item" key={method}>
             <CreationMethodTile
               setSelectedCreationMethod={(selectedCreationMethod) =>
-                setValue('vmData.creationMethod', selectedCreationMethod)
+                setValue(CREATE_VM_FORM_FIELDS_VM_DATA.CREATION_METHOD, selectedCreationMethod)
               }
               creationMethod={method}
               isChecked={creationMethod === method}

--- a/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/DeploymentDetailsStepFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/DeploymentDetailsStepFooter.tsx
@@ -16,13 +16,14 @@ import {
 import VMNameConfirmationNextButton from '@virtualmachines/creation-wizard-new/components/VMNameConfirmationNextButton';
 import useCloseWizard from '@virtualmachines/creation-wizard-new/hooks/useCloseWizard';
 import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import { isCloneCreationMethod } from '@virtualmachines/creation-wizard-new/utils/utils';
 
 const DeploymentDetailsStepFooter: FC = () => {
   const hasOLSConsole = useFlag(FLAG_LIGHTSPEED_PLUGIN);
   const { goToNextStep } = useWizardContext();
   const { control } = useVMWizard();
-  const creationMethod = useWatch({ control, name: 'vmData.creationMethod' });
+  const creationMethod = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.CREATION_METHOD });
   const isCloneMethod = isCloneCreationMethod(creationMethod);
   const closeWizard = useCloseWizard();
   const { backButtonText, cancelButtonText, nextButtonText } = useWizardFooterProps();

--- a/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/VMCreationLocationDisplay.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/VMCreationLocationDisplay.tsx
@@ -10,6 +10,7 @@ import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { ButtonVariant } from '@patternfly/react-core';
 import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 
 import './VMCreationLocationDisplay.scss';
 
@@ -31,7 +32,11 @@ const VMCreationLocationDisplay: FC<VMCreationLocationDisplayProps> = ({
   const { control } = useVMWizard();
   const [cluster, folder, project] = useWatch({
     control,
-    name: ['vmData.cluster', 'vmData.folder', 'vmData.project'],
+    name: [
+      CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER,
+      CREATE_VM_FORM_FIELDS_VM_DATA.FOLDER,
+      CREATE_VM_FORM_FIELDS_VM_DATA.PROJECT,
+    ],
   });
 
   return (

--- a/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/VMCreationLocationForm.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/DeploymentDetailsStep/components/VMCreationLocationForm.tsx
@@ -13,6 +13,7 @@ import useIsACMPage from '@multicluster/useIsACMPage';
 import { Form, FormGroup } from '@patternfly/react-core';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 
 import './VMCreationLocationForm.scss';
 
@@ -27,7 +28,11 @@ const VMCreationLocationForm: FC = () => {
   const { control, setValue } = useVMWizard();
   const [cluster, folder, project] = useWatch({
     control,
-    name: ['vmData.cluster', 'vmData.folder', 'vmData.project'],
+    name: [
+      CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER,
+      CREATE_VM_FORM_FIELDS_VM_DATA.FOLDER,
+      CREATE_VM_FORM_FIELDS_VM_DATA.PROJECT,
+    ],
   });
 
   return (
@@ -40,8 +45,9 @@ const VMCreationLocationForm: FC = () => {
                 {...field}
                 onChange={(selectedCluster) => {
                   field.onChange(selectedCluster);
-                  setValue('vmData.folder', '');
-                  if (selectedCluster !== cluster) setValue('vmData.project', '');
+                  setValue(CREATE_VM_FORM_FIELDS_VM_DATA.FOLDER, '');
+                  if (selectedCluster !== cluster)
+                    setValue(CREATE_VM_FORM_FIELDS_VM_DATA.PROJECT, '');
                 }}
                 bookmarkCluster={hubClusterName}
                 includeAllClusters={false}
@@ -49,7 +55,7 @@ const VMCreationLocationForm: FC = () => {
               />
             )}
             control={control}
-            name="vmData.cluster"
+            name={CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER}
           />
         </FormGroup>
       )}
@@ -60,7 +66,7 @@ const VMCreationLocationForm: FC = () => {
               {...field}
               onChange={(selectedProject) => {
                 field.onChange(selectedProject);
-                setValue('vmData.folder', '');
+                setValue(CREATE_VM_FORM_FIELDS_VM_DATA.FOLDER, '');
               }}
               bookmarkCluster={hubClusterName}
               cluster={cluster}
@@ -69,7 +75,7 @@ const VMCreationLocationForm: FC = () => {
             />
           )}
           control={control}
-          name="vmData.project"
+          name={CREATE_VM_FORM_FIELDS_VM_DATA.PROJECT}
         />
       </FormGroup>
       <FormGroup
@@ -85,11 +91,13 @@ const VMCreationLocationForm: FC = () => {
         label={t('Folder (optional)')}
       >
         <FolderSelect
+          setSelectedFolder={(newFolder) =>
+            setValue(CREATE_VM_FORM_FIELDS_VM_DATA.FOLDER, newFolder)
+          }
           cluster={cluster}
           isDisabled={treeViewFoldersLoading || !treeViewFoldersEnabled}
           namespace={project}
           selectedFolder={folder}
-          setSelectedFolder={(newFolder) => setValue('vmData.folder', newFolder)}
         />
       </FormGroup>
     </Form>

--- a/src/views/virtualmachines/creation-wizard-new/steps/InstanceTypesSteps/BootSourceStep/BootSourceStep.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/InstanceTypesSteps/BootSourceStep/BootSourceStep.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { ALL_PROJECTS } from '@kubevirt-utils/hooks/constants';
 import useInstanceTypesAndPreferences from '@kubevirt-utils/hooks/useInstanceTypesAndPreferences';
@@ -16,7 +17,8 @@ import {
   TitleSizes,
 } from '@patternfly/react-core';
 import useInstanceTypeVMStore from '@virtualmachines/creation-wizard-new/state/instance-type-vm-store/useInstanceTypeVMStore';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import BootableVolumeList from '@virtualmachines/creation-wizard-new/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/BootableVolumeList';
 
 import AddBootableVolumeButton from './components/AddBootableVolumeButton';
@@ -25,7 +27,8 @@ const BootSourceStep: FC = () => {
   const { t } = useKubevirtTranslation();
   const isAdmin = useIsAdmin();
   const { setUseBootSource, useBootSource, volumeListNamespace } = useInstanceTypeVMStore();
-  const { project } = useVMWizardStore();
+  const { control } = useVMWizard();
+  const project = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.PROJECT });
   const instanceTypesAndPreferencesData = useInstanceTypesAndPreferences(
     getValidNamespace(project),
   );

--- a/src/views/virtualmachines/creation-wizard-new/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/SelectInstanceTypeSection.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/SelectInstanceTypeSection.tsx
@@ -1,11 +1,13 @@
 import React, { FC, useEffect, useMemo, useState } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { getInstanceTypeMenuItems } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/utils';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import useInstanceTypesAndPreferences from '@kubevirt-utils/hooks/useInstanceTypesAndPreferences';
 import { Tab, Tabs } from '@patternfly/react-core';
 import useInstanceTypeVMStore from '@virtualmachines/creation-wizard-new/state/instance-type-vm-store/useInstanceTypeVMStore';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import RedHatProvidedInstanceTypesSection from '@virtualmachines/creation-wizard-new/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/RedHatProvidedInstanceTypesSection/RedHatProvidedInstanceTypesSection';
 import UserProvidedInstanceTypesList from '@virtualmachines/creation-wizard-new/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/UserProvidedInstanceTypeList/UserProvidedInstanceTypeList';
 import { getUserProvidedInstanceTypes } from '@virtualmachines/creation-wizard-new/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/UserProvidedInstanceTypeList/utils/utils';
@@ -15,7 +17,11 @@ import { TabKey } from './utils/constants';
 const SelectInstanceTypeSection: FC = ({}) => {
   const [activeTabKey, setActiveTabKey] = useState<TabKey>(TabKey.RedHat);
 
-  const { cluster, project } = useVMWizardStore();
+  const { control } = useVMWizard();
+  const [cluster, project] = useWatch({
+    control,
+    name: [CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER, CREATE_VM_FORM_FIELDS_VM_DATA.PROJECT],
+  });
   const { selectedInstanceType } = useInstanceTypeVMStore();
   const { allInstanceTypes, loaded } = useInstanceTypesAndPreferences(project, cluster);
 

--- a/src/views/virtualmachines/creation-wizard-new/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/PreferenceSelectMenu.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/PreferenceSelectMenu.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/types';
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
@@ -7,14 +8,19 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { FormGroup, SelectOption } from '@patternfly/react-core';
 import useInstanceTypeVMStore from '@virtualmachines/creation-wizard-new/state/instance-type-vm-store/useInstanceTypeVMStore';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import usePreferenceSelectOptions from '@virtualmachines/creation-wizard-new/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/hooks/usePreferenceSelectOptions/usePreferenceSelectOptions';
 
 import './PreferenceSelectMenu.scss';
 
 const PreferenceSelectMenu: FC = () => {
   const { t } = useKubevirtTranslation();
-  const { cluster, project } = useVMWizardStore();
+  const { control } = useVMWizard();
+  const [cluster, project] = useWatch({
+    control,
+    name: [CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER, CREATE_VM_FORM_FIELDS_VM_DATA.PROJECT],
+  });
   const { operatingSystemType, preference, setPreference } = useInstanceTypeVMStore();
 
   const { preferences, preferencesLoaded } = usePreferenceSelectOptions(

--- a/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplateStepFooter.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplateStepFooter.tsx
@@ -3,7 +3,8 @@ import React, { FC } from 'react';
 import { useWizardContext, WizardFooter } from '@patternfly/react-core';
 import useCloseWizard from '@virtualmachines/creation-wizard-new/hooks/useCloseWizard';
 import useWizardStepValidation from '@virtualmachines/creation-wizard-new/hooks/useWizardStepValidation';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_UI_STATE } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import useCreateVMFromTemplate from '@virtualmachines/creation-wizard-new/steps/TemplateStep/hooks/useCreateVMFromTemplate';
 import { VMWizardStep } from '@virtualmachines/creation-wizard-new/utils/constants';
 
@@ -11,12 +12,12 @@ const TemplateStepFooter: FC = () => {
   const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
   const { createVMFromTemplate } = useCreateVMFromTemplate();
   const closeWizard = useCloseWizard();
-  const { setTemplatesDrawerIsOpen } = useVMWizardStore();
+  const { setValue } = useVMWizard();
   const { isNextDisabledForStep } = useWizardStepValidation();
 
   const handleGoToNextStep = async () => {
     await createVMFromTemplate();
-    setTemplatesDrawerIsOpen(false);
+    setValue(CREATE_VM_FORM_FIELDS_UI_STATE.IS_TEMPLATES_DRAWER_OPEN, false);
     goToNextStep();
   };
 

--- a/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalog/TemplatesCatalog.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalog/TemplatesCatalog.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useMemo } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { V1Template } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { useApplyFiltersWithQuery } from '@kubevirt-utils/components/ListPageFilter/hooks/useApplyFiltersWithQuery';
@@ -14,7 +15,11 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useListPageFilter } from '@openshift-console/dynamic-plugin-sdk';
 import { Card, Split, SplitItem } from '@patternfly/react-core';
 import useVirtualMachineTemplatesFilters from '@templates/list/filters/useVirtualMachineTemplatesFilters';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import {
+  CREATE_VM_FORM_FIELDS_UI_STATE,
+  CREATE_VM_FORM_FIELDS_VM_DATA,
+} from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import TemplatesCatalogEmptyState from '@virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesCatalogEmptyState';
 import TemplatesCatalogItems from '@virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesCatalogItems/TemplatesCatalogItems';
 import CatalogSkeleton from '@virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesCatalogSkeleton';
@@ -26,7 +31,11 @@ import useCatalogUIState from './hooks/useCatalogUIState';
 import './TemplateCatalog.scss';
 
 const TemplatesCatalog: FC = () => {
-  const { selectedTemplate, setSelectedTemplate, setTemplatesDrawerIsOpen } = useVMWizardStore();
+  const { control, setValue } = useVMWizard();
+  const selectedTemplate = useWatch({
+    control,
+    name: CREATE_VM_FORM_FIELDS_VM_DATA.SELECTED_TEMPLATE,
+  });
   const { isList, namespace, setIsList, setNamespace } = useCatalogUIState();
 
   const { availableDataSources, availableTemplatesUID, bootSourcesLoaded, loaded, templates } =
@@ -53,9 +62,9 @@ const TemplatesCatalog: FC = () => {
   const applyFiltersWithQuery = useApplyFiltersWithQuery(onFilterChange);
 
   const handleTemplateSelect = (template: V1Template) => {
-    setSelectedTemplate(template);
+    setValue(CREATE_VM_FORM_FIELDS_VM_DATA.SELECTED_TEMPLATE, template);
     logTemplateFlowEvent(TEMPLATE_SELECTED, template);
-    setTemplatesDrawerIsOpen(true);
+    setValue(CREATE_VM_FORM_FIELDS_UI_STATE.IS_TEMPLATES_DRAWER_OPEN, true);
   };
 
   const clearAll = () => {

--- a/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesTable/TemplatesTable.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesTable/TemplatesTable.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useMemo } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -6,7 +7,8 @@ import { getUID } from '@kubevirt-utils/resources/shared';
 import { getTemplateName, Template } from '@kubevirt-utils/resources/template';
 import { ARCHITECTURE_ID, ARCHITECTURE_TITLE } from '@kubevirt-utils/utils/architecture';
 import { Table, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 
 import TemplatesTableRow from './TemplatesTableRow';
 
@@ -28,7 +30,11 @@ const TemplatesTable: FC<TemplatesTableProps> = ({
   templates,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { selectedTemplate } = useVMWizardStore();
+  const { control } = useVMWizard();
+  const selectedTemplate = useWatch({
+    control,
+    name: CREATE_VM_FORM_FIELDS_VM_DATA.SELECTED_TEMPLATE,
+  });
 
   const activeColumnIDs = useMemo(
     () => ['name', ARCHITECTURE_ID, 'workload', 'source', 'cpu-memory'],

--- a/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalogDrawer/components/ParametersSections.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalogDrawer/components/ParametersSections.tsx
@@ -6,7 +6,8 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
 import { Button, ButtonVariant, Stack, StackItem } from '@patternfly/react-core';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import { useDrawerContext } from '@virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalogDrawer/hooks/useDrawerContext';
 import { changeTemplateParameterValue } from '@virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalogDrawer/utils/utils';
 
@@ -19,7 +20,7 @@ type ParametersSectionProps = {
 const ParametersSections: FC<ParametersSectionProps> = ({ requiredParameters }) => {
   const { t } = useKubevirtTranslation();
   const { setTemplate, template } = useDrawerContext();
-  const { setSelectedTemplate } = useVMWizardStore();
+  const { setValue } = useVMWizard();
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const workingTemplate = cloneDeep(template);
 
@@ -32,7 +33,7 @@ const ParametersSections: FC<ParametersSectionProps> = ({ requiredParameters }) 
   const handleButtonClick = () => {
     if (isEdit) {
       setTemplate(workingTemplate);
-      setSelectedTemplate(workingTemplate);
+      setValue(CREATE_VM_FORM_FIELDS_VM_DATA.SELECTED_TEMPLATE, workingTemplate);
       vmSignal.value = getTemplateVirtualMachineObject(workingTemplate);
       setIsEdit(false);
       return;

--- a/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalogDrawer/components/TemplateInfoSection.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalogDrawer/components/TemplateInfoSection.tsx
@@ -1,4 +1,5 @@
 import React, { FC, memo } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import CPUDescription from '@kubevirt-utils/components/CPUDescription/CPUDescription';
 import CPUMemory from '@kubevirt-utils/components/CPUMemory/CPUMemory';
@@ -21,14 +22,16 @@ import { getOperatingSystemName } from '@kubevirt-utils/resources/vm/utils/opera
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import { Alert, DescriptionList } from '@patternfly/react-core';
 import useWizardDisksTableData from '@virtualmachines/creation-wizard-new/components/DisksReviewTable/hooks/useWizardDisksTableData/useWizardDisksTableData';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import { useDrawerContext } from '@virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalogDrawer/hooks/useDrawerContext';
 
 import TemplateExpandableDescription from './TemplateExpandableDescription';
 
 const TemplateInfoSection: FC = memo(() => {
   const { t } = useKubevirtTranslation();
-  const { cluster } = useVMWizardStore();
+  const { control } = useVMWizard();
+  const cluster = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER });
   const isIPv6SingleStack = useIsIPv6SingleStackCluster(cluster);
   const { template, vm } = useDrawerContext();
   const [disks] = useWizardDisksTableData(vm);

--- a/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalogDrawer/hooks/useDrawerContext.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/components/TemplatesCatalogDrawer/hooks/useDrawerContext.tsx
@@ -1,11 +1,13 @@
 import React, { createContext, FC, ReactNode, useContext, useEffect, useMemo } from 'react';
+import { useWatch } from 'react-hook-form';
 import { Updater, useImmer } from 'use-immer';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getTemplateVirtualMachineObject, Template } from '@kubevirt-utils/resources/template';
 import { useVMTemplateSource } from '@kubevirt-utils/resources/template';
 import useVMTemplateGeneratedParams from '@kubevirt-utils/resources/template/hooks/useVMTemplateGeneratedParams';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 
 export type DrawerContext = {
   setTemplate: Updater<Template>;
@@ -17,7 +19,8 @@ export type DrawerContext = {
 
 const useDrawer = (initialTemplate: Template) => {
   const [template, setTemplate] = useImmer(initialTemplate);
-  const { project } = useVMWizardStore();
+  const { control } = useVMWizard();
+  const project = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.PROJECT });
   const [templateWithGeneratedParams, loading, error] = useVMTemplateGeneratedParams(
     initialTemplate,
     project || undefined,

--- a/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/hooks/useCreateVMFromTemplate.ts
+++ b/src/views/virtualmachines/creation-wizard-new/steps/TemplateStep/hooks/useCreateVMFromTemplate.ts
@@ -13,7 +13,11 @@ import {
 } from '@kubevirt-utils/resources/template';
 import { getDefaultRunningStrategy } from '@kubevirt-utils/resources/vm';
 import { vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
-import useVMWizardStore from '@virtualmachines/creation-wizard-new/state/vm-wizard-store/useVMWizardStore';
+import { useVMWizard } from '@virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext';
+import {
+  CREATE_VM_FORM_FIELDS_UI_STATE,
+  CREATE_VM_FORM_FIELDS_VM_DATA,
+} from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/consts';
 import { resolveVMFromTemplate } from '@virtualmachines/creation-wizard-new/steps/TemplateStep/hooks/utils';
 import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
 
@@ -24,18 +28,19 @@ type UseCreateVMFromTemplate = () => {
 
 const useCreateVMFromTemplate: UseCreateVMFromTemplate = () => {
   const [createError, setCreateError] = useState(undefined);
-  const {
-    cluster,
-    folder,
-    lastProcessedTemplateKey,
-    project: namespace,
-    selectedTemplate,
-    setLastProcessedTemplateKey,
-    vmDescription,
-    vmName,
-  } = useVMWizardStore();
+  const { getValues, setValue } = useVMWizard();
 
   const createVMFromTemplate = async () => {
+    const {
+      cluster,
+      folder,
+      name: vmName,
+      project: namespace,
+      selectedTemplate,
+    } = getValues(CREATE_VM_FORM_FIELDS_VM_DATA.ROOT);
+    const lastProcessedTemplateKey = getValues(
+      CREATE_VM_FORM_FIELDS_UI_STATE.LAST_PROCESSED_TEMPLATE_KEY,
+    );
     setCreateError(undefined);
 
     const selectedKey = getResourceKey(selectedTemplate);
@@ -44,6 +49,7 @@ const useCreateVMFromTemplate: UseCreateVMFromTemplate = () => {
     logTemplateFlowEvent(CUSTOMIZE_VM_BUTTON_CLICKED, selectedTemplate);
 
     try {
+      const vmDescription = getValues(CREATE_VM_FORM_FIELDS_VM_DATA.DESCRIPTION);
       const vmObject = await resolveVMFromTemplate(selectedTemplate, namespace, cluster, vmName);
 
       vmObject.metadata.namespace = namespace;
@@ -62,7 +68,7 @@ const useCreateVMFromTemplate: UseCreateVMFromTemplate = () => {
       vmObject.spec.runStrategy = getDefaultRunningStrategy();
 
       vmSignal.value = vmObject;
-      setLastProcessedTemplateKey(selectedKey);
+      setValue(CREATE_VM_FORM_FIELDS_UI_STATE.LAST_PROCESSED_TEMPLATE_KEY, selectedKey);
     } catch (error) {
       setCreateError(error);
       logTemplateFlowEvent(CUSTOMIZE_VM_FAILED, selectedTemplate);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Continues migrating the new VM creation wizard from Zustand to react-hook-form.
* Template step — templates catalog, drawer, and useCreateVMFromTemplate read/write vmData / uiState via the form
* Clone step — Replace useVMWizardStore with the form in the VM list and useCloneVM
* Customization step — Read vmData.cluster from the form instead of the wizard store
* Instance-type flow — In Boot Source, Guest OS, and Compute Resources, read deployment location (vmData.project / vmData.cluster) from the form; instance-type selections still use useInstanceTypeVMStore for now
* /vm-wizard flow is unchanged
## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-89616

## 🎥 Demo


https://github.com/user-attachments/assets/6805f793-99c7-4922-a109-7f5f1e69e797



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the VM creation wizard to use reactive form state consistently for step logic and selections across clone, templates, customization, deployment details, and instance type steps.
  * Introduced shared constants for form field paths to remove hardcoded field names and keep watch/setValue usage aligned.
* **Bug Fixes**
  * Improved templates drawer open/close and selected template state during step navigation.
  * Kept clone/customization/instance type inputs properly synced with the chosen cluster and project.
* **Documentation**
  * Clarified the Kubernetes/DNS-1123 naming convention comment for DNS label validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->