### PR TITLE
CNV-92597: Replace expiring BOT_PAT with GitHub App tokens for CI bot operations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Login to Quay.io
         uses: docker/login-action@v4
-        env:
-          GITHUB_TOKEN: '${{ secrets.BOT_PAT }}'
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/hot-cluster-e2e-cancel-on-close.yml
+++ b/.github/workflows/hot-cluster-e2e-cancel-on-close.yml
@@ -17,10 +17,6 @@ jobs:
       - name: Cancel in-progress/queued hot-cluster-e2e runs for this PR
         uses: actions/github-script@v9
         with:
-          # No BOT_PAT needed: listing/cancelling workflow runs is a plain
-          # Actions-API operation, not an identity-sensitive one, so the
-          # default GITHUB_TOKEN (scoped via `permissions: actions: write`
-          # above) is sufficient.
           script: |
             const prNumber = context.payload.pull_request.number;
             const headSha = context.payload.pull_request.head.sha;

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -1,5 +1,5 @@
 name: Hot Cluster E2E
-run-name: "Hot Cluster E2E [${{ inputs.cluster_name || github.base_ref || 'kubevirt-plugin-ci' }}]"
+run-name: "Hot Cluster E2E [${{ inputs.cluster_name || github.head_ref || github.base_ref || 'kubevirt-plugin-ci' }}]"
 
 on:
   pull_request_target:
@@ -44,11 +44,19 @@ permissions:
   actions: write
 
 concurrency:
-  group: hot-cluster-e2e-${{ github.event.pull_request.number || format('{0}-{1}', github.ref, inputs.cluster_name || 'kubevirt-plugin-ci') }}
-  # Only cancel a real in-progress run for events that actually warrant one
-  # (push/reopen, or an ok-to-test labeling). Routine bot-added labels (lgtm,
-  # approved, jira/valid-reference, ...) must not cancel a genuine run.
-  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'ok-to-test' }}
+  # Irrelevant label events (lgtm, approved, jira/valid-reference, ...) get
+  # their own run-id-unique group instead of sharing the real per-PR group.
+  # Sharing the group with cancel-in-progress: false (an earlier attempt at
+  # this) queues them behind a real in-progress run instead of cancelling
+  # it — which is an improvement, but means the queued run only evaluates
+  # (and skips) its jobs *after* the real run finishes, so its "skipped"
+  # Run Gating Tests can complete with a later timestamp than the real
+  # run's genuine success/failure, making GitHub treat the harmless skip as
+  # the latest, authoritative result. A fully isolated group avoids this
+  # entirely: the irrelevant-label run never shares a queue slot with the
+  # real one, so it always executes (and skips) immediately.
+  group: ${{ (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test') && format('hot-cluster-e2e-{0}', github.event.pull_request.number || format('{0}-{1}', github.ref, inputs.cluster_name || 'kubevirt-plugin-ci')) || format('hot-cluster-e2e-noop-{0}', github.run_id) }}
+  cancel-in-progress: true
 
 env:
   INFRASTRUCTURE_TYPE: ${{ inputs.infrastructure_type || 'ipi' }}
@@ -100,11 +108,15 @@ jobs:
       # the same source Prow uses for /lgtm, /approve. author_association and
       # org membership are unreliable proxies (misreport private membership,
       # need extra token scope), so we don't use them here.
+      #
+      # No elevated token needed: this script only reads the local OWNERS
+      # file, it never calls the GitHub API, so the default GITHUB_TOKEN is
+      # sufficient (a bot/app token would be unused dead weight here).
       - name: Determine if PR author is a trusted repo owner
         id: check
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const author = context.payload.pull_request.user.login;
@@ -139,7 +151,7 @@ jobs:
     secrets: inherit
 
   cluster-health-check:
-    name: Cluster Health Check
+    name: Manual Cluster Health Check
     needs: [cluster-check, resolve-cluster-config]
     if: github.event_name == 'workflow_dispatch' && needs.cluster-check.result == 'success'
     runs-on: ubuntu-latest
@@ -200,7 +212,7 @@ jobs:
       - name: Health check summary
         if: always()
         run: |
-          echo "## Cluster Health Check" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Manual Cluster Health Check" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Parameter | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-----------|-------|" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ibmc-cleanup-all.yml
+++ b/.github/workflows/ibmc-cleanup-all.yml
@@ -367,11 +367,24 @@ jobs:
           echo "=== ROKS Clusters ==="
           ibmcloud oc cluster ls 2>&1 | rg "${CLUSTER_NAME}" || echo "No ROKS clusters matching '${CLUSTER_NAME}'."
 
+      # Reuses the existing kubevirt-plugin-arc GitHub App (already scoped to
+      # exactly `administration: write`, the permission runner
+      # registration/deregistration needs).
+      - name: Generate ARC app token for ghost-runner cleanup
+        id: arc-app-token
+        if: env.DRY_RUN == 'false'
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.ARC_GITHUB_APP_ID }}
+          private-key: ${{ secrets.ARC_GITHUB_APP_PRIVATE_KEY }}
+          permission-administration: write
+
       - name: Clean up ghost runners for matched clusters
         if: env.DRY_RUN == 'false'
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          GH_TOKEN: ${{ steps.arc-app-token.outputs.token }}
           MATCHED_CLUSTERS: ${{ steps.detect_clusters.outputs.clusters }}
         run: |
           echo "=== Offline Self-Hosted Runners ==="

--- a/.github/workflows/ibmc-cluster-teardown.yml
+++ b/.github/workflows/ibmc-cluster-teardown.yml
@@ -47,7 +47,9 @@ on:
     secrets:
       IC_KEY:
         required: true
-      BOT_PAT:
+      ARC_GITHUB_APP_ID:
+        required: false
+      ARC_GITHUB_APP_PRIVATE_KEY:
         required: false
       OPENSHIFT_PULL_SECRET:
         required: false
@@ -261,10 +263,24 @@ jobs:
       # ──────────────────────────────────────────────────────────────────────
       # Common cleanup
       # ──────────────────────────────────────────────────────────────────────
+      # Reuses the existing kubevirt-plugin-arc GitHub App (already scoped to
+      # exactly `administration: write`, the permission runner
+      # registration/deregistration needs).
+      - name: Generate ARC app token for ghost-runner cleanup
+        id: arc-app-token
+        if: always()
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.ARC_GITHUB_APP_ID }}
+          private-key: ${{ secrets.ARC_GITHUB_APP_PRIVATE_KEY }}
+          permission-administration: write
+
       - name: Clean up ghost runners
