### PR TITLE
Fix unit-test CI to exclude and run .github/scripts tests separately

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -71,6 +71,18 @@ jobs:
       - name: Run Unit Tests
         run: npm run test-cov
 
+      - name: Install script dependencies
+        working-directory: .github/scripts
+        run: npm ci
+
+      - name: Check workflow script types
+        working-directory: .github/scripts
+        run: npm run check-types
+
+      - name: Run workflow script tests
+        working-directory: .github/scripts
+        run: npm test
+
       - name: Coverage Upload
         uses: codecov/codecov-action@v2
         with:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -31,7 +31,11 @@ const config: Config.InitialOptions = {
   testEnvironmentOptions: {
     url: 'http://localhost/',
   },
-  testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/dist/'],
+  testPathIgnorePatterns: [
+    '<rootDir>/node_modules/',
+    '<rootDir>/dist/',
+    '<rootDir>/.github/scripts/',
+  ],
   testRegex: '.*\\.test\\.(ts|tsx|js|jsx)$',
   transform: {
     '^.+\\.[t|j]sx?$': ['ts-jest', tsJestOptions],


### PR DESCRIPTION
## Summary
- Exclude `.github/scripts/` from Jest via `testPathIgnorePatterns` so `npm run test-cov` no longer picks up workflow script tests
- Run `.github/scripts` type checks and tests explicitly in the existing `unit-test` job (Node 22)

## Test plan
- [ ] CI `unit-test` job passes on this PR
- [ ] Main Jest suite still runs with coverage upload
- [ ] `.github/scripts` tests and type checks run successfully in the same job


Made with [Cursor](https://cursor.com)