### PR TITLE
CNV-92064: Fix overview responsiveness issues

### DIFF
--- a/src/views/virtualmachines/list/components/OverviewTab/_overview-variables.scss
+++ b/src/views/virtualmachines/list/components/OverviewTab/_overview-variables.scss
@@ -1,0 +1,4 @@
+$overview-breakpoint--wide: 105rem;
+$overview-breakpoint--medium: 100rem;
+$overview-breakpoint--medium-narrow: 80rem;
+$overview-breakpoint--narrow: 48rem;

--- a/src/views/virtualmachines/list/components/OverviewTab/constants.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/constants.ts
@@ -1,0 +1,15 @@
+export const OVERVIEW_LEVEL_PROJECT = 'project' as const;
+export const OVERVIEW_LEVEL_CLUSTER = 'cluster' as const;
+export const OVERVIEW_LEVEL_MULTICLUSTER = 'multicluster' as const;
+
+export const SECTION_ID_VM_HEALTH = 'vm-health';
+export const SECTION_ID_CLUSTER_STATUS = 'cluster-status';
+export const SECTION_ID_MIGRATION_STATUS = 'migration-status';
+export const SECTION_ID_RESOURCE_ALLOCATION = 'resource-allocation';
+
+export const GRID_THREE_EQUAL = '1fr 1fr 1fr';
+export const GRID_TWO_EQUAL = '1fr 1fr';
+export const GRID_NARROW_WIDE = '1fr 3fr';
+export const GRID_FOUR_EQUAL = '1fr 1fr 1fr 1fr';
+export const GRID_VM_HEALTH = '8fr 10fr 5fr';
+export const GRID_CLUSTER_MIGRATION_STATUS = '3fr 2fr 1fr';

--- a/src/views/virtualmachines/list/components/OverviewTab/types.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/types.ts
@@ -2,25 +2,32 @@ import { FC, ReactNode } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 
-export const OVERVIEW_LEVEL_PROJECT = 'project' as const;
-export const OVERVIEW_LEVEL_CLUSTER = 'cluster' as const;
-export const OVERVIEW_LEVEL_MULTICLUSTER = 'multicluster' as const;
+import {
+  OVERVIEW_LEVEL_CLUSTER,
+  OVERVIEW_LEVEL_MULTICLUSTER,
+  OVERVIEW_LEVEL_PROJECT,
+} from './constants';
+
+export {
+  GRID_CLUSTER_MIGRATION_STATUS,
+  GRID_FOUR_EQUAL,
+  GRID_NARROW_WIDE,
+  GRID_THREE_EQUAL,
+  GRID_TWO_EQUAL,
+  GRID_VM_HEALTH,
+  OVERVIEW_LEVEL_CLUSTER,
+  OVERVIEW_LEVEL_MULTICLUSTER,
+  OVERVIEW_LEVEL_PROJECT,
+  SECTION_ID_CLUSTER_STATUS,
+  SECTION_ID_MIGRATION_STATUS,
+  SECTION_ID_RESOURCE_ALLOCATION,
+  SECTION_ID_VM_HEALTH,
+} from './constants';
 
 export type OverviewLevel =
   | typeof OVERVIEW_LEVEL_CLUSTER
   | typeof OVERVIEW_LEVEL_MULTICLUSTER
   | typeof OVERVIEW_LEVEL_PROJECT;
