### PR TITLE
[release-4.21] Add mayarub and bmaio-redhat as OWNERS reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -25,4 +25,5 @@ reviewers:
   - batyana
   - aviavissar
   - mayarub
+  - bmaio-redhat
   - Pedro-S-Abreu

--- a/OWNERS
+++ b/OWNERS
@@ -24,4 +24,5 @@ reviewers:
   - gouyang
   - batyana
   - aviavissar
+  - mayarub
   - Pedro-S-Abreu


### PR DESCRIPTION
## Summary
- Add `mayarub` and `bmaio-redhat` to the `reviewers` list in `OWNERS`

## Test plan
- [ ] N/A — OWNERS file update only