### PR TITLE
CNV-91888: Add Konflux hermetic build CI check

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -37,9 +37,22 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Detect package-lock.json changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            package-lock:
+              - package-lock.json
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -56,6 +69,28 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Prefetch npm dependencies with Hermeto
+        if: steps.filter.outputs.package-lock == 'true'
+        run: |
+          git checkout -- package.json package-lock.json
+          rm -rf node_modules hermeto-output
+          HERMETO_OUTPUT="${{ github.workspace }}/hermeto-output"
+          docker run --rm \
+            -v "${{ github.workspace }}:${{ github.workspace }}" \
+            -w "${{ github.workspace }}" \
+            ghcr.io/hermetoproject/hermeto:latest \
+            fetch-deps --source "${{ github.workspace }}" --output "$HERMETO_OUTPUT" npm
+          docker run --rm \
+            -v "${{ github.workspace }}:${{ github.workspace }}" \
+            -w "${{ github.workspace }}" \
+            ghcr.io/hermetoproject/hermeto:latest \
+            inject-files "$HERMETO_OUTPUT" --for-output-dir "$HERMETO_OUTPUT"
+
+      - name: Verify offline install
+        if: steps.filter.outputs.package-lock == 'true'
+        run: |
+          HUSKY=0 npm ci --offline --ignore-scripts --no-audit
 
   unit-test:
     name: unit-test


### PR DESCRIPTION
## Summary

Adds a `hermetic-build` CI job that simulates Konflux offline installs:

1. Prefetch npm dependencies with [Hermeto](https://hermetoproject.github.io/hermeto/npm/) (`fetch-deps` + `inject-files`)
2. Run `npm ci --offline --ignore-scripts` with no npm registry access

This mirrors the cachi2/hermeto prefetch flow used in Konflux container builds.

## Expected behavior

This PR is **expected to fail on `main`** because `package-lock.json` hoists `cosmiconfig@8.3.6` while `cosmiconfig-typescript-loader` requires `cosmiconfig >= 9`. Unresolved peer dependencies are not prefetched by Hermeto, causing offline `npm ci` to fail.

## Fix

Merge https://github.com/kubevirt-ui/kubevirt-plugin/pull/4167 first — it pins `cosmiconfig@^9.0.2` as a devDependency so the lockfile satisfies the peer and hermetic installs succeed.

- Jira: https://redhat.atlassian.net/browse/CNV-91888

## Test plan

- [ ] CI `hermetic-build` job fails on this PR (demonstrates the problem on main)
- [ ] Rebase on #4167 or merge #4167 first, then re-run — `hermetic-build` should pass

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI build checks to more reliably validate dependency installs when the lockfile changes.
  * Added an offline installation verification step using pre-fetched dependencies to detect environment or caching issues earlier.
  * Tightened workflow permissions and disabled persistent checkout credentials to improve security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->