### PR TITLE
CNV-92380: Allow actions/checkout@v7 to check out fork PR code in hot-cluster-e2e-run workflow

### DIFF
--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -176,6 +176,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          allow-unsafe-pr-checkout: true
 
       - name: Check if kubevirt-plugin image exists in registry
         id: check_image
@@ -238,6 +239,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          allow-unsafe-pr-checkout: true
 
       - name: Provision CI test environment
         id: ci-env


### PR DESCRIPTION
## 📝 Description

`actions/checkout@v7` (June 2026) introduced a new security default that blocks checking out fork PR code in pull_request_target workflows. This causes the Build `Kubevirt` Plugin Image and Run Gating Tests jobs in `hot-cluster-e2e-run.yml` to fail with:
```
Refusing to check out fork pull request code from a 'pull_request_target' workflow.
```

This breaks e2e tests for all PRs opened from personal forks, even for org members.

## 🔗 Links

Jira ticket: [CNV-92380](https://redhat.atlassian.net/browse/CNV-92380)

## 🎥 Demo

N/A