### PR TITLE
CNV-92534 - add main client classes

### DIFF
--- a/playwright/project-dependencies/global.teardown.ts
+++ b/playwright/project-dependencies/global.teardown.ts
@@ -6,8 +6,9 @@ import { logger } from '@/utils/logger';
 import { TestConfigManager } from '@/utils/test-config';
 import type { FullConfig } from '@playwright/test';
 
-import type { TeardownContext } from './rule-engine';
-import { getTeardownRules, RuleEngine } from './rule-engine';
+import { RuleEngine } from './rule-engine';
+import type { TeardownContext } from './rule-engine/types';
+import { getTeardownRules } from './rule-engine/teardown-rules';
 
 async function globalTeardown(_config: FullConfig) {
   if (process.env.SKIP_GLOBAL_TEARDOWN === 'true') {
@@ -38,7 +39,15 @@ async function globalTeardown(_config: FullConfig) {
       logger.warn('⚠️ Kubeconfig from setup is missing — cleanup operations may fail');
     }
 
-    k8sClient = new KubernetesClient(kubeConfigPath!);
+    k8sClient = new KubernetesClient(
+      undefined,
+      {
+        baseUrl: EnvVariables.clusterUrl,
+        username: EnvVariables.username,
+        password: EnvVariables.password,
+      },
+      kubeConfigPath!,
+    );
 
     try {
       await k8sClient.verifyAuthentication();
@@ -59,8 +68,8 @@ async function globalTeardown(_config: FullConfig) {
     shouldCleanupClusterResources,
   };
 
-  const engine = new RuleEngine();
   const rules = getTeardownRules();
+  const engine = new RuleEngine();
   await engine.runTeardown(rules, ctx);
 
   logger.info('🏁 Global teardown complete');

--- a/playwright/src/clients/base-client.ts
+++ b/playwright/src/clients/base-client.ts
@@ -1,0 +1,117 @@
+import type { ContextKey, ContextValueType } from '@/context-managers/context-keys';
+import ScenarioContextManager from '@/context-managers/scenario-context-manager';
+import type { TrackedResourceType } from '@/utils/test-resource-tracker';
+import type { Page } from '@playwright/test';
+
+/**
+ * Configuration interface for cluster authentication.
+ *
+ * This interface defines the authentication parameters required to connect
+ * to a Kubernetes/OpenShift cluster for API operations.
+ *
+ * @since 1.0.0
+ */
+export type ClusterAuthConfig = {
+  /** The base URL of the cluster API server */
+  baseUrl: string;
+
+  /** The password for authentication */
+  password: string;
+
+  /** Optional OC authentication token for Kubernetes API calls */
+  token?: string;
+
+  /** The username for authentication */
+  username: string;
+};
+
+/**
+ * Base class for all client implementations in the test framework.
+ *
+ * Client classes provide a clean abstraction layer for interacting with external
+ * APIs and services, specifically the Kubernetes/OpenShift API. This base class
+ * establishes common authentication and configuration patterns that all client
+ * implementations inherit.
+ *
+ * The class handles:
+ * - Cluster authentication configuration
+ * - Base URL management for API endpoints
+ * - Credential management (username/password/token)
+ * - Optional Playwright page integration for UI-based operations
+ *
+ * Client implementations typically extend this class to provide specific
+ * API interaction methods for different Kubernetes resources (VMs, templates,
+ * instance types, etc.).
+ *
+ * @example
+ * ```typescript
+ * export default class VirtualMachineClient extends BaseClient {
+ *   async createVm(vmConfig: VirtualMachineConfig) {
+ *     // Implementation for VM creation via API
+ *   }
+ * }
+ * ```
+ *
+ * @abstract
+ * @since 1.0.0
+ */
+export default abstract class BaseClient {
+  /** The base URL of the cluster API server */
+  protected readonly baseUrl: string;
+
+  /** Optional Playwright page instance for UI-based operations */
+  public readonly page?: Page;
+
+  /** The password for cluster authentication */
+  protected readonly password: string;
+
+  /** The username for cluster authentication */
+  protected readonly username: string;
+
+  /**
+   * Creates a new BaseClient instance.
+   *
+   * @param page - Optional Playwright page instance for UI-based operations
+   * @param config - Cluster authentication configuration
+   * @param config.baseUrl - The base URL of the cluster API server
+   * @param config.password - The password for authentication
+   * @param config.token - Optional OC authentication token for Kubernetes API calls
+   * @param config.username - The username for authentication
+   *
+   * @example
+   * ```typescript
+   * const config: ClusterAuthConfig = {
+   *   baseUrl: 'https://api.example.com:6443',
+   *   username: 'admin',
+   *   password: 'password123',
+   *   token: 'optional-token'
+   * };
+   * const client = new MyClient(page, config);
+   * ```
+   *
+   * @since 1.0.0
+   */
+  constructor(page: Page | undefined, config: ClusterAuthConfig) {
+    this.page = page;
+    this.baseUrl = config.baseUrl;
+    this.username = config.username;
+    this.password = config.password;
+  }
+
+  protected get ctx(): ScenarioContextManager {
+    return ScenarioContextManager.getInstance();
+  }
+
+  protected getCtxVal<K extends ContextKey>(key: K): ContextValueType<K> | undefined {
+    return this.ctx.get(key);
+  }
+
+  protected setCtxVal<K extends ContextKey>(key: K, value: ContextValueType<K>): void {
+    this.ctx.set(key, value);
+  }
+
+  /** Register a resource for automatic cleanup after the current test. */
+  public trackResource(type: TrackedResourceType, name: string, namespace?: string): void {
+    this.ctx.trackResource(type, name, namespace);
+  }
+}

--- a/playwright/src/clients/kubernetes-client-singleton.ts
+++ b/playwright/src/clients/kubernetes-client-singleton.ts
@@ -1,0 +1,156 @@
+/**
+ * Kubernetes Client Singleton
+ *
+ * Provides a singleton KubernetesClient instance for API-only operations.
+ * This avoids creating multiple client instances across different fixtures
+ * and utilities, reducing connection overhead and improving performance.
+ *
+ * The singleton is worker-scoped (shared across tests in the same worker)
+ * and is automatically invalidated if the auth token changes.
+ *
+ * @module kubernetes-client-singleton
+ *
+ * @example
+ * ```typescript
+ * import { getKubernetesClient } from '@/clients/kubernetes-client-singleton';
+ *
+ * async function doSomething() {
+ *   const client = getKubernetesClient();
+ *   if (client) {
+ *     await client.getCustomResource(...);
+ *   }
+ * }
+ * ```
+ */
+
+import { EnvVariables } from '@/utils/env-variables';
+import { TestConfigManager } from '@/utils/test-config';
+
+import KubernetesClient from './kubernetes-client';
+
+// Singleton instance
+let clientInstance: KubernetesClient | null = null;
+
+// Track the token used to create the instance (for invalidation)
+let instanceToken: string | undefined = undefined;
+
+/**
+ * Get the singleton KubernetesClient instance.
+ *
+ * The client is created on first call and reused for subsequent calls.
+ * If the auth token changes, a new client is created.
+ *
+ * @returns KubernetesClient instance, or null if no auth token is available
+ *
+ * @example
+ * ```typescript
+ * const client = getKubernetesClient();
+ * if (client) {
+ *   const vm = await client.getCustomResource('kubevirt.io', 'v1', 'default', 'virtualmachines', 'my-vm');
+ * }
+ * ```
+ */
+export function getKubernetesClient(): KubernetesClient | null {
+  const testConfig = TestConfigManager.getConfig();
+  const currentToken = testConfig.authToken;
+
+  // No auth token available
+  if (!currentToken) {
+    return null;
+  }
+
+  // Invalidate instance if token changed
+  if (instanceToken !== currentToken) {
+    clientInstance = null;
+    instanceToken = undefined;
+  }
+
+  // Create new instance if needed
+  if (!clientInstance) {
+    try {
+      clientInstance = new KubernetesClient(
+        undefined,
+        {
+          baseUrl: EnvVariables.clusterUrl,
+          password: EnvVariables.password,
+          token: currentToken,
+          username: EnvVariables.username,
+        },
+        testConfig.kubeConfigPath,
+      );
+      instanceToken = currentToken;
+    } catch (error) {
+      // Failed to create client
+      return null;
+    }
+  }
+
+  return clientInstance;
+}
+
+/**
+ * Check if a singleton client is available (has valid auth)
+ *
+ * @returns true if a client can be obtained, false otherwise
+ */
+export function hasKubernetesClient(): boolean {
+  const testConfig = TestConfigManager.getConfig();
+  return !!testConfig.authToken;
+}
+
+/**
+ * Set the singleton instance to a pre-built client.
+ *
+ * Used by the worker-scoped fixture to inject the per-worker client
+ * so that all code paths (cleanup, shared resources, etc.) reuse the
+ * same HTTPS agent and TLS connection.
+ */
+export function setKubernetesClient(client: KubernetesClient): void {
+  clientInstance = client;
+  instanceToken = client.getCurrentUserToken() ?? undefined;
+}
+
+/**
+ * Reset the singleton instance.
+ *
+ * This is mainly useful for testing purposes or when you need to force
+ * a new client to be created (e.g., after token refresh).
+ */
+export function resetKubernetesClient(): void {
+  clientInstance = null;
+  instanceToken = undefined;
+}
+
+/**
+ * Get or create a KubernetesClient with specific configuration.
+ *
+ * Unlike getKubernetesClient(), this creates a new instance with the
+ * provided configuration. Use this when you need a client with different
+ * settings than the singleton.
+ *
+ * Note: Prefer getKubernetesClient() for most use cases to benefit from
+ * connection reuse.
+ *
+ * @param config - Client configuration
+ * @returns New KubernetesClient instance
+ */
+export function createKubernetesClient(config: {
+  baseUrl?: string;
+  token?: string;
+  username?: string;
+  password?: string;
+  kubeConfigPath?: string;
+}): KubernetesClient {
+  const testConfig = TestConfigManager.getConfig();
+
+  return new KubernetesClient(
+    undefined,
+    {
+      baseUrl: config.baseUrl || EnvVariables.clusterUrl,
+      password: config.password || EnvVariables.password,
+      token: config.token || testConfig.authToken,
+      username: config.username || EnvVariables.username,
+    },
+    config.kubeConfigPath || testConfig.kubeConfigPath,
+  );
+}

--- a/playwright/src/clients/kubernetes-client.ts
+++ b/playwright/src/clients/kubernetes-client.ts
@@ -1,381 +1,1328 @@
 import * as fs from 'fs';
+import * as https from 'https';
+import * as net from 'net';
+import * as path from 'path';
+import { URL } from 'url';
 
-import * as k8s from '@kubernetes/client-node';
+import type * as http from 'http';
+import type * as stream from 'stream';
 
 import {
-  createProxyAgent,
-  generateInClusterKubeconfig,
-  generateKubeconfig,
-  getOAuthToken,
-  getProxyUrl,
-  isInClusterEnvironment,
-} from './kubernetes-auth';
+  type JsonPatchOp,
+  type KubernetesCondition,
+  type KubernetesResource,
+  getErrorMessage,
+} from '@/data-models/kubernetes-types';
+import { logger } from '@/utils/logger';
+import { EnvVariables } from '@/utils/env-variables';
+import { TestTimeouts } from '@/utils/test-config';
+import * as k8s from '@kubernetes/client-node';
+import type { Page } from '@playwright/test';
 
-const POLL_INTERVAL = 2000;
+import { ClusterSetupHandler } from './handlers/cluster-setup-handler';
+import { CustomResourceCrudHandler } from './handlers/custom-resource-crud-handler';
+import { DataVolumeHandler } from './handlers/data-volume-handler';
+import { HyperConvergedHandler } from './handlers/hco-handler';
+import type { KubernetesHandlerContext } from './handlers/kubernetes-api-context';
+import { NamespaceHandler } from './handlers/namespace-handler';
+import { NodeHandler } from './handlers/node-handler';
+import { SecretConfigMapHandler } from './handlers/secret-configmap-handler';
+import { SnapshotHandler } from './handlers/snapshot-handler';
+import { TemplateHandler } from './handlers/template-handler';
+import { VirtualMachineHandler } from './handlers/vm-handler';
+import type { ClusterAuthConfig } from './base-client';
+import BaseClient from './base-client';
+import { makeKubernetesProxyRequest } from './kubernetes-proxy';
 
 /**
- * Kubernetes client for scenario E2E tests.
- * Wraps @kubernetes/client-node directly — extend with new methods as tests require them.
+ * Kubernetes API client for interacting with OpenShift/Kubernetes clusters.
+ *
+ * This client leverages the official Kubernetes client library (@kubernetes/client-node)
+ * to provide programmatic access to cluster resources via the Kubernetes API.
+ * It supports both token-based and username/password authentication methods.
+ *
+ * The client provides comprehensive functionality for:
+ * - Custom resource management (VMs, Templates, MigrationPolicies, DataVolumes)
+ * - Core Kubernetes resource operations (Pods, Namespaces, etc.)
+ * - Resource verification with polling and timeout support
+ * - Error handling with detailed status codes
+ * - Multiple authentication methods (kubeconfig file, token, username/password)
+ *
+ * Key features:
+ * - Automatic retry logic for resource verification
+ * - Comprehensive error handling with status code preservation
+ * - Support for both namespaced and cluster-scoped resources
+ * - Timeout-based polling for resource state verification
+ *
+ * @example
+ * ```typescript
+ * const config: ClusterAuthConfig = {
+ *   baseUrl: 'https://api.example.com:6443',
+ *   username: 'admin',
+ *   password: 'password123',
+ *   token: 'optional-token'
+ * };
+ * const k8sClient = new KubernetesClient(page, config);
+ *
+ * // Create and verify a VM
+ * await k8sClient.createCustomResource('kubevirt.io', 'v1', 'default', 'virtualmachines', vmConfig);
+ * const result = await k8sClient.verifyVmCreated('test-vm', 'default');
+ * ```
+ *
+ * @extends BaseClient
+ * @since 1.0.0
+ * @see {@link https://github.com/kubernetes-client/javascript} for Kubernetes client documentation
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type K8sResource = Record<string, any>;
+export default class KubernetesClient extends BaseClient implements KubernetesHandlerContext {
+  private static hasShownAuthWarning = false;
 
-export class KubernetesClient {
-  static readonly generateInClusterKubeconfig = generateInClusterKubeconfig;
-  static readonly generateKubeconfig = generateKubeconfig;
-  static readonly getOAuthToken = getOAuthToken;
-  static readonly isInClusterEnvironment = isInClusterEnvironment;
+  /** Kubernetes Apps V1 API client for deployments, statefulsets, etc. */
+  private appsApi: k8s.AppsV1Api;
 
-  private readonly coApi: k8s.CustomObjectsApi;
-  private readonly coreApi: k8s.CoreV1Api;
-  private readonly kc: k8s.KubeConfig;
-  private rbacApi?: k8s.RbacAuthorizationV1Api;
+  /** Kubernetes Custom Objects API client for custom resources */
+  private coApi: k8s.CustomObjectsApi;
 
-  constructor(kubeConfigPath: string) {
-    this.kc = new k8s.KubeConfig();
+  /** Generic custom-object CRUD + proxy-aware service delete */
+  private readonly customResource: CustomResourceCrudHandler;
 
-    if (!fs.existsSync(kubeConfigPath)) {
-      throw new Error(`Kubeconfig not found: ${kubeConfigPath}`);
+  /** Kubernetes Core V1 API client for core resources */
+  private k8sApi: k8s.CoreV1Api;
+
+  /** Kubernetes configuration object */
+  private kubeConfig: k8s.KubeConfig;
+
+  /** Path to the kubeconfig file for token refresh */
+  private kubeConfigPath?: string;
+
+  /** Kubernetes RBAC API client for RoleBindings */
+  private rbacAuthorizationApi: k8s.RbacAuthorizationV1Api;
+
+  readonly clusterSetup!: ClusterSetupHandler;
+
+  readonly dataVolume!: DataVolumeHandler;
+
+  readonly hco!: HyperConvergedHandler;
+
+  readonly namespace!: NamespaceHandler;
+
+  readonly node!: NodeHandler;
+
+  readonly secret!: SecretConfigMapHandler;
+  readonly snapshot!: SnapshotHandler;
+  readonly template!: TemplateHandler;
+  readonly vm!: VirtualMachineHandler;
+  /**
+   * Creates a new KubernetesClient instance.
+   *
+   * The constructor initializes the Kubernetes client with the provided authentication
+   * configuration. It supports three authentication methods:
+   * 1. Kubeconfig file path (if provided)
+   * 2. Token-based authentication (if token is provided)
+   * 3. Username/password authentication (fallback)
+   *
+   * @param page - Optional Playwright page instance for UI-based operations
+   * @param config - Cluster authentication configuration with optional token
+   * @param config.baseUrl - The base URL of the cluster API server
+   * @param config.password - The password for authentication
+   * @param config.token - Optional OC authentication token for Kubernetes API calls
+   * @param config.username - The username for authentication
+   * @param kubeConfigPath - Optional path to kubeconfig file for authentication
+   * @since 1.0.0
+   */
+  constructor(
+    page: Page | undefined,
+    config: ClusterAuthConfig & { token?: string },
+    kubeConfigPath?: string,
+  ) {
+    super(page, config);
+    this.kubeConfig = new k8s.KubeConfig();
+
+    let effectiveKubeConfigPath = kubeConfigPath;
+    if (!effectiveKubeConfigPath) {
+      effectiveKubeConfigPath = this.tryDiscoverKubeConfig();
     }
 
-    this.kc.loadFromFile(kubeConfigPath);
-
-    const proxyUrl = getProxyUrl();
-    const origCreateAgent = (
-      this.kc as unknown as {
-        createAgent: (c: unknown, o: Record<string, unknown>) => unknown;
+    if (effectiveKubeConfigPath && fs.existsSync(effectiveKubeConfigPath)) {
+      try {
+        fs.accessSync(effectiveKubeConfigPath, fs.constants.R_OK);
+      } catch (error: unknown) {
+        throw new Error(
+          `Kubeconfig file is not readable: ${effectiveKubeConfigPath}. Error: ${getErrorMessage(
+            error,
+          )}.`,
+        );
       }
-    ).createAgent.bind(this.kc);
 
-    let sharedAgent: unknown = null;
-    (
-      this.kc as unknown as {
-        createAgent: (c: unknown, o: unknown) => unknown;
+      this.kubeConfig.loadFromFile(effectiveKubeConfigPath);
+      this.kubeConfigPath = effectiveKubeConfigPath;
+
+      const currentContext = this.kubeConfig.getCurrentContext();
+      if (!currentContext) {
+        throw new Error(
+          `Kubeconfig file ${effectiveKubeConfigPath} does not have a current context set.`,
+        );
       }
-    ).createAgent = (cluster: unknown, agentOptions: unknown) => {
+    } else if (config.token) {
+      this.kubeConfig.loadFromOptions({
+        clusters: [{ name: 'cluster', server: this.baseUrl, skipTLSVerify: true }],
+        contexts: [{ cluster: 'cluster', name: 'context', user: 'user' }],
+        currentContext: 'context',
+        users: [{ name: 'user', token: config.token }],
+      });
+    } else {
+      if (!KubernetesClient.hasShownAuthWarning) {
+        KubernetesClient.hasShownAuthWarning = true;
+        logger.warn(
+          '⚠️ WARNING: Using username/password authentication without token or kubeconfig. ' +
+            'This may result in "system:anonymous" errors. ' +
+            'Please ensure a kubeconfig file (via oc login) or token is provided.',
+        );
+      }
+
+      this.kubeConfig.loadFromOptions({
+        clusters: [{ name: 'cluster', server: this.baseUrl, skipTLSVerify: true }],
+        contexts: [{ cluster: 'cluster', name: 'context', user: 'user' }],
+        currentContext: 'context',
+        users: [{ name: 'user', password: this.password, username: this.username }],
+      });
+    }
+
+    const proxyUrlForTls = KubernetesClient.getProxyUrl();
+
+    // Do not set NODE_TLS_REJECT_UNAUTHORIZED globally — Node prints a security warning and it
+    // disables verification for every TLS socket in the process. Cluster TLS is handled via
+    // kubeconfig skipTLSVerify / cluster CA, plus rejectUnauthorized: false on makeProxyRequest
+    // and createProxyAgent() when using an HTTP CONNECT tunnel.
+
+    // Force HTTP/1.1 ALPN negotiation to prevent node-fetch v2 hanging on
+    // HTTP/2-capable servers (OpenShift API). node-fetch v2 doesn't support
+    // HTTP/2 but the default ALPN allows the server to negotiate h2, causing
+    // subsequent requests to hang on the reused TLS connection.
+    // Share a single HTTPS agent across all requests. Creating a new agent per
+    // request causes rapid TLS connection cycling that triggers 401s from the
+    // OpenShift API server. A shared agent with HTTP/1.1 ALPN and keep-alive
+    // reuses the TCP/TLS connection, avoiding both the HTTP/2 negotiation issue
+    // in node-fetch v2 and the connection-cycling 401 problem.
+    //
+    // When HTTP(S)_PROXY is set (e.g. IPv6 jobs), @kubernetes/client-node must
+    // use an HTTP CONNECT tunnel for every API call — not only makeProxyRequest.
+    // Otherwise CoreV1Api (readNamespace, etc.) attempts a direct connection and
+    // fails while verifyAuthentication via makeProxyRequest succeeds.
+    interface KubeConfigWithAgents {
+      createAgent: (
+        cluster: unknown,
+        agentOptions: Record<string, unknown>,
+      ) => https.Agent | http.Agent;
+    }
+    const kubeCfgRef = this.kubeConfig;
+    const kc = kubeCfgRef as unknown as KubeConfigWithAgents;
+    const origCreateAgent = kc.createAgent.bind(kubeCfgRef);
+    let sharedAgent: https.Agent | null = null;
+    kc.createAgent = (cluster: unknown, agentOptions: unknown) => {
       if (!sharedAgent) {
         const baseOpts =
           typeof agentOptions === 'object' && agentOptions !== null
             ? (agentOptions as Record<string, unknown>)
             : {};
-        sharedAgent = proxyUrl
-          ? createProxyAgent(proxyUrl)
-          : origCreateAgent(cluster, {
+        sharedAgent = proxyUrlForTls
+          ? KubernetesClient.createProxyAgent(proxyUrlForTls)
+          : (origCreateAgent(cluster, {
               ...baseOpts,
               ALPNProtocols: ['http/1.1'],
               keepAlive: true,
               keepAliveMsecs: 30000,
-            });
+            }) as https.Agent);
       }
       return sharedAgent;
     };
 
-    this.coreApi = this.kc.makeApiClient(k8s.CoreV1Api);
-    this.coApi = this.kc.makeApiClient(k8s.CustomObjectsApi);
-  }
+    this.k8sApi = this.kubeConfig.makeApiClient(k8s.CoreV1Api);
+    this.coApi = this.kubeConfig.makeApiClient(k8s.CustomObjectsApi);
+    this.appsApi = this.kubeConfig.makeApiClient(k8s.AppsV1Api);
+    this.rbacAuthorizationApi = this.kubeConfig.makeApiClient(k8s.RbacAuthorizationV1Api);
 
-  private async waitForNamespaceActive(name: string, timeoutMs = 30_000): Promise<void> {
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      try {
-        const ns = await this.coreApi.readNamespace({ name });
-        if (ns?.status?.phase === 'Active') return;
-      } catch {
-        // Not ready yet
-      }
-      await new Promise((r) => setTimeout(r, 1000));
-    }
-    throw new Error(`Timeout: Namespace ${name} did not become Active in ${timeoutMs}ms`);
+    const ctx = this as KubernetesHandlerContext;
+    this.customResource = new CustomResourceCrudHandler(ctx);
+    this.template = new TemplateHandler(ctx);
+    this.dataVolume = new DataVolumeHandler(ctx);
+    this.secret = new SecretConfigMapHandler(ctx);
+    this.hco = new HyperConvergedHandler(ctx);
+    this.snapshot = new SnapshotHandler(ctx);
+    this.vm = new VirtualMachineHandler(ctx, this.template, this.dataVolume, this.secret);
+    this.node = new NodeHandler(ctx, this.vm);
+    this.namespace = new NamespaceHandler(ctx, this.secret, this.vm);
+    this.clusterSetup = new ClusterSetupHandler(this);
   }
+  /**
+   * Create an HTTPS agent that tunnels through an HTTP proxy.
+   * Uses HTTP CONNECT method to establish a tunnel to the target host.
+   *
+   * @param proxyUrl - The proxy URL (e.g., http://proxy.example.com:3128)
+   * @returns An HTTPS agent configured to use the proxy
+   */
+  private static createProxyAgent(proxyUrl: string): https.Agent {
+    const proxy = new URL(proxyUrl);
 
-  async cleanupTestNamespace(name: string): Promise<void> {
-    try {
-      await this.coreApi.deleteNamespace({ name });
-    } catch {
-      // Ignore — namespace may already be gone
-    }
-  }
-
-  async createContainerDiskVm(vmName: string, namespace: string): Promise<void> {
-    const vmResource = {
-      apiVersion: 'kubevirt.io/v1',
-      kind: 'VirtualMachine',
-      metadata: {
-        name: vmName,
-        namespace,
-        labels: { app: vmName, 'test-framework': 'playwright' },
-      },
-      spec: {
-        runStrategy: 'Always',
-        template: {
-          metadata: { labels: { 'kubevirt.io/domain': vmName } },
-          spec: {
-            domain: {
-              cpu: { cores: 1, sockets: 1, threads: 1 },
-              memory: { guest: '128Mi' },
-              devices: {
-                disks: [{ disk: { bus: 'virtio' }, name: 'containerdisk' }],
-                rng: {},
-              },
-            },
-            volumes: [
-              {
-                name: 'containerdisk',
-                containerDisk: {
-                  image: 'quay.io/kubevirt/cirros-container-disk-demo:latest',
-                },
-              },
-            ],
+    return new https.Agent({
+      rejectUnauthorized: false,
+      createConnection: (options, callback) => {
+        const proxySocket = net.connect(
+          {
+            host: proxy.hostname,
+            port: parseInt(proxy.port || '3128', 10),
           },
-        },
-      },
-    };
+          () => {
+            const connectReq = [
+              `CONNECT ${options.host}:${options.port} HTTP/1.1`,
+              `Host: ${options.host}:${options.port}`,
+              'Connection: keep-alive',
+              '',
+              '',
+            ].join('\r\n');
+            proxySocket.write(connectReq);
+          },
+        );
 
-    try {
-      await this.coApi.createNamespacedCustomObject({
-        group: 'kubevirt.io',
-        version: 'v1',
-        namespace,
-        plural: 'virtualmachines',
-        body: vmResource,
-      });
-    } catch (error: unknown) {
-      const msg = error instanceof Error ? error.message : String(error);
-      if (msg.includes('409') || msg.includes('AlreadyExists')) return;
-      throw error;
+        let responseData = '';
+        const onData = (chunk: Buffer) => {
+          responseData += chunk.toString();
+
+          if (responseData.includes('\r\n\r\n')) {
+            proxySocket.removeListener('data', onData);
+            const [statusLine] = responseData.split('\r\n');
+            const statusCode = parseInt(statusLine.split(' ')[1], 10);
+
+            if (statusCode === 200) {
+              callback(null, proxySocket);
+            } else {
+              const error = new Error(
+                `Proxy CONNECT failed with status ${statusCode}: ${statusLine}`,
+              );
+              proxySocket.destroy();
+              callback(error, undefined as unknown as stream.Duplex);
+            }
+          }
+        };
+
+        proxySocket.on('data', onData);
+        proxySocket.on('error', (err) => {
+          callback(err, undefined as unknown as stream.Duplex);
+        });
+      },
+    } as https.AgentOptions);
+  }
+  static async generateKubeconfig(
+    clusterUrl: string,
+    username: string,
+    password: string,
+    outputPath: string,
+  ): Promise<string> {
+    const token = await KubernetesClient.getOAuthToken(clusterUrl, username, password);
+
+    const kubeconfigYaml = `apiVersion: v1
+kind: Config
+clusters:
+  - name: cluster
+    cluster:
+      server: ${clusterUrl}
+      insecure-skip-tls-verify: true
+contexts:
+  - name: context
+    context:
+      cluster: cluster
+      user: user
+current-context: context
+users:
+  - name: user
+    user:
+      token: ${token}
+`;
+
+    const dir = path.dirname(outputPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
     }
+
+    fs.writeFileSync(outputPath, kubeconfigYaml, 'utf8');
+
+    return outputPath;
+  }
+  private static async getOAuthServerUrl(clusterUrl: string): Promise<string> {
+    return new Promise((resolve) => {
+      const url = new URL('/.well-known/oauth-authorization-server', clusterUrl);
+
+      // Get proxy configuration if available
+      const proxyUrl = KubernetesClient.getProxyUrl();
+      const agent = proxyUrl ? KubernetesClient.createProxyAgent(proxyUrl) : undefined;
+
+      const options: https.RequestOptions = {
+        hostname: url.hostname,
+        port: url.port || 443,
+        path: url.pathname,
+        method: 'GET',
+        rejectUnauthorized: false,
+        agent, // Use proxy agent if configured
+      };
+
+      const req = https.request(options, (res) => {
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          try {
+            const config = JSON.parse(body);
+            resolve(config.issuer || clusterUrl);
+          } catch {
+            resolve(clusterUrl);
+          }
+        });
+      });
+
+      req.on('error', () => {
+        resolve(clusterUrl);
+      });
+
+      req.end();
+    });
+  }
+  /**
+   * Authenticate with OpenShift using username/password and get an OAuth token.
+   * This uses the OpenShift OAuth server to exchange credentials for a bearer token.
+   *
+   * @param clusterUrl - The cluster API URL (e.g., https://api.cluster.example.com:6443)
+   * @param username - The username to authenticate with
+   * @param password - The password to authenticate with
+   * @returns The OAuth bearer token
+   * @throws Error if authentication fails
+   */
+  static async getOAuthToken(
+    clusterUrl: string,
+    username: string,
+    password: string,
+  ): Promise<string> {
+    const oauthServerUrl = await KubernetesClient.getOAuthServerUrl(clusterUrl);
+
+    return new Promise((resolve, reject) => {
+      const authHeader = Buffer.from(`${username}:${password}`).toString('base64');
+      const tokenUrl = new URL('/oauth/authorize', oauthServerUrl);
+      tokenUrl.searchParams.set('response_type', 'token');
+      tokenUrl.searchParams.set('client_id', 'openshift-challenging-client');
+
+      // Get proxy configuration if available
+      const proxyUrl = KubernetesClient.getProxyUrl();
+      const agent = proxyUrl ? KubernetesClient.createProxyAgent(proxyUrl) : undefined;
+
+      const options: https.RequestOptions = {
+        hostname: tokenUrl.hostname,
+        port: tokenUrl.port || 443,
+        path: tokenUrl.pathname + tokenUrl.search,
+        method: 'GET',
+        headers: {
+          Authorization: `Basic ${authHeader}`,
+          'X-CSRF-Token': '1',
+        },
+        rejectUnauthorized: false, // Skip TLS verification for self-signed certs
+        agent, // Use proxy agent if configured
+      };
+
+      const req = https.request(options, (res) => {
+        const location = res.headers.location;
+        if (location && location.includes('access_token=')) {
+          const match = location.match(/access_token=([^&]+)/);
+          if (match) {
+            resolve(match[1]);
+            return;
+          }
+        }
+
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          reject(
+            new Error(
+              `OAuth authentication failed: HTTP ${res.statusCode}. Response: ${body.substring(
+                0,
+                200,
+              )}`,
+            ),
+          );
+        });
+      });
+
+      req.on('error', (err) => {
+        reject(new Error(`OAuth request failed: ${err.message}`));
+      });
+
+      req.end();
+    });
   }
 
-  async deleteClusterCustomResource(
+  /**
+   * Get the proxy URL from environment variables if configured.
+   * Supports both HTTP_PROXY/HTTPS_PROXY and http_proxy/https_proxy.
+   *
+   * @returns The proxy URL string or undefined if no proxy is configured
+   */
+  private static getProxyUrl(): string | undefined {
+    return (
+      process.env.HTTPS_PROXY ||
+      process.env.https_proxy ||
+      process.env.HTTP_PROXY ||
+      process.env.http_proxy
+    );
+  }
+
+  /**
+   * Try to discover kubeconfig file from standard locations.
+   * Checks the .kubeconfigs directory for test config files.
+   * @returns Path to kubeconfig file if found, undefined otherwise
+   */
+  private tryDiscoverKubeConfig(): string | undefined {
+    const kubeConfigDir = path.join(process.cwd(), '.kubeconfigs');
+    const shardIndex = EnvVariables.shardIndex;
+    const fileName = shardIndex ? `shard-${shardIndex}-config` : 'test-config';
+    const configPath = path.join(kubeConfigDir, fileName);
+
+    if (fs.existsSync(configPath)) {
+      return configPath;
+    }
+
+    return undefined;
+  }
+
+  async addBlankDiskToVm(
+    vmName: string,
+    namespace: string,
+    diskName: string,
+    size = '1Gi',
+  ): Promise<void> {
+    return this.vm.addBlankDiskToVm(vmName, namespace, diskName, size);
+  }
+
+  async addCdromDiskToVm(
+    vmName: string,
+    namespace: string,
+    options?: { volumeName?: string; pvcClaimName?: string; containerImage?: string },
+  ): Promise<void> {
+    return this.vm.addCdromDiskToVm(vmName, namespace, options);
+  }
+
+  /**
+   * Check if a DataVolume exists in the specified namespace
+   * @param dataVolumeName - Name of the DataVolume
+   * @param namespace - Namespace where the DataVolume should exist
+   * @returns true if DataVolume exists, false otherwise
+   */
+
+  get appsV1Api(): k8s.AppsV1Api {
+    return this.appsApi;
+  }
+
+  /**
+   * Check whether a user can perform a specific action on a resource via LocalSubjectAccessReview.
+   * Requires admin privileges (the calling client must be able to create access reviews).
+   */
+  async canUserPerformAction(
+    username: string,
+    namespace: string,
+    verb: string,
+    group: string,
+    resource: string,
+  ): Promise<boolean> {
+    return this.clusterSetup.canUserPerformAction(username, namespace, verb, group, resource);
+  }
+
+  async cleanupTestNamespace(namespace: string): Promise<void> {
+    return this.namespace.cleanupTestNamespace(namespace);
+  }
+
+  async cloneVirtualMachine(
+    sourceVmName: string,
+    targetVmName: string,
+    namespace: string,
+    startAfterClone = false,
+    timeoutMs: number = TestTimeouts.VM_CREATION,
+  ) {
+    return this.vm.cloneVirtualMachine(
+      sourceVmName,
+      targetVmName,
+      namespace,
+      startAfterClone,
+      timeoutMs,
+    );
+  }
+
+  async cordonNode(nodeName: string): Promise<void> {
+    return this.node.cordonNode(nodeName);
+  }
+
+  get coreV1Api(): k8s.CoreV1Api {
+    return this.k8sApi;
+  }
+
+  async createBlankDataVolume(
+    dataVolumeName: string,
+    namespace: string,
+    size = '1Gi',
+  ): Promise<KubernetesResource> {
+    return this.dataVolume.createBlankDataVolume(dataVolumeName, namespace, size);
+  }
+
+  /**
+   * Create a cluster-scoped custom resource
+   */
+  async createClusterCustomResource(group: string, version: string, plural: string, body: unknown) {
+    return this.customResource.createClusterCustomResource(group, version, plural, body);
+  }
+
+  /**
+   * Creates a custom resource in the specified namespace.
+   *
+   * This method provides a generic way to create any custom Kubernetes resource
+   * by specifying the API group, version, namespace, and resource type.
+   *
+   * @param group - The API group of the custom resource (e.g., 'kubevirt.io')
+   * @param version - The API version of the custom resource (e.g., 'v1')
+   * @param namespace - The namespace where the resource should be created
+   * @param plural - The plural name of the resource type (e.g., 'virtualmachines')
+   * @param body - The resource configuration object
+   * @returns The created resource object
+   * @throws {Error} When resource creation fails
+   * @since 1.0.0
+   */
+  async createCustomResource(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+    body: unknown,
+  ) {
+    return this.customResource.createCustomResource(group, version, namespace, plural, body);
+  }
+
+  async createFedoraTemplateWithDataVolumeRootDisk(templateName: string, namespace: string) {
+    return this.template.createFedoraTemplateWithDataVolumeRootDisk(templateName, namespace);
+  }
+
+  async createNamespace(name: string, labels?: Record<string, string>): Promise<boolean> {
+    return this.namespace.createNamespace(name, labels);
+  }
+
+  /**
+   * POST /api/v1/namespaces. Uses makeProxyRequest when a proxy is set (same rationale as getNamespaceByName).
+   */
+  async createNamespaceResource(body: k8s.V1Namespace): Promise<void> {
+    return this.clusterSetup.createNamespaceResource(body);
+  }
+
+  async createPvc(
+    name: string,
+    namespace: string,
+    size = '10Gi',
+    storageClassName?: string,
+    accessModes: string[] = ['ReadWriteOnce'],
+  ): Promise<k8s.V1PersistentVolumeClaim> {
+    return this.secret.createPvc(name, namespace, size, storageClassName, accessModes);
+  }
+
+  async createSecret(
+    name: string,
+    namespace: string,
+    data: { [key: string]: string },
+    type = 'Opaque',
+  ): Promise<k8s.V1Secret> {
+    return this.secret.createSecret(name, namespace, data, type);
+  }
+
+  async createSSHKeySecret(
+    name: string,
+    namespace: string,
+    sshPublicKey?: string,
+  ): Promise<KubernetesResource> {
+    const secret = await this.secret.createSSHKeySecret(name, namespace, sshPublicKey);
+    return secret as unknown as KubernetesResource;
+  }
+
+  async createSysprepConfigMap(
+    name: string,
+    namespace: string,
+    unattendXml?: string,
+  ): Promise<KubernetesResource> {
+    const cm = await this.secret.createSysprepConfigMap(name, namespace, unattendXml);
+    return cm as unknown as KubernetesResource;
+  }
+
+  async createTlsCaCertConfigMap(
+    name: string,
+    namespace: string,
+    caPem: string,
+  ): Promise<k8s.V1ConfigMap> {
+    return this.secret.createTlsCaCertConfigMap(name, namespace, caPem);
+  }
+
+  async createVmFromInstanceType(
+    volumeName: string,
+    vmName: string,
+    namespace: string,
+    series = 'U series',
+    instanceTypeSize = 'small',
+    startAfterCreation = true,
+    volumeNamespace = 'openshift-virtualization-os-images',
+    storageClassName?: string,
+    rootDiskName = 'rootdisk',
+  ) {
+    return this.vm.createVmFromInstanceType(
+      volumeName,
+      vmName,
+      namespace,
+      series,
+      instanceTypeSize,
+      startAfterCreation,
+      volumeNamespace,
+      storageClassName,
+      rootDiskName,
+    );
+  }
+
+  /**
+   * Get the number of namespaces (projects) in the cluster.
+   * Optionally exclude system namespaces (kube-*, openshift-*) to match UI "Projects" count.
+   * @param excludeSystem - If true, exclude kube-*, openshift-*, and default (default: true)
+   * @param onlyWithVms - If true, count only namespaces that have at least one VM (matches UI tree)
+   */
+
+  async createVmFromTemplate(
+    templateMetadataName: string,
+    vmName: string,
+    namespace: string,
+    templateNamespace = 'openshift',
+    startAfterCreation = true,
+    sysprepConfigMapName?: string,
+    cloudInitConfig?: { username?: string; password?: string },
+    vmCustomization?: {
+      description?: string;
+      cpu?: number;
+      memory?: number;
+      bootMode?: 'BIOS' | 'UEFI' | 'UEFI (secure)';
+      workload?: string;
+      hostname?: string;
+      headless?: boolean;
+    },
+    storageClassName?: string,
+    folderName?: string,
+  ) {
+    return this.vm.createVmFromTemplate(
+      templateMetadataName,
+      vmName,
+      namespace,
+      templateNamespace,
+      startAfterCreation,
+      sysprepConfigMapName,
+      cloudInitConfig,
+      vmCustomization,
+      storageClassName,
+      folderName,
+    );
+  }
+
+  /**
+   * Get HCO status and installed version for VM Overview cluster status validation.
+   * Status is derived from status.conditions (e.g. Degraded, Available).
+   * Version is taken from status.versions (e.g. cnv or kubevirt component).
+   */
+
+  /**
+   * Get list of nodes that are available for VM migration (matching UI filtering)
+   * The migration UI filters nodes based on:
+   * 1. Ready status (Ready=True)
+   * 2. Worker role label (node-role.kubernetes.io/worker)
+   * 3. Schedulable (not SchedulingDisabled)
+   * 4. Optionally excludes the current node where the VM is running
+   * @param excludeNodeName - Optional node name to exclude (e.g., current VM node)
+   * @returns Array of Node resources available for migration
+   */
+
+  /**
+   * Get a Template resource
+   * @param templateName - Name of the Template
+   * @param namespace - Namespace where the Template exists
+   * @returns The Template resource
+   */
+
+  async createVmSnapshot(
+    snapshotName: string,
+    vmName: string,
+    namespace: string,
+  ): Promise<KubernetesResource> {
+    return this.snapshot.createVmSnapshot(snapshotName, vmName, namespace);
+  }
+
+  async createVolumeSnapshot(
+    snapshotName: string,
+    namespace: string,
+    sourcePvcName: string,
+    volumeSnapshotClassName?: string,
+  ): Promise<KubernetesResource> {
+    return this.snapshot.createVolumeSnapshot(
+      snapshotName,
+      namespace,
+      sourcePvcName,
+      volumeSnapshotClassName,
+    );
+  }
+
+  get customObjectsApi(): k8s.CustomObjectsApi {
+    return this.coApi;
+  }
+
+  async dataSourceExists(dataSourceName: string, namespace: string): Promise<boolean> {
+    return this.dataVolume.dataSourceExists(dataSourceName, namespace);
+  }
+
+  async dataVolumeExists(dataVolumeName: string, namespace: string): Promise<boolean> {
+    return this.dataVolume.dataVolumeExists(dataVolumeName, namespace);
+  }
+
+  /**
+   * Delete all resources of a specific kind in a namespace.
+   * This is used for cleanup operations.
+   *
+   * @param group - API group (e.g., 'kubevirt.io')
+   * @param version - API version (e.g., 'v1')
+   * @param plural - Resource plural name (e.g., 'virtualmachines')
+   * @param namespace - The namespace to clean up
+   * @param options - Optional settings
+   * @since 1.0.0
+   */
+  async deleteAllCustomResources(
     group: string,
     version: string,
     plural: string,
-    name: string,
+    namespace: string,
+    options?: { ignoreErrors?: boolean },
   ): Promise<void> {
-    await this.coApi.deleteClusterCustomObject({ group, version, plural, name });
+    return this.customResource.deleteAllCustomResources(group, version, plural, namespace, options);
   }
 
+  async deleteAllSecrets(namespace: string, options?: { ignoreErrors?: boolean }): Promise<void> {
+    return this.secret.deleteAllSecrets(namespace, options);
+  }
+
+  /**
+   * Delete a cluster-scoped custom resource
+   */
+  async deleteClusterCustomResource(group: string, version: string, plural: string, name: string) {
+    return this.customResource.deleteClusterCustomResource(group, version, plural, name);
+  }
+
+  async deleteClusterRoleBinding(name: string): Promise<void> {
+    return this.namespace.deleteClusterRoleBinding(name);
+  }
+
+  // =====================================================================
+  // Global Setup/Teardown Support Methods
+  // These methods replace OC CLI operations for test environment management
+  // =====================================================================
+
+  async deleteConfigMapsWithPrefix(
+    namespace: string,
+    prefix: string,
+    options?: { ignoreErrors?: boolean },
+  ): Promise<void> {
+    return this.secret.deleteConfigMapsWithPrefix(namespace, prefix, options);
+  }
+
+  /**
+   * Example: Delete a custom resource
+   */
   async deleteCustomResource(
     group: string,
     version: string,
     namespace: string,
     plural: string,
     name: string,
-  ): Promise<void> {
-    await this.coApi.deleteNamespacedCustomObject({ group, version, namespace, plural, name });
+  ) {
+    return this.customResource.deleteCustomResource(group, version, namespace, plural, name);
+  }
+
+  async deleteNamespace(name: string, options?: { ignoreNotFound?: boolean }): Promise<boolean> {
+    return this.namespace.deleteNamespace(name, options);
+  }
+
+  /**
+   * DELETE /api/v1/namespaces/{namespace}/services/{name}. Uses makeProxyRequest when HTTP(S)_PROXY is set.
+   */
+  async deleteNamespacedService(namespace: string, name: string): Promise<void> {
+    return this.customResource.deleteNamespacedService(namespace, name);
+  }
+
+  async deletePvc(
+    name: string,
+    namespace: string,
+    options?: { ignoreNotFound?: boolean },
+  ): Promise<boolean> {
+    return this.secret.deletePvc(name, namespace, options);
+  }
+
+  async deleteSecret(name: string, namespace: string): Promise<boolean> {
+    return this.secret.deleteSecret(name, namespace);
+  }
+
+  async deleteVolumesnapshotsByLabel(
+    namespace: string,
+    labels: Record<string, string>,
+    timeoutMs = 30000,
+  ): Promise<boolean> {
+    return this.snapshot.deleteVolumesnapshotsByLabel(namespace, labels, timeoutMs);
+  }
+
+  async disableDeleteProtection(vmName: string, namespace: string) {
+    return this.vm.disableDeleteProtection(vmName, namespace);
   }
 
   async disableNativeVmTemplateFeatureGate(
     name = 'kubevirt-hyperconverged',
     namespace = 'openshift-cnv',
-  ): Promise<void> {
-    await this.patchHyperConverged(name, namespace, [
-      { op: 'remove', path: '/spec/featureGates/withHostPassthroughCPU' },
-    ]);
+  ): Promise<boolean> {
+    return this.hco.disableNativeVmTemplateFeatureGate(name, namespace);
   }
 
-  // ── Public API accessors ─────────────────────────────────────────────
-
+  /**
+   * Disable virtualization welcome modal, guided tour, and getting started settings via K8s API.
+   * Patches the kubevirt-user-settings ConfigMap to set:
+   * - quickStart.dontShowWelcomeModal = true (disables the welcome modal)
+   * - quickStart.activeQuickStartID = "" (clears any active quick start)
+   * - guidedTour = false (disables the virtualization guided tour)
+   * - onboardingPopoversHidden = { vmsTab, catalog, createProject } (suppresses info popovers)
+   *
+   * Patches both the username key and (optionally) the user UID key, since the
+   * kubevirt plugin may look up settings by UID rather than username.
+   *
+   * @param cnvNamespace - The CNV namespace (default: 'openshift-cnv')
+   * @param username - The username key in the ConfigMap (default: 'kube-admin')
+   * @param userUid - Optional user UID to also patch (resolved via getUserUid)
+   * @returns true if settings were patched, false if ConfigMap doesn't exist or patch failed
+   */
   async disableVirtualizationWelcomeSettings(
-    cnvNamespace: string,
-    username: string,
-    _userUid?: string,
+    cnvNamespace = 'openshift-cnv',
+    username = 'kube-admin',
+    userUid?: string,
   ): Promise<boolean> {
-    try {
-      const cmName = `kubevirt-ui-settings-${username}`;
-      await this.patchConfigMap(cmName, cnvNamespace, {
-        quickStart: JSON.stringify({ dontShowWelcomeModal: true }),
-      });
-      return true;
-    } catch {
-      return false;
-    }
+    return this.clusterSetup.disableVirtualizationWelcomeSettings(cnvNamespace, username, userUid);
   }
 
   async enableNativeVmTemplateFeatureGate(
     name = 'kubevirt-hyperconverged',
     namespace = 'openshift-cnv',
-  ): Promise<void> {
-    await this.patchHyperConverged(name, namespace, [
-      { op: 'add', path: '/spec/featureGates', value: { withHostPassthroughCPU: true } },
-    ]);
+  ): Promise<boolean> {
+    return this.hco.enableNativeVmTemplateFeatureGate(name, namespace);
   }
 
-  // ── Generic custom resource operations ──────────────────────────────
+  async enableNodePortFeature(
+    enabled = true,
+    nodePortAddress?: string,
+    cnvNamespace = 'openshift-cnv',
+  ) {
+    return this.vm.enableNodePortFeature(enabled, nodePortAddress, cnvNamespace);
+  }
 
-  async ensureNonPrivUserExists(username: string, password: string): Promise<boolean> {
-    try {
-      const secret = await this.coreApi.readNamespacedSecret({
-        name: 'htpass-secret',
-        namespace: 'openshift-config',
-      });
-      const currentData = secret?.data?.htpasswd
-        ? Buffer.from(secret.data.htpasswd, 'base64').toString('utf-8')
-        : '';
+  async enableSshAccess(
+    vmName: string,
+    namespace: string,
+    sshServiceType: 'NodePort' | 'LoadBalancer' = 'NodePort',
+  ) {
+    return this.vm.enableSshAccess(vmName, namespace, sshServiceType);
+  }
 
-      if (currentData.includes(`${username}:`)) {
-        return false;
-      }
+  /**
+   * Check if Cluster Observability Operator (COO) is installed and uninstall it if so.
+   * Removes OLM Subscriptions and ClusterServiceVersions in openshift-cluster-observability-operator
+   * so the test can run from a clean state and the UI does not show "Subscription already exists".
+   */
+  async ensureClusterObservabilityOperatorUninstalled(): Promise<void> {
+    return this.clusterSetup.ensureClusterObservabilityOperatorUninstalled();
+  }
 
-      const { execSync } = await import('child_process');
-      const hash = execSync(`htpasswd -nbB "${username}" "${password}"`, {
-        encoding: 'utf8',
-        timeout: 10_000,
-      }).trim();
+  /** RBAC for network latency checkup tests  */
+  async ensureNetworkCheckupPermissions(namespace: string): Promise<{
+    results: Record<string, { created: boolean; alreadyExisted: boolean }>;
+    anyCreated: boolean;
+  }> {
+    return this.namespace.ensureNetworkCheckupPermissions(namespace);
+  }
 
-      const updated = currentData.endsWith('\n')
-        ? `${currentData}${hash}\n`
-        : `${currentData}\n${hash}\n`;
+  async ensureNonPrivUserExists(username: string, password = 'test'): Promise<boolean> {
+    return this.namespace.ensureNonPrivUserExists(username, password);
+  }
 
-      await this.coreApi.patchNamespacedSecret({
-        name: 'htpass-secret',
-        namespace: 'openshift-config',
-        body: { data: { htpasswd: Buffer.from(updated).toString('base64') } },
-      });
-      return true;
-    } catch {
-      return false;
+  /**
+   * Ensures an OVN layer2 NetworkAttachmentDefinition exists; tracks it for cleanup when created.
+   *
+   */
+  async ensureOvnNadExists(
+    nadName: string,
+    namespace: string,
+  ): Promise<{
+    created: boolean;
+    alreadyExisted: boolean;
+  }> {
+    const result = await this.namespace.ensureOvnNadExists(nadName, namespace);
+    if (result.created) {
+      this.trackResource('NetworkAttachmentDefinition', nadName, namespace);
     }
+    return result;
   }
 
-  async ensureVmFoldersEnabled(cnvNamespace: string): Promise<K8sResource | null> {
-    try {
-      await this.patchConfigMap('kubevirt-ui-features', cnvNamespace, {
-        treeViewFolders: 'true',
-      });
-      return { data: { treeViewFolders: 'true' } };
-    } catch {
-      return null;
+  /** RBAC + ServiceAccount for storage checkup flows  */
+  async ensureStorageCheckupPermissions(namespace: string): Promise<{
+    results: Record<string, { created: boolean; alreadyExisted: boolean }>;
+    anyCreated: boolean;
+  }> {
+    return this.namespace.ensureStorageCheckupPermissions(namespace);
+  }
+
+  async ensureVmFoldersEnabled(cnvNamespace = 'openshift-cnv'): Promise<KubernetesResource | null> {
+    return this.vm.ensureVmFoldersEnabled(cnvNamespace);
+  }
+
+  async findTemplateByMetadataName(metadataName: string, namespace = 'openshift') {
+    return this.template.findTemplateByMetadataName(metadataName, namespace);
+  }
+
+  /**
+   * Get the AppsV1Api client for interacting with deployments, statefulsets, etc.
+   */
+  getAppsV1Api(): k8s.AppsV1Api {
+    return this.appsApi;
+  }
+
+  /**
+   * Get a cluster-scoped custom resource (not namespaced)
+   * @param group - API group
+   * @param version - API version
+   * @param plural - Resource plural name
+   * @param name - Resource name
+   * @returns The custom resource
+   */
+  async getClusterCustomResource(group: string, version: string, plural: string, name: string) {
+    return this.customResource.getClusterCustomResource(group, version, plural, name);
+  }
+
+  /**
+   * Get total count of VirtualMachines across all namespaces (cluster-wide).
+   * Used to validate the VM Overview cluster-level "VMs" metric card.
+   */
+  async getClusterVirtualMachineCount(): Promise<number> {
+    const namespaces = await this.getNamespaces();
+    let total = 0;
+    for (const ns of namespaces) {
+      const vms = await this.listVirtualMachines(ns);
+      total += vms.length;
     }
+    return total;
   }
 
+  async getConfigMap(name: string, namespace: string): Promise<KubernetesResource | null> {
+    return this.secret.getConfigMap(name, namespace);
+  }
+
+  /**
+   * Get the CoreV1Api client for interacting with core Kubernetes resources
+   */
   getCoreV1Api(): k8s.CoreV1Api {
-    return this.coreApi;
+    return this.k8sApi;
   }
 
+  /**
+   * Get the current user's authentication token from the kubeconfig.
+   * This is used to pass the token to other clients or for API calls.
+   *
+   * @returns The authentication token or undefined if not available
+   * @since 1.0.0
+   */
   getCurrentUserToken(): string | undefined {
     try {
-      return this.kc.getCurrentUser()?.token;
+      const user = this.kubeConfig.getCurrentUser();
+      return user?.token;
     } catch {
       return undefined;
     }
   }
 
-  // ── VM operations ───────────────────────────────────────────────────
+  /**
+   * Get the CustomObjectsApi client for interacting with custom resources (like VMs)
+   */
+  getCustomObjectsApi(): k8s.CustomObjectsApi {
+    return this.coApi;
+  }
 
-  async getHyperConverged(
+  /**
+   * Example: Get a custom resource (like a VirtualMachine)
+   */
+  async getCustomResource(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+    name: string,
+  ) {
+    return this.customResource.getCustomResource(group, version, namespace, plural, name);
+  }
+
+  async getHyperConverged(name = 'kubevirt-hyperconverged', namespace = 'openshift-cnv') {
+    return this.hco.getHyperConverged(name, namespace);
+  }
+
+  async getHyperConvergedField(
+    jsonPath: string,
     name = 'kubevirt-hyperconverged',
     namespace = 'openshift-cnv',
-  ): Promise<K8sResource> {
-    return (await this.coApi.getNamespacedCustomObject({
-      group: 'hco.kubevirt.io',
-      version: 'v1beta1',
-      namespace,
-      plural: 'hyperconvergeds',
-      name,
-    })) as K8sResource;
+  ): Promise<string | undefined> {
+    return this.hco.getHyperConvergedField(jsonPath, name, namespace);
   }
 
-  // ── HyperConverged operations ───────────────────────────────────────
-
-  getRbacApi(): k8s.RbacAuthorizationV1Api {
-    if (!this.rbacApi) {
-      this.rbacApi = this.kc.makeApiClient(k8s.RbacAuthorizationV1Api);
-    }
-    return this.rbacApi;
+  async getHyperConvergedStatusAndVersion(
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+  ): Promise<{ status: string; version: string | undefined }> {
+    return this.hco.getHyperConvergedStatusAndVersion(name, namespace);
   }
 
+  /**
+   * Get the raw KubeConfig object
+   */
+  getKubeConfig(): k8s.KubeConfig {
+    return this.kubeConfig;
+  }
+
+  /**
+   * Get a MigrationPolicy resource
+   * @param policyName - Name of the MigrationPolicy
+   * @returns The MigrationPolicy resource
+   */
+  async getMigrationPolicy(policyName: string) {
+    return await this.getClusterCustomResource(
+      'migrations.kubevirt.io',
+      'v1alpha1',
+      'migrationpolicies',
+      policyName,
+    );
+  }
+
+  async getMigrationTargetNodes(excludeNodeName?: string): Promise<KubernetesResource[]> {
+    return this.node.getMigrationTargetNodes(excludeNodeName);
+  }
+
+  /**
+   * GET /api/v1/namespaces/{name}. Uses makeProxyRequest when a proxy is set so IPv6 CI jobs
+   * match verifyAuthentication; CoreV1Api.readNamespace may not honor the patched createAgent.
+   */
+  async getNamespaceByName(name: string): Promise<k8s.V1Namespace | undefined> {
+    return this.clusterSetup.getNamespaceByName(name);
+  }
+
+  async getNamespaceCount(excludeSystem = true, onlyWithVms = false): Promise<number> {
+    return this.namespace.getNamespaceCount(excludeSystem, onlyWithVms);
+  }
+
+  /**
+   * Get expected resource allocation for a namespace (running VMs, vCPU, memory MiB, storage GiB).
+   * Used to validate VM Overview resource allocation cards.
+   */
+  async getNamespaceResourceAllocationForOverview(namespace: string): Promise<{
+    runningCount: number;
+    vcpu: number;
+    memoryMiB: number;
+    storageGiB: number;
+  }> {
+    return this.namespace.getNamespaceResourceAllocationForOverview(namespace);
+  }
+
+  async getNamespaces(): Promise<string[]> {
+    return this.namespace.getNamespaces();
+  }
+
+  async getNativeVmTemplate(templateName: string, namespace: string) {
+    return this.template.getNativeVmTemplate(templateName, namespace);
+  }
+
+  getNodeNameWithLowerAllocatable(nodes: KubernetesResource[]): string | undefined {
+    return this.node.getNodeNameWithLowerAllocatable(nodes);
+  }
+
+  async getNodes() {
+    return this.node.getNodes();
+  }
+
+  async getNodesWithVmsInNamespace(namespace: string): Promise<string[]> {
+    return this.node.getNodesWithVmsInNamespace(namespace);
+  }
+
+  /**
+   * Example: Get a list of pods in a namespace
+   */
+  async getPods(namespace: string) {
+    return this.namespace.getPods(namespace);
+  }
+
+  async getReadyNodes() {
+    return this.node.getReadyNodes();
+  }
+
+  /**
+   * Returns StorageClass resource names in the cluster.
+   */
+  async getStorageClassNames(): Promise<string[]> {
+    return this.clusterSetup.getStorageClassNames();
+  }
+
+  async getTemplate(templateName: string, namespace: string) {
+    return this.template.getTemplate(templateName, namespace);
+  }
+
+  getTemplateBootDataSourceRef(
+    template: KubernetesResource,
+    defaultDataSourceNamespace = 'openshift-virtualization-os-images',
+  ): { name: string; namespace: string } | null {
+    return this.template.getTemplateBootDataSourceRef(template, defaultDataSourceNamespace);
+  }
+
+  /**
+   * Resolve an OpenShift user's UID via the User API (user.openshift.io/v1).
+   * Returns undefined if the user doesn't exist or the API is unavailable.
+   */
   async getUserUid(username: string): Promise<string | undefined> {
-    try {
-      const result = await this.coApi.getClusterCustomObject({
-        group: 'user.openshift.io',
-        version: 'v1',
-        plural: 'users',
-        name: username,
-      });
-      return (result as K8sResource)?.metadata?.uid;
-    } catch {
-      return undefined;
-    }
+    return this.clusterSetup.getUserUid(username);
+  }
+
+  async getVirtualMachine(vmName: string, namespace: string) {
+    return this.vm.getVirtualMachine(vmName, namespace);
+  }
+
+  async getVirtualMachineInstance(vmName: string, namespace: string) {
+    return this.vm.getVirtualMachineInstance(vmName, namespace);
+  }
+
+  async getVirtualMachineSnapshot(
+    snapshotName: string,
+    namespace: string,
+  ): Promise<KubernetesResource> {
+    return this.snapshot.getVirtualMachineSnapshot(snapshotName, namespace);
+  }
+
+  async getVmiCpuSockets(vmName: string, namespace: string): Promise<string | null> {
+    return this.vm.getVmiCpuSockets(vmName, namespace);
+  }
+
+  async getVmiDiskBus(vmName: string, namespace: string, diskName: string): Promise<string | null> {
+    return this.vm.getVmiDiskBus(vmName, namespace, diskName);
+  }
+
+  async getVmiFilesystemList(vmName: string, namespace: string) {
+    return this.vm.getVmiFilesystemList(vmName, namespace);
+  }
+
+  async getVmiMemoryGuest(vmName: string, namespace: string): Promise<string | null> {
+    return this.vm.getVmiMemoryGuest(vmName, namespace);
+  }
+
+  async getVmIpAddress(vmName: string, namespace: string): Promise<string | null> {
+    return this.vm.getVmIpAddress(vmName, namespace);
+  }
+
+  async getVmNodeName(vmName: string, namespace: string): Promise<string | null> {
+    return this.node.getVmNodeName(vmName, namespace);
+  }
+
+  async getVolumeSnapshotNameFromVirtualMachineSnapshot(
+    virtualMachineSnapshotName: string,
+    namespace: string,
+    timeoutMs: number = TestTimeouts.DATA_VOLUME_STATUS,
+    singleAttempt = false,
+  ): Promise<string> {
+    return this.snapshot.getVolumeSnapshotNameFromVirtualMachineSnapshot(
+      virtualMachineSnapshotName,
+      namespace,
+      timeoutMs,
+      singleAttempt,
+    );
+  }
+
+  async getVolumesnapshotsByLabel(
+    namespace: string,
+    labels: Record<string, string>,
+    namePattern?: string,
+    timeoutMs = 60000,
+  ): Promise<KubernetesResource[]> {
+    return this.snapshot.getVolumesnapshotsByLabel(namespace, labels, namePattern, timeoutMs);
+  }
+
+  async grantUserAccessToNamespace(namespace: string, username: string): Promise<void> {
+    return this.namespace.grantUserAccessToNamespace(namespace, username);
   }
 
   async grantUserCdiClusterReadAccess(username: string): Promise<void> {
-    const rbac = this.getRbacApi();
-    const name = `${username}-cdi-cluster-read`;
-    try {
-      await rbac.createClusterRoleBinding({
-        body: {
-          metadata: { name },
-          roleRef: {
-            apiGroup: 'rbac.authorization.k8s.io',
-            kind: 'ClusterRole',
-            name: 'cdi.kubevirt.io:config-reader',
-          },
-          subjects: [{ apiGroup: 'rbac.authorization.k8s.io', kind: 'User', name: username }],
-        },
-      });
-    } catch (e: unknown) {
-      const msg = (e as Error).message || '';
-      if (!msg.includes('409') && !msg.includes('AlreadyExists')) throw e;
-    }
+    return this.namespace.grantUserCdiClusterReadAccess(username);
   }
 
   async grantUserClusterViewAccess(username: string): Promise<void> {
-    const rbac = this.getRbacApi();
-    const name = `${username}-cluster-view`;
-    try {
-      await rbac.createClusterRoleBinding({
-        body: {
-          metadata: { name },
-          roleRef: {
-            apiGroup: 'rbac.authorization.k8s.io',
-            kind: 'ClusterRole',
-            name: 'cluster-reader',
-          },
-          subjects: [{ apiGroup: 'rbac.authorization.k8s.io', kind: 'User', name: username }],
-        },
-      });
-    } catch (e: unknown) {
-      const msg = (e as Error).message || '';
-      if (!msg.includes('409') && !msg.includes('AlreadyExists')) throw e;
-    }
+    return this.namespace.grantUserClusterViewAccess(username);
+  }
+
+  async grantUserHotplugSubresourceAccess(namespace: string, username: string): Promise<void> {
+    return this.namespace.grantUserHotplugSubresourceAccess(namespace, username);
   }
 
   async grantUserKubevirtAccessToNamespace(namespace: string, username: string): Promise<void> {
-    const rbac = this.getRbacApi();
-    const bindingName = `${username}-kubevirt-${namespace}`;
-    try {
-      await rbac.createNamespacedRoleBinding({
-        namespace,
-        body: {
-          metadata: { name: bindingName, namespace },
-          roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'ClusterRole', name: 'admin' },
-          subjects: [{ apiGroup: 'rbac.authorization.k8s.io', kind: 'User', name: username }],
-        },
-      });
-    } catch (e: unknown) {
-      const msg = (e as Error).message || '';
-      if (!msg.includes('409') && !msg.includes('AlreadyExists')) throw e;
-    }
+    return this.namespace.grantUserKubevirtAccessToNamespace(namespace, username);
   }
 
-  // ── ConfigMap operations ────────────────────────────────────────────
+  async grantUserTemplateListAccess(namespace: string, username: string): Promise<void> {
+    return this.namespace.grantUserTemplateListAccess(namespace, username);
+  }
 
   async grantUserViewAccessToNamespace(namespace: string, username: string): Promise<void> {
-    const rbac = this.getRbacApi();
-    const bindingName = `${username}-view-${namespace}`;
+    return this.namespace.grantUserViewAccessToNamespace(namespace, username);
+  }
+
+  async hotplugVolumeToVm(
+    vmName: string,
+    namespace: string,
+    diskName: string,
+    dataVolumeName: string,
+  ): Promise<void> {
+    return this.vm.hotplugVolumeToVm(vmName, namespace, diskName, dataVolumeName);
+  }
+
+  /**
+   * Check if Cluster Observability Operator (COO) is installed via OLM.
+   * Returns true if any subscription in openshift-cluster-observability-operator has status.installedCSV set.
+   */
+  async isClusterObservabilityOperatorInstalled(): Promise<boolean> {
+    return this.clusterSetup.isClusterObservabilityOperatorInstalled();
+  }
+
+  async isClusterSingleNode(): Promise<boolean> {
+    return this.node.isClusterSingleNode();
+  }
+
+  async isDataSourceReady(name: string, namespace: string): Promise<boolean> {
     try {
-      await rbac.createNamespacedRoleBinding({
+      const ds = (await this.getCustomResource(
+        'cdi.kubevirt.io',
+        'v1beta1',
         namespace,
-        body: {
-          metadata: { name: bindingName, namespace },
-          roleRef: { apiGroup: 'rbac.authorization.k8s.io', kind: 'ClusterRole', name: 'view' },
-          subjects: [{ apiGroup: 'rbac.authorization.k8s.io', kind: 'User', name: username }],
-        },
-      });
-    } catch (e: unknown) {
-      const msg = (e as Error).message || '';
-      if (!msg.includes('409') && !msg.includes('AlreadyExists')) throw e;
+        'datasources',
+        name,
+      )) as KubernetesResource;
+      const conditions = ds?.status?.conditions;
+      const list = Array.isArray(conditions) ? conditions : [];
+      return list.some((c: KubernetesCondition) => c.type === 'Ready' && c.status === 'True');
+    } catch {
+      return false;
     }
   }
 
@@ -383,167 +1330,706 @@ export class KubernetesClient {
     name = 'kubevirt-hyperconverged',
     namespace = 'openshift-cnv',
   ): Promise<boolean> {
-    try {
-      const hco = await this.getHyperConverged(name, namespace);
-      const featureGates = (hco?.spec as K8sResource)?.featureGates as K8sResource | undefined;
-      return featureGates?.withHostPassthroughCPU === true;
-    } catch {
-      return false;
-    }
+    return this.hco.isNativeVmTemplateFeatureGateEnabled(name, namespace);
   }
 
-  async listClusterCustomResources(
+  async isVmDiskPersistent(vmName: string, namespace: string, diskName: string): Promise<boolean> {
+    return this.vm.isVmDiskPersistent(vmName, namespace, diskName);
+  }
+
+  get kc(): k8s.KubeConfig {
+    return this.kubeConfig;
+  }
+
+  /**
+   * Create a VM from a template using the Kubernetes API
+   * Processes the template and creates the VM resource
+   * @param templateMetadataName - The template metadata name (e.g., 'rhel9-server-small')
+   * @param vmName - Name for the VM to create
+   * @param namespace - Namespace where the VM should be created
+   * @param templateNamespace - Namespace where the template exists (default: 'openshift')
+   * @param startAfterCreation - Whether to start the VM after creation (default: true)
+   * @param sysprepConfigMapName - Optional ConfigMap name for Windows sysprep
+   * @param cloudInitConfig - Optional cloud-init configuration for Linux VMs
+   * @param vmCustomization - Optional VM customization (CPU, memory, etc.)
+   * @param storageClassName - Optional storage class name for the root disk (e.g., 'ocs-storagecluster-ceph-rbd')
+   * @returns The created VM resource
+   */
+  /**
+   * List cluster-scoped custom resources (not namespaced)
+   * @param group - API group
+   * @param version - API version
+   * @param plural - Resource plural name
+   * @returns Array of custom resources
+   */
+  async listClusterCustomResources(group: string, version: string, plural: string) {
+    return this.customResource.listClusterCustomResources(group, version, plural);
+  }
+
+  /**
+   * List custom resources in a namespace
+   * @param group - API group
+   * @param version - API version
+   * @param namespace - Namespace to list from
+   * @param plural - Resource plural name
+   * @returns Array of custom resources
+   */
+  async listCustomResources(group: string, version: string, namespace: string, plural: string) {
+    return this.customResource.listCustomResources(group, version, namespace, plural);
+  }
+
+  /**
+   * List all MigrationPolicies in the cluster
+   * @returns Array of MigrationPolicy resources
+   */
+  async listMigrationPolicies() {
+    return await this.listClusterCustomResources(
+      'migrations.kubevirt.io',
+      'v1alpha1',
+      'migrationpolicies',
+    );
+  }
+
+  async listTemplates(namespace: string) {
+    return this.template.listTemplates(namespace);
+  }
+
+  async listVirtualMachines(namespace: string) {
+    return this.vm.listVirtualMachines(namespace);
+  }
+
+  async listVolumeSnapshotsInNamespace(namespace: string): Promise<KubernetesResource[]> {
+    return this.snapshot.listVolumeSnapshotsInNamespace(namespace);
+  }
+
+  /**
+   * Make a raw Kubernetes API request through the proxy tunnel.
+   * This bypasses @kubernetes/client-node which uses node-fetch (incompatible with proxy).
+   *
+   * @param method - HTTP method (GET, POST, PUT, DELETE, PATCH)
+   * @param path - API path (e.g., '/api/v1/namespaces')
+   * @param body - Optional request body (will be JSON stringified)
+   * @returns Parsed JSON response
+   * @throws {Error} When request fails
+   */
+  async makeProxyRequest(
+    method: string,
+    apiPath: string,
+    body?: KubernetesResource | JsonPatchOp[] | k8s.V1Namespace,
+  ): Promise<unknown> {
+    return makeKubernetesProxyRequest(this.kubeConfig, method, apiPath, body);
+  }
+
+  /**
+   * Check if a MigrationPolicy exists
+   * @param policyName - Name of the MigrationPolicy
+   * @returns true if MigrationPolicy exists, false otherwise
+   */
+  async migrationPolicyExists(policyName: string): Promise<boolean> {
+    return this.namespace.migrationPolicyExists(policyName);
+  }
+
+  async namespaceExists(name: string): Promise<boolean> {
+    return this.namespace.namespaceExists(name);
+  }
+
+  /**
+   * Patch a cluster-scoped custom resource using merge-patch.
+   *
+   * @param group - API group
+   * @param version - API version
+   * @param plural - Resource plural name
+   * @param name - Resource name
+   * @param patchBody - The patch body to apply
+   * @returns The patched resource
+   * @since 1.0.0
+   */
+  async patchClusterCustomResource(
     group: string,
     version: string,
     plural: string,
-  ): Promise<K8sResource[]> {
-    const result = await this.coApi.listClusterCustomObject({ group, version, plural });
-    return ((result as K8sResource).items as K8sResource[]) || [];
-  }
-
-  async listCustomResources(
-    group: string,
-    version: string,
-    namespace: string,
-    plural: string,
-  ): Promise<K8sResource[]> {
-    const result = await this.coApi.listNamespacedCustomObject({
+    name: string,
+    patchBody:
+      | JsonPatchOp[]
+      | Record<string, unknown>
+      | ReadonlyArray<{ op: string; path: string; value?: unknown }>,
+  ) {
+    return this.customResource.patchClusterCustomResource(
       group,
       version,
-      namespace,
       plural,
-    });
-    return ((result as K8sResource).items as K8sResource[]) || [];
+      name,
+      patchBody as JsonPatchOp[] | Record<string, unknown>,
+    );
+  }
+
+  /**
+   * Patch a cluster-scoped resource using JSON Patch (RFC 6902).
+   * Use this when the client's default Content-Type is application/json-patch+json.
+   *
+   * @param group - API group
+   * @param version - API version
+   * @param plural - Resource plural name
+   * @param name - Resource name
+   * @param patchOps - JSON Patch operations array (e.g. [{ op: 'add', path: '/metadata/annotations/key', value: 'v' }])
+   * @returns The patched resource
+   */
+  async patchClusterCustomResourceWithJsonPatch(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    patchOps: Array<{ op: 'add' | 'remove' | 'replace'; path: string; value?: unknown }>,
+  ) {
+    return this.customResource.patchClusterCustomResourceWithJsonPatch(
+      group,
+      version,
+      plural,
+      name,
+      patchOps,
+    );
   }
 
   async patchConfigMap(
     name: string,
     namespace: string,
-    data: Record<string, string>,
-  ): Promise<void> {
-    await this.coreApi.patchNamespacedConfigMap({
-      name,
-      namespace,
-      body: { data },
-    });
+    patchData: Record<string, string>,
+  ): Promise<KubernetesResource> {
+    const cm = await this.secret.patchConfigMap(name, namespace, patchData);
+    return cm as unknown as KubernetesResource;
   }
 
-  // ── StorageClass operations ─────────────────────────────────────────
+  async patchDataSourceAnnotations(
+    dataSourceName: string,
+    namespace: string,
+    annotations: Record<string, string>,
+  ): Promise<void> {
+    return this.dataVolume.patchDataSourceAnnotations(dataSourceName, namespace, annotations);
+  }
 
   async patchHyperConverged(
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+    patchOps: Array<{ op: string; path: string; value?: unknown }>,
+  ) {
+    return this.hco.patchHyperConverged(name, namespace, patchOps as JsonPatchOp[]);
+  }
+
+  /**
+   * Patch a namespaced custom resource using merge-patch.
+   * @param group - API group (e.g., 'kubevirt.io')
+   * @param version - API version (e.g., 'v1')
+   * @param plural - Resource plural name (e.g., 'virtualmachines')
+   * @param name - Resource name
+   * @param namespace - Kubernetes namespace
+   * @param patchBody - The patch body to apply
+   * @returns The patched resource
+   */
+  async patchResource(
+    group: string,
+    version: string,
+    plural: string,
     name: string,
     namespace: string,
-    patchOps: Array<{ op: string; path: string; value?: unknown }>,
-  ): Promise<void> {
-    await this.coApi.patchNamespacedCustomObject({
-      group: 'hco.kubevirt.io',
-      version: 'v1beta1',
-      namespace,
-      plural: 'hyperconvergeds',
+    patchBody:
+      | JsonPatchOp[]
+      | Record<string, unknown>
+      | ReadonlyArray<{ op: string; path: string; value?: unknown }>,
+  ) {
+    return this.customResource.patchResource(
+      group,
+      version,
+      plural,
       name,
-      body: patchOps,
-    });
-  }
-
-  // ── Non-priv user operations ────────────────────────────────────────
-
-  async removeVmDeleteProtection(vmName: string, namespace: string): Promise<void> {
-    await this.coApi.patchNamespacedCustomObject({
-      group: 'kubevirt.io',
-      version: 'v1',
       namespace,
-      plural: 'virtualmachines',
-      name: vmName,
-      body: [{ op: 'remove', path: '/metadata/labels/kubevirt.io~1vm-delete-protection' }],
-    });
+      patchBody as JsonPatchOp[] | Record<string, unknown>,
+    );
   }
 
-  // ── RBAC operations ─────────────────────────────────────────────────
+  async patchVirtualMachineInstanceStatus(
+    vmiName: string,
+    namespace: string,
+    conditions: Array<{
+      type: string;
+      status: string;
+      reason?: string;
+      message?: string;
+      lastTransitionTime?: string;
+    }>,
+  ) {
+    return this.vm.patchVirtualMachineInstanceStatus(vmiName, namespace, conditions);
+  }
 
+  async patchVirtualMachineNodeSelector(
+    vmName: string,
+    namespace: string,
+    nodeSelector: { [key: string]: string },
+  ) {
+    return this.vm.patchVirtualMachineNodeSelector(vmName, namespace, nodeSelector);
+  }
+
+  async patchVirtualMachineResources(
+    vmName: string,
+    namespace: string,
+    resources: { cpuSockets?: number; cpuCores?: number; memory?: string },
+  ) {
+    return this.vm.patchVirtualMachineResources(vmName, namespace, resources);
+  }
+
+  async patchVirtualMachineRunStrategy(
+    vmName: string,
+    namespace: string,
+    runStrategy: 'Always' | 'Manual' | 'RerunOnFailure',
+  ) {
+    return this.vm.patchVirtualMachineRunStrategy(vmName, namespace, runStrategy);
+  }
+
+  async patchVmDeschedulerEvictAnnotation(
+    vmName: string,
+    namespace: string,
+    enabled: boolean,
+  ): Promise<void> {
+    return this.vm.patchVmDeschedulerEvictAnnotation(vmName, namespace, enabled);
+  }
+
+  async patchVmEvictionStrategy(
+    vmName: string,
+    namespace: string,
+    evictionStrategy: 'LiveMigrate' | 'None',
+  ) {
+    return this.vm.patchVmEvictionStrategy(vmName, namespace, evictionStrategy);
+  }
+
+  async patchVmToErrorState(vmName: string, namespace: string): Promise<void> {
+    return this.vm.patchVmToErrorState(vmName, namespace);
+  }
+
+  get rbacApi(): k8s.RbacAuthorizationV1Api {
+    return this.rbacAuthorizationApi;
+  }
+
+  async removeVmDeleteProtection(vmName: string, namespace: string): Promise<boolean> {
+    return this.vm.removeVmDeleteProtection(vmName, namespace);
+  }
+
+  /**
+   * Check if a Service exists in a namespace.
+   *
+   * @param name - Service name
+   * @param namespace - Namespace name
+   * @returns True if the Service exists, false otherwise (e.g. 404)
+   * @since 1.0.0
+   */
+  async serviceExists(name: string, namespace: string): Promise<boolean> {
+    return this.namespace.serviceExists(name, namespace);
+  }
+
+  /**
+   * Set the default StorageClass for VirtualMachines (KubeVirt/CNV).
+   * Sets the annotation storageclass.kubevirt.io/is-default-virt-class=true on the
+   * given StorageClass and false on all others. Equivalent to the console action
+   * "Set as default for VirtualMachines".
+   *
+   * Uses JSON Patch (RFC 6902) because the Kubernetes client-node library sends
+   * Content-Type: application/json-patch+json by default for patch operations.
+   *
+   * @param storageClassName - Name of the StorageClass to set as default for VMs
+   * @throws {Error} When listing or patching StorageClasses fails
+   * @since 1.0.0
+   */
   async setDefaultStorageClassForVirtualMachines(storageClassName: string): Promise<void> {
-    const storageApi = this.kc.makeApiClient(k8s.StorageV1Api);
-    await storageApi.patchStorageClass({
-      name: storageClassName,
-      body: {
-        metadata: {
-          annotations: {
-            'storageclass.kubevirt.io/is-default-virt-class': 'true',
-          },
-        },
-      },
-    });
+    return this.clusterSetup.setDefaultStorageClassForVirtualMachines(storageClassName);
   }
 
+  /**
+   * Setup OpenShift Console user settings to mark guided tours as completed
+   * and set the default namespace for tests.
+   *
+   * Patches the user-settings-{username} ConfigMap in the openshift-console-user-settings namespace.
+   *
+   * @param username - The username to configure settings for (default: 'kubeadmin')
+   * @param defaultNamespace - The namespace to set as the default/last namespace
+   * @returns true if settings were configured, false if ConfigMap doesn't exist or no permissions
+   * @since 1.0.0
+   */
   async setupConsoleUserSettings(
-    username: string,
-    _namespace?: string,
-    _maxRetries = 5,
+    username = 'kubeadmin',
+    defaultNamespace?: string,
+    maxAttempts?: number,
   ): Promise<boolean> {
-    try {
-      const settingsKey = username === 'kubeadmin' ? 'kube-admin' : username;
-      const cmName = `user-settings-${settingsKey}`;
-      const ns = 'openshift-console-user-settings';
-      await this.patchConfigMap(cmName, ns, {
-        [settingsKey]: JSON.stringify({ guidedTour: { status: 'complete' } }),
-      });
-      return true;
-    } catch {
-      return false;
-    }
+    return this.clusterSetup.setupConsoleUserSettings(username, defaultNamespace, maxAttempts);
   }
 
-  async setupTestNamespace(name: string): Promise<void> {
-    try {
-      const existing = await this.coreApi.readNamespace({ name }).catch(() => null);
-      if (existing) {
-        await this.waitForNamespaceActive(name);
-        return;
-      }
-    } catch {
-      // Namespace doesn't exist — create it
-    }
-
-    await this.coreApi.createNamespace({
-      body: {
-        apiVersion: 'v1',
-        kind: 'Namespace',
-        metadata: {
-          name,
-          labels: {
-            'test-framework': 'playwright',
-            'e2e-test': 'true',
-          },
-        },
-      },
-    });
-    await this.waitForNamespaceActive(name);
+  /**
+   * Setup KubeVirt UI configuration.
+   * Patches the user settings and UI features configmaps.
+   * This replaces OcCliClient.setupKubevirtUiConfig()
+   *
+   * @param cnvNamespace - The CNV namespace (default: 'openshift-cnv')
+   * @param username - The username to configure settings for (default: 'kube-admin')
+   * @since 1.0.0
+   */
+  async setupKubevirtUiConfig(
+    cnvNamespace = 'openshift-cnv',
+    username = 'kube-admin',
+  ): Promise<void> {
+    return this.clusterSetup.setupKubevirtUiConfig(cnvNamespace, username);
   }
 
+  async setupTestNamespace(namespace: string, labels?: Record<string, string>): Promise<boolean> {
+    return this.namespace.setupTestNamespace(namespace, labels);
+  }
+
+  async startVirtualMachine(vmName: string, namespace: string) {
+    return this.vm.startVirtualMachine(vmName, namespace);
+  }
+
+  async startVm(vmName: string, namespace: string): Promise<boolean> {
+    return this.vm.startVm(vmName, namespace);
+  }
+
+  async stopVm(vmName: string, namespace: string): Promise<boolean> {
+    return this.vm.stopVm(vmName, namespace);
+  }
+
+  async uncordonNode(nodeName: string): Promise<void> {
+    return this.node.uncordonNode(nodeName);
+  }
+
+  /**
+   * Verify that we can authenticate to the cluster.
+   * This performs a simple API call to check connectivity and authentication.
+   *
+   * @returns True if authentication is successful
+   * @throws {Error} When authentication fails
+   * @since 1.0.0
+   */
   async verifyAuthentication(): Promise<boolean> {
-    await this.coreApi.listNamespace({ limit: 1 });
-    return true;
+    return this.clusterSetup.verifyAuthentication();
   }
 
-  async waitForVmRunning(vmName: string, namespace: string, timeoutMs = 300_000): Promise<void> {
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
+  async verifyDataVolumeCreated(
+    dataVolumeName: string,
+    namespace: string,
+    timeoutMs = 60000,
+  ): Promise<{ dataVolume?: KubernetesResource; error?: string; exists: boolean }> {
+    return this.dataVolume.verifyDataVolumeCreated(dataVolumeName, namespace, timeoutMs);
+  }
+
+  async verifyFolderDeleted(
+    folderName: string,
+    namespace: string,
+    timeoutMs: number = TestTimeouts.CLUSTER_OPERATION,
+  ): Promise<{ folderDeleted: boolean; errors?: string[] }> {
+    return this.vm.verifyFolderDeleted(folderName, namespace, timeoutMs);
+  }
+
+  async verifyHCOSpec(
+    jsonPath: string,
+    expectedValue: string,
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+  ): Promise<boolean> {
+    return this.hco.verifyHCOSpec(jsonPath, expectedValue, name, namespace);
+  }
+
+  async verifyLiveMigrationLimits(
+    expectedParallelMigrationsPerCluster: string,
+    expectedParallelOutboundMigrationsPerNode: string,
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+  ): Promise<{
+    parallelMigrationsPerCluster: boolean;
+    parallelOutboundMigrationsPerNode: boolean;
+    actualParallelMigrationsPerCluster?: string | number;
+    actualParallelOutboundMigrationsPerNode?: string | number;
+  }> {
+    return this.hco.verifyLiveMigrationLimits(
+      expectedParallelMigrationsPerCluster,
+      expectedParallelOutboundMigrationsPerNode,
+      name,
+      namespace,
+    );
+  }
+
+  async verifyMemoryDensity(
+    expectedMemoryOvercommitPercentage: string,
+    name = 'kubevirt-hyperconverged',
+    namespace = 'openshift-cnv',
+    maxRetries = 10,
+    retryInterval = 2000,
+  ): Promise<{
+    memoryOvercommitPercentage: boolean;
+    actualMemoryOvercommitPercentage?: string | number;
+  }> {
+    return this.hco.verifyMemoryDensity(
+      expectedMemoryOvercommitPercentage,
+      name,
+      namespace,
+      maxRetries,
+      retryInterval,
+    );
+  }
+
+  /**
+   * Verify that a MigrationPolicy was created successfully
+   * Polls the API until the MigrationPolicy exists or timeout is reached
+   *
+   * @param policyName - Name of the MigrationPolicy to verify
+   * @param timeoutMs - Maximum time to wait for creation (default: 30s)
+   * @returns Object with verification result and details
+   */
+  async verifyMigrationPolicyCreated(
+    policyName: string,
+    timeoutMs = 30000,
+  ): Promise<{
+    error?: string;
+    exists: boolean;
+    policy?: KubernetesResource;
+  }> {
+    return this.namespace.verifyMigrationPolicyCreated(policyName, timeoutMs);
+  }
+
+  async verifyNativeVmTemplateCreated(
+    templateName: string,
+    namespace: string,
+    timeoutMs = 30000,
+  ): Promise<{ error?: string; exists: boolean; template?: KubernetesResource }> {
+    return this.template.verifyNativeVmTemplateCreated(templateName, namespace, timeoutMs);
+  }
+
+  async verifySecretExists(
+    name: string,
+    namespace: string,
+    timeout: number = TestTimeouts.CLUSTER_OPERATION,
+  ): Promise<boolean> {
+    return this.secret.verifySecretExists(name, namespace, timeout);
+  }
+
+  async verifySysprepConfigMapExists(
+    name: string,
+    namespace: string,
+    timeout: number = TestTimeouts.CLUSTER_OPERATION,
+  ): Promise<{ exists: boolean; hasAutounattend?: boolean; data?: Record<string, string> }> {
+    return this.secret.verifySysprepConfigMapExists(name, namespace, timeout);
+  }
+
+  async verifyTemplateCreated(
+    templateName: string,
+    namespace: string,
+    timeoutMs = 30000,
+  ): Promise<{ error?: string; exists: boolean; template?: KubernetesResource }> {
+    return this.template.verifyTemplateCreated(templateName, namespace, timeoutMs);
+  }
+
+  async verifyVmCreated(
+    vmName: string,
+    namespace: string,
+    timeoutMs = 30000,
+  ): Promise<{ error?: string; exists: boolean; vm?: KubernetesResource }> {
+    return this.vm.verifyVmCreated(vmName, namespace, timeoutMs);
+  }
+
+  async verifyVmFolderAndVmsDeleted(
+    vmNames: string[],
+    folderName: string,
+    namespace: string,
+    timeoutMs = 60000,
+  ): Promise<{
+    folderDeleted: boolean;
+    vmsDeleted: { [vmName: string]: boolean };
+    allDeleted: boolean;
+    errors?: string[];
+  }> {
+    return this.vm.verifyVmFolderAndVmsDeleted(vmNames, folderName, namespace, timeoutMs);
+  }
+
+  async verifyVmHasSSHKey(
+    vmName: string,
+    namespace: string,
+  ): Promise<{ hasSSHKey: boolean; secretName?: string }> {
+    return this.vm.verifyVmHasSSHKey(vmName, namespace);
+  }
+
+  /**
+   * Verifies VM spec JSON contains (or excludes) text .
+   */
+  async verifyVmSpecContains(
+    expectedText: string,
+    shouldContain = true,
+    vmName: string,
+    namespace: string,
+  ): Promise<boolean> {
+    return this.vm.verifyVmSpecContains(expectedText, shouldContain, vmName, namespace);
+  }
+
+  async vmExists(vmName: string, namespace: string): Promise<boolean> {
+    return this.vm.vmExists(vmName, namespace);
+  }
+
+  /**
+   * Wait until the Cluster Observability Operator is installed (subscription has installedCSV).
+   * Polls the K8s API until the condition is met or timeout.
+   * @param timeoutMs - Max time to wait (default TestTimeouts.OPERATOR_INSTALL, 5 min, under test timeout)
+   * @returns true if operator was detected as installed, false on timeout
+   */
+  async waitForClusterObservabilityOperatorInstalled(
+    timeoutMs: number = TestTimeouts.OPERATOR_INSTALL,
+  ): Promise<boolean> {
+    return this.clusterSetup.waitForClusterObservabilityOperatorInstalled(timeoutMs);
+  }
+
+  async waitForDataVolumeSucceeded(
+    dataVolumeName: string,
+    namespace: string,
+    timeoutMs: number = TestTimeouts.VM_BOOTUP,
+  ): Promise<void> {
+    return this.dataVolume.waitForDataVolumeSucceeded(dataVolumeName, namespace, timeoutMs);
+  }
+
+  async waitForNamespaceReady(name: string, timeout = 30000): Promise<boolean> {
+    return this.namespace.waitForNamespaceReady(name, timeout);
+  }
+
+  /**
+   * Example: Wait for a pod to be ready
+   */
+  async waitForPodReady(namespace: string, podName: string, timeoutMs = 60000): Promise<boolean> {
+    return this.namespace.waitForPodReady(namespace, podName, timeoutMs);
+  }
+
+  async waitForRestoreDeleted(
+    restoreName: string,
+    namespace: string,
+    timeoutMs = 60000,
+  ): Promise<boolean> {
+    return this.snapshot.waitForRestoreDeleted(restoreName, namespace, timeoutMs);
+  }
+
+  /**
+   * Poll until a Service exists or timeout (VMI subdomain services can appear after the VM is Running).
+   */
+  async waitForServiceExists(
+    name: string,
+    namespace: string,
+    timeoutMs: number = TestTimeouts.VM_BOOTUP,
+    pollIntervalMs: number = TestTimeouts.POLLING_INTERVAL,
+  ): Promise<boolean> {
+    return this.namespace.waitForServiceExists(name, namespace, timeoutMs, pollIntervalMs);
+  }
+
+  async waitForSnapshotDeleted(
+    snapshotName: string,
+    namespace: string,
+    timeoutMs = 60000,
+  ): Promise<boolean> {
+    return this.snapshot.waitForSnapshotDeleted(snapshotName, namespace, timeoutMs);
+  }
+
+  async waitForSnapshotReady(
+    snapshotName: string,
+    namespace: string,
+    timeoutMs = 60000,
+  ): Promise<boolean> {
+    return this.snapshot.waitForSnapshotReady(snapshotName, namespace, timeoutMs);
+  }
+
+  async waitForTestUserInNamespace(
+    namespace: string,
+    username: string,
+    timeoutMs = 15 * 1000,
+  ): Promise<void> {
+    return this.namespace.waitForTestUserInNamespace(namespace, username, timeoutMs);
+  }
+
+  async waitForVmCloneSucceeded(cloneName: string, namespace: string, timeoutMs = 120000) {
+    return this.vm.waitForVmCloneSucceeded(cloneName, namespace, timeoutMs);
+  }
+
+  async waitForVmDeleted(vmName: string, namespace: string, timeoutMs = 60000): Promise<boolean> {
+    return this.vm.waitForVmDeleted(vmName, namespace, timeoutMs);
+  }
+
+  async waitForVmDiskPresent(
+    vmName: string,
+    namespace: string,
+    diskName: string,
+    timeoutMs: number = TestTimeouts.VM_CREATION,
+  ): Promise<void> {
+    return this.vm.waitForVmDiskPresent(vmName, namespace, diskName, timeoutMs);
+  }
+
+  async waitForVmError(vmName: string, namespace: string, timeoutMs = 120000): Promise<boolean> {
+    return this.vm.waitForVmError(vmName, namespace, timeoutMs);
+  }
+
+  async waitForVmExists(vmName: string, namespace: string, timeoutMs = 120000): Promise<boolean> {
+    return this.vm.waitForVmExists(vmName, namespace, timeoutMs);
+  }
+
+  async waitForVmRunning(vmName: string, namespace: string, timeoutMs = 300000): Promise<boolean> {
+    return this.vm.waitForVmRunning(vmName, namespace, timeoutMs);
+  }
+
+  async waitForVolumeSnapshotReady(
+    snapshotName: string,
+    namespace: string,
+    timeoutMs: number = TestTimeouts.RESOURCE_CREATION,
+  ): Promise<void> {
+    return this.snapshot.waitForVolumeSnapshotReady(snapshotName, namespace, timeoutMs);
+  }
+
+  /**
+   * Retry an operation with exponential backoff for transient network/TLS failures.
+   * Handles common connection issues like socket disconnects and TLS handshake failures.
+   *
+   * @param operation - The async operation to retry
+   * @param operationName - Name for logging purposes
+   * @param maxRetries - Maximum number of retry attempts (default: 3)
+   * @param initialDelayMs - Initial delay in milliseconds (default: 1000)
+   * @returns The result of the operation
+   * @throws The last error if all retries fail
+   */
+  async withRetry<T>(
+    operation: () => Promise<T>,
+    label: string,
+    maxRetries = 3,
+    delayMs = 1000,
+  ): Promise<T> {
+    const operationName = label;
+    const initialDelayMs = delayMs;
+    let lastError: Error | null = null;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        const vm = await this.coApi.getNamespacedCustomObject({
-          group: 'kubevirt.io',
-          version: 'v1',
-          namespace,
-          plural: 'virtualmachines',
-          name: vmName,
-        });
-        const status = (vm as Record<string, unknown>).status as
-          | { printableStatus?: string }
-          | undefined;
-        if (status?.printableStatus === 'Running') return;
-      } catch {
-        // VM may not exist yet — keep polling
+        return await operation();
+      } catch (error: unknown) {
+        lastError = error instanceof Error ? error : new Error(getErrorMessage(error));
+        const errorMessage = getErrorMessage(error);
+
+        const isTransientError =
+          errorMessage.includes('socket disconnected') ||
+          errorMessage.includes('TLS connection') ||
+          errorMessage.includes('ECONNRESET') ||
+          errorMessage.includes('ETIMEDOUT') ||
+          errorMessage.includes('ECONNREFUSED') ||
+          errorMessage.includes('socket hang up') ||
+          errorMessage.includes('network socket') ||
+          errorMessage.includes('401') ||
+          errorMessage.includes('Unauthorized');
+
+        if (!isTransientError || attempt === maxRetries) {
+          throw error;
+        }
+
+        const delay = initialDelayMs * Math.pow(2, attempt - 1);
+        logger.warn(
+          `⚠️ ${operationName} failed (attempt ${attempt}/${maxRetries}), retrying in ${delay}ms: ${errorMessage}`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
       }
-      await new Promise((r) => setTimeout(r, POLL_INTERVAL));
     }
-    throw new Error(`Timeout: VM ${vmName} did not reach Running in ${timeoutMs}ms`);
+
+    throw lastError;
   }
 }

--- a/playwright/src/clients/kubernetes-oauth.ts
+++ b/playwright/src/clients/kubernetes-oauth.ts
@@ -1,0 +1,203 @@
+import * as fs from 'fs';
+import * as https from 'https';
+import * as net from 'net';
+import * as path from 'path';
+import { URL } from 'url';
+
+import type { Duplex } from 'stream';
+
+import { getKubernetesProxyUrl } from './kubernetes-proxy';
+
+/** HTTPS agent that CONNECT-tunnels through an HTTP proxy (IPv6 / proxy CI jobs). */
+export function createKubernetesConnectProxyAgent(proxyUrl: string): https.Agent {
+  const proxy = new URL(proxyUrl);
+
+  return new https.Agent({
+    rejectUnauthorized: false,
+    createConnection: (options, callback) => {
+      const proxySocket = net.connect(
+        {
+          host: proxy.hostname,
+          port: parseInt(proxy.port || '3128', 10),
+        },
+        () => {
+          const connectReq = [
+            `CONNECT ${options.host}:${options.port} HTTP/1.1`,
+            `Host: ${options.host}:${options.port}`,
+            'Connection: keep-alive',
+            '',
+            '',
+          ].join('\r\n');
+          proxySocket.write(connectReq);
+        },
+      );
+
+      let responseData = '';
+      const onData = (chunk: Buffer) => {
+        responseData += chunk.toString();
+
+        if (responseData.includes('\r\n\r\n')) {
+          proxySocket.removeListener('data', onData);
+          const [statusLine] = responseData.split('\r\n');
+          const statusCode = parseInt(statusLine.split(' ')[1], 10);
+
+          if (statusCode === 200) {
+            callback(null, proxySocket as Duplex);
+          } else {
+            const error = new Error(
+              `Proxy CONNECT failed with status ${statusCode}: ${statusLine}`,
+            );
+            proxySocket.destroy();
+            callback(error, undefined);
+          }
+        }
+      };
+
+      proxySocket.on('data', onData);
+      proxySocket.on('error', (err) => {
+        callback(err instanceof Error ? err : new Error(String(err)), undefined);
+      });
+    },
+  } as https.AgentOptions);
+}
+
+async function getOAuthServerUrl(clusterUrl: string): Promise<string> {
+  return new Promise((resolve) => {
+    const url = new URL('/.well-known/oauth-authorization-server', clusterUrl);
+
+    const proxyUrl = getKubernetesProxyUrl();
+    const agent = proxyUrl ? createKubernetesConnectProxyAgent(proxyUrl) : undefined;
+
+    const options: https.RequestOptions = {
+      hostname: url.hostname,
+      port: url.port || 443,
+      path: url.pathname,
+      method: 'GET',
+      rejectUnauthorized: false,
+      agent,
+    };
+
+    const req = https.request(options, (res) => {
+      let body = '';
+      res.on('data', (chunk) => {
+        body += chunk;
+      });
+      res.on('end', () => {
+        try {
+          const config = JSON.parse(body);
+          resolve(config.issuer || clusterUrl);
+        } catch {
+          resolve(clusterUrl);
+        }
+      });
+    });
+
+    req.on('error', () => {
+      resolve(clusterUrl);
+    });
+
+    req.end();
+  });
+}
+
+/** Exchange OpenShift username/password for an OAuth bearer token (proxy-aware). */
+export async function getOpenshiftOAuthToken(
+  clusterUrl: string,
+  username: string,
+  password: string,
+): Promise<string> {
+  const oauthServerUrl = await getOAuthServerUrl(clusterUrl);
+
+  return new Promise((resolve, reject) => {
+    const authHeader = Buffer.from(`${username}:${password}`).toString('base64');
+    const tokenUrl = new URL('/oauth/authorize', oauthServerUrl);
+    tokenUrl.searchParams.set('response_type', 'token');
+    tokenUrl.searchParams.set('client_id', 'openshift-challenging-client');
+
+    const proxyUrl = getKubernetesProxyUrl();
+    const agent = proxyUrl ? createKubernetesConnectProxyAgent(proxyUrl) : undefined;
+
+    const options: https.RequestOptions = {
+      hostname: tokenUrl.hostname,
+      port: tokenUrl.port || 443,
+      path: tokenUrl.pathname + tokenUrl.search,
+      method: 'GET',
+      headers: {
+        Authorization: `Basic ${authHeader}`,
+        'X-CSRF-Token': '1',
+      },
+      rejectUnauthorized: false,
+      agent,
+    };
+
+    const req = https.request(options, (res) => {
+      const location = res.headers.location;
+      if (location && location.includes('access_token=')) {
+        const match = location.match(/access_token=([^&]+)/);
+        if (match) {
+          resolve(match[1]);
+          return;
+        }
+      }
+
+      let body = '';
+      res.on('data', (chunk) => {
+        body += chunk;
+      });
+      res.on('end', () => {
+        reject(
+          new Error(
+            `OAuth authentication failed: HTTP ${res.statusCode}. Response: ${body.substring(
+              0,
+              200,
+            )}`,
+          ),
+        );
+      });
+    });
+
+    req.on('error', (err) => {
+      reject(new Error(`OAuth request failed: ${err.message}`));
+    });
+
+    req.end();
+  });
+}
+
+/** Write a kubeconfig file using a token from {@link getOpenshiftOAuthToken}. */
+export async function generateOpenshiftKubeconfig(
+  clusterUrl: string,
+  username: string,
+  password: string,
+  outputPath: string,
+): Promise<string> {
+  const token = await getOpenshiftOAuthToken(clusterUrl, username, password);
+
+  const kubeconfigYaml = `apiVersion: v1
+kind: Config
+clusters:
+  - name: cluster
+    cluster:
+      server: ${clusterUrl}
+      insecure-skip-tls-verify: true
+contexts:
+  - name: context
+    context:
+      cluster: cluster
+      user: user
+current-context: context
+users:
+  - name: user
+    user:
+      token: ${token}
+`;
+
+  const dir = path.dirname(outputPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  fs.writeFileSync(outputPath, kubeconfigYaml, 'utf8');
+
+  return outputPath;
+}

--- a/playwright/src/clients/kubernetes-proxy.ts
+++ b/playwright/src/clients/kubernetes-proxy.ts
@@ -1,0 +1,230 @@
+import * as net from 'net';
+import * as tls from 'tls';
+import { URL } from 'url';
+import * as zlib from 'zlib';
+
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import type * as k8s from '@kubernetes/client-node';
+
+/**
+ * Proxy URL from environment (HTTPS_PROXY / HTTP_PROXY), shared by KubernetesClient and handlers.
+ */
+export function getKubernetesProxyUrl(): string | undefined {
+  return (
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy
+  );
+}
+
+function decodeHttpChunkedPayload(payload: string): string {
+  let pos = 0;
+  let result = '';
+  while (pos < payload.length) {
+    const lineEnd = payload.indexOf('\r\n', pos);
+    if (lineEnd === -1) {
+      break;
+    }
+    const sizeLine = (payload.slice(pos, lineEnd).split(';')[0] ?? '').trim();
+    const chunkSize = parseInt(sizeLine, 16);
+    if (Number.isNaN(chunkSize)) {
+      break;
+    }
+    if (chunkSize === 0) {
+      break;
+    }
+    pos = lineEnd + 2;
+    result += payload.slice(pos, pos + chunkSize);
+    pos += chunkSize;
+    if (payload.slice(pos, pos + 2) !== '\r\n') {
+      break;
+    }
+    pos += 2;
+  }
+  return result;
+}
+
+function normalizeProxyResponseBody(headerSection: string, rawBody: string): string {
+  const headersLower = headerSection.toLowerCase();
+  let bodyText = rawBody;
+  if (headersLower.includes('transfer-encoding: chunked')) {
+    bodyText = decodeHttpChunkedPayload(bodyText);
+  }
+  if (headersLower.includes('content-encoding: gzip')) {
+    bodyText = zlib.gunzipSync(Buffer.from(bodyText, 'binary')).toString('utf8');
+  }
+  return bodyText;
+}
+
+/**
+ * Raw Kubernetes API request through HTTP CONNECT proxy (IPv6 / proxy-only jobs).
+ */
+export async function makeKubernetesProxyRequest(
+  kubeConfig: k8s.KubeConfig,
+  method: string,
+  apiPath: string,
+  body?: unknown,
+): Promise<KubernetesResource | null> {
+  const proxyUrl = getKubernetesProxyUrl();
+  const cluster = kubeConfig.getCurrentCluster();
+  const user = kubeConfig.getCurrentUser();
+
+  if (!cluster || !user) {
+    throw new Error('No current cluster or user context in kubeconfig');
+  }
+
+  const u = user as k8s.User & {
+    authProvider?: { config?: Record<string, string | undefined> };
+    certData?: string;
+    keyData?: string;
+  };
+  const token = u.token || u.authProvider?.config?.['access-token'];
+  const certData = u.certData;
+  const keyData = u.keyData;
+
+  let clientCert: Buffer | undefined;
+  let clientKey: Buffer | undefined;
+  if (certData && keyData) {
+    clientCert = Buffer.from(certData, 'base64');
+    clientKey = Buffer.from(keyData, 'base64');
+  }
+
+  const apiUrl = new URL(apiPath, cluster.server);
+  const targetHost = apiUrl.hostname;
+  const targetPort = parseInt(apiUrl.port, 10) || 443;
+
+  if (!proxyUrl) {
+    throw new Error('No proxy configured for IPv6 cluster connection');
+  }
+
+  return new Promise((resolve, reject) => {
+    const proxy = new URL(proxyUrl);
+
+    const proxySocket = net.connect(
+      {
+        host: proxy.hostname,
+        port: parseInt(proxy.port || '3128', 10),
+      },
+      () => {
+        const connectReq = [
+          `CONNECT ${targetHost}:${targetPort} HTTP/1.1`,
+          `Host: ${targetHost}:${targetPort}`,
+          'Connection: keep-alive',
+          '',
+          '',
+        ].join('\r\n');
+        proxySocket.write(connectReq);
+      },
+    );
+
+    let responseData = '';
+    const onData = (chunk: Buffer) => {
+      responseData += chunk.toString();
+
+      if (responseData.includes('\r\n\r\n')) {
+        proxySocket.removeListener('data', onData);
+
+        const [statusLine] = responseData.split('\r\n');
+        const statusCode = parseInt(statusLine.split(' ')[1], 10);
+
+        if (statusCode === 200) {
+          const tlsOptions: tls.ConnectionOptions = {
+            socket: proxySocket,
+            servername: targetHost,
+            rejectUnauthorized: false,
+          };
+
+          if (clientCert && clientKey) {
+            tlsOptions.cert = clientCert;
+            tlsOptions.key = clientKey;
+          }
+
+          const tlsSocket = tls.connect(tlsOptions, () => {
+            const headers = [
+              `${method} ${apiUrl.pathname}${apiUrl.search} HTTP/1.1`,
+              `Host: ${targetHost}`,
+              'Accept: application/json',
+              'Accept-Encoding: identity',
+            ];
+
+            if (token) {
+              headers.push(`Authorization: Bearer ${token}`);
+            }
+
+            if (body !== undefined && body !== null) {
+              const bodyStr = JSON.stringify(body);
+              const contentType =
+                method === 'PATCH' ? 'application/json-patch+json' : 'application/json';
+              headers.push(`Content-Type: ${contentType}`);
+              headers.push(`Content-Length: ${Buffer.byteLength(bodyStr)}`);
+              headers.push('Connection: close', '', bodyStr);
+            } else {
+              headers.push('Connection: close', '', '');
+            }
+
+            tlsSocket.write(headers.join('\r\n'));
+          });
+
+          let httpResponse = '';
+          tlsSocket.on('data', (tlsChunk) => {
+            httpResponse += tlsChunk.toString();
+          });
+
+          tlsSocket.on('end', () => {
+            const sep = httpResponse.indexOf('\r\n\r\n');
+            if (sep === -1) {
+              reject(new Error('Incomplete HTTP response'));
+              return;
+            }
+            const headerSection = httpResponse.slice(0, sep);
+            const rawBody = httpResponse.slice(sep + 4);
+            const [httpStatusLine] = headerSection.split('\r\n');
+            const httpStatus = parseInt(httpStatusLine.split(' ')[1], 10);
+
+            if (httpStatus >= 200 && httpStatus < 300) {
+              try {
+                const bodyText = normalizeProxyResponseBody(headerSection, rawBody);
+                resolve(
+                  bodyText
+                    ? (JSON.parse(bodyText) as KubernetesResource)
+                    : ({} as KubernetesResource),
+                );
+              } catch (e) {
+                const msg = e instanceof Error ? e.message : String(e);
+                reject(
+                  new Error(
+                    `Failed to parse Kubernetes API JSON response: ${msg}. ` +
+                      `Status ${httpStatus}.`,
+                  ),
+                );
+              }
+            } else if (httpStatus === 404) {
+              resolve(null);
+            } else {
+              reject(new Error(`HTTP ${httpStatus}: ${httpStatusLine}`));
+            }
+          });
+
+          tlsSocket.on('error', (err) => {
+            reject(new Error(`TLS error: ${err.message}`));
+          });
+        } else {
+          proxySocket.destroy();
+          reject(new Error(`Proxy CONNECT failed with status ${statusCode}: ${statusLine}`));
+        }
+      }
+    };
+
+    proxySocket.on('data', onData);
+
+    proxySocket.on('error', (err) => {
+      reject(new Error(`Proxy connection failed: ${err.message}`));
+    });
+
+    proxySocket.setTimeout(60000, () => {
+      proxySocket.destroy();
+      reject(new Error('Connection timeout after 60s'));
+    });
+  });
+}

--- a/playwright/src/clients/oc-cli-client.ts
+++ b/playwright/src/clients/oc-cli-client.ts
@@ -1,0 +1,1239 @@
+import { exec } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
+
+import { dump, loadAll } from 'js-yaml';
+
+import type { KubernetesListResource, KubernetesResource } from '@/data-models/kubernetes-types';
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+import { logger } from '@/utils/logger';
+import type { Page } from '@playwright/test';
+
+import type { ClusterAuthConfig } from './base-client';
+import BaseClient from './base-client';
+
+const execAsync = promisify(exec);
+
+/**
+ * OpenShift CLI client for executing oc commands and managing cluster resources.
+ *
+ * This client provides a comprehensive interface for interacting with OpenShift/Kubernetes
+ * clusters using the oc command-line tool. It handles authentication, resource management,
+ * cleanup operations, and various cluster administration tasks.
+ *
+ * Key features:
+ * - Automatic authentication with username/password or token
+ * - Resource creation, deletion, and management
+ * - Comprehensive cleanup operations for test environments
+ * - Namespace and project management
+ * - Pod execution and log retrieval
+ * - Configuration patching and setup
+ * - Support for both namespaced and cluster-scoped resources
+ *
+ * The client supports multiple authentication methods:
+ * - Username/password authentication
+ * - Token-based authentication
+ * - Kubeconfig file usage
+ *
+ * @example
+ * ```typescript
+ * const config: ClusterAuthConfig = {
+ *   baseUrl: 'https://api.example.com:6443',
+ *   username: 'admin',
+ *   password: 'password123'
+ * };
+ * const ocClient = new OcCliClient(page, config);
+ *
+ * // Initialize and create resources
+ * await ocClient.initialize();
+ * await ocClient.createProject('test-namespace');
+ * await ocClient.applyResource('vm.yaml', 'test-namespace');
+ * ```
+ *
+ * @extends BaseClient
+ * @since 1.0.0
+ */
+export default class OcCliClient extends BaseClient {
+  /** Flag indicating whether the client is logged into the cluster */
+  private isLoggedIn = false;
+
+  /** Optional path to kubeconfig file for authentication */
+  private kubeConfigPath?: string;
+
+  /** Path to the oc command-line tool */
+  private ocPath: string;
+
+  /**
+   * Creates a new OcCliClient instance.
+   *
+   * @param page - Optional Playwright page instance for UI-based operations
+   * @param config - Cluster authentication configuration
+   * @param config.baseUrl - The base URL of the cluster API server
+   * @param config.password - The password for authentication
+   * @param config.username - The username for authentication
+   * @param ocPath - Path to the oc command-line tool (default: 'oc')
+   * @param kubeConfigPath - Optional path to kubeconfig file for authentication
+   *
+   * @since 1.0.0
+   */
+  constructor(
+    page: Page | undefined,
+    config: ClusterAuthConfig,
+    ocPath = 'oc',
+    kubeConfigPath?: string,
+  ) {
+    super(page, config);
+    this.ocPath = ocPath;
+    this.kubeConfigPath = kubeConfigPath;
+  }
+
+  /**
+   * Executes an oc command and returns the result.
+   *
+   * This is the core method that handles all oc command execution. It handles
+   * command construction and error handling. Authentication is handled by using
+   * the kubeconfig file if it exists (created during login).
+   *
+   * Note: Login should only happen when explicitly calling login methods.
+   * This method does not automatically trigger login - it relies on the kubeconfig
+   * file that was created during the original login.
+   *
+   * @param args - Array of command arguments (e.g., ['get', 'pods', '-n', 'default'])
+   * @param options - Optional execution options
+   * @param options.ignoreError - Whether to ignore command errors and return empty string
+   * @param options.skipAuth - Whether to skip authentication check (deprecated, kept for compatibility)
+   * @returns The command output as a string
+   * @throws {Error} When command execution fails (unless ignoreError is true)
+   * @private
+   * @since 1.0.0
+   */
+  private async executeOc(
+    args: string[],
+    options?: { ignoreError?: boolean; skipAuth?: boolean },
+  ): Promise<string> {
+    // Use kubeconfig file if it exists (created during login)
+    // Login should only happen when explicitly calling login methods, not automatically
+    const kubeConfigFlag = this.kubeConfigPath ? `--kubeconfig=${this.kubeConfigPath}` : '';
+    const command = `${this.ocPath} ${kubeConfigFlag} ${args.join(' ')}`.trim();
+
+    try {
+      const { stderr: _stderr, stdout } = await execAsync(command, {
+        maxBuffer: 10 * 1024 * 1024, // 10MB buffer
+      });
+
+      return stdout.trim();
+    } catch (error: unknown) {
+      if (options?.ignoreError) {
+        const stdout =
+          typeof error === 'object' && error !== null && 'stdout' in error
+            ? String((error as { stdout?: unknown }).stdout ?? '')
+            : '';
+        return stdout;
+      }
+      const stderr =
+        typeof error === 'object' && error !== null && 'stderr' in error
+          ? String((error as { stderr?: unknown }).stderr ?? '')
+          : '';
+      throw new Error(
+        `OC command failed: ${command}\nError: ${getErrorMessage(error)}\nStderr: ${stderr}`,
+      );
+    }
+  }
+
+  /**
+   * Execute an oc command and parse JSON output
+   */
+  private async executeOcJson<T = KubernetesResource>(args: string[]): Promise<T> {
+    const output = await this.executeOc([...args, '-o', 'json']);
+    try {
+      return JSON.parse(output);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to parse JSON output from oc command: ${msg}`);
+    }
+  }
+
+  /**
+   * Login to the cluster using username and password
+   * If kubeConfigPath is set, the login will use that specific kubeconfig file
+   */
+  private async loginWithCredentials(): Promise<void> {
+    try {
+      const args = [
+        'login',
+        this.baseUrl,
+        `--username=${this.username}`,
+        `--password=${this.password}`,
+        '--insecure-skip-tls-verify=true',
+      ];
+
+      await this.executeOc(args);
+      this.isLoggedIn = true;
+    } catch (error: unknown) {
+      throw new Error(`Failed to login to cluster: ${getErrorMessage(error)}`);
+    }
+  }
+
+  /**
+   * Apply manifest(s) from a local path. Does not pass `-n` — use for cluster-scoped
+   * resources or for YAML that already sets metadata.namespace on each document.
+   */
+  async applyManifestFromPath(yamlPath: string): Promise<string> {
+    return await this.executeOc(['apply', '-f', yamlPath]);
+  }
+
+  /**
+   * Load YAML (multi-doc supported), set metadata.namespace on namespaced kinds, then apply.
+   * Cluster-scoped kinds (NodeNetworkConfigurationPolicy, etc.) are left without a namespace.
+   */
+  async applyNamespacedManifestFromFile(absolutePath: string, namespace: string): Promise<string> {
+    const clusterScopedKinds = new Set([
+      'Namespace',
+      'ClusterRole',
+      'ClusterRoleBinding',
+      'NodeNetworkConfigurationPolicy',
+      'MachineConfig',
+      'StorageClass',
+      'PersistentVolume',
+    ]);
+    const raw = fs.readFileSync(absolutePath, 'utf8');
+    const docs = loadAll(raw) as Array<{ kind?: string; metadata?: { namespace?: string } }>;
+    for (const doc of docs) {
+      if (!doc?.kind || clusterScopedKinds.has(doc.kind)) {
+        continue;
+      }
+      if (!doc.metadata) {
+        doc.metadata = {};
+      }
+      doc.metadata.namespace = namespace;
+    }
+    const out = docs.map((d) => dump(d, { lineWidth: -1 })).join('---\n');
+    const tmp = path.join(
+      os.tmpdir(),
+      `pw-apply-${path.basename(absolutePath)}-${Date.now()}.yaml`,
+    );
+    fs.writeFileSync(tmp, out, 'utf8');
+    try {
+      return await this.executeOc(['apply', '-f', tmp]);
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  }
+
+  /**
+   * Apply a resource from a file
+   */
+  async applyResource(yamlPath: string, namespace: string): Promise<string> {
+    const args = ['apply', '-f', yamlPath, '-n', namespace];
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Cleanup cluster-wide test resources
+   */
+  async cleanupClusterResources(): Promise<void> {
+    await this.deleteResourcesByLabel(
+      'template',
+      { 'app.kubernetes.io/name': 'custom-templates' },
+      'openshift',
+      { wait: false },
+    );
+
+    await this.deleteResource('VirtualMachineClusterInstancetype', 'example', undefined, {
+      ignoreNotFound: true,
+      wait: false,
+    });
+
+    await this.deleteResource('VirtualMachineClusterPreference', 'example', undefined, {
+      ignoreNotFound: true,
+      wait: false,
+    });
+
+    await this.deleteResource('MigrationPolicy', 'example', undefined, {
+      ignoreNotFound: true,
+      wait: false,
+    });
+  }
+
+  /**
+   * Cleanup CNV namespace resources
+   */
+  async cleanupCnvNamespace(): Promise<void> {
+    await this.deleteResourcesByLabelSelector(
+      'pvc',
+      'k8s-app!=hostpath-provisioner',
+      'openshift-cnv',
+      { wait: false },
+    );
+  }
+
+  /**
+   * Cleanup openshift namespace resources
+   */
+  async cleanupOpenshiftNamespace(): Promise<void> {
+    await this.deleteAllResources('pvc', 'openshift', { wait: false });
+  }
+
+  /**
+   * Cleanup test namespace resources
+   * Deletes VMs, VMIs, templates, snapshots, volumes, PVCs, secrets, network attachments, and VMIMs
+   * All deletions run in parallel for faster cleanup
+   * Uses force deletion for VMs to handle stuck VMs with finalizers
+   */
+  async cleanupTestNamespace(namespace: string): Promise<void> {
+    // VirtualMachineInstances need to be deleted before or with VMs
+    await Promise.allSettled([
+      this.deleteAllResources('vmi', namespace, { ignoreNotFound: true, wait: false }).catch(() => {
+        return;
+      }),
+      // Delete VMs with force to handle stuck VMs with finalizers (ErrorUnschedulable state)
+      this.deleteAllResourcesWithForce('vm', namespace, { ignoreNotFound: true, wait: true }).catch(
+        () => {
+          return;
+        },
+      ),
+    ]);
+
+    await Promise.allSettled([
+      this.deleteAllResources('template', namespace, { ignoreNotFound: true, wait: false }).catch(
+        () => {
+          return;
+        },
+      ),
+      this.deleteAllResources('VirtualMachineSnapshot', namespace, { ignoreNotFound: true }).catch(
+        () => {
+          return;
+        },
+      ),
+      // this.deleteAllResources('datavolume', namespace, { ignoreNotFound: true, wait: false }).catch(() => { }),
+      // this.deleteAllResources('datasource', namespace, { ignoreNotFound: true, wait: false }).catch(() => { }),
+      // this.deleteAllResources('pvc', namespace, { ignoreNotFound: true, wait: false }).catch(() => { }),
+      this.deleteAllResources('secret', namespace, { ignoreNotFound: true, wait: false }).catch(
+        () => {
+          return;
+        },
+      ),
+      this.deleteAllResources('net-attach-def', namespace, {
+        ignoreNotFound: true,
+        wait: false,
+      }).catch(() => {
+        return;
+      }),
+      // Delete ALL instance types, not just 'example'
+      this.deleteAllResources('VirtualMachineInstancetype', namespace, {
+        ignoreNotFound: true,
+        wait: false,
+      }).catch(() => {
+        return;
+      }),
+      // Delete ALL preferences, not just 'example'
+      this.deleteAllResources('VirtualMachinePreference', namespace, {
+        ignoreNotFound: true,
+        wait: false,
+      }).catch(() => {
+        return;
+      }),
+      this.deleteAllResources('migplan', namespace, { ignoreNotFound: true, wait: false }).catch(
+        () => {
+          return;
+        },
+      ),
+      this.deleteAllResources('vmim', namespace, { ignoreNotFound: true, wait: false }).catch(
+        () => {
+          return;
+        },
+      ),
+      this.deleteSysprepConfigMaps(namespace).catch(() => {
+        return;
+      }),
+    ]);
+  }
+
+  /**
+   * Cleanup virtualization OS images resources
+   */
+  async cleanupVirtualizationOsImages(): Promise<void> {
+    const namespace = 'openshift-virtualization-os-images';
+
+    await this.deleteResourcesByLabelSelector(
+      'datasource',
+      'app.kubernetes.io/part-of!=hyperconverged-cluster',
+      namespace,
+    );
+
+    await this.deleteResourcesByLabelSelector(
+      'datavolume',
+      'app.kubernetes.io/part-of!=hyperconverged-cluster',
+      namespace,
+    );
+
+    await this.deleteAllResources('pvc', namespace, { wait: false });
+  }
+
+  /**
+   * Cordon a node (mark as unschedulable). Equivalent to `oc adm cordon <nodeName>`.
+   */
+  async cordonNode(nodeName: string): Promise<void> {
+    await this.executeOc(['adm', 'cordon', nodeName]);
+  }
+
+  /**
+   * Create a new project (namespace)
+   */
+  async createProject(name: string): Promise<string> {
+    return await this.executeOc(['new-project', name]);
+  }
+
+  /**
+   * Create a resource from a file or stdin
+   */
+  async createResource(yamlPath: string, namespace: string): Promise<string> {
+    const args = ['create', '-f', yamlPath, '-n', namespace];
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Create a resource from YAML content
+   */
+  async createResourceFromYaml(yamlContent: string, namespace: string): Promise<string> {
+    const args = ['create', '-f', '-', '-n', namespace];
+
+    // For stdin input, we need a different approach
+    return new Promise((resolve, reject) => {
+      const kubeConfigFlag = this.kubeConfigPath ? `--kubeconfig=${this.kubeConfigPath}` : '';
+      const command = `${this.ocPath} ${kubeConfigFlag} ${args.join(' ')}`.trim();
+
+      const child = exec(command, (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`Failed to create resource: ${error.message}\n${stderr}`));
+        } else {
+          resolve(stdout.trim());
+        }
+      });
+
+      child.stdin?.write(yamlContent);
+      child.stdin?.end();
+    });
+  }
+
+  /**
+   * Create a secret from YAML file
+   */
+  async createSecretFromFile(yamlPath: string, namespace: string): Promise<string> {
+    const args = ['create', '-f', yamlPath, '-n', namespace];
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Delete all resources of a kind in a namespace
+   */
+  async deleteAllResources(
+    kind: string,
+    namespace: string,
+    options?: { ignoreNotFound?: boolean; wait?: boolean },
+  ): Promise<string> {
+    const args = ['delete', kind, '--all', '-n', namespace];
+    if (options?.ignoreNotFound) {
+      args.push('--ignore-not-found');
+    }
+    if (options?.wait !== undefined) {
+      args.push(`--wait=${options.wait}`);
+    }
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Delete all resources of a specific kind with force deletion
+   * Used for VMs that may have finalizers preventing normal deletion
+   */
+  async deleteAllResourcesWithForce(
+    kind: string,
+    namespace: string,
+    options?: { ignoreNotFound?: boolean; wait?: boolean },
+  ): Promise<string> {
+    const args = ['delete', kind, '--all', '-n', namespace, '--force', '--grace-period=0'];
+    if (options?.ignoreNotFound) {
+      args.push('--ignore-not-found');
+    }
+    if (options?.wait !== undefined) {
+      args.push(`--wait=${options.wait}`);
+    }
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Delete a project (namespace)
+   */
+  async deleteProject(
+    name: string,
+    options?: { ignoreNotFound?: boolean; wait?: boolean },
+  ): Promise<string> {
+    const args = ['delete', 'project', name];
+    if (options?.ignoreNotFound) {
+      args.push('--ignore-not-found');
+    }
+    if (options?.wait !== undefined) {
+      args.push(`--wait=${options.wait}`);
+    }
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Delete a resource
+   * For cluster-scoped resources, pass undefined as namespace
+   */
+  async deleteResource(
+    kind: string,
+    name: string,
+    namespace: string | undefined,
+    options?: { ignoreNotFound?: boolean; wait?: boolean },
+  ): Promise<string> {
+    const args = ['delete', kind, name];
+    if (namespace !== undefined) {
+      args.push('-n', namespace);
+    }
+    if (options?.ignoreNotFound) {
+      args.push('--ignore-not-found');
+    }
+    if (options?.wait !== undefined) {
+      args.push(`--wait=${options.wait}`);
+    }
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Delete resources by label selector
+   * For cluster-scoped resources, pass undefined as namespace
+   */
+  async deleteResourcesByLabel(
+    kind: string,
+    labels: Record<string, string>,
+    namespace: string | undefined,
+    options?: { ignoreNotFound?: boolean; wait?: boolean },
+  ): Promise<string> {
+    const args = ['delete', kind];
+    const labelSelector = Object.entries(labels)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(',');
+    args.push('-l', labelSelector);
+    if (namespace !== undefined) {
+      args.push('-n', namespace);
+    }
+    if (options?.ignoreNotFound) {
+      args.push('--ignore-not-found');
+    }
+    if (options?.wait !== undefined) {
+      args.push(`--wait=${options.wait}`);
+    }
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Delete resources by label selector with advanced options (supports negation)
+   */
+  async deleteResourcesByLabelSelector(
+    kind: string,
+    labelSelector: string,
+    namespace: string,
+    options?: { ignoreNotFound?: boolean; wait?: boolean },
+  ): Promise<string> {
+    const args = ['delete', kind, '-l', labelSelector, '-n', namespace];
+    if (options?.ignoreNotFound) {
+      args.push('--ignore-not-found');
+    }
+    if (options?.wait !== undefined) {
+      args.push(`--wait=${options.wait}`);
+    }
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Delete sysprep ConfigMaps created for Windows VM tests
+   * These are ConfigMaps with names starting with 'sysprep-'
+   */
+  async deleteSysprepConfigMaps(namespace: string): Promise<void> {
+    try {
+      const output = await this.executeOc([
+        'get',
+        'configmap',
+        '-n',
+        namespace,
+        '-o',
+        'jsonpath={.items[*].metadata.name}',
+      ]);
+
+      if (!output || output.trim() === '') {
+        return;
+      }
+
+      const configMapNames = output.trim().split(/\s+/);
+      const sysprepConfigMaps = configMapNames.filter((name) => name.startsWith('sysprep-'));
+
+      if (sysprepConfigMaps.length === 0) {
+        return;
+      }
+
+      await Promise.allSettled(
+        sysprepConfigMaps.map((name) =>
+          this.executeOc([
+            'delete',
+            'configmap',
+            name,
+            '-n',
+            namespace,
+            '--ignore-not-found',
+          ]).catch(() => {
+            return;
+          }),
+        ),
+      );
+    } catch {
+      // Ignore errors during cleanup
+    }
+  }
+
+  /**
+   * Delete volumesnapshots by label selector and wait for deletion to complete
+   * @param namespace - Namespace where volumesnapshots exist
+   * @param labels - Label selector (e.g., { 'cdi.kubevirt.io/dataImportCron': 'centos-stream9-image-cron' })
+   * @param timeoutMs - Maximum time to wait for deletion (default: 30000ms)
+   * @returns True if volumesnapshots were deleted successfully
+   */
+  async deleteVolumesnapshotsByLabel(
+    namespace: string,
+    labels: Record<string, string>,
+    timeoutMs = 30000,
+  ): Promise<boolean> {
+    await this.deleteResourcesByLabel('volumesnapshot', labels, namespace, {
+      ignoreNotFound: true,
+      wait: false,
+    });
+
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const resources = await this.getResources('volumesnapshot', namespace, labels);
+        const items = resources?.items || [];
+        if (items.length === 0) {
+          return true; // All resources deleted
+        }
+      } catch (error: unknown) {
+        // If getResources fails (e.g., resource not found), deletion is complete
+        const msg = getErrorMessage(error);
+        if (msg.includes('not found') || msg.includes('NotFound')) {
+          return true;
+        }
+        // For other errors, continue waiting
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+
+    try {
+      const resources = await this.getResources('volumesnapshot', namespace, labels);
+      const items = resources?.items || [];
+      return items.length === 0;
+    } catch {
+      return true; // Assume deleted if we can't check
+    }
+  }
+
+  /**
+   * Ensure namespace exists (get or create)
+   */
+  async ensureNamespace(namespace: string): Promise<string> {
+    const exists = await this.namespaceExists(namespace);
+    if (exists) {
+      return await this.executeOc(['get', 'namespace', namespace, '-o', 'json']);
+    } else {
+      return await this.createProject(namespace);
+    }
+  }
+
+  /**
+   * Ensure secret exists (get or create from file)
+   */
+  async ensureSecret(name: string, namespace: string, yamlPath: string): Promise<string> {
+    const exists = await this.secretExists(name, namespace);
+    if (exists) {
+      return await this.executeOc(['get', 'secret', name, '-n', namespace, '-o', 'json']);
+    } else {
+      return await this.createSecretFromFile(yamlPath, namespace);
+    }
+  }
+
+  /**
+   * Execute a command in a pod
+   */
+  async execInPod(
+    podName: string,
+    command: string[],
+    namespace: string,
+    options?: { container?: string },
+  ): Promise<string> {
+    const args = ['exec', podName, '-n', namespace];
+    if (options?.container) {
+      args.push('-c', options.container);
+    }
+    args.push('--', ...command);
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Execute complete cleanup (all test resources)
+   * Always keeps the namespace - only cleans up resources within it
+   */
+  async executeCompleteCleanup(testNamespace: string): Promise<void> {
+    await this.cleanupTestNamespace(testNamespace);
+
+    // Always keep the namespace - don't delete it
+    logger.info(`ℹ️  Keeping namespace ${testNamespace} (namespace persistence enabled)`);
+  }
+
+  /**
+   * Execute complete test setup
+   * Creates namespace, configures UI, and creates secrets
+   */
+  async executeCompleteSetup(config: {
+    cnvNamespace: string;
+    secretName: string;
+    testNamespace: string;
+  }): Promise<void> {
+    await this.setupTestNamespace(config.testNamespace);
+
+    await this.setupKubevirtUiConfig(config.cnvNamespace);
+
+    // await this.setupTestSecret(config.secretName, config.testNamespace);
+  }
+
+  /**
+   * Execute a raw oc command (for advanced use cases)
+   * Note: The command should not include 'oc' prefix as it's added automatically
+   * Supports shell commands with pipes (e.g., 'get pods | grep name')
+   */
+  async executeRawCommand(command: string): Promise<string> {
+    const trimmedCommand = command.trim();
+
+    // Remove 'oc' prefix if present (executeOc already adds it)
+    const commandWithoutOc = trimmedCommand.startsWith('oc ')
+      ? trimmedCommand.substring(3).trim()
+      : trimmedCommand;
+
+    // If command contains pipes or other shell operators, execute as shell command
+    if (
+      commandWithoutOc.includes('|') ||
+      commandWithoutOc.includes('&&') ||
+      commandWithoutOc.includes('||')
+    ) {
+      const kubeConfigFlag = this.kubeConfigPath ? `--kubeconfig=${this.kubeConfigPath}` : '';
+      const fullCommand = `${this.ocPath} ${kubeConfigFlag} ${commandWithoutOc}`.trim();
+
+      try {
+        const { stderr: _stderr, stdout } = await execAsync(fullCommand, {
+          maxBuffer: 10 * 1024 * 1024, // 10MB buffer
+          shell: '/bin/bash', // Use bash to support pipes
+        });
+
+        return stdout.trim();
+      } catch (error: unknown) {
+        // For grep commands, no match is not necessarily an error
+        const code =
+          typeof error === 'object' && error !== null && 'code' in error
+            ? (error as { code?: unknown }).code
+            : undefined;
+        if (commandWithoutOc.includes('grep') && code === 1) {
+          return ''; // Return empty string for grep with no matches
+        }
+        const stderr =
+          typeof error === 'object' && error !== null && 'stderr' in error
+            ? String((error as { stderr?: unknown }).stderr ?? '')
+            : '';
+        throw new Error(
+          `OC command failed: ${fullCommand}\nError: ${getErrorMessage(error)}\nStderr: ${stderr}`,
+        );
+      }
+    }
+
+    const args = commandWithoutOc.split(' ');
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Log in as an arbitrary user and return their OAuth Bearer token.
+   *
+   * Uses `oc login --server=<clusterUrl> -u <username> -p <password>` in a
+   * throw-away temp kubeconfig so the main kubeconfig is never mutated, then
+   * extracts the token with `oc whoami --show-token`.
+   *
+   * The temp kubeconfig is deleted after the token is extracted.
+   *
+   * @param username - OpenShift username
+   * @param password - OpenShift password
+   * @returns Bearer token (trimmed, no newlines)
+   */
+  async fetchTokenForUser(username: string, password: string): Promise<string> {
+    const tmpKubeconfig = path.join(os.tmpdir(), `oc-kubeconfig-${username}-${Date.now()}`);
+    try {
+      const loginArgs = [
+        'login',
+        this.baseUrl,
+        '-u',
+        username,
+        '-p',
+        password,
+        '--insecure-skip-tls-verify=true',
+        '--kubeconfig',
+        tmpKubeconfig,
+      ];
+      await this.executeOc(loginArgs);
+      const token = await this.executeOc(['whoami', '--show-token', '--kubeconfig', tmpKubeconfig]);
+      return token.trim();
+    } finally {
+      try {
+        fs.unlinkSync(tmpKubeconfig);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+
+  /**
+   * Get cluster version
+   */
+  async getClusterVersion(): Promise<KubernetesResource> {
+    return await this.executeOcJson<KubernetesResource>(['get', 'clusterversion', 'version']);
+  }
+
+  /**
+   * Get the current project
+   */
+  async getCurrentProject(): Promise<string> {
+    return await this.executeOc(['project', '-q']);
+  }
+
+  /**
+   * Get current user token
+   * @param kubeConfigPath - Optional path to kubeconfig file to use
+   */
+  async getCurrentUserToken(kubeConfigPath?: string): Promise<string> {
+    const args = ['whoami', '--show-token'];
+    if (kubeConfigPath) {
+      args.push('--kubeconfig', kubeConfigPath);
+    }
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Get KubeVirt console plugin version
+   */
+  async getKubevirtPluginVersion(): Promise<string | undefined> {
+    try {
+      const version = await this.executeOc([
+        'get',
+        'consoleplugin',
+        'kubevirt-plugin',
+        '-o',
+        'jsonpath="{.metadata.labels.app\\.kubernetes\\.io/version}"',
+      ]);
+      // Remove quotes if present
+      return version.replace(/^"|"$/g, '').trim() || undefined;
+    } catch (error) {
+      // Console plugin might not exist or not be accessible
+      return undefined;
+    }
+  }
+
+  /**
+   * Get logs from a pod
+   */
+  async getLogs(
+    podName: string,
+    namespace: string,
+    options?: { container?: string; previous?: boolean; tail?: number },
+  ): Promise<string> {
+    const args = ['logs', podName, '-n', namespace];
+    if (options?.container) {
+      args.push('-c', options.container);
+    }
+    if (options?.previous) {
+      args.push('--previous');
+    }
+    if (options?.tail) {
+      args.push('--tail', options.tail.toString());
+    }
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Get the operating system (osImage) of the first cluster node.
+   * Used for Allure environment reporting (e.g. RHCOS version).
+   */
+  async getNodeOsImage(): Promise<string | undefined> {
+    try {
+      interface NodesList {
+        items?: Array<{ status?: { nodeInfo?: { osImage?: string } } }>;
+      }
+      const nodes = await this.executeOcJson<NodesList>(['get', 'nodes']);
+      const firstNode = nodes?.items?.[0];
+      const osImage = firstNode?.status?.nodeInfo?.osImage;
+      return osImage?.trim() || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async getResource(
+    kind: string,
+    name: string,
+    namespace: string | undefined,
+  ): Promise<KubernetesResource> {
+    const args = ['get', kind, name];
+    if (namespace !== undefined) {
+      args.push('-n', namespace);
+    }
+    return await this.executeOcJson<KubernetesResource>(args);
+  }
+
+  /**
+   * Get multiple resources
+   * For cluster-scoped resources, pass undefined as namespace
+   */
+  async getResources(
+    kind: string,
+    namespace: string | undefined,
+    labels?: Record<string, string>,
+  ): Promise<KubernetesListResource<KubernetesResource>> {
+    const args = ['get', kind];
+    if (namespace !== undefined) {
+      args.push('-n', namespace);
+    }
+    if (labels) {
+      const labelSelector = Object.entries(labels)
+        .map(([key, value]) => `${key}=${value}`)
+        .join(',');
+      args.push('-l', labelSelector);
+    }
+    return await this.executeOcJson<KubernetesListResource<KubernetesResource>>(args);
+  }
+
+  /**
+   * Get VMI CPU sockets count.
+   * Matches Cypress: cy.exec(`oc get vmi ${vmName} -o jsonpath='{.spec.domain.cpu.sockets}'`)
+   */
+  async getVmiCpuSockets(vmName: string, namespace: string): Promise<string | null> {
+    try {
+      const result = await this.executeOc([
+        'get',
+        'vmi',
+        vmName,
+        '-n',
+        namespace,
+        '-o',
+        "jsonpath='{.spec.domain.cpu.sockets}'",
+      ]);
+      return result.trim().replace(/'/g, '');
+    } catch (error) {
+      return null;
+    }
+  }
+
+  /**
+   * Get VMI memory guest value.
+   * Matches Cypress: cy.exec(`oc get vmi ${vmName} -o jsonpath='{.spec.domain.memory.guest}'`)
+   */
+  async getVmiMemoryGuest(vmName: string, namespace: string): Promise<string | null> {
+    try {
+      const result = await this.executeOc([
+        'get',
+        'vmi',
+        vmName,
+        '-n',
+        namespace,
+        '-o',
+        "jsonpath='{.spec.domain.memory.guest}'",
+      ]);
+      return result.trim().replace(/'/g, '');
+    } catch (error) {
+      return null;
+    }
+  }
+
+  /**
+   * Get volumesnapshots by label selector and wait for them to exist
+   * @param namespace - Namespace where volumesnapshots should exist
+   * @param labels - Label selector (e.g., { 'cdi.kubevirt.io/dataImportCron': 'centos-stream9-image-cron' })
+   * @param namePattern - Optional pattern to match in resource names (e.g., 'centos-stream9')
+   * @param timeoutMs - Maximum time to wait for resources (default: 60000ms)
+   * @returns Array of matching volumesnapshot resources
+   */
+  async getVolumesnapshotsByLabel(
+    namespace: string,
+    labels: Record<string, string>,
+    namePattern?: string,
+    timeoutMs = 60000,
+  ): Promise<KubernetesResource[]> {
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeoutMs) {
+      try {
+        const resources = await this.getResources('volumesnapshot', namespace, labels);
+        const items = resources?.items || [];
+
+        if (items.length > 0) {
+          // If namePattern is provided, filter by name
+          if (namePattern) {
+            const matching = items.filter((item) => item.metadata?.name?.includes(namePattern));
+            if (matching.length > 0) {
+              return matching;
+            }
+          } else {
+            return items;
+          }
+        }
+      } catch (error: unknown) {
+        // If resources don't exist yet, continue waiting
+        const msg = getErrorMessage(error);
+        if (!msg.includes('not found') && !msg.includes('NotFound')) {
+          throw error; // Re-throw unexpected errors
+        }
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+
+    throw new Error(
+      `Timeout waiting for volumesnapshots with labels ${JSON.stringify(
+        labels,
+      )} in namespace ${namespace}`,
+    );
+  }
+
+  /**
+   * Initializes the client by logging into the cluster.
+   *
+   * This method should be called before using other methods to ensure proper
+   * authentication. It automatically handles login if not already authenticated
+   * and no kubeconfig file is provided.
+   *
+   * @since 1.0.0
+   */
+  async initialize(): Promise<void> {
+    if (!this.isLoggedIn && !this.kubeConfigPath) {
+      await this.loginWithCredentials();
+    }
+  }
+
+  /**
+   * Check if oc CLI is available
+   */
+  async isOcAvailable(): Promise<boolean> {
+    try {
+      await this.executeOc(['version', '--client'], { ignoreError: true });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Login and create a kubeconfig file at the specified path
+   * This is useful for creating persistent kubeconfig files that can be reused
+   * @param kubeConfigPath - Path where the kubeconfig file should be created
+   */
+  async loginAndCreateKubeConfig(kubeConfigPath: string): Promise<void> {
+    // Temporarily clear kubeConfigPath so executeOc doesn't add --kubeconfig at the beginning
+    const previousKubeConfigPath = this.kubeConfigPath;
+    try {
+      this.kubeConfigPath = undefined;
+
+      // Use executeOc with skipAuth to avoid login check loop
+      // Add --kubeconfig flag at the end of the command
+      const args = [
+        'login',
+        this.baseUrl,
+        `--username=${this.username}`,
+        `--password=${this.password}`,
+        '--insecure-skip-tls-verify=true',
+        `--kubeconfig=${kubeConfigPath}`,
+      ];
+
+      await this.executeOc(args, { skipAuth: true });
+
+      // Set kubeconfig path after successful login
+      this.kubeConfigPath = kubeConfigPath;
+      this.isLoggedIn = true;
+
+      return;
+    } catch (error: unknown) {
+      // Restore previous kubeConfigPath on error
+      this.kubeConfigPath = previousKubeConfigPath;
+      throw new Error(`Failed to login and create kubeconfig: ${getErrorMessage(error)}`);
+    }
+  }
+
+  /**
+   * Login to OpenShift cluster using token
+   */
+  async loginWithToken(
+    token: string,
+    options?: { insecureSkipTlsVerify?: boolean },
+  ): Promise<void> {
+    const args = ['login', this.baseUrl, `--token=${token}`];
+    if (options?.insecureSkipTlsVerify) {
+      args.push('--insecure-skip-tls-verify');
+    }
+    await this.executeOc(args, { skipAuth: true });
+    this.isLoggedIn = true;
+  }
+
+  /**
+   * Check if a namespace exists
+   */
+  async namespaceExists(namespace: string): Promise<boolean> {
+    try {
+      await this.executeOc(['get', 'namespace', namespace]);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  /**
+   * Patch a resource with merge strategy
+   * Note: The patch parameter should be a JSON string. It will be properly escaped for shell execution.
+   * For cluster-scoped resources, pass undefined as namespace
+   */
+  async patchResource(
+    kind: string,
+    name: string,
+    patch: string,
+    namespace: string | undefined,
+    patchType = 'merge',
+  ): Promise<string> {
+    // Escape the patch JSON for shell execution
+    // Single quotes prevent shell interpretation, but we need to escape any single quotes in the patch
+    const escapedPatch = patch.replace(/'/g, "'\\''");
+    const args = ['patch', kind, name, `--type=${patchType}`, '--patch', `'${escapedPatch}'`];
+    if (namespace !== undefined) {
+      args.push('-n', namespace);
+    }
+    return await this.executeOc(args);
+  }
+
+  /**
+   * Check if a secret exists
+   */
+  async secretExists(name: string, namespace: string): Promise<boolean> {
+    try {
+      await this.executeOc(['get', 'secret', name, '-n', namespace]);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  /**
+   * Setup KubeVirt UI configuration
+   * Patches user settings and UI features configmaps
+   *
+   * @param cnvNamespace - The CNV namespace
+   * @param username - The username to configure settings for (default: 'kube-admin')
+   */
+  async setupKubevirtUiConfig(cnvNamespace: string, username = 'kube-admin'): Promise<void> {
+    const userSettingsPatch = `{"data": {"${username}": "{\\"quickStart\\":{\\"dontShowWelcomeModal\\":true}}"}}`;
+    await this.patchResource(
+      'configmap',
+      'kubevirt-user-settings',
+      userSettingsPatch,
+      cnvNamespace,
+      'merge',
+    );
+
+    const uiFeaturesPatch = '{"data": {"advancedSearch": "true", "treeViewFolders": "true"}}';
+    await this.patchResource(
+      'configmap',
+      'kubevirt-ui-features',
+      uiFeaturesPatch,
+      cnvNamespace,
+      'merge',
+    );
+  }
+
+  /**
+   * Setup test namespace
+   * Creates namespace if it doesn't exist
+   */
+  async setupTestNamespace(namespace: string): Promise<void> {
+    const exists = await this.namespaceExists(namespace);
+    if (exists) {
+      logger.info(`✓ Namespace '${namespace}' already exists, reusing it`);
+    } else {
+      logger.info(`📦 Creating namespace '${namespace}'...`);
+    }
+    await this.ensureNamespace(namespace);
+    if (!exists) {
+      logger.success(`✓ Namespace '${namespace}' created successfully`);
+    }
+  }
+
+  /**
+   * Setup test secret
+   * Creates secret if it doesn't exist
+   */
+  async setupTestSecret(secretName: string, namespace: string, yamlPath: string): Promise<void> {
+    await this.ensureSecret(secretName, namespace, yamlPath);
+  }
+
+  /**
+   * Switch to a different project/namespace
+   */
+  async switchProject(namespace: string): Promise<void> {
+    await this.executeOc(['project', namespace]);
+  }
+
+  /**
+   * Uncordon a node (mark as schedulable again). Equivalent to `oc adm uncordon <nodeName>`.
+   */
+  async uncordonNode(nodeName: string): Promise<void> {
+    await this.executeOc(['adm', 'uncordon', nodeName]);
+  }
+
+  /**
+   * Verifies that a resource exists in the cluster.
+   * Matches Cypress: cy.exec('oc get service headless');
+   *
+   * @param kind - The resource kind (e.g., 'service', 'vm', 'vmi')
+   * @param name - The resource name
+   * @param namespace - The namespace (optional for cluster-scoped resources)
+   * @returns True if the resource exists
+   */
+  async verifyResourceExists(kind: string, name: string, namespace?: string): Promise<boolean> {
+    try {
+      const args = ['get', kind, name];
+      if (namespace) {
+        args.push('-n', namespace);
+      }
+      await this.executeOc(args, { ignoreError: false });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Wait for a resource condition
+   * For cluster-scoped resources, pass undefined as namespace
+   */
+  async waitForCondition(
+    kind: string,
+    name: string,
+    condition: string,
+    namespace: string | undefined,
+    timeoutSeconds = 60,
+  ): Promise<void> {
+    const args = ['wait', kind, name, `--for=${condition}`, `--timeout=${timeoutSeconds}s`];
+    if (namespace !== undefined) {
+      args.push('-n', namespace);
+    }
+    await this.executeOc(args);
+  }
+}

--- a/playwright/src/clients/request-context-client.ts
+++ b/playwright/src/clients/request-context-client.ts
@@ -1,0 +1,650 @@
+import type {
+  JsonPatchOp,
+  KubernetesListResource,
+  KubernetesResource,
+} from '@/data-models/kubernetes-types';
+import type { APIRequestContext, APIResponse, Page } from '@playwright/test';
+
+import type { ClusterAuthConfig } from './base-client';
+import BaseClient from './base-client';
+import type { ProxyApiContext } from './proxy-handlers';
+import {
+  CdiProxyHandler,
+  CoreProxyHandler,
+  InfraProxyHandler,
+  InstanceTypeProxyHandler,
+  SnapshotProxyHandler,
+  TemplateProxyHandler,
+  VirtualMachineProxyHandler,
+} from './proxy-handlers';
+
+function isPage(p: Page | APIRequestContext): p is Page {
+  return typeof (p as Page).goto === 'function';
+}
+
+/**
+ * Client for interacting with the OpenShift console proxy API.
+ *
+ * Supports two authentication modes:
+ *
+ * **Browser-session mode** (pass a `Page`):
+ *   - Shares cookies + CSRF token from the active browser context.
+ *   - Use this inside E2E tests where a browser is already running.
+ *
+ * **Token mode** (pass an `APIRequestContext`):
+ *   - Uses a Bearer token from `ClusterAuthConfig.token`.
+ *   - No browser required — suitable for lightweight API-only tests.
+ *   - Use this with Playwright's built-in `request` fixture.
+ *
+ * All requests target the console proxy path `/api/kubernetes/...` so the
+ * same endpoint URLs work in both modes.
+ *
+ * Domain handlers are exposed as properties for concise access:
+ *   - `apiClient.vm.*`         — VirtualMachines, VMIs, Migrations
+ *   - `apiClient.snapshot.*`   — Snapshots, Restores, VolumeSnapshots
+ *   - `apiClient.template.*`   — OpenShift Templates
+ *   - `apiClient.instanceType.*` — InstanceTypes & Preferences
+ *   - `apiClient.cdi.*`        — DataVolumes, DataSources, etc.
+ *   - `apiClient.infra.*`      — HCO, KubeVirt CR, MigrationPolicies, NADs
+ *   - `apiClient.core.*`       — ConfigMaps, Pods, PVCs
+ *
+ * Flat methods (e.g. `apiClient.getVirtualMachines()`) are kept as one-line
+ * delegates to the handlers so existing call sites continue to work.
+ */
+export default class RequestContextClient extends BaseClient implements ProxyApiContext {
+  private readonly _httpContext: APIRequestContext;
+  private readonly _token: string;
+
+  // ---------------------------------------------------------------------------
+  // Domain handlers
+  // ---------------------------------------------------------------------------
+
+  readonly cdi: CdiProxyHandler;
+  readonly core: CoreProxyHandler;
+  readonly infra: InfraProxyHandler;
+  readonly instanceType: InstanceTypeProxyHandler;
+  readonly snapshot: SnapshotProxyHandler;
+  readonly template: TemplateProxyHandler;
+  readonly vm: VirtualMachineProxyHandler;
+
+  constructor(page: Page, config: ClusterAuthConfig);
+  constructor(apiContext: APIRequestContext, config: ClusterAuthConfig);
+  constructor(pageOrContext: Page | APIRequestContext, config: ClusterAuthConfig) {
+    super(isPage(pageOrContext) ? pageOrContext : undefined, config);
+    this._httpContext = isPage(pageOrContext) ? pageOrContext.request : pageOrContext;
+    this._token = config.token ?? '';
+
+    this.vm = new VirtualMachineProxyHandler(this);
+    this.snapshot = new SnapshotProxyHandler(this);
+    this.template = new TemplateProxyHandler(this);
+    this.instanceType = new InstanceTypeProxyHandler(this);
+    this.cdi = new CdiProxyHandler(this);
+    this.infra = new InfraProxyHandler(this);
+    this.core = new CoreProxyHandler(this);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private transport helpers
+  // ---------------------------------------------------------------------------
+
+  private async _buildCookieAuthOptions(
+    extra?: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const page = this.page;
+    if (!page) {
+      throw new Error('_buildCookieAuthOptions called without a Page instance');
+    }
+
+    const cookies = await page.context().cookies();
+    const csrfToken = cookies.find((c) => c.name === 'csrf-token')?.value ?? '';
+    const cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join('; ');
+    const pageUrl = new URL(page.url());
+    const origin = `${pageUrl.protocol}//${pageUrl.host}`;
+
+    return {
+      ...extra,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json;charset=UTF-8',
+        Cookie: cookieHeader,
+        Origin: origin,
+        Referer: page.url(),
+        'User-Agent': await page.evaluate(() => navigator.userAgent),
+        'X-CSRFToken': csrfToken,
+        ...((extra?.headers as Record<string, string> | undefined) ?? {}),
+      },
+      ignoreHTTPSErrors: true,
+    };
+  }
+
+  private async _buildTokenAuthOptions(
+    extra?: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    // The console proxy sets a csrf-token cookie on every response. APIRequestContext
+    // stores it automatically, so after the first GET the cookie is present. For mutating
+    // requests the proxy checks that X-CSRFToken matches the csrf-token cookie — read it
+    // back from storageState() so write ops are accepted without a browser session.
+    let csrfToken = '';
+    try {
+      const state = await this._httpContext.storageState();
+      csrfToken = state.cookies.find((c) => c.name === 'csrf-token')?.value ?? '';
+    } catch {
+      // storageState unavailable — proceed without CSRF header (GET-only contexts)
+    }
+
+    return {
+      ...extra,
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json;charset=UTF-8',
+        ...(this._token ? { Authorization: `Bearer ${this._token}` } : {}),
+        ...(csrfToken ? { 'X-CSRFToken': csrfToken } : {}),
+        ...((extra?.headers as Record<string, string> | undefined) ?? {}),
+      },
+      ignoreHTTPSErrors: true,
+    };
+  }
+
+  private async _parseResponse(response: APIResponse): Promise<KubernetesResource | null> {
+    const body = await response.text();
+    if (!response.ok()) {
+      throw new Error(`HTTP ${response.status()} ${response.statusText()} — ${body}`);
+    }
+    if (!body) return null;
+    try {
+      return JSON.parse(body) as KubernetesResource;
+    } catch {
+      throw new Error(`Non-JSON response: ${body}`);
+    }
+  }
+
+  private buildConsoleApiUrl(path: string): string {
+    const base = this.baseUrl.endsWith('/') ? this.baseUrl.slice(0, -1) : this.baseUrl;
+    return `${base}/api${path}`;
+  }
+
+  private async buildRequestOptions(
+    extra?: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (this.page) {
+      return this._buildCookieAuthOptions(extra);
+    }
+    return this._buildTokenAuthOptions(extra);
+  }
+
+  // ---------------------------------------------------------------------------
+  // ProxyApiContext implementation — shared transport used by all handlers
+  // ---------------------------------------------------------------------------
+
+  async _request(
+    method: 'get' | 'post' | 'put' | 'patch' | 'delete',
+    path: string,
+    extra?: Record<string, unknown>,
+  ): Promise<KubernetesResource | null> {
+    const url = this.buildConsoleApiUrl(path);
+    const opts = await this.buildRequestOptions(extra);
+    const dispatcher = this._httpContext;
+
+    const getOpts = opts as Parameters<APIRequestContext['get']>[1];
+    const mutateOpts = opts as Parameters<APIRequestContext['post']>[1];
+
+    let response: APIResponse;
+    switch (method) {
+      case 'get':
+        response = await dispatcher.get(url, getOpts);
+        break;
+      case 'post':
+        response = await dispatcher.post(url, mutateOpts);
+        break;
+      case 'put':
+        response = await dispatcher.put(url, mutateOpts);
+        break;
+      case 'patch':
+        response = await dispatcher.patch(url, mutateOpts);
+        break;
+      case 'delete':
+        response = await dispatcher.delete(url, opts as Parameters<APIRequestContext['delete']>[1]);
+        break;
+      default: {
+        const _: never = method;
+        throw new Error(`Unsupported HTTP method: ${String(_)}`);
+      }
+    }
+    return this._parseResponse(response);
+  }
+
+  async checkPluginHealth(): Promise<boolean> {
+    const url = this.buildConsoleApiUrl(
+      '/proxy/plugin/kubevirt-plugin/kubevirt-apiserver-proxy/health',
+    );
+    const opts = await this.buildRequestOptions();
+    const response = await this._httpContext.get(url, opts);
+    return response.ok();
+  }
+
+  configureUserSettings(
+    username = 'kube-admin',
+    namespace = 'openshift-cnv',
+    favoriteBootableVolumes: string[] = ['fedora'],
+    dontShowWelcomeModal = true,
+  ) {
+    return this.core.configureUserSettings(
+      username,
+      namespace,
+      favoriteBootableVolumes,
+      dontShowWelcomeModal,
+    );
+  }
+
+  createDataSource(namespace: string, spec: KubernetesResource) {
+    return this.cdi.createDataSource(namespace, spec);
+  }
+
+  createDataVolume(namespace: string, spec: KubernetesResource) {
+    return this.cdi.createDataVolume(namespace, spec);
+  }
+
+  createMigrationPolicy(spec: KubernetesResource) {
+    return this.infra.createMigrationPolicy(spec);
+  }
+
+  createMultiNsStorageMigrationPlan(spec: KubernetesResource, namespace: string) {
+    return this.infra.createMultiNsStorageMigrationPlan(spec, namespace);
+  }
+
+  // ---------------------------------------------------------------------------
+  // project.openshift.io — Project patch
+  // (Uses a non-standard /k8s/cluster/... URL, not delegated to a handler)
+  // ---------------------------------------------------------------------------
+
+  async createResource(
+    group: string,
+    version: string,
+    plural: string,
+    spec: KubernetesResource,
+    namespace?: string,
+  ): Promise<KubernetesResource | null> {
+    const apiSegment = group
+      ? `/kubernetes/apis/${group}/${version}`
+      : `/kubernetes/api/${version}`;
+    const nsSegment = namespace ? `/namespaces/${namespace}` : '';
+    return this._request('post', `${apiSegment}${nsSegment}/${plural}`, { data: spec });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Plugin health check
+  // Uses a direct HTTP GET rather than _request because the health endpoint
+  // returns a plain-text body (not JSON), so _parseResponse would throw.
+  // ---------------------------------------------------------------------------
+
+  createStorageMigrationPlan(spec: KubernetesResource, namespace: string) {
+    return this.infra.createStorageMigrationPlan(spec, namespace);
+  }
+
+  createTemplate(namespace: string, spec: KubernetesResource) {
+    return this.template.create(namespace, spec);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Backward-compat flat methods — delegate to domain handlers
+  // New code should use apiClient.<handler>.<method>() directly.
+  // ---------------------------------------------------------------------------
+
+  createVirtualMachine(namespace: string, spec: KubernetesResource) {
+    return this.vm.create(namespace, spec);
+  }
+  createVirtualMachineClusterInstanceType(spec: KubernetesResource) {
+    return this.instanceType.createClusterInstanceType(spec);
+  }
+  createVirtualMachineInstanceMigration(namespace: string, spec: KubernetesResource) {
+    return this.vm.createMigration(namespace, spec);
+  }
+  createVirtualMachineInstanceType(namespace: string, spec: KubernetesResource) {
+    return this.instanceType.createInstanceType(namespace, spec);
+  }
+  createVirtualMachinePreference(namespace: string, spec: KubernetesResource) {
+    return this.instanceType.createPreference(namespace, spec);
+  }
+  createVirtualMachineRestore(namespace: string, spec: KubernetesResource) {
+    return this.snapshot.createRestore(namespace, spec);
+  }
+  createVirtualMachineSnapshot(namespace: string, spec: KubernetesResource) {
+    return this.snapshot.create(namespace, spec);
+  }
+  deleteDataSource(namespace: string, name: string) {
+    return this.cdi.deleteDataSource(namespace, name);
+  }
+
+  deleteDataVolume(namespace: string, name: string) {
+    return this.cdi.deleteDataVolume(namespace, name);
+  }
+  deleteMigrationPolicy(name: string) {
+    return this.infra.deleteMigrationPolicy(name);
+  }
+  deleteMultiNsStorageMigrationPlan(name: string, namespace: string) {
+    return this.infra.deleteMultiNsStorageMigrationPlan(name, namespace);
+  }
+
+  async deleteResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    namespace?: string,
+  ): Promise<KubernetesResource | null> {
+    const apiSegment = group
+      ? `/kubernetes/apis/${group}/${version}`
+      : `/kubernetes/api/${version}`;
+    const nsSegment = namespace ? `/namespaces/${namespace}` : '';
+    return this._request('delete', `${apiSegment}${nsSegment}/${plural}/${name}`);
+  }
+  deleteStorageMigrationPlan(name: string, namespace: string) {
+    return this.infra.deleteStorageMigrationPlan(name, namespace);
+  }
+  deleteTemplate(namespace: string, name: string) {
+    return this.template.delete(namespace, name);
+  }
+  deleteVirtualMachine(namespace: string, name: string) {
+    return this.vm.delete(namespace, name);
+  }
+
+  deleteVirtualMachineClusterInstanceType(name: string) {
+    return this.instanceType.deleteClusterInstanceType(name);
+  }
+  deleteVirtualMachineInstanceMigration(namespace: string, name: string) {
+    return this.vm.deleteMigration(namespace, name);
+  }
+  deleteVirtualMachineInstanceType(namespace: string, name: string) {
+    return this.instanceType.deleteInstanceType(namespace, name);
+  }
+  deleteVirtualMachinePreference(namespace: string, name: string) {
+    return this.instanceType.deletePreference(namespace, name);
+  }
+  deleteVirtualMachineRestore(namespace: string, name: string) {
+    return this.snapshot.deleteRestore(namespace, name);
+  }
+  deleteVirtualMachineSnapshot(namespace: string, name: string) {
+    return this.snapshot.delete(namespace, name);
+  }
+  getCdiConfig() {
+    return this.cdi.getCdiConfig();
+  }
+  // -- Core --
+  getConfigMap(namespace: string, name: string) {
+    return this.core.getConfigMap(namespace, name);
+  }
+  getDataImportCrons(namespace?: string) {
+    return this.cdi.listDataImportCrons(namespace);
+  }
+
+  getDataSource(namespace: string, name: string) {
+    return this.cdi.getDataSource(namespace, name);
+  }
+  getDataSources(namespace?: string, labelSelector?: string) {
+    return this.cdi.listDataSources(namespace, labelSelector);
+  }
+  getDataVolume(namespace: string, name: string) {
+    return this.cdi.getDataVolume(namespace, name);
+  }
+  // -- CDI --
+  getDataVolumes(namespace?: string) {
+    return this.cdi.listDataVolumes(namespace);
+  }
+  getHyperConverged(namespace = 'openshift-cnv', name = 'kubevirt-hyperconverged') {
+    return this.infra.getHyperConverged(namespace, name);
+  }
+
+  // -- Infra --
+  getHyperConvergeds(namespace = 'openshift-cnv') {
+    return this.infra.listHyperConvergeds(namespace);
+  }
+  getKubeVirt(namespace = 'openshift-cnv', name = 'kubevirt-kubevirt-hyperconverged') {
+    return this.infra.getKubeVirt(namespace, name);
+  }
+  getKubeVirtUiFeatures(namespace = 'openshift-cnv') {
+    return this.core.getUiFeatures(namespace);
+  }
+  getKubeVirtUserSettings(namespace = 'openshift-cnv') {
+    return this.core.getUserSettings(namespace);
+  }
+  getMigrationPolicies() {
+    return this.infra.listMigrationPolicies();
+  }
+  getMultiNsStorageMigrationPlan(name: string, namespace: string) {
+    return this.infra.getMultiNsStorageMigrationPlan(name, namespace);
+  }
+  getNamespacedStorageMigrationPlans(namespace: string) {
+    return this.infra.listNamespacedStorageMigrationPlans(namespace);
+  }
+  getNetworkAttachmentDefinitions(namespace: string) {
+    return this.infra.listNetworkAttachmentDefinitions(namespace);
+  }
+  getPersistentVolumeClaims(namespace: string) {
+    return this.core.listPersistentVolumeClaims(namespace);
+  }
+  getPods(namespace: string) {
+    return this.core.listPods(namespace);
+  }
+
+  async getResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    namespace?: string,
+  ): Promise<KubernetesResource | null> {
+    const apiSegment = group
+      ? `/kubernetes/apis/${group}/${version}`
+      : `/kubernetes/api/${version}`;
+    const nsSegment = namespace ? `/namespaces/${namespace}` : '';
+    return this._request('get', `${apiSegment}${nsSegment}/${plural}/${name}`);
+  }
+  getStorageMigrationPlan(name: string, namespace: string) {
+    return this.infra.getStorageMigrationPlan(name, namespace);
+  }
+  getStorageMigrationPlans(namespace?: string) {
+    return this.infra.listStorageMigrationPlans(namespace);
+  }
+  getStorageProfiles() {
+    return this.cdi.listStorageProfiles();
+  }
+  getTemplate(namespace: string, name: string) {
+    return this.template.get(namespace, name);
+  }
+  // -- Templates --
+  getTemplates(namespace?: string, labelSelector?: string) {
+    return this.template.list(namespace, labelSelector);
+  }
+  getVirtualMachine(namespace: string, name: string) {
+    return this.vm.get(namespace, name);
+  }
+  // -- Instance types & Preferences --
+  getVirtualMachineClusterInstanceTypes() {
+    return this.instanceType.listClusterInstanceTypes();
+  }
+  getVirtualMachineClusterPreferences() {
+    return this.instanceType.listClusterPreferences();
+  }
+  getVirtualMachineInstance(namespace: string, name: string) {
+    return this.vm.getInstance(namespace, name);
+  }
+  getVirtualMachineInstanceMigration(namespace: string, name: string) {
+    return this.vm.getMigration(namespace, name);
+  }
+  // -- VirtualMachineInstanceMigrations --
+  getVirtualMachineInstanceMigrations(namespace?: string, queryParams?: Record<string, string>) {
+    return this.vm.listMigrations(namespace, queryParams);
+  }
+  // -- VMIs --
+  getVirtualMachineInstances(namespace?: string, queryParams?: Record<string, string>) {
+    return this.vm.listInstances(namespace, queryParams);
+  }
+
+  getVirtualMachineInstanceTypes(namespace: string) {
+    return this.instanceType.listInstanceTypes(namespace);
+  }
+  getVirtualMachinePreferences(namespace: string) {
+    return this.instanceType.listPreferences(namespace);
+  }
+  getVirtualMachineRestore(namespace: string, name: string) {
+    return this.snapshot.getRestore(namespace, name);
+  }
+  getVirtualMachineRestores(namespace: string) {
+    return this.snapshot.listRestores(namespace);
+  }
+  // -- VMs --
+  getVirtualMachines(namespace?: string, queryParams?: Record<string, string>) {
+    return this.vm.list(namespace, queryParams);
+  }
+  getVirtualMachineSnapshot(namespace: string, name: string) {
+    return this.snapshot.get(namespace, name);
+  }
+  // -- Snapshots --
+  getVirtualMachineSnapshots(namespace: string) {
+    return this.snapshot.list(namespace);
+  }
+  getVolumeSnapshots(namespace: string) {
+    return this.snapshot.listVolumeSnapshots(namespace);
+  }
+  async listResources(
+    group: string,
+    version: string,
+    plural: string,
+    namespace?: string,
+    queryParams?: Record<string, string>,
+  ): Promise<KubernetesListResource> {
+    const apiSegment = group
+      ? `/kubernetes/apis/${group}/${version}`
+      : `/kubernetes/api/${version}`;
+    const nsSegment = namespace ? `/namespaces/${namespace}` : '';
+    const qs = queryParams ? '?' + new URLSearchParams(queryParams).toString() : '';
+    return (await this._request(
+      'get',
+      `${apiSegment}${nsSegment}/${plural}${qs}`,
+    )) as unknown as KubernetesListResource;
+  }
+  /**
+   * JSON Merge Patch (RFC 7396) any resource through the console proxy.
+   * Prefer over `patchResource` when the target sub-path may not exist yet —
+   * merge-patch creates missing intermediate objects automatically.
+   * Required for CRDs (strategic-merge-patch is not supported).
+   */
+  async mergePatchResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    patch: Record<string, unknown>,
+    namespace?: string,
+  ): Promise<KubernetesResource | null> {
+    const apiSegment = group
+      ? `/kubernetes/apis/${group}/${version}`
+      : `/kubernetes/api/${version}`;
+    const nsSegment = namespace ? `/namespaces/${namespace}` : '';
+    return this._request('patch', `${apiSegment}${nsSegment}/${plural}/${name}`, {
+      data: patch,
+      headers: { 'Content-Type': 'application/merge-patch+json' },
+    });
+  }
+  patchConfigMap(name: string, namespace: string, patchPayload: JsonPatchOp[]) {
+    return this.core.patchConfigMap(name, namespace, patchPayload);
+  }
+  patchDataSource(namespace: string, name: string, patch: JsonPatchOp[]) {
+    return this.cdi.patchDataSource(namespace, name, patch);
+  }
+  patchDataVolume(namespace: string, name: string, patch: JsonPatchOp[]) {
+    return this.cdi.patchDataVolume(namespace, name, patch);
+  }
+  patchHyperConverged(
+    namespace = 'openshift-cnv',
+    name = 'kubevirt-hyperconverged',
+    patchPayload: JsonPatchOp[],
+  ) {
+    return this.infra.patchHyperConverged(namespace, name, patchPayload);
+  }
+  patchMigrationPolicy(name: string, patch: JsonPatchOp[]) {
+    return this.infra.patchMigrationPolicy(name, patch);
+  }
+  async patchProject(projectName: string, patchPayload: JsonPatchOp[]): Promise<void> {
+    const base = this.baseUrl.endsWith('/') ? this.baseUrl.slice(0, -1) : this.baseUrl;
+    const url = `${base}/k8s/cluster/project.openshift.io~v1~Project/${projectName}`;
+    const opts = await this.buildRequestOptions({
+      data: patchPayload,
+      headers: { 'Content-Type': 'application/json-patch+json' },
+    });
+    const response = await this._httpContext.patch(url, opts);
+    if (!response.ok()) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Failed to patch Project: ${response.status()} ${body}`);
+    }
+  }
+  async patchResource(
+    group: string,
+    version: string,
+    plural: string,
+    name: string,
+    patch: JsonPatchOp[],
+    namespace?: string,
+  ): Promise<KubernetesResource | null> {
+    const apiSegment = group
+      ? `/kubernetes/apis/${group}/${version}`
+      : `/kubernetes/api/${version}`;
+    const nsSegment = namespace ? `/namespaces/${namespace}` : '';
+    return this._request('patch', `${apiSegment}${nsSegment}/${plural}/${name}`, {
+      data: patch,
+      headers: { 'Content-Type': 'application/json-patch+json' },
+    });
+  }
+  patchTemplate(namespace: string, name: string, patch: JsonPatchOp[]) {
+    return this.template.patch(namespace, name, patch);
+  }
+
+  patchVirtualMachine(namespace: string, name: string, patch: JsonPatchOp[]) {
+    return this.vm.patch(namespace, name, patch);
+  }
+  /**
+   * Prime the csrf-token cookie by fetching the console root page.
+   * The OpenShift console only sets the csrf-token cookie on HTML page responses (not API calls).
+   * Must be called before any mutating API request in token-auth (browserless) mode.
+   */
+  async primeCsrfToken(): Promise<void> {
+    const base = this.baseUrl.endsWith('/') ? this.baseUrl.slice(0, -1) : this.baseUrl;
+    await this._httpContext
+      .get(base + '/', {
+        headers: {
+          ...(this._token ? { Authorization: `Bearer ${this._token}` } : {}),
+        },
+        ignoreHTTPSErrors: true,
+      })
+      .catch(() => undefined);
+  }
+  resetVirtualMachineInstance(namespace: string, vmName: string) {
+    return this.vm.resetInstance(namespace, vmName);
+  }
+  restartVirtualMachine(namespace: string, name: string) {
+    return this.vm.restart(namespace, name);
+  }
+  setConfirmVmActions(enabled: string, namespace = 'openshift-cnv') {
+    return this.core.setConfirmVmActions(enabled, namespace);
+  }
+  setConsoleGuidedTourCompleted(
+    completed: boolean,
+    username = 'kubeadmin',
+    namespace = 'openshift-console-user-settings',
+  ) {
+    return this.core.setConsoleGuidedTourCompleted(completed, username, namespace);
+  }
+  setMemoryDensity(
+    memoryOvercommitPercentage: number,
+    namespace = 'openshift-cnv',
+    name = 'kubevirt-hyperconverged',
+  ) {
+    return this.infra.setMemoryDensity(memoryOvercommitPercentage, namespace, name);
+  }
+  startVirtualMachine(namespace: string, name: string) {
+    return this.vm.start(namespace, name);
+  }
+  stopVirtualMachine(namespace: string, name: string) {
+    return this.vm.stop(namespace, name);
+  }
+}

--- a/playwright/src/clients/virtctl-client.ts
+++ b/playwright/src/clients/virtctl-client.ts
@@ -1,0 +1,455 @@
+import { exec } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from 'util';
+
+import { getErrorMessage } from '@/data-models/kubernetes-types';
+import type { Page } from '@playwright/test';
+
+import type { ClusterAuthConfig } from './base-client';
+import BaseClient from './base-client';
+
+const execAsync = promisify(exec);
+
+/**
+ * Virtctl CLI client for executing virtctl commands and managing KubeVirt resources.
+ *
+ * This client provides a comprehensive interface for interacting with KubeVirt
+ * VirtualMachines and VirtualMachineInstances using the virtctl command-line tool.
+ * It handles authentication via kubeconfig and provides methods for common virtctl
+ * operations like VM migration, console access, and other lifecycle management tasks.
+ *
+ * Key features:
+ * - Kubeconfig-based authentication
+ * - VirtualMachine migration operations
+ * - Support for common virtctl commands
+ * - Error handling and command execution
+ *
+ * The client assumes virtctl binary is available in the PATH or can be specified
+ * via the virtctlPath constructor parameter.
+ *
+ * @example
+ * ```typescript
+ * const config: ClusterAuthConfig = {
+ *   baseUrl: 'https://api.example.com:6443',
+ *   username: 'admin',
+ *   password: 'password123'
+ * };
+ * const virtctlClient = new VirtctlClient(page, config);
+ *
+ * // Migrate a VM
+ * await virtctlClient.migrateVm('test-vm', 'default');
+ * ```
+ *
+ * @extends BaseClient
+ * @since 1.0.0
+ */
+export default class VirtctlClient extends BaseClient {
+  /** Optional path to kubeconfig file for authentication */
+  private kubeConfigPath?: string;
+
+  /** Path to the virtctl command-line tool */
+  private virtctlPath: string;
+
+  /**
+   * Creates a new VirtctlClient instance.
+   *
+   * @param page - Optional Playwright page instance for UI-based operations
+   * @param config - Cluster authentication configuration
+   * @param config.baseUrl - The base URL of the cluster API server
+   * @param config.password - The password for authentication
+   * @param config.username - The username for authentication
+   * @param virtctlPath - Path to the virtctl command-line tool (default: 'virtctl')
+   * @param kubeConfigPath - Optional path to kubeconfig file for authentication
+   *
+   * @since 1.0.0
+   */
+  constructor(
+    page: Page | undefined,
+    config: ClusterAuthConfig,
+    virtctlPath = 'virtctl',
+    kubeConfigPath?: string,
+  ) {
+    super(page, config);
+    this.virtctlPath = virtctlPath;
+    this.kubeConfigPath = kubeConfigPath;
+  }
+
+  /**
+   * Executes a virtctl command and returns the result.
+   *
+   * This is the core method that handles all virtctl command execution. It automatically
+   * handles kubeconfig configuration and command construction.
+   *
+   * @param args - Array of command arguments (e.g., ['migrate', 'vm-name', '-n', 'default'])
+   * @param options - Optional execution options
+   * @param options.ignoreError - Whether to ignore command errors and return empty string
+   * @returns The command output as a string
+   * @throws {Error} When command execution fails (unless ignoreError is true)
+   * @private
+   * @since 1.0.0
+   */
+  private async executeVirtctl(
+    args: string[],
+    options?: { ignoreError?: boolean },
+  ): Promise<string> {
+    const kubeConfigFlag = this.kubeConfigPath ? `--kubeconfig=${this.kubeConfigPath}` : '';
+    const command = `${this.virtctlPath} ${kubeConfigFlag} ${args.join(' ')}`.trim();
+
+    try {
+      const { stderr: _stderr, stdout } = await execAsync(command, {
+        maxBuffer: 10 * 1024 * 1024, // 10MB buffer
+      });
+
+      return stdout.trim();
+    } catch (error: unknown) {
+      if (options?.ignoreError) {
+        const stdout =
+          typeof error === 'object' && error !== null && 'stdout' in error
+            ? String((error as { stdout?: unknown }).stdout ?? '')
+            : '';
+        return stdout;
+      }
+      const stderr =
+        typeof error === 'object' && error !== null && 'stderr' in error
+          ? String((error as { stderr?: unknown }).stderr ?? '')
+          : '';
+      throw new Error(
+        `Virtctl command failed: ${command}\nError: ${getErrorMessage(error)}\nStderr: ${stderr}`,
+      );
+    }
+  }
+
+  /**
+   * Adds an SSH public key to a VM using virtctl credentials command.
+   * This allows SSH access to the VM using the corresponding private key.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param publicKeyPath - Path to the SSH public key file
+   * @param username - Username to associate with the key (default: 'cloud-user')
+   * @returns The command output as a string
+   * @throws {Error} When the command fails
+   * @since 1.0.0
+   */
+  async addSSHKeyToVm(
+    vmName: string,
+    namespace: string,
+    publicKeyPath: string,
+    username = 'cloud-user',
+  ): Promise<string> {
+    if (!fs.existsSync(publicKeyPath)) {
+      throw new Error(`SSH public key file not found: ${publicKeyPath}`);
+    }
+
+    const args = [
+      'credentials',
+      'add-ssh-key',
+      '--user',
+      username,
+      '-n',
+      namespace,
+      '--file',
+      publicKeyPath,
+      vmName,
+    ];
+
+    return await this.executeVirtctl(args);
+  }
+
+  /**
+   * Creates an SSH key pair file for testing.
+   * Returns the paths to both the private and public key files.
+   *
+   * @param keyName - Base name for the key files (default: 'test-ssh-key')
+   * @param outputDir - Directory to store key files (default: '.test-data')
+   * @returns Object with paths to private and public key files
+   * @since 1.0.0
+   */
+  async createSSHKeyPair(
+    keyName = 'test-ssh-key',
+    outputDir = '.test-data',
+  ): Promise<{ privateKeyPath: string; publicKeyPath: string }> {
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    const privateKeyPath = path.join(outputDir, keyName);
+    const publicKeyPath = path.join(outputDir, `${keyName}.pub`);
+
+    if (fs.existsSync(privateKeyPath) && fs.existsSync(publicKeyPath)) {
+      return { privateKeyPath, publicKeyPath };
+    }
+
+    try {
+      await execAsync(`ssh-keygen -t rsa -b 4096 -f "${privateKeyPath}" -N "" -q`, {
+        maxBuffer: 10 * 1024 * 1024,
+      });
+
+      fs.chmodSync(privateKeyPath, 0o600);
+
+      return { privateKeyPath, publicKeyPath };
+    } catch (error: unknown) {
+      throw new Error(`Failed to generate SSH key pair: ${getErrorMessage(error)}`);
+    }
+  }
+
+  /**
+   * Execute a raw virtctl command (for advanced use cases).
+   *
+   * This method allows executing any virtctl command directly, useful for commands
+   * that don't have dedicated methods or for testing new features.
+   *
+   * @param command - The full virtctl command as a string (e.g., 'migrate vm-name -n default')
+   * @returns The command output as a string
+   * @throws {Error} When command execution fails
+   * @since 1.0.0
+   */
+  async executeRawCommand(command: string): Promise<string> {
+    return await this.executeVirtctl(command.split(' '));
+  }
+
+  /**
+   * Execute a command inside a VM via SSH using virtctl.
+   *
+   * This method uses virtctl ssh to execute commands inside the VM's guest OS.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param command - Command to execute inside the VM
+   * @param options - Optional SSH configuration
+   * @param options.sshKeyPath - Path to SSH key file (default: 'fixtures/cnv.key')
+   * @param options.username - SSH username (default: 'cloud-user')
+   * @returns The command output as a string
+   * @throws {Error} When SSH command execution fails
+   * @since 1.0.0
+   */
+  async executeSshCommand(
+    vmName: string,
+    namespace: string,
+    command: string,
+    options?: {
+      sshKeyPath?: string;
+      username?: string;
+    },
+  ): Promise<string> {
+    const sshKeyPath = options?.sshKeyPath || 'fixtures/cnv.key';
+    const username = options?.username || 'cloud-user';
+
+    const args = ['ssh', '-i', sshKeyPath, `${username}@${vmName}`, '-n', namespace, '-c', command];
+
+    return await this.executeVirtctl(args);
+  }
+
+  /**
+   * Get the VM's guest OS uptime in seconds.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param options - Optional SSH configuration
+   * @param options.sshKeyPath - Path to SSH key file (default: 'fixtures/cnv.key')
+   * @param options.username - SSH username (default: 'cloud-user')
+   * @returns Uptime in seconds, or null if unable to determine
+   * @since 1.0.0
+   */
+  async getGuestOsUptime(
+    vmName: string,
+    namespace: string,
+    options?: {
+      sshKeyPath?: string;
+      username?: string;
+    },
+  ): Promise<number | null> {
+    try {
+      const uptimeOutput = await this.executeSshCommand(
+        vmName,
+        namespace,
+        "awk '{print $1}' /proc/uptime",
+        options,
+      );
+
+      const trimmedOutput = uptimeOutput.trim();
+      if (!trimmedOutput) {
+        return null;
+      }
+
+      const uptimeSeconds = parseFloat(trimmedOutput);
+      return isNaN(uptimeSeconds) ? null : uptimeSeconds;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Upload an image to a PVC using virtctl.
+   *
+   * @param namespace - Namespace where the PVC will be created
+   * @param pvcName - Name of the PVC to create
+   * @param size - Size of the PVC (e.g., '1Gi')
+   * @param imagePath - Local path to the image file
+   * @returns The command output as a string
+   */
+  async imageUpload(
+    namespace: string,
+    pvcName: string,
+    size: string,
+    imagePath: string,
+  ): Promise<string> {
+    const args = [
+      'image-upload',
+      '-n',
+      namespace,
+      'pvc',
+      pvcName,
+      `--size=${size}`,
+      `--image-path=${imagePath}`,
+      '--insecure',
+      '--force-bind',
+    ];
+    return await this.executeVirtctl(args);
+  }
+
+  /**
+   * Check if the VM's guest OS is rebooting by checking system uptime.
+   * A system is considered rebooting if uptime is very low (less than 30 seconds).
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param options - Optional SSH configuration
+   * @param options.sshKeyPath - Path to SSH key file (default: 'fixtures/cnv.key')
+   * @param options.username - SSH username (default: 'cloud-user')
+   * @param options.rebootThresholdSeconds - Uptime threshold in seconds to consider as rebooting (default: 30)
+   * @returns True if the system appears to be rebooting, false otherwise
+   * @throws {Error} When SSH command execution fails
+   * @since 1.0.0
+   */
+  async isGuestOsRebooting(
+    vmName: string,
+    namespace: string,
+    options?: {
+      sshKeyPath?: string;
+      username?: string;
+      rebootThresholdSeconds?: number;
+    },
+  ): Promise<boolean> {
+    try {
+      const uptimeOutput = await this.executeSshCommand(
+        vmName,
+        namespace,
+        "awk '{print $1}' /proc/uptime",
+        options,
+      );
+
+      const trimmedOutput = uptimeOutput.trim();
+      if (!trimmedOutput) {
+        return false;
+      }
+
+      const uptimeSeconds = parseFloat(trimmedOutput);
+      if (isNaN(uptimeSeconds)) {
+        return false;
+      }
+
+      const threshold = options?.rebootThresholdSeconds || 30;
+      return uptimeSeconds < threshold;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Check if virtctl CLI is available
+   *
+   * @returns true if virtctl is available, false otherwise
+   * @since 1.0.0
+   */
+  async isVirtctlAvailable(): Promise<boolean> {
+    try {
+      await this.executeVirtctl(['version'], { ignoreError: true });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Migrate a VirtualMachine to a different node.
+   *
+   * This method executes the virtctl migrate command to migrate a VM to a different node.
+   * The migration is performed live, meaning the VM continues running during the migration.
+   *
+   * @param vmName - Name of the VirtualMachine to migrate
+   * @param namespace - Namespace where the VM exists
+   * @returns The command output as a string
+   * @throws {Error} When migration command fails
+   * @since 1.0.0
+   */
+  async migrateVm(vmName: string, namespace: string): Promise<string> {
+    return await this.executeVirtctl(['migrate', vmName, '-n', namespace]);
+  }
+
+  /**
+   * Pause a VirtualMachine (or VMI) using virtctl.
+   * The VM must be Running for pause to apply.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @returns The command output as a string
+   * @throws {Error} When pause command fails
+   */
+  async pauseVm(vmName: string, namespace: string): Promise<string> {
+    return await this.executeVirtctl(['pause', 'vm', vmName, '-n', namespace]);
+  }
+
+  /**
+   * Removes SSH credentials from a VM.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param username - Username whose credentials to remove (default: 'cloud-user')
+   * @returns The command output as a string
+   * @since 1.0.0
+   */
+  async removeSSHKeyFromVm(
+    vmName: string,
+    namespace: string,
+    username = 'cloud-user',
+  ): Promise<string> {
+    const args = ['credentials', 'remove-ssh-key', '--user', username, '-n', namespace, vmName];
+
+    return await this.executeVirtctl(args, { ignoreError: true });
+  }
+
+  /**
+   * Creates SSH key pair and adds the public key to a VM.
+   * This is a convenience method that combines key generation and VM configuration.
+   *
+   * @param vmName - Name of the VirtualMachine
+   * @param namespace - Namespace where the VM exists
+   * @param options - Optional configuration
+   * @param options.keyName - Base name for the key files
+   * @param options.username - Username to associate with the key
+   * @param options.outputDir - Directory to store key files
+   * @returns Object with key paths and command output
+   * @since 1.0.0
+   */
+  async setupSSHKeyForVm(
+    vmName: string,
+    namespace: string,
+    options?: {
+      keyName?: string;
+      username?: string;
+      outputDir?: string;
+    },
+  ): Promise<{ privateKeyPath: string; publicKeyPath: string; output: string }> {
+    const keyName = options?.keyName || `ssh-key-${vmName}`;
+    const username = options?.username || 'cloud-user';
+    const outputDir = options?.outputDir || '.test-data';
+
+    const { privateKeyPath, publicKeyPath } = await this.createSSHKeyPair(keyName, outputDir);
+
+    const output = await this.addSSHKeyToVm(vmName, namespace, publicKeyPath, username);
+
+    return { privateKeyPath, publicKeyPath, output };
+  }
+}


### PR DESCRIPTION
## 📝 Description

Add main client classes (KubernetesClient, OAuth, virtctl, oc CLI)

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-92534


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified clients for Kubernetes, OpenShift command-line operations, console APIs, and virtual machine tooling.
  * Added support for token- and credential-based authentication, kubeconfig generation, OAuth, and proxy connections.
  * Added VM lifecycle, SSH, migration, image upload, resource management, and cluster setup/cleanup operations.
  * Added automatic resource tracking and cleanup across test workflows.

* **Improvements**
  * Improved connection resilience with retry handling, shared connections, and proxy tunneling.
  * Added support for browser-session and API-token authentication modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->