### PR TITLE
CNV-92533 -  add client handlers and code cleanup

### DIFF
--- a/playwright/src/clients/handlers/cluster-resource-handler.ts
+++ b/playwright/src/clients/handlers/cluster-resource-handler.ts
@@ -1,0 +1,185 @@
+import type { JsonPatchOp, KubernetesResource } from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+import { TestTimeouts } from '@/utils/test-config';
+import { waitForCondition } from '@/utils/wait-helpers';
+
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+
+export class ClusterResourceHandler {
+  constructor(private readonly ctx: KubernetesHandlerContext) {}
+
+  async deleteAllCustomResources(
+    group: string,
+    version: string,
+    plural: string,
+    namespace: string,
+    options?: { ignoreErrors?: boolean },
+  ): Promise<void> {
+    try {
+      const resources = await this.ctx.listCustomResources(group, version, namespace, plural);
+      const deletePromises = resources.map((resource: KubernetesResource) => {
+        const name = resource.metadata?.name;
+        if (!name) return Promise.resolve();
+        return this.ctx
+          .deleteCustomResource(group, version, namespace, plural, name)
+          .catch((error: unknown) => {
+            if (!options?.ignoreErrors) {
+              throw error;
+            }
+          });
+      });
+      await Promise.allSettled(deletePromises);
+    } catch (error: unknown) {
+      if (!options?.ignoreErrors) {
+        throw error;
+      }
+    }
+  }
+
+  async ensureClusterObservabilityOperatorUninstalled(): Promise<void> {
+    const namespace = 'openshift-cluster-observability-operator';
+    const group = 'operators.coreos.com';
+    const version = 'v1alpha1';
+
+    const subscriptions = await this.ctx.listCustomResources(
+      group,
+      version,
+      namespace,
+      'subscriptions',
+    );
+    await Promise.allSettled(
+      subscriptions.map((sub: { metadata?: { name?: string } }) => {
+        const name = sub.metadata?.name;
+        if (!name) return Promise.resolve();
+        return this.ctx
+          .deleteCustomResource(group, version, namespace, 'subscriptions', name)
+          .catch(() => {
+            return;
+          });
+      }),
+    );
+
+    const csvs = await this.ctx.listCustomResources(
+      group,
+      version,
+      namespace,
+      'clusterserviceversions',
+    );
+    await Promise.allSettled(
+      csvs.map((csv: { metadata?: { name?: string } }) => {
+        const name = csv.metadata?.name;
+        if (!name) return Promise.resolve();
+        return this.ctx
+          .deleteCustomResource(group, version, namespace, 'clusterserviceversions', name)
+          .catch(() => {
+            return;
+          });
+      }),
+    );
+  }
+
+  async getStorageClassNames(): Promise<string[]> {
+    const items = await this.ctx.listClusterCustomResources(
+      'storage.k8s.io',
+      'v1',
+      'storageclasses',
+    );
+    return items
+      .map((sc) => sc?.metadata?.name as string | undefined)
+      .filter((n): n is string => Boolean(n && String(n).trim()))
+      .map((n) => n.trim());
+  }
+
+  async isClusterObservabilityOperatorInstalled(): Promise<boolean> {
+    const namespace = 'openshift-cluster-observability-operator';
+    const subscriptions = await this.ctx.listCustomResources(
+      'operators.coreos.com',
+      'v1alpha1',
+      namespace,
+      'subscriptions',
+    );
+    return subscriptions.some(
+      (sub: { status?: { installedCSV?: string } }) => !!sub.status?.installedCSV,
+    );
+  }
+
+  async patchClusterCustomResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    patchBody: JsonPatchOp[] | Record<string, unknown>,
+  ): Promise<KubernetesResource> {
+    try {
+      const response = await this.ctx.customObjectsApi.patchClusterCustomObject({
+        body: patchBody,
+        group,
+        name,
+        plural,
+        version,
+      });
+      const res = response as { body?: KubernetesResource } | KubernetesResource;
+      return ('body' in res && res.body !== undefined ? res.body : res) as KubernetesResource;
+    } catch (error: unknown) {
+      throw new Error(`Failed to patch cluster custom resource ${name}: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async patchClusterCustomResourceWithJsonPatch(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    patchOps: JsonPatchOp[],
+  ): Promise<KubernetesResource> {
+    try {
+      const response = await this.ctx.customObjectsApi.patchClusterCustomObject(
+        {
+          body: patchOps,
+          group,
+          name,
+          plural,
+          version,
+        },
+        undefined,
+      );
+      const res = response as { body?: KubernetesResource } | KubernetesResource;
+      return ('body' in res && res.body !== undefined ? res.body : res) as KubernetesResource;
+    } catch (error: unknown) {
+      throw new Error(`Failed to patch cluster custom resource ${name}: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async setDefaultStorageClassForVirtualMachines(storageClassName: string): Promise<void> {
+    const group = 'storage.k8s.io';
+    const version = 'v1';
+    const plural = 'storageclasses';
+    const annotationPath = '/metadata/annotations/storageclass.kubevirt.io~1is-default-virt-class';
+
+    const items = await this.ctx.listClusterCustomResources(group, version, plural);
+    const names = items
+      .map((sc) => sc?.metadata?.name as string | undefined)
+      .filter((n): n is string => Boolean(n && n.trim()))
+      .map((n) => n.trim());
+
+    const clearPatch = [{ op: 'add' as const, path: annotationPath, value: 'false' }];
+    const setPatch = [{ op: 'add' as const, path: annotationPath, value: 'true' }];
+
+    for (const name of names) {
+      await this.patchClusterCustomResourceWithJsonPatch(group, version, plural, name, clearPatch);
+    }
+    await this.patchClusterCustomResourceWithJsonPatch(
+      group,
+      version,
+      plural,
+      storageClassName,
+      setPatch,
+    );
+  }
+
+  async waitForClusterObservabilityOperatorInstalled(
+    timeoutMs: number = TestTimeouts.OPERATOR_INSTALL,
+  ): Promise<boolean> {
+    return waitForCondition(() => this.isClusterObservabilityOperatorInstalled(), timeoutMs, 10000);
+  }
+}

--- a/playwright/src/clients/handlers/cluster-setup-handler.ts
+++ b/playwright/src/clients/handlers/cluster-setup-handler.ts
@@ -1,0 +1,450 @@
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+import { logger } from '@/utils/logger';
+import { TestTimeouts } from '@/utils/test-config';
+import { waitForCondition } from '@/utils/wait-helpers';
+import * as k8s from '@kubernetes/client-node';
+
+import type KubernetesClient from '../kubernetes-client';
+import { getKubernetesProxyUrl } from '../kubernetes-proxy';
+
+export class ClusterSetupHandler {
+  constructor(private readonly client: KubernetesClient) {}
+
+  async canUserPerformAction(
+    username: string,
+    namespace: string,
+    verb: string,
+    group: string,
+    resource: string,
+  ): Promise<boolean> {
+    const body = {
+      apiVersion: 'authorization.k8s.io/v1',
+      kind: 'LocalSubjectAccessReview',
+      metadata: { namespace },
+      spec: {
+        user: username,
+        resourceAttributes: { namespace, verb, group, resource },
+      },
+    };
+
+    try {
+      const proxyUrl = getKubernetesProxyUrl();
+      let result: KubernetesResource | null | undefined;
+      if (proxyUrl) {
+        result = (await this.client.makeProxyRequest(
+          'POST',
+          `/apis/authorization.k8s.io/v1/namespaces/${namespace}/localsubjectaccessreviews`,
+          body,
+        )) as KubernetesResource | null | undefined;
+      } else {
+        const authApi = this.client.getKubeConfig().makeApiClient(k8s.AuthorizationV1Api);
+        const response = await authApi.createNamespacedLocalSubjectAccessReview({
+          namespace,
+          body: body as k8s.V1LocalSubjectAccessReview,
+        });
+        const r = response as { body?: KubernetesResource } | KubernetesResource;
+        result = ('body' in r && r.body !== undefined ? r.body : r) as KubernetesResource;
+      }
+      return result?.status?.['allowed'] === true;
+    } catch {
+      return false;
+    }
+  }
+
+  async createNamespaceResource(body: k8s.V1Namespace): Promise<void> {
+    const proxyUrl = getKubernetesProxyUrl();
+
+    if (proxyUrl) {
+      await this.client.makeProxyRequest('POST', '/api/v1/namespaces', body);
+      return;
+    }
+    await this.client.getCoreV1Api().createNamespace({ body });
+  }
+
+  async disableVirtualizationWelcomeSettings(
+    cnvNamespace = 'openshift-cnv',
+    username = 'kube-admin',
+    userUid?: string,
+  ): Promise<boolean> {
+    try {
+      const existingConfigMap = await this.client.getConfigMap(
+        'kubevirt-user-settings',
+        cnvNamespace,
+      );
+
+      const keysToUpdate = [username];
+      if (userUid && userUid !== username) {
+        keysToUpdate.push(userUid);
+      }
+
+      const patchData: Record<string, string> = {};
+
+      for (const key of keysToUpdate) {
+        let existingUserSettings: Record<string, unknown> = {};
+        if (existingConfigMap?.data?.[key]) {
+          try {
+            existingUserSettings = JSON.parse(existingConfigMap.data[key]) as Record<
+              string,
+              unknown
+            >;
+          } catch {
+            existingUserSettings = {};
+          }
+        }
+
+        const currentQuickStart =
+          typeof existingUserSettings['quickStart'] === 'object' &&
+          existingUserSettings['quickStart'] !== null &&
+          !Array.isArray(existingUserSettings['quickStart'])
+            ? (existingUserSettings['quickStart'] as Record<string, unknown>)
+            : {};
+
+        const prevOnboarding =
+          typeof existingUserSettings['onboardingPopoversHidden'] === 'object' &&
+          existingUserSettings['onboardingPopoversHidden'] !== null &&
+          !Array.isArray(existingUserSettings['onboardingPopoversHidden'])
+            ? (existingUserSettings['onboardingPopoversHidden'] as Record<string, unknown>)
+            : {};
+
+        const updatedUserSettings = {
+          ...existingUserSettings,
+          navigation: { autoHideNav: false },
+          quickStart: {
+            ...currentQuickStart,
+            dontShowWelcomeModal: true,
+            activeQuickStartID: '',
+          },
+          guidedTour: false,
+          onboardingPopoversHidden: {
+            vmsTab: true,
+            catalog: true,
+            createProject: true,
+            ...prevOnboarding,
+          },
+        };
+        patchData[key] = JSON.stringify(updatedUserSettings);
+      }
+
+      await this.client.patchConfigMap('kubevirt-user-settings', cnvNamespace, patchData);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * If Cluster Observability Operator is installed, remove OLM Subscriptions and CSVs in
+   * openshift-cluster-observability-operator so tests start from a clean OLM state.
+   */
+  async ensureClusterObservabilityOperatorUninstalled(): Promise<void> {
+    const namespace = 'openshift-cluster-observability-operator';
+    const group = 'operators.coreos.com';
+    const version = 'v1alpha1';
+
+    const subscriptions = await this.client.listCustomResources(
+      group,
+      version,
+      namespace,
+      'subscriptions',
+    );
+    await Promise.allSettled(
+      subscriptions.map((sub: { metadata?: { name?: string } }) => {
+        const name = sub.metadata?.name;
+        if (!name) return Promise.resolve();
+        return this.client
+          .deleteCustomResource(group, version, namespace, 'subscriptions', name)
+          .catch(() => undefined);
+      }),
+    );
+
+    const csvs = await this.client.listCustomResources(
+      group,
+      version,
+      namespace,
+      'clusterserviceversions',
+    );
+    await Promise.allSettled(
+      csvs.map((csv: { metadata?: { name?: string } }) => {
+        const name = csv.metadata?.name;
+        if (!name) return Promise.resolve();
+        return this.client
+          .deleteCustomResource(group, version, namespace, 'clusterserviceversions', name)
+          .catch(() => undefined);
+      }),
+    );
+  }
+
+  async getNamespaceByName(name: string): Promise<k8s.V1Namespace | undefined> {
+    const proxyUrl = getKubernetesProxyUrl();
+
+    if (proxyUrl) {
+      const result = await this.client.makeProxyRequest(
+        'GET',
+        `/api/v1/namespaces/${encodeURIComponent(name)}`,
+      );
+      return result ?? undefined;
+    }
+    try {
+      const response = await this.client.getCoreV1Api().readNamespace({ name });
+      const r = response as { body?: k8s.V1Namespace } | k8s.V1Namespace;
+      return ('body' in r && r.body !== undefined ? r.body : r) as k8s.V1Namespace | undefined;
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      const statusCode =
+        typeof error === 'object' && error !== null && 'statusCode' in error
+          ? (error as { statusCode?: number }).statusCode
+          : undefined;
+      const code =
+        typeof error === 'object' && error !== null && 'code' in error
+          ? (error as { code?: number }).code
+          : undefined;
+      const body =
+        typeof error === 'object' && error !== null && 'body' in error
+          ? (error as { body?: { code?: number } }).body
+          : undefined;
+      const responseStatus =
+        typeof error === 'object' && error !== null && 'response' in error
+          ? (error as { response?: { statusCode?: number } }).response?.statusCode
+          : undefined;
+      if (
+        statusCode === 404 ||
+        code === 404 ||
+        body?.code === 404 ||
+        responseStatus === 404 ||
+        msg.includes('404') ||
+        msg.includes('not found') ||
+        msg.includes('NotFound')
+      ) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  /** Returns StorageClass resource names in the cluster. */
+  async getStorageClassNames(): Promise<string[]> {
+    const items = await this.client.listClusterCustomResources(
+      'storage.k8s.io',
+      'v1',
+      'storageclasses',
+    );
+    return items
+      .map((sc) => sc?.metadata?.name as string | undefined)
+      .filter((n): n is string => Boolean(n && String(n).trim()))
+      .map((n) => n.trim());
+  }
+
+  async getUserUid(username: string): Promise<string | undefined> {
+    try {
+      const user = await this.client.getClusterCustomResource(
+        'user.openshift.io',
+        'v1',
+        'users',
+        username,
+      );
+      return user?.metadata?.uid;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** True if any subscription in openshift-cluster-observability-operator has status.installedCSV. */
+  async isClusterObservabilityOperatorInstalled(): Promise<boolean> {
+    const namespace = 'openshift-cluster-observability-operator';
+    const subscriptions = await this.client.listCustomResources(
+      'operators.coreos.com',
+      'v1alpha1',
+      namespace,
+      'subscriptions',
+    );
+    return subscriptions.some(
+      (sub: { status?: { installedCSV?: string } }) => !!sub.status?.installedCSV,
+    );
+  }
+
+  /**
+   * Set the default StorageClass for VirtualMachines (KubeVirt/CNV).
+   * Sets the annotation storageclass.kubevirt.io/is-default-virt-class=true on the
+   * given StorageClass and false on all others.
+   */
+  async setDefaultStorageClassForVirtualMachines(storageClassName: string): Promise<void> {
+    const group = 'storage.k8s.io';
+    const version = 'v1';
+    const plural = 'storageclasses';
+    const annotationPath = '/metadata/annotations/storageclass.kubevirt.io~1is-default-virt-class';
+
+    const items = await this.client.listClusterCustomResources(group, version, plural);
+    const names = items.map((sc) => (sc?.metadata?.name as string).trim()).filter(Boolean);
+
+    const clearPatch = [{ op: 'add' as const, path: annotationPath, value: 'false' }];
+    const setPatch = [{ op: 'add' as const, path: annotationPath, value: 'true' }];
+
+    for (const name of names) {
+      await this.client.patchClusterCustomResourceWithJsonPatch(
+        group,
+        version,
+        plural,
+        name,
+        clearPatch,
+      );
+    }
+    await this.client.patchClusterCustomResourceWithJsonPatch(
+      group,
+      version,
+      plural,
+      storageClassName,
+      setPatch,
+    );
+  }
+
+  async setupConsoleUserSettings(
+    username = 'kubeadmin',
+    defaultNamespace?: string,
+    maxAttempts = 5,
+  ): Promise<boolean> {
+    const namespace = 'openshift-console-user-settings';
+    const configMapName = `user-settings-${username}`;
+
+    const patchData: Record<string, string> = {
+      'console.guidedTour': JSON.stringify({
+        admin: { completed: true },
+        dev: { completed: true },
+        'virtualization-perspective': { completed: true },
+      }),
+    };
+
+    if (defaultNamespace) {
+      patchData['console.lastNamespace'] = defaultNamespace;
+    }
+
+    // The console creates the user-settings ConfigMap asynchronously after first login.
+    // Retry a few times to give it a chance to appear before giving up.
+    const delayMs = 3000;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await this.client.patchConfigMap(configMapName, namespace, patchData);
+        return true;
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        if (msg.includes('404')) {
+          if (attempt < maxAttempts) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+            continue;
+          }
+          return false;
+        }
+        if (msg.includes('403')) {
+          return false;
+        }
+        throw error;
+      }
+    }
+    return false;
+  }
+
+  async setupKubevirtUiConfig(
+    cnvNamespace = 'openshift-cnv',
+    username = 'kube-admin',
+  ): Promise<void> {
+    try {
+      const existingConfigMap = await this.client.getConfigMap(
+        'kubevirt-user-settings',
+        cnvNamespace,
+      );
+      let existingUserSettings: Record<string, unknown> = {};
+
+      if (existingConfigMap?.data?.[username]) {
+        try {
+          existingUserSettings = JSON.parse(existingConfigMap.data[username]) as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          existingUserSettings = {};
+        }
+      }
+
+      const prevQuick =
+        typeof existingUserSettings['quickStart'] === 'object' &&
+        existingUserSettings['quickStart'] !== null &&
+        !Array.isArray(existingUserSettings['quickStart'])
+          ? (existingUserSettings['quickStart'] as Record<string, unknown>)
+          : {};
+
+      const updatedUserSettings = {
+        ...existingUserSettings,
+        navigation: { autoHideNav: false },
+        quickStart: {
+          ...prevQuick,
+          dontShowWelcomeModal: true,
+        },
+      };
+
+      await this.client.patchConfigMap('kubevirt-user-settings', cnvNamespace, {
+        [username]: JSON.stringify(updatedUserSettings),
+      });
+      const configMap = await this.client.getConfigMap('kubevirt-user-settings', cnvNamespace);
+      if (configMap) {
+        const userSettings = configMap?.data?.[username];
+        if (userSettings) {
+          try {
+            const parsed = JSON.parse(userSettings) as Record<string, unknown>;
+            const quickStart = parsed?.quickStart as Record<string, unknown> | undefined;
+            if (quickStart?.dontShowWelcomeModal !== true) {
+              logger.warn(
+                `Welcome modal setting verification failed: Setting is not correct in ConfigMap`,
+              );
+              logger.warn(
+                `   Expected: dontShowWelcomeModal=true, Got: ${JSON.stringify(quickStart)}`,
+              );
+            }
+          } catch (parseError) {
+            logger.warn(`Failed to parse user settings from ConfigMap: ${parseError}`);
+          }
+        } else {
+          logger.warn(`User settings key '${username}' not found in ConfigMap after patch`);
+        }
+      } else {
+        logger.warn(
+          `ConfigMap 'kubevirt-user-settings' not found after patch (might not exist yet)`,
+        );
+      }
+    } catch (error: unknown) {
+      const errorMessage = getErrorMessage(error);
+      logger.warn(
+        `Failed to patch kubevirt-user-settings ConfigMap: ${errorMessage}. Continuing setup...`,
+      );
+      logger.warn(
+        `   ConfigMap: kubevirt-user-settings, Namespace: ${cnvNamespace}, Username: ${username}`,
+      );
+    }
+
+    try {
+      await this.client.patchConfigMap('kubevirt-ui-features', cnvNamespace, {
+        advancedSearch: 'true',
+        treeViewFolders: 'true',
+      });
+    } catch {
+      logger.warn('Failed to patch kubevirt-ui-features ConfigMap. Continuing setup...');
+    }
+  }
+
+  async verifyAuthentication(): Promise<boolean> {
+    const proxyUrl = getKubernetesProxyUrl();
+
+    if (proxyUrl) {
+      await this.client.makeProxyRequest('GET', '/api/v1/namespaces?limit=1');
+    } else {
+      await this.client.getCoreV1Api().listNamespace({ limit: 1 });
+    }
+
+    return true;
+  }
+
+  async waitForClusterObservabilityOperatorInstalled(
+    timeoutMs: number = TestTimeouts.OPERATOR_INSTALL,
+  ): Promise<boolean> {
+    return waitForCondition(() => this.isClusterObservabilityOperatorInstalled(), timeoutMs, 10000);
+  }
+}

--- a/playwright/src/clients/handlers/custom-resource-crud-handler.ts
+++ b/playwright/src/clients/handlers/custom-resource-crud-handler.ts
@@ -1,0 +1,421 @@
+import type { JsonPatchOp, KubernetesResource } from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+
+import { getKubernetesProxyUrl, makeKubernetesProxyRequest } from '../kubernetes-proxy';
+
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+
+function unwrapCustomObjectResponse(response: unknown): KubernetesResource {
+  if (typeof response === 'object' && response !== null && 'body' in response) {
+    return (response as { body: KubernetesResource }).body;
+  }
+  return response as KubernetesResource;
+}
+
+function asK8sClientError(error: unknown): {
+  statusCode?: number;
+  response?: { statusCode?: number; status?: number };
+  message?: string;
+} {
+  return error as {
+    statusCode?: number;
+    response?: { statusCode?: number; status?: number };
+    message?: string;
+  };
+}
+
+/**
+ * Generic namespaced / cluster CustomObject CRUD via CustomObjectsApi, with HTTP(S)_PROXY
+ * support matching KubernetesClient historical behavior.
+ */
+export class CustomResourceCrudHandler {
+  constructor(private readonly ctx: KubernetesHandlerContext) {}
+
+  async createClusterCustomResource(
+    group: string,
+    version: string,
+    plural: string,
+    body: unknown,
+  ): Promise<KubernetesResource> {
+    try {
+      const response = await this.ctx.customObjectsApi.createClusterCustomObject({
+        group,
+        body: body as KubernetesResource,
+        plural,
+        version,
+      });
+      return response.body as KubernetesResource;
+    } catch (error: unknown) {
+      throw new Error(`Failed to create cluster custom resource: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async createCustomResource(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+    body: unknown,
+  ): Promise<KubernetesResource> {
+    try {
+      const response = await this.ctx.customObjectsApi.createNamespacedCustomObject({
+        body: body as KubernetesResource,
+        group,
+        namespace,
+        plural,
+        version,
+      });
+      return response.body as KubernetesResource;
+    } catch (error: unknown) {
+      throw new Error(`Failed to create custom resource: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async deleteAllCustomResources(
+    group: string,
+    version: string,
+    plural: string,
+    namespace: string,
+    options?: { ignoreErrors?: boolean },
+  ): Promise<void> {
+    try {
+      const resources = await this.listCustomResources(group, version, namespace, plural);
+      const deletePromises = resources.map((resource: KubernetesResource) => {
+        const resName = resource.metadata?.name;
+        if (!resName) return Promise.resolve();
+        return this.deleteCustomResource(group, version, namespace, plural, resName).catch(
+          (err: unknown) => {
+            if (!options?.ignoreErrors) {
+              throw err;
+            }
+          },
+        );
+      });
+      if (options?.ignoreErrors) {
+        await Promise.allSettled(deletePromises);
+      } else {
+        await Promise.all(deletePromises);
+      }
+    } catch (error: unknown) {
+      if (!options?.ignoreErrors) {
+        throw error;
+      }
+    }
+  }
+
+  async deleteClusterCustomResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+  ): Promise<KubernetesResource | undefined> {
+    const proxyUrl = getKubernetesProxyUrl();
+
+    if (proxyUrl) {
+      try {
+        await makeKubernetesProxyRequest(
+          this.ctx.kc,
+          'DELETE',
+          `/apis/${group}/${version}/${plural}/${encodeURIComponent(name)}`,
+        );
+        return undefined;
+      } catch (error: unknown) {
+        throw new Error(
+          `Failed to delete cluster custom resource ${name}: ${getErrorMessage(error)}`,
+        );
+      }
+    }
+
+    try {
+      const response = await this.ctx.customObjectsApi.deleteClusterCustomObject({
+        group,
+        name,
+        plural,
+        version,
+      });
+      return response.body;
+    } catch (error: unknown) {
+      throw new Error(
+        `Failed to delete cluster custom resource ${name}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  async deleteCustomResource(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+    name: string,
+  ): Promise<KubernetesResource | undefined> {
+    const proxyUrl = getKubernetesProxyUrl();
+
+    if (proxyUrl) {
+      try {
+        await makeKubernetesProxyRequest(
+          this.ctx.kc,
+          'DELETE',
+          `/apis/${group}/${version}/namespaces/${encodeURIComponent(
+            namespace,
+          )}/${plural}/${encodeURIComponent(name)}`,
+        );
+        return undefined;
+      } catch (error: unknown) {
+        throw new Error(`Failed to delete custom resource ${name}: ${getErrorMessage(error)}`);
+      }
+    }
+
+    try {
+      const response = await this.ctx.customObjectsApi.deleteNamespacedCustomObject({
+        group,
+        name,
+        namespace,
+        plural,
+        version,
+      });
+      return response.body;
+    } catch (error: unknown) {
+      throw new Error(`Failed to delete custom resource ${name}: ${getErrorMessage(error)}`);
+    }
+  }
+
+  /** DELETE /api/v1/namespaces/{namespace}/services/{name}. Uses proxy path when HTTP(S)_PROXY is set. */
+  async deleteNamespacedService(namespace: string, name: string): Promise<void> {
+    const proxyUrl = getKubernetesProxyUrl();
+
+    if (proxyUrl) {
+      await makeKubernetesProxyRequest(
+        this.ctx.kc,
+        'DELETE',
+        `/api/v1/namespaces/${encodeURIComponent(namespace)}/services/${encodeURIComponent(name)}`,
+      );
+      return;
+    }
+
+    await this.ctx.coreV1Api.deleteNamespacedService({ name, namespace });
+  }
+
+  async getClusterCustomResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+  ): Promise<KubernetesResource> {
+    const proxyUrl = getKubernetesProxyUrl();
+
+    if (proxyUrl) {
+      try {
+        return await makeKubernetesProxyRequest(
+          this.ctx.kc,
+          'GET',
+          `/apis/${group}/${version}/${plural}/${name}`,
+        );
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        const statusCode = msg.match(/HTTP (\d+)/)?.[1];
+        const errorMsg = `Failed to get cluster custom resource ${name}${
+          statusCode ? ` (${statusCode})` : ''
+        }: ${msg}`;
+        const newError = new Error(errorMsg) as Error & { statusCode?: number };
+        newError.statusCode = statusCode ? parseInt(statusCode, 10) : undefined;
+        throw newError;
+      }
+    }
+
+    try {
+      const response: unknown = await this.ctx.customObjectsApi.getClusterCustomObject({
+        group,
+        name,
+        plural,
+        version,
+      });
+      return unwrapCustomObjectResponse(response);
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const statusCode = e.statusCode || e.response?.statusCode;
+      const statusText = statusCode ? ` (${statusCode})` : '';
+      const msg = getErrorMessage(error);
+      const errorMsg = `Failed to get cluster custom resource ${name}${statusText}: ${msg}`;
+      const newError = new Error(errorMsg) as Error & { statusCode?: number };
+      newError.statusCode = typeof statusCode === 'number' ? statusCode : e.response?.status;
+      throw newError;
+    }
+  }
+
+  async getCustomResource(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+    name: string,
+  ): Promise<KubernetesResource> {
+    const proxyUrl = getKubernetesProxyUrl();
+
+    if (proxyUrl) {
+      try {
+        return await makeKubernetesProxyRequest(
+          this.ctx.kc,
+          'GET',
+          `/apis/${group}/${version}/namespaces/${namespace}/${plural}/${name}`,
+        );
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        const statusCode = msg.match(/HTTP (\d+)/)?.[1];
+        const errorMsg = `Failed to get custom resource ${name} in namespace ${namespace}${
+          statusCode ? ` (${statusCode})` : ''
+        }: ${msg}`;
+        const newError = new Error(errorMsg) as Error & { statusCode?: number };
+        newError.statusCode = statusCode ? parseInt(statusCode, 10) : undefined;
+        throw newError;
+      }
+    }
+
+    try {
+      const response: unknown = await this.ctx.customObjectsApi.getNamespacedCustomObject({
+        group,
+        name,
+        namespace,
+        plural,
+        version,
+      });
+      return unwrapCustomObjectResponse(response);
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const statusCode = e.statusCode || e.response?.statusCode;
+      const statusText = statusCode ? ` (${statusCode})` : '';
+      const msg = getErrorMessage(error);
+      const errorMsg = `Failed to get custom resource ${name} in namespace ${namespace}${statusText}: ${msg}`;
+      const newError = new Error(errorMsg) as Error & { statusCode?: number };
+      newError.statusCode = typeof statusCode === 'number' ? statusCode : e.response?.status;
+      throw newError;
+    }
+  }
+
+  async listClusterCustomResources(
+    group: string,
+    version: string,
+    plural: string,
+  ): Promise<KubernetesResource[]> {
+    try {
+      let body: unknown;
+
+      if (getKubernetesProxyUrl()) {
+        body = await makeKubernetesProxyRequest(
+          this.ctx.kc,
+          'GET',
+          `/apis/${group}/${version}/${plural}`,
+        );
+      } else {
+        const response = await this.ctx.customObjectsApi.listClusterCustomObject({
+          group,
+          plural,
+          version,
+        });
+        body = (response as { body?: unknown })?.body ?? response;
+      }
+
+      return (body as { items?: KubernetesResource[] })?.items || [];
+    } catch {
+      return [];
+    }
+  }
+
+  async listCustomResources(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+  ): Promise<KubernetesResource[]> {
+    try {
+      let body: unknown;
+
+      if (getKubernetesProxyUrl()) {
+        body = await makeKubernetesProxyRequest(
+          this.ctx.kc,
+          'GET',
+          `/apis/${group}/${version}/namespaces/${namespace}/${plural}`,
+        );
+      } else {
+        const response = await this.ctx.customObjectsApi.listNamespacedCustomObject({
+          group,
+          namespace,
+          plural,
+          version,
+        });
+        body = (response as { body?: unknown })?.body ?? response;
+      }
+
+      return (body as { items?: KubernetesResource[] })?.items || [];
+    } catch {
+      return [];
+    }
+  }
+
+  async patchClusterCustomResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    patchBody: JsonPatchOp[] | Record<string, unknown>,
+  ): Promise<KubernetesResource> {
+    try {
+      const response = await this.ctx.customObjectsApi.patchClusterCustomObject({
+        body: patchBody,
+        group,
+        name,
+        plural,
+        version,
+      });
+      return unwrapCustomObjectResponse(response);
+    } catch (error: unknown) {
+      throw new Error(`Failed to patch cluster custom resource ${name}: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async patchClusterCustomResourceWithJsonPatch(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    patchOps: JsonPatchOp[],
+  ): Promise<KubernetesResource> {
+    try {
+      const response = await this.ctx.customObjectsApi.patchClusterCustomObject(
+        {
+          body: patchOps,
+          group,
+          name,
+          plural,
+          version,
+        },
+        undefined,
+      );
+      return unwrapCustomObjectResponse(response);
+    } catch (error: unknown) {
+      throw new Error(`Failed to patch cluster custom resource ${name}: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async patchResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    namespace: string,
+    patchBody: JsonPatchOp[] | Record<string, unknown>,
+  ): Promise<KubernetesResource> {
+    try {
+      const response = await this.ctx.customObjectsApi.patchNamespacedCustomObject({
+        group,
+        version,
+        namespace,
+        plural,
+        name,
+        body: patchBody,
+      });
+      return unwrapCustomObjectResponse(response);
+    } catch (error: unknown) {
+      throw new Error(`Failed to patch custom resource ${name}: ${getErrorMessage(error)}`);
+    }
+  }
+}

--- a/playwright/src/clients/handlers/data-volume-handler.ts
+++ b/playwright/src/clients/handlers/data-volume-handler.ts
@@ -1,0 +1,262 @@
+import type { KubernetesCondition, KubernetesResource } from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+import { TestTimeouts } from '@/utils/test-config';
+
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+
+export class DataVolumeHandler {
+  constructor(private readonly ctx: KubernetesHandlerContext) {}
+
+  async createBlankDataVolume(
+    dataVolumeName: string,
+    namespace: string,
+    size = '1Gi',
+  ): Promise<KubernetesResource> {
+    const dataVolumeResource: KubernetesResource = {
+      apiVersion: 'cdi.kubevirt.io/v1beta1',
+      kind: 'DataVolume',
+      metadata: {
+        name: dataVolumeName,
+        namespace,
+        annotations: {
+          'cdi.kubevirt.io/storage.bind.immediate.requested': 'true',
+        },
+      },
+      spec: {
+        source: {
+          blank: {},
+        },
+        storage: {
+          resources: {
+            requests: {
+              storage: size,
+            },
+          },
+        },
+      },
+    };
+
+    return await this.ctx.createCustomResource(
+      'cdi.kubevirt.io',
+      'v1beta1',
+      namespace,
+      'datavolumes',
+      dataVolumeResource,
+    );
+  }
+
+  async dataSourceExists(dataSourceName: string, namespace: string): Promise<boolean> {
+    try {
+      await this.ctx.getCustomResource(
+        'cdi.kubevirt.io',
+        'v1beta1',
+        namespace,
+        'datasources',
+        dataSourceName,
+      );
+      return true;
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      if (msg.includes('404') || msg.includes('not found')) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async dataVolumeExists(dataVolumeName: string, namespace: string): Promise<boolean> {
+    try {
+      await this.ctx.getCustomResource(
+        'cdi.kubevirt.io',
+        'v1beta1',
+        namespace,
+        'datavolumes',
+        dataVolumeName,
+      );
+      return true;
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      if (msg.includes('404') || msg.includes('not found')) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async isDataSourceReady(name: string, namespace: string): Promise<boolean> {
+    try {
+      const ds = (await this.ctx.getCustomResource(
+        'cdi.kubevirt.io',
+        'v1beta1',
+        namespace,
+        'datasources',
+        name,
+      )) as KubernetesResource;
+      return (
+        (
+          (ds?.status as Record<string, unknown> | undefined)?.conditions as
+            | KubernetesCondition[]
+            | undefined
+        )?.some((c) => c.type === 'Ready' && c.status === 'True') ?? false
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  async patchDataSourceAnnotations(
+    dataSourceName: string,
+    namespace: string,
+    annotations: Record<string, string>,
+  ): Promise<void> {
+    if (Object.keys(annotations).length === 0) {
+      return;
+    }
+    const existing = (await this.ctx.getCustomResource(
+      'cdi.kubevirt.io',
+      'v1beta1',
+      namespace,
+      'datasources',
+      dataSourceName,
+    )) as KubernetesResource;
+    const existingAnnotations = existing?.metadata?.annotations ?? {};
+    const merged = { ...existingAnnotations, ...annotations };
+
+    const patchOps = [
+      {
+        op: Object.keys(existingAnnotations).length === 0 ? 'add' : 'replace',
+        path: '/metadata/annotations',
+        value: merged,
+      },
+    ];
+
+    const patchApi = this.ctx.customObjectsApi as unknown as {
+      patchNamespacedCustomObject: (
+        request: {
+          group: string;
+          version: string;
+          namespace: string;
+          plural: string;
+          name: string;
+          body: unknown;
+          dryRun?: string;
+          fieldManager?: string;
+          fieldValidation?: string;
+        },
+        contentType?: string,
+        options?: { headers?: Record<string, string> },
+      ) => Promise<{ body?: KubernetesResource }>;
+    };
+
+    await patchApi.patchNamespacedCustomObject(
+      {
+        group: 'cdi.kubevirt.io',
+        version: 'v1beta1',
+        namespace,
+        plural: 'datasources',
+        name: dataSourceName,
+        body: patchOps,
+        dryRun: undefined,
+        fieldManager: undefined,
+        fieldValidation: undefined,
+      },
+      'json',
+      {
+        headers: {
+          'Content-Type': 'application/json-patch+json',
+        },
+      },
+    );
+  }
+
+  async verifyDataVolumeCreated(
+    dataVolumeName: string,
+    namespace: string,
+    timeoutMs = 60000,
+  ): Promise<{
+    dataVolume?: KubernetesResource;
+    error?: string;
+    exists: boolean;
+  }> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const dataVolume = await this.ctx.getCustomResource(
+          'cdi.kubevirt.io',
+          'v1beta1',
+          namespace,
+          'datavolumes',
+          dataVolumeName,
+        );
+
+        return {
+          dataVolume: dataVolume,
+          exists: true,
+        };
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        if (msg.includes('404') || msg.includes('not found')) {
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+          continue;
+        }
+
+        return {
+          error: msg,
+          exists: false,
+        };
+      }
+    }
+
+    return {
+      error: `Timeout after ${timeoutMs}ms waiting for DataVolume ${dataVolumeName} to be created`,
+      exists: false,
+    };
+  }
+
+  async waitForDataVolumeSucceeded(
+    dataVolumeName: string,
+    namespace: string,
+    timeoutMs: number = TestTimeouts.VM_BOOTUP,
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      try {
+        const dv = (await this.ctx.getCustomResource(
+          'cdi.kubevirt.io',
+          'v1beta1',
+          namespace,
+          'datavolumes',
+          dataVolumeName,
+        )) as KubernetesResource;
+        const phase = dv?.status?.phase;
+        if (phase === 'Succeeded') {
+          return;
+        }
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        // DV may not exist yet (still being created) or may have already been
+        // garbage-collected after succeeding (CDI deletes the DV once it becomes a PVC).
+        // In both cases, continue polling rather than throwing immediately.
+        if (!msg.includes('404') && !msg.includes('not found')) {
+          throw error;
+        }
+        // Check if a PVC with the same name already exists — that means the DV
+        // completed and was replaced by the PVC (i.e. it already succeeded).
+        const pvcExists = await this.ctx.coreV1Api
+          .readNamespacedPersistentVolumeClaim({ name: dataVolumeName, namespace })
+          .then(() => true)
+          .catch(() => false);
+        if (pvcExists) {
+          return;
+        }
+      }
+      await new Promise((r) => setTimeout(r, TestTimeouts.POLLING_INTERVAL));
+    }
+
+    throw new Error(
+      `Timeout waiting for DataVolume ${dataVolumeName} to reach Succeeded in namespace ${namespace}`,
+    );
+  }
+}

--- a/playwright/src/clients/handlers/hco-handler.ts
+++ b/playwright/src/clients/handlers/hco-handler.ts
@@ -1,0 +1,388 @@
+import type {
+  JsonPatchOp,
+  KubernetesCondition,
+  KubernetesResource,
+} from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+
+type HcoVersionEntry = {
+  name?: string;
+  version?: string;
+};
+
+export class HyperConvergedHandler {
+  private static readonly JSONPATCH_ANNOTATION = 'kubevirt.kubevirt.io/jsonpatch';
+
+  constructor(private readonly ctx: KubernetesHandlerContext) {}
+
+  /**
+   * Disable the native VM template feature gate by removing the
+   * `kubevirt.kubevirt.io/jsonpatch` annotation from the HCO CR.
+   *
+   * No-op if the annotation is not present.
+   */
+  async disableNativeVmTemplateFeatureGate(
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+  ): Promise<boolean> {
+    if (!(await this.isNativeVmTemplateFeatureGateEnabled(name, namespace))) {
+      return true;
+    }
+    const annotationPath = `/metadata/annotations/${HyperConvergedHandler.JSONPATCH_ANNOTATION.replace(
+      '/',
+      '~1',
+    )}`;
+    try {
+      await this.patchHyperConverged(name, namespace, [
+        { op: 'replace', path: annotationPath, value: '[]' },
+      ]);
+      return true;
+    } catch (error: unknown) {
+      throw new Error(
+        `Failed to disable native VM template feature gate: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Enable the native VM template feature gate by setting the
+   * `kubevirt.kubevirt.io/jsonpatch` annotation on the HCO CR.
+   *
+   * The annotation instructs the HCO to add "Template" to
+   * `/spec/configuration/developerConfiguration/featureGates` on the
+   * KubeVirt CR.
+   *
+   * No-op if the feature gate is already enabled.
+   */
+  async enableNativeVmTemplateFeatureGate(
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+  ): Promise<boolean> {
+    if (await this.isNativeVmTemplateFeatureGateEnabled(name, namespace)) {
+      return true;
+    }
+    const annotationPath = `/metadata/annotations/${HyperConvergedHandler.JSONPATCH_ANNOTATION.replace(
+      '/',
+      '~1',
+    )}`;
+    const featureGateValue = JSON.stringify([
+      {
+        op: 'add',
+        path: '/spec/configuration/developerConfiguration/featureGates/-',
+        value: 'Template',
+      },
+    ]);
+
+    try {
+      await this.patchHyperConverged(name, namespace, [
+        { op: 'add', path: '/metadata/annotations', value: {} },
+        { op: 'add', path: annotationPath, value: featureGateValue },
+      ]);
+      return true;
+    } catch {
+      try {
+        await this.patchHyperConverged(name, namespace, [
+          { op: 'replace', path: annotationPath, value: featureGateValue },
+        ]);
+        return true;
+      } catch (error: unknown) {
+        throw new Error(
+          `Failed to enable native VM template feature gate: ${getErrorMessage(error)}`,
+        );
+      }
+    }
+  }
+
+  async getHyperConverged(name = 'kubevirt-hyperconverged', namespace = 'openshift-cnv') {
+    return await this.ctx.getCustomResource(
+      'hco.kubevirt.io',
+      'v1beta1',
+      namespace,
+      'hyperconvergeds',
+      name,
+    );
+  }
+
+  async getHyperConvergedField(
+    jsonPath: string,
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+  ): Promise<string | undefined> {
+    const hco = await this.getHyperConverged(name, namespace);
+
+    const cleanPath = jsonPath.startsWith('.') ? jsonPath.slice(1) : jsonPath;
+    const pathParts = cleanPath.split('.');
+
+    let value: unknown = hco;
+    for (const part of pathParts) {
+      if (value === null || value === undefined) {
+        return undefined;
+      }
+      value =
+        typeof value === 'object' && value !== null && part in value
+          ? (value as Record<string, unknown>)[part]
+          : undefined;
+    }
+
+    return value !== undefined && value !== null ? String(value) : undefined;
+  }
+
+  async getHyperConvergedStatusAndVersion(
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+  ): Promise<{ status: string; version: string | undefined }> {
+    const hco = await this.getHyperConverged(name, namespace);
+    const status = hco?.status as Record<string, unknown> | undefined;
+    let statusText = 'Unknown';
+    const conditions = (status?.conditions as KubernetesCondition[] | undefined) ?? [];
+    const degraded = conditions.find((c) => c.type === 'Degraded' && c.status === 'True');
+    const available = conditions.find((c) => c.type === 'Available' && c.status === 'True');
+    if (degraded) statusText = 'Degraded';
+    else if (available) statusText = 'Healthy';
+    const versions = (status?.versions as HcoVersionEntry[] | undefined) ?? [];
+    const versionEntry =
+      versions.find((v) => v.name === 'cnv' || v.name === 'openshift-cnv') ??
+      versions.find((v) => v.name === 'kubevirt');
+    const version = versionEntry?.version;
+    return { status: statusText, version };
+  }
+
+  /**
+   * Check whether the "Template" feature gate is already present in the
+   * `kubevirt.kubevirt.io/jsonpatch` annotation on the HCO CR.
+   */
+  async isNativeVmTemplateFeatureGateEnabled(
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+  ): Promise<boolean> {
+    try {
+      const hco = await this.getHyperConverged(name, namespace);
+      if (!hco) return false;
+      const annotation =
+        hco.metadata?.annotations?.[HyperConvergedHandler.JSONPATCH_ANNOTATION] ?? '';
+      if (!annotation) return false;
+      const ops = JSON.parse(annotation) as Array<{ value?: string }>;
+      return ops.some((op) => op.value === 'Template');
+    } catch {
+      return false;
+    }
+  }
+
+  async patchHyperConverged(
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+    patchOps: JsonPatchOp[],
+  ) {
+    try {
+      const patchApi = this.ctx.customObjectsApi as unknown as {
+        patchNamespacedCustomObject: (
+          request: {
+            group: string;
+            version: string;
+            namespace: string;
+            plural: string;
+            name: string;
+            body: unknown;
+            dryRun?: string;
+            fieldManager?: string;
+            fieldValidation?: string;
+          },
+          contentType?: string,
+          options?: { headers?: Record<string, string> },
+        ) => Promise<{ body?: KubernetesResource } | KubernetesResource>;
+      };
+      const response = await patchApi.patchNamespacedCustomObject(
+        {
+          group: 'hco.kubevirt.io',
+          version: 'v1beta1',
+          namespace: namespace,
+          plural: 'hyperconvergeds',
+          name: name,
+          body: patchOps,
+          dryRun: undefined,
+          fieldManager: undefined,
+          fieldValidation: undefined,
+        },
+        'json',
+        {
+          headers: {
+            'Content-Type': 'application/json-patch+json',
+          },
+        },
+      );
+      const r = response as { body?: KubernetesResource } | KubernetesResource;
+      return ('body' in r && r.body !== undefined ? r.body : r) as KubernetesResource;
+    } catch (error: unknown) {
+      const statusCode =
+        (typeof error === 'object' && error !== null && 'statusCode' in error
+          ? (error as { statusCode?: number }).statusCode
+          : undefined) ??
+        (typeof error === 'object' && error !== null && 'response' in error
+          ? (error as { response?: { statusCode?: number } }).response?.statusCode
+          : undefined);
+      const newError = new Error(
+        `Failed to patch HyperConverged ${name}: ${getErrorMessage(error)}`,
+      ) as Error & { statusCode?: number };
+      newError.statusCode = statusCode;
+      throw newError;
+    }
+  }
+
+  async verifyHCOSpec(
+    jsonPath: string,
+    expectedValue: string,
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+  ): Promise<boolean> {
+    try {
+      const hco = await this.getHyperConverged(name, namespace);
+
+      if (!hco) {
+        return false;
+      }
+
+      const pathParts = jsonPath.split('.').filter((part) => part && part !== 'spec');
+      let current: unknown = hco.spec || hco;
+
+      for (const part of pathParts) {
+        if (
+          current &&
+          typeof current === 'object' &&
+          part in (current as Record<string, unknown>)
+        ) {
+          current = (current as Record<string, unknown>)[part];
+        } else {
+          return false;
+        }
+      }
+
+      const actualValue = String(current ?? '');
+      return actualValue.includes(expectedValue);
+    } catch (error) {
+      return false;
+    }
+  }
+
+  async verifyLiveMigrationLimits(
+    expectedParallelMigrationsPerCluster: string,
+    expectedParallelOutboundMigrationsPerNode: string,
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+  ): Promise<{
+    parallelMigrationsPerCluster: boolean;
+    parallelOutboundMigrationsPerNode: boolean;
+    actualParallelMigrationsPerCluster?: string | number;
+    actualParallelOutboundMigrationsPerNode?: string | number;
+  }> {
+    try {
+      const hco = await this.getHyperConverged(name, namespace);
+
+      if (!hco) {
+        throw new Error('HCO resource is undefined');
+      }
+
+      const liveMigrationConfig = (hco.spec?.['liveMigrationConfig'] ?? {}) as Record<
+        string,
+        unknown
+      >;
+
+      const actualParallelMigrationsPerCluster =
+        liveMigrationConfig['parallelMigrationsPerCluster'];
+      const actualParallelOutboundMigrationsPerNode =
+        liveMigrationConfig['parallelOutboundMigrationsPerNode'];
+
+      const actualClusterStr = String(actualParallelMigrationsPerCluster ?? '');
+      const actualNodeStr = String(actualParallelOutboundMigrationsPerNode ?? '');
+
+      const clusterMatches = actualClusterStr === expectedParallelMigrationsPerCluster;
+      const nodeMatches = actualNodeStr === expectedParallelOutboundMigrationsPerNode;
+
+      return {
+        parallelMigrationsPerCluster: clusterMatches,
+        parallelOutboundMigrationsPerNode: nodeMatches,
+        actualParallelMigrationsPerCluster: actualParallelMigrationsPerCluster as
+          | string
+          | number
+          | undefined,
+        actualParallelOutboundMigrationsPerNode: actualParallelOutboundMigrationsPerNode as
+          | string
+          | number
+          | undefined,
+      };
+    } catch (error) {
+      return {
+        parallelMigrationsPerCluster: false,
+        parallelOutboundMigrationsPerNode: false,
+      };
+    }
+  }
+
+  async verifyMemoryDensity(
+    expectedMemoryOvercommitPercentage: string,
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+    maxRetries = 10,
+    retryInterval = 2000,
+  ): Promise<{
+    memoryOvercommitPercentage: boolean;
+    actualMemoryOvercommitPercentage?: string | number;
+  }> {
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        const hco = await this.getHyperConverged(name, namespace);
+
+        if (!hco) {
+          throw new Error('HCO resource is undefined');
+        }
+
+        const higherWorkloadDensity = (hco.spec?.['higherWorkloadDensity'] ?? {}) as Record<
+          string,
+          unknown
+        >;
+
+        const actualMemoryOvercommitPercentage =
+          higherWorkloadDensity['memoryOvercommitPercentage'];
+
+        const actualPercentageStr = String(actualMemoryOvercommitPercentage ?? '');
+
+        const matches = actualPercentageStr === expectedMemoryOvercommitPercentage;
+
+        if (matches) {
+          return {
+            memoryOvercommitPercentage: true,
+            actualMemoryOvercommitPercentage: actualMemoryOvercommitPercentage as
+              | string
+              | number
+              | undefined,
+          };
+        }
+
+        if (attempt < maxRetries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, retryInterval));
+        } else {
+          return {
+            memoryOvercommitPercentage: false,
+            actualMemoryOvercommitPercentage: actualMemoryOvercommitPercentage as
+              | string
+              | number
+              | undefined,
+          };
+        }
+      } catch (error) {
+        if (attempt < maxRetries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, retryInterval));
+        } else {
+          return {
+            memoryOvercommitPercentage: false,
+          };
+        }
+      }
+    }
+
+    return {
+      memoryOvercommitPercentage: false,
+    };
+  }
+}

--- a/playwright/src/clients/handlers/index.ts
+++ b/playwright/src/clients/handlers/index.ts
@@ -1,0 +1,12 @@
+export { ClusterResourceHandler } from './cluster-resource-handler';
+export { ClusterSetupHandler } from './cluster-setup-handler';
+export { CustomResourceCrudHandler } from './custom-resource-crud-handler';
+export { HyperConvergedHandler } from './hco-handler';
+export type { KubernetesApiContext, KubernetesHandlerContext } from './kubernetes-api-context';
+export { NamespaceHandler } from './namespace-handler';
+export { NodeHandler } from './node-handler';
+export { PolicyHandler } from './policy-handler';
+export { SecretConfigMapHandler } from './secret-configmap-handler';
+export { SnapshotHandler } from './snapshot-handler';
+export { TemplateHandler } from './template-handler';
+export { VirtualMachineHandler } from './vm-handler';

--- a/playwright/src/clients/handlers/kubernetes-api-context.ts
+++ b/playwright/src/clients/handlers/kubernetes-api-context.ts
@@ -1,0 +1,93 @@
+import type { JsonPatchOp, KubernetesResource } from '@/data-models/kubernetes-types';
+import type * as k8s from '@kubernetes/client-node';
+
+export type KubernetesApiContext = {
+  readonly kc: k8s.KubeConfig;
+  readonly coreV1Api: k8s.CoreV1Api;
+  readonly customObjectsApi: k8s.CustomObjectsApi;
+  readonly appsV1Api: k8s.AppsV1Api;
+  readonly rbacApi: k8s.RbacAuthorizationV1Api;
+  withRetry<T>(
+    operation: () => Promise<T>,
+    label: string,
+    maxRetries?: number,
+    delayMs?: number,
+  ): Promise<T>;
+  /**
+   * Read namespace by name. When HTTP(S)_PROXY is set, uses the same CONNECT tunnel as
+   * verifyAuthentication — @kubernetes/client-node v1.x does not reliably use KubeConfig.createAgent.
+   */
+  getNamespaceByName(name: string): Promise<k8s.V1Namespace | undefined>;
+  /** POST /api/v1/namespaces — proxy-aware when HTTP(S)_PROXY is set. */
+  createNamespaceResource(body: k8s.V1Namespace): Promise<void>;
+};
+
+export type KubernetesHandlerCrContext = {
+  getCustomResource(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+    name: string,
+  ): Promise<KubernetesResource>;
+  createCustomResource(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+    body: unknown,
+  ): Promise<KubernetesResource>;
+  deleteCustomResource(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+    name: string,
+  ): Promise<KubernetesResource>;
+  patchResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    namespace: string,
+    patchBody: JsonPatchOp[] | Record<string, unknown>,
+  ): Promise<KubernetesResource>;
+  listCustomResources(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+  ): Promise<KubernetesResource[]>;
+  listClusterCustomResources(
+    group: string,
+    version: string,
+    plural: string,
+  ): Promise<KubernetesResource[]>;
+  getClusterCustomResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+  ): Promise<KubernetesResource>;
+  createClusterCustomResource(
+    group: string,
+    version: string,
+    plural: string,
+    body: unknown,
+  ): Promise<KubernetesResource>;
+  deleteClusterCustomResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+  ): Promise<KubernetesResource>;
+  deleteAllCustomResources(
+    group: string,
+    version: string,
+    plural: string,
+    namespace: string,
+    options?: { ignoreErrors?: boolean },
+  ): Promise<void>;
+};
+
+export type KubernetesHandlerContext = KubernetesApiContext & KubernetesHandlerCrContext;

--- a/playwright/src/clients/handlers/namespace-handler.ts
+++ b/playwright/src/clients/handlers/namespace-handler.ts
@@ -1,0 +1,1791 @@
+import { createHash } from 'crypto';
+
+import type { KubernetesListResource, KubernetesResource } from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+import { EnvVariables } from '@/utils/env-variables';
+import { TestTimeouts } from '@/utils/test-config';
+import type * as k8s from '@kubernetes/client-node';
+
+import { getKubernetesProxyUrl, makeKubernetesProxyRequest } from '../kubernetes-proxy';
+
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+import type { SecretConfigMapHandler } from './secret-configmap-handler';
+import type { VirtualMachineHandler } from './vm-handler';
+
+/** Narrow unknown API errors for status/body checks (client-node / proxy). */
+function asK8sClientError(error: unknown): {
+  statusCode?: number;
+  code?: number;
+  body?: { code?: number };
+  response?: { statusCode?: number; status?: number };
+} {
+  return error as {
+    statusCode?: number;
+    code?: number;
+    body?: { code?: number };
+    response?: { statusCode?: number; status?: number };
+  };
+}
+
+function unwrapApiBody<T>(response: unknown): T {
+  if (typeof response === 'object' && response !== null && 'body' in response) {
+    return (response as { body: T }).body;
+  }
+  return response as T;
+}
+
+export class NamespaceHandler {
+  constructor(
+    private readonly ctx: KubernetesHandlerContext,
+    private readonly secret: SecretConfigMapHandler,
+    private readonly vm: VirtualMachineHandler,
+  ) {}
+
+  /** Returns the htpasswd credential username for the non-priv test user (TEST_USERNAME env, default "test"). */
+  private _nonPrivUsername(): string {
+    return EnvVariables.testUsername;
+  }
+
+  private isAlreadyExistsK8sError(error: unknown): boolean {
+    const e = error as {
+      statusCode?: number;
+      response?: { status?: number; statusCode?: number };
+      message?: string;
+    };
+    return (
+      e.statusCode === 409 ||
+      e.response?.status === 409 ||
+      e.response?.statusCode === 409 ||
+      e.message?.includes('409') ||
+      e.message?.includes('AlreadyExists') ||
+      e.message?.includes('already exists') ||
+      false
+    );
+  }
+
+  private isNotFoundK8sError(error: unknown): boolean {
+    const e = error as {
+      statusCode?: number;
+      response?: { status?: number; statusCode?: number };
+      message?: string;
+    };
+    return (
+      e.statusCode === 404 ||
+      e.response?.status === 404 ||
+      e.response?.statusCode === 404 ||
+      e.message?.includes('404') ||
+      e.message?.includes('not found') ||
+      e.message?.includes('NotFound') ||
+      false
+    );
+  }
+
+  private isSystemNamespaceExcludedForTestUser(namespace: string): boolean {
+    return namespace === 'default' || namespace.startsWith('openshift-');
+  }
+
+  private parseQuantityToBytes(q: string | undefined): number {
+    if (!q || typeof q !== 'string') return 0;
+    const s = q.trim();
+    const match = s.match(/^(\d+(?:\.\d+)?)\s*([KMGTPE]i?)?$/);
+    if (!match) return 0;
+    const num = parseFloat(match[1]);
+    const unit = (match[2] || '').toLowerCase();
+    if (unit === 'ki') return num * 1024;
+    if (unit === 'mi') return num * 1024 ** 2;
+    if (unit === 'gi') return num * 1024 ** 3;
+    if (unit === 'ti') return num * 1024 ** 4;
+    if (unit === 'pi') return num * 1024 ** 5;
+    if (unit === 'ei') return num * 1024 ** 6;
+    if (unit === 'k') return num * 1000;
+    if (unit === 'm') return num * 1000 ** 2;
+    if (unit === 'g') return num * 1000 ** 3;
+    if (unit === 't') return num * 1000 ** 4;
+    if (unit === 'p') return num * 1000 ** 5;
+    if (unit === 'e') return num * 1000 ** 6;
+    return num;
+  }
+
+  async cleanupTestNamespace(namespace: string): Promise<void> {
+    await Promise.allSettled([
+      this.ctx.deleteAllCustomResources('kubevirt.io', 'v1', 'virtualmachineinstances', namespace, {
+        ignoreErrors: true,
+      }),
+    ]);
+
+    await this.ctx.deleteAllCustomResources('kubevirt.io', 'v1', 'virtualmachines', namespace, {
+      ignoreErrors: true,
+    });
+
+    await Promise.allSettled([
+      this.ctx.deleteAllCustomResources('template.openshift.io', 'v1', 'templates', namespace, {
+        ignoreErrors: true,
+      }),
+      this.ctx.deleteAllCustomResources(
+        'snapshot.kubevirt.io',
+        'v1beta1',
+        'virtualmachinesnapshots',
+        namespace,
+        { ignoreErrors: true },
+      ),
+      this.secret.deleteAllSecrets(namespace, { ignoreErrors: true }),
+      this.ctx.deleteAllCustomResources(
+        'k8s.cni.cncf.io',
+        'v1',
+        'network-attachment-definitions',
+        namespace,
+        { ignoreErrors: true },
+      ),
+      this.ctx.deleteAllCustomResources(
+        'instancetype.kubevirt.io',
+        'v1beta1',
+        'virtualmachineinstancetypes',
+        namespace,
+        { ignoreErrors: true },
+      ),
+      this.ctx.deleteAllCustomResources(
+        'instancetype.kubevirt.io',
+        'v1beta1',
+        'virtualmachinepreferences',
+        namespace,
+        { ignoreErrors: true },
+      ),
+      this.ctx.deleteAllCustomResources(
+        'kubevirt.io',
+        'v1',
+        'virtualmachineinstancemigrations',
+        namespace,
+        { ignoreErrors: true },
+      ),
+      this.ctx.deleteAllCustomResources('k8s.ovn.org', 'v1', 'userdefinednetworks', namespace, {
+        ignoreErrors: true,
+      }),
+      this.secret.deleteConfigMapsWithPrefix(namespace, 'sysprep-', { ignoreErrors: true }),
+    ]);
+  }
+
+  async createNamespace(name: string, labels?: Record<string, string>): Promise<boolean> {
+    try {
+      const namespaceManifest: k8s.V1Namespace = {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: {
+          name,
+          labels,
+        },
+      };
+      await this.ctx.createNamespaceResource(namespaceManifest);
+      if (EnvVariables.isNonPrivUser) {
+        const username = this._nonPrivUsername();
+        await this.grantUserAccessToNamespace(name, username);
+        await this.grantUserKubevirtAccessToNamespace(name, username);
+      }
+      return true;
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (
+        e.statusCode === 409 ||
+        e.code === 409 ||
+        e.body?.code === 409 ||
+        e.response?.statusCode === 409 ||
+        msg.includes('409') ||
+        msg.includes('already exists') ||
+        msg.includes('AlreadyExists')
+      ) {
+        if (EnvVariables.isNonPrivUser) {
+          const username = this._nonPrivUsername();
+          await this.grantUserAccessToNamespace(name, username);
+          await this.grantUserKubevirtAccessToNamespace(name, username);
+        }
+        return true;
+      }
+      throw new Error(`Failed to create namespace ${name}: ${msg}`);
+    }
+  }
+
+  /**
+   * Deletes a ClusterRoleBinding by name. 404 is silently ignored so teardown
+   * is safe to call even if the binding was never created.
+   */
+  async deleteClusterRoleBinding(name: string): Promise<void> {
+    try {
+      await this.ctx.rbacApi.deleteClusterRoleBinding({ name });
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      if (msg.includes('404') || msg.includes('not found')) {
+        return;
+      }
+      throw new Error(`Failed to delete ClusterRoleBinding "${name}": ${msg}`);
+    }
+  }
+
+  async deleteNamespace(name: string, options?: { ignoreNotFound?: boolean }): Promise<boolean> {
+    try {
+      await this.ctx.coreV1Api.deleteNamespace({
+        name,
+      });
+      return true;
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (e.statusCode === 404 || e.body?.code === 404) {
+        if (options?.ignoreNotFound) {
+          return true;
+        }
+        return false;
+      }
+      throw new Error(`Failed to delete namespace ${name}: ${msg}`);
+    }
+  }
+
+  /**
+   * Ensures RBAC for network latency checkup tests.
+   *
+   */
+  async ensureNetworkCheckupPermissions(namespace: string): Promise<{
+    results: Record<string, { created: boolean; alreadyExisted: boolean }>;
+    anyCreated: boolean;
+  }> {
+    const saName = 'vm-latency-checkup-sa';
+    const latencyRoleName = 'kubevirt-vm-latency-checker';
+    const configmapRoleName = 'kiagnose-configmap-access';
+
+    const latencyRules = [
+      {
+        apiGroups: ['kubevirt.io'],
+        resources: ['virtualmachineinstances'],
+        verbs: ['get', 'create', 'delete'],
+      },
+      {
+        apiGroups: ['subresources.kubevirt.io'],
+        resources: ['virtualmachineinstances/console'],
+        verbs: ['get'],
+      },
+      {
+        apiGroups: ['k8s.cni.cncf.io'],
+        resources: ['network-attachment-definitions'],
+        verbs: ['get'],
+      },
+    ];
+
+    const configmapRules = [
+      { apiGroups: [''], resources: ['configmaps'], verbs: ['get', 'update'] },
+    ];
+
+    const results: Record<string, { created: boolean; alreadyExisted: boolean }> = {};
+    const rbacGroup = 'rbac.authorization.k8s.io';
+    const rbacVersion = 'v1';
+
+    try {
+      await this.ctx.coreV1Api.readNamespacedServiceAccount({ name: saName, namespace });
+      results.serviceAccount = { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        try {
+          await this.ctx.coreV1Api.createNamespacedServiceAccount({
+            namespace,
+            body: {
+              apiVersion: 'v1',
+              kind: 'ServiceAccount',
+              metadata: { name: saName, namespace },
+            },
+          });
+          results.serviceAccount = { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            results.serviceAccount = { created: false, alreadyExisted: true };
+          } else {
+            throw createError;
+          }
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    try {
+      await this.ctx.getCustomResource(rbacGroup, rbacVersion, namespace, 'roles', latencyRoleName);
+      results.latencyRole = { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        try {
+          await this.ctx.createCustomResource(rbacGroup, rbacVersion, namespace, 'roles', {
+            apiVersion: `${rbacGroup}/${rbacVersion}`,
+            kind: 'Role',
+            metadata: { name: latencyRoleName, namespace },
+            rules: latencyRules,
+          });
+          results.latencyRole = { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            results.latencyRole = { created: false, alreadyExisted: true };
+          } else {
+            throw createError;
+          }
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    try {
+      await this.ctx.getCustomResource(
+        rbacGroup,
+        rbacVersion,
+        namespace,
+        'rolebindings',
+        latencyRoleName,
+      );
+      results.latencyRoleBinding = { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        try {
+          await this.ctx.createCustomResource(rbacGroup, rbacVersion, namespace, 'rolebindings', {
+            apiVersion: `${rbacGroup}/${rbacVersion}`,
+            kind: 'RoleBinding',
+            metadata: { name: latencyRoleName, namespace },
+            subjects: [{ kind: 'ServiceAccount', name: saName, namespace }],
+            roleRef: { apiGroup: rbacGroup, kind: 'Role', name: latencyRoleName },
+          });
+          results.latencyRoleBinding = { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            results.latencyRoleBinding = { created: false, alreadyExisted: true };
+          } else {
+            throw createError;
+          }
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    try {
+      await this.ctx.getCustomResource(
+        rbacGroup,
+        rbacVersion,
+        namespace,
+        'roles',
+        configmapRoleName,
+      );
+      results.configmapRole = { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        try {
+          await this.ctx.createCustomResource(rbacGroup, rbacVersion, namespace, 'roles', {
+            apiVersion: `${rbacGroup}/${rbacVersion}`,
+            kind: 'Role',
+            metadata: { name: configmapRoleName, namespace },
+            rules: configmapRules,
+          });
+          results.configmapRole = { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            results.configmapRole = { created: false, alreadyExisted: true };
+          } else {
+            throw createError;
+          }
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    try {
+      await this.ctx.getCustomResource(
+        rbacGroup,
+        rbacVersion,
+        namespace,
+        'rolebindings',
+        configmapRoleName,
+      );
+      results.configmapRoleBinding = { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        try {
+          await this.ctx.createCustomResource(rbacGroup, rbacVersion, namespace, 'rolebindings', {
+            apiVersion: `${rbacGroup}/${rbacVersion}`,
+            kind: 'RoleBinding',
+            metadata: { name: configmapRoleName, namespace },
+            subjects: [{ kind: 'ServiceAccount', name: saName, namespace }],
+            roleRef: { apiGroup: rbacGroup, kind: 'Role', name: configmapRoleName },
+          });
+          results.configmapRoleBinding = { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            results.configmapRoleBinding = { created: false, alreadyExisted: true };
+          } else {
+            throw createError;
+          }
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    try {
+      await this.ctx.getClusterCustomResource(
+        rbacGroup,
+        rbacVersion,
+        'clusterroles',
+        latencyRoleName,
+      );
+      results.latencyClusterRole = { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        try {
+          await this.ctx.createClusterCustomResource(rbacGroup, rbacVersion, 'clusterroles', {
+            apiVersion: `${rbacGroup}/${rbacVersion}`,
+            kind: 'ClusterRole',
+            metadata: { name: latencyRoleName },
+            rules: latencyRules,
+          });
+          results.latencyClusterRole = { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            results.latencyClusterRole = { created: false, alreadyExisted: true };
+          } else {
+            throw createError;
+          }
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    try {
+      await this.ctx.getClusterCustomResource(
+        rbacGroup,
+        rbacVersion,
+        'clusterrolebindings',
+        latencyRoleName,
+      );
+      results.latencyClusterRoleBinding = { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        try {
+          await this.ctx.createClusterCustomResource(
+            rbacGroup,
+            rbacVersion,
+            'clusterrolebindings',
+            {
+              apiVersion: `${rbacGroup}/${rbacVersion}`,
+              kind: 'ClusterRoleBinding',
+              metadata: { name: latencyRoleName },
+              subjects: [
+                {
+                  kind: 'ServiceAccount',
+                  name: saName,
+                  namespace,
+                },
+              ],
+              roleRef: { apiGroup: rbacGroup, kind: 'ClusterRole', name: latencyRoleName },
+            },
+          );
+          results.latencyClusterRoleBinding = { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            results.latencyClusterRoleBinding = { created: false, alreadyExisted: true };
+          } else {
+            throw createError;
+          }
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    try {
+      await this.ctx.getClusterCustomResource(
+        rbacGroup,
+        rbacVersion,
+        'clusterroles',
+        configmapRoleName,
+      );
+      results.configmapClusterRole = { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        try {
+          await this.ctx.createClusterCustomResource(rbacGroup, rbacVersion, 'clusterroles', {
+            apiVersion: `${rbacGroup}/${rbacVersion}`,
+            kind: 'ClusterRole',
+            metadata: { name: configmapRoleName },
+            rules: configmapRules,
+          });
+          results.configmapClusterRole = { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            results.configmapClusterRole = { created: false, alreadyExisted: true };
+          } else {
+            throw createError;
+          }
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    try {
+      await this.ctx.getClusterCustomResource(
+        rbacGroup,
+        rbacVersion,
+        'clusterrolebindings',
+        configmapRoleName,
+      );
+      results.configmapClusterRoleBinding = { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        try {
+          await this.ctx.createClusterCustomResource(
+            rbacGroup,
+            rbacVersion,
+            'clusterrolebindings',
+            {
+              apiVersion: `${rbacGroup}/${rbacVersion}`,
+              kind: 'ClusterRoleBinding',
+              metadata: { name: configmapRoleName },
+              subjects: [
+                {
+                  kind: 'ServiceAccount',
+                  name: saName,
+                  namespace,
+                },
+              ],
+              roleRef: { apiGroup: rbacGroup, kind: 'ClusterRole', name: configmapRoleName },
+            },
+          );
+          results.configmapClusterRoleBinding = { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            results.configmapClusterRoleBinding = { created: false, alreadyExisted: true };
+          } else {
+            throw createError;
+          }
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    const anyCreated = Object.values(results).some((r) => r.created);
+    return { results, anyCreated };
+  }
+
+  /**
+   * Ensures the non-privileged test user exists in the cluster's htpasswd identity provider.
+   *
+   * Strategy:
+   *   1. Check for a Secret named `htpasswd-secret` in `openshift-config`.
+   *   2. If found, decode the existing htpasswd data; skip if the username is already present,
+   *      otherwise append the bcrypt hash for the new password and patch the secret.
+   *   3. If not found, create the secret and add/patch the HTPasswd IDP entry on the
+   *      `OAuth` cluster custom resource.
+   *
+   * Idempotent: repeated calls with the same username are safe (no-op if user already present).
+   * Uses a pure-Node bcrypt implementation to avoid a dependency on the `htpasswd` CLI binary.
+   */
+  /**
+   * Returns `true` if a user entry or OAuth IDP was newly created (triggering
+   * OAuth pod rollout), or `false` if everything was already in place.
+   */
+  async ensureNonPrivUserExists(username: string, password = 'test'): Promise<boolean> {
+    const SECRET_NAME = 'htpasswd-secret';
+    const SECRET_NS = 'openshift-config';
+    const IDP_NAME = 'test-users';
+
+    // --- 1. Generate a SHA-1 htpasswd entry using Node.js built-in crypto ---
+    // OpenShift OAuth accepts the {SHA} scheme (RFC 2307 LDAP password format).
+    // This avoids any dependency on the htpasswd CLI (httpd-tools), which is not
+    // installed on all hosts (e.g. fresh RHEL/Fedora, macOS, minimal containers).
+    // Format: username:{SHA}base64(sha1(password))
+    const sha1Hash = createHash('sha1').update(password).digest('base64');
+    const newEntry = `${username}:{SHA}${sha1Hash}`;
+
+    // --- 2. Read the existing secret (if any) ---
+    // Any error here (including 404 returned as a string body) means the secret
+    // does not exist yet — fall through to create it.
+    let existingData: string | undefined;
+    try {
+      const secret = unwrapApiBody<{ data?: Record<string, string> }>(
+        await this.ctx.coreV1Api.readNamespacedSecret({ name: SECRET_NAME, namespace: SECRET_NS }),
+      );
+      existingData = secret?.data?.htpasswd
+        ? Buffer.from(secret.data.htpasswd, 'base64').toString('utf8')
+        : undefined;
+    } catch {
+      // Secret does not exist or is unreadable — proceed to create it below.
+    }
+
+    if (existingData !== undefined) {
+      const lines = existingData.split('\n');
+      const existingLineIndex = lines.findIndex((line) => line.startsWith(`${username}:`));
+
+      let updatedContent: string;
+      if (existingLineIndex !== -1) {
+        // User exists — replace the line to ensure the expected password hash is current.
+        // This fixes stale hashes on clusters where the user was created with a different password.
+        lines[existingLineIndex] = newEntry;
+        updatedContent = lines.join('\n').trimEnd() + '\n';
+      } else {
+        // User not in file — append the new entry.
+        updatedContent = existingData.trimEnd() + '\n' + newEntry + '\n';
+      }
+
+      const encoded = Buffer.from(updatedContent).toString('base64');
+      try {
+        // The k8s client library defaults to application/json-patch+json — use JSON Patch ops
+        // to replace only the htpasswd data field so the content type matches the body format.
+        await this.ctx.coreV1Api.patchNamespacedSecret({
+          name: SECRET_NAME,
+          namespace: SECRET_NS,
+          body: [{ op: 'replace', path: '/data/htpasswd', value: encoded }],
+        });
+      } catch (patchError: unknown) {
+        throw new Error(`Failed to patch htpasswd secret: ${getErrorMessage(patchError)}`);
+      }
+    } else {
+      // --- 3. Secret does not exist — create it ---
+      const encoded = Buffer.from(newEntry + '\n').toString('base64');
+      try {
+        await this.ctx.coreV1Api.createNamespacedSecret({
+          namespace: SECRET_NS,
+          body: {
+            apiVersion: 'v1',
+            kind: 'Secret',
+            metadata: { name: SECRET_NAME, namespace: SECRET_NS },
+            data: { htpasswd: encoded },
+          },
+        });
+      } catch (createError: unknown) {
+        const e = asK8sClientError(createError);
+        const msg = getErrorMessage(createError);
+        if (e.statusCode !== 409 && e.body?.code !== 409 && !msg.includes('already exists')) {
+          throw new Error(`Failed to create htpasswd secret: ${msg}`);
+        }
+      }
+    }
+
+    // --- 4. Ensure the OAuth cluster resource has the HTPasswd IDP entry ---
+    // Always checked: the secret may have been created in a previous run but the OAuth
+    // CR patch may have failed (e.g. 400 from a stale client content-type bug).
+    try {
+      const oauth = unwrapApiBody<{
+        spec?: { identityProviders?: Array<{ name: string; type: string; htpasswd?: unknown }> };
+      }>(
+        await this.ctx.customObjectsApi.getClusterCustomObject({
+          group: 'config.openshift.io',
+          version: 'v1',
+          plural: 'oauths',
+          name: 'cluster',
+        }),
+      );
+
+      const idps: Array<{ name: string; type: string; htpasswd?: unknown }> =
+        oauth?.spec?.identityProviders ?? [];
+      const hasIdp = idps.some((idp) => idp.name === IDP_NAME && idp.type === 'HTPasswd');
+
+      if (!hasIdp) {
+        idps.push({
+          name: IDP_NAME,
+          type: 'HTPasswd',
+          htpasswd: { fileData: { name: SECRET_NAME } },
+        });
+
+        // The library defaults to application/json-patch+json, so send JSON Patch ops.
+        // Use 'replace' when identityProviders already existed, 'add' when it did not.
+        const patchOp = oauth?.spec?.identityProviders !== undefined ? 'replace' : 'add';
+        await this.ctx.customObjectsApi.patchClusterCustomObject({
+          group: 'config.openshift.io',
+          version: 'v1',
+          plural: 'oauths',
+          name: 'cluster',
+          body: [{ op: patchOp, path: '/spec/identityProviders', value: idps }],
+        });
+      }
+    } catch (oauthError: unknown) {
+      // OAuth patching is best-effort — if the IDP already exists via another mechanism
+      // (e.g. cluster was already configured), the login will still work.
+      const msg = getErrorMessage(oauthError);
+      // Re-throw only for unexpected errors; ignore "not found" (test env may not have OAuth CR)
+      const e = asK8sClientError(oauthError);
+      if (e.statusCode !== 404 && e.body?.code !== 404) {
+        throw new Error(`Failed to patch OAuth cluster resource: ${msg}`);
+      }
+    }
+
+    // --- 5. Remove stale Identity/User objects that map the username to a different IDP ---
+    // When a cluster is re-used after an IDP rename (e.g. "test" → "test-users"), OpenShift
+    // rejects login with "user cannot be claimed by identity X because it is mapped to Y".
+    // Delete any Identity for this username that does NOT match the current IDP_NAME so the
+    // user object is recreated with the correct mapping on next login.
+    try {
+      const expectedIdentityPrefix = `${IDP_NAME}:${username}`;
+      const identitiesResponse = unwrapApiBody<{
+        items?: Array<{ metadata?: { name?: string }; user?: { name?: string } }>;
+      }>(
+        await this.ctx.customObjectsApi.listClusterCustomObject({
+          group: 'user.openshift.io',
+          version: 'v1',
+          plural: 'identities',
+        }),
+      );
+      const staleIdentities = (identitiesResponse?.items ?? []).filter(
+        (id) =>
+          id.user?.name === username &&
+          id.metadata?.name !== undefined &&
+          id.metadata.name !== expectedIdentityPrefix,
+      );
+      for (const staleId of staleIdentities) {
+        const idName = staleId.metadata?.name;
+        if (!idName) continue;
+        await this.ctx.customObjectsApi
+          .deleteClusterCustomObject({
+            group: 'user.openshift.io',
+            version: 'v1',
+            plural: 'identities',
+            name: idName,
+          })
+          .catch(() => undefined);
+        // Also delete the User object so it is recreated with the correct identity on next login.
+        await this.ctx.customObjectsApi
+          .deleteClusterCustomObject({
+            group: 'user.openshift.io',
+            version: 'v1',
+            plural: 'users',
+            name: username,
+          })
+          .catch(() => undefined);
+      }
+    } catch {
+      // Best-effort — if identity cleanup fails the login attempt will still surface the error.
+    }
+
+    return true;
+  }
+
+  /**
+   * Creates an OVN layer2 NAD if missing.
+   */
+  async ensureOvnNadExists(
+    nadName: string,
+    namespace: string,
+  ): Promise<{
+    created: boolean;
+    alreadyExisted: boolean;
+  }> {
+    const group = 'k8s.cni.cncf.io';
+    const version = 'v1';
+    const plural = 'network-attachment-definitions';
+
+    try {
+      await this.ctx.getCustomResource(group, version, namespace, plural, nadName);
+      return { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        const nadResource = {
+          apiVersion: `${group}/${version}`,
+          kind: 'NetworkAttachmentDefinition',
+          metadata: {
+            name: nadName,
+            namespace,
+            labels: {
+              'app.kubernetes.io/managed-by': 'playwright-test',
+            },
+          },
+          spec: {
+            config: JSON.stringify({
+              cniVersion: '0.3.1',
+              type: 'ovn-k8s-cni-overlay',
+              topology: 'layer2',
+              netAttachDefName: `${namespace}/${nadName}`,
+            }),
+          },
+        };
+        try {
+          await this.ctx.createCustomResource(group, version, namespace, plural, nadResource);
+          return { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            return { created: false, alreadyExisted: true };
+          }
+          throw createError;
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Ensures ServiceAccount, Role, RoleBinding, and ClusterRoleBinding required for storage checkup tests.
+   *
+   */
+  async ensureStorageCheckupPermissions(namespace: string): Promise<{
+    results: Record<string, { created: boolean; alreadyExisted: boolean }>;
+    anyCreated: boolean;
+  }> {
+    const saName = 'storage-checkup-sa';
+    const roleName = 'storage-checkup-role';
+    const clusterRoleBindingName = 'kubevirt-storage-checkup-clustereader';
+
+    const storageRules = [
+      { apiGroups: [''], resources: ['configmaps'], verbs: ['get', 'update'] },
+      {
+        apiGroups: ['kubevirt.io'],
+        resources: ['virtualmachines'],
+        verbs: ['create', 'delete'],
+      },
+      { apiGroups: ['kubevirt.io'], resources: ['virtualmachineinstances'], verbs: ['get'] },
+      {
+        apiGroups: ['subresources.kubevirt.io'],
+        resources: ['virtualmachineinstances/addvolume', 'virtualmachineinstances/removevolume'],
+        verbs: ['update'],
+      },
+      {
+        apiGroups: ['kubevirt.io'],
+        resources: ['virtualmachineinstancemigrations'],
+        verbs: ['create'],
+      },
+      {
+        apiGroups: ['cdi.kubevirt.io'],
+        resources: ['datavolumes'],
+        verbs: ['create', 'delete'],
+      },
+      { apiGroups: [''], resources: ['persistentvolumeclaims'], verbs: ['delete'] },
+    ];
+
+    const results: Record<string, { created: boolean; alreadyExisted: boolean }> = {};
+
+    try {
+      await this.ctx.coreV1Api.readNamespacedServiceAccount({ name: saName, namespace });
+      results.serviceAccount = { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        try {
+          await this.ctx.coreV1Api.createNamespacedServiceAccount({
+            namespace,
+            body: {
+              apiVersion: 'v1',
+              kind: 'ServiceAccount',
+              metadata: { name: saName, namespace },
+            },
+          });
+          results.serviceAccount = { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            results.serviceAccount = { created: false, alreadyExisted: true };
+          } else {
+            throw createError;
+          }
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    const rbacGroup = 'rbac.authorization.k8s.io';
+    const rbacVersion = 'v1';
+
+    try {
+      await this.ctx.getCustomResource(rbacGroup, rbacVersion, namespace, 'roles', roleName);
+      results.role = { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        try {
+          await this.ctx.createCustomResource(rbacGroup, rbacVersion, namespace, 'roles', {
+            apiVersion: `${rbacGroup}/${rbacVersion}`,
+            kind: 'Role',
+            metadata: { name: roleName, namespace },
+            rules: storageRules,
+          });
+          results.role = { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            results.role = { created: false, alreadyExisted: true };
+          } else {
+            throw createError;
+          }
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    try {
+      await this.ctx.getCustomResource(rbacGroup, rbacVersion, namespace, 'rolebindings', roleName);
+      results.roleBinding = { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        try {
+          await this.ctx.createCustomResource(rbacGroup, rbacVersion, namespace, 'rolebindings', {
+            apiVersion: `${rbacGroup}/${rbacVersion}`,
+            kind: 'RoleBinding',
+            metadata: { name: roleName, namespace },
+            subjects: [{ kind: 'ServiceAccount', name: saName, namespace }],
+            roleRef: { apiGroup: rbacGroup, kind: 'Role', name: roleName },
+          });
+          results.roleBinding = { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            results.roleBinding = { created: false, alreadyExisted: true };
+          } else {
+            throw createError;
+          }
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    try {
+      await this.ctx.getClusterCustomResource(
+        rbacGroup,
+        rbacVersion,
+        'clusterrolebindings',
+        clusterRoleBindingName,
+      );
+      results.clusterRoleBinding = { created: false, alreadyExisted: true };
+    } catch (error: unknown) {
+      if (this.isNotFoundK8sError(error)) {
+        try {
+          await this.ctx.createClusterCustomResource(
+            rbacGroup,
+            rbacVersion,
+            'clusterrolebindings',
+            {
+              apiVersion: `${rbacGroup}/${rbacVersion}`,
+              kind: 'ClusterRoleBinding',
+              metadata: { name: clusterRoleBindingName },
+              subjects: [
+                {
+                  kind: 'ServiceAccount',
+                  name: saName,
+                  namespace,
+                },
+              ],
+              roleRef: { apiGroup: rbacGroup, kind: 'ClusterRole', name: 'cluster-reader' },
+            },
+          );
+          results.clusterRoleBinding = { created: true, alreadyExisted: false };
+        } catch (createError: unknown) {
+          if (this.isAlreadyExistsK8sError(createError)) {
+            results.clusterRoleBinding = { created: false, alreadyExisted: true };
+          } else {
+            throw createError;
+          }
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    const anyCreated = Object.values(results).some((r) => r.created);
+    return { results, anyCreated };
+  }
+
+  async getNamespaceCount(excludeSystem = true, onlyWithVms = false): Promise<number> {
+    const names = await this.getNamespaces();
+    let filtered = names;
+    if (excludeSystem) {
+      filtered = filtered.filter(
+        (n) => !n.startsWith('kube-') && !n.startsWith('openshift-') && n !== 'default',
+      );
+    }
+    if (!onlyWithVms) return filtered.length;
+    let count = 0;
+    for (const ns of filtered) {
+      const vms = await this.vm.listVirtualMachines(ns);
+      if (vms.length > 0) count += 1;
+    }
+    return count;
+  }
+
+  /** Expected resource allocation for VM Overview cards (running VMI count, vCPU, memory MiB, storage GiB). */
+  async getNamespaceResourceAllocationForOverview(namespace: string): Promise<{
+    runningCount: number;
+    vcpu: number;
+    memoryMiB: number;
+    storageGiB: number;
+  }> {
+    const vmis = (await this.ctx.listCustomResources(
+      'kubevirt.io',
+      'v1',
+      namespace,
+      'virtualmachineinstances',
+    )) as KubernetesResource[];
+    const running = vmis.filter(
+      (v) => (v.status as { phase?: string } | undefined)?.phase === 'Running',
+    );
+    let vcpu = 0;
+    let memoryBytes = 0;
+    for (const vmi of running) {
+      const spec = vmi.spec as
+        | {
+            domain?: {
+              cpu?: { sockets?: number; cores?: number };
+              memory?: { guest?: string };
+            };
+          }
+        | undefined;
+      const cpu = spec?.domain?.cpu;
+      const sockets = cpu?.sockets ?? 1;
+      const cores = cpu?.cores ?? 1;
+      vcpu += sockets * cores;
+      const mem = spec?.domain?.memory?.guest;
+      memoryBytes += this.parseQuantityToBytes(mem);
+    }
+    const memoryMiB = memoryBytes / 1024 / 1024;
+
+    const dvs = (await this.ctx.listCustomResources(
+      'cdi.kubevirt.io',
+      'v1beta1',
+      namespace,
+      'datavolumes',
+    )) as KubernetesResource[];
+    let storageBytes = 0;
+    for (const dv of dvs) {
+      const spec = dv.spec as
+        | { pvc?: { resources?: { requests?: { storage?: string } } } }
+        | undefined;
+      const req = spec?.pvc?.resources?.requests?.storage;
+      storageBytes += this.parseQuantityToBytes(req);
+    }
+    const storageGiB = storageBytes / 1024 / 1024 / 1024;
+
+    return {
+      runningCount: running.length,
+      vcpu,
+      memoryMiB,
+      storageGiB,
+    };
+  }
+
+  async getNamespaces(): Promise<string[]> {
+    if (getKubernetesProxyUrl()) {
+      try {
+        const body = await makeKubernetesProxyRequest(this.ctx.kc, 'GET', '/api/v1/namespaces');
+        const items = (body as unknown as KubernetesListResource<KubernetesResource>).items ?? [];
+        return items
+          .map((item) => item.metadata?.name)
+          .filter((n): n is string => typeof n === 'string');
+      } catch (error: unknown) {
+        throw new Error(`Failed to list namespaces: ${getErrorMessage(error)}`);
+      }
+    }
+
+    try {
+      const response = await this.ctx.coreV1Api.listNamespace();
+      const responseBody = unwrapApiBody<KubernetesListResource>(response as unknown);
+      const items = responseBody.items ?? [];
+      return items
+        .map((item) => item.metadata?.name)
+        .filter((n): n is string => typeof n === 'string');
+    } catch (error: unknown) {
+      throw new Error(`Failed to list namespaces: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async getPods(namespace: string) {
+    try {
+      const response = await this.ctx.coreV1Api.listNamespacedPod({ namespace });
+      return response.items || [];
+    } catch (error: unknown) {
+      throw new Error(`Failed to get pods in namespace ${namespace}: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async grantUserAccessToNamespace(namespace: string, username: string): Promise<void> {
+    if (this.isSystemNamespaceExcludedForTestUser(namespace)) {
+      return;
+    }
+    const bindingName = 'test-user-admin';
+    try {
+      const roleBinding: k8s.V1RoleBinding = {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'RoleBinding',
+        metadata: {
+          name: bindingName,
+          namespace,
+        },
+        roleRef: {
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'ClusterRole',
+          name: 'admin',
+        },
+        subjects: [
+          {
+            apiGroup: 'rbac.authorization.k8s.io',
+            kind: 'User',
+            name: username,
+          },
+        ],
+      };
+      await this.ctx.rbacApi.createNamespacedRoleBinding({ namespace, body: roleBinding });
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (
+        e.statusCode === 409 ||
+        e.code === 409 ||
+        e.body?.code === 409 ||
+        msg.includes('409') ||
+        msg.includes('already exists')
+      ) {
+        try {
+          const existing = await this.ctx.rbacApi.readNamespacedRoleBinding({
+            name: bindingName,
+            namespace,
+          });
+          const body = unwrapApiBody<KubernetesResource>(existing);
+          const subjects = Array.isArray(body.subjects) ? body.subjects : [];
+          const hasUser = subjects.some(
+            (s: { kind?: string; name?: string }) => s.kind === 'User' && s.name === username,
+          );
+          if (hasUser) {
+            return;
+          }
+          const newSubject = {
+            apiGroup: 'rbac.authorization.k8s.io' as const,
+            kind: 'User' as const,
+            name: username,
+          };
+          // The k8s client library defaults to application/json-patch+json — use JSON Patch ops.
+          await this.ctx.rbacApi.patchNamespacedRoleBinding({
+            name: bindingName,
+            namespace,
+            body: [{ op: 'replace', path: '/subjects', value: [...subjects, newSubject] }],
+          });
+        } catch (patchError: unknown) {
+          throw new Error(
+            `Failed to add user ${username} to RoleBinding in namespace ${namespace}: ${getErrorMessage(
+              patchError,
+            )}`,
+          );
+        }
+      } else {
+        throw new Error(
+          `Failed to grant user ${username} access to namespace ${namespace}: ${msg}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Grants the non-priv test user cluster-wide read access to CDI resources
+   * (datasources, datavolumes, dataimportcrons, datavolumes/source).
+   *
+   * The built-in `view` ClusterRole does not cover CDI custom resources, so the
+   * Bootable Volumes page returns 403 for non-priv users without this grant.
+   * A dedicated ClusterRole + ClusterRoleBinding is created idempotently.
+   */
+  async grantUserCdiClusterReadAccess(username: string): Promise<void> {
+    const roleName = 'test-user-cdi-reader';
+    const bindingName = `test-user-cdi-reader-${username
+      .replace(/[^a-z0-9]/gi, '-')
+      .toLowerCase()}`;
+
+    // Ensure the ClusterRole exists (idempotent)
+    try {
+      await this.ctx.rbacApi.createClusterRole({
+        body: {
+          apiVersion: 'rbac.authorization.k8s.io/v1',
+          kind: 'ClusterRole',
+          metadata: { name: roleName },
+          rules: [
+            {
+              apiGroups: ['cdi.kubevirt.io'],
+              resources: ['datasources', 'datavolumes', 'dataimportcrons', 'cdiconfigs'],
+              verbs: ['get', 'list', 'watch'],
+            },
+          ],
+        },
+      });
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (
+        e.statusCode !== 409 &&
+        e.code !== 409 &&
+        e.body?.code !== 409 &&
+        !msg.includes('already exists')
+      ) {
+        throw new Error(`Failed to create CDI reader ClusterRole: ${msg}`);
+      }
+    }
+
+    // Bind the ClusterRole to the user (idempotent)
+    try {
+      await this.ctx.rbacApi.createClusterRoleBinding({
+        body: {
+          apiVersion: 'rbac.authorization.k8s.io/v1',
+          kind: 'ClusterRoleBinding',
+          metadata: { name: bindingName },
+          roleRef: {
+            apiGroup: 'rbac.authorization.k8s.io',
+            kind: 'ClusterRole',
+            name: roleName,
+          },
+          subjects: [
+            {
+              apiGroup: 'rbac.authorization.k8s.io',
+              kind: 'User',
+              name: username,
+            },
+          ],
+        },
+      });
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (
+        e.statusCode !== 409 &&
+        e.code !== 409 &&
+        e.body?.code !== 409 &&
+        !msg.includes('already exists')
+      ) {
+        throw new Error(`Failed to grant CDI cluster read access for user ${username}: ${msg}`);
+      }
+    }
+  }
+
+  /**
+   * Grants the test user a cluster-level ClusterRoleBinding for the `view` ClusterRole.
+   * This gives the non-priv user read access to resources across all namespaces,
+   * enabling access to the VM creation wizard catalog, templates, bootable volumes, and
+   * overview widgets that query cluster-wide resources.
+   *
+   * The binding name is deterministic so repeated calls are idempotent (409 → skip).
+   */
+  async grantUserClusterViewAccess(username: string): Promise<void> {
+    const bindingName = `test-user-cluster-view-${username
+      .replace(/[^a-z0-9]/gi, '-')
+      .toLowerCase()}`;
+    try {
+      const clusterRoleBinding: k8s.V1ClusterRoleBinding = {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'ClusterRoleBinding',
+        metadata: { name: bindingName },
+        roleRef: {
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'ClusterRole',
+          name: 'view',
+        },
+        subjects: [
+          {
+            apiGroup: 'rbac.authorization.k8s.io',
+            kind: 'User',
+            name: username,
+          },
+        ],
+      };
+      await this.ctx.rbacApi.createClusterRoleBinding({ body: clusterRoleBinding });
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (
+        e.statusCode === 409 ||
+        e.code === 409 ||
+        e.body?.code === 409 ||
+        msg.includes('already exists')
+      ) {
+        return;
+      }
+      throw new Error(`Failed to grant cluster view access for user ${username}: ${msg}`);
+    }
+  }
+
+  /**
+   * Grant the test user a custom Role with ONLY addvolume/removevolume subresource permissions
+   * (subresources.kubevirt.io). This is the minimum permission required to hotplug a disk to a
+   * running VM via the WebUI (CNV-83495 fix). Intentionally does NOT grant kubevirt.io:edit or
+   * admin, so the SubjectAccessReview for the main VM resource fails and only the subresource
+   * check passes — exercising the exact fix in DiskList.tsx.
+   */
+  async grantUserHotplugSubresourceAccess(namespace: string, username: string): Promise<void> {
+    const roleName = 'test-user-hotplug-subresource';
+    const bindingName = 'test-user-hotplug-subresource';
+    try {
+      const role: k8s.V1Role = {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'Role',
+        metadata: { name: roleName, namespace },
+        rules: [
+          {
+            apiGroups: ['subresources.kubevirt.io'],
+            resources: ['virtualmachines/addvolume', 'virtualmachines/removevolume'],
+            verbs: ['update'],
+          },
+        ],
+      };
+      await this.ctx.rbacApi.createNamespacedRole({ namespace, body: role });
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (e.statusCode !== 409 && e.body?.code !== 409 && !msg.includes('409')) {
+        throw new Error(
+          `Failed to create hotplug subresource Role in namespace ${namespace}: ${msg}`,
+        );
+      }
+    }
+    try {
+      const roleBinding: k8s.V1RoleBinding = {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'RoleBinding',
+        metadata: { name: bindingName, namespace },
+        roleRef: {
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'Role',
+          name: roleName,
+        },
+        subjects: [{ apiGroup: 'rbac.authorization.k8s.io', kind: 'User', name: username }],
+      };
+      await this.ctx.rbacApi.createNamespacedRoleBinding({ namespace, body: roleBinding });
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (e.statusCode !== 409 && e.body?.code !== 409 && !msg.includes('409')) {
+        throw new Error(
+          `Failed to create hotplug subresource RoleBinding in namespace ${namespace}: ${msg}`,
+        );
+      }
+    }
+  }
+
+  async grantUserKubevirtAccessToNamespace(namespace: string, username: string): Promise<void> {
+    if (this.isSystemNamespaceExcludedForTestUser(namespace)) {
+      return;
+    }
+    const bindingName = 'test-user-kubevirt-edit';
+    const clusterRoleName = 'kubevirt.io:edit';
+    try {
+      const roleBinding: k8s.V1RoleBinding = {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'RoleBinding',
+        metadata: {
+          name: bindingName,
+          namespace,
+        },
+        roleRef: {
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'ClusterRole',
+          name: clusterRoleName,
+        },
+        subjects: [
+          {
+            apiGroup: 'rbac.authorization.k8s.io',
+            kind: 'User',
+            name: username,
+          },
+        ],
+      };
+      await this.ctx.rbacApi.createNamespacedRoleBinding({ namespace, body: roleBinding });
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (
+        e.statusCode === 409 ||
+        e.code === 409 ||
+        e.body?.code === 409 ||
+        msg.includes('already exists')
+      ) {
+        try {
+          const existing = await this.ctx.rbacApi.readNamespacedRoleBinding({
+            name: bindingName,
+            namespace,
+          });
+          const body = unwrapApiBody<KubernetesResource>(existing);
+          const subjects = Array.isArray(body.subjects) ? body.subjects : [];
+          const hasUser = subjects.some(
+            (s: { kind?: string; name?: string }) => s.kind === 'User' && s.name === username,
+          );
+          if (hasUser) {
+            return;
+          }
+          const newSubject = {
+            apiGroup: 'rbac.authorization.k8s.io' as const,
+            kind: 'User' as const,
+            name: username,
+          };
+          // The k8s client library defaults to application/json-patch+json — use JSON Patch ops.
+          await this.ctx.rbacApi.patchNamespacedRoleBinding({
+            name: bindingName,
+            namespace,
+            body: [{ op: 'replace', path: '/subjects', value: [...subjects, newSubject] }],
+          });
+        } catch (patchError: unknown) {
+          throw new Error(
+            `Failed to add user ${username} to KubeVirt RoleBinding in namespace ${namespace}: ${getErrorMessage(
+              patchError,
+            )}`,
+          );
+        }
+      } else {
+        // 404 on the namespace itself — it may not be ready yet; re-raise with context
+        if (
+          e.statusCode === 404 ||
+          e.code === 404 ||
+          e.body?.code === 404 ||
+          msg.includes('404') ||
+          msg.includes('not found')
+        ) {
+          throw new Error(
+            `Failed to grant user ${username} KubeVirt access in namespace ${namespace}: namespace not found (404). ` +
+              `Ensure the namespace exists and is Active before granting RBAC.`,
+          );
+        }
+        throw new Error(
+          `Failed to grant user ${username} KubeVirt access in namespace ${namespace}: ${msg}. ` +
+            `Ensure ClusterRole ${clusterRoleName} exists (KubeVirt operator install).`,
+        );
+      }
+    }
+  }
+
+  async grantUserTemplateListAccess(namespace: string, username: string): Promise<void> {
+    if (this.isSystemNamespaceExcludedForTestUser(namespace)) {
+      return;
+    }
+    const roleName = 'test-user-template-reader';
+    const bindingName = 'test-user-template-reader';
+    try {
+      const role: k8s.V1Role = {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'Role',
+        metadata: { name: roleName, namespace },
+        rules: [
+          {
+            apiGroups: ['template.openshift.io'],
+            resources: ['templates'],
+            verbs: ['get', 'list'],
+          },
+        ],
+      };
+      await this.ctx.rbacApi.createNamespacedRole({ namespace, body: role });
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (e.statusCode !== 409 && e.body?.code !== 409 && !msg.includes('409')) {
+        throw new Error(`Failed to create Role ${roleName} in namespace ${namespace}: ${msg}`);
+      }
+    }
+    try {
+      const roleBinding: k8s.V1RoleBinding = {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'RoleBinding',
+        metadata: { name: bindingName, namespace },
+        roleRef: {
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'Role',
+          name: roleName,
+        },
+        subjects: [{ apiGroup: 'rbac.authorization.k8s.io', kind: 'User', name: username }],
+      };
+      await this.ctx.rbacApi.createNamespacedRoleBinding({ namespace, body: roleBinding });
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (e.statusCode !== 409 && e.body?.code !== 409 && !msg.includes('409')) {
+        throw new Error(
+          `Failed to create RoleBinding ${bindingName} in namespace ${namespace}: ${msg}`,
+        );
+      }
+    }
+  }
+
+  async grantUserViewAccessToNamespace(namespace: string, username: string): Promise<void> {
+    const bindingName = 'test-user-view';
+    try {
+      const roleBinding: k8s.V1RoleBinding = {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'RoleBinding',
+        metadata: { name: bindingName, namespace },
+        roleRef: {
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'ClusterRole',
+          name: 'view',
+        },
+        subjects: [{ apiGroup: 'rbac.authorization.k8s.io', kind: 'User', name: username }],
+      };
+      await this.ctx.rbacApi.createNamespacedRoleBinding({ namespace, body: roleBinding });
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (
+        e.statusCode === 409 ||
+        e.code === 409 ||
+        e.body?.code === 409 ||
+        msg.includes('already exists')
+      ) {
+        return;
+      }
+      throw new Error(
+        `Failed to grant user ${username} view access in namespace ${namespace}: ${msg}`,
+      );
+    }
+  }
+
+  async migrationPolicyExists(policyName: string): Promise<boolean> {
+    try {
+      await this.ctx.getClusterCustomResource(
+        'migrations.kubevirt.io',
+        'v1alpha1',
+        'migrationpolicies',
+        policyName,
+      );
+      return true;
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      if (msg.includes('404') || msg.includes('not found')) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async namespaceExists(name: string): Promise<boolean> {
+    try {
+      const ns = await this.ctx.withRetry(
+        () => this.ctx.getNamespaceByName(name),
+        `Check namespace ${name} exists`,
+      );
+      return !!ns;
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (
+        e.statusCode === 404 ||
+        e.code === 404 ||
+        e.body?.code === 404 ||
+        e.response?.statusCode === 404 ||
+        msg.includes('404') ||
+        msg.includes('not found') ||
+        msg.includes('NotFound')
+      ) {
+        return false;
+      }
+      throw new Error(`Failed to check namespace ${name}: ${msg}`);
+    }
+  }
+
+  async serviceExists(name: string, namespace: string): Promise<boolean> {
+    try {
+      await (
+        this.ctx.coreV1Api as unknown as {
+          readNamespacedService: (p: { name: string; namespace: string }) => Promise<unknown>;
+        }
+      ).readNamespacedService({ name, namespace });
+      return true;
+    } catch (error: unknown) {
+      const e = asK8sClientError(error);
+      const msg = getErrorMessage(error);
+      if (
+        e.statusCode === 404 ||
+        e.response?.status === 404 ||
+        msg.includes('404') ||
+        msg.includes('not found')
+      ) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async setupTestNamespace(namespace: string, labels?: Record<string, string>): Promise<boolean> {
+    const exists = await this.namespaceExists(namespace);
+
+    if (exists) {
+      const isReady = await this.waitForNamespaceReady(namespace);
+      if (!isReady) {
+        throw new Error(`Namespace ${namespace} exists but did not become Active`);
+      }
+      if (EnvVariables.isNonPrivUser) {
+        await this.grantUserAccessToNamespace(namespace, EnvVariables.uiLoginUsername);
+        await this.grantUserKubevirtAccessToNamespace(namespace, EnvVariables.uiLoginUsername);
+      }
+      return true;
+    }
+
+    const created = await this.createNamespace(namespace, labels);
+
+    if (created) {
+      const isReady = await this.waitForNamespaceReady(namespace);
+      if (!isReady) {
+        throw new Error(`Namespace ${namespace} was created but did not become Active`);
+      }
+    }
+    return created;
+  }
+
+  async verifyMigrationPolicyCreated(
+    policyName: string,
+    timeoutMs = 30000,
+  ): Promise<{
+    error?: string;
+    exists: boolean;
+    policy?: KubernetesResource;
+  }> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const policy = await this.ctx.getClusterCustomResource(
+          'migrations.kubevirt.io',
+          'v1alpha1',
+          'migrationpolicies',
+          policyName,
+        );
+
+        return {
+          exists: true,
+          policy,
+        };
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        if (msg.includes('404') || msg.includes('not found')) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return {
+          error: msg,
+          exists: false,
+        };
+      }
+    }
+
+    return {
+      error: `Timeout after ${timeoutMs}ms waiting for MigrationPolicy ${policyName} to be created`,
+      exists: false,
+    };
+  }
+
+  async waitForNamespaceReady(name: string, timeout = 30000): Promise<boolean> {
+    const pollInterval = 1000;
+    const startTime = Date.now();
+
+    if (getKubernetesProxyUrl()) {
+      while (Date.now() - startTime < timeout) {
+        try {
+          const ns = await makeKubernetesProxyRequest(
+            this.ctx.kc,
+            'GET',
+            `/api/v1/namespaces/${name}`,
+          );
+          const unwrapped = unwrapApiBody<KubernetesResource>(ns as unknown);
+          const phase = (unwrapped.status as { phase?: string } | undefined)?.phase;
+
+          if (phase === 'Active') {
+            return true;
+          }
+        } catch (error: unknown) {
+          const e = asK8sClientError(error);
+          const msg = getErrorMessage(error);
+          const is404 = e.statusCode === 404 || e.body?.code === 404 || msg.includes('404');
+          if (!is404) {
+            throw new Error(`Failed to check namespace ${name} status: ${msg}`);
+          }
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, pollInterval));
+      }
+
+      return false;
+    }
+
+    while (Date.now() - startTime < timeout) {
+      try {
+        const ns = await this.ctx.getNamespaceByName(name);
+        const unwrapped = unwrapApiBody<KubernetesResource>(ns as unknown);
+        const phase = (unwrapped.status as { phase?: string } | undefined)?.phase;
+
+        if (phase === 'Active') {
+          return true;
+        }
+      } catch (error: unknown) {
+        const e = asK8sClientError(error);
+        const msg = getErrorMessage(error);
+        if (e.statusCode !== 404 && e.body?.code !== 404) {
+          throw new Error(`Failed to check namespace ${name} status: ${msg}`);
+        }
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+    }
+
+    return false;
+  }
+
+  async waitForPodReady(namespace: string, podName: string, timeoutMs = 60000): Promise<boolean> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const response = await this.ctx.coreV1Api.readNamespacedPod({ name: podName, namespace });
+        const pod = response;
+
+        if (
+          pod.status?.phase === 'Running' &&
+          pod.status?.conditions?.some(
+            (c: k8s.V1PodCondition) => c.type === 'Ready' && c.status === 'True',
+          )
+        ) {
+          return true;
+        }
+      } catch {
+        //
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+
+    return false;
+  }
+
+  async waitForServiceExists(
+    name: string,
+    namespace: string,
+    timeoutMs: number = TestTimeouts.VM_BOOTUP,
+    pollIntervalMs: number = TestTimeouts.POLLING_INTERVAL,
+  ): Promise<boolean> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (await this.serviceExists(name, namespace)) {
+        return true;
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+    return false;
+  }
+
+  async waitForTestUserInNamespace(
+    namespace: string,
+    username: string,
+    timeoutMs = 15 * 1000,
+  ): Promise<void> {
+    const bindingName = 'test-user-admin';
+    const deadline = Date.now() + timeoutMs;
+    const pollMs = TestTimeouts.POLLING_INTERVAL;
+
+    while (Date.now() < deadline) {
+      try {
+        const existing = await this.ctx.rbacApi.readNamespacedRoleBinding({
+          name: bindingName,
+          namespace,
+        });
+        const body = unwrapApiBody<KubernetesResource>(existing);
+        const subjects = Array.isArray(body.subjects) ? body.subjects : [];
+        const hasUser = subjects.some(
+          (s: { kind?: string; name?: string }) => s.kind === 'User' && s.name === username,
+        );
+        if (hasUser) {
+          return;
+        }
+      } catch {
+        // RoleBinding may not exist yet or not have user
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollMs));
+    }
+    throw new Error(
+      `Test user ${username} was not in namespace ${namespace} within ${timeoutMs}ms`,
+    );
+  }
+}

--- a/playwright/src/clients/handlers/node-handler.ts
+++ b/playwright/src/clients/handlers/node-handler.ts
@@ -1,0 +1,267 @@
+import type { KubernetesCondition, KubernetesResource } from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+import type { VirtualMachineHandler } from './vm-handler';
+
+type CoreV1ApiNodeOps = {
+  readNode: (args: { name: string }) => Promise<{ body?: KubernetesResource } | KubernetesResource>;
+  replaceNode: (args: {
+    name: string;
+    body: KubernetesResource;
+  }) => Promise<{ body?: KubernetesResource } | KubernetesResource>;
+};
+
+export class NodeHandler {
+  constructor(
+    private readonly ctx: KubernetesHandlerContext,
+    private readonly vm: VirtualMachineHandler,
+  ) {}
+
+  private parseCpuQuantity(q: string | undefined): number {
+    if (!q || typeof q !== 'string') return 0;
+    const s = q.trim();
+    if (s.endsWith('m') && !s.endsWith('mi')) {
+      return parseFloat(s) || 0;
+    }
+    const num = parseFloat(s) || 0;
+    return num * 1000;
+  }
+
+  private parseMemoryQuantity(q: string | undefined): number {
+    if (!q || typeof q !== 'string') return 0;
+    const s = q.trim();
+    const match = s.match(/^(\d+(?:\.\d+)?)\s*([KMGTPE]i?)?$/);
+    if (!match) return 0;
+    const num = parseFloat(match[1]);
+    const unit = (match[2] || '').toLowerCase();
+    if (unit === 'ki') return num * 1024;
+    if (unit === 'mi') return num * 1024 * 1024;
+    if (unit === 'gi') return num * 1024 * 1024 * 1024;
+    if (unit === 'ti') return num * 1024 * 1024 * 1024 * 1024;
+    return num;
+  }
+
+  async cordonNode(nodeName: string): Promise<void> {
+    const maxAttempts = 3;
+    let lastError: Error | null = null;
+    const api = this.ctx.coreV1Api as unknown as CoreV1ApiNodeOps;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const response = await api.readNode({ name: nodeName });
+        const r = response as { body?: KubernetesResource } | KubernetesResource;
+        const node = ('body' in r && r.body !== undefined ? r.body : r) as KubernetesResource;
+        if (!node) throw new Error('Node not found');
+        const spec = (node.spec ?? {}) as Record<string, unknown>;
+        const body: KubernetesResource = {
+          ...node,
+          spec: { ...spec, unschedulable: true },
+        };
+        await api.replaceNode({ name: nodeName, body });
+        return;
+      } catch (error: unknown) {
+        lastError = error instanceof Error ? error : new Error(getErrorMessage(error));
+        const msg = getErrorMessage(error);
+        const bodyCode =
+          typeof error === 'object' && error !== null && 'body' in error
+            ? (error as { body?: { code?: number } }).body?.code
+            : undefined;
+        const rspBodyCode =
+          typeof error === 'object' && error !== null && 'response' in error
+            ? (error as { response?: { body?: { code?: number } } }).response?.body?.code
+            : undefined;
+        const is409 =
+          rspBodyCode === 409 ||
+          bodyCode === 409 ||
+          msg.includes('409') ||
+          msg.includes('Conflict');
+        if (!is409 || attempt === maxAttempts) {
+          throw new Error(`Failed to cordon node ${nodeName}: ${msg || String(error)}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+    throw lastError || new Error(`Failed to cordon node ${nodeName}`);
+  }
+
+  async getMigrationTargetNodes(excludeNodeName?: string): Promise<KubernetesResource[]> {
+    try {
+      const allNodes = await this.getNodes();
+      return allNodes.filter((node) => {
+        const conditions =
+          ((node.status as Record<string, unknown> | undefined)
+            ?.conditions as KubernetesCondition[]) || [];
+        const readyCondition = conditions.find((c) => c.type === 'Ready');
+        if (readyCondition?.status !== 'True') {
+          return false;
+        }
+
+        const labels = node.metadata?.labels || {};
+        const hasWorkerLabel =
+          labels['node-role.kubernetes.io/worker'] === '' ||
+          labels['node-role.kubernetes.io/worker'] === 'true' ||
+          node.metadata?.name?.toLowerCase().includes('worker');
+        if (!hasWorkerLabel) {
+          return false;
+        }
+
+        const schedulingCondition = conditions.find((c) => c.type === 'SchedulingDisabled');
+        if (schedulingCondition?.status === 'True') {
+          return false;
+        }
+
+        if (excludeNodeName && node.metadata?.name === excludeNodeName) {
+          return false;
+        }
+
+        return true;
+      });
+    } catch (error: unknown) {
+      throw new Error(`Failed to get migration target nodes: ${getErrorMessage(error)}`);
+    }
+  }
+
+  getNodeNameWithLowerAllocatable(nodes: KubernetesResource[]): string | undefined {
+    if (!nodes?.length) return undefined;
+    let minScore = Number.POSITIVE_INFINITY;
+    let name: string | undefined;
+    for (const node of nodes) {
+      const allocatable =
+        ((node.status as Record<string, unknown> | undefined)?.['allocatable'] as
+          | Record<string, string>
+          | undefined) || {};
+      const cpu = this.parseCpuQuantity(allocatable.cpu);
+      const memBytes = this.parseMemoryQuantity(allocatable.memory);
+      const score = cpu + memBytes / (1024 * 1024 * 1024);
+      if (score < minScore) {
+        minScore = score;
+        name = node?.metadata?.name;
+      }
+    }
+    return name;
+  }
+
+  async getNodes() {
+    try {
+      const response = await this.ctx.coreV1Api.listNode();
+      const r = response as unknown as KubernetesResource & {
+        items?: KubernetesResource[];
+        body?: { items?: KubernetesResource[] };
+      };
+      return r.items ?? r.body?.items ?? [];
+    } catch (error: unknown) {
+      throw new Error(`Failed to get nodes: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async getNodesWithVmsInNamespace(namespace: string): Promise<string[]> {
+    try {
+      const vms = await this.vm.listVirtualMachines(namespace);
+      const nodeNames = new Set<string>();
+
+      for (const vm of vms) {
+        if (vm.metadata?.name) {
+          try {
+            const nodeName = await this.getVmNodeName(vm.metadata.name, namespace);
+            if (nodeName) {
+              nodeNames.add(nodeName);
+            }
+          } catch {
+            continue;
+          }
+        }
+      }
+
+      return Array.from(nodeNames);
+    } catch (error: unknown) {
+      throw new Error(
+        `Failed to get nodes with VMs in namespace ${namespace}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  async getReadyNodes() {
+    try {
+      const nodes = await this.getNodes();
+      return nodes.filter((node) => {
+        const conditions =
+          ((node.status as Record<string, unknown> | undefined)
+            ?.conditions as KubernetesCondition[]) || [];
+        const readyCondition = conditions.find((c) => c.type === 'Ready');
+        return readyCondition?.status === 'True';
+      });
+    } catch (error: unknown) {
+      throw new Error(`Failed to get ready nodes: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async getVmNodeName(vmName: string, namespace: string): Promise<string | null> {
+    try {
+      const vmi = (await this.vm.getVirtualMachineInstance(
+        vmName,
+        namespace,
+      )) as KubernetesResource;
+
+      const st = vmi.status as Record<string, unknown> | undefined;
+      const nodeNm = st?.['nodeName'];
+      if (typeof nodeNm === 'string' && nodeNm) {
+        return nodeNm;
+      }
+
+      return null;
+    } catch (error: unknown) {
+      throw new Error(`Failed to get VM node name: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async isClusterSingleNode(): Promise<boolean> {
+    try {
+      const readyNodes = await this.getReadyNodes();
+      return readyNodes.length === 1;
+    } catch (error: unknown) {
+      throw new Error(`Failed to determine if cluster is single-node: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async uncordonNode(nodeName: string): Promise<void> {
+    const maxAttempts = 3;
+    let lastError: Error | null = null;
+    const api = this.ctx.coreV1Api as unknown as CoreV1ApiNodeOps;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const response = await api.readNode({ name: nodeName });
+        const r = response as { body?: KubernetesResource } | KubernetesResource;
+        const node = ('body' in r && r.body !== undefined ? r.body : r) as KubernetesResource;
+        if (!node) throw new Error('Node not found');
+        const spec = (node.spec ?? {}) as Record<string, unknown>;
+        const body: KubernetesResource = {
+          ...node,
+          spec: { ...spec, unschedulable: false },
+        };
+        await api.replaceNode({ name: nodeName, body });
+        return;
+      } catch (error: unknown) {
+        lastError = error instanceof Error ? error : new Error(getErrorMessage(error));
+        const msg = getErrorMessage(error);
+        const bodyCode =
+          typeof error === 'object' && error !== null && 'body' in error
+            ? (error as { body?: { code?: number } }).body?.code
+            : undefined;
+        const rspBodyCode =
+          typeof error === 'object' && error !== null && 'response' in error
+            ? (error as { response?: { body?: { code?: number } } }).response?.body?.code
+            : undefined;
+        const is409 =
+          rspBodyCode === 409 ||
+          bodyCode === 409 ||
+          msg.includes('409') ||
+          msg.includes('Conflict');
+        if (!is409 || attempt === maxAttempts) {
+          throw new Error(`Failed to uncordon node ${nodeName}: ${msg || String(error)}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+    throw lastError || new Error(`Failed to uncordon node ${nodeName}`);
+  }
+}

--- a/playwright/src/clients/handlers/policy-handler.ts
+++ b/playwright/src/clients/handlers/policy-handler.ts
@@ -1,0 +1,280 @@
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+import { TestTimeouts } from '@/utils/test-config';
+
+import { getKubernetesProxyUrl, makeKubernetesProxyRequest } from '../kubernetes-proxy';
+
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+import type { NamespaceHandler } from './namespace-handler';
+import type { VirtualMachineHandler } from './vm-handler';
+
+export class PolicyHandler {
+  constructor(
+    private readonly ctx: KubernetesHandlerContext,
+    private readonly namespace: NamespaceHandler,
+    private readonly vm: VirtualMachineHandler,
+  ) {}
+
+  async deleteNamespacedService(namespace: string, name: string): Promise<void> {
+    const proxyUrl = getKubernetesProxyUrl();
+
+    if (proxyUrl) {
+      await makeKubernetesProxyRequest(
+        this.ctx.kc,
+        'DELETE',
+        `/api/v1/namespaces/${encodeURIComponent(namespace)}/services/${encodeURIComponent(name)}`,
+      );
+      return;
+    }
+
+    await this.ctx.coreV1Api.deleteNamespacedService({ name, namespace });
+  }
+
+  async getClusterVirtualMachineCount(): Promise<number> {
+    const namespaces = await this.namespace.getNamespaces();
+    let total = 0;
+    for (const ns of namespaces) {
+      const vms = await this.vm.listVirtualMachines(ns);
+      total += vms.length;
+    }
+    return total;
+  }
+
+  async getMigrationPolicy(policyName: string) {
+    return await this.ctx.getClusterCustomResource(
+      'migrations.kubevirt.io',
+      'v1alpha1',
+      'migrationpolicies',
+      policyName,
+    );
+  }
+
+  async getNamespaceResourceAllocationForOverview(namespace: string): Promise<{
+    runningCount: number;
+    vcpu: number;
+    memoryMiB: number;
+    storageGiB: number;
+  }> {
+    const vmis = (await this.ctx.listCustomResources(
+      'kubevirt.io',
+      'v1',
+      namespace,
+      'virtualmachineinstances',
+    )) as KubernetesResource[];
+    const running = vmis.filter((v) => v?.status?.phase === 'Running');
+    let vcpu = 0;
+    let memoryBytes = 0;
+    for (const vmi of running) {
+      const cpu = (
+        (vmi?.spec as Record<string, unknown> | undefined)?.['domain'] as
+          | Record<string, unknown>
+          | undefined
+      )?.['cpu'];
+      const sockets = (cpu as Record<string, unknown> | undefined)?.sockets ?? 1;
+      const cores = (cpu as Record<string, unknown> | undefined)?.cores ?? 1;
+      vcpu += Number(sockets) * Number(cores);
+      const mem = (
+        (vmi?.spec as Record<string, unknown> | undefined)?.['domain'] as
+          | Record<string, unknown>
+          | undefined
+      )?.['memory'] as Record<string, unknown> | undefined;
+      const guest = mem?.['guest'];
+      let guestStr: string | undefined;
+      if (typeof guest === 'string') {
+        guestStr = guest;
+      } else if (guest != null) {
+        guestStr = String(guest);
+      }
+      memoryBytes += this.parseQuantityToBytes(guestStr);
+    }
+    const memoryMiB = memoryBytes / 1024 / 1024;
+
+    const dvs = (await this.ctx.listCustomResources(
+      'cdi.kubevirt.io',
+      'v1beta1',
+      namespace,
+      'datavolumes',
+    )) as KubernetesResource[];
+    let storageBytes = 0;
+    for (const dv of dvs) {
+      const dvSpec = dv.spec as Record<string, unknown> | undefined;
+      const pvc = dvSpec?.['pvc'] as Record<string, unknown> | undefined;
+      const resources = pvc?.['resources'] as Record<string, unknown> | undefined;
+      const requests = resources?.['requests'] as Record<string, unknown> | undefined;
+      const req = requests?.['storage'];
+      let reqStr: string | undefined;
+      if (typeof req === 'string') {
+        reqStr = req;
+      } else if (req != null) {
+        reqStr = String(req);
+      }
+      storageBytes += this.parseQuantityToBytes(reqStr);
+    }
+    const storageGiB = storageBytes / 1024 / 1024 / 1024;
+
+    return {
+      runningCount: running.length,
+      vcpu,
+      memoryMiB,
+      storageGiB,
+    };
+  }
+
+  async getPods(namespace: string) {
+    try {
+      const response = await this.ctx.coreV1Api.listNamespacedPod({ namespace });
+      return response.items || [];
+    } catch (error: unknown) {
+      throw new Error(`Failed to get pods in namespace ${namespace}: ${getErrorMessage(error)}`);
+    }
+  }
+
+  async listMigrationPolicies() {
+    return await this.ctx.listClusterCustomResources(
+      'migrations.kubevirt.io',
+      'v1alpha1',
+      'migrationpolicies',
+    );
+  }
+
+  async migrationPolicyExists(policyName: string): Promise<boolean> {
+    try {
+      await this.ctx.getClusterCustomResource(
+        'migrations.kubevirt.io',
+        'v1alpha1',
+        'migrationpolicies',
+        policyName,
+      );
+      return true;
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      if (msg.includes('404') || msg.includes('not found')) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  parseQuantityToBytes(q: string | undefined): number {
+    if (!q || typeof q !== 'string') return 0;
+    const s = q.trim();
+    const match = s.match(/^(\d+(?:\.\d+)?)\s*([KMGTPE]i?)?$/);
+    if (!match) return 0;
+    const num = parseFloat(match[1]);
+    const unit = (match[2] || '').toLowerCase();
+    if (unit === 'ki') return num * 1024;
+    if (unit === 'mi') return num * 1024 * 1024;
+    if (unit === 'gi') return num * 1024 * 1024 * 1024;
+    if (unit === 'ti') return num * 1024 * 1024 * 1024 * 1024;
+    if (unit === 'k') return num * 1000;
+    if (unit === 'm') return num * 1000 * 1000;
+    if (unit === 'g') return num * 1000 * 1000 * 1000;
+    return num;
+  }
+
+  async serviceExists(name: string, namespace: string): Promise<boolean> {
+    try {
+      const api = this.ctx.coreV1Api as unknown as {
+        readNamespacedService: (p: { name: string; namespace: string }) => Promise<unknown>;
+      };
+      await api.readNamespacedService({ name, namespace });
+      return true;
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      const statusCode =
+        typeof error === 'object' && error !== null && 'statusCode' in error
+          ? (error as { statusCode?: number }).statusCode
+          : undefined;
+      const responseStatus =
+        typeof error === 'object' && error !== null && 'response' in error
+          ? (error as { response?: { status?: number } }).response?.status
+          : undefined;
+      if (
+        statusCode === 404 ||
+        responseStatus === 404 ||
+        msg.includes('404') ||
+        msg.includes('not found')
+      ) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async verifyMigrationPolicyCreated(
+    policyName: string,
+    timeoutMs = 30000,
+  ): Promise<{
+    error?: string;
+    exists: boolean;
+    policy?: KubernetesResource;
+  }> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const policy = await this.getMigrationPolicy(policyName);
+
+        return {
+          exists: true,
+          policy: policy,
+        };
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        if (msg.includes('404') || msg.includes('not found')) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return {
+          error: msg,
+          exists: false,
+        };
+      }
+    }
+
+    return {
+      error: `Timeout after ${timeoutMs}ms waiting for MigrationPolicy ${policyName} to be created`,
+      exists: false,
+    };
+  }
+
+  async waitForPodReady(namespace: string, podName: string, timeoutMs = 60000): Promise<boolean> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const response = await this.ctx.coreV1Api.readNamespacedPod({ name: podName, namespace });
+        const pod = response;
+
+        if (
+          pod.status?.phase === 'Running' &&
+          pod.status?.conditions?.some((c) => c.type === 'Ready' && c.status === 'True')
+        ) {
+          return true;
+        }
+      } catch {
+        //
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+
+    return false;
+  }
+
+  async waitForServiceExists(
+    name: string,
+    namespace: string,
+    timeoutMs: number = TestTimeouts.VM_BOOTUP,
+    pollIntervalMs: number = TestTimeouts.POLLING_INTERVAL,
+  ): Promise<boolean> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      if (await this.serviceExists(name, namespace)) {
+        return true;
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+    return false;
+  }
+}

--- a/playwright/src/clients/handlers/secret-configmap-handler.ts
+++ b/playwright/src/clients/handlers/secret-configmap-handler.ts
@@ -1,0 +1,713 @@
+import type {
+  JsonPatchOp,
+  KubernetesListResource,
+  KubernetesResource,
+} from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+import { TestTimeouts } from '@/utils/test-config';
+import type * as k8s from '@kubernetes/client-node';
+import { setHeaderOptions } from '@kubernetes/client-node';
+
+import { getKubernetesProxyUrl, makeKubernetesProxyRequest } from '../kubernetes-proxy';
+
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getHttpStatusCode(error: unknown): number | undefined {
+  if (!isRecord(error)) return undefined;
+  const direct = error['statusCode'];
+  if (typeof direct === 'number') return direct;
+  const response = error['response'];
+  if (isRecord(response) && typeof response['statusCode'] === 'number') {
+    return response['statusCode'];
+  }
+  return undefined;
+}
+
+function getKubernetesErrorBodyCode(error: unknown): number | undefined {
+  if (!isRecord(error)) return undefined;
+  const body = error['body'];
+  if (isRecord(body) && typeof body['code'] === 'number') return body['code'];
+  return undefined;
+}
+
+function getKubernetesPatchErrorMessage(error: unknown): string {
+  if (!isRecord(error)) return getErrorMessage(error);
+  const response = error['response'];
+  if (isRecord(response)) {
+    const rspBody = response['body'];
+    if (isRecord(rspBody) && typeof rspBody['message'] === 'string') {
+      return rspBody['message'];
+    }
+    if (typeof rspBody === 'string') return rspBody;
+  }
+  const body = error['body'];
+  if (isRecord(body) && typeof body['message'] === 'string') return body['message'];
+  if (typeof error['message'] === 'string') return error['message'];
+  return getErrorMessage(error);
+}
+
+export class SecretConfigMapHandler {
+  constructor(private readonly ctx: KubernetesHandlerContext) {}
+
+  async createPvc(
+    name: string,
+    namespace: string,
+    size = '10Gi',
+    storageClassName?: string,
+    accessModes: string[] = ['ReadWriteOnce'],
+  ): Promise<k8s.V1PersistentVolumeClaim> {
+    try {
+      const pvc: k8s.V1PersistentVolumeClaim = {
+        apiVersion: 'v1',
+        kind: 'PersistentVolumeClaim',
+        metadata: {
+          name,
+          namespace,
+        },
+        spec: {
+          accessModes,
+          resources: {
+            requests: {
+              storage: size,
+            },
+          },
+        },
+      };
+
+      if (storageClassName && pvc.spec) {
+        pvc.spec.storageClassName = storageClassName;
+      }
+
+      const response = await this.ctx.coreV1Api.createNamespacedPersistentVolumeClaim({
+        namespace,
+        body: pvc,
+      });
+      return response;
+    } catch (error: unknown) {
+      if (getHttpStatusCode(error) === 409 || getKubernetesErrorBodyCode(error) === 409) {
+        const existing = await this.ctx.coreV1Api.readNamespacedPersistentVolumeClaim({
+          name,
+          namespace,
+        });
+        return existing;
+      }
+      throw new Error(
+        `Failed to create PVC ${name} in namespace ${namespace}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  async createSecret(
+    name: string,
+    namespace: string,
+    data: { [key: string]: string },
+    type = 'Opaque',
+  ): Promise<k8s.V1Secret> {
+    try {
+      const currentContext = this.ctx.kc.getCurrentContext();
+      if (!currentContext) {
+        throw new Error(
+          'No Kubernetes context is set. Authentication may not be configured properly.',
+        );
+      }
+
+      const context = this.ctx.kc.getContextObject(currentContext);
+      if (!context || !context.user) {
+        throw new Error(
+          `Context '${currentContext}' does not have a user configured. Authentication may not be set up correctly.`,
+        );
+      }
+
+      const user = this.ctx.kc.getUser(context.user);
+      if (!user) {
+        throw new Error(
+          `User '${context.user}' from context '${currentContext}' not found in kubeconfig.`,
+        );
+      }
+
+      if (user.username && user.password && !user.token) {
+        throw new Error(
+          'Authentication configured with username/password but no token. ' +
+            'Username/password authentication does not work directly with Kubernetes API. ' +
+            'Please ensure a kubeconfig file (created via oc login) or token is provided.',
+        );
+      }
+
+      if (!user.token) {
+        throw new Error(
+          'No authentication token found. ' +
+            'The Kubernetes API requires a token for authentication. ' +
+            'Please ensure a kubeconfig file (created via oc login) or token is provided.',
+        );
+      }
+
+      const secret: k8s.V1Secret = {
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: {
+          name: name,
+          namespace: namespace,
+        },
+        type: type,
+        data: {},
+      };
+
+      if (!secret.data) secret.data = {};
+      for (const [key, value] of Object.entries(data)) {
+        secret.data[key] = Buffer.from(value).toString('base64');
+      }
+
+      const response = await this.ctx.coreV1Api.createNamespacedSecret({
+        namespace,
+        body: secret,
+      });
+      return response;
+    } catch (error: unknown) {
+      const errorMessage = getErrorMessage(error);
+      const errorBody =
+        isRecord(error) && error['body'] !== undefined
+          ? JSON.stringify(error['body'], null, 2)
+          : '';
+      const httpCode = getHttpStatusCode(error);
+      const errorStatus = httpCode !== undefined ? `HTTP-Code: ${httpCode}` : '';
+      let errorResponse = '';
+      let responseHeadersJson = '';
+      if (isRecord(error)) {
+        const rawResponse = error['response'];
+        if (rawResponse !== undefined) {
+          errorResponse = JSON.stringify(rawResponse, null, 2);
+          if (
+            isRecord(rawResponse) &&
+            rawResponse['headers'] !== undefined &&
+            rawResponse['headers'] !== null
+          ) {
+            responseHeadersJson = JSON.stringify(rawResponse['headers'], null, 2);
+          }
+        }
+      }
+
+      let detailedError = `Failed to create secret ${name} in namespace ${namespace}`;
+      if (errorStatus) {
+        detailedError += `\n    ${errorStatus}`;
+      }
+      if (errorMessage && errorMessage !== errorStatus) {
+        detailedError += `\n    Message: ${errorMessage}`;
+      }
+      if (errorBody) {
+        detailedError += `\n    Body: ${errorBody}`;
+      }
+      if (errorResponse && errorResponse !== errorBody) {
+        detailedError += `\n    Response: ${errorResponse}`;
+      }
+      if (responseHeadersJson) {
+        detailedError += `\n    Headers: ${responseHeadersJson}`;
+      }
+
+      throw new Error(detailedError);
+    }
+  }
+
+  async createSSHKeySecret(
+    name: string,
+    namespace: string,
+    sshPublicKey?: string,
+  ): Promise<k8s.V1Secret> {
+    try {
+      const defaultPublicKey =
+        'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC7vbqajDRqNQn0gB3KyEDXQVSTmJYDxm5q3NcNqcxC9EqW0YqXa3M5FMzP7qLFWELRLbDgHmlb0nvBWD3TbQjGmJTvBMxl5HBaEFf3AQAIWWxnYrZvMz6kc2IzGzMz5n5j5n5k5n5m5n5o5n5p5n5q5n5r5n5s5n5t5n5u5n5v5n5w5n5x5n5y5n5z5n5AAAA test-key@playwright';
+
+      const secretData = {
+        key: sshPublicKey || defaultPublicKey,
+      };
+
+      return await this.createSecret(name, namespace, secretData, 'Opaque');
+    } catch (error: unknown) {
+      const errorMessage = getErrorMessage(error);
+      throw new Error(
+        `Failed to create SSH key secret ${name} in namespace ${namespace}: ${errorMessage}`,
+      );
+    }
+  }
+
+  async createSysprepConfigMap(
+    name: string,
+    namespace: string,
+    unattendXml?: string,
+  ): Promise<k8s.V1ConfigMap> {
+    try {
+      const defaultUnattendXml = `<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+  </settings>
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <ComputerName>*</ComputerName>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <ProtectYourPC>3</ProtectYourPC>
+      </OOBE>
+      <UserAccounts>
+        <AdministratorPassword>
+          <Value>cnv-tester</Value>
+          <PlainText>true</PlainText>
+        </AdministratorPassword>
+      </UserAccounts>
+    </component>
+  </settings>
+</unattend>`;
+
+      const configMap: k8s.V1ConfigMap = {
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: {
+          name: name,
+          namespace: namespace,
+        },
+        data: {
+          'autounattend.xml': unattendXml || defaultUnattendXml,
+        },
+      };
+
+      const response = await this.ctx.coreV1Api.createNamespacedConfigMap({
+        namespace,
+        body: configMap,
+      });
+      return response;
+    } catch (error: unknown) {
+      const errorMessage = getErrorMessage(error);
+      const httpCode = getHttpStatusCode(error);
+      const errorStatus = httpCode !== undefined ? `HTTP-Code: ${httpCode}` : '';
+      throw new Error(
+        `Failed to create sysprep ConfigMap ${name} in namespace ${namespace}: ${errorStatus} ${errorMessage}`,
+      );
+    }
+  }
+
+  async createTlsCaCertConfigMap(
+    name: string,
+    namespace: string,
+    caPem: string,
+  ): Promise<k8s.V1ConfigMap> {
+    try {
+      const configMap: k8s.V1ConfigMap = {
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: {
+          name,
+          namespace,
+        },
+        data: {
+          'ca.pem': caPem,
+        },
+      };
+
+      const response = await this.ctx.coreV1Api.createNamespacedConfigMap({
+        namespace,
+        body: configMap,
+      });
+      return response;
+    } catch (error: unknown) {
+      const errorMessage = getErrorMessage(error);
+      const httpCode = getHttpStatusCode(error);
+      const errorStatus = httpCode !== undefined ? `HTTP-Code: ${httpCode}` : '';
+      throw new Error(
+        `Failed to create TLS CA ConfigMap ${name} in namespace ${namespace}: ${errorStatus} ${errorMessage}`,
+      );
+    }
+  }
+
+  async deleteAllSecrets(namespace: string, options?: { ignoreErrors?: boolean }): Promise<void> {
+    try {
+      const response = await this.ctx.withRetry(
+        () => this.ctx.coreV1Api.listNamespacedSecret({ namespace }),
+        `List Secrets in ${namespace}`,
+      );
+      const secrets = response.items ?? [];
+      const deletePromises = secrets.map((secret) => {
+        const name = secret.metadata?.name;
+        if (!name || name.startsWith('default-') || name.includes('-token-')) {
+          return Promise.resolve();
+        }
+        return this.deleteSecret(name, namespace).catch((error: unknown) => {
+          if (!options?.ignoreErrors) {
+            throw error;
+          }
+        });
+      });
+      await Promise.allSettled(deletePromises);
+    } catch (error: unknown) {
+      if (!options?.ignoreErrors) {
+        throw error;
+      }
+    }
+  }
+
+  async deleteConfigMapsWithPrefix(
+    namespace: string,
+    prefix: string,
+    options?: { ignoreErrors?: boolean },
+  ): Promise<void> {
+    const proxyUrl = getKubernetesProxyUrl();
+
+    if (proxyUrl) {
+      try {
+        const response = (await makeKubernetesProxyRequest(
+          this.ctx.kc,
+          'GET',
+          `/api/v1/namespaces/${namespace}/configmaps`,
+        )) as unknown as KubernetesListResource<KubernetesResource>;
+        const configMaps = response.items ?? [];
+        const matchingMaps = configMaps.filter((cm) => cm.metadata?.name?.startsWith(prefix));
+        const deletePromises = matchingMaps.map(async (cm) => {
+          const name = cm.metadata?.name;
+          if (!name) return Promise.resolve();
+
+          try {
+            await makeKubernetesProxyRequest(
+              this.ctx.kc,
+              'DELETE',
+              `/api/v1/namespaces/${namespace}/configmaps/${name}`,
+            );
+          } catch (error: unknown) {
+            if (!options?.ignoreErrors) {
+              throw error;
+            }
+          }
+        });
+        await Promise.allSettled(deletePromises);
+      } catch (error: unknown) {
+        if (!options?.ignoreErrors) {
+          throw error;
+        }
+      }
+      return;
+    }
+
+    try {
+      const response = await this.ctx.withRetry(
+        () => this.ctx.coreV1Api.listNamespacedConfigMap({ namespace }),
+        `List ConfigMaps in ${namespace}`,
+      );
+      const configMaps = response.items ?? [];
+      const matchingMaps = configMaps.filter((cm) => cm.metadata?.name?.startsWith(prefix));
+      const deletePromises = matchingMaps.map((cm) => {
+        const name = cm.metadata?.name;
+        if (!name) return Promise.resolve();
+        return this.ctx.coreV1Api
+          .deleteNamespacedConfigMap({ name, namespace })
+          .catch((error: unknown) => {
+            if (!options?.ignoreErrors) {
+              throw error;
+            }
+          });
+      });
+      await Promise.allSettled(deletePromises);
+    } catch (error: unknown) {
+      if (!options?.ignoreErrors) {
+        throw error;
+      }
+    }
+  }
+
+  async deletePvc(
+    name: string,
+    namespace: string,
+    options?: { ignoreNotFound?: boolean },
+  ): Promise<boolean> {
+    try {
+      await this.ctx.coreV1Api.deleteNamespacedPersistentVolumeClaim({
+        name,
+        namespace,
+      });
+      return true;
+    } catch (error: unknown) {
+      if (getHttpStatusCode(error) === 404 || getKubernetesErrorBodyCode(error) === 404) {
+        if (options?.ignoreNotFound) {
+          return true;
+        }
+        return false;
+      }
+      throw new Error(
+        `Failed to delete PVC ${name} in namespace ${namespace}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  async deleteSecret(name: string, namespace: string): Promise<boolean> {
+    try {
+      await this.ctx.coreV1Api.deleteNamespacedSecret({
+        name,
+        namespace,
+      });
+      return true;
+    } catch (error: unknown) {
+      if (getHttpStatusCode(error) === 404) {
+        return true;
+      }
+      return false;
+    }
+  }
+
+  async getConfigMap(name: string, namespace: string): Promise<KubernetesResource | null> {
+    const proxyUrl = getKubernetesProxyUrl();
+
+    if (proxyUrl) {
+      try {
+        return (await makeKubernetesProxyRequest(
+          this.ctx.kc,
+          'GET',
+          `/api/v1/namespaces/${namespace}/configmaps/${name}`,
+        )) as KubernetesResource;
+      } catch (error: unknown) {
+        if (getErrorMessage(error).includes('404')) {
+          return null;
+        }
+        throw error;
+      }
+    }
+
+    try {
+      const response = await this.ctx.coreV1Api.readNamespacedConfigMap({
+        name,
+        namespace,
+      });
+      return response as unknown as KubernetesResource;
+    } catch (error: unknown) {
+      if (getHttpStatusCode(error) === 404) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async patchConfigMap(
+    name: string,
+    namespace: string,
+    patchData: Record<string, string>,
+  ): Promise<k8s.V1ConfigMap> {
+    const proxyUrl = getKubernetesProxyUrl();
+
+    if (!proxyUrl) {
+      try {
+        const existingConfigMap = await this.getConfigMap(name, namespace);
+
+        if (!existingConfigMap) {
+          const newConfigMap: k8s.V1ConfigMap = {
+            apiVersion: 'v1',
+            kind: 'ConfigMap',
+            metadata: {
+              name,
+              namespace,
+            },
+            data: patchData,
+          };
+
+          const createResponse = await this.ctx.coreV1Api.createNamespacedConfigMap({
+            namespace,
+            body: newConfigMap,
+          });
+
+          return createResponse;
+        }
+
+        const existingData = existingConfigMap?.data;
+        const patchOps: JsonPatchOp[] = [];
+
+        const hasDataField = existingData && typeof existingData === 'object';
+
+        if (!hasDataField) {
+          patchOps.push({
+            op: 'add',
+            path: '/data',
+            value: patchData,
+          });
+        } else {
+          const dataObj = existingData as Record<string, unknown>;
+          for (const [key, value] of Object.entries(patchData)) {
+            const escapedKey = key.replace(/~/g, '~0').replace(/\//g, '~1');
+
+            if (dataObj[key] !== undefined) {
+              patchOps.push({
+                op: 'replace',
+                path: `/data/${escapedKey}`,
+                value: value,
+              });
+            } else {
+              patchOps.push({
+                op: 'add',
+                path: `/data/${escapedKey}`,
+                value: value,
+              });
+            }
+          }
+        }
+
+        const response = await this.ctx.coreV1Api.patchNamespacedConfigMap(
+          {
+            name,
+            namespace,
+            body: patchOps,
+          },
+          setHeaderOptions('Content-Type', 'application/json-patch+json'),
+        );
+
+        return response;
+      } catch (error: unknown) {
+        const httpCode = getHttpStatusCode(error);
+        const statusCode = httpCode ?? 'unknown';
+        const message = getKubernetesPatchErrorMessage(error);
+        throw new Error(`Failed to patch ConfigMap ${name}: HTTP ${statusCode}: ${message}`);
+      }
+    }
+
+    try {
+      const existingConfigMap = await this.getConfigMap(name, namespace);
+
+      if (!existingConfigMap) {
+        const newConfigMap: k8s.V1ConfigMap = {
+          apiVersion: 'v1',
+          kind: 'ConfigMap',
+          metadata: {
+            name,
+            namespace,
+          },
+          data: patchData,
+        };
+
+        return (await makeKubernetesProxyRequest(
+          this.ctx.kc,
+          'POST',
+          `/api/v1/namespaces/${namespace}/configmaps`,
+          newConfigMap,
+        )) as unknown as k8s.V1ConfigMap;
+      }
+
+      const existingData = existingConfigMap?.data;
+      const patchOps: JsonPatchOp[] = [];
+
+      const hasDataField = existingData && typeof existingData === 'object';
+
+      if (!hasDataField) {
+        patchOps.push({
+          op: 'add',
+          path: '/data',
+          value: patchData,
+        });
+      } else {
+        const dataObj = existingData as Record<string, unknown>;
+        for (const [key, value] of Object.entries(patchData)) {
+          const escapedKey = key.replace(/~/g, '~0').replace(/\//g, '~1');
+
+          if (dataObj[key] !== undefined) {
+            patchOps.push({
+              op: 'replace',
+              path: `/data/${escapedKey}`,
+              value: value,
+            });
+          } else {
+            patchOps.push({
+              op: 'add',
+              path: `/data/${escapedKey}`,
+              value: value,
+            });
+          }
+        }
+      }
+
+      return (await makeKubernetesProxyRequest(
+        this.ctx.kc,
+        'PATCH',
+        `/api/v1/namespaces/${namespace}/configmaps/${name}`,
+        patchOps,
+      )) as unknown as k8s.V1ConfigMap;
+    } catch (error: unknown) {
+      const httpCode = getHttpStatusCode(error);
+      const statusCode = httpCode ?? 'unknown';
+      const message = getKubernetesPatchErrorMessage(error);
+      throw new Error(`Failed to patch ConfigMap ${name}: HTTP ${statusCode}: ${message}`);
+    }
+  }
+
+  async verifySecretExists(
+    name: string,
+    namespace: string,
+    timeout: number = TestTimeouts.CLUSTER_OPERATION,
+  ): Promise<boolean> {
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeout) {
+      try {
+        const response = await this.ctx.coreV1Api.readNamespacedSecret({
+          name,
+          namespace,
+        });
+        return !!response;
+      } catch (error: unknown) {
+        if (getHttpStatusCode(error) === 404) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return false;
+      }
+    }
+    return false;
+  }
+
+  async verifySysprepConfigMapExists(
+    name: string,
+    namespace: string,
+    timeout: number = TestTimeouts.CLUSTER_OPERATION,
+  ): Promise<{ exists: boolean; hasAutounattend?: boolean; data?: Record<string, string> }> {
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeout) {
+      try {
+        const configMap = await this.ctx.coreV1Api.readNamespacedConfigMap({
+          name,
+          namespace,
+        });
+
+        if (configMap) {
+          const data = configMap.data || {};
+          const hasAutounattend = !!(
+            data['autounattend.xml'] ||
+            data['unattend.xml'] ||
+            data['Autounattend.xml'] ||
+            data['Unattend.xml']
+          );
+          return {
+            exists: true,
+            hasAutounattend,
+            data,
+          };
+        }
+        return { exists: false };
+      } catch (error: unknown) {
+        if (getHttpStatusCode(error) === 404) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return { exists: false };
+      }
+    }
+    return { exists: false };
+  }
+}

--- a/playwright/src/clients/handlers/snapshot-handler.ts
+++ b/playwright/src/clients/handlers/snapshot-handler.ts
@@ -1,0 +1,395 @@
+import type { KubernetesListResource, KubernetesResource } from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+import { TestTimeouts } from '@/utils/test-config';
+
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+
+export class SnapshotHandler {
+  constructor(private readonly ctx: KubernetesHandlerContext) {}
+
+  private isNonZeroQuantity(q: unknown): boolean {
+    if (q == null) return false;
+    if (typeof q === 'number') return q > 0;
+    const str = typeof q === 'string' ? q : (q as { value?: string })?.value;
+    if (str == null || str === '') return false;
+    const parsed = parseInt(str, 10);
+    if (!Number.isNaN(parsed)) return parsed > 0;
+    return str !== '0' && !/^0+$/.test(str);
+  }
+
+  async createVmSnapshot(
+    snapshotName: string,
+    vmName: string,
+    namespace: string,
+  ): Promise<KubernetesResource> {
+    const snapshotSpec: KubernetesResource = {
+      apiVersion: 'snapshot.kubevirt.io/v1beta1',
+      kind: 'VirtualMachineSnapshot',
+      metadata: {
+        name: snapshotName,
+        namespace: namespace,
+      },
+      spec: {
+        source: {
+          apiGroup: 'kubevirt.io',
+          kind: 'VirtualMachine',
+          name: vmName,
+        },
+      },
+    };
+
+    return await this.ctx.createCustomResource(
+      'snapshot.kubevirt.io',
+      'v1beta1',
+      namespace,
+      'virtualmachinesnapshots',
+      snapshotSpec,
+    );
+  }
+
+  async createVolumeSnapshot(
+    snapshotName: string,
+    namespace: string,
+    sourcePvcName: string,
+    volumeSnapshotClassName?: string,
+  ): Promise<KubernetesResource> {
+    const body: KubernetesResource = {
+      apiVersion: 'snapshot.storage.k8s.io/v1',
+      kind: 'VolumeSnapshot',
+      metadata: { name: snapshotName, namespace },
+      spec: {
+        source: { persistentVolumeClaimName: sourcePvcName },
+      },
+    };
+    if (volumeSnapshotClassName) {
+      const spec = (body.spec as Record<string, unknown>) ?? {};
+      body.spec = { ...spec, volumeSnapshotClassName };
+    }
+    return await this.ctx.createCustomResource(
+      'snapshot.storage.k8s.io',
+      'v1',
+      namespace,
+      'volumesnapshots',
+      body,
+    );
+  }
+
+  async deleteVolumesnapshotsByLabel(
+    namespace: string,
+    labels: Record<string, string>,
+    timeoutMs = 30000,
+  ): Promise<boolean> {
+    const labelSelector = Object.entries(labels)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(',');
+
+    try {
+      const response = await this.ctx.customObjectsApi.listNamespacedCustomObject({
+        group: 'snapshot.storage.k8s.io',
+        version: 'v1',
+        namespace,
+        plural: 'volumesnapshots',
+        labelSelector,
+      });
+
+      const items =
+        (response.body as KubernetesListResource<KubernetesResource>).items ??
+        ([] as KubernetesResource[]);
+
+      for (const item of items) {
+        const name = item.metadata?.name;
+        if (name) {
+          try {
+            await this.ctx.customObjectsApi.deleteNamespacedCustomObject({
+              group: 'snapshot.storage.k8s.io',
+              version: 'v1',
+              namespace,
+              plural: 'volumesnapshots',
+              name,
+            });
+          } catch {
+            // Ignore deletion errors (already deleted or not found)
+          }
+        }
+      }
+    } catch {
+      // If listing fails, continue to wait loop
+    }
+
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const response = await this.ctx.customObjectsApi.listNamespacedCustomObject({
+          group: 'snapshot.storage.k8s.io',
+          version: 'v1',
+          namespace,
+          plural: 'volumesnapshots',
+          labelSelector,
+        });
+
+        const items =
+          (response.body as KubernetesListResource<KubernetesResource>).items ??
+          ([] as KubernetesResource[]);
+        if (items.length === 0) {
+          return true;
+        }
+      } catch {
+        return true;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+
+    try {
+      const response = await this.ctx.customObjectsApi.listNamespacedCustomObject({
+        group: 'snapshot.storage.k8s.io',
+        version: 'v1',
+        namespace,
+        plural: 'volumesnapshots',
+        labelSelector,
+      });
+
+      const items =
+        (response.body as KubernetesListResource<KubernetesResource>).items ??
+        ([] as KubernetesResource[]);
+      return items.length === 0;
+    } catch {
+      return true;
+    }
+  }
+
+  async getVirtualMachineSnapshot(
+    snapshotName: string,
+    namespace: string,
+  ): Promise<KubernetesResource> {
+    return await this.ctx.getCustomResource(
+      'snapshot.kubevirt.io',
+      'v1beta1',
+      namespace,
+      'virtualmachinesnapshots',
+      snapshotName,
+    );
+  }
+
+  async getVolumeSnapshotNameFromVirtualMachineSnapshot(
+    virtualMachineSnapshotName: string,
+    namespace: string,
+    timeoutMs: number = TestTimeouts.DATA_VOLUME_STATUS,
+    singleAttempt = false,
+  ): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const items = await this.listVolumeSnapshotsInNamespace(namespace);
+      for (const vs of items) {
+        const owners = vs.metadata?.ownerReferences || [];
+        const ownedByVms = owners.some(
+          (ref: { kind?: string; name?: string }) =>
+            ref.kind === 'VirtualMachineSnapshot' && ref.name === virtualMachineSnapshotName,
+        );
+        if (ownedByVms && vs.metadata?.name) {
+          return vs.metadata.name;
+        }
+      }
+      if (singleAttempt) {
+        break;
+      }
+      await new Promise((r) => setTimeout(r, TestTimeouts.POLLING_INTERVAL));
+    }
+    throw new Error(
+      `No VolumeSnapshot found for VirtualMachineSnapshot ${virtualMachineSnapshotName} in namespace ${namespace}${
+        singleAttempt ? '' : ` within ${timeoutMs}ms`
+      }`,
+    );
+  }
+
+  async getVolumesnapshotsByLabel(
+    namespace: string,
+    labels: Record<string, string>,
+    namePattern?: string,
+    timeoutMs = 60000,
+  ): Promise<KubernetesResource[]> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const labelSelector = Object.entries(labels)
+          .map(([key, value]) => `${key}=${value}`)
+          .join(',');
+
+        const response = await this.ctx.customObjectsApi.listNamespacedCustomObject({
+          group: 'snapshot.storage.k8s.io',
+          version: 'v1',
+          namespace,
+          plural: 'volumesnapshots',
+          labelSelector,
+        });
+
+        const items =
+          (response.body as KubernetesListResource<KubernetesResource>).items ??
+          ([] as KubernetesResource[]);
+
+        if (items.length > 0) {
+          if (namePattern) {
+            const matching = items.filter((item) => item.metadata?.name?.includes(namePattern));
+            if (matching.length > 0) {
+              return matching;
+            }
+          } else {
+            return items;
+          }
+        }
+      } catch {
+        // Continue waiting if there's an error
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+
+    return [];
+  }
+
+  async listVolumeSnapshotsInNamespace(namespace: string): Promise<KubernetesResource[]> {
+    return await this.ctx.listCustomResources(
+      'snapshot.storage.k8s.io',
+      'v1',
+      namespace,
+      'volumesnapshots',
+    );
+  }
+
+  async waitForRestoreDeleted(
+    restoreName: string,
+    namespace: string,
+    timeoutMs = 60000,
+  ): Promise<boolean> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        await this.ctx.getCustomResource(
+          'snapshot.kubevirt.io',
+          'v1beta1',
+          namespace,
+          'virtualmachinerestores',
+          restoreName,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        if (msg.includes('404') || msg.includes('not found')) {
+          return true;
+        }
+        throw error;
+      }
+    }
+
+    throw new Error(`Restore ${restoreName} was not deleted within ${timeoutMs}ms`);
+  }
+
+  async waitForSnapshotDeleted(
+    snapshotName: string,
+    namespace: string,
+    timeoutMs = 60000,
+  ): Promise<boolean> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        await this.ctx.getCustomResource(
+          'snapshot.kubevirt.io',
+          'v1beta1',
+          namespace,
+          'virtualmachinesnapshots',
+          snapshotName,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        if (msg.includes('404') || msg.includes('not found')) {
+          return true;
+        }
+        throw error;
+      }
+    }
+
+    throw new Error(`Snapshot ${snapshotName} was not deleted within ${timeoutMs}ms`);
+  }
+
+  async waitForSnapshotReady(
+    snapshotName: string,
+    namespace: string,
+    timeoutMs = 60000,
+  ): Promise<boolean> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const snapshot = (await this.ctx.getCustomResource(
+          'snapshot.kubevirt.io',
+          'v1beta1',
+          namespace,
+          'virtualmachinesnapshots',
+          snapshotName,
+        )) as KubernetesResource;
+
+        const status = snapshot.status as Record<string, unknown> | undefined;
+        const readyToUse = status?.['readyToUse'];
+        if (readyToUse === true) {
+          return true;
+        }
+
+        const phase = status?.['phase'];
+        if (phase === 'Failed') {
+          throw new Error(`Snapshot ${snapshotName} failed`);
+        }
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        if (msg.includes('404') || msg.includes('not found')) {
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+          continue;
+        }
+        if (msg.includes('Snapshot') && msg.includes('failed')) {
+          throw error;
+        }
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+
+    throw new Error(`Snapshot ${snapshotName} did not become ready within ${timeoutMs}ms`);
+  }
+
+  async waitForVolumeSnapshotReady(
+    snapshotName: string,
+    namespace: string,
+    timeoutMs: number = TestTimeouts.RESOURCE_CREATION,
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      try {
+        const vs = (await this.ctx.getCustomResource(
+          'snapshot.storage.k8s.io',
+          'v1',
+          namespace,
+          'volumesnapshots',
+          snapshotName,
+        )) as KubernetesResource;
+        const vsStatus = vs.status as Record<string, unknown> | undefined;
+        if (vsStatus?.['readyToUse'] !== true) {
+          await new Promise((r) => setTimeout(r, TestTimeouts.POLLING_INTERVAL));
+          continue;
+        }
+        const restoreSize = vsStatus?.['restoreSize'];
+        if (restoreSize != null && this.isNonZeroQuantity(restoreSize)) {
+          return;
+        }
+      } catch {
+        // Not found or not ready yet
+      }
+      await new Promise((r) => setTimeout(r, TestTimeouts.POLLING_INTERVAL));
+    }
+    throw new Error(
+      `Timeout waiting for VolumeSnapshot ${snapshotName} to be ready with non-zero size in namespace ${namespace}`,
+    );
+  }
+}

--- a/playwright/src/clients/handlers/template-handler.ts
+++ b/playwright/src/clients/handlers/template-handler.ts
@@ -1,0 +1,321 @@
+import type { KubernetesListResource, KubernetesResource } from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+
+export class TemplateHandler {
+  constructor(private readonly ctx: KubernetesHandlerContext) {}
+
+  /** Fedora VM template with a DataVolume root disk (registry-sourced), suitable for snapshot workflows. */
+  async createFedoraTemplateWithDataVolumeRootDisk(templateName: string, namespace: string) {
+    const templateResource = {
+      apiVersion: 'template.openshift.io/v1',
+      kind: 'Template',
+      metadata: {
+        name: templateName,
+        namespace: namespace,
+        labels: {
+          'template.kubevirt.io/type': 'vm',
+          'os.template.kubevirt.io/fedora': 'true',
+          'workload.template.kubevirt.io/server': 'true',
+        },
+        annotations: {
+          'name.os.template.kubevirt.io/fedora': 'Fedora',
+          description: 'Fedora server template (DataVolume root disk, snapshotable)',
+          'openshift.io/display-name': 'Fedora Server (snapshotable disk)',
+          iconClass: 'icon-fedora',
+        },
+      },
+      objects: [
+        {
+          apiVersion: 'kubevirt.io/v1',
+          kind: 'VirtualMachine',
+          metadata: {
+            name: '${NAME}',
+            labels: {
+              app: '${NAME}',
+              'os.template.kubevirt.io/fedora': 'true',
+              'vm.kubevirt.io/template': templateName,
+            },
+          },
+          spec: {
+            runStrategy: 'Always',
+            dataVolumeTemplates: [
+              {
+                metadata: {
+                  name: '${NAME}-rootdisk',
+                },
+                spec: {
+                  source: {
+                    registry: {
+                      url: 'docker://quay.io/containerdisks/fedora:latest',
+                    },
+                  },
+                  storage: {
+                    resources: {
+                      requests: {
+                        storage: '30Gi',
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+            template: {
+              metadata: {
+                annotations: {
+                  'vm.kubevirt.io/flavor': 'medium',
+                  'vm.kubevirt.io/os': 'fedora',
+                  'vm.kubevirt.io/workload': 'server',
+                },
+                labels: {
+                  'kubevirt.io/domain': '${NAME}',
+                  'kubevirt.io/size': 'medium',
+                },
+              },
+              spec: {
+                domain: {
+                  cpu: {
+                    cores: 2,
+                    sockets: 1,
+                    threads: 1,
+                  },
+                  devices: {
+                    disks: [
+                      {
+                        disk: { bus: 'virtio' },
+                        name: 'rootdisk',
+                      },
+                      {
+                        disk: { bus: 'virtio' },
+                        name: 'cloudinitdisk',
+                      },
+                    ],
+                  },
+                  resources: {
+                    requests: {
+                      memory: '4Gi',
+                    },
+                  },
+                },
+                volumes: [
+                  {
+                    dataVolume: {
+                      name: '${NAME}-rootdisk',
+                    },
+                    name: 'rootdisk',
+                  },
+                  {
+                    cloudInitNoCloud: {
+                      userData: `#cloud-config\nuser: fedora\npassword: '\${CLOUD_USER_PASSWORD}'\nchpasswd: { expire: False }`,
+                    },
+                    name: 'cloudinitdisk',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+      parameters: [
+        {
+          name: 'NAME',
+          description: 'Name for the new VM',
+          required: true,
+        },
+        {
+          name: 'CLOUD_USER_PASSWORD',
+          description: 'Randomized password for the cloud-init user',
+          generate: 'expression',
+          from: '[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}',
+        },
+      ],
+    };
+
+    return await this.ctx.createCustomResource(
+      'template.openshift.io',
+      'v1',
+      namespace,
+      'templates',
+      templateResource,
+    );
+  }
+
+  async findTemplateByMetadataName(metadataName: string, namespace = 'openshift') {
+    try {
+      try {
+        return await this.getTemplate(metadataName, namespace);
+      } catch {
+        const templates = await this.listTemplates(namespace);
+        if (Array.isArray(templates)) {
+          for (const template of templates) {
+            const annotations = template.metadata?.annotations || {};
+            const labels = template.metadata?.labels || {};
+            const templateName = template.metadata?.name || '';
+
+            if (
+              templateName === metadataName ||
+              annotations['name.os.template.kubevirt.io/rhel9'] === metadataName ||
+              Object.keys(labels).some((key) => key.includes(metadataName))
+            ) {
+              return template;
+            }
+          }
+        }
+      }
+      return null;
+    } catch (error: unknown) {
+      throw new Error(
+        `Failed to find template by metadata name ${metadataName}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  async getNativeVmTemplate(templateName: string, namespace: string) {
+    return await this.ctx.getCustomResource(
+      'template.kubevirt.io',
+      'v1beta1',
+      namespace,
+      'virtualmachinetemplates',
+      templateName,
+    );
+  }
+
+  async getTemplate(templateName: string, namespace: string) {
+    return await this.ctx.getCustomResource(
+      'template.openshift.io',
+      'v1',
+      namespace,
+      'templates',
+      templateName,
+    );
+  }
+
+  getTemplateBootDataSourceRef(
+    template: KubernetesResource,
+    defaultDataSourceNamespace = 'openshift-virtualization-os-images',
+  ): { name: string; namespace: string } | null {
+    const objects = template?.objects;
+    if (!Array.isArray(objects)) return null;
+
+    const paramMap = new Map<string, string>();
+    if (Array.isArray(template.parameters)) {
+      for (const p of template.parameters as Array<{ name?: string; value?: string }>) {
+        if (p.name && p.value !== undefined) {
+          paramMap.set(p.name, p.value);
+        }
+      }
+    }
+
+    const resolve = (val: string | undefined): string | undefined => {
+      if (!val) return val;
+      return val.replace(/\$\{(\w+)\}/g, (_, key) => paramMap.get(key) ?? _);
+    };
+
+    const vmObject = objects.find((obj: KubernetesResource) => obj.kind === 'VirtualMachine');
+    const dvTemplates = vmObject?.spec?.dataVolumeTemplates;
+    if (!Array.isArray(dvTemplates)) return null;
+    for (const dv of dvTemplates) {
+      const ref = dv.spec?.sourceRef;
+      if (ref?.kind === 'DataSource' && ref?.name) {
+        const name = resolve(ref.name) || ref.name;
+        const namespace = resolve(ref.namespace) || defaultDataSourceNamespace;
+        return { name, namespace };
+      }
+    }
+    return null;
+  }
+
+  async listTemplates(namespace: string) {
+    try {
+      const response = await this.ctx.customObjectsApi.listNamespacedCustomObject({
+        group: 'template.openshift.io',
+        namespace,
+        plural: 'templates',
+        version: 'v1',
+      });
+      const bodyUnknown = response?.body ?? response;
+      const listBody = bodyUnknown as KubernetesListResource<KubernetesResource>;
+      return listBody?.items ?? [];
+    } catch (error: unknown) {
+      throw new Error(
+        `Failed to list Templates in namespace ${namespace}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  async verifyNativeVmTemplateCreated(
+    templateName: string,
+    namespace: string,
+    timeoutMs = 30000,
+  ): Promise<{
+    error?: string;
+    exists: boolean;
+    template?: KubernetesResource;
+  }> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const template = await this.getNativeVmTemplate(templateName, namespace);
+        return { exists: true, template };
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        if (msg.includes('404') || msg.includes('not found')) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return { error: msg, exists: false };
+      }
+    }
+
+    return {
+      error: `Timeout after ${timeoutMs}ms waiting for native VirtualMachineTemplate ${templateName}`,
+      exists: false,
+    };
+  }
+
+  async verifyTemplateCreated(
+    templateName: string,
+    namespace: string,
+    timeoutMs = 30000,
+  ): Promise<{
+    error?: string;
+    exists: boolean;
+    template?: KubernetesResource;
+  }> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const template = await this.ctx.getCustomResource(
+          'template.openshift.io',
+          'v1',
+          namespace,
+          'templates',
+          templateName,
+        );
+
+        return {
+          exists: true,
+          template: template,
+        };
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        if (msg.includes('404') || msg.includes('not found')) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return {
+          error: msg,
+          exists: false,
+        };
+      }
+    }
+
+    return {
+      error: `Timeout after ${timeoutMs}ms waiting for Template ${templateName} to be created`,
+      exists: false,
+    };
+  }
+}

--- a/playwright/src/clients/handlers/vm-disk-query-handler.ts
+++ b/playwright/src/clients/handlers/vm-disk-query-handler.ts
@@ -1,0 +1,755 @@
+import * as https from 'https';
+
+import type {
+  JsonPatchOp,
+  KubernetesListResource,
+  KubernetesResource,
+} from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+import { TestTimeouts } from '@/utils/test-config';
+
+import type { DataVolumeHandler } from './data-volume-handler';
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+import type { VmLifecycleHandler } from './vm-lifecycle-handler';
+
+export class VmDiskQueryHandler {
+  constructor(
+    private readonly ctx: KubernetesHandlerContext,
+    private readonly dataVolume: DataVolumeHandler,
+    private readonly lifecycle: VmLifecycleHandler,
+  ) {}
+
+  /**
+   * Add a blank disk to an existing VirtualMachine: creates a DataVolume with blank source,
+   * waits for it to be Succeeded, then patches the VM to attach the volume and disk.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param diskName - Name for the new disk/volume (and the DataVolume resource)
+   * @param size - Storage size for the blank DataVolume (default: '1Gi')
+   */
+  async addBlankDiskToVm(
+    vmName: string,
+    namespace: string,
+    diskName: string,
+    size = '1Gi',
+  ): Promise<void> {
+    await this.dataVolume.createBlankDataVolume(diskName, namespace, size);
+    await this.dataVolume.waitForDataVolumeSucceeded(diskName, namespace);
+
+    const patchBody = [
+      {
+        op: 'add',
+        path: '/spec/template/spec/volumes/-',
+        value: {
+          name: diskName,
+          dataVolume: { name: diskName },
+        },
+      },
+      {
+        op: 'add',
+        path: '/spec/template/spec/domain/devices/disks/-',
+        value: {
+          name: diskName,
+          disk: { bus: 'virtio' },
+        },
+      },
+    ];
+
+    await this.ctx.customObjectsApi.patchNamespacedCustomObject({
+      group: 'kubevirt.io',
+      version: 'v1',
+      namespace,
+      plural: 'virtualmachines',
+      name: vmName,
+      body: patchBody,
+    });
+  }
+
+  /**
+   * Add a CD-ROM disk to a stopped VM via JSON patch.
+   * When pvcClaimName is provided, the CD-ROM uses a PVC source (required for eject).
+   * Otherwise falls back to a containerDisk source.
+   */
+  async addCdromDiskToVm(
+    vmName: string,
+    namespace: string,
+    options?: { volumeName?: string; pvcClaimName?: string; containerImage?: string },
+  ): Promise<void> {
+    const volumeName = options?.volumeName ?? 'cdrom-test';
+
+    const volumeValue = options?.pvcClaimName
+      ? { name: volumeName, persistentVolumeClaim: { claimName: options.pvcClaimName } }
+      : {
+          name: volumeName,
+          containerDisk: {
+            image: options?.containerImage ?? 'registry.redhat.io/rhel9/rhel-guest-image:latest',
+          },
+        };
+
+    const patchBody = [
+      { op: 'add', path: '/spec/template/spec/volumes/-', value: volumeValue },
+      {
+        op: 'add',
+        path: '/spec/template/spec/domain/devices/disks/-',
+        value: { name: volumeName, cdrom: { bus: 'sata' } },
+      },
+    ];
+
+    await this.ctx.customObjectsApi.patchNamespacedCustomObject({
+      group: 'kubevirt.io',
+      version: 'v1',
+      namespace,
+      plural: 'virtualmachines',
+      name: vmName,
+      body: patchBody,
+    });
+  }
+
+  /**
+   * Enable SSH access on a VirtualMachine by adding the SSH access annotation.
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param sshServiceType - SSH service type: 'NodePort' or 'LoadBalancer' (default: 'NodePort')
+   * @returns The patched VirtualMachine resource
+   * @throws {Error} When patch operation fails
+   */
+  async enableSshAccess(
+    vmName: string,
+    namespace: string,
+    sshServiceType: 'NodePort' | 'LoadBalancer' = 'NodePort',
+  ) {
+    try {
+      const currentVm = await this.lifecycle.getVirtualMachine(vmName, namespace);
+      const hasAnnotations = currentVm?.metadata?.annotations !== undefined;
+      const annotationExists =
+        currentVm?.metadata?.annotations?.['vm.kubevirt.io/ssh-access'] !== undefined;
+
+      const patchOps: JsonPatchOp[] = [];
+
+      if (!hasAnnotations) {
+        patchOps.push({
+          op: 'add',
+          path: '/metadata/annotations',
+          value: {},
+        });
+      }
+
+      const annotationPath = '/metadata/annotations/vm.kubevirt.io~1ssh-access';
+      patchOps.push({
+        op: annotationExists ? 'replace' : 'add',
+        path: annotationPath,
+        value: sshServiceType,
+      });
+
+      type PatchNamespacedCustomObject = (
+        requestParameters: unknown,
+        contentType?: string,
+        options?: { headers?: Record<string, string> },
+      ) => Promise<{ body?: KubernetesResource } | KubernetesResource>;
+
+      const customObjectsApi = this.ctx.customObjectsApi as unknown as {
+        patchNamespacedCustomObject: PatchNamespacedCustomObject;
+      };
+
+      const response = await customObjectsApi.patchNamespacedCustomObject(
+        {
+          group: 'kubevirt.io',
+          version: 'v1',
+          namespace: namespace,
+          plural: 'virtualmachines',
+          name: vmName,
+          body: patchOps,
+          dryRun: undefined,
+          fieldManager: undefined,
+          fieldValidation: undefined,
+        },
+        'json',
+        {
+          headers: {
+            'Content-Type': 'application/json-patch+json',
+          },
+        },
+      );
+      if (response && typeof response === 'object' && 'body' in response) {
+        const withBody = response as { body?: KubernetesResource };
+        return withBody.body ?? (response as KubernetesResource);
+      }
+      return response as KubernetesResource;
+    } catch (error: unknown) {
+      throw new Error(`Failed to enable SSH access on VirtualMachine: ${getErrorMessage(error)}`);
+    }
+  }
+
+  /**
+   * Get VMI CPU sockets count.
+   * @param vmName - Name of the VirtualMachineInstance
+   * @param namespace - Namespace where the VMI exists
+   * @returns The CPU sockets count as a string, or null if not available
+   */
+  async getVmiCpuSockets(vmName: string, namespace: string): Promise<string | null> {
+    try {
+      const vmi = (await this.lifecycle.getVirtualMachineInstance(
+        vmName,
+        namespace,
+      )) as KubernetesResource;
+      const domain = vmi.spec?.['domain'] as Record<string, unknown> | undefined;
+      const cpu = domain?.['cpu'] as Record<string, unknown> | undefined;
+      const sockets = cpu?.['sockets'];
+      return sockets != null && sockets !== '' ? String(sockets) : null;
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      if (msg.includes('404') || msg.includes('not found')) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Get the disk bus type from a running VMI for a specific disk.
+   * KubeVirt resolves the bus at runtime (e.g., virtio, scsi, sata) even when
+   * the VM spec doesn't set it explicitly.
+   * @param vmName - Name of the VirtualMachineInstance
+   * @param namespace - Namespace where the VMI exists
+   * @param diskName - Name of the disk (e.g., "rootdisk")
+   * @returns The bus type string (e.g., "virtio"), or null if not available
+   */
+  async getVmiDiskBus(vmName: string, namespace: string, diskName: string): Promise<string | null> {
+    try {
+      const vmi = (await this.lifecycle.getVirtualMachineInstance(
+        vmName,
+        namespace,
+      )) as KubernetesResource;
+      const domain = vmi.spec?.['domain'] as Record<string, unknown> | undefined;
+      const devices = domain?.['devices'] as Record<string, unknown> | undefined;
+      const disks = devices?.['disks'];
+      if (!Array.isArray(disks)) return null;
+
+      const diskRecord = disks.find((d: unknown) => {
+        const rec = d as Record<string, unknown>;
+        return rec['name'] === diskName;
+      }) as Record<string, unknown> | undefined;
+      if (!diskRecord) return null;
+
+      for (const key of ['disk', 'cdrom', 'lun'] as const) {
+        const section = diskRecord[key] as Record<string, unknown> | undefined;
+        const bus = section?.['bus'];
+        if (typeof bus === 'string' && bus) return bus;
+      }
+      return null;
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      if (msg.includes('404') || msg.includes('not found')) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Get the filesystem list from a running VMI via the filesystemlist subresource API.
+   * Returns all filesystems reported by the guest agent (no item cap, unlike guestosinfo).
+   */
+  async getVmiFilesystemList(
+    vmName: string,
+    namespace: string,
+  ): Promise<{
+    items: Array<{
+      diskName: string;
+      mountPoint: string;
+      fileSystemType: string;
+      totalBytes: number;
+      usedBytes: number;
+    }>;
+  }> {
+    const cluster = this.ctx.kc.getCurrentCluster();
+    if (!cluster) throw new Error('No current cluster in kubeconfig');
+
+    const requestPath = `/apis/subresources.kubevirt.io/v1/namespaces/${namespace}/virtualmachineinstances/${vmName}/filesystemlist`;
+    const url = new URL(requestPath, cluster.server);
+
+    const opts: https.RequestOptions = {
+      hostname: url.hostname,
+      port: url.port || '443',
+      path: url.pathname,
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      rejectUnauthorized: false,
+    };
+
+    await this.ctx.kc.applyToHTTPSOptions(opts);
+
+    return new Promise((resolve, reject) => {
+      const req = https.request(opts, (res) => {
+        let data = '';
+        res.on('data', (chunk: string) => (data += chunk));
+        res.on('end', () => {
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            try {
+              resolve(JSON.parse(data));
+            } catch {
+              reject(new Error(`Failed to parse filesystemlist response: ${data.slice(0, 200)}`));
+            }
+          } else {
+            reject(new Error(`filesystemlist failed (${res.statusCode}): ${data.slice(0, 200)}`));
+          }
+        });
+      });
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  /**
+   * Get VMI memory guest value.
+   * @param vmName - Name of the VirtualMachineInstance
+   * @param namespace - Namespace where the VMI exists
+   * @returns The memory guest value (e.g., "3Gi"), or null if not available
+   */
+  async getVmiMemoryGuest(vmName: string, namespace: string): Promise<string | null> {
+    try {
+      const vmi = (await this.lifecycle.getVirtualMachineInstance(
+        vmName,
+        namespace,
+      )) as KubernetesResource;
+      const domain = vmi.spec?.['domain'] as Record<string, unknown> | undefined;
+      const memory = domain?.['memory'] as Record<string, unknown> | undefined;
+      const memoryGuest = memory?.['guest'];
+      if (memoryGuest == null || memoryGuest === '') return null;
+      return typeof memoryGuest === 'string' ? memoryGuest : String(memoryGuest);
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      if (msg.includes('404') || msg.includes('not found')) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Get the IP address of a running VirtualMachine from its VMI.
+   * The VM must be running for this to return an IP address.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @returns The IP address of the VM, or null if not available
+   */
+  async getVmIpAddress(vmName: string, namespace: string): Promise<string | null> {
+    try {
+      const vmi = (await this.lifecycle.getVirtualMachineInstance(
+        vmName,
+        namespace,
+      )) as KubernetesResource;
+      const status = vmi.status as Record<string, unknown> | undefined;
+      const interfaces = status?.['interfaces'];
+      if (Array.isArray(interfaces) && interfaces.length > 0) {
+        const first = interfaces[0] as Record<string, unknown> | undefined;
+        const ipAddress = first?.['ipAddress'];
+        if (typeof ipAddress === 'string' && ipAddress) {
+          return ipAddress;
+        }
+      }
+
+      return null;
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      if (msg.includes('404') || msg.includes('not found')) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Hotplug a DataVolume to a running VM via the KubeVirt addvolume subresource API.
+   * As of CNV v4.22, hotplugged disks are persistent by default.
+   * Requires a pre-existing DataVolume in the same namespace.
+   */
+  async hotplugVolumeToVm(
+    vmName: string,
+    namespace: string,
+    diskName: string,
+    dataVolumeName: string,
+  ): Promise<void> {
+    const cluster = this.ctx.kc.getCurrentCluster();
+    if (!cluster) throw new Error('No current cluster in kubeconfig');
+
+    const requestPath = `/apis/subresources.kubevirt.io/v1/namespaces/${namespace}/virtualmachines/${vmName}/addvolume`;
+    const body = JSON.stringify({
+      name: diskName,
+      disk: { disk: { bus: 'virtio' }, name: diskName },
+      volumeSource: { dataVolume: { name: dataVolumeName } },
+    });
+
+    const url = new URL(requestPath, cluster.server);
+
+    const opts: https.RequestOptions = {
+      hostname: url.hostname,
+      port: url.port || '443',
+      path: url.pathname,
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
+      rejectUnauthorized: false,
+    };
+
+    await this.ctx.kc.applyToHTTPSOptions(opts);
+
+    return new Promise<void>((resolve, reject) => {
+      const req = https.request(opts, (res) => {
+        let data = '';
+        res.on('data', (chunk: string) => (data += chunk));
+        res.on('end', () => {
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            resolve();
+          } else {
+            reject(new Error(`addvolume failed (${res.statusCode}): ${data}`));
+          }
+        });
+      });
+      req.on('error', reject);
+      req.write(body);
+      req.end();
+    });
+  }
+
+  /**
+   * Check the VM spec to verify a disk is present in the template (persisted across restarts).
+   * After "Make persistent", the volume should exist in `spec.template.spec.volumes`
+   * and the corresponding disk in `spec.template.spec.domain.devices.disks`.
+   */
+  async isVmDiskPersistent(vmName: string, namespace: string, diskName: string): Promise<boolean> {
+    const vm = (await this.lifecycle.getVirtualMachine(vmName, namespace)) as KubernetesResource;
+    const template = vm?.spec?.['template'] as Record<string, unknown> | undefined;
+    const tmplSpec = template?.['spec'] as Record<string, unknown> | undefined;
+    const domain = tmplSpec?.['domain'] as Record<string, unknown> | undefined;
+    const devices = domain?.['devices'] as Record<string, unknown> | undefined;
+    const volumesUnknown = tmplSpec?.['volumes'];
+    const disksUnknown = devices?.['disks'];
+    const volumes: KubernetesResource[] = Array.isArray(volumesUnknown)
+      ? (volumesUnknown as KubernetesResource[])
+      : [];
+    const disks: KubernetesResource[] = Array.isArray(disksUnknown)
+      ? (disksUnknown as KubernetesResource[])
+      : [];
+
+    const hasVolume = volumes.some((v) => v['name'] === diskName);
+    const hasDisk = disks.some((d) => d['name'] === diskName);
+
+    return hasVolume && hasDisk;
+  }
+
+  async listVirtualMachines(namespace: string): Promise<KubernetesResource[]> {
+    try {
+      const response = await this.ctx.customObjectsApi.listNamespacedCustomObject({
+        group: 'kubevirt.io',
+        namespace,
+        plural: 'virtualmachines',
+        version: 'v1',
+      });
+      const body = response.body || response;
+      const list = body as KubernetesListResource;
+      return list?.items ?? [];
+    } catch (error: unknown) {
+      throw new Error(
+        `Failed to list VirtualMachines in namespace ${namespace}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Verify that a folder is deleted from the cluster (no VMs with folder label exist)
+   * @param folderName - Name of the folder to check
+   * @param namespace - Namespace where the folder should be deleted from
+   * @param timeoutMs - Timeout in milliseconds (default: TestTimeouts.CLUSTER_OPERATION)
+   * @returns Object with folder deletion status
+   */
+  async verifyFolderDeleted(
+    folderName: string,
+    namespace: string,
+    timeoutMs: number = TestTimeouts.CLUSTER_OPERATION,
+  ): Promise<{
+    folderDeleted: boolean;
+    errors?: string[];
+  }> {
+    const startTime = Date.now();
+    const errors: string[] = [];
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const allVMs = await this.ctx.listCustomResources(
+          'kubevirt.io',
+          'v1',
+          namespace,
+          'virtualmachines',
+        );
+
+        const vmsWithFolderLabel = allVMs.filter(
+          (vm: KubernetesResource) =>
+            vm.metadata?.labels?.['vm.openshift.io/folder'] === folderName,
+        );
+
+        if (vmsWithFolderLabel.length === 0) {
+          return {
+            folderDeleted: true,
+            errors: errors.length > 0 ? errors : undefined,
+          };
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      } catch (error: unknown) {
+        errors.push(`Error checking folder ${folderName}: ${getErrorMessage(error)}`);
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      }
+    }
+
+    return {
+      folderDeleted: false,
+      errors: errors.length > 0 ? errors : undefined,
+    };
+  }
+
+  async verifyVmCreated(
+    vmName: string,
+    namespace: string,
+    timeoutMs = 30000,
+  ): Promise<{
+    error?: string;
+    exists: boolean;
+    vm?: KubernetesResource;
+  }> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const vm = await this.ctx.getCustomResource(
+          'kubevirt.io',
+          'v1',
+          namespace,
+          'virtualmachines',
+          vmName,
+        );
+
+        return {
+          exists: true,
+          vm: vm,
+        };
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        if (msg.includes('404') || msg.includes('not found')) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return {
+          error: msg,
+          exists: false,
+        };
+      }
+    }
+
+    return {
+      error: `Timeout after ${timeoutMs}ms waiting for VM ${vmName} to be created`,
+      exists: false,
+    };
+  }
+
+  /**
+   * Verify that VMs and folder are deleted from the cluster
+   * @param vmNames - Array of VM names to check
+   * @param folderName - Name of the folder to check
+   * @param namespace - Namespace where the VMs and folder should be deleted from
+   * @param timeoutMs - Timeout in milliseconds (default: 60000)
+   * @returns Object with deletion status for each VM and folder
+   */
+  async verifyVmFolderAndVmsDeleted(
+    vmNames: string[],
+    folderName: string,
+    namespace: string,
+    timeoutMs = 60000,
+  ): Promise<{
+    folderDeleted: boolean;
+    vmsDeleted: { [vmName: string]: boolean };
+    allDeleted: boolean;
+    errors?: string[];
+  }> {
+    const startTime = Date.now();
+    const errors: string[] = [];
+    const vmsDeleted: { [vmName: string]: boolean } = {};
+
+    vmNames.forEach((vmName) => {
+      vmsDeleted[vmName] = false;
+    });
+
+    while (Date.now() - startTime < timeoutMs) {
+      let allVmsDeleted = true;
+      let folderDeleted = false;
+
+      for (const vmName of vmNames) {
+        try {
+          const exists = await this.lifecycle.vmExists(vmName, namespace);
+          vmsDeleted[vmName] = !exists;
+          if (exists) {
+            allVmsDeleted = false;
+          }
+        } catch (error: unknown) {
+          errors.push(`Error checking VM ${vmName}: ${getErrorMessage(error)}`);
+          allVmsDeleted = false;
+        }
+      }
+
+      try {
+        const allVMs = await this.ctx.listCustomResources(
+          'kubevirt.io',
+          'v1',
+          namespace,
+          'virtualmachines',
+        );
+
+        const vmsWithFolderLabel = allVMs.filter(
+          (vm: KubernetesResource) =>
+            vm.metadata?.labels?.['vm.openshift.io/folder'] === folderName,
+        );
+
+        folderDeleted = vmsWithFolderLabel.length === 0;
+      } catch (error: unknown) {
+        errors.push(`Error checking folder ${folderName}: ${getErrorMessage(error)}`);
+        folderDeleted = false;
+      }
+
+      if (allVmsDeleted && folderDeleted) {
+        return {
+          folderDeleted: true,
+          vmsDeleted,
+          allDeleted: true,
+          errors: errors.length > 0 ? errors : undefined,
+        };
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+
+    return {
+      folderDeleted: false,
+      vmsDeleted,
+      allDeleted: false,
+      errors: errors.length > 0 ? errors : undefined,
+    };
+  }
+
+  async verifyVmHasSSHKey(
+    vmName: string,
+    namespace: string,
+  ): Promise<{ hasSSHKey: boolean; secretName?: string }> {
+    try {
+      const vm = await this.ctx.getCustomResource(
+        'kubevirt.io',
+        'v1',
+        namespace,
+        'virtualmachines',
+        vmName,
+      );
+
+      if (!vm) {
+        return { hasSSHKey: false };
+      }
+
+      const template = vm.spec?.['template'] as Record<string, unknown> | undefined;
+      const tmplSpec = template?.['spec'] as Record<string, unknown> | undefined;
+      const accessCredentials = tmplSpec?.['accessCredentials'];
+      if (accessCredentials && Array.isArray(accessCredentials) && accessCredentials.length > 0) {
+        const sshCredential = accessCredentials.find((cred: unknown) => {
+          const rec = cred as Record<string, unknown>;
+          const sshPk = rec['sshPublicKey'] as Record<string, unknown> | undefined;
+          const source = sshPk?.['source'] as Record<string, unknown> | undefined;
+          return !!source?.['secret'];
+        }) as Record<string, unknown> | undefined;
+        if (sshCredential) {
+          const sshPk = sshCredential['sshPublicKey'] as Record<string, unknown> | undefined;
+          const source = sshPk?.['source'] as Record<string, unknown> | undefined;
+          const secret = source?.['secret'] as Record<string, unknown> | undefined;
+          const secretNameRaw = secret?.['secretName'];
+          const secretName = typeof secretNameRaw === 'string' ? secretNameRaw : undefined;
+          return {
+            hasSSHKey: true,
+            secretName,
+          };
+        }
+      }
+
+      return { hasSSHKey: false };
+    } catch {
+      return { hasSSHKey: false };
+    }
+  }
+
+  /**
+   * Wait until a disk with the given name is present in the VM spec.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param diskName - Disk name to look for
+   * @param timeoutMs - Maximum time to wait in milliseconds (default: VM_CREATION)
+   */
+  async waitForVmDiskPresent(
+    vmName: string,
+    namespace: string,
+    diskName: string,
+    timeoutMs: number = TestTimeouts.VM_CREATION,
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      const vm = (await this.lifecycle.getVirtualMachine(vmName, namespace)) as KubernetesResource;
+      const template = vm?.spec?.['template'] as Record<string, unknown> | undefined;
+      const tmplSpec = template?.['spec'] as Record<string, unknown> | undefined;
+      const domain = tmplSpec?.['domain'] as Record<string, unknown> | undefined;
+      const devices = domain?.['devices'] as Record<string, unknown> | undefined;
+      const disksUnknown = devices?.['disks'];
+      const disks: Array<{ name?: string }> = Array.isArray(disksUnknown)
+        ? (disksUnknown as Array<{ name?: string }>)
+        : [];
+      if (disks.some((d) => d.name === diskName)) {
+        return;
+      }
+      await new Promise((r) => setTimeout(r, TestTimeouts.POLLING_INTERVAL));
+    }
+
+    throw new Error(
+      `Timeout waiting for disk "${diskName}" to appear in VM ${vmName} in namespace ${namespace}`,
+    );
+  }
+
+  /**
+   * Wait for a VirtualMachine to reach Error status (printableStatus).
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param timeoutMs - Maximum time to wait in milliseconds (default: 120000)
+   */
+  async waitForVmError(vmName: string, namespace: string, timeoutMs = 120000): Promise<boolean> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const vm = await this.ctx.getCustomResource(
+          'kubevirt.io',
+          'v1',
+          namespace,
+          'virtualmachines',
+          vmName,
+        );
+        const status = (vm as KubernetesResource)?.status?.['printableStatus'];
+        if (status === 'Error') {
+          return true;
+        }
+        await new Promise((resolve) => setTimeout(resolve, TestTimeouts.POLLING_INTERVAL));
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, TestTimeouts.POLLING_INTERVAL));
+      }
+    }
+
+    throw new Error(
+      `Timeout waiting for VM ${vmName} to reach Error status in namespace ${namespace}`,
+    );
+  }
+}

--- a/playwright/src/clients/handlers/vm-handler.ts
+++ b/playwright/src/clients/handlers/vm-handler.ts
@@ -1,0 +1,372 @@
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { TestTimeouts } from '@/utils/test-config';
+
+import type { DataVolumeHandler } from './data-volume-handler';
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+import type { SecretConfigMapHandler } from './secret-configmap-handler';
+import type { TemplateHandler } from './template-handler';
+import { VmDiskQueryHandler } from './vm-disk-query-handler';
+import { VmLifecycleHandler } from './vm-lifecycle-handler';
+import { VmPatchHandler } from './vm-patch-handler';
+
+/**
+ * Facade preserving `client.vm.*` API; implementation is split across lifecycle, patch, and disk/query handlers.
+ */
+export class VirtualMachineHandler {
+  private readonly diskQuery: VmDiskQueryHandler;
+  private readonly lifecycle: VmLifecycleHandler;
+  private readonly patch: VmPatchHandler;
+
+  constructor(
+    ctx: KubernetesHandlerContext,
+    template: TemplateHandler,
+    dataVolume: DataVolumeHandler,
+    secret: SecretConfigMapHandler,
+  ) {
+    this.lifecycle = new VmLifecycleHandler(ctx, template);
+    this.patch = new VmPatchHandler(ctx, this.lifecycle, secret);
+    this.diskQuery = new VmDiskQueryHandler(ctx, dataVolume, this.lifecycle);
+  }
+
+  addBlankDiskToVm(
+    vmName: string,
+    namespace: string,
+    diskName: string,
+    size = '1Gi',
+  ): Promise<void> {
+    return this.diskQuery.addBlankDiskToVm(vmName, namespace, diskName, size);
+  }
+
+  addCdromDiskToVm(
+    vmName: string,
+    namespace: string,
+    options?: { volumeName?: string; pvcClaimName?: string; containerImage?: string },
+  ): Promise<void> {
+    return this.diskQuery.addCdromDiskToVm(vmName, namespace, options);
+  }
+
+  cloneVirtualMachine(
+    sourceVmName: string,
+    targetVmName: string,
+    namespace: string,
+    startAfterClone = false,
+    timeoutMs: number = TestTimeouts.VM_CREATION,
+  ) {
+    return this.lifecycle.cloneVirtualMachine(
+      sourceVmName,
+      targetVmName,
+      namespace,
+      startAfterClone,
+      timeoutMs,
+    );
+  }
+
+  createVmFromInstanceType(
+    volumeName: string,
+    vmName: string,
+    namespace: string,
+    series = 'U series',
+    instanceTypeSize = 'small',
+    startAfterCreation = true,
+    volumeNamespace = 'openshift-virtualization-os-images',
+    storageClassName?: string,
+    rootDiskName = 'rootdisk',
+  ) {
+    return this.lifecycle.createVmFromInstanceType(
+      volumeName,
+      vmName,
+      namespace,
+      series,
+      instanceTypeSize,
+      startAfterCreation,
+      volumeNamespace,
+      storageClassName,
+      rootDiskName,
+    );
+  }
+
+  createVmFromTemplate(
+    templateMetadataName: string,
+    vmName: string,
+    namespace: string,
+    templateNamespace = 'openshift',
+    startAfterCreation = true,
+    sysprepConfigMapName?: string,
+    cloudInitConfig?: {
+      username?: string;
+      password?: string;
+    },
+    vmCustomization?: {
+      description?: string;
+      cpu?: number;
+      memory?: number;
+      bootMode?: 'BIOS' | 'UEFI' | 'UEFI (secure)';
+      workload?: string;
+      hostname?: string;
+      headless?: boolean;
+    },
+    storageClassName?: string,
+    folderName?: string,
+  ) {
+    return this.lifecycle.createVmFromTemplate(
+      templateMetadataName,
+      vmName,
+      namespace,
+      templateNamespace,
+      startAfterCreation,
+      sysprepConfigMapName,
+      cloudInitConfig,
+      vmCustomization,
+      storageClassName,
+      folderName,
+    );
+  }
+
+  disableDeleteProtection(vmName: string, namespace: string) {
+    return this.lifecycle.disableDeleteProtection(vmName, namespace);
+  }
+
+  enableNodePortFeature(enabled = true, nodePortAddress?: string, cnvNamespace = 'openshift-cnv') {
+    return this.patch.enableNodePortFeature(enabled, nodePortAddress, cnvNamespace);
+  }
+
+  enableSshAccess(
+    vmName: string,
+    namespace: string,
+    sshServiceType: 'NodePort' | 'LoadBalancer' = 'NodePort',
+  ) {
+    return this.diskQuery.enableSshAccess(vmName, namespace, sshServiceType);
+  }
+
+  ensureVmFoldersEnabled(cnvNamespace = 'openshift-cnv'): Promise<KubernetesResource | null> {
+    return this.patch.ensureVmFoldersEnabled(cnvNamespace);
+  }
+
+  getVirtualMachine(vmName: string, namespace: string) {
+    return this.lifecycle.getVirtualMachine(vmName, namespace);
+  }
+
+  getVirtualMachineInstance(vmName: string, namespace: string) {
+    return this.lifecycle.getVirtualMachineInstance(vmName, namespace);
+  }
+
+  getVmiCpuSockets(vmName: string, namespace: string): Promise<string | null> {
+    return this.diskQuery.getVmiCpuSockets(vmName, namespace);
+  }
+
+  getVmiDiskBus(vmName: string, namespace: string, diskName: string): Promise<string | null> {
+    return this.diskQuery.getVmiDiskBus(vmName, namespace, diskName);
+  }
+
+  getVmiFilesystemList(vmName: string, namespace: string) {
+    return this.diskQuery.getVmiFilesystemList(vmName, namespace);
+  }
+
+  getVmiMemoryGuest(vmName: string, namespace: string): Promise<string | null> {
+    return this.diskQuery.getVmiMemoryGuest(vmName, namespace);
+  }
+
+  getVmIpAddress(vmName: string, namespace: string): Promise<string | null> {
+    return this.diskQuery.getVmIpAddress(vmName, namespace);
+  }
+
+  hotplugVolumeToVm(
+    vmName: string,
+    namespace: string,
+    diskName: string,
+    dataVolumeName: string,
+  ): Promise<void> {
+    return this.diskQuery.hotplugVolumeToVm(vmName, namespace, diskName, dataVolumeName);
+  }
+
+  isVmDiskPersistent(vmName: string, namespace: string, diskName: string): Promise<boolean> {
+    return this.diskQuery.isVmDiskPersistent(vmName, namespace, diskName);
+  }
+
+  listVirtualMachines(namespace: string) {
+    return this.diskQuery.listVirtualMachines(namespace);
+  }
+
+  patchVirtualMachineInstanceStatus(
+    vmiName: string,
+    namespace: string,
+    conditions: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+      lastTransitionTime?: string;
+    }>,
+  ) {
+    return this.patch.patchVirtualMachineInstanceStatus(vmiName, namespace, conditions);
+  }
+
+  patchVirtualMachineNodeSelector(
+    vmName: string,
+    namespace: string,
+    nodeSelector: { [key: string]: string },
+  ) {
+    return this.patch.patchVirtualMachineNodeSelector(vmName, namespace, nodeSelector);
+  }
+
+  patchVirtualMachineResources(
+    vmName: string,
+    namespace: string,
+    resources: {
+      cpuSockets?: number;
+      cpuCores?: number;
+      memory?: string;
+    },
+  ) {
+    return this.patch.patchVirtualMachineResources(vmName, namespace, resources);
+  }
+
+  patchVirtualMachineRunStrategy(
+    vmName: string,
+    namespace: string,
+    runStrategy: 'Always' | 'Manual' | 'RerunOnFailure',
+  ) {
+    return this.patch.patchVirtualMachineRunStrategy(vmName, namespace, runStrategy);
+  }
+
+  patchVmDeschedulerEvictAnnotation(
+    vmName: string,
+    namespace: string,
+    enabled: boolean,
+  ): Promise<void> {
+    return this.patch.patchVmDeschedulerEvictAnnotation(vmName, namespace, enabled);
+  }
+
+  patchVmEvictionStrategy(
+    vmName: string,
+    namespace: string,
+    evictionStrategy: 'LiveMigrate' | 'None',
+  ) {
+    return this.patch.patchVmEvictionStrategy(vmName, namespace, evictionStrategy);
+  }
+
+  patchVmNetworkInterfaceModel(
+    vmName: string,
+    namespace: string,
+    model: 'virtio' | 'e1000e',
+    interfaceIndex = 0,
+  ): Promise<void> {
+    return this.patch.patchVmNetworkInterfaceModel(vmName, namespace, model, interfaceIndex);
+  }
+
+  patchVmToErrorState(vmName: string, namespace: string): Promise<void> {
+    return this.patch.patchVmToErrorState(vmName, namespace);
+  }
+
+  removeVmDeleteProtection(vmName: string, namespace: string): Promise<boolean> {
+    return this.lifecycle.removeVmDeleteProtection(vmName, namespace);
+  }
+
+  startVirtualMachine(vmName: string, namespace: string) {
+    return this.lifecycle.startVirtualMachine(vmName, namespace);
+  }
+
+  startVm(vmName: string, namespace: string): Promise<boolean> {
+    return this.lifecycle.startVm(vmName, namespace);
+  }
+
+  stopVm(vmName: string, namespace: string): Promise<boolean> {
+    return this.lifecycle.stopVm(vmName, namespace);
+  }
+
+  verifyFolderDeleted(
+    folderName: string,
+    namespace: string,
+    timeoutMs: number = TestTimeouts.CLUSTER_OPERATION,
+  ): Promise<{
+    folderDeleted: boolean;
+    errors?: string[];
+  }> {
+    return this.diskQuery.verifyFolderDeleted(folderName, namespace, timeoutMs);
+  }
+
+  verifyVmCreated(
+    vmName: string,
+    namespace: string,
+    timeoutMs = 30000,
+  ): Promise<{
+    error?: string;
+    exists: boolean;
+    vm?: KubernetesResource;
+  }> {
+    return this.diskQuery.verifyVmCreated(vmName, namespace, timeoutMs);
+  }
+
+  verifyVmFolderAndVmsDeleted(
+    vmNames: string[],
+    folderName: string,
+    namespace: string,
+    timeoutMs = 60000,
+  ): Promise<{
+    folderDeleted: boolean;
+    vmsDeleted: { [vmName: string]: boolean };
+    allDeleted: boolean;
+    errors?: string[];
+  }> {
+    return this.diskQuery.verifyVmFolderAndVmsDeleted(vmNames, folderName, namespace, timeoutMs);
+  }
+
+  verifyVmHasSSHKey(
+    vmName: string,
+    namespace: string,
+  ): Promise<{ hasSSHKey: boolean; secretName?: string }> {
+    return this.diskQuery.verifyVmHasSSHKey(vmName, namespace);
+  }
+
+  /**
+   * Verifies the VM spec JSON contains (or excludes) a substring.
+   */
+  async verifyVmSpecContains(
+    expectedText: string,
+    shouldContain = true,
+    vmName: string,
+    namespace: string,
+  ): Promise<boolean> {
+    try {
+      const vm = await this.getVirtualMachine(vmName, namespace);
+      const specString = JSON.stringify((vm as { spec?: unknown })?.spec ?? {});
+      const contains = specString.includes(expectedText);
+      return shouldContain ? contains : !contains;
+    } catch {
+      return false;
+    }
+  }
+
+  vmExists(vmName: string, namespace: string): Promise<boolean> {
+    return this.lifecycle.vmExists(vmName, namespace);
+  }
+
+  waitForVmCloneSucceeded(cloneName: string, namespace: string, timeoutMs = 120000) {
+    return this.lifecycle.waitForVmCloneSucceeded(cloneName, namespace, timeoutMs);
+  }
+
+  waitForVmDeleted(vmName: string, namespace: string, timeoutMs = 60000): Promise<boolean> {
+    return this.lifecycle.waitForVmDeleted(vmName, namespace, timeoutMs);
+  }
+
+  waitForVmDiskPresent(
+    vmName: string,
+    namespace: string,
+    diskName: string,
+    timeoutMs: number = TestTimeouts.VM_CREATION,
+  ): Promise<void> {
+    return this.diskQuery.waitForVmDiskPresent(vmName, namespace, diskName, timeoutMs);
+  }
+
+  waitForVmError(vmName: string, namespace: string, timeoutMs = 120000): Promise<boolean> {
+    return this.diskQuery.waitForVmError(vmName, namespace, timeoutMs);
+  }
+
+  waitForVmExists(vmName: string, namespace: string, timeoutMs = 120000): Promise<boolean> {
+    return this.lifecycle.waitForVmExists(vmName, namespace, timeoutMs);
+  }
+
+  waitForVmRunning(vmName: string, namespace: string, timeoutMs = 300000): Promise<boolean> {
+    return this.lifecycle.waitForVmRunning(vmName, namespace, timeoutMs);
+  }
+}

--- a/playwright/src/clients/handlers/vm-lifecycle-handler.ts
+++ b/playwright/src/clients/handlers/vm-lifecycle-handler.ts
@@ -1,0 +1,880 @@
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+import { TestTimeouts } from '@/utils/test-config';
+
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+import type { TemplateHandler } from './template-handler';
+
+export class VmLifecycleHandler {
+  constructor(
+    private readonly ctx: KubernetesHandlerContext,
+    private readonly template: TemplateHandler,
+  ) {}
+
+  /**
+   * Clone a VirtualMachine using the KubeVirt VirtualMachineClone CRD
+   * @param sourceVmName - Name of the source VirtualMachine to clone
+   * @param targetVmName - Name for the cloned VirtualMachine
+   * @param namespace - Namespace where both VMs reside
+   * @param startAfterClone - Whether to start the cloned VM after creation (default: false)
+   * @param timeoutMs - Maximum time to wait for clone to complete (default: VM_CREATION timeout)
+   * @returns The created VirtualMachineClone resource
+   */
+  async cloneVirtualMachine(
+    sourceVmName: string,
+    targetVmName: string,
+    namespace: string,
+    startAfterClone = false,
+    timeoutMs: number = TestTimeouts.VM_CREATION,
+  ) {
+    const cloneName = `${targetVmName}-clone`;
+    const cloneResource = {
+      apiVersion: 'clone.kubevirt.io/v1alpha1',
+      kind: 'VirtualMachineClone',
+      metadata: {
+        name: cloneName,
+        namespace: namespace,
+      },
+      spec: {
+        source: {
+          apiGroup: 'kubevirt.io',
+          kind: 'VirtualMachine',
+          name: sourceVmName,
+        },
+        target: {
+          apiGroup: 'kubevirt.io',
+          kind: 'VirtualMachine',
+          name: targetVmName,
+        },
+      },
+    };
+
+    const cloneResult = await this.ctx.createCustomResource(
+      'clone.kubevirt.io',
+      'v1alpha1',
+      namespace,
+      'virtualmachineclones',
+      cloneResource,
+    );
+
+    await this.waitForVmCloneSucceeded(cloneName, namespace, timeoutMs);
+
+    if (startAfterClone) {
+      await this.startVirtualMachine(targetVmName, namespace);
+    }
+
+    return cloneResult;
+  }
+
+  /**
+   * Create a VM from an instance type using the Kubernetes API
+   * @param volumeName - The name of the bootable volume (DataSource name, e.g., 'rhel9')
+   * @param vmName - Name for the VM to create
+   * @param namespace - Namespace where the VM should be created
+   * @param series - The instance type series (e.g., 'U series' maps to 'u1')
+   * @param instanceTypeSize - The instance type size (e.g., 'small', 'medium', 'large')
+   * @param startAfterCreation - Whether to start the VM after creation (default: true)
+   * @param volumeNamespace - Namespace where the DataSource exists (default: 'openshift-virtualization-os-images')
+   * @param storageClassName - Optional storage class name for the DataVolume (e.g., 'ocs-storagecluster-ceph-rbd-virtualization' for live migration support)
+   * @param rootDiskName - Name of the root disk/volume in the VM spec (default: 'rootdisk'). DataVolume resource remains `${vmName}-volume`.
+   * @returns The created VM resource
+   */
+  async createVmFromInstanceType(
+    volumeName: string,
+    vmName: string,
+    namespace: string,
+    series = 'U series',
+    instanceTypeSize = 'small',
+    startAfterCreation = true,
+    volumeNamespace = 'openshift-virtualization-os-images',
+    storageClassName?: string,
+    rootDiskName = 'rootdisk',
+  ) {
+    const seriesMap: { [key: string]: string } = {
+      'U series': 'u1',
+      'u series': 'u1',
+      U: 'u1',
+      u: 'u1',
+      'C series': 'cx1',
+      'c series': 'cx1',
+      CX: 'cx1',
+      cx: 'cx1',
+      C: 'cx1',
+      c: 'cx1',
+    };
+    const seriesPrefix = seriesMap[series] || series.toLowerCase().replace(' series', '1');
+
+    const instanceTypeName = `${seriesPrefix}.${instanceTypeSize}`;
+
+    const vmResource = {
+      apiVersion: 'kubevirt.io/v1',
+      kind: 'VirtualMachine',
+      metadata: {
+        name: vmName,
+        namespace: namespace,
+        labels: {
+          app: vmName,
+          'test-framework': 'playwright',
+        },
+      },
+      spec: {
+        runStrategy: startAfterCreation ? 'Always' : 'Manual',
+        instancetype: {
+          name: instanceTypeName,
+        },
+        preference: {
+          inferFromVolume: rootDiskName,
+        },
+        dataVolumeTemplates: [
+          {
+            metadata: {
+              name: `${vmName}-volume`,
+            },
+            spec: {
+              sourceRef: {
+                kind: 'DataSource',
+                name: volumeName,
+                namespace: volumeNamespace,
+              },
+              storage: {
+                ...(storageClassName && { storageClassName }),
+                resources: {
+                  requests: {
+                    storage: '30Gi',
+                  },
+                },
+              },
+            },
+          },
+        ],
+        template: {
+          metadata: {
+            labels: {
+              'kubevirt.io/domain': vmName,
+            },
+          },
+          spec: {
+            domain: {
+              devices: {
+                disks: [
+                  {
+                    disk: {
+                      bus: 'virtio',
+                    },
+                    name: rootDiskName,
+                  },
+                  {
+                    disk: {
+                      bus: 'virtio',
+                    },
+                    name: 'cloudinitdisk',
+                  },
+                ],
+                interfaces: [
+                  {
+                    masquerade: {},
+                    name: 'default',
+                  },
+                ],
+                rng: {},
+              },
+            },
+            networks: [
+              {
+                name: 'default',
+                pod: {},
+              },
+            ],
+            volumes: [
+              {
+                dataVolume: {
+                  name: `${vmName}-volume`,
+                },
+                name: rootDiskName,
+              },
+              {
+                cloudInitNoCloud: {
+                  userData: `#cloud-config
+user: cnv-tester
+password: set-own-pwd
+chpasswd:
+  expire: false
+`,
+                },
+                name: 'cloudinitdisk',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    return await this.ctx.createCustomResource(
+      'kubevirt.io',
+      'v1',
+      namespace,
+      'virtualmachines',
+      vmResource,
+    );
+  }
+
+  async createVmFromTemplate(
+    templateMetadataName: string,
+    vmName: string,
+    namespace: string,
+    templateNamespace = 'openshift',
+    startAfterCreation = true,
+    sysprepConfigMapName?: string,
+    cloudInitConfig?: {
+      username?: string;
+      password?: string;
+    },
+    vmCustomization?: {
+      description?: string;
+      cpu?: number;
+      memory?: number; // in GiB
+      bootMode?: 'BIOS' | 'UEFI' | 'UEFI (secure)';
+      workload?: string;
+      hostname?: string;
+      headless?: boolean;
+    },
+    storageClassName?: string,
+    folderName?: string,
+  ) {
+    const template = await this.template.findTemplateByMetadataName(
+      templateMetadataName,
+      templateNamespace,
+    );
+    if (!template) {
+      throw new Error(
+        `Template with metadata name '${templateMetadataName}' not found in namespace '${templateNamespace}'`,
+      );
+    }
+
+    interface TemplateParameter {
+      name?: string;
+      generate?: string;
+      value?: string;
+      default?: string;
+    }
+
+    const templateParameters = Array.isArray(template.parameters)
+      ? (template.parameters as TemplateParameter[])
+      : [];
+
+    const parameterMap: { [key: string]: string } = {
+      NAME: vmName,
+    };
+
+    for (const param of templateParameters) {
+      const pname = param.name ?? '';
+      if (!parameterMap[pname]) {
+        if (param.generate) {
+          parameterMap[pname] = param.value || param.default || '';
+        } else {
+          parameterMap[pname] = param.value || param.default || '';
+        }
+      }
+    }
+
+    const rawObjects = template.objects;
+    if (!Array.isArray(rawObjects)) {
+      throw new Error(`Template '${templateMetadataName}' has no objects array`);
+    }
+
+    const processedObjects = rawObjects.map((obj: KubernetesResource) => {
+      let objStr = JSON.stringify(obj);
+      for (const [paramName, paramValue] of Object.entries(parameterMap)) {
+        const regex = new RegExp(`\\$\\{${paramName}\\}`, 'g');
+        objStr = objStr.replace(regex, paramValue);
+      }
+      return JSON.parse(objStr);
+    });
+
+    const vmObject = processedObjects.find(
+      (obj: KubernetesResource) => obj.kind === 'VirtualMachine',
+    );
+    if (!vmObject) {
+      throw new Error(`No VirtualMachine object found in template '${templateMetadataName}'`);
+    }
+
+    vmObject.metadata.namespace = namespace;
+
+    if (!vmObject.metadata.labels) {
+      vmObject.metadata.labels = {};
+    }
+    const templateName = template.metadata?.name || templateMetadataName;
+    if (!vmObject.metadata.labels['vm.kubevirt.io/template']) {
+      vmObject.metadata.labels['vm.kubevirt.io/template'] = templateName;
+    }
+    if (!vmObject.metadata.labels['vm.kubevirt.io/template.namespace']) {
+      vmObject.metadata.labels['vm.kubevirt.io/template.namespace'] = templateNamespace;
+    }
+
+    if (folderName) {
+      vmObject.metadata.labels['vm.openshift.io/folder'] = folderName;
+    }
+
+    if (!vmObject.metadata.annotations) {
+      vmObject.metadata.annotations = {};
+    }
+    if (!vmObject.metadata.annotations['vm.kubevirt.io/template']) {
+      vmObject.metadata.annotations['vm.kubevirt.io/template'] = templateName;
+    }
+
+    if (vmObject.spec) {
+      if (vmObject.spec.running !== undefined) {
+        delete vmObject.spec.running;
+      }
+
+      if (startAfterCreation) {
+        vmObject.spec.runStrategy = 'Always';
+      } else {
+        vmObject.spec.runStrategy = 'Manual';
+      }
+    }
+
+    if (sysprepConfigMapName) {
+      if (!vmObject.spec) {
+        vmObject.spec = {};
+      }
+      if (!vmObject.spec.template) {
+        vmObject.spec.template = {};
+      }
+      if (!vmObject.spec.template.spec) {
+        vmObject.spec.template.spec = {};
+      }
+
+      const templateSpec = vmObject.spec.template.spec;
+
+      if (!templateSpec.domain) {
+        templateSpec.domain = {};
+      }
+      if (!templateSpec.domain.devices) {
+        templateSpec.domain.devices = {};
+      }
+      if (!templateSpec.domain.devices.disks) {
+        templateSpec.domain.devices.disks = [];
+      }
+
+      templateSpec.domain.devices.disks.push({
+        cdrom: {
+          bus: 'sata',
+        },
+        name: 'sysprep',
+      });
+
+      if (!templateSpec.volumes) {
+        templateSpec.volumes = [];
+      }
+      templateSpec.volumes.push({
+        name: 'sysprep',
+        sysprep: {
+          configMap: {
+            name: sysprepConfigMapName,
+          },
+        },
+      });
+    }
+
+    if (cloudInitConfig && (cloudInitConfig.username || cloudInitConfig.password)) {
+      if (!vmObject.spec) {
+        vmObject.spec = {};
+      }
+      if (!vmObject.spec.template) {
+        vmObject.spec.template = {};
+      }
+      if (!vmObject.spec.template.spec) {
+        vmObject.spec.template.spec = {};
+      }
+
+      const templateSpec = vmObject.spec.template.spec;
+
+      if (!templateSpec.volumes) {
+        templateSpec.volumes = [];
+      }
+
+      const userDataLines: string[] = ['#cloud-config'];
+
+      if (cloudInitConfig.username || cloudInitConfig.password) {
+        userDataLines.push('user: ' + (cloudInitConfig.username || 'cloud-user'));
+        if (cloudInitConfig.password) {
+          userDataLines.push('password: ' + cloudInitConfig.password);
+          userDataLines.push('chpasswd:');
+          userDataLines.push('  expire: false');
+        }
+      }
+
+      const userData = userDataLines.join('\n');
+
+      const cloudInitVolumeIndex = templateSpec.volumes.findIndex((v: Record<string, unknown>) => {
+        const vol = v as KubernetesResource & Record<string, unknown>;
+        return (
+          vol.name === 'cloudinitdisk' || 'cloudInitNoCloud' in vol || 'cloudInitConfigDrive' in vol
+        );
+      });
+
+      if (cloudInitVolumeIndex >= 0) {
+        templateSpec.volumes[cloudInitVolumeIndex] = {
+          name: templateSpec.volumes[cloudInitVolumeIndex].name || 'cloudinitdisk',
+          cloudInitNoCloud: {
+            userData: userData,
+          },
+        };
+      } else {
+        templateSpec.volumes.push({
+          name: 'cloudinitdisk',
+          cloudInitNoCloud: {
+            userData: userData,
+          },
+        });
+
+        if (!templateSpec.domain) {
+          templateSpec.domain = {};
+        }
+        if (!templateSpec.domain.devices) {
+          templateSpec.domain.devices = {};
+        }
+        if (!templateSpec.domain.devices.disks) {
+          templateSpec.domain.devices.disks = [];
+        }
+
+        const cloudInitDiskExists = templateSpec.domain.devices.disks.some(
+          (d: Record<string, unknown>) => d['name'] === 'cloudinitdisk',
+        );
+        if (!cloudInitDiskExists) {
+          templateSpec.domain.devices.disks.push({
+            disk: {
+              bus: 'virtio',
+            },
+            name: 'cloudinitdisk',
+          });
+        }
+      }
+    }
+
+    if (vmCustomization) {
+      if (!vmObject.spec) {
+        vmObject.spec = {};
+      }
+      if (!vmObject.spec.template) {
+        vmObject.spec.template = {};
+      }
+      if (!vmObject.spec.template.spec) {
+        vmObject.spec.template.spec = {};
+      }
+
+      const templateSpec = vmObject.spec.template.spec;
+
+      if (!templateSpec.domain) {
+        templateSpec.domain = {};
+      }
+
+      if (vmCustomization.description) {
+        if (!vmObject.metadata.annotations) {
+          vmObject.metadata.annotations = {};
+        }
+        vmObject.metadata.annotations['description'] = vmCustomization.description;
+      }
+
+      if (vmCustomization.cpu) {
+        if (!templateSpec.domain.cpu) {
+          templateSpec.domain.cpu = {};
+        }
+        templateSpec.domain.cpu.cores = vmCustomization.cpu;
+        templateSpec.domain.cpu.sockets = 1;
+        templateSpec.domain.cpu.threads = 1;
+      }
+
+      if (vmCustomization.memory) {
+        if (!templateSpec.domain.memory) {
+          templateSpec.domain.memory = {};
+        }
+        templateSpec.domain.memory.guest = `${vmCustomization.memory}Gi`;
+      }
+
+      if (vmCustomization.bootMode) {
+        if (!templateSpec.domain.firmware) {
+          templateSpec.domain.firmware = {};
+        }
+        if (vmCustomization.bootMode === 'BIOS') {
+          delete templateSpec.domain.firmware.bootloader;
+        } else {
+          templateSpec.domain.firmware.bootloader = {
+            efi: vmCustomization.bootMode === 'UEFI (secure)' ? { secureBoot: true } : {},
+          };
+        }
+      }
+
+      if (vmCustomization.workload) {
+        if (!vmObject.spec.template.metadata) {
+          vmObject.spec.template.metadata = {};
+        }
+        if (!vmObject.spec.template.metadata.annotations) {
+          vmObject.spec.template.metadata.annotations = {};
+        }
+        vmObject.spec.template.metadata.annotations['vm.kubevirt.io/workload'] =
+          vmCustomization.workload.toLowerCase().replace(/\s+/g, '-');
+      }
+
+      if (vmCustomization.hostname) {
+        templateSpec.hostname = vmCustomization.hostname;
+      }
+
+      if (vmCustomization.headless) {
+        if (!templateSpec.domain.devices) {
+          templateSpec.domain.devices = {};
+        }
+        templateSpec.domain.devices.autoattachGraphicsDevice = false;
+        templateSpec.subdomain = 'headless';
+        if (!vmObject.spec.template.metadata) {
+          vmObject.spec.template.metadata = {};
+        }
+        if (!vmObject.spec.template.metadata.labels) {
+          vmObject.spec.template.metadata.labels = {};
+        }
+        vmObject.spec.template.metadata.labels['app.kubernetes.io/name'] = 'headless';
+      }
+    }
+
+    if (storageClassName && vmObject.spec?.dataVolumeTemplates) {
+      for (const dvTemplate of vmObject.spec.dataVolumeTemplates) {
+        if (dvTemplate.spec?.storage) {
+          dvTemplate.spec.storage.storageClassName = storageClassName;
+        } else if (dvTemplate.spec) {
+          dvTemplate.spec.storage = {
+            storageClassName: storageClassName,
+          };
+        }
+      }
+    }
+
+    return await this.ctx.createCustomResource(
+      'kubevirt.io',
+      'v1',
+      namespace,
+      'virtualmachines',
+      vmObject,
+    );
+  }
+
+  /**
+   * Disable delete protection on a VirtualMachine
+   * Sets the kubevirt.io/vm-delete-protection label to 'false'
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   */
+  async disableDeleteProtection(vmName: string, namespace: string) {
+    try {
+      const patchBody = [
+        {
+          op: 'replace',
+          path: '/metadata/labels/kubevirt.io~1vm-delete-protection',
+          value: 'false',
+        },
+      ];
+
+      await this.ctx.customObjectsApi.patchNamespacedCustomObject({
+        group: 'kubevirt.io',
+        version: 'v1',
+        namespace,
+        plural: 'virtualmachines',
+        name: vmName,
+        body: patchBody,
+      });
+    } catch {
+      // Ignore errors - label might not exist or VM not found
+    }
+  }
+
+  /**
+   * Get a VirtualMachine resource
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @returns The VirtualMachine resource
+   */
+  async getVirtualMachine(vmName: string, namespace: string) {
+    return await this.ctx.getCustomResource(
+      'kubevirt.io',
+      'v1',
+      namespace,
+      'virtualmachines',
+      vmName,
+    );
+  }
+
+  /**
+   * Get a VirtualMachineInstance resource
+   * @param vmName - Name of the VirtualMachineInstance (same as VM name when running)
+   * @param namespace - Namespace where the VMI exists
+   * @returns The VirtualMachineInstance resource
+   */
+  async getVirtualMachineInstance(vmName: string, namespace: string) {
+    return await this.ctx.getCustomResource(
+      'kubevirt.io',
+      'v1',
+      namespace,
+      'virtualmachineinstances',
+      vmName,
+    );
+  }
+
+  async removeVmDeleteProtection(vmName: string, namespace: string): Promise<boolean> {
+    try {
+      const vm = (await this.getVirtualMachine(vmName, namespace)) as KubernetesResource;
+      const labels = vm.metadata?.labels || {};
+
+      const hasProtection =
+        labels['kubevirt.io/vm-delete-protection'] === 'enabled' ||
+        labels['kubevirt.io/vm-delete-protection'] === 'true';
+
+      if (!hasProtection) {
+        return true;
+      }
+
+      await this.ctx.patchResource('kubevirt.io', 'v1', 'virtualmachines', vmName, namespace, {
+        metadata: {
+          labels: {
+            'kubevirt.io/vm-delete-protection': null,
+          },
+        },
+      });
+
+      return true;
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      if (msg.includes('404')) {
+        return true;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Start a VirtualMachine by patching its running state
+   * @param vmName - Name of the VirtualMachine to start
+   * @param namespace - Namespace where the VM exists
+   */
+  async startVirtualMachine(vmName: string, namespace: string) {
+    return await this.ctx.patchResource('kubevirt.io', 'v1', 'virtualmachines', vmName, namespace, {
+      spec: { running: true },
+    });
+  }
+
+  /**
+   * Starts a VirtualMachine by patching its runStrategy to 'Always'.
+   */
+  async startVm(vmName: string, namespace: string): Promise<boolean> {
+    try {
+      const patchBody = [
+        {
+          op: 'replace',
+          path: '/spec/runStrategy',
+          value: 'Always',
+        },
+      ];
+
+      await this.ctx.customObjectsApi.patchNamespacedCustomObject({
+        group: 'kubevirt.io',
+        version: 'v1',
+        namespace,
+        plural: 'virtualmachines',
+        name: vmName,
+        body: patchBody,
+      });
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async stopVm(vmName: string, namespace: string): Promise<boolean> {
+    try {
+      const patchBody = [
+        {
+          op: 'replace',
+          path: '/spec/runStrategy',
+          value: 'Halted',
+        },
+      ];
+
+      await this.ctx.customObjectsApi.patchNamespacedCustomObject({
+        group: 'kubevirt.io',
+        version: 'v1',
+        namespace,
+        plural: 'virtualmachines',
+        name: vmName,
+        body: patchBody,
+      });
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Check if a VirtualMachine exists in the specified namespace
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM should exist
+   * @returns true if VM exists, false otherwise
+   */
+  async vmExists(vmName: string, namespace: string): Promise<boolean> {
+    try {
+      await this.ctx.getCustomResource(
+        'kubevirt.io', // group
+        'v1', // version
+        namespace,
+        'virtualmachines', // plural
+        vmName,
+      );
+      return true;
+    } catch (error: unknown) {
+      const msg = getErrorMessage(error);
+      if (msg.includes('404') || msg.includes('not found')) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Wait for a VirtualMachineClone to complete successfully
+   * Polls the API until the clone phase is 'Succeeded' or timeout is reached
+   * @param cloneName - Name of the VirtualMachineClone resource
+   * @param namespace - Namespace where the clone exists
+   * @param timeoutMs - Maximum time to wait in milliseconds (default: 120000)
+   * @returns true if clone succeeded, throws error if timeout or failed
+   */
+  async waitForVmCloneSucceeded(
+    cloneName: string,
+    namespace: string,
+    timeoutMs = 120000,
+  ): Promise<boolean> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const clone = (await this.ctx.getCustomResource(
+          'clone.kubevirt.io',
+          'v1alpha1',
+          namespace,
+          'virtualmachineclones',
+          cloneName,
+        )) as KubernetesResource;
+
+        const phase = clone?.status?.phase;
+        if (phase === 'Succeeded') {
+          return true;
+        }
+        if (phase === 'Failed') {
+          throw new Error(
+            `VirtualMachineClone ${cloneName} failed: ${
+              clone?.status?.conditions?.[0]?.message || 'Unknown error'
+            }`,
+          );
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, TestTimeouts.POLLING_INTERVAL));
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        if (msg.includes('failed')) {
+          throw error;
+        }
+        await new Promise((resolve) => setTimeout(resolve, TestTimeouts.POLLING_INTERVAL));
+      }
+    }
+
+    throw new Error(
+      `Timeout waiting for VirtualMachineClone ${cloneName} to succeed in namespace ${namespace}`,
+    );
+  }
+
+  /**
+   * Wait for a VirtualMachine to be deleted from the cluster
+   * Polls the API until the VM no longer exists or timeout is reached
+   * @param vmName - Name of the VirtualMachine to wait for deletion
+   * @param namespace - Namespace where the VM should be deleted from
+   * @param timeoutMs - Maximum time to wait for VM deletion in milliseconds (default: 60000)
+   * @returns true if VM was deleted, throws error if timeout is reached
+   */
+  async waitForVmDeleted(vmName: string, namespace: string, timeoutMs = 60000): Promise<boolean> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        await this.ctx.getCustomResource('kubevirt.io', 'v1', namespace, 'virtualmachines', vmName);
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        if (msg.includes('404') || msg.includes('not found')) {
+          return true;
+        }
+        throw error;
+      }
+    }
+
+    throw new Error(`VM ${vmName} was not deleted within ${timeoutMs}ms`);
+  }
+
+  /**
+   * Wait for a VirtualMachine to exist in the cluster
+   * Polls the API until the VM exists or timeout is reached
+   * @param vmName - Name of the VirtualMachine to wait for
+   * @param namespace - Namespace where the VM should exist
+   * @param timeoutMs - Maximum time to wait in milliseconds (default: 120000)
+   * @returns true if VM exists, throws error if timeout is reached
+   */
+  async waitForVmExists(vmName: string, namespace: string, timeoutMs = 120000): Promise<boolean> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        await this.ctx.getCustomResource('kubevirt.io', 'v1', namespace, 'virtualmachines', vmName);
+        return true;
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, TestTimeouts.POLLING_INTERVAL));
+      }
+    }
+
+    throw new Error(`Timeout waiting for VM ${vmName} to exist in namespace ${namespace}`);
+  }
+
+  /**
+   * Wait for a VirtualMachine to reach Running status
+   * Polls the API until the VM status is Running or timeout is reached
+   * @param vmName - Name of the VirtualMachine to wait for
+   * @param namespace - Namespace where the VM exists
+   * @param timeoutMs - Maximum time to wait in milliseconds (default: 300000)
+   * @returns true if VM is running, throws error if timeout is reached
+   */
+  async waitForVmRunning(vmName: string, namespace: string, timeoutMs = 300000): Promise<boolean> {
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const vm = await this.ctx.getCustomResource(
+          'kubevirt.io',
+          'v1',
+          namespace,
+          'virtualmachines',
+          vmName,
+        );
+        const status = ((vm as KubernetesResource).status as Record<string, unknown> | undefined)?.[
+          'printableStatus'
+        ];
+        if (status === 'Running') {
+          return true;
+        }
+        await new Promise((resolve) => setTimeout(resolve, TestTimeouts.POLLING_INTERVAL));
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, TestTimeouts.POLLING_INTERVAL));
+      }
+    }
+
+    throw new Error(
+      `Timeout waiting for VM ${vmName} to reach Running status in namespace ${namespace}`,
+    );
+  }
+}

--- a/playwright/src/clients/handlers/vm-patch-handler.ts
+++ b/playwright/src/clients/handlers/vm-patch-handler.ts
@@ -1,0 +1,655 @@
+import type {
+  JsonPatchOp,
+  KubernetesCondition,
+  KubernetesResource,
+} from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+import { generateRandomString } from '@/utils/random-data-generator';
+
+import type { KubernetesHandlerContext } from './kubernetes-api-context';
+import type { SecretConfigMapHandler } from './secret-configmap-handler';
+import type { VmLifecycleHandler } from './vm-lifecycle-handler';
+
+/** JSON Patch request options (e.g. application/json-patch+json). */
+type JsonPatchRequestOptions = {
+  headers: Record<string, string>;
+};
+
+/** Narrow view of CustomObjectsApi patch overloads used with json-patch content type. */
+type CustomObjectsJsonPatchApi = {
+  patchNamespacedCustomObject(
+    requestParameters: Record<string, unknown>,
+    contentType: string,
+    options?: JsonPatchRequestOptions,
+  ): Promise<unknown>;
+  patchNamespacedCustomObjectStatus(
+    requestParameters: Record<string, unknown>,
+    contentType: string,
+    options?: JsonPatchRequestOptions,
+  ): Promise<unknown>;
+};
+
+type CoreV1JsonPatchApi = {
+  patchNamespacedConfigMap(
+    requestParameters: Record<string, unknown>,
+    contentType: string,
+    options?: Record<string, unknown>,
+  ): Promise<unknown>;
+};
+
+function getKubeClientHttpStatus(error: unknown): number | undefined {
+  if (error === null || typeof error !== 'object') return undefined;
+  const e = error as { statusCode?: unknown; response?: unknown };
+  if (typeof e.statusCode === 'number') return e.statusCode;
+  if (e.response !== null && typeof e.response === 'object' && 'statusCode' in e.response) {
+    const status = (e.response as { statusCode?: unknown }).statusCode;
+    return typeof status === 'number' ? status : undefined;
+  }
+  return undefined;
+}
+
+function unwrapPatchResponse(response: unknown): KubernetesResource {
+  if (response !== null && typeof response === 'object' && 'body' in response) {
+    const body = (response as { body?: unknown }).body;
+    if (body !== null && typeof body === 'object') return body as KubernetesResource;
+  }
+  return response as KubernetesResource;
+}
+
+export class VmPatchHandler {
+  private static readonly DESCHEDULER_EVICT_ANNOTATION_KEY =
+    'descheduler.alpha.kubernetes.io/evict';
+
+  constructor(
+    private readonly ctx: KubernetesHandlerContext,
+    private readonly lifecycle: VmLifecycleHandler,
+    private readonly secret: SecretConfigMapHandler,
+  ) {}
+
+  private get coreV1JsonPatch(): CoreV1JsonPatchApi {
+    return this.ctx.coreV1Api as unknown as CoreV1JsonPatchApi;
+  }
+
+  private get customObjectsJsonPatch(): CustomObjectsJsonPatchApi {
+    return this.ctx.customObjectsApi as unknown as CustomObjectsJsonPatchApi;
+  }
+
+  /**
+   * Enable or disable SSH NodePort feature in the kubevirt-ui-features ConfigMap.
+   * This is a cluster-wide setting that must be enabled before VMs can use SSH over NodePort.
+   *
+   * @param enabled - Whether to enable (true) or disable (false) the NodePort feature
+   * @param nodePortAddress - Optional node address to set for SSH connections
+   * @param cnvNamespace - Namespace where the ConfigMap exists (default: 'openshift-cnv')
+   * @returns The patched ConfigMap
+   * @throws {Error} When patch operation fails
+   */
+  async enableNodePortFeature(
+    enabled = true,
+    nodePortAddress?: string,
+    cnvNamespace = 'openshift-cnv',
+  ): Promise<KubernetesResource> {
+    try {
+      const patchOps: JsonPatchOp[] = [
+        {
+          op: 'replace',
+          path: '/data/nodePortEnabled',
+          value: enabled ? 'true' : 'false',
+        },
+      ];
+
+      if (nodePortAddress) {
+        patchOps.push({
+          op: 'replace',
+          path: '/data/nodePortAddress',
+          value: nodePortAddress,
+        });
+      }
+
+      const response = await this.coreV1JsonPatch.patchNamespacedConfigMap(
+        {
+          name: 'kubevirt-ui-features',
+          namespace: cnvNamespace,
+          body: patchOps,
+        },
+        'json',
+        {
+          headers: {
+            'Content-Type': 'application/json-patch+json',
+          },
+        },
+      );
+
+      return unwrapPatchResponse(response);
+    } catch (error: unknown) {
+      throw new Error(`Failed to enable NodePort feature: ${getErrorMessage(error)}`);
+    }
+  }
+
+  /**
+   * Ensure VM folders (tree view) are enabled in the kubevirt-ui-features ConfigMap.
+   * If treeViewFolders is not already "true", patches the ConfigMap using the Kubernetes client.
+   *
+   * @param cnvNamespace - Namespace where the ConfigMap exists (default: 'openshift-cnv')
+   * @returns The patched ConfigMap, or null if ConfigMap does not exist or patch was not needed
+   */
+  async ensureVmFoldersEnabled(cnvNamespace = 'openshift-cnv'): Promise<KubernetesResource | null> {
+    try {
+      const cm = await this.secret.getConfigMap('kubevirt-ui-features', cnvNamespace);
+      if (!cm) {
+        return null;
+      }
+      const cmData = cm.data as Record<string, string> | undefined;
+      if (cmData?.treeViewFolders === 'true') {
+        return cm as KubernetesResource;
+      }
+      const patched = await this.secret.patchConfigMap('kubevirt-ui-features', cnvNamespace, {
+        treeViewFolders: 'true',
+      });
+      return patched as unknown as KubernetesResource;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Patch a VirtualMachineInstance's status to add conditions that indicate it's stuck/unhealthy.
+   * This can trigger warnings like "VirtualMachineStuckOnNode".
+   *
+   * @param vmiName - Name of the VirtualMachineInstance
+   * @param namespace - Namespace where the VMI exists
+   * @param conditions - Array of condition objects to add/replace
+   * @returns The patched VirtualMachineInstance resource
+   * @throws {Error} When patch operation fails
+   */
+  async patchVirtualMachineInstanceStatus(
+    vmiName: string,
+    namespace: string,
+    conditions: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+      lastTransitionTime?: string;
+    }>,
+  ): Promise<KubernetesResource> {
+    try {
+      const currentVmi = await this.lifecycle.getVirtualMachineInstance(vmiName, namespace);
+      const hasStatus = currentVmi?.status !== undefined;
+      const hasConditions = currentVmi?.status?.conditions !== undefined;
+
+      const patchOps: JsonPatchOp[] = [];
+
+      if (!hasStatus) {
+        patchOps.push({
+          op: 'add',
+          path: '/status',
+          value: {},
+        });
+      }
+
+      if (!hasConditions) {
+        patchOps.push({
+          op: 'add',
+          path: '/status/conditions',
+          value: [],
+        });
+      }
+
+      conditions.forEach((condition, _index) => {
+        const now = new Date().toISOString();
+        const conditionValue = {
+          type: condition.type,
+          status: condition.status,
+          reason: condition.reason || 'VMStuck',
+          message: condition.message || 'Virtual machine stuck in unhealthy state',
+          lastTransitionTime: condition.lastTransitionTime || now,
+          lastProbeTime: condition.lastTransitionTime || now,
+        };
+
+        const conditionsList = currentVmi?.status?.conditions as KubernetesCondition[] | undefined;
+        const existingConditionIndex = conditionsList?.findIndex(
+          (c: KubernetesCondition) => c.type === condition.type,
+        );
+
+        if (existingConditionIndex !== undefined && existingConditionIndex >= 0) {
+          patchOps.push({
+            op: 'replace',
+            path: `/status/conditions/${existingConditionIndex}`,
+            value: conditionValue,
+          });
+        } else {
+          patchOps.push({
+            op: 'add',
+            path: '/status/conditions/-',
+            value: conditionValue,
+          });
+        }
+      });
+
+      try {
+        const response = await this.customObjectsJsonPatch.patchNamespacedCustomObjectStatus(
+          {
+            group: 'kubevirt.io',
+            version: 'v1',
+            namespace: namespace,
+            plural: 'virtualmachineinstances',
+            name: vmiName,
+            body: patchOps,
+            dryRun: undefined,
+            fieldManager: undefined,
+            fieldValidation: undefined,
+          },
+          'json',
+          {
+            headers: {
+              'Content-Type': 'application/json-patch+json',
+            },
+          },
+        );
+        return unwrapPatchResponse(response);
+      } catch {
+        const response = await this.customObjectsJsonPatch.patchNamespacedCustomObject(
+          {
+            group: 'kubevirt.io',
+            version: 'v1',
+            namespace: namespace,
+            plural: 'virtualmachineinstances',
+            name: vmiName,
+            body: patchOps,
+            dryRun: undefined,
+            fieldManager: undefined,
+            fieldValidation: undefined,
+          },
+          'json',
+          {
+            headers: {
+              'Content-Type': 'application/json-patch+json',
+            },
+          },
+        );
+        return unwrapPatchResponse(response);
+      }
+    } catch (error: unknown) {
+      const statusCode = getKubeClientHttpStatus(error);
+      const statusText = statusCode ? ` (${statusCode})` : '';
+      throw new Error(
+        `Failed to patch VirtualMachineInstance status${statusText}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Patch a VirtualMachine to add a node selector.
+   * This can trigger scheduling alerts if the selector doesn't match any nodes.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param nodeSelector - Node selector key-value pairs (e.g., { 'nonexistent-label': 'nonexistent-value' })
+   * @returns The patched VirtualMachine resource
+   * @throws {Error} When patch operation fails
+   */
+  async patchVirtualMachineNodeSelector(
+    vmName: string,
+    namespace: string,
+    nodeSelector: { [key: string]: string },
+  ): Promise<KubernetesResource> {
+    try {
+      const patchOps: JsonPatchOp[] = [
+        {
+          op: 'replace',
+          path: '/spec/template/spec/nodeSelector',
+          value: nodeSelector,
+        },
+      ];
+
+      const response = await this.customObjectsJsonPatch.patchNamespacedCustomObject(
+        {
+          group: 'kubevirt.io',
+          version: 'v1',
+          namespace: namespace,
+          plural: 'virtualmachines',
+          name: vmName,
+          body: patchOps,
+          dryRun: undefined,
+          fieldManager: undefined,
+          fieldValidation: undefined,
+        },
+        'json',
+        {
+          headers: {
+            'Content-Type': 'application/json-patch+json',
+          },
+        },
+      );
+      return unwrapPatchResponse(response);
+    } catch (error: unknown) {
+      const statusCode = getKubeClientHttpStatus(error);
+      const statusText = statusCode ? ` (${statusCode})` : '';
+      throw new Error(
+        `Failed to patch VirtualMachine node selector${statusText}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Patch a VirtualMachine's CPU and memory resources.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param resources - Resource configuration (cpuSockets, cpuCores, memory)
+   * @returns The patched VirtualMachine resource
+   * @throws {Error} When patch operation fails
+   */
+  async patchVirtualMachineResources(
+    vmName: string,
+    namespace: string,
+    resources: {
+      cpuSockets?: number;
+      cpuCores?: number;
+      memory?: string;
+    },
+  ): Promise<KubernetesResource> {
+    try {
+      const patchOps: JsonPatchOp[] = [];
+
+      if (resources.cpuSockets !== undefined) {
+        patchOps.push({
+          op: 'replace',
+          path: '/spec/template/spec/domain/cpu/sockets',
+          value: resources.cpuSockets,
+        });
+      }
+
+      if (resources.cpuCores !== undefined) {
+        patchOps.push({
+          op: 'replace',
+          path: '/spec/template/spec/domain/cpu/cores',
+          value: resources.cpuCores,
+        });
+      }
+
+      if (resources.memory !== undefined) {
+        patchOps.push({
+          op: 'replace',
+          path: '/spec/template/spec/domain/memory/guest',
+          value: resources.memory,
+        });
+      }
+
+      if (patchOps.length === 0) {
+        throw new Error('No resource values provided to patch');
+      }
+
+      const response = await this.customObjectsJsonPatch.patchNamespacedCustomObject(
+        {
+          group: 'kubevirt.io',
+          version: 'v1',
+          namespace: namespace,
+          plural: 'virtualmachines',
+          name: vmName,
+          body: patchOps,
+          dryRun: undefined,
+          fieldManager: undefined,
+          fieldValidation: undefined,
+        },
+        'json',
+        {
+          headers: {
+            'Content-Type': 'application/json-patch+json',
+          },
+        },
+      );
+      return unwrapPatchResponse(response);
+    } catch (error: unknown) {
+      const statusCode = getKubeClientHttpStatus(error);
+      const statusText = statusCode ? ` (${statusCode})` : '';
+      throw new Error(
+        `Failed to patch VirtualMachine resources${statusText}: ${getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Patch a VirtualMachine to set the run strategy.
+   * This removes the deprecated 'running' field and sets 'runStrategy' instead.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param runStrategy - The run strategy ('Always', 'Manual', or 'RerunOnFailure')
+   * @returns The patched VirtualMachine resource
+   * @throws {Error} When patch operation fails
+   */
+  async patchVirtualMachineRunStrategy(
+    vmName: string,
+    namespace: string,
+    runStrategy: 'Always' | 'Manual' | 'RerunOnFailure',
+  ): Promise<KubernetesResource> {
+    try {
+      const currentVm = await this.lifecycle.getVirtualMachine(vmName, namespace);
+
+      const patchOps: JsonPatchOp[] = [
+        {
+          op: 'replace',
+          path: '/spec/runStrategy',
+          value: runStrategy,
+        },
+      ];
+
+      if (currentVm?.spec?.running !== undefined) {
+        patchOps.push({
+          op: 'remove',
+          path: '/spec/running',
+        });
+      }
+
+      const response = await this.customObjectsJsonPatch.patchNamespacedCustomObject(
+        {
+          group: 'kubevirt.io',
+          version: 'v1',
+          namespace: namespace,
+          plural: 'virtualmachines',
+          name: vmName,
+          body: patchOps,
+          dryRun: undefined,
+          fieldManager: undefined,
+          fieldValidation: undefined,
+        },
+        'json',
+        {
+          headers: {
+            'Content-Type': 'application/json-patch+json',
+          },
+        },
+      );
+      return unwrapPatchResponse(response);
+    } catch (error: unknown) {
+      throw new Error(`Failed to patch VirtualMachine run strategy: ${getErrorMessage(error)}`);
+    }
+  }
+
+  /**
+   * Set or clear the descheduler eviction annotation on the VM pod template.
+   * The Scheduling tab should reflect this value after refresh/navigation.
+   */
+  async patchVmDeschedulerEvictAnnotation(
+    vmName: string,
+    namespace: string,
+    enabled: boolean,
+  ): Promise<void> {
+    const key = VmPatchHandler.DESCHEDULER_EVICT_ANNOTATION_KEY;
+    const keySegment = key.replace(/\//g, '~1').replace(/~/g, '~0');
+    const annPath = '/spec/template/metadata/annotations';
+    const keyPath = `${annPath}/${keySegment}`;
+
+    const vm = (await this.lifecycle.getVirtualMachine(vmName, namespace)) as KubernetesResource;
+    const spec = vm.spec as Record<string, unknown> | undefined;
+    const template = spec?.template as Record<string, unknown> | undefined;
+    const templateMeta = template?.metadata as KubernetesResource['metadata'] | undefined;
+    const annotations = templateMeta?.annotations;
+    const hasKey =
+      annotations != null && typeof annotations === 'object' && annotations[key] !== undefined;
+
+    const patchOps: JsonPatchOp[] = [];
+
+    if (enabled) {
+      if (!templateMeta) {
+        patchOps.push({
+          op: 'add',
+          path: '/spec/template/metadata',
+          value: { annotations: { [key]: 'true' } },
+        });
+      } else if (!annotations || typeof annotations !== 'object') {
+        patchOps.push({ op: 'add', path: annPath, value: { [key]: 'true' } });
+      } else if (hasKey) {
+        patchOps.push({ op: 'replace', path: keyPath, value: 'true' });
+      } else {
+        patchOps.push({ op: 'add', path: keyPath, value: 'true' });
+      }
+    } else if (hasKey) {
+      patchOps.push({ op: 'remove', path: keyPath });
+    } else {
+      return;
+    }
+
+    await this.customObjectsJsonPatch.patchNamespacedCustomObject(
+      {
+        group: 'kubevirt.io',
+        version: 'v1',
+        namespace,
+        plural: 'virtualmachines',
+        name: vmName,
+        body: patchOps,
+      },
+      'json',
+      {
+        headers: {
+          'Content-Type': 'application/json-patch+json',
+        },
+      },
+    );
+  }
+
+  /**
+   * Patch a VirtualMachine's eviction strategy (e.g. LiveMigrate).
+   * When set to LiveMigrate on a single-node cluster, the VM becomes "not migratable"
+   * and can trigger the VMCannotBeEvicted warning in the overview alerts card.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param evictionStrategy - Eviction strategy ('LiveMigrate' | 'None')
+   */
+  async patchVmEvictionStrategy(
+    vmName: string,
+    namespace: string,
+    evictionStrategy: 'LiveMigrate' | 'None',
+  ) {
+    const patchOps: JsonPatchOp[] = [
+      {
+        op: 'add',
+        path: '/spec/template/spec/evictionStrategy',
+        value: evictionStrategy,
+      },
+    ];
+    await this.customObjectsJsonPatch.patchNamespacedCustomObject(
+      {
+        group: 'kubevirt.io',
+        version: 'v1',
+        namespace,
+        plural: 'virtualmachines',
+        name: vmName,
+        body: patchOps,
+      },
+      'json',
+      {
+        headers: {
+          'Content-Type': 'application/json-patch+json',
+        },
+      },
+    );
+  }
+
+  /**
+   * Patch a VirtualMachine's network interface model (e.g. virtio → e1000e).
+   * Triggers a "Pending changes" alert in the UI for the running VM.
+   * On LiveUpdate clusters (4.20+), the change may auto-apply; otherwise a restart is needed.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param model - Target NIC model ('virtio' | 'e1000e')
+   * @param interfaceIndex - Zero-based index of the interface to patch (default: 0)
+   */
+  async patchVmNetworkInterfaceModel(
+    vmName: string,
+    namespace: string,
+    model: 'virtio' | 'e1000e',
+    interfaceIndex = 0,
+  ): Promise<void> {
+    const patchOps: JsonPatchOp[] = [
+      {
+        op: 'add',
+        path: `/spec/template/spec/domain/devices/interfaces/${interfaceIndex}/model`,
+        value: model,
+      },
+    ];
+    await this.customObjectsJsonPatch.patchNamespacedCustomObject(
+      {
+        group: 'kubevirt.io',
+        version: 'v1',
+        namespace,
+        plural: 'virtualmachines',
+        name: vmName,
+        body: patchOps,
+      },
+      'json',
+      {
+        headers: {
+          'Content-Type': 'application/json-patch+json',
+        },
+      },
+    );
+  }
+
+  /**
+   * Patch a VirtualMachine to induce an error state by adding a volume that references
+   * a non-existent PVC. After patching, stop and start the VM so the VMI creation fails.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   */
+  async patchVmToErrorState(vmName: string, namespace: string): Promise<void> {
+    const nonExistentPvcName = `non-existent-pvc-${vmName}-${generateRandomString(
+      8,
+      'alphanumeric',
+    ).toLowerCase()}`;
+    const errorVolumeName = 'error-disk';
+
+    const patchBody: JsonPatchOp[] = [
+      {
+        op: 'add',
+        path: '/spec/template/spec/volumes/-',
+        value: {
+          name: errorVolumeName,
+          persistentVolumeClaim: { claimName: nonExistentPvcName },
+        },
+      },
+      {
+        op: 'add',
+        path: '/spec/template/spec/domain/devices/disks/-',
+        value: {
+          name: errorVolumeName,
+          disk: { bus: 'virtio' },
+        },
+      },
+    ];
+
+    await this.ctx.customObjectsApi.patchNamespacedCustomObject({
+      group: 'kubevirt.io',
+      version: 'v1',
+      namespace,
+      plural: 'virtualmachines',
+      name: vmName,
+      body: patchBody,
+    });
+  }
+}


### PR DESCRIPTION
## 📝 Description

Adds Kubernetes API client handlers for test automation:
- VM lifecycle, patch, disk-query, and handler management
- Namespace, node, policy, template, snapshot handlers
- Secret/ConfigMap, DataVolume, HCO, cluster resource handlers
- interface → type conversions per coding standards

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-92533


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Kubernetes and OpenShift automation for namespaces, permissions, storage classes, operators, nodes, policies, secrets, ConfigMaps, snapshots, templates, and custom resources.
  * Added Virtual Machine lifecycle management, including creation, cloning, start/stop operations, disk attachment, hotplugging, SSH configuration, migration settings, and status verification.
  * Added DataVolume, DataSource, and HyperConverged resource operations with readiness checks, feature-gate management, and configurable polling.
  * Added consistent proxy support, retries, error handling, and resource existence verification across operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->