### PR TITLE
CNV-92509: Use in-cluster ServiceAccount auth instead of kubeadmin for Playwright scenario test setup

### DIFF
--- a/ci-scripts/hot-cluster/arc/arc-runner-rbac.yaml
+++ b/ci-scripts/hot-cluster/arc/arc-runner-rbac.yaml
@@ -44,9 +44,10 @@ rules:
     verbs: ['get', 'list']
 
   # --- Cypress cy.exec runs: oc patch virtualmachine ---
+  # --- Playwright scenario tests: KubernetesClient.createContainerDiskVm/cleanup ---
   - apiGroups: ['kubevirt.io']
     resources: ['virtualmachines']
-    verbs: ['get', 'list', 'watch', 'patch']
+    verbs: ['get', 'list', 'watch', 'patch', 'create', 'delete']
 
   # --- E2E test setup: user-settings and feature-flag configmaps in HCO namespace ---
   - apiGroups: ['']

--- a/playwright/project-dependencies/rule-engine/setup-rules.ts
+++ b/playwright/project-dependencies/rule-engine/setup-rules.ts
@@ -43,6 +43,20 @@ export function getSetupRules(): SetupRule[] {
     },
     {
       guard: (ctx) => !ctx.effectiveKubeConfigPath,
+      id: 'in-cluster-service-account',
+      name: 'Generate kubeconfig via in-cluster ServiceAccount',
+      onError: 'warn',
+      phase: SetupPhase.AUTH,
+      run: async (ctx) => {
+        if (!KubernetesClient.isInClusterEnvironment()) return;
+        logger.info('🔐 Authenticating via in-cluster ServiceAccount token...');
+        KubernetesClient.generateInClusterKubeconfig(ctx.kubeConfigPath);
+        ctx.effectiveKubeConfigPath = ctx.kubeConfigPath;
+        logger.success('✓ Kubeconfig generated from in-cluster ServiceAccount');
+      },
+    },
+    {
+      guard: (ctx) => !ctx.effectiveKubeConfigPath,
       id: 'oc-login',
       name: 'Generate kubeconfig via oc login',
       onError: 'warn',

--- a/playwright/src/clients/kubernetes-auth.ts
+++ b/playwright/src/clients/kubernetes-auth.ts
@@ -186,6 +186,74 @@ export async function getOAuthToken(
   });
 }
 
+const SERVICE_ACCOUNT_DIR = '/var/run/secrets/kubernetes.io/serviceaccount';
+const SERVICE_ACCOUNT_TOKEN_PATH = `${SERVICE_ACCOUNT_DIR}/token`;
+const SERVICE_ACCOUNT_CA_PATH = `${SERVICE_ACCOUNT_DIR}/ca.crt`;
+
+/**
+ * True when running inside a pod with a mounted ServiceAccount token — i.e. the
+ * standard in-cluster auth mechanism is available without needing kubeadmin
+ * (or any other) credentials.
+ */
+export function isInClusterEnvironment(): boolean {
+  return (
+    !!process.env.KUBERNETES_SERVICE_HOST &&
+    fs.existsSync(SERVICE_ACCOUNT_TOKEN_PATH) &&
+    fs.existsSync(SERVICE_ACCOUNT_CA_PATH)
+  );
+}
+
+/**
+ * Generate a kubeconfig from the pod's mounted ServiceAccount token, avoiding
+ * any need for a static admin username/password. The token is short-lived and
+ * scoped by RBAC to the ServiceAccount's identity, and the real cluster CA
+ * cert is used instead of skipping TLS verification.
+ */
+export function generateInClusterKubeconfig(outputPath: string): string {
+  if (!isInClusterEnvironment()) {
+    throw new Error(
+      'Not running in-cluster: KUBERNETES_SERVICE_HOST or the ServiceAccount token/CA files are missing.',
+    );
+  }
+
+  const host = process.env.KUBERNETES_SERVICE_HOST;
+  const port =
+    process.env.KUBERNETES_SERVICE_PORT_HTTPS || process.env.KUBERNETES_SERVICE_PORT || '443';
+  // IPv6 literals must be bracketed in a URL (e.g. https://[::1]:443); IPv4
+  // addresses and hostnames contain no colons and pass through unchanged.
+  const formattedHost = host?.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+  const server = `https://${formattedHost}:${port}`;
+  const token = fs.readFileSync(SERVICE_ACCOUNT_TOKEN_PATH, 'utf8').trim();
+
+  const kubeconfigYaml = `apiVersion: v1
+kind: Config
+clusters:
+  - name: cluster
+    cluster:
+      server: ${server}
+      certificate-authority: ${SERVICE_ACCOUNT_CA_PATH}
+contexts:
+  - name: context
+    context:
+      cluster: cluster
+      user: user
+current-context: context
+users:
+  - name: user
+    user:
+      token: ${token}
+`;
+
+  const dir = path.dirname(outputPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  fs.writeFileSync(outputPath, kubeconfigYaml, { encoding: 'utf8', mode: 0o600 });
+  fs.chmodSync(outputPath, 0o600);
+  return outputPath;
+}
+
 export async function generateKubeconfig(
   clusterUrl: string,
   username: string,

--- a/playwright/src/clients/kubernetes-client.ts
+++ b/playwright/src/clients/kubernetes-client.ts
@@ -4,9 +4,11 @@ import * as k8s from '@kubernetes/client-node';
 
 import {
   createProxyAgent,
+  generateInClusterKubeconfig,
   generateKubeconfig,
   getOAuthToken,
   getProxyUrl,
+  isInClusterEnvironment,
 } from './kubernetes-auth';
 
 const POLL_INTERVAL = 2000;
@@ -16,8 +18,10 @@ const POLL_INTERVAL = 2000;
  * Wraps @kubernetes/client-node directly — extend with new methods as tests require them.
  */
 export class KubernetesClient {
+  static readonly generateInClusterKubeconfig = generateInClusterKubeconfig;
   static readonly generateKubeconfig = generateKubeconfig;
   static readonly getOAuthToken = getOAuthToken;
+  static readonly isInClusterEnvironment = isInClusterEnvironment;
 
   private readonly coApi: k8s.CustomObjectsApi;
   private readonly coreApi: k8s.CoreV1Api;


### PR DESCRIPTION
## 📝 Description

Prep work for the upstream test-infra migration.

The Playwright scenario/migration test rule engine (`playwright/project-dependencies/rule-engine/setup-rules.ts`) authenticates to the cluster via `oc login -u kubeadmin -p <password>` when no `kubeconfig` is already present. In the hot-cluster CI setup, this password has no real source (falls back to hardcoded placeholders), and even when supplied, it means exposing a static, cluster-admin credential to a `pull_request_target` workflow that runs PR-branch code.

Adds a higher-priority setup rule that authenticates using the `RC runner pod's already-mounted `ServiceAccount` token instead (via `KubeConfig.loadFromCluster()`-equivalent `kubeconfig` generation), falling back to `oc-login/oauth-login` only when not running in-cluster (e.g. local dev). Also extends the `arc-runner-ci` ClusterRole with create/delete on virtualmachines to support VM lifecycle test 

## 🔗 Links

Jira ticket: [CNV-92509](https://redhat.atlassian.net/browse/CNV-92509)

## 🎥 Demo

N/A 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added automatic in-cluster Kubernetes authentication by generating a kubeconfig from the current service account when running inside the cluster.

* **Bug Fixes**
  * Improved reliability of Playwright scenarios by ensuring in-cluster Kubernetes access is correctly configured.

* **Chores**
  * Updated test-run permissions to allow creating and cleaning up temporary virtual machines during Playwright scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
