### PR TITLE
CNV-87133: fix installation bugs and simplify resource watches

### DIFF
--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/utils/hooks/useCreateOperator/utils/constants.ts
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/utils/hooks/useCreateOperator/utils/constants.ts
@@ -8,3 +8,8 @@ export const RED_HAT = 'Red Hat';
 export const RED_HAT_CATALOG_SOURCE = 'redhat-operators';
 
 export const CONSOLE_OPERATOR_CONFIG_NAME = 'cluster';
+
+export const OPENSHIFT_OPERATORS_NAMESPACE = 'openshift-operators';
+
+export const HTTP_CONFLICT_CODE = 409;
+export const K8S_ALREADY_EXISTS_REASON = 'AlreadyExists';

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/utils/hooks/useCreateOperator/utils/createOperator.ts
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/utils/hooks/useCreateOperator/utils/createOperator.ts
@@ -13,6 +13,7 @@ import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { kubevirtK8sCreate, kubevirtK8sPatch } from '@multicluster/k8sRequests';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import {
+  InstallModeType,
   InstallPlanApproval,
   K8sResourceKind,
   OperatorGroupKind,
@@ -21,7 +22,10 @@ import {
 import { VirtFeatureOperatorItem } from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/VirtualizationFeaturesContext/utils/types';
 import {
   CLUSTER_MONITORING_ANNOTATION_KEY,
+  HTTP_CONFLICT_CODE,
+  K8S_ALREADY_EXISTS_REASON,
   OPENSHIFT_CLUSTER_MONITORING_ANNOTATION_KEY,
+  OPENSHIFT_OPERATORS_NAMESPACE,
   OPERATOR_MONITORING_DEFAULT_ANNOTATION_KEY,
   RED_HAT,
   SUGGESTED_NAMESPACE_ANNOTATION_KEY,
@@ -69,10 +73,16 @@ export const createOperator = async (
       onError: () => kubevirtConsole.error('Could not parse JSON annotation.'),
     }) ?? {};
   const suggestedNamespaceTemplateName = getName(suggestedNamespaceTemplate);
-  const targetNamespace = suggestedNamespaceTemplateName || suggestedNamespace;
 
   const approval = InstallPlanApproval.Automatic;
   const selectedInstallMode = getDefaultInstallMode(packageManifest, updateChannelName);
+
+  const targetNamespace =
+    suggestedNamespaceTemplateName ||
+    suggestedNamespace ||
+    (selectedInstallMode === InstallModeType.InstallModeTypeAllNamespaces
+      ? OPENSHIFT_OPERATORS_NAMESPACE
+      : undefined);
 
   const defaultNS: K8sResourceCommon = {
     metadata: {
@@ -114,6 +124,7 @@ export const createOperator = async (
   try {
     if (!namespaceExists) {
       await kubevirtK8sCreate({ cluster, data: ns, model: NamespaceModel }).catch((err) => {
+        if (err?.code === HTTP_CONFLICT_CODE || err?.reason === K8S_ALREADY_EXISTS_REASON) return;
         kubevirtConsole.error('Error creating namespace: ', err);
         throw err;
       });
@@ -127,6 +138,7 @@ export const createOperator = async (
     if (!operatorGroupExists) {
       await kubevirtK8sCreate({ cluster, data: operatorGroup, model: OperatorGroupModel }).catch(
         (err) => {
+          if (err?.code === HTTP_CONFLICT_CODE || err?.reason === K8S_ALREADY_EXISTS_REASON) return;
           kubevirtConsole.error('Error creating operator group: ', err);
           throw err;
         },
@@ -136,6 +148,7 @@ export const createOperator = async (
     if (!subscriptionExists) {
       await kubevirtK8sCreate({ cluster, data: subscription, model: SubscriptionModel }).catch(
         (err) => {
+          if (err?.code === HTTP_CONFLICT_CODE || err?.reason === K8S_ALREADY_EXISTS_REASON) return;
           kubevirtConsole.error('Error creating subscription: ', err);
           throw err;
         },
@@ -163,5 +176,6 @@ export const createOperator = async (
     }
   } catch (err) {
     kubevirtConsole.error('*Error: ', err);
+    throw err;
   }
 };

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/utils/hooks/useCreateOperator/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/utils/hooks/useCreateOperator/utils/utils.ts
@@ -122,7 +122,7 @@ export const getOperatorGroup = (
   apiVersion: getAPIVersionForModel(OperatorGroupModel) as OperatorGroupKind['apiVersion'],
   kind: 'OperatorGroup',
   metadata: {
-    generateName: `${namespace}-`,
+    name: namespace,
     namespace: namespace,
   },
   ...(installMode === InstallModeType.InstallModeTypeAllNamespaces

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/VirtualizationFeaturesContext/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/VirtualizationFeaturesContext/utils/utils.ts
@@ -154,6 +154,7 @@ export const computeInstallState = (
   if (installPhase === ClusterServiceVersionPhase.CSVPhaseSucceeded) return InstallState.INSTALLED;
   if (installPhase === ClusterServiceVersionPhase.CSVPhaseFailed) return InstallState.FAILED;
   if (installInProgress) return InstallState.INSTALLING;
+  if (subscription?.status?.installedCSV) return InstallState.INSTALLED;
   return InstallState.NOT_INSTALLED;
 };
 

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/hooks/useOperatorResources/useOperatorResources.ts
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/hooks/useOperatorResources/useOperatorResources.ts
@@ -16,6 +16,7 @@ import { getWatchedOperatorResources } from '@settings/tabs/ClusterTab/component
 export type UseOperatorResourcesReturn = {
   clusterServiceVersions: ClusterServiceVersionKind[];
   filteredPackageManifests: PackageManifestKind[];
+  loadErrors: unknown[];
   operatorGroups: OperatorGroupKind[];
   operatorResourcesLoaded: boolean;
   subscriptions: SubscriptionKind[];
@@ -30,25 +31,29 @@ const useOperatorResources = (
 
   const clusterServiceVersions = data?.clusterServiceVersions?.data ?? [];
   const operatorGroups = data?.operatorGroups?.data ?? [];
-  const marketplacePackageManifests = data?.marketplacePackageManifests?.data ?? [];
-  const packageManifests = data?.packageManifests?.data ?? [];
   const subscriptions = data?.subscriptions?.data ?? [];
 
-  const allPackageManifests = [...packageManifests, ...marketplacePackageManifests];
-  const filteredPackageManifests = allPackageManifests.filter((pkg) =>
+  const filteredPackageManifests = (data?.allPackageManifests?.data ?? []).filter((pkg) =>
     packageNames.includes(getName(pkg)),
   );
 
   const operatorResourcesLoaded =
+    data?.allPackageManifests?.loaded &&
     data?.clusterServiceVersions?.loaded &&
-    data?.packageManifests?.loaded &&
-    data?.marketplacePackageManifests?.loaded &&
     data?.operatorGroups?.loaded &&
     data?.subscriptions?.loaded;
+
+  const loadErrors = [
+    data?.allPackageManifests?.loadError,
+    data?.clusterServiceVersions?.loadError,
+    data?.operatorGroups?.loadError,
+    data?.subscriptions?.loadError,
+  ].filter(Boolean);
 
   return {
     clusterServiceVersions,
     filteredPackageManifests,
+    loadErrors,
     operatorGroups,
     operatorResourcesLoaded,
     subscriptions,

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/hooks/useOperatorResources/utils/types.ts
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/hooks/useOperatorResources/utils/types.ts
@@ -6,9 +6,8 @@ import {
 } from '@overview/utils/types';
 
 export type OperatorResources = {
+  allPackageManifests: PackageManifestKind[];
   clusterServiceVersions: ClusterServiceVersionKind[];
-  marketplacePackageManifests: PackageManifestKind[];
   operatorGroups: OperatorGroupKind[];
-  packageManifests: PackageManifestKind[];
   subscriptions: SubscriptionKind[];
 };

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/hooks/useOperatorResources/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/hooks/useOperatorResources/utils/utils.ts
@@ -4,37 +4,23 @@ import {
   PackageManifestModel,
   SubscriptionModel,
 } from '@kubevirt-utils/models';
-import { getGroupVersionKindForModel, Operator } from '@openshift-console/dynamic-plugin-sdk';
+import { getGroupVersionKindForModel } from '@openshift-console/dynamic-plugin-sdk';
 
 export const getWatchedOperatorResources = (cluster?: string) => ({
+  allPackageManifests: {
+    cluster,
+    groupVersionKind: getGroupVersionKindForModel(PackageManifestModel),
+    isList: true,
+  },
   clusterServiceVersions: {
     cluster,
     groupVersionKind: getGroupVersionKindForModel(ClusterServiceVersionModel),
-    isList: true,
-  },
-  marketplacePackageManifests: {
-    cluster,
-    groupVersionKind: getGroupVersionKindForModel(PackageManifestModel),
     isList: true,
   },
   operatorGroups: {
     cluster,
     groupVersionKind: getGroupVersionKindForModel(OperatorGroupModel),
     isList: true,
-  },
-  packageManifests: {
-    cluster,
-    groupVersionKind: getGroupVersionKindForModel(PackageManifestModel),
-    isList: true,
-    selector: {
-      matchExpressions: [
-        {
-          key: 'opsrc-owner-name',
-          operator: Operator.DoesNotExist,
-        },
-        { key: 'csc-owner-name', operator: Operator.DoesNotExist },
-      ],
-    },
   },
   subscriptions: {
     cluster,


### PR DESCRIPTION

## 📝 Description

Three bugfixes and one refactor in the operator installation infrastructure:
- **Duplicate OperatorGroups**: `createOperator` uses `generateName` when
  creating an OperatorGroup, so parallel installs to the same namespace each
  create a separate one. OLM requires exactly one per namespace — with
  multiples it refuses to create InstallPlans and no operators ever install.
  Fixed by using a deterministic `name` so subsequent calls get a 409 and
  skip creation.
- **Wrong 409 detection**: the idempotency check read `err?.response?.status`
  (axios shape) instead of `err?.code` / `err?.reason` (Console SDK shape).
- **`computeInstallState` false negative**: returned `NOT_INSTALLED` when a
  subscription existed but its CSV wasn't in watch data. Added fallback:
  if `subscription.status.installedCSV` is set, return `INSTALLED`.
- **`useOperatorResources` simplification**: reduced from 7 redundant watches
  to 4 clean cluster-wide watches.

## 🔗 Links

Jira ticket:https://redhat.atlassian.net/browse/CNV-87133

