### PR TITLE
CNV-92017 Upload file via bootable volume triggers React error #185 (infinite loop) on Console 4.22

### DIFF
--- a/src/utils/hooks/useKubevirtToast.ts
+++ b/src/utils/hooks/useKubevirtToast.ts
@@ -24,7 +24,7 @@ type UseKubevirtToastResult = ToastActions & {
   addToast: AddToast;
 };
 
-const noopAddToast = () => '';
+const noopAddToast = () => 'noop';
 const noopRemoveToast = () => undefined;
 const noopResult = { addToast: noopAddToast, removeToast: noopRemoveToast };
 

--- a/src/utils/hooks/useUploadProgressToast/UploadProgressToastListener.tsx
+++ b/src/utils/hooks/useUploadProgressToast/UploadProgressToastListener.tsx
@@ -20,28 +20,34 @@ const UploadProgressToastListener: FC = () => {
   const trySetToastId = useUploadProgressStore((state) => state.trySetToastId);
   const removeUpload = useUploadProgressStore((state) => state.removeUpload);
   const prevUploadsRef = useRef(useUploadProgressStore.getState().uploads);
+  const processedToastsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     cleanupRemovedUploads({
       addWarningToast,
       currentUploads: uploads,
       previousUploads: prevUploadsRef.current,
+      processedToasts: processedToastsRef.current,
       removeToast,
       t,
     });
 
-    syncUploadToasts(uploads, {
-      addDangerToast,
-      addInfoToast,
-      addSuccessToast,
-      addWarningToast,
-      navigate,
-      removeToast,
-      removeUpload,
-      t,
-      tryMarkTerminalToastShown,
-      trySetToastId,
-    });
+    syncUploadToasts(
+      uploads,
+      {
+        addDangerToast,
+        addInfoToast,
+        addSuccessToast,
+        addWarningToast,
+        navigate,
+        removeToast,
+        removeUpload,
+        t,
+        tryMarkTerminalToastShown,
+        trySetToastId,
+      },
+      processedToastsRef.current,
+    );
 
     prevUploadsRef.current = uploads;
   }, [

--- a/src/utils/hooks/useUploadProgressToast/toast/cleanupRemovedUploads.ts
+++ b/src/utils/hooks/useUploadProgressToast/toast/cleanupRemovedUploads.ts
@@ -10,6 +10,7 @@ type CleanupRemovedUploadsParams = {
   addWarningToast: ToastActions['addWarningToast'];
   currentUploads: Record<string, UploadEntry>;
   previousUploads: Record<string, UploadEntry>;
+  processedToasts: Set<string>;
   removeToast: ToastActions['removeToast'];
   t: TFunction;
 };
@@ -18,6 +19,7 @@ export const cleanupRemovedUploads = ({
   addWarningToast,
   currentUploads,
   previousUploads,
+  processedToasts,
   removeToast,
   t,
 }: CleanupRemovedUploadsParams): void => {
@@ -25,6 +27,7 @@ export const cleanupRemovedUploads = ({
 
   Object.entries(previousUploads).forEach(([uploadKey, upload]) => {
     if (!currentUploads[uploadKey]) {
+      processedToasts.delete(uploadKey);
       if (upload.toastId) {
         removeToast(upload.toastId);
       }

--- a/src/utils/hooks/useUploadProgressToast/uploadProgressStore.ts
+++ b/src/utils/hooks/useUploadProgressToast/uploadProgressStore.ts
@@ -97,13 +97,14 @@ export const useUploadProgressStore = create<UploadProgressStoreState>((set, get
     }
 
     set((state) => {
-      if (!state.uploads[uploadKey]) {
+      const entry = state.uploads[uploadKey];
+      if (!entry || entry.terminalToastShown) {
         return state;
       }
       return {
         uploads: {
           ...state.uploads,
-          [uploadKey]: { ...state.uploads[uploadKey], terminalToastShown: true },
+          [uploadKey]: { ...entry, terminalToastShown: true },
         },
       };
     });
@@ -116,13 +117,14 @@ export const useUploadProgressStore = create<UploadProgressStoreState>((set, get
     }
 
     set((state) => {
-      if (!state.uploads[uploadKey]) {
+      const entry = state.uploads[uploadKey];
+      if (!entry || entry.toastId) {
         return state;
       }
       return {
         uploads: {
           ...state.uploads,
-          [uploadKey]: { ...state.uploads[uploadKey], toastId },
+          [uploadKey]: { ...entry, toastId },
         },
       };
     });

--- a/src/utils/hooks/useUploadProgressToast/uploadToastSync.test.tsx
+++ b/src/utils/hooks/useUploadProgressToast/uploadToastSync.test.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import { TFunction } from 'i18next';
+
+import { UPLOAD_PROGRESS_STATUS } from './constants';
+import { UploadEntry } from './types';
+import {
+  replaceWithTerminalUploadToast,
+  showInProgressUploadToast,
+  syncUploadToasts,
+} from './uploadToastSync';
+
+jest.mock('./components/UploadProgressToastContent', () => () => <div>toast-content</div>);
+jest.mock('./toast/uploadTitles', () => ({
+  getUploadTitle: (_upload: UploadEntry, t: (s: string) => string) => t('Uploading'),
+  isTerminalUploadStatus: jest.fn(
+    (status) => status === 'success' || status === 'error' || status === 'canceled',
+  ),
+}));
+
+const UPLOAD_KEY = 'test-upload-key';
+const TOAST_ID = 'toast-123';
+
+const createMockContext = () => ({
+  addDangerToast: jest.fn(() => 'danger-toast-id'),
+  addInfoToast: jest.fn(() => TOAST_ID),
+  addSuccessToast: jest.fn(() => 'success-toast-id'),
+  addWarningToast: jest.fn(() => 'warning-toast-id'),
+  navigate: jest.fn(),
+  removeToast: jest.fn(),
+  removeUpload: jest.fn(),
+  t: ((key: string) => key) as unknown as TFunction,
+  tryMarkTerminalToastShown: jest.fn(() => true),
+  trySetToastId: jest.fn(() => true),
+});
+
+const createUploadEntry = (overrides: Partial<UploadEntry> = {}): UploadEntry => ({
+  fileName: 'image.iso',
+  progress: 50,
+  status: UPLOAD_PROGRESS_STATUS.UPLOADING,
+  ...overrides,
+});
+
+describe('showInProgressUploadToast', () => {
+  it('should skip if upload already has a toastId', () => {
+    const context = createMockContext();
+    const processedToasts = new Set<string>();
+    const upload = createUploadEntry({ toastId: 'existing-toast' });
+
+    showInProgressUploadToast(UPLOAD_KEY, upload, context, processedToasts);
+
+    expect(context.addInfoToast).not.toHaveBeenCalled();
+    expect(processedToasts.has(UPLOAD_KEY)).toBe(false);
+  });
+
+  it('should skip if uploadKey is already in processedToasts', () => {
+    const context = createMockContext();
+    const processedToasts = new Set<string>([UPLOAD_KEY]);
+    const upload = createUploadEntry();
+
+    showInProgressUploadToast(UPLOAD_KEY, upload, context, processedToasts);
+
+    expect(context.addInfoToast).not.toHaveBeenCalled();
+  });
+
+  it('should create toast and set toastId on success', () => {
+    const context = createMockContext();
+    const processedToasts = new Set<string>();
+    const upload = createUploadEntry();
+
+    showInProgressUploadToast(UPLOAD_KEY, upload, context, processedToasts);
+
+    expect(processedToasts.has(UPLOAD_KEY)).toBe(true);
+    expect(context.addInfoToast).toHaveBeenCalledTimes(1);
+    expect(context.trySetToastId).toHaveBeenCalledWith(UPLOAD_KEY, TOAST_ID);
+  });
+
+  it('should remove toast and processedToasts entry if trySetToastId fails', () => {
+    const context = createMockContext();
+    context.trySetToastId.mockReturnValue(false);
+    const processedToasts = new Set<string>();
+    const upload = createUploadEntry();
+
+    showInProgressUploadToast(UPLOAD_KEY, upload, context, processedToasts);
+
+    expect(context.removeToast).toHaveBeenCalledWith(TOAST_ID);
+    expect(processedToasts.has(UPLOAD_KEY)).toBe(false);
+  });
+});
+
+describe('replaceWithTerminalUploadToast', () => {
+  it('should skip non-terminal upload statuses', () => {
+    const context = createMockContext();
+    const upload = createUploadEntry({ status: UPLOAD_PROGRESS_STATUS.UPLOADING });
+
+    replaceWithTerminalUploadToast(UPLOAD_KEY, upload, context);
+
+    expect(context.addSuccessToast).not.toHaveBeenCalled();
+    expect(context.addDangerToast).not.toHaveBeenCalled();
+    expect(context.addWarningToast).not.toHaveBeenCalled();
+  });
+
+  it('should skip if terminalToastShown is already true', () => {
+    const context = createMockContext();
+    const upload = createUploadEntry({
+      status: UPLOAD_PROGRESS_STATUS.SUCCESS,
+      terminalToastShown: true,
+    });
+
+    replaceWithTerminalUploadToast(UPLOAD_KEY, upload, context);
+
+    expect(context.tryMarkTerminalToastShown).not.toHaveBeenCalled();
+    expect(context.addSuccessToast).not.toHaveBeenCalled();
+  });
+
+  it('should skip if tryMarkTerminalToastShown returns false', () => {
+    const context = createMockContext();
+    context.tryMarkTerminalToastShown.mockReturnValue(false);
+    const upload = createUploadEntry({ status: UPLOAD_PROGRESS_STATUS.SUCCESS });
+
+    replaceWithTerminalUploadToast(UPLOAD_KEY, upload, context);
+
+    expect(context.addSuccessToast).not.toHaveBeenCalled();
+  });
+
+  it('should remove existing toast and show success toast', () => {
+    const context = createMockContext();
+    const upload = createUploadEntry({
+      status: UPLOAD_PROGRESS_STATUS.SUCCESS,
+      toastId: 'old-toast',
+    });
+
+    replaceWithTerminalUploadToast(UPLOAD_KEY, upload, context);
+
+    expect(context.removeToast).toHaveBeenCalledWith('old-toast');
+    expect(context.addSuccessToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show danger toast for error status', () => {
+    const context = createMockContext();
+    const upload = createUploadEntry({ status: UPLOAD_PROGRESS_STATUS.ERROR });
+
+    replaceWithTerminalUploadToast(UPLOAD_KEY, upload, context);
+
+    expect(context.addDangerToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show warning toast for canceled status', () => {
+    const context = createMockContext();
+    const upload = createUploadEntry({ status: UPLOAD_PROGRESS_STATUS.CANCELED });
+
+    replaceWithTerminalUploadToast(UPLOAD_KEY, upload, context);
+
+    expect(context.addWarningToast).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('syncUploadToasts', () => {
+  it('should call showInProgressUploadToast for uploading entries', () => {
+    const context = createMockContext();
+    const processedToasts = new Set<string>();
+    const uploads = { [UPLOAD_KEY]: createUploadEntry() };
+
+    syncUploadToasts(uploads, context, processedToasts);
+
+    expect(context.addInfoToast).toHaveBeenCalledTimes(1);
+    expect(processedToasts.has(UPLOAD_KEY)).toBe(true);
+  });
+
+  it('should call replaceWithTerminalUploadToast for terminal entries', () => {
+    const context = createMockContext();
+    const processedToasts = new Set<string>();
+    const uploads = {
+      [UPLOAD_KEY]: createUploadEntry({ status: UPLOAD_PROGRESS_STATUS.SUCCESS }),
+    };
+
+    syncUploadToasts(uploads, context, processedToasts);
+
+    expect(context.addSuccessToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('should remove terminal upload keys from processedToasts', () => {
+    const context = createMockContext();
+    const processedToasts = new Set<string>([UPLOAD_KEY]);
+    const uploads = {
+      [UPLOAD_KEY]: createUploadEntry({ status: UPLOAD_PROGRESS_STATUS.SUCCESS }),
+    };
+
+    syncUploadToasts(uploads, context, processedToasts);
+
+    expect(processedToasts.has(UPLOAD_KEY)).toBe(false);
+  });
+
+  it('should not re-process uploads already in processedToasts', () => {
+    const context = createMockContext();
+    const processedToasts = new Set<string>([UPLOAD_KEY]);
+    const uploads = { [UPLOAD_KEY]: createUploadEntry() };
+
+    syncUploadToasts(uploads, context, processedToasts);
+
+    expect(context.addInfoToast).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/hooks/useUploadProgressToast/uploadToastSync.tsx
+++ b/src/utils/hooks/useUploadProgressToast/uploadToastSync.tsx
@@ -27,10 +27,13 @@ export const showInProgressUploadToast = (
   uploadKey: string,
   upload: UploadEntry,
   context: UploadToastContext,
+  processedToasts: Set<string>,
 ): void => {
-  if (upload.toastId) {
+  if (upload.toastId || processedToasts.has(uploadKey)) {
     return;
   }
+
+  processedToasts.add(uploadKey);
 
   const toastId = context.addInfoToast({
     content: <UploadProgressToastContent navigate={context.navigate} uploadKey={uploadKey} />,
@@ -41,6 +44,7 @@ export const showInProgressUploadToast = (
 
   if (!context.trySetToastId(uploadKey, toastId)) {
     context.removeToast(toastId);
+    processedToasts.delete(uploadKey);
   }
 };
 
@@ -81,13 +85,15 @@ export const replaceWithTerminalUploadToast = (
 export const syncUploadToasts = (
   uploads: Record<string, UploadEntry>,
   context: UploadToastContext,
+  processedToasts: Set<string>,
 ): void => {
   Object.entries(uploads).forEach(([uploadKey, upload]) => {
     if (upload.status === UPLOAD_PROGRESS_STATUS.UPLOADING) {
-      showInProgressUploadToast(uploadKey, upload, context);
+      showInProgressUploadToast(uploadKey, upload, context, processedToasts);
       return;
     }
 
+    processedToasts.delete(uploadKey);
     replaceWithTerminalUploadToast(uploadKey, upload, context);
   });
 };


### PR DESCRIPTION
## 📝 Description

Fixes a React error that crashes the app when `useToast` is not available from `console`.
This should not be an issue when `useToast` is available however `noopResult` should be a reliable backup option and should not crash the app. 

## 🔗 Links

Jira ticket: [CNV-92017](https://redhat.atlassian.net/browse/CNV-92017)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/e325313c-fe1d-4768-b3fe-976bbfcfed79


After (note that the toast notification is not shown as expected due to a mismatch on console version): 

https://github.com/user-attachments/assets/b568361d-0f36-4b1a-8c3c-d549685e8acc

