### PR TITLE
CNV-90663: VM creation wizard shows hub cluster project instead of spoke cluster project

### DIFF
--- a/src/utils/resources/vmi/utils/cloud-init.ts
+++ b/src/utils/resources/vmi/utils/cloud-init.ts
@@ -28,7 +28,7 @@ export const getCloudInitCredentials = (
         users: [
           {
             name: userDataObject?.user || CLOUD_INIT_MISSING_USERNAME,
-            password: userDataObject?.password.toString(),
+            password: userDataObject?.password?.toString(),
           },
         ],
       };

--- a/src/views/virtualmachines/creation-wizard-new/VMCreationWizardContent.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/VMCreationWizardContent.tsx
@@ -4,11 +4,11 @@ import {
   logVMCreationStarted,
   mapWizardStepToCreationMethodTelemetry,
 } from '@kubevirt-utils/extensions/telemetry/vm-creation';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getValidNamespace } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { Wizard, WizardHeader, WizardStep } from '@patternfly/react-core';
 import DefaultWizardFooter from '@virtualmachines/creation-wizard-new/components/DefaultWizardFooter';
 import useCloseWizard from '@virtualmachines/creation-wizard-new/hooks/useCloseWizard';
@@ -56,7 +56,7 @@ const VMCreationWizardContent: FC = () => {
   const hasLoggedCreationStarted = useRef(false);
   const closeWizard = useCloseWizard();
   const isAdmin = useIsAdmin();
-  const [activeNamespace] = useActiveNamespace();
+  const activeNamespace = useActiveNamespace();
   const namespace = getValidNamespace(activeNamespace);
 
   useEffect(() => {

--- a/src/views/virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/state/vm-wizard-context/VMWizardContext.tsx
@@ -1,10 +1,10 @@
 import React, { FC, ReactNode, useEffect } from 'react';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { clearCustomizeInstanceType } from '@kubevirt-utils/store/customizeInstanceType';
 import { getValidNamespace } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import useInstanceTypeVMStore from '@virtualmachines/creation-wizard-new/state/instance-type-vm-store/useInstanceTypeVMStore';
 import { createInitialVMWizardFormValues } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/initialValues';
 import { VMWizardFormValues } from '@virtualmachines/creation-wizard-new/state/vm-wizard-form/types';
@@ -15,7 +15,7 @@ type VMWizardProviderProps = {
 
 export const VMWizardProvider: FC<VMWizardProviderProps> = ({ children }) => {
   const clusterParam = useClusterParam();
-  const [activeNamespace] = useActiveNamespace();
+  const activeNamespace = useActiveNamespace();
   const namespace = getValidNamespace(activeNamespace);
   const methods = useForm<VMWizardFormValues>({
     defaultValues: createInitialVMWizardFormValues({ cluster: clusterParam ?? '', namespace }),

--- a/src/views/virtualmachines/creation-wizard-new/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/UserProvidedInstanceTypeList/UserProvidedInstanceTypeList.tsx
+++ b/src/views/virtualmachines/creation-wizard-new/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/UserProvidedInstanceTypeList/UserProvidedInstanceTypeList.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useMemo, useState } from 'react';
 
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
@@ -8,7 +9,6 @@ import {
   getGroupVersionKindForResource,
   ResourceLink,
   Timestamp,
-  useActiveNamespace,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
   ActionList,
@@ -35,7 +35,7 @@ const UserProvidedInstanceTypesList: FC<UserProvidedInstanceTypesListProps> = ({
   userProvidedInstanceTypes,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [activeNamespace] = useActiveNamespace();
+  const activeNamespace = useActiveNamespace();
   const { selectedInstanceType, setSelectedInstanceType } = useInstanceTypeVMStore();
 
   const [searchInput, setSearchInput] = useState('');

--- a/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
+++ b/src/views/virtualmachines/creation-wizard/VMCreationWizard.tsx
@@ -4,11 +4,11 @@ import {
   logVMCreationStarted,
   mapWizardStepToCreationMethodTelemetry,
 } from '@kubevirt-utils/extensions/telemetry/vm-creation';
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getValidNamespace } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
-import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { Wizard, WizardHeader, WizardStep } from '@patternfly/react-core';
 import DefaultWizardFooter from '@virtualmachines/creation-wizard/components/DefaultWizardFooter';
 import useCloseWizard from '@virtualmachines/creation-wizard/hooks/useCloseWizard';
@@ -56,7 +56,7 @@ const VMCreationWizard: FC = () => {
   const hasLoggedCreationStarted = useRef(false);
   const closeWizard = useCloseWizard();
   const isAdmin = useIsAdmin();
-  const [activeNamespace] = useActiveNamespace();
+  const activeNamespace = useActiveNamespace();
   const namespace = getValidNamespace(activeNamespace);
 
   useEffect(() => {

--- a/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/UserProvidedInstanceTypeList/UserProvidedInstanceTypeList.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/UserProvidedInstanceTypeList/UserProvidedInstanceTypeList.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useMemo, useState } from 'react';
 
+import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
@@ -8,7 +9,6 @@ import {
   getGroupVersionKindForResource,
   ResourceLink,
   Timestamp,
-  useActiveNamespace,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
   ActionList,
@@ -35,7 +35,7 @@ const UserProvidedInstanceTypesList: FC<UserProvidedInstanceTypesListProps> = ({
   userProvidedInstanceTypes,
 }) => {
   const { t } = useKubevirtTranslation();
-  const [activeNamespace] = useActiveNamespace();
+  const activeNamespace = useActiveNamespace();
   const { selectedInstanceType, setSelectedInstanceType } = useInstanceTypeVMStore();
 
   const [searchInput, setSearchInput] = useState('');


### PR DESCRIPTION
## 📝 Description

When creating a VirtualMachine on a spoke cluster from the Fleet Virtualization perspective in ACM, the VM creation wizard pre-fills the Location with a project from the hub cluster instead of the project/namespace for the selected spoke cluster.

## 🔗 Links

Jira ticket: [CNV-90663](https://redhat.atlassian.net/browse/CNV-90663)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/04f2395f-5561-4767-9e8a-d25df55a915a


After:

https://github.com/user-attachments/assets/ee0eb91b-615d-47ef-ac84-1744ea7fb1ab



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Cloud-init credentials now safely handle missing passwords, preventing runtime errors during virtual machine creation.

## Refactors
* Updated VM creation wizard components to improve namespace handling across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->