### PR TITLE
CNV-91458 Remove kubeconfig from IPI setup workflow artifacts

### DIFF
--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -29,7 +29,7 @@ on:
           - vpc
           - classic
       ipi_setup_run_id:
-        description: Setup workflow run ID (required for IPI to download kubeconfig)
+        description: Setup workflow run ID (required for IPI to download install state)
         required: false
         default: ''
         type: string

--- a/.github/workflows/ibmc-cluster-setup.yml
+++ b/.github/workflows/ibmc-cluster-setup.yml
@@ -463,7 +463,6 @@ jobs:
           name: ipi-install-state-${{ github.run_id }}
           path: |
             ${{ runner.temp }}/ipi-install/metadata.json
-            ${{ runner.temp }}/ipi-install/auth/kubeconfig
             ${{ runner.temp }}/ipi-install/.openshift_install.log
           retention-days: 7
           if-no-files-found: ignore

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -33,11 +33,11 @@ hot-cluster-e2e-run.yml → "Hot Cluster E2E Run"
 
 ## Infrastructure Types
 
-| Type | Description | IAM needed | Cluster management |
-|------|------------|------------|-------------------|
-| **classic** | IBM-managed ROKS on classic infrastructure | K8s Admin + Classic Super User | IBM manages control plane |
-| **vpc** | IBM-managed ROKS on VPC Gen2 | K8s Admin + VPC Admin + COS auth | IBM manages control plane |
-| **ipi** | Self-managed OpenShift via `openshift-install` | VPC Admin + COS Manager + DNS + IAM Identity | You manage everything |
+| Type        | Description                                    | IAM needed                                   | Cluster management        |
+| ----------- | ---------------------------------------------- | -------------------------------------------- | ------------------------- |
+| **classic** | IBM-managed ROKS on classic infrastructure     | K8s Admin + Classic Super User               | IBM manages control plane |
+| **vpc**     | IBM-managed ROKS on VPC Gen2                   | K8s Admin + VPC Admin + COS auth             | IBM manages control plane |
+| **ipi**     | Self-managed OpenShift via `openshift-install` | VPC Admin + COS Manager + DNS + IAM Identity | You manage everything     |
 
 ### VPC ROKS (recommended)
 
@@ -68,22 +68,22 @@ Uses `openshift-install` to create a fully self-managed OpenShift cluster on IBM
 
 ### IBM Cloud
 
-| Secret | Description | Required for |
-|--------|-------------|-------------|
-| `IC_KEY` | IBM Cloud IAM API key | All paths |
-| `OPENSHIFT_PULL_SECRET` | Red Hat pull secret (from console.redhat.com) | IPI only |
+| Secret                  | Description                                   | Required for |
+| ----------------------- | --------------------------------------------- | ------------ |
+| `IC_KEY`                | IBM Cloud IAM API key                         | All paths    |
+| `OPENSHIFT_PULL_SECRET` | Red Hat pull secret (from console.redhat.com) | IPI only     |
 
 ### ARC Authentication (choose one)
 
-| Secret | Description |
-|--------|-------------|
-| `ARC_GITHUB_APP_ID` + `ARC_GITHUB_APP_INSTALL_ID` + `ARC_GITHUB_APP_PRIVATE_KEY` | GitHub App (recommended) |
-| `ARC_GITHUB_PAT` | Fine-grained PAT (simpler, less secure) |
+| Secret                                                                           | Description                             |
+| -------------------------------------------------------------------------------- | --------------------------------------- |
+| `ARC_GITHUB_APP_ID` + `ARC_GITHUB_APP_INSTALL_ID` + `ARC_GITHUB_APP_PRIVATE_KEY` | GitHub App (recommended)                |
+| `ARC_GITHUB_PAT`                                                                 | Fine-grained PAT (simpler, less secure) |
 
 ### Optional
 
