### PR TITLE
CNV-91998: Surface SSH access fetch errors instead of infinite loading

### DIFF
--- a/src/utils/components/SSHAccess/SSHAccess.tsx
+++ b/src/utils/components/SSHAccess/SSHAccess.tsx
@@ -10,6 +10,7 @@ import SSHCommand from './components/SSHCommand';
 type SSHAccessProps = {
   isCustomizeInstanceType?: boolean;
   sshService: IoK8sApiCoreV1Service;
+  sshServiceError?: Error;
   sshServiceLoaded?: boolean;
   vm: V1VirtualMachine;
 };
@@ -17,13 +18,19 @@ type SSHAccessProps = {
 const SSHAccess: FC<SSHAccessProps> = ({
   isCustomizeInstanceType,
   sshService,
+  sshServiceError,
   sshServiceLoaded,
   vm,
 }) => {
   return (
     <DescriptionList>
       {!isCustomizeInstanceType && (
-        <SSHCommand sshService={sshService} sshServiceLoaded={sshServiceLoaded} vm={vm} />
+        <SSHCommand
+          sshService={sshService}
+          sshServiceError={sshServiceError}
+          sshServiceLoaded={sshServiceLoaded}
+          vm={vm}
+        />
       )}
       <ConsoleOverVirtctl vm={vm} />
     </DescriptionList>

--- a/src/utils/components/SSHAccess/components/SSHCommand.tsx
+++ b/src/utils/components/SSHAccess/components/SSHCommand.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useState } from 'react';
 
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import Loading from '@kubevirt-utils/components/Loading/Loading';
+import StateHandler from '@kubevirt-utils/components/StateHandler/StateHandler';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
@@ -31,12 +31,14 @@ import SSHServiceStateIcon from './SSHServiceState';
 
 type SSHCommandProps = {
   sshService: IoK8sApiCoreV1Service;
+  sshServiceError?: Error;
   sshServiceLoaded?: boolean;
   vm: V1VirtualMachine;
 };
 
 const SSHCommand: FC<SSHCommandProps> = ({
   sshService: initialSSHService,
+  sshServiceError,
   sshServiceLoaded,
   vm,
 }) => {
@@ -47,10 +49,12 @@ const SSHCommand: FC<SSHCommandProps> = ({
   const [error, setError] = useState<Error>();
 
   const {
+    error: vmiAndPodsError,
     loaded: vmiAndPodsLoaded,
     pods,
     vmi,
   } = useVMIAndPodsForVM(getName(vm), getNamespace(vm), getCluster(vm));
+  const loadError = sshServiceError || vmiAndPodsError;
   const pod = getVMIPod(vmi, pods);
 
   const onSSHChange = async (newServiceType: SERVICE_TYPES) => {
@@ -84,6 +88,8 @@ const SSHCommand: FC<SSHCommandProps> = ({
   const showBondingWarning =
     sshService?.spec?.type === SERVICE_TYPES.LOAD_BALANCER && !isLoadBalancerBonded(sshService);
 
+  const isLoaded = sshServiceLoaded && vmiAndPodsLoaded && !loading;
+
   return (
     <DescriptionListGroup>
       <DescriptionListTerm className="pf-v6-u-font-size-xs">
@@ -92,41 +98,34 @@ const SSHCommand: FC<SSHCommandProps> = ({
 
       <DescriptionListDescription>
         <Stack hasGutter>
-          {sshServiceLoaded && vmiAndPodsLoaded && !loading ? (
-            <>
-              <StackItem>
-                <Flex direction={{ default: 'row' }}>
-                  <FlexItem flex={{ default: 'flex_1' }}>
-                    <SSHServiceSelect
-                      onSSHChange={onSSHChange}
-                      sshService={sshService}
-                      sshServiceLoaded={sshServiceLoaded}
-                    />
-                  </FlexItem>
-
-                  <SSHServiceStateIcon
+          <StateHandler error={loadError} hasData={false} loaded={isLoaded}>
+            <StackItem>
+              <Flex direction={{ default: 'row' }}>
+                <FlexItem flex={{ default: 'flex_1' }}>
+                  <SSHServiceSelect
+                    onSSHChange={onSSHChange}
                     sshService={sshService}
                     sshServiceLoaded={sshServiceLoaded}
                   />
-                </Flex>
-              </StackItem>
+                </FlexItem>
 
-              {sshServiceRunning && !showBondingWarning && (
-                <StackItem>
-                  <ClipboardCopy
-                    clickTip={t('Copied')}
-                    data-test="ssh-command-copy"
-                    hoverTip={t('Copy to clipboard')}
-                    isReadOnly
-                  >
-                    {command}
-                  </ClipboardCopy>
-                </StackItem>
-              )}
-            </>
-          ) : (
-            <Loading />
-          )}
+                <SSHServiceStateIcon sshService={sshService} sshServiceLoaded={sshServiceLoaded} />
+              </Flex>
+            </StackItem>
+
+            {sshServiceRunning && !showBondingWarning && (
+              <StackItem>
+                <ClipboardCopy
+                  clickTip={t('Copied')}
+                  data-test="ssh-command-copy"
+                  hoverTip={t('Copy to clipboard')}
+                  isReadOnly
+                >
+                  {command}
+                </ClipboardCopy>
+              </StackItem>
+            )}
+          </StateHandler>
           {error && (
             <StackItem>
               <Alert isInline title={t('Error')} variant={AlertVariant.danger}>

--- a/src/utils/components/SSHAccess/useSSHService.tsx
+++ b/src/utils/components/SSHAccess/useSSHService.tsx
@@ -13,7 +13,7 @@ import { SSH_PORT } from './constants';
 export type UseSSHServiceReturnType = [
   service: IoK8sApiCoreV1Service,
   loaded: boolean,
-  error: Error,
+  error: Error | undefined,
 ];
 
 const useSSHService = (vm: V1VirtualMachine): UseSSHServiceReturnType => {

--- a/src/views/virtualmachines/details/tabs/configuration/ssh/components/SSHTabSSHAccess.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/ssh/components/SSHTabSSHAccess.tsx
@@ -14,7 +14,7 @@ type SSHTabSSHAccessProps = {
 
 const SSHTabSSHAccess: FC<SSHTabSSHAccessProps> = ({ isCustomizeInstanceType, vm }) => {
   const { t } = useKubevirtTranslation();
-  const [sshService, sshServiceLoaded] = useSSHService(vm);
+  const [sshService, sshServiceLoaded, sshServiceError] = useSSHService(vm);
 
   return (
     <DescriptionItem
@@ -22,6 +22,7 @@ const SSHTabSSHAccess: FC<SSHTabSSHAccessProps> = ({ isCustomizeInstanceType, vm
         <SSHAccess
           isCustomizeInstanceType={isCustomizeInstanceType}
           sshService={sshService}
+          sshServiceError={sshServiceError}
           sshServiceLoaded={sshServiceLoaded}
           vm={vm}
         />

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Details.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Details.tsx
@@ -52,7 +52,7 @@ const Details: FC<DetailsProps> = ({ pathname, vmi }) => {
     name: getName(vmi),
     namespace: getNamespace(vmi),
   });
-  const [sshService, sshServiceLoaded] = useSSHService(vm);
+  const [sshService, sshServiceLoaded, sshServiceError] = useSSHService(vm);
 
   return (
     <div>
@@ -129,7 +129,12 @@ const Details: FC<DetailsProps> = ({ pathname, vmi }) => {
             />
             <DescriptionItem
               descriptionData={
-                <SSHAccess sshService={sshService} sshServiceLoaded={sshServiceLoaded} vm={vm} />
+                <SSHAccess
+                  sshService={sshService}
+                  sshServiceError={sshServiceError}
+                  sshServiceLoaded={sshServiceLoaded}
+                  vm={vm}
+                />
               }
               descriptionHeader={t('SSH access')}
             />


### PR DESCRIPTION
## 📝 Description

When loading SSH service data fails (e.g. API or permission error), the SSH access section previously showed an infinite loading spinner because only the `loaded` boolean was checked.

This change passes the service fetch error from `useSSHService` through `SSHAccess` into `SSHCommand`, combines it with VMI/pod load errors, and renders the result via `StateHandler` so users see a clear error state (including 403 access denied) instead of perpetual loading.

## 🔗 Links

- [CNV-91998](https://redhat.atlassian.net/browse/CNV-91998)

## 🎥 Demo

N/A — error state replaces infinite loading when the services API call fails.

## Test plan

- [ ] Open a VM details page → Configuration → SSH access with normal permissions; verify SSH controls and command still load correctly
- [ ] Revoke the user's permission to list services in the namespace; verify the SSH access section shows an error instead of a loading spinner
- [ ] Change SSH service type on a VM with permissions; verify mutation errors still display below the controls
- [ ] Verify SSH access on the VMI details page behaves the same way

Made with [Cursor](https://cursor.com)