### PR TITLE
CNV-89750: Simplify PR validation workflows and slash-command rechecks

### DIFF
--- a/.github/actions/setup-gh-scripts/action.yml
+++ b/.github/actions/setup-gh-scripts/action.yml
@@ -1,0 +1,29 @@
+name: Setup GitHub Scripts
+description: Checkout PR validation scripts and install npm dependencies
+
+inputs:
+  ref:
+    description: Git ref to checkout scripts from (typically the PR base branch)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout scripts
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.ref }}
+        sparse-checkout: .github/scripts
+        persist-credentials: false
+
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        cache: npm
+        cache-dependency-path: .github/scripts/package-lock.json
+
+    - name: Install script dependencies
+      shell: bash
+      working-directory: .github/scripts
+      run: npm ci

--- a/.github/scripts/src/ai-config-validation/constants.ts
+++ b/.github/scripts/src/ai-config-validation/constants.ts
@@ -13,7 +13,14 @@ export const AI_CONFIG = {
     SKIP: 'skip-ai-config-check',
   },
   PATH_PREFIXES: ['.cursor/', '.claude/', '.codex/', '.windsurf/', '.gemini/', '.vscode/'] as const,
-  RELATED_AUTOMATION_PATHS: ['.github/workflows/pr_validation.yml'] as const,
+  RELATED_AUTOMATION_PATHS: [
+    '.github/workflows/pr_validation.yml',
+    '.github/workflows/pr_validation_commands.yml',
+    '.github/actions/setup-gh-scripts/action.yml',
+  ] as const,
   RELATED_AUTOMATION_PREFIXES: ['.github/scripts/'] as const,
   STATUS_CONTEXT: 'ai-config-validation',
+  EVENT_ACTIONS: {
+    AI_APPROVED: 'ai-approved',
+  },
 } as const;

--- a/.github/scripts/src/ai-config-validation/errors.ts
+++ b/.github/scripts/src/ai-config-validation/errors.ts
@@ -1,0 +1,8 @@
+export class HandledValidationError extends Error {
+  readonly handled = true as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'HandledValidationError';
+  }
+}

--- a/.github/scripts/src/ai-config-validation/execute.ts
+++ b/.github/scripts/src/ai-config-validation/execute.ts
@@ -1,0 +1,67 @@
+import { runAiConfigValidation } from './run-validation';
+import { createOctokit } from '../github-repo';
+import { setCommitStatus } from '../github-comments';
+import { AI_CONFIG } from './constants';
+import { HandledValidationError } from './errors';
+import type { GitHubConfig } from '../types/index';
+import { safeErrorMessage } from '../utils';
+
+export type AiConfigValidationInput = {
+  config: GitHubConfig;
+  eventAction?: string;
+  headSha?: string;
+  prNumber: number;
+};
+
+/** Run AI/editor configuration validation for a pull request. */
+export const executeAiConfigValidation = async (input: AiConfigValidationInput): Promise<void> => {
+  const { config, prNumber, headSha, eventAction } = input;
+  const octokit = createOctokit(config);
+
+  const outcome = await runAiConfigValidation({
+    octokit,
+    config,
+    prNumber,
+    headSha,
+    event: { action: eventAction },
+  });
+
+  if (outcome.kind === 'skipped') {
+    console.log('Skipped: skip-ai-config-check label present.');
+    return;
+  }
+
+  if (outcome.kind === 'failed') {
+    throw new HandledValidationError(
+      'AI configuration validation failed. An OWNERS reviewer can comment /ai-approved after security review to re-run validation.',
+    );
+  }
+
+  console.log('AI configuration validation passed.');
+};
+
+export const reportAiConfigError = async (
+  config: GitHubConfig,
+  headSha: string | undefined,
+  err: unknown,
+): Promise<void> => {
+  console.error('Unexpected error:', safeErrorMessage(err));
+  if (!headSha) {
+    return;
+  }
+
+  try {
+    const octokit = createOctokit(config);
+    await setCommitStatus(
+      octokit,
+      config.owner,
+      config.repo,
+      headSha,
+      'error',
+      'AI configuration validation encountered an unexpected error',
+      AI_CONFIG.STATUS_CONTEXT,
+    );
+  } catch {
+    // best-effort
+  }
+};

--- a/.github/scripts/src/ai-config-validation/index.ts
+++ b/.github/scripts/src/ai-config-validation/index.ts
@@ -1,75 +1,34 @@
-import { runAiConfigValidation } from './run-validation';
-import { createOctokit } from '../github-repo';
-import { setCommitStatus } from '../github-comments';
-import { AI_CONFIG } from './constants';
+import { executeAiConfigValidation, reportAiConfigError } from './execute';
+import { HandledValidationError } from './errors';
+import { requireEnv } from '../utils';
 import type { GitHubConfig } from '../types/index';