+        if: always()
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          GH_TOKEN: ${{ steps.arc-app-token.outputs.token }}
         run: |
           echo "Checking for offline self-hosted runners with label '${CLUSTER_NAME}'..."
           # gh api's --jq only accepts a single jq-expression string (no --arg

--- a/.github/workflows/retest-e2e.yml
+++ b/.github/workflows/retest-e2e.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   actions: write
+  issues: write
   pull-requests: write
 
 jobs:
@@ -22,83 +23,154 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # Short-lived installation token from the kubevirt-plugin-bot GitHub
+      # App (Pull requests: Read, Actions: Read and write).
+      #
+      # continue-on-error: if BOT_APP_ID/BOT_APP_PRIVATE_KEY themselves ever
+      # go bad, this must not skip the retest step below — an empty token
+      # input still lets that step run, fail its first API call, and get
+      # caught by its own try/catch, which is what actually drives the PR
+      # comment in the reporting step further down. Without this, a broken
+      # app credential would reproduce the exact silent-failure bug we're
+      # fixing here, just one level up.
+      - name: Generate bot token
+        id: bot-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       # OWNERS (approvers/reviewers) is the single source of truth for trust —
       # the same source Prow uses for /lgtm, /approve. author_association and
       # org membership are unreliable proxies (misreport private membership,
       # need extra token scope), so we don't use them here.
+      #
+      # continue-on-error: an unforeseen failure here must not fail silently —
+      # steps.retest.outcome still reports 'failure' for the final step below,
+      # while the reporting step in between uses the default GITHUB_TOKEN
+      # (independent of the bot token) to explain what went wrong on the PR
+      # itself.
       - name: Check trusted author and re-run E2E workflow
+        id: retest
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.bot-token.outputs.token }}
           script: |
             const fs = require('fs');
             const author = context.payload.comment.user.login;
 
