### PR TITLE
CNV-92617: Make hot cluster provisioning visible as a nested job in triggering/queued PRs

### DIFF
--- a/.github/workflows/hot-cluster-check.yml
+++ b/.github/workflows/hot-cluster-check.yml
@@ -46,23 +46,18 @@ on:
     outputs:
       cluster_ready:
         description: Whether the cluster is ready (true/false)
-        value: ${{ jobs.check-and-provision.outputs.cluster_ready }}
+        value: ${{ jobs.result.outputs.cluster_ready }}
 
 permissions:
-  actions: write
   contents: read
 
 jobs:
-  check-and-provision:
-    name: Check & Provision
+  probe:
+    name: Probe for Cluster
     runs-on: ubuntu-latest
-    timeout-minutes: 180
-    concurrency:
-      group: hot-cluster-provision-${{ inputs.cluster_name }}
-      cancel-in-progress: false
-      queue: max
+    timeout-minutes: 2
     outputs:
-      cluster_ready: ${{ steps.probe.outputs.cluster_ready || steps.wait_setup.outputs.cluster_ready }}
+      cluster_ready: ${{ steps.probe.outputs.cluster_ready }}
     steps:
       - name: Probe for cluster
         id: probe
@@ -81,128 +76,85 @@ jobs:
             echo "cluster_ready=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Auto-provision cluster
