### PR TITLE
CNV-89616: Navigate vm wizard

### DIFF
--- a/src/multicluster/urls.ts
+++ b/src/multicluster/urls.ts
@@ -1,4 +1,4 @@
-import { matchPath } from 'react-router';
+import { matchPath, NavigateFunction } from 'react-router';
 
 import {
   TemplateModel,
@@ -77,6 +77,20 @@ export const getVMWizardURL = (cluster: string, namespace?: string): string => {
   return cluster === ALL_CLUSTERS_KEY
     ? `${FLEET_WIZARD_PATH}/${ALL_CLUSTERS_KEY}/${ALL_NAMESPACES}`
     : `${FLEET_WIZARD_PATH}/cluster/${cluster}/${namespacePath}`;
+};
+
+type NavigateToVMWizardParams = {
+  cluster: string;
+  namespace?: string;
+  navigate: NavigateFunction;
+};
+
+export const navigateToVMWizard = ({
+  cluster,
+  namespace,
+  navigate,
+}: NavigateToVMWizardParams): void => {
+  navigate(getVMWizardURL(cluster, namespace), { state: { namespace } });
 };
 
 export const getConsoleStandaloneURL = (

--- a/src/views/virtualmachines/list/components/OverviewTab/components/NoVMsAlert.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/components/NoVMsAlert.tsx
@@ -53,7 +53,9 @@ const NoVMsAlert: FC<NoVMsAlertProps> = ({ namespace }) => {
           {alertMessage}
           {canCreateVM && (
             <div className="pf-v6-u-mt-sm">
-              <Link to={vmWizardURL}>{t('Create VM')}</Link>
+              <Link state={{ namespace }} to={vmWizardURL}>
+                {t('Create VM')}
+              </Link>
             </div>
           )}
         </>

--- a/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachinesCreateButton/VirtualMachinesCreateButton.tsx
@@ -8,7 +8,7 @@ import { logVMCreationStarted } from '@kubevirt-utils/extensions/telemetry/vm-cr
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getVMListPath } from '@kubevirt-utils/resources/vm';
 import useCluster from '@multicluster/hooks/useCluster';
-import { getACMVMListURL, getVMWizardURL } from '@multicluster/urls';
+import { getACMVMListURL, navigateToVMWizard } from '@multicluster/urls';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import {
   Button,
@@ -48,10 +48,7 @@ const VirtualMachinesCreateButton: FC<VirtualMachinesCreateButtonProps> = ({
     verb: 'create',
   });
 
-  const vmWizardURL = useMemo(
-    () => getVMWizardURL(isACMPage ? cluster || '' : '', namespace),
-    [isACMPage, cluster, namespace],
-  );
+  const wizardCluster = useMemo(() => (isACMPage ? cluster || '' : ''), [isACMPage, cluster]);
 
   const yamlURL = useMemo(
     () =>
@@ -69,17 +66,21 @@ const VirtualMachinesCreateButton: FC<VirtualMachinesCreateButtonProps> = ({
           logVMCreationStarted(TELEMETRY_VM_CREATION_METHOD.SCRATCH);
           return navigate(yamlURL);
         default:
-          return navigate(vmWizardURL, { state: { namespace } });
+          return navigateToVMWizard({ cluster: wizardCluster, namespace, navigate });
       }
     },
-    [navigate, vmWizardURL, yamlURL],
+    [navigate, wizardCluster, namespace, yamlURL],
   );
 
   if (!canCreateVM) return null;
 
   if (!showDropdown) {
     return (
-      <Button data-test="item-create" onClick={() => navigate(vmWizardURL)} variant="primary">
+      <Button
+        data-test="item-create"
+        onClick={() => navigateToVMWizard({ cluster: wizardCluster, namespace, navigate })}
+        variant="primary"
+      >
         {buttonText ?? t('Create VirtualMachine')}
       </Button>
     );
@@ -94,7 +95,7 @@ const VirtualMachinesCreateButton: FC<VirtualMachinesCreateButtonProps> = ({
               <MenuToggleAction
                 aria-label={t('Create VirtualMachine')}
                 key="create-vm"
-                onClick={() => navigate(vmWizardURL, { state: { namespace } })}
+                onClick={() => navigateToVMWizard({ cluster: wizardCluster, namespace, navigate })}
               >
                 {t('Create')}
               </MenuToggleAction>,

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/utils.ts
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/utils.ts
@@ -6,7 +6,7 @@ import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
 import { getLabel, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
-import { getVMWizardURL } from '@multicluster/urls';
+import { navigateToVMWizard } from '@multicluster/urls';
 import {
   CLUSTER_SELECTOR_PREFIX,
   FOLDER_SELECTOR_PREFIX,
@@ -27,7 +27,7 @@ export const getCreateVMAction = (
 ): ActionDropdownItemType => {
   return {
     cta: () => {
-      navigate(getVMWizardURL(cluster, namespace), { state: { namespace } });
+      navigateToVMWizard({ cluster, namespace, navigate });
     },
     id: 'create-vm',
     label: t('Create VirtualMachine'),

--- a/src/views/virtualmachinesinstance/list/VirtualMachinesInstancesList.tsx
+++ b/src/views/virtualmachinesinstance/list/VirtualMachinesInstancesList.tsx
@@ -9,7 +9,6 @@ import useKubevirtDataViewFilters from '@kubevirt-utils/hooks/useKubevirtDataVie
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
-import { getVMWizardURL } from '@multicluster/urls';
 import { ListPageBody, ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
 
 import VirtualMachineInstanceEmptyState from './components/VirtualMachineInstanceEmptyState/VirtualMachineInstanceEmptyState';
@@ -23,7 +22,6 @@ type VirtualMachinesInstancesListProps = {
 const VirtualMachinesInstancesList: FC<VirtualMachinesInstancesListProps> = ({ namespace }) => {
   const { t } = useKubevirtTranslation();
   const cluster = useClusterParam();
-  const wizardURL = getVMWizardURL(cluster, namespace || DEFAULT_NAMESPACE);
 
   const [vmis, loaded, loadError] = useK8sWatchData<V1VirtualMachineInstance[]>({
     cluster,
@@ -60,7 +58,12 @@ const VirtualMachinesInstancesList: FC<VirtualMachinesInstancesListProps> = ({ n
           initialSortKey={VMI_COLUMN_KEYS.name}
           loaded={loaded}
           loadError={loadError}
-          noDataMsg={<VirtualMachineInstanceEmptyState wizardURL={wizardURL} />}
+          noDataMsg={
+            <VirtualMachineInstanceEmptyState
+              cluster={cluster}
+              namespace={namespace || DEFAULT_NAMESPACE}
+            />
+          }
           unfilteredData={vmis}
         />
       </ListPageBody>

--- a/src/views/virtualmachinesinstance/list/components/VirtualMachineInstanceEmptyState/VirtualMachineInstanceEmptyState.tsx
+++ b/src/views/virtualmachinesinstance/list/components/VirtualMachineInstanceEmptyState/VirtualMachineInstanceEmptyState.tsx
@@ -3,14 +3,17 @@ import { useNavigate } from 'react-router';
 
 import ListEmptyState from '@kubevirt-utils/components/ListEmptyState/ListEmptyState';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { navigateToVMWizard } from '@multicluster/urls';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { RocketIcon, VirtualMachineIcon } from '@patternfly/react-icons';
 
 type VirtualMachineInstanceEmptyStateProps = {
-  wizardURL: string;
+  cluster: string;
+  namespace: string;
 };
 const VirtualMachineInstanceEmptyState: FC<VirtualMachineInstanceEmptyStateProps> = ({
-  wizardURL,
+  cluster,
+  namespace,
 }) => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
@@ -18,7 +21,10 @@ const VirtualMachineInstanceEmptyState: FC<VirtualMachineInstanceEmptyStateProps
   return (
     <ListEmptyState
       buttonAction={
-        <Button onClick={() => navigate(wizardURL)} variant={ButtonVariant.primary}>
+        <Button
+          onClick={() => navigateToVMWizard({ cluster, namespace, navigate })}
+          variant={ButtonVariant.primary}
+        >
           {t('Create VirtualMachine')}
         </Button>
       }

--- a/src/views/welcome/components/WelcomeButtons.tsx
+++ b/src/views/welcome/components/WelcomeButtons.tsx
@@ -7,7 +7,7 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
 import { getName } from '@kubevirt-utils/resources/shared';
-import { getVMWizardURL } from '@multicluster/urls';
+import { navigateToVMWizard } from '@multicluster/urls';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, ButtonVariant, Split, SplitItem } from '@patternfly/react-core';
 
@@ -26,7 +26,7 @@ const WelcomeButtons: FC<WelcomeButtonsProps> = ({ onClose }) => {
   const hasNoProjects = projectsLoaded && !projectsError && (!projects || projects.length === 0);
 
   const onCreateVM = () => {
-    navigate(getVMWizardURL(''));
+    navigateToVMWizard({ cluster: '', navigate });
     onClose();
   };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

* added a shared function that navigates to create-vm and set location state
## 🔗 Links

jira ticket: https://redhat.atlassian.net/browse/CNV-89616
## 🎥 Demo

https://github.com/user-attachments/assets/36e28ec3-8ca8-4841-92a5-6c8902665d45





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved VM creation navigation across the UI, keeping users in the correct cluster and namespace when launching the VM wizard.
  * Empty-state and shortcut actions now open the VM creation flow more consistently from list, tree, and welcome screens.

* **Bug Fixes**
  * Fixed cases where the VM wizard could lose namespace context during navigation.
  * Updated “Create VM” actions to behave consistently across different entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->