### PR TITLE
[release-4.13] Add mayarub and bmaio-redhat as OWNERS reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -22,3 +22,4 @@ reviewers:
   - hstastna
   - upalatucci
   - adamviktora
+  - mayarub

--- a/OWNERS
+++ b/OWNERS
@@ -23,3 +23,4 @@ reviewers:
   - upalatucci
   - adamviktora
   - mayarub
+  - bmaio-redhat


### PR DESCRIPTION
## Summary
- Add `mayarub` and `bmaio-redhat` to the `reviewers` list in `OWNERS`

## Test plan
- [ ] N/A — OWNERS file update only