### PR TITLE
CNV-92532 - add client proxy handlers

### DIFF
--- a/playwright/src/clients/proxy-handlers/cdi-proxy-handler.ts
+++ b/playwright/src/clients/proxy-handlers/cdi-proxy-handler.ts
@@ -1,0 +1,140 @@
+import type {
+  JsonPatchOp,
+  KubernetesListResource,
+  KubernetesResource,
+} from '@/data-models/kubernetes-types';
+
+import type { ProxyApiContext } from './proxy-api-context';
+
+/**
+ * Console-proxy handler for CDI resources (cdi.kubevirt.io/v1beta1):
+ * DataVolumes, DataSources, DataImportCrons, CDIConfig, and StorageProfiles.
+ *
+ * Access via `apiClient.cdi.*`
+ */
+export class CdiProxyHandler {
+  constructor(private readonly ctx: ProxyApiContext) {}
+
+  // ---------------------------------------------------------------------------
+  // DataVolumes
+  // ---------------------------------------------------------------------------
+
+  createDataSource(
+    namespace: string,
+    spec: KubernetesResource,
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.createResource('cdi.kubevirt.io', 'v1beta1', 'datasources', spec, namespace);
+  }
+
+  createDataVolume(
+    namespace: string,
+    spec: KubernetesResource,
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.createResource('cdi.kubevirt.io', 'v1beta1', 'datavolumes', spec, namespace);
+  }
+
+  deleteDataSource(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.deleteResource('cdi.kubevirt.io', 'v1beta1', 'datasources', name, namespace);
+  }
+
+  deleteDataVolume(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.deleteResource('cdi.kubevirt.io', 'v1beta1', 'datavolumes', name, namespace);
+  }
+
+  getCdiConfig(): Promise<KubernetesResource | null> {
+    return this.ctx.getResource('cdi.kubevirt.io', 'v1beta1', 'cdiconfigs', 'config');
+  }
+
+  // ---------------------------------------------------------------------------
+  // DataSources
+  // ---------------------------------------------------------------------------
+
+  getDataSource(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.getResource('cdi.kubevirt.io', 'v1beta1', 'datasources', name, namespace);
+  }
+
+  getDataVolume(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.getResource('cdi.kubevirt.io', 'v1beta1', 'datavolumes', name, namespace);
+  }
+
+  listDataImportCrons(
+    namespace?: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    return this.ctx.listResources('cdi.kubevirt.io', 'v1beta1', 'dataimportcrons', namespace, {
+      limit: '250',
+      ...queryParams,
+    });
+  }
+
+  listDataSources(namespace?: string, labelSelector?: string): Promise<KubernetesListResource> {
+    const queryParams: Record<string, string> = { limit: '250' };
+    if (labelSelector) queryParams.labelSelector = labelSelector;
+    return this.ctx.listResources(
+      'cdi.kubevirt.io',
+      'v1beta1',
+      'datasources',
+      namespace,
+      queryParams,
+    );
+  }
+
+  listDataVolumes(
+    namespace?: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    return this.ctx.listResources('cdi.kubevirt.io', 'v1beta1', 'datavolumes', namespace, {
+      limit: '250',
+      ...queryParams,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // DataImportCrons
+  // ---------------------------------------------------------------------------
+
+  listStorageProfiles(queryParams?: Record<string, string>): Promise<KubernetesListResource> {
+    return this.ctx.listResources('cdi.kubevirt.io', 'v1beta1', 'storageprofiles', undefined, {
+      limit: '250',
+      ...queryParams,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // CDIConfig (cluster-scoped singleton)
+  // ---------------------------------------------------------------------------
+
+  patchDataSource(
+    namespace: string,
+    name: string,
+    patch: JsonPatchOp[],
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.patchResource(
+      'cdi.kubevirt.io',
+      'v1beta1',
+      'datasources',
+      name,
+      patch,
+      namespace,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // StorageProfiles (cluster-scoped)
+  // ---------------------------------------------------------------------------
+
+  patchDataVolume(
+    namespace: string,
+    name: string,
+    patch: JsonPatchOp[],
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.patchResource(
+      'cdi.kubevirt.io',
+      'v1beta1',
+      'datavolumes',
+      name,
+      patch,
+      namespace,
+    );
+  }
+}

--- a/playwright/src/clients/proxy-handlers/core-proxy-handler.ts
+++ b/playwright/src/clients/proxy-handlers/core-proxy-handler.ts
@@ -1,0 +1,118 @@
+import type {
+  JsonPatchOp,
+  KubernetesListResource,
+  KubernetesResource,
+} from '@/data-models/kubernetes-types';
+
+import type { ProxyApiContext } from './proxy-api-context';
+
+/**
+ * Console-proxy handler for Kubernetes core API resources:
+ * ConfigMaps, Pods, and PersistentVolumeClaims.
+ *
+ * Also provides named helpers for the KubeVirt UI feature / user-settings ConfigMaps
+ * and the console guided-tour ConfigMap.
+ *
+ * Note: `patchProject` is intentionally NOT included here because it targets
+ * the non-standard `/k8s/cluster/...` URL path (outside `/api/`). It is
+ * exposed directly on `RequestContextClient` as a standalone method.
+ *
+ * Access via `apiClient.core.*`
+ */
+export class CoreProxyHandler {
+  constructor(private readonly ctx: ProxyApiContext) {}
+
+  // ---------------------------------------------------------------------------
+  // ConfigMaps
+  // ---------------------------------------------------------------------------
+
+  configureUserSettings(
+    username = 'kube-admin',
+    namespace = 'openshift-cnv',
+    favoriteBootableVolumes: string[] = ['fedora'],
+    dontShowWelcomeModal = true,
+  ): Promise<KubernetesResource | null> {
+    const userSettings = {
+      favoriteBootableVolumes,
+      quickStart: { dontShowWelcomeModal },
+    };
+    return this.patchConfigMap('kubevirt-user-settings', namespace, [
+      { op: 'replace', path: `/data/${username}`, value: JSON.stringify(userSettings) },
+    ]);
+  }
+
+  getConfigMap(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.getResource('', 'v1', 'configmaps', name, namespace);
+  }
+
+  // Named helpers for well-known ConfigMaps
+
+  getUiFeatures(namespace = 'openshift-cnv'): Promise<KubernetesResource | null> {
+    return this.getConfigMap(namespace, 'kubevirt-ui-features');
+  }
+
+  getUserSettings(namespace = 'openshift-cnv'): Promise<KubernetesResource | null> {
+    return this.getConfigMap(namespace, 'kubevirt-user-settings');
+  }
+
+  listPersistentVolumeClaims(
+    namespace: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    return this.ctx.listResources('', 'v1', 'persistentvolumeclaims', namespace, {
+      limit: '250',
+      ...queryParams,
+    });
+  }
+
+  listPods(
+    namespace: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    return this.ctx.listResources('', 'v1', 'pods', namespace, { limit: '250', ...queryParams });
+  }
+
+  patchConfigMap(
+    name: string,
+    namespace: string,
+    patchPayload: JsonPatchOp[],
+  ): Promise<KubernetesResource | null> {
+    return this.ctx._request(
+      'patch',
+      `/kubernetes/api/v1/namespaces/${namespace}/configmaps/${name}`,
+      {
+        data: patchPayload,
+        headers: { 'Content-Type': 'application/json-patch+json' },
+      },
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pods & PersistentVolumeClaims
+  // ---------------------------------------------------------------------------
+
+  setConfirmVmActions(
+    enabled: string,
+    namespace = 'openshift-cnv',
+  ): Promise<KubernetesResource | null> {
+    return this.patchConfigMap('kubevirt-ui-features', namespace, [
+      { op: 'replace', path: '/data/confirmVMActions', value: enabled },
+    ]);
+  }
+
+  setConsoleGuidedTourCompleted(
+    completed: boolean,
+    username = 'kubeadmin',
+    namespace = 'openshift-console-user-settings',
+  ): Promise<KubernetesResource | null> {
+    const configMapName = `user-settings-${username}`;
+    const guidedTour = {
+      admin: { completed },
+      dev: { completed },
+      'virtualization-perspective': { completed },
+    };
+    return this.patchConfigMap(configMapName, namespace, [
+      { op: 'replace', path: '/data/console.guidedTour', value: JSON.stringify(guidedTour) },
+    ]);
+  }
+}

--- a/playwright/src/clients/proxy-handlers/index.ts
+++ b/playwright/src/clients/proxy-handlers/index.ts
@@ -1,0 +1,8 @@
+export { CdiProxyHandler } from './cdi-proxy-handler';
+export { CoreProxyHandler } from './core-proxy-handler';
+export { InfraProxyHandler } from './infra-proxy-handler';
+export { InstanceTypeProxyHandler } from './instance-type-proxy-handler';
+export { ProxyApiContext } from './proxy-api-context';
+export { SnapshotProxyHandler } from './snapshot-proxy-handler';
+export { TemplateProxyHandler } from './template-proxy-handler';
+export { VirtualMachineProxyHandler } from './vm-proxy-handler';

--- a/playwright/src/clients/proxy-handlers/infra-proxy-handler.ts
+++ b/playwright/src/clients/proxy-handlers/infra-proxy-handler.ts
@@ -1,0 +1,238 @@
+import type {
+  JsonPatchOp,
+  KubernetesListResource,
+  KubernetesResource,
+} from '@/data-models/kubernetes-types';
+
+import type { ProxyApiContext } from './proxy-api-context';
+
+/**
+ * Console-proxy handler for KubeVirt infrastructure-level resources:
+ * HyperConverged, KubeVirt CR, MigrationPolicies, StorageMigrationPlans,
+ * Network Attachment Definitions, and the plugin health endpoint.
+ *
+ * Access via `apiClient.infra.*`
+ */
+export class InfraProxyHandler {
+  private static readonly _MIGRATION_GROUP = 'migrations.kubevirt.io';
+
+  // ---------------------------------------------------------------------------
+  // HyperConverged (hco.kubevirt.io/v1beta1)
+  // ---------------------------------------------------------------------------
+
+  private static readonly _MIGRATION_PLAN_MULTI_NS =
+    'multinamespacevirtualmachinestoragemigrationplans';
+
+  private static readonly _MIGRATION_PLAN_PLURAL = 'virtualmachinestoragemigrationplans';
+
+  private static readonly _MIGRATION_VERSION = 'v1alpha1';
+
+  constructor(private readonly ctx: ProxyApiContext) {}
+
+  // ---------------------------------------------------------------------------
+  // KubeVirt CR (kubevirt.io/v1)
+  // ---------------------------------------------------------------------------
+
+  createMigrationPolicy(spec: KubernetesResource): Promise<KubernetesResource | null> {
+    return this.ctx.createResource('migrations.kubevirt.io', 'v1alpha1', 'migrationpolicies', spec);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Migration Policies (migrations.kubevirt.io/v1alpha1)
+  // ---------------------------------------------------------------------------
+
+  createMultiNsStorageMigrationPlan(
+    spec: KubernetesResource,
+    namespace: string,
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.createResource(
+      InfraProxyHandler._MIGRATION_GROUP,
+      InfraProxyHandler._MIGRATION_VERSION,
+      InfraProxyHandler._MIGRATION_PLAN_MULTI_NS,
+      spec,
+      namespace,
+    );
+  }
+
+  createStorageMigrationPlan(
+    spec: KubernetesResource,
+    namespace: string,
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.createResource(
+      InfraProxyHandler._MIGRATION_GROUP,
+      InfraProxyHandler._MIGRATION_VERSION,
+      InfraProxyHandler._MIGRATION_PLAN_PLURAL,
+      spec,
+      namespace,
+    );
+  }
+
+  deleteMigrationPolicy(name: string): Promise<KubernetesResource | null> {
+    return this.ctx.deleteResource('migrations.kubevirt.io', 'v1alpha1', 'migrationpolicies', name);
+  }
+
+  deleteMultiNsStorageMigrationPlan(
+    name: string,
+    namespace: string,
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.deleteResource(
+      InfraProxyHandler._MIGRATION_GROUP,
+      InfraProxyHandler._MIGRATION_VERSION,
+      InfraProxyHandler._MIGRATION_PLAN_MULTI_NS,
+      name,
+      namespace,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Storage Migration Plans (migrations.kubevirt.io/v1alpha1)
+  // ---------------------------------------------------------------------------
+
+  deleteStorageMigrationPlan(name: string, namespace: string): Promise<KubernetesResource | null> {
+    return this.ctx.deleteResource(
+      InfraProxyHandler._MIGRATION_GROUP,
+      InfraProxyHandler._MIGRATION_VERSION,
+      InfraProxyHandler._MIGRATION_PLAN_PLURAL,
+      name,
+      namespace,
+    );
+  }
+  getHyperConverged(
+    namespace = 'openshift-cnv',
+    name = 'kubevirt-hyperconverged',
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.getResource('hco.kubevirt.io', 'v1beta1', 'hyperconvergeds', name, namespace);
+  }
+  getKubeVirt(
+    namespace = 'openshift-cnv',
+    name = 'kubevirt-kubevirt-hyperconverged',
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.getResource('kubevirt.io', 'v1', 'kubevirts', name, namespace);
+  }
+  getMultiNsStorageMigrationPlan(
+    name: string,
+    namespace: string,
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.getResource(
+      InfraProxyHandler._MIGRATION_GROUP,
+      InfraProxyHandler._MIGRATION_VERSION,
+      InfraProxyHandler._MIGRATION_PLAN_MULTI_NS,
+      name,
+      namespace,
+    );
+  }
+
+  getStorageMigrationPlan(name: string, namespace: string): Promise<KubernetesResource | null> {
+    return this.ctx.getResource(
+      InfraProxyHandler._MIGRATION_GROUP,
+      InfraProxyHandler._MIGRATION_VERSION,
+      InfraProxyHandler._MIGRATION_PLAN_PLURAL,
+      name,
+      namespace,
+    );
+  }
+
+  listHyperConvergeds(namespace = 'openshift-cnv'): Promise<KubernetesListResource> {
+    return this.ctx.listResources('hco.kubevirt.io', 'v1beta1', 'hyperconvergeds', namespace, {
+      limit: '250',
+    });
+  }
+
+  listMigrationPolicies(queryParams?: Record<string, string>): Promise<KubernetesListResource> {
+    return this.ctx.listResources(
+      'migrations.kubevirt.io',
+      'v1alpha1',
+      'migrationpolicies',
+      undefined,
+      { limit: '250', ...queryParams },
+    );
+  }
+
+  /**
+   * Lists namespaced VirtualMachineStorageMigrationPlan resources (child plans).
+   * Created automatically when a MultiNamespace plan is applied.
+   */
+  listNamespacedStorageMigrationPlans(
+    namespace: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    return this.ctx.listResources(
+      InfraProxyHandler._MIGRATION_GROUP,
+      InfraProxyHandler._MIGRATION_VERSION,
+      InfraProxyHandler._MIGRATION_PLAN_PLURAL,
+      namespace,
+      { limit: '250', ...queryParams },
+    );
+  }
+
+  listNetworkAttachmentDefinitions(
+    namespace: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    return this.ctx.listResources(
+      'k8s.cni.cncf.io',
+      'v1',
+      'network-attachment-definitions',
+      namespace,
+      { limit: '250', ...queryParams },
+    );
+  }
+
+  /**
+   * Lists MultiNamespaceVirtualMachineStorageMigrationPlan resources.
+   * This is the CRD the UI uses on the "Storage migrations" page.
+   */
+  listStorageMigrationPlans(
+    namespace?: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    return this.ctx.listResources(
+      InfraProxyHandler._MIGRATION_GROUP,
+      InfraProxyHandler._MIGRATION_VERSION,
+      InfraProxyHandler._MIGRATION_PLAN_MULTI_NS,
+      namespace,
+      { limit: '250', ...queryParams },
+    );
+  }
+
+  patchHyperConverged(
+    namespace = 'openshift-cnv',
+    name = 'kubevirt-hyperconverged',
+    patchPayload: JsonPatchOp[],
+  ): Promise<KubernetesResource | null> {
+    return this.ctx._request(
+      'patch',
+      `/kubernetes/apis/hco.kubevirt.io/v1beta1/namespaces/${namespace}/hyperconvergeds/${name}`,
+      { data: patchPayload, headers: { 'Content-Type': 'application/json-patch+json' } },
+    );
+  }
+
+  patchMigrationPolicy(name: string, patch: JsonPatchOp[]): Promise<KubernetesResource | null> {
+    return this.ctx.patchResource(
+      'migrations.kubevirt.io',
+      'v1alpha1',
+      'migrationpolicies',
+      name,
+      patch,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Network Attachment Definitions (k8s.cni.cncf.io/v1)
+  // ---------------------------------------------------------------------------
+
+  setMemoryDensity(
+    memoryOvercommitPercentage: number,
+    namespace = 'openshift-cnv',
+    name = 'kubevirt-hyperconverged',
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.mergePatchResource(
+      'hco.kubevirt.io',
+      'v1beta1',
+      'hyperconvergeds',
+      name,
+      { spec: { higherWorkloadDensity: { memoryOvercommitPercentage } } },
+      namespace,
+    );
+  }
+}

--- a/playwright/src/clients/proxy-handlers/instance-type-proxy-handler.ts
+++ b/playwright/src/clients/proxy-handlers/instance-type-proxy-handler.ts
@@ -1,0 +1,155 @@
+import type { KubernetesListResource, KubernetesResource } from '@/data-models/kubernetes-types';
+
+import type { ProxyApiContext } from './proxy-api-context';
+
+/**
+ * Console-proxy handler for KubeVirt instance types and preferences
+ * (instancetype.kubevirt.io/v1beta1).
+ *
+ * Access via `apiClient.instanceType.*`
+ */
+export class InstanceTypeProxyHandler {
+  constructor(private readonly ctx: ProxyApiContext) {}
+
+  // ---------------------------------------------------------------------------
+  // Cluster-scoped instance types & preferences
+  // ---------------------------------------------------------------------------
+
+  createClusterInstanceType(spec: KubernetesResource): Promise<KubernetesResource | null> {
+    return this.ctx.createResource(
+      'instancetype.kubevirt.io',
+      'v1beta1',
+      'virtualmachineclusterinstancetypes',
+      spec,
+    );
+  }
+
+  createInstanceType(
+    namespace: string,
+    spec: KubernetesResource,
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.createResource(
+      'instancetype.kubevirt.io',
+      'v1beta1',
+      'virtualmachineinstancetypes',
+      spec,
+      namespace,
+    );
+  }
+
+  createPreference(
+    namespace: string,
+    spec: KubernetesResource,
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.createResource(
+      'instancetype.kubevirt.io',
+      'v1beta1',
+      'virtualmachinepreferences',
+      spec,
+      namespace,
+    );
+  }
+
+  deleteClusterInstanceType(name: string): Promise<KubernetesResource | null> {
+    return this.ctx.deleteResource(
+      'instancetype.kubevirt.io',
+      'v1beta1',
+      'virtualmachineclusterinstancetypes',
+      name,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Namespace-scoped instance types
+  // ---------------------------------------------------------------------------
+
+  deleteInstanceType(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.deleteResource(
+      'instancetype.kubevirt.io',
+      'v1beta1',
+      'virtualmachineinstancetypes',
+      name,
+      namespace,
+    );
+  }
+
+  deletePreference(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.deleteResource(
+      'instancetype.kubevirt.io',
+      'v1beta1',
+      'virtualmachinepreferences',
+      name,
+      namespace,
+    );
+  }
+
+  getInstanceType(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.getResource(
+      'instancetype.kubevirt.io',
+      'v1beta1',
+      'virtualmachineinstancetypes',
+      name,
+      namespace,
+    );
+  }
+
+  getPreference(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.getResource(
+      'instancetype.kubevirt.io',
+      'v1beta1',
+      'virtualmachinepreferences',
+      name,
+      namespace,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Namespace-scoped preferences
+  // ---------------------------------------------------------------------------
+
+  listClusterInstanceTypes(queryParams?: Record<string, string>): Promise<KubernetesListResource> {
+    return this.ctx.listResources(
+      'instancetype.kubevirt.io',
+      'v1beta1',
+      'virtualmachineclusterinstancetypes',
+      undefined,
+      { limit: '250', ...queryParams },
+    );
+  }
+
+  listClusterPreferences(queryParams?: Record<string, string>): Promise<KubernetesListResource> {
+    return this.ctx.listResources(
+      'instancetype.kubevirt.io',
+      'v1beta1',
+      'virtualmachineclusterpreferences',
+      undefined,
+      { limit: '250', ...queryParams },
+    );
+  }
+
+  listInstanceTypes(
+    namespace: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    return this.ctx.listResources(
+      'instancetype.kubevirt.io',
+      'v1beta1',
+      'virtualmachineinstancetypes',
+      namespace,
+      { limit: '250', ...queryParams },
+    );
+  }
+
+  listPreferences(
+    namespace: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    return this.ctx.listResources(
+      'instancetype.kubevirt.io',
+      'v1beta1',
+      'virtualmachinepreferences',
+      namespace,
+      { limit: '250', ...queryParams },
+    );
+  }
+}

--- a/playwright/src/clients/proxy-handlers/proxy-api-context.ts
+++ b/playwright/src/clients/proxy-handlers/proxy-api-context.ts
@@ -1,0 +1,94 @@
+import type {
+  JsonPatchOp,
+  KubernetesListResource,
+  KubernetesResource,
+} from '@/data-models/kubernetes-types';
+
+/**
+ * Transport context shared by all console-proxy handler classes.
+ *
+ * `RequestContextClient` satisfies this contract and passes `this` to every
+ * handler constructor, giving handlers access to the generic HTTP helpers
+ * without coupling them to the full client class.
+ *
+ * Pattern mirrors `KubernetesHandlerContext` used by the K8s client handlers.
+ */
+export type ProxyApiContext = {
+  /**
+   * List any Kubernetes resource through the console proxy.
+   * Omit `namespace` for cluster-scoped or all-namespace lists.
+   */
+  listResources(
+    group: string,
+    version: string,
+    plural: string,
+    namespace?: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource>;
+
+  /** Get a single Kubernetes resource through the console proxy. */
+  getResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    namespace?: string,
+  ): Promise<KubernetesResource | null>;
+
+  /** Create any Kubernetes resource through the console proxy. */
+  createResource(
+    group: string,
+    version: string,
+    plural: string,
+    spec: KubernetesResource,
+    namespace?: string,
+  ): Promise<KubernetesResource | null>;
+
+  /** Delete any Kubernetes resource through the console proxy. */
+  deleteResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    namespace?: string,
+  ): Promise<KubernetesResource | null>;
+
+  /**
+   * JSON Patch (RFC 6902) any resource through the console proxy.
+   * Requires each target path to already exist.
+   */
+  patchResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    patch: JsonPatchOp[],
+    namespace?: string,
+  ): Promise<KubernetesResource | null>;
+
+  /**
+   * JSON Merge Patch (RFC 7396) any resource through the console proxy.
+   * Prefer over `patchResource` when the target sub-path may not exist yet —
+   * merge-patch creates missing intermediate objects automatically.
+   * Required for CRDs (strategic-merge-patch is not supported).
+   */
+  mergePatchResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    patch: Record<string, unknown>,
+    namespace?: string,
+  ): Promise<KubernetesResource | null>;
+
+  /**
+   * Raw HTTP request through the console proxy.
+   * Use for subresource paths (e.g. `/start`, `/stop`, `/restart`) that are
+   * not covered by the generic resource helpers.
+   */
+  _request(
+    method: 'get' | 'post' | 'put' | 'patch' | 'delete',
+    path: string,
+    extra?: Record<string, unknown>,
+  ): Promise<KubernetesResource | null>;
+};

--- a/playwright/src/clients/proxy-handlers/snapshot-proxy-handler.ts
+++ b/playwright/src/clients/proxy-handlers/snapshot-proxy-handler.ts
@@ -1,0 +1,147 @@
+import type {
+  JsonPatchOp,
+  KubernetesListResource,
+  KubernetesResource,
+} from '@/data-models/kubernetes-types';
+
+import type { ProxyApiContext } from './proxy-api-context';
+
+/**
+ * Console-proxy handler for VM snapshot/restore resources and storage volume snapshots.
+ *
+ * Access via `apiClient.snapshot.*`
+ */
+export class SnapshotProxyHandler {
+  constructor(private readonly ctx: ProxyApiContext) {}
+
+  // ---------------------------------------------------------------------------
+  // VirtualMachineSnapshots (snapshot.kubevirt.io/v1beta1)
+  // ---------------------------------------------------------------------------
+
+  create(namespace: string, spec: KubernetesResource): Promise<KubernetesResource | null> {
+    return this.ctx.createResource(
+      'snapshot.kubevirt.io',
+      'v1beta1',
+      'virtualmachinesnapshots',
+      spec,
+      namespace,
+    );
+  }
+
+  createRestore(namespace: string, spec: KubernetesResource): Promise<KubernetesResource | null> {
+    return this.ctx.createResource(
+      'snapshot.kubevirt.io',
+      'v1beta1',
+      'virtualmachinerestores',
+      spec,
+      namespace,
+    );
+  }
+
+  delete(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.deleteResource(
+      'snapshot.kubevirt.io',
+      'v1beta1',
+      'virtualmachinesnapshots',
+      name,
+      namespace,
+    );
+  }
+
+  deleteRestore(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.deleteResource(
+      'snapshot.kubevirt.io',
+      'v1beta1',
+      'virtualmachinerestores',
+      name,
+      namespace,
+    );
+  }
+
+  get(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.getResource(
+      'snapshot.kubevirt.io',
+      'v1beta1',
+      'virtualmachinesnapshots',
+      name,
+      namespace,
+    );
+  }
+
+  getRestore(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.getResource(
+      'snapshot.kubevirt.io',
+      'v1beta1',
+      'virtualmachinerestores',
+      name,
+      namespace,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // VirtualMachineRestores (snapshot.kubevirt.io/v1beta1)
+  // ---------------------------------------------------------------------------
+
+  list(namespace: string, queryParams?: Record<string, string>): Promise<KubernetesListResource> {
+    return this.ctx.listResources(
+      'snapshot.kubevirt.io',
+      'v1beta1',
+      'virtualmachinesnapshots',
+      namespace,
+      { limit: '250', ...queryParams },
+    );
+  }
+
+  listRestores(
+    namespace: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    return this.ctx.listResources(
+      'snapshot.kubevirt.io',
+      'v1beta1',
+      'virtualmachinerestores',
+      namespace,
+      { limit: '250', ...queryParams },
+    );
+  }
+
+  listVolumeSnapshots(
+    namespace: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    return this.ctx.listResources('snapshot.storage.k8s.io', 'v1', 'volumesnapshots', namespace, {
+      limit: '250',
+      ...queryParams,
+    });
+  }
+
+  mergePatch(
+    namespace: string,
+    name: string,
+    patch: Record<string, unknown>,
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.mergePatchResource(
+      'snapshot.kubevirt.io',
+      'v1beta1',
+      'virtualmachinesnapshots',
+      name,
+      patch,
+      namespace,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // VolumeSnapshots (snapshot.storage.k8s.io/v1)
+  // ---------------------------------------------------------------------------
+
+  patch(namespace: string, name: string, patch: JsonPatchOp[]): Promise<KubernetesResource | null> {
+    return this.ctx.patchResource(
+      'snapshot.kubevirt.io',
+      'v1beta1',
+      'virtualmachinesnapshots',
+      name,
+      patch,
+      namespace,
+    );
+  }
+}

--- a/playwright/src/clients/proxy-handlers/template-proxy-handler.ts
+++ b/playwright/src/clients/proxy-handlers/template-proxy-handler.ts
@@ -1,0 +1,71 @@
+import type {
+  JsonPatchOp,
+  KubernetesListResource,
+  KubernetesResource,
+} from '@/data-models/kubernetes-types';
+
+import type { ProxyApiContext } from './proxy-api-context';
+
+/**
+ * Console-proxy handler for OpenShift Templates (template.openshift.io/v1).
+ *
+ * Access via `apiClient.template.*`
+ */
+export class TemplateProxyHandler {
+  constructor(private readonly ctx: ProxyApiContext) {}
+
+  create(namespace: string, spec: KubernetesResource): Promise<KubernetesResource | null> {
+    return this.ctx.createResource('template.openshift.io', 'v1', 'templates', spec, namespace);
+  }
+
+  delete(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.deleteResource('template.openshift.io', 'v1', 'templates', name, namespace);
+  }
+
+  get(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.getResource('template.openshift.io', 'v1', 'templates', name, namespace);
+  }
+
+  /**
+   * List OpenShift templates, optionally filtered by a label selector.
+   * Pass `labelSelector: 'template.kubevirt.io/type'` for VM templates.
+   * Pass `labelSelector: 'template.kubevirt.io/type in (base,vm)'` for the catalog.
+   */
+  list(namespace?: string, labelSelector?: string): Promise<KubernetesListResource> {
+    const queryParams: Record<string, string> = { limit: '250' };
+    if (labelSelector) queryParams.labelSelector = labelSelector;
+    return this.ctx.listResources(
+      'template.openshift.io',
+      'v1',
+      'templates',
+      namespace,
+      queryParams,
+    );
+  }
+
+  mergePatch(
+    namespace: string,
+    name: string,
+    patch: Record<string, unknown>,
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.mergePatchResource(
+      'template.openshift.io',
+      'v1',
+      'templates',
+      name,
+      patch,
+      namespace,
+    );
+  }
+
+  patch(namespace: string, name: string, patch: JsonPatchOp[]): Promise<KubernetesResource | null> {
+    return this.ctx.patchResource(
+      'template.openshift.io',
+      'v1',
+      'templates',
+      name,
+      patch,
+      namespace,
+    );
+  }
+}

--- a/playwright/src/clients/proxy-handlers/vm-proxy-handler.ts
+++ b/playwright/src/clients/proxy-handlers/vm-proxy-handler.ts
@@ -1,0 +1,164 @@
+import type {
+  JsonPatchOp,
+  KubernetesListResource,
+  KubernetesResource,
+} from '@/data-models/kubernetes-types';
+
+import type { ProxyApiContext } from './proxy-api-context';
+
+/**
+ * Console-proxy handler for KubeVirt VirtualMachine, VirtualMachineInstance,
+ * and VirtualMachineInstanceMigration resources.
+ *
+ * Access via `apiClient.vm.*`
+ */
+export class VirtualMachineProxyHandler {
+  constructor(private readonly ctx: ProxyApiContext) {}
+
+  // ---------------------------------------------------------------------------
+  // VirtualMachines
+  // ---------------------------------------------------------------------------
+
+  create(namespace: string, spec: KubernetesResource): Promise<KubernetesResource | null> {
+    return this.ctx.createResource('kubevirt.io', 'v1', 'virtualmachines', spec, namespace);
+  }
+
+  createMigration(namespace: string, spec: KubernetesResource): Promise<KubernetesResource | null> {
+    return this.ctx.createResource(
+      'kubevirt.io',
+      'v1',
+      'virtualmachineinstancemigrations',
+      spec,
+      namespace,
+    );
+  }
+
+  delete(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.deleteResource('kubevirt.io', 'v1', 'virtualmachines', name, namespace);
+  }
+
+  deleteMigration(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.deleteResource(
+      'kubevirt.io',
+      'v1',
+      'virtualmachineinstancemigrations',
+      name,
+      namespace,
+    );
+  }
+
+  get(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.getResource('kubevirt.io', 'v1', 'virtualmachines', name, namespace);
+  }
+
+  getInstance(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.getResource('kubevirt.io', 'v1', 'virtualmachineinstances', name, namespace);
+  }
+
+  // ---------------------------------------------------------------------------
+  // VM subresource actions
+  // ---------------------------------------------------------------------------
+
+  getMigration(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.getResource(
+      'kubevirt.io',
+      'v1',
+      'virtualmachineinstancemigrations',
+      name,
+      namespace,
+    );
+  }
+
+  list(namespace?: string, queryParams?: Record<string, string>): Promise<KubernetesListResource> {
+    return this.ctx.listResources('kubevirt.io', 'v1', 'virtualmachines', namespace, {
+      limit: '250',
+      ...queryParams,
+    });
+  }
+
+  listInstances(
+    namespace?: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    return this.ctx.listResources('kubevirt.io', 'v1', 'virtualmachineinstances', namespace, {
+      limit: '250',
+      ...queryParams,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // VirtualMachineInstances
+  // ---------------------------------------------------------------------------
+
+  listMigrations(
+    namespace?: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    return this.ctx.listResources(
+      'kubevirt.io',
+      'v1',
+      'virtualmachineinstancemigrations',
+      namespace,
+      { limit: '250', ...queryParams },
+    );
+  }
+
+  mergePatch(
+    namespace: string,
+    name: string,
+    patch: Record<string, unknown>,
+  ): Promise<KubernetesResource | null> {
+    return this.ctx.mergePatchResource(
+      'kubevirt.io',
+      'v1',
+      'virtualmachines',
+      name,
+      patch,
+      namespace,
+    );
+  }
+
+  patch(namespace: string, name: string, patch: JsonPatchOp[]): Promise<KubernetesResource | null> {
+    return this.ctx.patchResource('kubevirt.io', 'v1', 'virtualmachines', name, patch, namespace);
+  }
+
+  // ---------------------------------------------------------------------------
+  // VirtualMachineInstanceMigrations
+  // ---------------------------------------------------------------------------
+
+  /** Hard-reset a VMI (VMI-level subresource). */
+  resetInstance(namespace: string, vmName: string): Promise<KubernetesResource | null> {
+    return this.ctx._request(
+      'put',
+      `/kubernetes/apis/subresources.kubevirt.io/v1/namespaces/${namespace}/virtualmachineinstances/${vmName}/reset`,
+      { data: {}, headers: { Accept: '*/*' } },
+    );
+  }
+
+  /** Gracefully restart a running VM (recreates the VMI). */
+  restart(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx._request(
+      'put',
+      `/kubernetes/apis/subresources.kubevirt.io/v1/namespaces/${namespace}/virtualmachines/${name}/restart`,
+      { data: {}, headers: { Accept: '*/*' } },
+    );
+  }
+
+  /** Start a VM (sets runStrategy: Always via subresource). */
+  start(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx._request(
+      'put',
+      `/kubernetes/apis/subresources.kubevirt.io/v1/namespaces/${namespace}/virtualmachines/${name}/start`,
+      { data: {}, headers: { Accept: '*/*' } },
+    );
+  }
+
+  /** Stop a VM (sets runStrategy: Halted via subresource). */
+  stop(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx._request(
+      'put',
+      `/kubernetes/apis/subresources.kubevirt.io/v1/namespaces/${namespace}/virtualmachines/${name}/stop`,
+      { data: {}, headers: { Accept: '*/*' } },
+    );
+  }
+}


### PR DESCRIPTION
## 📝 Description

Adds console-proxy handler classes for browser-based API operations:
    - CDI, core, infra, instance-type, snapshot, template, VM proxy handlers
    - Shared ProxyApiContext contract
    - interface → type conversion per coding standards
    
## 🔗 Links
https://redhat.atlassian.net/browse/CNV-92532



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader console proxy support for managing KubeVirt-related resources, including virtual machines, snapshots, templates, storage, instance types, and CDI objects.
  * Added convenience actions for common VM operations such as start, stop, restart, and reset.
  * Added support for updating user settings, guided tour completion, and configuration-related settings through the console proxy layer.
  * Improved list and patch capabilities for several resource types to make UI-driven workflows more complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->