### PR TITLE
CNV-92150: Fix ci script

### DIFF
--- a/ci-scripts/hot-cluster/images/setup-ci-env-runner-image.sh
+++ b/ci-scripts/hot-cluster/images/setup-ci-env-runner-image.sh
@@ -109,16 +109,47 @@ for i in $(seq 1 12); do
   sleep 5
 done
 
-# The ci-env-runner/ directory contains a symlink to the Helm chart.
-# Use tar -ch to dereference symlinks so the build pod receives the actual
-# chart files (including templates/ subdirectory), then pipe to --from-archive.
+# The ci-env-runner/ directory contains symlinks to the Helm chart and the
+# manual-console scripts. Use tar -ch to dereference symlinks so the build
+# pod receives the actual files (including subdirectories), then pipe to
+# --from-archive.
+#
+# --format=ustar (not the default archive format): macOS's bundled bsdtar
+# writes PAX extended headers by default, which OpenShift's build-source
+# extractor rejects outright ("unable to extract binary build input, must
+# be a zip, tar, or gzipped tar"), silently leaving the old image in place.
+# ustar is the oldest, most universally-interoperable tar format and is
+# supported identically by GNU tar (`--format=ustar`) and bsdtar/libarchive
+# -- forcing it produces the same practical archive content on both,
+# since none of this build context's paths approach ustar's ~100-255 byte
+# name-length limit.
 echo "Starting binary build from ${IMAGE_DIR} (dereferencing symlinks)..."
 for attempt in 1 2 3; do
-  if tar -ch -C "${IMAGE_DIR}" . \
+  if tar --format=ustar -ch -C "${IMAGE_DIR}" . \
        | oc start-build -n "${NS}" "${IMAGE_NAME}-build" \
            --from-archive=- \
            --follow; then
-    break
+    # `oc start-build --follow` can return exit 0 even when the build
+    # actually failed (confirmed: a source-extraction failure reports
+    # success at the CLI level). Don't trust the exit code alone --
+    # verify the build's real phase via the API before treating it as a
+    # successful attempt. The build controller updates .status.phase to
+    # "Complete" a few seconds AFTER the pushed-image log line appears
+    # (confirmed by testing), so poll briefly rather than checking once
+    # immediately -- a single immediate check reliably false-negatives on
+    # a build that actually succeeded, wasting two unnecessary rebuilds.
+    BUILD_NAME="$(oc get builds -n "${NS}" -l "buildconfig=${IMAGE_NAME}-build" \
+      --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1:].metadata.name}' 2>/dev/null)"
+    BUILD_PHASE="Unknown"
+    for _ in $(seq 1 12); do
+      BUILD_PHASE="$(oc get build "${BUILD_NAME}" -n "${NS}" -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")"
+      [[ "${BUILD_PHASE}" == "Complete" || "${BUILD_PHASE}" == "Failed" || "${BUILD_PHASE}" == "Error" ]] && break
+      sleep 5
+    done
+    if [[ "${BUILD_PHASE}" == "Complete" ]]; then
+      break
+    fi
+    echo "  oc start-build reported success but build ${BUILD_NAME} is actually '${BUILD_PHASE}'"
   fi
   if [[ "${attempt}" -lt 3 ]]; then
     echo "  Build attempt ${attempt}/3 failed, retrying in 15s..."


### PR DESCRIPTION
## 📝 Description

Fix for `setup-ci-env-runner-image.sh's tar -ch | oc start-build --from-archive=-` as it fails on macOS.

## 🔗 Links

Jira ticket: [CNV-92150](https://redhat.atlassian.net/browse/CNV-92150)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of image builds by better handling linked files in the build context.
  * Updated build status checks so build completion is detected more accurately, reducing false success reports and premature exits.
  * Added clearer status reporting when a build is still in progress or has failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->