### PR TITLE
CNV-90313: CD-ROM drive not ejected when canceling upload during new VM creation

### DIFF
--- a/src/utils/components/DiskModal/AddCDROMModal.tsx
+++ b/src/utils/components/DiskModal/AddCDROMModal.tsx
@@ -30,6 +30,7 @@ import { submitCDROM } from './utils/submitCDROM';
 import { SourceTypes, V1DiskFormState, V1SubDiskModalProps } from './utils/types';
 
 const AddCDROMModal: FC<V1SubDiskModalProps> = ({
+  getCurrentVM,
   isOpen,
   onClose,
   onSubmit,
@@ -103,6 +104,7 @@ const AddCDROMModal: FC<V1SubDiskModalProps> = ({
       }
 
       const result = await submitCDROM(getValues(), {
+        getCurrentVM,
         isHotPluggable,
         onSubmit,
         onUploadedDataVolume,

--- a/src/utils/components/DiskModal/DiskModal.tsx
+++ b/src/utils/components/DiskModal/DiskModal.tsx
@@ -15,6 +15,7 @@ const DiskModal: FC<V1DiskModalProps> = ({
   createdPVCName,
   defaultFormValues,
   editDiskName,
+  getCurrentVM,
   isOpen,
   onClose,
   onSubmit,
@@ -39,6 +40,7 @@ const DiskModal: FC<V1DiskModalProps> = ({
       createDiskSource={createDiskSource}
       defaultFormValues={defaultFormValues}
       editDiskName={editDiskName}
+      getCurrentVM={getCurrentVM}
       isCreated={!isEmpty(createdPVCName)}
       isOpen={isOpen}
       onClose={onClose}

--- a/src/utils/components/DiskModal/utils/helpers.test.ts
+++ b/src/utils/components/DiskModal/utils/helpers.test.ts
@@ -1,6 +1,20 @@
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { updateDisks } from '@virtualmachines/details/tabs/configuration/details/utils/utils';
+import { kubevirtK8sGet } from '@multicluster/k8sRequests';
 
-import { createDataVolumeName } from './helpers';
+import {
+  createDataVolumeName,
+  createDetachDiskCancelCleanup,
+  createEjectMountedDiskCancelCleanup,
+} from './helpers';
+
+jest.mock('@multicluster/k8sRequests', () => ({
+  kubevirtK8sGet: jest.fn(),
+}));
+
+jest.mock('@virtualmachines/details/tabs/configuration/details/utils/utils', () => ({
+  updateDisks: jest.fn(),
+}));
 
 const vm = (name: string): V1VirtualMachine => ({ metadata: { name }, spec: { template: {} } });
 const RANDOM_CHARS = /[a-z0-9]/;
@@ -24,5 +38,99 @@ describe('Generate names for data volume', () => {
     expect(name).toHaveLength(9);
     expect(name.substring(0, 3)).toEqual('dv-');
     expect(name.substring(3, 9)).toMatch(RANDOM_CHARS);
+  });
+});
+
+describe('createEjectMountedDiskCancelCleanup / createDetachDiskCancelCleanup', () => {
+  const cdromName = 'cdrom-1';
+
+  const vmWithCdrom = (): V1VirtualMachine => ({
+    metadata: { name: 'test-vm', namespace: 'test-ns' },
+    spec: {
+      template: {
+        spec: {
+          domain: { devices: { disks: [{ cdrom: {}, name: cdromName }] } },
+          volumes: [{ dataVolume: { name: 'dv-1' }, name: cdromName }],
+        },
+      },
+    },
+  });
+
+  const mockKubevirtK8sGet = kubevirtK8sGet as jest.Mock;
+  const mockUpdateDisks = updateDisks as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('without getCurrentVM (persisted VM / details page)', () => {
+    it('re-fetches the VM from the cluster and patches it', async () => {
+      const freshVM = vmWithCdrom();
+      mockKubevirtK8sGet.mockResolvedValue(freshVM);
+
+      const cleanup = createEjectMountedDiskCancelCleanup(vmWithCdrom(), cdromName);
+      await cleanup();
+
+      expect(mockKubevirtK8sGet).toHaveBeenCalledTimes(1);
+      expect(mockUpdateDisks).toHaveBeenCalledTimes(1);
+      const patchedVM = mockUpdateDisks.mock.calls[0][0] as V1VirtualMachine;
+      expect(patchedVM.spec.template.spec.volumes).toEqual([]);
+    });
+  });
+
+  describe('with getCurrentVM (in-memory wizard VM)', () => {
+    it('transforms the live VM from getCurrentVM and submits it via onSubmit', async () => {
+      const currentVM = vmWithCdrom();
+      const getCurrentVM = jest.fn().mockReturnValue(currentVM);
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+      const cleanup = createEjectMountedDiskCancelCleanup(
+        vmWithCdrom(),
+        cdromName,
+        getCurrentVM,
+        onSubmit,
+      );
+      await cleanup();
+
+      expect(mockKubevirtK8sGet).not.toHaveBeenCalled();
+      expect(getCurrentVM).toHaveBeenCalledTimes(1);
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      const submittedVM = onSubmit.mock.calls[0][0] as V1VirtualMachine;
+      expect(submittedVM.spec.template.spec.volumes).toEqual([]);
+    });
+
+    it('detaches (rather than ejects) the disk when using createDetachDiskCancelCleanup', async () => {
+      const currentVM = vmWithCdrom();
+      const getCurrentVM = jest.fn().mockReturnValue(currentVM);
+      const onSubmit = jest.fn().mockResolvedValue(undefined);
+
+      const cleanup = createDetachDiskCancelCleanup(
+        vmWithCdrom(),
+        cdromName,
+        getCurrentVM,
+        onSubmit,
+      );
+      await cleanup();
+
+      const submittedVM = onSubmit.mock.calls[0][0] as V1VirtualMachine;
+      expect(submittedVM.spec.template.spec.domain.devices.disks).toEqual([]);
+      expect(submittedVM.spec.template.spec.volumes).toEqual([]);
+    });
+
+    it('skips cleanup without calling onSubmit when getCurrentVM returns null', async () => {
+      const getCurrentVM = jest.fn().mockReturnValue(null);
+      const onSubmit = jest.fn();
+
+      const cleanup = createEjectMountedDiskCancelCleanup(
+        vmWithCdrom(),
+        cdromName,
+        getCurrentVM,
+        onSubmit,
+      );
+      await expect(cleanup()).resolves.toBeUndefined();
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(mockKubevirtK8sGet).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -25,7 +25,7 @@ import {
 import { ANNOTATIONS } from '@kubevirt-utils/resources/template';
 import { getBootDisk, getDataVolumeTemplates, getVolumes } from '@kubevirt-utils/resources/vm';
 import { getOperatingSystem } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
-import { ensurePath, getRandomChars, isEmpty } from '@kubevirt-utils/utils/utils';
+import { ensurePath, getRandomChars, isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { isDNS1123Label } from '@kubevirt-utils/utils/validation';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { kubevirtK8sCreate, kubevirtK8sGet } from '@multicluster/k8sRequests';
@@ -33,7 +33,12 @@ import { addPersistentVolume, removeVolume } from '@virtualmachines/actions/acti
 import { updateDisks } from '@virtualmachines/details/tabs/configuration/details/utils/utils';
 
 import { HotPlugFeatures } from './constants';
-import { BuildUploadTrackMetadataParams, SourceTypes, V1DiskFormState } from './types';
+import {
+  BuildUploadTrackMetadataParams,
+  GetCurrentVM,
+  SourceTypes,
+  V1DiskFormState,
+} from './types';
 
 export const getEmptyVMDataVolumeResource = (
   vm: V1VirtualMachine,
@@ -415,15 +420,43 @@ const createDiskCancelCleanup =
     await updateDisks(transform(freshVM, diskName));
   };
 
+// For in-memory VMs (the creation wizard): read the VM back via getCurrentVM instead of
+// re-fetching from the cluster. Skips silently if it's gone (e.g. wizard was aborted).
+const createSignalBackedDiskCancelCleanup =
+  (
+    getCurrentVM: GetCurrentVM,
+    diskName: string,
+    transform: (vm: V1VirtualMachine, name: string) => V1VirtualMachine,
+    onSubmit: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine | void>,
+  ): (() => Promise<void>) =>
+  async () => {
+    const currentVM = getCurrentVM();
+    if (!currentVM) {
+      kubevirtConsole.warn('Cancel cleanup skipped: VM no longer available in local state');
+      return;
+    }
+    await onSubmit(transform(currentVM, diskName));
+  };
+
 export const createEjectMountedDiskCancelCleanup = (
   vm: V1VirtualMachine,
   diskName: string,
-): (() => Promise<void>) => createDiskCancelCleanup(vm, diskName, ejectISOFromCDROM);
+  getCurrentVM?: GetCurrentVM,
+  onSubmit?: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine | void>,
+): (() => Promise<void>) =>
+  getCurrentVM
+    ? createSignalBackedDiskCancelCleanup(getCurrentVM, diskName, ejectISOFromCDROM, onSubmit)
+    : createDiskCancelCleanup(vm, diskName, ejectISOFromCDROM);
 
 export const createDetachDiskCancelCleanup = (
   vm: V1VirtualMachine,
   diskName: string,
-): (() => Promise<void>) => createDiskCancelCleanup(vm, diskName, detachDiskFromVM);
+  getCurrentVM?: GetCurrentVM,
+  onSubmit?: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine | void>,
+): (() => Promise<void>) =>
+  getCurrentVM
+    ? createSignalBackedDiskCancelCleanup(getCurrentVM, diskName, detachDiskFromVM, onSubmit)
+    : createDiskCancelCleanup(vm, diskName, detachDiskFromVM);
 
 /**
  * Creates a shallow copy of the form data with a mutable dataVolumeTemplate.spec.source.

--- a/src/utils/components/DiskModal/utils/submitCDROM.test.ts
+++ b/src/utils/components/DiskModal/utils/submitCDROM.test.ts
@@ -1,0 +1,163 @@
+import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { isRunning } from '@virtualmachines/utils';
+
+import {
+  createDetachDiskCancelCleanup,
+  createEjectMountedDiskCancelCleanup,
+  mountISOToCDROM,
+} from './helpers';
+import { submitCDROM } from './submitCDROM';
+import { V1DiskFormState } from './types';
+import { runVmCdromBackgroundUpload } from './vmCdromBackgroundUpload';
+
+jest.mock('@virtualmachines/utils', () => ({
+  isRunning: jest.fn(),
+}));
+
+jest.mock('./helpers', () => ({
+  createDetachDiskCancelCleanup: jest.fn(() => 'detach-cleanup'),
+  createEjectMountedDiskCancelCleanup: jest.fn(() => 'eject-cleanup'),
+  createMutableUploadData: jest.fn((data) => data),
+  mountISOToCDROM: jest.fn(async (vm) => vm),
+}));
+
+jest.mock('./submit', () => ({
+  addDisk: jest.fn((_data, vm) => vm),
+}));
+
+jest.mock('./bootDiskUtils', () => ({
+  reorderBootDisk: jest.fn((vm) => vm),
+}));
+
+jest.mock('./vmCdromBackgroundUpload', () => ({
+  logBackgroundUploadError: jest.fn(),
+  runVmCdromBackgroundUpload: jest.fn().mockResolvedValue(undefined),
+}));
+
+const baseVM: V1VirtualMachine = {
+  metadata: { name: 'test-vm', namespace: 'test-ns' },
+  spec: { running: false, template: { spec: { domain: { devices: {} } } } },
+};
+
+const buildData = (overrides: Partial<V1DiskFormState> = {}): V1DiskFormState => ({
+  disk: { cdrom: {}, name: 'cdrom-1' },
+  isBootSource: false,
+  uploadFile: { file: new File(['iso'], 'test.iso'), filename: 'test.iso' },
+  ...overrides,
+});
+
+describe('submitCDROM - cancel cleanup wiring', () => {
+  const onSubmit = jest.fn(async (vm: V1VirtualMachine) => vm);
+  const uploadData = jest.fn();
+  const t = ((key: string) => key) as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    onSubmit.mockImplementation(async (vm: V1VirtualMachine) => vm);
+    (isRunning as jest.Mock).mockReturnValue(false);
+  });
+
+  it('builds an eject cancel cleanup (hotpluggable) forwarding getCurrentVM and onSubmit', async () => {
+    const getCurrentVM = jest.fn().mockReturnValue(baseVM);
+
+    await submitCDROM(buildData(), {
+      getCurrentVM,
+      isHotPluggable: true,
+      onSubmit,
+      t,
+      uploadData,
+      uploadEnabled: true,
+      vm: baseVM,
+    } as any);
+
+    expect(createEjectMountedDiskCancelCleanup).toHaveBeenCalledWith(
+      baseVM,
+      'cdrom-1',
+      getCurrentVM,
+      onSubmit,
+    );
+    expect(createDetachDiskCancelCleanup).not.toHaveBeenCalled();
+  });
+
+  it('builds a detach cancel cleanup (non-hotpluggable) forwarding getCurrentVM and onSubmit', async () => {
+    const getCurrentVM = jest.fn().mockReturnValue(baseVM);
+
+    await submitCDROM(buildData(), {
+      getCurrentVM,
+      isHotPluggable: false,
+      onSubmit,
+      t,
+      uploadData,
+      uploadEnabled: true,
+      vm: baseVM,
+    } as any);
+
+    expect(createDetachDiskCancelCleanup).toHaveBeenCalledWith(
+      baseVM,
+      'cdrom-1',
+      getCurrentVM,
+      onSubmit,
+    );
+    expect(createEjectMountedDiskCancelCleanup).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the k8s-fetch-based cleanup when getCurrentVM is not provided', async () => {
+    await submitCDROM(buildData(), {
+      isHotPluggable: true,
+      onSubmit,
+      t,
+      uploadData,
+      uploadEnabled: true,
+      vm: baseVM,
+    } as any);
+
+    expect(createEjectMountedDiskCancelCleanup).toHaveBeenCalledWith(
+      baseVM,
+      'cdrom-1',
+      undefined,
+      onSubmit,
+    );
+  });
+
+  it('mounts the ISO against the live signal VM (not the stale closure) once the upload completes', async () => {
+    (isRunning as jest.Mock).mockReturnValue(true);
+    const liveVM: V1VirtualMachine = {
+      ...baseVM,
+      metadata: { ...baseVM.metadata, name: 'live-vm' },
+    };
+    const getCurrentVM = jest.fn().mockReturnValue(liveVM);
+
+    await submitCDROM(buildData(), {
+      getCurrentVM,
+      isHotPluggable: true,
+      onSubmit,
+      t,
+      uploadData,
+      uploadEnabled: true,
+      vm: baseVM,
+    } as any);
+
+    const backgroundUploadArgs = (runVmCdromBackgroundUpload as jest.Mock).mock.calls[0][0];
+    await backgroundUploadArgs.afterUpload();
+
+    expect(mountISOToCDROM).toHaveBeenCalledWith(liveVM, expect.anything(), true);
+  });
+
+  it('falls back to the closed-over VM for mounting when getCurrentVM is not provided', async () => {
+    (isRunning as jest.Mock).mockReturnValue(true);
+
+    await submitCDROM(buildData(), {
+      isHotPluggable: true,
+      onSubmit,
+      t,
+      uploadData,
+      uploadEnabled: true,
+      vm: baseVM,
+    } as any);
+
+    const backgroundUploadArgs = (runVmCdromBackgroundUpload as jest.Mock).mock.calls[0][0];
+    await backgroundUploadArgs.afterUpload();
+
+    expect(mountISOToCDROM).toHaveBeenCalledWith(baseVM, expect.anything(), true);
+  });
+});

--- a/src/utils/components/DiskModal/utils/submitCDROM.ts
+++ b/src/utils/components/DiskModal/utils/submitCDROM.ts
@@ -21,6 +21,7 @@ import { logBackgroundUploadError, runVmCdromBackgroundUpload } from './vmCdromB
 export const submitCDROM = async (
   data: V1DiskFormState,
   {
+    getCurrentVM,
     isHotPluggable,
     onSubmit,
     onUploadedDataVolume,
@@ -55,9 +56,12 @@ export const submitCDROM = async (
     const diskName = data.disk.name;
     const file = data?.uploadFile?.file;
     const uploadKey = getVmCdromUploadKeyFromVm(vm, diskName);
+
     const createCancelCleanup = isHotPluggable
       ? createEjectMountedDiskCancelCleanup
       : createDetachDiskCancelCleanup;
+    const buildCancelCleanup = (vmForCleanup: V1VirtualMachine, name: string) =>
+      createCancelCleanup(vmForCleanup, name, getCurrentVM, onSubmit);
 
     const mutableData = {
       ...createMutableUploadData(data),
@@ -87,13 +91,14 @@ export const submitCDROM = async (
             delete draft.dataVolumeTemplate;
           });
 
-          const mountedVm = await mountISOToCDROM(vmAfterEmptyAdd, dataWithVolume, isHotPluggable);
+          const vmForMount = getCurrentVM?.() ?? vmAfterEmptyAdd;
+          const mountedVm = await mountISOToCDROM(vmForMount, dataWithVolume, isHotPluggable);
           await onSubmit(mountedVm);
         },
         diskState: mutableData,
         dvName,
         isHotPluggable,
-        onCancelCleanup: createCancelCleanup(vmAfterEmptyAdd, diskName),
+        onCancelCleanup: buildCancelCleanup(vmAfterEmptyAdd, diskName),
         onUploadedDataVolume,
         t,
         uploadData,
@@ -110,7 +115,7 @@ export const submitCDROM = async (
       diskState: mutableData,
       dvName,
       isHotPluggable,
-      onCancelCleanup: createCancelCleanup(vm, diskName),
+      onCancelCleanup: buildCancelCleanup(vm, diskName),
       onUploadedDataVolume,
       t,
       uploadData,

--- a/src/utils/components/DiskModal/utils/types.ts
+++ b/src/utils/components/DiskModal/utils/types.ts
@@ -58,11 +58,14 @@ export type V1DiskFormState = {
 
 export type DefaultFormValues = Partial<V1DiskFormState>;
 
+export type GetCurrentVM = () => V1VirtualMachine | null;
+
 export type V1DiskModalProps = {
   createDiskSource?: SourceTypes;
   createdPVCName?: string;
   defaultFormValues?: DefaultFormValues;
   editDiskName?: string;
+  getCurrentVM?: GetCurrentVM;
   isOpen: boolean;
   onClose: () => void;
   onSubmit: (
@@ -120,6 +123,7 @@ export type SubmitInput = {
 };
 
 export type SubmitCDROMInput = {
+  getCurrentVM?: GetCurrentVM;
   isHotPluggable: boolean;
   onSubmit: V1DiskModalProps['onSubmit'];
   onUploadedDataVolume?: V1DiskModalProps['onUploadedDataVolume'];

--- a/src/utils/signals/customizeWizardVMSignal.ts
+++ b/src/utils/signals/customizeWizardVMSignal.ts
@@ -6,6 +6,8 @@ import { signal } from '@preact/signals-react';
 
 export const customizeWizardVMSignal = signal<V1VirtualMachine>(null);
 
+export const getCustomizeWizardVM = (): V1VirtualMachine | null => customizeWizardVMSignal.value;
+
 export const mergeVMData = (currentData: any, updateData: any) => {
   // Handle null/undefined cases
   if (currentData == null && updateData == null) {

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/EjectCDROMModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/EjectCDROMModal.tsx
@@ -3,6 +3,7 @@ import { Trans } from 'react-i18next';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { ejectISOFromCDROM } from '@kubevirt-utils/components/DiskModal/utils/helpers';
+import { GetCurrentVM } from '@kubevirt-utils/components/DiskModal/utils/types';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ButtonVariant } from '@patternfly/react-core';
@@ -11,6 +12,7 @@ import { updateDisks } from '../../../details/utils/utils';
 
 type EjectCDROMModalProps = {
   cdromName: string;
+  getCurrentVM?: GetCurrentVM;
   isOpen: boolean;
   onClose: () => void;
   onSubmit?: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine>;
@@ -20,6 +22,7 @@ type EjectCDROMModalProps = {
 
 const EjectCDROMModal: FC<EjectCDROMModalProps> = ({
   cdromName,
+  getCurrentVM,
   isOpen,
   onClose,
   onSubmit,
@@ -29,7 +32,8 @@ const EjectCDROMModal: FC<EjectCDROMModalProps> = ({
   const { t } = useKubevirtTranslation();
 
   const handleEject = () => {
-    const updatedVM = ejectISOFromCDROM(vm, cdromName);
+    const currentVM = getCurrentVM?.() ?? vm;
+    const updatedVM = ejectISOFromCDROM(currentVM, cdromName);
 
     if (onSubmit) {
       return onSubmit(updatedVM);

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/MountCDROMModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/MountCDROMModal.tsx
@@ -14,6 +14,7 @@ import {
   isHotPluggableEnabled,
   mountISOToCDROM,
 } from '@kubevirt-utils/components/DiskModal/utils/helpers';
+import { GetCurrentVM } from '@kubevirt-utils/components/DiskModal/utils/types';
 import {
   logBackgroundUploadError,
   runVmCdromBackgroundUpload,
@@ -39,6 +40,7 @@ import { buildDiskState, produceMountUploadVolumeState } from './utils';
 
 type MountCDROMModalProps = {
   cdromName: string;
+  getCurrentVM?: GetCurrentVM;
   isOpen: boolean;
   onClose: () => void;
   onSubmit?: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine>;
@@ -47,6 +49,7 @@ type MountCDROMModalProps = {
 
 const MountCDROMModal: FC<MountCDROMModalProps> = ({
   cdromName,
+  getCurrentVM,
   isOpen,
   onClose,
   onSubmit,
@@ -128,7 +131,12 @@ const MountCDROMModal: FC<MountCDROMModalProps> = ({
           diskState,
           dvName,
           isHotPluggable,
-          onCancelCleanup: createEjectMountedDiskCancelCleanup(vmAfterMount, cdromName),
+          onCancelCleanup: createEjectMountedDiskCancelCleanup(
+            vmAfterMount,
+            cdromName,
+            getCurrentVM,
+            onSubmit,
+          ),
           t,
           uploadData,
           uploadKey: cdromUploadKey,

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskList.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskList.tsx
@@ -5,7 +5,7 @@ import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kub
 import DiskListTitle from '@kubevirt-utils/components/DiskListTitle/DiskListTitle';
 import DiskSourceSelect from '@kubevirt-utils/components/DiskModal/components/DiskSourceSelect/DiskSourceSelect';
 import DiskModal from '@kubevirt-utils/components/DiskModal/DiskModal';
-import { SourceTypes } from '@kubevirt-utils/components/DiskModal/utils/types';
+import { GetCurrentVM, SourceTypes } from '@kubevirt-utils/components/DiskModal/utils/types';
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import WindowsDrivers from '@kubevirt-utils/components/WindowsDrivers/WindowsDrivers';
@@ -34,12 +34,19 @@ import './disklist.scss';
 
 type DiskListProps = {
   customize?: boolean;
+  getCurrentVM?: GetCurrentVM;
   onDiskUpdate?: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine>;
   vm: V1VirtualMachine;
   vmi?: V1VirtualMachineInstance;
 };
 
-const DiskList: FC<DiskListProps> = ({ customize = false, onDiskUpdate, vm, vmi }) => {
+const DiskList: FC<DiskListProps> = ({
+  customize = false,
+  getCurrentVM,
+  onDiskUpdate,
+  vm,
+  vmi,
+}) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const isWindowsSupported = useIsWindowsSupportedArchitecture();
@@ -77,13 +84,14 @@ const DiskList: FC<DiskListProps> = ({ customize = false, onDiskUpdate, vm, vmi 
   const callbacks: DiskListCallbacks = useMemo(
     () => ({
       customize,
+      getCurrentVM,
       onSubmit,
       provisioningPercentages,
       sourcesLoaded,
       vm,
       vmi,
     }),
-    [customize, onSubmit, provisioningPercentages, sourcesLoaded, vm, vmi],
+    [customize, getCurrentVM, onSubmit, provisioningPercentages, sourcesLoaded, vm, vmi],
   );
 
   return (
@@ -94,6 +102,7 @@ const DiskList: FC<DiskListProps> = ({ customize = false, onDiskUpdate, vm, vmi 
           return createModal(({ isOpen, onClose }) => (
             <DiskModal
               createDiskSource={diskSource}
+              getCurrentVM={getCurrentVM}
               isOpen={isOpen}
               onClose={onClose}
               onSubmit={onSubmit}

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
@@ -10,6 +10,7 @@ import {
   isDeclarativeHotplugVolumesEnabled,
   produceVMDisks,
 } from '@kubevirt-utils/components/DiskModal/utils/helpers';
+import { GetCurrentVM } from '@kubevirt-utils/components/DiskModal/utils/types';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import { getCancelUploadLabel } from '@kubevirt-utils/hooks/useCDIUpload/utils';
@@ -25,6 +26,7 @@ import {
   isCDROMDisk,
 } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
 import { isEmptyContainerDiskImage } from '@kubevirt-utils/resources/vm/utils/disk/utils';
+import { getVMIVolumes } from '@kubevirt-utils/resources/vmi';
 import { getContentScrollableElement } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import {
@@ -49,6 +51,7 @@ import { isHotplugVolume, isPVCSource } from './utils/helpers';
 
 type DiskRowActionsProps = {
   customize?: boolean;
+  getCurrentVM?: GetCurrentVM;
   obj: DiskRowDataLayout;
   onDiskUpdate?: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine>;
   vm: V1VirtualMachine;
@@ -57,6 +60,7 @@ type DiskRowActionsProps = {
 
 const DiskRowActions: FC<DiskRowActionsProps> = ({
   customize = false,
+  getCurrentVM,
   obj,
   onDiskUpdate,
   vm,
@@ -80,7 +84,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
   );
 
   const { isCDROMMountedState, volume } = useMemo(() => {
-    const vols = isVMRunning && !isCDROM ? vmi?.spec?.volumes : getVolumes(vm);
+    const vols = isVMRunning && !isCDROM ? getVMIVolumes(vmi) : getVolumes(vm);
     const vol = vols?.find(({ name }) => name === diskName);
 
     const isMountedVolume = (targetVolume: undefined | V1Volume): boolean => {
@@ -133,6 +137,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
       <DiskModal
         createdPVCName={isPVCSource(obj) ? obj?.source : null}
         editDiskName={diskName}
+        getCurrentVM={getCurrentVM}
         isOpen={isOpen}
         onClose={onClose}
         onSubmit={onDiskUpdate || updateDisks}
@@ -180,6 +185,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
     return createModal(({ isOpen, onClose }) => (
       <Component
         cdromName={diskName}
+        getCurrentVM={getCurrentVM}
         isOpen={isOpen}
         onClose={onClose}
         onSubmit={onDiskUpdate || updateDisks}

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/diskListDefinition.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/diskListDefinition.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react';
 import { TFunction } from 'i18next';
 
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { GetCurrentVM } from '@kubevirt-utils/components/DiskModal/utils/types';
 import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { NameWithPercentages } from '@kubevirt-utils/resources/vm/hooks/types';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
@@ -16,6 +17,7 @@ import '../tables.scss';
 
 export type DiskListCallbacks = {
   customize?: boolean;
+  getCurrentVM?: GetCurrentVM;
   onSubmit?: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine>;
   provisioningPercentages: NameWithPercentages;
   sourcesLoaded?: boolean;
@@ -24,9 +26,16 @@ export type DiskListCallbacks = {
 };
 
 const renderActionsCell = (row: DiskRowDataLayout, callbacks: DiskListCallbacks): ReactNode => {
-  const { customize, onSubmit, vm, vmi } = callbacks;
+  const { customize, getCurrentVM, onSubmit, vm, vmi } = callbacks;
   return (
-    <DiskRowActions customize={customize} obj={row} onDiskUpdate={onSubmit} vm={vm} vmi={vmi} />
+    <DiskRowActions
+      customize={customize}
+      getCurrentVM={getCurrentVM}
+      obj={row}
+      onDiskUpdate={onSubmit}
+      vm={vm}
+      vmi={vmi}
+    />
   );
 };
 

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeStorageTab.tsx
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeStorageTab.tsx
@@ -6,6 +6,7 @@ import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { getDataVolumeTemplates, getDisks, getVolumes } from '@kubevirt-utils/resources/vm';
 import {
   customizeWizardVMSignal,
+  getCustomizeWizardVM,
   patchCustomizeWizardVMSignal,
   updateVMCustomizeIT,
 } from '@kubevirt-utils/signals/customizeWizardVMSignal';
@@ -45,6 +46,7 @@ const CustomizeInstanceTypeStorageTab = () => {
               return Promise.resolve(vmModified ?? updatedVM);
             }}
             customize
+            getCurrentVM={getCustomizeWizardVM}
             vm={vm}
           />
         </PageSection>

--- a/src/views/virtualmachines/wizard/utils/utils.test.ts
+++ b/src/views/virtualmachines/wizard/utils/utils.test.ts
@@ -1,0 +1,42 @@
+import { cancelAllWizardPendingUploads } from '@kubevirt-utils/hooks/useUploadProgressToast';
+import { setCustomizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
+
+import { clearVMPendingUploadsAndSignal } from './utils';
+
+jest.mock('@kubevirt-utils/hooks/useUploadProgressToast', () => ({
+  cancelAllWizardPendingUploads: jest.fn(),
+}));
+
+jest.mock('@kubevirt-utils/signals/customizeWizardVMSignal', () => ({
+  setCustomizeWizardVMSignal: jest.fn(),
+}));
+
+describe('clearVMPendingUploadsAndSignal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('nulls the wizard VM signal before cancelling pending uploads', () => {
+    const callOrder: string[] = [];
+    (setCustomizeWizardVMSignal as jest.Mock).mockImplementation(() => callOrder.push('setSignal'));
+    (cancelAllWizardPendingUploads as jest.Mock).mockImplementation(() =>
+      callOrder.push('cancelUploads'),
+    );
+
+    clearVMPendingUploadsAndSignal();
+
+    expect(callOrder).toEqual(['setSignal', 'cancelUploads']);
+  });
+
+  it('clears the signal with null', () => {
+    clearVMPendingUploadsAndSignal();
+
+    expect(setCustomizeWizardVMSignal).toHaveBeenCalledWith(null);
+  });
+
+  it('cancels all pending wizard uploads', () => {
+    clearVMPendingUploadsAndSignal();
+
+    expect(cancelAllWizardPendingUploads).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 📝 Description

When a user cancels a CD-ROM upload during new VM creation (customize instance type wizard), the CD-ROM drive is not ejected from the draft VM (When advanced CD-ROM features are enabled). 
This works correctly when adding a CD-ROM to an existing VM.

## 🔗 Links

Jira ticket: [CNV-90313](https://redhat.atlassian.net/browse/CNV-90313)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/05a1660a-20a3-4189-a442-b783f7426ecc


After:

https://github.com/user-attachments/assets/7a8d829c-a855-4413-b848-f25204f9972d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved disk and CD-ROM mount/eject actions so they can use the latest available virtual machine state during long-running operations.
  * Storage disk actions in the customization wizard now stay in sync with the most up-to-date wizard virtual machine state.
* **Bug Fixes**
  * Stabilized cancel-cleanup and final disk/volume state when virtual machine state changes mid-operation.
  * Refined mounted-state detection and available disk/CD-ROM actions for running virtual machines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->