-import { requireEnv, safeErrorMessage } from '../utils';
 
-const loadContext = () => ({
-  config: {
+const main = async (): Promise<void> => {
+  const config: GitHubConfig = {
     token: requireEnv('GITHUB_TOKEN'),
     owner: requireEnv('REPO_OWNER'),
     repo: requireEnv('REPO_NAME'),
-  } satisfies GitHubConfig,
-  prNumber: parseInt(requireEnv('PR_NUMBER'), 10),
-  headSha: process.env.PR_HEAD_SHA,
-  event: {
-    action: process.env.GITHUB_EVENT_ACTION,
-  },
-});
+  };
 
-/** Entrypoint: detect AI/editor config changes and gate merge via labels only. */
-const main = async (): Promise<void> => {
-  const { config, prNumber, headSha, event } = loadContext();
-  const octokit = createOctokit(config);
-
-  const outcome = await runAiConfigValidation({
-    octokit,
+  await executeAiConfigValidation({
     config,
-    prNumber,
-    headSha,
-    event,
+    eventAction: process.env.GITHUB_EVENT_ACTION,
+    headSha: process.env.PR_HEAD_SHA,
+    prNumber: parseInt(requireEnv('PR_NUMBER'), 10),
   });
-
-  if (outcome.kind === 'skipped') {
-    console.log('Skipped: skip-ai-config-check label present.');
-    return;
-  }
-
-  if (outcome.kind === 'failed') {
-    console.error(
-      `AI configuration validation failed. Add "${AI_CONFIG.LABELS.REVIEWED}" label after security review.`,
-    );
-    process.exit(1);
-  }
-
-  console.log('AI configuration validation passed.');
 };
 
 main().catch(async (err) => {
-  console.error('Unexpected error:', safeErrorMessage(err));
-  const headSha = process.env.PR_HEAD_SHA;
-  if (!headSha) {
-    process.exit(1);
-  }
-
-  try {
-    const octokit = createOctokit({
-      token: process.env.GITHUB_TOKEN ?? '',
-      owner: process.env.REPO_OWNER ?? '',
-      repo: process.env.REPO_NAME ?? '',
-    });
-    await setCommitStatus(
-      octokit,
-      process.env.REPO_OWNER ?? '',
-      process.env.REPO_NAME ?? '',
-      headSha,
-      'error',
-      'AI configuration validation encountered an unexpected error',
-      AI_CONFIG.STATUS_CONTEXT,
+  if (!(err instanceof HandledValidationError)) {
+    await reportAiConfigError(
+      {
+        token: process.env.GITHUB_TOKEN ?? '',
+        owner: process.env.REPO_OWNER ?? '',
+        repo: process.env.REPO_NAME ?? '',
+      },
+      process.env.PR_HEAD_SHA,
+      err,
     );
-  } catch {
-    // best-effort
   }
   process.exit(1);
 });

--- a/.github/scripts/src/ai-config-validation/utils.ts
+++ b/.github/scripts/src/ai-config-validation/utils.ts
@@ -1,6 +1,6 @@
 export const buildStatusDescription = (passed: boolean, hasSensitiveChanges: boolean): string => {
   if (!passed) {
-    return 'Add ai-config-reviewed label after security review';
+    return 'Comment /ai-approved after security review (OWNERS only)';
   }
   if (!hasSensitiveChanges) {
     return 'No AI configuration changes detected';

--- a/.github/scripts/src/commands/commands.test.ts
+++ b/.github/scripts/src/commands/commands.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { parseCommand } from './parse-command';
+
+describe('validation comment commands', () => {
+  it('detects slash commands in PR comments', () => {
+    assert.equal(parseCommand('please /recheck-jira'), 'recheck-jira');
+    assert.equal(parseCommand('/ai-approved'), 'ai-approved');
+    assert.equal(parseCommand('thanks!'), null);
+  });
+
+  it('prefers /recheck-jira over /ai-approved when both are present', () => {
+    assert.equal(parseCommand('/recheck-jira and /ai-approved'), 'recheck-jira');
+  });
+});

--- a/.github/scripts/src/commands/index.ts
+++ b/.github/scripts/src/commands/index.ts
@@ -1,0 +1,136 @@
+/* eslint-disable no-console */
+import { executeAiConfigValidation, reportAiConfigError } from '../ai-config-validation/execute';
+import { HandledValidationError } from '../ai-config-validation/errors';
+import { AI_CONFIG } from '../ai-config-validation/constants';
+import { addLabel, setCommitStatus } from '../github-comments';
+import { createOctokit } from '../github-repo';
+import { executeJiraValidation } from '../jira-validation/execute';
+import { isListedInOwners } from './owners';
+import { parseCommand } from './parse-command';
+import { requireEnv, safeErrorMessage } from '../utils';
+import type { GitHubConfig } from '../types/index';
+
+const reactToComment = async (
+  octokit: ReturnType<typeof createOctokit>,
+  owner: string,
+  repo: string,
+  commentId: number,
+  content: '+1' | '-1',
+): Promise<void> => {
+  try {
+    await octokit.reactions.createForIssueComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      content,
+    });
+  } catch (err) {
+    console.warn(`Could not react to comment: ${safeErrorMessage(err)}`);
+  }
+};
+
+const approveAiConfig = async (
+  config: GitHubConfig,
+  prNumber: number,
+  baseBranch: string,
+  author: string,
+  commentId: number,
+): Promise<void> => {
+  const octokit = createOctokit(config);
+  const trusted = await isListedInOwners(octokit, config.owner, config.repo, baseBranch, author);
+
+  console.log(
+    `${author} is ${trusted ? '' : 'not '}listed in OWNERS — ${trusted ? 'trusted' : 'untrusted, ignoring /ai-approved'}.`,
+  );
+
+  if (!trusted) {
+    await reactToComment(octokit, config.owner, config.repo, commentId, '-1');
+    throw new Error(`${author} is not authorized to use /ai-approved`);
+  }
+
+  await addLabel(octokit, config.owner, config.repo, prNumber, AI_CONFIG.LABELS.REVIEWED, {
+    color: '0e8a16',
+    description: 'AI/editor configuration security review completed',
+  });
+  await reactToComment(octokit, config.owner, config.repo, commentId, '+1');
+  console.log(`Added ${AI_CONFIG.LABELS.REVIEWED} label to PR #${prNumber}.`);
+};
+
+const isAiApprovedAuthError = (err: unknown): boolean =>
+  err instanceof Error && err.message.includes('not authorized to use /ai-approved');
+
+const main = async (): Promise<void> => {
+  const command = parseCommand(requireEnv('COMMENT_BODY'));
+
+  const config: GitHubConfig = {
+    token: requireEnv('GITHUB_TOKEN'),
+    owner: requireEnv('REPO_OWNER'),
+    repo: requireEnv('REPO_NAME'),
+  };
+
+  const prNumber = parseInt(requireEnv('PR_NUMBER'), 10);
+  const prTitle = requireEnv('PR_TITLE');
+  const baseBranch = requireEnv('BASE_BRANCH');
+  const headSha = process.env.PR_HEAD_SHA;
+  const author = requireEnv('COMMENT_AUTHOR');
+  const commentId = parseInt(requireEnv('COMMENT_ID'), 10);
+
+  if (command === 'ai-approved') {
+    await approveAiConfig(config, prNumber, baseBranch, author, commentId);
+    await executeAiConfigValidation({
+      config,
+      eventAction: AI_CONFIG.EVENT_ACTIONS.AI_APPROVED,
+      headSha,
+      prNumber,
+    });
+    return;
+  }
+
+  if (command === 'recheck-jira') {
+    await executeJiraValidation({
+      baseBranch,
+      config,
+      headSha,
+      prNumber,
+      prTitle,
+    });
+  }
+};
+
+main().catch(async (err) => {
+  console.error(safeErrorMessage(err));
+
+  const command = parseCommand(process.env.COMMENT_BODY ?? '');
+  const config: GitHubConfig = {
+    token: process.env.GITHUB_TOKEN ?? '',
+    owner: process.env.REPO_OWNER ?? '',
+    repo: process.env.REPO_NAME ?? '',
+  };
+  const headSha = process.env.PR_HEAD_SHA;
+
+  if (command === 'recheck-jira' && headSha) {
+    try {
+      const octokit = createOctokit(config);
+      await setCommitStatus(
+        octokit,
+        config.owner,
+        config.repo,
+        headSha,
+        'error',
+        'Jira validation encountered an unexpected error',
+      );
+    } catch {
+      // best-effort
+    }
+  }
+
+  if (
+    command === 'ai-approved' &&
+    !isAiApprovedAuthError(err) &&
+    !(err instanceof HandledValidationError)
+  ) {
+    await reportAiConfigError(config, headSha, err);
+  }
+
+  process.exit(1);
+});

--- a/.github/scripts/src/commands/owners.ts
+++ b/.github/scripts/src/commands/owners.ts
@@ -1,0 +1,22 @@
+import type { Octokit } from '@octokit/rest';
+
+/** Return true when the user is listed in OWNERS approvers or reviewers. */
+export const isListedInOwners = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  ref: string,
+  username: string,
+): Promise<boolean> => {
+  try {
+    const { data } = await octokit.repos.getContent({ owner, path: 'OWNERS', ref, repo });
+    if (!('content' in data) || typeof data.content !== 'string') {
+      return false;
+    }
+
+    const owners = Buffer.from(data.content, 'base64').toString('utf8');
+    return new RegExp(`^\\s*-\\s*${username}\\s*$`, 'm').test(owners);
+  } catch {
+    return false;
+  }
+};

--- a/.github/scripts/src/commands/parse-command.ts
+++ b/.github/scripts/src/commands/parse-command.ts
@@ -1,0 +1,11 @@
+export type ValidationCommand = 'recheck-jira' | 'ai-approved';
+
+export const parseCommand = (commentBody: string): ValidationCommand | null => {
+  if (commentBody.includes('/recheck-jira')) {
+    return 'recheck-jira';
+  }
+  if (commentBody.includes('/ai-approved')) {
+    return 'ai-approved';
+  }
+  return null;
+};

--- a/.github/scripts/src/jira-validation/execute.ts
+++ b/.github/scripts/src/jira-validation/execute.ts
@@ -1,0 +1,176 @@
+/* eslint-disable no-console */
+import { JiraClient } from '../jira-client';
+import { createOctokit, getReleaseBranches } from '../github-repo';
+import { hasLabel, reportValidation, setCommitStatus } from '../github-comments';
+import { extractTicketIds, getExpectedVersionForBranch } from '../version-utils';
+import { validateTicket, formatValidationComment } from './validation-checks';
+import { safeErrorMessage } from '../utils';
+import { JIRA_BASE_URL, SKIP_LABEL } from '../types/index';
+import type { GitHubConfig, JiraIssue, ValidationCheck } from '../types/index';
+
+export type JiraValidationInput = {
+  baseBranch: string;
+  config: GitHubConfig;
+  headSha?: string;
+  prNumber: number;
+  prTitle: string;
+};
+
+const JIRA_STATUS_CONTEXT = 'jira-validation';
+
+/** Validate Jira tickets referenced in a pull request title. */
+export const executeJiraValidation = async (input: JiraValidationInput): Promise<void> => {
+  const { config, prNumber, prTitle, baseBranch, headSha } = input;
+  const octokit = createOctokit(config);
+
+  if (headSha) {
+    await setCommitStatus(
+      octokit,
+      config.owner,
+      config.repo,
+      headSha,
+      'pending',
+      'Jira validation in progress…',
+      JIRA_STATUS_CONTEXT,
+    );
+  }
+
+  const shouldSkip = await hasLabel(octokit, config.owner, config.repo, prNumber, SKIP_LABEL);
+  if (shouldSkip) {
+    console.log(`Label "${SKIP_LABEL}" found, skipping Jira validation.`);
+    await reportValidation(
+      octokit,
+      config.owner,
+      config.repo,
+      prNumber,
+      true,
+      `:white_check_mark: **Jira Validation Skipped** — \`${SKIP_LABEL}\` label is present.`,
+    );
+    if (headSha) {
+      await setCommitStatus(
+        octokit,
+        config.owner,
+        config.repo,
+        headSha,
+        'success',
+        'Jira validation skipped',
+        JIRA_STATUS_CONTEXT,
+      );
+    }
+    return;
+  }
+
+  const ticketIds = extractTicketIds(prTitle);
+  if (ticketIds.length === 0) {
+    const msg =
+      ':x: **Jira Validation Failed**\n\n' +
+      'No `CNV-XXXXX` ticket ID found in the PR title.\n\n' +
+      'PR titles must start with a Jira ticket ID, e.g.:\n' +
+      '- `CNV-12345: Fix the login button`\n' +
+      '- `[release-4.21] CNV-12345: Backport fix`\n\n' +
+      '> Edit your PR title to include a valid Jira ticket ID, then comment `/recheck-jira`.';
+
+    await reportValidation(octokit, config.owner, config.repo, prNumber, false, msg);
+    if (headSha) {
+      await setCommitStatus(
+        octokit,
+        config.owner,
+        config.repo,
+        headSha,
+        'failure',
+        'No CNV ticket ID found in PR title',
+        JIRA_STATUS_CONTEXT,
+      );
+    }
+    throw new Error('No CNV ticket ID found in PR title');
+  }
+
+  const releaseBranches = await getReleaseBranches(octokit, config.owner, config.repo).catch(
+    async (err) => {
+      const message = `Failed to resolve release branches: ${safeErrorMessage(err)}`;
+      if (headSha) {
+        await setCommitStatus(
+          octokit,
+          config.owner,
+          config.repo,
+          headSha,
+          'error',
+          message,
+          JIRA_STATUS_CONTEXT,
+        );
+      }
+      throw new Error(message);
+    },
+  );
+  const expectedVersion = getExpectedVersionForBranch(baseBranch, releaseBranches);
+
+  if (!process.env.JIRA_TOKEN) {
+    const message = 'Jira validation misconfigured: missing JIRA_TOKEN';
+    if (headSha) {
+      await setCommitStatus(
+        octokit,
+        config.owner,
+        config.repo,
+        headSha,
+        'error',
+        message,
+        JIRA_STATUS_CONTEXT,
+      );
+    }
+    throw new Error('Missing required environment variable: JIRA_TOKEN');
+  }
+
+  const jira = new JiraClient({
+    baseUrl: JIRA_BASE_URL,
+    token: process.env.JIRA_TOKEN,
+    projectKey: 'CNV',
+  });
+
+  const allChecks = new Map<string, ValidationCheck[]>();
+  let allPassed = true;
+
+  for (const ticketKey of ticketIds) {
+    let issue: JiraIssue;
+    try {
+      issue = await jira.getIssue(ticketKey);
+    } catch (err) {
+      allChecks.set(ticketKey, [
+        {
+          name: 'Ticket Exists',
+          passed: false,
+          message: `Could not fetch ticket: ${safeErrorMessage(err)}`,
+        },
+      ]);
+      allPassed = false;
+      continue;
+    }
+
+    const checks = await validateTicket(jira, issue, expectedVersion, baseBranch);
+    allChecks.set(ticketKey, checks);
+
+    if (checks.some((c) => !c.passed)) {
+      allPassed = false;
+    }
+  }
+
+  const commentBody = formatValidationComment(ticketIds, allChecks, allPassed);
+  await reportValidation(octokit, config.owner, config.repo, prNumber, allPassed, commentBody);
+
+  if (headSha) {
+    await setCommitStatus(
+      octokit,
+      config.owner,
+      config.repo,
+      headSha,
+      allPassed ? 'success' : 'failure',
+      allPassed ? 'All Jira checks passed' : 'One or more Jira checks failed',
+      JIRA_STATUS_CONTEXT,
+    );
+  }
+
+  if (!allPassed) {
+    throw new Error('Jira validation failed. See PR comment for details.');
+  }
+
+  console.log('Jira validation passed.');
+};

--- a/.github/scripts/src/jira-validation/index.ts
+++ b/.github/scripts/src/jira-validation/index.ts
@@ -1,14 +1,10 @@
 /* eslint-disable no-console */
-import { JiraClient } from '../jira-client';
-import { createOctokit, getReleaseBranches } from '../github-repo';
-import { hasLabel, reportValidation, setCommitStatus } from '../github-comments';
-import { extractTicketIds, getExpectedVersionForBranch } from '../version-utils';
-import { validateTicket, formatValidationComment } from './validation-checks';
+import { createOctokit } from '../github-repo';
+import { setCommitStatus } from '../github-comments';
 import { requireEnv, safeErrorMessage } from '../utils';
-import { JIRA_BASE_URL, SKIP_LABEL } from '../types/index';
-import type { GitHubConfig, JiraIssue, ValidationCheck } from '../types/index';
+import type { GitHubConfig } from '../types/index';
+import { executeJiraValidation } from './execute';
 
-/** Entrypoint: extract ticket IDs from PR title and validate each against Jira. */
 const main = async (): Promise<void> => {
   const ghConfig: GitHubConfig = {
     token: requireEnv('GITHUB_TOKEN'),
@@ -16,127 +12,13 @@ const main = async (): Promise<void> => {
     repo: requireEnv('REPO_NAME'),
   };
 
-  const prNumber = parseInt(requireEnv('PR_NUMBER'), 10);
-  const prTitle = requireEnv('PR_TITLE');
-  const baseBranch = requireEnv('BASE_BRANCH');
-  const headSha = process.env.PR_HEAD_SHA;
-  const octokit = createOctokit(ghConfig);
-
-  if (headSha) {
-    await setCommitStatus(
-      octokit,
-      ghConfig.owner,
-      ghConfig.repo,
-      headSha,
-      'pending',
-      'Jira validation in progress…',
-    );
-  }
-
-  const shouldSkip = await hasLabel(octokit, ghConfig.owner, ghConfig.repo, prNumber, SKIP_LABEL);
-  if (shouldSkip) {
-    console.log(`Label "${SKIP_LABEL}" found, skipping Jira validation.`);
-    await reportValidation(
-      octokit,
-      ghConfig.owner,
-      ghConfig.repo,
-      prNumber,
-      true,
-      `:white_check_mark: **Jira Validation Skipped** — \`${SKIP_LABEL}\` label is present.`,
-    );
-    if (headSha) {
-      await setCommitStatus(
-        octokit,
-        ghConfig.owner,
-        ghConfig.repo,
-        headSha,
-        'success',
-        'Jira validation skipped',
-      );
-    }
-    return;
-  }
-
-  const ticketIds = extractTicketIds(prTitle);
-  if (ticketIds.length === 0) {
-    const msg =
-      ':x: **Jira Validation Failed**\n\n' +
-      'No `CNV-XXXXX` ticket ID found in the PR title.\n\n' +
-      'PR titles must start with a Jira ticket ID, e.g.:\n' +
-      '- `CNV-12345: Fix the login button`\n' +
-      '- `[release-4.21] CNV-12345: Backport fix`\n\n' +
-      '> Edit your PR title to include a valid Jira ticket ID.';
-
-    await reportValidation(octokit, ghConfig.owner, ghConfig.repo, prNumber, false, msg);
-    if (headSha) {
-      await setCommitStatus(
-        octokit,
-        ghConfig.owner,
-        ghConfig.repo,
-        headSha,
-        'failure',
-        'No CNV ticket ID found in PR title',
-      );
-    }
-    process.exit(1);
-  }
-
-  const releaseBranches = await getReleaseBranches(octokit, ghConfig.owner, ghConfig.repo);
-  const expectedVersion = getExpectedVersionForBranch(baseBranch, releaseBranches);
-
-  const jira = new JiraClient({
-    baseUrl: JIRA_BASE_URL,
-    token: requireEnv('JIRA_TOKEN'),
-    projectKey: 'CNV',
+  await executeJiraValidation({
+    baseBranch: requireEnv('BASE_BRANCH'),
+    config: ghConfig,
+    headSha: process.env.PR_HEAD_SHA,
+    prNumber: parseInt(requireEnv('PR_NUMBER'), 10),
+    prTitle: requireEnv('PR_TITLE'),
   });
-
-  const allChecks = new Map<string, ValidationCheck[]>();
-  let allPassed = true;
-
-  for (const ticketKey of ticketIds) {
-    let issue: JiraIssue;
-    try {
-      issue = await jira.getIssue(ticketKey);
-    } catch (err) {
-      allChecks.set(ticketKey, [
-        {
-          name: 'Ticket Exists',
-          passed: false,
-          message: `Could not fetch ticket: ${safeErrorMessage(err)}`,
-        },
-      ]);
-      allPassed = false;
-      continue;
-    }
-
-    const checks = await validateTicket(jira, issue, expectedVersion, baseBranch);
-    allChecks.set(ticketKey, checks);
-
-    if (checks.some((c) => !c.passed)) {
-      allPassed = false;
-    }
-  }
-
-  const commentBody = formatValidationComment(ticketIds, allChecks, allPassed);
-  await reportValidation(octokit, ghConfig.owner, ghConfig.repo, prNumber, allPassed, commentBody);
-
-  if (headSha) {
-    await setCommitStatus(
-      octokit,
-      ghConfig.owner,
-      ghConfig.repo,
-      headSha,
-      allPassed ? 'success' : 'failure',
-      allPassed ? 'All Jira checks passed' : 'One or more Jira checks failed',
-    );
-  }
-
-  if (!allPassed) {
-    console.error('Jira validation failed. See PR comment for details.');
-    process.exit(1);
-  }
-
-  console.log('Jira validation passed.');
 };
 
 main().catch(async (err) => {

--- a/.github/scripts/src/jira-validation/validation-checks.ts
+++ b/.github/scripts/src/jira-validation/validation-checks.ts
@@ -128,7 +128,7 @@ export const formatValidationComment = (
   if (!allPassed) {
     lines.push('---');
     lines.push(
-      '> Fix the issues above in Jira, then push a new commit or re-edit the PR title to re-run validation.',
+      '> Fix the issues above in Jira, then push a new commit or comment `/recheck-jira` on this PR.',
     );
   }
 

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -2,68 +2,57 @@ name: PR Validation
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
-  issue_comment:
-    types: [created]
-
-permissions:
-  pull-requests: write
-  issues: write
-  statuses: write
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
+  jira-validation:
+    name: jira-validation
+    if: github.event.action != 'edited' || github.event.changes.title != null
+    permissions:
+      pull-requests: write
+      issues: write
+      statuses: write
+    runs-on: ubuntu-latest
+    concurrency:
+      group: jira-check-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Setup validation scripts
+        uses: ./.github/actions/setup-gh-scripts
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Run Jira PR validation
+        working-directory: .github/scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: npx tsx src/jira-validation/index.ts
+
   ai-config-validation:
     name: ai-config-validation
-    if: github.event_name == 'pull_request_target'
+    if: github.event.action != 'edited' || github.event.changes.title != null
+    permissions:
+      pull-requests: write
+      issues: write
+      statuses: write
     runs-on: ubuntu-latest
     concurrency:
       group: ai-config-check-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - name: Should run
-        id: trigger
-        run: |
-          should_run=false
-
-          case "${{ github.event.action }}" in
-            opened|synchronize|reopened)
-              should_run=true
-              ;;
-            labeled|unlabeled)
-              case "${{ github.event.label.name }}" in
-                # Sync with .github/scripts/src/ai-config-validation/constants.ts
-                ai-config-changed|do-not-merge/ai-config-review|ai-config-reviewed|skip-ai-config-check)
-                  should_run=true
-                  ;;
-              esac
-              ;;
-          esac
-
-          echo "should-run=$should_run" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout base branch scripts
-        if: steps.trigger.outputs.should-run == 'true'
-        uses: actions/checkout@v7
+      - name: Setup validation scripts
+        uses: ./.github/actions/setup-gh-scripts
         with:
           ref: ${{ github.event.pull_request.base.ref }}
-          sparse-checkout: .github/scripts
-          persist-credentials: false
-
-      - name: Setup Node
-        if: steps.trigger.outputs.should-run == 'true'
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: .github/scripts/package-lock.json
-
-      - name: Install script dependencies
-        if: steps.trigger.outputs.should-run == 'true'
-        working-directory: .github/scripts
-        run: npm ci
 
       - name: Run AI configuration PR validation
-        if: steps.trigger.outputs.should-run == 'true'
         working-directory: .github/scripts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -73,91 +62,3 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
         run: npx tsx src/ai-config-validation/index.ts
-
-  jira-validation:
-    name: jira-validation
-    if: github.event_name == 'pull_request_target' || github.event_name == 'issue_comment'
-    runs-on: ubuntu-latest
-    concurrency:
-      group: jira-check-${{ github.event.pull_request.number || github.event.issue.number }}
-      cancel-in-progress: true
-    steps:
-      - name: Should run
-        id: trigger
-        env:
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          IS_PULL_REQUEST: ${{ github.event.issue.pull_request != null }}
-        run: |
-          should_run=false
-
-          if [ "${{ github.event_name }}" = "issue_comment" ]; then
-            if [ "$IS_PULL_REQUEST" = "true" ] && [[ "$COMMENT_BODY" == *"/recheck-jira"* ]]; then
-              should_run=true
-            fi
-          else
-            case "${{ github.event.action }}" in
-              opened|synchronize|reopened)
-                should_run=true
-                ;;
-              labeled|unlabeled)
-                case "${{ github.event.label.name }}" in
-                  # Sync with .github/scripts/src/types/config.ts
-                  skip-jira-check|do-not-merge/jira-invalid)
-                    should_run=true
-                    ;;
-                esac
-                ;;
-            esac
-          fi
-
-          echo "should-run=$should_run" >> "$GITHUB_OUTPUT"
-
-      - name: Get PR info (comment trigger)
-        if: steps.trigger.outputs.should-run == 'true' && github.event_name == 'issue_comment'
-        id: pr-info
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            });
-            core.setOutput('title', pr.title);
-            core.setOutput('base_ref', pr.base.ref);
-            core.setOutput('head_sha', pr.head.sha);
-
-      - name: Checkout base branch scripts
-        if: steps.trigger.outputs.should-run == 'true'
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.base.ref || steps.pr-info.outputs.base_ref }}
-          sparse-checkout: .github/scripts
-          persist-credentials: false
-
-      - name: Setup Node
-        if: steps.trigger.outputs.should-run == 'true'
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: npm
-          cache-dependency-path: .github/scripts/package-lock.json
-
-      - name: Install script dependencies
-        if: steps.trigger.outputs.should-run == 'true'
-        working-directory: .github/scripts
-        run: npm ci
-
-      - name: Run Jira PR validation
-        if: steps.trigger.outputs.should-run == 'true'
-        working-directory: .github/scripts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          PR_TITLE: ${{ github.event.pull_request.title || steps.pr-info.outputs.title }}
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref || steps.pr-info.outputs.base_ref }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || steps.pr-info.outputs.head_sha }}
-          REPO_OWNER: ${{ github.repository_owner }}
-          REPO_NAME: ${{ github.event.repository.name }}
-        run: npx tsx src/jira-validation/index.ts

