### PR TITLE
CNV-91783 Fix hot-cluster E2E workflow to support fork PRs without blocking Tide

### DIFF
--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -52,14 +52,9 @@ env:
 jobs:
   cluster-health-check:
     name: Cluster Health Check
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository ||
-      contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
-      (github.event.action == 'labeled' && contains(github.event.pull_request.labels.*.name, 'ok-to-test'))
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## 📝 Description

Preventing hot cluster health check from being triggered (`continue-on-error` was not sufficient). 
It is not restricted to manual trigger. 

## 🔗 Links

Jira ticket: [CNV-91783](https://redhat.atlassian.net/browse/CNV-91783)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened the conditions for a scheduled health check so it runs only when manually triggered, and failures now correctly surface instead of being ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->