### PR TITLE
[release-4.18] Add mayarub and bmaio-redhat as OWNERS reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -16,3 +16,4 @@ reviewers:
   - vojtechszocs
   - upalatucci
   - adamviktora
+  - mayarub

--- a/OWNERS
+++ b/OWNERS
@@ -17,3 +17,4 @@ reviewers:
   - upalatucci
   - adamviktora
   - mayarub
+  - bmaio-redhat


### PR DESCRIPTION
## Summary
- Add `mayarub` and `bmaio-redhat` to the `reviewers` list in `OWNERS`

## Test plan
- [ ] N/A — OWNERS file update only