### PR TITLE
CNV-91783 Fix hot-cluster E2E workflow to support fork PRs without blocking Tide

### DIFF
--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -59,13 +59,14 @@ jobs:
       (github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'ok-to-test'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       # ROKS health check (classic/vpc)
       - name: Setup IBM Cloud CLI
-        if: inputs.infrastructure_type != 'ipi'
+        if: env.INFRASTRUCTURE_TYPE != 'ipi'
         uses: IBM/actions-ibmcloud-cli@v1
         with:
           api_key: ${{ secrets.IC_KEY }}
@@ -74,14 +75,14 @@ jobs:
           plugins: kubernetes-service
 
       - name: Install oc client (ROKS)
-        if: inputs.infrastructure_type != 'ipi'
+        if: env.INFRASTRUCTURE_TYPE != 'ipi'
         run: |
           CLUSTER_JSON="$(ibmcloud oc cluster get --cluster "${CLUSTER_NAME}" --output json)"
           export CLUSTER_JSON
           bash ./ci-scripts/install-oc-client.sh
 
       - name: Configure kubeconfig (ROKS)
-        if: inputs.infrastructure_type != 'ipi'
+        if: env.INFRASTRUCTURE_TYPE != 'ipi'
         run: |
           ibmcloud oc cluster config --cluster "${CLUSTER_NAME}" --admin
           oc cluster-info
@@ -89,7 +90,7 @@ jobs:
 
       # IPI health check
       - name: Download IPI kubeconfig
-        if: inputs.infrastructure_type == 'ipi'
+        if: env.INFRASTRUCTURE_TYPE == 'ipi'
         env:
           GH_TOKEN: ${{ github.token }}
           SETUP_RUN_ID: ${{ inputs.ipi_setup_run_id }}


### PR DESCRIPTION
## 📝 Description

1. Change `inputs.infrastructure_type` to `env.INFRASTRUCTURE_TYPE` in four step conditions -- Fixes a bug where inputs is empty on PR events, causing the ROKS steps to run instead of IPI.

2. `continue-on-error: true` on the cluster-health-check job -- Until a hot cluster is provisioned, the health check reports as neutral so it doesn't block Tide.

## 🔗 Links

Jira ticket: [CNV-91783](https://redhat.atlassian.net/browse/CNV-91783)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster health-check reliability in end-to-end testing.
  * Made the check less likely to fail the workflow by allowing non-critical errors to continue.
  * Updated cluster access setup so health validation runs more consistently across infrastructure types.
  * Added clearer verification steps for cluster connectivity and node status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->