### PR TITLE
CNV-91457: Support multiple concurrent hot-cluster deployments with version-specific runner labels

### DIFF
--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -1,4 +1,5 @@
 name: Hot Cluster E2E Run
+run-name: "Hot Cluster E2E Run [${{ inputs.cluster_name || inputs.runner_label || 'kubevirt-plugin-ci' }}]"
 
 on:
   workflow_dispatch:
@@ -11,6 +12,16 @@ on:
         options:
           - gating
           - features
+      runner_label:
+        description: ARC runner label (defaults to kubevirt-plugin-ci)
+        required: false
+        default: ''
+        type: string
+      cluster_name:
+        description: Cluster name for run tagging (defaults to runner_label)
+        required: false
+        default: ''
+        type: string
   workflow_call:
     inputs:
       test_project:
@@ -18,6 +29,16 @@ on:
         type: string
         required: false
         default: gating
+      runner_label:
+        description: ARC runner label (defaults to kubevirt-plugin-ci)
+        type: string
+        required: false
+        default: ''
+      cluster_name:
+        description: Cluster name for run tagging (defaults to runner_label)
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -37,7 +58,7 @@ env:
 jobs:
   check-runner:
     name: Check Runner Image
-    runs-on: kubevirt-plugin-ci
+    runs-on: ${{ inputs.runner_label || 'kubevirt-plugin-ci' }}
     timeout-minutes: 15
     steps:
       - name: Log environment summary
@@ -227,7 +248,7 @@ jobs:
   run-gating-tests:
     name: Run Gating Tests
     needs: [check-runner, build-kubevirt-plugin-image]
-    runs-on: kubevirt-plugin-ci
+    runs-on: ${{ inputs.runner_label || 'kubevirt-plugin-ci' }}
     timeout-minutes: 120
     env:
       PLUGIN_IMAGE: ${{ needs.build-kubevirt-plugin-image.outputs.kubevirt-plugin-image }}

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -1,4 +1,5 @@
 name: Hot Cluster E2E
+run-name: "Hot Cluster E2E [${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}]"
 
 on:
   pull_request_target:
@@ -27,10 +28,15 @@ on:
           - ipi
           - vpc
           - classic
-      ipi_setup_run_id:
-        description: Setup workflow run ID (required for IPI to download install state)
+      runner_label:
+        description: ARC runner label (defaults to cluster_name)
         required: false
         default: ''
+        type: string
+      openshift_version:
+        description: 'OpenShift version (e.g. 4.22_openshift)'
+        required: false
+        default: '4.22_openshift'
         type: string
 
 permissions:
@@ -38,7 +44,7 @@ permissions:
   actions: write
 
 concurrency:
-  group: hot-cluster-e2e-${{ github.event.pull_request.number || github.ref }}
+  group: hot-cluster-e2e-${{ github.event.pull_request.number || format('{0}-{1}', github.ref, inputs.cluster_name || 'kubevirt-plugin-ci') }}
   cancel-in-progress: true
 
 env:
@@ -49,21 +55,68 @@ env:
   BASE_DOMAIN: cnv-ui.com
 
 jobs:
+  check-trust:
+    name: Check Trusted Author
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      trusted: ${{ steps.check.outputs.trusted }}
+    steps:
+      # author_association only reflects PUBLICLY visible org membership. Members
+      # with private membership (Settings > Organizations > "Publicize") are
+      # misreported as CONTRIBUTOR, so fall back to an explicit org membership
+      # check via the API before requiring the 'ok-to-test' label.
+      - name: Determine if PR author is a trusted org member
+        id: check
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          script: |
+            const association = context.payload.pull_request.author_association;
+            const trustedAssociations = ['MEMBER', 'OWNER', 'COLLABORATOR'];
+            const author = context.payload.pull_request.user.login;
+
+            if (trustedAssociations.includes(association)) {
+              core.info(`${author} has author_association=${association} — trusted.`);
+              core.setOutput('trusted', 'true');
+              return;
+            }
+
+            try {
+              await github.rest.orgs.checkMembershipForUser({
+                org: context.repo.owner,
+                username: author,
+              });
+              core.info(`${author} is a member of ${context.repo.owner} (author_association was '${association}', likely private membership) — trusted.`);
+              core.setOutput('trusted', 'true');
+            } catch (err) {
+              core.info(`${author} is not a member of ${context.repo.owner} (author_association='${association}') — untrusted.`);
+              core.setOutput('trusted', 'false');
+            }
+
   cluster-check:
