### PR TITLE
CNV-91888: Fix cosmiconfig peer dependency for hermetic offline builds

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -99,3 +99,34 @@ jobs:
       - name: Run workflow script tests
         working-directory: .github/scripts
         run: npm test
+
+  offline-install:
+    name: offline-install
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Populate npm cache
+        run: npm ci --ignore-scripts
+
+      - name: Verify offline install
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          rm -rf node_modules
+          HUSKY=0 npm ci --offline --ignore-scripts --no-audit
+
+          if npm ls cosmiconfig 2>&1 | grep -q "UNMET PEER DEPENDENCY"; then
+            echo "ERROR: cosmiconfig has an unresolved peer dependency."
+            echo "Add an explicit devDependency or override so the lockfile pins a compatible version."
+            npm ls cosmiconfig
+            exit 1
+          fi

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: npm
       - run: npm ci --ignore-scripts
 
       - name: Check i18n
@@ -44,7 +45,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
-      - run: npm ci --ignore-scripts
+          cache: npm
+
+      - name: Populate npm cache
+        run: npm ci --ignore-scripts
+
+      - name: Verify offline install
+        run: |
+          rm -rf node_modules
+          HUSKY=0 npm ci --offline --ignore-scripts --no-audit
 
       - name: Lint
         run: npm run lint:fix
@@ -66,6 +75,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: npm
       - run: npm ci --ignore-scripts
 
       - name: Run Unit Tests
@@ -87,6 +97,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: npm
+          cache-dependency-path: .github/scripts/package-lock.json
 
       - name: Install script dependencies
         working-directory: .github/scripts
@@ -99,34 +111,3 @@ jobs:
       - name: Run workflow script tests
         working-directory: .github/scripts
         run: npm test
-
-  offline-install:
-    name: offline-install
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: npm
-
-      - name: Populate npm cache
-        run: npm ci --ignore-scripts
-
-      - name: Verify offline install
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          rm -rf node_modules
-          HUSKY=0 npm ci --offline --ignore-scripts --no-audit
-
-          if npm ls cosmiconfig 2>&1 | grep -q "UNMET PEER DEPENDENCY"; then
-            echo "ERROR: cosmiconfig has an unresolved peer dependency."
-            echo "Add an explicit devDependency or override so the lockfile pins a compatible version."
-            npm ls cosmiconfig
-            exit 1
-          fi

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -46,14 +46,7 @@ jobs:
         with:
           node-version: '22'
           cache: npm
-
-      - name: Populate npm cache
-        run: npm ci --ignore-scripts
-
-      - name: Verify offline install
-        run: |
-          rm -rf node_modules
-          HUSKY=0 npm ci --offline --ignore-scripts --no-audit
+      - run: npm ci --ignore-scripts
 
       - name: Lint
         run: npm run lint:fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "@types/react": "^18.3.28",
         "@types/react-dom": "^18.3.7",
         "copy-webpack-plugin": "^12.0.2",
+        "cosmiconfig": "^9.0.2",
         "css-loader": "^6.11.0",
         "esbuild": "^0.28.0",
         "esbuild-loader": "^4.4.3",
@@ -998,33 +999,6 @@
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/@commitlint/load/node_modules/cosmiconfig": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
-      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@commitlint/message": {
@@ -4792,9 +4766,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4809,9 +4780,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4826,9 +4794,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4843,9 +4808,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9328,16 +9290,16 @@
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
+        "parse-json": "^5.2.0"
       },
       "engines": {
         "node": ">=14"
@@ -11514,9 +11476,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11534,9 +11493,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11554,9 +11510,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11574,9 +11527,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13170,6 +13120,33 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/fs-extra": {
       "version": "10.1.0",
@@ -24249,33 +24226,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/stylelint/node_modules/cosmiconfig": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
-      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/react": "^18.3.28",
     "@types/react-dom": "^18.3.7",
     "copy-webpack-plugin": "^12.0.2",
+    "cosmiconfig": "^9.0.2",
     "css-loader": "^6.11.0",
     "esbuild": "^0.28.0",
     "esbuild-loader": "^4.4.3",


### PR DESCRIPTION
## Summary

- Add `cosmiconfig@^9.0.2` as an explicit devDependency so `cosmiconfig-typescript-loader`'s peer dependency is satisfied in `package-lock.json`
- Hoist `cosmiconfig@9` at the root; `fork-ts-checker-webpack-plugin` keeps its nested `cosmiconfig@8.3.6`
- Add an `offline-install` CI job that populates the npm cache, removes `node_modules`, and verifies `npm ci --offline` succeeds

## Problem

`cosmiconfig-typescript-loader@6.3.0` (via `@commitlint/cli`) requires `cosmiconfig >= 9`, but the lockfile hoisted `cosmiconfig@8.3.6` from `fork-ts-checker-webpack-plugin`. Hermetic prefetch tools (cachi2/hermeto) do not cache unresolved peers, so Konflux offline builds fail when `npm ci --offline` tries to fetch `cosmiconfig` from the registry.

## Links

- Jira: https://redhat.atlassian.net/browse/CNV-91888

## Test plan

- [x] `npm ci --ignore-scripts && rm -rf node_modules && npm ci --offline --ignore-scripts` passes locally
- [x] `npm run check-types` passes
- [x] `npm ls cosmiconfig` shows v9 at root and v8 nested under `fork-ts-checker-webpack-plugin`
- [ ] CI `offline-install` job passes on this PR