### PR TITLE
[release-4.22] CNV-90048: Fix incomplete clone source list cherry-pick

### DIFF
--- a/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
@@ -116,18 +116,6 @@ const VirtualMachinesList = forwardRef(({}, ref) => {
     clearCustomizeInstanceType();
   }, [cluster, targetNamespace]);
 
-  useEffect(() => {
-    const filteredDataLength = filteredVMs?.length ?? 0;
-    if (filteredDataLength > 0 && pagination.startIndex >= filteredDataLength) {
-      setPagination((prevPagination) => ({
-        ...prevPagination,
-        endIndex: prevPagination.perPage,
-        page: 1,
-        startIndex: 0,
-      }));
-    }
-  }, [filteredVMs?.length, pagination.startIndex, pagination.perPage]);
-
   useImperativeHandle(
     ref,
     () => ({

--- a/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
@@ -14,7 +14,6 @@ import {
 } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { buildColumnLayout } from '@kubevirt-utils/components/KubevirtTable/utils';
-import { useQueryParamsMethods } from '@kubevirt-utils/components/ListPageFilter/hooks/useQueryParamsMethods';
 import ListPageFilter from '@kubevirt-utils/components/ListPageFilter/ListPageFilter';
 import useContainerWidth from '@kubevirt-utils/hooks/useContainerWidth';
 import { KUBEVIRT_APISERVER_PROXY } from '@kubevirt-utils/hooks/useFeatures/constants';
@@ -27,12 +26,10 @@ import {
   paginationInitialState,
 } from '@kubevirt-utils/hooks/usePagination/utils/constants';
 import { usePVCMapper } from '@kubevirt-utils/hooks/usePVCMapper';
-import useQuery from '@kubevirt-utils/hooks/useQuery';
 import { getDescription, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import useVirtualMachineInstanceMigrationMapper from '@kubevirt-utils/resources/vmim/hooks/useVirtualMachineInstanceMigrationMapper';
 import useVirtualMachineInstanceMigrations from '@kubevirt-utils/resources/vmim/hooks/useVirtualMachineInstanceMigrations';
 import { clearCustomizeInstanceType, vmSignal } from '@kubevirt-utils/store/customizeInstanceType';
-import { PROJECT_LIST_FILTER_PARAM } from '@kubevirt-utils/utils/constants';
 import { isVM } from '@kubevirt-utils/utils/typeGuards';
 import { truncateToK8sName } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -64,21 +61,6 @@ const VirtualMachinesList = forwardRef(({}, ref) => {
   useSignals();
   useVMMetrics();
   const { cluster, project: targetNamespace, setVMDescription, setVMName } = useVMWizardStore();
-
-  // Initialize project dropdown filter to targetNamespace
-  const queryParams = useQuery();
-  const { setAllQueryArguments } = useQueryParamsMethods();
-  const hasInitializedFilter = useRef(false);
-
-  useEffect(() => {
-    if (hasInitializedFilter.current || !targetNamespace) return;
-
-    setAllQueryArguments({
-      [PROJECT_LIST_FILTER_PARAM]: targetNamespace,
-    });
-
-    hasInitializedFilter.current = true;
-  }, [targetNamespace, queryParams, setAllQueryArguments]);
 
   const isAllClustersPage = useIsAllClustersPage();
   const { loading: loadingFeatureProxy } = useFeatures(KUBEVIRT_APISERVER_PROXY);
@@ -120,19 +102,31 @@ const VirtualMachinesList = forwardRef(({}, ref) => {
   const vmimMapper = useVirtualMachineInstanceMigrationMapper(vmims);
   const pvcMapper = usePVCMapper(targetNamespace, cluster);
 
-  const { filtersWithSelect, rowFilters } = useCloneSourceVMFilters(vms, vmiMapper, pvcMapper);
+  const { rowFilters } = useCloneSourceVMFilters(vms, vmiMapper, pvcMapper);
 
   const [pagination, setPagination] = useState(paginationInitialState);
 
   const [unfilteredData, filteredVMs, onFilterChange] = useListPageFilter<
     V1VirtualMachine,
     V1VirtualMachine
-  >(vms, [...filtersWithSelect, ...rowFilters], {});
+  >(vms, rowFilters, {});
 
   // Clear selection when namespace/cluster changes
   useEffect(() => {
     clearCustomizeInstanceType();
   }, [cluster, targetNamespace]);
+
+  useEffect(() => {
+    const filteredDataLength = filteredVMs?.length ?? 0;
+    if (filteredDataLength > 0 && pagination.startIndex >= filteredDataLength) {
+      setPagination((prevPagination) => ({
+        ...prevPagination,
+        endIndex: prevPagination.perPage,
+        page: 1,
+        startIndex: 0,
+      }));
+    }
+  }, [filteredVMs?.length, pagination.startIndex, pagination.perPage]);
 
   useImperativeHandle(
     ref,

--- a/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/hooks/useCloneSourceVMFilters.ts
+++ b/src/views/virtualmachines/creation-wizard/steps/CloneSourceStep/components/VirtualMachinesList/hooks/useCloneSourceVMFilters.ts
@@ -1,6 +1,5 @@
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { useProjectFilter } from '@kubevirt-utils/hooks/useProjectFilter';
 import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 import { useNodesFilter } from '@virtualmachines/list/hooks/useVMListFilters/useNodesFilter';
 import { useStorageClassFilter } from '@virtualmachines/list/hooks/useVMListFilters/useStorageClassFilter';
@@ -17,15 +16,10 @@ export const useCloneSourceVMFilters = (
   vmiMapper: VMIMapper,
   pvcMapper: PVCMapper,
 ): {
-  filtersWithSelect: RowFilter<V1VirtualMachine>[];
   rowFilters: RowFilter<V1VirtualMachine>[];
 } => {
   const { t } = useKubevirtTranslation();
 
-  // Only project filter shown separately
-  const projectFilter = useProjectFilter<V1VirtualMachine>();
-
-  // All other filters grouped into rowFilters dropdown
   const statusFilter = getStatusFilter(t);
   const osFilters = getOSFilter(t);
   const storageClassFilter = useStorageClassFilter(vms, pvcMapper);
@@ -36,7 +30,6 @@ export const useCloneSourceVMFilters = (
   const architectureFilter = getArchitectureFilter(t, vms);
 
   return {
-    filtersWithSelect: [projectFilter],
     rowFilters: [
       statusFilter,
       osFilters,


### PR DESCRIPTION
## Summary

Follow-up fix for [CNV-90048](https://redhat.atlassian.net/browse/CNV-90048) after ON_QA verification found missing radio buttons and search filter flicker.

PR #4066 cherry-picked the UI changes from #3948 onto `release-4.22`, but left release-branch-only code that was already removed on `main`:

- `useProjectFilter` in the clone source VM list (redundant with the project label)
- URL query-param sync via `setAllQueryArguments(PROJECT_LIST_FILTER_PARAM)` on mount

That combination caused:
- Search/name filter flicker on every keystroke (URL updates remounted the list)
- Pagination showing items while the table rendered empty ("No VirtualMachines found")
- Radio buttons never visible because rows were not rendered

This PR aligns the clone source list with `main` by removing the project filter/query-param sync and resetting pagination when the current page is out of range after filtering.

## Links

- Jira: https://redhat.atlassian.net/browse/CNV-90048
- Original fix: #3948
- Incomplete cherry-pick: #4066

## Test plan

- [ ] Open `/vm-wizard`, choose **Clone existing VirtualMachine**, go to **Source**
- [ ] Confirm **Project: default** label is shown
- [ ] Confirm VMs appear with **radio buttons** (`input[name="clone-source-vm"]`)
- [ ] Type in search filter — no flicker/remount
- [ ] Reload browser on Source step — VMs still load, wizard stays on Source
- [ ] Location edit form does not offer **All projects**


Made with [Cursor](https://cursor.com)