### PR TITLE
Ignore missing Project API for cluster-wide VM listing

### DIFF
--- a/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
+++ b/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
@@ -106,12 +106,14 @@ export const useAccessibleResources = <T>({
     return vms || [];
   }, [allResources, allowedResources, loadPerNamespace]);
 
-  const loaded =
-    projectNamesLoaded &&
-    (loadPerNamespace
-      ? isEmpty(allowedResources) ||
-        Object.values(allowedResources).some((resource) => resource.loaded || resource.loadError)
-      : allResourcesLoaded);
+  const loaded = shouldFetchClusterWide
+    ? allResourcesLoaded
+    : projectNamesLoaded &&
+      (isEmpty(allowedResources) ||
+        Object.values(allowedResources).some((resource) => resource.loaded || resource.loadError));
 
-  return { loaded, loadError: projectNamesError, resources };
+  // Cluster-wide watches do not need OpenShift Project discovery.
+  const loadError = shouldFetchClusterWide ? undefined : projectNamesError;
+
+  return { loaded, loadError, resources };
 };


### PR DESCRIPTION
## 📝 Description

Fixes regression introduced in version `v4.21.0`. This was not present in `v4.20.0`. Tested against a cluster with vanilla K8s (no OpenShift CRDs installed)

URL tested: <http://localhost:9000/k8s/all-namespaces/kubevirt.io~v1~VirtualMachine/search>

## 🎥 Demo

With change, renders correctly rather than error:
<img width="1179" height="665" alt="Screenshot 2026-06-18 at 5 51 32 AM" src="https://github.com/user-attachments/assets/d2cdc2ef-7b9c-484b-abc9-70bfa06f03e5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved virtual machine resource discovery when performing cluster-wide searches.
  * The app now treats certain cluster-wide readiness/error states as non-fatal, avoiding premature failures and allowing searches to proceed more reliably.
  * Namespace-scoped behavior remains unchanged for error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->