### PR TITLE
CNV-91783: Fix hot-cluster E2E workflow to support fork PRs without blocking Tide

### DIFF
--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -174,6 +174,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Check if kubevirt-plugin image exists in registry
         id: check_image
@@ -234,6 +236,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Provision CI test environment
         id: ci-env

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -1,8 +1,9 @@
 name: Hot Cluster E2E
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
+    types: [opened, synchronize, labeled]
   workflow_dispatch:
     inputs:
       test_project:
@@ -49,20 +50,13 @@ env:
   BASE_DOMAIN: cnv-ui.com
 
 jobs:
-  fork-pr-notice:
-    name: Fork PR — secrets unavailable
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Explain why Hot Cluster E2E cannot run
-        run: |
-          echo "::error::Hot Cluster E2E needs the IC_KEY secret, which GitHub does not pass to pull_request workflows from forks."
-          echo "Push your branch to kubevirt-ui/kubevirt-plugin and open a same-repo PR, or run this workflow manually (workflow_dispatch) from an upstream branch."
-          exit 1
-
   cluster-health-check:
     name: Cluster Health Check
-    if: github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+      (github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'ok-to-test'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## 📝 Description

Fix hot-cluster E2E workflow to support fork PRs without blocking Tide: 

- **Same-repo PRs**: run automatically (no trust issue)
- **Fork PRs from org members** (`author_association` is `MEMBER`, `OWNER`, or `COLLABORATOR`): run automatically
- **Fork PRs from external contributors**: require an `ok-to-test` label added by a maintainer

## 🔗 Links

Jira ticket: [CNV-91783](https://redhat.atlassian.net/browse/CNV-91783)


## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request validation so checks run more reliably across supported PR event scenarios.
  * Ensured CI workflows test the correct pull request code by preferring the PR head commit when available.
  * Expanded cluster health checks to run for more eligible pull requests (including approved and labeled cases), with fork-related gating adjusted accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->