### PR TITLE
CNV-90655: VirtualMachines tree view: show all projects by default when no VirtualMachines exist

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "arrowParens": "always",
+  "endOfLine": "auto",
   "printWidth": 100,
   "singleQuote": true,
   "trailingComma": "all",

--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -520,6 +520,7 @@
   "Create a new VM by selecting an operating system and the right performance for your workload.": "Create a new VM by selecting an operating system and the right performance for your workload.",
   "Create a pre-configured VM using standardized images. This option requires an existing template.": "Create a pre-configured VM using standardized images. This option requires an existing template.",
   "Create a VirtualMachine from a template": "Create a VirtualMachine from a template",
+  "Create a VirtualMachine to enable this filter.": "Create a VirtualMachine to enable this filter.",
   "Create a VM": "Create a VM",
   "Create activation key": "Create activation key",
   "Create application-aware quota": "Create application-aware quota",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -531,6 +531,7 @@
   "Create a new VM by selecting an operating system and the right performance for your workload.": "Cree una nueva máquina virtual seleccionando un sistema operativo y el rendimiento adecuado para su carga de trabajo.",
   "Create a pre-configured VM using standardized images. This option requires an existing template.": "Cree una máquina virtual preconfigurada utilizando imágenes estandarizadas. Esta opción requiere una plantilla existente.",
   "Create a VirtualMachine from a template": "Crear una VirtualMachine a partir de una plantilla",
+  "Create a VirtualMachine to enable this filter.": "Create a VirtualMachine to enable this filter.",
   "Create a VM": "Crear una máquina virtual",
   "Create activation key": "Crear clave de activación",
   "Create application-aware quota": "Crear cuota con reconocimiento de aplicación",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -531,6 +531,7 @@
   "Create a new VM by selecting an operating system and the right performance for your workload.": "Créez une nouvelle machine virtuelle en sélectionnant un système d'exploitation et les performances adaptées à votre charge de travail.",
   "Create a pre-configured VM using standardized images. This option requires an existing template.": "Créez une machine virtuelle préconfigurée à l'aide d'images standardisées. Cette option nécessite un modèle existant.",
   "Create a VirtualMachine from a template": "Créer une VirtualMachine à partir d'un modèle",
+  "Create a VirtualMachine to enable this filter.": "Create a VirtualMachine to enable this filter.",
   "Create a VM": "Créer une machine virtuelle",
   "Create activation key": "Créer une clé d'activation",
   "Create application-aware quota": "Créer un quota prenant en compte les applications",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -519,6 +519,7 @@
   "Create a new VM by selecting an operating system and the right performance for your workload.": "オペレーティングシステムとワークロードに最適なパフォーマンスを選択して、新しい仮想マシンを作成します。",
   "Create a pre-configured VM using standardized images. This option requires an existing template.": "標準化されたイメージを使用して、事前設定済みの仮想マシンを作成します。このオプションを使用するには、既存のテンプレートが必要です。",
   "Create a VirtualMachine from a template": "テンプレートからVirtualMachineを作成",
+  "Create a VirtualMachine to enable this filter.": "Create a VirtualMachine to enable this filter.",
   "Create a VM": "仮想マシンの作成",
   "Create activation key": "アクティベーションキーの作成",
   "Create application-aware quota": "アプリケーション認識クォータの作成",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -519,6 +519,7 @@
   "Create a new VM by selecting an operating system and the right performance for your workload.": "운영 체제 및 워크로드에 적합한 성능을 선택하여 새 VM을 생성합니다.",
   "Create a pre-configured VM using standardized images. This option requires an existing template.": "표준화된 이미지를 사용하여 사전 구성된 VM을 생성합니다. 이 옵션에는 기존 템플릿이 필요합니다.",
   "Create a VirtualMachine from a template": "템플릿에서 VirtualMachine 생성",
+  "Create a VirtualMachine to enable this filter.": "Create a VirtualMachine to enable this filter.",
   "Create a VM": "VM 생성",
   "Create activation key": "활성화 키 생성",
   "Create application-aware quota": "애플리케이션 인식 할당량 생성",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -519,6 +519,7 @@
   "Create a new VM by selecting an operating system and the right performance for your workload.": "通过为您的工作负载选择操作系统和正确的性能来创建新的虚拟机。",
   "Create a pre-configured VM using standardized images. This option requires an existing template.": "使用标准化镜像创建一个预配置的虚拟机。此选项需要有一个现有的模板。",
   "Create a VirtualMachine from a template": "从模板创建 VirtualMachine",
+  "Create a VirtualMachine to enable this filter.": "Create a VirtualMachine to enable this filter.",
   "Create a VM": "创建虚拟机",
   "Create activation key": "创建激活码",
   "Create application-aware quota": "创建应用程序感知配额",

--- a/playwright/fixtures/index.ts
+++ b/playwright/fixtures/index.ts
@@ -10,6 +10,7 @@ import {
 } from '../pages/ResourceListPage';
 import { SettingsPage } from '../pages/SettingsPage';
 import { TemplatesPage } from '../pages/TemplatesPage';
+import { VMTreeViewPage } from '../pages/vm-tree';
 import { VMDetailsPage } from '../pages/VMDetailsPage';
 import { VMListPage } from '../pages/VMListPage';
 