-            let trusted = false;
+            // kubevirt-plugin-bot deliberately doesn't have `issues: write`
+            // (PR comments are "issue comments" under the hood, so reacting
+            // to one needs that permission, not `pull-requests`). Reactions
+            // are cosmetic feedback on the /retest-e2e comment — a missing
+            // reaction must never be mistaken for the retest itself failing.
+            const react = async (content) => {
+              try {
+                await github.rest.reactions.createForIssueComment({
+                  ...context.repo,
+                  comment_id: context.payload.comment.id,
+                  content,
+                });
+              } catch (err) {
+                core.warning(`Could not react to comment with "${content}": ${err.message || err}`);
+              }
+            };
+
             try {
-              const owners = fs.readFileSync('OWNERS', 'utf8');
-              trusted = new RegExp(`^\\s*-\\s*${author}\\s*$`, 'm').test(owners);
+              let trusted = false;
+              try {
+                const owners = fs.readFileSync('OWNERS', 'utf8');
+                trusted = new RegExp(`^\\s*-\\s*${author}\\s*$`, 'm').test(owners);
+              } catch (err) {
+                core.warning(`Could not read OWNERS file: ${err.message}`);
+              }
+
+              core.info(`${author} is ${trusted ? '' : 'not '}listed in OWNERS (approvers/reviewers) — ${trusted ? 'trusted' : 'untrusted, ignoring /retest-e2e'}.`);
+
+              if (!trusted) {
+                await react('-1');
+                core.setFailed(`${author} is not authorized to use /retest-e2e`);
+                return;
+              }
+
+              const prNumber = context.issue.number;
+              const pr = await github.rest.pulls.get({
+                ...context.repo,
+                pull_number: prNumber,
+              });
+              const headSha = pr.data.head.sha;
+
+              core.info(`/retest-e2e requested by ${author} on PR #${prNumber} (HEAD: ${headSha})`);
+
+              const runs = await github.rest.actions.listWorkflowRuns({
+                ...context.repo,
+                workflow_id: 'hot-cluster-e2e.yml',
+                event: 'pull_request_target',
+                per_page: 10,
+              });
+
+              const prRun = runs.data.workflow_runs.find(r => {
+                const prMatch = r.pull_requests?.some(p => p.number === prNumber);
+                const shaMatch = r.head_sha === headSha;
+                return prMatch || shaMatch;
+              });
+
+              if (!prRun) {
+                const msg = `No Hot Cluster E2E workflow run found for PR #${prNumber}. ` +
+                  `Push a commit to trigger the initial run.`;
+                core.warning(msg);
+                await react('confused');
+                return;
+              }
+
+              core.info(`Re-running workflow run ${prRun.id} (attempt ${prRun.run_attempt})...`);
+
+              await react('rocket');
+
+              await github.rest.actions.reRunWorkflow({
+                ...context.repo,
+                run_id: prRun.id,
+              });
+
+              core.info(`Re-run triggered: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${prRun.id}`);
             } catch (err) {
-              core.warning(`Could not read OWNERS file: ${err.message}`);
+              // Distinct from the expected "not authorized" rejection above:
+              // this is an unforeseen failure (bad bot token, API outage,
+              // ...) that the PR author has no way to diagnose from a
+              // missing reaction alone.
+              core.setOutput('unexpected_error', 'true');
+              core.setOutput('error_message', err.message || String(err));
+              core.setFailed(`Unexpected error while processing /retest-e2e: ${err.message || err}`);
             }
 
