### PR TITLE
CNV-92150: Deploy standalone console for manual UI testing on hot cluster

### DIFF
--- a/.github/actions/manual-console-request/action.yml
+++ b/.github/actions/manual-console-request/action.yml
@@ -1,0 +1,160 @@
+name: Request Manual Console Environment
+description: >
+  Create (or update) a trigger ConfigMap for the ci-env-controller to
+  provision the persistent, OAuth-protected manual-console environment
+  (CNV-92150), and wait until it is ready. Separate from ci-env-request
+  (used by E2E) so E2E behavior is unaffected -- distinguished by the
+  "ci.kubevirt-plugin/type: manual-console" label instead of
+  "test-environment", which also exempts it from the controller's TTL
+  reaper.
+
+inputs:
+  plugin-image:
+    description: Plugin container image to deploy
+    required: true
+  test-namespace:
+    description: Kubernetes namespace for the manual console environment
+    default: manual-console
+  configmap-name:
+    description: Name of the trigger ConfigMap
+    default: manual-console
+  ci-env-namespace:
+    description: Namespace where ci-env-controller runs
+    default: ci-env
+  htpasswd-user:
+    description: Username to grant OAuth login access
+    required: true
+  htpasswd-secret-name:
+    description: >
+      Name of a short-lived Secret (in ci-env-namespace) with key "password".
+      The controller reads it and deletes it immediately after applying the
+      htpasswd user -- the password itself is never written to the
+      ConfigMap.
+    required: true
+  timeout:
+    description: Max seconds to wait for environment to become ready
+    default: '360'
+
+outputs:
+  console-route:
+    description: External HTTPS route for the manual console
+    value: ${{ steps.wait.outputs.console-route }}
+  bridge-base-address:
+    description: In-cluster URL for the console bridge (debugging)
+    value: ${{ steps.wait.outputs.bridge-base-address }}
+
+runs:
+  using: composite
+  steps:
+    # Uses `apply` (not `create`, unlike ci-env-request) because the
+    # manual-console ConfigMap is a single, reused name across deploys
+    # rather than one unique name per run.
+    #
+    # IMPORTANT: `kubectl apply`'s 3-way merge does NOT reset `data.status`.
+    # It only patches fields that changed between the previous and new
+    # *applied* manifest -- since this manifest never included `status`
+    # (the controller sets it separately via `oc patch`), apply has no record
+    # of ever owning that field and leaves the live value (e.g. "ready" from
+    # the last deploy) untouched. Without an explicit reset, reconcile_one()
+    # would see status=ready and skip provisioning entirely on every
+    # redeploy. The follow-up `oc patch` below forces status back to
+    # "pending" unconditionally so the controller always re-provisions.
+    - name: Create or update trigger ConfigMap
+      shell: bash
+      run: |
+        cat <<EOF | oc apply -f -
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${{ inputs.configmap-name }}
+          namespace: ${{ inputs.ci-env-namespace }}
+          labels:
+            ci.kubevirt-plugin/type: manual-console
+        data:
+          desired-state: "present"
+          plugin-image: "${{ inputs.plugin-image }}"
+          test-namespace: "${{ inputs.test-namespace }}"
+          helm-release: "manual-console"
+          auth-mode: "openshift"
+          htpasswd-user: "${{ inputs.htpasswd-user }}"
+          htpasswd-secret-name: "${{ inputs.htpasswd-secret-name }}"
+        EOF
+        echo "Created/updated trigger ConfigMap ${{ inputs.configmap-name }} in ${{ inputs.ci-env-namespace }}"
+
+        oc patch configmap ${{ inputs.configmap-name }} -n ${{ inputs.ci-env-namespace }} \
+          --type merge -p '{"data":{"status":"pending","error-message":null}}'
+        echo "Reset status=pending so ci-env-controller re-provisions on this dispatch"
+
+    - name: Wait for environment ready
+      id: wait
+      shell: bash
+      env:
+        CM_NAME: ${{ inputs.configmap-name }}
+        CM_NS: ${{ inputs.ci-env-namespace }}
+        TIMEOUT: ${{ inputs.timeout }}
+      run: |
+        echo "Waiting for ci-env-controller to provision the manual console environment..."
+        INTERVAL=10
+        ELAPSED=0
+
+        while true; do
+          STATUS="$(oc get configmap "${CM_NAME}" -n "${CM_NS}" \
+            -o jsonpath='{.data.status}' 2>/dev/null || echo "")"
+
+          case "${STATUS}" in
+            ready)
+              echo "Environment is ready."
+              break
+              ;;
+            error)
+              ERR_MSG="$(oc get configmap "${CM_NAME}" -n "${CM_NS}" \
+                -o jsonpath='{.data.error-message}' 2>/dev/null || echo "unknown error")"
+              echo "::error::Environment provisioning failed: ${ERR_MSG}"
+              exit 1
+              ;;
+            *)
+              if (( ELAPSED >= TIMEOUT )); then
+                echo "::error::Timed out waiting for environment (status=${STATUS:-pending})"
+                exit 1
+              fi
+              echo "  status=${STATUS:-pending} (${ELAPSED}s / ${TIMEOUT}s)..."
+              sleep "${INTERVAL}"
+              ELAPSED=$(( ELAPSED + INTERVAL ))
+              ;;
+          esac
+        done
+
+        BRIDGE_BASE_ADDRESS="$(oc get configmap "${CM_NAME}" -n "${CM_NS}" \
+          -o jsonpath='{.data.bridge-base-address}' 2>/dev/null || echo "")"
+        CONSOLE_ROUTE="$(oc get configmap "${CM_NAME}" -n "${CM_NS}" \
+          -o jsonpath='{.data.console-route}' 2>/dev/null || echo "")"
+
+        echo "bridge-base-address=${BRIDGE_BASE_ADDRESS}" >> "${GITHUB_OUTPUT}"
+        echo "console-route=${CONSOLE_ROUTE}" >> "${GITHUB_OUTPUT}"
+
+    - name: Write job summary
+      shell: bash
+      env:
+        CM_NAME: ${{ inputs.configmap-name }}
+        CM_NS: ${{ inputs.ci-env-namespace }}
+        PLUGIN_IMAGE: ${{ inputs.plugin-image }}
+        TEST_NS: ${{ inputs.test-namespace }}
+        HTPASSWD_USER: ${{ inputs.htpasswd-user }}
+        ROUTE: ${{ steps.wait.outputs.console-route }}
+      run: |
+        {
+          echo "<details><summary>Manual Console Environment</summary>"
+          echo ""
+          echo "| Input Parameter | Value |"
+          echo "|------|-------|"
+          echo "| ConfigMap | \`${CM_NS}/${CM_NAME}\` |"
+          echo "| Plugin image | \`${PLUGIN_IMAGE}\` |"
+          echo "| Namespace | \`${TEST_NS}\` |"
+          echo "| Login username | \`${HTPASSWD_USER}\` |"
+          echo ""
+          echo "| Output Parameter | Value |"
+          echo "|------|-------|"
+          echo "| Console route | \`${ROUTE}\` |"
+          echo ""
+          echo "</details>"
+        } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/deploy-manual-console.yml
+++ b/.github/workflows/deploy-manual-console.yml
@@ -1,0 +1,184 @@
+name: Deploy Manual Console
+run-name: 'Deploy Manual Console [${{ inputs.cluster_name }}] @ ${{ inputs.branch }}'
+
+# Deploys a standalone, OAuth-protected console + kubevirt-plugin stack to an
+# existing hot cluster for manual UI testing (CNV-92150). Entirely separate
+# from the E2E path (hot-cluster-e2e*.yml, ci-env-request): it builds its own
+# in-cluster plugin image, uses its own trigger ConfigMap/action, and does
+# not touch the CNV-managed console, HCO, or SSP.
+#
+# Prerequisites: the target cluster must already be provisioned via
+# "IBM Cloud Hot Cluster Setup" (ibmc-cluster-setup.yml), which installs the
+# ARC runner scale set and the ci-env-controller this workflow depends on.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Git branch or ref to build the kubevirt-plugin image from
+        required: true
+        default: main
+        type: string
+      cluster_name:
+        description: ARC runner label / hot cluster name (must already be provisioned)
+        required: true
+        default: kubevirt-plugin-ci
+        type: string
+      infrastructure_type:
+        description: Infrastructure type of the target cluster (informational only)
+        required: false
+        default: ipi
+        type: choice
+        options:
+          - ipi
+          - vpc
+          - classic
+
+permissions:
+  contents: read
+
+# Persistent environment: never cancel an in-flight deploy for the same
+# cluster, since that could leave the manual console mid-provision.
+concurrency:
+  group: deploy-manual-console-${{ inputs.cluster_name }}
+  cancel-in-progress: false
+
+env:
+  CI_ENV_NS: ci-env
+  MANUAL_CONSOLE_CM: manual-console
+  MANUAL_CONSOLE_NS: manual-console
+  MANUAL_CONSOLE_USER: manual-console
+
+jobs:
+  deploy:
+    name: Deploy Manual Console
+    runs-on: ${{ inputs.cluster_name }}
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.branch }}
+          persist-credentials: false
+
+      - name: Log environment summary
+        env:
+          BRANCH: ${{ inputs.branch }}
+          CLUSTER_NAME: ${{ inputs.cluster_name }}
+        run: |
+          {
+            echo "## Manual Console Deploy"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Branch | \`${BRANCH}\` |"
+            echo "| Cluster | \`${CLUSTER_NAME}\` |"
+            echo "| Infrastructure | \`${{ inputs.infrastructure_type }}\` |"
+            echo "| Triggered by | @${{ github.actor }} |"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Build kubevirt-plugin image in-cluster
+        id: build
+        run: |
+          NS="${MANUAL_CONSOLE_NS}"
+          export NS
+          OUTPUT_FILE="$(mktemp)"
+          bash ci-scripts/manual-console/images/setup-plugin-image.sh | tee "${OUTPUT_FILE}"
+          IMAGE_REF="$(grep '^IMAGE_REF=' "${OUTPUT_FILE}" | cut -d= -f2-)"
+          rm -f "${OUTPUT_FILE}"
+          if [[ -z "${IMAGE_REF}" ]]; then
+            echo "::error::setup-plugin-image.sh did not output IMAGE_REF="
+            exit 1
+          fi
+          echo "image=${IMAGE_REF}" >> "${GITHUB_OUTPUT}"
+
+      - name: Generate manual console password
+        id: creds
+        run: |
+          PASSWORD="$(openssl rand -base64 24)"
+          echo "::add-mask::${PASSWORD}"
+          echo "password=${PASSWORD}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create short-lived credentials Secret
+        id: secret
+        env:
+          MANUAL_CONSOLE_PASSWORD: ${{ steps.creds.outputs.password }}
+        run: |
+          SECRET_NAME="manual-console-creds-${{ github.run_id }}"
+          oc create secret generic "${SECRET_NAME}" \
+            --namespace="${CI_ENV_NS}" \
+            --from-literal=password="${MANUAL_CONSOLE_PASSWORD}" \
+            --dry-run=client -o yaml | oc apply -f -
+          echo "name=${SECRET_NAME}" >> "${GITHUB_OUTPUT}"
+
+      - name: Provision manual console
+        id: deploy
+        uses: ./.github/actions/manual-console-request
+        with:
+          plugin-image: ${{ steps.build.outputs.image }}
+          test-namespace: ${{ env.MANUAL_CONSOLE_NS }}
+          configmap-name: ${{ env.MANUAL_CONSOLE_CM }}
+          ci-env-namespace: ${{ env.CI_ENV_NS }}
+          htpasswd-user: ${{ env.MANUAL_CONSOLE_USER }}
+          htpasswd-secret-name: ${{ steps.secret.outputs.name }}
+
+      - name: Send manual console credentials to Slack
+        if: always() && steps.deploy.outcome == 'success'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          CONSOLE_URL: ${{ steps.deploy.outputs.console-route }}
+          MANUAL_CONSOLE_PASSWORD: ${{ steps.creds.outputs.password }}
+          ACTOR: ${{ github.actor }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
+            echo "::warning::SLACK_WEBHOOK_URL not set — skipping Slack notification"
+            exit 0
+          fi
+
+          echo "::add-mask::${MANUAL_CONSOLE_PASSWORD}"
+
+          TEXT=":rocket: *Manual console ready*"
+          TEXT+=$'\n'"*Triggered by:* @${ACTOR}"
+          TEXT+=$'\n'"*URL:* <${CONSOLE_URL}>"
+          TEXT+=$'\n'"*User:* \`${MANUAL_CONSOLE_USER}\`"
+          TEXT+=$'\n'"*Password:* \`${MANUAL_CONSOLE_PASSWORD}\`"
+          TEXT+=$'\n'"*Branch:* \`${BRANCH}\`"
+          TEXT+=$'\n'"*Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>"
+
+          PAYLOAD=$(jq -n --arg text "${TEXT}" '{text: $text}')
+
+          curl -sS -X POST -H 'Content-Type: application/json' -d "${PAYLOAD}" "${SLACK_WEBHOOK_URL}"
+          echo "Slack notification sent."
+
+      - name: Write final job summary
+        if: always()
+        env:
+          CONSOLE_URL: ${{ steps.deploy.outputs.console-route }}
+        run: |
+          {
+            echo ""
+            echo "### Result"
+            echo ""
+            if [[ -n "${CONSOLE_URL}" ]]; then
+              echo "Console URL: ${CONSOLE_URL}"
+              echo ""
+              echo "Login credentials were sent to Slack (if \`SLACK_WEBHOOK_URL\` is configured)."
+            else
+              echo ":x: Deploy did not complete successfully — see logs above."
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # Defense-in-depth: ci-env-controller already deletes this Secret once
+      # it reads the password during provisioning, but only if it gets that
+      # far (e.g. not if cluster discovery or the htpasswd upsert fails
+      # first, or the controller pod is unavailable). Without this, a failed
+      # or timed-out provisioning run would leave a Secret with a plaintext
+      # password behind indefinitely. if: always() guarantees this runs on
+      # every exit path, including job failure; --ignore-not-found makes it
+      # a no-op on the normal path where the controller already deleted it.
+      - name: Clean up credentials Secret
+        if: always()
+        run: |
+          SECRET_NAME="manual-console-creds-${{ github.run_id }}"
+          oc delete secret "${SECRET_NAME}" --namespace="${CI_ENV_NS}" --ignore-not-found

--- a/.github/workflows/deploy-plugin.yml
+++ b/.github/workflows/deploy-plugin.yml
@@ -1,0 +1,150 @@
+name: Deploy Plugin (Manual Console Quick Redeploy)
+run-name: 'Deploy Plugin [${{ inputs.cluster_name }}] @ ${{ inputs.branch }}'
+
+# Lightweight companion to deploy-manual-console.yml (CNV-92150) for quickly
+# iterating on UI changes against an already-deployed manual console: builds
+# a fresh plugin image and re-provisions the same "manual-console" release,
+# without repeating the full job summary / Slack notification of the main
+# workflow. Use deploy-manual-console.yml for the first deploy, or whenever
+# you need a fresh URL/credentials reminder.
+#
+# Prerequisites: same as deploy-manual-console.yml -- the target cluster must
+# already be provisioned, and a manual console should already exist (though
+# this workflow works standalone too, it will just deploy fresh).
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Git branch or ref to build the kubevirt-plugin image from
+        required: true
+        default: main
+        type: string
+      cluster_name:
+        description: ARC runner label / hot cluster name (must already be provisioned)
+        required: true
+        default: kubevirt-plugin-ci
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-manual-console-${{ inputs.cluster_name }}
+  cancel-in-progress: false
+
+env:
+  CI_ENV_NS: ci-env
+  MANUAL_CONSOLE_CM: manual-console
+  MANUAL_CONSOLE_NS: manual-console
+  MANUAL_CONSOLE_USER: manual-console
+
+jobs:
+  redeploy:
+    name: Redeploy Plugin
+    runs-on: ${{ inputs.cluster_name }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.branch }}
+          persist-credentials: false
+
+      - name: Build kubevirt-plugin image in-cluster
+        id: build
+        run: |
+          NS="${MANUAL_CONSOLE_NS}"
+          export NS
+          OUTPUT_FILE="$(mktemp)"
+          bash ci-scripts/manual-console/images/setup-plugin-image.sh | tee "${OUTPUT_FILE}"
+          IMAGE_REF="$(grep '^IMAGE_REF=' "${OUTPUT_FILE}" | cut -d= -f2-)"
+          rm -f "${OUTPUT_FILE}"
+          if [[ -z "${IMAGE_REF}" ]]; then
+            echo "::error::setup-plugin-image.sh did not output IMAGE_REF="
+            exit 1
+          fi
+          echo "image=${IMAGE_REF}" >> "${GITHUB_OUTPUT}"
+
+      # provision() always re-runs the htpasswd/OAuth ensure step regardless
+      # of whether credentials changed, so a fresh Secret is still required
+      # here -- this keeps ci-env-controller's logic simple (one code path)
+      # at the cost of a new (unused, if unchanged) password each redeploy.
+      - name: Generate manual console password
+        id: creds
+        run: |
+          PASSWORD="$(openssl rand -base64 24)"
+          echo "::add-mask::${PASSWORD}"
+          echo "password=${PASSWORD}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create short-lived credentials Secret
+        id: secret
+        env:
+          MANUAL_CONSOLE_PASSWORD: ${{ steps.creds.outputs.password }}
+        run: |
+          SECRET_NAME="manual-console-creds-${{ github.run_id }}"
+          oc create secret generic "${SECRET_NAME}" \
+            --namespace="${CI_ENV_NS}" \
+            --from-literal=password="${MANUAL_CONSOLE_PASSWORD}" \
+            --dry-run=client -o yaml | oc apply -f -
+          echo "name=${SECRET_NAME}" >> "${GITHUB_OUTPUT}"
+
+      - name: Redeploy manual console
+        id: deploy
+        uses: ./.github/actions/manual-console-request
+        with:
+          plugin-image: ${{ steps.build.outputs.image }}
+          test-namespace: ${{ env.MANUAL_CONSOLE_NS }}
+          configmap-name: ${{ env.MANUAL_CONSOLE_CM }}
+          ci-env-namespace: ${{ env.CI_ENV_NS }}
+          htpasswd-user: ${{ env.MANUAL_CONSOLE_USER }}
+          htpasswd-secret-name: ${{ steps.secret.outputs.name }}
+
+      # ci-env-controller re-applies the htpasswd user on every provision, so
+      # the previous login password is no longer valid after this step --
+      # a fresh reminder must be sent, otherwise the user is silently locked
+      # out with no way to discover the new password.
+      - name: Send updated credentials to Slack
+        if: always() && steps.deploy.outcome == 'success'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          CONSOLE_URL: ${{ steps.deploy.outputs.console-route }}
+          MANUAL_CONSOLE_PASSWORD: ${{ steps.creds.outputs.password }}
+          ACTOR: ${{ github.actor }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
+            echo "::warning::SLACK_WEBHOOK_URL not set — skipping Slack notification"
+            exit 0
+          fi
+
+          echo "::add-mask::${MANUAL_CONSOLE_PASSWORD}"
+
+          TEXT=":arrows_counterclockwise: *Manual console plugin redeployed*"
+          TEXT+=$'\n'"*Triggered by:* @${ACTOR}"
+          TEXT+=$'\n'"*URL:* <${CONSOLE_URL}>"
+          TEXT+=$'\n'"*User:* \`${MANUAL_CONSOLE_USER}\`"
+          TEXT+=$'\n'"*Password (rotated):* \`${MANUAL_CONSOLE_PASSWORD}\`"
+          TEXT+=$'\n'"*Branch:* \`${BRANCH}\`"
+
+          PAYLOAD=$(jq -n --arg text "${TEXT}" '{text: $text}')
+
+          curl -sS -X POST -H 'Content-Type: application/json' -d "${PAYLOAD}" "${SLACK_WEBHOOK_URL}"
+          echo "Slack notification sent."
+
+      - name: Write job summary
+        if: always()
+        env:
+          CONSOLE_URL: ${{ steps.deploy.outputs.console-route }}
+        run: |
+          {
+            echo "## Plugin Redeployed"
+            echo ""
+            if [[ -n "${CONSOLE_URL}" ]]; then
+              echo "Console URL: ${CONSOLE_URL}"
+              echo ""
+              echo "Login password was rotated and sent to Slack (if \`SLACK_WEBHOOK_URL\` is configured)."
+            else
+              echo ":x: Redeploy did not complete successfully — see logs above."
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -246,12 +246,25 @@ jobs:
   # so this is the job branch protection can actually match. if: always()
   # guarantees it reports a real success/failure for every meaningful push,
   # even when upstream jobs are skipped (e.g. untrusted author, no ok-to-test
-  # label), so Tide can never merge on a silently-vanished check again. The
-  # event-relevance guard below stops it from also running on irrelevant
-  # label events (lgtm, approved, ...), which would otherwise overwrite a
-  # prior passing result for the same commit SHA with a bogus failure.
+  # label), so Tide can never merge on a silently-vanished check again.
+  #
+  # IMPORTANT: an `if:` guard alone does NOT stop this job from posting a
+  # check-run under its `name` — GitHub still reports skipped jobs as
+  # `<name>: skipped` for the commit SHA. Two separate workflow runs (the
+  # real one, and a noop run from an irrelevant label like jira/valid-
+  # reference) both create a "Run Gating Tests" check-run for the same SHA;
+  # GitHub's merge box always shows whichever reported most recently,
+  # regardless of Actions concurrency grouping (that only prevents execution
+  # contention, not duplicate check-run names). Since the noop run finishes
+  # in seconds while the real run takes 15-20+ minutes, its "skipped" result
+  # is misleadingly the only thing visible for most of the real run's
+  # lifetime. The conditional `name:` below fixes this at the source: only
+  # the relevant-event path ever reports under the literal "Run Gating
+  # Tests" context that branch protection/Tide requires, so an irrelevant
+  # label event doesn't touch that check at all (leaving it correctly
+  # `expected`/pending until the real run reports).
   verify-gating-tests:
-    name: Run Gating Tests
+    name: ${{ (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test') && 'Run Gating Tests' || 'Run Gating Tests (skipped - irrelevant label event)' }}
     needs: [check-trust, cluster-check, cluster-health-check, run-e2e-tests]
     if: |
       always() &&

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -105,6 +105,17 @@ All paths converge after cluster creation: the workflow installs HCO, builds the
 5. Playwright gating tests run against the in-cluster console
 6. Artifacts are uploaded, test environment is released
 
+## Manual UI Testing
+
+Actions → **Deploy Manual Console** deploys a persistent, OAuth-protected
+console + kubevirt-plugin stack on an already-provisioned hot cluster, for
+browsing branch UI code as a human instead of running automated tests. It
+reuses `ci-env-controller` and the `ci-test-stack` Helm chart through a
+separate, opt-in path (own trigger label, own namespace) with zero effect on
+E2E behavior. See [`manual-console/README.md`](manual-console/README.md)
+for the full architecture, credential model, and ConfigMap contract
+additions.
+
 ## Teardown
 
 **Manual:** Actions → **IBM Cloud Hot Cluster Teardown** (select infrastructure type)
@@ -145,6 +156,10 @@ ci-scripts/
     ci-env/
     helm/
     images/
+  manual-console/                  (manual UI testing; CNV-92150 -- see manual-console/README.md)
+    ensure-manual-console-user.sh
+    images/
+      setup-plugin-image.sh
 ```
 
 ## Scripts

--- a/ci-scripts/hot-cluster/helm/ci-env-controller/scripts/ci-env-controller.sh
+++ b/ci-scripts/hot-cluster/helm/ci-env-controller/scripts/ci-env-controller.sh
@@ -8,15 +8,25 @@
 # Environment variables (set on the Deployment):
 #   CI_ENV_NS              Namespace where trigger ConfigMaps live (default: ci-env)
 #   CI_ENV_TTL_SECONDS     Force-clean environments older than this (default: 7200 = 2h)
-#   CI_ENV_LABEL           Label selector for trigger ConfigMaps
+#   CI_ENV_LABEL           Label selector for E2E trigger ConfigMaps (TTL-reaped)
+#   CI_ENV_MANUAL_LABEL    Label selector for persistent manual-console ConfigMaps
+#                          (CNV-92150; reconciled like CI_ENV_LABEL but never
+#                          reaped -- see reap_stale, which only scans CI_ENV_LABEL)
 #   HELM_CHART_PATH        Path to the ci-test-stack Helm chart inside the container
+#   ENSURE_MANUAL_CONSOLE_USER_SCRIPT
+#                          Path to ensure-manual-console-user.sh inside the
+#                          container; only invoked when a ConfigMap sets
+#                          auth-mode=openshift (default:
+#                          /opt/ci-env/manual-console/ensure-manual-console-user.sh)
 
 set -uo pipefail
 
 CI_ENV_NS="${CI_ENV_NS:-ci-env}"
 CI_ENV_TTL_SECONDS="${CI_ENV_TTL_SECONDS:-7200}"
 CI_ENV_LABEL="${CI_ENV_LABEL:-ci.kubevirt-plugin/type=test-environment}"
+CI_ENV_MANUAL_LABEL="${CI_ENV_MANUAL_LABEL:-ci.kubevirt-plugin/type=manual-console}"
 HELM_CHART_PATH="${HELM_CHART_PATH:-/opt/ci-env/helm/ci-test-stack}"
+ENSURE_MANUAL_CONSOLE_USER_SCRIPT="${ENSURE_MANUAL_CONSOLE_USER_SCRIPT:-/opt/ci-env/manual-console/ensure-manual-console-user.sh}"
 
 RUNNER_SA_NAME="${RUNNER_SA_NAME:-kubevirt-plugin-ci-gha-rs-no-permission}"
 RUNNER_SA_NS="${RUNNER_SA_NS:-arc-runners}"
@@ -119,6 +129,56 @@ patch_cm() {
 }
 
 # --------------------------------------------------------------------------- #
+#  Ensure an htpasswd user for OAuth-mode deploys (manual-console; CNV-92150)
+#
+#  Reads the plaintext password from a short-lived Secret named by
+#  htpasswd_secret_name (in CI_ENV_NS), deletes that Secret immediately
+#  (best-effort, regardless of outcome below), then delegates to
+#  ensure-manual-console-user.sh to upsert the htpasswd user and extract the
+#  cluster CA bundle. Sets MANUAL_AUTH_CA_CERT_FILE on success.
+# --------------------------------------------------------------------------- #
+ensure_manual_console_auth() {
+  local htpasswd_user="$1"
+  local htpasswd_secret_name="$2"
+
+  if [[ -z "${htpasswd_user}" || -z "${htpasswd_secret_name}" ]]; then
+    log "ERROR: auth-mode=openshift requires htpasswd-user and htpasswd-secret-name"
+    return 1
+  fi
+
+  local htpasswd_password
+  htpasswd_password="$(oc get secret "${htpasswd_secret_name}" -n "${CI_ENV_NS}" \
+    -o jsonpath='{.data.password}' 2>/dev/null | base64 -d || true)"
+
+  # The password must never outlive this single reconciliation: delete the
+  # Secret now regardless of whether reading it succeeded.
+  oc delete secret "${htpasswd_secret_name}" -n "${CI_ENV_NS}" --ignore-not-found 2>/dev/null || true
+
+  if [[ -z "${htpasswd_password}" ]]; then
+    log "ERROR: could not read password from Secret ${htpasswd_secret_name}"
+    return 1
+  fi
+
+  log "Ensuring htpasswd user ${htpasswd_user} via ${ENSURE_MANUAL_CONSOLE_USER_SCRIPT}..."
+  local ensure_output
+  # Password goes over stdin, never argv: CLI args are visible to any
+  # co-located process for the child's whole lifetime via `ps`/
+  # `/proc/<pid>/cmdline`, unlike a pipe that only exists transiently.
+  if ! ensure_output="$(printf '%s' "${htpasswd_password}" \
+    | bash "${ENSURE_MANUAL_CONSOLE_USER_SCRIPT}" "${htpasswd_user}" 2>&1)"; then
+    log "ERROR: ensure-manual-console-user.sh failed: ${ensure_output}"
+    return 1
+  fi
+  log "${ensure_output}"
+
+  MANUAL_AUTH_CA_CERT_FILE="$(echo "${ensure_output}" | grep '^CA_CERT_FILE=' | cut -d= -f2-)"
+  if [[ -z "${MANUAL_AUTH_CA_CERT_FILE}" || ! -f "${MANUAL_AUTH_CA_CERT_FILE}" ]]; then
+    log "ERROR: ensure-manual-console-user.sh did not produce a CA_CERT_FILE"
+    return 1
+  fi
+}
+
+# --------------------------------------------------------------------------- #
 #  Provision a test environment
 # --------------------------------------------------------------------------- #
 provision() {
@@ -127,10 +187,13 @@ provision() {
   local test_ns="$3"
   local console_image_override="${4:-}"
   local helm_release_override="${5:-}"
+  local auth_mode="${6:-disabled}"
+  local htpasswd_user="${7:-}"
+  local htpasswd_secret_name="${8:-}"
 
   local helm_release="${helm_release_override:-${cm_name}}"
 
-  log "Provisioning: cm=${cm_name} ns=${test_ns} release=${helm_release}"
+  log "Provisioning: cm=${cm_name} ns=${test_ns} release=${helm_release} auth-mode=${auth_mode}"
   patch_cm "${cm_name}" '{"data":{"status":"provisioning"}}'
 
   discover_cluster || {
@@ -147,6 +210,19 @@ provision() {
   log "Creating namespace ${test_ns}..."
   oc create namespace "${test_ns}" --dry-run=client -o yaml | oc apply -f - || true
 
+  # Opt-in only: unset/disabled auth-mode (the default for every existing E2E
+  # ConfigMap) skips this block entirely and behaves exactly as before.
+  local extra_helm_args=()
+  local MANUAL_AUTH_CA_CERT_FILE=""
+  if [[ "${auth_mode}" == "openshift" ]]; then
+    if ! ensure_manual_console_auth "${htpasswd_user}" "${htpasswd_secret_name}"; then
+      patch_cm "${cm_name}" '{"data":{"status":"error","error-message":"failed to provision htpasswd user"}}'
+      return 1
+    fi
+    extra_helm_args+=(--set "console.auth.mode=openshift")
+    extra_helm_args+=(--set-file "console.auth.caCert=${MANUAL_AUTH_CA_CERT_FILE}")
+  fi
+
   log "Running helm upgrade --install ${helm_release}..."
   if ! helm upgrade --install "${helm_release}" \
     "${HELM_CHART_PATH}" \
@@ -161,13 +237,16 @@ provision() {
     --set "rbac.consoleClusterRole=cluster-admin" \
     --set "runner.saName=${RUNNER_SA_NAME}" \
     --set "runner.saNamespace=${RUNNER_SA_NS}" \
+    "${extra_helm_args[@]}" \
     --wait --timeout 5m 2>&1; then
 
     local err="helm install failed"
     log "ERROR: ${err}"
     patch_cm "${cm_name}" "{\"data\":{\"status\":\"error\",\"error-message\":\"${err}\"}}"
+    [[ -n "${MANUAL_AUTH_CA_CERT_FILE}" ]] && rm -f "${MANUAL_AUTH_CA_CERT_FILE}"
     return 1
   fi
+  [[ -n "${MANUAL_AUTH_CA_CERT_FILE}" ]] && rm -f "${MANUAL_AUTH_CA_CERT_FILE}"
 
   local bridge_base="http://${helm_release}-console.${test_ns}.svc.cluster.local:9000"
   log "Waiting for console at ${bridge_base}..."
@@ -218,6 +297,7 @@ reconcile_one() {
   local cm_json="$1"
 
   local cm_name desired status plugin_image test_ns console_image helm_release
+  local auth_mode htpasswd_user htpasswd_secret_name
   cm_name="$(echo "${cm_json}" | jq -r '.metadata.name')"
   desired="$(echo "${cm_json}" | jq -r '.data["desired-state"] // "unknown"')"
   status="$(echo "${cm_json}" | jq -r '.data["status"] // ""')"
@@ -225,6 +305,11 @@ reconcile_one() {
   test_ns="$(echo "${cm_json}" | jq -r '.data["test-namespace"] // ""')"
   console_image="$(echo "${cm_json}" | jq -r '.data["console-image"] // ""')"
   helm_release="$(echo "${cm_json}" | jq -r '.data["helm-release"] // ""')"
+  # Manual-console-only fields (CNV-92150); empty for every existing E2E
+  # ConfigMap, which keeps provision() on its original disabled-auth path.
+  auth_mode="$(echo "${cm_json}" | jq -r '.data["auth-mode"] // "disabled"')"
+  htpasswd_user="$(echo "${cm_json}" | jq -r '.data["htpasswd-user"] // ""')"
+  htpasswd_secret_name="$(echo "${cm_json}" | jq -r '.data["htpasswd-secret-name"] // ""')"
 
   if [[ "${desired}" == "present" && "${status}" != "ready" && "${status}" != "provisioning" ]]; then
     if [[ -z "${plugin_image}" || -z "${test_ns}" ]]; then
@@ -232,7 +317,8 @@ reconcile_one() {
       patch_cm "${cm_name}" '{"data":{"status":"error","error-message":"missing required fields: plugin-image and test-namespace"}}'
       return
     fi
-    if ! provision "${cm_name}" "${plugin_image}" "${test_ns}" "${console_image}" "${helm_release}"; then
+    if ! provision "${cm_name}" "${plugin_image}" "${test_ns}" "${console_image}" "${helm_release}" \
+      "${auth_mode}" "${htpasswd_user}" "${htpasswd_secret_name}"; then
       log "ERROR: provision failed for ${cm_name}, ensuring status=error"
       local cur_status
       cur_status="$(oc get configmap "${cm_name}" -n "${CI_ENV_NS}" -o jsonpath='{.data.status}' 2>/dev/null || echo "")"
@@ -296,6 +382,7 @@ main() {
   log "  CI_ENV_NS=${CI_ENV_NS}"
   log "  CI_ENV_TTL_SECONDS=${CI_ENV_TTL_SECONDS}"
   log "  CI_ENV_LABEL=${CI_ENV_LABEL}"
+  log "  CI_ENV_MANUAL_LABEL=${CI_ENV_MANUAL_LABEL}"
   log "  HELM_CHART_PATH=${HELM_CHART_PATH}"
 
   local reap_interval=300
@@ -305,14 +392,21 @@ main() {
     local now
     now="$(date +%s)"
     if (( now - last_reap > reap_interval )); then
+      # Only ever scans CI_ENV_LABEL (E2E), so manual-console ConfigMaps
+      # (CI_ENV_MANUAL_LABEL) are never force-cleaned by the TTL reaper.
       reap_stale
       last_reap="${now}"
     fi
 
-    local cms
+    # Reconcile both the ephemeral E2E stream and the persistent
+    # manual-console stream (CNV-92150) in the same pass; they're
+    # independent ConfigMaps distinguished only by label value.
+    local cms manual_cms combined
     cms="$(oc get configmap -n "${CI_ENV_NS}" -l "${CI_ENV_LABEL}" -o json 2>/dev/null || echo '{"items":[]}')"
+    manual_cms="$(oc get configmap -n "${CI_ENV_NS}" -l "${CI_ENV_MANUAL_LABEL}" -o json 2>/dev/null || echo '{"items":[]}')"
+    combined="$(jq -n --argjson a "${cms}" --argjson b "${manual_cms}" '{items: ($a.items + $b.items)}' 2>/dev/null || echo '{"items":[]}')"
 
-    echo "${cms}" | jq -c '.items[]' 2>/dev/null | while IFS= read -r cm; do
+    echo "${combined}" | jq -c '.items[]' 2>/dev/null | while IFS= read -r cm; do
       reconcile_one "${cm}"
     done
 

--- a/ci-scripts/hot-cluster/helm/ci-env-controller/templates/role-trigger.yaml
+++ b/ci-scripts/hot-cluster/helm/ci-env-controller/templates/role-trigger.yaml
@@ -12,3 +12,10 @@ rules:
   - apiGroups: ['']
     resources: ['configmaps']
     verbs: ['get', 'list', 'watch', 'create', 'update', 'patch', 'delete']
+  # Additive (CNV-92150): lets the runner hand off a generated htpasswd
+  # password to the controller via a short-lived Secret instead of the
+  # ConfigMap, without needing cluster-admin. Only used by the manual-console
+  # deploy path -- E2E never creates Secrets here.
+  - apiGroups: ['']
+    resources: ['secrets']
+    verbs: ['create', 'get', 'delete']

--- a/ci-scripts/hot-cluster/helm/ci-test-stack/templates/_helpers.tpl
+++ b/ci-scripts/hot-cluster/helm/ci-test-stack/templates/_helpers.tpl
@@ -28,3 +28,21 @@ In-cluster URL the console uses to reach the plugin Service.
 {{- define "ci-test-stack.pluginUrl" -}}
 http://{{ include "ci-test-stack.pluginName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.plugin.port }}
 {{- end }}
+
+{{/*
+OAuthClient name (cluster-scoped, so it's release-namespaced to avoid
+collisions between manual-console and any concurrent E2E test releases).
+*/}}
+{{- define "ci-test-stack.oauthClientName" -}}
+{{ .Release.Name }}-console-oauth-client
+{{- end }}
+
+{{/*
+NOTE: there is deliberately no "oauthClientSecret" helper here. A helper
+that falls back to a random value (e.g. randAlphaNum) when no existing
+OAuthClient/Secret is found would re-evaluate that randomness independently
+each time it's `include`d, diverging between the OAuthClient and the Secret
+that must both carry the identical value on a fresh install. See
+console-oauthclient.yaml, which computes the secret once as a local
+variable and emits both resources from that single render pass instead.
+*/}}

--- a/ci-scripts/hot-cluster/helm/ci-test-stack/templates/console-deployment.yaml
+++ b/ci-scripts/hot-cluster/helm/ci-test-stack/templates/console-deployment.yaml
@@ -41,6 +41,20 @@ spec:
             {{- end }}
 
             # User auth settings
+            {{- if eq .Values.console.auth.mode "openshift" }}
+            - name: BRIDGE_USER_AUTH
+              value: "openshift"
+            - name: BRIDGE_K8S_AUTH
+              value: "openshift"
+            - name: BRIDGE_CA_FILE
+              value: "/etc/console-auth/ca.crt"
+            - name: BRIDGE_USER_AUTH_OIDC_CLIENT_ID
+              value: {{ include "ci-test-stack.oauthClientName" . | quote }}
+            - name: BRIDGE_USER_AUTH_OIDC_CLIENT_SECRET_FILE
+              value: "/etc/console-auth/client-secret"
+            - name: BRIDGE_USER_AUTH_OIDC_CA_FILE
+              value: "/etc/console-auth/ca.crt"
+            {{- else }}
             - name: BRIDGE_USER_AUTH
               value: "disabled"
             - name: BRIDGE_K8S_AUTH_BEARER_TOKEN
@@ -48,6 +62,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "ci-test-stack.consoleName" . }}-token
                   key: token
+            {{- end }}
 
             # Branding and docs settings
             - name: BRIDGE_BRANDING
@@ -89,3 +104,13 @@ spec:
               port: {{ .Values.console.port }}
             initialDelaySeconds: 15
             periodSeconds: 30
+          {{- if eq .Values.console.auth.mode "openshift" }}
+          volumeMounts:
+            - name: console-auth
+              mountPath: /etc/console-auth
+              readOnly: true
+      volumes:
+        - name: console-auth
+          secret:
+            secretName: {{ include "ci-test-stack.consoleName" . }}-oauth
+          {{- end }}

--- a/ci-scripts/hot-cluster/helm/ci-test-stack/templates/console-oauthclient.yaml
+++ b/ci-scripts/hot-cluster/helm/ci-test-stack/templates/console-oauthclient.yaml
@@ -1,0 +1,58 @@
+{{- if eq .Values.console.auth.mode "openshift" }}
+{{- /*
+Compute the OAuth client secret ONCE per render and reuse it for both
+resources below. `lookup` is safe to call from a helper (idempotent within a
+single render, since it just reads live cluster state), but `randAlphaNum`
+is NOT: each `include`/template invocation re-executes the template body
+from scratch, so a helper that falls back to `randAlphaNum` would render a
+DIFFERENT random value when called from two separate files, silently
+breaking OAuth login on every fresh install (OAuthClient.secret would never
+match the Secret's client-secret). Computing it once as a local variable
+here and emitting both resources via `---` in this single file is the only
+way to guarantee they render the identical value when neither the
+OAuthClient nor the Secret already exists on the cluster.
+
+Lookup order: reuse the existing OAuthClient's secret first (the value
+actually in use), then the existing Secret's (covers the unlikely case one
+was deleted without the other), and only generate a fresh random secret if
+neither exists yet -- i.e. a genuinely first-time install.
+*/}}
+{{- $existingClient := lookup "oauth.openshift.io/v1" "OAuthClient" "" (include "ci-test-stack.oauthClientName" .) }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-oauth" (include "ci-test-stack.consoleName" .)) }}
+{{- $clientSecret := "" }}
+{{- if $existingClient }}
+{{- $clientSecret = $existingClient.secret }}
+{{- else if $existingSecret }}
+{{- $clientSecret = (index $existingSecret.data "client-secret" | b64dec) }}
+{{- else }}
+{{- $clientSecret = randAlphaNum 40 }}
+{{- end }}
+---
+# Cluster-scoped OAuthClient used by the console for the OAuth login flow.
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+metadata:
+  name: {{ include "ci-test-stack.oauthClientName" . }}
+  labels:
+    {{- include "ci-test-stack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: console
+grantMethod: auto
+secret: {{ $clientSecret | quote }}
+redirectURIs:
+  - https://{{ required "console.route.host is required for auth.mode=openshift" .Values.console.route.host }}{{ .Values.console.auth.redirectPath }}
+---
+# Holds the OAuth client secret (identical to the OAuthClient's `secret`
+# field above) and the cluster CA bundle needed to verify the OAuth server.
+# Mounted into the console Deployment at /etc/console-auth.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ci-test-stack.consoleName" . }}-oauth
+  labels:
+    {{- include "ci-test-stack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: console
+type: Opaque
+stringData:
+  client-secret: {{ $clientSecret | quote }}
+  ca.crt: {{ required "console.auth.caCert is required for auth.mode=openshift" .Values.console.auth.caCert | quote }}
+{{- end }}

--- a/ci-scripts/hot-cluster/helm/ci-test-stack/values.yaml
+++ b/ci-scripts/hot-cluster/helm/ci-test-stack/values.yaml
@@ -23,6 +23,19 @@ console:
     thanosUrl: ''
     alertmanagerUrl: ''
 
+  # User authentication mode.
+  #   disabled:  bearer-token auth via the console ServiceAccount (E2E default,
+  #              set by ci-env-controller for ephemeral test environments).
+  #   openshift: OAuth login via an htpasswd identity provider (used by the
+  #              persistent manual-console deploy path). Requires
+  #              console.route.host and auth.caCert to be set.
+  auth:
+    mode: disabled
+    redirectPath: /auth/callback
+    # PEM CA bundle used to verify the OAuth server. Only consumed when
+    # auth.mode=openshift; ci-env-controller passes this via --set-file.
+    caCert: ''
+
 # ClusterRole created by the ci-env-controller Helm chart (clusterrole-console.yaml).
 rbac:
   consoleClusterRole: cluster-admin

--- a/ci-scripts/hot-cluster/images/ci-env-runner/Dockerfile
+++ b/ci-scripts/hot-cluster/images/ci-env-runner/Dockerfile
@@ -1,13 +1,13 @@
 # CI Environment Controller image.
 # Lightweight UBI9 image with only the CLI tools needed by ci-env-controller.sh:
-#   oc, helm, jq, yq, curl
+#   oc, helm, jq, yq, curl, htpasswd (manual-console auth mode; CNV-92150)
 #
 # Using UBI9 avoids FIPS/OpenSSL DSO issues on hardened OpenShift clusters
 # (the Ubuntu-based ARC runner image fails OpenSSL loads on FIPS nodes).
 #
-# The Helm chart is staged into the build context by setup-ci-env-runner-image.sh
-# and COPY'd into the image, avoiding the ConfigMap flat-key limitation that
-# drops subdirectories (templates/).
+# The Helm chart and the manual-console scripts are staged into the build
+# context by setup-ci-env-runner-image.sh and COPY'd into the image, avoiding
+# the ConfigMap flat-key limitation that drops subdirectories (templates/).
 
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
@@ -19,6 +19,7 @@ ARG YQ_VERSION=v4.52.5
 
 RUN dnf install -y --nodocs \
       jq \
+      httpd-tools \
     && dnf clean all
 
 # oc (OpenShift CLI) -- prefer cluster-resolved URL if provided.
@@ -50,9 +51,14 @@ RUN curl -sL -o /usr/local/bin/yq \
       "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
     && chmod +x /usr/local/bin/yq
 
-# Embed the Helm chart into the image. The chart is staged into the build
-# context by setup-ci-env-runner-image.sh via a symlink dereferenced by tar -ch.
+# Embed the Helm chart and ensure-manual-console-user.sh into the image. Both
+# are staged into the build context by setup-ci-env-runner-image.sh via
+# symlinks dereferenced by tar -ch. Only the single script the controller
+# invokes is copied (not the sibling images/ dir, which is unused here).
 COPY helm/ci-test-stack/ /opt/ci-env/helm/ci-test-stack/
+COPY manual-console/ensure-manual-console-user.sh /opt/ci-env/manual-console/ensure-manual-console-user.sh
+
+RUN chmod +x /opt/ci-env/manual-console/ensure-manual-console-user.sh
 
 RUN useradd -r -u 1001 -g 0 -d /home/controller -s /sbin/nologin controller \
     && mkdir -p /home/controller \

--- a/ci-scripts/hot-cluster/images/ci-env-runner/manual-console
+++ b/ci-scripts/hot-cluster/images/ci-env-runner/manual-console
@@ -1,0 +1,1 @@
+../../../manual-console

--- a/ci-scripts/manual-console/README.md
+++ b/ci-scripts/manual-console/README.md
@@ -1,0 +1,139 @@
+# Manual Console (CNV-92150)
+
+Deploys a standalone, OAuth-protected OpenShift console + kubevirt-plugin
+stack on an existing hot cluster, for manually testing branch UI code
+against a real CNV environment. Complements the [E2E test stack](../hot-cluster/ci-env/README.md)
+without modifying it: manual-console reuses the same `ci-env-controller` and
+`ci-test-stack` Helm chart, but through its own trigger label, ConfigMap
+fields, and namespace, so it has zero effect on E2E behavior.
+
+## Why not just use the E2E console?
+
+The E2E test stack is ephemeral (torn down after every run), namespaced per
+CI run, and runs with `BRIDGE_USER_AUTH=disabled` (a bearer token, no login
+wall) -- suitable for automated Playwright tests, not for a human to browse.
+Manual-console is the same underlying stack with three differences:
+
+| | E2E | Manual console |
+| - | --- | --------------- |
+| Namespace | Ephemeral `kubevirt-plugin-ci-test-<run_id>` | Persistent `manual-console` |
+| Lifecycle | Torn down after the test run; 2h TTL reaper | Persists until the next deploy; **not** TTL-reaped |
+| Auth | `BRIDGE_USER_AUTH=disabled` (bearer token) | `BRIDGE_USER_AUTH=openshift` (OAuth login) |
+| Plugin image | Built on `ubuntu-latest`, pushed to `ttl.sh` | Built in-cluster via an OpenShift BuildConfig |
+
+## Prerequisites
+
+The target cluster must already be provisioned via **IBM Cloud Hot Cluster
+Setup** ([`ibmc-cluster-setup.yml`](../../.github/workflows/ibmc-cluster-setup.yml)),
+which installs the ARC runner scale set and `ci-env-controller` this
+workflow depends on.
+
+## Deploying
+
+Actions -> **Deploy Manual Console** -> Run workflow, with:
+
+- `branch` -- the branch to build the plugin image from
+- `cluster_name` -- the ARC runner label / hot cluster name (default `kubevirt-plugin-ci`)
+- `infrastructure_type` -- informational only, no kubeconfig is downloaded
+
+For UI-only iteration afterwards, **Deploy Plugin** rebuilds and
+redeploys just the plugin image against the same release.
+
+## How it works
+
+```
+ARC runner (deploy-manual-console.yml)     ci-env namespace              manual-console namespace
++-----------------------------+     +------------------------+    +--------------------+
+| setup-plugin-image.sh       |     |                        |    |                    |
+|  -> in-cluster BuildConfig   |     | ci-env-controller      |    | console Deployment |
+| generate password (openssl) |---->| (watches ConfigMaps    |--->| plugin Deployment  |
+| create short-lived Secret   |     |  labeled manual-console)|   | OAuthClient, Route |
+| create/update ConfigMap     |     |                        |    |                    |
++-----------------------------+     +------------------------+    +--------------------+
+      |                                       |
+      |  poll status=ready                    |  reads password Secret, upserts
+      |<--------------------------------------+  htpasswd user, deletes Secret,
+      |                                          runs helm upgrade, patches
+      v                                          ConfigMap with console-route
+  Slack: URL + username + password
+```
+
+No kubeconfig is ever downloaded or uploaded as an artifact: every step runs
+on the ARC runner (an in-cluster pod, authenticated via its mounted
+ServiceAccount token), the same model already used by
+[hot-cluster-e2e-run.yml](../../.github/workflows/hot-cluster-e2e-run.yml).
+
+## Credentials
+
+Unlike the cluster-setup Slack notification (which uses either the IPI
+`kubeadmin` password or the `CLUSTER_ADMIN_PASSWORD` secret), manual-console
+credentials are generated fresh on every deploy -- no GitHub secret is
+required beyond `SLACK_WEBHOOK_URL`:
+
+1. The workflow generates a random password (`openssl rand -base64 24`) and
+   masks it in the logs.
+2. It writes that password into a short-lived Kubernetes `Secret` in the
+   `ci-env` namespace (never into the trigger ConfigMap).
+3. `ci-env-controller` reads the Secret, upserts an htpasswd identity
+   provider user named `manual-console` with that password, grants it
+   `cluster-admin`, and **deletes the Secret immediately** -- the password
+   never persists in the cluster.
+4. The workflow posts the console URL, username, and password to Slack
+   (`SLACK_WEBHOOK_URL`), along with the GitHub user who triggered the
+   deploy and a link to the run.
+
+Redeploying (either workflow) rotates the password; the previous one stops
+working. **Deploy Plugin** sends its own Slack reminder for this reason.
+
+If `SLACK_WEBHOOK_URL` isn't configured, the workflow logs a warning and
+skips notification -- the deploy still succeeds, but credentials must be
+retrieved by watching the workflow logs (masked) or re-running with the
+webhook configured.
+
+## ConfigMap contract additions
+
+`ci-env-controller` treats these fields as strictly optional; any E2E
+ConfigMap that omits them (i.e. every existing one) behaves exactly as
+before. See [`ci-env/README.md`](../hot-cluster/ci-env/README.md) for the
+base contract.
+
+| Field | Description |
+| ----- | ------------ |
+| `auth-mode` | `openshift` to enable OAuth login; omitted/anything else keeps the default disabled (bearer-token) behavior |
+| `htpasswd-user` | Username to upsert into the cluster's htpasswd identity provider (required when `auth-mode=openshift`) |
+| `htpasswd-secret-name` | Name of a Secret (in the same `ci-env-namespace`) with key `password`; read once and deleted by the controller |
+
+The manual-console ConfigMap also uses the label
+`ci.kubevirt-plugin/type: manual-console` instead of `test-environment`, so
+it is reconciled by the same controller loop but **exempt from the 2-hour
+TTL reaper** that force-cleans stale E2E environments.
+
+## Isolation from E2E and the CNV console
+
+- Separate namespace (`manual-console`) from every E2E test namespace.
+- No patches to `openshift-console`, HCO, SSP, or any CNV operator.
+- The CNV-bundled console at the cluster's normal console URL is untouched.
+- Running `hot-cluster-e2e.yml` on the same cluster provisions its own
+  ephemeral namespace independently; the two do not interact.
+
+## Files
+
+| File | Purpose |
+| ---- | ------- |
+| `images/setup-plugin-image.sh` | Builds the kubevirt-plugin image in-cluster via an OpenShift BuildConfig |
+| `ensure-manual-console-user.sh` | Upserts the htpasswd user + extracts the cluster CA bundle; invoked by `ci-env-controller` (embedded into its image -- see below) |
+
+`ensure-manual-console-user.sh` is embedded into the `ci-env-runner` image at
+build time (via a symlink in
+[`../hot-cluster/images/ci-env-runner/`](../hot-cluster/images/ci-env-runner/),
+the same mechanism already used for the `ci-test-stack` Helm chart). If this
+script changes, the cluster's `ci-env-controller` must be reinstalled to
+pick up the new image:
+
+```bash
+./ci-scripts/hot-cluster/ci-env/install-ci-env-controller.sh
+```
+
+Until that reinstall happens, the cluster's existing `ci-env-controller`
+keeps running its old image -- E2E is unaffected either way, since it never
+sets `auth-mode`.

--- a/ci-scripts/manual-console/ensure-manual-console-user.sh
+++ b/ci-scripts/manual-console/ensure-manual-console-user.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Ensure an htpasswd identity provider exists on the cluster, upsert a user +
+# password into it, grant that user cluster-admin, and extract the cluster CA
+# bundle for OIDC verification. Used by the manual-console deploy path
+# (CNV-92150) so a fresh, dedicated login can be generated on every deploy --
+# no CLUSTER_ADMIN_PASSWORD secret or kubeadmin dependency required.
+#
+# Invoked by ci-env-controller.sh (in-cluster, cluster-admin ServiceAccount)
+# only when a ConfigMap's auth-mode=openshift; never touched by the default
+# E2E provisioning path.
+#
+# Usage: echo <password> | ensure-manual-console-user.sh <username>
+#
+# The password is read from stdin, not argv -- CLI arguments persist for the
+# process's whole lifetime and are visible to any co-located process via
+# `ps`/`/proc/<pid>/cmdline`, unlike a pipe.
+#
+# Idempotent: safe to re-run on every deploy. Re-running with the same
+# username replaces that user's password hash; other users already present
+# in the htpasswd secret (e.g. cluster setup's "admin") are preserved.
+#
+# Output (stdout): CA_CERT_FILE=<path to a temp file with the PEM CA bundle>
+#   Caller is responsible for deleting this file after use.
+#
+# Requires: oc logged in with cluster-admin (or equivalent) permissions to
+# manage openshift-config secrets, the cluster OAuth config, and
+# cluster-admin ClusterRoleBindings. Also requires the `htpasswd` CLI
+# (httpd-tools / apache2-utils).
+set -euo pipefail
+
+USERNAME="${1:?Usage: ensure-manual-console-user.sh <username> (password via stdin)}"
+
+PASSWORD="$(cat)"
+if [[ -z "${PASSWORD}" ]]; then
+  echo "ERROR: password not provided on stdin. Usage: ensure-manual-console-user.sh <username> (password via stdin)" >&2
+  exit 1
+fi
+
+if ! command -v htpasswd &>/dev/null; then
+  echo "ERROR: htpasswd (httpd-tools / apache2-utils) is required" >&2
+  exit 1
+fi
+
+echo "Ensuring htpasswd user '${USERNAME}'..."
+
+EXISTING_HTPASSWD=""
+if oc get secret htpass-secret -n openshift-config &>/dev/null; then
+  EXISTING_HTPASSWD="$(oc get secret htpass-secret -n openshift-config \
+    -o jsonpath='{.data.htpasswd}' | base64 -d)"
+fi
+
+# -i (stdin) instead of -b (argv): htpasswd's own argv is visible to any
+# co-located process for its whole (brief) lifetime, same reasoning as the
+# stdin handoff above.
+NEW_HASH="$(printf '%s' "${PASSWORD}" | htpasswd -niB "${USERNAME}")"
+
+# Drop any existing line for this user, then append the fresh hash. Uses awk
+# with a literal field comparison (not grep -v "^${USERNAME}:") so usernames
+# containing regex metacharacters (., *, [, etc.) can't misfire.
+UPDATED_HTPASSWD="$(printf '%s\n' "${EXISTING_HTPASSWD}" \
+  | awk -F: -v u="${USERNAME}" '$1 != u && NF' )"
+UPDATED_HTPASSWD="$(printf '%s\n%s' "${UPDATED_HTPASSWD}" "${NEW_HASH}" | sed '/^$/d')"
+
+oc create secret generic htpass-secret \
+  --from-literal=htpasswd="${UPDATED_HTPASSWD}" \
+  -n openshift-config --dry-run=client -o yaml | oc apply -f -
+
+HAS_HTPASSWD_IDP="$(oc get oauth cluster \
+  -o jsonpath='{.spec.identityProviders[?(@.type=="HTPasswd")].name}' 2>/dev/null || true)"
+
+if [[ -z "${HAS_HTPASSWD_IDP}" ]]; then
+  echo "Adding htpasswd identity provider to cluster OAuth config (preserving existing identity providers)..."
+
+  # Read-merge-patch, not a full-manifest apply: identityProviders is a plain
+  # array with no merge key, so a JSON merge patch replaces it wholesale with
+  # whatever we send. Fetching the current list and appending to it (instead
+  # of sending a single-entry list) is what actually preserves any other
+  # identity provider (LDAP, GitHub, ...) already configured on this cluster.
+  EXISTING_IDPS="$(oc get oauth cluster -o jsonpath='{.spec.identityProviders}' 2>/dev/null || true)"
+  [[ -z "${EXISTING_IDPS}" ]] && EXISTING_IDPS='[]'
+
+  PATCH_JSON="$(jq -nc --argjson existing "${EXISTING_IDPS}" '{
+    spec: {
+      identityProviders: ($existing + [{
+        name: "htpasswd",
+        mappingMethod: "claim",
+        type: "HTPasswd",
+        htpasswd: {fileData: {name: "htpass-secret"}}
+      }])
+    }
+  }')"
+
+  oc patch oauth cluster --type=merge -p "${PATCH_JSON}"
+
+  echo "Waiting for OAuth pods to roll out..."
+  oc rollout status deployment/oauth-openshift -n openshift-authentication --timeout=120s 2>&1 \
+    || echo "WARN: OAuth rollout did not complete within 120s" >&2
+else
+  echo "htpasswd identity provider '${HAS_HTPASSWD_IDP}' already present; secret updated in place."
+fi
+
+echo "Granting cluster-admin to ${USERNAME}..."
+oc adm policy add-cluster-role-to-user cluster-admin "${USERNAME}" 2>&1 || true
+
+# Extract the cluster CA bundle so the console pod can verify the OAuth
+# server when running in off-cluster mode. Kubernetes 1.24+ no longer
+# auto-provisions a `type: kubernetes.io/service-account-token` Secret per
+# ServiceAccount, so indexing `.items[0]` on that list can silently hit an
+# empty array on newer clusters and produce a garbage CA file (jq returns
+# null for an out-of-range index rather than erroring, and `base64 -d` then
+# "decodes" that into junk bytes instead of failing loudly). kube-root-ca.crt
+# is a ConfigMap Kubernetes auto-creates in every namespace since 1.20
+# specifically to publish this CA bundle, independent of that SA-secret
+# auto-provisioning behavior -- and ConfigMap data is plain text, so no
+# base64 decoding step is needed either.
+CA_CERT_FILE="$(mktemp)"
+oc get configmap kube-root-ca.crt -n default -o jsonpath='{.data.ca\.crt}' > "${CA_CERT_FILE}"
+if [[ ! -s "${CA_CERT_FILE}" ]]; then
+  echo "ERROR: could not read CA bundle from configmap/kube-root-ca.crt in the default namespace" >&2
+  rm -f "${CA_CERT_FILE}"
+  exit 1
+fi
+
+echo "User '${USERNAME}' ready with cluster-admin access."
+echo "CA_CERT_FILE=${CA_CERT_FILE}"

--- a/ci-scripts/manual-console/images/setup-plugin-image.sh
+++ b/ci-scripts/manual-console/images/setup-plugin-image.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+#
+# OpenShift only: create ImageStream + BuildConfig and run a binary Docker build
+# for the kubevirt-plugin image (repo root Dockerfile), for the manual-console
+# deploy path (CNV-92150). This mirrors the ci-env-runner/arc-runner image
+# build scripts but builds the actual plugin from the checked-out branch,
+# instead of a static tool image, so no image tag/registry push is required.
+#
+# Output: prints IMAGE_REF= to stdout (and to PLUGIN_IMAGE_FILE if set).
+#
+# Optional environment variables:
+#   NS                    Namespace for the build (default: manual-console)
+#   IMAGE_NAME            ImageStream/BuildConfig name (default: kubevirt-plugin)
+#   BUILD_DIR             Directory to build from (default: repo root)
+#   BUILD_TIMEOUT_SECONDS Wrap the build in `timeout` if set (default: unset = no limit)
+#
+# Requires: oc logged into OpenShift; run from a checkout of the branch to deploy.
+#
+# Namespace note: If the namespace does not match the console/plugin Deployment
+# namespace, the running service account will need role "system:image-puller"
+# so the built image can be pulled (ci-env-controller's console/plugin SAs
+# already have this via the ci-test-stack chart's namespace-local defaults).
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+source "${REPO_ROOT}/ci-scripts/_cluster-helpers.sh"
+verify_oc
+
+NS="${NS:-manual-console}"
+IMAGE_NAME="${IMAGE_NAME:-kubevirt-plugin}"
+BUILD_DIR="${BUILD_DIR:-${REPO_ROOT}}"
+
+if [[ ! -f "${BUILD_DIR}/Dockerfile" ]]; then
+  echo "ERROR: Dockerfile not found at ${BUILD_DIR}/Dockerfile"
+  exit 1
+fi
+
+echo "=== Build kubevirt-plugin image (in-cluster, OpenShift) ==="
+echo "  NS:         ${NS}"
+echo "  IMAGE_NAME: ${IMAGE_NAME}"
+echo "  BUILD_DIR:  ${BUILD_DIR}"
+echo ""
+
+oc create namespace "${NS}" --dry-run=client -o yaml | oc apply -f -
+
+oc apply -f - <<EOF
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: ${IMAGE_NAME}
+  namespace: ${NS}
+spec:
+  lookupPolicy:
+    local: true
+EOF
+
+oc apply -f - <<EOF
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: ${IMAGE_NAME}-build
+  namespace: ${NS}
+spec:
+  source:
+    type: Binary
+    binary: {}
+  strategy:
+    type: Docker
+    dockerStrategy:
+      dockerfilePath: Dockerfile
+  output:
+    to:
+      kind: ImageStreamTag
+      name: ${IMAGE_NAME}:latest
+  runPolicy: Serial
+EOF
+
+echo "Waiting for ImageStream to be resolvable..."
+for i in $(seq 1 12); do
+  REPO=$(oc get imagestream "${IMAGE_NAME}" -n "${NS}" -o jsonpath='{.status.dockerImageRepository}' 2>/dev/null)
+  if [[ -n "${REPO}" ]]; then
+    echo "  ImageStream ready: ${REPO}"
+    break
+  fi
+  echo "  Waiting... (${i}/12)"
+  sleep 5
+done
+
+BUILD_CMD=(oc start-build -n "${NS}" "${IMAGE_NAME}-build" --from-dir="${BUILD_DIR}" --follow)
+
+echo "Starting binary build from ${BUILD_DIR}..."
+for attempt in 1 2 3; do
+  if [[ -n "${BUILD_TIMEOUT_SECONDS:-}" ]] && command -v timeout &>/dev/null; then
+    RUN_RESULT=0
+    timeout "${BUILD_TIMEOUT_SECONDS}" "${BUILD_CMD[@]}" || RUN_RESULT=$?
+  else
+    RUN_RESULT=0
+    "${BUILD_CMD[@]}" || RUN_RESULT=$?
+  fi
+
+  if [[ "${RUN_RESULT}" -eq 0 ]]; then
+    break
+  fi
+  if [[ "${attempt}" -lt 3 ]]; then
+    echo "  Build attempt ${attempt}/3 failed (exit ${RUN_RESULT}), retrying in 15s..."
+    sleep 15
+  else
+    echo "  Build failed after 3 attempts"
+    exit 1
+  fi
+done
+
+resolve_internal_registry
+IMAGE_REF="${INTERNAL_REGISTRY}/${NS}/${IMAGE_NAME}:latest"
+
+echo ""
+echo "=== Build complete ==="
+echo "Image: ${IMAGE_REF}"
+echo ""
+
+if [[ -n "${PLUGIN_IMAGE_FILE:-}" ]]; then
+  printf '%s\n' "${IMAGE_REF}" > "${PLUGIN_IMAGE_FILE}"
+  echo "Wrote ${PLUGIN_IMAGE_FILE}"
+fi
+echo "IMAGE_REF=${IMAGE_REF}"


### PR DESCRIPTION
## 📝 Description

Create a new GitHub Actions workflow (`deploy-manual-console.yml`) that deploys a standalone OpenShift console with a custom-built kubevirt-plugin image on an existing hot cluster, enabling manual UI testing of branch code against a real CNV environment.

## 🔗 Links

Jira ticket: [CNV-92150](https://redhat.atlassian.net/browse/CNV-92150)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-demand “manual console” deployment workflows for OAuth-protected UI testing on existing hot clusters.
  * Added quick redeploy to rebuild and redeploy the plugin with fresh login credentials.
  * Added OpenShift OAuth authentication support, including automatic console OAuth client/secret and htpasswd identity setup.
* **Documentation**
  * Documented manual console architecture, inputs, credential behavior, and ConfigMap options.
* **Bug Fixes**
  * Improved redeploy reliability via explicit reprovision signaling and readiness/error handling for the console setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->