### PR TITLE
CNV-92531 - Migrate  D/S to U/S - apply coding standards to migrated data models

### DIFF
--- a/playwright/src/data-models/create-vm-test-fixtures.ts
+++ b/playwright/src/data-models/create-vm-test-fixtures.ts
@@ -1,9 +1,12 @@
 import { InstanceTypeSeries, InstanceTypeSize, OperatingSystem } from '@/data-factories';
 
+const CREATE_VM_TIMEOUT_MS = 60000;
+const CREATE_VM_LARGE_TIMEOUT_MS = 90000;
+
 /**
- * Interface for catalog VM creation test case parameters
+ * Catalog VM creation test case parameters
  */
-export interface CreateVmTestScenario {
+export type CreateVmTestScenario = {
   description: string;
   os: OperatingSystem;
   series: InstanceTypeSeries;
@@ -14,7 +17,7 @@ export interface CreateVmTestScenario {
     shouldCreate: boolean;
     timeout?: number;
   };
-}
+};
 
 /**
  * Catalog VM creation test fixtures - different VM configurations using Instance Types
@@ -35,7 +38,7 @@ export const CREATE_VM_CREATION_SCENARIOS: CreateVmTestScenario[] = [
     startAfterCreation: false,
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: CREATE_VM_TIMEOUT_MS,
     },
   },
   {
@@ -47,7 +50,7 @@ export const CREATE_VM_CREATION_SCENARIOS: CreateVmTestScenario[] = [
     startAfterCreation: false,
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: CREATE_VM_TIMEOUT_MS,
     },
   },
   {
@@ -59,7 +62,7 @@ export const CREATE_VM_CREATION_SCENARIOS: CreateVmTestScenario[] = [
     startAfterCreation: true,
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: CREATE_VM_TIMEOUT_MS,
     },
   },
   {
@@ -71,7 +74,7 @@ export const CREATE_VM_CREATION_SCENARIOS: CreateVmTestScenario[] = [
     startAfterCreation: false,
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: CREATE_VM_TIMEOUT_MS,
     },
   },
   {
@@ -83,7 +86,7 @@ export const CREATE_VM_CREATION_SCENARIOS: CreateVmTestScenario[] = [
     startAfterCreation: true,
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: CREATE_VM_TIMEOUT_MS,
     },
   },
   {
@@ -95,7 +98,7 @@ export const CREATE_VM_CREATION_SCENARIOS: CreateVmTestScenario[] = [
     startAfterCreation: false,
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: CREATE_VM_TIMEOUT_MS,
     },
   },
 ];
@@ -114,7 +117,7 @@ export const CREATE_VM_SMOKE_SCENARIOS: CreateVmTestScenario[] = [
     startAfterCreation: false,
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: CREATE_VM_TIMEOUT_MS,
     },
   },
   {
@@ -126,7 +129,7 @@ export const CREATE_VM_SMOKE_SCENARIOS: CreateVmTestScenario[] = [
     startAfterCreation: true,
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: CREATE_VM_TIMEOUT_MS,
     },
   },
 ];
@@ -145,7 +148,7 @@ export const CREATE_VM_EXTENDED_SCENARIOS: CreateVmTestScenario[] = [
     startAfterCreation: false,
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: CREATE_VM_TIMEOUT_MS,
     },
   },
   {
@@ -157,7 +160,7 @@ export const CREATE_VM_EXTENDED_SCENARIOS: CreateVmTestScenario[] = [
     startAfterCreation: false,
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 90000,
+      timeout: CREATE_VM_LARGE_TIMEOUT_MS,
     },
   },
   {
@@ -169,7 +172,7 @@ export const CREATE_VM_EXTENDED_SCENARIOS: CreateVmTestScenario[] = [
     startAfterCreation: true,
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 90000,
+      timeout: CREATE_VM_LARGE_TIMEOUT_MS,
     },
   },
   {
@@ -181,7 +184,7 @@ export const CREATE_VM_EXTENDED_SCENARIOS: CreateVmTestScenario[] = [
     startAfterCreation: false,
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 90000,
+      timeout: CREATE_VM_LARGE_TIMEOUT_MS,
     },
   },
 ];

--- a/playwright/src/data-models/data-volume-test-fixtures.ts
+++ b/playwright/src/data-models/data-volume-test-fixtures.ts
@@ -13,17 +13,20 @@
 
 import type { DataVolumeConfig } from '@/data-factories/data-volume-factory';
 
+const DATA_VOLUME_TIMEOUT_MS = 60000;
+const DATA_VOLUME_HTTP_TIMEOUT_MS = 90000;
+
 /**
- * Base interface for DataVolume test case parameters
+ * Base type for DataVolume test case parameters
  */
