### PR TITLE
CNV-92615: DEPLOY workflow merge job fails intermittently due to concurrent Quay tag races

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ on:
 
 concurrency:
   group: deploy-${{ github.ref }}
+  # Cancel superseded runs so :latest tracks HEAD. Safe with platform-only
+  # build tags below — cancelled runs never reach merge, so Quay digest races
+  # from overlapping merges cannot occur.
   cancel-in-progress: true
 
 jobs:
@@ -54,9 +57,10 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          tags: |
-            ${{ env.REGISTRY_IMAGE }}
-            ${{ env.REGISTRY_IMAGE }}:${{ env.VERSION_TAG }}-${{ env.PLATFORM_PAIR }}
+          # Platform tags only — keep digests referenced until merge publishes :latest.
+          # Do not push bare REGISTRY_IMAGE (:latest); concurrent runs would race and
+          # mid-deploy :latest would be a single-arch image until the merge job finishes.
+          tags: ${{ env.REGISTRY_IMAGE }}:${{ env.VERSION_TAG }}-${{ env.PLATFORM_PAIR }}
           push: true
           outputs: type=image,name-canonical=true,push=true
 
@@ -96,17 +100,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
@@ -115,4 +108,4 @@ jobs:
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ env.VERSION_TAG }}


### PR DESCRIPTION
## 📝 Description

DEPLOY workflow merge job fails intermittently due to concurrent Quay tag races

## 🔗 Links

Jira ticket: [CNV-92615](https://redhat.atlassian.net/browse/CNV-92615)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by preventing overlapping releases from causing container image digest conflicts.
  * Ensured platform-specific images are tagged consistently during builds.
  * Updated release verification to inspect the correct versioned image tag.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->