### PR TITLE
CNV-92590: Hot cluster E2E reruns unnecessarily on unrelated label events

### DIFF
--- a/.github/workflows/hot-cluster-e2e-cancel-on-close.yml
+++ b/.github/workflows/hot-cluster-e2e-cancel-on-close.yml
@@ -1,0 +1,55 @@
+name: Cancel Hot Cluster E2E on PR Close
+run-name: 'Cancel Hot Cluster E2E [PR #${{ github.event.pull_request.number }}]'
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+
+jobs:
+  cancel:
+    name: Cancel pending E2E runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Cancel in-progress/queued hot-cluster-e2e runs for this PR
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const headSha = context.payload.pull_request.head.sha;
+            const headBranch = context.payload.pull_request.head.ref;
+            const merged = context.payload.pull_request.merged;
+
+            core.info(`PR #${prNumber} closed (merged: ${merged}). Checking for pending E2E runs...`);
+
+            const runs = await github.rest.actions.listWorkflowRuns({
+              ...context.repo,
+              workflow_id: 'hot-cluster-e2e.yml',
+              event: 'pull_request_target',
+              per_page: 20,
+            });
+
+            const active = runs.data.workflow_runs.filter(r =>
+              ['queued', 'in_progress', 'waiting', 'requested', 'pending'].includes(r.status) &&
+              (
+                r.pull_requests?.some(p => p.number === prNumber) ||
+                r.head_sha === headSha ||
+                r.head_branch === headBranch
+              )
+            );
+
+            if (active.length === 0) {
+              core.info(`No in-progress hot-cluster-e2e runs found for PR #${prNumber}.`);
+              return;
+            }
+
+            for (const run of active) {
+              core.info(`Cancelling run ${run.id} (status: ${run.status})`);
+              await github.rest.actions.cancelWorkflowRun({ ...context.repo, run_id: run.id }).catch(err => {
+                core.warning(`Failed to cancel run ${run.id}: ${err.message}`);
+              });
+            }

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -45,7 +45,10 @@ permissions:
 
 concurrency:
   group: hot-cluster-e2e-${{ github.event.pull_request.number || format('{0}-{1}', github.ref, inputs.cluster_name || 'kubevirt-plugin-ci') }}
-  cancel-in-progress: true
+  # Only cancel a real in-progress run for events that actually warrant one
+  # (push/reopen, or an ok-to-test labeling). Routine bot-added labels (lgtm,
+  # approved, jira/valid-reference, ...) must not cancel a genuine run.
+  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'ok-to-test' }}
 
 env:
   CLUSTER_NAME: ${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}
@@ -96,6 +99,7 @@ jobs:
     needs: check-trust
     if: |
       always() &&
+      (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test') &&
       (
         github.event_name == 'workflow_dispatch' ||
         github.event.pull_request.head.repo.full_name == github.repository ||
@@ -201,13 +205,18 @@ jobs:
   # A top-level job (unlike run-e2e-tests, which is a `uses:` reusable-workflow
   # call) posts its check-run under its own bare name — no composite prefix —
   # so this is the job branch protection can actually match. if: always()
-  # guarantees it reports a real success/failure for every push, even when
-  # upstream jobs are skipped (e.g. untrusted author, no ok-to-test label),
-  # so Tide can never merge on a silently-vanished check again.
+  # guarantees it reports a real success/failure for every meaningful push,
+  # even when upstream jobs are skipped (e.g. untrusted author, no ok-to-test
+  # label), so Tide can never merge on a silently-vanished check again. The
+  # event-relevance guard below stops it from also running on irrelevant
+  # label events (lgtm, approved, ...), which would otherwise overwrite a
+  # prior passing result for the same commit SHA with a bogus failure.
   verify-gating-tests:
     name: Run Gating Tests
     needs: [check-trust, cluster-check, cluster-health-check, run-e2e-tests]
-    if: always()
+    if: |
+      always() &&
+      (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## 📝 Description

Hot cluster E2E reruns unnecessarily on unrelated label events.

## 🔗 Links

Jira ticket: [CNV-92590](https://redhat.atlassian.net/browse/CNV-92590)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hot-cluster E2E run handling so routine label changes no longer cancel valid in-progress checks.
  * Tightened gating behavior to keep test results from being overwritten by unrelated label events.
  * Added automatic cleanup that cancels matching E2E runs when a pull request is closed, helping prevent stale jobs from continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->