### PR TITLE
[release-4.11] Add mayarub and bmaio-redhat as OWNERS reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -21,3 +21,4 @@ reviewers:
   - upalatucci
   - adamviktora
   - mayarub
+  - bmaio-redhat

--- a/OWNERS
+++ b/OWNERS
@@ -20,3 +20,4 @@ reviewers:
   - hstastna
   - upalatucci
   - adamviktora
+  - mayarub


### PR DESCRIPTION
## Summary
- Add `mayarub` and `bmaio-redhat` to the `reviewers` list in `OWNERS`

## Test plan
- [ ] N/A — OWNERS file update only