### PR TITLE
CNV-91852: Fix auto-teardown to pass IPI setup run ID to teardown workflow

### DIFF
--- a/.github/workflows/ibmc-cluster-teardown.yml
+++ b/.github/workflows/ibmc-cluster-teardown.yml
@@ -176,8 +176,15 @@ jobs:
           mkdir -p "${INSTALL_DIR}"
 
           if [[ -z "${SETUP_RUN_ID}" ]]; then
-            echo "::error::ipi_setup_run_id is required for IPI teardown. Provide the run ID from the setup workflow that created the cluster."
-            exit 1
+            echo "No setup run ID provided. Looking up latest successful setup run..."
+            SETUP_RUN_ID=$(gh run list --repo "${{ github.repository }}" \
+              --workflow="IBM Cloud Hot Cluster Setup" --status=success --limit=1 \
+              --json databaseId -q '.[0].databaseId' 2>/dev/null || true)
+            if [[ -z "${SETUP_RUN_ID}" ]]; then
+              echo "::error::No successful IPI setup run found and no ipi_setup_run_id provided."
+              exit 1
+            fi
+            echo "Using latest successful setup run: ${SETUP_RUN_ID}"
           fi
 
           echo "Downloading IPI install state from run ${SETUP_RUN_ID}..."


### PR DESCRIPTION
## 📝 Description

Fix auto-teardown to pass IPI setup run ID to teardown workflow

## 🔗 Links

Jira ticket: [CNV-91852](https://redhat.atlassian.net/browse/CNV-91852)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The cluster teardown workflow now automatically finds the most recent successful setup run when a setup run ID isn’t provided.
  * If no successful setup run is available, the workflow now fails with a clear error instead of stopping immediately.
  * Teardown continues to download the required install state artifact as before once a valid run is identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->