### PR TITLE
CNV-92379: Fix hot-cluster-check concurrency so PR workflows queue instead of being cancelled

### DIFF
--- a/.github/workflows/hot-cluster-check.yml
+++ b/.github/workflows/hot-cluster-check.yml
@@ -60,6 +60,7 @@ jobs:
     concurrency:
       group: hot-cluster-provision-${{ inputs.cluster_name }}
       cancel-in-progress: false
+      queue: max
     outputs:
       cluster_ready: ${{ steps.probe.outputs.cluster_ready || steps.wait_setup.outputs.cluster_ready }}
     steps:


### PR DESCRIPTION
## 📝 Description

Fix hot-cluster-check concurrency so PR workflows queue instead of being cancelled.

## 🔗 Links

Jira ticket: [CNV-92379](https://redhat.atlassian.net/browse/CNV-92379)

## 🎥 Demo

N/A