-        id: dispatch_setup
-        if: steps.probe.outputs.cluster_ready == 'false'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            core.info('No cluster found — dispatching IBM Cloud Hot Cluster Setup...');
+  # Native reusable-workflow call (instead of the old createWorkflowDispatch
+  # + poll pattern) so the actual cluster build shows up as a real, nested,
+  # expandable job in the Checks tab of every PR that runs cluster-check --
+  # including PRs queued behind an in-progress build via the concurrency
+  # lock below, once their turn comes. ibmc-cluster-setup.yml's own
+  # `precheck` job re-probes DNS right after this lock is acquired, so a PR
+  # that was queued behind an already-finished build skips straight through
+  # instead of racing into a duplicate one.
+  provision:
+    name: Provision Cluster
+    needs: probe
+    if: needs.probe.outputs.cluster_ready == 'false'
+    concurrency:
+      group: hot-cluster-provision-${{ inputs.cluster_name }}
+      cancel-in-progress: false
+      queue: max
+    uses: ./.github/workflows/ibmc-cluster-setup.yml
+    with:
+      infrastructure_type: ${{ inputs.infrastructure_type }}
+      cluster_name: ${{ inputs.cluster_name }}
+      zone: ${{ inputs.zone }}
+      openshift_version: ${{ inputs.openshift_version }}
+      worker_flavor: ${{ inputs.worker_flavor }}
+      worker_count: ${{ inputs.worker_count }}
+      # kvm_emulation is declared as a string here (matching workflow_call's
+      # own quirky type rules for workflow_dispatch-style default inputs)
+      # but as an actual boolean on ibmc-cluster-setup.yml's workflow_call
+      # input. Passing the raw string through fails GitHub Actions' strict
+      # workflow_call type validation ("string cannot be cast to boolean") --
+      # only surfaces once this job actually runs (cold cluster / default
+      # path), not at YAML-parse time. Comparing to produce a real boolean
+      # expression result avoids that.
+      kvm_emulation: ${{ inputs.kvm_emulation == 'true' }}
+    secrets: inherit
 
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'ibmc-cluster-setup.yml',
-              ref: context.ref,
-              inputs: {
-                infrastructure_type: '${{ inputs.infrastructure_type }}',
-                cluster_name: '${{ inputs.cluster_name }}',
-                zone: '${{ inputs.zone }}',
-                openshift_version: '${{ inputs.openshift_version }}',
-                worker_flavor: '${{ inputs.worker_flavor }}',
-                worker_count: '${{ inputs.worker_count }}',
-                kvm_emulation: '${{ inputs.kvm_emulation }}',
-              },
-            });
-
-            core.info('Setup workflow dispatched. Waiting for run to appear...');
-
-            let setupRunId = null;
-            const startTime = Date.now();
-            for (let i = 0; i < 12; i++) {
-              await new Promise(r => setTimeout(r, 5000));
-              const runs = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'ibmc-cluster-setup.yml',
-                status: 'in_progress',
-                per_page: 5,
-              });
-              const recent = runs.data.workflow_runs.find(
-                r => new Date(r.created_at).getTime() > startTime - 30000
-              );
-              if (recent) {
-                setupRunId = recent.id;
-                break;
-              }
-            }
-
-            if (!setupRunId) {
-              const queued = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'ibmc-cluster-setup.yml',
-                per_page: 1,
-              });
-              if (queued.data.workflow_runs.length > 0) {
-                setupRunId = queued.data.workflow_runs[0].id;
-              }
-            }
-
-            if (!setupRunId) {
-              core.setFailed('Setup workflow was dispatched but no run was found.');
-              return;
-            }
-
-            core.info(`Setup run started: ${setupRunId}`);
-            core.setOutput('setup_run_id', setupRunId);
-
-      - name: Wait for cluster setup
-        id: wait_setup
-        if: steps.dispatch_setup.outputs.setup_run_id != ''
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const runId = parseInt('${{ steps.dispatch_setup.outputs.setup_run_id }}', 10);
-            const maxWaitMs = 170 * 60 * 1000; // ~2h 50m
-            const pollIntervalMs = 120 * 1000;  // 2 min
-            const startTime = Date.now();
-
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}`;
-            core.info(`Polling setup run ${runId} (every 2 min, up to ~2h 50m)...`);
-            core.info(`Setup run: ${runUrl}`);
-
-            while (Date.now() - startTime < maxWaitMs) {
-              await new Promise(r => setTimeout(r, pollIntervalMs));
-
-              const run = await github.rest.actions.getWorkflowRun({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: runId,
-              });
-
-              const status = run.data.status;
-              const conclusion = run.data.conclusion;
-              const elapsed = Math.floor((Date.now() - startTime) / 60000);
-              core.info(`[${elapsed}m] Status: ${status}, Conclusion: ${conclusion || 'pending'}`);
-
-              if (status === 'completed') {
-                if (conclusion === 'success') {
-                  core.info('Cluster setup completed successfully.');
-                  core.setOutput('cluster_ready', 'true');
-                  return;
-                } else {
-                  core.setFailed(`Cluster setup failed (conclusion: ${conclusion}). See: ${runUrl}`);
-                  return;
-                }
-              }
-            }
-
-            core.setFailed(`Cluster setup timed out after ~2h 50m. See: ${runUrl}`);
+  result:
+    name: Availability Result
+    needs: [probe, provision]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      cluster_ready: ${{ steps.compute.outputs.cluster_ready }}
+    steps:
+      - name: Compute final readiness
+        id: compute
+        env:
+          PROBE_READY: ${{ needs.probe.outputs.cluster_ready }}
+          PROVISION_RESULT: ${{ needs.provision.result }}
+        run: |
+          if [[ "${PROBE_READY}" == "true" || "${PROVISION_RESULT}" == "success" ]]; then
+            echo "cluster_ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "cluster_ready=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Summary
         if: always()
         env:
           CLUSTER_NAME: ${{ inputs.cluster_name }}
-          CLUSTER_READY: ${{ steps.probe.outputs.cluster_ready }}
-          SETUP_RUN_ID: ${{ steps.dispatch_setup.outputs.setup_run_id }}
+          PROBE_READY: ${{ needs.probe.outputs.cluster_ready }}
+          PROVISION_RESULT: ${{ needs.provision.result }}
         run: |
           echo "## Cluster Availability Check" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Check | Result |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"
           echo "| Cluster | \`${CLUSTER_NAME}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| DNS Probe | \`${CLUSTER_READY}\` |" >> "$GITHUB_STEP_SUMMARY"
-          if [[ -n "${SETUP_RUN_ID}" ]]; then
-            echo "| Setup Run | [${SETUP_RUN_ID}](https://github.com/${{ github.repository }}/actions/runs/${SETUP_RUN_ID}) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| DNS Probe | \`${PROBE_READY}\` |" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "${PROVISION_RESULT}" != "skipped" ]]; then
+            echo "| Provision Job | \`${PROVISION_RESULT}\` |" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Fail if cluster is not ready
+        if: steps.compute.outputs.cluster_ready != 'true'
+        env:
+          CLUSTER_NAME: ${{ inputs.cluster_name }}
+          PROBE_READY: ${{ needs.probe.outputs.cluster_ready }}
+          PROVISION_RESULT: ${{ needs.provision.result }}
+        run: |
+          echo "::error::Cluster '${CLUSTER_NAME}' is not ready (probe=${PROBE_READY}, provision=${PROVISION_RESULT})."
+          exit 1

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -1,5 +1,5 @@
 name: Hot Cluster E2E
-run-name: "Hot Cluster E2E [${{ inputs.cluster_name || github.base_ref || 'kubevirt-plugin-ci' }}]"
+run-name: "Hot Cluster E2E [${{ inputs.cluster_name || github.base_ref || 'kubevirt-plugin-ci' }}] @ ${{ github.head_ref || github.ref_name }}"
 
 on:
   pull_request_target:

--- a/.github/workflows/ibmc-cluster-setup.yml
+++ b/.github/workflows/ibmc-cluster-setup.yml
@@ -1,5 +1,5 @@
 name: IBM Cloud Hot Cluster Setup
-run-name: "Hot Cluster Setup [${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}]"
+run-name: "Hot Cluster Setup [${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}] @ ${{ github.ref_name }}"
 
 on:
   workflow_dispatch:
@@ -53,6 +53,70 @@ on:
         required: false
         default: 'stable'
         type: string
+  workflow_call:
+    inputs:
+      infrastructure_type:
+        description: 'Infrastructure type'
+        required: false
+        default: 'ipi'
+        type: string
+      cluster_name:
+        description: 'Cluster name (max 21 chars — IBM Cloud IPI limit, longer names get silently truncated)'
+        required: false
+        default: 'kubevirt-plugin-ci'
+        type: string
+      zone:
+        description: 'Zone (classic: wdc04, fra02; vpc/ipi: us-south-1, eu-de-1)'
+        required: false
+        default: 'us-south-1'
+        type: string
+      openshift_version:
+        description: 'OpenShift version (e.g. 4.22_openshift)'
+        required: false
+        default: '4.22_openshift'
+        type: string
+      worker_flavor:
+        description: 'Worker node flavor (classic: mb4c.4x32; vpc/ipi: bx2.8x32)'
+        required: false
+        default: 'bx2.8x32'
+        type: string
+      worker_count:
+        description: 'Number of worker nodes (at least 2 so ingress is happy)'
+        required: false
+        default: '2'
+        type: string
+      kvm_emulation:
+        description: 'KVM emulation (true for vpc/shared, false for bare metal)'
+        required: false
+        default: true
+        type: boolean
+      cos_instance_crn:
+        description: 'COS instance CRN for VPC internal registry (auto-created if empty)'
+        required: false
+        default: ''
+        type: string
+      cnv_channel:
+        description: 'CNV OLM subscription channel (e.g. stable, stable-4.17)'
+        required: false
+        default: 'stable'
+        type: string
+    secrets:
+      IC_KEY:
+        required: true
+      OPENSHIFT_PULL_SECRET:
+        required: false
+      ARC_GITHUB_APP_ID:
+        required: false
+      ARC_GITHUB_APP_INSTALL_ID:
+        required: false
+      ARC_GITHUB_APP_PRIVATE_KEY:
+        required: false
+      ARC_GITHUB_PAT:
+        required: false
+      CLUSTER_ADMIN_PASSWORD:
+        required: false
+      SLACK_WEBHOOK_URL:
+        required: false
 
 permissions:
   contents: read
@@ -68,8 +132,48 @@ env:
   CONTROL_PLANE_FLAVOR: bx2-4x16
 
 jobs:
+  # Re-probes cluster existence after any concurrency lock a caller might
+  # hold is acquired (e.g. hot-cluster-check.yml's provision job), so that if
+  # another caller already finished building the same cluster_name while
+  # this one was queued, provision-cluster skips instead of racing into a
+  # duplicate build. Also protects plain workflow_dispatch runs, which have
+  # no concurrency/existence-check of their own today.
+  precheck:
+    name: Check if Cluster Already Exists
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      already_ready: ${{ steps.probe.outputs.already_ready }}
+    steps:
+      - name: Probe for cluster
+        id: probe
+        env:
+          CLUSTER_NAME: ${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}
+          INFRASTRUCTURE_TYPE: ${{ inputs.infrastructure_type || 'ipi' }}
+        run: |
+          # The api.<cluster>.<base_domain> DNS hostname is an IPI-only
+          # construct (see configure-kubeconfig.sh) -- ROKS-based vpc/classic
+          # clusters are accessed via `ibmcloud oc cluster config`/`get`
+          # instead, never that hostname. Their existence check already
+          # happens directly inside provision-cluster's own "Check for
+          # existing ROKS cluster" step, so just pass through here.
+          if [[ "${INFRASTRUCTURE_TYPE}" != "ipi" ]]; then
+            echo "already_ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          API_HOST="api.${CLUSTER_NAME}.${BASE_DOMAIN}"
+          if dig +short "${API_HOST}" 2>/dev/null | grep -q .; then
+            echo "Cluster '${CLUSTER_NAME}' is already reachable (${API_HOST} resolves) — skipping provisioning."
+            echo "already_ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_ready=false" >> "$GITHUB_OUTPUT"
+          fi
+
   provision-cluster:
     name: Provision OpenShift Cluster
+    needs: precheck
+    if: needs.precheck.outputs.already_ready != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:

--- a/ci-scripts/hot-cluster/create-ipi-cluster.sh
+++ b/ci-scripts/hot-cluster/create-ipi-cluster.sh
@@ -12,7 +12,11 @@ for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
 
   if [[ "${attempt}" -gt 1 ]]; then
     echo "Preparing fresh install directory for retry..."
-    rm -rf "${INSTALL_DIR}/manifests" "${INSTALL_DIR}/openshift" "${INSTALL_DIR}/.openshift_install"* "${INSTALL_DIR}/auth" "${INSTALL_DIR}/metadata.json" "${INSTALL_DIR}/install.log" "${INSTALL_DIR}/terraform"*
+    # .clusterapi_output holds the local envtest control-plane datastore --
+    # without wiping it, a failed attempt's Cluster/Machine objects (created
+    # locally before any real cloud infra existed) persist alongside the next
+    # attempt's fresh ones, piling up stale entries across retries.
+    rm -rf "${INSTALL_DIR}/manifests" "${INSTALL_DIR}/openshift" "${INSTALL_DIR}/.openshift_install"* "${INSTALL_DIR}/auth" "${INSTALL_DIR}/metadata.json" "${INSTALL_DIR}/install.log" "${INSTALL_DIR}/terraform"* "${INSTALL_DIR}/.clusterapi_output"
     cp "${INSTALL_DIR}/install-config.yaml.bak" "${INSTALL_DIR}/install-config.yaml"
 
     echo "Regenerating manifests and CCO secrets..."


### PR DESCRIPTION
## 📝 Description

Make hot cluster provisioning visible as a nested job in triggering/queued PRs

## 🔗 Links

Jira ticket: [CNV-92617](https://redhat.atlassian.net/browse/CNV-92617)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable workflow support for IBM Cloud hot-cluster setup (callable via `workflow_call`).
  * Added DNS-based prechecks to skip provisioning when the cluster is already reachable, preventing duplicate runs.
  * Improved orchestration to compute and report final cluster readiness, including explicit failure when readiness isn’t achieved.
* **Bug Fixes**
  * Expanded retry cleanup to remove additional stale local artifacts, reducing retry flakiness.
* **Chores / Security**
  * Tightened workflow permissions to read-only for hot-cluster orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->