### PR TITLE
CNV-92525: Branch-aware hot cluster selection for release-branch PRs

### DIFF
--- a/.github/workflows/hot-cluster-e2e-cancel-on-close.yml
+++ b/.github/workflows/hot-cluster-e2e-cancel-on-close.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Cancel in-progress/queued hot-cluster-e2e runs for this PR
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          # No BOT_PAT needed: listing/cancelling workflow runs is a plain
+          # Actions-API operation, not an identity-sensitive one, so the
+          # default GITHUB_TOKEN (scoped via `permissions: actions: write`
+          # above) is sufficient.
           script: |
             const prNumber = context.payload.pull_request.number;
             const headSha = context.payload.pull_request.head.sha;

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -1,5 +1,5 @@
 name: Hot Cluster E2E
-run-name: "Hot Cluster E2E [${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}]"
+run-name: "Hot Cluster E2E [${{ inputs.cluster_name || github.base_ref || 'kubevirt-plugin-ci' }}]"
 
 on:
   pull_request_target:
@@ -51,13 +51,38 @@ concurrency:
   cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'ok-to-test' }}
 
 env:
-  CLUSTER_NAME: ${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}
   INFRASTRUCTURE_TYPE: ${{ inputs.infrastructure_type || 'ipi' }}
   IBM_REGION: eu-de
   IBM_RESOURCE_GROUP: cnv-ui
   BASE_DOMAIN: cnv-ui.com
 
 jobs:
