### PR TITLE
CNV-92150: Fix manual console deployment script

### DIFF
--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -1,5 +1,5 @@
 name: Hot Cluster E2E
-run-name: "Hot Cluster E2E [${{ inputs.cluster_name || github.head_ref || github.base_ref || 'kubevirt-plugin-ci' }}]"
+run-name: "Hot Cluster E2E [${{ inputs.cluster_name || github.base_ref || 'kubevirt-plugin-ci' }}]"
 
 on:
   pull_request_target:

--- a/ci-scripts/hot-cluster/helm/ci-test-stack/templates/console-deployment.yaml
+++ b/ci-scripts/hot-cluster/helm/ci-test-stack/templates/console-deployment.yaml
@@ -48,6 +48,11 @@ spec:
               value: "openshift"
             - name: BRIDGE_CA_FILE
               value: "/etc/console-auth/ca.crt"
+            # Required so bridge builds an absolute redirect_uri (matching the
+            # OAuthClient's registered redirectURIs) instead of a relative
+            # "/auth/callback", which the OAuth server rejects as invalid_request.
+            - name: BRIDGE_BASE_ADDRESS
+              value: {{ printf "https://%s" (required "console.route.host is required for auth.mode=openshift" .Values.console.route.host) | quote }}
             - name: BRIDGE_USER_AUTH_OIDC_CLIENT_ID
               value: {{ include "ci-test-stack.oauthClientName" . | quote }}
             - name: BRIDGE_USER_AUTH_OIDC_CLIENT_SECRET_FILE

--- a/ci-scripts/manual-console/README.md
+++ b/ci-scripts/manual-console/README.md
@@ -14,12 +14,12 @@ CI run, and runs with `BRIDGE_USER_AUTH=disabled` (a bearer token, no login
 wall) -- suitable for automated Playwright tests, not for a human to browse.
 Manual-console is the same underlying stack with three differences:
 
-| | E2E | Manual console |
-| - | --- | --------------- |
-| Namespace | Ephemeral `kubevirt-plugin-ci-test-<run_id>` | Persistent `manual-console` |
-| Lifecycle | Torn down after the test run; 2h TTL reaper | Persists until the next deploy; **not** TTL-reaped |
-| Auth | `BRIDGE_USER_AUTH=disabled` (bearer token) | `BRIDGE_USER_AUTH=openshift` (OAuth login) |
-| Plugin image | Built on `ubuntu-latest`, pushed to `ttl.sh` | Built in-cluster via an OpenShift BuildConfig |
+|              | E2E                                          | Manual console                                     |
+| ------------ | -------------------------------------------- | -------------------------------------------------- |
+| Namespace    | Ephemeral `kubevirt-plugin-ci-test-<run_id>` | Persistent `manual-console`                        |
+| Lifecycle    | Torn down after the test run; 2h TTL reaper  | Persists until the next deploy; **not** TTL-reaped |
+| Auth         | `BRIDGE_USER_AUTH=disabled` (bearer token)   | `BRIDGE_USER_AUTH=openshift` (OAuth login)         |
+| Plugin image | Built on `ubuntu-latest`, pushed to `ttl.sh` | Built in-cluster via an OpenShift BuildConfig      |
 
 ## Prerequisites
 
@@ -27,6 +27,23 @@ The target cluster must already be provisioned via **IBM Cloud Hot Cluster
 Setup** ([`ibmc-cluster-setup.yml`](../../.github/workflows/ibmc-cluster-setup.yml)),
 which installs the ARC runner scale set and `ci-env-controller` this
 workflow depends on.
+
+The ARC runner's ServiceAccount also needs permission to manage
+ImageStreams/BuildConfigs inside the `manual-console` namespace so it can
+build the plugin image (see "How it works" below). This is a one-time,
+per-cluster bootstrap -- `arc-runner-rbac.yaml` intentionally keeps that
+permission out of the cluster-wide E2E RBAC, so it's granted separately and
+scoped to just this namespace:
+
+```bash
+oc create namespace manual-console --dry-run=client -o yaml | oc apply -f -
+oc apply -f ci-scripts/manual-console/manual-console-rbac.yaml
+```
+
+If your cluster uses a custom `RUNNER_SCALE_SET_NAME` or `ARC_RUNNERS_NS` (see
+[`arc/README.md`](../hot-cluster/arc/README.md)), edit the `ServiceAccount`
+subject in `manual-console-rbac.yaml` first -- it hardcodes the default
+`kubevirt-plugin-ci-gha-rs-no-permission` / `arc-runners`.
 
 ## Deploying
 
@@ -97,10 +114,10 @@ ConfigMap that omits them (i.e. every existing one) behaves exactly as
 before. See [`ci-env/README.md`](../hot-cluster/ci-env/README.md) for the
 base contract.
 
