### PR TITLE
CNV-71181: fix VM advanced search for Memory and CPU

### DIFF
--- a/src/utils/resources/bootableresources/helpers.ts
+++ b/src/utils/resources/bootableresources/helpers.ts
@@ -32,10 +32,10 @@ import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { kubevirtK8sDelete } from '@multicluster/k8sRequests';
 
-import { SINGLE_CLUSTER_KEY } from '../constants';
 import { VirtualMachinePreference } from '../preference/types';
 import {
   ClusterNamespacedResourceMap,
+  getClusterKey,
   getLabel,
   getName,
   getNamespace,
@@ -64,7 +64,7 @@ export const getBootableVolumePVCSource = (
 
   return isBootableVolumePVCKind(bootableVolume)
     ? bootableVolume
-    : pvcSources?.[getCluster(bootableVolume) || SINGLE_CLUSTER_KEY]?.[
+    : pvcSources?.[getClusterKey(bootableVolume)]?.[
         getDataSourcePVCNamespace(bootableVolume as V1beta1DataSource)
       ]?.[getDataSourcePVCName(bootableVolume as V1beta1DataSource)];
 };
@@ -72,10 +72,7 @@ export const getBootableVolumePVCSource = (
 export const getDataVolumeForPVC = (
   pvc: IoK8sApiCoreV1PersistentVolumeClaim,
   dvSources: ClusterNamespacedResourceMap<V1beta1DataVolume>,
-) =>
-  pvc
-    ? dvSources?.[getCluster(pvc) || SINGLE_CLUSTER_KEY]?.[getNamespace(pvc)]?.[getName(pvc)]
-    : null;
+) => (pvc ? dvSources?.[getClusterKey(pvc)]?.[getNamespace(pvc)]?.[getName(pvc)] : null);
 
 export const getInstanceTypePrefix = (instanceTypeNamePrefix: string): string => {
   if (instanceTypeNamePrefix?.includes('.')) {

--- a/src/utils/resources/shared.ts
+++ b/src/utils/resources/shared.ts
@@ -502,7 +502,7 @@ export function convertResourceArrayToMapWithCluster<
 >(resources: A[], isNamespaced?: boolean): ClusterNamespacedResourceMap<A> | ClusterResourceMap<A> {
   return (resources || []).reduce(
     (map, resource) => {
-      const cluster = getCluster(resource) || SINGLE_CLUSTER_KEY;
+      const cluster = getClusterKey(resource);
       const { name, namespace } = resource?.metadata || {};
       if (!map[cluster]) map[cluster] = {};
 
@@ -628,3 +628,6 @@ const VM_FOLDER_LABEL_PREFIX = `${VM_FOLDER_LABEL}=`;
 
 export const getFolderNameFromLabel = (label: string): string | undefined =>
   isFolderLabel(label) ? label.slice(VM_FOLDER_LABEL_PREFIX.length) || undefined : undefined;
+
+export const getClusterKey = (resource: K8sResourceCommon): string =>
+  getCluster(resource) || SINGLE_CLUSTER_KEY;

--- a/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActions.tsx
+++ b/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActions.tsx
@@ -9,9 +9,7 @@ import ActionsDropdown from '@kubevirt-utils/components/ActionsDropdown/ActionsD
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import useKubevirtToast from '@kubevirt-utils/hooks/useKubevirtToast';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
-import { getName } from '@kubevirt-utils/resources/shared';
-import { getCluster } from '@multicluster/helpers/selectors';
+import { getClusterKey, getName } from '@kubevirt-utils/resources/shared';
 
 import { isJobRunning } from '../../utils';
 import { useAllRunningSelfValidationJobs } from '../hooks/useAllRunningSelfValidationJobs';
@@ -41,15 +39,14 @@ const CheckupsSelfValidationActions: FC<CheckupsSelfValidationActionsProps> = ({
   );
 
   const thisCheckupJobNames = useMemo(
-    () => new Set(jobs.map((job) => `${getCluster(job) || SINGLE_CLUSTER_KEY}-${getName(job)}`)),
+    () => new Set(jobs.map((job) => `${getClusterKey(job)}-${getName(job)}`)),
     [jobs],
   );
 
   const otherRunningJobs = useMemo(
     () =>
       (clusterRunningJobs || []).filter(
-        (job) =>
-          !thisCheckupJobNames.has(`${getCluster(job) || SINGLE_CLUSTER_KEY}-${getName(job)}`),
+        (job) => !thisCheckupJobNames.has(`${getClusterKey(job)}-${getName(job)}`),
       ),
     [clusterRunningJobs, thisCheckupJobNames],
   );

--- a/src/views/virtualmachines/list/filters/getCPUFilter.ts
+++ b/src/views/virtualmachines/list/filters/getCPUFilter.ts
@@ -5,17 +5,24 @@ import {
   KubevirtFilter,
   KubevirtFilterLayout,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import { getInstanceTypeCPU } from '@kubevirt-utils/resources/instancetype/selectors';
 import { vCPUCount } from '@kubevirt-utils/resources/template';
 import { getCPU } from '@kubevirt-utils/resources/vm';
 import { numberOperatorInfo } from '@kubevirt-utils/utils/constants';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
-import { getVMIFromMapper, VMIMapper } from '@virtualmachines/utils/mappers';
+import {
+  getInstanceTypeFromMapper,
+  getVMIFromMapper,
+  InstanceTypeMapper,
+  VMIMapper,
+} from '@virtualmachines/utils/mappers';
 
 import { getOperatorChipLabel } from './utils';
 
 export const getCPUFilter = (
   t: TFunction,
   vmiMapper: VMIMapper,
+  instanceTypeMapper: InstanceTypeMapper,
 ): KubevirtFilter<V1VirtualMachine> => ({
   categoryLabel: t('vCPU'),
   filterLayout: KubevirtFilterLayout.HIDDEN,
@@ -28,7 +35,12 @@ export const getCPUFilter = (
     const vmi = getVMIFromMapper(vmiMapper, obj);
     const [operator, cpu] = cpuInfo.split(' ');
     const filterCPU = Number(cpu);
-    const vmCPU = vCPUCount(getCPU(obj) || getCPU(vmi));
+
+    const cpuSpec = getCPU(obj) || getCPU(vmi);
+    const vmCPU = cpuSpec
+      ? vCPUCount(cpuSpec)
+      : getInstanceTypeCPU(getInstanceTypeFromMapper(instanceTypeMapper, obj));
+
     return numberOperatorInfo[operator].compareFunction(vmCPU, filterCPU);
   },
 });

--- a/src/views/virtualmachines/list/filters/getMemoryFilter.ts
+++ b/src/views/virtualmachines/list/filters/getMemoryFilter.ts
@@ -5,17 +5,24 @@ import {
   KubevirtFilter,
   KubevirtFilterLayout,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import { getInstanceTypeMemory } from '@kubevirt-utils/resources/instancetype/selectors';
 import { getMemory } from '@kubevirt-utils/resources/vm';
 import { numberOperatorInfo } from '@kubevirt-utils/utils/constants';
 import { convertToBaseValue } from '@kubevirt-utils/utils/humanize.js';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
-import { getVMIFromMapper, VMIMapper } from '@virtualmachines/utils/mappers';
+import {
+  getInstanceTypeFromMapper,
+  getVMIFromMapper,
+  InstanceTypeMapper,
+  VMIMapper,
+} from '@virtualmachines/utils/mappers';
 
 import { getOperatorChipLabel } from './utils';
 
 export const getMemoryFilter = (
   t: TFunction,
   vmiMapper: VMIMapper,
+  instanceTypeMapper: InstanceTypeMapper,
 ): KubevirtFilter<V1VirtualMachine> => ({
   categoryLabel: t('Memory'),
   filterLayout: KubevirtFilterLayout.HIDDEN,
@@ -28,7 +35,10 @@ export const getMemoryFilter = (
     const vmi = getVMIFromMapper(vmiMapper, obj);
     const [operator, memoryFilterValue, memoryFilterUnit] = memoryInfo.split(' ');
     const filterBytes = convertToBaseValue(`${memoryFilterValue} ${memoryFilterUnit.slice(0, -1)}`);
-    const vmMemory = getMemory(obj) || getMemory(vmi);
+    const vmMemory =
+      getMemory(obj) ||
+      getMemory(vmi) ||
+      getInstanceTypeMemory(getInstanceTypeFromMapper(instanceTypeMapper, obj))?.toString();
     const vmBytes = convertToBaseValue(vmMemory);
     return numberOperatorInfo[operator].compareFunction(vmBytes, filterBytes);
   },

--- a/src/views/virtualmachines/list/hooks/useInstanceTypeMapper.ts
+++ b/src/views/virtualmachines/list/hooks/useInstanceTypeMapper.ts
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+
+import {
+  VirtualMachineClusterInstancetypeModelGroupVersionKind,
+  VirtualMachineInstancetypeModelGroupVersionKind,
+} from '@kubevirt-ui-ext/kubevirt-api/console';
+import {
+  V1beta1VirtualMachineClusterInstancetype,
+  V1beta1VirtualMachineInstancetype,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getClusterKey, getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
+import { InstanceTypeMapper } from '@virtualmachines/utils/mappers';
+
+export const useInstanceTypeMapper = () => {
+  const { loaded: clusterITsLoaded, resources: clusterITs } =
+    useAccessibleResources<V1beta1VirtualMachineClusterInstancetype>({
+      groupVersionKind: VirtualMachineClusterInstancetypeModelGroupVersionKind,
+    });
+
+  const { loaded: namespacedITsLoaded, resources: namespacedITs } =
+    useAccessibleResources<V1beta1VirtualMachineInstancetype>({
+      groupVersionKind: VirtualMachineInstancetypeModelGroupVersionKind,
+    });
+
+  const instanceTypeMapper: InstanceTypeMapper = useMemo(() => {
+    const clusterInstanceTypes = (clusterITs ?? []).reduce<
+      InstanceTypeMapper['clusterInstanceTypes']
+    >((acc, it) => {
+      const cluster = getClusterKey(it);
+      if (!acc[cluster]) acc[cluster] = {};
+      acc[cluster][getName(it)] = it;
+      return acc;
+    }, {});
+
+    const namespacedInstanceTypes = (namespacedITs ?? []).reduce<
+      InstanceTypeMapper['namespacedInstanceTypes']
+    >((acc, it) => {
+      const cluster = getClusterKey(it);
+      const ns = getNamespace(it);
+      if (!acc[cluster]) acc[cluster] = {};
+      if (!acc[cluster][ns]) acc[cluster][ns] = {};
+      acc[cluster][ns][getName(it)] = it;
+      return acc;
+    }, {});
+
+    return { clusterInstanceTypes, namespacedInstanceTypes };
+  }, [clusterITs, namespacedITs]);
+
+  return { instanceTypeMapper, instanceTypesLoaded: clusterITsLoaded && namespacedITsLoaded };
+};

--- a/src/views/virtualmachines/list/hooks/useVMListFilters.ts
+++ b/src/views/virtualmachines/list/hooks/useVMListFilters.ts
@@ -27,6 +27,8 @@ import useArchitectureFilter from '../filters/useArchitectureFilter';
 import useNodeFilter from '../filters/useNodeFilter';
 import useStorageClassFilter from '../filters/useStorageClassFilter';
 
+import { useInstanceTypeMapper } from './useInstanceTypeMapper';
+
 const useVMListFilters = (
   vmiMapper: VMIMapper,
   pvcMapper: PVCMapper,
@@ -39,6 +41,7 @@ const useVMListFilters = (
   const { resources: vms } = useAccessibleResources<V1VirtualMachine>({
     groupVersionKind: VirtualMachineModelGroupVersionKind,
   });
+  const { instanceTypeMapper } = useInstanceTypeMapper();
 
   const clusterFilter = useClusterFilter();
   const projectFilter = useProjectFilter();
@@ -79,8 +82,8 @@ const useVMListFilters = (
       nodeFilter,
       getGuestAgentFilter(t),
       getDescriptionFilter(t),
-      getCPUFilter(t, vmiMapper),
-      getMemoryFilter(t, vmiMapper),
+      getCPUFilter(t, vmiMapper, instanceTypeMapper),
+      getMemoryFilter(t, vmiMapper, instanceTypeMapper),
       getDateFromFilter(t),
       getDateToFilter(t),
       architectureFilter,
@@ -99,6 +102,7 @@ const useVMListFilters = (
     storageClassFilter,
     nodeFilter,
     vmiMapper,
+    instanceTypeMapper,
     architectureFilter,
   ]);
 };

--- a/src/views/virtualmachines/list/hooks/useVirtualMachineInstanceMapper.ts
+++ b/src/views/virtualmachines/list/hooks/useVirtualMachineInstanceMapper.ts
@@ -2,8 +2,7 @@ import { useMemo } from 'react';
 
 import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
-import { getCluster } from '@multicluster/helpers/selectors';
+import { getClusterKey } from '@kubevirt-utils/resources/shared';
 import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
 import { VMIMapper } from '@virtualmachines/utils/mappers';
 
@@ -17,7 +16,7 @@ export const useVirtualMachineInstanceMapper = () => {
       (acc, vmi) => {
         const name = vmi?.metadata?.name;
         const namespace = vmi?.metadata?.namespace;
-        const cluster = getCluster(vmi) || SINGLE_CLUSTER_KEY;
+        const cluster = getClusterKey(vmi);
         if (!acc.mapper[cluster]) {
           acc.mapper[cluster] = {};
         }

--- a/src/views/virtualmachines/list/metrics.ts
+++ b/src/views/virtualmachines/list/metrics.ts
@@ -4,10 +4,9 @@ import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { V1CPU } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
 import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getClusterKey, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getVCPUCount } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { getCluster } from '@multicluster/helpers/selectors';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
 import { signal } from '@preact/signals-core';
 
@@ -32,7 +31,7 @@ type MetricsType = {
 const vmsMetrics = signal<MetricsType>({});
 
 export const getVMMetrics = (vm: V1VirtualMachine) => {
-  const cluster = getCluster(vm) || SINGLE_CLUSTER_KEY;
+  const cluster = getClusterKey(vm);
   const namespace = getNamespace(vm);
   const name = getName(vm);
 

--- a/src/views/virtualmachines/list/tests/metrics.test.ts
+++ b/src/views/virtualmachines/list/tests/metrics.test.ts
@@ -1,4 +1,5 @@
 import { V1CPU, V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
 
 import {
@@ -29,6 +30,7 @@ const TWO_GIB_IN_BYTES = 2147483648;
 const ONE_MIB_IN_BYTES = 1048576;
 
 jest.mock('@kubevirt-utils/resources/shared', () => ({
+  getClusterKey: (obj: { cluster?: string }) => obj?.cluster || SINGLE_CLUSTER_KEY,
   getName: (obj: { metadata?: { name?: string } }) => obj?.metadata?.name,
   getNamespace: (obj: { metadata?: { namespace?: string } }) => obj?.metadata?.namespace,
 }));

--- a/src/views/virtualmachines/utils/mappers.ts
+++ b/src/views/virtualmachines/utils/mappers.ts
@@ -4,11 +4,12 @@ import {
   V1VirtualMachineInstance,
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { VirtualMachineInstancetypeModel } from '@kubevirt-utils/models';
 import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
-import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { getVolumes } from '@kubevirt-utils/resources/vm';
+import { InstanceTypeUnion } from '@kubevirt-utils/resources/instancetype/types';
+import { getClusterKey, getName, getNamespace } from '@kubevirt-utils/resources/shared';
+import { getInstanceTypeMatcher, getVolumes } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { getCluster } from '@multicluster/helpers/selectors';
 
 export type VMIMapper = {
   mapper: {
@@ -24,7 +25,7 @@ export type VMIMMapper = {
 };
 
 export const getVMIFromMapper = (VMIMapper: VMIMapper, vm: V1VirtualMachine) =>
-  VMIMapper?.mapper?.[getCluster(vm) || SINGLE_CLUSTER_KEY]?.[getNamespace(vm)]?.[getName(vm)];
+  VMIMapper?.mapper?.[getClusterKey(vm)]?.[getNamespace(vm)]?.[getName(vm)];
 
 export const getVMIMFromMapper = (
   VMIMMapper: VMIMMapper,
@@ -32,6 +33,30 @@ export const getVMIMFromMapper = (
   namespace: string,
   cluster?: string,
 ) => VMIMMapper?.[cluster || SINGLE_CLUSTER_KEY]?.[namespace]?.[name];
+
+export type InstanceTypeMapper = {
+  clusterInstanceTypes: {
+    [cluster: string]: { [name: string]: InstanceTypeUnion };
+  };
+  namespacedInstanceTypes: {
+    [cluster: string]: { [namespace: string]: { [name: string]: InstanceTypeUnion } };
+  };
+};
+
+export const getInstanceTypeFromMapper = (
+  mapper: InstanceTypeMapper,
+  vm: V1VirtualMachine,
+): InstanceTypeUnion | undefined => {
+  const matcher = getInstanceTypeMatcher(vm);
+  if (!mapper || !matcher?.name) return undefined;
+
+  const cluster = getClusterKey(vm);
+
+  if (matcher.kind === VirtualMachineInstancetypeModel.kind) {
+    return mapper.namespacedInstanceTypes?.[cluster]?.[getNamespace(vm)]?.[matcher.name];
+  }
+  return mapper.clusterInstanceTypes?.[cluster]?.[matcher.name];
+};
 
 export type PVCMapper = {
   [cluster in string]: {
@@ -41,7 +66,7 @@ export type PVCMapper = {
 
 export const convertIntoPVCMapper = (pvcs: IoK8sApiCoreV1PersistentVolumeClaim[]): PVCMapper => {
   return (pvcs || []).reduce((acc, pvc) => {
-    const cluster = getCluster(pvc) || SINGLE_CLUSTER_KEY;
+    const cluster = getClusterKey(pvc);
     const namespace = getNamespace(pvc);
 
     if (isEmpty(acc[cluster])) acc[cluster] = {};
@@ -54,7 +79,7 @@ export const convertIntoPVCMapper = (pvcs: IoK8sApiCoreV1PersistentVolumeClaim[]
 };
 
 export const getVirtualMachineStorageClasses = (vm: V1VirtualMachine, pvcMapper: PVCMapper) => {
-  const cluster = getCluster(vm) || SINGLE_CLUSTER_KEY;
+  const cluster = getClusterKey(vm);
   const storageClassesSet = (getVolumes(vm) || []).reduce((acc, volume) => {
     const volumePVC =
       pvcMapper?.[cluster]?.[getNamespace(vm)]?.[


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes VM advanced search for Memory and CPU for stopped VMs created from `InstanceType`

**BUG:** If a VM doesn't have a running VMI and doesn't have `cpu` or `memory` specified in its YAML, then memory and cpu filters didn't work

**FIX:** read memory and cpu fields from corresponding `VirtualMachineClusterInstanceType` or `VirtualMachineInstanceType`

_____

Also adds `getClusterKey` helper:

```
export const getClusterKey = (resource: K8sResourceCommon): string =>
  getCluster(resource) || SINGLE_CLUSTER_KEY;
```

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-71181

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/87f58ccb-171c-4662-ae64-42123f18b10e


After:

https://github.com/user-attachments/assets/218ec0d0-a142-42ab-9824-d962b3ed0665



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Virtual Machine list CPU and memory filters with a more reliable fallback using instance-type data when direct VM details are missing.
  * Filters now update correctly once instance-type information finishes loading.
  * Fixed multi-cluster consistency for Virtual Machine metrics caching, self-validation “current job” detection, and bootable-volume source mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->