### PR TITLE
Add mayarub and bmaio-redhat as OWNERS reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -25,4 +25,5 @@ reviewers:
   - batyana
   - aviavissar
   - benbassatido
+  - mayarub
   - Pedro-S-Abreu

--- a/OWNERS
+++ b/OWNERS
@@ -26,4 +26,5 @@ reviewers:
   - aviavissar
   - benbassatido
   - mayarub
+  - bmaio-redhat
   - Pedro-S-Abreu


### PR DESCRIPTION
## Summary
- Add `mayarub` and `bmaio-redhat` to the `reviewers` list in `OWNERS`

## Test plan
- [ ] N/A — OWNERS file update only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ownership settings by adding two reviewers to the review list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->