--- a/.github/workflows/pr_validation_commands.yml
+++ b/.github/workflows/pr_validation_commands.yml
@@ -1,0 +1,57 @@
+name: PR Validation Commands
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  command:
+    name: pr-validation-command
+    if: >-
+      github.event.issue.pull_request != null &&
+      (contains(github.event.comment.body, '/recheck-jira') ||
+       contains(github.event.comment.body, '/ai-approved'))
+    permissions:
+      pull-requests: write
+      issues: write
+      statuses: write
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-validation-cmd-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Resolve PR context
+        id: pr
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('number', String(pr.number));
+            core.setOutput('title', pr.title);
+            core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('head_sha', pr.head.sha);
+
+      - name: Setup validation scripts
+        uses: ./.github/actions/setup-gh-scripts
+        with:
+          ref: ${{ steps.pr.outputs.base_ref }}
+
+      - name: Run validation command
+        working-directory: .github/scripts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          BASE_BRANCH: ${{ steps.pr.outputs.base_ref }}
+          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: npx tsx src/commands/index.ts


### PR DESCRIPTION
## Summary

- Split PR validation into two workflows: automatic checks on code changes, and slash-command rechecks on demand
- Add a shared `setup-gh-scripts` composite action and route comment commands through `commands/index.ts`
- Eliminate Actions noise from bot labels (`lgtm`, `approved`) and unrelated PR comments

