### PR TITLE
[release-4.11] Add galkremer1 and adamviktora as approvers in OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,6 +7,8 @@ approvers:
   - vojtechszocs
   - glekner
   - pcbailey
+  - adamviktora
+  - galkremer1
 reviewers:
   - tnisan
   - yaacov
@@ -17,3 +19,4 @@ reviewers:
   - vojtechszocs
   - hstastna
   - upalatucci
+  - adamviktora


### PR DESCRIPTION
## 📝 Description

Add `galkremer1` and `adamviktora` as approvers in the OWNERS file for the `release-4.11` branch.

Also adds `adamviktora` to reviewers, matching the `release-4.19` OWNERS configuration.

## 🎥 Demo

N/A — OWNERS file change only.

Made with [Cursor](https://cursor.com)