-| Field | Description |
-| ----- | ------------ |
-| `auth-mode` | `openshift` to enable OAuth login; omitted/anything else keeps the default disabled (bearer-token) behavior |
-| `htpasswd-user` | Username to upsert into the cluster's htpasswd identity provider (required when `auth-mode=openshift`) |
+| Field                  | Description                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `auth-mode`            | `openshift` to enable OAuth login; omitted/anything else keeps the default disabled (bearer-token) behavior    |
+| `htpasswd-user`        | Username to upsert into the cluster's htpasswd identity provider (required when `auth-mode=openshift`)         |
 | `htpasswd-secret-name` | Name of a Secret (in the same `ci-env-namespace`) with key `password`; read once and deleted by the controller |
 
 The manual-console ConfigMap also uses the label
@@ -118,10 +135,11 @@ TTL reaper** that force-cleans stale E2E environments.
 
 ## Files
 
-| File | Purpose |
-| ---- | ------- |
-| `images/setup-plugin-image.sh` | Builds the kubevirt-plugin image in-cluster via an OpenShift BuildConfig |
-| `ensure-manual-console-user.sh` | Upserts the htpasswd user + extracts the cluster CA bundle; invoked by `ci-env-controller` (embedded into its image -- see below) |
+| File                            | Purpose                                                                                                                                         |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `images/setup-plugin-image.sh`  | Builds the kubevirt-plugin image in-cluster via an OpenShift BuildConfig                                                                        |
+| `ensure-manual-console-user.sh` | Upserts the htpasswd user + extracts the cluster CA bundle; invoked by `ci-env-controller` (embedded into its image -- see below)               |
+| `manual-console-rbac.yaml`      | One-time, per-cluster Role/RoleBinding granting the ARC runner SA ImageStream/BuildConfig access, scoped to the `manual-console` namespace only |
 
 `ensure-manual-console-user.sh` is embedded into the `ci-env-runner` image at
 build time (via a symlink in

--- a/ci-scripts/manual-console/manual-console-rbac.yaml
+++ b/ci-scripts/manual-console/manual-console-rbac.yaml
@@ -1,0 +1,53 @@
+# Grants the ARC runner ServiceAccount just enough permission to build the
+# kubevirt-plugin image in-cluster (CNV-92150), scoped to the manual-console
+# namespace only. arc-runner-rbac.yaml intentionally does NOT grant
+# ImageStream/BuildConfig access cluster-wide (or even namespace-scoped) to
+# keep the E2E path's RBAC surface minimal; this file is additive and only
+# takes effect inside the manual-console namespace.
+#
+# Idempotent, one-time bootstrap per cluster (namespace must already exist,
+# or be created first -- see below). Apply manually:
+#   oc create namespace manual-console --dry-run=client -o yaml | oc apply -f -
+#   oc apply -f ci-scripts/manual-console/manual-console-rbac.yaml
+#
+# If RUNNER_SCALE_SET_NAME / ARC_RUNNERS_NS differ from defaults, edit the
+# subject below (see arc-runner-rbac.yaml for the same caveat).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: manual-console-image-build
+  namespace: manual-console
+  labels:
+    app.kubernetes.io/component: manual-console-rbac
+rules:
+  - apiGroups: ['image.openshift.io']
+    resources: ['imagestreams', 'imagestreams/layers', 'imagestreamtags']
+    verbs: ['get', 'list', 'watch', 'create', 'update', 'patch']
+  - apiGroups: ['build.openshift.io']
+    resources: ['buildconfigs']
+    verbs: ['get', 'list', 'watch', 'create', 'update', 'patch']
+  - apiGroups: ['build.openshift.io']
+    resources: ['buildconfigs/instantiatebinary']
+    verbs: ['create']
+  - apiGroups: ['build.openshift.io']
+    resources: ['builds']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['build.openshift.io']
+    resources: ['builds/log']
+    verbs: ['get']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manual-console-image-build
+  namespace: manual-console
+  labels:
+    app.kubernetes.io/component: manual-console-rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manual-console-image-build
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-plugin-ci-gha-rs-no-permission
+    namespace: arc-runners


### PR DESCRIPTION
## 📝 Description

Fix manual console deployment script

## 🔗 Links

Jira ticket: [CNV-92150](https://redhat.atlassian.net/browse/CNV-92150)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified Manual Console vs ephemeral E2E Console differences (lifecycle, namespaces, auth modes, and plugin image build approach).
  - Expanded setup prerequisites with an added one-time per-cluster RBAC step and explicit `oc` commands.
  - Reworked auth-related config documentation into clearer tables and updated the file overview.

- **New Features**
  - Added `manual-console` namespace RBAC to enable plugin image build operations.

- **Bug Fixes**
  - Improved Console OAuth bridging by setting `BRIDGE_BASE_ADDRESS` for OpenShift auth flows.

- **Chores**
  - Updated the hot-cluster E2E workflow run-name fallback logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->