-export interface DataVolumeTestCaseParams {
+export type DataVolumeTestCaseParams = {
   dataVolumeConfig: Partial<DataVolumeConfig>;
   expectedBehavior?: {
     shouldCreate: boolean;
-    timeout?: number; // Time to wait for DataVolume to appear
+    timeout?: number;
   };
   testCaseName: string;
-}
+};
 
 /**
  * DataVolume creation test fixtures
@@ -49,7 +52,7 @@ export const DATA_VOLUME_CREATION_FIXTURES: DataVolumeTestCaseParams[] = [
     },
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: DATA_VOLUME_TIMEOUT_MS,
     },
     testCaseName: 'DataVolume with Fedora from registry',
   },
@@ -70,7 +73,7 @@ export const DATA_VOLUME_CREATION_FIXTURES: DataVolumeTestCaseParams[] = [
     },
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: DATA_VOLUME_TIMEOUT_MS,
     },
     testCaseName: 'DataVolume with CentOS Stream from registry',
   },
@@ -91,7 +94,7 @@ export const DATA_VOLUME_CREATION_FIXTURES: DataVolumeTestCaseParams[] = [
     },
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: DATA_VOLUME_TIMEOUT_MS,
     },
     testCaseName: 'DataVolume with CentOS from registry',
   },
@@ -112,7 +115,7 @@ export const DATA_VOLUME_CREATION_FIXTURES: DataVolumeTestCaseParams[] = [
     },
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: DATA_VOLUME_TIMEOUT_MS,
     },
     testCaseName: 'DataVolume with custom storage size',
   },
@@ -133,7 +136,7 @@ export const DATA_VOLUME_CREATION_FIXTURES: DataVolumeTestCaseParams[] = [
     },
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: DATA_VOLUME_TIMEOUT_MS,
     },
     testCaseName: 'DataVolume with custom instance type',
   },
@@ -160,7 +163,7 @@ export const DATA_VOLUME_SMOKE_TEST_FIXTURE: DataVolumeTestCaseParams = {
   },
   expectedBehavior: {
     shouldCreate: true,
-    timeout: 60000,
+    timeout: DATA_VOLUME_TIMEOUT_MS,
   },
   testCaseName: 'smoke test: standard Fedora DataVolume',
 };
@@ -186,7 +189,7 @@ export const DATA_VOLUME_EDGE_CASE_FIXTURES: DataVolumeTestCaseParams[] = [
     },
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: DATA_VOLUME_TIMEOUT_MS,
     },
     testCaseName: 'DataVolume with minimal storage (10Gi)',
   },
@@ -207,7 +210,7 @@ export const DATA_VOLUME_EDGE_CASE_FIXTURES: DataVolumeTestCaseParams[] = [
     },
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 90000,
+      timeout: DATA_VOLUME_HTTP_TIMEOUT_MS,
     },
     testCaseName: 'DataVolume with large storage (100Gi)',
   },
@@ -229,7 +232,7 @@ export const DATA_VOLUME_EDGE_CASE_FIXTURES: DataVolumeTestCaseParams[] = [
     },
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: DATA_VOLUME_TIMEOUT_MS,
     },
     testCaseName: 'DataVolume without bind immediately annotation',
   },
@@ -254,7 +257,7 @@ export const DATA_VOLUME_EDGE_CASE_FIXTURES: DataVolumeTestCaseParams[] = [
     },
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: DATA_VOLUME_TIMEOUT_MS,
     },
     testCaseName: 'DataVolume with custom labels',
   },
@@ -279,7 +282,7 @@ export const DATA_VOLUME_EDGE_CASE_FIXTURES: DataVolumeTestCaseParams[] = [
     },
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: DATA_VOLUME_TIMEOUT_MS,
     },
     testCaseName: 'DataVolume with custom annotations',
   },
@@ -300,7 +303,7 @@ export const DATA_VOLUME_EDGE_CASE_FIXTURES: DataVolumeTestCaseParams[] = [
     },
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 90000, // HTTP downloads may take longer
+      timeout: DATA_VOLUME_HTTP_TIMEOUT_MS, // HTTP downloads may take longer
     },
     testCaseName: 'DataVolume from HTTP source',
   },
@@ -336,7 +339,7 @@ export const DATA_VOLUME_COMPREHENSIVE_FIXTURES: DataVolumeTestCaseParams[] = [
     },
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 60000,
+      timeout: DATA_VOLUME_TIMEOUT_MS,
     },
     testCaseName: 'DataVolume with all metadata options',
   },

--- a/playwright/src/data-models/instance-type-test-fixtures.ts
+++ b/playwright/src/data-models/instance-type-test-fixtures.ts
@@ -221,7 +221,7 @@ export const CLUSTER_INSTANCE_TYPE_CREATION_FIXTURES: InstanceTypeTestCaseParams
 export const INSTANCE_TYPE_SMOKE_TEST_FIXTURE: InstanceTypeTestCaseParams = {
   expectedBehavior: {
     shouldCreate: true,
-    timeout: 15000,
+    timeout: INSTANCE_TYPE_LIST_TIMEOUT_MS,
   },
   instanceTypeConfig: {
     cpuGuest: 2,

--- a/playwright/src/data-models/migration-policy-test-fixtures.ts
+++ b/playwright/src/data-models/migration-policy-test-fixtures.ts
@@ -186,7 +186,7 @@ export const MIGRATION_POLICY_CREATION_FIXTURES: MigrationPolicyTestCaseParams[]
 export const MIGRATION_POLICY_SMOKE_TEST_FIXTURE: MigrationPolicyTestCaseParams = {
   expectedBehavior: {
     shouldCreate: true,
-    timeout: 30000,
+    timeout: MIGRATION_POLICY_TIMEOUT_MS,
   },
   migrationPolicyConfig: {
     allowAutoConverge: true,
@@ -386,7 +386,7 @@ export const MIGRATION_POLICY_FORM_FIXTURES: MigrationPolicyTestCaseParams[] = [
 export const MIGRATION_POLICY_FORM_SMOKE_TEST_FIXTURE: MigrationPolicyTestCaseParams = {
   expectedBehavior: {
     shouldCreate: true,
-    timeout: 30000,
+    timeout: MIGRATION_POLICY_TIMEOUT_MS,
   },
   migrationPolicyConfig: {
     allowAutoConverge: true,

--- a/playwright/src/data-models/request-context-template-test-fixtures.ts
+++ b/playwright/src/data-models/request-context-template-test-fixtures.ts
@@ -1,5 +1,7 @@
 import type { RequestContextTemplateConfig } from '@/data-factories';
 
+const REQUEST_CONTEXT_TIMEOUT_MS = 30000;
+
 /**
  * Base type for RequestContext Template API test case parameters
  */
