### PR TITLE
[release-4.12] Add mayarub and bmaio-redhat as OWNERS reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -24,3 +24,4 @@ reviewers:
   - upalatucci
   - adamviktora
   - mayarub
+  - bmaio-redhat

--- a/OWNERS
+++ b/OWNERS
@@ -23,3 +23,4 @@ reviewers:
   - hstastna
   - upalatucci
   - adamviktora
+  - mayarub


### PR DESCRIPTION
## Summary
- Add `mayarub` and `bmaio-redhat` to the `reviewers` list in `OWNERS`

## Test plan
- [ ] N/A — OWNERS file update only