### PR TITLE
CNV-91853 Fix ARC runner image missing kubectl when built with console OC_URL

### DIFF
--- a/ci-scripts/images/arc-runner/Dockerfile
+++ b/ci-scripts/images/arc-runner/Dockerfile
@@ -85,7 +85,8 @@ RUN if [ -n "${OC_URL}" ]; then \
     else \
       wget2 -qO- "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-${OC_VERSION}/openshift-client-linux.tar.gz" \
            | tar -xzf - -C /usr/local/bin; \
-    fi
+    fi \
+    && [ -f /usr/local/bin/kubectl ] || ln -s oc /usr/local/bin/kubectl
 
 # virtctl (KubeVirt CLI) — use console download URL if resolved, else GitHub releases.
 # Console route serves a .tar.gz; fallback uses wget2 (GnuTLS) for the external HTTPS download.


### PR DESCRIPTION
## 📝 Description

When the setup workflow resolves `OC_URL` from the cluster's `ConsoleCLIDownload` route, the runner image ends up without `kubectl`. The E2E "Check Runner Image" step then fails with "Required tools are missing on the ARC runner".

This fix ensures that whenever the runner image is built with `OC_URL`, `kubectl` is created as a symlink to `oc`. 

## 🔗 Links

Jira ticket: [CNV-91853](https://redhat.atlassian.net/browse/CNV-91853)

## 🎥 Demo

N/A