-            core.info(`${author} is ${trusted ? '' : 'not '}listed in OWNERS (approvers/reviewers) — ${trusted ? 'trusted' : 'untrusted, ignoring /retest-e2e'}.`);
-
-            if (!trusted) {
-              await github.rest.reactions.createForIssueComment({
-                ...context.repo,
-                comment_id: context.payload.comment.id,
-                content: '-1',
-              });
-              core.setFailed(`${author} is not authorized to use /retest-e2e`);
-              return;
-            }
-
-            const prNumber = context.issue.number;
-            const pr = await github.rest.pulls.get({
+      - name: Report unexpected retest failure on the PR
+        if: steps.retest.outputs.unexpected_error == 'true'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const errorMessage = ${{ toJSON(steps.retest.outputs.error_message) }};
+            await github.rest.issues.createComment({
               ...context.repo,
-              pull_number: prNumber,
-            });
-            const headSha = pr.data.head.sha;
-
-            core.info(`/retest-e2e requested by ${author} on PR #${prNumber} (HEAD: ${headSha})`);
-
-            const runs = await github.rest.actions.listWorkflowRuns({
-              ...context.repo,
-              workflow_id: 'hot-cluster-e2e.yml',
-              event: 'pull_request_target',
-              per_page: 10,
-            });
-
-            const prRun = runs.data.workflow_runs.find(r => {
-              const prMatch = r.pull_requests?.some(p => p.number === prNumber);
-              const shaMatch = r.head_sha === headSha;
-              return prMatch || shaMatch;
+              issue_number: context.issue.number,
+              body: [
+                '⚠️ `/retest-e2e` hit an unexpected error and did not re-run the Hot Cluster E2E workflow:',
+                '',
+                '```',
+                errorMessage,
+                '```',
+                '',
+                'This usually means the `kubevirt-plugin-bot` GitHub App token (BOT_APP_ID / BOT_APP_PRIVATE_KEY) is misconfigured or the app was uninstalled — a maintainer should check it. ' +
+                  'In the meantime, re-run the failed workflow manually from the Actions tab.',
+              ].join('\n'),
             });
 
-            if (!prRun) {
-              const msg = `No Hot Cluster E2E workflow run found for PR #${prNumber}. ` +
-                `Push a commit to trigger the initial run.`;
-              core.warning(msg);
-              await github.rest.reactions.createForIssueComment({
-                ...context.repo,
-                comment_id: context.payload.comment.id,
-                content: 'confused',
-              });
-              return;
-            }
-
-            core.info(`Re-running workflow run ${prRun.id} (attempt ${prRun.run_attempt})...`);
-
-            await github.rest.reactions.createForIssueComment({
-              ...context.repo,
-              comment_id: context.payload.comment.id,
-              content: 'rocket',
-            });
-
-            await github.rest.actions.reRunWorkflow({
-              ...context.repo,
-              run_id: prRun.id,
-            });
-
-            core.info(`Re-run triggered: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${prRun.id}`);
+      # Re-fail the job for both the "not authorized" and "unexpected error"
+      # cases above: continue-on-error on the retest step only exists so the
+      # reporting step can run afterwards, not to hide a genuine failure from
+      # the job's overall status.
+      - name: Fail job if retest did not succeed
+        if: steps.retest.outcome == 'failure'
+        run: exit 1

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -84,8 +84,9 @@ Uses `openshift-install` to create a fully self-managed OpenShift cluster on IBM
 
 | Secret              | Description                                                                 |
 | ------------------- | --------------------------------------------------------------------------- |
-| `BOT_PAT`           | PAT with repo admin scope for ghost runner cleanup                          |
 | `SLACK_WEBHOOK_URL` | Slack Incoming Webhook URL for credential notifications on cluster creation |
+
+Ghost runner cleanup reuses the ARC Authentication GitHub App credentials above (`ARC_GITHUB_APP_ID` + `ARC_GITHUB_APP_PRIVATE_KEY`) — no separate secret needed, since that app is already scoped to `administration: write`, exactly what deregistering offline runners requires.
 
 ## Setting Up the Hot Cluster
 
@@ -174,7 +175,6 @@ Key defaults:
 - `KVM_EMULATION=false` (bare metal has real KVM; set `true` for VPC/shared)
 - `RUNNER_SCALE_SET_NAME=kubevirt-plugin-ci` (the `runs-on:` label)
 - `ARC_CONTROLLER_INSTALL_NAME=arc` (Helm release for controller)
-- `CONTAINER_MODE=dind` (Docker-in-Docker for container jobs)
 - `ARC_VERSION=0.14.0` (pinned Helm chart version)
 
 ## Cost Control
@@ -190,9 +190,8 @@ Always verify the cluster has been torn down when done testing. The auto-teardow
 
 ## Known Limitations
 
-- **Privileged dind + broad SCC**: The `github-arc` SCC allows privileged containers for the Docker-in-Docker sidecar. Scope runner namespaces and RBAC accordingly.
 - **`ttl.sh` for plugin images**: Plugin images use ephemeral `ttl.sh` tags with 2h TTL per CI run. Suitable for CI but not for long-term storage.
-- **Ghost runner cleanup**: Requires `BOT_PAT` with repo admin scope. Without it, offline runners must be cleaned up manually.
+- **Ghost runner cleanup**: Requires the ARC GitHub App credentials (`ARC_GITHUB_APP_ID` + `ARC_GITHUB_APP_PRIVATE_KEY`). If ARC auth is instead configured via `ARC_GITHUB_PAT`, offline runners must be cleaned up manually.
 - **IBM Cloud VPC hairpin NAT**: VPC load balancers don't support hairpin NAT. On IPI clusters, ingress canary checks fail and the authentication operator may report Degraded. This is cosmetic -- the console works fine for browser access from outside the cluster, and CI tests are unaffected (they use internal service URLs).
 
 ## Troubleshooting

--- a/ci-scripts/hot-cluster/arc/README.md
+++ b/ci-scripts/hot-cluster/arc/README.md
@@ -1,6 +1,6 @@
 # GitHub Actions Runner Controller (ARC) on OpenShift
 
-Scripts in this directory install **Actions Runner Controller** with the **`gha-runner-scale-set`** chart on **OpenShift** (ROKS or other OCP clusters). They apply a custom **SecurityContextConstraints** (`github-arc`), bind it to the runner ServiceAccount, **mirror `docker:dind`** into the internal registry (the stable Helm chart hardcodes Docker Hub; we rewrite manifests to use the mirror), build a **custom runner image** in-cluster, and apply **ClusterRole** RBAC so jobs can use `oc` / KubeVirt APIs.
+Scripts in this directory install **Actions Runner Controller** with the **`gha-runner-scale-set`** chart on **OpenShift** (ROKS or other OCP clusters). They apply a custom **SecurityContextConstraints** (`github-arc`), bind it to the runner ServiceAccount, and apply **ClusterRole** RBAC so jobs can use `oc` / KubeVirt APIs. The custom runner image is built in-cluster by [`../images/setup-arc-runner-image.sh`](../images/setup-arc-runner-image.sh) — see that script's header comments for its environment variables.
 
 All scripts expect **`oc login`** to an OpenShift cluster with permissions to create namespaces, SCC-related `ClusterRole`s, and Helm releases.
 
@@ -8,18 +8,16 @@ All scripts expect **`oc login`** to an OpenShift cluster with permissions to cr
 
 Run from the **repository root** (paths below assume that).
 
-1. **`setup-dind-mirror.sh`** — `oc import-image` **`docker:dind`** → `image-registry.../arc-runners/arc-docker-dind:dind` and write **`ci-scripts/hot-cluster/generated/arc-dind-replace.env`**. Use `SKIP_DIND_MIRROR=1` only if dind is provided via **`ImageContentSourcePolicy`** or another cluster mirror (no import from Docker Hub).
-2. **`setup-runner-image.sh`** — OpenShift `BuildConfig` binary build from [`runner-image/Dockerfile`](runner-image/Dockerfile) → `arc-runner-custom:latest` in the internal registry. Prints **`IMAGE_REF=...`** for automation.
-3. **`install-arc-controller.sh`** — Once per cluster: namespace `arc-systems`, apply **`arc-openshift-scc.yaml`**, Helm **`gha-runner-scale-set-controller`**.
-4. **`install-runner-scale-set.sh`** — Per scale set: namespace `arc-runners`, Helm **`gha-runner-scale-set`** with GitHub auth, optional **`ARC_RUNNER_IMAGE`**, Helm **post-renderer** (always for dind: injects **`--storage-driver=vfs`** for OpenShift; optional **`docker:dind` → mirror** when `arc-dind-replace.env` exists or **`ARC_DIND_INTERNAL_IMAGE`** is set), **`oc policy add-role-to-user system:openshift:scc:github-arc`** on the runner SA, apply **`arc-runner-rbac.yaml`** (unless `SKIP_ARC_RUNNER_RBAC=1`).
+1. **`../images/setup-arc-runner-image.sh`** — OpenShift `ImageStream`/`BuildConfig` binary build from [`../images/arc-runner/Dockerfile`](../images/arc-runner/Dockerfile) → custom runner image in the internal registry (namespace `arc-runners` by default). Prints **`IMAGE_REF=...`** for automation.
+2. **`install-arc-controller.sh`** — Once per cluster: namespace `arc-systems`, apply **`arc-openshift-scc.yaml`**, Helm **`gha-runner-scale-set-controller`**.
+3. **`install-runner-scale-set.sh`** — Per scale set: namespace `arc-runners`, Helm **`gha-runner-scale-set`** with GitHub auth, optional **`ARC_RUNNER_IMAGE`**, **`oc policy add-role-to-user system:openshift:scc:github-arc`** on the runner SA, apply **`arc-runner-rbac.yaml`** (unless `SKIP_ARC_RUNNER_RBAC=1`).
 
 ```bash
 export ARC_CONFIG_URL="https://github.com/org/repo"
 export ARC_APP_ID="..." ARC_APP_INSTALL_ID="..." ARC_APP_PRIVATE_KEY="$(cat app.pem)"
-# optional: export ARC_RUNNER_IMAGE after setup-runner-image prints IMAGE_REF=
+# optional: export ARC_RUNNER_IMAGE after setup-arc-runner-image.sh prints IMAGE_REF=
 
-./ci-scripts/hot-cluster/arc/setup-dind-mirror.sh
-IMAGE_REF=$(./ci-scripts/hot-cluster/arc/setup-runner-image.sh | grep '^IMAGE_REF=' | cut -d= -f2-)
+IMAGE_REF=$(./ci-scripts/hot-cluster/images/setup-arc-runner-image.sh | grep '^IMAGE_REF=' | cut -d= -f2-)
 export ARC_RUNNER_IMAGE="${IMAGE_REF}"
 
 ./ci-scripts/hot-cluster/arc/install-arc-controller.sh
@@ -28,12 +26,11 @@ export ARC_RUNNER_IMAGE="${IMAGE_REF}"
 
 ## Environment variables (summary)
 
-| Area                   | Variables                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Dind mirror**        | `ARC_RUNNERS_NS`, `SKIP_DIND_MIRROR`, `DIND_SOURCE_IMAGE`                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| **Runner image build** | `ARC_RUNNERS_NS`, `OC_VERSION`, `VIRTCTL_VERSION`, `ARC_RUNNER_IMAGE_FILE`                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| **Controller**         | `ARC_CONTROLLER_NS`, `ARC_CONTROLLER_INSTALL_NAME`, `ARC_VERSION`                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| **Scale set**          | `ARC_CONFIG_URL` (required), GitHub App (`ARC_APP_ID`, `ARC_APP_INSTALL_ID`, `ARC_APP_PRIVATE_KEY`) **or** `ARC_PAT`; `RUNNER_SCALE_SET_NAME`, `MIN_RUNNERS`, `MAX_RUNNERS`, `ARC_RUNNERS_NS`, `ARC_CONTROLLER_NS`, `ARC_CONTROLLER_INSTALL_NAME`, `ARC_VERSION`, `CONTAINER_MODE` (default `dind`; use `none` to disable), `ARC_RUNNER_IMAGE`, `ARC_DIND_INTERNAL_IMAGE` (writes replace env for this run), `ARC_USE_DIND_POST_RENDER`, `ARC_RUNNER_EXTRA_VALUES`, `ARC_SCALE_SET_LABELS`, `SKIP_ARC_RUNNER_RBAC` |
+| Area                   | Variables                                                                                                                                                                                                                                                                                                    |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Runner image build** | `NS`, `OC_VERSION`, `HELM_VERSION`, `VIRTCTL_VERSION`, `YQ_VERSION`, `ARC_RUNNER_IMAGE_FILE` (see [`../images/setup-arc-runner-image.sh`](../images/setup-arc-runner-image.sh))                                                                                                                              |
+| **Controller**         | `ARC_CONTROLLER_NS`, `ARC_CONTROLLER_INSTALL_NAME`, `ARC_VERSION`                                                                                                                                                                                                                                            |
+| **Scale set**          | `ARC_CONFIG_URL` (required), GitHub App (`ARC_APP_ID`, `ARC_APP_INSTALL_ID`, `ARC_APP_PRIVATE_KEY`) **or** `ARC_PAT`; `RUNNER_SCALE_SET_NAME`, `MIN_RUNNERS`, `MAX_RUNNERS`, `ARC_RUNNERS_NS`, `ARC_CONTROLLER_NS`, `ARC_CONTROLLER_INSTALL_NAME`, `ARC_VERSION`, `ARC_RUNNER_IMAGE`, `SKIP_ARC_RUNNER_RBAC` |
 
 Details are in each script’s header comments.
 
@@ -42,7 +39,7 @@ Details are in each script’s header comments.
 - **GitHub App** (recommended): repository **Administration: Read and write**, organization **Self-hosted runners: Read and write**. Install the app on the target repo/org; use App ID, installation ID, and private key PEM.
 - **PAT**: fine-grained or classic with sufficient repo + runner permissions (see [HOT_CLUSTER_CI.md](../HOT_CLUSTER_CI.md)).
 
-Workflows must use `runs-on:` labels that match **`RUNNER_SCALE_SET_NAME`** (default **`kubevirt-plugin-ci`**) or every label in **`ARC_SCALE_SET_LABELS`** if set.
+Workflows must use `runs-on:` labels that match **`RUNNER_SCALE_SET_NAME`** (default **`kubevirt-plugin-ci`**).
 
 ## Second runner scale set
 
@@ -54,19 +51,17 @@ You do **not** need to re-apply **`arc-openshift-scc.yaml`**.
 
 ## Files in this directory
 
-| File                            | Purpose                                                                                                                      |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `arc-openshift-scc.yaml`        | SCC `github-arc` + `ClusterRole` to use it                                                                                   |
-| `arc-runner-rbac.yaml`          | `arc-runner-ci` ClusterRole + Binding (subject patched by install script)                                                    |
-| `arc-runner-scale-set.pod.yaml` | Helm values fragment for the runner container (volumes, securityContext)                                                     |
-| `arc-helm-helpers.sh`           | Shared Helm/auth helpers                                                                                                     |
-| `arc-dind-post-render.sh`       | Helm post-renderer: OpenShift dind `vfs` storage driver; optional `docker:dind` swap via `../generated/arc-dind-replace.env` |
-| `runner-image/Dockerfile`       | Custom runner (Node, kubectl, oc, virtctl, jq)                                                                               |
+| File                            | Purpose                                                                   |
+| ------------------------------- | ------------------------------------------------------------------------- |
+| `arc-openshift-scc.yaml`        | SCC `github-arc` + `ClusterRole` to use it                                |
+| `arc-runner-rbac.yaml`          | `arc-runner-ci` ClusterRole + Binding (subject patched by install script) |
+| `arc-runner-scale-set.pod.yaml` | Helm values fragment for the runner container (volumes, securityContext)  |
+| `arc-helm-helpers.sh`           | Shared Helm/auth helpers                                                  |
 
-Generated **`ci-scripts/hot-cluster/generated/arc-dind-replace.env`** is gitignored; it is produced by **`setup-dind-mirror.sh`** or by **`install-runner-scale-set.sh`** when **`ARC_DIND_INTERNAL_IMAGE`** is set.
+The custom runner image and its `Dockerfile` live in [`../images/`](../images/) (built by `../images/setup-arc-runner-image.sh`), not in this directory.
 
 ## Further reading
 
-- [ci-scripts/README.md](../README.md) — secrets, dind mirror, multilabel, experimental chart notes.
+- [ci-scripts/README.md](../README.md) — secrets, multilabel, experimental chart notes.
 - [Red Hat: ARC on OpenShift](https://developers.redhat.com/articles/2025/02/17/how-securely-deploy-github-arc-openshift)
 - Upstream chart: `oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set`

--- a/ci-scripts/hot-cluster/arc/install-runner-scale-set.sh
+++ b/ci-scripts/hot-cluster/arc/install-runner-scale-set.sh
@@ -119,5 +119,5 @@ fi
 echo ""
 echo "=== Runner scale set installation complete ==="
 echo "  runs-on: ${RUNNER_SCALE_SET_NAME}"
-echo "  To refresh runner image: re-run this script with ARC_RUNNER_IMAGE set (after setup-runner-image.sh)."
+echo "  To refresh runner image: re-run this script with ARC_RUNNER_IMAGE set (after ../images/setup-arc-runner-image.sh)."
 echo ""

--- a/ci-scripts/hot-cluster/helm/ci-test-stack/templates/console-clusterrolebinding.yaml
+++ b/ci-scripts/hot-cluster/helm/ci-test-stack/templates/console-clusterrolebinding.yaml
@@ -1,6 +1,7 @@
-# Binds the console SA to the ci-console ClusterRole that was pre-created at
-# ARC install time. The ClusterRoleBinding is cluster-scoped so it must be
-# explicitly deleted on cleanup (helm uninstall handles this).
+# Binds the console SA to the ci-console ClusterRole created by the
+# ci-env-controller Helm chart (independent of the ARC install). The
+# ClusterRoleBinding is cluster-scoped so it must be explicitly deleted on
+# cleanup (helm uninstall handles this).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/ci-scripts/hot-cluster/images/ci-env-runner/Dockerfile
+++ b/ci-scripts/hot-cluster/images/ci-env-runner/Dockerfile
@@ -5,7 +5,7 @@
 # Using UBI9 avoids FIPS/OpenSSL DSO issues on hardened OpenShift clusters
 # (the Ubuntu-based ARC runner image fails OpenSSL loads on FIPS nodes).
 #
-# The Helm chart is staged into the build context by setup-controller-image.sh
+# The Helm chart is staged into the build context by setup-ci-env-runner-image.sh
 # and COPY'd into the image, avoiding the ConfigMap flat-key limitation that
 # drops subdirectories (templates/).
 
@@ -51,7 +51,7 @@ RUN curl -sL -o /usr/local/bin/yq \
     && chmod +x /usr/local/bin/yq
 
 # Embed the Helm chart into the image. The chart is staged into the build
-# context by setup-controller-image.sh via a symlink dereferenced by tar -ch.
+# context by setup-ci-env-runner-image.sh via a symlink dereferenced by tar -ch.
 COPY helm/ci-test-stack/ /opt/ci-env/helm/ci-test-stack/
 
 RUN useradd -r -u 1001 -g 0 -d /home/controller -s /sbin/nologin controller \

--- a/ci-scripts/hot-cluster/images/setup-arc-runner-image.sh
+++ b/ci-scripts/hot-cluster/images/setup-arc-runner-image.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 #
 # OpenShift only: create ImageStream + BuildConfig and run a binary Docker build for the
-# custom ARC runner image (ci-scripts/hot-cluster/arc/runner-image/Dockerfile).
+# custom ARC runner image (ci-scripts/hot-cluster/images/arc-runner/Dockerfile).
 #
 # Output: prints IMAGE_REF= to stdout (and to ARC_RUNNER_IMAGE_FILE if set).
 #
 # Optional environment variables:
-#   NS               Namespace for the runner (default: ci-env-images)
+#   NS               Namespace for the runner (default: arc-runners)
 #   OC_VERSION       OpenShift client version build-arg (default: detect or 4.20)
 #   HELM_VERSION     Helm version build-arg (default: 3.19.0)
 #   VIRTCTL_VERSION  (default: v1.4.0)

--- a/ci-scripts/hot-cluster/images/setup-ci-env-runner-image.sh
+++ b/ci-scripts/hot-cluster/images/setup-ci-env-runner-image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # OpenShift only: create ImageStream + BuildConfig and run a binary Docker build for the
-# ci-env-controller image (ci-scripts/hot-cluster/ci-env/controller-image/Dockerfile).
+# ci-env-controller image (ci-scripts/hot-cluster/images/ci-env-runner/Dockerfile).
 #
 # Output: prints IMAGE_REF= to stdout (and to CI_ENV_CONTROLLER_IMAGE_FILE if set).
 #
@@ -109,7 +109,7 @@ for i in $(seq 1 12); do
   sleep 5
 done
 
-# The controller-image/ directory contains a symlink to the Helm chart.
+# The ci-env-runner/ directory contains a symlink to the Helm chart.
 # Use tar -ch to dereference symlinks so the build pod receives the actual
 # chart files (including templates/ subdirectory), then pipe to --from-archive.
 echo "Starting binary build from ${IMAGE_DIR} (dereferencing symlinks)..."

--- a/ci-scripts/hot-cluster/test-cleanup.sh
+++ b/ci-scripts/hot-cluster/test-cleanup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# A copy of `../test-cleanup.sh` to use the correct namespace from the e2e run, and only delete resources in that namespace.
+# Deletes test-created VM/template/storage resources from the e2e run's test
+# namespace only (TEST_NS), leaving cluster-wide resources untouched.
 #
 export TEST_NS=${TEST_NS:-${CYPRESS_TEST_NS:-'auto-test-ns'}}
 
@@ -14,13 +15,3 @@ oc -n ${TEST_NS} delete secret --all --ignore-not-found --wait=false || true
 oc -n ${TEST_NS} delete net-attach-def --all --ignore-not-found --wait=false || true
 oc -n ${TEST_NS} delete VirtualMachineInstancetype example --ignore-not-found --wait=false || true
 oc -n ${TEST_NS} delete VirtualMachinePreference example --ignore-not-found --wait=false || true
-
-#oc -n openshift-virtualization-os-images delete datasource  -l app.kubernetes.io/part-of!=hyperconverged-cluster
-#oc -n openshift-virtualization-os-images delete datavolume  -l app.kubernetes.io/part-of!=hyperconverged-cluster
-#oc -n openshift-virtualization-os-images delete pvc --all --wait=false
-#oc -n openshift-cnv delete pvc -l k8s-app!=hostpath-provisioner --wait=false
-#oc -n openshift delete template -l app.kubernetes.io/name=custom-templates --wait=false
-#oc -n openshift delete pvc --all --wait=false
-#oc -n openshift delete VirtualMachineClusterInstancetype example --ignore-not-found --wait=false
-#oc -n openshift delete VirtualMachineClusterPreference example --ignore-not-found --wait=false
-#oc -n openshift delete MigrationPolicy example --ignore-not-found --wait=false

--- a/playwright/project-dependencies/rule-engine/setup-rules.ts
+++ b/playwright/project-dependencies/rule-engine/setup-rules.ts
@@ -1,5 +1,7 @@
 import { execFileSync, execSync } from 'child_process';
 import * as fs from 'fs';
+import * as http from 'http';
+import * as https from 'https';
 import * as path from 'path';
 
 import { KubernetesClient } from '@/clients/kubernetes-client';
@@ -153,6 +155,65 @@ export function getSetupRules(): SetupRule[] {
         } as SharedTestConfig;
         TestConfigManager.saveConfig(setupConfig);
         logger.info(`✓ Saved test configuration`);
+      },
+    },
+    {
+      id: 'wait-for-console-ready',
+      name: 'Wait for console web endpoint to become reachable',
+      phase: SetupPhase.CLUSTER,
+      guard: () => !EnvVariables.isLocalhost,
+      onError: 'throw',
+      run: async () => {
+        const baseUrl = EnvVariables.webConsoleUrl;
+        const timeoutMs = 2 * MINUTE;
+        const pollIntervalMs = 5 * SECOND;
+        logger.info(`⏳ Waiting for console to become reachable at ${baseUrl}...`);
+
+        // Plain http/https.get instead of fetch(): fetch performs strict TLS
+        // validation and rejects the self-signed/cluster-CA certs OpenShift
+        // console routes commonly use, which would time this probe out even
+        // when browser-login (Chromium with --ignore-certificate-errors)
+        // would connect just fine. rejectUnauthorized: false mirrors that
+        // same TLS-relaxed behavior here.
+        const probe = (): Promise<number> =>
+          new Promise<number>((resolve, reject) => {
+            const client = baseUrl.startsWith('https:') ? https : http;
+            const req = client.get(
+              baseUrl,
+              { rejectUnauthorized: false, timeout: 10 * SECOND },
+              (res) => {
+                res.resume(); // drain the response body to free the socket
+                resolve(res.statusCode ?? 0);
+              },
+            );
+            req.on('timeout', () => req.destroy(new Error('Probe request timed out')));
+            req.on('error', reject);
+          });
+
+        const start = Date.now();
+        let lastError: unknown;
+        while (Date.now() - start < timeoutMs) {
+          try {
+            // Any HTTP response (even a redirect/4xx) means the service is
+            // accepting connections — that's all browser-login needs. A
+            // connection error means the connection itself was refused/reset,
+            // typically because the per-run console Helm release is still
+            // rolling out.
+            const status = await probe();
+            logger.success(
+              `✓ Console responded with HTTP ${status} after ${Math.round((Date.now() - start) / 1000)}s`,
+            );
+            return;
+          } catch (err) {
+            lastError = err;
+            await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+          }
+        }
+
+        const msg = lastError instanceof Error ? lastError.message : String(lastError);
+        throw new Error(
+          `Console at ${baseUrl} did not become reachable within ${timeoutMs / 1000}s: ${msg}`,
+        );
       },
     },
 


### PR DESCRIPTION
## 📝 Description

Replace expiring BOT_PAT with GitHub App tokens for CI bot operations, remove redundant comments and fix /retest-e2e command. 

## 🔗 Links

Jira ticket: [CNV-92597](https://redhat.atlassian.net/browse/CNV-92597)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined hot-cluster E2E scheduling/concurrency so irrelevant label events no longer interfere with gated runs.
  * Retest E2E now relies on short-lived GitHub App tokens and improves unauthorized/unexpected error reporting behavior.
  * Ghost-runner cleanup now uses short-lived GitHub App installation tokens for safer authentication.
  * Cluster setup includes a wait step for the web console to reduce flakiness.
* **Documentation**
  * Updated CI/ARC runner docs: current required secrets, runner image build order, and dind-related guidance/limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->