### PR TITLE
CNV-92614: Improve hot-cluster E2E check visibility on PRs (dynamic phase narration + fix broken/fragmented check names)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,13 @@
+self-hosted-runner:
+  labels: []
+
+config-variables: null
+
+paths:
+  .github/workflows/**/*.yml:
+    ignore:
+      # queue: max is a real, valid `concurrency` option (GitHub Actions
+      # changelog, May 2026: larger concurrency-group queues) that
+      # actionlint v1.7.12's schema doesn't recognize yet -- not a bug in
+      # our workflows. Safe to drop once actionlint's schema catches up.
+      - 'unexpected key "queue" for "concurrency" section'

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -61,6 +61,53 @@ jobs:
             exit 1
           fi
 
+  # No GitHub Actions semantic linter existed in this repo before -- only
+  # Prettier/YAML formatting is checked elsewhere, which can't catch invalid
+  # `needs.*.outputs` references, expression type errors, or other
+  # GHA-specific mistakes in workflow files. actionlint is installed via
+  # `go install` pinned to a specific released version (checksum-verified
+  # through the Go module proxy) rather than curling and piping the
+  # maintainer's download script from `main`, which is a known supply-chain
+  # risk for CI runners (see https://github.com/rhysd/actionlint/issues/617).
+  #
+  # shellcheck/pyflakes integration is disabled: enabling it surfaces a long
+  # tail of pre-existing style/robustness findings across `run:` scripts in
+  # other, unrelated workflow files, which would fail this brand new check
+  # on unrelated debt. actionlint's own GHA-specific checks (the thing this
+  # job exists for -- invalid needs.*.outputs references, expression type
+  # errors, etc.) are unaffected by this. Revisit enabling shellcheck once
+  # that pre-existing debt has been triaged separately.
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Detect workflow changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            workflows:
+              - '.github/workflows/**'
+
+      - name: Skip actionlint
+        if: github.event_name != 'push' && steps.filter.outputs.workflows != 'true'
+        run: echo "No workflow file changes detected, skipping."
+
+      - name: Install actionlint
+        if: github.event_name == 'push' || steps.filter.outputs.workflows == 'true'
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Run actionlint
+        if: github.event_name == 'push' || steps.filter.outputs.workflows == 'true'
+        run: actionlint -color -shellcheck= -pyflakes=
+
   build:
     name: build
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-manual-console.yml
+++ b/.github/workflows/deploy-manual-console.yml
@@ -1,5 +1,5 @@
 name: Deploy Manual Console
-run-name: 'Deploy Manual Console [${{ inputs.cluster_name }}] @ ${{ inputs.branch }}'
+run-name: "Deploy Manual Console [${{ inputs.cluster_name }}] @ ${{ inputs.pr_number && format('PR#{0}', inputs.pr_number) || inputs.branch }}"
 
 # Deploys a standalone, OAuth-protected console + kubevirt-plugin stack to an
 # existing hot cluster for manual UI testing (CNV-92150). Entirely separate
@@ -15,9 +15,14 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: Git branch or ref to build the kubevirt-plugin image from
+        description: Git branch or ref to build the kubevirt-plugin image from. Ignored when pr_number is set.
         required: true
         default: main
+        type: string
+      pr_number:
+        description: 'PR number to deploy instead (works with PRs from forks -- the OWNERS-listed author check below still applies). Takes precedence over "branch" when set.'
+        required: false
+        default: ''
         type: string
       cluster_name:
         description: ARC runner label / hot cluster name (must already be provisioned)
@@ -36,6 +41,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # Persistent environment: never cancel an in-flight deploy for the same
 # cluster, since that could leave the manual console mid-provision.
@@ -50,20 +56,113 @@ env:
   MANUAL_CONSOLE_USER: manual-console
 
 jobs:
