### PR TITLE
CNV-74174: prefill Advanced search modal with current filter state

### DIFF
--- a/src/utils/hooks/useKubevirtDataViewFilters/filters/useProjectFilter.ts
+++ b/src/utils/hooks/useKubevirtDataViewFilters/filters/useProjectFilter.ts
@@ -14,7 +14,12 @@ import useIsACMPage from '@multicluster/useIsACMPage';
 
 import { KubevirtFilter, KubevirtFilterLayout } from '../types';
 
-const useProjectFilter = (): KubevirtFilter => {
+type UseProjectFilterOptions = {
+  /** When provided, overrides the default project list with these project names */
+  allowedProjects?: string[];
+};
+
+const useProjectFilter = (options?: UseProjectFilterOptions): KubevirtFilter => {
   const { t } = useKubevirtTranslation();
   const isACMPage = useIsACMPage();
   const selectedClusters = useListClusters(CLUSTER_LIST_FILTER_TYPE);
@@ -36,10 +41,15 @@ const useProjectFilter = (): KubevirtFilter => {
     [multiclusterNamespaces],
   );
 
-  const projectNames = useMemo(
-    () => (isACMPage ? multiclusterNamespacesNames : (projects ?? [])),
-    [isACMPage, multiclusterNamespacesNames, projects],
-  );
+  const projectNames = useMemo(() => {
+    if (options?.allowedProjects) {
+      return options.allowedProjects;
+    }
+    if (isACMPage) {
+      return multiclusterNamespacesNames;
+    }
+    return projects ?? [];
+  }, [options?.allowedProjects, isACMPage, multiclusterNamespacesNames, projects]);
 
   return useMemo(
     () => ({

--- a/src/utils/resources/namespace/helper.ts
+++ b/src/utils/resources/namespace/helper.ts
@@ -1,3 +1,7 @@
+import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { universalComparator } from '@kubevirt-utils/utils/utils';
+
 import { SYSTEM_NAMESPACES, SYSTEM_NAMESPACES_PREFIX } from './constants';
 
 export const isSystemNamespace = (projectName: string) => {
@@ -6,3 +10,6 @@ export const isSystemNamespace = (projectName: string) => {
 
   return startsWithNamespace || isNamespace;
 };
+
+export const getProjectsWithVMs = (vms: V1VirtualMachine[]): string[] =>
+  [...new Set(vms?.map(getNamespace))].sort((a, b) => universalComparator(a, b));

--- a/src/views/search/components/AdvancedSearchModal/AdvancedSearchModal.tsx
+++ b/src/views/search/components/AdvancedSearchModal/AdvancedSearchModal.tsx
@@ -1,11 +1,8 @@
 import React, { FC, useRef } from 'react';
 
-import { VirtualMachineModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { ModalComponentProps } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
-import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import {
   Button,
@@ -17,9 +14,6 @@ import {
   ModalFooter,
   ModalHeader,
 } from '@patternfly/react-core';
-import { buildContextSearchInputs } from '@search/utils/query';
-import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
-import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
 
 import { AdvancedSearchInputs, AdvancedSearchQueryInputs } from '../../utils/types';
 
@@ -42,17 +36,14 @@ import ProjectField from './formFields/ProjectField';
 import SchedulingField from './formFields/SchedulingField';
 import StatusField from './formFields/StatusField';
 import StorageClassField from './formFields/StorageClassField';
-import {
-  useAdvancedSearchActions,
-  useAdvancedSearchField,
-  useIsSearchDisabled,
-} from './store/useAdvancedSearchStore';
+import { useAdvancedSearchActions, useIsSearchDisabled } from './store/useAdvancedSearchStore';
 
 import './advanced-search-modal.scss';
 
 type AdvancedSearchModalProps = Pick<ModalComponentProps, 'isOpen' | 'onClose'> & {
   onSubmit: (searchInputs: AdvancedSearchQueryInputs) => void;
   prefillInputs?: AdvancedSearchInputs;
+  vms: V1VirtualMachine[];
 };
 
 const AdvancedSearchModal: FC<AdvancedSearchModalProps> = ({
@@ -60,23 +51,9 @@ const AdvancedSearchModal: FC<AdvancedSearchModalProps> = ({
   onClose,
   onSubmit,
   prefillInputs = {},
+  vms,
 }) => {
   const { t } = useKubevirtTranslation();
-
-  const { value: selectedClusters } = useAdvancedSearchField(VirtualMachineRowFilterType.Cluster);
-
-  const { resources: vms } = useAccessibleResources<V1VirtualMachine>({
-    clusters: selectedClusters,
-    groupVersionKind: VirtualMachineModelGroupVersionKind,
-  });
-  const namespace = useNamespaceParam();
-  const cluster = useClusterParam();
-
-  const prefillInputsWithClusterAndNamespace = {
-    ...prefillInputs,
-    ...buildContextSearchInputs(cluster, namespace),
-  };
-
   const isACMPage = useIsACMPage();
 
   const isSearchDisabled = useIsSearchDisabled();
@@ -85,7 +62,7 @@ const AdvancedSearchModal: FC<AdvancedSearchModalProps> = ({
   // Initialize store with prefill inputs when component mounts
   const hasInitialized = useRef(false);
   if (!hasInitialized.current) {
-    initializeWithPrefill(prefillInputsWithClusterAndNamespace);
+    initializeWithPrefill(prefillInputs);
     hasInitialized.current = true;
   }
 

--- a/src/views/search/components/AdvancedSearchModal/hooks/useProjectsWithVMs.ts
+++ b/src/views/search/components/AdvancedSearchModal/hooks/useProjectsWithVMs.ts
@@ -1,13 +1,9 @@
 import { useMemo } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { getNamespace } from '@kubevirt-utils/resources/shared';
-import { universalComparator } from '@kubevirt-utils/utils/utils';
+import { getProjectsWithVMs } from '@kubevirt-utils/resources/namespace/helper';
 
 const useProjectsWithVMs = (vms: V1VirtualMachine[]): string[] =>
-  useMemo(
-    () => [...new Set(vms?.map(getNamespace))].sort((a, b) => universalComparator(a, b)),
-    [vms],
-  );
+  useMemo(() => getProjectsWithVMs(vms), [vms]);
 
 export default useProjectsWithVMs;

--- a/src/views/search/components/AdvancedSearchModal/store/useAdvancedSearchStore.ts
+++ b/src/views/search/components/AdvancedSearchModal/store/useAdvancedSearchStore.ts
@@ -14,12 +14,12 @@ import {
   initialVCPU,
 } from '../constants/initialValues';
 
-export type AdvancedSearchState = AdvancedSearchInputs & {
+type AdvancedSearchState = AdvancedSearchInputs & {
   dateOption?: DateSelectOption;
   isValidDate?: boolean;
 };
 
-export type SetAdvancedSearchField = <K extends keyof AdvancedSearchState>(
+type SetAdvancedSearchField = <K extends keyof AdvancedSearchState>(
   field: K,
 ) => (value: AdvancedSearchState[K]) => void;
 

--- a/src/views/search/components/SearchBar.tsx
+++ b/src/views/search/components/SearchBar.tsx
@@ -1,5 +1,6 @@
-import React, { FC, RefObject, useCallback } from 'react';
+import React, { FC, RefObject, useCallback, useMemo } from 'react';
 
+import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
   KubevirtFilter,
   KubevirtFilterState,
@@ -8,6 +9,7 @@ import {
 import { InputGroup, InputGroupItem } from '@patternfly/react-core';
 import useShowAdvancedSearchModal from '@search/hooks/useShowAdvancedSearchModal';
 import { useSearchLanguageInput } from '@search/searchLanguage/hooks/useSearchLanguageInput/useSearchLanguageInput';
+import { convertFilterStateToModalInputs } from '@search/utils/query';
 
 import SavedSearchesDropdown from './SavedSearchesDropdown/SavedSearchesDropdown';
 import useRecentSearches from './SearchDropdown/hooks/useRecentSearches';
@@ -22,6 +24,7 @@ type SearchBarProps = {
   filters: KubevirtFilterState;
   inputRef?: RefObject<HTMLInputElement>;
   onSetFilters: OnSetFilters;
+  vms: V1VirtualMachine[];
 };
 
 const SearchBar: FC<SearchBarProps> = ({
@@ -30,8 +33,10 @@ const SearchBar: FC<SearchBarProps> = ({
   filters,
   inputRef,
   onSetFilters,
+  vms,
 }) => {
-  const showSearchModal = useShowAdvancedSearchModal(onSetFilters, clearAllFilters);
+  const showSearchModal = useShowAdvancedSearchModal(onSetFilters, clearAllFilters, vms);
+  const modalInputs = useMemo(() => convertFilterStateToModalInputs(filters), [filters]);
 
   const { addRecentSearch, recentSearches } = useRecentSearches();
 
@@ -57,7 +62,7 @@ const SearchBar: FC<SearchBarProps> = ({
           filterDefinitions={filterDefinitions}
           filters={filters}
           inputRef={inputRef}
-          onOpenAdvancedSearch={showSearchModal}
+          onOpenAdvancedSearch={() => showSearchModal(modalInputs)}
           onSelectQueryText={onSelectQueryText}
           onSetFilters={onSetFilters}
           recentSearches={recentSearches}

--- a/src/views/search/hooks/useShowAdvancedSearchModal.tsx
+++ b/src/views/search/hooks/useShowAdvancedSearchModal.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 
+import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { logVMAdvancedSearchModalUsed } from '@kubevirt-utils/extensions/telemetry/dashboard';
 import { OnSetFilters } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
@@ -10,9 +11,14 @@ import { AdvancedSearchInputs } from '@search/utils/types';
 type UseShowAdvancedSearchModal = (
   onSetFilters: OnSetFilters,
   clearAllFilters: () => void,
+  vms: V1VirtualMachine[],
 ) => (prefillInputs?: AdvancedSearchInputs) => void;
 
-const useShowAdvancedSearchModal: UseShowAdvancedSearchModal = (onSetFilters, clearAllFilters) => {
+const useShowAdvancedSearchModal: UseShowAdvancedSearchModal = (
+  onSetFilters,
+  clearAllFilters,
+  vms,
+) => {
   const { createModal } = useModal();
 
   const showSearchModal = useCallback(
@@ -29,10 +35,11 @@ const useShowAdvancedSearchModal: UseShowAdvancedSearchModal = (onSetFilters, cl
           isOpen={isOpen}
           onClose={onClose}
           prefillInputs={prefillInputs}
+          vms={vms}
         />
       ));
     },
-    [createModal, clearAllFilters, onSetFilters],
+    [createModal, clearAllFilters, onSetFilters, vms],
   );
 
   return showSearchModal;

--- a/src/views/search/utils/constants.ts
+++ b/src/views/search/utils/constants.ts
@@ -15,6 +15,26 @@ export enum GuestAgentStatus {
   REPORTING = 'reporting',
 }
 
+export const singleStringFields = new Set([
+  VirtualMachineRowFilterType.DateCreatedFrom,
+  VirtualMachineRowFilterType.DateCreatedTo,
+  VirtualMachineRowFilterType.Description,
+  VirtualMachineRowFilterType.IP,
+  VirtualMachineRowFilterType.Name,
+]);
+
+export const arrayFields = new Set([
+  VirtualMachineRowFilterType.Architecture,
+  VirtualMachineRowFilterType.Cluster,
+  VirtualMachineRowFilterType.Labels,
+  VirtualMachineRowFilterType.NAD,
+  VirtualMachineRowFilterType.Node,
+  VirtualMachineRowFilterType.OS,
+  VirtualMachineRowFilterType.Project,
+  VirtualMachineRowFilterType.Status,
+  VirtualMachineRowFilterType.StorageClass,
+]);
+
 export const skipRowFilterPrefix = new Set([
   VirtualMachineRowFilterType.Name,
   VirtualMachineRowFilterType.Labels,

--- a/src/views/search/utils/query.test.ts
+++ b/src/views/search/utils/query.test.ts
@@ -1,0 +1,338 @@
+import { CAPACITY_UNITS } from '@kubevirt-utils/components/CapacityInput/utils';
+import { KubevirtFilterState } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import { NumberOperator } from '@kubevirt-utils/utils/constants';
+import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
+
+import { convertFilterStateToModalInputs, convertModalInputsToFilterState } from './query';
+
+describe('convertFilterStateToModalInputs', () => {
+  describe('simple string fields', () => {
+    it('should convert name filter to single string', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.Name]: ['my-vm'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.Name]).toBe('my-vm');
+    });
+
+    it('should convert description filter to single string', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.Description]: ['database server'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.Description]).toBe('database server');
+    });
+
+    it('should convert IP filter to single string', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.IP]: ['10.0.0.1'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.IP]).toBe('10.0.0.1');
+    });
+
+    it('should convert date fields to single strings', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.DateCreatedFrom]: ['2024-01-01'],
+        [VirtualMachineRowFilterType.DateCreatedTo]: ['2024-12-31'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.DateCreatedFrom]).toBe('2024-01-01');
+      expect(result[VirtualMachineRowFilterType.DateCreatedTo]).toBe('2024-12-31');
+    });
+  });
+
+  describe('array fields', () => {
+    it('should pass through status array', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.Status]: ['Running', 'Stopped'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.Status]).toEqual(['Running', 'Stopped']);
+    });
+
+    it('should pass through OS array', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.OS]: ['RHEL', 'Windows'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.OS]).toEqual(['RHEL', 'Windows']);
+    });
+
+    it('should pass through project, labels, and node arrays', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.Labels]: ['app=db', 'env=prod'],
+        [VirtualMachineRowFilterType.Node]: ['worker-01'],
+        [VirtualMachineRowFilterType.Project]: ['default', 'openshift'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.Labels]).toEqual(['app=db', 'env=prod']);
+      expect(result[VirtualMachineRowFilterType.Node]).toEqual(['worker-01']);
+      expect(result[VirtualMachineRowFilterType.Project]).toEqual(['default', 'openshift']);
+    });
+  });
+
+  describe('CPU field', () => {
+    it('should parse CPU value with GreaterThan operator', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.CPU]: ['GreaterThan 4'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.CPU]).toEqual({
+        operator: NumberOperator.GreaterThan,
+        value: 4,
+      });
+    });
+
+    it('should parse CPU value with Equals operator', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.CPU]: ['Equals 8'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.CPU]).toEqual({
+        operator: NumberOperator.Equals,
+        value: 8,
+      });
+    });
+
+    it('should skip malformed CPU value', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.CPU]: ['invalid'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.CPU]).toBeUndefined();
+    });
+
+    it('should skip CPU with non-numeric value', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.CPU]: ['GreaterThan abc'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.CPU]).toBeUndefined();
+    });
+  });
+
+  describe('memory field', () => {
+    it('should parse memory value with unit', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.Memory]: ['GreaterThan 2 GiB'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.Memory]).toEqual({
+        operator: NumberOperator.GreaterThan,
+        unit: CAPACITY_UNITS.GiB,
+        value: 2,
+      });
+    });
+
+    it('should parse memory with MiB unit', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.Memory]: ['LessThan 512 MiB'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.Memory]).toEqual({
+        operator: NumberOperator.LessThan,
+        unit: CAPACITY_UNITS.MiB,
+        value: 512,
+      });
+    });
+
+    it('should skip malformed memory value', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.Memory]: ['invalid'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.Memory]).toBeUndefined();
+    });
+
+    it('should skip memory with unknown unit', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.Memory]: ['GreaterThan 2 PiB'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.Memory]).toBeUndefined();
+    });
+  });
+
+  describe('boolean-map fields', () => {
+    it('should parse guest agent values', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.GuestAgent]: ['reporting'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.GuestAgent]).toEqual({
+        notReporting: false,
+        reporting: true,
+      });
+    });
+
+    it('should parse hardware devices values', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.HWDevices]: ['gpu', 'host'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.HWDevices]).toEqual({
+        gpu: true,
+        host: true,
+      });
+    });
+
+    it('should parse scheduling values', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.Scheduling]: ['nodeSelector'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.Scheduling]).toEqual({
+        affinityRules: false,
+        nodeSelector: true,
+      });
+    });
+
+    it('should ignore unknown boolean keys', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.GuestAgent]: ['unknownKey'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.GuestAgent]).toEqual({
+        notReporting: false,
+        reporting: false,
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return empty object for empty filters', () => {
+      const result = convertFilterStateToModalInputs({});
+
+      expect(result).toEqual({});
+    });
+
+    it('should skip empty arrays', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.Status]: [],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.Status]).toBeUndefined();
+    });
+
+    it('should handle multiple filter types simultaneously', () => {
+      const filters: Partial<KubevirtFilterState> = {
+        [VirtualMachineRowFilterType.CPU]: ['GreaterThan 4'],
+        [VirtualMachineRowFilterType.Name]: ['my-vm'],
+        [VirtualMachineRowFilterType.Status]: ['Running'],
+      };
+
+      const result = convertFilterStateToModalInputs(filters);
+
+      expect(result[VirtualMachineRowFilterType.Name]).toBe('my-vm');
+      expect(result[VirtualMachineRowFilterType.Status]).toEqual(['Running']);
+      expect(result[VirtualMachineRowFilterType.CPU]).toEqual({
+        operator: NumberOperator.GreaterThan,
+        value: 4,
+      });
+    });
+  });
+
+  describe('round-trip with convertModalInputsToFilterState', () => {
+    it('should round-trip simple array fields', () => {
+      const original = { [VirtualMachineRowFilterType.Status]: ['Running', 'Stopped'] };
+      const filterState = convertModalInputsToFilterState(original);
+      const restored = convertFilterStateToModalInputs(filterState);
+
+      expect(restored[VirtualMachineRowFilterType.Status]).toEqual(
+        original[VirtualMachineRowFilterType.Status],
+      );
+    });
+
+    it('should round-trip CPU values', () => {
+      const original = {
+        [VirtualMachineRowFilterType.CPU]: {
+          operator: NumberOperator.GreaterThan,
+          value: 4,
+        },
+      };
+      const filterState = convertModalInputsToFilterState(original);
+      const restored = convertFilterStateToModalInputs(filterState);
+
+      expect(restored[VirtualMachineRowFilterType.CPU]).toEqual(
+        original[VirtualMachineRowFilterType.CPU],
+      );
+    });
+
+    it('should round-trip memory values', () => {
+      const original = {
+        [VirtualMachineRowFilterType.Memory]: {
+          operator: NumberOperator.LessOrEquals,
+          unit: CAPACITY_UNITS.TiB,
+          value: 1,
+        },
+      };
+      const filterState = convertModalInputsToFilterState(original);
+      const restored = convertFilterStateToModalInputs(filterState);
+
+      expect(restored[VirtualMachineRowFilterType.Memory]).toEqual(
+        original[VirtualMachineRowFilterType.Memory],
+      );
+    });
+
+    it('should round-trip boolean-map fields', () => {
+      const original = {
+        [VirtualMachineRowFilterType.GuestAgent]: { notReporting: false, reporting: true },
+        [VirtualMachineRowFilterType.HWDevices]: { gpu: true, host: false },
+        [VirtualMachineRowFilterType.Scheduling]: { affinityRules: true, nodeSelector: false },
+      };
+      const filterState = convertModalInputsToFilterState(original);
+      const restored = convertFilterStateToModalInputs(filterState);
+
+      expect(restored[VirtualMachineRowFilterType.GuestAgent]).toEqual(
+        original[VirtualMachineRowFilterType.GuestAgent],
+      );
+      expect(restored[VirtualMachineRowFilterType.HWDevices]).toEqual(
+        original[VirtualMachineRowFilterType.HWDevices],
+      );
+      expect(restored[VirtualMachineRowFilterType.Scheduling]).toEqual(
+        original[VirtualMachineRowFilterType.Scheduling],
+      );
+    });
+  });
+});

