### PR TITLE
CNV-92582: Verify that merging is blocked upon e2e failure [DO-NOT-MERGE] 

### DIFF
--- a/playwright/tests/gating/template-list.spec.ts
+++ b/playwright/tests/gating/template-list.spec.ts
@@ -21,7 +21,9 @@ test.describe('Template list page', () => {
   test('filter template by name', async ({ templatesPage }) => {
     await templatesPage.filterByName(CENTOSSTREAM9);
     await templatesPage.expectTemplateVisible(CENTOSSTREAM9);
-    await templatesPage.expectTemplateNotVisible(CENTOSSTREAM10);
+    // TEMPORARY: intentional failure to verify the "Run Gating Tests" required
+    // check actually blocks merging (CNV-92582). Revert this line before merging.
+    await templatesPage.expectTemplateVisible(CENTOSSTREAM10);
   });
 
   test('filter by template type', async ({ templatesPage }) => {


### PR DESCRIPTION
## 📝 Description

Verify that merging is blocked when e2e tests are not passing. 

## 🔗 Links

Jira ticket: [CNV-92582](https://redhat.atlassian.net/browse/CNV-92582)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated coverage for template name filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->