### PR TITLE
[release-4.22] Add mayarub and bmaio-redhat as OWNERS reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -23,4 +23,5 @@ reviewers:
   - lkladnit
   - gouyang
   - batyana
+  - mayarub
   - Pedro-S-Abreu

--- a/OWNERS
+++ b/OWNERS
@@ -24,4 +24,5 @@ reviewers:
   - gouyang
   - batyana
   - mayarub
+  - bmaio-redhat
   - Pedro-S-Abreu


### PR DESCRIPTION
## Summary
- Add `mayarub` and `bmaio-redhat` to the `reviewers` list in `OWNERS`

## Test plan
- [ ] N/A — OWNERS file update only