## Architecture

| Workflow | Trigger | Runs |
|----------|---------|------|
| `pr_validation.yml` | `pull_request_target` opened / synchronize / reopened | `jira-validation` + `ai-config-validation` |
| `pr_validation_commands.yml` | PR comment with a slash command | Command handler only |

**Slash commands** (on `pr_validation_commands.yml`):

| Command | Who | Action |
|---------|-----|--------|
| `/recheck-jira` | Anyone | Re-run Jira validation |
| `/ai-approved` | OWNERS only | Add `ai-config-reviewed` label, then re-run AI config validation |

Shared validation logic lives in:

- `.github/scripts/src/jira-validation/execute.ts`
- `.github/scripts/src/ai-config-validation/execute.ts`
- `.github/scripts/src/commands/index.ts`

## Problem

On PRs targeting `main`, `jira-validation` was showing as cancelled/skipped instead of success because:

1. All events shared one concurrency group, so bot label events cancelled real `synchronize` validation runs
2. Irrelevant events (`labeled: lgtm`, bot comments) started workflow runs that skipped all steps without setting commit status

## Solution

- Run automatic validation only when the PR or its commits change
- Handle manual rechecks via explicit slash commands in a separate workflow
- Keep YAML thin; put trigger routing, OWNERS approval, and validation in TypeScript

