### PR TITLE
[release-4.18] Add galkremer1 and adamviktora as approvers in OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,9 +7,12 @@ approvers:
   - metalice
   - avivtur
   - upalatucci
+  - adamviktora
+  - galkremer1
 reviewers:
   - metalice
   - pcbailey
   - avivtur
   - vojtechszocs
   - upalatucci
+  - adamviktora


### PR DESCRIPTION
## 📝 Description

Add `galkremer1` and `adamviktora` as approvers in the OWNERS file for the `release-4.18` branch.

Also adds `adamviktora` to reviewers, matching the `release-4.19` OWNERS configuration.

## 🎥 Demo

N/A — OWNERS file change only.

Made with [Cursor](https://cursor.com)