### PR TITLE
[release-4.20] CNV-91888: Add Konflux hermetic build CI check

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -55,6 +55,25 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Prefetch npm dependencies with Hermeto
+        run: |
+          rm -rf node_modules
+          HERMETO_OUTPUT="${{ github.workspace }}/hermeto-output"
+          docker run --rm \
+            -v "${{ github.workspace }}:${{ github.workspace }}" \
+            -w "${{ github.workspace }}" \
+            ghcr.io/hermetoproject/hermeto:latest \
+            fetch-deps --source "${{ github.workspace }}" --output "$HERMETO_OUTPUT" npm
+          docker run --rm \
+            -v "${{ github.workspace }}:${{ github.workspace }}" \
+            -w "${{ github.workspace }}" \
+            ghcr.io/hermetoproject/hermeto:latest \
+            inject-files "$HERMETO_OUTPUT" --for-output-dir "$HERMETO_OUTPUT"
+
+      - name: Verify offline install
+        run: |
+          HUSKY=0 npm ci --offline --ignore-scripts --no-audit
+
   unit-test:
     name: unit-test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Backport of #4173 for `release-4.20`. Adds hermetic build verification to the `build` CI job that simulates Konflux offline installs:

1. Prefetch npm dependencies with [Hermeto](https://hermetoproject.github.io/hermeto/npm/) (`fetch-deps` + `inject-files`)
2. Run `npm ci --offline --ignore-scripts` with no npm registry access

This mirrors the cachi2/hermeto prefetch flow used in Konflux container builds.

Unlike #4173, the hermetic steps run unconditionally on every build (no `package-lock.json` change detection).

- Jira: https://redhat.atlassian.net/browse/CNV-91888

## Test plan

- [ ] CI `build` job runs Hermeto prefetch and offline `npm ci` successfully on `release-4.20`


Made with [Cursor](https://cursor.com)