## Test plan

- [ ] Open or push to a PR with a valid `CNV-XXXXX` title → `jira-validation` runs and reports **success**
- [ ] PR touches AI/editor config paths → `ai-config-validation` fails until reviewed
- [ ] openshift-ci adds `lgtm`/`approved` labels → **no** validation workflow runs
- [ ] Random PR comments ("thanks", "lgtm") → **no** command workflow runs
- [ ] Comment `/recheck-jira` after fixing Jira/title → Jira validation re-runs
- [ ] OWNERS member comments `/ai-approved` → `ai-config-reviewed` label added, AI config validation re-runs, check passes
- [ ] Non-OWNERS comments `/ai-approved` → rejected with 👎 reaction, check unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated PR validation to run on key PR lifecycle events (including edits) with special handling for title changes.
  * Added a **PR Validation Commands** workflow for `/recheck-jira` and `/ai-approved` issue comments.
  * `/ai-approved` now validates only when the commenter is listed in `OWNERS`.
* **Bug Fixes**
  * Improved Jira rerun guidance to direct users to push a new commit or post `/recheck-jira`.
  * Updated failed-case messaging for OWNERS-only AI approval.
* **Chores**
  * Streamlined validation runs via shared setup and simpler script entrypoints.
  * Added coverage for command parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->