-| Secret | Description |
-|--------|-------------|
+| Secret    | Description                                        |
+| --------- | -------------------------------------------------- |
 | `BOT_PAT` | PAT with repo admin scope for ghost runner cleanup |
 
 ## Setting Up the Hot Cluster
@@ -109,20 +109,26 @@ All paths converge after cluster creation: the workflow installs HCO, builds the
 
 **Automatic:** The auto-teardown workflow runs every 30 minutes and tears down the cluster after 2 hours of CI inactivity. It detects both ROKS clusters (via `ibmcloud oc`) and IPI clusters (via DNS probe).
 
-For IPI teardown, provide the `ipi_setup_run_id` (the GitHub Actions run ID from the setup workflow) so the teardown can download the install state artifacts needed by `openshift-install destroy cluster`.
+For IPI teardown, the workflow auto-discovers the latest successful setup run to download the install state (`metadata.json`) needed by `openshift-install destroy cluster`. You can also provide `ipi_setup_run_id` manually to target a specific setup run.
+
+## Security
+
+- The kubeconfig is **not** uploaded as a workflow artifact (the repo is public and artifacts are downloadable by anyone).
+- CI runners (ARC) access the cluster via their in-cluster service account.
+- Manual cluster access: use the `ibmcloud` CLI with the `IC_KEY` API key, or use the kubeadmin credentials sent to Slack on cluster creation (see CNV-91497).
 
 ## Scripts
 
-| Script | Purpose |
-|--------|---------|
-| `install-hco.sh` | Installs HCO operator, HPP storage, and virtctl |
-| `check-cluster-health.sh` | Verifies cluster, HCO, ARC, storage, console |
-| `check-roks-cluster-state.sh` | Polls until ROKS cluster is ready |
-| `log-ibmcloud-iam-diagnostics.sh` | Logs IAM permissions for debugging (classic, VPC, and IPI) |
-| `arc/install-arc-controller.sh` | Installs ARC controller (once per cluster) |
-| `arc/install-runner-scale-set.sh` | Installs ARC runner scale set |
-| `arc/setup-dind-mirror.sh` | Mirrors `docker:dind` to internal registry |
-| `ci-env/install-ci-env-controller.sh` | Installs the ConfigMap-driven CI environment controller |
+| Script                                | Purpose                                                    |
+| ------------------------------------- | ---------------------------------------------------------- |
+| `install-hco.sh`                      | Installs HCO operator, HPP storage, and virtctl            |
+| `check-cluster-health.sh`             | Verifies cluster, HCO, ARC, storage, console               |
+| `check-roks-cluster-state.sh`         | Polls until ROKS cluster is ready                          |
+| `log-ibmcloud-iam-diagnostics.sh`     | Logs IAM permissions for debugging (classic, VPC, and IPI) |
+| `arc/install-arc-controller.sh`       | Installs ARC controller (once per cluster)                 |
+| `arc/install-runner-scale-set.sh`     | Installs ARC runner scale set                              |
+| `arc/setup-dind-mirror.sh`            | Mirrors `docker:dind` to internal registry                 |
+| `ci-env/install-ci-env-controller.sh` | Installs the ConfigMap-driven CI environment controller    |
 
 See [`arc/README.md`](arc/README.md) for ARC-specific details and [`ci-env/README.md`](ci-env/README.md) for the ci-env-controller.
 


### PR DESCRIPTION
## 📝 Description

Remove `kubeconfig` from IPI setup workflow artifacts

## 🔗 Links

Jira ticket: [CNV-91458](https://redhat.atlassian.net/browse/CNV-91458)



## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI setup instructions and reorganized the setup guide for easier reading.
  * Clarified which credentials are required, optional, or alternatives.
  * Improved teardown guidance to better explain automatic run discovery and manual override options.

* **Bug Fixes**
  * Adjusted CI artifact handling so uploaded install artifacts no longer include an unnecessary kubeconfig file.
  * Clarified workflow input guidance for downloading the correct install-state artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->