### PR TITLE
CNV-92449: add checkups toast notification scenario test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,9 @@
+import * as path from 'path';
+
 import { defineConfig, devices } from '@playwright/test';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 import { env } from './playwright/utils/env';
 

--- a/playwright/project-dependencies/global.setup.ts
+++ b/playwright/project-dependencies/global.setup.ts
@@ -1,5 +1,9 @@
 import * as path from 'path';
 
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: path.resolve(__dirname, '..', '..', '.env') });
+
 import { EnvVariables } from '@/utils/env-variables';
 import { getStorageStatePath, logger } from '@/utils/file-utils';
 
@@ -12,11 +16,11 @@ async function globalSetup(): Promise<void> {
 
   const projectRoot = path.resolve(__dirname, '..', '..');
   const kubeConfigPath = path.join(projectRoot, '.kubeconfigs', 'test-config');
-  const storageStateDir = path.join(projectRoot, '.storage-states');
   const testNamespace = `pw-scenario-${Date.now().toString(36)}`;
 
+  const derivedStorageStateDir = path.resolve(kubeConfigPath, '..', '.storage-states');
   const storageStatePath =
-    getStorageStatePath(kubeConfigPath) || path.join(storageStateDir, 'test-state.json');
+    getStorageStatePath(kubeConfigPath) || path.join(derivedStorageStateDir, 'test-state.json');
 
   const ctx: SetupContext = {
     cnvNamespace: EnvVariables.cnvNamespace,

--- a/playwright/src/fixtures/scenario-fixture.ts
+++ b/playwright/src/fixtures/scenario-fixture.ts
@@ -1,4 +1,5 @@
 import { KubernetesClient } from '@/clients/kubernetes-client';
+import { CheckupsPage } from '@/page-objects/checkups-page';
 import { OverviewPage } from '@/page-objects/overview-page';
 import { VirtualMachinesPage } from '@/page-objects/virtual-machines-page';
 import { getStorageStatePath } from '@/utils/file-utils';
@@ -6,6 +7,7 @@ import { TestConfigManager } from '@/utils/test-config';
 import { test as base, expect } from '@playwright/test';
 
 interface ScenarioFixtures {
+  checkupsPage: CheckupsPage;
   k8sClient: KubernetesClient;
   overviewPage: OverviewPage;
   virtualMachinesPage: VirtualMachinesPage;
@@ -15,6 +17,10 @@ export const scenarioTest = base.extend<ScenarioFixtures>({
   storageState: async ({}, use) => {
     const kubeConfigPath = process.env.KUBECONFIG || '.kubeconfigs/test-config';
     await use(getStorageStatePath(kubeConfigPath, true) ?? undefined);
+  },
+
+  checkupsPage: async ({ page }, use) => {
+    await use(new CheckupsPage(page));
   },
 
   k8sClient: async ({}, use) => {

--- a/playwright/src/page-objects/checkups-page.ts
+++ b/playwright/src/page-objects/checkups-page.ts
@@ -1,0 +1,18 @@
+import { Page } from '@playwright/test';
+
+import { EnvVariables } from '@/utils/env-variables';
+
+const NAV_TIMEOUT = 30_000;
+
+/**
+ * Page object for the Checkups page.
+ * Injected via the scenarioTest fixture.
+ */
+export class CheckupsPage {
+  constructor(private readonly page: Page) {}
+
+  async navigate(ns = EnvVariables.cnvNamespace): Promise<void> {
+    await this.page.goto(`/k8s/ns/${ns}/checkups`, { waitUntil: 'domcontentloaded' });
+    await this.page.getByRole('heading', { name: 'Checkups' }).waitFor({ timeout: NAV_TIMEOUT });
+  }
+}

--- a/playwright/src/utils/toast-test-helper.ts
+++ b/playwright/src/utils/toast-test-helper.ts
@@ -1,0 +1,165 @@
+/**
+ * Toast test helper — fires Console SDK toast notifications by walking the
+ * React fiber tree to locate the ToastContext provider.
+ *
+ * The OpenShift Console exposes `{ addToast, removeToast }` via a React
+ * context at the app root. The kubevirt-plugin's `useKubevirtToast` hook
+ * wraps this context. By calling `addToast` directly we can validate toast
+ * rendering without triggering real checkup operations.
+ *
+ * This helper is intentionally low-level: it uses `page.evaluate()` to
+ * interact with React internals. Keep all such calls here — never in specs.
+ */
+
+import type { Page } from '@playwright/test';
+
+export type ToastVariant = 'danger' | 'info' | 'success' | 'warning';
+
+interface ToastOptions {
+  variant: ToastVariant;
+  title: string;
+  content?: string;
+  dismissible?: boolean;
+  timeout?: boolean;
+}
+
+export class ToastTestHelper {
+  private contextCached = false;
+
+  constructor(private page: Page) {}
+
+  private ensureCached(): void {
+    if (!this.contextCached) {
+      throw new Error('ToastTestHelper: call cacheToastContext() before using toast methods.');
+    }
+  }
+
+  /**
+   * Fire a toast notification via the Console SDK's `addToast`.
+   * Returns the toast ID (e.g. "toast-1") for later removal.
+   */
+  async addToast(options: ToastOptions): Promise<string> {
+    this.ensureCached();
+    return this.page.evaluate((opts) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const helper = (window as any).__toastHelper;
+      return helper.addToast({
+        variant: opts.variant,
+        title: opts.title,
+        content: opts.content,
+        dismissible: opts.dismissible ?? true,
+        timeout: opts.timeout ?? false,
+      }) as string;
+    }, options);
+  }
+
+  /**
+   * Walks the React fiber tree from `#app` to find the Console SDK's
+   * ToastContext provider and caches `addToast` / `removeToast` on `window`.
+   *
+   * Must be called once after a full page load, before any `addToast` call.
+   * Throws if the context is not found (Console version too old or structure changed).
+   */
+  async cacheToastContext(): Promise<void> {
+    const found = await this.page.evaluate(() => {
+      const MAX_DEPTH = 40;
+      const rootEl = document.getElementById('app');
+      if (!rootEl) return false;
+
+      const rootFiberKey = Object.keys(rootEl).find((k) => k.startsWith('__reactContainer'));
+      if (!rootFiberKey) return false;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const fiber = (rootEl as any)[rootFiberKey];
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      function findToastProvider(f: any, depth: number): any {
+        if (!f || depth > MAX_DEPTH) return null;
+        if (f.tag === 10 && f.memoizedProps?.value) {
+          const val = f.memoizedProps.value;
+          if (typeof val === 'object' && val !== null && typeof val.addToast === 'function') {
+            return val;
+          }
+        }
+        return findToastProvider(f.child, depth + 1) || findToastProvider(f.sibling, depth + 1);
+      }
+
+      const ctx = findToastProvider(fiber, 0);
+      if (!ctx) return false;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__toastHelper = {
+        addToast: ctx.addToast,
+        removeToast: ctx.removeToast,
+      };
+      return true;
+    });
+
+    if (!found) {
+      throw new Error(
+        'ToastTestHelper: Console SDK ToastContext not found in React fiber tree. ' +
+          'Ensure the page is fully loaded before calling cacheToastContext().',
+      );
+    }
+    this.contextCached = true;
+  }
+
+  /** Remove all toasts fired during this session (IDs toast-1 through toast-50). */
+  async clearAllToasts(): Promise<void> {
+    if (!this.contextCached) return;
+    await this.page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const helper = (window as any).__toastHelper;
+      if (!helper) return;
+      for (let i = 1; i <= 50; i++) {
+        try {
+          helper.removeToast(`toast-${i}`);
+        } catch {
+          // already removed or never existed
+        }
+      }
+    });
+  }
+
+  /**
+   * Assert that a toast with the given variant and title text is visible in the DOM.
+   * Looks for PatternFly alert elements rendered by the Console's ToastProvider.
+   */
+  async getVisibleToast(
+    variant: ToastVariant,
+    titleSubstring: string,
+  ): Promise<{ found: boolean; title: string; content: string }> {
+    return this.page.evaluate(
+      ({ v, t }) => {
+        const alerts = Array.from(
+          document.querySelectorAll(`.pf-v6-c-alert.pf-m-${v}, .pf-v5-c-alert.pf-m-${v}`),
+        );
+        for (const alert of alerts) {
+          const titleEl = alert.querySelector('.pf-v6-c-alert__title, .pf-v5-c-alert__title');
+          const titleText = titleEl?.textContent?.trim() ?? '';
+          if (titleText.includes(t)) {
+            const contentEl = alert.querySelector(
+              '.pf-v6-c-alert__description, .pf-v5-c-alert__description',
+            );
+            return {
+              found: true,
+              title: titleText,
+              content: contentEl?.textContent?.trim() ?? '',
+            };
+          }
+        }
+        return { found: false, title: '', content: '' };
+      },
+      { v: variant, t: titleSubstring },
+    );
+  }
+
+  /** Remove a toast by ID. */
+  async removeToast(toastId: string): Promise<void> {
+    this.ensureCached();
+    await this.page.evaluate((id) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__toastHelper.removeToast(id);
+    }, toastId);
+  }
+}

--- a/playwright/tests/scenario/checkups-toasts.spec.ts
+++ b/playwright/tests/scenario/checkups-toasts.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Console SDK toast notification rendering.
+ *
+ * Validates that the OpenShift Console's toast system (used by the kubevirt-plugin
+ * for checkup rerun/delete feedback) renders all PatternFly alert variants correctly.
+ *
+ * Strategy: navigates to the Checkups page, then injects toasts via the Console SDK's
+ * ToastContext (React fiber traversal). No checkup operations are executed — this is a
+ * pure rendering validation.
+ *
+ * Covers: CNV-74440 (toast notification support for checkups)
+ */
+
+import { scenarioTest as test, expect } from '@/fixtures/scenario-fixture';
+import type { ToastVariant } from '@/utils/toast-test-helper';
+import { ToastTestHelper } from '@/utils/toast-test-helper';
+
+interface ToastCase {
+  variant: ToastVariant;
+  title: string;
+  content: string;
+}
+
+const TOAST_CASES: ToastCase[] = [
+  {
+    variant: 'danger',
+    title: 'Failed to rerun checkup',
+    content: 'Network error: connection refused',
+  },
+  {
+    variant: 'info',
+    title: 'Checkup rerun started',
+    content: 'Storage checkup is being rerun',
+  },
+  {
+    variant: 'success',
+    title: 'Checkup deleted successfully',
+    content: '',
+  },
+  {
+    variant: 'warning',
+    title: 'Checkup completed with warnings',
+    content: 'Some nodes did not respond within the timeout',
+  },
+];
+
+test.describe('Checkups toast notifications', () => {
+  let toastHelper: ToastTestHelper;
+
+  test.beforeEach(async ({ checkupsPage, page }) => {
+    await checkupsPage.navigate();
+    toastHelper = new ToastTestHelper(page);
+    await toastHelper.cacheToastContext();
+  });
+
+  test.afterEach(async () => {
+    await toastHelper.clearAllToasts();
+  });
+
+  for (const tc of TOAST_CASES) {
+    test(`Toast renders correctly for ${tc.variant} variant`, async () => {
+      await test.step(`Fire ${tc.variant} toast via Console SDK context`, async () => {
+        await toastHelper.addToast({
+          variant: tc.variant,
+          title: tc.title,
+          content: tc.content || undefined,
+          dismissible: true,
+          timeout: false,
+        });
+      });
+
+      await test.step(`Verify ${tc.variant} toast is visible with correct text`, async () => {
+        const result = await toastHelper.getVisibleToast(tc.variant, tc.title);
+        expect.soft(result.found, `${tc.variant} toast should be visible in the DOM`).toBe(true);
+        expect.soft(result.title, `Toast title should contain "${tc.title}"`).toContain(tc.title);
+        if (tc.content) {
+          expect
+            .soft(result.content, `Toast content should contain "${tc.content}"`)
+            .toContain(tc.content);
+        }
+      });
+
+      await test.step(`Dismiss ${tc.variant} toast and verify removal`, async () => {
+        await toastHelper.clearAllToasts();
+
+        const afterClear = await toastHelper.getVisibleToast(tc.variant, tc.title);
+        expect
+          .soft(afterClear.found, `${tc.variant} toast should be removed after dismissal`)
+          .toBe(false);
+      });
+    });
+  }
+
+  test('Multiple toasts render simultaneously without overlap', async () => {
+    await test.step('Fire all four toast variants at once', async () => {
+      for (const tc of TOAST_CASES) {
+        await toastHelper.addToast({
+          variant: tc.variant,
+          title: tc.title,
+          content: tc.content || undefined,
+          dismissible: true,
+          timeout: false,
+        });
+      }
+    });
+
+    await test.step('Verify all four toasts are visible simultaneously', async () => {
+      for (const tc of TOAST_CASES) {
+        const result = await toastHelper.getVisibleToast(tc.variant, tc.title);
+        expect
+          .soft(result.found, `${tc.variant} toast ("${tc.title}") should be visible`)
+          .toBe(true);
+      }
+    });
+
+    await test.step('Clear all toasts and verify none remain', async () => {
+      await toastHelper.clearAllToasts();
+
+      for (const tc of TOAST_CASES) {
+        const result = await toastHelper.getVisibleToast(tc.variant, tc.title);
+        expect.soft(result.found, `${tc.variant} toast should be cleared`).toBe(false);
+      }
+    });
+  });
+});

--- a/playwright/utils/env.ts
+++ b/playwright/utils/env.ts
@@ -6,7 +6,8 @@ import {
 /** Environment variables consumed by Playwright tests. */
 export const env = {
   baseURL: (() => {
-    const addr = process.env.BRIDGE_BASE_ADDRESS ?? 'http://localhost:9000';
+    const addr =
+      process.env.WEB_CONSOLE_URL || process.env.BRIDGE_BASE_ADDRESS || 'http://localhost:9000';
     const path = process.env.BRIDGE_BASE_PATH ?? '/';
     return `${addr}${path}`.replace(/\/$/, '');
   })(),


### PR DESCRIPTION
## 📝 Description

Migrate toast rendering tests from kubevirt-ui gating suite to the scenario infrastructure. Adds ToastTestHelper utility, CheckupsPage page object, and fixes dotenv/.env loading and storage state path resolution for scenario tests.

## 🔗 Links
https://redhat.atlassian.net/browse/CNV-92449

## 🎥 Demo

<img width="1920" height="1022" alt="image" src="https://github.com/user-attachments/assets/b8eb3c76-9de4-4189-b656-82e47c0b3021" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Playwright support for the Checkups page.
  * Expanded end-to-end test helpers to create, inspect, and clear toast notifications.
  * Added test coverage for multiple toast variants, including displaying several at once.

* **Bug Fixes**
  * Improved environment loading so local settings are picked up more reliably.
  * Updated test URL selection to better match the available console address.
  * Adjusted test storage-state handling to use a more consistent fallback location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->