### PR TITLE
CNV-90382: Added testLibrary and i18next, changed husky from pre-commit to pre-push  

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,7 +1,7 @@
 {
   "parserPreset": {
     "parserOpts": {
-      "headerPattern": "^([A-Z]+-\\d+)\\s(.+)$",
+      "headerPattern": "^([A-Z]+-\\d+):?\\s(.+)$",
       "headerCorrespondence": ["type", "subject"]
     }
   },

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,0 @@
-npx commitlint --edit "$1"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,6 @@
+branch=$(git branch --show-current)
+if [ "$branch" = "main" ]; then
+  exit 0
+fi
+
+npx commitlint --from "$(git merge-base HEAD upstream/main)" --to HEAD

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -8,7 +8,8 @@
     "no-descending-specificity": null,
     "scss/no-global-function-names": null,
     "declaration-no-important": true,
-    "max-nesting-depth": 3
+    "max-nesting-depth": 3,
+    "custom-property-pattern": null
   },
   "ignoreFiles": ["dist/**", "node_modules/**", "coverage/**"]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,10 @@
+import i18next from 'eslint-plugin-i18next';
 import jsdoc from 'eslint-plugin-jsdoc';
 import perfectionist from 'eslint-plugin-perfectionist';
 import prettier from 'eslint-plugin-prettier/recommended';
 import reactHooks from 'eslint-plugin-react-hooks';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import testingLibrary from 'eslint-plugin-testing-library';
 import tseslint from 'typescript-eslint';
 
 const ignoresConfig = {
@@ -38,12 +40,14 @@ const baseConfig = {
     reportUnusedDisableDirectives: 'off',
   },
   plugins: {
+    i18next,
     jsdoc,
     perfectionist,
     'react-hooks': reactHooks,
     'simple-import-sort': simpleImportSort,
   },
   rules: {
+    'i18next/no-literal-string': 'error',
     'no-console': 'error',
     'no-nested-ternary': 'error',
     'perfectionist/sort-classes': [
@@ -90,6 +94,11 @@ const githubScriptsOverrides = {
   },
 };
 
+const testingLibraryConfig = {
+  ...testingLibrary.configs['flat/react'],
+  files: ['src/**/*.test.{ts,tsx}', 'src/**/*.spec.{ts,tsx}', 'src/**/__tests__/**/*.{ts,tsx}'],
+};
+
 export default [
   ignoresConfig,
   baseConfig,
@@ -97,4 +106,5 @@ export default [
   prettier,
   prettierOverrides,
   githubScriptsOverrides,
+  testingLibraryConfig,
 ];

--- a/eslintv10.config.js
+++ b/eslintv10.config.js
@@ -19,6 +19,7 @@ const ignoresConfig = {
     'dist/**',
     'node_modules/**',
     'eslint.config.js',
+    'eslintv10.config.js',
     'package-lock.json',
     'i18n-scripts/**',
     'coverage/**',
@@ -61,8 +62,8 @@ const baseConfig = {
     curly: ['error', 'all'],
     eqeqeq: ['error', 'always'],
     'i18next/no-literal-string': 'error',
-    'id-length': ['error', { exceptions: ['t', 'e', 'i', 'a', 'b'], min: 3, properties: 'never' }],
-    'max-lines': ['warn', { max: 150, skipBlankLines: true, skipComments: true }],
+    'id-length': ['error', { exceptions: ['t', 'e', 'i', 'a', 'b','vm'], min: 3, properties: 'never' }],
+    'max-lines': ['error', { max: 150, skipBlankLines: true, skipComments: true }],
     'no-console': 'error',
     'no-else-return': ['error', { allowElseIf: false }],
     'no-nested-ternary': 'error',
@@ -84,7 +85,7 @@ const baseConfig = {
     'no-warning-comments': ['warn', { location: 'start', terms: ['todo', 'fixme', 'hack', 'xxx'] }],
     'prefer-const': 'error',
     'promise/always-return': 'warn',
-    'promise/catch-or-return': 'error',
+    'promise/catch-or-return': ['error', { allowFinally: true }],
     'promise/no-nesting': 'warn',
     'promise/no-return-wrap': 'error',
     'promise/param-names': 'error',
@@ -96,7 +97,7 @@ const baseConfig = {
     'react-hooks/refs': 'error',
 
     'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/set-state-in-effect': 'error',
+    'react-hooks/set-state-in-effect': 'off',
     'react-hooks/set-state-in-render': 'error',
     'react-hooks/unsupported-syntax': 'error',
     'simple-import-sort/exports': 'error',
@@ -123,7 +124,6 @@ const baseConfig = {
     'unicorn/prefer-array-some': 'error',
     'unicorn/prefer-includes': 'error',
 
-    'unicorn/prefer-node-protocol': 'error',
     'unicorn/throw-new-error': 'error',
   },
   settings: {
@@ -207,11 +207,31 @@ const tsConfigs = tseslint.configs.recommended.map((config) => ({
 const sonarConfig = {
   ...sonarjs.configs.recommended,
   files: ['**/*.{js,jsx,ts,tsx}'],
+  rules: {
+    ...sonarjs.configs.recommended.rules,
+    'sonarjs/deprecation': 'off',
+    'sonarjs/fixme-tag': 'off',
+    'sonarjs/function-return-type': 'off',
+    'sonarjs/no-globals-shadowing': 'off',
+    'sonarjs/no-unused-vars': 'off',
+    'sonarjs/todo-tag': 'off',
+    'sonarjs/unused-import': 'off',
+  },
 };
 
 const reactConfig = {
   ...eslintReact.configs['recommended-typescript'],
   files: ['**/*.{ts,tsx}'],
+  rules: {
+    ...eslintReact.configs['recommended-typescript'].rules,
+    '@eslint-react/exhaustive-deps': 'off',
+    '@eslint-react/purity': 'off',
+    '@eslint-react/rules-of-hooks': 'off',
+    // TODO: tackle set-state-in-effect in a later version — 82 files affected
+    '@eslint-react/set-state-in-effect': 'off',
+    '@eslint-react/set-state-in-render': 'off',
+    '@eslint-react/unsupported-syntax': 'off',
+  },
 };
 
 const perfectionistOverrides = {
@@ -251,7 +271,6 @@ const jsdocConfig = {
       },
     ],
     'jsdoc/require-param': 'warn',
-    'jsdoc/require-param-description': 'warn',
     'jsdoc/require-param-name': 'warn',
     'jsdoc/require-param-type': 'off',
     'jsdoc/require-property': 'warn',

--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -725,7 +725,7 @@
   "Domain": "Domain",
   "Down": "Down",
   "Download results": "Download results",
-  "Download the MSI from ": "Download the MSI from ",
+  "Download the MSI from <2>virt-manager.org</2>": "Download the MSI from <2>virt-manager.org</2>",
   "Download URL is not needed when an existing Windows DataSource is selected.": "Download URL is not needed when an existing Windows DataSource is selected.",
   "Drag and drop a certificate file or paste PEM content": "Drag and drop a certificate file or paste PEM content",
   "Drag and drop an image or upload one": "Drag and drop an image or upload one",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -736,7 +736,7 @@
   "Domain": "Dominio",
   "Down": "Abajo",
   "Download results": "Descargar resultados",
-  "Download the MSI from ": "Descargar el MSI desde ",
+  "Download the MSI from <2>virt-manager.org</2>": "Descargar el MSI desde <2>virt-manager.org</2>",
   "Download URL is not needed when an existing Windows DataSource is selected.": "Download URL is not needed when an existing Windows DataSource is selected.",
   "Drag and drop a certificate file or paste PEM content": "Arrastre y suelte un archivo de certificado o pegue el contenido PEM",
   "Drag and drop an image or upload one": "Arrastrar y soltar una imagen o cargar una",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -736,7 +736,7 @@
   "Domain": "Domaine",
   "Down": "Vers le bas",
   "Download results": "Résultats du téléchargement",
-  "Download the MSI from ": "Téléchargez le MSI depuis ",
+  "Download the MSI from <2>virt-manager.org</2>": "Téléchargez le MSI depuis <2>virt-manager.org</2>",
   "Download URL is not needed when an existing Windows DataSource is selected.": "Download URL is not needed when an existing Windows DataSource is selected.",
   "Drag and drop a certificate file or paste PEM content": "Glissez-déposez un fichier de certificat ou collez du contenu PEM.",
   "Drag and drop an image or upload one": "Faites glisser et déposez une image ou téléchargez-en une",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -723,7 +723,7 @@
   "Domain": "ドメイン",
   "Down": "停止中",
   "Download results": "結果のダウンロード",
-  "Download the MSI from ": "MSI のダウンロード元 ",
+  "Download the MSI from <2>virt-manager.org</2>": "MSI のダウンロード元 <2>virt-manager.org</2>",
   "Download URL is not needed when an existing Windows DataSource is selected.": "Download URL is not needed when an existing Windows DataSource is selected.",
   "Drag and drop a certificate file or paste PEM content": "証明書ファイルをドラッグアンドドロップするか、PEM コンテンツを貼り付けます",
   "Drag and drop an image or upload one": "イメージをドラッグアンドドロップするかアップロードします",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -723,7 +723,7 @@
   "Domain": "도메인",
   "Down": "중지",
   "Download results": "결과 다운로드",
-  "Download the MSI from ": "MSI를 다운로드하세요 ",
+  "Download the MSI from <2>virt-manager.org</2>": "<2>virt-manager.org</2>에서 MSI를 다운로드하세요",
   "Download URL is not needed when an existing Windows DataSource is selected.": "Download URL is not needed when an existing Windows DataSource is selected.",
   "Drag and drop a certificate file or paste PEM content": "인증서 파일을 드래그 앤 드롭하거나 PEM 콘텐츠를 붙여넣습니다.",
   "Drag and drop an image or upload one": "이미지를 드래그 앤 드롭하거나 업로드",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -723,7 +723,7 @@
   "Domain": "域",
   "Down": "下",
   "Download results": "下载结果",
-  "Download the MSI from ": "下载 MSI，从",
+  "Download the MSI from <2>virt-manager.org</2>": "从 <2>virt-manager.org</2> 下载 MSI",
   "Download URL is not needed when an existing Windows DataSource is selected.": "Download URL is not needed when an existing Windows DataSource is selected.",
   "Drag and drop a certificate file or paste PEM content": "拖放证书文件或粘贴 PEM 内容",
   "Drag and drop an image or upload one": "拖放镜像或上传一个",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
       "npm run i18n"
     ],
     "*.{js,ts,tsx,jsx}": [
-      "eslint --config eslintv10.config.js --fix"
+      "eslint --config eslintv10.config.js --no-warn-ignored --fix"
     ],
     "*.scss": [
       "stylelint --fix"

--- a/src/perspective/virtualization-icon.tsx
+++ b/src/perspective/virtualization-icon.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 
-export default () => (
+export default (): JSX.Element => (
   <>
     <svg
       aria-hidden="true"
@@ -11,6 +11,7 @@ export default () => (
       width="1em"
       xmlns="http://www.w3.org/2000/svg"
     >
+      {/* eslint-disable-next-line i18next/no-literal-string */}
       <title>Red Hat OpenShift Virtualization icon</title>
       <desc>RHOCPV</desc>
       <path

--- a/src/utils/components/Consoles/components/DesktopViewer/Components/MoreInformationDefault.tsx
+++ b/src/utils/components/Consoles/components/DesktopViewer/Components/MoreInformationDefault.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { Trans } from 'react-i18next';
 
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
@@ -6,15 +6,14 @@ import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Content, DescriptionList } from '@patternfly/react-core';
 
-import { MoreInformationDefaultProps } from '../utils/types';
-
+import { type MoreInformationDefaultProps } from '../utils/types';
 import Detail from './Detail';
 
 const MoreInformationDefault: FC<MoreInformationDefaultProps> = ({ textMoreInfoContent }) => {
   const { t } = useKubevirtTranslation();
   return (
     <>
-      {textMoreInfoContent || (
+      {textMoreInfoContent ?? (
         <Content>
           <Trans ns="plugin__kubevirt-plugin" t={t}>
             <p>
@@ -34,8 +33,8 @@ const MoreInformationDefault: FC<MoreInformationDefaultProps> = ({ textMoreInfoC
         <Detail title={'Ubuntu, Debian'} value={'sudo apt-get install virt-viewer'} />
         <DescriptionItem
           descriptionData={
-            <div>
-              {t('Download the MSI from ')}
+            <Trans ns="plugin__kubevirt-plugin" t={t}>
+              Download the MSI from{' '}
               <a
                 href={documentationURL.VIRT_MANAGER_DOWNLOAD}
                 rel="noopener noreferrer"
@@ -43,7 +42,7 @@ const MoreInformationDefault: FC<MoreInformationDefaultProps> = ({ textMoreInfoC
               >
                 virt-manager.org
               </a>
-            </div>
+            </Trans>
           }
           descriptionHeader={t('Windows')}
         />

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/NetworkInterfaceNetworkSelect.tsx
@@ -1,216 +1,28 @@
-import React, {
-  Dispatch,
-  FC,
-  ReactNode,
-  SetStateAction,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import SelectTypeahead from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
-import useIsIPv6SingleStackCluster from '@kubevirt-utils/hooks/useIPStackType/useIsIPv6SingleStackCluster';
-import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getNamespace } from '@kubevirt-utils/resources/shared';
-import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
-import {
-  getNetworks,
-  NAD_TYPE_OVN_K8S_CNI_OVERLAY,
-  POD_NETWORK,
-} from '@kubevirt-utils/resources/vm';
-import { interfaceTypesProxy } from '@kubevirt-utils/resources/vm/utils/network/constants';
-import { getCluster } from '@multicluster/helpers/selectors';
 import { FormGroup, ValidatedOptions } from '@patternfly/react-core';
 
-import {
-  getNadFullName,
-  getNameAndNs,
-  isNadFullName,
-  isOvnOverlayNad,
-  podNetworkExists,
-} from '../../utils/helpers';
-import useNADsData from '../hooks/useNADsData';
-
 import NetworkSelectHelperPopover from './components/NetworkSelectHelperPopover';
-import { buildNetworkSelectOptions, getShowPodNetworkingOption } from './editNetworkSelectUtils';
-import { NetworkSelectTypeaheadOptionProps } from './types';
-import useEditNetworkSelect from './useEditNetworkSelect';
-import { createNewNetworkOption, getCreateNetworkOption, validateNADNamespace } from './utils';
+import { type NetworkInterfaceNetworkSelectProps } from './types';
+import useNetworkInterfaceData from './useNetworkInterfaceData';
+import { createNewNetworkOption, getCreateNetworkOption } from './utils';
 
 export type { NetworkSelectTypeaheadOptionProps } from './types';
 
-type NetworkInterfaceNetworkSelectProps = {
-  editInitValueNetworkName?: string | undefined;
-  isEditing?: boolean | undefined;
-  namespace?: string;
-  networkName: string;
-  setInterfaceType: Dispatch<SetStateAction<string>>;
-  setNetworkName: Dispatch<SetStateAction<string>>;
-  setSubmitDisabled: Dispatch<SetStateAction<boolean>>;
-  vm: V1VirtualMachine;
-};
-
-const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
-  editInitValueNetworkName,
-  isEditing,
-  namespace,
-  networkName,
-  setInterfaceType,
-  setNetworkName,
-  setSubmitDisabled,
-  vm,
-}) => {
-  const { t } = useKubevirtTranslation();
-  const isIPv6SingleStack = useIsIPv6SingleStackCluster(getCluster(vm));
-  const vmiNamespace = getNamespace(vm) || namespace;
-  const { loaded, loadError, nads, primaryNADs } = useNADsData(vmiNamespace, getCluster(vm));
-  const [isNamespaceManagedByUDN] = useNamespaceUDN(vmiNamespace);
-  const podNetworkType = isNamespaceManagedByUDN
-    ? interfaceTypesProxy.l2bridge
-    : interfaceTypesProxy.masquerade;
-  const [createdNetworkOptions, setCreatedNetworkOptions] = useState<
-    NetworkSelectTypeaheadOptionProps[]
-  >([]);
-
-  const currentlyUsedNADFullNames = useMemo(
-    () =>
-      getNetworks(vm)
-        ?.map((network) => network?.multus?.networkName)
-        .filter(Boolean)
-        .map((name) =>
-          isNadFullName(name) ? name : getNadFullName({ name, namespace: getNamespace(vm) }),
-        ) ?? [],
-    [vm],
-  );
-
+const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = (props) => {
   const {
-    filteredNADs,
-    selectedFirstOnLoad,
+    handleChange,
+    loaded,
+    networkOptions,
     selectNetworkName,
     selectTypeaheadKey,
-    setSelectedFirstOnLoad,
-  } = useEditNetworkSelect({
-    currentlyUsedNADFullNames,
-    editInitValueNetworkName,
-    isEditing,
-    loaded,
-    nads,
-    networkName,
-    setSubmitDisabled,
-    vmiNamespace,
-  });
-
-  const ovnNADFullNames =
-    nads?.filter(isOvnOverlayNad).map((nad) => getNadFullName(getNameAndNs(nad))) ?? [];
-
-  const validators: ((fullName: string) => ReactNode)[] = [
-    (fullName) =>
-      primaryNADs.map((nad) => getNadFullName(getNameAndNs(nad))).includes(fullName) &&
-      t('Primary user-defined network cannot be used as a secondary network.'),
-    (fullName) =>
-      currentlyUsedNADFullNames.includes(fullName) &&
-      ovnNADFullNames.includes(fullName) &&
-      t('NetworkAttachmentDefinition of type [{{type}}] can be only used once.', {
-        type: NAD_TYPE_OVN_K8S_CNI_OVERLAY,
-      }),
-    (fullName) => validateNADNamespace(fullName, vmiNamespace),
-  ];
-
-  const hasPodNetwork = useMemo(() => podNetworkExists(vm), [vm]);
-  const hasNads = useMemo(() => filteredNADs?.length > 0, [filteredNADs]);
-  const showPodNetworkingOption = getShowPodNetworkingOption({
-    editInitValueNetworkName,
-    hasPodNetwork,
-    isEditing,
-    isIPv6SingleStack,
-  });
-
-  const canCreateNetworkInterface = useMemo(
-    () => hasNads || !hasPodNetwork,
-    [hasNads, hasPodNetwork],
-  );
-
-  const podNetworkingText = useMemo(() => t('Pod networking'), [t]);
-
-  const networkOptions = useMemo(
-    () =>
-      buildNetworkSelectOptions({
-        createdNetworkOptions,
-        editInitValueNetworkName,
-        filteredNADs,
-        isEditing,
-        podNetworkingText,
-        podNetworkType,
-        selectNetworkName,
-        showPodNetworkingOption,
-        vmiNamespace,
-      }),
-    [
-      showPodNetworkingOption,
-      filteredNADs,
-      podNetworkingText,
-      vmiNamespace,
-      createdNetworkOptions,
-      podNetworkType,
-      isEditing,
-      editInitValueNetworkName,
-      selectNetworkName,
-    ],
-  );
-
-  const validated =
-    canCreateNetworkInterface || isEditing ? ValidatedOptions.default : ValidatedOptions.error;
-
-  const handleChange = useCallback(
-    (value: string) => {
-      setNetworkName(value);
-      setInterfaceType(
-        value === POD_NETWORK
-          ? podNetworkType
-          : networkOptions.find((netOption) => value === netOption?.value)?.type,
-      );
-    },
-    [setNetworkName, setInterfaceType, networkOptions, podNetworkType],
-  );
-
-  useEffect(() => {
-    if (networkName || isEditing) {
-      return;
-    }
-
-    if (loaded && !loadError && !selectedFirstOnLoad) {
-      setSelectedFirstOnLoad(true);
-      const networkToPreselect = networkOptions?.[0]?.value;
-      if (networkToPreselect) {
-        handleChange(networkToPreselect);
-      }
-      return;
-    }
-
-    if (loaded && (loadError || !canCreateNetworkInterface)) {
-      setSubmitDisabled(true);
-    }
-  }, [
-    loadError,
-    canCreateNetworkInterface,
-    isEditing,
-    loaded,
-    networkName,
-    networkOptions,
-    selectedFirstOnLoad,
-    setSelectedFirstOnLoad,
-    setSubmitDisabled,
-    handleChange,
-  ]);
-
-  useEffect(() => {
-    if (networkName && !isEditing) {
-      setSubmitDisabled(false);
-    }
-  }, [isEditing, networkName, setSubmitDisabled]);
+    setCreatedNetworkOptions,
+    t,
+    validated,
+    validators,
+  } = useNetworkInterfaceData(props);
 
   return (
     <FormGroup
@@ -230,7 +42,7 @@ const NetworkInterfaceNetworkSelect: FC<NetworkInterfaceNetworkSelectProps> = ({
             }
             setCreatedNetworkOptions((prev) => [
               ...prev.filter((option) => option.value !== value),
-              createNewNetworkOption(value),
+              createNewNetworkOption(value, t),
             ]);
             return true;
           }}

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/buildNetworkOptions.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/buildNetworkOptions.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+
+import { POD_NETWORK } from '@kubevirt-utils/resources/vm';
+import { interfaceTypesProxy } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { Label } from '@patternfly/react-core';
+
+import { getNadType, isNadFullName, isPodNetworkName } from '../../utils/helpers';
+import { getNadOptionValue } from './editNetworkSelectUtils';
+import type {
+  BuildNetworkSelectOptionsArgs,
+  GetEditingNetworkOptionIfMissingArgs,
+  NetworkSelectTypeaheadOptionProps,
+} from './types';
+
+const getNetworkOptionLabel = (networkName: string, vmiNamespace: string): string =>
+  isNadFullName(networkName) ? networkName : `${vmiNamespace}/${networkName}`;
+
+export const getEditingNetworkOptionIfMissing = ({
+  editInitValueNetworkName,
+  isEditing,
+  options,
+  selectNetworkName,
+  t,
+  vmiNamespace,
+}: GetEditingNetworkOptionIfMissingArgs): NetworkSelectTypeaheadOptionProps | undefined => {
+  if (
+    !isEditing ||
+    !editInitValueNetworkName ||
+    !selectNetworkName ||
+    isPodNetworkName(editInitValueNetworkName) ||
+    options.some((option) => option.value === selectNetworkName)
+  ) {
+    return undefined;
+  }
+
+  const label = getNetworkOptionLabel(editInitValueNetworkName, vmiNamespace);
+
+  return {
+    label,
+    optionProps: {
+      children: (
+        <>
+          {label}{' '}
+          <Label isCompact>
+            {interfaceTypesProxy.bridge} {t('Binding')}
+          </Label>
+        </>
+      ),
+      key: selectNetworkName,
+    },
+    type: interfaceTypesProxy.bridge,
+    value: selectNetworkName,
+  };
+};
+
+export const buildNetworkSelectOptions = ({
+  createdNetworkOptions,
+  editInitValueNetworkName,
+  filteredNADs,
+  isEditing,
+  podNetworkingText,
+  podNetworkType,
+  selectNetworkName,
+  showPodNetworkingOption,
+  t,
+  vmiNamespace,
+}: BuildNetworkSelectOptionsArgs): NetworkSelectTypeaheadOptionProps[] => {
+  const options: NetworkSelectTypeaheadOptionProps[] = filteredNADs.map((nad) => {
+    const { name, namespace: nadNamespace } = nad.metadata;
+    const type = getNadType(nad);
+    const displayedValue = `${nadNamespace}/${name}`;
+    const value = getNadOptionValue(nad, vmiNamespace);
+
+    return {
+      label: displayedValue,
+      optionProps: {
+        children: (
+          <>
+            {displayedValue}{' '}
+            <Label isCompact>
+              {getNadType(nad)} {t('Binding')}
+            </Label>
+          </>
+        ),
+        key: value,
+      },
+      type,
+      value,
+    };
+  });
+
+  options.sort((a, b) =>
+    (a.label ?? '').localeCompare(b.label ?? '', undefined, { numeric: true }),
+  );
+
+  if (showPodNetworkingOption) {
+    options.unshift({
+      label: podNetworkingText,
+      optionProps: {
+        children: (
+          <>
+            {podNetworkingText}{' '}
+            <Label isCompact>
+              {podNetworkType} {t('Binding')}
+            </Label>
+          </>
+        ),
+        key: POD_NETWORK,
+      },
+      type: podNetworkType,
+      value: POD_NETWORK,
+    });
+  }
+
+  const editingNetworkOption = getEditingNetworkOptionIfMissing({
+    editInitValueNetworkName,
+    isEditing,
+    options,
+    selectNetworkName,
+    t,
+    vmiNamespace,
+  });
+
+  if (editingNetworkOption) {
+    options.push(editingNetworkOption);
+  }
+
+  return [
+    ...options,
+    ...createdNetworkOptions.filter(({ value }) =>
+      options.every((option) => option.value !== value),
+    ),
+  ];
+};

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/editNetworkSelectUtils.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/editNetworkSelectUtils.tsx
@@ -1,25 +1,19 @@
-import React from 'react';
-
-import { POD_NETWORK } from '@kubevirt-utils/resources/vm';
-import { interfaceTypesProxy } from '@kubevirt-utils/resources/vm/utils/network/constants';
-import { Label } from '@patternfly/react-core';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { getNetworks } from '@kubevirt-utils/resources/vm';
 
 import {
-  getNadType,
+  getNadFullName,
   isNadFullName,
   isNADUsedInVM,
   isOvnOverlayNad,
   isPodNetworkName,
 } from '../../utils/helpers';
-import { NetworkAttachmentDefinition } from '../hooks/types';
-
+import { type NetworkAttachmentDefinition } from '../hooks/types';
 import type {
-  BuildNetworkSelectOptionsArgs,
   FilterNADsForSelectArgs,
-  GetEditingNetworkOptionIfMissingArgs,
   GetSelectTypeaheadKeyArgs,
   GetShowPodNetworkingOptionArgs,
-  NetworkSelectTypeaheadOptionProps,
 } from './types';
 
 export const getNadOptionValue = (
@@ -66,17 +60,14 @@ export const getSelectNetworkName = (
   }
 
   if (isNadFullName(networkName)) {
-    const [ns, name] = networkName.split('/');
-    if (ns === vmiNamespace) {
+    const [nadNamespace, name] = networkName.split('/');
+    if (nadNamespace === vmiNamespace) {
       return name;
     }
   }
 
   return networkName;
 };
-
-const getNetworkOptionLabel = (networkName: string, vmiNamespace: string): string =>
-  isNadFullName(networkName) ? networkName : `${vmiNamespace}/${networkName}`;
 
 export const filterNADsForSelect = ({
   currentlyUsedNADFullNames,
@@ -120,106 +111,12 @@ export const getSelectTypeaheadKey = ({
     ? 'select-nad-with-preselect'
     : 'select-nad-without-preselect';
 
-export const getEditingNetworkOptionIfMissing = ({
-  editInitValueNetworkName,
-  isEditing,
-  options,
-  selectNetworkName,
-  vmiNamespace,
-}: GetEditingNetworkOptionIfMissingArgs): NetworkSelectTypeaheadOptionProps | undefined => {
-  if (
-    !isEditing ||
-    !editInitValueNetworkName ||
-    !selectNetworkName ||
-    isPodNetworkName(editInitValueNetworkName) ||
-    options.some((option) => option.value === selectNetworkName)
-  ) {
-    return undefined;
-  }
+export const getCurrentlyUsedNADFullNames = (vm: V1VirtualMachine): string[] =>
+  getNetworks(vm)
+    ?.map((network) => network?.multus?.networkName)
+    .filter((name): name is string => Boolean(name))
+    .map((name) =>
+      isNadFullName(name) ? name : getNadFullName({ name, namespace: getNamespace(vm) }),
+    ) ?? [];
 
-  const label = getNetworkOptionLabel(editInitValueNetworkName, vmiNamespace);
-
-  return {
-    label,
-    optionProps: {
-      children: (
-        <>
-          {label} <Label isCompact>{interfaceTypesProxy.bridge} Binding</Label>
-        </>
-      ),
-      key: selectNetworkName,
-    },
-    type: interfaceTypesProxy.bridge,
-    value: selectNetworkName,
-  };
-};
-
-export const buildNetworkSelectOptions = ({
-  createdNetworkOptions,
-  editInitValueNetworkName,
-  filteredNADs,
-  isEditing,
-  podNetworkingText,
-  podNetworkType,
-  selectNetworkName,
-  showPodNetworkingOption,
-  vmiNamespace,
-}: BuildNetworkSelectOptionsArgs): NetworkSelectTypeaheadOptionProps[] => {
-  const options: NetworkSelectTypeaheadOptionProps[] = filteredNADs.map((nad) => {
-    const { name, namespace: nadNamespace } = nad.metadata;
-    const type = getNadType(nad);
-    const displayedValue = `${nadNamespace}/${name}`;
-    const value = getNadOptionValue(nad, vmiNamespace);
-
-    return {
-      label: displayedValue,
-      optionProps: {
-        children: (
-          <>
-            {displayedValue} <Label isCompact>{getNadType(nad)} Binding</Label>
-          </>
-        ),
-        key: value,
-      },
-      type,
-      value,
-    };
-  });
-
-  options.sort((a, b) => a.label.localeCompare(b.label, undefined, { numeric: true }));
-
-  if (showPodNetworkingOption) {
-    options.unshift({
-      label: podNetworkingText,
-      optionProps: {
-        children: (
-          <>
-            {podNetworkingText} <Label isCompact>{podNetworkType} Binding</Label>
-          </>
-        ),
-        key: POD_NETWORK,
-      },
-      type: podNetworkType,
-      value: POD_NETWORK,
-    });
-  }
-
-  const editingNetworkOption = getEditingNetworkOptionIfMissing({
-    editInitValueNetworkName,
-    isEditing,
-    options,
-    selectNetworkName,
-    vmiNamespace,
-  });
-
-  if (editingNetworkOption) {
-    options.push(editingNetworkOption);
-  }
-
-  return [
-    ...options,
-    ...createdNetworkOptions.filter(({ value }) =>
-      options.every((option) => option.value !== value),
-    ),
-  ];
-};
+export { buildNetworkSelectOptions, getEditingNetworkOptionIfMissing } from './buildNetworkOptions';

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/types.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/types.ts
@@ -1,9 +1,37 @@
-import { SelectTypeaheadOptionProps } from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
+import { type Dispatch, type ReactNode, type SetStateAction } from 'react';
+import { type TFunction } from 'i18next';
 
-import { NetworkAttachmentDefinition } from '../hooks/types';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type SelectTypeaheadOptionProps } from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
+import { type ValidatedOptions } from '@patternfly/react-core';
+
+import { type NetworkAttachmentDefinition } from '../hooks/types';
 
 export type NetworkSelectTypeaheadOptionProps = SelectTypeaheadOptionProps & {
   type: string;
+};
+
+export type NetworkInterfaceNetworkSelectProps = {
+  editInitValueNetworkName?: string | undefined;
+  isEditing?: boolean | undefined;
+  namespace?: string;
+  networkName: string;
+  setInterfaceType: Dispatch<SetStateAction<string>>;
+  setNetworkName: Dispatch<SetStateAction<string>>;
+  setSubmitDisabled: Dispatch<SetStateAction<boolean>>;
+  vm: V1VirtualMachine;
+};
+
+export type UseNetworkInterfaceDataReturn = {
+  handleChange: (value: string) => void;
+  loaded: boolean;
+  networkOptions: NetworkSelectTypeaheadOptionProps[];
+  selectNetworkName: string;
+  selectTypeaheadKey: string;
+  setCreatedNetworkOptions: Dispatch<SetStateAction<NetworkSelectTypeaheadOptionProps[]>>;
+  t: TFunction;
+  validated: ValidatedOptions;
+  validators: ((fullName: string) => ReactNode)[];
 };
 
 export type GetShowPodNetworkingOptionArgs = {
@@ -32,6 +60,7 @@ export type GetEditingNetworkOptionIfMissingArgs = {
   isEditing?: boolean;
   options: NetworkSelectTypeaheadOptionProps[];
   selectNetworkName: string;
+  t: TFunction;
   vmiNamespace: string;
 };
 
@@ -44,5 +73,6 @@ export type BuildNetworkSelectOptionsArgs = {
   podNetworkType: string;
   selectNetworkName: string;
   showPodNetworkingOption: boolean;
+  t: TFunction;
   vmiNamespace: string;
 };

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useNetworkAutoSelect.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useNetworkAutoSelect.ts
@@ -1,0 +1,79 @@
+import { type Dispatch, type SetStateAction, useCallback, useEffect } from 'react';
+
+import { POD_NETWORK } from '@kubevirt-utils/resources/vm';
+
+import { type NetworkSelectTypeaheadOptionProps } from './types';
+
+type UseNetworkAutoSelectArgs = {
+  canCreateNetworkInterface: boolean;
+  isEditing?: boolean;
+  loaded: boolean;
+  loadError: unknown;
+  networkName: string;
+  networkOptions: NetworkSelectTypeaheadOptionProps[];
+  podNetworkType: string;
+  selectedFirstOnLoad: boolean;
+  setInterfaceType: Dispatch<SetStateAction<string>>;
+  setNetworkName: Dispatch<SetStateAction<string>>;
+  setSelectedFirstOnLoad: (val: boolean) => void;
+  setSubmitDisabled: Dispatch<SetStateAction<boolean>>;
+};
+
+export const useNetworkAutoSelect = ({
+  canCreateNetworkInterface,
+  isEditing,
+  loaded,
+  loadError,
+  networkName,
+  networkOptions,
+  podNetworkType,
+  selectedFirstOnLoad,
+  setInterfaceType,
+  setNetworkName,
+  setSelectedFirstOnLoad,
+  setSubmitDisabled,
+}: UseNetworkAutoSelectArgs): ((value: string) => void) => {
+  const handleChange = useCallback(
+    (value: string) => {
+      setNetworkName(value);
+      setInterfaceType(
+        value === POD_NETWORK
+          ? podNetworkType
+          : networkOptions.find((netOption) => value === netOption?.value)?.type,
+      );
+    },
+    [setNetworkName, setInterfaceType, networkOptions, podNetworkType],
+  );
+
+  useEffect(() => {
+    if (networkName && !isEditing) {
+      setSubmitDisabled(false);
+      return;
+    }
+    if (networkName || isEditing) return;
+
+    if (loaded && !loadError && !selectedFirstOnLoad) {
+      setSelectedFirstOnLoad(true);
+      const networkToPreselect = networkOptions?.[0]?.value;
+      if (networkToPreselect) handleChange(networkToPreselect);
+      return;
+    }
+
+    if (loaded && (loadError || !canCreateNetworkInterface)) {
+      setSubmitDisabled(true);
+    }
+  }, [
+    loadError,
+    canCreateNetworkInterface,
+    isEditing,
+    loaded,
+    networkName,
+    networkOptions,
+    selectedFirstOnLoad,
+    setSelectedFirstOnLoad,
+    setSubmitDisabled,
+    handleChange,
+  ]);
+
+  return handleChange;
+};

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useNetworkInterfaceData.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useNetworkInterfaceData.ts
@@ -1,0 +1,151 @@
+import { useMemo, useState } from 'react';
+
+import useIsIPv6SingleStackCluster from '@kubevirt-utils/hooks/useIPStackType/useIsIPv6SingleStackCluster';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
+import { interfaceTypesProxy } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { getCluster } from '@multicluster/helpers/selectors';
+import { ValidatedOptions } from '@patternfly/react-core';
+
+import { podNetworkExists } from '../../utils/helpers';
+import useNADsData from '../hooks/useNADsData';
+import {
+  buildNetworkSelectOptions,
+  getCurrentlyUsedNADFullNames,
+  getShowPodNetworkingOption,
+} from './editNetworkSelectUtils';
+import {
+  type NetworkInterfaceNetworkSelectProps,
+  type NetworkSelectTypeaheadOptionProps,
+  type UseNetworkInterfaceDataReturn,
+} from './types';
+import useEditNetworkSelect from './useEditNetworkSelect';
+import { useNetworkAutoSelect } from './useNetworkAutoSelect';
+import { buildValidators } from './utils';
+
+/**
+ *
+ * @param root0
+ * @param root0.editInitValueNetworkName
+ * @param root0.isEditing
+ * @param root0.namespace
+ * @param root0.networkName
+ * @param root0.setInterfaceType
+ * @param root0.setNetworkName
+ * @param root0.setSubmitDisabled
+ * @param root0.vm
+ */
+export default function useNetworkInterfaceData({
+  editInitValueNetworkName,
+  isEditing,
+  namespace,
+  networkName,
+  setInterfaceType,
+  setNetworkName,
+  setSubmitDisabled,
+  vm,
+}: NetworkInterfaceNetworkSelectProps): UseNetworkInterfaceDataReturn {
+  const { t } = useKubevirtTranslation();
+  const isIPv6SingleStack = useIsIPv6SingleStackCluster(getCluster(vm));
+  const vmiNamespace = getNamespace(vm) ?? namespace;
+  const { loaded, loadError, nads, primaryNADs } = useNADsData(vmiNamespace, getCluster(vm));
+  const [isNamespaceManagedByUDN] = useNamespaceUDN(vmiNamespace);
+  const podNetworkType = isNamespaceManagedByUDN
+    ? interfaceTypesProxy.l2bridge
+    : interfaceTypesProxy.masquerade;
+  const [createdNetworkOptions, setCreatedNetworkOptions] = useState<
+    NetworkSelectTypeaheadOptionProps[]
+  >([]);
+
+  const currentlyUsedNADFullNames = useMemo(() => getCurrentlyUsedNADFullNames(vm), [vm]);
+
+  const {
+    filteredNADs,
+    selectedFirstOnLoad,
+    selectNetworkName,
+    selectTypeaheadKey,
+    setSelectedFirstOnLoad,
+  } = useEditNetworkSelect({
+    currentlyUsedNADFullNames,
+    editInitValueNetworkName,
+    isEditing,
+    loaded,
+    nads,
+    networkName,
+    setSubmitDisabled,
+    vmiNamespace,
+  });
+
+  const validators = buildValidators({
+    currentlyUsedNADFullNames,
+    nads,
+    primaryNADs,
+    t,
+    vmiNamespace,
+  });
+
+  const hasPodNetwork = podNetworkExists(vm);
+  const showPodNetworkingOption = getShowPodNetworkingOption({
+    editInitValueNetworkName,
+    hasPodNetwork,
+    isEditing,
+    isIPv6SingleStack,
+  });
+  const canCreateNetworkInterface = filteredNADs?.length > 0 || !hasPodNetwork;
+
+  const networkOptions = useMemo(
+    () =>
+      buildNetworkSelectOptions({
+        createdNetworkOptions,
+        editInitValueNetworkName,
+        filteredNADs,
+        isEditing,
+        podNetworkingText: t('Pod networking'),
+        podNetworkType,
+        selectNetworkName,
+        showPodNetworkingOption,
+        t,
+        vmiNamespace,
+      }),
+    [
+      showPodNetworkingOption,
+      filteredNADs,
+      vmiNamespace,
+      createdNetworkOptions,
+      podNetworkType,
+      isEditing,
+      editInitValueNetworkName,
+      selectNetworkName,
+      t,
+    ],
+  );
+
+  const handleChange = useNetworkAutoSelect({
+    canCreateNetworkInterface,
+    isEditing,
+    loaded,
+    loadError,
+    networkName,
+    networkOptions,
+    podNetworkType,
+    selectedFirstOnLoad,
+    setInterfaceType,
+    setNetworkName,
+    setSelectedFirstOnLoad,
+    setSubmitDisabled,
+  });
+
+  return {
+    handleChange,
+    loaded,
+    networkOptions,
+    selectNetworkName,
+    selectTypeaheadKey,
+    setCreatedNetworkOptions,
+    t,
+    validated:
+      canCreateNetworkInterface || isEditing ? ValidatedOptions.default : ValidatedOptions.error,
+    validators,
+  };
+}

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/utils.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/utils.tsx
@@ -1,23 +1,29 @@
-import React, { ReactNode } from 'react';
-import { TFunction } from 'i18next';
+import React, { type ReactNode } from 'react';
+import { type TFunction } from 'i18next';
 
 import { GLOBAL_NAD_NAMESPACES } from '@kubevirt-utils/constants/constants';
+import { NAD_TYPE_OVN_K8S_CNI_OVERLAY } from '@kubevirt-utils/resources/vm';
 import { interfaceTypesProxy } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { getDNS1123LabelError } from '@kubevirt-utils/utils/validation';
-import { HelperText, HelperTextItem, Label, SelectOptionProps } from '@patternfly/react-core';
+import { HelperText, HelperTextItem, Label, type SelectOptionProps } from '@patternfly/react-core';
 import { InfoIcon } from '@patternfly/react-icons';
 
-import { isNadFullName } from '../../utils/helpers';
-
+import { getNadFullName, getNameAndNs, isNadFullName, isOvnOverlayNad } from '../../utils/helpers';
+import { type NetworkAttachmentDefinition } from '../hooks/types';
 import InvalidNADNamespace from './components/InvalidNADNamespace';
-import { NetworkSelectTypeaheadOptionProps } from './types';
+import { type NetworkSelectTypeaheadOptionProps } from './types';
 
-export const createNewNetworkOption = (value): NetworkSelectTypeaheadOptionProps => ({
+export const createNewNetworkOption = (
+  value: string,
+  t: TFunction,
+): NetworkSelectTypeaheadOptionProps => ({
   optionProps: {
     children: (
       <>
         {value}
-        <Label isCompact>{interfaceTypesProxy.bridge} Binding</Label>
+        <Label isCompact>
+          {interfaceTypesProxy.bridge} {t('Binding')}
+        </Label>
       </>
     ),
   },
@@ -28,7 +34,7 @@ export const createNewNetworkOption = (value): NetworkSelectTypeaheadOptionProps
 export const getCreateNetworkOption =
   (validators: ((name: string) => ReactNode)[]) =>
   (input: string, t: TFunction): SelectOptionProps => {
-    if (!input || input.split('/').length !== 2 || input.split('/').some((part) => !part)) {
+    if (input?.split('/').length !== 2 || input.split('/').some((part) => !part)) {
       return {
         children: (
           <HelperText>
@@ -75,20 +81,55 @@ export const getCreateNetworkOption =
       children: (
         <>
           {t('Use "{{inputValue}}"', { inputValue: input })}{' '}
-          <Label isCompact>{interfaceTypesProxy.bridge} Binding</Label>
+          <Label isCompact>
+            {interfaceTypesProxy.bridge} {t('Binding')}
+          </Label>
         </>
       ),
     };
   };
 
-export const validateNADNamespace = (name: string, vmNamespace: string): ReactNode => {
+export const buildValidators = ({
+  currentlyUsedNADFullNames,
+  nads,
+  primaryNADs,
+  t,
+  vmiNamespace,
+}: {
+  currentlyUsedNADFullNames: string[];
+  nads: NetworkAttachmentDefinition[];
+  primaryNADs: NetworkAttachmentDefinition[];
+  t: TFunction;
+  vmiNamespace: string;
+}): ((fullName: string) => ReactNode)[] => {
+  const ovnNADFullNames =
+    nads?.filter(isOvnOverlayNad).map((nad) => getNadFullName(getNameAndNs(nad))) ?? [];
+
+  return [
+    (fullName): ReactNode =>
+      primaryNADs.map((nad) => getNadFullName(getNameAndNs(nad))).includes(fullName) &&
+      t('Primary user-defined network cannot be used as a secondary network.'),
+    (fullName): ReactNode =>
+      currentlyUsedNADFullNames.includes(fullName) &&
+      ovnNADFullNames.includes(fullName) &&
+      t('NetworkAttachmentDefinition of type [{{type}}] can be only used once.', {
+        type: NAD_TYPE_OVN_K8S_CNI_OVERLAY,
+      }),
+    (fullName): ReactNode => validateNADNamespace(fullName, vmiNamespace),
+  ];
+};
+
+// eslint-disable-next-line
+export const validateNADNamespace = (name: string, vmNamespace: string): false | ReactNode => {
   if (!isNadFullName(name)) {
     return false;
   }
   const allowedNamespaces = Array.from(new Set([vmNamespace, ...GLOBAL_NAD_NAMESPACES]));
-  const [ns] = name.split('/');
+  const [nadNamespace] = name.split('/');
   return (
-    ns &&
-    !allowedNamespaces.includes(ns) && <InvalidNADNamespace allowedNamespaces={allowedNamespaces} />
+    nadNamespace &&
+    !allowedNamespaces.includes(nadNamespace) && (
+      <InvalidNADNamespace allowedNamespaces={allowedNamespaces} />
+    )
   );
 };

--- a/src/utils/components/SidebarEditor/SidebarEditor.tsx
+++ b/src/utils/components/SidebarEditor/SidebarEditor.tsx
@@ -1,8 +1,9 @@
-import React, { ReactNode, Suspense, useContext, useMemo, useState } from 'react';
+import React, { type JSX, type ReactNode, Suspense, useContext, useMemo, useState } from 'react';
 import { dump } from 'js-yaml';
 
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { PATHS_TO_HIGHLIGHT } from '@kubevirt-utils/resources/vm/utils/constants';
-import { K8sResourceCommon, YAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon, YAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Alert,
   AlertActionCloseButton,
@@ -19,7 +20,6 @@ import {
 } from '@patternfly/react-core';
 
 import Loading from '../Loading/Loading';
-
 import { SidebarEditorContext } from './SidebarEditorContext';
 import { useEditorHighlighter } from './useEditorHighlighter';
 import { safeLoad } from './utils';
@@ -41,47 +41,53 @@ const SidebarEditor = <Resource extends K8sResourceCommon>({
   pathsToHighlight = PATHS_TO_HIGHLIGHT.DEFAULT,
   resource,
 }: SidebarEditorProps<Resource>): JSX.Element => {
-  const [editableYAML, setEditableYAML] = useState('');
+  const { t } = useKubevirtTranslation();
+  const resourceYAML = useMemo(
+    () => dump(resource, { forceQuotes: true, skipInvalid: true }),
+    [resource],
+  );
+
+  const [editableYAML, setEditableYAML] = useState(resourceYAML);
+  const [prevResourceYAML, setPrevResourceYAML] = useState(resourceYAML);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
 
-  const resourceYAML = useMemo(() => {
-    const yaml = dump(resource, { forceQuotes: true, skipInvalid: true });
-    setEditableYAML(yaml);
-    return yaml;
-  }, [resource]);
+  if (prevResourceYAML !== resourceYAML) {
+    setPrevResourceYAML(resourceYAML);
+    setEditableYAML(resourceYAML);
+  }
 
   const { isEditable, showEditor } = useContext(SidebarEditorContext);
   const editedResource = safeLoad<Resource>(editableYAML);
   const editorRef = useEditorHighlighter(editableYAML, pathsToHighlight, showEditor);
 
-  const changeResource = (newValue: string) => {
+  const changeResource = (newValue: string): Record<string, never> => {
     setEditableYAML(newValue);
 
     if (onChange) onChange(safeLoad<Resource>(newValue));
     return {};
   };
 
-  const onUpdate = (newResource: Resource) => {
+  const onUpdate = (newResource: Resource): void => {
     if (!onResourceUpdate) return;
 
     setSuccess(false);
     setError(null);
     setLoading(true);
-    return onResourceUpdate(newResource)
+    void onResourceUpdate(newResource)
       .then(() => setSuccess(true))
       .catch(setError)
       .finally(() => setLoading(false));
   };
 
-  const onReload = () => {
+  const onReload = (): void => {
     setSuccess(false);
     setError(null);
     setEditableYAML(resourceYAML);
   };
 
-  const childrenComponent = useMemo(() => {
+  const childrenComponent = useMemo((): ReactNode => {
     if (children instanceof Function) return children(editedResource ?? resource);
     return children;
   }, [children, editedResource, resource]);
@@ -96,6 +102,7 @@ const SidebarEditor = <Resource extends K8sResourceCommon>({
         >
           <Stack hasGutter>
             <Suspense fallback={<Loading />}>
+              {/* eslint-disable-next-line */}
               <YAMLEditor
                 minHeight="300px"
                 onChange={changeResource}
@@ -131,7 +138,7 @@ const SidebarEditor = <Resource extends K8sResourceCommon>({
                       onClick={() => onUpdate(editedResource)}
                       variant={ButtonVariant.primary}
                     >
-                      Save
+                      {t('Save')}
                     </Button>
                   </FlexItem>
                   <FlexItem>
@@ -140,7 +147,7 @@ const SidebarEditor = <Resource extends K8sResourceCommon>({
                       onClick={onReload}
                       variant={ButtonVariant.secondary}
                     >
-                      Reload
+                      {t('Reload')}
                     </Button>
                   </FlexItem>
                 </Flex>

--- a/src/views/storagemigrations/list/hooks/useStorageMigrationResources.test.mocks.ts
+++ b/src/views/storagemigrations/list/hooks/useStorageMigrationResources.test.mocks.ts
@@ -1,0 +1,37 @@
+import {
+  modelToGroupVersionKind,
+  MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+  VirtualMachineStorageMigrationPlanModel,
+} from '@kubevirt-utils/models';
+import {
+  type MultiNamespaceVirtualMachineStorageMigrationPlan,
+  type VirtualMachineStorageMigrationPlan,
+} from '@kubevirt-utils/resources/migrations/constants';
+
+export const multiNsGVK = modelToGroupVersionKind(
+  MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+);
+export const singleNsGVK = modelToGroupVersionKind(VirtualMachineStorageMigrationPlanModel);
+
+export const multiNsPlan = {
+  apiVersion: 'migrations.kubevirt.io/v1alpha1',
+  kind: 'MultiNamespaceVirtualMachineStorageMigrationPlan',
+  metadata: { name: 'multi-plan-1', namespace: 'test-ns' },
+  spec: {
+    namespaces: [
+      {
+        name: 'test-ns',
+        virtualMachines: [{ name: 'vm-a', targetMigrationPVCs: [{ volumeName: 'disk0' }] }],
+      },
+    ],
+  },
+} as MultiNamespaceVirtualMachineStorageMigrationPlan;
+
+export const singleNsPlan = {
+  apiVersion: 'migrations.kubevirt.io/v1alpha1',
+  kind: 'VirtualMachineStorageMigrationPlan',
+  metadata: { name: 'single-plan-1', namespace: 'test-ns' },
+  spec: {
+    virtualMachines: [{ name: 'vm-b', targetMigrationPVCs: [{ volumeName: 'disk1' }] }],
+  },
+} as VirtualMachineStorageMigrationPlan;

--- a/src/views/storagemigrations/list/hooks/useStorageMigrationResources.test.ts
+++ b/src/views/storagemigrations/list/hooks/useStorageMigrationResources.test.ts
@@ -1,16 +1,14 @@
-import {
-  modelToGroupVersionKind,
-  MultiNamespaceVirtualMachineStorageMigrationPlanModel,
-  VirtualMachineStorageMigrationPlanModel,
-} from '@kubevirt-utils/models';
-import {
-  MultiNamespaceVirtualMachineStorageMigrationPlan,
-  VirtualMachineStorageMigrationPlan,
-} from '@kubevirt-utils/resources/migrations/constants';
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
-import { cleanup, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
 import useStorageMigrationResources from './useStorageMigrationResources';
+import {
+  multiNsGVK,
+  multiNsPlan,
+  singleNsGVK,
+  singleNsPlan,
+} from './useStorageMigrationResources.test.mocks';
 
 jest.mock('@kubevirt-utils/hooks/useNamespaceParam', () => ({
   __esModule: true,
@@ -22,34 +20,7 @@ jest.mock('@multicluster/hooks/useK8sWatchData', () => ({
   default: jest.fn(() => [[], true, undefined]),
 }));
 
-const multiNsGVK = modelToGroupVersionKind(MultiNamespaceVirtualMachineStorageMigrationPlanModel);
-const singleNsGVK = modelToGroupVersionKind(VirtualMachineStorageMigrationPlanModel);
-
-const multiNsPlan: MultiNamespaceVirtualMachineStorageMigrationPlan = {
-  apiVersion: 'migrations.kubevirt.io/v1alpha1',
-  kind: 'MultiNamespaceVirtualMachineStorageMigrationPlan',
-  metadata: { name: 'multi-plan-1', namespace: 'test-ns' },
-  spec: {
-    namespaces: [
-      {
-        name: 'test-ns',
-        virtualMachines: [{ name: 'vm-a', targetMigrationPVCs: [{ volumeName: 'disk0' }] }],
-      },
-    ],
-  },
-} as MultiNamespaceVirtualMachineStorageMigrationPlan;
-
-const singleNsPlan: VirtualMachineStorageMigrationPlan = {
-  apiVersion: 'migrations.kubevirt.io/v1alpha1',
-  kind: 'VirtualMachineStorageMigrationPlan',
-  metadata: { name: 'single-plan-1', namespace: 'test-ns' },
-  spec: {
-    virtualMachines: [{ name: 'vm-b', targetMigrationPVCs: [{ volumeName: 'disk1' }] }],
-  },
-} as VirtualMachineStorageMigrationPlan;
-
 afterEach(() => {
-  cleanup();
   (useK8sWatchData as jest.Mock).mockReset();
 });
 
@@ -73,7 +44,7 @@ describe('useStorageMigrationResources', () => {
     expect(result.current.loadError).toBeUndefined();
     expect(result.current.storageMigPlans).toHaveLength(2);
 
-    const names = result.current.storageMigPlans.map((p) => p.metadata.name);
+    const names = result.current.storageMigPlans.map((plan) => plan.metadata.name);
     expect(names).toContain('multi-plan-1');
     expect(names).toContain('single-plan-1');
   });

--- a/src/views/virtualmachines/actions/hooks/storageMigrationApi/storageMigrationAPITests/constants.test.ts
+++ b/src/views/virtualmachines/actions/hooks/storageMigrationApi/storageMigrationAPITests/constants.test.ts
@@ -2,7 +2,7 @@ import {
   csvLoadedIndicatesMultiNsStorageMigrationApi,
   csvVersionMeetsMultiNsAssumeThreshold,
   STORAGE_MIGRATION_ASSUME_MULTI_NS_API_MIN_VERSION,
-} from './constants';
+} from '../constants';
 
 describe('STORAGE_MIGRATION_ASSUME_MULTI_NS_API_MIN_VERSION', () => {
   it('is 4.21 per storage migration API assumptions', () => {

--- a/src/views/virtualmachines/actions/hooks/storageMigrationApi/storageMigrationAPITests/storageMigrationProbeListError.test.ts
+++ b/src/views/virtualmachines/actions/hooks/storageMigrationApi/storageMigrationAPITests/storageMigrationProbeListError.test.ts
@@ -1,4 +1,4 @@
-import { handleStorageMigrationProbeListError } from './storageMigrationProbeListError';
+import { handleStorageMigrationProbeListError } from '../storageMigrationProbeListError';
 
 describe('handleStorageMigrationProbeListError', () => {
   it('invokes onNotFound when canceled is false and error is 404-shaped', () => {

--- a/src/views/virtualmachines/actions/hooks/storageMigrationApi/storageMigrationAPITests/useClusterStorageMigrationApiProbe.fallback.test.ts
+++ b/src/views/virtualmachines/actions/hooks/storageMigrationApi/storageMigrationAPITests/useClusterStorageMigrationApiProbe.fallback.test.ts
@@ -6,11 +6,11 @@ import {
 import { STORAGE_MIGRATION_API } from '@kubevirt-utils/resources/migrations/constants';
 import { kubevirtK8sListItems } from '@multicluster/k8sRequests';
 import useIsACMPage from '@multicluster/useIsACMPage';
-import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 
-import useClusterStorageMigrationApiProbe, {
-  type StorageMigrationProbeCsv,
-} from './useClusterStorageMigrationApiProbe';
+import useClusterStorageMigrationApiProbe from '../useClusterStorageMigrationApiProbe';
+
+import { csvBelow21 } from './useClusterStorageMigrationApiProbe.test.mocks';
 
 jest.mock('@multicluster/k8sRequests', () => ({
   kubevirtK8sListItems: jest.fn(),
@@ -26,98 +26,11 @@ jest.mock('@stolostron/multicluster-sdk', () => ({
 }));
 
 afterEach(() => {
-  cleanup();
   (kubevirtK8sListItems as jest.Mock).mockReset();
   (useIsACMPage as jest.Mock).mockImplementation(() => true);
 });
 
-describe('useClusterStorageMigrationApiProbe', () => {
-  it('single-cluster (non-ACM): assumes MULTI_NS without LIST probe', () => {
-    (useIsACMPage as jest.Mock).mockImplementation(() => false);
-
-    const csv = {
-      installedCSV: undefined,
-      loaded: false,
-    } as StorageMigrationProbeCsv;
-
-    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
-
-    expect(result.current).toBe(STORAGE_MIGRATION_API.MULTI_NS);
-    expect(kubevirtK8sListItems).not.toHaveBeenCalled();
-
-    (useIsACMPage as jest.Mock).mockImplementation(() => true);
-  });
-
-  it('resolves MULTI_NS without LIST when CSV is loaded and minor is 21 or above', async () => {
-    const csv = {
-      installedCSV: { spec: { version: '4.21.0' } },
-      loaded: true,
-    } as StorageMigrationProbeCsv;
-
-    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
-
-    await waitFor(() => {
-      expect(result.current).toBe(STORAGE_MIGRATION_API.MULTI_NS);
-    });
-
-    expect(kubevirtK8sListItems).not.toHaveBeenCalled();
-  });
-
-  it('resolves MULTI_NS without LIST when CSV major is above 4 even if minor is below 21', async () => {
-    const csv = {
-      installedCSV: { spec: { version: '5.1.0' } },
-      loaded: true,
-    } as StorageMigrationProbeCsv;
-
-    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
-
-    await waitFor(() => {
-      expect(result.current).toBe(STORAGE_MIGRATION_API.MULTI_NS);
-    });
-
-    expect(kubevirtK8sListItems).not.toHaveBeenCalled();
-  });
-
-  it('runs LIST probe when CSV minor is below 21', async () => {
-    (kubevirtK8sListItems as jest.Mock).mockResolvedValue([]);
-
-    const csv = {
-      installedCSV: { spec: { version: '4.20.5' } },
-      loaded: true,
-    } as StorageMigrationProbeCsv;
-
-    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
-
-    await waitFor(() => {
-      expect(result.current).toBe(STORAGE_MIGRATION_API.MULTI_NS);
-    });
-
-    expect(kubevirtK8sListItems).toHaveBeenCalled();
-  });
-
-  it('resolves MTC when multi-namespace API 404s and MigPlan LIST succeeds (CSV minor below 21)', async () => {
-    (kubevirtK8sListItems as jest.Mock).mockImplementation(({ model }) => {
-      if (model === MultiNamespaceVirtualMachineStorageMigrationPlanModel) {
-        return Promise.reject({ code: 404 });
-      }
-      if (model === MigPlanModel) {
-        return Promise.resolve([]);
-      }
-      return Promise.reject(new Error('unexpected LIST model in probe'));
-    });
-
-    const csv = {
-      installedCSV: { spec: { version: '4.20.5' } },
-      loaded: true,
-    } as StorageMigrationProbeCsv;
-
-    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
-
-    await waitFor(() => {
-      expect(result.current).toBe(STORAGE_MIGRATION_API.MTC);
-    });
-  });
-
+describe('useClusterStorageMigrationApiProbe – fallback scenarios', () => {
   it('resolves SINGLE_NS when multi-namespace API and MigPlan 404 but single-namespace plan LIST succeeds', async () => {
     (kubevirtK8sListItems as jest.Mock).mockImplementation(({ model }) => {
       if (model === MultiNamespaceVirtualMachineStorageMigrationPlanModel) {
@@ -132,12 +45,9 @@ describe('useClusterStorageMigrationApiProbe', () => {
       return Promise.reject(new Error('unexpected LIST model in probe'));
     });
 
-    const csv = {
-      installedCSV: { spec: { version: '4.20.5' } },
-      loaded: true,
-    } as StorageMigrationProbeCsv;
-
-    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
+    const { result } = renderHook(() =>
+      useClusterStorageMigrationApiProbe('my-cluster', csvBelow21),
+    );
 
     await waitFor(() => {
       expect(result.current).toBe(STORAGE_MIGRATION_API.SINGLE_NS);
@@ -156,12 +66,9 @@ describe('useClusterStorageMigrationApiProbe', () => {
       return Promise.reject(new Error('unexpected LIST model in probe'));
     });
 
-    const csv = {
-      installedCSV: { spec: { version: '4.20.5' } },
-      loaded: true,
-    } as StorageMigrationProbeCsv;
-
-    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
+    const { result } = renderHook(() =>
+      useClusterStorageMigrationApiProbe('my-cluster', csvBelow21),
+    );
 
     await waitFor(() => {
       expect(result.current).toBe(STORAGE_MIGRATION_API.NONE);
@@ -179,12 +86,9 @@ describe('useClusterStorageMigrationApiProbe', () => {
       return Promise.reject(new Error('unexpected LIST model in probe'));
     });
 
-    const csv = {
-      installedCSV: { spec: { version: '4.20.5' } },
-      loaded: true,
-    } as StorageMigrationProbeCsv;
-
-    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
+    const { result } = renderHook(() =>
+      useClusterStorageMigrationApiProbe('my-cluster', csvBelow21),
+    );
 
     await waitFor(() => {
       expect(result.current).toBe(STORAGE_MIGRATION_API.SINGLE_NS);
@@ -202,12 +106,9 @@ describe('useClusterStorageMigrationApiProbe', () => {
       return Promise.reject(new Error('unexpected LIST model in probe'));
     });
 
-    const csv = {
-      installedCSV: { spec: { version: '4.20.5' } },
-      loaded: true,
-    } as StorageMigrationProbeCsv;
-
-    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
+    const { result } = renderHook(() =>
+      useClusterStorageMigrationApiProbe('my-cluster', csvBelow21),
+    );
 
     await waitFor(() => {
       expect(result.current).toBe(STORAGE_MIGRATION_API.SINGLE_NS);
@@ -225,12 +126,9 @@ describe('useClusterStorageMigrationApiProbe', () => {
       return Promise.reject(new Error('unexpected LIST model in probe'));
     });
 
-    const csv = {
-      installedCSV: { spec: { version: '4.20.5' } },
-      loaded: true,
-    } as StorageMigrationProbeCsv;
-
-    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
+    const { result } = renderHook(() =>
+      useClusterStorageMigrationApiProbe('my-cluster', csvBelow21),
+    );
 
     await waitFor(() => {
       expect(result.current).toBe(STORAGE_MIGRATION_API.NONE);
@@ -248,12 +146,9 @@ describe('useClusterStorageMigrationApiProbe', () => {
       return Promise.reject(new Error('unexpected LIST model in probe'));
     });
 
-    const csv = {
-      installedCSV: { spec: { version: '4.20.5' } },
-      loaded: true,
-    } as StorageMigrationProbeCsv;
-
-    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
+    const { result } = renderHook(() =>
+      useClusterStorageMigrationApiProbe('my-cluster', csvBelow21),
+    );
 
     await waitFor(() => {
       expect(result.current).toBe(STORAGE_MIGRATION_API.MTC);

--- a/src/views/virtualmachines/actions/hooks/storageMigrationApi/storageMigrationAPITests/useClusterStorageMigrationApiProbe.test.mocks.ts
+++ b/src/views/virtualmachines/actions/hooks/storageMigrationApi/storageMigrationAPITests/useClusterStorageMigrationApiProbe.test.mocks.ts
@@ -1,0 +1,6 @@
+import { type StorageMigrationProbeCsv } from '../useClusterStorageMigrationApiProbe';
+
+export const csvBelow21 = {
+  installedCSV: { spec: { version: '4.20.5' } },
+  loaded: true,
+} as StorageMigrationProbeCsv;

--- a/src/views/virtualmachines/actions/hooks/storageMigrationApi/storageMigrationAPITests/useClusterStorageMigrationApiProbe.test.ts
+++ b/src/views/virtualmachines/actions/hooks/storageMigrationApi/storageMigrationAPITests/useClusterStorageMigrationApiProbe.test.ts
@@ -1,0 +1,114 @@
+import {
+  MigPlanModel,
+  MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+} from '@kubevirt-utils/models';
+import { STORAGE_MIGRATION_API } from '@kubevirt-utils/resources/migrations/constants';
+import { kubevirtK8sListItems } from '@multicluster/k8sRequests';
+import useIsACMPage from '@multicluster/useIsACMPage';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import useClusterStorageMigrationApiProbe, {
+  type StorageMigrationProbeCsv,
+} from '../useClusterStorageMigrationApiProbe';
+
+import { csvBelow21 } from './useClusterStorageMigrationApiProbe.test.mocks';
+
+jest.mock('@multicluster/k8sRequests', () => ({
+  kubevirtK8sListItems: jest.fn(),
+}));
+
+jest.mock('@multicluster/useIsACMPage', () => ({
+  __esModule: true,
+  default: jest.fn(() => true),
+}));
+
+jest.mock('@stolostron/multicluster-sdk', () => ({
+  useHubClusterName: jest.fn(() => ['hub-cluster', true, undefined]),
+}));
+
+afterEach(() => {
+  (kubevirtK8sListItems as jest.Mock).mockReset();
+  (useIsACMPage as jest.Mock).mockImplementation(() => true);
+});
+
+describe('useClusterStorageMigrationApiProbe', () => {
+  it('single-cluster (non-ACM): assumes MULTI_NS without LIST probe', () => {
+    (useIsACMPage as jest.Mock).mockImplementation(() => false);
+
+    const csv = {
+      installedCSV: undefined,
+      loaded: false,
+    } as StorageMigrationProbeCsv;
+
+    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
+
+    expect(result.current).toBe(STORAGE_MIGRATION_API.MULTI_NS);
+    expect(kubevirtK8sListItems).not.toHaveBeenCalled();
+
+    (useIsACMPage as jest.Mock).mockImplementation(() => true);
+  });
+
+  it('resolves MULTI_NS without LIST when CSV is loaded and minor is 21 or above', async () => {
+    const csv = {
+      installedCSV: { spec: { version: '4.21.0' } },
+      loaded: true,
+    } as StorageMigrationProbeCsv;
+
+    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
+
+    await waitFor(() => {
+      expect(result.current).toBe(STORAGE_MIGRATION_API.MULTI_NS);
+    });
+
+    expect(kubevirtK8sListItems).not.toHaveBeenCalled();
+  });
+
+  it('resolves MULTI_NS without LIST when CSV major is above 4 even if minor is below 21', async () => {
+    const csv = {
+      installedCSV: { spec: { version: '5.1.0' } },
+      loaded: true,
+    } as StorageMigrationProbeCsv;
+
+    const { result } = renderHook(() => useClusterStorageMigrationApiProbe('my-cluster', csv));
+
+    await waitFor(() => {
+      expect(result.current).toBe(STORAGE_MIGRATION_API.MULTI_NS);
+    });
+
+    expect(kubevirtK8sListItems).not.toHaveBeenCalled();
+  });
+
+  it('runs LIST probe when CSV minor is below 21', async () => {
+    (kubevirtK8sListItems as jest.Mock).mockResolvedValue([]);
+
+    const { result } = renderHook(() =>
+      useClusterStorageMigrationApiProbe('my-cluster', csvBelow21),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe(STORAGE_MIGRATION_API.MULTI_NS);
+    });
+
+    expect(kubevirtK8sListItems).toHaveBeenCalled();
+  });
+
+  it('resolves MTC when multi-namespace API 404s and MigPlan LIST succeeds (CSV minor below 21)', async () => {
+    (kubevirtK8sListItems as jest.Mock).mockImplementation(({ model }) => {
+      if (model === MultiNamespaceVirtualMachineStorageMigrationPlanModel) {
+        return Promise.reject({ code: 404 });
+      }
+      if (model === MigPlanModel) {
+        return Promise.resolve([]);
+      }
+      return Promise.reject(new Error('unexpected LIST model in probe'));
+    });
+
+    const { result } = renderHook(() =>
+      useClusterStorageMigrationApiProbe('my-cluster', csvBelow21),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toBe(STORAGE_MIGRATION_API.MTC);
+    });
+  });
+});

--- a/src/views/virtualmachines/actions/tests/useVirtualMachineActionsProvider.test.tsx
+++ b/src/views/virtualmachines/actions/tests/useVirtualMachineActionsProvider.test.tsx
@@ -1,9 +1,8 @@
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
-import { cleanup, renderHook } from '@testing-library/react';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
+import { renderHook } from '@testing-library/react';
 
 import useVirtualMachineActionsProvider from '../hooks/useVirtualMachineActionsProvider';
-
 import { exampleRunningVirtualMachine } from './mocks';
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
@@ -19,9 +18,8 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
 jest.mock('@kubevirt-utils/hooks/useFeatures/useFeatures', () => ({
   useFeatures: jest.fn(() => ({ featureEnabled: true })),
 }));
-afterEach(cleanup);
 
-const testTopLevelActions = (actions: ActionDropdownItemType[]) => {
+const testTopLevelActions = (actions: ActionDropdownItemType[]): void => {
   const topLevelVMActions = actions.map((action) => action.id);
 
   // top level action independent from the VM state

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationNavigation.test.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationNavigation.test.ts
@@ -1,6 +1,6 @@
 import { STORAGE_MIGRATION_API } from '@kubevirt-utils/resources/migrations/constants';
 import useManagedClusterConsoleURLs from '@multicluster/hooks/useManagedClusterConsoleURLs';
-import { cleanup, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
 import useStorageMigrationNavigation from './useStorageMigrationNavigation';
 
@@ -29,7 +29,6 @@ jest.mock('@virtualmachines/actions/hooks/storageMigrationApi/constants', () => 
 const mockUseManagedClusterConsoleURLs = useManagedClusterConsoleURLs as jest.Mock;
 
 afterEach(() => {
-  cleanup();
   mockUseManagedClusterConsoleURLs.mockReset();
   mockUseManagedClusterConsoleURLs.mockReturnValue({ spokeConsoleURL: '' });
 });
@@ -38,7 +37,7 @@ describe('useStorageMigrationNavigation', () => {
   describe('when storageMigAPI is LOADING', () => {
     it('should return empty paths', () => {
       const { result } = renderHook(() =>
-        useStorageMigrationNavigation(undefined, STORAGE_MIGRATION_API.LOADING, undefined),
+        useStorageMigrationNavigation(undefined, STORAGE_MIGRATION_API.LOADING),
       );
 
       expect(result.current.basePath).toBe('');
@@ -51,7 +50,7 @@ describe('useStorageMigrationNavigation', () => {
   describe('when storageMigAPI is NONE', () => {
     it('should return empty paths', () => {
       const { result } = renderHook(() =>
-        useStorageMigrationNavigation(undefined, STORAGE_MIGRATION_API.NONE, undefined),
+        useStorageMigrationNavigation(undefined, STORAGE_MIGRATION_API.NONE),
       );
 
       expect(result.current.basePath).toBe('');
@@ -72,7 +71,7 @@ describe('useStorageMigrationNavigation', () => {
 
     it('should always use custom route even when CSV version is undefined', () => {
       const { result } = renderHook(() =>
-        useStorageMigrationNavigation(undefined, STORAGE_MIGRATION_API.MULTI_NS, undefined),
+        useStorageMigrationNavigation(undefined, STORAGE_MIGRATION_API.MULTI_NS),
       );
 
       expect(result.current.basePath).toBe('/k8s/all-namespaces/storagemigrations');
@@ -124,7 +123,7 @@ describe('useStorageMigrationNavigation', () => {
 
     it('should fall back to GVK resource URL when CSV version is undefined', () => {
       const { result } = renderHook(() =>
-        useStorageMigrationNavigation('spoke-cluster', STORAGE_MIGRATION_API.MULTI_NS, undefined),
+        useStorageMigrationNavigation('spoke-cluster', STORAGE_MIGRATION_API.MULTI_NS),
       );
 
       expect(result.current.basePath).toContain('https://spoke.example.com');

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/components/NetworkUsage.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/components/NetworkUsage.tsx
@@ -1,7 +1,7 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import xbytes from 'xbytes';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getNetworkUsagePercentage } from '@virtualmachines/list/metrics';
@@ -12,14 +12,16 @@ type NetworkUsageProps = {
 };
 
 const NetworkUsage: FC<NetworkUsageProps> = ({ vm }) => {
-  const totalTransferred = getNetworkUsagePercentage(vm);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const totalTransferred: number | undefined = getNetworkUsagePercentage(vm);
 
   if (isEmpty(totalTransferred) || !isRunning(vm)) return <>{NO_DATA_DASH}</>;
 
-  const formattedUsage = xbytes(totalTransferred || 0, {
+  const formattedUsage = xbytes(totalTransferred ?? 0, {
     fixed: 0,
     iec: true,
   });
+  // eslint-disable-next-line i18next/no-literal-string
   return <div>{formattedUsage}ps</div>;
 };
 


### PR DESCRIPTION
## 📝 Description

Adds i18next/no-literal-string, testing-library ESLint rules to the root config. replaces the commit-msg hook with a pre-push hook for commit message validation. And splits few files exceeding the 150 line limit. 


## 🔗 Links

https://redhat.atlassian.net/browse/CNV-90382






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved network interface selection with smarter auto-selection, better option handling, and clearer validation messages.
  * Added localized labels in editor and network-related UI text.

* **Bug Fixes**
  * Preserved valid empty values in several places by using safer fallback logic.
  * Adjusted commit message checks to better handle `TYPE-123:` style headers.

* **Chores**
  * Updated linting, formatting, and editor settings for a smoother development experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->