--- a/src/views/search/utils/query.ts
+++ b/src/views/search/utils/query.ts
@@ -2,11 +2,21 @@ import { CAPACITY_UNITS } from '@kubevirt-utils/components/CapacityInput/utils';
 import { KubevirtFilterState } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { NumberOperator, ROW_FILTERS_PREFIX } from '@kubevirt-utils/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+import {
+  initialGuestAgent,
+  initialHWDevices,
+  initialScheduling,
+} from '@search/components/AdvancedSearchModal/constants/initialValues';
 import { filtersToSearchText } from '@search/searchLanguage/filtersToSearchText';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
 
-import { skipRowFilterPrefix, validSearchQueryParams } from './constants';
-import { AdvancedSearchQueryInputs } from './types';
+import {
+  arrayFields,
+  singleStringFields,
+  skipRowFilterPrefix,
+  validSearchQueryParams,
+} from './constants';
+import { AdvancedSearchQueryInputs, CPUValue, MemoryValue } from './types';
 
 type AdvancedSearchQueryInputValue = AdvancedSearchQueryInputs[keyof AdvancedSearchQueryInputs];
 
@@ -142,10 +152,65 @@ export const areQueriesEqual = (queryA: string, queryB: string): boolean => {
   return entriesA.every(([key, value], i) => entriesB[i][0] === key && entriesB[i][1] === value);
 };
 
