### PR TITLE
CNV-92125: Prevent auto-teardown during cluster setup

### DIFF
--- a/.github/workflows/ibmc-cluster-auto-teardown.yml
+++ b/.github/workflows/ibmc-cluster-auto-teardown.yml
@@ -50,7 +50,7 @@ jobs:
         id: check_ci
         uses: actions/github-script@v9
         env:
-          INCLUDE_WORKFLOWS: '[".github/workflows/hot-cluster-e2e.yml", ".github/workflows/hot-cluster-e2e-run.yml"]'
+          INCLUDE_WORKFLOWS: '[".github/workflows/hot-cluster-e2e.yml", ".github/workflows/hot-cluster-e2e-run.yml", ".github/workflows/ibmc-cluster-setup.yml"]'
         with:
           script: |
             const INCLUDE_WORKFLOWS = JSON.parse(process.env.INCLUDE_WORKFLOWS);


### PR DESCRIPTION
## 📝 Description

Auto teardown is tearing down the cluster while it is being deployed - if a cluster is currently being built we need to skip this automated cron job. 

## 🔗 Links

Jira ticket: [CNV-92125](https://redhat.atlassian.net/browse/CNV-92125)

## 🎥 Demo

N/A