### PR TITLE
[release-4.13] Add galkremer1 and adamviktora as approvers in OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,8 @@ approvers:
   - avivtur
   - hstastna
   - upalatucci
+  - adamviktora
+  - galkremer1
 reviewers:
   - tnisan
   - yaacov
@@ -19,3 +21,4 @@ reviewers:
   - vojtechszocs
   - hstastna
   - upalatucci
+  - adamviktora


### PR DESCRIPTION
## 📝 Description

Add `galkremer1` and `adamviktora` as approvers in the OWNERS file for the `release-4.13` branch.

Also adds `adamviktora` to reviewers, matching the `release-4.19` OWNERS configuration.

## 🎥 Demo

N/A — OWNERS file change only.

Made with [Cursor](https://cursor.com)