-
-export const SECTION_ID_VM_HEALTH = 'vm-health';
-export const SECTION_ID_CLUSTER_STATUS = 'cluster-status';
-export const SECTION_ID_MIGRATION_STATUS = 'migration-status';
-export const SECTION_ID_RESOURCE_ALLOCATION = 'resource-allocation';
-
-export const GRID_THREE_EQUAL = '1fr 1fr 1fr';
-export const GRID_TWO_EQUAL = '1fr 1fr';
-export const GRID_NARROW_WIDE = '1fr 3fr';
-export const GRID_FOUR_EQUAL = '1fr 1fr 1fr 1fr';
-export const GRID_VM_HEALTH = '2fr 3fr 1fr';
 
 export type OverviewSectionData = {
   cluster?: string;

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/ClustersLoadBalanceCard/ClustersLoadBalanceCard.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/ClustersLoadBalanceCard/ClustersLoadBalanceCard.tsx
@@ -32,6 +32,7 @@ const ClustersLoadBalanceCard: FC<ClustersLoadBalanceCardProps> = ({ metricsUnav
       rightTitle={rightTitle}
       scoreHeader={t('Score')}
       severityCounts={severityCounts}
+      stackable
       title={t('Clusters load balance')}
     />
   );

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/ClustersUtilizationCard/ClustersUtilizationCard.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/ClustersUtilizationCard/ClustersUtilizationCard.tsx
@@ -29,6 +29,7 @@ const ClustersUtilizationCard: FC<ClustersUtilizationCardProps> = ({ metricsUnav
       rightTitle={rightTitle}
       scoreHeader={t('Score')}
       severityCounts={severityCounts}
+      stackable
       title={t('Clusters utilization')}
     />
   );

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/TwoColumnCard/TwoColumnCard.scss
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/TwoColumnCard/TwoColumnCard.scss
@@ -1,3 +1,5 @@
+@use '../../../../overview-variables' as *;
+
 .two-column-card {
   &__title {
     display: flex;
@@ -9,6 +11,24 @@
     display: grid;
     grid-template-columns: var(--two-column-card--columns, 2fr 3fr);
     min-height: 12.5rem;
+
+    &--stackable {
+      @media (max-width: $overview-breakpoint--medium) {
+        grid-template-columns: 1fr;
+
+        .two-column-card__left {
+          border-right: none;
+          padding-right: 0;
+          border-bottom: 1px solid var(--pf-t--global--border--color--default);
+          padding-bottom: var(--pf-t--global--spacer--lg);
+        }
+
+        .two-column-card__right {
+          padding-left: 0;
+          padding-top: var(--pf-t--global--spacer--lg);
+        }
+      }
+    }
   }
 
   &__left {

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/TwoColumnCard/TwoColumnCard.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/TwoColumnCard/TwoColumnCard.tsx
@@ -24,6 +24,7 @@ const TwoColumnCard: FC<TwoColumnCardProps> = ({
   scoreHeader,
   severityCounts,
   severityItemLabel,
+  stackable,
   title,
 }) => {
   const style = gridColumns
@@ -73,6 +74,7 @@ const TwoColumnCard: FC<TwoColumnCardProps> = ({
           scoreHeader={scoreHeader}
           severityCounts={severityCounts}
           severityItemLabel={severityItemLabel}
+          stackable={stackable}
           style={style}
         />
       </CardBody>

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/TwoColumnCard/TwoColumnCardBody.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/TwoColumnCard/TwoColumnCardBody.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import classNames from 'classnames';
 
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { Bullseye } from '@patternfly/react-core';
@@ -20,6 +21,7 @@ const TwoColumnCardBody: FC<TwoColumnCardBodyProps> = ({
   scoreHeader,
   severityCounts,
   severityItemLabel,
+  stackable,
   style,
 }) => {
   if (noDataMessage) {
@@ -35,7 +37,12 @@ const TwoColumnCardBody: FC<TwoColumnCardBodyProps> = ({
   }
 
   return (
-    <div className="two-column-card__layout" style={style}>
+    <div
+      className={classNames('two-column-card__layout', {
+        'two-column-card__layout--stackable': stackable,
+      })}
+      style={style}
+    >
       <div className="two-column-card__left">
         {leftContent ?? (
           <SeverityCountList itemLabel={severityItemLabel} severityCounts={severityCounts ?? []} />

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/TwoColumnCard/types.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/TwoColumnCard/types.ts
@@ -21,6 +21,7 @@ export type TwoColumnCardBodyProps = {
   scoreHeader: string;
   severityCounts?: SeverityCount[];
   severityItemLabel?: string;
+  stackable?: boolean;
   style?: CSSProperties;
 };
 
@@ -53,6 +54,8 @@ export type TwoColumnCardProps = {
   severityCounts?: SeverityCount[];
   /** Label for severity count items (defaults to "clusters") */
   severityItemLabel?: string;
+  /** Whether the inner columns should stack vertically at medium breakpoint */
+  stackable?: boolean;
   /** Card title */
   title: string;
 };

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationStatusSection/MigrationStatusSection.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationStatusSection/MigrationStatusSection.tsx
@@ -12,7 +12,7 @@ import useMigrationCardDataAndFilters from '@overview/MigrationsTab/hooks/useMig
 
 import { determineOverviewLevel } from '../../config';
 import {
-  GRID_THREE_EQUAL,
+  GRID_CLUSTER_MIGRATION_STATUS,
   OVERVIEW_LEVEL_CLUSTER,
   OVERVIEW_LEVEL_MULTICLUSTER,
   OverviewSectionData,
@@ -88,7 +88,10 @@ const MigrationStatusSection: FC<OverviewSectionData> = ({
 
   return (
     <OverviewSection dataTestId="migration-status-section" title={title}>
-      <OverviewSectionRow gridColumns={isClusterLevel ? GRID_THREE_EQUAL : undefined}>
+      <OverviewSectionRow
+        className="overview-section__row--single-column-wide"
+        gridColumns={GRID_CLUSTER_MIGRATION_STATUS}
+      >
         <MigrationsWidget
           cardTitle={t('Compute migrations')}
           isLoading={!migrationsLoaded || !clusterVersionLoaded}

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationStatusSection/MultiClusterMigrationStatusSection.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationStatusSection/MultiClusterMigrationStatusSection.tsx
@@ -27,7 +27,7 @@ const MultiClusterMigrationStatusSection: FC<MultiClusterMigrationStatusSectionP
 
   return (
     <OverviewSection dataTestId="migration-status-section" title={title}>
-      <OverviewSectionRow>
+      <OverviewSectionRow className="overview-section__row--single-column-wide">
         {!isMTVInstalled && <MTVNotInstalledCard />}
         {isMTVInstalled && loadError && <ErrorAlert error={loadError} />}
         {isMTVInstalled && !loadError && (

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/OverviewSection/OverviewSection.scss
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/OverviewSection/OverviewSection.scss
@@ -1,3 +1,5 @@
+@use '../../overview-variables' as *;
+
 .overview-section {
   &__toggle-header {
     display: flex;
@@ -5,6 +7,12 @@
     justify-content: space-between;
     color: var(--pf-t--global--text--color--regular);
     width: 100%;
+
+    @media (max-width: $overview-breakpoint--wide) {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--pf-t--global--spacer--xs);
+    }
   }
 
   &__toggle-title {
@@ -60,16 +68,32 @@
       }
     }
 
-    @media (max-width: 100rem) {
+    @media (max-width: $overview-breakpoint--medium) {
       grid-template-columns: 1fr 1fr;
     }
 
-    @media (max-width: 48rem) {
+    @media (max-width: $overview-breakpoint--narrow) {
       grid-template-columns: 1fr;
     }
 
     &--single-column-wide {
-      @media (max-width: 100rem) {
+      @media (max-width: $overview-breakpoint--medium) {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    &--single-column-medium {
+      @media (max-width: $overview-breakpoint--medium-narrow) {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    &--two-columns-wide {
+      @media (max-width: $overview-breakpoint--wide) {
+        grid-template-columns: 1fr 1fr;
+      }
+
+      @media (max-width: $overview-breakpoint--narrow) {
         grid-template-columns: 1fr;
       }
     }

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/ResourceAllocationWidget/components/ResourceAllocationSection/ResourceAllocationSection.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/ResourceAllocationWidget/components/ResourceAllocationSection/ResourceAllocationSection.tsx
@@ -122,7 +122,10 @@ const ResourceAllocationSection: FC<OverviewSectionData> = ({
 
   return (
     <OverviewSection dataTestId="resource-allocation-section" subHeader={subHeader} title={title}>
-      <OverviewSectionRow gridColumns={GRID_FOUR_EQUAL}>
+      <OverviewSectionRow
+        className="overview-section__row--two-columns-wide"
+        gridColumns={GRID_FOUR_EQUAL}
+      >
         {widgetConfigs.map(({ graphTitle, metric, subtitle, title: widgetTitle }) => {
           const { clusterData, metricChartData, quotaData } = dataMap[metric];
           return (

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/VirtualMachinesHealthWidget/VirtualMachinesHealthWidget.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/VirtualMachinesHealthWidget/VirtualMachinesHealthWidget.tsx
@@ -24,7 +24,10 @@ const VirtualMachinesHealthWidget: FC<OverviewSectionData> = ({
 
   return (
     <OverviewSection dataTestId="vm-health-widget" title={title}>
-      <OverviewSectionRow gridColumns={GRID_VM_HEALTH}>
+      <OverviewSectionRow
+        className="overview-section__row--single-column-medium"
+        gridColumns={GRID_VM_HEALTH}
+      >
         {metricsUnavailable ? (
           <VMAlertsCard alertsBaseHref={alertsBaseHref} alertsBasePath={alertsBasePath} />
         ) : (

--- a/src/views/virtualmachines/navigator/VirtualMachineNavigator.scss
+++ b/src/views/virtualmachines/navigator/VirtualMachineNavigator.scss
@@ -4,6 +4,6 @@
   position: sticky;
   top: 0;
   z-index: var(--pf-t--global--z-index--md);
-  background-color: var(--pf-t--global--background--color--primary--default);
+  background-color: var(--pf-t--global--background--color--sticky--default);
   padding-top: var(--pf-t--global--spacer--sm);
 }


### PR DESCRIPTION
## 📝 Description

The Virtualization overview dashboard does not adapt well when the browser window is resized to smaller widths (e.g. 1600px and below). Several widgets exhibit layout issues:

- Overview section grid rows do not collapse to full-width - Widgets like Compute Migrations, Storage Migration Plans, and VM Health cards remain in multi-column layouts even when the available space is too narrow, causing horizontal scrollbars or cramped content.

- `TwoColumnCard` inner layout does not stack vertically - Cards like Clusters Utilization and Clusters Load Balance use a side-by-side two-column layout (severity counts | score list) that does not switch to a vertical stack when space is constrained. The vertical divider should become a horizontal divider when stacked.
 
- Resource Allocation section jumps from 4 columns to 1 column - The four resource allocation chart widgets (VMs, vCPU, Memory, Storage) collapse directly from 4 columns to 1 column. An intermediate 2-column layout would provide a better experience at medium screen widths.
 
- Resource Allocation subheader overlaps title - The subheader (containing the "Top clusters by" dropdown and "Time range" label) is positioned to the right of the section title. At smaller widths there is not enough space, and it should stack below the title instead.
 
- In addition the tab headers navigation bar should not be semi transparent.  

## 🔗 Links

Jira ticket: [CNV-92064](https://redhat.atlassian.net/browse/CNV-92064)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/144d61c3-2f81-4dbf-88a3-c9730d7793bf


After:


https://github.com/user-attachments/assets/86a92324-cd18-4602-b2a0-258c3f4f2faa





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the Virtual Machines overview layout with new responsive breakpoints and shared grid layouts.
  * Added stackable two-column cards so cluster details can switch to a single-column view on smaller screens.

* **Bug Fixes**
  * Updated several overview sections to use clearer, more consistent responsive column behavior.
  * Adjusted the virtual machine navigator header background for better sticky-state appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->