-    if: >-
+    needs: check-trust
+    if: |
+      always() &&
       (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test') &&
       (
         github.event_name == 'workflow_dispatch' ||
         github.event.pull_request.head.repo.full_name == github.repository ||
-        contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+        needs.check-trust.outputs.trusted == 'true' ||
         (github.event.action == 'labeled' && github.event.label.name == 'ok-to-test')
       )
     uses: ./.github/workflows/hot-cluster-check.yml
+    with:
+      cluster_name: ${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}
+      infrastructure_type: ${{ inputs.infrastructure_type || 'ipi' }}
+      openshift_version: ${{ inputs.openshift_version || '4.22_openshift' }}
     secrets: inherit
 
   cluster-health-check:
     name: Cluster Health Check
-    if: github.event_name == 'workflow_dispatch' && inputs.ipi_setup_run_id != ''
+    needs: cluster-check
+    if: github.event_name == 'workflow_dispatch' && needs.cluster-check.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -144,4 +197,6 @@ jobs:
     uses: ./.github/workflows/hot-cluster-e2e-run.yml
     with:
       test_project: ${{ inputs.test_project || 'gating' }}
+      runner_label: ${{ inputs.runner_label || inputs.cluster_name || 'kubevirt-plugin-ci' }}
+      cluster_name: ${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}
     secrets: inherit

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -15,7 +15,7 @@ on:
           - gating
           - features
       cluster_name:
-        description: Cluster name
+        description: 'Cluster name (max 21 chars — IBM Cloud IPI limit, longer names get silently truncated)'
         required: true
         default: kubevirt-plugin-ci
         type: string

--- a/.github/workflows/ibmc-cleanup-all.yml
+++ b/.github/workflows/ibmc-cleanup-all.yml
@@ -24,8 +24,19 @@ on:
         options:
           - 'false'
           - 'true'
+      expected_cluster_count:
+        description: >-
+          Safety gate (destructive runs only): cluster_name is a PREFIX match, and
+          with multiple concurrent hot clusters (e.g. kubevirt-plugin-ci-91 also
+          starts with kubevirt-plugin-ci) it can silently match more than one
+          cluster. Set this to how many distinct clusters you expect to match; the
+          run fails before deleting anything if the actual count differs.
+        required: true
+        default: '1'
+        type: string
 
 permissions:
+  actions: read
   contents: read
 
 env:
@@ -38,6 +49,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Validate cluster_name format
+        run: |
+          if [[ ! "${CLUSTER_NAME}" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+            echo "::error::Invalid cluster_name: '${CLUSTER_NAME}'. Must start with a lower-case letter/digit and contain only lower-case letters, digits, and hyphens (matches real cluster naming). No length cap here since it's used as a prefix filter, not a single cluster's literal name."
+            exit 1
+          fi
+
       - name: Setup IBM Cloud CLI
         uses: IBM/actions-ibmcloud-cli@v2
         with:
@@ -48,6 +66,96 @@ jobs:
 
       - name: Install CIS plugin
         run: ibmcloud plugin install cis -f 2>/dev/null || true
+
+      - name: Detect distinct clusters matching prefix
+        id: detect_clusters
+        run: |
+          CIS_ID=$(ibmcloud cis instances --output json 2>/dev/null | jq -r '.[0].crn // empty' || true)
+
+          DNS_CLUSTERS="[]"
+          if [[ -n "${CIS_ID}" ]]; then
+            ibmcloud cis instance-set "${CIS_ID}" 2>/dev/null || true
+            for zone_id in $(ibmcloud cis domains --output json 2>/dev/null | jq -r '.[].id' || true); do
+              ZONE_CLUSTERS=$(ibmcloud cis dns-records "${zone_id}" --output json 2>/dev/null \
+                | jq -c --arg cn "${CLUSTER_NAME}" \
+                  '[.[] | select(.type == "A" or .type == "CNAME") | .name
+                    | capture("^api\\.(?<name>[^.]+)\\.") | .name
+                    | select(startswith($cn))] | unique' \
+                2>/dev/null || echo "[]")
+              DNS_CLUSTERS=$(echo "${DNS_CLUSTERS}" | jq -c --argjson z "${ZONE_CLUSTERS}" '. + $z | unique' 2>/dev/null || echo "${DNS_CLUSTERS}")
+            done
+          fi
+
+          ROKS_CLUSTERS=$(ibmcloud oc cluster ls --output json 2>/dev/null \
+            | jq -c --arg cn "${CLUSTER_NAME}" '[.[] | select(.name | startswith($cn)) | .name] // []' \
+            || echo "[]")
+
+          ALL_CLUSTERS=$(jq -cn --argjson a "${DNS_CLUSTERS}" --argjson b "${ROKS_CLUSTERS}" '($a + $b) | unique')
+          COUNT=$(echo "${ALL_CLUSTERS}" | jq 'length')
+          DETECTION_AVAILABLE="true"
+          if [[ -z "${CIS_ID}" ]]; then
+            echo "::warning::No CIS instance found — IPI cluster detection via DNS is unavailable (ROKS-only detection still applied). Safety gate will be skipped; proceed carefully."
+            if [[ "${COUNT}" -eq 0 ]]; then
+              DETECTION_AVAILABLE="false"
+            fi
+          fi
+
+          echo "Distinct clusters matching prefix '${CLUSTER_NAME}': ${ALL_CLUSTERS}"
+          echo "clusters=$(echo "${ALL_CLUSTERS}" | jq -c .)" >> "$GITHUB_OUTPUT"
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+          echo "detection_available=${DETECTION_AVAILABLE}" >> "$GITHUB_OUTPUT"
+
+      - name: Enforce expected cluster count
+        if: env.DRY_RUN == 'false' && steps.detect_clusters.outputs.detection_available == 'true'
+        env:
+          EXPECTED_COUNT: ${{ inputs.expected_cluster_count || '1' }}
+          ACTUAL_COUNT: ${{ steps.detect_clusters.outputs.count }}
+          MATCHED_CLUSTERS: ${{ steps.detect_clusters.outputs.clusters }}
+        run: |
+          if [[ "${ACTUAL_COUNT}" != "${EXPECTED_COUNT}" ]]; then
+            echo "::error::cluster_name '${CLUSTER_NAME}' matches ${ACTUAL_COUNT} distinct cluster(s): ${MATCHED_CLUSTERS} — but expected_cluster_count=${EXPECTED_COUNT}."
+            echo "::error::Narrow cluster_name to target one cluster precisely, or set expected_cluster_count=${ACTUAL_COUNT} to confirm you intend to sweep all of them."
+            exit 1
+          fi
+          echo "Confirmed: cluster_name matches exactly ${ACTUAL_COUNT} distinct cluster(s), as expected."
+
+      - name: Check for active CI jobs on matched clusters
+        if: env.DRY_RUN == 'false' && steps.detect_clusters.outputs.detection_available == 'true'
+        uses: actions/github-script@v9
+        env:
+          MATCHED_CLUSTERS: ${{ steps.detect_clusters.outputs.clusters }}
+        with:
+          script: |
+            const clusters = JSON.parse(process.env.MATCHED_CLUSTERS || '[]');
+            const workflows = [
+              '.github/workflows/hot-cluster-e2e.yml',
+              '.github/workflows/hot-cluster-e2e-run.yml',
+              '.github/workflows/ibmc-cluster-setup.yml',
+            ];
+            const busy = new Set();
+
+            for (const clusterName of clusters) {
+              const tag = `[${clusterName}]`;
+              for (const workflow of workflows) {
+                for (const status of ['in_progress', 'queued']) {
+                  const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                    ...context.repo,
+                    workflow_id: workflow,
+                    status,
+                    per_page: 100,
+                  });
+                  if (runs.some(r => r.display_title && r.display_title.includes(tag))) {
+                    busy.add(clusterName);
+                  }
+                }
+              }
+            }
+
+            if (busy.size > 0) {
+              core.setFailed(`Refusing to clean up — these matched clusters have active CI jobs: ${[...busy].join(', ')}. Wait for them to finish, or narrow cluster_name to exclude them.`);
+            } else {
+              core.info('No active CI jobs found on any matched cluster — safe to proceed.');
+            }
 
       - name: Find and delete VMs
         run: |
@@ -259,8 +367,42 @@ jobs:
           echo "=== ROKS Clusters ==="
           ibmcloud oc cluster ls 2>&1 | rg "${CLUSTER_NAME}" || echo "No ROKS clusters matching '${CLUSTER_NAME}'."
 
+      - name: Clean up ghost runners for matched clusters
+        if: env.DRY_RUN == 'false'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          MATCHED_CLUSTERS: ${{ steps.detect_clusters.outputs.clusters }}
+        run: |
+          echo "=== Offline Self-Hosted Runners ==="
+          CLUSTERS_JSON="${MATCHED_CLUSTERS:-[]}"
+          # Fall back to the raw prefix if detection found nothing (e.g. no CIS
+          # instance / non-IPI cluster), so ghost-runner cleanup still runs.
+          if [[ "${CLUSTERS_JSON}" == "[]" || -z "${CLUSTERS_JSON}" ]]; then
+            CLUSTERS_JSON=$(jq -cn --arg cn "${CLUSTER_NAME}" '[$cn]')
+          fi
+
+          echo "${CLUSTERS_JSON}" | jq -r '.[]' | while read -r name; do
+            echo "Checking for offline self-hosted runners with label '${name}'..."
+            # gh api's --jq only accepts a single jq-expression string (no --arg
+            # support), so interpolate the already-validated/detected name directly.
+            RUNNERS=$(gh api "/repos/${{ github.repository }}/actions/runners" --jq ".runners[] | select(.status == \"offline\") | select(.labels[].name == \"${name}\") | .id" 2>/dev/null || true)
+            if [[ -z "${RUNNERS}" ]]; then
+              echo "  No offline '${name}' runners found"
+            else
+              for runner_id in ${RUNNERS}; do
+                echo "  Deleting offline runner ${runner_id} (label: ${name})..."
+                gh api -X DELETE "/repos/${{ github.repository }}/actions/runners/${runner_id}" || echo "  Failed to delete runner ${runner_id}"
+              done
+            fi
+          done
+
       - name: Summary
         if: always()
+        env:
+          MATCHED_CLUSTERS: ${{ steps.detect_clusters.outputs.clusters }}
+          MATCHED_COUNT: ${{ steps.detect_clusters.outputs.count }}
+          DETECTION_AVAILABLE: ${{ steps.detect_clusters.outputs.detection_available }}
         run: |
           echo "## IBM Cloud Resource Cleanup" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -269,7 +411,12 @@ jobs:
           echo "| Cluster prefix | \`${CLUSTER_NAME}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Dry run | \`${DRY_RUN}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Clean VPC | \`${{ inputs.clean_vpc }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Detected distinct clusters | \`${MATCHED_COUNT:-N/A} (${MATCHED_CLUSTERS:-unavailable})\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Expected cluster count | \`${{ inputs.expected_cluster_count }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${DETECTION_AVAILABLE}" != "true" ]]; then