+  # Resolves cluster_name/openshift_version for this run. workflow_dispatch
+  # always uses its own inputs unchanged. Automatic pull_request_target runs
+  # against a release-4.X branch get a dedicated, version-matched cluster
+  # (kubevirt-plugin-<major><minor>) instead of silently colliding with
+  # main's kubevirt-plugin-ci cluster; any other base branch falls back to
+  # the same default as today.
+  resolve-cluster-config:
+    name: Resolve Cluster Config
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      cluster_name: ${{ steps.resolve.outputs.cluster_name }}
+      openshift_version: ${{ steps.resolve.outputs.openshift_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Resolve cluster_name/openshift_version for this branch
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          INPUT_CLUSTER_NAME: ${{ inputs.cluster_name }}
+          INPUT_OPENSHIFT_VERSION: ${{ inputs.openshift_version }}
+        run: ./ci-scripts/hot-cluster/resolve-cluster-config.sh >> "$GITHUB_OUTPUT"
+
   check-trust:
     name: Check Trusted Author
     if: github.event_name == 'pull_request_target'
@@ -96,7 +121,7 @@ jobs:
             core.setOutput('trusted', trusted ? 'true' : 'false');
 
   cluster-check:
-    needs: check-trust
+    needs: [check-trust, resolve-cluster-config]
     if: |
       always() &&
       (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test') &&
@@ -108,17 +133,19 @@ jobs:
       )
     uses: ./.github/workflows/hot-cluster-check.yml
     with:
-      cluster_name: ${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}
+      cluster_name: ${{ needs.resolve-cluster-config.outputs.cluster_name }}
       infrastructure_type: ${{ inputs.infrastructure_type || 'ipi' }}
-      openshift_version: ${{ inputs.openshift_version || '4.22_openshift' }}
+      openshift_version: ${{ needs.resolve-cluster-config.outputs.openshift_version }}
     secrets: inherit
 
   cluster-health-check:
     name: Cluster Health Check
-    needs: cluster-check
+    needs: [cluster-check, resolve-cluster-config]
     if: github.event_name == 'workflow_dispatch' && needs.cluster-check.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      CLUSTER_NAME: ${{ needs.resolve-cluster-config.outputs.cluster_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -188,7 +215,7 @@ jobs:
 
   run-e2e-tests:
     name: Run E2E Tests
-    needs: [cluster-check, cluster-health-check]
+    needs: [cluster-check, cluster-health-check, resolve-cluster-config]
     if: |
       always() && (
         needs.cluster-check.result == 'success' ||
@@ -197,8 +224,8 @@ jobs:
     uses: ./.github/workflows/hot-cluster-e2e-run.yml
     with:
       test_project: ${{ inputs.test_project || 'gating' }}
-      runner_label: ${{ inputs.runner_label || inputs.cluster_name || 'kubevirt-plugin-ci' }}
-      cluster_name: ${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}
+      runner_label: ${{ inputs.runner_label || needs.resolve-cluster-config.outputs.cluster_name }}
+      cluster_name: ${{ needs.resolve-cluster-config.outputs.cluster_name }}
     secrets: inherit
 
   # Single source of truth for the "Run Gating Tests" required status check.

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -137,6 +137,7 @@ ci-scripts/
     ipi-install-config.yaml.tpl
     log-ibmcloud-iam-diagnostics.sh
     provision-vpc-resources.sh
+    resolve-cluster-config.sh
     resolve-console-image.sh
     test-cleanup.sh
     arc/
@@ -147,20 +148,20 @@ ci-scripts/
 
 ## Scripts
 
-| Script                                           | Purpose                                                    |
-| ------------------------------------------------ | ---------------------------------------------------------- |
-| `hot-cluster/install-hco.sh`                     | Installs HCO operator, HPP storage, and virtctl            |
-| `hot-cluster/check-cluster-health.sh`            | Verifies cluster, HCO, ARC, storage, console               |
-| `hot-cluster/check-roks-cluster-state.sh`        | Polls until ROKS cluster is ready                          |
-| `hot-cluster/log-ibmcloud-iam-diagnostics.sh`    | Logs IAM permissions for debugging (classic, VPC, and IPI) |
-| `hot-cluster/cleanup-ipi-resources.sh`           | Cleans stale IPI resources before provisioning             |
-| `hot-cluster/create-ipi-cluster.sh`              | Creates IPI cluster with retry logic                       |
-| `hot-cluster/configure-kubeconfig.sh`            | Configures kubeconfig with DNS retry                       |
-| `hot-cluster/provision-vpc-resources.sh`         | Provisions VPC, subnet, and public gateway                 |
-| `hot-cluster/configure-image-registry.sh`        | Configures the internal image registry                     |
-| `hot-cluster/arc/install-arc-controller.sh`      | Installs ARC controller (once per cluster)                 |
-| `hot-cluster/arc/install-runner-scale-set.sh`    | Installs ARC runner scale set                              |
-| `hot-cluster/ci-env/install-ci-env-controller.sh`| Installs the ConfigMap-driven CI environment controller    |
+| Script                                            | Purpose                                                    |
+| ------------------------------------------------- | ---------------------------------------------------------- |
+| `hot-cluster/install-hco.sh`                      | Installs HCO operator, HPP storage, and virtctl            |
+| `hot-cluster/check-cluster-health.sh`             | Verifies cluster, HCO, ARC, storage, console               |
+| `hot-cluster/check-roks-cluster-state.sh`         | Polls until ROKS cluster is ready                          |
+| `hot-cluster/log-ibmcloud-iam-diagnostics.sh`     | Logs IAM permissions for debugging (classic, VPC, and IPI) |
+| `hot-cluster/cleanup-ipi-resources.sh`            | Cleans stale IPI resources before provisioning             |
+| `hot-cluster/create-ipi-cluster.sh`               | Creates IPI cluster with retry logic                       |
+| `hot-cluster/configure-kubeconfig.sh`             | Configures kubeconfig with DNS retry                       |
+| `hot-cluster/provision-vpc-resources.sh`          | Provisions VPC, subnet, and public gateway                 |
+| `hot-cluster/configure-image-registry.sh`         | Configures the internal image registry                     |
+| `hot-cluster/arc/install-arc-controller.sh`       | Installs ARC controller (once per cluster)                 |
+| `hot-cluster/arc/install-runner-scale-set.sh`     | Installs ARC runner scale set                              |
+| `hot-cluster/ci-env/install-ci-env-controller.sh` | Installs the ConfigMap-driven CI environment controller    |
 
 See [`hot-cluster/arc/README.md`](hot-cluster/arc/README.md) for ARC-specific details and [`hot-cluster/ci-env/README.md`](hot-cluster/ci-env/README.md) for the ci-env-controller.
 

--- a/ci-scripts/hot-cluster/resolve-cluster-config.sh
+++ b/ci-scripts/hot-cluster/resolve-cluster-config.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Emits cluster_name=... and openshift_version=... for GITHUB_OUTPUT.
+#
+# Automatic pull_request_target runs against a release-<major>.<minor>
+# branch get a dedicated, version-matched cluster (kubevirt-plugin-<major><minor>)
+# instead of silently colliding with main's kubevirt-plugin-ci cluster. Any
+# other base branch, and every workflow_dispatch run, falls back to the
+# provided input (or the repo's long-standing default).
+#
+# Env:
+#   EVENT_NAME              - github.event_name (e.g. pull_request_target, workflow_dispatch)
+#   BASE_REF                - github.base_ref (PR target branch, e.g. release-4.20)
+#   INPUT_CLUSTER_NAME       - workflow_dispatch inputs.cluster_name, if set
+#   INPUT_OPENSHIFT_VERSION  - workflow_dispatch inputs.openshift_version, if set
+#
+# Usage (from a workflow step):
+#   ./ci-scripts/hot-cluster/resolve-cluster-config.sh >> "$GITHUB_OUTPUT"
+
+DEFAULT_CLUSTER_NAME="kubevirt-plugin-ci"
+DEFAULT_OPENSHIFT_VERSION="4.22_openshift"
+
+EVENT_NAME="${EVENT_NAME:-}"
+BASE_REF="${BASE_REF:-}"
+INPUT_CLUSTER_NAME="${INPUT_CLUSTER_NAME:-}"
+INPUT_OPENSHIFT_VERSION="${INPUT_OPENSHIFT_VERSION:-}"
+
+if [[ "${EVENT_NAME}" == "pull_request_target" && "${BASE_REF}" =~ ^release-([0-9]+)\.([0-9]+)$ ]]; then
+  MAJOR="${BASH_REMATCH[1]}"
+  MINOR="${BASH_REMATCH[2]}"
+  CLUSTER_NAME="kubevirt-plugin-${MAJOR}${MINOR}"
+  OPENSHIFT_VERSION="${MAJOR}.${MINOR}_openshift"
+  echo "Base branch '${BASE_REF}' is a release branch → cluster '${CLUSTER_NAME}' (${OPENSHIFT_VERSION})" >&2
+else
+  CLUSTER_NAME="${INPUT_CLUSTER_NAME:-${DEFAULT_CLUSTER_NAME}}"
+  OPENSHIFT_VERSION="${INPUT_OPENSHIFT_VERSION:-${DEFAULT_OPENSHIFT_VERSION}}"
+  echo "Using default/workflow_dispatch cluster config: '${CLUSTER_NAME}' (${OPENSHIFT_VERSION})" >&2
+fi
+
+echo "cluster_name=${CLUSTER_NAME}"
+echo "openshift_version=${OPENSHIFT_VERSION}"


### PR DESCRIPTION
## 📝 Description

Add a branch-aware resolver to `hot-cluster-e2e.yml` that derives cluster_name/openshift_version from the PR's base branch when triggered automatically:

Release branches follow `release-<major>.<minor>` 

Derived cluster name: `kubevirt-plugin-<major><minor>` (major and minor concatenated, dot removed, no -ci suffix), e.g. release-4.20 -> `kubevirt-plugin-420` (19 chars, fits under the 21-char IBM Cloud cluster-name limit with 2 chars of margin). Major is preserved in the name, so different major versions do not collide (release-4.20 -> `kubevirt-plugin-420` vs a hypothetical release-5.20 ->` kubevirt-plugin-520`).

## 🔗 Links

Jira ticket: [CNV-92525](https://redhat.atlassian.net/browse/CNV-92525)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Displayed CI run names now better reflect the selected cluster or pull request target branch.
  * Workflow runs now automatically resolve cluster settings before launching checks, improving consistency across jobs.

* **Bug Fixes**
  * Cluster checks, health checks, and test jobs now use the same resolved cluster details, reducing mismatches during CI runs.
  * The cancel-on-close workflow now uses the built-in token permissions instead of a separate token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->