### PR TITLE
[release-4.19] Add mayarub and bmaio-redhat as OWNERS reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -23,3 +23,4 @@ reviewers:
   - lkladnit
   - gouyang
   - batyana
+  - mayarub

--- a/OWNERS
+++ b/OWNERS
@@ -24,3 +24,4 @@ reviewers:
   - gouyang
   - batyana
   - mayarub
+  - bmaio-redhat


### PR DESCRIPTION
## Summary
- Add `mayarub` and `bmaio-redhat` to the `reviewers` list in `OWNERS`

## Test plan
- [ ] N/A — OWNERS file update only