### PR TITLE
CNV-91699: Manual BP for vm clone name fix 4.20

### DIFF
--- a/src/utils/components/CloneVMModal/CloneVMModal.tsx
+++ b/src/utils/components/CloneVMModal/CloneVMModal.tsx
@@ -42,6 +42,8 @@ const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, sour
     `${name}${isVM(source) ? '-clone-' : '-'}${getRandomChars()}`.substring(0, MAX_K8S_NAME_LENGTH),
   );
 
+  const [isVMNameValid, setIsVMNameValid] = useState(false);
+
   const [startCloneVM, setStartCloneVM] = useState(false);
 
   const [initialCloneRequest, setInitialCloneRequest] = useState<V1beta1VirtualMachineClone>();
@@ -75,7 +77,7 @@ const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, sour
     <TabModal
       closeOnSubmit={false}
       headerText={headerText ?? t('Clone {{sourceKind}}', { sourceKind: source.kind })}
-      isDisabled={Boolean(initialCloneRequest)}
+      isDisabled={Boolean(initialCloneRequest) || !isVMNameValid}
       isLoading={Boolean(initialCloneRequest)}
       isOpen={isOpen}
       modalVariant={ModalVariant.large}
@@ -85,7 +87,7 @@ const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, sour
       submitBtnText={isVM(source) ? t('Clone') : t('Create')}
     >
       <Form className="pf-v6-u-w-75-on-md pf-v6-u-w-66-on-lg pf-v6-u-m-auto" isHorizontal>
-        <NameInput name={cloneName} setName={setCloneName} />
+        <NameInput name={cloneName} setIsValid={setIsVMNameValid} setName={setCloneName} />
         <StartClonedVMCheckbox setStartCloneVM={setStartCloneVM} startCloneVM={startCloneVM} />
         {isVM(source) ? (
           <ConfigurationSummary vm={source} />

--- a/src/utils/components/CloneVMModal/components/NameInput.tsx
+++ b/src/utils/components/CloneVMModal/components/NameInput.tsx
@@ -1,23 +1,44 @@
-import React, { Dispatch, FC, SetStateAction } from 'react';
+import React, { FC, FormEvent, useEffect, useState } from 'react';
 
+import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { FormGroup, TextInput } from '@patternfly/react-core';
+import { getDNS1120LabelError } from '@kubevirt-utils/utils/validation';
+import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
 
 type NameInputProps = {
   name: string;
-  setName: Dispatch<SetStateAction<string>>;
+  setIsValid: (valid: boolean) => void;
+  setName: (value: string) => void;
 };
 
-const NameInput: FC<NameInputProps> = ({ name, setName }) => {
+const NameInput: FC<NameInputProps> = ({ name, setIsValid, setName }) => {
   const { t } = useKubevirtTranslation();
+  const [hasInteracted, setHasInteracted] = useState(false);
+
+  const errorFn = getDNS1120LabelError(name);
+  const errorText = errorFn?.(t);
+
+  useEffect(() => {
+    setIsValid(!errorText);
+  }, [errorText, setIsValid]);
+
+  const handleChange = (_event: FormEvent<HTMLInputElement>, value: string) => {
+    if (!hasInteracted) setHasInteracted(true);
+    setName(value);
+  };
+
   return (
-    <FormGroup fieldId="name" isRequired label={t('Name')}>
+    <FormGroup fieldId="clone-name" isRequired label={t('Name')}>
       <TextInput
-        id="name"
-        onChange={(_, value: string) => setName(value)}
+        id="clone-name"
+        onChange={handleChange}
         type="text"
+        validated={hasInteracted && errorText ? ValidatedOptions.error : ValidatedOptions.default}
         value={name}
       />
+      {hasInteracted && errorText && (
+        <FormGroupHelperText validated={ValidatedOptions.error}>{errorText}</FormGroupHelperText>
+      )}
     </FormGroup>
   );
 };


### PR DESCRIPTION

## 📝 Description

Manual backport of PR https://github.com/kubevirt-ui/kubevirt-plugin/pull/3866 ([CNV-85822](https://redhat.atlassian.net/browse/CNV-85822)) to release-4.20.
Adds RFC 1123 / DNS-1123 name validation to the Clone VM modal. Names longer
than 63 characters, or names with invalid characters (uppercase, special chars),
now show an inline error message and disable the Clone button.

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-91699


