### PR TITLE
CNV-92537: add cluster page objects

### DIFF
--- a/playwright/src/page-objects/cluster/checkups-page.ts
+++ b/playwright/src/page-objects/cluster/checkups-page.ts
@@ -1,0 +1,470 @@
+/**
+ * Page object for the Checkups page.
+ */
+
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+import PageCommons from '../page-commons';
+
+export default class CheckupsPage extends PageCommons {
+  private readonly _inputconfirmNonProductionCheckbox = this.locator(
+    'input#confirm-non-production-checkbox',
+  );
+  private readonly _installPermissionsBtn = this.locator('button:has-text("Install permissions")');
+  private readonly _roleDialogH1HasTextHeavyLoadCheckups = this.locator(
+    '[role="dialog"] h1:has-text("Heavy load checkups")',
+  );
+  private readonly _runButton = this.locator('button:has-text("Run")');
+  private readonly _runCheckupButton = this.locator('#checkups-run-button');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  override async clickCancelInModal(): Promise<void> {
+    const cancelBtn = this.locator('[role="dialog"] footer button:has-text("Cancel")');
+    await cancelBtn.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await this.robustClick(cancelBtn);
+  }
+
+  async clickCheckup(checkupName: string) {
+    const checkupLink = this.locator(`a:has-text("${checkupName}")`).first();
+    await checkupLink.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(checkupLink);
+  }
+
+  async clickCheckupActions() {
+    const actionsButton = this.locator('#content-scrollable button:has-text("Actions")');
+    await actionsButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(actionsButton);
+  }
+
+  async clickConfirmationCheckbox(): Promise<void> {
+    await this.robustClick(this._inputconfirmNonProductionCheckbox);
+  }
+
+  override async clickDeleteButton() {
+    const deleteButton = this.locator('button:has-text("Delete")');
+    await deleteButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(deleteButton);
+  }
+
+  async clickFooterDelete() {
+    const footerDeleteButton = this.locator('footer').locator('button:has-text("Delete")');
+    await footerDeleteButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(footerDeleteButton);
+  }
+
+  /**
+   * Clicks the "Install permissions" button shown when no checkups are found.
+   * This is required before running storage checkups for the first time.
+   */
+  async clickInstallPermissions() {
+    const installPermissionsButton = this._installPermissionsBtn;
+    await installPermissionsButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(installPermissionsButton);
+  }
+
+  async clickNetworkLatencyCheckup() {
+    const networkLatencyCheckupButton = this.locator('button:has-text("Network latency checkup")');
+    await networkLatencyCheckupButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.DEFAULT,
+    });
+    await this.robustClick(networkLatencyCheckupButton);
+  }
+
+  async clickNetworkLatencyTab() {
+    const networkLatencyTab = this.locator('[data-test-id="horizontal-link-Network latency"]');
+    await networkLatencyTab.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(networkLatencyTab);
+  }
+
+  async clickNodesCheckbox() {
+    const nodesCheckbox = this.locator('input#nodes');
+    await nodesCheckbox.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(nodesCheckbox);
+  }
+
+  async clickRun() {
+    await this._runButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(this._runButton);
+    await this.page.waitForLoadState('networkidle', { timeout: TestTimeouts.DEFAULT });
+  }
+
+  async clickRunAndConfirm() {
+    await this._runButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(this._runButton);
+    await this._inputconfirmNonProductionCheckbox.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.DEFAULT,
+    });
+    await this.robustClick(this._inputconfirmNonProductionCheckbox);
+    await this.clickButtonByText('Run checkup');
+  }
+
+  async clickRunCheckup() {
+    await this._runCheckupButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._runCheckupButton);
+  }
+
+  async clickSelectSourceNode() {
+    const selectSourceNodeButton = this.locator('[placeholder="Select source node"]');
+    await selectSourceNodeButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(selectSourceNodeButton);
+  }
+
+  async clickSelectTargetNode() {
+    const selectTargetNodeButton = this.locator('[placeholder="Select target node"]');
+    await selectTargetNodeButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(selectTargetNodeButton);
+  }
+
+  async clickSelfValidationTab() {
+    const selfValidationTabButton = this.locator(
+      '[data-test-id="horizontal-link-Self validation"]',
+    );
+    await selfValidationTabButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.DEFAULT,
+    });
+    await this.robustClick(selfValidationTabButton);
+  }
+
+  async clickStorageCheckup() {
+    const storageCheckupButton = this.locator('button:has-text("Storage checkup")');
+    await storageCheckupButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(storageCheckupButton);
+  }
+
+  async clickStorageCheckupOption() {
+    const storageCheckupOption = this.locator(
+      'button[role="menuitem"]:has-text("Storage")',
+    ).first();
+    await storageCheckupOption.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(storageCheckupOption);
+  }
+
+  async clickStorageTab() {
+    const storageTabButton = this.locator('button:has-text("Storage")');
+    await storageTabButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(storageTabButton);
+  }
+
+  async enableDryRun() {
+    await this.clickButtonByText('Advanced settings');
+    await this.robustClick(this.locator('input#dry-run'));
+  }
+
+  async getCheckupStatus(): Promise<string> {
+    const statusIcon = this.locator('.CheckupsNetworkStatusIcon--main');
+    await statusIcon.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    const statusText = await statusIcon.textContent();
+    return statusText || '';
+  }
+
+  /**
+   * Installs permissions if the "Install permissions" button is visible, otherwise does nothing.
+   * After clicking, waits for the install to complete and the view to update (e.g. Run checkup to appear).
+   * Wraps the click in a try/catch to handle the race condition where the button briefly appears
+   * during React's async loading phase but disappears once the actual permissions state is resolved.
+   */
+  async installPermissionsIfNeeded() {
+    const isVisible = await this.isInstallPermissionsVisible();
+    if (isVisible) {
+      try {
+        await this.clickInstallPermissions();
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      } catch {
+        // Button may have disappeared if permissions were already installed and the UI
+        // stabilized between the visibility check and the click attempt.
+      }
+    }
+  }
+
+  async isConfirmationModalHidden(): Promise<boolean> {
+    try {
+      const modalTitle = this._roleDialogH1HasTextHeavyLoadCheckups;
+      await modalTitle.waitFor({ state: 'hidden', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isConfirmationModalVisible(): Promise<boolean> {
+    try {
+      const modalTitle = this._roleDialogH1HasTextHeavyLoadCheckups;
+      await modalTitle.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return await modalTitle.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Checks if the "Install permissions" button is visible (indicating permissions are not installed).
+   */
+  async isInstallPermissionsVisible(): Promise<boolean> {
+    try {
+      const installPermissionsButton = this._installPermissionsBtn;
+      await installPermissionsButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.ELEMENT_WAIT,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** True when Run checkup is visible and enabled (UI may show it disabled until prerequisites are met). */
+  async isRunCheckupButtonClickable(): Promise<boolean> {
+    try {
+      await this._runCheckupButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.ELEMENT_WAIT,
+      });
+      return await this._runCheckupButton.isEnabled();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Returns true if the Run checkup button is visible (Storage/checkup view is ready for that cluster).
+   */
+  async isRunCheckupButtonVisible(): Promise<boolean> {
+    try {
+      await this._runCheckupButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.ELEMENT_WAIT,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isRunCheckupModalButtonDisabled(): Promise<boolean> {
+    try {
+      const runBtn = this.locator('[role="dialog"] footer button:has-text("Run checkup")');
+      await runBtn.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return await runBtn.isDisabled();
+    } catch {
+      return false;
+    }
+  }
+
+  async navigateToAllNamespacesNetworkCheckups() {
+    await this.goTo('/k8s/all-namespaces/checkups/network');
+  }
+
+  async navigateToAllNamespacesSelfValidationCheckups() {
+    await this.goTo('/k8s/all-namespaces/checkups/self-validation');
+  }
+
+  async navigateToAllNamespacesStorageCheckups() {
+    await this.goTo('/k8s/all-namespaces/checkups/storage');
+  }
+
+  /**
+   * Navigates to the Checkups page by clicking the sidebar nav item [data-test-id="checkups-nav-item"].
+   * Expands the Virtualization nav section first so the item is visible in Fleet context.
+   */
+  async navigateToCheckupsViaCheckupsNavItem(): Promise<void> {
+    const checkupsNavItem = this.locator('[data-test-id="checkups-nav-item"]');
+    await checkupsNavItem.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(checkupsNavItem);
+    await this.page.waitForLoadState('load', {
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+  }
+
+  /**
+   * Navigates to the Checkups page via sidebar UI click (uses [data-test-id="virtualization-checkups-nav-item"] from PageCommons).
+   */
+  async navigateToCheckupsViaUI(): Promise<void> {
+    await this.expandVirtualizationNavSection();
+    await this.clickNavCheckups();
+  }
+
+  async navigateToProjectNetworkCheckups(projectName: string) {
+    await this.goTo(`/k8s/ns/${projectName}/checkups/network`);
+  }
+
+  /**
+   * Navigates to Network latency checkups for a specific namespace via UI.
+   * Uses sidebar navigation, namespace switching, and tab clicking.
+   * @param namespace - The namespace to switch to
+   */
+  async navigateToProjectNetworkCheckupsViaUI(namespace: string): Promise<void> {
+    await this.switchToNamespace(namespace);
+    // Direct route is stable across console versions; horizontal tab data-test-id labels vary.
+    await this.navigateToProjectNetworkCheckups(namespace);
+  }
+
+  async navigateToProjectSelfValidationCheckups(projectName: string) {
+    await this.goTo(`/k8s/ns/${projectName}/checkups/self-validation`);
+  }
+
+  async navigateToProjectStorageCheckups(projectName: string) {
+    await this.goTo(`/k8s/ns/${projectName}/checkups/storage`);
+  }
+
+  /**
+   * Navigates to Storage checkups for a specific namespace via UI.
+   * Uses sidebar navigation, namespace switching, and tab clicking.
+   * @param namespace - The namespace to switch to
+   */
+  async navigateToProjectStorageCheckupsViaUI(namespace: string): Promise<void> {
+    await this.switchToNamespace(namespace);
+    await this.clickStorageTab();
+  }
+
+  async selectFirstNodeFromDropdown() {
+    const firstNodeOption = this.locator('[role="listbox"] li button').first();
+    await firstNodeOption.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(firstNodeOption);
+  }
+
+  async selectNad(nadName: string) {
+    const selectNadDropdown = this.locator('[placeholder="Select NetworkAttachmentDefinition"]');
+    await selectNadDropdown.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(selectNadDropdown);
+    const nadOption = this.locator(`[role="listbox"] li button:has-text("${nadName}")`);
+    await nadOption.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(nadOption);
+  }
+
+  async selectNodeFromDropdown(nodeName: string) {
+    const nodeOption = this.locator(`[role="listbox"] li button:has-text("${nodeName}")`);
+    await nodeOption.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(nodeOption);
+  }
+
+  async setCheckupName(name: string) {
+    const nameInput = this.locator('input#name');
+    await nameInput.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await nameInput.clear();
+    await nameInput.fill(name);
+  }
+
+  async setTimeout(timeout: string) {
+    const timeoutInput = this.locator('input#timeout');
+    await timeoutInput.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await timeoutInput.clear();
+    await timeoutInput.fill(timeout);
+  }
+
+  /**
+   * Switches to the given namespace in preparation for self-validation checkups.
+   * Does not navigate to the self-validation tab — callers must handle tab selection separately.
+   * @param namespace - The namespace to switch to
+   */
+  async switchNamespaceForSelfValidationCheckups(namespace: string): Promise<void> {
+    await this.switchToNamespace(namespace);
+  }
+
+  async verifyCheckupDeleted(checkupName: string): Promise<boolean> {
+    try {
+      const checkupRow = this.locator(`tr:has-text("${checkupName}")`);
+      await checkupRow.waitFor({ state: 'hidden', timeout: TestTimeouts.ELEMENT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCheckupNotRunning(checkupName: string): Promise<boolean> {
+    try {
+      const checkupRow = this.locator(`tr:has-text("${checkupName}")`);
+      await checkupRow.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      const runningStatus = checkupRow.locator('text=Running');
+
+      return !(await runningStatus
+        .isVisible({ timeout: TestTimeouts.VM_BOOTUP })
+        .catch(() => false));
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Verifies that a checkup row exists containing the name and is in an active/completed state.
+   * Accepts Running, Succeeded, or Failed — the checkup may complete before we poll.
+   */
+  async verifyCheckupRunning(checkupName: string): Promise<boolean> {
+    try {
+      const tableSelector = this.locator(
+        '[data-test-rows="resource-row"], table, [role="grid"]',
+      ).first();
+      await tableSelector.waitFor({ state: 'visible', timeout: TestTimeouts.VM_BOOTUP });
+
+      const checkupRow = this.locator(
+        `tr:has-text("${checkupName}"), [role="row"]:has-text("${checkupName}")`,
+      ).first();
+      await checkupRow.waitFor({ state: 'visible', timeout: TestTimeouts.VM_BOOTUP });
+
+      const hasActiveState = checkupRow.filter({
+        hasText: /Running|Succeeded|Failed|Completed/,
+      });
+      await hasActiveState.waitFor({ state: 'visible', timeout: TestTimeouts.VM_BOOTUP });
+      return await hasActiveState.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyLinkExists(linkText: string): Promise<boolean> {
+    try {
+      const link = this.locator(`a:has-text("${linkText}")`);
+      await link.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return await link.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyNodeDropdownVisible(): Promise<boolean> {
+    try {
+      const nodeDropdown = this.locator('#select-inline-filter');
+      await nodeDropdown.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return await nodeDropdown.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  override async verifySubtitle(subtitle: string): Promise<boolean> {
+    const timeout = TestTimeouts.DEFAULT;
+    const selectors = [
+      `h2:has-text("${subtitle}")`,
+      `h1:has-text("${subtitle}")`,
+      `[role="heading"]:has-text("${subtitle}")`,
+    ];
+    for (const selector of selectors) {
+      try {
+        const locator = this.locator(selector).first();
+        await locator.waitFor({ state: 'visible', timeout });
+        if (await locator.isVisible()) {
+          return true;
+        }
+      } catch {
+        // try next selector
+      }
+    }
+    return false;
+  }
+}

--- a/playwright/src/page-objects/cluster/console-standalone-page.ts
+++ b/playwright/src/page-objects/cluster/console-standalone-page.ts
@@ -1,0 +1,119 @@
+/**
+ * Page object for the standalone VNC console page.
+ * Handles VNC console navigation, connection, and session management.
+ */
+
+import { EnvVariables } from '@/utils/env-variables';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+import BasePage from '../base-page';
+
+export default class ConsoleStandalonePage extends BasePage {
+  private readonly _dialog = this.locator('[role="dialog"]');
+  private readonly _vncCanvas = this.locator('.console-container canvas');
+  private readonly _vncNoConnectionPlaceholder = this.locator('.vnc-no-connection-placeholder');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async clickConnectButton(): Promise<void> {
+    const connectButton = this.locator('button.pf-m-primary:has-text("Connect")');
+    await connectButton.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(connectButton);
+  }
+
+  async clickDisconnectButton(): Promise<void> {
+    const disconnectButton = this.locator('button.vnc-actions-disconnect-button');
+    await disconnectButton.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(disconnectButton);
+  }
+
+  async clickDisconnectUserAndConnectButton(): Promise<void> {
+    const disconnectUserAndConnectButton = this.locator(
+      'button:has-text("Disconnect user and connect")',
+    );
+    await disconnectUserAndConnectButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.ELEMENT_WAIT,
+    });
+    await this.robustClick(disconnectUserAndConnectButton);
+  }
+
+  async clickTryLaterButton(): Promise<void> {
+    const tryLaterButton = this.locator('button:has-text("Try later")');
+    await tryLaterButton.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(tryLaterButton);
+  }
+
+  async dialogContainsText(
+    text: string,
+    timeout: number = TestTimeouts.ELEMENT_WAIT,
+  ): Promise<boolean> {
+    try {
+      await this._dialog.waitFor({ state: 'visible', timeout });
+      const dialogText = await this._dialog.textContent();
+      return dialogText?.includes(text) ?? false;
+    } catch {
+      return false;
+    }
+  }
+
+  async isDialogVisible(timeout: number = TestTimeouts.ELEMENT_WAIT): Promise<boolean> {
+    try {
+      await this._dialog.waitFor({ state: 'visible', timeout });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isStandaloneConsolePageLoaded(
+    stabilizationMs = TestTimeouts.UI_VISIBILITY_QUICK,
+  ): Promise<boolean> {
+    try {
+      await this.page.waitForTimeout(stabilizationMs);
+      const url = this.page.url();
+      if (!url.includes('/console/standalone')) return false;
+
+      const detailTabsVisible = await this.locator('[data-test-id="horizontal-link-Overview"]')
+        .isVisible()
+        .catch(() => false);
+
+      return !detailTabsVisible;
+    } catch {
+      return false;
+    }
+  }
+
+  async isVncConsoleActive(): Promise<boolean> {
+    const canvasVisible = await this._vncCanvas.isVisible().catch(() => false);
+    const placeholderVisible = await this._vncNoConnectionPlaceholder
+      .isVisible()
+      .catch(() => false);
+    return canvasVisible && !placeholderVisible;
+  }
+
+  async navigateToStandaloneConsole(vmName: string, namespace: string): Promise<void> {
+    const baseUrl = EnvVariables.webConsoleUrl.replace(/\/$/, '');
+    const url = `${baseUrl}/k8s/ns/${namespace}/kubevirt.io~v1~VirtualMachine/${vmName}/console/standalone`;
+    await this.page.goto(url);
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  async waitForVncConsoleActive(
+    timeout: number = TestTimeouts.VNC_CONSOLE_READY,
+  ): Promise<boolean> {
+    try {
+      await this._vncCanvas.waitFor({ state: 'visible', timeout });
+      await this._vncNoConnectionPlaceholder.waitFor({
+        state: 'hidden',
+        timeout: TestTimeouts.UI_DELAY_LONG,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/playwright/src/page-objects/cluster/data-volume-detail-page.ts
+++ b/playwright/src/page-objects/cluster/data-volume-detail-page.ts
@@ -1,0 +1,126 @@
+/**
+ * Page object for the DataVolume detail page.
+ * Handles DataVolume status verification and deletion.
+ */
+
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+import BasePage from '../base-page';
+
+export default class DataVolumeDetailPage extends BasePage {
+  private readonly _deleteBtn = this.locator('button:has-text("Delete")');
+  private readonly _resourceTitle = this.locator('[data-test-id="resource-title"]');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async deleteDataVolume(volumeName: string, deletePvc = false): Promise<boolean> {
+    try {
+      const actionsButton = this.locator('button:has-text("Actions")');
+      const deleteButton = this._deleteBtn;
+      const pvcCheckbox = this.locator('input[id="pvc-checkbox"]');
+      const confirmDeleteButton = this._deleteBtn;
+
+      await actionsButton.waitFor({ state: 'visible', timeout: 10000 });
+      await this.robustClick(actionsButton);
+
+      await deleteButton.waitFor({ state: 'visible', timeout: 5000 });
+      await this.robustClick(deleteButton);
+
+      await this.locator('text=Delete DataVolume?').waitFor({ state: 'visible', timeout: 5000 });
+
+      const volumeNameInModal = this.locator(`strong:has-text("${volumeName}")`);
+      const volumeNameExists = await volumeNameInModal
+        .isVisible({ timeout: 5000 })
+        .catch(() => false);
+      if (!volumeNameExists) {
+        return false;
+      }
+
+      if (deletePvc) {
+        const pvcCheckboxExists = await pvcCheckbox
+          .isVisible({ timeout: 60000 })
+          .catch(() => false);
+        if (pvcCheckboxExists) {
+          await pvcCheckbox.check({ force: true });
+        }
+      }
+
+      await confirmDeleteButton.waitFor({ state: 'visible', timeout: 5000 });
+      await this.robustClick(confirmDeleteButton);
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getResourceTitle(): Promise<string> {
+    await this._resourceTitle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    return await this._resourceTitle.innerText();
+  }
+
+  async getStatusText(): Promise<string> {
+    const statusText = this.locator('[data-test="status-text"]');
+    await statusText.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    return await statusText.innerText();
+  }
+
+  async isResourceTitleEqualTo(
+    expectedName: string,
+    timeout: number = TestTimeouts.UI_ELEMENT_VISIBILITY,
+  ): Promise<boolean> {
+    try {
+      const startTime = Date.now();
+      const pollInterval = 500;
+
+      while (Date.now() - startTime < timeout) {
+        try {
+          await this._resourceTitle.waitFor({ state: 'visible', timeout: pollInterval });
+
+          const actualTitle = await this._resourceTitle.innerText();
+          if (actualTitle?.trim() === expectedName.trim()) {
+            return true;
+          }
+        } catch (error) {}
+
+        await this.page.waitForTimeout(pollInterval);
+      }
+
+      return false;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  async isStatusEqualTo(
+    expectedStatus: string,
+    timeout: number = TestTimeouts.DATA_VOLUME_STATUS,
+  ): Promise<boolean> {
+    try {
+      await this.page.waitForFunction(
+        ({ selector, expected }) => {
+          const element = document.querySelector(selector);
+          return element?.textContent?.trim() === expected;
+        },
+        { selector: '[data-test="status-text"]', expected: expectedStatus.trim() },
+        { timeout },
+      );
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  async navigateToDataVolumeDetail(volumeName: string, namespace: string): Promise<void> {
+    await this.goTo(`/k8s/ns/${namespace}/cdi.kubevirt.io~v1beta1~DataVolume/${volumeName}`);
+  }
+}

--- a/playwright/src/page-objects/cluster/data-volumes-page.ts
+++ b/playwright/src/page-objects/cluster/data-volumes-page.ts
@@ -1,0 +1,48 @@
+/**
+ * Page object for the DataVolumes list page.
+ * Handles DataVolume creation, navigation, and verification.
+ */
+
+import type { Page } from '@playwright/test';
+
+import BasePage from '../base-page';
+
+export default class DataVolumesPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  override async clickCreateAndSelectOption(option: 'With form' | 'With YAML'): Promise<void> {
+    const optionSelectors = {
+      'With form': 'button[role="menuitem"]:has-text("With form")',
+      'With YAML': 'button[role="menuitem"]:has-text("With YAML")',
+    };
+    await super.clickCreateAndSelectOption('[data-test="item-create"]', optionSelectors[option]);
+  }
+
+  async navigateToAllNamespacesDataVolumes(): Promise<void> {
+    await this.goTo('/k8s/all-namespaces/cdi.kubevirt.io~v1beta1~DataVolume');
+  }
+
+  async navigateToProjectDataVolumes(projectName: string): Promise<void> {
+    await this.goTo(`/k8s/ns/${projectName}/cdi.kubevirt.io~v1beta1~DataVolume`);
+  }
+
+  async verifyDataVolumeDoesNotExist(volumeName: string, timeout = 60000): Promise<boolean> {
+    try {
+      const volumeRow = this.locator(`tr:has-text("${volumeName}")`);
+      const volumeExists = await volumeRow.isVisible({ timeout }).catch(() => false);
+      return !volumeExists;
+    } catch {
+      return true; // If we can't find it, that's what we want
+    }
+  }
+
+  override async verifyPageLoaded(
+    indicatorSelectors: string[] = [],
+    includeCreateButton = true,
+    timeout = 10000,
+  ): Promise<boolean> {
+    return await super.verifyPageLoaded(indicatorSelectors, includeCreateButton, timeout);
+  }
+}

--- a/playwright/src/page-objects/cluster/index.ts
+++ b/playwright/src/page-objects/cluster/index.ts
@@ -1,0 +1,9 @@
+export { default as CheckupsPage } from './checkups-page';
+export { default as ConsoleStandalonePage } from './console-standalone-page';
+export { default as DataVolumeDetailPage } from './data-volume-detail-page';
+export { default as DataVolumesPage } from './data-volumes-page';
+export { default as LoginPage } from './login-page';
+export { default as MigrationPoliciesPage } from './migration-policies-page';
+export { default as QuotasPage } from './quotas-page';
+export { default as VirtualizationOverviewPage } from './virtualization-overview-page';
+export { default as WorkloadsSecretsPage } from './workloads-secrets-page';

--- a/playwright/src/page-objects/cluster/login-page.ts
+++ b/playwright/src/page-objects/cluster/login-page.ts
@@ -1,90 +1,206 @@
+/**
+ * Page object for the OpenShift console login page.
+ */
+
 import type { Page } from '@playwright/test';
 
-const SECOND = 1000;
+import BasePage from '../base-page';
 
-/**
- * Page object for the OpenShift OAuth login page.
- * Handles IDP selection, form filling, and login submission.
- */
-export default class LoginPage {
-  constructor(private readonly page: Page) {}
+export default class LoginPage extends BasePage {
+  // Cluster login pages use either <button title="Log in with X"> or <a href="...idp=X"> (link style)
+  private readonly _kubeAdminButton = this.locator(
+    '[title="Log in with kube:admin"], a[href*="idp=kube%3Aadmin"]',
+  );
+  // Any non-admin IDP entry — button style (title attr) or link style (idp= param, excluding kube:admin)
+  private readonly _nonAdminIdpEntry = this.locator(
+    '[title^="Log in with"]:not([title*="admin"]), a[href*="idp="]:not([href*="kube%3Aadmin"])',
+  );
 
-  async clickKubeAdminLogin(): Promise<void> {
-    const btn = this.page.locator('[title="Log in with kube:admin"], a[href*="idp=kube%3Aadmin"]');
-    await btn.click();
+  private readonly _userDropdownToggle = this.locator('[data-test="user-dropdown-toggle"]');
+  constructor(page: Page) {
+    super(page);
   }
 
-  async clickTestLogin(idpName = 'test-users'): Promise<void> {
-    const btn = this.page.locator(`a:has-text("${idpName}")`);
-    await btn.click();
+  /**
+   * Returns a locator targeting a specific IDP entry by name (e.g. "test-users").
+   * Matches both button style (`title="Log in with test-users"`) and link style
+   * (text content or `idp=test-users` href param).
+   */
+  private _idpEntryByName(name: string): ReturnType<typeof this.locator> {
+    const encoded = encodeURIComponent(name);
+    return this.locator(`[title="Log in with ${name}"], a[href*="idp=${encoded}"]`);
   }
 
-  async fillAndSubmitLoginForm(username: string, password: string): Promise<void> {
-    await this.page.locator('#inputUsername').fill(username);
-    await this.page.locator('#inputPassword').fill(password);
+  async clickKubeAdminLogin() {
+    await this._kubeAdminButton.click();
+  }
 
-    const coLoginBtn = this.page.locator('#co-login-button');
-    const submitBtn = this.page.locator('button[type="submit"]');
-    const useCoLogin = await coLoginBtn.isVisible({ timeout: 5000 }).catch(() => false);
+  async clickTestLogin(idpName?: string) {
+    const entry = idpName ? this._idpEntryByName(idpName) : this._nonAdminIdpEntry.first();
+    await entry.click();
+  }
 
-    if (useCoLogin) {
+  async fillAndSubmitLoginForm(username: string, password: string) {
+    await this.locator('[id="inputUsername"]').fill(username);
+    await this.locator('[id="inputPassword"]').fill(password);
+    // Some clusters show a dedicated login button (#co-login-button), others use a plain submit button
+    const coLoginBtn = this.locator('[id="co-login-button"]');
+    const submitBtn = this.locator('button[type="submit"]');
+    const useCoLoginBtn = await coLoginBtn.isVisible({ timeout: 5000 }).catch(() => false);
+    if (useCoLoginBtn) {
       await coLoginBtn.click();
     } else {
       await submitBtn.click();
     }
   }
 
-  async isKubeAdminButtonVisible(opts?: { timeout?: number }): Promise<boolean> {
-    const timeout = opts?.timeout ?? 10 * SECOND;
-    const btn = this.page.locator('[title="Log in with kube:admin"], a[href*="idp=kube%3Aadmin"]');
-    return btn
-      .waitFor({ state: 'visible', timeout })
-      .then(() => true)
-      .catch(() => false);
+  /**
+   * Returns the display name of the first non-admin IDP entry (button title or link text).
+   * E.g. "test" on clusters with htpasswd IDP, "test@redhat.com" on others.
+   * Falls back to "test" if the entry is not found.
+   */
+  async getNonPrivIdpUsername(options?: { timeout?: number }): Promise<string> {
+    try {
+      await this._nonAdminIdpEntry
+        .first()
+        .waitFor({ state: 'visible', timeout: options?.timeout ?? 5000 });
+      const entry = this._nonAdminIdpEntry.first();
+      // Link style: extract text content (e.g. "test@redhat.com")
+      // Button style: read the title attribute and strip "Log in with " prefix
+      const title = await entry.getAttribute('title');
+      if (title) {
+        return title.replace(/^Log in with\s*/i, '').trim();
+      }
+      const text = (await entry.textContent())?.trim();
+      return text || 'test';
+    } catch {
+      return 'test';
+    }
   }
 
-  async isTestButtonVisible(opts?: { timeout?: number; idpName?: string }): Promise<boolean> {
-    const timeout = opts?.timeout ?? 10 * SECOND;
-    const idpName = opts?.idpName ?? 'test-users';
-    const btn = this.page.locator(`a:has-text("${idpName}")`);
-    return btn
-      .waitFor({ state: 'visible', timeout })
-      .then(() => true)
-      .catch(() => false);
+  async isKubeAdminButtonVisible(options?: { timeout?: number }): Promise<boolean> {
+    try {
+      await this._kubeAdminButton.waitFor({ state: 'visible', timeout: options?.timeout ?? 5000 });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
-  async navigateToLogin(baseUrl: string): Promise<void> {
-    await this.page.goto(`${baseUrl}/auth/login`, {
-      timeout: 60 * SECOND,
-      waitUntil: 'load',
+  async isTestButtonVisible(options?: { timeout?: number; idpName?: string }): Promise<boolean> {
+    try {
+      const entry = options?.idpName
+        ? this._idpEntryByName(options.idpName)
+        : this._nonAdminIdpEntry.first();
+      await entry.waitFor({ state: 'visible', timeout: options?.timeout ?? 5000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async navigateToLogin(baseUrl?: string) {
+    const isLocalhost = baseUrl
+      ? /localhost|127\.0\.0\.1/.test(baseUrl)
+      : this.page.url().includes('localhost') || this.page.url().includes('127.0.0.1');
+
+    if (isLocalhost) {
+      await this.goTo('/');
+    } else {
+      await this.goTo('/auth/login');
+    }
+  }
+
+  async performLogout() {
+    const loggedUser = this.locator(
+      '[data-test="user-dropdown"], [data-test="username"], [data-test="user-dropdown-toggle"]',
+    ).first();
+    const logoutBtn = this.locator('[data-test="log-out"]');
+    await loggedUser.waitFor({ state: 'visible', timeout: 30000 });
+    await loggedUser.scrollIntoViewIfNeeded();
+    // PF6 page drawer may overlap the header; use dispatchEvent as fallback
+    try {
+      await loggedUser.click({ timeout: 5000 });
+    } catch {
+      await loggedUser.dispatchEvent('click');
+    }
+    await logoutBtn.waitFor({ state: 'visible', timeout: 10000 });
+    await logoutBtn.click();
+  }
+
+  /**
+   * Impersonate a user via the OpenShift console user menu.
+   * Opens the user menu → clicks "Impersonate User" → fills the username → submits.
+   * The browser session will reflect the impersonated user's permissions until
+   * {@link stopImpersonating} is called. No OAuth session switching is required.
+   */
+  async startImpersonating(username: string): Promise<void> {
+    const toggle = this._userDropdownToggle;
+    await toggle.waitFor({ state: 'visible', timeout: 15000 });
+    await toggle.click();
+    const impersonateItem = this.page.getByRole('menuitem', { name: 'Impersonate User' });
+    await impersonateItem.waitFor({ state: 'visible', timeout: 10000 });
+    await impersonateItem.click();
+    const usernameInput = this.locator('[data-test="username-input"]');
+    await usernameInput.waitFor({ state: 'visible', timeout: 10000 });
+    await usernameInput.fill(username);
+    const impersonateBtn = this.locator('[data-test="impersonate-button"]');
+    await impersonateBtn.waitFor({ state: 'visible', timeout: 5000 });
+    await impersonateBtn.click();
+    // Wait for the impersonation banner to confirm the switch
+    await this.page
+      .locator('button:has-text("Stop impersonating")')
+      .waitFor({ state: 'visible', timeout: 15000 });
+  }
+
+  /**
+   * Stop impersonating and return to the original kubeadmin session.
+   * Clicks the "Stop impersonating" button from the impersonation alert banner.
+   */
+  async stopImpersonating(): Promise<void> {
+    const stopBtn = this.page.locator('button:has-text("Stop impersonating")');
+    await stopBtn.waitFor({ state: 'visible', timeout: 10000 });
+    await stopBtn.click();
+    // Wait for header to show kubeadmin again
+    await this._userDropdownToggle.waitFor({
+      state: 'visible',
+      timeout: 15000,
     });
   }
 
+  /**
+   * Polls the login page with reloads until the non-admin IDP button appears.
+   * Required after a fresh OAuth rollout: the OAuth server may take several seconds
+   * to register the new IDP even after its pods are Ready.
+   *
+   * @param baseUrl - Console base URL, used to reload the login page on each attempt.
+   * @param options.maxAttempts - Maximum reload attempts before giving up (default: 10).
+   * @param options.retryIntervalMs - Wait between reloads in ms (default: 5000).
+   * @param options.perAttemptTimeoutMs - Visibility check timeout per attempt (default: 3000).
+   */
   async waitForTestButtonWithReload(
     baseUrl: string,
-    opts: {
+    options?: {
       maxAttempts?: number;
       retryIntervalMs?: number;
       perAttemptTimeoutMs?: number;
       idpName?: string;
     },
   ): Promise<boolean> {
-    const maxAttempts = opts.maxAttempts ?? 10;
-    const retryIntervalMs = opts.retryIntervalMs ?? 5 * SECOND;
-    const perAttemptTimeoutMs = opts.perAttemptTimeoutMs ?? 3 * SECOND;
-    const idpName = opts.idpName ?? 'test-users';
+    const maxAttempts = options?.maxAttempts ?? 10;
+    const retryIntervalMs = options?.retryIntervalMs ?? 5_000;
+    const perAttemptTimeoutMs = options?.perAttemptTimeoutMs ?? 3_000;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       const visible = await this.isTestButtonVisible({
         timeout: perAttemptTimeoutMs,
-        idpName,
+        idpName: options?.idpName,
       });
       if (visible) return true;
-
       if (attempt < maxAttempts) {
-        await this.page.waitForTimeout(retryIntervalMs);
         await this.navigateToLogin(baseUrl);
         await this.page.waitForLoadState('load');
+        await this.page.waitForTimeout(retryIntervalMs);
       }
     }
     return false;

--- a/playwright/src/page-objects/cluster/migration-policies-page.ts
+++ b/playwright/src/page-objects/cluster/migration-policies-page.ts
@@ -1,0 +1,526 @@
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+import PageCommons from '../page-commons';
+
+export default class MigrationPoliciesPage extends PageCommons {
+  private readonly _dataTestRowsResourceRow = this.locator('[data-test-rows="resource-row"]');
+
+  /** Filter toolbar (Fleet ACM: Cluster filter) – first Cluster menu-toggle in toolbar only. */
+  private readonly _filterToolbarClusterButton = this.locator(
+    '[data-test="filter-toolbar"] button.pf-v6-c-menu-toggle',
+  )
+    .filter({ hasText: 'Cluster' })
+    .first();
+
+  private readonly _nameInput = this.locator('[role="dialog"] input[type="text"]').first();
+
+  override readonly _createButton = this.locator('[data-test="item-create"]');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Clicks the actions dropdown button on the detail page.
+   */
+  override async clickActionsDropdown() {
+    const actionsDropdown = this.locator('[data-test="actions-dropdown"]');
+    await actionsDropdown.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(actionsDropdown);
+  }
+
+  async clickCancelButton() {
+    const byTestId = this.locator('[data-test-id="modal-cancel-action"]');
+    const formCancelButton = this.page
+      .locator('[role="dialog"]')
+      .getByRole('button', { name: /^Cancel$/i });
+    const cancel = byTestId.or(formCancelButton).first();
+    await cancel.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(cancel);
+  }
+
+  override async clickCreateAndSelectOption(option: 'With form' | 'From Form' | 'With YAML') {
+    const optionSelectors: Record<string, string> = {
+      'With form':
+        'button[role="menuitem"]:has-text("From Form"), button[role="menuitem"]:has-text("With form"), [role="menuitem"]:has-text("With form")',
+      'From Form':
+        'button[role="menuitem"]:has-text("From Form"), button[role="menuitem"]:has-text("With form"), [role="menuitem"]:has-text("With form")',
+      'With YAML':
+        'button[role="menuitem"]:has-text("With YAML"), [role="menuitem"]:has-text("With YAML")',
+    };
+    await super.clickCreateAndSelectOption('[data-test="item-create"]', optionSelectors[option]);
+  }
+
+  async clickCreateButton() {
+    // Use text-based locator for the Create button in the form
+    const createButton = this.page.locator('[role="dialog"] button', { hasText: 'Create' });
+    await createButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+    await createButton.click();
+  }
+
+  /**
+   * Clicks the delete action from the actions dropdown.
+   */
+  async clickDeleteAction() {
+    const deleteAction = this.locator('[data-test-id="mp-action-delete"]');
+    await deleteAction.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(deleteAction);
+  }
+
+  /**
+   * Clicks the save button in the delete confirmation modal.
+   */
+  async clickSaveButton() {
+    const saveButton = this.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(saveButton);
+  }
+
+  /**
+   * Returns a locator scoped to the detail page content area for a given text pattern.
+   * Useful for soft-asserting detail page values without exposing raw `page`.
+   */
+  detailContentLocator(text: string | RegExp) {
+    return this.page.getByText(text).first();
+  }
+
+  async fillBandwidthPerMigration(bandwidth: string) {
+    const bandwidthInput = this.locator('[data-test-id="bandwidthPerMigration-selected"] input');
+    await bandwidthInput.waitFor({ state: 'visible' });
+    await bandwidthInput.click();
+    await bandwidthInput.press('Control+a');
+    await bandwidthInput.pressSequentially(bandwidth);
+  }
+
+  async fillCompletionTimeout(timeout: string) {
+    const completionTimeoutInput = this.locator(
+      '[data-test-id="migration-policy-completion-timeout-input"] input',
+    );
+    await completionTimeoutInput.waitFor({ state: 'visible' });
+    await completionTimeoutInput.click();
+    await completionTimeoutInput.press('Control+a');
+    await completionTimeoutInput.pressSequentially(timeout);
+  }
+
+  async fillDescription(description: string) {
+    const descriptionInput = this.locator('[role="dialog"] input[type="text"]').nth(1);
+    await descriptionInput.waitFor({ state: 'visible' });
+    await descriptionInput.clear();
+    await descriptionInput.fill(description);
+  }
+
+  // Form field interaction methods
+  async fillPolicyName(name: string) {
+    await this._nameInput.waitFor({ state: 'visible' });
+    await this._nameInput.clear();
+    await this._nameInput.fill(name);
+  }
+
+  /**
+   * Reads the current bandwidth value and unit from the migration policy
+   * create/edit form. The bandwidth field must already be visible.
+   */
+  async getBandwidthFieldInfo(): Promise<{
+    value: string | null;
+    unit: string | null;
+  }> {
+    const bandwidthSection = this.locator('[data-test-id="bandwidthPerMigration-selected"]');
+    await bandwidthSection.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const input = bandwidthSection.locator('input').first();
+    const value = await input.inputValue();
+
+    const unitButton = bandwidthSection.locator('button.pf-v6-c-menu-toggle').first();
+    let unit: string | null = null;
+    const unitVisible = await unitButton
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+    if (unitVisible) {
+      unit = (await unitButton.textContent())?.trim() || null;
+    }
+
+    return { value, unit };
+  }
+
+  /**
+   * Gets the names of all visible migration policies on the page.
+   * Extracts names from elements with data-test attributes like "policy-silver-planarian-22".
+   *
+   * @returns Array of policy names found on the page
+   */
+  async getExistingPolicyNames(): Promise<string[]> {
+    try {
+      const policyElements = this.locator('[data-test^="policy-"]');
+      const count = await policyElements.count();
+
+      if (count === 0) {
+        return [];
+      }
+
+      const policyNames: string[] = [];
+      for (let i = 0; i < count; i++) {
+        const dataTestValue = await policyElements.nth(i).getAttribute('data-test');
+        if (dataTestValue) {
+          // Extract name from "policy-<name>" pattern
+          const name = dataTestValue.replace('policy-', '');
+          if (name && !policyNames.includes(name)) {
+            policyNames.push(name);
+          }
+        }
+      }
+
+      return policyNames;
+    } catch {
+      return [];
+    }
+  }
+
+  async getFormErrorMessage(): Promise<string> {
+    const alertTitle = this.locator(
+      '.pf-v6-c-alert__title, .pf-v5-c-alert__title, .pf-c-alert__title',
+    );
+    try {
+      await alertTitle
+        .first()
+        .waitFor({ state: 'visible', timeout: TestTimeouts.UI_VISIBILITY_QUICK });
+      const text = await alertTitle.first().textContent();
+      if (text?.trim()) {
+        return text.trim();
+      }
+    } catch {
+      // continue to inline helpers
+    }
+
+    const inlineError = this.locator(
+      '.pf-v6-c-form__helper-text.pf-m-error, .pf-v5-c-form__helper-text.pf-m-error, .pf-c-form__helper-text.pf-m-error',
+    );
+    try {
+      await inlineError
+        .first()
+        .waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+      return ((await inlineError.first().textContent()) || '').trim();
+    } catch {
+      // Name field invalid + helper linked via aria-describedby (no alert on some builds)
+    }
+
+    const invalid = await this._nameInput.getAttribute('aria-invalid');
+    if (invalid === 'true') {
+      const describedBy = (await this._nameInput.getAttribute('aria-describedby'))
+        ?.split(/\s+/)
+        .find(Boolean);
+      if (describedBy) {
+        const helper = this.page.locator(`[id="${describedBy}"]`);
+        try {
+          await helper.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_EXTRA });
+          return ((await helper.textContent()) || '').trim();
+        } catch {
+          return '';
+        }
+      }
+    }
+
+    return '';
+  }
+
+  // Details page methods
+  async getNameDetailsValue(policyName: string): Promise<string> {
+    const descriptionLocator = this.locator('h1', { hasText: policyName });
+    await descriptionLocator.waitFor({ state: 'visible' });
+
+    return (await descriptionLocator.textContent()) || '';
+  }
+
+  /**
+   * Returns true if the Create MigrationPolicy dropdown options (With form / With YAML) are visible.
+   * Call after clicking the Create MigrationPolicy button to verify the creation flow is open.
+   */
+  async isCreateDropdownOptionsVisible(): Promise<boolean> {
+    try {
+      const withFormOption = this.locator('button[role="menuitem"]:has-text("From Form")');
+      const withYamlOption = this.locator('button[role="menuitem"]:has-text("With YAML")');
+      const dropdownOption = withFormOption.or(withYamlOption).first();
+      await dropdownOption.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await dropdownOption.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Checks if a specific migration policy is visible on the page.
+   *
+   * @param policyName - The name of the policy to check
+   * @returns true if the policy is visible, false otherwise
+   */
+  async isPolicyVisible(policyName: string): Promise<boolean> {
+    try {
+      const policyLocator = this.locator(`[data-test="policy-${policyName}"]`);
+      return await policyLocator
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  // Navigation methods
+  /**
+   * Navigates to Migration Policies via URL.
+   * @deprecated Use navigateToMigrationPoliciesViaUI() for more reliable navigation
+   */
+  async navigateToMigrationPolicies() {
+    await this.goTo('/k8s/cluster/migrations.kubevirt.io~v1alpha1~MigrationPolicy');
+  }
+
+  /**
+   * Navigates to Migration Policies page by clicking [data-test-id="migrationpolicies-nav-item"] (Fleet context).
+   * Expands the Virtualization nav section first so the item is visible.
+   */
+  async navigateToMigrationPoliciesViaMigrationpoliciesNavItem(): Promise<void> {
+    const navItem = this.locator('[data-test-id="migrationpolicies-nav-item"]');
+    await navItem.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(navItem);
+    await this.page.waitForLoadState('load', {
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+  }
+
+  /**
+   * Navigates to Migration Policies page via sidebar UI click, falling back to URL navigation.
+   */
+  async navigateToMigrationPoliciesViaUI(): Promise<void> {
+    try {
+      await this.clickNavMigrationPolicies();
+    } catch {
+      await this.navigateToMigrationPolicies();
+    }
+  }
+
+  /**
+   * Navigates to the migration policy detail page for a specific policy.
+   * Tries clicking the policy link from the list page first (UI-first),
+   * falling back to URL navigation. Waits for the detail page heading
+   * to confirm the page has fully rendered.
+   *
+   * @param policyName - The name of the migration policy to navigate to
+   *
+   * @example
+   * ```typescript
+   * await migrationPoliciesPage.navigateToMigrationPolicyDetail('my-policy');
+   * ```
+   */
+  async navigateToMigrationPolicyDetail(policyName: string) {
+    const policyLink = this.locator(`[data-test="policy-${policyName}"]`);
+    try {
+      await policyLink
+        .first()
+        .waitFor({ state: 'visible', timeout: TestTimeouts.UI_VISIBILITY_QUICK });
+      await this.robustClick(policyLink.first());
+    } catch {
+      await this.goTo(`/k8s/cluster/migrations.kubevirt.io~v1alpha1~MigrationPolicy/${policyName}`);
+    }
+    await this.waitForDetailPageHeading(policyName);
+  }
+
+  /**
+   * Opens the Cluster filter dropdown from the filter toolbar.
+   */
+  async openClusterFilter(): Promise<void> {
+    await this._filterToolbarClusterButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._filterToolbarClusterButton);
+  }
+
+  /**
+   * Opens the Edit modal for a migration policy from its detail page.
+   * Navigates to the detail page, clicks Actions → Edit MigrationPolicy.
+   */
+  async openEditPolicyModal(policyName: string): Promise<void> {
+    await this.navigateToMigrationPolicyDetail(policyName);
+    await this.clickActionsDropdown();
+    const editAction = this.locator('[data-test-id="mp-action-edit"]').or(
+      this.locator('[role="menuitem"]:has-text("Edit MigrationPolicy")'),
+    );
+    await editAction.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(editAction.first());
+    await this.waitForFormToLoad();
+  }
+
+  /**
+   * Selects a cluster from the open filter menu (#checkbox-select li with the given cluster name).
+   * Call after openClusterFilter().
+   */
+  async selectClusterInFilterMenu(clusterName: string): Promise<void> {
+    const clusterOption = this.locator('#checkbox-select li', {
+      hasText: clusterName,
+    }).first();
+    await clusterOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(clusterOption);
+  }
+
+  async selectConfiguration(
+    configurationType:
+      | 'Auto converge'
+      | 'Bandwidth per migration'
+      | 'Completion timeout'
+      | 'Post-copy',
+  ) {
+    const dropdown = this.page.getByRole('button', { name: 'Add configuration' });
+    await dropdown.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+    await dropdown.click();
+
+    const optionLocator = this.page.getByRole('menuitem', { name: configurationType });
+    await optionLocator.click();
+  }
+
+  async setAutoConverge(enable: boolean) {
+    const autoConvergeToggle = this.locator('[data-test-id="allowAutoConverge-selected"] button');
+    await autoConvergeToggle.waitFor({ state: 'visible' });
+    await autoConvergeToggle.click();
+
+    // Select Yes or No based on the boolean value
+    const optionText = enable ? 'Yes' : 'No';
+    const optionLocator = this.locator(`button:has-text("${optionText}")`);
+    await optionLocator.click();
+  }
+
+  async setPostCopy(enable: boolean) {
+    const postCopyToggle = this.locator('[data-test-id="allowPostCopy-selected"] button');
+    await postCopyToggle.waitFor({ state: 'visible' });
+    await postCopyToggle.click();
+
+    // Select Yes or No based on the boolean value
+    const optionText = enable ? 'Yes' : 'No';
+    const optionLocator = this.locator(`button:has-text("${optionText}")`);
+    await optionLocator.click();
+  }
+
+  /**
+   * Verifies the filter toolbar contains a button with text "Cluster" (Fleet ACM).
+   */
+  async verifyClusterFilterButtonVisible(): Promise<boolean> {
+    try {
+      await this._filterToolbarClusterButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await this._filterToolbarClusterButton.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Verifies that the migration policies page is loaded.
+   * Checks for multiple indicators: empty state, resource rows, table headers, or create button.
+   * Uses combined locators with `or()` for robust detection.
+   *
+   * @param expectedPolicyNamesOrIndicators - Optional array of policy names fetched from K8s API to verify on UI, or indicator selectors for base class compatibility
+   * @param includeCreateButton - Whether to include create button check (for base class compatibility, defaults to true)
+   * @param timeout - Timeout in milliseconds (defaults to DEFAULT timeout)
+   * @returns true if the page is loaded (empty or with policies), false otherwise
+   */
+  override async verifyPageLoaded(
+    expectedPolicyNamesOrIndicators?: string[],
+    includeCreateButton = true,
+    timeout: number = TestTimeouts.DEFAULT,
+  ): Promise<boolean> {
+    try {
+      // Wait for page to settle
+      await this.page.waitForLoadState('domcontentloaded');
+
+      // Build a combined locator for all possible "page loaded" indicators
+      // 1. Empty state message
+      const emptyStateLocator = this.locator('text=No MigrationPolicies found').first();
+
+      // 2. Resource rows in the table (standard pattern for list pages)
+      const resourceRowLocator = this._dataTestRowsResourceRow.first();
+
+      // 3. Table headers (indicates table structure is loaded)
+      const tableHeaderLocator = this.locator('th').filter({ hasText: 'Name' }).first();
+
+      // Start with base indicators
+      let combinedLocator = emptyStateLocator.or(resourceRowLocator).or(tableHeaderLocator);
+
+      // 4. Create button (if requested)
+      if (includeCreateButton) {
+        combinedLocator = combinedLocator.or(
+          this.locator('[data-test="item-create"]', { hasText: 'Create MigrationPolicy' }),
+        );
+      }
+
+      // If specific policy names are provided, also check for rows containing those names
+      if (expectedPolicyNamesOrIndicators && expectedPolicyNamesOrIndicators.length > 0) {
+        for (const policyName of expectedPolicyNamesOrIndicators) {
+          // Check for row containing the policy name (more flexible than exact data-test attribute)
+          const policyRowLocator = this._dataTestRowsResourceRow
+            .filter({ hasText: policyName })
+            .first();
+          combinedLocator = combinedLocator.or(policyRowLocator);
+
+          // Also try link/anchor elements with the policy name
+          const policyLinkLocator = this.locator('a', { hasText: policyName }).first();
+          combinedLocator = combinedLocator.or(policyLinkLocator);
+        }
+      }
+
+      // Wait for any indicator to be visible
+      await combinedLocator.first().waitFor({ state: 'visible', timeout });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Waits for the detail page heading containing the policy name to be visible.
+   * Used after navigation to confirm the detail page has fully rendered.
+   */
+  async waitForDetailPageHeading(
+    policyName: string,
+    timeout: number = TestTimeouts.DEFAULT,
+  ): Promise<void> {
+    await this.locator('h1')
+      .filter({ hasText: policyName })
+      .first()
+      .waitFor({ state: 'visible', timeout });
+  }
+
+  async waitForFormToLoad() {
+    await this._nameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+  }
+
+  async waitForPolicyRowDetached(
+    policyName: string,
+    timeout: number = TestTimeouts.DEFAULT,
+  ): Promise<void> {
+    await this.locator(`[data-test="policy-${policyName}"]`).waitFor({
+      state: 'detached',
+      timeout,
+    });
+  }
+}

--- a/playwright/src/page-objects/cluster/quotas-page.ts
+++ b/playwright/src/page-objects/cluster/quotas-page.ts
@@ -1,0 +1,264 @@
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+import BasePage from '../base-page';
+
+export default class QuotasPage extends BasePage {
+  private readonly _aHasTextLearnMoreAboutManagingVMQuotasWithAAQ = this.locator(
+    'a:has-text("Learn more about managing VM quotas with AAQ")',
+  );
+
+  private readonly _createButton = this.locator('[data-test="item-create"]');
+  private readonly _pageHeading = this.locator('[data-test="page-heading"] h1');
+  private readonly _roleMenuitemHasTextWithForm = this.locator(
+    '[role="menuitem"]:has-text("With form")',
+  );
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async clickCancelOnForm(): Promise<void> {
+    const cancelBtn = this.locator('main button:has-text("Cancel")');
+    await cancelBtn.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await this.robustClick(cancelBtn);
+    await this.page.waitForLoadState('domcontentloaded');
+    await this.page.waitForTimeout(1000);
+  }
+
+  async clickCreateQuota(): Promise<void> {
+    await this._createButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(this._createButton);
+    await this.page.waitForTimeout(500);
+  }
+
+  async clickCreateWithForm(): Promise<void> {
+    const formOption = this._roleMenuitemHasTextWithForm;
+    await formOption.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await this.robustClick(formOption);
+    await this.page.waitForLoadState('domcontentloaded');
+    await this.page.waitForTimeout(2000);
+  }
+
+  async deleteQuotaFromList(quotaName: string): Promise<void> {
+    const kebab = this.locator(`tr:has-text("${quotaName}") [data-test="actions-dropdown"] button`);
+    await kebab.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    await this.robustClick(kebab);
+    await this.page.waitForTimeout(500);
+
+    const deleteOption = this.locator('[role="menuitem"]:has-text("Delete quota")');
+    await deleteOption.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await this.robustClick(deleteOption.first());
+    await this.page.waitForTimeout(500);
+
+    const confirmBtn = this.locator('[data-test="save-button"]:has-text("Delete")');
+    await confirmBtn.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await this.robustClick(confirmBtn);
+    await this.page.waitForTimeout(2000);
+  }
+
+  async fillMemoryAllocation(value: string): Promise<void> {
+    const input = this.locator('input[placeholder="i.e., 16"]');
+    await input.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await input.fill(value);
+  }
+
+  async fillQuotaName(name: string): Promise<void> {
+    const nameInput = this.locator('#quota-name');
+    await nameInput.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await nameInput.fill(name);
+  }
+
+  async fillVcpuAllocation(value: string): Promise<void> {
+    const input = this.locator('input[placeholder="i.e., 8"]');
+    await input.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await input.fill(value);
+  }
+
+  async fillVmiLimits(value: string): Promise<void> {
+    const input = this.locator('input[placeholder="i.e., 4"]');
+    await input.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await input.fill(value);
+  }
+
+  async getCurrentUrl(): Promise<string> {
+    return this.page.url();
+  }
+
+  async getDocumentationLinkHref(): Promise<string | null> {
+    try {
+      const docLink = this._aHasTextLearnMoreAboutManagingVMQuotasWithAAQ;
+      await docLink.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return await docLink.first().getAttribute('href');
+    } catch {
+      return null;
+    }
+  }
+
+  async isCreateQuotaSubmitDisabled(): Promise<boolean> {
+    const submitBtn = this.locator('main button:has-text("Create quota")');
+    try {
+      await submitBtn.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return await submitBtn.isDisabled();
+    } catch {
+      return true;
+    }
+  }
+
+  async isDocumentationLinkVisible(): Promise<boolean> {
+    try {
+      const docLink = this._aHasTextLearnMoreAboutManagingVMQuotasWithAAQ;
+      await docLink.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async navigateToNamespaceQuotas(namespace: string): Promise<void> {
+    await this.goTo(`/k8s/ns/${namespace}/quotas`);
+    await this.page.waitForLoadState('domcontentloaded');
+    await this.page.waitForTimeout(2000);
+  }
+
+  async navigateToQuotasViaUI(): Promise<void> {
+    try {
+      const quotasNav = this.locator('nav a[href*="/quotas"]');
+      await quotasNav.first().waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      await this.robustClick(quotasNav.first());
+      await this.page.waitForLoadState('domcontentloaded');
+      await this.page.waitForTimeout(2000);
+    } catch {
+      await this.goTo('/k8s/all-namespaces/quotas');
+    }
+  }
+
+  async submitCreateQuota(): Promise<void> {
+    const submitBtn = this.locator('main button:has-text("Create quota"):not([disabled])');
+    await submitBtn.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await this.robustClick(submitBtn);
+    await this.page.waitForLoadState('domcontentloaded');
+    await this.page.waitForTimeout(2000);
+  }
+
+  async verifyCreateButtonVisible(): Promise<boolean> {
+    try {
+      await this._createButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCreateDropdownOptions(): Promise<{ withForm: boolean; withYaml: boolean }> {
+    try {
+      const formOption = this._roleMenuitemHasTextWithForm;
+      const yamlOption = this.locator('[role="menuitem"]:has-text("With YAML")');
+
+      const withForm = await formOption
+        .waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT })
+        .then(() => true)
+        .catch(() => false);
+      const withYaml = await yamlOption
+        .waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT })
+        .then(() => true)
+        .catch(() => false);
+
+      return { withForm, withYaml };
+    } catch {
+      return { withForm: false, withYaml: false };
+    }
+  }
+
+  async verifyCreateFormHeadingVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('h1:has-text("Create application-aware quota")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyEmptyStateGuidanceVisible(): Promise<boolean> {
+    try {
+      const guidance = this.locator(
+        'text=/create.*application-aware quota|application-aware quota.*limit/i',
+      );
+      await guidance.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyEmptyStateVisible(): Promise<boolean> {
+    try {
+      const emptyHeading = this.locator(
+        ':is(h4, h5, [class*="empty-state"]):has-text("application-aware quota")',
+      );
+      await emptyHeading.first().waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyFormFieldsVisible(): Promise<{
+    name: boolean;
+    project: boolean;
+    vcpu: boolean;
+    memory: boolean;
+    vmiLimits: boolean;
+  }> {
+    const check = async (text: string) => {
+      try {
+        const label = this.locator(`main label:has-text("${text}"), main :text("${text}")`);
+        await label.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    return {
+      name: await check('Name'),
+      project: await check('Project'),
+      vcpu: await check('vCPU allocation'),
+      memory: await check('Virtual memory allocation'),
+      vmiLimits: await check('VMI limits'),
+    };
+  }
+
+  async verifyFormViewSelected(): Promise<boolean> {
+    try {
+      const formRadio = this.locator('[data-test="form-view-input"]');
+      return await formRadio.isChecked();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyOnQuotasListPage(): Promise<boolean> {
+    return this.page.url().includes('/quotas') && !this.page.url().includes('~new');
+  }
+
+  async verifyPageHeadingVisible(): Promise<boolean> {
+    try {
+      await this._pageHeading.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      const text = await this._pageHeading.textContent();
+      return text?.includes('Application-aware quotas') ?? false;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyQuotaInList(quotaName: string): Promise<boolean> {
+    try {
+      const row = this.locator(`a:has-text("${quotaName}")`);
+      await row.first().waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/playwright/src/page-objects/cluster/virtualization-overview-page.ts
+++ b/playwright/src/page-objects/cluster/virtualization-overview-page.ts
@@ -1,0 +1,109 @@
+/**
+ * Page object for the Virtualization Overview page (namespace-specific).
+ */
+
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+import BasePage from '../base-page';
+
+export const VmChartType = {
+  TEMPLATES: 'Show VirtualMachine per Templates',
+  INSTANCE_TYPES: 'Show VirtualMachine per InstanceTypes',
+  UNCATEGORIZED: 'Show uncategorized VirtualMachines',
+} as const;
+
+export type VmChartTypeValue = (typeof VmChartType)[keyof typeof VmChartType];
+
+export default class VirtualizationOverviewPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async clickVmListLink(linkText: string): Promise<void> {
+    const link = this.locator('#link-to-vm-list').filter({ hasText: linkText });
+    await link.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(link);
+  }
+
+  async navigateToNamespaceVirtualizationOverview(namespace: string) {
+    await this.goTo(`/k8s/ns/${namespace}/virtualization-overview`);
+  }
+
+  async selectChartType(chartType: VmChartTypeValue): Promise<void> {
+    const chartTypeSelect = this.locator('button[id="overview-vms-per-resource-card"]');
+    await chartTypeSelect.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(chartTypeSelect);
+    await this.page.waitForTimeout(1000);
+    const chartOption = this.locator(`text=${chartType}`);
+    await chartOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(chartOption);
+  }
+
+  async selectInstanceTypeChart(): Promise<void> {
+    await this.selectChartType(VmChartType.INSTANCE_TYPES);
+  }
+
+  async selectTemplatesChart(): Promise<void> {
+    await this.selectChartType(VmChartType.TEMPLATES);
+  }
+
+  async selectUncategorizedChart(): Promise<void> {
+    await this.selectChartType(VmChartType.UNCATEGORIZED);
+  }
+
+  async verifyInstanceTypeChart(
+    expectedCount: string,
+    expectedSeries: string,
+  ): Promise<{
+    success: boolean;
+    actualCount: number | null;
+    seriesFound: boolean;
+  }> {
+    try {
+      const runningVmsCardLegendLabel = this.locator('.kv-running-vms-card__legend-label--count');
+      await runningVmsCardLegendLabel.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+
+      const legendLabels = await runningVmsCardLegendLabel.all();
+      let actualCount: number | null = null;
+
+      for (const label of legendLabels) {
+        const text = await label.textContent();
+        if (text) {
+          const count = parseInt(text.trim(), 10);
+          if (!isNaN(count)) {
+            if (actualCount === null || count > actualCount) {
+              actualCount = count;
+            }
+          }
+        }
+      }
+
+      const seriesLocator = this.locator(`text=${expectedSeries}`);
+      const seriesFound = await seriesLocator
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false);
+
+      const expectedCountNum = parseInt(expectedCount, 10);
+      const countValid = actualCount !== null && actualCount >= expectedCountNum;
+
+      return {
+        success: countValid && seriesFound,
+        actualCount,
+        seriesFound,
+      };
+    } catch {
+      return {
+        success: false,
+        actualCount: null,
+        seriesFound: false,
+      };
+    }
+  }
+}

--- a/playwright/src/page-objects/cluster/workloads-secrets-page.ts
+++ b/playwright/src/page-objects/cluster/workloads-secrets-page.ts
@@ -1,0 +1,33 @@
+/**
+ * Page object for the Workloads Secrets page.
+ * Handles navigation and visibility checks for secrets.
+ */
+
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+import BasePage from '../base-page';
+
+export default class WorkloadsSecretsPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async isSecretVisible(
+    secretName: string,
+    timeout: number = TestTimeouts.UI_ELEMENT_VISIBILITY,
+  ): Promise<boolean> {
+    const secretLocator = this.locator(`[data-test="${secretName}"]`);
+    try {
+      await secretLocator.waitFor({ state: 'visible', timeout });
+      return await secretLocator.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async navigateToSecrets(namespace: string): Promise<void> {
+    await this.goTo(`/k8s/ns/${namespace}/core~v1~Secret`);
+    await this.page.waitForLoadState('networkidle', { timeout: TestTimeouts.NAVIGATION });
+  }
+}


### PR DESCRIPTION
## 📝 Description

Add cluster page objects

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-92537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage for checkups, including navigation, configuration, permissions, execution, status verification, and deletion.
  - Added automated coverage for standalone VNC console connection and dialog workflows.
  - Added DataVolume creation, status, deletion, and navigation verification.
  - Added coverage for migration policies, application-aware quotas, virtualization dashboards, login/session flows, and workload secrets.
  - Improved reusable test access across cluster UI areas through centralized page-object exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->