-export const buildContextSearchInputs = (
-  cluster?: string,
-  namespace?: string,
-): AdvancedSearchQueryInputs => ({
-  ...(cluster && { [VirtualMachineRowFilterType.Cluster]: [cluster] }),
-  ...(namespace && { [VirtualMachineRowFilterType.Project]: [namespace] }),
-});
+const parseCPUValue = (values: string[]): CPUValue | undefined => {
+  const parts = values[0]?.split(' ');
+  if (parts?.length !== 2) return undefined;
+
+  const operator = Object.values(NumberOperator).find((op) => op === parts[0]);
+  const value = Number(parts[1]);
+
+  if (!operator || isNaN(value)) return undefined;
+  return { operator, value };
+};
+
+const parseMemoryValue = (values: string[]): MemoryValue | undefined => {
+  const parts = values[0]?.split(' ');
+  if (parts?.length !== 3) return undefined;
+
+  const operator = Object.values(NumberOperator).find((op) => op === parts[0]);
+  const value = Number(parts[1]);
+  const unit = Object.values(CAPACITY_UNITS).find((u) => u === parts[2]);
+
+  if (!operator || isNaN(value) || !unit) return undefined;
+  return { operator, unit, value };
+};
+
+const parseBooleanMap = <T extends Record<string, boolean>>(values: string[], initial: T): T => {
+  const result = { ...initial };
+  for (const key of values) {
+    if (key in result) {
+      (result as Record<string, boolean>)[key] = true;
+    }
+  }
+  return result;
+};
+
+export const convertFilterStateToModalInputs = (
+  filters: Partial<KubevirtFilterState>,
+): AdvancedSearchQueryInputs => {
+  const result: AdvancedSearchQueryInputs = {};
+
+  for (const [key, values] of Object.entries(filters)) {
+    if (!validSearchQueryParams.includes(key) || isEmpty(values)) continue;
+
+    if (singleStringFields.has(key as VirtualMachineRowFilterType)) {
+      result[key] = values[0] ?? '';
+    } else if (arrayFields.has(key as VirtualMachineRowFilterType)) {
+      result[key] = values;
+    } else if (key === VirtualMachineRowFilterType.CPU) {
+      const parsed = parseCPUValue(values);
+      if (parsed) result[key] = parsed;
+    } else if (key === VirtualMachineRowFilterType.Memory) {
+      const parsed = parseMemoryValue(values);
+      if (parsed) result[key] = parsed;
+    } else if (key === VirtualMachineRowFilterType.GuestAgent) {
+      result[key] = parseBooleanMap(values, initialGuestAgent);
+    } else if (key === VirtualMachineRowFilterType.HWDevices) {
+      result[key] = parseBooleanMap(values, initialHWDevices);
+    } else if (key === VirtualMachineRowFilterType.Scheduling) {
+      result[key] = parseBooleanMap(values, initialScheduling);
+    }
+  }
+
+  return result;
+};

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -228,6 +228,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({
                 filters={filters}
                 inputRef={searchInputRef}
                 onSetFilters={handleSetFilters}
+                vms={accessibleVMs}
               />
               <VirtIODriversAlert vms={vmsToShow} />
               <VirtualMachineFilterToolbar

--- a/src/views/virtualmachines/list/hooks/useVMListFilters.ts
+++ b/src/views/virtualmachines/list/hooks/useVMListFilters.ts
@@ -25,6 +25,7 @@ import useArchitectureFilter from '../filters/useArchitectureFilter';
 import useNodeFilter from '../filters/useNodeFilter';
 import useStorageClassFilter from '../filters/useStorageClassFilter';
 
+import useProjectsWithVMs from '@search/components/AdvancedSearchModal/hooks/useProjectsWithVMs';
 import { useInstanceTypeMapper } from './useInstanceTypeMapper';
 
 const useVMListFilters = (
@@ -39,8 +40,10 @@ const useVMListFilters = (
   });
   const { instanceTypeMapper } = useInstanceTypeMapper();
 
+  const projectsWithVMs = useProjectsWithVMs(vms);
+
   const clusterFilter = useClusterFilter();
-  const projectFilter = useProjectFilter();
+  const projectFilter = useProjectFilter({ allowedProjects: projectsWithVMs });
   const nodeFilter = useNodeFilter(vmiMapper);
   const storageClassFilter = useStorageClassFilter(vms, pvcMapper);
   const architectureFilter = useArchitectureFilter(vms);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- prefill Advanced search modal with current filter state
- update toolbar Project filter to only include projects with VMs
- pass `accessibleVMs` to `AdvancedSearchModal` to avoid another fetch

## 🔗 Links

[Design doc link](https://docs.google.com/document/d/1lmNyJrkHjwiFPJr8F7Vfq0mJYOkdUsdKH8jIJ16122k/edit?usp=sharing)
Jira: https://redhat.atlassian.net/browse/CNV-74174

## 🎥 Demo

After:

https://github.com/user-attachments/assets/871c5b85-d43f-4e56-9421-63d161ce3cda







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced search now opens with values prefilled from the current search filters.
  * Cluster and project selection controls can be disabled automatically in context-aware search flows.
  * Typeahead selection controls now support being disabled.
* **Bug Fixes**
  * Improved conversion of existing search filter values into advanced search inputs, including string, array, CPU, memory, and boolean-style fields.
  * Enhanced handling of empty/cleared advanced search state to keep reset behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->