### PR TITLE
CNV-92566: Fix hot-cluster CI trust-gate skip and auto-teardown cluster discovery bugs

### DIFF
--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -99,7 +99,6 @@ jobs:
     needs: check-trust
     if: |
       always() &&
-      (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test') &&
       (
         github.event_name == 'workflow_dispatch' ||
         github.event.pull_request.head.repo.full_name == github.repository ||

--- a/.github/workflows/ibmc-cluster-auto-teardown.yml
+++ b/.github/workflows/ibmc-cluster-auto-teardown.yml
@@ -56,6 +56,9 @@ jobs:
           group: ${{ env.IBM_RESOURCE_GROUP }}
           plugins: kubernetes-service
 
+      - name: Install CIS plugin
+        run: ibmcloud plugin install cis -f 2>/dev/null || true
+
       - name: Discover active clusters
         id: discover
         run: |


### PR DESCRIPTION
## 📝 Description

Fix hot-cluster CI trust-gate skip and auto-teardown cluster discovery bugs

## 🔗 Links

Jira ticket: [CNV-92566](https://redhat.atlassian.net/browse/CNV-92566)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster maintenance workflow reliability by ensuring a required cloud plugin is available during cluster discovery.
* **Chores**
  * Streamlined automated test gating for cluster checks, reducing redundant conditions while preserving access controls and label-based approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->