+            echo "⚠️ Cluster-count/active-job safety checks were **skipped** (detection unavailable — no CIS instance and no matching ROKS clusters found)." >> "$GITHUB_STEP_SUMMARY"
+          fi
           if [[ "${DRY_RUN}" == "true" ]]; then
             echo "**Dry run** — no resources were deleted. Set dry_run to false to delete." >> "$GITHUB_STEP_SUMMARY"
           else

--- a/.github/workflows/ibmc-cluster-auto-teardown.yml
+++ b/.github/workflows/ibmc-cluster-auto-teardown.yml
@@ -108,8 +108,8 @@ jobs:
         env:
           INPUT_CLUSTER_NAME: ${{ inputs.cluster_name }}
         run: |
-          if [[ ! "${INPUT_CLUSTER_NAME}" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
-            echo "::error::Invalid cluster_name: '${INPUT_CLUSTER_NAME}'. Must match [a-zA-Z0-9][a-zA-Z0-9._-]*"
+          if [[ ! "${INPUT_CLUSTER_NAME}" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]{0,20}$ ]]; then
+            echo "::error::Invalid cluster_name: '${INPUT_CLUSTER_NAME}'. Must match [a-zA-Z0-9][a-zA-Z0-9._-]* and be at most 21 characters."
             exit 1
           fi
           echo "matrix=[\"${INPUT_CLUSTER_NAME}\"]" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ibmc-cluster-auto-teardown.yml
+++ b/.github/workflows/ibmc-cluster-auto-teardown.yml
@@ -1,4 +1,5 @@
 name: IBM Cloud Hot Cluster Auto-Teardown
+run-name: "Hot Cluster Auto-Teardown [${{ inputs.cluster_name || 'all' }}]"
 
 on:
   schedule:
@@ -6,12 +7,12 @@ on:
   workflow_dispatch:
     inputs:
       cluster_name:
-        description: 'Cluster name to check'
+        description: 'Cluster name to check (leave default for all clusters)'
         required: true
         default: 'kubevirt-plugin-ci'
         type: string
       idle_threshold_minutes:
-        description: 'Minutes of CI inactivity before teardown'
+        description: 'Minutes of CI inactivity before teardown (overrides per-cluster defaults)'
         required: true
         default: '240'
         type: string
@@ -34,52 +35,157 @@ permissions:
   actions: write
 
 env:
-  CLUSTER_NAME: ${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}
-  IDLE_THRESHOLD_MINUTES: ${{ inputs.idle_threshold_minutes || '240' }}
   IBM_REGION: eu-de
   IBM_RESOURCE_GROUP: cnv-ui
   BASE_DOMAIN: cnv-ui.com
 
 jobs:
+  discover-clusters:
+    name: Discover Clusters
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      clusters: ${{ steps.discover.outputs.clusters }}
+    steps:
+      - name: Setup IBM Cloud CLI
+        uses: IBM/actions-ibmcloud-cli@v2
+        with:
+          api_key: ${{ secrets.IC_KEY }}
+          region: ${{ env.IBM_REGION }}
+          group: ${{ env.IBM_RESOURCE_GROUP }}
+          plugins: kubernetes-service
+
+      - name: Discover active clusters
+        id: discover
+        run: |
+          CLUSTERS="[]"
+
+          echo "=== Discovering IPI clusters via CIS DNS ==="
+          CIS_CRN=$(ibmcloud cis instances --output json 2>/dev/null | jq -r '.[0].crn // empty' || true)
+          if [[ -n "${CIS_CRN}" ]]; then
+            ibmcloud cis instance-set "${CIS_CRN}" 2>/dev/null || true
+            ZONE_ID=$(ibmcloud cis domains --output json 2>/dev/null | jq -r '.[0].id // empty' || true)
+            if [[ -n "${ZONE_ID}" ]]; then
+              IPI_CLUSTERS=$(ibmcloud cis dns-records "${ZONE_ID}" --output json 2>/dev/null \
+                | jq -c '[.[] | select(.type == "A" or .type == "CNAME") | .name
+                    | capture("^api\\.(?<name>[^.]+)\\.'"${BASE_DOMAIN}"'$") | .name] | unique' \
+                || echo "[]")
+              echo "IPI clusters from DNS: ${IPI_CLUSTERS}"
+              CLUSTERS=$(echo "${CLUSTERS}" | jq -c --argjson ipi "${IPI_CLUSTERS}" '. + $ipi' || echo "[]")
+            else
+              echo "WARNING: Could not find CIS zone"
+            fi
+          else
+            echo "WARNING: No CIS instance found"
+          fi
+
+          echo "=== Discovering ROKS clusters ==="
+          ROKS_CLUSTERS=$(ibmcloud oc cluster ls --output json 2>/dev/null \
+            | jq -c '[.[].name] // []' \
+            || echo "[]")
+          echo "ROKS clusters: ${ROKS_CLUSTERS}"
+          CLUSTERS=$(echo "${CLUSTERS}" | jq -c --argjson roks "${ROKS_CLUSTERS}" '. + $roks | unique' || echo "[]")
+
+          if [[ $(echo "${CLUSTERS}" | jq 'length') -eq 0 ]]; then
+            echo "No clusters discovered — nothing to check"
+            echo "clusters=[]" >> "$GITHUB_OUTPUT"
+          else
+            echo "Discovered clusters: ${CLUSTERS}"
+            echo "clusters=${CLUSTERS}" >> "$GITHUB_OUTPUT"
+          fi
+
+  validate-input:
+    name: Validate Input
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      cluster_matrix: ${{ steps.sanitize.outputs.matrix }}
+    steps:
+      - name: Sanitize cluster_name input
+        id: sanitize
+        env:
+          INPUT_CLUSTER_NAME: ${{ inputs.cluster_name }}
+        run: |
+          if [[ ! "${INPUT_CLUSTER_NAME}" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+            echo "::error::Invalid cluster_name: '${INPUT_CLUSTER_NAME}'. Must match [a-zA-Z0-9][a-zA-Z0-9._-]*"
+            exit 1
+          fi
+          echo "matrix=[\"${INPUT_CLUSTER_NAME}\"]" >> "$GITHUB_OUTPUT"
+
   check-and-teardown:
-    name: Check Idle & Teardown
+    name: 'Check & Teardown [${{ matrix.cluster_name }}]'
+    needs: [discover-clusters, validate-input]
+    if: |
+      always() && (
+        (github.event_name == 'schedule' && needs.discover-clusters.outputs.clusters != '[]') ||
+        (github.event_name == 'workflow_dispatch' && needs.validate-input.result == 'success')
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster_name: ${{ github.event_name == 'schedule' && fromJSON(needs.discover-clusters.outputs.clusters) || fromJSON(needs.validate-input.outputs.cluster_matrix) }}
+    env:
+      CLUSTER_NAME: ${{ matrix.cluster_name }}
     steps:
-      - name: Check CI jobs
+      - name: Determine idle threshold for this cluster
+        id: threshold
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_IDLE_THRESHOLD: ${{ inputs.idle_threshold_minutes }}
+        run: |
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" && -n "${INPUT_IDLE_THRESHOLD}" ]]; then
+            echo "minutes=${INPUT_IDLE_THRESHOLD}" >> "$GITHUB_OUTPUT"
+            echo "Using workflow_dispatch override: ${INPUT_IDLE_THRESHOLD} minutes"
+          elif [[ "${CLUSTER_NAME}" == "kubevirt-plugin-ci" ]]; then
+            echo "minutes=240" >> "$GITHUB_OUTPUT"
+            echo "Default/main cluster: 240 minutes (4h)"
+          else
+            echo "minutes=120" >> "$GITHUB_OUTPUT"
+            echo "Release-branch cluster: 120 minutes (2h)"
+          fi
+
+      - name: Check CI jobs for this cluster
         id: check_ci
         uses: actions/github-script@v9
         env:
           INCLUDE_WORKFLOWS: '[".github/workflows/hot-cluster-e2e.yml", ".github/workflows/hot-cluster-e2e-run.yml", ".github/workflows/ibmc-cluster-setup.yml"]'
+          CLUSTER_NAME: ${{ matrix.cluster_name }}
         with:
           script: |
             const INCLUDE_WORKFLOWS = JSON.parse(process.env.INCLUDE_WORKFLOWS);
+            const clusterName = process.env.CLUSTER_NAME;
+            const clusterTag = `[${clusterName}]`;
 
             let inProgress = 0;
             let queued = 0;
-            let completed = 0;
             let lastRunTime = null;
 
             try {
-              const results = await Promise.all(
-                INCLUDE_WORKFLOWS.map(workflow =>
-                  Promise.all([
-                    github.rest.actions.listWorkflowRuns({ ...context.repo, workflow_id: workflow, status: 'in_progress', per_page: 1 }),
-                    github.rest.actions.listWorkflowRuns({ ...context.repo, workflow_id: workflow, status: 'queued',      per_page: 1 }),
-                    github.rest.actions.listWorkflowRuns({ ...context.repo, workflow_id: workflow, status: 'completed',   per_page: 1 }),
-                  ])
-                )
-              );
+              for (const workflow of INCLUDE_WORKFLOWS) {
+                for (const status of ['in_progress', 'queued', 'completed']) {
+                  const runs = await github.rest.actions.listWorkflowRuns({
+                    ...context.repo,
+                    workflow_id: workflow,
+                    status,
+                    per_page: 10,
+                  });
 
-              for (const [ipRes, qRes, completedRes] of results) {
-                inProgress += ipRes.data.total_count;
-                queued     += qRes.data.total_count;
-                completed  += completedRes.data.total_count;
+                  const matching = runs.data.workflow_runs.filter(
+                    r => r.display_title && r.display_title.includes(clusterTag)
+                  );
 
-                const lastRun = completedRes.data.workflow_runs[0];
-                if (lastRun) {
-                  const t = new Date(lastRun.updated_at);
-                  if (!lastRunTime || t > lastRunTime) lastRunTime = t;
+                  if (status === 'in_progress') inProgress += matching.length;
+                  if (status === 'queued') queued += matching.length;
+                  if (status === 'completed') {
+                    for (const run of matching) {
+                      const t = new Date(run.updated_at);
+                      if (!lastRunTime || t > lastRunTime) lastRunTime = t;
+                    }
+                  }
                 }
               }
             } catch (err) {
@@ -89,10 +195,10 @@ jobs:
 
             const minutesAgo = lastRunTime ? Math.floor((new Date().getTime() - lastRunTime.getTime()) / 60000) : 'N/A';
             core.summary.addList([
-              `In-progress CI runs: ${inProgress}`,
-              `Queued CI runs: ${queued}`,
-              `Completed CI runs: ${completed}`,
-              `Last run time: ${lastRunTime ? lastRunTime.toISOString() : 'N/A'} (${minutesAgo} minutes ago)`,
+              `Cluster: ${clusterName}`,
+              `In-progress CI runs (tagged): ${inProgress}`,
+              `Queued CI runs (tagged): ${queued}`,
+              `Last tagged run: ${lastRunTime ? lastRunTime.toISOString() : 'N/A'} (${minutesAgo} minutes ago)`,
             ]);
             await core.summary.write();
             core.setOutput('active_jobs', (inProgress > 0 || queued > 0) ? 'true' : 'false');
@@ -139,26 +245,30 @@ jobs:
         uses: actions/github-script@v9
         env:
           LAST_RUN_TIME: ${{ steps.check_ci.outputs.last_run_time }}
-          IDLE_THRESHOLD_MINUTES: ${{ env.IDLE_THRESHOLD_MINUTES }}
-          CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
+          IDLE_THRESHOLD_MINUTES: ${{ steps.threshold.outputs.minutes }}
+          CLUSTER_NAME: ${{ matrix.cluster_name }}
         with:
           script: |
             let lastRunTime = process.env.LAST_RUN_TIME;
+            const clusterName = process.env.CLUSTER_NAME;
+            const clusterTag = `[${clusterName}]`;
 
             if (!lastRunTime) {
-              core.info('No completed CI runs found, checking cluster setup time as fallback...');
+              core.info('No completed tagged CI runs found, checking cluster setup time as fallback...');
 
-              // Try the latest successful setup workflow run
               try {
                 const runs = await github.rest.actions.listWorkflowRuns({
                   ...context.repo,
                   workflow_id: 'ibmc-cluster-setup.yml',
                   status: 'success',
-                  per_page: 1,
+                  per_page: 10,
                 });
-                if (runs.data.workflow_runs.length > 0) {
-                  lastRunTime = runs.data.workflow_runs[0].updated_at;
-                  core.info(`Using last successful setup run time: ${lastRunTime}`);
+                const match = runs.data.workflow_runs.find(
+                  r => r.display_title && r.display_title.includes(clusterTag)
+                );
+                if (match) {
+                  lastRunTime = match.updated_at;
+                  core.info(`Using last successful setup run time for ${clusterName}: ${lastRunTime}`);
                 }
               } catch (err) {
                 core.warning(`Failed to query setup runs: ${err.message}`);
@@ -176,6 +286,7 @@ jobs:
             const idleMinutes = Math.floor((Date.now() - lastTime.getTime()) / 60000);
             const threshold = parseInt(process.env.IDLE_THRESHOLD_MINUTES, 10);
 
+            core.info(`Cluster: ${clusterName}`);
             core.info(`Last activity: ${lastRunTime}`);
             core.info(`Idle for ${idleMinutes} minutes (threshold: ${threshold} minutes)`);
 
@@ -218,16 +329,20 @@ jobs:
       - name: Trigger teardown
         if: steps.check_idle.outputs.recent_activity == 'false' && steps.check_cluster.outputs.exists == 'true'
         uses: actions/github-script@v9
+        env:
+          INFRA_TYPE: ${{ steps.check_cluster.outputs.infra_type }}
+          CLUSTER_NAME: ${{ matrix.cluster_name }}
         with:
           script: |
-            const infraType = '${{ steps.check_cluster.outputs.infra_type }}' || 'classic';
+            const infraType = process.env.INFRA_TYPE || 'classic';
+            const clusterName = process.env.CLUSTER_NAME;
 
             const inputs = {
-              cluster_name: '${{ env.CLUSTER_NAME }}',
+              cluster_name: clusterName,
               infrastructure_type: infraType,
             };
 
-            core.info(`Triggering teardown for ${infraType} cluster '${inputs.cluster_name}'`);
+            core.info(`Triggering teardown for ${infraType} cluster '${clusterName}'`);
 
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
@@ -246,8 +361,9 @@ jobs:
           IDLE_RECENT_ACTIVITY: ${{ steps.check_idle.outputs.recent_activity }}
           IDLE_REASON: ${{ steps.check_idle.outputs.reason }}
           BUSINESS_HOURS_SKIP: ${{ steps.check_hours.outputs.skip }}
+          IDLE_THRESHOLD_MINUTES: ${{ steps.threshold.outputs.minutes }}
         run: |
-          echo "## Auto-Teardown Check" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Auto-Teardown Check: ${CLUSTER_NAME}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Check | Result |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ibmc-cluster-auto-teardown.yml
+++ b/.github/workflows/ibmc-cluster-auto-teardown.yml
@@ -164,17 +164,30 @@ jobs:
             let queued = 0;
             let lastRunTime = null;
 
+            // Bound the "completed" lookup to recent history so pagination stays
+            // fast — idle thresholds top out at a few hours, so a few days of
+            // lookback is ample and avoids paging through a workflow's full run history.
+            const lookbackDate = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+
             try {
               for (const workflow of INCLUDE_WORKFLOWS) {
                 for (const status of ['in_progress', 'queued', 'completed']) {
-                  const runs = await github.rest.actions.listWorkflowRuns({
+                  const params = {
                     ...context.repo,
                     workflow_id: workflow,
                     status,
-                    per_page: 10,
-                  });
+                    per_page: 100,
+                  };
+                  if (status === 'completed') {
+                    params.created = `>=${lookbackDate}`;
+                  }
 
-                  const matching = runs.data.workflow_runs.filter(
+                  // Paginate fully before filtering — with multiple concurrent
+                  // clusters, a specific cluster's tagged run can easily fall
+                  // outside the first page.
+                  const runs = await github.paginate(github.rest.actions.listWorkflowRuns, params);
+
+                  const matching = runs.filter(
                     r => r.display_title && r.display_title.includes(clusterTag)
                   );
 

--- a/.github/workflows/ibmc-cluster-setup.yml
+++ b/.github/workflows/ibmc-cluster-setup.yml
@@ -14,7 +14,7 @@ on:
           - vpc
           - classic
       cluster_name:
-        description: 'Cluster name'
+        description: 'Cluster name (max 21 chars — IBM Cloud IPI limit, longer names get silently truncated)'
         required: true
         default: 'kubevirt-plugin-ci'
         type: string
@@ -73,6 +73,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:
+      - name: Validate cluster_name format
+        run: |
+          if [[ ! "${CLUSTER_NAME}" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]{0,20}$ ]]; then
+            echo "::error::Invalid cluster_name: '${CLUSTER_NAME}'. Must match [a-zA-Z0-9][a-zA-Z0-9._-]* and be at most 21 characters (IBM Cloud IPI cluster name limit — longer names are silently truncated, which breaks health checks, teardown, and auto-teardown discovery)."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v7
 

--- a/.github/workflows/ibmc-cluster-setup.yml
+++ b/.github/workflows/ibmc-cluster-setup.yml
@@ -1,4 +1,5 @@
 name: IBM Cloud Hot Cluster Setup
+run-name: "Hot Cluster Setup [${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}]"
 
 on:
   workflow_dispatch:
@@ -481,11 +482,14 @@ jobs:
           ARC_PAT: ${{ secrets.ARC_GITHUB_PAT }}
           ARC_RUNNER_IMAGE: ${{ steps.build_runner.outputs.image_ref }}
           ARC_VERSION: '0.14.0'
+          RUNNER_SCALE_SET_NAME: ${{ env.CLUSTER_NAME }}
         run: |
           ./ci-scripts/hot-cluster/arc/install-arc-controller.sh
           ./ci-scripts/hot-cluster/arc/install-runner-scale-set.sh
 
       - name: Install CI environment controller
+        env:
+          RUNNER_SCALE_SET_NAME: ${{ env.CLUSTER_NAME }}
         run: |
           ./ci-scripts/hot-cluster/ci-env/install-ci-env-controller.sh
 

--- a/.github/workflows/ibmc-cluster-setup.yml
+++ b/.github/workflows/ibmc-cluster-setup.yml
@@ -75,8 +75,8 @@ jobs:
     steps:
       - name: Validate cluster_name format
         run: |
-          if [[ ! "${CLUSTER_NAME}" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]{0,20}$ ]]; then
-            echo "::error::Invalid cluster_name: '${CLUSTER_NAME}'. Must match [a-zA-Z0-9][a-zA-Z0-9._-]* and be at most 21 characters (IBM Cloud IPI cluster name limit — longer names are silently truncated, which breaks health checks, teardown, and auto-teardown discovery)."
+          if [[ ! "${CLUSTER_NAME}" =~ ^[a-z0-9]([a-z0-9-]{0,19}[a-z0-9])?$ ]]; then
+            echo "::error::Invalid cluster_name: '${CLUSTER_NAME}'. Must be a lower-case RFC 1123 DNS label (start/end with alphanumeric, only lower-case letters/digits/hyphens in between — no uppercase, underscores, or dots) and at most 21 characters (IBM Cloud IPI cluster name limit — longer names are silently truncated, which breaks health checks, teardown, and auto-teardown discovery). This name is also used as-is for the ARC Helm release and the api.\${CLUSTER_NAME}.\${BASE_DOMAIN} hostname, both of which require RFC 1123-safe values."
             exit 1
           fi
 

--- a/.github/workflows/ibmc-cluster-teardown.yml
+++ b/.github/workflows/ibmc-cluster-teardown.yml
@@ -66,7 +66,17 @@ jobs:
     name: Tear Down Hot Cluster
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    concurrency:
+      group: hot-cluster-teardown-${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}
+      cancel-in-progress: false
     steps:
+      - name: Validate cluster_name format
+        run: |
+          if [[ ! "${CLUSTER_NAME}" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+            echo "::error::Invalid cluster_name: '${CLUSTER_NAME}'. Must match [a-zA-Z0-9][a-zA-Z0-9._-]*"
+            exit 1
+          fi
+
       - name: Check for active setup/e2e workflows
         if: inputs.force != true
         uses: actions/github-script@v9
@@ -121,8 +131,8 @@ jobs:
         continue-on-error: true
         run: |
           if command -v helm &>/dev/null || (curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash); then
-            echo "Uninstalling ARC runner scale set..."
-            helm uninstall kubevirt-plugin-ci --namespace arc-runners --wait --timeout 5m 2>/dev/null || echo "Runner scale set not found or already removed"
+            echo "Uninstalling ARC runner scale set '${CLUSTER_NAME}'..."
+            helm uninstall "${CLUSTER_NAME}" --namespace arc-runners --wait --timeout 5m 2>/dev/null || echo "Runner scale set not found or already removed"
 
             echo "Uninstalling ARC controller..."
             helm uninstall arc --namespace arc-systems --wait --timeout 5m 2>/dev/null || echo "ARC controller not found or already removed"
@@ -206,15 +216,17 @@ jobs:
           mkdir -p "${INSTALL_DIR}"
 
           if [[ -z "${SETUP_RUN_ID}" ]]; then
-            echo "No setup run ID provided. Looking up latest successful setup run..."
+            echo "No setup run ID provided. Looking up latest successful setup run for cluster '${CLUSTER_NAME}'..."
             SETUP_RUN_ID=$(gh run list --repo "${{ github.repository }}" \
-              --workflow="IBM Cloud Hot Cluster Setup" --status=success --limit=1 \
-              --json databaseId -q '.[0].databaseId' 2>/dev/null || true)
+              --workflow="IBM Cloud Hot Cluster Setup" --status=success --limit=20 \
+              --json databaseId,displayTitle 2>/dev/null \
+              | jq -r --arg tag "[${CLUSTER_NAME}]" '.[] | select(.displayTitle | contains($tag)) | .databaseId' \
+              | head -1 || true)
             if [[ -z "${SETUP_RUN_ID}" ]]; then
-              echo "::error::No successful IPI setup run found and no ipi_setup_run_id provided."
+              echo "::error::No successful IPI setup run found for cluster '${CLUSTER_NAME}' and no ipi_setup_run_id provided."
               exit 1
             fi
-            echo "Using latest successful setup run: ${SETUP_RUN_ID}"
+            echo "Using latest successful setup run for '${CLUSTER_NAME}': ${SETUP_RUN_ID}"
           fi
 
           echo "Downloading IPI install state from run ${SETUP_RUN_ID}..."
@@ -254,11 +266,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.BOT_PAT }}
         run: |
-          echo "Checking for offline self-hosted runners..."
-          RUNNERS=$(gh api "/repos/${{ github.repository }}/actions/runners" --jq '.runners[] | select(.status == "offline") | select(.labels[].name == "kubevirt-plugin-ci") | .id' 2>/dev/null || true)
+          echo "Checking for offline self-hosted runners with label '${CLUSTER_NAME}'..."
+          RUNNERS=$(gh api "/repos/${{ github.repository }}/actions/runners" --jq --arg label "${CLUSTER_NAME}" '.runners[] | select(.status == "offline") | select(.labels[].name == $label) | .id' 2>/dev/null || true)
 
           if [[ -z "${RUNNERS}" ]]; then
-            echo "No offline 'kubevirt-plugin-ci' runners found"
+            echo "No offline '${CLUSTER_NAME}' runners found"
           else
             for runner_id in ${RUNNERS}; do
               echo "Deleting offline runner ${runner_id}..."

--- a/.github/workflows/ibmc-cluster-teardown.yml
+++ b/.github/workflows/ibmc-cluster-teardown.yml
@@ -72,8 +72,8 @@ jobs:
     steps:
       - name: Validate cluster_name format
         run: |
-          if [[ ! "${CLUSTER_NAME}" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
-            echo "::error::Invalid cluster_name: '${CLUSTER_NAME}'. Must match [a-zA-Z0-9][a-zA-Z0-9._-]*"
+          if [[ ! "${CLUSTER_NAME}" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]{0,20}$ ]]; then
+            echo "::error::Invalid cluster_name: '${CLUSTER_NAME}'. Must match [a-zA-Z0-9][a-zA-Z0-9._-]* and be at most 21 characters."
             exit 1
           fi
 

--- a/.github/workflows/ibmc-cluster-teardown.yml
+++ b/.github/workflows/ibmc-cluster-teardown.yml
@@ -267,7 +267,10 @@ jobs:
           GH_TOKEN: ${{ secrets.BOT_PAT }}
         run: |
           echo "Checking for offline self-hosted runners with label '${CLUSTER_NAME}'..."
-          RUNNERS=$(gh api "/repos/${{ github.repository }}/actions/runners" --jq --arg label "${CLUSTER_NAME}" '.runners[] | select(.status == "offline") | select(.labels[].name == $label) | .id' 2>/dev/null || true)
+          # gh api's --jq only accepts a single jq-expression string (no --arg
+          # support for variable binding), so interpolate CLUSTER_NAME directly.
+          # Safe here since it was already regex-validated earlier in this job.
+          RUNNERS=$(gh api "/repos/${{ github.repository }}/actions/runners" --jq ".runners[] | select(.status == \"offline\") | select(.labels[].name == \"${CLUSTER_NAME}\") | .id" 2>/dev/null || true)
 
           if [[ -z "${RUNNERS}" ]]; then
             echo "No offline '${CLUSTER_NAME}' runners found"

--- a/.github/workflows/retest-e2e.yml
+++ b/.github/workflows/retest-e2e.yml
@@ -1,0 +1,100 @@
+name: Retest E2E
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  pull-requests: write
+
+jobs:
+  retest:
+    name: Retest Hot Cluster E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/retest-e2e')
+    steps:
+      - name: Check trusted author and re-run E2E workflow
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          script: |
+            const author = context.payload.comment.user.login;
+            const association = context.payload.comment.author_association;
+            const trustedAssociations = ['MEMBER', 'OWNER', 'COLLABORATOR'];
+            let trusted = trustedAssociations.includes(association);
+
+            if (!trusted) {
+              try {
+                await github.rest.orgs.checkMembershipForUser({
+                  org: context.repo.owner,
+                  username: author,
+                });
+                core.info(`${author} is a member of ${context.repo.owner} (author_association was '${association}', likely private membership) — trusted.`);
+                trusted = true;
+              } catch {
+                core.info(`${author} is not a trusted member (author_association='${association}') — ignoring /retest-e2e.`);
+              }
+            }
+
+            if (!trusted) {
+              await github.rest.reactions.createForIssueComment({
+                ...context.repo,
+                comment_id: context.payload.comment.id,
+                content: '-1',
+              });
+              core.setFailed(`${author} is not authorized to use /retest-e2e`);
+              return;
+            }
+
+            const prNumber = context.issue.number;
+            const pr = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: prNumber,
+            });
+            const headSha = pr.data.head.sha;
+
+            core.info(`/retest-e2e requested by ${author} on PR #${prNumber} (HEAD: ${headSha})`);
+
+            const runs = await github.rest.actions.listWorkflowRuns({
+              ...context.repo,
+              workflow_id: 'hot-cluster-e2e.yml',
+              event: 'pull_request_target',
+              per_page: 10,
+            });
+
+            const prRun = runs.data.workflow_runs.find(r => {
+              const prMatch = r.pull_requests?.some(p => p.number === prNumber);
+              const shaMatch = r.head_sha === headSha;
+              return prMatch || shaMatch;
+            });
+
+            if (!prRun) {
+              const msg = `No Hot Cluster E2E workflow run found for PR #${prNumber}. ` +
+                `Push a commit to trigger the initial run.`;
+              core.warning(msg);
+              await github.rest.reactions.createForIssueComment({
+                ...context.repo,
+                comment_id: context.payload.comment.id,
+                content: 'confused',
+              });
+              return;
+            }
+
+            core.info(`Re-running workflow run ${prRun.id} (attempt ${prRun.run_attempt})...`);
+
+            await github.rest.reactions.createForIssueComment({
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+            await github.rest.actions.reRunWorkflow({
+              ...context.repo,
+              run_id: prRun.id,
+            });
+
+            core.info(`Re-run triggered: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${prRun.id}`);

--- a/ci-scripts/hot-cluster/arc/install-arc-controller.sh
+++ b/ci-scripts/hot-cluster/arc/install-arc-controller.sh
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 ARC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CI_SCRIPTS_DIR="$(cd "${ARC_DIR}/.." && pwd)"
+CI_SCRIPTS_DIR="$(cd "${ARC_DIR}/../.." && pwd)"
 source "${CI_SCRIPTS_DIR}/_cluster-helpers.sh"
 verify_oc
 

--- a/ci-scripts/hot-cluster/arc/install-runner-scale-set.sh
+++ b/ci-scripts/hot-cluster/arc/install-runner-scale-set.sh
@@ -25,7 +25,7 @@
 
 set -euo pipefail
 ARC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CI_SCRIPTS_DIR="$(cd "${ARC_DIR}/.." && pwd)"
+CI_SCRIPTS_DIR="$(cd "${ARC_DIR}/../.." && pwd)"
 source "${CI_SCRIPTS_DIR}/_cluster-helpers.sh"
 verify_oc
 

--- a/ci-scripts/hot-cluster/ci-env/install-ci-env-controller.sh
+++ b/ci-scripts/hot-cluster/ci-env/install-ci-env-controller.sh
@@ -18,8 +18,13 @@
 set -euo pipefail
 
 CI_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# NOTE: despite the name, this is ci-scripts/hot-cluster (not ci-scripts/) —
+# it's what the other paths below (CHART_DIR, setup-ci-env-runner-image.sh)
+# actually need, since those live under hot-cluster/. _cluster-helpers.sh is
+# the one file that stayed at the top-level ci-scripts/, hence the separate var.
 CI_SCRIPTS_DIR="$(cd "${CI_ENV_DIR}/.." && pwd)"
-source "${CI_SCRIPTS_DIR}/_cluster-helpers.sh"
+REPO_CI_SCRIPTS_DIR="$(cd "${CI_ENV_DIR}/../.." && pwd)"
+source "${REPO_CI_SCRIPTS_DIR}/_cluster-helpers.sh"
 verify_oc
 
 CHART_DIR="${CI_SCRIPTS_DIR}/helm/ci-env-controller"

--- a/ci-scripts/hot-cluster/images/setup-arc-runner-image.sh
+++ b/ci-scripts/hot-cluster/images/setup-arc-runner-image.sh
@@ -22,8 +22,8 @@
 # can be pulled.
 #
 set -euo pipefail
-SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
 source "${REPO_ROOT}/ci-scripts/_cluster-helpers.sh"
 verify_oc

--- a/ci-scripts/hot-cluster/images/setup-ci-env-runner-image.sh
+++ b/ci-scripts/hot-cluster/images/setup-ci-env-runner-image.sh
@@ -21,8 +21,8 @@
 # can be pulled.
 #
 set -euo pipefail
-SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
 source "${REPO_ROOT}/ci-scripts/_cluster-helpers.sh"
 verify_oc

--- a/ci-scripts/hot-cluster/install-hco.sh
+++ b/ci-scripts/hot-cluster/install-hco.sh
@@ -85,11 +85,12 @@ done
 # --- Wait for HCO operator deployment ---
 echo "Waiting for HCO operator deployment to be created..."
 for i in $(seq 1 60); do
-  DEPLOY_COUNT=$(oc get deployments -n ${CNV_NS} \
-    -l "app.kubernetes.io/component=deployment,app.kubernetes.io/managed-by=hco-operator" \
-    --no-headers 2>/dev/null | wc -l || echo "0")
-  # Also check the operator deployment itself
-  HCO_DEPLOY=$(oc get deployment hco-operator -n ${CNV_NS} --no-headers 2>/dev/null | wc -l || echo "0")
+  # Note: `|| true` (not `|| echo "0"`) — with `pipefail`, a failing `oc get`
+  # (e.g. resource not found, which is expected while polling) makes the
+  # pipeline's exit status non-zero even though `wc -l` already succeeded and
+  # printed "0"; `|| echo "0"` would then append a second "0" line, breaking
+  # the numeric comparison below.
+  HCO_DEPLOY=$(oc get deployment hco-operator -n ${CNV_NS} --no-headers 2>/dev/null | wc -l || true)
   if [[ "${HCO_DEPLOY}" -gt 0 ]]; then
     echo "HCO operator deployment found"
     break

--- a/ci-scripts/hot-cluster/install-hco.sh
+++ b/ci-scripts/hot-cluster/install-hco.sh
@@ -23,7 +23,7 @@ HPP_VERSION="${HPP_VERSION:-release-v0.21}"
 CNV_NS="openshift-cnv"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 echo "=== OpenShift Virtualization (CNV) Installation ==="
 echo "  KVM_EMULATION: ${KVM_EMULATION}"


### PR DESCRIPTION
## 📝 Description

Enable multiple hot-cluster IPI deployments to run concurrently (e.g. one for `OpenShift 4.20`, another for `4.22`), each with a unique ARC runner label so E2E tests can target a specific cluster version.

## 🔗 Links

Jira ticket: [CNV-91457](https://redhat.atlassian.net/browse/CNV-91457)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Retest E2E** workflow to authorized users, triggered by a `/retest-e2e` PR comment.
  * Expanded Hot Cluster workflows with **cluster-specific run tagging**, selectable ARC runner label, and configurable OpenShift version.
  * Added an **expected cluster count safety gate** to the all-cluster cleanup workflow.
* **Bug Fixes**
  * Improved trust/gating logic and refined when cluster checks run.
  * Strengthened cluster matching for setup/teardown, added **cluster name validation**, and improved offline runner cleanup accuracy.
  * Improved HCO operator readiness polling reliability.
* **Refactor**
  * Reworked per-cluster discovery, concurrency/serialization, and per-cluster idle thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->