### PR TITLE
CNV-91940 resolve-console-image.sh overrides CONSOLE_IMAGE default in start-console.sh

### DIFF
--- a/ci-scripts/resolve-console-image.sh
+++ b/ci-scripts/resolve-console-image.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 CONSOLE_IMAGE_REGISTRY="${CONSOLE_IMAGE_REGISTRY:-quay.io/openshift/origin-console}"
+CONSOLE_IMAGE_DEFAULT_TAG="${CONSOLE_IMAGE_DEFAULT_TAG:-latest}"
 
 if [[ -n "${CONSOLE_IMAGE:-}" ]]; then
   echo "CONSOLE_IMAGE already set (${CONSOLE_IMAGE}); skipping cluster version lookup." >&2
@@ -11,16 +12,36 @@ if [[ -n "${CONSOLE_IMAGE:-}" ]]; then
   exit 0
 fi
 
+CONSOLE_IMAGE_SKIP_DETECTION="${CONSOLE_IMAGE_SKIP_DETECTION:-false}"
+if [[ "${CONSOLE_IMAGE_SKIP_DETECTION}" == "true" ]]; then
+  CONSOLE_IMAGE="${CONSOLE_IMAGE_REGISTRY}:${CONSOLE_IMAGE_DEFAULT_TAG}"
+  echo "Auto-detection disabled; using ${CONSOLE_IMAGE}" >&2
+  echo "CONSOLE_IMAGE=${CONSOLE_IMAGE}"
+  exit 0
+fi
+
 VERSION="$(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null || true)"
 if [[ -z "${VERSION}" ]]; then
-  echo "::error::Could not read .status.desired.version from ClusterVersion 'version'. Is this an OpenShift cluster and is oc authenticated?" >&2
-  exit 1
+  if [[ -n "${CI:-}" ]]; then
+    echo "::error::Could not read .status.desired.version from ClusterVersion 'version'. Is this an OpenShift cluster and is oc authenticated?" >&2
+    exit 1
+  fi
+  CONSOLE_IMAGE="${CONSOLE_IMAGE_REGISTRY}:${CONSOLE_IMAGE_DEFAULT_TAG}"
+  echo "Could not detect cluster version; falling back to ${CONSOLE_IMAGE}" >&2
+  echo "CONSOLE_IMAGE=${CONSOLE_IMAGE}"
+  exit 0
 fi
 
 IFS='.' read -r major minor _rest <<< "${VERSION}"
 if [[ -z "${major:-}" || -z "${minor:-}" ]]; then
-  echo "::error::Could not parse OpenShift version '${VERSION}' as major.minor.*" >&2
-  exit 1
+  if [[ -n "${CI:-}" ]]; then
+    echo "::error::Could not parse OpenShift version '${VERSION}' as major.minor.*" >&2
+    exit 1
+  fi
+  CONSOLE_IMAGE="${CONSOLE_IMAGE_REGISTRY}:${CONSOLE_IMAGE_DEFAULT_TAG}"
+  echo "Could not parse cluster version '${VERSION}'; falling back to ${CONSOLE_IMAGE}" >&2
+  echo "CONSOLE_IMAGE=${CONSOLE_IMAGE}"
+  exit 0
 fi
 
 OCP_XY="${major}.${minor}"

--- a/start-console.sh
+++ b/start-console.sh
@@ -97,7 +97,6 @@ for arg in "$@"; do
 done
 
 eval "$(bash ./ci-scripts/resolve-console-image.sh)" || true
-CONSOLE_IMAGE="${CONSOLE_IMAGE:-quay.io/openshift/origin-console:latest}"
 CONSOLE_PORT=${CONSOLE_PORT:-9000}
 
 echo "Starting local OpenShift console..."


### PR DESCRIPTION
## 📝 Description

`resolve-console-image.sh` was added in PR #4099 ([CNV-74265](https://redhat.atlassian.net/browse/CNV-74265)) for CI hot-cluster E2E. It auto-detects the cluster's OpenShift version and sets `CONSOLE_IMAGE` accordingly. When wired into start-console.sh, it made the existing fallback line unreachable.

In order for the `CONSOLE_IMAGE` version to be overridden `CONSOLE_IMAGE_SKIP_DETECTION` needs to be set to `false`.

## 🔗 Links

Jira ticket: [CNV-91940](https://redhat.atlassian.net/browse/CNV-91940)

## 🎥 Demo


https://github.com/user-attachments/assets/b3b5b27f-0eca-4b67-a3b3-3ea974dea56c