@@ -19,7 +21,7 @@ export const REQUEST_CONTEXT_TEMPLATE_FIXTURES: RequestContextTemplateTestCasePa
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: REQUEST_CONTEXT_TIMEOUT_MS,
     },
     templateConfig: {
       cpuCores: 1,
@@ -39,7 +41,7 @@ export const REQUEST_CONTEXT_TEMPLATE_FIXTURES: RequestContextTemplateTestCasePa
 export const REQUEST_CONTEXT_TEMPLATE_SMOKE_TEST_FIXTURE: RequestContextTemplateTestCaseParams = {
   expectedBehavior: {
     shouldCreate: true,
-    timeout: 30000,
+    timeout: REQUEST_CONTEXT_TIMEOUT_MS,
   },
   templateConfig: {
     cpuCores: 2,

--- a/playwright/src/data-models/template-test-fixtures.ts
+++ b/playwright/src/data-models/template-test-fixtures.ts
@@ -1,5 +1,8 @@
 import type { TemplateConfig } from '@/data-factories/template-factory';
 
+const TEMPLATE_TIMEOUT_MS = 30000;
+const TEMPLATE_LARGE_TIMEOUT_MS = 45000;
+
 /**
  * Base type for Template test case parameters
  */
@@ -19,7 +22,7 @@ export const TEMPLATE_CREATION_FIXTURES: TemplateTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_TIMEOUT_MS,
     },
     templateConfig: {
       cpuCores: 1,
@@ -34,7 +37,7 @@ export const TEMPLATE_CREATION_FIXTURES: TemplateTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_TIMEOUT_MS,
     },
     templateConfig: {
       cpuCores: 2,
@@ -48,7 +51,7 @@ export const TEMPLATE_CREATION_FIXTURES: TemplateTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 45000,
+      timeout: TEMPLATE_LARGE_TIMEOUT_MS,
     },
     templateConfig: {
       cpuCores: 4,
@@ -70,7 +73,7 @@ export const TEMPLATE_OS_FIXTURES: TemplateTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_TIMEOUT_MS,
     },
     templateConfig: {
       cloudInitUser: 'fedora',
@@ -88,7 +91,7 @@ export const TEMPLATE_OS_FIXTURES: TemplateTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_TIMEOUT_MS,
     },
     templateConfig: {
       cloudInitUser: 'ubuntu',
@@ -107,7 +110,7 @@ export const TEMPLATE_OS_FIXTURES: TemplateTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_TIMEOUT_MS,
     },
     templateConfig: {
       cloudInitUser: 'cloud-user',
@@ -132,7 +135,7 @@ export const TEMPLATE_WORKLOAD_FIXTURES: TemplateTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_TIMEOUT_MS,
     },
     templateConfig: {
       cpuCores: 2,
@@ -146,7 +149,7 @@ export const TEMPLATE_WORKLOAD_FIXTURES: TemplateTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_TIMEOUT_MS,
     },
     templateConfig: {
       cpuCores: 2,
@@ -160,7 +163,7 @@ export const TEMPLATE_WORKLOAD_FIXTURES: TemplateTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 45000,
+      timeout: TEMPLATE_LARGE_TIMEOUT_MS,
     },
     templateConfig: {
       cpuCores: 4,
@@ -181,7 +184,7 @@ export const TEMPLATE_WORKLOAD_FIXTURES: TemplateTestCaseParams[] = [
 export const TEMPLATE_SMOKE_TEST_FIXTURE: TemplateTestCaseParams = {
   expectedBehavior: {
     shouldCreate: true,
-    timeout: 30000,
+    timeout: TEMPLATE_TIMEOUT_MS,
   },
   templateConfig: {
     cpuCores: 2,

--- a/playwright/src/data-models/template-vm-test-fixtures.ts
+++ b/playwright/src/data-models/template-vm-test-fixtures.ts
@@ -1,5 +1,7 @@
 import type { VirtualMachineConfig } from '@/data-factories/virtual-machine-factory';
 
+const TEMPLATE_VM_TIMEOUT_MS = 30000;
+
 /**
  * Template selector configuration for VM creation
  */
@@ -37,7 +39,7 @@ export const TEMPLATE_VM_CREATION_FIXTURES: TemplateVmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_VM_TIMEOUT_MS,
     },
     testCaseName: 'CentOS Stream 9 VM from template',
     templateConfig: {
@@ -57,7 +59,7 @@ export const TEMPLATE_VM_CREATION_FIXTURES: TemplateVmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_VM_TIMEOUT_MS,
     },
     testCaseName: 'Fedora VM from template (not started)',
     templateConfig: {
@@ -77,7 +79,7 @@ export const TEMPLATE_VM_CREATION_FIXTURES: TemplateVmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_VM_TIMEOUT_MS,
     },
     testCaseName: 'Red Hat Enterprise Linux 8 VM from template',
     templateConfig: {
@@ -97,7 +99,7 @@ export const TEMPLATE_VM_CREATION_FIXTURES: TemplateVmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_VM_TIMEOUT_MS,
     },
     testCaseName: 'Red Hat Enterprise Linux 9 VM from template (not started)',
     templateConfig: {
@@ -123,7 +125,7 @@ export const TEMPLATE_VM_OS_FIXTURES: TemplateVmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_VM_TIMEOUT_MS,
     },
     testCaseName: 'RHEL8 template VM with custom resources',
     templateConfig: {
@@ -143,7 +145,7 @@ export const TEMPLATE_VM_OS_FIXTURES: TemplateVmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_VM_TIMEOUT_MS,
     },
     testCaseName: 'RHEL9 template VM with high resources',
     templateConfig: {
@@ -169,7 +171,7 @@ export const TEMPLATE_VM_WORKLOAD_FIXTURES: TemplateVmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_VM_TIMEOUT_MS,
     },
     testCaseName: 'Server workload template VM',
     templateConfig: {
@@ -189,7 +191,7 @@ export const TEMPLATE_VM_WORKLOAD_FIXTURES: TemplateVmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: TEMPLATE_VM_TIMEOUT_MS,
     },
     testCaseName: 'CentOS Stream9 workload template VM (not started)',
     templateConfig: {
@@ -214,7 +216,7 @@ export const TEMPLATE_VM_WORKLOAD_FIXTURES: TemplateVmTestCaseParams[] = [
 export const TEMPLATE_VM_SMOKE_TEST_FIXTURE: TemplateVmTestCaseParams = {
   expectedBehavior: {
     shouldCreate: true,
-    timeout: 30000,
+    timeout: TEMPLATE_VM_TIMEOUT_MS,
   },
   testCaseName: 'standard template VM for smoke testing',
   templateConfig: {

--- a/playwright/src/data-models/virtual-machine-test-fixtures.ts
+++ b/playwright/src/data-models/virtual-machine-test-fixtures.ts
@@ -1,16 +1,19 @@
 import type { VirtualMachineConfig } from '@/data-factories/virtual-machine-factory';
 
+const VM_CREATION_TIMEOUT_MS = 30000;
+const VM_CREATION_LARGE_TIMEOUT_MS = 45000;
+
 /**
- * Base interface for VM test case parameters
+ * Base type for VM test case parameters
  */
-export interface VmTestCaseParams {
+export type VmTestCaseParams = {
   expectedBehavior?: {
     shouldCreate: boolean;
     timeout?: number;
   };
   testCaseName: string;
   vmConfig: Partial<VirtualMachineConfig>;
-}
+};
 
 /**
  * VM creation test fixtures - different VM configurations to test
@@ -19,7 +22,7 @@ export const VM_CREATION_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'basic VM with minimal resources',
     vmConfig: {
@@ -31,7 +34,7 @@ export const VM_CREATION_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'VM with standard resources',
     vmConfig: {
@@ -43,7 +46,7 @@ export const VM_CREATION_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 45000,
+      timeout: VM_CREATION_LARGE_TIMEOUT_MS,
     },
     testCaseName: 'VM with high resources',
     vmConfig: {
@@ -59,7 +62,7 @@ export const VM_CREATION_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'VM with Manual run strategy',
     vmConfig: {
@@ -71,7 +74,7 @@ export const VM_CREATION_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'VM with RerunOnFailure strategy',
     vmConfig: {
@@ -83,7 +86,7 @@ export const VM_CREATION_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'VM with BIOS boot mode',
     vmConfig: {
@@ -96,7 +99,7 @@ export const VM_CREATION_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'VM with UEFI boot mode',
     vmConfig: {
@@ -109,7 +112,7 @@ export const VM_CREATION_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'VM with UEFI Secure Boot mode',
     vmConfig: {
@@ -128,7 +131,7 @@ export const VM_OS_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'Fedora server VM',
     vmConfig: {
@@ -144,7 +147,7 @@ export const VM_OS_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'Ubuntu server VM',
     vmConfig: {
@@ -160,7 +163,7 @@ export const VM_OS_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'RHEL server VM',
     vmConfig: {
@@ -182,7 +185,7 @@ export const VM_WORKLOAD_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'desktop workload VM',
     vmConfig: {
@@ -195,7 +198,7 @@ export const VM_WORKLOAD_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'server workload VM',
     vmConfig: {
@@ -208,7 +211,7 @@ export const VM_WORKLOAD_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 45000,
+      timeout: VM_CREATION_LARGE_TIMEOUT_MS,
     },
     testCaseName: 'high-performance workload VM',
     vmConfig: {
@@ -229,7 +232,7 @@ export const VM_NETWORK_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'VM with virtio network interface',
     vmConfig: {
@@ -242,7 +245,7 @@ export const VM_NETWORK_FIXTURES: VmTestCaseParams[] = [
   {
     expectedBehavior: {
       shouldCreate: true,
-      timeout: 30000,
+      timeout: VM_CREATION_TIMEOUT_MS,
     },
     testCaseName: 'VM with e1000 network interface',
     vmConfig: {
@@ -260,7 +263,7 @@ export const VM_NETWORK_FIXTURES: VmTestCaseParams[] = [
 export const VM_SMOKE_TEST_FIXTURE: VmTestCaseParams = {
   expectedBehavior: {
     shouldCreate: true,
-    timeout: 30000,
+    timeout: VM_CREATION_TIMEOUT_MS,
   },
   testCaseName: 'standard VM for smoke testing',
   vmConfig: {

--- a/playwright/src/utils/env-variables.ts
+++ b/playwright/src/utils/env-variables.ts
@@ -245,6 +245,7 @@ export class EnvVariables {
     if (value === '0' || value === 'false') {
       return false;
     }
+    // Enabled by default when resource check is enabled
     return true;
   }
 


### PR DESCRIPTION
## 📝 Description
 
- interface → type conversions (CreateVmTestScenario, VmTestCaseParams, DataVolumeTestCaseParams)
- Extract magic number timeouts to named constants per coding-standards.mdc
- Fix remaining hardcoded timeouts missed in prior passes


## 🔗 Links

https://redhat.atlassian.net/browse/CNV-92531


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized timeout values across multiple test fixtures by replacing hard-coded delays with shared constants.
  * Updated several exported type definitions to use type aliases while keeping the same data shape.
* **Documentation**
  * Added a clarifying comment about the default cleanup behavior when resource checking is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->