@@ -24,6 +25,7 @@ type KubevirtFixtures = {
   templatesPage: TemplatesPage;
   vmDetails: VMDetailsPage;
   vmList: VMListPage;
+  vmTreeView: VMTreeViewPage;
 };
 
 export const test = base.extend<KubevirtFixtures>({
@@ -67,6 +69,10 @@ export const test = base.extend<KubevirtFixtures>({
 
   vmList: async ({ page }, use) => {
     await use(new VMListPage(page));
+  },
+
+  vmTreeView: async ({ page }, use) => {
+    await use(new VMTreeViewPage(page));
   },
 });
 

--- a/playwright/pages/LoginPage.ts
+++ b/playwright/pages/LoginPage.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from '@playwright/test';
+import { expect, Locator, Page } from '@playwright/test';
 
 import { MINUTE } from '../utils/constants';
 import { env } from '../utils/env';
@@ -15,28 +15,58 @@ const SEL = {
 export class LoginPage {
   constructor(private readonly page: Page) {}
 
+  private async isOpenShiftOAuthLoginPage(): Promise<boolean> {
+    return this.page.getByRole('heading', { name: 'Log in to your account' }).isVisible();
+  }
+
+  private async loginViaOpenShiftOAuth(username: string, password: string) {
+    await this.page.getByRole('textbox', { name: 'Username' }).fill(username);
+    await this.page.getByRole('textbox', { name: 'Password' }).fill(password);
+    await this.page.getByRole('button', { name: 'Log in' }).click();
+  }
+
+  /** Wait until the console loads or a known login screen appears after redirect. */
+  private async waitForLoginOrConsole(userDropdown: Locator) {
+    const oauthLogin = this.page.getByRole('heading', { name: 'Log in to your account' });
+    const htpasswdLogin = this.page.locator(SEL.usernameInput);
+
+    await Promise.race([
+      userDropdown.waitFor({ state: 'visible', timeout: MINUTE }),
+      oauthLogin.waitFor({ state: 'visible', timeout: MINUTE }),
+      htpasswdLogin.waitFor({ state: 'visible', timeout: MINUTE }),
+    ]).catch(() => undefined);
+  }
+
   /** Log in with the given credentials. Skips login if auth is disabled. */
   async login(
     idp = env.kubeadminIdp,
     username = env.kubeadminUsername,
     password = env.kubeadminPassword,
   ) {
-    await this.page.goto('/');
-    await this.page.waitForLoadState('domcontentloaded');
+    const userDropdown = byTest(this.page, USER_DROPDOWN_TOGGLE);
 
-    // Skip login when the console runs with auth disabled
-    const authDisabled = await this.page.evaluate(
-      () =>
-        (window as Window & { SERVER_FLAGS?: { authDisabled?: boolean } }).SERVER_FLAGS
-          ?.authDisabled,
-    );
+    await this.page.goto('/');
+    await this.waitForLoginOrConsole(userDropdown);
+
+    if (await userDropdown.isVisible()) return;
+
+    const authDisabled = await this.page
+      .evaluate(
+        () =>
+          (window as Window & { SERVER_FLAGS?: { authDisabled?: boolean } }).SERVER_FLAGS
+            ?.authDisabled,
+      )
+      .catch(() => false);
 
     if (authDisabled) return;
 
-    // Already logged in
-    if (await byTest(this.page, USER_DROPDOWN_TOGGLE).isVisible()) return;
+    if (await this.isOpenShiftOAuthLoginPage()) {
+      await this.loginViaOpenShiftOAuth(username, password);
+      await expect(userDropdown).toBeVisible({ timeout: MINUTE });
+      return;
+    }
 
-    // IDP selection screen
+    // Console bridge htpasswd login with optional IDP picker
     const bodyText = await this.page.locator('body').innerText();
     if (bodyText.includes(idp)) {
       await this.page.getByText(idp).click();
@@ -46,7 +76,7 @@ export class LoginPage {
     await this.page.locator(SEL.passwordInput).fill(password);
     await this.page.locator(SEL.submitButton).click();
 
-    await expect(byTest(this.page, USER_DROPDOWN_TOGGLE)).toBeVisible({ timeout: MINUTE });
+    await expect(userDropdown).toBeVisible({ timeout: MINUTE });
   }
 
   /** Seed guided-tour completion into localStorage so tour banners never appear. */

--- a/playwright/pages/SettingsPage.ts
+++ b/playwright/pages/SettingsPage.ts
@@ -15,7 +15,9 @@ const MEMORY_DENSITY_DISABLE_CONFIRM_BUTTON = 'memory-density-disable-confirm-bu
 const MEMORY_DENSITY_MODIFY_BUTTON = 'memory-density-modify-button';
 const MEMORY_DENSITY_SAVE_BUTTON = 'memory-density-save-button';
 const MEMORY_DENSITY_SLIDER = 'memory-density-slider';
+const CLUSTER_TAB = 'Cluster';
 const PREVIEW_FEATURES_TAB = 'Preview features';
+const SETTINGS_HEADING = 'Settings';
 const SAVE_BUTTON = 'save-button';
 const SELECT_PROJECT_TOGGLE = 'select-project-toggle';
 const SELECT_SECRET = 'select-secret';
@@ -24,6 +26,16 @@ export class SettingsPage {
   constructor(private readonly page: Page) {}
 
   // ── SSH key configuration ─────────────────────────────────────────────────────
+
+  /** Wait for the settings shell — works regardless of which tab is active. */
+  private async expectSettingsPageLoaded() {
+    await expect(this.page.getByRole('heading', { level: 1, name: SETTINGS_HEADING })).toBeVisible({
+      timeout: NAV_TIMEOUT,
+    });
+    await expect(this.page.getByRole('tab', { exact: true, name: CLUSTER_TAB })).toBeVisible({
+      timeout: NAV_TIMEOUT,
+    });
+  }
 
   private async toggleVMActionsConfirmation(enable: boolean, retries: number) {
     for (let attempt = 1; attempt <= retries; attempt++) {
@@ -41,13 +53,12 @@ export class SettingsPage {
       } catch (err) {
         if (attempt === retries) throw err;
         await this.page.waitForLoadState('domcontentloaded');
-        await this.page
-          .getByText('Configure features')
-          .waitFor({ timeout: NAV_TIMEOUT })
-          .catch(() => {});
+        await this.expectSettingsPageLoaded().catch(() => {});
       }
     }
   }
+
+  // ── Section clicks ───────────────────────────────────────────────────────────
 
   async configureSSHSecret(ns: string, secretName: string) {
     await byTestId(this.page, SELECT_PROJECT_TOGGLE).click();
@@ -61,7 +72,7 @@ export class SettingsPage {
     await byTest(this.page, SAVE_BUTTON).click();
   }
 
-  // ── Section clicks ───────────────────────────────────────────────────────────
+  // ── VM Actions confirmation ───────────────────────────────────────────────────
 
   async disableMemoryDensity() {
     await this.openSection(GENERAL_SETTINGS_SECTION);
@@ -82,8 +93,6 @@ export class SettingsPage {
       timeout: NAV_TIMEOUT,
     });
   }
-
-  // ── VM Actions confirmation ───────────────────────────────────────────────────
 
   /** Disable VM actions confirmation, retrying if the page reloads during the click. */
   async disableVMActionsConfirmation(retries = DEFAULT_RETRIES) {
@@ -120,12 +129,12 @@ export class SettingsPage {
     }
   }
 
+  // ── Assertions ────────────────────────────────────────────────────────────────
+
   /** Enable VM actions confirmation, retrying if the page reloads during the click. */
   async enableVMActionsConfirmation(retries = DEFAULT_RETRIES) {
     await this.toggleVMActionsConfirmation(true, retries);
   }
-
-  // ── Assertions ────────────────────────────────────────────────────────────────
 
   async expectInstalledVersion(versionPrefix: string) {
     await expect(byTestId(this.page, GENERAL_INFORMATION_INSTALLED_VERSION)).toContainText(
@@ -149,17 +158,11 @@ export class SettingsPage {
     await this.page.goto(`/k8s/ns/${env.cnvNamespace}/virtualization-settings`, {
       waitUntil: 'domcontentloaded',
     });
-    await expect(this.page.locator('[data-test-id]').first()).toBeVisible({
-      timeout: NAV_TIMEOUT,
-    });
-    await this.page.getByText('Configure features').waitFor({ timeout: NAV_TIMEOUT });
+    await this.expectSettingsPageLoaded();
   }
 
   async navigateToSSHKeys() {
     await this.navigate();
-    await expect(byTestId(this.page, GENERAL_INFORMATION_INSTALLED_VERSION)).toBeVisible({
-      timeout: NAV_TIMEOUT,
-    });
     await this.page.getByRole('tab', { exact: true, name: 'User' }).click();
     // Wait for the URL hash to reflect the tab change before navigating to #ssh-keys
     await this.page.waitForURL(/user/, { timeout: SHORT_TIMEOUT }).catch(() => {});

--- a/playwright/pages/VMListPage.ts
+++ b/playwright/pages/VMListPage.ts
@@ -3,12 +3,16 @@ import { expect, Locator, Page } from '@playwright/test';
 import { ITEM_CREATE, KEBAB_BUTTON, MINUTE, SECOND } from '../utils/constants';
 import { byTest, byTestId } from '../utils/locators';
 
+import { VMTreeViewPage } from './vm-tree';
+
 const VM_FILTER_NAME_INPUT = 'vm-filter-name-input';
-const VM_LIST_TAB = 'vm-list-tab';
-const VMS_TREEVIEW = 'vms-treeview';
 
 export class VMListPage {
-  constructor(private readonly page: Page) {}
+  readonly treeView: VMTreeViewPage;
+
+  constructor(private readonly page: Page) {
+    this.treeView = new VMTreeViewPage(page);
+  }
 
   // ── Navigation ──────────────────────────────────────────────────────────────
 
@@ -43,34 +47,22 @@ export class VMListPage {
     ).toBeVisible({ timeout });
   }
 
-  /** Assert the tree-view panel is rendered alongside the list. */
-  async expectTreeViewVisible() {
-    await expect(byTest(this.page, VMS_TREEVIEW)).toBeVisible();
-  }
-
   async filterByName(name: string) {
     await this.page.locator(`[data-test="${VM_FILTER_NAME_INPUT}"] input`).fill(name);
   }
 
-  // ── Filters ──────────────────────────────────────────────────────────────────
-
   /**
    * Navigate directly to the VM list for the given namespace (or all-namespaces).
-   * The page loads with the Overview tab selected by default, so we explicitly
-   * click the "VirtualMachines" tab (`data-test="vm-list-tab"`) to show the list.
+   * Opens the Virtual machines tab via the `tab=vms` query param.
    */
   async navigateToVMList(ns?: string) {
     const nsPath = ns ? `ns/${ns}` : 'all-namespaces';
-    await this.page.goto(`/k8s/${nsPath}/kubevirt.io~v1~VirtualMachine`);
+    await this.page.goto(`/k8s/${nsPath}/kubevirt.io~v1~VirtualMachine?tab=vms`);
     await this.page.waitForLoadState('domcontentloaded');
 
-    // Click the VirtualMachines tab to switch from the default Overview tab
-    const vmListTab = byTest(this.page, VM_LIST_TAB);
-    await expect(vmListTab).toBeVisible({ timeout: MINUTE });
-    await vmListTab.click();
-
-    // Confirm the tab is selected and the list body is shown
-    await expect(byTest(this.page, ITEM_CREATE)).toBeVisible({ timeout: MINUTE });
+    await expect(this.page.getByRole('tabpanel', { name: 'Virtual machines' })).toBeVisible({
+      timeout: MINUTE,
+    });
   }
 
   /** Click the row's kebab actions menu toggle. */
@@ -84,7 +76,7 @@ export class VMListPage {
     await byTestId(this.page, vmName).click();
   }
 
-  // ── Assertions ────────────────────────────────────────────────────────────────
+  // ── Filters ──────────────────────────────────────────────────────────────────
 
   /**
    * Returns the table row containing the given resource name.

--- a/playwright/pages/vm-tree/VMTreeViewPage.ts
+++ b/playwright/pages/vm-tree/VMTreeViewPage.ts
@@ -1,0 +1,140 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+import { MINUTE } from '../../utils/constants';
+import { byTest } from '../../utils/locators';
+
+import {
+  DISABLED_FILTER_TOOLTIP,
+  HIDE,
+  NO_VM_PROJECTS_EMPTY_STATE,
+  SHOW,
+  SHOW_EMPTY_PROJECTS_KEY,
+  SHOW_ONLY_VM_PROJECTS_SWITCH,
+  SHOW_ONLY_VM_PROJECTS_SWITCH_LABEL,
+  SHOW_ONLY_VM_PROJECTS_SWITCH_TARGET,
+  SHOW_TREE_VIEW_KEY,
+  TREE_VIEW_SEARCH_INPUT,
+  VMS_TREEVIEW,
+} from './constants';
+
+export class VMTreeViewPage {
+  constructor(private readonly page: Page) {}
+
+  // ── Locators ────────────────────────────────────────────────────────────────
+
+  async expectDisabledFilterTooltip() {
+    await expect(this.page.getByRole('tooltip', { name: DISABLED_FILTER_TOOLTIP })).toBeVisible();
+  }
+
+  async expectEmptyState(visible: boolean) {
+    const emptyState = this.page.getByText(NO_VM_PROJECTS_EMPTY_STATE);
+    if (visible) {
+      await expect(emptyState).toBeVisible();
+      return;
+    }
+    await expect(emptyState).toBeHidden();
+  }
+
+  async expectLoaded() {
+    await this.expectVisible();
+    await expect(this.showOnlyVMProjectsSwitchLabel()).toBeVisible({ timeout: MINUTE });
+  }
+
+  async expectProjectVisible(projectName: string, visible: boolean) {
+    const project = this.projectTreeItem(projectName);
+    if (visible) {
+      await expect(project).toBeVisible();
+      return;
+    }
+    await expect(project).toBeHidden();
+  }
+
+  async expectShowOnlyVMProjectsSwitch(checked: boolean, disabled?: boolean) {
+    const switchInput = this.showOnlyVMProjectsSwitchInput();
+    if (checked) {
+      await expect(switchInput).toBeChecked();
+    } else {
+      await expect(switchInput).not.toBeChecked();
+    }
+
+    if (disabled === undefined) return;
+
+    if (disabled) {
+      await expect(switchInput).toBeDisabled();
+    } else {
+      await expect(switchInput).toBeEnabled();
+    }
+  }
+
+  // ── State setup ─────────────────────────────────────────────────────────────
+
+  async expectVisible() {
+    await expect(this.panel()).toBeVisible();
+  }
+
+  // ── Actions ─────────────────────────────────────────────────────────────────
+
+  async hoverShowOnlyVMProjectsSwitch() {
+    const target = this.showOnlyVMProjectsSwitchTarget();
+    if (await target.count()) {
+      await target.hover();
+      return;
+    }
+    await this.showOnlyVMProjectsSwitchLabel().hover({ force: true });
+  }
+
+  panel(): Locator {
+    return byTest(this.page, VMS_TREEVIEW);
+  }
+
+  // ── Assertions ──────────────────────────────────────────────────────────────
+
+  projectTreeItem(projectName: string): Locator {
+    return this.page.getByRole('treeitem', { name: projectName });
+  }
+
+  searchInput(): Locator {
+    return this.page.locator(`#${TREE_VIEW_SEARCH_INPUT}`);
+  }
+
+  /** Seed localStorage so the tree panel is open and the VM-only filter defaults to ON. */
+  async seedDefaultState() {
+    await this.page.addInitScript(
+      ({ hide, show, showEmptyProjectsKey, showTreeViewKey }) => {
+        localStorage.setItem(showEmptyProjectsKey, JSON.stringify(hide));
+        localStorage.setItem(showTreeViewKey, JSON.stringify(show));
+      },
+      {
+        hide: HIDE,
+        show: SHOW,
+        showEmptyProjectsKey: SHOW_EMPTY_PROJECTS_KEY,
+        showTreeViewKey: SHOW_TREE_VIEW_KEY,
+      },
+    );
+  }
+
+  async setShowOnlyVMProjectsFilter(enabled: boolean) {
+    const switchInput = this.showOnlyVMProjectsSwitchInput();
+    const isChecked = await switchInput.isChecked();
+
+    if (enabled === isChecked) return;
+
+    // PatternFly v6 Switch: the toggle span covers the input — click the label wrapper.
+    await switchInput.locator('..').click();
+  }
+
+  showOnlyVMProjectsSwitchInput(): Locator {
+    return this.panel().locator(`[data-test="${SHOW_ONLY_VM_PROJECTS_SWITCH}"]`);
+  }
+
+  showOnlyVMProjectsSwitchLabel(): Locator {
+    return this.panel().getByRole('switch', { name: SHOW_ONLY_VM_PROJECTS_SWITCH_LABEL });
+  }
+
+  showOnlyVMProjectsSwitchTarget(): Locator {
+    return byTest(this.page, SHOW_ONLY_VM_PROJECTS_SWITCH_TARGET);
+  }
+
+  // Future: expandNode(name), selectProject(name), selectVM(name),
+  // searchProjects(query), openPanel(), closePanel()
+}

--- a/playwright/pages/vm-tree/constants.ts
+++ b/playwright/pages/vm-tree/constants.ts
@@ -1,0 +1,22 @@
+/** Tree view panel drawer. */
+export const VMS_TREEVIEW = 'vms-treeview';
+
+/** "Show only projects with VirtualMachines" filter switch. */
+export const SHOW_ONLY_VM_PROJECTS_SWITCH = 'show-only-vm-projects-switch';
+
+export const SHOW_ONLY_VM_PROJECTS_SWITCH_LABEL = 'Show only projects with VirtualMachines';
+
+/** Hover target for the disabled filter switch tooltip. */
+export const SHOW_ONLY_VM_PROJECTS_SWITCH_TARGET = 'show-only-vm-projects-switch-target';
+
+/** Tree view search input id (matches TREE_VIEW_SEARCH_ID). */
+export const TREE_VIEW_SEARCH_INPUT = 'vms-tree-view-search-input';
+
+/** localStorage keys — must match src/views/virtualmachines/tree/utils/constants.ts */
+export const SHOW_EMPTY_PROJECTS_KEY = 'showEmptyProjects';
+export const SHOW_TREE_VIEW_KEY = 'showTreeView';
+export const SHOW = 'show';
+export const HIDE = 'hide';
+
+export const DISABLED_FILTER_TOOLTIP = 'Create a VirtualMachine to enable this filter.';
+export const NO_VM_PROJECTS_EMPTY_STATE = 'No projects with VirtualMachines found';

--- a/playwright/pages/vm-tree/index.ts
+++ b/playwright/pages/vm-tree/index.ts
@@ -1,0 +1,2 @@
+export * from './constants';
+export { VMTreeViewPage } from './VMTreeViewPage';

--- a/playwright/tests/gating/vm-tree-filter.spec.ts
+++ b/playwright/tests/gating/vm-tree-filter.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * VM tree view — "Show only projects with VirtualMachines" filter.
+ *
+ * Standard gating test (not a preview feature). Run locally with:
+ *   npx playwright test playwright/tests/gating/vm-tree-filter.spec.ts --config=playwright.config.ts --project=gating
+ */
+import { BrowserContext, Page } from '@playwright/test';
+
+import { test } from '../../fixtures';
+import { VMTreeViewPage } from '../../pages/vm-tree';
+import { VMListPage } from '../../pages/VMListPage';
+import { env } from '../../utils/env';
+import { clusterHasVMs, createEmptyNamespace, deleteNamespace } from '../../utils/oc';
+
+const EMPTY_NS = 'pw-tree-empty';
+
+test.describe.serial('VM tree view — show only projects with VirtualMachines', () => {
+  let context: BrowserContext;
+  let page: Page;
+  let vmList: VMListPage;
+  let treeView: VMTreeViewPage;
+
+  test.beforeAll(async ({ browser }) => {
+    createEmptyNamespace(EMPTY_NS);
+
+    context = await browser.newContext({
+      storageState: 'playwright/.auth/session.json',
+    });
+    page = await context.newPage();
+    vmList = new VMListPage(page);
+    treeView = vmList.treeView;
+    await treeView.seedDefaultState();
+  });
+
+  test.afterAll(async () => {
+    deleteNamespace(EMPTY_NS);
+    await page?.close();
+    await context?.close();
+  });
+
+  test('switch is ON by default when the cluster has VirtualMachines', async () => {
+    test.skip(!clusterHasVMs(), 'Requires at least one VirtualMachine in the cluster');
+
+    await vmList.navigateToVMList();
+    await treeView.expectLoaded();
+    await treeView.expectShowOnlyVMProjectsSwitch(true, false);
+  });
+
+  test('empty namespace is hidden when the filter is ON', async () => {
+    test.skip(!clusterHasVMs(), 'Requires at least one VirtualMachine in the cluster');
+
+    await treeView.expectProjectVisible(EMPTY_NS, false);
+  });
+
+  test('empty namespace is visible when the filter is OFF', async () => {
+    test.skip(!clusterHasVMs(), 'Requires at least one VirtualMachine in the cluster');
+
+    await treeView.setShowOnlyVMProjectsFilter(false);
+    await treeView.expectShowOnlyVMProjectsSwitch(false, false);
+    await treeView.expectProjectVisible(EMPTY_NS, true);
+  });
+
+  test('empty namespace is hidden again when the filter is re-enabled', async () => {
+    test.skip(!clusterHasVMs(), 'Requires at least one VirtualMachine in the cluster');
+
+    await treeView.setShowOnlyVMProjectsFilter(true);
+    await treeView.expectShowOnlyVMProjectsSwitch(true, false);
+    await treeView.expectProjectVisible(EMPTY_NS, false);
+  });
+});
+
+test('switch is disabled when the cluster has no VirtualMachines', async ({ browser }) => {
+  test.skip(clusterHasVMs(), 'Requires cluster with zero VirtualMachines');
+
+  const context = await browser.newContext({
+    storageState: 'playwright/.auth/session.json',
+  });
+  const page = await context.newPage();
+  const vmList = new VMListPage(page);
+  const treeView = vmList.treeView;
+
+  await treeView.seedDefaultState();
+  await vmList.navigateToVMList();
+  await treeView.expectLoaded();
+  await treeView.expectShowOnlyVMProjectsSwitch(false, true);
+
+  await treeView.hoverShowOnlyVMProjectsSwitch();
+  await treeView.expectDisabledFilterTooltip();
+
+  await treeView.expectEmptyState(false);
+
+  const projectToExpect = env.testNamespace || 'default';
+  await treeView.expectProjectVisible(projectToExpect, true);
+
+  await page.close();
+  await context.close();
+});

--- a/playwright/utils/oc.ts
+++ b/playwright/utils/oc.ts
@@ -45,6 +45,24 @@ export function deleteResource(kind: string, name: string, ns?: string) {
   ocIgnore(`delete ${kind} ${name} ${nsFlag} --ignore-not-found --wait=false`);
 }
 
+/** Create an empty namespace, replacing any existing namespace with the same name. */
+export function createEmptyNamespace(name: string) {
+  ocIgnore(`delete namespace ${name} --ignore-not-found --wait=true`);
+  ocIgnore(`wait namespace/${name} --for=delete --timeout=60s`);
+  oc(`create namespace ${name}`);
+}
+
+/** Returns true when the cluster has at least one VirtualMachine. */
+export function clusterHasVMs(): boolean {
+  const out = ocIgnore('get vm -A --no-headers');
+  return out.trim().length > 0;
+}
+
+/** Delete a namespace, ignoring not-found errors. */
+export function deleteNamespace(name: string) {
+  ocIgnore(`delete namespace ${name} --ignore-not-found --wait=false`);
+}
+
 /** Patch a VirtualMachine's run strategy. */
 export function patchVMRunStrategy(name: string, ns: string, strategy: 'Always' | 'Halted') {
   oc(`patch vm ${name} -n ${ns} --type=merge -p '{"spec":{"runStrategy":"${strategy}"}}'`);

--- a/src/views/virtualmachines/tree/components/ShowOnlyVMProjectsSwitch.tsx
+++ b/src/views/virtualmachines/tree/components/ShowOnlyVMProjectsSwitch.tsx
@@ -1,0 +1,50 @@
+import React, { FC } from 'react';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useLocalStorage from '@kubevirt-utils/hooks/useLocalStorage';
+import { Content, Split, SplitItem, Switch, Tooltip } from '@patternfly/react-core';
+
+import { HIDE, SHOW, SHOW_EMPTY_PROJECTS_KEY } from '../utils/constants';
+import { isShowOnlyVMProjectsChecked } from '../utils/utils';
+
+type ShowOnlyVMProjectsSwitchProps = {
+  hasVMs: boolean;
+};
+
+const ShowOnlyVMProjectsSwitch: FC<ShowOnlyVMProjectsSwitchProps> = ({ hasVMs }) => {
+  const { t } = useKubevirtTranslation();
+  const [showEmptyProjects, setShowEmptyProjects] = useLocalStorage(SHOW_EMPTY_PROJECTS_KEY, HIDE);
+  const showOnlyVMProjectsLabel = t('Show only projects with VirtualMachines');
+
+  const switchControl = (
+    <Switch
+      aria-label={showOnlyVMProjectsLabel}
+      checked={isShowOnlyVMProjectsChecked(hasVMs, showEmptyProjects)}
+      className="vms-tree-view__toolbar-switch"
+      data-test="show-only-vm-projects-switch"
+      isDisabled={!hasVMs}
+      isReversed
+      onChange={(_, checked) => setShowEmptyProjects(checked ? HIDE : SHOW)}
+    />
+  );
+
+  return (
+    <Split>
+      <SplitItem className="pf-v6-u-ml-md">
+        <Content component="p">{showOnlyVMProjectsLabel}</Content>
+      </SplitItem>
+      <SplitItem isFilled />
+      {!hasVMs ? (
+        <Tooltip content={t('Create a VirtualMachine to enable this filter.')}>
+          <span data-test="show-only-vm-projects-switch-target" tabIndex={0}>
+            {switchControl}
+          </span>
+        </Tooltip>
+      ) : (
+        switchControl
+      )}
+    </Split>
+  );
+};
+
+export default ShowOnlyVMProjectsSwitch;

--- a/src/views/virtualmachines/tree/components/TreeViewContent.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewContent.tsx
@@ -47,7 +47,7 @@ const TreeViewContent: FC<TreeViewContentProps> = ({
   treeData,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { filteredTreeData, onSearch, searchText } = useFilteredTreeView(treeData);
+  const { filteredTreeData, hasVMs, onSearch, searchText } = useFilteredTreeView(treeData);
 
   const { addListeners, hideMenu, triggerElement } = useTreeViewItemActions(treeData);
 
@@ -87,7 +87,7 @@ const TreeViewContent: FC<TreeViewContentProps> = ({
   return (
     <>
       {!isSmallScreen && panelToggleButton}
-      <TreeViewToolbar onSearch={onSearch} />
+      <TreeViewToolbar hasVMs={hasVMs} onSearch={onSearch} />
       <DrawerPanelBody className="vms-tree-view-body">
         {isEmpty(filteredTreeData) ? (
           <EmptyState

--- a/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
@@ -1,31 +1,28 @@
 import React, { ChangeEvent, FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useLocalStorage from '@kubevirt-utils/hooks/useLocalStorage';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import {
-  Content,
   Divider,
-  Split,
-  SplitItem,
   Stack,
   StackItem,
-  Switch,
   Toolbar,
   ToolbarContent,
   TreeViewSearch,
 } from '@patternfly/react-core';
 
-import { HIDE, SHOW, SHOW_EMPTY_PROJECTS_KEY, TREE_VIEW_SEARCH_ID } from '../utils/constants';
+import { TREE_VIEW_SEARCH_ID } from '../utils/constants';
+
+import ShowOnlyVMProjectsSwitch from './ShowOnlyVMProjectsSwitch';
 
 type TreeViewToolbarProps = {
+  hasVMs: boolean;
   onSearch: (event: ChangeEvent<HTMLInputElement>) => void;
 };
 
-const TreeViewToolbar: FC<TreeViewToolbarProps> = ({ onSearch }) => {
+const TreeViewToolbar: FC<TreeViewToolbarProps> = ({ hasVMs, onSearch }) => {
   const { t } = useKubevirtTranslation();
   const isACMPage = useIsACMPage();
-  const [showEmptyProjects, setShowEmptyProjects] = useLocalStorage(SHOW_EMPTY_PROJECTS_KEY, HIDE);
 
   return (
     <Toolbar className="vms-tree-view-toolbar" isSticky>
@@ -41,18 +38,7 @@ const TreeViewToolbar: FC<TreeViewToolbarProps> = ({ onSearch }) => {
             />
           </StackItem>
           <StackItem className="pf-v6-u-mb-md">
-            <Split>
-              <SplitItem className="pf-v6-u-ml-md">
-                <Content component="p">{t('Show only projects with VirtualMachines')}</Content>
-              </SplitItem>
-              <SplitItem isFilled />
-              <Switch
-                checked={showEmptyProjects === HIDE}
-                className="vms-tree-view__toolbar-switch"
-                isReversed
-                onChange={(_, checked) => setShowEmptyProjects(checked ? HIDE : SHOW)}
-              />
-            </Split>
+            <ShowOnlyVMProjectsSwitch hasVMs={hasVMs} />
           </StackItem>
           <Divider />
         </Stack>

--- a/src/views/virtualmachines/tree/hooks/useAutoSelectTreeViewItem/useAutoSelectTreeViewItem.ts
+++ b/src/views/virtualmachines/tree/hooks/useAutoSelectTreeViewItem/useAutoSelectTreeViewItem.ts
@@ -5,14 +5,21 @@ import { runningTourSignal } from '@kubevirt-utils/components/GuidedTour/utils/g
 import { ALL_NAMESPACES, ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import useLocalStorage from '@kubevirt-utils/hooks/useLocalStorage';
 import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { getVMListURL } from '@multicluster/urls';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { useLastNamespace } from '@openshift-console/dynamic-plugin-sdk-internal';
+import { useSignals } from '@preact/signals-react/runtime';
 import { TEXT_FILTER_LABELS_ID } from '@virtualmachines/list/hooks/constants';
 
 import { FOLDER_SELECTOR_PREFIX, HIDE, SHOW_EMPTY_PROJECTS_KEY } from '../../utils/constants';
-import { getVMInfoFromPathname, getVMTreeViewItemID } from '../../utils/utils';
+import { vmsSignal } from '../../utils/signals';
+import {
+  getEffectiveShowEmptyProjects,
+  getVMInfoFromPathname,
+  getVMTreeViewItemID,
+} from '../../utils/utils';
 import useTreeViewSelect from '../useTreeViewSelect';
 
 import {
@@ -23,6 +30,7 @@ import {
 } from './utils';
 
 const useAutoSelectTreeViewItem = ({ dataMap, loaded }: UseAutoSelectTreeViewItemProps) => {
+  useSignals();
   const [selected, onSelect, setSelected] = useTreeViewSelect();
 
   const [searchParams] = useSearchParams();
@@ -34,6 +42,8 @@ const useAutoSelectTreeViewItem = ({ dataMap, loaded }: UseAutoSelectTreeViewIte
   const cluster = useClusterParam();
   const { ns } = useParams<{ ns: string }>();
   const [showEmptyProjects] = useLocalStorage(SHOW_EMPTY_PROJECTS_KEY, HIDE);
+  const hasVMs = !isEmpty(vmsSignal.value);
+  const effectiveShowEmptyProjects = getEffectiveShowEmptyProjects(hasVMs, showEmptyProjects);
 
   // Select VM tree view item based on path
   useEffect(() => {
@@ -57,7 +67,7 @@ const useAutoSelectTreeViewItem = ({ dataMap, loaded }: UseAutoSelectTreeViewIte
 
       const projectTreeItem = getProjectTreeItem(dataMap, cluster, ns);
 
-      if (projectTreeItem && isProjectVisibleInTree(projectTreeItem, showEmptyProjects)) {
+      if (projectTreeItem && isProjectVisibleInTree(projectTreeItem, effectiveShowEmptyProjects)) {
         if (selected?.id !== projectTreeItem.id) {
           setSelected(projectTreeItem);
         }
@@ -80,6 +90,7 @@ const useAutoSelectTreeViewItem = ({ dataMap, loaded }: UseAutoSelectTreeViewIte
   }, [
     cluster,
     dataMap,
+    effectiveShowEmptyProjects,
     isACMPage,
     loaded,
     location.pathname,
@@ -88,7 +99,6 @@ const useAutoSelectTreeViewItem = ({ dataMap, loaded }: UseAutoSelectTreeViewIte
     searchParams,
     selected?.id,
     setSelected,
-    showEmptyProjects,
   ]);
 
   // Select namespace based on current URL and filter state
@@ -121,7 +131,10 @@ const useAutoSelectTreeViewItem = ({ dataMap, loaded }: UseAutoSelectTreeViewIte
       if (ns) {
         const projectTreeItem = getProjectTreeItem(dataMap, SINGLE_CLUSTER_KEY, ns);
 
-        if (projectTreeItem && isProjectVisibleInTree(projectTreeItem, showEmptyProjects)) {
+        if (
+          projectTreeItem &&
+          isProjectVisibleInTree(projectTreeItem, effectiveShowEmptyProjects)
+        ) {
           setSelected(projectTreeItem);
           return;
         }
@@ -142,7 +155,7 @@ const useAutoSelectTreeViewItem = ({ dataMap, loaded }: UseAutoSelectTreeViewIte
     if (ns) {
       const projectTreeItem = getProjectTreeItem(dataMap, SINGLE_CLUSTER_KEY, ns);
 
-      if (projectTreeItem && !isProjectVisibleInTree(projectTreeItem, showEmptyProjects)) {
+      if (projectTreeItem && !isProjectVisibleInTree(projectTreeItem, effectiveShowEmptyProjects)) {
         selectNamespaceOrFallback();
         return;
       }
@@ -154,6 +167,7 @@ const useAutoSelectTreeViewItem = ({ dataMap, loaded }: UseAutoSelectTreeViewIte
     }
   }, [
     dataMap,
+    effectiveShowEmptyProjects,
     isACMPage,
     loaded,
     location.pathname,
@@ -164,7 +178,6 @@ const useAutoSelectTreeViewItem = ({ dataMap, loaded }: UseAutoSelectTreeViewIte
     selected?.id,
     setLastNamespace,
     setSelected,
-    showEmptyProjects,
   ]);
 
   return {

--- a/src/views/virtualmachines/tree/hooks/useFilteredTreeView.ts
+++ b/src/views/virtualmachines/tree/hooks/useFilteredTreeView.ts
@@ -1,21 +1,28 @@
 import { ChangeEvent, useCallback, useMemo, useState } from 'react';
 
 import useLocalStorage from '@kubevirt-utils/hooks/useLocalStorage';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { TreeViewDataItem } from '@patternfly/react-core';
+import { useSignals } from '@preact/signals-react/runtime';
 
 import { HIDE, SHOW, SHOW_EMPTY_PROJECTS_KEY } from '../utils/constants';
-import { filterItems, filterNamespaceItems } from '../utils/utils';
+import { vmsSignal } from '../utils/signals';
+import { filterItems, filterNamespaceItems, getEffectiveShowEmptyProjects } from '../utils/utils';
 
 type UseFilteredTreeView = (treeData: TreeViewDataItem[]) => {
   filteredTreeData: TreeViewDataItem[];
+  hasVMs: boolean;
   onSearch: (event: ChangeEvent<HTMLInputElement>) => void;
   searchText: string;
 };
 
 const useFilteredTreeView: UseFilteredTreeView = (treeData) => {
+  useSignals();
   const [showEmptyProjects] = useLocalStorage(SHOW_EMPTY_PROJECTS_KEY, HIDE);
   const [filteredItems, setFilteredItems] = useState<TreeViewDataItem[]>(null);
   const [searchText, setSearchText] = useState('');
+  const hasVMs = !isEmpty(vmsSignal.value);
+  const effectiveShowEmptyProjects = getEffectiveShowEmptyProjects(hasVMs, showEmptyProjects);
 
   const onSearch = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -40,10 +47,10 @@ const useFilteredTreeView: UseFilteredTreeView = (treeData) => {
 
     return items
       .map((opt) => Object.assign({}, opt))
-      .filter((item) => filterNamespaceItems(item, showEmptyProjects === SHOW));
-  }, [filteredItems, treeData, showEmptyProjects]);
+      .filter((item) => filterNamespaceItems(item, effectiveShowEmptyProjects === SHOW));
+  }, [effectiveShowEmptyProjects, filteredItems, treeData]);
 
-  return { filteredTreeData, onSearch, searchText };
+  return { filteredTreeData, hasVMs, onSearch, searchText };
 };
 
 export default useFilteredTreeView;

--- a/src/views/virtualmachines/tree/utils/utils.tsx
+++ b/src/views/virtualmachines/tree/utils/utils.tsx
@@ -43,7 +43,9 @@ import {
   ALL_CLUSTERS_ID,
   CLUSTER_SELECTOR_PREFIX,
   FOLDER_SELECTOR_PREFIX,
+  HIDE,
   PROJECT_SELECTOR_PREFIX,
+  SHOW,
   VM_FOLDER_LABEL,
 } from './constants';
 
@@ -470,6 +472,14 @@ export const filterItems = (item: TreeViewDataItem, input: string) => {
     );
   }
 };
+
+export const getEffectiveShowEmptyProjects = (
+  hasVMs: boolean,
+  showEmptyProjects: string,
+): string => (hasVMs ? showEmptyProjects : SHOW);
+
+export const isShowOnlyVMProjectsChecked = (hasVMs: boolean, showEmptyProjects: string): boolean =>
+  getEffectiveShowEmptyProjects(hasVMs, showEmptyProjects) === HIDE;
 
 // Show projects that have VMs all the time
 // Show / hide projects that have no VMs depending on showEmptyProjects flag


### PR DESCRIPTION
## 📝 Description

Improve the VirtualMachines navigation tree view when a cluster has no VirtualMachines, so users can still browse and navigate projects instead of seeing an empty tree.

## 🔗 Links

Jira ticket: [CNV-90655](https://redhat.atlassian.net/browse/CNV-90655)

## 🎥 Demo


https://github.com/user-attachments/assets/0bfa078a-966e-476d-a6a2-d25b8180ada9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Show only projects with VirtualMachines” filter switch to the VM tree view. It remembers your preference, is disabled when no VirtualMachines are present (with tooltip guidance), and updates empty-state/project visibility accordingly.
* **Improvements**
  * Refined OpenShift OAuth login flow for redirects and already-logged-in scenarios.
  * Improved Settings page load verification for more consistent navigation.
  * Updated VM list/tree navigation to load the Virtual Machines tab more directly for steadier UI state.
* **Tests**
  * Added Playwright gating coverage for VM tree filter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->