-  deploy:
-    name: Deploy Manual Console
-    runs-on: ${{ inputs.cluster_name }}
-    timeout-minutes: 30
+  # Only runs when pr_number is set (deploying a PR, possibly from a fork,
+  # instead of a same-repo branch). This is workflow_dispatch-only, so
+  # triggering it at all already requires write access to this repo -- but
+  # per CNV team decision, that boundary alone isn't treated as sufficient
+  # for a PR whose actual code lives in someone else's fork. This mirrors
+  # hot-cluster-e2e.yml's check-trust: only PR authors listed in OWNERS
+  # (approvers/reviewers) can have their PR deployed here. Unlike e2e, there
+  # is no "ok-to-test"-label escape hatch for untrusted authors -- if you
+  # need to deploy an untrusted PR's changes anyway, push its branch to this
+  # repository directly and use the "branch" input instead.
+  resolve-pr:
+    name: Resolve PR
+    if: inputs.pr_number != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+      head_repo: ${{ steps.resolve.outputs.head_repo }}
     steps:
+      # Pinned to the default branch explicitly: without a ref:, checkout
+      # falls back to github.ref, which for workflow_dispatch is whatever
+      # branch was selected in the dispatch UI -- not necessarily the
+      # default branch. Reading OWNERS from an unpinned, dispatcher-chosen
+      # branch would let a modified OWNERS file on that branch self-approve
+      # trust for a fork PR.
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Resolve PR and verify author is a trusted repo owner
+        id: resolve
+        uses: actions/github-script@v9
+        env:
+          # Passed via env, not interpolated into the script string below:
+          # inputs.pr_number is a raw, unvalidated workflow_dispatch string
+          # input, and substituting it directly into the JS source would let
+          # a crafted value break out of the string literal and inject
+          # arbitrary script.
+          PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const author = pr.user.login;
+            const headSha = pr.head.sha;
+            const headRepo = pr.head.repo ? pr.head.repo.full_name : '(source repository deleted)';
+            core.info(`PR #${prNumber}: author=${author}, head=${headRepo}@${headSha}`);
+
+            let trusted = false;
+            try {
+              const owners = fs.readFileSync('OWNERS', 'utf8');
+              trusted = new RegExp(`^\\s*-\\s*${author}\\s*$`, 'm').test(owners);
+            } catch (err) {
+              core.warning(`Could not read OWNERS file: ${err.message}`);
+            }
+
+            core.info(`${author} is ${trusted ? '' : 'not '}listed in OWNERS (approvers/reviewers) — ${trusted ? 'trusted' : 'untrusted'}.`);
+            core.setOutput('head_sha', headSha);
+            core.setOutput('head_repo', headRepo);
+
+            if (!trusted) {
+              core.setFailed(`PR #${prNumber}'s author '${author}' is not listed in OWNERS (approvers/reviewers). Only PRs from trusted repo owners can be deployed via this workflow. To deploy this PR's changes anyway, push its branch to this repository directly and use the "branch" input instead.`);
+            }
+
+  # if: always() so this still runs when resolve-pr was skipped (no
+  # pr_number given -- the plain "branch" input path), but not when
+  # resolve-pr ran and failed the trust check.
+  deploy:
+    name: Deploy Manual Console
+    needs: resolve-pr
+    if: always() && needs.resolve-pr.result != 'failure'
+    runs-on: ${{ inputs.cluster_name }}
+    timeout-minutes: 30
+    steps:
+      # allow-unsafe-pr-checkout is not needed here: actions/checkout only
+      # enforces that guard for pull_request_target/workflow_run triggers,
+      # not workflow_dispatch. The OWNERS check above (resolve-pr) is this
+      # workflow's actual trust gate for fork PRs.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # Falls back to the default repository (github.repository, actions/
+          # checkout's own default) both for the plain "branch" input path
+          # and if the PR's source repo was deleted -- head_sha in that case
+          # is a fork commit unreachable from this repo anyway, so checkout
+          # would fail regardless, but this at least avoids literally passing
+          # the '(source repository deleted)' sentinel as a repository name.
+          repository: ${{ (needs.resolve-pr.outputs.head_repo != '' && needs.resolve-pr.outputs.head_repo != '(source repository deleted)') && needs.resolve-pr.outputs.head_repo || github.repository }}
+          ref: ${{ needs.resolve-pr.outputs.head_sha || inputs.branch }}
           persist-credentials: false
 
       - name: Log environment summary
         env:
           BRANCH: ${{ inputs.branch }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          HEAD_REPO: ${{ needs.resolve-pr.outputs.head_repo }}
+          HEAD_SHA: ${{ needs.resolve-pr.outputs.head_sha }}
           CLUSTER_NAME: ${{ inputs.cluster_name }}
         run: |
           {
@@ -71,7 +170,11 @@ jobs:
             echo ""
             echo "| Field | Value |"
             echo "|---|---|"
-            echo "| Branch | \`${BRANCH}\` |"
+            if [[ -n "${PR_NUMBER}" ]]; then
+              echo "| PR | #${PR_NUMBER} (\`${HEAD_REPO}@${HEAD_SHA}\`) |"
+            else
+              echo "| Branch | \`${BRANCH}\` |"
+            fi
             echo "| Cluster | \`${CLUSTER_NAME}\` |"
             echo "| Infrastructure | \`${{ inputs.infrastructure_type }}\` |"
             echo "| Triggered by | @${{ github.actor }} |"
@@ -130,6 +233,8 @@ jobs:
           MANUAL_CONSOLE_PASSWORD: ${{ steps.creds.outputs.password }}
           ACTOR: ${{ github.actor }}
           BRANCH: ${{ inputs.branch }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          HEAD_REPO: ${{ needs.resolve-pr.outputs.head_repo }}
         run: |
           if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
             echo "::warning::SLACK_WEBHOOK_URL not set — skipping Slack notification"
@@ -138,12 +243,18 @@ jobs:
 
           echo "::add-mask::${MANUAL_CONSOLE_PASSWORD}"
 
+          if [[ -n "${PR_NUMBER}" ]]; then
+            SOURCE_LINE="*PR:* <https://github.com/${{ github.repository }}/pull/${PR_NUMBER}|#${PR_NUMBER}> (\`${HEAD_REPO}\`)"
+          else
+            SOURCE_LINE="*Branch:* \`${BRANCH}\`"
+          fi
+
           TEXT=":rocket: *Manual console ready*"
           TEXT+=$'\n'"*Triggered by:* @${ACTOR}"
           TEXT+=$'\n'"*URL:* <${CONSOLE_URL}>"
           TEXT+=$'\n'"*User:* \`${MANUAL_CONSOLE_USER}\`"
           TEXT+=$'\n'"*Password:* \`${MANUAL_CONSOLE_PASSWORD}\`"
-          TEXT+=$'\n'"*Branch:* \`${BRANCH}\`"
+          TEXT+=$'\n'"${SOURCE_LINE}"
           TEXT+=$'\n'"*Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>"
 
           PAYLOAD=$(jq -n --arg text "${TEXT}" '{text: $text}')

--- a/.github/workflows/hot-cluster-check.yml
+++ b/.github/workflows/hot-cluster-check.yml
@@ -43,6 +43,17 @@ on:
         type: string
         required: false
         default: 'true'
+      should_run:
+        description: |
+          Whether this check should actually probe/provision. Set to false
+          for no-op/irrelevant trigger events so the caller can invoke this
+          workflow unconditionally (avoiding the bare-skipped-vs-compound-
+          nested-job-names fragmentation a caller-side `if:` would cause)
+          while still getting a fast, correctly-named success and a
+          cluster_ready output that's reliably 'false'.
+        type: boolean
+        required: false
+        default: true
     outputs:
       cluster_ready:
         description: Whether the cluster is ready (true/false)
@@ -59,8 +70,14 @@ jobs:
     outputs:
       cluster_ready: ${{ steps.probe.outputs.cluster_ready }}
     steps:
+      # if: inputs.should_run -- skip the live DNS lookup entirely for a
+      # no-op/irrelevant event; result's compute step already forces
+      # cluster_ready=false whenever should_run is false regardless of this
+      # step's (skipped, empty) output, so there's nothing to gain from
+      # actually probing.
       - name: Probe for cluster
         id: probe
+        if: inputs.should_run
         env:
           CLUSTER_NAME: ${{ inputs.cluster_name }}
           BASE_DOMAIN: ${{ inputs.base_domain }}
@@ -87,7 +104,7 @@ jobs:
   provision:
     name: Provision Cluster
     needs: probe
-    if: needs.probe.outputs.cluster_ready == 'false'
+    if: inputs.should_run && needs.probe.outputs.cluster_ready == 'false'
     concurrency:
       group: hot-cluster-provision-${{ inputs.cluster_name }}
       cancel-in-progress: false
@@ -123,10 +140,15 @@ jobs:
       - name: Compute final readiness
         id: compute
         env:
+          SHOULD_RUN: ${{ inputs.should_run }}
           PROBE_READY: ${{ needs.probe.outputs.cluster_ready }}
           PROVISION_RESULT: ${{ needs.provision.result }}
         run: |
-          if [[ "${PROBE_READY}" == "true" || "${PROVISION_RESULT}" == "success" ]]; then
+          # A no-op caller (should_run=false) always reports cluster_ready=false,
+          # regardless of the real probe result -- downstream jobs must never
+          # treat a no-op/irrelevant-event run as a green light to proceed,
+          # even if the cluster happens to genuinely be ready.
+          if [[ "${SHOULD_RUN}" == "true" && ( "${PROBE_READY}" == "true" || "${PROVISION_RESULT}" == "success" ) ]]; then
             echo "cluster_ready=true" >> "$GITHUB_OUTPUT"
           else
             echo "cluster_ready=false" >> "$GITHUB_OUTPUT"
@@ -150,7 +172,7 @@ jobs:
           fi
 
       - name: Fail if cluster is not ready
-        if: steps.compute.outputs.cluster_ready != 'true'
+        if: inputs.should_run && steps.compute.outputs.cluster_ready != 'true'
         env:
           CLUSTER_NAME: ${{ inputs.cluster_name }}
           PROBE_READY: ${{ needs.probe.outputs.cluster_ready }}

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -132,28 +132,115 @@ jobs:
             core.info(`${author} is ${trusted ? '' : 'not '}listed in OWNERS (approvers/reviewers) — ${trusted ? 'trusted' : 'untrusted'}.`);
             core.setOutput('trusted', trusted ? 'true' : 'false');
 
+  # Creates a single, always-present, non-required "Hot Cluster E2E Progress"
+  # check-run that's explicitly rewritten as the pipeline advances through
+  # phases -- unlike a regular job's name/status, which is computed once and
+  # never rewritten afterwards. This is purely informational and never a
+  # substitute for the "Run Gating Tests" required check (verify-gating-
+  # tests below), which branch protection/Tide actually key off.
+  progress-check-start:
+    name: Start Progress Check
+    needs: [check-trust, resolve-cluster-config]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    # Scoped here (rather than at the workflow level) because this is the
+    # only job needing checks.create -- for the "Hot Cluster E2E Progress"
+    # check-run, a non-required, informational check separate from "Run
+    # Gating Tests" that narrates pipeline phase. No new privilege exposure:
+    # pull_request_target already grants base-repo write-level permissions
+    # via GITHUB_TOKEN.
+    permissions:
+      checks: write
+    outputs:
+      check_run_id: ${{ steps.create.outputs.check_run_id }}
+    steps:
+      # Best-effort: a Checks API failure here must never block or fail the
+      # pipeline itself -- this check is purely informational.
+      - name: Create progress check-run
+        id: create
+        continue-on-error: true
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // pull_request_target's github.sha/context.sha is the BASE
+            // branch's commit, not the PR head -- posting the check-run
+            // there would make it silently never appear in the PR's own
+            // Checks tab.
+            const headSha = context.eventName === 'pull_request_target'
+              ? context.payload.pull_request.head.sha
+              : context.sha;
+
+            const isIrrelevantLabel = context.payload.action === 'labeled'
+              && context.payload.label?.name !== 'ok-to-test';
+
+            // A distinct name for no-op runs prevents them from creating a
+            // same-named, same-SHA check-run that could collide with (and,
+            // per GitHub's "most recent wins" display behavior, obscure) an
+            // active real run's own "Hot Cluster E2E Progress" check --
+            // mirroring the same duplicate-name pitfall called out for
+            // "Run Gating Tests" on verify-gating-tests below.
+            const params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: isIrrelevantLabel
+                ? 'Hot Cluster E2E Progress (skipped - irrelevant label event)'
+                : 'Hot Cluster E2E Progress',
+              head_sha: headSha,
+              output: {
+                title: isIrrelevantLabel
+                  ? 'Skipped (irrelevant label event)'
+                  : 'Waiting for cluster to be built',
+                summary: isIrrelevantLabel
+                  ? `Label '${context.payload.label?.name}' does not trigger gating tests -- this run is a no-op.`
+                  : 'The hot cluster E2E pipeline has started.',
+              },
+            };
+
+            if (isIrrelevantLabel) {
+              params.status = 'completed';
+              params.conclusion = 'neutral';
+            } else {
+              params.status = 'in_progress';
+            }
+
+            const { data: check } = await github.rest.checks.create(params);
+            core.setOutput('check_run_id', check.id);
+
+  # if: always() unconditionally -- this job is a `uses:` reusable-workflow
+  # call, so GitHub reports its sub-jobs as compound-named check contexts
+  # (`cluster-check / probe`, `cluster-check / result`, ...) only while it
+  # actually runs; a job-level `if:` skip instead reports a single bare
+  # `cluster-check` context. Alternating between the two across different
+  # trigger events (e.g. irrelevant label vs. real push) fragments what
+  # should be one logical check into unrelated, inconsistently-named ones
+  # that can't be unified by renaming alone. Always invoking the reusable
+  # workflow and pushing the actual gating decision down into its
+  # `should_run` input (which its always-running `probe`/`result` jobs
+  # already handle) keeps the check names stable across every event type.
   cluster-check:
     needs: [check-trust, resolve-cluster-config]
-    if: |
-      always() &&
-      (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test') &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        github.event.pull_request.head.repo.full_name == github.repository ||
-        needs.check-trust.outputs.trusted == 'true' ||
-        (github.event.action == 'labeled' && github.event.label.name == 'ok-to-test')
-      )
+    if: always()
     uses: ./.github/workflows/hot-cluster-check.yml
     with:
       cluster_name: ${{ needs.resolve-cluster-config.outputs.cluster_name }}
       infrastructure_type: ${{ inputs.infrastructure_type || 'ipi' }}
       openshift_version: ${{ needs.resolve-cluster-config.outputs.openshift_version }}
+      # Single-line plain scalar (same well-precedented `${{ ... }}` pattern
+      # used for run-name/other with: values throughout this file) rather
+      # than a multi-line expression wrapped in a literal block scalar --
+      # the latter has no local test coverage for how GitHub Actions'
+      # expression engine handles embedded newlines before a real PR run.
+      should_run: ${{ (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test') && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository || needs.check-trust.outputs.trusted == 'true' || (github.event.action == 'labeled' && github.event.label.name == 'ok-to-test')) }}
     secrets: inherit
 
   cluster-health-check:
     name: Manual Cluster Health Check
     needs: [cluster-check, resolve-cluster-config]
-    if: github.event_name == 'workflow_dispatch' && needs.cluster-check.result == 'success'
+    # cluster-check now always runs (see comment above it) and quickly
+    # reports 'success' even as a no-op, so gate on the actual readiness
+    # output rather than the job result.
+    if: github.event_name == 'workflow_dispatch' && needs.cluster-check.outputs.cluster_ready == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -225,13 +312,88 @@ jobs:
             echo "Health checks **failed**. E2E workflow was not invoked." >> "$GITHUB_STEP_SUMMARY"
           fi
 
+  # Advances the progress check-run to its second phase once the cluster is
+  # confirmed ready (mirrors the condition run-e2e-tests itself uses below),
+  # or completes it as a failure now if the cluster never became ready --
+  # narrating the same outcome run-e2e-tests's own skip would otherwise
+  # leave unexplained on this check.
+  progress-check-running-tests:
+    name: Update Progress Check
+    needs: [progress-check-start, cluster-check, cluster-health-check]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    # Scoped here (rather than at the workflow level) -- see
+    # progress-check-start above.
+    permissions:
+      checks: write
+    steps:
+      # Best-effort, same as progress-check-start above.
+      - name: Update progress check-run
+        continue-on-error: true
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const isIrrelevantLabel = context.payload.action === 'labeled'
+              && context.payload.label?.name !== 'ok-to-test';
+            if (isIrrelevantLabel) {
+              core.info('Irrelevant label event — progress check already completed as a no-op.');
+              return;
+            }
+
+            const checkRunId = parseInt('${{ needs.progress-check-start.outputs.check_run_id }}', 10);
+            if (!checkRunId) {
+              core.warning('No progress check-run id — skipping update.');
+              return;
+            }
+
+            // cluster-health-check only ever runs for workflow_dispatch (its
+            // own `if:` skips it otherwise) -- branch on event type here,
+            // rather than a plain `||` of the two, so a manual run whose
+            // health check failed isn't reported as ready just because
+            // cluster_ready == 'true'. See run-e2e-tests below for the same
+            // fix applied to its own `if:` condition.
+            const clusterReady = context.eventName === 'workflow_dispatch'
+              ? '${{ needs.cluster-health-check.result }}' === 'success'
+              : '${{ needs.cluster-check.outputs.cluster_ready }}' === 'true';
+
+            const params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: checkRunId,
+            };
+
+            if (clusterReady) {
+              params.status = 'in_progress';
+              params.output = {
+                title: 'Running gating tests',
+                summary: 'The hot cluster is ready; Playwright gating tests are starting.',
+              };
+            } else {
+              params.status = 'completed';
+              params.conclusion = 'failure';
+              params.output = {
+                title: 'Cluster not ready — gating tests not run',
+                summary: 'The hot cluster could not be provisioned or verified healthy; gating tests were not started.',
+              };
+            }
+
+            await github.rest.checks.update(params);
+
   run-e2e-tests:
     name: Run E2E Tests
     needs: [cluster-check, cluster-health-check, resolve-cluster-config]
+    # See cluster-health-check above: key off cluster-check's cluster_ready
+    # output, not its job result, now that a no-op event still reports
+    # 'success' for cluster-check. cluster-health-check only ever runs for
+    # workflow_dispatch (its own `if:` skips it otherwise), so branching on
+    # event type here -- rather than a plain `||` of the two -- is required:
+    # an unconditional `||` would let a manual run with cluster_ready ==
+    # 'true' proceed even if its own health check subsequently failed.
     if: |
       always() && (
-        needs.cluster-check.result == 'success' ||
-        needs.cluster-health-check.result == 'success'
+        (github.event_name == 'workflow_dispatch' && needs.cluster-health-check.result == 'success') ||
+        (github.event_name != 'workflow_dispatch' && needs.cluster-check.outputs.cluster_ready == 'true')
       )
     uses: ./.github/workflows/hot-cluster-e2e-run.yml
     with:
@@ -263,20 +425,56 @@ jobs:
   # Tests" context that branch protection/Tide requires, so an irrelevant
   # label event doesn't touch that check at all (leaving it correctly
   # `expected`/pending until the real run reports).
+  #
+  # if: is unconditional `always()` — the irrelevant-label short-circuit is
+  # handled inside the step below, not via a job-level `if:` — because
+  # GitHub Actions only evaluates a dynamic `name:` expression on the runner
+  # as the job starts. A job skipped via `if:` never dispatches to a runner,
+  # so GitHub falls back to displaying the raw, unevaluated name expression
+  # instead of either ternary branch (see
+  # https://github.com/actions/runner/issues/1215, closed as won't-fix).
+  # Always running the job guarantees the name always renders correctly.
+  # needs: includes progress-check-running-tests (not just progress-check-
+  # start) so this job's own terminal checks.update call is guaranteed to
+  # happen *after* progress-check-running-tests's -- without that edge,
+  # GitHub Actions gives no ordering guarantee between the two, and a fast
+  # run-e2e-tests failure (racing against progress-check-running-tests's own
+  # in_progress update, which only needs cluster-check/cluster-health-check)
+  # could post the terminal completed/failure update first, only for the
+  # in_progress update to land afterwards and permanently strand the
+  # progress check-run as "in progress" on an already-finished run.
   verify-gating-tests:
     name: ${{ (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test') && 'Run Gating Tests' || 'Run Gating Tests (skipped - irrelevant label event)' }}
-    needs: [check-trust, cluster-check, cluster-health-check, run-e2e-tests]
-    if: |
-      always() &&
-      (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test')
+    needs:
+      [
+        check-trust,
+        cluster-check,
+        cluster-health-check,
+        run-e2e-tests,
+        progress-check-start,
+        progress-check-running-tests,
+      ]
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Scoped here (rather than at the workflow level) -- needed by the
+    # "Complete progress check-run" step's checks.update call below. See
+    # progress-check-start above.
+    permissions:
+      checks: write
     steps:
       - name: Verify hot cluster E2E ran and passed
         env:
           TRUSTED: ${{ needs.check-trust.outputs.trusted }}
           E2E_RESULT: ${{ needs.run-e2e-tests.result }}
+          IS_IRRELEVANT_LABEL: ${{ github.event.action == 'labeled' && github.event.label.name != 'ok-to-test' }}
+          LABEL_NAME: ${{ github.event.label.name }}
         run: |
+          if [[ "${IS_IRRELEVANT_LABEL}" == "true" ]]; then
+            echo "Irrelevant label event ('${LABEL_NAME}') — this run does not represent a real gating-test outcome."
+            exit 0
+          fi
+
           echo "run-e2e-tests result: ${E2E_RESULT}"
 
           if [[ "${E2E_RESULT}" == "success" ]]; then
@@ -290,3 +488,44 @@ jobs:
             echo "::error::Hot cluster gating tests did not pass (run-e2e-tests result: '${E2E_RESULT}'). See the 'Run E2E Tests' job for details, or use /retest-e2e once fixed."
           fi
           exit 1
+
+      # if: always() so this still runs and reports the failure even when
+      # the step above exits 1 (steps default to skipping after a prior
+      # failure otherwise). continue-on-error: true so a transient Checks
+      # API failure here (e.g. a network blip) can never flip this job's --
+      # this is the required "Run Gating Tests" check -- own conclusion;
+      # the informational progress check is best-effort only.
+      - name: Complete progress check-run
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const isIrrelevantLabel = context.payload.action === 'labeled'
+              && context.payload.label?.name !== 'ok-to-test';
+            if (isIrrelevantLabel) {
+              core.info('Irrelevant label event — progress check already completed as a no-op.');
+              return;
+            }
+
+            const checkRunId = parseInt('${{ needs.progress-check-start.outputs.check_run_id }}', 10);
+            if (!checkRunId) {
+              core.warning('No progress check-run id — skipping update.');
+              return;
+            }
+
+            const passed = '${{ job.status }}' === 'success';
+
+            await github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: checkRunId,
+              status: 'completed',
+              conclusion: passed ? 'success' : 'failure',
+              output: {
+                title: passed ? 'Passed' : 'Failed',
+                summary: passed
+                  ? 'Hot cluster gating tests passed.'
+                  : 'Hot cluster gating tests did not pass. See the "Run Gating Tests" check for details.',
+              },
+            });

--- a/.github/workflows/ibmc-cluster-setup.yml
+++ b/.github/workflows/ibmc-cluster-setup.yml
@@ -663,6 +663,12 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           ADMIN_PASSWORD: ${{ secrets.CLUSTER_ADMIN_PASSWORD }}
           INSTALL_DIR: ${{ runner.temp }}/ipi-install
+          # github.head_ref is only set for pull_request*/pull_request_target
+          # events (the PR's source branch); github.ref_name would otherwise
+          # resolve to the *base* branch for pull_request_target (e.g. this
+          # workflow reached via hot-cluster-e2e.yml's auto-provision chain),
+          # misreporting the branch in the Slack message below.
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
           CONSOLE_URL=$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}' 2>/dev/null || echo "unknown")
 
@@ -686,7 +692,7 @@ jobs:
             exit 0
           fi
 
-          TEXT=":white_check_mark: *Hot cluster ready*"
+          TEXT=":white_check_mark: *Hot cluster ready [${BRANCH_NAME}]*"
           TEXT+=$'\n'"*Console:* <${CONSOLE_URL}>"
           TEXT+="${CREDS}"
 


### PR DESCRIPTION
## 📝 Description

- Improve hot-cluster E2E check visibility on PRs (dynamic phase narration + fix broken/fragmented check names)
- Modify `deploy-manual-console.yml` script to allow deployments from forked branches for trusted members who are included in the owners file. 

## 🔗 Links

Jira ticket: [CNV-92614](https://redhat.atlassian.net/browse/CNV-92614)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pull-request–driven manual console deployments, including PR context in run summaries and Slack notifications.
  * Introduced always-on Hot Cluster E2E progress reporting that updates through pipeline phases.
  * Added an option to skip hot-cluster probing/provisioning and force readiness to a safe value.
* **Bug Fixes**
  * Improved hot-cluster gating and verification to keep check contexts stable and correctly handle irrelevant-label events.
  * Strengthened PR deployment flow with PR-author validation and richer Slack messaging.
* **Chores**
  * Added `actionlint` configuration and a dedicated workflow-linting CI job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->