### PR TITLE
CNV-92538: add create-VM page objects and components

### DIFF
--- a/playwright/src/components/create-vm/bootable-volumes-actions-instance-components.ts
+++ b/playwright/src/components/create-vm/bootable-volumes-actions-instance-components.ts
@@ -1,0 +1,1117 @@
+/**
+ * Bootable volume detail page and instance type catalog components.
+ */
+
+import BaseComponent from '@/components/shared/base-component';
+import { STEP_INSTANCE_TYPE_CONFIG } from '@/data-models/step-defaults';
+import { MOCK_ENDPOINTS } from '@/utils/mock-responses';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+/**
+ * Page object for BootableVolume detail page.
+ * Handles viewing, verifying status, detail field inspection, and deleting bootable volumes.
+ */
+export class BootableVolumeDetailComponent extends BaseComponent {
+  private readonly _deleteBtn = this.locator('button:has-text("Delete")');
+  private readonly _resourceTitle = this.locator('[data-test-id="resource-title"]');
+  private readonly _roleTab = this.locator('[role="tab"]');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async deleteBootableVolume(volumeName: string, deletePvc = false): Promise<boolean> {
+    try {
+      const actionsButton = this.locator('button:has-text("Actions")');
+      await actionsButton.waitFor({ state: 'visible', timeout: 10000 });
+      await this.robustClick(actionsButton);
+
+      const deleteButton = this._deleteBtn;
+      await deleteButton.waitFor({ state: 'visible', timeout: 5000 });
+      await this.robustClick(deleteButton);
+
+      await this.locator('text=Delete DataSource?').waitFor({ state: 'visible', timeout: 5000 });
+
+      const volumeNameInModal = this.locator(`strong:has-text("${volumeName}")`);
+      const volumeNameExists = await volumeNameInModal
+        .isVisible({ timeout: 5000 })
+        .catch(() => false);
+      if (!volumeNameExists) {
+        return false;
+      }
+
+      if (deletePvc) {
+        const pvcCheckbox = this.locator('input[id="pvc-checkbox"]');
+        const pvcCheckboxExists = await pvcCheckbox
+          .isVisible({ timeout: 60000 })
+          .catch(() => false);
+        if (pvcCheckboxExists) {
+          await pvcCheckbox.check({ force: true });
+        }
+      }
+
+      const confirmDeleteButton = this._deleteBtn;
+      await confirmDeleteButton.waitFor({ state: 'visible', timeout: 5000 });
+      await this.robustClick(confirmDeleteButton);
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Returns the breadcrumb link text (first breadcrumb).
+   */
+  async getBreadcrumbText(): Promise<string | null> {
+    try {
+      const breadcrumb = this.locator('nav[aria-label="Breadcrumb"] a').first();
+      await breadcrumb.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await breadcrumb.innerText();
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Returns all detail field labels visible on the page.
+   * Polls briefly so that async-rendered fields (InstanceType, Preference) have time to appear.
+   */
+  async getDetailFieldLabels(minExpected = 6, timeoutMs = 30_000): Promise<string[]> {
+    const deadline = Date.now() + timeoutMs;
+    let labels: string[] = [];
+    while (Date.now() < deadline) {
+      try {
+        labels = await this.page.evaluate(() => {
+          const dts = document.querySelectorAll('main dt');
+          return Array.from(dts)
+            .map((dt) => dt.textContent?.trim() || '')
+            .filter(Boolean);
+        });
+        if (labels.length >= minExpected) return labels;
+      } catch {
+        /* retry */
+      }
+      await this.page.waitForTimeout(500);
+    }
+    return labels;
+  }
+
+  /**
+   * Returns the text content of a detail field (dd) by its label (dt).
+   * Uses the dt/dd sibling pattern on the detail page.
+   */
+  async getDetailFieldValue(label: string): Promise<string | null> {
+    try {
+      const value = await this.page.evaluate((lbl: string) => {
+        const dts = Array.from(document.querySelectorAll('main dt'));
+        for (const dt of dts) {
+          if (dt.textContent?.trim().startsWith(lbl)) {
+            const dd = dt.nextElementSibling;
+            if (dd?.tagName === 'DD') {
+              return dd.textContent?.trim() || null;
+            }
+          }
+        }
+        return null;
+      }, label);
+      return value;
+    } catch {
+      return null;
+    }
+  }
+
+  async getResourceTitle(): Promise<string> {
+    await this._resourceTitle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    return await this._resourceTitle.innerText();
+  }
+
+  async getStatusText(): Promise<string> {
+    const statusText = this.locator('[data-test="status-text"]');
+    await statusText.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    return await statusText.innerText();
+  }
+
+  async isResourceTitleEqualTo(
+    expectedName: string,
+    timeout: number = TestTimeouts.UI_ELEMENT_VISIBILITY,
+  ): Promise<boolean> {
+    try {
+      const startTime = Date.now();
+      const pollInterval = 500;
+
+      while (Date.now() - startTime < timeout) {
+        try {
+          await this._resourceTitle.waitFor({ state: 'visible', timeout: pollInterval });
+          const actualTitle = await this._resourceTitle.innerText();
+          if (actualTitle?.trim() === expectedName.trim()) {
+            return true;
+          }
+        } catch {}
+        await this.page.waitForTimeout(pollInterval);
+      }
+
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  async isStatusEqualTo(
+    expectedStatus: string,
+    timeout: number = TestTimeouts.DATA_VOLUME_STATUS,
+  ): Promise<boolean> {
+    try {
+      await this.page.waitForFunction(
+        ({ selector, expected }) => {
+          const element = document.querySelector(selector);
+          return element?.textContent?.trim() === expected;
+        },
+        { selector: '[data-test="status-text"]', expected: expectedStatus.trim() },
+        { timeout },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async navigateToBootableVolumeDetail(volumeName: string, namespace: string) {
+    await this.goTo(`/k8s/ns/${namespace}/cdi.kubevirt.io~v1beta1~DataSource/${volumeName}`);
+    await this.page
+      .waitForLoadState('networkidle', { timeout: TestTimeouts.UI_VISIBILITY_QUICK })
+      .catch(() => undefined);
+    await this._resourceTitle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+  }
+
+  /**
+   * Verifies that a detail field contains expected text (partial match).
+   */
+  async verifyDetailFieldContains(label: string, expectedText: string): Promise<boolean> {
+    const value = await this.getDetailFieldValue(label);
+    if (!value) return false;
+    return value.includes(expectedText);
+  }
+
+  /**
+   * Verifies that both "Details" and "YAML" tabs are visible on the detail page.
+   */
+  async verifyDetailTabsVisible(): Promise<boolean> {
+    try {
+      const detailsTab = this._roleTab.filter({ hasText: 'Details' });
+      const yamlTab = this._roleTab.filter({ hasText: 'YAML' });
+      await detailsTab.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await yamlTab.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export class CreateVmInstanceTypesComponent extends BaseComponent {
+  private readonly _addVolumeButton = this.locator('#tour-step-add-volume');
+  private readonly _bootableVolumeTableBody = this.locator('table.BootableVolumeList-table tbody');
+  private readonly _buttonSortFavorites = this.locator('button[aria-label="Sort favorites"]');
+  private readonly _createFolderButton = this.locator('button:has-text("Create folder")');
+  private readonly _createVirtualMachineButton = this.locator('button', {
+    hasText: 'Create VirtualMachine',
+  });
+  private readonly _createVmInstanceTypeSectionHeaderSvg = this.locator(
+    '.create-vm-instance-type-section__header svg',
+  );
+  private readonly _customizeVirtualMachineFooterButton = this.locator(
+    '.create-vm-instance-type-footer button',
+    { hasText: 'Customize VirtualMachine' },
+  );
+  private readonly _dialogModalDescription = this.locator(
+    '[data-test="dialog-modal"] #description',
+  );
+  private readonly _filterDropdownToggle = this.locator('[data-test-id="filter-dropdown-toggle"]');
+  private readonly _instanceTypeHelpText = this.locator(
+    '.create-vm-instance-type-section__HelpTextIcon:has-text("From the Volume table, select a bootable volume to boot your VirtualMachine")',
+  );
+  private readonly _instancetypesTab = this.locator('[data-test="instancetypes-tab"]');
+  private readonly _instanceTypesVmDetailsSection = this.locator(
+    '.instancetypes-vm-details-section',
+  );
+  private readonly _instancetypesVmDetailsSectionPlaceholderSearchFolder = this.locator(
+    '.instancetypes-vm-details-section [placeholder="Search folder"]',
+  );
+  private readonly _nameFilterInput = this.locator('[data-test="name-filter-input"]');
+  private readonly _nameVmname = this.locator('[name="vmname"]');
+  private readonly _rootRedHatProvidedBtn = this.locator(
+    '#root button:has-text("Red Hat provided")',
+  );
+  private readonly _rootUSeriesBtn = this.locator('#root button:has-text("U series")');
+  private readonly _selectVolumeToBootFrom = this.locator('text=Select volume to boot from');
+  private readonly _startAfterCreationCheckbox = this.locator(
+    '#start-after-create-checkbox',
+  ).first();
+  private readonly _tabModal = this.locator('#tab-modal');
+
+  private readonly _tdIdNameHasTextRhel9 = this.locator('td[id="name"]:has-text("rhel9")');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async addVolumeViaRegistry(
+    volumeName: string,
+    registryUrl: string,
+    username: string,
+    password: string,
+    instanceType: string = STEP_INSTANCE_TYPE_CONFIG.SMALL,
+    preference: string = STEP_INSTANCE_TYPE_CONFIG.FEDORA,
+    cronExpression = '0 0 * * 2',
+  ): Promise<boolean> {
+    try {
+      await this._addVolumeButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.RESOURCE_CREATION,
+      });
+      await this.robustClick(this._addVolumeButton);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+      const sourceTypeSelect = this.locator(
+        '[data-test="dialog-modal"] [data-test-id="source-type-select"]',
+      );
+      await sourceTypeSelect.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(sourceTypeSelect);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const registryOption = this.locator('[data-test-id="use-registry"]');
+      await this.robustClick(registryOption);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+      const containerImageInput = this.locator(
+        '[data-test="dialog-modal"] [data-test-id="volume-registry-container-source-input"]',
+      );
+      await containerImageInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await containerImageInput.fill(registryUrl);
+
+      const usernameInput = this.locator(
+        '[data-test="dialog-modal"] [data-test-id="volume-registry-container-source-username"]',
+      );
+      await usernameInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await usernameInput.fill(username);
+
+      const passwordInput = this.locator(
+        '[data-test="dialog-modal"] [data-test-id="volume-registry-container-source-password"]',
+      );
+      await passwordInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await passwordInput.fill(password);
+
+      const cronExpInput = this.locator(
+        '[data-test="dialog-modal"] input[data-test-id="volume-registry-retain-cron-expression"]',
+      );
+      await cronExpInput.scrollIntoViewIfNeeded();
+      await cronExpInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await cronExpInput.clear();
+      await cronExpInput.fill(cronExpression);
+
+      const volumeNameInput = this.locator(
+        '[data-test="dialog-modal"] #volume-name, [data-test="dialog-modal"] #name',
+      ).first();
+      await volumeNameInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await volumeNameInput.fill(volumeName);
+
+      const selectPreferenceButton = this.locator(
+        '[data-test="dialog-modal"] button:has-text("Select preference")',
+      );
+      await selectPreferenceButton.scrollIntoViewIfNeeded();
+      await selectPreferenceButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(selectPreferenceButton);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const searchPreferenceInput = this.locator('input[placeholder="Select preference"]');
+      await searchPreferenceInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await searchPreferenceInput.fill(preference);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const preferenceOption = this.locator(
+        `button#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
+      );
+      await preferenceOption.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(preferenceOption);
+
+      const selectInstanceButton = this.locator(
+        '[data-test="dialog-modal"] button:has-text("Select InstanceType")',
+      );
+      await selectInstanceButton.scrollIntoViewIfNeeded();
+      await selectInstanceButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(selectInstanceButton);
+
+      const redHatProvidedIT = this._rootRedHatProvidedBtn.first();
+      await redHatProvidedIT.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(redHatProvidedIT);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const uSeries = this._rootUSeriesBtn.first();
+      await uSeries.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(uSeries);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}")`).first();
+      await instanceTypeOption.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(instanceTypeOption);
+
+      const descriptionInput = this._dialogModalDescription;
+      await descriptionInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await descriptionInput.fill(`Test volume from Registry`);
+
+      await this.clickSave();
+
+      const addVolModal = this._tabModal;
+      await addVolModal.waitFor({
+        state: 'hidden',
+        timeout: TestTimeouts.TEST_EXTENDED,
+      });
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async addVolumeViaUpload(
+    volumeName: string,
+    isoFilePath: string,
+    instanceType = 'nano',
+    preference = 'alpine',
+  ): Promise<boolean> {
+    try {
+      await this._addVolumeButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.RESOURCE_CREATION,
+      });
+      await this.robustClick(this._addVolumeButton);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+      const uploadInput = this.locator('[data-test="dialog-modal"] input[type="file"]');
+
+      await uploadInput.setInputFiles(isoFilePath);
+
+      const isoCheckbox = this.locator('[data-test="dialog-modal"] input[id="iso-checkbox"]');
+      const isChecked = await isoCheckbox.isChecked().catch(() => false);
+      if (!isChecked) {
+        await isoCheckbox.check({ force: true });
+      }
+
+      const volumeNameInput = this.locator(
+        '[data-test="dialog-modal"] #volume-name, [data-test="dialog-modal"] #name',
+      ).first();
+      await volumeNameInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await volumeNameInput.fill(volumeName);
+
+      const selectPreferenceButton = this.locator(
+        '[data-test="dialog-modal"] button:has-text("Select preference")',
+      );
+      await selectPreferenceButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(selectPreferenceButton);
+
+      const searchPreferenceInput = this.locator('#select-inline-filter input');
+      await searchPreferenceInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await searchPreferenceInput.fill(preference);
+
+      const preferenceOption = this.locator(
+        `#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
+      );
+      await this.robustClick(preferenceOption);
+
+      const selectInstanceButton = this.locator(
+        '[data-test="dialog-modal"] button:has-text("Select InstanceType")',
+      );
+      await selectInstanceButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(selectInstanceButton);
+
+      const redHatProvided = this._rootRedHatProvidedBtn.first();
+      await this.robustClick(redHatProvided);
+
+      const uSeries = this._rootUSeriesBtn.first();
+      await this.robustClick(uSeries);
+
+      const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}:")`).first();
+      await this.robustClick(instanceTypeOption);
+
+      const descriptionInput = this._dialogModalDescription;
+      await descriptionInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await descriptionInput.fill(`Test volume from Upload`);
+
+      await this.clickSave();
+
+      const addVolModal = this._tabModal;
+      await addVolModal.waitFor({
+        state: 'hidden',
+        timeout: TestTimeouts.TEST_EXTENDED,
+      });
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async clearSecretsApiMock(namespace?: string): Promise<void> {
+    await this.page.unroute(MOCK_ENDPOINTS.NAMESPACE_SECRETS(namespace));
+  }
+
+  async clickAddConfigMapSecretOrServiceAccount(): Promise<void> {
+    const addButton = this.locator('button', {
+      hasText: 'Add Config Map, Secret, or Service Account',
+    });
+    await addButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(addButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const resourceToggle = this.locator('button.pf-v6-c-menu-toggle:has-text("Select a resource")');
+    await resourceToggle.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(resourceToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+  }
+
+  async clickAddVolumeButton() {
+    await this._addVolumeButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+    await this.robustClick(this._addVolumeButton);
+  }
+
+  async clickCliTab(): Promise<void> {
+    const cliTab = this.locator('.pf-v6-c-modal-box__body button:has-text("CLI")');
+    await cliTab.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(cliTab);
+  }
+  async clickCreateVirtualMachine() {
+    await this.robustClick(this._createVirtualMachineButton);
+  }
+
+  async clickCustomizeVirtualMachineFooterButton() {
+    await this._customizeVirtualMachineFooterButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._customizeVirtualMachineFooterButton);
+  }
+
+  async clickHugepages() {
+    await this.locator(`button:has-text("Hugepages")`).click();
+  }
+
+  async clickInstanceSize(sizeOption: string) {
+    await this.locator(`button:has-text("${sizeOption}")`).click();
+  }
+  async clickInstanceTypesTab() {
+    await this._instancetypesTab.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this._instancetypesTab.click();
+  }
+  async clickInstanceTypesVmDetailsSection() {
+    await this._instanceTypesVmDetailsSection.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(this._instanceTypesVmDetailsSection);
+  }
+
+  async clickOperatingSystem(osName: string) {
+    const osLocator = this.locator('#name small').filter({ hasText: osName }).first();
+    await osLocator.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+    await osLocator.click();
+  }
+
+  async clickSeriesDropdown(seriesName: string) {
+    await this.locator(`button:has-text("${seriesName} series")`).click();
+  }
+
+  async clickStartAfterCreationCheckbox() {
+    await this._startAfterCreationCheckbox.waitFor({
+      state: 'attached',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    const isChecked = await this._startAfterCreationCheckbox.isChecked().catch(() => false);
+    if (!isChecked) {
+      await this._startAfterCreationCheckbox.evaluate((el: HTMLInputElement) => {
+        el.checked = true;
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    }
+  }
+
+  async clickViewYamlAndCli(): Promise<void> {
+    const yamlCliButton = this.locator('button:has-text("View YAML & CLI")');
+    await yamlCliButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(yamlCliButton);
+  }
+
+  async fillVmName(vmName: string) {
+    await this._nameVmname.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this._nameVmname.fill(vmName);
+    await this._nameVmname.press('Tab');
+  }
+
+  async filterVolumeByName(volumeName = 'fedora'): Promise<boolean> {
+    try {
+      await this.locator(
+        '.create-vm-instance-type-section input[data-test-id="item-filter"]',
+      ).waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+
+      await this.locator('.create-vm-instance-type-section input[data-test-id="item-filter"]').fill(
+        volumeName,
+      );
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+
+      const volumeCell = this.locator(`td[id="name"]:has-text("${volumeName}")`).first();
+      await volumeCell.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+      const volumeExists = await volumeCell.isVisible().catch(() => false);
+      const rhel9Cell = this._tdIdNameHasTextRhel9;
+      const rhel9NotExists = !(await rhel9Cell.isVisible().catch(() => false));
+
+      return volumeExists && rhel9NotExists;
+    } catch {
+      return false;
+    }
+  }
+
+  async filterVolumeByOS(osName = 'Fedora'): Promise<boolean> {
+    try {
+      await this._filterDropdownToggle.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await this._filterDropdownToggle.click();
+
+      const osFilterOption = this.locator(`.co-filter-dropdown-item__name:has-text("${osName}")`);
+      await osFilterOption.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await osFilterOption.click();
+
+      const volumeNameButton = this.locator('button:has-text("Volume name")');
+      await volumeNameButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await volumeNameButton.click();
+
+      const selectVolumeText = this._selectVolumeToBootFrom;
+      await selectVolumeText.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await selectVolumeText.scrollIntoViewIfNeeded();
+
+      const fedoraCell = this.locator('td[id="name"]:has-text("fedora")').first();
+      const rhel9Cell = this._tdIdNameHasTextRhel9;
+
+      const fedoraExists = await fedoraCell.isVisible().catch(() => false);
+      const rhel9NotExists = !(await rhel9Cell.isVisible().catch(() => false));
+
+      return fedoraExists && rhel9NotExists;
+    } catch {
+      return false;
+    }
+  }
+
+  async getEnvironmentResourceGroupTitles(): Promise<string[]> {
+    const listbox = this.locator('#select-inline-filter-listbox');
+    await listbox.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const headings = listbox.locator('h1');
+    const count = await headings.count();
+    const titles: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const text = await headings.nth(i).textContent();
+      if (text) titles.push(text.trim());
+    }
+    return titles;
+  }
+
+  async getInstanceTypeText(): Promise<string> {
+    const instanceTypeLocator = this.locator(
+      '.pf-v6-c-description-list__group:has-text("InstanceType")',
+    );
+    await instanceTypeLocator.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    return (await instanceTypeLocator.textContent()) || '';
+  }
+
+  async getOperatingSystemText(): Promise<string> {
+    const osLocator = this.locator('.pf-v6-c-description-list__group:has-text("Operating system")');
+    await osLocator.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return (await osLocator.textContent()) || '';
+  }
+
+  /**
+   * Returns the text labels of all visible instance-type series buttons in the order they
+   * appear in the DOM. Use this to verify alphabetical/expected sort order (CNV-75583).
+   */
+  async getSeriesButtonTexts(): Promise<string[]> {
+    const buttons = this.locator('button[class*="series"], button:has-text(" series")');
+    const count = await buttons.count().catch(() => 0);
+    const texts: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const text = (await buttons.nth(i).textContent())?.trim() ?? '';
+      if (text) texts.push(text);
+    }
+    return texts;
+  }
+
+  isAddConfigMapButtonVisible(): Promise<boolean> {
+    return this.locator('button', { hasText: 'Add Config Map, Secret, or Service Account' })
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+  }
+
+  async isBootableVolumesSectionVisible(): Promise<boolean> {
+    const tableVisible = await this._bootableVolumeTableBody
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+    if (tableVisible) return true;
+    const selectVolumeText = this._selectVolumeToBootFrom;
+    return await selectVolumeText
+      .isVisible({ timeout: TestTimeouts.RETRY_DELAY })
+      .catch(() => false);
+  }
+
+  async isEnvironmentEditorVisible(): Promise<boolean> {
+    try {
+      await this.locator(
+        '.wizard-environment-tab, .environment-form__form, [data-test="save-button"]',
+      )
+        .first()
+        .waitFor({ state: 'attached', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  isEnvironmentErrorAlertVisible(waitMs = 3000): Promise<boolean> {
+    return this.locator('[aria-label*="Danger"], [aria-label*="danger"], .pf-m-danger')
+      .first()
+      .isVisible({ timeout: waitMs })
+      .catch(() => false);
+  }
+
+  async isInstanceTypesSectionVisible(): Promise<boolean> {
+    const sectionVisible = await this._instanceTypesVmDetailsSection
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+    if (sectionVisible) return true;
+    return await this._instanceTypeHelpText
+      .isVisible({ timeout: TestTimeouts.RETRY_DELAY })
+      .catch(() => false);
+  }
+
+  async markVolumeFavorite(): Promise<boolean> {
+    try {
+      await this._bootableVolumeTableBody.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      const tableBody = this._bootableVolumeTableBody;
+
+      const rows = tableBody.locator('tr');
+      const rowCount = await rows.count();
+
+      if (rowCount === 0) {
+        return false;
+      }
+
+      const lastRow = rows.nth(rowCount - 1);
+      const favoritesButton = lastRow.locator('td[id="favorites"] button');
+      await favoritesButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await favoritesButton.click();
+
+      const firstRow = rows.first();
+      const firstRowText = await firstRow.textContent();
+      if (!firstRowText?.includes('rhel9')) {
+        return false;
+      }
+
+      await favoritesButton.click();
+
+      const firstRowText2 = await firstRow.textContent();
+      if (!firstRowText2?.includes('rhel8')) {
+        return false;
+      }
+
+      await this._buttonSortFavorites.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await this._buttonSortFavorites.click();
+
+      const lastRowText = await lastRow.textContent();
+      if (!lastRowText?.includes('rhel')) {
+        return false;
+      }
+
+      await favoritesButton.click();
+      await favoritesButton.click();
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async markVolumeFavoriteWithUnfavorite(_volumeName: string): Promise<boolean> {
+    try {
+      await this._bootableVolumeTableBody.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+
+      const favoritesButton = this.page.locator('td[id="favorites"] button').first();
+      await favoritesButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+
+      const isFavorited = await favoritesButton
+        .evaluate((button) => {
+          const ariaPressed = button.getAttribute('aria-pressed');
+          if (ariaPressed === 'true') {
+            return true;
+          }
+
+          const svg = button.querySelector('svg');
+          if (svg) {
+            const path = svg.querySelector('path');
+            if (path) {
+              const fill = path.getAttribute('fill');
+
+              if (fill && fill !== 'none' && fill !== 'transparent' && fill !== 'currentColor') {
+                return true;
+              }
+            }
+          }
+
+          const classList = Array.from(button.classList);
+          return classList.some(
+            (cls) => cls.includes('filled') || cls.includes('active') || cls.includes('pressed'),
+          );
+        })
+        .catch(() => false);
+
+      if (isFavorited) {
+        await favoritesButton.click();
+
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      }
+
+      await favoritesButton.click();
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async mockSecretsApiWith403(namespace?: string): Promise<void> {
+    const pattern = MOCK_ENDPOINTS.NAMESPACE_SECRETS(namespace);
+    await this.page.route(pattern, async (route) => {
+      const ns = namespace ?? 'the requested namespace';
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          kind: 'Status',
+          apiVersion: 'v1',
+          status: 'Failure',
+          message: `secrets is forbidden: User cannot list resource "secrets" in API group "" in the namespace "${ns}"`,
+          reason: 'Forbidden',
+          code: 403,
+        }),
+      });
+    });
+  }
+
+  /**
+   * @deprecated Use {@link navigateToWizardInstanceTypes} on 4.22+.
+   */
+  async navigateToInstanceTypeCatalogViaVmList(namespace?: string): Promise<void> {
+    const ns = namespace || 'default';
+    await this.goTo(`/k8s/ns/${ns}/catalog/instancetype`);
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  async selectBootableVolume(volumeName: string): Promise<boolean> {
+    try {
+      await this._bootableVolumeTableBody.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+
+      const nameFilterInput = this._nameFilterInput;
+      await nameFilterInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await nameFilterInput.clear();
+      await nameFilterInput.fill(volumeName);
+
+      const volumeElement = this.locator('small', { hasText: volumeName }).first();
+      await volumeElement.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await this.robustClick(volumeElement);
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async selectFolderForInstanceType(folderName: string) {
+    try {
+      await this._instanceTypesVmDetailsSection.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+
+      await this._instancetypesVmDetailsSectionPlaceholderSearchFolder.focus();
+      await this._instancetypesVmDetailsSectionPlaceholderSearchFolder.fill(folderName);
+      await this._instancetypesVmDetailsSectionPlaceholderSearchFolder.press('Enter');
+
+      await this.robustClick(this._createFolderButton);
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async setStartAfterCreationInstanceType(enabled: boolean): Promise<void> {
+    const startAfterCheckbox = this.locator('#start-after-create-checkbox').first();
+    await startAfterCheckbox.scrollIntoViewIfNeeded().catch(() => undefined);
+    await startAfterCheckbox.waitFor({
+      state: 'attached',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    if (enabled) {
+      await startAfterCheckbox.check({ force: true });
+    } else {
+      await startAfterCheckbox.uncheck({ force: true });
+    }
+  }
+
+  async uncheckStartAfterCreationCheckbox() {
+    await this._startAfterCreationCheckbox.waitFor({
+      state: 'attached',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    const isChecked = await this._startAfterCreationCheckbox.isChecked().catch(() => false);
+    if (isChecked) {
+      await this._startAfterCreationCheckbox.evaluate((el: HTMLInputElement) => {
+        el.checked = false;
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    }
+  }
+
+  async verifyCliCommandComponents(components: string[]): Promise<Record<string, boolean>> {
+    const results: Record<string, boolean> = {};
+    for (const component of components) {
+      results[component] = await this.verifyCliCommandContains(component);
+    }
+    return results;
+  }
+
+  async verifyCliCommandContains(expectedText: string): Promise<boolean> {
+    const modalBody = this.locator('.pf-v6-c-modal-box__body');
+    const textLocator = modalBody.locator(`text=${expectedText}`);
+    try {
+      await textLocator.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return await textLocator.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyInstanceTypeHelpText(): Promise<boolean> {
+    try {
+      await this.page.waitForLoadState('domcontentloaded', {
+        timeout: TestTimeouts.RESOURCE_CREATION,
+      });
+      await this.page.waitForLoadState('load', {
+        timeout: TestTimeouts.RESOURCE_CREATION,
+      });
+
+      await this._createVmInstanceTypeSectionHeaderSvg.waitFor({
+        state: 'attached',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await this._createVmInstanceTypeSectionHeaderSvg.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+
+      await this.robustClick(this._createVmInstanceTypeSectionHeaderSvg);
+
+      await this._instanceTypeHelpText.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await this._instanceTypeHelpText.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyInstanceTypeSeries(): Promise<boolean> {
+    try {
+      const series = ['CX series', 'U series', 'O series', 'N series', 'M series', 'RT series'];
+      const results = await Promise.all(
+        series.map(async (seriesName) => {
+          const seriesLocator = this.locator('button', { hasText: seriesName });
+          await seriesLocator.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+          });
+          await seriesLocator.scrollIntoViewIfNeeded();
+          return await seriesLocator.isVisible().catch(() => false);
+        }),
+      );
+
+      return results.every((result) => result === true);
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyInstanceTypeText(expectedText: string): Promise<boolean> {
+    const instanceTypeText = await this.getInstanceTypeText();
+    return instanceTypeText.includes(expectedText);
+  }
+
+  async verifyOperatingSystemText(expectedText: string): Promise<boolean> {
+    const osText = await this.getOperatingSystemText();
+    return osText.includes(expectedText);
+  }
+
+  async verifyVolumeExistsInList(volumeName: string): Promise<boolean> {
+    try {
+      const nameFilterInput = this._nameFilterInput;
+      await nameFilterInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await nameFilterInput.clear();
+      await nameFilterInput.fill(volumeName);
+
+      return await this.locator('small', { hasText: volumeName })
+        .isVisible({ timeout: TestTimeouts.RESOURCE_CREATION })
+        .catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyVolumeNameInNameField(volumeName: string): Promise<boolean> {
+    try {
+      const nameField = this.locator('#name', { hasText: volumeName });
+      await nameField.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await nameField.isVisible();
+    } catch {
+      return false;
+    }
+  }
+}

--- a/playwright/src/components/create-vm/bootable-volumes-create-components.ts
+++ b/playwright/src/components/create-vm/bootable-volumes-create-components.ts
@@ -1,0 +1,1807 @@
+/**
+ * Bootable volumes list row actions, modals, and detail assertions.
+ */
+
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+/** Options for the Add volume (create Bootable Volume) form. */
+export interface CreateBootableVolumeFormOptions {
+  /** Preference name to select (e.g. 'alpine'). Default 'alpine'. */
+  preference?: string;
+  /** Instance type to select (e.g. 'nano'). Default 'nano'. */
+  instanceType?: string;
+}
+
+export class BootableVolumesRowActionsComponent extends BaseComponent {
+  private readonly _dialogModal = this.locator('[data-test="dialog-modal"]');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /** Clicks a menu item by its exact visible text label. */
+  private async clickMenuItemByText(label: string): Promise<void> {
+    const item = this.locator('[role="menuitem"]').filter({
+      has: this.locator('.pf-v6-c-menu__item-text', { hasText: label }),
+    });
+    await item.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(item);
+  }
+
+  /**
+   * Opens the kebab menu for a volume row and waits for the dropdown to be visible.
+   * The kebab toggle is the only <button> in each row (the name is an <a> link).
+   * Menu items have no data-test attributes — they are plain PF6 .pf-v6-c-menu__item buttons.
+   */
+  private async openRowKebabMenu(volumeName: string): Promise<void> {
+    const byTestId = this.locator('tbody tr').filter({
+      has: this.locator(`[data-test-id="${volumeName}"]`),
+    });
+    const byLink = this.locator('tbody tr').filter({
+      has: this.locator(`a:has-text("${volumeName}")`),
+    });
+    const row = byTestId.or(byLink).first();
+    await row.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const kebabButton = row.locator('button.pf-v6-c-menu-toggle');
+    await kebabButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(kebabButton);
+    await this.locator('[role="menuitem"]')
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+  }
+
+  /**
+   * In the Edit annotations modal ([data-test="dialog-modal"]): clicks "Add more", fills
+   * annotation key and value placeholders, and saves with [data-test="save-button"].
+   * Call after clickRowActionEditAnnotations(volumeName) when the modal is open.
+   */
+  async addAnnotationInEditAnnotationsModalAndSave(
+    annotationKey: string,
+    annotationValue: string,
+  ): Promise<void> {
+    const dialog = this._dialogModal;
+    await dialog.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    const addMoreButton = dialog.locator('button:has-text("Add more")');
+    await addMoreButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(addMoreButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const keyInput = dialog.locator('[placeholder="annotation key"]').last();
+    const valueInput = dialog.locator('[placeholder="annotation value"]').last();
+    await keyInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await keyInput.fill(annotationKey);
+    await valueInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await valueInput.fill(annotationValue);
+
+    const saveButton = dialog.locator('[data-test="save-button"]');
+    await saveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(saveButton);
+  }
+
+  /**
+   * In the Edit labels modal: fills the tags input with the given label (e.g. "key=value")
+   * and saves with [data-test="save-button"].
+   * Call after clickRowActionEditLabels(volumeName) when the modal is open.
+   */
+  async addLabelInEditLabelsModalAndSave(labelTag: string): Promise<void> {
+    const tagsInput = this.locator('[data-test="tags-input"]');
+    await tagsInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await tagsInput.fill(labelTag);
+    await this.page.keyboard.press('Enter');
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    const saveButton = this.locator('[data-test="save-button"]');
+    await saveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(saveButton);
+  }
+
+  /**
+   * Clicks Cancel in the Manage source modal.
+   */
+  async cancelManageSourceModal(): Promise<void> {
+    const cancelButton = this._dialogModal.locator('button', { hasText: 'Cancel' });
+    await cancelButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(cancelButton);
+    await this._dialogModal
+      .waitFor({ state: 'hidden', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => undefined);
+  }
+
+  /**
+   * In the Delete confirmation modal: checks the "delete PVC" checkbox (#delete-pvc-checkbox).
+   * Call after clickRowActionDelete(volumeName) when the modal is open.
+   */
+  async checkDeletePvcCheckbox(): Promise<void> {
+    const dialog = this._dialogModal;
+    await dialog.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const checkbox = dialog.locator('#delete-pvc-checkbox');
+    await checkbox.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const isChecked = await checkbox.isChecked();
+    if (!isChecked) {
+      await checkbox.click({ force: true });
+    }
+  }
+
+  async clickRowActionDelete(volumeName: string): Promise<void> {
+    await this.openRowKebabMenu(volumeName);
+    await this.clickMenuItemByText('Delete');
+  }
+
+  async clickRowActionEditAnnotations(volumeName: string): Promise<void> {
+    await this.openRowKebabMenu(volumeName);
+    await this.clickMenuItemByText('Edit annotations');
+  }
+
+  async clickRowActionEditLabels(volumeName: string): Promise<void> {
+    await this.openRowKebabMenu(volumeName);
+    await this.clickMenuItemByText('Edit labels');
+  }
+
+  /** Opens the kebab menu for the given volume row and clicks the "Manage source" action. */
+  async clickRowActionManageSource(volumeName: string): Promise<void> {
+    await this.openRowKebabMenu(volumeName);
+    await this.clickMenuItemByText('Manage source');
+  }
+
+  async clickRowActionUploadToRegistry(volumeName: string): Promise<void> {
+    await this.openRowKebabMenu(volumeName);
+    await this.clickMenuItemByText('Upload to registry');
+  }
+
+  /**
+   * In the Delete confirmation modal: clicks [data-test="save-button"] to confirm deletion.
+   * Call after checkDeletePvcCheckbox() when the modal is open.
+   */
+  async clickSaveInDeleteModal(): Promise<void> {
+    const dialog = this._dialogModal;
+    const saveButton = dialog.locator('[data-test="save-button"]');
+    await saveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(saveButton);
+  }
+
+  /**
+   * In the Upload to registry modal: clicks [data-test="save-button"].
+   * Call after fillUploadToRegistryForm() when the modal is open.
+   */
+  async clickSaveInUploadToRegistryModal(): Promise<void> {
+    const dialog = this._dialogModal;
+    const saveButton = dialog.locator('[data-test="save-button"]');
+    await saveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(saveButton);
+  }
+
+  /**
+   * Clicks the bootable volume name link in the list row to navigate to its detail page.
+   */
+  async clickVolumeNameToGoToDetail(volumeName: string): Promise<void> {
+    const row = this.locator('tbody tr').filter({
+      has: this.locator(`[data-test-id="${volumeName}"]`),
+    });
+    const nameLink = row.locator('a').filter({ hasText: volumeName }).first();
+    await nameLink.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(nameLink);
+  }
+
+  /**
+   * Fills the Cron expression field in the Manage source modal.
+   */
+  async fillManageSourceCronExpression(cron: string): Promise<void> {
+    const cronInput = this._dialogModal.locator('#dataimportcron-manage-source-cron');
+    await cronInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await cronInput.clear();
+    await cronInput.fill(cron);
+  }
+
+  /**
+   * Fills the Registry URL field in the Manage source modal.
+   * Call after isManageSourceModalVisible() returns true.
+   */
+  async fillManageSourceRegistryUrl(url: string): Promise<void> {
+    const urlInput = this._dialogModal.locator('#dataimportcron-manage-source-url');
+    await urlInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await urlInput.clear();
+    await urlInput.fill(url);
+  }
+
+  /**
+   * In the Upload to registry modal ([data-test="dialog-modal"]): fills Registry Name,
+   * Destination, Username, and Password. Does not click Save/Upload.
+   * Call after clickRowActionUploadToRegistry(volumeName) when the modal is open.
+   */
+  async fillUploadToRegistryForm(
+    registryName: string,
+    destination: string,
+    username: string,
+    password: string,
+  ): Promise<void> {
+    const dialog = this._dialogModal;
+    await dialog.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    await dialog.locator('#registryName').fill(registryName);
+    await dialog.locator('#destination').fill(destination);
+    await dialog.locator('#username').fill(username);
+    await dialog.locator('#password').fill(password);
+  }
+
+  /**
+   * Returns the current value of the Registry URL field in the Manage source modal.
+   */
+  async getManageSourceRegistryUrl(): Promise<string> {
+    const urlInput = this._dialogModal.locator('#dataimportcron-manage-source-url');
+    await urlInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return (await urlInput.inputValue()) ?? '';
+  }
+
+  /**
+   * Returns the text label of the submit button in the Upload to registry modal (CNV-82501).
+   */
+  async getUploadToRegistryModalButtonText(): Promise<string> {
+    const dialog = this._dialogModal;
+    const saveButton = dialog.locator('[data-test="save-button"]');
+    await saveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    return (await saveButton.textContent())?.trim() ?? '';
+  }
+
+  /**
+   * Returns true when the Manage source modal is open (dialog with [data-test="dialog-modal"]
+   * containing a heading that includes "source" or "Source").
+   */
+  async isManageSourceModalVisible(timeout = TestTimeouts.UI_ELEMENT_VISIBILITY): Promise<boolean> {
+    return this._dialogModal
+      .waitFor({ state: 'visible', timeout })
+      .then(() => true)
+      .catch(() => false);
+  }
+
+  /**
+   * Returns whether the submit button is disabled in the Upload to registry modal (CNV-82501).
+   */
+  async isUploadToRegistryModalButtonDisabled(): Promise<boolean> {
+    const dialog = this._dialogModal;
+    const saveButton = dialog.locator('[data-test="save-button"]');
+    await saveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    return await saveButton.isDisabled();
+  }
+
+  /**
+   * Clicks Save in the Manage source modal (type="submit" button).
+   * Waits for the modal to close.
+   */
+  async saveManageSourceModal(): Promise<void> {
+    const saveButton = this._dialogModal.locator('button[type="submit"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(saveButton);
+    await this._dialogModal
+      .waitFor({ state: 'hidden', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => undefined);
+  }
+
+  /**
+   * Sets the "Allow automatic update" checkbox in the Manage source modal.
+   * Pass true to enable, false to disable.
+   */
+  async setManageSourceAllowAutoUpdate(enable: boolean): Promise<void> {
+    const checkbox = this._dialogModal.locator('#dataimportcron-manage-allow-checkbox');
+    await checkbox.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const isChecked = await checkbox.isChecked();
+    if (isChecked !== enable) {
+      await checkbox.click();
+    }
+  }
+
+  /**
+   * On the bootable volume detail page: verifies that the annotations count text is visible
+   * (e.g. "1 Annotations").
+   */
+  async verifyAnnotationsCountTextOnDetailPage(expectedText: string): Promise<boolean> {
+    await this.page.waitForLoadState('load', {
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+
+    return await this.page
+      .getByText(expectedText)
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+  }
+
+  /**
+   * On the bootable volume detail page: verifies the labels section shows the expected label text.
+   * Finds the labels control via [data-test-id^="pw-bv-"][data-test-id$="-labels"] (clicks it if
+   * it is a button to expand), then checks that the expected label text is visible on the page.
+   */
+  async verifyLabelVisibleOnDetailPage(expectedLabelText: string): Promise<boolean> {
+    const labelsControl = this.locator('[data-test-id^="pw-bv-"][data-test-id$="-labels"]').first();
+    await labelsControl.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    const isButton = (await labelsControl.evaluate((el) => el.tagName === 'BUTTON')) ?? false;
+    if (isButton) {
+      await this.robustClick(labelsControl);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+    return await this.locator(`text=${expectedLabelText}`)
+      .isVisible()
+      .catch(() => false);
+  }
+
+  /**
+   * Verifies that the Upload to registry modal shows the Upload steps section
+   * ([aria-label="Upload steps"]). Call after clickRowActionUploadToRegistry(volumeName).
+   */
+  async verifyUploadStepsVisibleInUploadToRegistryModal(): Promise<boolean> {
+    await this.page.waitForLoadState('load', {
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+
+    const uploadSteps = this.locator('[aria-label="Upload steps"]');
+    return await uploadSteps
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+  }
+}
+
+/**
+ * Add-volume (create bootable volume) form interactions — upload, PVC, snapshot, registry, HTTP.
+ */
+export class BootableVolumesCreateFormsComponent extends BaseComponent {
+  /** Add volume modal (data-test="dialog-modal", id="tab-modal") */
+  private readonly _addVolumeDialog = this.locator('#tab-modal');
+
+  /** Volume name input (#name) in the Add volume form */
+  private readonly _createFormNameInput = this._addVolumeDialog.locator('#volume-name, #name');
+
+  /** Save button in the Add volume form footer */
+  private readonly _createFormSaveButton = this._addVolumeDialog.locator(
+    '[data-test="save-button"]',
+  );
+
+  private readonly _roleOption = this.locator('[role="option"]');
+  private readonly _selectInlineFilterInput = this.locator('#select-inline-filter input');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  private async _waitForSnapshotSizeAndContinue(
+    volumeName: string,
+    options: CreateBootableVolumeFormOptions,
+  ): Promise<void> {
+    const { preference = 'alpine', instanceType = 'nano' } = options;
+
+    // Wait for snapshot size to populate in the form (disk size is determined by the volume snapshot).
+    // The UI shows "Size cannot be zero" until the snapshot size is available.
+    const sizeCannotBeZero = this._addVolumeDialog.getByText('Size cannot be zero');
+    await sizeCannotBeZero.waitFor({
+      state: 'hidden',
+      timeout: TestTimeouts.DATA_VOLUME_STATUS,
+    });
+
+    await this._createFormNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._createFormNameInput.fill(volumeName);
+
+    const selectPreferenceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select preference")',
+    );
+    await selectPreferenceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectPreferenceButton);
+
+    const searchPreferenceInput = this._selectInlineFilterInput;
+    await searchPreferenceInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await searchPreferenceInput.fill(preference);
+
+    const preferenceOption = this.locator(
+      `#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
+    );
+    await this.robustClick(preferenceOption);
+
+    const selectInstanceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select InstanceType")',
+    );
+    await selectInstanceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectInstanceButton);
+
+    const redHatProvided = this._addVolumeDialog
+      .locator('button:has-text("Red Hat provided")')
+      .first();
+    await this.robustClick(redHatProvided);
+
+    const uSeries = this._addVolumeDialog.locator('button:has-text("U series")').first();
+    await this.robustClick(uSeries);
+
+    const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}:")`).first();
+    await this.robustClick(instanceTypeOption);
+
+    await this._createFormSaveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await expect(
+      this._createFormSaveButton,
+      'Create volume form Save button should be enabled after selecting volume snapshot source and instance type',
+    ).toBeEnabled({
+      timeout: TestTimeouts.FILE_UPLOAD,
+    });
+    await this.robustClick(this._createFormSaveButton);
+  }
+
+  /**
+   * Fills and submits the Add volume (create Bootable Volume) form.
+   * Call after clickCreateAndSelectOption('With form').
+   * Uploads the given image file, fills volume name, selects preference and instance type,
+   * then clicks Save once the button is enabled.
+   *
+   * @param volumeName - Name for the bootable volume
+   * @param imageFilePath - Absolute path to the image file to upload (e.g. from TestFileFactory.downloadCirrosImage)
+   * @param options - Optional preference and instance type (defaults: alpine, nano)
+   */
+  async fillCreateBootableVolumeFormAndSave(
+    volumeName: string,
+    imageFilePath: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    const { preference = 'alpine', instanceType = 'nano' } = options;
+
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const createFormFileInput = this._addVolumeDialog.locator('input[type="file"]');
+    await createFormFileInput.waitFor({
+      state: 'attached',
+      timeout: TestTimeouts.FILE_UPLOAD,
+    });
+    await createFormFileInput.setInputFiles(imageFilePath);
+
+    await this._createFormNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._createFormNameInput.fill(volumeName);
+
+    const selectPreferenceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select preference")',
+    );
+    await selectPreferenceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectPreferenceButton);
+
+    const searchPreferenceInput = this._selectInlineFilterInput;
+    await searchPreferenceInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await searchPreferenceInput.fill(preference);
+
+    const preferenceOption = this.locator(
+      `#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
+    );
+    await this.robustClick(preferenceOption);
+
+    const selectInstanceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select InstanceType")',
+    );
+    await selectInstanceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectInstanceButton);
+
+    const redHatProvided = this._addVolumeDialog
+      .locator('button:has-text("Red Hat provided")')
+      .first();
+    await this.robustClick(redHatProvided);
+
+    const uSeries = this._addVolumeDialog.locator('button:has-text("U series")').first();
+    await this.robustClick(uSeries);
+
+    const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}:")`).first();
+    await this.robustClick(instanceTypeOption);
+
+    await this._createFormSaveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await expect(
+      this._createFormSaveButton,
+      'Create volume form Save button should be enabled after selecting instance type',
+    ).toBeEnabled({
+      timeout: TestTimeouts.FILE_UPLOAD,
+    });
+    await this.robustClick(this._createFormSaveButton);
+  }
+
+  /**
+   * Fills and submits the Add volume form using an existing volume as source.
+   * Call after clickCreateAndSelectOption('With form').
+   * Selects source type "Volume", then Volume project and Volume name, fills destination
+   * volume name, preference and instance type, then saves.
+   *
+   * @param volumeName - Name for the new bootable volume
+   * @param existingVolumeName - Name of the existing DataVolume to use as source
+   * @param projectNamespace - Namespace (project) where the existing volume lives
+   * @param options - Optional preference and instance type (defaults: alpine, nano)
+   */
+  async fillCreateBootableVolumeFormFromExistingAndSave(
+    volumeName: string,
+    existingVolumeName: string,
+    projectNamespace: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    const { preference = 'alpine', instanceType = 'nano' } = options;
+
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const sourceTypeSelect = this._addVolumeDialog.locator('[data-test-id="source-type-select"]');
+    await sourceTypeSelect.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(sourceTypeSelect);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const useExistingVolume = this.locator('[data-test-id="use-existing-volume"] button');
+    await this.robustClick(useExistingVolume, { force: true });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const volumeProjectToggle = this._addVolumeDialog.locator('#pvc-project-select button');
+    await volumeProjectToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(volumeProjectToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const projectFilterInput = this._selectInlineFilterInput;
+    const projectFilterVisible = await projectFilterInput
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+    if (projectFilterVisible) {
+      await projectFilterInput.fill(projectNamespace);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const projectOption = this.locator(`[data-test-id="select-option-${projectNamespace}"]`);
+    await projectOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+    await this.robustClick(projectOption);
+
+    const volumeNameToggle = this._addVolumeDialog.locator('#pvc-name-select button');
+    await volumeNameToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(volumeNameToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const volumeNameFilterInput = this._selectInlineFilterInput;
+    const volumeFilterVisible = await volumeNameFilterInput
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+    if (volumeFilterVisible) {
+      await volumeNameFilterInput.fill(existingVolumeName);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const existingVolumeOption = this.locator(
+      `[role="listbox"] [data-test-id="${existingVolumeName}"]`,
+    );
+    await existingVolumeOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(existingVolumeOption);
+
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    await this._createFormNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._createFormNameInput.fill(volumeName);
+
+    const selectPreferenceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select preference")',
+    );
+    await selectPreferenceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectPreferenceButton);
+
+    const searchPreferenceInput = this._selectInlineFilterInput;
+    await searchPreferenceInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await searchPreferenceInput.fill(preference);
+
+    const preferenceOption = this.locator(
+      `#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
+    );
+    await this.robustClick(preferenceOption);
+
+    const selectInstanceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select InstanceType")',
+    );
+    await selectInstanceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectInstanceButton);
+
+    const redHatProvided = this._addVolumeDialog
+      .locator('button:has-text("Red Hat provided")')
+      .first();
+    await this.robustClick(redHatProvided);
+
+    const uSeries = this._addVolumeDialog.locator('button:has-text("U series")').first();
+    await this.robustClick(uSeries);
+
+    const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}:")`).first();
+    await this.robustClick(instanceTypeOption);
+
+    await this._createFormSaveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await expect(
+      this._createFormSaveButton,
+      'Create volume form Save button should be enabled after selecting existing volume source and instance type',
+    ).toBeEnabled({
+      timeout: TestTimeouts.FILE_UPLOAD,
+    });
+    await this.robustClick(this._createFormSaveButton);
+  }
+
+  /**
+   * Fills and submits the Add volume form using "Volume snapshot" and the first snapshot in the namespace.
+   * Same as fillCreateBootableVolumeFormFromSnapshotAndSave but selects the first available snapshot
+   * in the VolumeSnapshot name dropdown instead of a specific name.
+   */
+  async fillCreateBootableVolumeFormFromFirstSnapshotInNamespaceAndSave(
+    volumeName: string,
+    projectNamespace: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const sourceTypeSelect = this._addVolumeDialog.locator('[data-test-id="source-type-select"]');
+    await sourceTypeSelect.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(sourceTypeSelect);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const useSnapshot = this._roleOption.filter({ hasText: 'Volume snapshot' });
+    await useSnapshot.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(useSnapshot);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const snapshotProjectToggle = this._addVolumeDialog.locator(
+      'button.pf-v6-c-menu-toggle:has-text("--- Select VolumeSnapshot project ---")',
+    );
+    await snapshotProjectToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotProjectToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const snapshotProjectFilterInput = this._selectInlineFilterInput;
+    const snapshotProjectFilterVisible = await snapshotProjectFilterInput
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+    if (snapshotProjectFilterVisible) {
+      await snapshotProjectFilterInput.fill(projectNamespace);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const snapshotProjectOption = this.locator(`#select-inline-filter-${projectNamespace}`);
+    await snapshotProjectOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotProjectOption);
+
+    const snapshotNameToggle = this._addVolumeDialog.locator(
+      'button.pf-v6-c-menu-toggle:has-text("--- Select VolumeSnapshot name ---")',
+    );
+    await snapshotNameToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotNameToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const firstSnapshotOption = this.locator('[id^="select-inline-filter-vmsnapshot-"]').first();
+    await firstSnapshotOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(firstSnapshotOption);
+
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    await this._waitForSnapshotSizeAndContinue(volumeName, options);
+  }
+
+  /**
+   * Fills and submits the Add volume form using HTTP/URL as source.
+   * Call after clickCreateAndSelectOption('With form').
+   * Selects source type "HTTP" ([data-test-id="use-http"]), fills Image URL in .disk-source-form-group,
+   * then volume name, preference and instance type, then saves.
+   *
+   * @param volumeName - Name for the bootable volume
+   * @param imageUrl - HTTP(S) URL of the disk image (e.g. https://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img)
+   * @param options - Optional preference and instance type (defaults: alpine, nano)
+   */
+  async fillCreateBootableVolumeFormFromHttpAndSave(
+    volumeName: string,
+    imageUrl: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    const { preference = 'alpine', instanceType = 'nano' } = options;
+
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const sourceTypeSelect = this._addVolumeDialog.locator('[data-test-id="source-type-select"]');
+    await sourceTypeSelect.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(sourceTypeSelect);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const useHttp = this.locator('[data-test-id="use-http"]');
+    await useHttp.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(useHttp);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const imageUrlInput = this._addVolumeDialog.locator(
+      'input[aria-label="Image URL"], .disk-source-form-group input[type="text"]',
+    );
+    await imageUrlInput.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await imageUrlInput.first().fill(imageUrl);
+
+    await this._createFormNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._createFormNameInput.fill(volumeName);
+
+    const selectPreferenceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select preference")',
+    );
+    await selectPreferenceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectPreferenceButton);
+
+    const searchPreferenceInput = this._selectInlineFilterInput;
+    await searchPreferenceInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await searchPreferenceInput.fill(preference);
+
+    const preferenceOption = this.locator(
+      `#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
+    );
+    await this.robustClick(preferenceOption);
+
+    const selectInstanceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select InstanceType")',
+    );
+    await selectInstanceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectInstanceButton);
+
+    const redHatProvided = this._addVolumeDialog
+      .locator('button:has-text("Red Hat provided")')
+      .first();
+    await this.robustClick(redHatProvided);
+
+    const uSeries = this._addVolumeDialog.locator('button:has-text("U series")').first();
+    await this.robustClick(uSeries);
+
+    const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}:")`).first();
+    await this.robustClick(instanceTypeOption);
+
+    await this._createFormSaveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await expect(
+      this._createFormSaveButton,
+      'Create volume form Save button should be enabled after selecting HTTP source and instance type',
+    ).toBeEnabled({
+      timeout: TestTimeouts.FILE_UPLOAD,
+    });
+    await this.robustClick(this._createFormSaveButton);
+  }
+
+  /**
+   * Fills and submits the Add volume form using Registry as source.
+   * Call after clickCreateAndSelectOption('With form').
+   * Selects source type "Registry" ([data-test-id="use-registry"]), fills container image URL,
+   * optional cron expression for retain, volume name, preference and instance type, then saves.
+   *
+   * @param volumeName - Name for the bootable volume
+   * @param registryUrl - Container image URL (e.g. quay.io/containerdisks/centos:7-2009)
+   * @param cronExpression - Cron expression for retain (e.g. '0 0 * * 2')
+   * @param options - Optional preference and instance type (defaults: alpine, nano)
+   */
+  async fillCreateBootableVolumeFormFromRegistryAndSave(
+    volumeName: string,
+    registryUrl: string,
+    cronExpression: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    const { preference = 'alpine', instanceType = 'nano' } = options;
+
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const sourceTypeSelect = this._addVolumeDialog.locator('[data-test-id="source-type-select"]');
+    await sourceTypeSelect.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(sourceTypeSelect);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const useRegistry = this.locator('[data-test-id="use-registry"]');
+    await useRegistry.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(useRegistry);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const containerImageInput = this._addVolumeDialog.locator(
+      '[data-test-id="volume-registry-container-source-input"]',
+    );
+    await containerImageInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await containerImageInput.fill(registryUrl);
+
+    const cronExpInput = this._addVolumeDialog.locator(
+      'input[data-test-id="volume-registry-retain-cron-expression"], #volume-registry-retain-cron-expression',
+    );
+    await cronExpInput.scrollIntoViewIfNeeded();
+    await cronExpInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await cronExpInput.clear();
+    await cronExpInput.fill(cronExpression);
+
+    await this._createFormNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._createFormNameInput.fill(volumeName);
+
+    const selectPreferenceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select preference")',
+    );
+    await selectPreferenceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectPreferenceButton);
+
+    const searchPreferenceInput = this._selectInlineFilterInput;
+    await searchPreferenceInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await searchPreferenceInput.fill(preference);
+
+    const preferenceOption = this.locator(
+      `#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
+    );
+    await this.robustClick(preferenceOption);
+
+    const selectInstanceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select InstanceType")',
+    );
+    await selectInstanceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectInstanceButton);
+
+    const redHatProvided = this._addVolumeDialog
+      .locator('button:has-text("Red Hat provided")')
+      .first();
+    await this.robustClick(redHatProvided);
+
+    const uSeries = this._addVolumeDialog.locator('button:has-text("U series")').first();
+    await this.robustClick(uSeries);
+
+    const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}:")`).first();
+    await this.robustClick(instanceTypeOption);
+
+    await this._createFormSaveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await expect(
+      this._createFormSaveButton,
+      'Create volume form Save button should be enabled after selecting registry source and instance type',
+    ).toBeEnabled({
+      timeout: TestTimeouts.FILE_UPLOAD,
+    });
+    await this.robustClick(this._createFormSaveButton);
+  }
+
+  /**
+   * Fills and submits the Add volume form using a Volume snapshot as source.
+   * Call after clickCreateAndSelectOption('With form').
+   * Selects source type "Volume snapshot" from the source type dropdown, then snapshot project and
+   * snapshot name, fills destination volume name, preference and instance type, then saves.
+   *
+   * @param volumeName - Name for the new bootable volume
+   * @param snapshotName - Name of the VolumeSnapshot to use as source
+   * @param projectNamespace - Namespace (project) where the snapshot lives
+   * @param options - Optional preference and instance type (defaults: alpine, nano)
+   */
+  async fillCreateBootableVolumeFormFromSnapshotAndSave(
+    volumeName: string,
+    snapshotName: string,
+    projectNamespace: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const sourceTypeSelect = this._addVolumeDialog.locator('[data-test-id="source-type-select"]');
+    await sourceTypeSelect.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(sourceTypeSelect);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const useSnapshot = this._roleOption.filter({ hasText: 'Volume snapshot' });
+    await useSnapshot.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(useSnapshot);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const snapshotProjectToggle = this._addVolumeDialog.locator(
+      'button.pf-v6-c-menu-toggle:has-text("--- Select VolumeSnapshot project ---")',
+    );
+    await snapshotProjectToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotProjectToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const snapshotProjectFilterInput = this._selectInlineFilterInput;
+    const snapshotProjectFilterVisible = await snapshotProjectFilterInput
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+    if (snapshotProjectFilterVisible) {
+      await snapshotProjectFilterInput.fill(projectNamespace);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const snapshotProjectOption = this.locator(`#select-inline-filter-${projectNamespace}`);
+    await snapshotProjectOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotProjectOption);
+
+    const snapshotNameToggle = this._addVolumeDialog.locator(
+      'button.pf-v6-c-menu-toggle:has-text("--- Select VolumeSnapshot name ---")',
+    );
+    await snapshotNameToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotNameToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const snapshotNameFilterInput = this._selectInlineFilterInput;
+    const snapshotNameFilterVisible = await snapshotNameFilterInput
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+    if (snapshotNameFilterVisible) {
+      await snapshotNameFilterInput.fill(snapshotName);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const snapshotOption = this.locator(
+      `[id^="select-inline-filter-${snapshotName}"], button:has-text("${snapshotName}")`,
+    ).first();
+    await snapshotOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotOption);
+
+    await this._waitForSnapshotSizeAndContinue(volumeName, options);
+  }
+}
+
+export class BootableVolumesCreateComponent extends BaseComponent {
+  private readonly _addVolumeDialog = this.locator('#tab-modal');
+  private readonly _createFormNameInput = this._addVolumeDialog.locator('#volume-name, #name');
+  private readonly _createFormSaveButton = this._addVolumeDialog.locator(
+    '[data-test="save-button"]',
+  );
+
+  private readonly _roleOption = this.locator('[role="option"]');
+
+  private readonly _selectInlineFilterInput = this.locator('#select-inline-filter input');
+
+  constructor(page: Page) {
+    super(page);
+  }
+  private async _waitForSnapshotSizeAndContinue(
+    volumeName: string,
+    options: CreateBootableVolumeFormOptions,
+  ): Promise<void> {
+    const { preference = 'alpine', instanceType = 'nano' } = options;
+
+    const sizeCannotBeZero = this._addVolumeDialog.getByText('Size cannot be zero');
+    await sizeCannotBeZero.waitFor({
+      state: 'hidden',
+      timeout: TestTimeouts.DATA_VOLUME_STATUS,
+    });
+
+    await this._createFormNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._createFormNameInput.fill(volumeName);
+
+    const selectPreferenceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select preference")',
+    );
+    await selectPreferenceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectPreferenceButton);
+
+    const searchPreferenceInput = this._selectInlineFilterInput;
+    await searchPreferenceInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await searchPreferenceInput.fill(preference);
+
+    const preferenceOption = this.locator(
+      `#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
+    );
+    await this.robustClick(preferenceOption);
+
+    const selectInstanceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select InstanceType")',
+    );
+    await selectInstanceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectInstanceButton);
+
+    const redHatProvided = this._addVolumeDialog
+      .locator('button:has-text("Red Hat provided")')
+      .first();
+    await this.robustClick(redHatProvided);
+
+    const uSeries = this._addVolumeDialog.locator('button:has-text("U series")').first();
+    await this.robustClick(uSeries);
+
+    const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}:")`).first();
+    await this.robustClick(instanceTypeOption);
+
+    await this._createFormSaveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await expect(
+      this._createFormSaveButton,
+      'Create volume form Save button should be enabled after selecting volume snapshot source and instance type',
+    ).toBeEnabled({
+      timeout: TestTimeouts.FILE_UPLOAD,
+    });
+    await this.robustClick(this._createFormSaveButton);
+  }
+
+  override async clickCreateAndSelectOption(option: 'With form' | 'With YAML') {
+    const optionSelectors = {
+      'With form': 'button[role="menuitem"]:has-text("With form")',
+      'With YAML': 'button[role="menuitem"]:has-text("With YAML")',
+    };
+    await super.clickCreateAndSelectOption('[data-test="item-create"]', optionSelectors[option]);
+  }
+
+  async fillCreateBootableVolumeFormAndSave(
+    volumeName: string,
+    imageFilePath: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    const { preference = 'alpine', instanceType = 'nano' } = options;
+
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const createFormFileInput = this._addVolumeDialog.locator('input[type="file"]');
+    await createFormFileInput.waitFor({
+      state: 'attached',
+      timeout: TestTimeouts.FILE_UPLOAD,
+    });
+    await createFormFileInput.setInputFiles(imageFilePath);
+
+    await this._createFormNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._createFormNameInput.fill(volumeName);
+
+    const selectPreferenceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select preference")',
+    );
+    await selectPreferenceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectPreferenceButton);
+
+    const searchPreferenceInput = this._selectInlineFilterInput;
+    await searchPreferenceInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await searchPreferenceInput.fill(preference);
+
+    const preferenceOption = this.locator(
+      `#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
+    );
+    await this.robustClick(preferenceOption);
+
+    const selectInstanceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select InstanceType")',
+    );
+    await selectInstanceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectInstanceButton);
+
+    const redHatProvided = this._addVolumeDialog
+      .locator('button:has-text("Red Hat provided")')
+      .first();
+    await this.robustClick(redHatProvided);
+
+    const uSeries = this._addVolumeDialog.locator('button:has-text("U series")').first();
+    await this.robustClick(uSeries);
+
+    const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}:")`).first();
+    await this.robustClick(instanceTypeOption);
+
+    await this._createFormSaveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await expect(
+      this._createFormSaveButton,
+      'Create volume form Save button should be enabled after selecting instance type',
+    ).toBeEnabled({
+      timeout: TestTimeouts.FILE_UPLOAD,
+    });
+    await this.robustClick(this._createFormSaveButton);
+  }
+
+  async fillCreateBootableVolumeFormFromExistingAndSave(
+    volumeName: string,
+    existingVolumeName: string,
+    projectNamespace: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    const { preference = 'alpine', instanceType = 'nano' } = options;
+
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const sourceTypeSelect = this._addVolumeDialog.locator('[data-test-id="source-type-select"]');
+    await sourceTypeSelect.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(sourceTypeSelect);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const useExistingVolume = this.locator('[data-test-id="use-existing-volume"] button');
+    await this.robustClick(useExistingVolume, { force: true });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const volumeProjectToggle = this._addVolumeDialog.locator('#pvc-project-select button');
+    await volumeProjectToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(volumeProjectToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const projectFilterInput = this._selectInlineFilterInput;
+    const projectFilterVisible = await projectFilterInput
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+    if (projectFilterVisible) {
+      await projectFilterInput.fill(projectNamespace);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const projectOption = this.locator(`[data-test-id="select-option-${projectNamespace}"]`);
+    await projectOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+    await this.robustClick(projectOption);
+
+    const volumeNameToggle = this._addVolumeDialog.locator('#pvc-name-select button');
+    await volumeNameToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(volumeNameToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const volumeNameFilterInput = this._selectInlineFilterInput;
+    const volumeFilterVisible = await volumeNameFilterInput
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+    if (volumeFilterVisible) {
+      await volumeNameFilterInput.fill(existingVolumeName);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const existingVolumeOption = this.locator(
+      `[role="listbox"] [data-test-id="${existingVolumeName}"]`,
+    );
+    await existingVolumeOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(existingVolumeOption);
+
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    await this._createFormNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._createFormNameInput.fill(volumeName);
+
+    const selectPreferenceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select preference")',
+    );
+    await selectPreferenceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectPreferenceButton);
+
+    const searchPreferenceInput = this._selectInlineFilterInput;
+    await searchPreferenceInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await searchPreferenceInput.fill(preference);
+
+    const preferenceOption = this.locator(
+      `#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
+    );
+    await this.robustClick(preferenceOption);
+
+    const selectInstanceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select InstanceType")',
+    );
+    await selectInstanceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectInstanceButton);
+
+    const redHatProvided = this._addVolumeDialog
+      .locator('button:has-text("Red Hat provided")')
+      .first();
+    await this.robustClick(redHatProvided);
+
+    const uSeries = this._addVolumeDialog.locator('button:has-text("U series")').first();
+    await this.robustClick(uSeries);
+
+    const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}:")`).first();
+    await this.robustClick(instanceTypeOption);
+
+    await this._createFormSaveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await expect(
+      this._createFormSaveButton,
+      'Create volume form Save button should be enabled after selecting existing volume source and instance type',
+    ).toBeEnabled({
+      timeout: TestTimeouts.FILE_UPLOAD,
+    });
+    await this.robustClick(this._createFormSaveButton);
+  }
+
+  async fillCreateBootableVolumeFormFromFirstSnapshotInNamespaceAndSave(
+    volumeName: string,
+    projectNamespace: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const sourceTypeSelect = this._addVolumeDialog.locator('[data-test-id="source-type-select"]');
+    await sourceTypeSelect.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(sourceTypeSelect);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const useSnapshot = this._roleOption.filter({ hasText: 'Volume snapshot' });
+    await useSnapshot.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(useSnapshot);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const snapshotProjectToggle = this._addVolumeDialog.locator(
+      'button.pf-v6-c-menu-toggle:has-text("--- Select VolumeSnapshot project ---")',
+    );
+    await snapshotProjectToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotProjectToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const snapshotProjectFilterInput = this._selectInlineFilterInput;
+    const snapshotProjectFilterVisible = await snapshotProjectFilterInput
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+    if (snapshotProjectFilterVisible) {
+      await snapshotProjectFilterInput.fill(projectNamespace);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const snapshotProjectOption = this.locator(`#select-inline-filter-${projectNamespace}`);
+    await snapshotProjectOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotProjectOption);
+
+    const snapshotNameToggle = this._addVolumeDialog.locator(
+      'button.pf-v6-c-menu-toggle:has-text("--- Select VolumeSnapshot name ---")',
+    );
+    await snapshotNameToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotNameToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const firstSnapshotOption = this.locator('[id^="select-inline-filter-vmsnapshot-"]').first();
+    await firstSnapshotOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(firstSnapshotOption);
+
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    await this._waitForSnapshotSizeAndContinue(volumeName, options);
+  }
+
+  async fillCreateBootableVolumeFormFromHttpAndSave(
+    volumeName: string,
+    imageUrl: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    const { preference = 'alpine', instanceType = 'nano' } = options;
+
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const sourceTypeSelect = this._addVolumeDialog.locator('[data-test-id="source-type-select"]');
+    await sourceTypeSelect.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(sourceTypeSelect);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const useHttp = this.locator('[data-test-id="use-http"]');
+    await useHttp.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(useHttp);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const imageUrlInput = this._addVolumeDialog.locator(
+      'input[aria-label="Image URL"], .disk-source-form-group input[type="text"]',
+    );
+    await imageUrlInput.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await imageUrlInput.first().fill(imageUrl);
+
+    await this._createFormNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._createFormNameInput.fill(volumeName);
+
+    const selectPreferenceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select preference")',
+    );
+    await selectPreferenceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectPreferenceButton);
+
+    const searchPreferenceInput = this._selectInlineFilterInput;
+    await searchPreferenceInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await searchPreferenceInput.fill(preference);
+
+    const preferenceOption = this.locator(
+      `#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
+    );
+    await this.robustClick(preferenceOption);
+
+    const selectInstanceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select InstanceType")',
+    );
+    await selectInstanceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectInstanceButton);
+
+    const redHatProvided = this._addVolumeDialog
+      .locator('button:has-text("Red Hat provided")')
+      .first();
+    await this.robustClick(redHatProvided);
+
+    const uSeries = this._addVolumeDialog.locator('button:has-text("U series")').first();
+    await this.robustClick(uSeries);
+
+    const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}:")`).first();
+    await this.robustClick(instanceTypeOption);
+
+    await this._createFormSaveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await expect(
+      this._createFormSaveButton,
+      'Create volume form Save button should be enabled after selecting HTTP source and instance type',
+    ).toBeEnabled({
+      timeout: TestTimeouts.FILE_UPLOAD,
+    });
+    await this.robustClick(this._createFormSaveButton);
+  }
+
+  async fillCreateBootableVolumeFormFromRegistryAndSave(
+    volumeName: string,
+    registryUrl: string,
+    cronExpression: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    const { preference = 'alpine', instanceType = 'nano' } = options;
+
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const sourceTypeSelect = this._addVolumeDialog.locator('[data-test-id="source-type-select"]');
+    await sourceTypeSelect.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(sourceTypeSelect);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const useRegistry = this.locator('[data-test-id="use-registry"]');
+    await useRegistry.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(useRegistry);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const containerImageInput = this._addVolumeDialog.locator(
+      '[data-test-id="volume-registry-container-source-input"]',
+    );
+    await containerImageInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await containerImageInput.fill(registryUrl);
+
+    const cronExpInput = this._addVolumeDialog.locator(
+      'input[data-test-id="volume-registry-retain-cron-expression"], #volume-registry-retain-cron-expression',
+    );
+    await cronExpInput.scrollIntoViewIfNeeded();
+    await cronExpInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await cronExpInput.clear();
+    await cronExpInput.fill(cronExpression);
+
+    await this._createFormNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._createFormNameInput.fill(volumeName);
+
+    const selectPreferenceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select preference")',
+    );
+    await selectPreferenceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectPreferenceButton);
+
+    const searchPreferenceInput = this._selectInlineFilterInput;
+    await searchPreferenceInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await searchPreferenceInput.fill(preference);
+
+    const preferenceOption = this.locator(
+      `#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
+    );
+    await this.robustClick(preferenceOption);
+
+    const selectInstanceButton = this._addVolumeDialog.locator(
+      'button:has-text("Select InstanceType")',
+    );
+    await selectInstanceButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(selectInstanceButton);
+
+    const redHatProvided = this._addVolumeDialog
+      .locator('button:has-text("Red Hat provided")')
+      .first();
+    await this.robustClick(redHatProvided);
+
+    const uSeries = this._addVolumeDialog.locator('button:has-text("U series")').first();
+    await this.robustClick(uSeries);
+
+    const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}:")`).first();
+    await this.robustClick(instanceTypeOption);
+
+    await this._createFormSaveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await expect(
+      this._createFormSaveButton,
+      'Create volume form Save button should be enabled after selecting registry source and instance type',
+    ).toBeEnabled({
+      timeout: TestTimeouts.FILE_UPLOAD,
+    });
+    await this.robustClick(this._createFormSaveButton);
+  }
+
+  async fillCreateBootableVolumeFormFromSnapshotAndSave(
+    volumeName: string,
+    snapshotName: string,
+    projectNamespace: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const sourceTypeSelect = this._addVolumeDialog.locator('[data-test-id="source-type-select"]');
+    await sourceTypeSelect.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(sourceTypeSelect);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const useSnapshot = this._roleOption.filter({ hasText: 'Volume snapshot' });
+    await useSnapshot.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(useSnapshot);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const snapshotProjectToggle = this._addVolumeDialog.locator(
+      'button.pf-v6-c-menu-toggle:has-text("--- Select VolumeSnapshot project ---")',
+    );
+    await snapshotProjectToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotProjectToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const snapshotProjectFilterInput = this._selectInlineFilterInput;
+    const snapshotProjectFilterVisible = await snapshotProjectFilterInput
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+    if (snapshotProjectFilterVisible) {
+      await snapshotProjectFilterInput.fill(projectNamespace);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const snapshotProjectOption = this.locator(`#select-inline-filter-${projectNamespace}`);
+    await snapshotProjectOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotProjectOption);
+
+    const snapshotNameToggle = this._addVolumeDialog.locator(
+      'button.pf-v6-c-menu-toggle:has-text("--- Select VolumeSnapshot name ---")',
+    );
+    await snapshotNameToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotNameToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const snapshotNameFilterInput = this._selectInlineFilterInput;
+    const snapshotNameFilterVisible = await snapshotNameFilterInput
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+    if (snapshotNameFilterVisible) {
+      await snapshotNameFilterInput.fill(snapshotName);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const snapshotOption = this.locator(
+      `[id^="select-inline-filter-${snapshotName}"], button:has-text("${snapshotName}")`,
+    ).first();
+    await snapshotOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(snapshotOption);
+
+    await this._waitForSnapshotSizeAndContinue(volumeName, options);
+  }
+
+  async selectSourceTypeInAddVolumeModal(
+    sourceType: 'URL' | 'Registry' | 'Volume' | 'Volume snapshot',
+  ): Promise<void> {
+    const sourceTypeMap: Record<string, string> = {
+      URL: '[data-test-id="use-http"]',
+      Registry: '[data-test-id="use-registry"]',
+      Volume: 'button[role="option"]:has-text("Volume"):not(:has-text("snapshot"))',
+      'Volume snapshot': 'button[role="option"]:has-text("Volume snapshot")',
+    };
+
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const sourceTypeSelect = this._addVolumeDialog.locator('[data-test-id="source-type-select"]');
+    await sourceTypeSelect.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(sourceTypeSelect);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const option = this.locator(sourceTypeMap[sourceType]);
+    await option.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(option);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+}

--- a/playwright/src/components/create-vm/catalog-template-components.ts
+++ b/playwright/src/components/create-vm/catalog-template-components.ts
@@ -1,0 +1,1851 @@
+/**
+ * Template catalog and template detail components.
+ */
+
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import { waitForElementStable } from '@/utils/wait-helpers';
+import type { Page } from '@playwright/test';
+
+export class TemplateDetailComponent extends BaseComponent {
+  private readonly _pfV6CDescriptionListGroupHasTextSSHKey = this.locator(
+    '.pf-v6-c-description-list__group:has-text("SSH key")',
+  );
+  private readonly _pfV6CModalBoxBody = this.locator('.pf-v6-c-modal-box__body');
+  private readonly _tableDiskRowRoleGrid = this.locator(
+    'table, [data-test="disk-row"], [role="grid"]',
+  );
+  private readonly _yamlTab = this.locator('[data-test-id="horizontal-link-YAML"]');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async clickActionsDropdown() {
+    await this.robustClick(this.locator('[data-test="actions-dropdown"]'));
+  }
+
+  async clickCloneTemplate() {
+    await this.robustClick(this.locator('[data-test="actions-dropdown-item-clone"]'));
+  }
+
+  async clickDeleteTemplate() {
+    await this.robustClick(this.locator('[data-test-id="delete-template"]'));
+  }
+
+  async clickEditAnnotations() {
+    await this.robustClick(this.locator('[data-test="actions-dropdown-item-edit-annotations"]'));
+  }
+
+  async clickEditBootSource() {
+    await this.robustClick(this.locator('[data-test="actions-dropdown-item-edit-boot-source"]'));
+  }
+
+  async clickEditBootSourceRef() {
+    await this.robustClick(
+      this.locator('[data-test="actions-dropdown-item-edit-boot-source-ref"]'),
+    );
+  }
+
+  async clickEditLabels() {
+    await this.robustClick(this.locator('[data-test="actions-dropdown-item-edit-labels"]'));
+  }
+
+  async editDetails(templateData: {
+    cpu?: string;
+    mem?: string;
+    bootMode?: string;
+    workload?: string;
+    headless?: boolean;
+  }): Promise<void> {
+    // Edit CPU/Memory
+    if (templateData.cpu && templateData.mem) {
+      const cpuButton = this.locator('.pf-v6-c-description-list__group:has-text("CPU")')
+        .locator('button.pf-m-link.pf-m-inline')
+        .first();
+      await cpuButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+      });
+      await this.robustClick(cpuButton);
+      const cpuInput = this.locator('input[name="cpu-input"]');
+      const memoryInput = this.locator('input[name="memory-input"]');
+      await cpuInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+      await cpuInput.clear();
+      await cpuInput.fill(templateData.cpu);
+      await memoryInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+      await memoryInput.clear();
+      await memoryInput.fill(templateData.mem);
+      await this.clickSave();
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA); // wait for backend update
+    }
+
+    // Edit boot mode
+    if (templateData.bootMode) {
+      const bootModeButton = this.locator(
+        '.pf-v6-c-description-list__group:has-text("Boot mode")',
+      ).locator('button');
+      await bootModeButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+      });
+      await this.robustClick(bootModeButton);
+      const modalBody = this._pfV6CModalBoxBody;
+      await modalBody.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+      const bootModeMenuToggle = this._pfV6CModalBoxBody.locator('button.pf-v6-c-menu-toggle');
+      await bootModeMenuToggle.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_DELAY_MEDIUM,
+      });
+      await this.robustClick(bootModeMenuToggle);
+      await this.clickButtonByText(templateData.bootMode);
+      await this.clickSave();
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA); // wait for backend update
+    }
+
+    // Edit workload profile
+    if (templateData.workload) {
+      const workloadButton = this.locator(
+        '.pf-v6-c-description-list__group:has-text("Workload profile")',
+      ).locator('button');
+      await workloadButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+      });
+      await this.robustClick(workloadButton);
+      const modalBody = this._pfV6CModalBoxBody;
+      await modalBody.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+      const workloadMenuToggle = this._pfV6CModalBoxBody.locator('button.pf-v6-c-menu-toggle');
+      await workloadMenuToggle.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_DELAY_MEDIUM,
+      });
+      await this.robustClick(workloadMenuToggle);
+      await this.clickButtonByText(templateData.workload);
+      await this.clickSave();
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA); // wait for backend update
+    }
+
+    // Enable headless mode
+    if (templateData.headless) {
+      const headlessCheckbox = this.locator('#headless-mode');
+      await headlessCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+      });
+      await headlessCheckbox.check({ force: true });
+      // Note: Cypress doesn't click save for headless, it just checks the checkbox
+    }
+  }
+
+  async editDisks(templateData: {
+    disks?: Array<{
+      name?: string;
+      diskSource?: {
+        selector?: string;
+        value?: string;
+      };
+      size?: string;
+      storageClass?: string;
+    }>;
+  }): Promise<void> {
+    if (templateData.disks) {
+      await this.navigateToDisks();
+      for (const disk of templateData.disks) {
+        const addDiskButton = this.locator('button:has-text("Add disk")');
+        await addDiskButton.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+        });
+        await this.robustClick(addDiskButton);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+
+        if (disk.name) {
+          const diskNameInput = this.locator('input[aria-label="Disk name"]');
+          await diskNameInput.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+          });
+          await diskNameInput.clear();
+          await diskNameInput.fill(disk.name);
+        }
+
+        if (disk.diskSource?.selector) {
+          const diskSourceSelect = this.locator('[data-test-id="disk-source-select"]');
+          await diskSourceSelect.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_DELAY_MEDIUM,
+          });
+          await this.robustClick(diskSourceSelect);
+          const sourceOption = this.locator(disk.diskSource.selector);
+          await sourceOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+          await this.robustClick(sourceOption);
+        }
+
+        // Note: Additional disk configuration (size, storage class, etc.) would be added here
+        // This is a simplified version matching the Cypress pattern
+
+        await this.clickSave();
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+      }
+    }
+  }
+
+  async editNetworks(templateData: {
+    nics?: Array<{
+      name?: string;
+      model?: string;
+      network?: string;
+      type?: string;
+    }>;
+  }): Promise<void> {
+    if (templateData.nics) {
+      await this.navigateToNetworks();
+      for (const nic of templateData.nics) {
+        const addNetworkInterfaceButton = this.locator('button:has-text("Add network interface")');
+        await addNetworkInterfaceButton.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+        });
+        await this.robustClick(addNetworkInterfaceButton);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+
+        if (nic.name) {
+          const nicNameInput = this.locator('input[aria-label="Network interface name"]');
+          await nicNameInput.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+          });
+          await nicNameInput.clear();
+          await nicNameInput.fill(nic.name);
+        }
+
+        if (nic.model) {
+          const nicModelSelect = this.locator('[data-test-id="model-select"]');
+          await nicModelSelect.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_DELAY_MEDIUM,
+          });
+          await this.robustClick(nicModelSelect);
+          const modelOption = this.locator(`[data-test-id="model-select-${nic.model}"]`);
+          await modelOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+          await this.robustClick(modelOption);
+        }
+
+        if (nic.network) {
+          const nicNetworkSelect = this.locator(
+            '[data-test-id="network-attachment-definition-select"]',
+          );
+          await nicNetworkSelect.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_DELAY_MEDIUM,
+          });
+          const networkToggle = nicNetworkSelect.locator('button.pf-v6-c-menu-toggle__button');
+          await networkToggle.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+          await this.robustClick(networkToggle);
+          await this.clickButtonByText(nic.network);
+        }
+
+        if (nic.type) {
+          const nicTypeSelect = this.locator('[data-test-id="network-interface-type-select"]');
+          await nicTypeSelect.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_DELAY_MEDIUM,
+          });
+          await this.robustClick(nicTypeSelect);
+          const typeOption = this.locator(
+            `button[data-test-id="network-interface-type-select-${nic.type}"]`,
+          );
+          await typeOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+          await this.robustClick(typeOption);
+        }
+
+        await this.clickSave();
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+      }
+    }
+  }
+
+  async editScheduling(templateData: {
+    dedicatedResources?: boolean;
+    evictionStrategy?: boolean;
+  }): Promise<void> {
+    await this.navigateToScheduling();
+
+    // Edit dedicated resources
+    if (templateData.dedicatedResources) {
+      const dedicatedResourcesButton = this.locator(
+        '.pf-v6-c-description-list__group:has-text("Dedicated resources")',
+      ).locator('button');
+      await dedicatedResourcesButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+      });
+      await this.robustClick(dedicatedResourcesButton);
+      const dedicatedResourcesCheckbox = this.locator('input[id="dedicated-resources"]');
+      await dedicatedResourcesCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_DELAY_MEDIUM,
+      });
+      await dedicatedResourcesCheckbox.check({ force: true });
+      await this.clickSave();
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA); // wait for backend update
+    }
+
+    // Edit eviction strategy
+    if (templateData.evictionStrategy) {
+      const evictionStrategyButton = this.locator(
+        '.pf-v6-c-description-list__group:has-text("Eviction strategy")',
+      ).locator('button');
+      await evictionStrategyButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+      });
+      await this.robustClick(evictionStrategyButton);
+      const evictionStrategyCheckbox = this.locator('input[id="eviction-strategy"]');
+      await evictionStrategyCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_DELAY_MEDIUM,
+      });
+      await evictionStrategyCheckbox.uncheck({ force: true });
+      await this.clickSave();
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA); // wait for backend update
+    }
+  }
+
+  async editScripts(templateData: {
+    username?: string;
+    password?: string;
+    ethName?: string;
+    ipAddr?: string;
+    gateway?: string;
+    newSecret?: string;
+    existSecret?: string;
+  }): Promise<void> {
+    if (
+      templateData.username ||
+      templateData.password ||
+      templateData.ethName ||
+      templateData.ipAddr ||
+      templateData.gateway ||
+      templateData.newSecret ||
+      templateData.existSecret
+    ) {
+      await this.navigateToScripts();
+    }
+
+    // Edit cloud-init
+    if (
+      templateData.username ||
+      templateData.password ||
+      templateData.ethName ||
+      templateData.ipAddr ||
+      templateData.gateway
+    ) {
+      const cloudInitButton = this.locator(
+        '.pf-v6-c-description-list__group:has-text("Cloud-init")',
+      )
+        .locator('button')
+        .first();
+      await cloudInitButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+      });
+      await this.robustClick(cloudInitButton);
+
+      if (templateData.username) {
+        const cloudInitUsernameInput = this.locator('input[id="cloudinit-user"]');
+        await cloudInitUsernameInput.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_DELAY_MEDIUM,
+        });
+        await cloudInitUsernameInput.clear();
+        await cloudInitUsernameInput.fill(templateData.username);
+      }
+
+      if (templateData.password) {
+        const cloudInitPasswordInput = this.locator('input[id="cloudinit-password"]');
+        await cloudInitPasswordInput.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_DELAY_MEDIUM,
+        });
+        await cloudInitPasswordInput.clear();
+        await cloudInitPasswordInput.fill(templateData.password);
+      }
+
+      if (templateData.ethName || templateData.ipAddr || templateData.gateway) {
+        const cloudInitNetworkCheckbox = this.locator('input[id="custom-network-checkbox"]');
+        await cloudInitNetworkCheckbox.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_DELAY_MEDIUM,
+        });
+        await cloudInitNetworkCheckbox.check({ force: true });
+
+        if (templateData.ethName) {
+          const cloudInitEthNameInput = this.locator('input[id="ethernet-name"]');
+          await cloudInitEthNameInput.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_DELAY_MEDIUM,
+          });
+          await cloudInitEthNameInput.fill(templateData.ethName);
+        }
+
+        if (templateData.ipAddr) {
+          const cloudInitIpAddressInput = this.locator('input[id="address"]');
+          await cloudInitIpAddressInput.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_DELAY_MEDIUM,
+          });
+          await cloudInitIpAddressInput.fill(templateData.ipAddr);
+        }
+
+        if (templateData.gateway) {
+          const cloudInitGatewayInput = this.locator('input[id="gateway"]');
+          await cloudInitGatewayInput.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_DELAY_MEDIUM,
+          });
+          await cloudInitGatewayInput.fill(templateData.gateway);
+        }
+      }
+
+      const cloudInitApplyButton = this.locator('button:has-text("Apply")');
+      await cloudInitApplyButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_DELAY_MEDIUM,
+      });
+      await this.robustClick(cloudInitApplyButton);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+    }
+
+    // Edit SSH keys - new secret
+    if (templateData.newSecret) {
+      const sshKeyButton = this._pfV6CDescriptionListGroupHasTextSSHKey.locator('button').first();
+      await sshKeyButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+      });
+      await this.robustClick(sshKeyButton);
+      const sshKeyAddNewButton = this.locator('#addNew');
+      await sshKeyAddNewButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_DELAY_MEDIUM,
+      });
+      await this.robustClick(sshKeyAddNewButton);
+      // Note: File upload would be handled here (cy.dropFile)
+      // For now, we'll just fill the secret name
+      const sshKeySecretNameInput = this.locator('#new-secret-name');
+      await sshKeySecretNameInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_DELAY_MEDIUM,
+      });
+      await sshKeySecretNameInput.clear();
+      await sshKeySecretNameInput.fill(templateData.newSecret);
+      await this.clickSave();
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+    }
+
+    // Edit SSH keys - existing secret
+    if (templateData.existSecret) {
+      const sshKeyButton = this._pfV6CDescriptionListGroupHasTextSSHKey.locator('button').first();
+      await sshKeyButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+      });
+      await this.robustClick(sshKeyButton);
+      const sshKeyUseExistingButton = this.locator('#useExisting');
+      await sshKeyUseExistingButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_DELAY_MEDIUM,
+      });
+      await this.robustClick(sshKeyUseExistingButton);
+      const sshKeySecretSelect = this.locator('text=Select project...');
+      await sshKeySecretSelect.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_DELAY_MEDIUM,
+      });
+      await this.robustClick(sshKeySecretSelect);
+      await this.clickButtonByText(templateData.existSecret);
+      await this.clickSave();
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+    }
+  }
+
+  async editTemplate(templateData: {
+    cpu?: string;
+    mem?: string;
+    bootMode?: string;
+    workload?: string;
+    headless?: boolean;
+    dedicatedResources?: boolean;
+    evictionStrategy?: boolean;
+    nics?: Array<{
+      name?: string;
+      model?: string;
+      network?: string;
+      type?: string;
+    }>;
+    disks?: Array<{
+      name?: string;
+      diskSource?: {
+        selector?: string;
+        value?: string;
+      };
+      size?: string;
+      storageClass?: string;
+    }>;
+    username?: string;
+    password?: string;
+    ethName?: string;
+    ipAddr?: string;
+    gateway?: string;
+    newSecret?: string;
+    existSecret?: string;
+  }): Promise<void> {
+    await this.editDetails(templateData);
+    await this.editScheduling(templateData);
+    await this.editNetworks(templateData);
+    await this.editDisks(templateData);
+    await this.editScripts(templateData);
+  }
+
+  async getDetailFieldValue(
+    fieldLabel: string,
+    timeout: number = TestTimeouts.UI_ELEMENT_VISIBILITY,
+  ): Promise<string> {
+    const group = this.locator('.pf-v6-c-description-list__group').filter({
+      has: this.page.locator(`.pf-v6-c-description-list__term`, { hasText: fieldLabel }),
+    });
+    const dd = group.locator('.pf-v6-c-description-list__description, dd');
+    try {
+      await dd.first().waitFor({ state: 'visible', timeout });
+      return (await dd.first().textContent())?.trim() ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  async isTemplateNameVisible(
+    templateName: string,
+    timeout: number = TestTimeouts.UI_ELEMENT_VISIBILITY,
+  ): Promise<boolean> {
+    try {
+      const templateNameElement = this.locator('span', { hasText: templateName });
+
+      await templateNameElement.waitFor({ state: 'visible', timeout });
+
+      return await templateNameElement.isVisible();
+    } catch (error) {
+      return false;
+    }
+  }
+
+  async isYamlTabHidden(timeout = 15000): Promise<boolean> {
+    try {
+      await this._yamlTab.waitFor({ state: 'hidden', timeout });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isYamlTabVisible(timeout = 15000): Promise<boolean> {
+    try {
+      await this._yamlTab.waitFor({ state: 'visible', timeout });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async navigateToDisks() {
+    await super.navigateToTab(this.locator('[data-test-id="horizontal-link-Disks"]'));
+
+    const diskTable = this._tableDiskRowRoleGrid;
+    await diskTable
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT })
+      .catch(() => {
+        return;
+      });
+  }
+
+  async navigateToNetworks() {
+    await super.navigateToTab(this.locator('[data-test-id="horizontal-link-Network interfaces"]'));
+
+    const networkTable = this.locator('table, [data-test="network-row"], [role="grid"]');
+    await networkTable
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT })
+      .catch(() => {
+        return;
+      });
+  }
+
+  async navigateToParameters() {
+    await super.navigateToTab(this.locator('[data-test-id="horizontal-link-Parameters"]'));
+
+    await this.waitForLoadingComplete(5000);
+  }
+
+  async navigateToScheduling() {
+    await super.navigateToTab(this.locator('[data-test-id="horizontal-link-Scheduling"]'));
+
+    await this.waitForLoadingComplete(5000);
+  }
+
+  async navigateToScripts() {
+    await super.navigateToTab(this.locator('[data-test-id="horizontal-link-Scripts"]'));
+
+    await this.waitForLoadingComplete(5000);
+  }
+
+  async navigateToTemplateDetail(templateName: string, namespace: string) {
+    await this.goTo(`/k8s/ns/${namespace}/templates/${templateName}`);
+  }
+
+  async navigateToYAML() {
+    await super.navigateToTab(this._yamlTab);
+
+    await this.waitForLoadingComplete(5000);
+  }
+
+  async verifyAllDetailFields(expected: Record<string, string>): Promise<{
+    passed: string[];
+    failed: Array<{ field: string; expected: string; actual: string }>;
+  }> {
+    const passed: string[] = [];
+    const failed: Array<{ field: string; expected: string; actual: string }> = [];
+    for (const [field, expectedValue] of Object.entries(expected)) {
+      const actual = await this.getDetailFieldValue(field);
+      if (actual.includes(expectedValue)) {
+        passed.push(field);
+      } else {
+        failed.push({ field, expected: expectedValue, actual });
+      }
+    }
+    return { passed, failed };
+  }
+
+  async verifyCloudInit(): Promise<boolean> {
+    await this.waitForLoadingComplete(5000);
+
+    return await super.verifyTextVisible('Cloud-init', true);
+  }
+
+  async verifyCloudUserPassword(): Promise<boolean> {
+    return await super.verifyTextVisible('CLOUD_USER_PASSWORD');
+  }
+
+  async verifyContainerDisk(): Promise<boolean> {
+    await this.waitForLoadingComplete(5000);
+
+    const diskTable = this._tableDiskRowRoleGrid;
+    await diskTable
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT })
+      .catch(() => {
+        return;
+      });
+
+    // Check multiple possible selectors for containerdisk
+    const containerdiskLocators = [
+      this.page.getByText('containerdisk', { exact: false }),
+      this.locator('[data-test*="containerdisk"]'),
+      this.locator('td:has-text("containerdisk")'),
+      this.locator('[role="cell"]:has-text("containerdisk")'),
+      this.locator('[data-test="disk-row"]:has-text("containerdisk")'),
+    ];
+
+    for (const locator of containerdiskLocators) {
+      const isVisible = await locator
+        .first()
+        .isVisible({ timeout: TestTimeouts.RETRY_DELAY })
+        .catch(() => false);
+      if (isVisible) {
+        return true;
+      }
+    }
+
+    return await super.verifyTextVisible('containerdisk', true);
+  }
+
+  async verifyCpuMemory(expectedCpu: string, expectedMemGi: string): Promise<boolean> {
+    const expectedText = `${expectedCpu} CPU | ${expectedMemGi} GiB Memory`;
+    try {
+      const cpuMemValue = this.locator(`text=${expectedText}`).first();
+      await cpuMemValue.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyDataSourceName(): Promise<boolean> {
+    await this.waitForLoadingComplete(5000);
+
+    return await super.verifyTextVisible('DATA_SOURCE_NAME', true);
+  }
+
+  async verifyDiskNameVisible(diskName: string): Promise<boolean> {
+    await this.waitForLoadingComplete(5000);
+
+    const diskTable = this._tableDiskRowRoleGrid;
+    await diskTable
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT })
+      .catch(() => {
+        return;
+      });
+
+    const diskLocators = [
+      this.page.getByText(diskName, { exact: true }),
+      this.locator(`td:has-text("${diskName}")`),
+      this.locator(`[role="cell"]:has-text("${diskName}")`),
+    ];
+
+    for (const locator of diskLocators) {
+      const isVisible = await locator
+        .first()
+        .isVisible({ timeout: TestTimeouts.RETRY_DELAY })
+        .catch(() => false);
+      if (isVisible) {
+        return true;
+      }
+    }
+
+    return await super.verifyTextVisible(diskName, true);
+  }
+
+  async verifyDisplayName(): Promise<boolean> {
+    return await super.verifyTextVisible('Display name', true);
+  }
+
+  async verifyDownload(): Promise<boolean> {
+    return await super.verifyTextVisible('Download');
+  }
+
+  async verifyPodNetworking(): Promise<boolean> {
+    return await super.verifyTextVisible('Network interfaces', true);
+  }
+
+  async verifyProvider(provider: string): Promise<boolean> {
+    try {
+      // The provider is typically in a description list text element
+      // Cypress uses: cy.contains(vmView.descrText, cloneTemplate.provider)
+      // where descrText = '.pf-v6-c-description-list__text'
+      const providerText = this.locator('.pf-v6-c-description-list__text').filter({
+        hasText: provider,
+      });
+      await providerText.waitFor({ state: 'visible', timeout: TestTimeouts.UI_VISIBILITY_QUICK });
+      return await providerText.isVisible().catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyRedHatTemplateNotEditable(): Promise<boolean> {
+    return await super.verifyTextVisible('Templates provided by Red Hat are not editable');
+  }
+
+  async verifyRootdisk(): Promise<boolean> {
+    await this.waitForLoadingComplete(5000);
+
+    const diskTable = this._tableDiskRowRoleGrid;
+    await diskTable
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT })
+      .catch(() => {
+        return;
+      });
+
+    // Check multiple possible selectors for rootdisk
+    const rootdiskLocators = [
+      this.page.getByText('rootdisk', { exact: false }),
+      this.locator('[data-test*="rootdisk"]'),
+      this.locator('td:has-text("rootdisk")'),
+      this.locator('[role="cell"]:has-text("rootdisk")'),
+      this.locator('[data-test="disk-row"]:has-text("rootdisk")'),
+    ];
+
+    for (const locator of rootdiskLocators) {
+      const isVisible = await locator
+        .first()
+        .isVisible({ timeout: TestTimeouts.RETRY_DELAY })
+        .catch(() => false);
+      if (isVisible) {
+        return true;
+      }
+    }
+
+    return await super.verifyTextVisible('rootdisk', true);
+  }
+
+  async verifyTolerations(): Promise<boolean> {
+    return await super.verifyTextVisible('Tolerations', true);
+  }
+}
+
+export class CreateVmTemplateCatalogComponent extends BaseComponent {
+  /**
+   * Maps legacy TEMPLATE_DISPLAY_NAMES to metadata names used as data-test-id in CNV 4.99+.
+   * In CNV 4.99+ the card text no longer contains the display name, so we look up by data-test-id.
+   */
+  private static readonly _displayNameToMetadataName: Record<string, string> = {
+    'Red Hat Enterprise Linux 8 VM': 'rhel8-server-small',
+    'Red Hat Enterprise Linux 9 VM': 'rhel9-server-small',
+    'Fedora VM': 'fedora-server-small',
+    'CentOS Stream 9 VM': 'centos-stream9-server-small',
+    'Microsoft Windows 11 VM': 'windows11-desktop-medium',
+    'Microsoft Windows Server 2022 VM': 'windows2k22-server-medium',
+    'Microsoft Windows Server 2016 VM': 'windows2k16-server-medium',
+    'Microsoft Windows Server 2019 VM': 'windows2k19-server-medium',
+  };
+  private readonly _architectureFilter = this.locator(
+    '[data-test-id="filter-category-Architecture"]',
+  );
+  private readonly _bootFromCDCheckbox = this.locator('[data-test-id="boot-cd"]');
+  private readonly _bootSourceDropdown = this.locator('[data-test-id="cd-boot-source"]');
+  private readonly _createFolderButton = this.locator('button:has-text("Create folder")');
+  private readonly _createVirtualMachineButton = this.locator('button', {
+    hasText: 'Create VirtualMachine',
+  });
+  private readonly _customizeVirtualMachineButton = this.locator(
+    '[data-test-id="customize-vm-btn"]',
+  );
+  private readonly _customizeVirtualMachineFooterButton = this.locator(
+    '.create-vm-instance-type-footer button',
+    { hasText: 'Customize VirtualMachine' },
+  );
+  private readonly _diskSourceDropdown = this.locator('[data-test-id="disk-boot-source"]');
+  private readonly _diskSourceRegistryInput = this.locator(
+    '[data-test-id="disk-boot-source-container-source-input"]',
+  );
+  private readonly _diskSourceURLInput = this.locator(
+    '[data-test-id="disk-boot-source-http-source-input"]',
+  );
+  private readonly _filterDropdownButton = this.locator('button:has-text("Filter")');
+
+  private readonly _quickCreateVmButton = this.locator('[data-test-id="quick-create-vm-btn"]');
+  private readonly _quickFormVmFolderInput = this.locator(
+    '[id="quick-create-form"] [placeholder="Search folder"]',
+  );
+  private readonly _quickFormVmFolderSelectButton = this.locator('#vm-folder-select button');
+  private readonly _searchCatalogInput = this.locator(
+    '[data-test="search-catalog"] input, input[placeholder="Filter by keyword..."]',
+  );
+
+  private readonly _selectInlineFilterInput = this.locator('#select-inline-filter input');
+  private readonly _startAfterCreationCheckbox = this.locator(
+    '#start-after-create-checkbox',
+  ).first();
+
+  private readonly _templateCatalogVmNameInput = this.locator(
+    '[data-test-id="template-catalog-vm-name-input"]',
+  );
+  private readonly _templatesTab = this.locator('[data-test="templates-tab"]');
+  private readonly _tlsCertRequiredCheckbox = this.locator('#tls-certificate-required');
+  private readonly _tlsCertSelectDropdown = this.locator(
+    'button[placeholder="Select TLS certificate"]',
+  );
+  private readonly _tlsCertTextArea = this.locator('[aria-label="TLS certificate"]');
+
+  private readonly _tlsProjectDropdown = this.locator('button[placeholder="Select project..."]');
+
+  private readonly _userProvidedTab = this.locator('#filter-templateScope-user, #user-templates');
+  private readonly _vmCatalogGrid = this.locator('#vm-catalog-grid');
+
+  private readonly _windowsDriversCheckbox = this.locator('[data-test-id="cdrom-drivers"]');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Opens the Filter dropdown, toggles a filter item by its data-test-row-filter key,
+   * then closes the dropdown. Used for wizard-based template catalog filtering.
+   */
+  private async _toggleWizardFilter(filterKey: string, enable: boolean): Promise<void> {
+    await this._filterDropdownButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const openDropdown = async () => {
+      const expanded = await this._filterDropdownButton
+        .getAttribute('aria-expanded')
+        .catch(() => null);
+      if (expanded !== 'true') {
+        await this._filterDropdownButton.click();
+        await this.page.waitForTimeout(200);
+      }
+    };
+
+    await openDropdown();
+    const checkbox = this.locator(`[data-test-row-filter="${filterKey}"] input[type="checkbox"]`);
+    await checkbox.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const isChecked = await checkbox.isChecked();
+    if (enable && !isChecked) {
+      await checkbox.dispatchEvent('click');
+    } else if (!enable && isChecked) {
+      // Re-open in case a previous check action caused a re-render/close
+      await openDropdown();
+      await checkbox.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      await checkbox.dispatchEvent('click');
+    }
+    // Close the dropdown
+    const expanded = await this._filterDropdownButton
+      .getAttribute('aria-expanded')
+      .catch(() => null);
+    if (expanded === 'true') {
+      await this._filterDropdownButton.click();
+    }
+    await this.page.waitForTimeout(TestTimeouts.UI_FILTER_APPLY / 3);
+  }
+  /**
+   * Clicks the "All" button to show all templates.
+   */
+  async clickAllTemplatesButton() {
+    const allTemplatesButton = this.locator('[data-test-id="catalog-template-filter-all-items"]');
+    const exists = await allTemplatesButton.isVisible({ timeout: 2000 }).catch(() => false);
+    if (exists) {
+      await this.robustClick(allTemplatesButton);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+  }
+
+  /**
+   * Clicks the Customize VirtualMachine button (text-based locator).
+   * This is different from clickCustomizeVmButton which uses a data-test-id.
+   */
+  async clickCustomizeVirtualMachineButton() {
+    await this._customizeVirtualMachineButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._customizeVirtualMachineButton);
+  }
+
+  /**
+   * Clicks the "Customize VirtualMachine" button in the instance type footer.
+   * Uses .create-vm-instance-type-footer button selector.
+   */
+  async clickCustomizeVirtualMachineFooterButton() {
+    await this._customizeVirtualMachineFooterButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._customizeVirtualMachineFooterButton);
+  }
+
+  /**
+   * Clicks the Customize VirtualMachine button.
+   */
+  async clickCustomizeVmButton() {
+    await this._customizeVirtualMachineFooterButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._customizeVirtualMachineFooterButton);
+  }
+
+  /**
+   * Clicks the quick create VM button in the template catalog form.
+   */
+  async clickQuickCreateVmButton() {
+    await this._quickCreateVmButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._quickCreateVmButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_LONG);
+  }
+
+  // PF6 hides native checkbox inputs; interact via `attached` + programmatic toggle.
+  async clickStartAfterCreationCheckbox() {
+    await this._startAfterCreationCheckbox.waitFor({
+      state: 'attached',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    const isChecked = await this._startAfterCreationCheckbox.isChecked().catch(() => false);
+    if (!isChecked) {
+      await this._startAfterCreationCheckbox.evaluate((el: HTMLInputElement) => {
+        el.checked = true;
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    }
+  }
+  /**
+   * Clicks on a template card by its metadataName (data-test-id).
+   *
+   * @param templateMetadataName - The template metadataName (data-test-id attribute)
+   */
+  async clickTemplateByMetadataName(templateMetadataName: string) {
+    await super.clickTemplateByTestId(
+      templateMetadataName,
+      `div[data-test-id="${templateMetadataName}"]`,
+    );
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_LONG);
+  }
+  async clickTemplatesTab() {
+    await this._templatesTab.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._templatesTab);
+  }
+
+  /**
+   * Clicks the User provided tab to show user templates.
+   */
+  async clickUserProvidedTab() {
+    const isWizardMode = await this._filterDropdownButton
+      .isVisible({ timeout: 2000 })
+      .catch(() => false);
+
+    if (isWizardMode) {
+      await this._toggleWizardFilter('user-templates', true);
+    } else {
+      await this._userProvidedTab.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await this.robustClick(this._userProvidedTab.first());
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+  }
+  /**
+   * Clicks the "User provided" tab to show user templates.
+   */
+  async clickUserTemplatesTab() {
+    const userTemplatesTab = this.locator('#filter-templateScope-user, #user-templates');
+    await userTemplatesTab.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(userTemplatesTab.first());
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+  /**
+   * Clicks the "View all projects" button in the empty namespace state.
+   * This button calls clearAll internally, which was the trigger for CNV-85594.
+   */
+  async clickViewAllProjectsButton(): Promise<void> {
+    const viewAllButton = this.locator('button', { hasText: 'View all projects' });
+    await viewAllButton.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(viewAllButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  /**
+   * Enables TLS certificate requirement and configures TLS source.
+   * Must be called after selectDiskSource('URL', ...) when the URL fields are visible.
+   *
+   * @param config - TLS certificate configuration
+   */
+  async configureTlsCertificate(config: {
+    source: 'existing' | 'new';
+    certProject?: string;
+    configMapName?: string;
+    certificate?: string;
+  }) {
+    await this._tlsCertRequiredCheckbox.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const isChecked = await this._tlsCertRequiredCheckbox.isChecked().catch(() => false);
+    if (!isChecked) {
+      await this.robustClick(this._tlsCertRequiredCheckbox);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+
+    if (config.source === 'existing') {
+      await this.robustClick(this.locator('#tls-use-existing'));
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+      if (config.certProject) {
+        await this._tlsProjectDropdown.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        await this.robustClick(this._tlsProjectDropdown);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+        const searchInput = this.page.locator('[role="listbox"]').locator('input');
+        const hasSearch = await searchInput.isVisible().catch(() => false);
+        if (hasSearch) {
+          await searchInput.fill(config.certProject);
+          await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+        }
+
+        const projectOption = this.page.locator('[role="option"]', {
+          hasText: config.certProject,
+        });
+        await projectOption.first().waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        await this.robustClick(projectOption.first());
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      }
+
+      if (config.configMapName) {
+        await this._tlsCertSelectDropdown.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        await this.robustClick(this._tlsCertSelectDropdown);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+        const certOption = this.page.locator('[role="option"]', {
+          hasText: config.configMapName,
+        });
+        await certOption.first().waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        await this.robustClick(certOption.first());
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      }
+    } else {
+      await this.robustClick(this.locator('#tls-add-new'));
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+      if (config.certificate) {
+        await this._tlsCertTextArea.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        await this._tlsCertTextArea.fill(config.certificate);
+      }
+    }
+  }
+
+  /**
+   * Verifies that a template card exists in the catalog grid.
+   *
+   * @param templateName - The template display name to look for
+   * @returns The count of matching template cards
+   */
+  async countTemplateCards(templateName: string): Promise<number> {
+    // CNV 4.99+: try metadata name lookup first
+    const metadataName = CreateVmTemplateCatalogComponent._displayNameToMetadataName[templateName];
+    if (metadataName) {
+      const byId = this._vmCatalogGrid.locator(`[data-test-id="${metadataName}"]`);
+      const countById = await byId.count();
+      if (countById > 0) return countById;
+    }
+    const wizardCards = this._vmCatalogGrid.locator('[data-test-id]', { hasText: templateName });
+    const wizardCount = await wizardCards.count();
+    if (wizardCount > 0) return wizardCount;
+    return this._vmCatalogGrid
+      .locator('.vm-catalog-grid-tile .catalog-tile-pf-title', { hasText: templateName })
+      .count();
+  }
+
+  /**
+   * Fills the VM name in the Review and Create form.
+   * Uses the template catalog VM name input which is used in both quick create and customize flows.
+   *
+   * @param vmName - The VM name
+   */
+  async fillReviewAndCreateVmName(vmName: string) {
+    await this._templateCatalogVmNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+
+    await this.page.waitForFunction(
+      (selector) => {
+        const el = document.querySelector(selector) as HTMLInputElement | null;
+        return el && !el.disabled && !el.readOnly;
+      },
+      '[data-test-id="template-catalog-vm-name-input"]',
+      { timeout: TestTimeouts.RESOURCE_CREATION },
+    );
+
+    await this._templateCatalogVmNameInput.clear();
+    await this._templateCatalogVmNameInput.fill(vmName);
+    await this._templateCatalogVmNameInput.press('Tab');
+  }
+
+  /**
+   * Fills the VM name input field in the template catalog form.
+   *
+   * @param vmName - The name to set for the VM
+   */
+  async fillTemplateCatalogVmName(vmName: string) {
+    await this._templateCatalogVmNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+    await this._templateCatalogVmNameInput.clear();
+    await this._templateCatalogVmNameInput.fill(vmName);
+    await this._templateCatalogVmNameInput.press('Tab');
+  }
+
+  /**
+   * Filters catalog templates by boot source availability.
+   *
+   * @param check - Whether to check or uncheck the filter (default: true)
+   */
+  async filterByBootSourceAvailable(check = true) {
+    const isWizardMode = await this._filterDropdownButton
+      .isVisible({ timeout: 2000 })
+      .catch(() => false);
+
+    if (isWizardMode) {
+      await this._toggleWizardFilter('only-available', check);
+    } else {
+      // CNV 4.99+: boot source filter removed from the catalog UI — skip gracefully
+      const bootSourceFilter = this.locator(
+        '[data-test-id="boot-source-available-Boot source available"]',
+      ).locator('input[type="checkbox"]');
+      const exists = await bootSourceFilter.isVisible({ timeout: 2000 }).catch(() => false);
+      if (!exists) {
+        return;
+      }
+      if (check) {
+        await bootSourceFilter.check({ force: true });
+      } else {
+        await bootSourceFilter.uncheck({ force: true });
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+  }
+
+  /**
+   * Filters catalog templates by OS name (RHEL, Windows, Fedora, CentOS).
+   *
+   * @param osName - The OS name to filter by ('RHEL', 'Windows', 'Fedora', 'CentOS')
+   * @param check - Whether to check or uncheck the filter (default: true)
+   */
+  async filterByOSName(osName: 'RHEL' | 'Windows' | 'Fedora' | 'CentOS', check = true) {
+    const wizardFilterKey = osName.toLowerCase();
+    const isWizardMode = await this._filterDropdownButton
+      .isVisible({ timeout: 2000 })
+      .catch(() => false);
+
+    if (isWizardMode) {
+      await this._toggleWizardFilter(wizardFilterKey, check);
+    } else {
+      // CNV 4.99+: filter inputs are directly accessible by ID
+      // Older builds: filter inputs are inside [data-test-id="osName-*"] containers
+      const osFilterById = this.locator(`input#filter-osName-${wizardFilterKey}`);
+      const osFilterLegacy = this.locator(
+        `[data-test-id="osName-${osName}"] input[type="checkbox"]`,
+      );
+      const osFilter = osFilterById.or(osFilterLegacy);
+      await osFilter
+        .first()
+        .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      if (check) {
+        await osFilter.first().check({ force: true });
+      } else {
+        await osFilter.first().uncheck({ force: true });
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_FILTER_APPLY / 3);
+    }
+    await this._vmCatalogGrid
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => {
+        return;
+      });
+  }
+
+  /**
+   * Filters catalog templates by provider (Red Hat or Other).
+   * Uses input#filter-provider-{provider} checkboxes (CNV 4.99+).
+   *
+   * @param provider - 'Red Hat' or 'Other'
+   * @param check - Whether to check or uncheck the filter (default: true)
+   */
+  async filterByProvider(provider: 'Red Hat' | 'Other', check = true) {
+    // Use attribute selector because "Red Hat" contains a space, making #filter-provider-Red Hat invalid CSS
+    const filterInput = this.locator(`input[id="filter-provider-${provider}"]`);
+    await filterInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    if (check) {
+      await filterInput.check({ force: true });
+    } else {
+      await filterInput.uncheck({ force: true });
+    }
+    await this._vmCatalogGrid
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => {
+        return;
+      });
+    await this.page.waitForTimeout(TestTimeouts.UI_FILTER_APPLY / 3);
+  }
+
+  /**
+   * Filters catalog templates by workload (Desktop, Server).
+   *
+   * @param workload - The workload to filter by ('Desktop' or 'Server')
+   * @param check - Whether to check or uncheck the filter (default: true)
+   */
+  async filterByWorkload(workload: 'Desktop' | 'Server', check = true) {
+    const isWizardMode = await this._filterDropdownButton
+      .isVisible({ timeout: 2000 })
+      .catch(() => false);
+
+    if (isWizardMode) {
+      await this._toggleWizardFilter(workload.toLowerCase(), check);
+    } else {
+      // CNV 4.99+: workload filter removed from the catalog UI — skip gracefully
+      const workloadFilter = this.locator(`[data-test-id="workload-${workload}"]`).locator(
+        'input[type="checkbox"]',
+      );
+      const exists = await workloadFilter.isVisible({ timeout: 2000 }).catch(() => false);
+      if (!exists) {
+        return;
+      }
+      if (check) {
+        await workloadFilter.check({ force: true });
+      } else {
+        await workloadFilter.uncheck({ force: true });
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_FILTER_APPLY / 3);
+    }
+    await this._vmCatalogGrid
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => {
+        return;
+      });
+  }
+
+  async isCreateVmFromCatalogAvailable(): Promise<boolean> {
+    const createBtn = await this._createVirtualMachineButton
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+    if (createBtn) return true;
+    return await this._vmCatalogGrid
+      .isVisible({ timeout: TestTimeouts.RETRY_DELAY })
+      .catch(() => false);
+  }
+
+  async isTemplateCatalogSectionVisible(): Promise<boolean> {
+    const tabVisible = await this._templatesTab
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+    if (!tabVisible) return false;
+    const gridVisible = await this._vmCatalogGrid
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+    return gridVisible;
+  }
+
+  /**
+   * Checks whether the TLS certificate required checkbox is visible.
+   * Useful for asserting TLS controls appear only with URL disk source.
+   */
+  async isTlsCertificateCheckboxVisible(timeout?: number): Promise<boolean> {
+    try {
+      await this._tlsCertRequiredCheckbox.waitFor({
+        state: 'visible',
+        timeout: timeout || TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Returns whether the TLS certificate required checkbox is checked.
+   */
+  async isTlsCertificateChecked(): Promise<boolean> {
+    return await this._tlsCertRequiredCheckbox.isChecked().catch(() => false);
+  }
+
+  /**
+   * Navigates to the template catalog via the VM list Create dropdown (same as {@link navigateToTemplateCatalogViaVmList}).
+   */
+  async navigateToCatalogViaUI(): Promise<void> {
+    await this.navigateToTemplateCatalogViaVmList();
+  }
+
+  /**
+   * @deprecated Use {@link navigateToWizardTemplateCatalog} instead.
+   * On 4.22+ the catalog is no longer a standalone linked page — VM creation
+   * goes through /vm-wizard. This method still navigates directly to the URL
+   * (which renders the new wizard) but callers should migrate to the wizard flow.
+   */
+  async navigateToNamespaceCatalogViaUI(namespace?: string): Promise<void> {
+    await this.navigateToTemplateCatalogViaVmList(namespace);
+  }
+
+  async navigateToProjectCatalog(projectName: string) {
+    await this.goTo(`/k8s/ns/${projectName}/catalog`);
+  }
+
+  /**
+   * Navigate to the template catalog page.
+   * CNV-82506 removed the "From template" dropdown item; navigate directly.
+   * @deprecated Use {@link navigateToWizardTemplateCatalog} for the current wizard flow.
+   */
+  async navigateToTemplateCatalogViaVmList(namespace?: string): Promise<void> {
+    const ns = namespace || 'default';
+    await this.goTo(`/k8s/ns/${ns}/catalog`);
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  async searchTemplate(templateName: string) {
+    await this._searchCatalogInput.clear();
+    await this._searchCatalogInput.fill(templateName);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  /**
+   * Selects boot source for CD boot.
+   *
+   * @param bootSource - The boot source type ('ISO', 'Registry', 'URL', 'PVC', 'Upload')
+   * @param value - Optional value for the boot source
+   */
+  async selectBootSource(
+    _bootSource: 'ISO' | 'Registry' | 'URL' | 'PVC' | 'Upload',
+    _value?: string,
+  ) {
+    const isChecked = await this._bootFromCDCheckbox.isChecked().catch(() => false);
+    if (!isChecked) {
+      await this._bootFromCDCheckbox.check({ force: true });
+    }
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    await this._bootSourceDropdown.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+    await this.robustClick(this._bootSourceDropdown);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  /**
+   * Selects disk source in the Review and Create form.
+   *
+   * @param diskSource - The disk source type ('URL', 'Registry', 'PVC', 'Upload')
+   * @param value - Optional value for the disk source (e.g., URL string, registry path)
+   * @param username - Optional username for registry (if diskSource is 'Registry')
+   * @param password - Optional password for registry (if diskSource is 'Registry')
+   */
+  async selectDiskSource(
+    diskSource: 'URL' | 'Registry' | 'PVC' | 'Upload',
+    value?: string,
+    username?: string,
+    password?: string,
+  ) {
+    await this._diskSourceDropdown.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+    await this.robustClick(this._diskSourceDropdown);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    switch (diskSource) {
+      case 'URL':
+        await this.robustClick(this.locator('[data-test-id="http"]'));
+        if (value) {
+          await this._diskSourceURLInput.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          await this._diskSourceURLInput.fill(value);
+        }
+        break;
+      case 'Registry':
+        await this.robustClick(this.locator('[data-test-id="registry"]'));
+        if (value) {
+          await this._diskSourceRegistryInput.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          await this._diskSourceRegistryInput.fill(value);
+        }
+        if (username) {
+          await this.locator('[data-test-id="disk-boot-source-container-source-username"]').fill(
+            username,
+          );
+        }
+        if (password) {
+          await this.locator('[data-test-id="disk-boot-source-container-source-password"]').fill(
+            password,
+          );
+        }
+        break;
+      case 'PVC':
+        await this.robustClick(this.locator('[data-test-id="pvc-clone"]'));
+        break;
+      case 'Upload': {
+        const uploadMenuItem = this.locator('.pf-v6-c-menu__item-main', {
+          hasText: 'Upload (Upload a new file to a PVC)',
+        });
+        await uploadMenuItem.scrollIntoViewIfNeeded();
+        await this.robustClick(uploadMenuItem, { force: true });
+        if (value) {
+          await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+          const fileUploadInput = this.locator('.pf-v6-c-file-upload input[type="file"]');
+          const fileUploadArea = this.locator('.pf-v6-c-file-upload');
+          await fileUploadArea.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          await fileUploadInput.setInputFiles(value);
+          await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+        }
+        break;
+      }
+    }
+  }
+
+  /**
+   * Selects a folder for template VM creation (quick create form).
+   *
+   * @param folderName - The folder name to create/select
+   */
+  async selectFolderForTemplate(folderName: string, createNew = true) {
+    try {
+      await this.locator('[id="quick-create-form"]').waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+
+      await this._quickFormVmFolderInput.focus();
+      await this._quickFormVmFolderInput.fill(folderName);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+      if (createNew) {
+        await this._quickFormVmFolderInput.press('Enter');
+        await this.robustClick(this._createFolderButton);
+      } else {
+        const folderOption = this.locator(`#select-typeahead-${folderName}`);
+        await this.robustClick(folderOption);
+      }
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Selects a namespace from the catalog project dropdown by opening the dropdown,
+   * searching in the #select-inline-filter input, and clicking the option with
+   * data-test-id equal to the namespace name.
+   *
+   * @param namespace - The namespace name to select (e.g. pw-bv-form-catalog-123)
+   */
+  async selectNamespaceInProjectDropdown(namespace: string): Promise<void> {
+    const projectDropdown = this.locator('.project-dropdown').locator('button').first();
+    await projectDropdown.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(projectDropdown);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const filterInput = this._selectInlineFilterInput;
+    await filterInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await filterInput.clear();
+    await filterInput.pressSequentially(namespace, { delay: 100 });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const namespaceOption = this.locator(`[data-test-id="${namespace}"]`).first();
+    await namespaceOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(namespaceOption);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  /**
+   * Selects a project from the templates catalog project dropdown.
+   *
+   * @param projectName - The project name to select
+   */
+  async selectProjectFromCatalog(projectName: string) {
+    // Wizard uses a full-width menu toggle with "All projects" text; old catalog uses .templates-catalog-project-dropdown
+    const projectDropdown = this.locator(
+      '.templates-catalog-project-dropdown button, button.pf-v6-c-menu-toggle.pf-m-full-width:has-text("project")',
+    ).last();
+    await projectDropdown.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(projectDropdown);
+
+    const projectItem = this.locator('.pf-v6-c-menu__item-text', { hasText: projectName });
+    await projectItem.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_LONG });
+    await this.robustClick(projectItem);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  /**
+   * Sets the Windows drivers checkbox.
+   *
+   * @param mount - Whether to mount Windows drivers (default: true)
+   */
+  async setWindowsDrivers(mount = true) {
+    const isChecked = await this._windowsDriversCheckbox.isChecked().catch(() => false);
+    if (mount && !isChecked) {
+      await this._windowsDriversCheckbox.check({ force: true });
+    } else if (!mount && isChecked) {
+      await this._windowsDriversCheckbox.uncheck({ force: true });
+    }
+  }
+
+  /**
+   * Switches between grid and list view in the catalog.
+   *
+   * @param view - The view to switch to ('grid' or 'list')
+   */
+  async switchView(view: 'grid' | 'list') {
+    if (view === 'list') {
+      const listButton = this.locator(
+        'button[aria-label="template list button"], #template-list-btn',
+      );
+      await this.robustClick(listButton);
+    } else {
+      const gridButton = this.locator(
+        'button[aria-label="template grid button"], #template-grid-btn',
+      );
+      await this.robustClick(gridButton);
+    }
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async uncheckStartAfterCreationCheckbox() {
+    await this._startAfterCreationCheckbox.waitFor({
+      state: 'attached',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    const isChecked = await this._startAfterCreationCheckbox.isChecked().catch(() => false);
+    if (isChecked) {
+      await this._startAfterCreationCheckbox.evaluate((el: HTMLInputElement) => {
+        el.checked = false;
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    }
+  }
+
+  /**
+   * Filters catalog templates by architecture.
+   * This verifies that the architecture filter category exists.
+   * Uses retry logic for resilience in CI environments.
+   *
+   * @returns True if the architecture filter category is visible and has checkboxes
+   */
+  async verifyArchitectureFilterExists(): Promise<boolean> {
+    const isWizardMode = await this._filterDropdownButton
+      .isVisible({ timeout: 2000 })
+      .catch(() => false);
+
+    if (isWizardMode) {
+      try {
+        await this._filterDropdownButton.click();
+        const archCheckbox = this.locator('[data-test-row-filter="amd64"]');
+        await archCheckbox.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        const visible = await archCheckbox.isVisible();
+        await this._filterDropdownButton.click();
+        return visible;
+      } catch {
+        return false;
+      }
+    }
+
+    const maxRetries = 3;
+    let lastError: Error | undefined;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        await this.page.waitForLoadState('networkidle', {
+          timeout: TestTimeouts.UI_ACTION_COMPLETE,
+        });
+
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+        await waitForElementStable(this._architectureFilter, TestTimeouts.UI_ELEMENT_VISIBILITY);
+
+        const hasCheckboxes = await this.waitForChildElements(
+          this._architectureFilter,
+          'input[type="checkbox"]',
+          { timeout: TestTimeouts.UI_ELEMENT_VISIBILITY },
+        );
+
+        if (hasCheckboxes) {
+          return true;
+        }
+
+        throw new Error('No checkboxes found in architecture filter');
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        if (attempt < maxRetries) {
+          console.warn(`Architecture filter verification attempt ${attempt} failed, retrying...`);
+          await this.page.waitForTimeout(TestTimeouts.RETRY_DELAY);
+        }
+      }
+    }
+
+    console.warn(
+      `Architecture filter verification failed after ${maxRetries} attempts: ${lastError?.message}`,
+    );
+    return false;
+  }
+
+  async verifyEmptyProjectState(): Promise<boolean> {
+    try {
+      const emptyStateTitle = this.locator('text=No templates found in this project');
+      await emptyStateTitle.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await emptyStateTitle.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyNoErrorBoundary(waitMs = 3000): Promise<boolean> {
+    const errorIndicator = this.page.locator('text=Something wrong happened');
+    const hasError = await errorIndicator.isVisible({ timeout: waitMs }).catch(() => false);
+    return !hasError;
+  }
+
+  /**
+   * Verifies that a template card is visible in the catalog grid.
+   *
+   * @param templateName - The template display name to look for
+   * @returns True if all matching template cards are visible
+   */
+  async verifyTemplateCardVisible(templateName: string): Promise<boolean> {
+    try {
+      await this._vmCatalogGrid.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+      const hasAnyCards = await this._vmCatalogGrid
+        .locator('[data-test-id], .vm-catalog-grid-tile')
+        .first()
+        .isVisible({ timeout: TestTimeouts.UI_ACTION_COMPLETE })
+        .catch(() => false);
+
+      if (!hasAnyCards) {
+        await this.page.waitForTimeout(TestTimeouts.UI_FILTER_APPLY / 3);
+      }
+
+      // CNV 4.99+: cards use data-test-id (metadata name), not display name in text.
+      // Try metadata name lookup first, then fall back to text-based match.
+      const metadataName =
+        CreateVmTemplateCatalogComponent._displayNameToMetadataName[templateName];
+
+      let cardLocator;
+      if (metadataName) {
+        const byMetadataId = this._vmCatalogGrid.locator(`[data-test-id="${metadataName}"]`);
+        const wizardCard = this._vmCatalogGrid.locator('[data-test-id]', {
+          hasText: templateName,
+        });
+        const oldCard = this._vmCatalogGrid.locator(
+          '.vm-catalog-grid-tile .catalog-tile-pf-title',
+          {
+            hasText: templateName,
+          },
+        );
+        cardLocator = byMetadataId.or(wizardCard).or(oldCard);
+      } else {
+        const wizardCard = this._vmCatalogGrid.locator('[data-test-id]', {
+          hasText: templateName,
+        });
+        const oldCard = this._vmCatalogGrid.locator(
+          '.vm-catalog-grid-tile .catalog-tile-pf-title',
+          { hasText: templateName },
+        );
+        cardLocator = wizardCard.or(oldCard);
+      }
+
+      await cardLocator
+        .first()
+        .waitFor({ state: 'visible', timeout: TestTimeouts.TEMPLATE_CREATION });
+
+      await this.page.waitForTimeout(TestTimeouts.POLLING_INTERVAL / 2);
+
+      const locators = await cardLocator.all();
+      if (locators.length === 0) {
+        return false;
+      }
+      const visibilityChecks = await Promise.all(locators.map((locator) => locator.isVisible()));
+      return visibilityChecks.every((isVisible) => isVisible);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Verifies that a template is visible in list view by finding a span with the expected name.
+   *
+   * @param templateName - The template display name to look for
+   * @returns True if the template is visible in list view
+   */
+  async verifyTemplateVisibleInListView(templateName: string): Promise<boolean> {
+    try {
+      const container = this.locator('.vm-catalog-table-container');
+      // In the wizard, the display name is in a <small> element; in old catalog it's in a <span>
+      const nameCell = container.locator('small, span', { hasText: templateName });
+      const nameVisible = await nameCell
+        .first()
+        .isVisible({ timeout: 3000 })
+        .catch(() => false);
+      if (nameVisible) return true;
+
+      // CNV 4.99+: display name is no longer used; try metadata name as data-test-id
+      const metadataName =
+        CreateVmTemplateCatalogComponent._displayNameToMetadataName[templateName];
+      if (metadataName) {
+        const byMetadataId = container.locator(`[data-test-id="${metadataName}"]`);
+        await byMetadataId.first().waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        return true;
+      }
+      // fall back to waiting for text-based match
+      await nameCell.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Verifies the Windows drivers checkbox state.
+   * Matches Cypress: cy.get(winDrivers).should('not.be.checked') or cy.get(winDrivers).should('be.checked')
+   *
+   * @param shouldBeChecked - Whether the checkbox should be checked (true) or unchecked (false)
+   * @returns True if the checkbox state matches the expected state, false otherwise
+   */
+  async verifyWindowsDriversCheckbox(shouldBeChecked: boolean): Promise<boolean> {
+    try {
+      await this._windowsDriversCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.RESOURCE_CREATION,
+      });
+      const isChecked = await this._windowsDriversCheckbox.isChecked().catch(() => false);
+      return isChecked === shouldBeChecked;
+    } catch {
+      return false;
+    }
+  }
+
+  override async waitForTemplateForm() {
+    await super.waitForTemplateForm();
+  }
+}

--- a/playwright/src/components/create-vm/catalog-wizard-tabs-components.ts
+++ b/playwright/src/components/create-vm/catalog-wizard-tabs-components.ts
@@ -1,0 +1,1780 @@
+/**
+ * VM creation wizard components — disks, tabs, and main wizard.
+ */
+
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+/**
+ * Disk / storage form interactions in the VM customize wizard (horizontal + sidebar flows).
+ */
+export class CreateVmWizardDisksComponent extends BaseComponent {
+  private readonly _advancedSettingsBtn = this.locator('button:has-text("Advanced settings")');
+  private readonly _buttonIncrement = this.locator('button[aria-label="Increment"]');
+  private readonly _inputInput = this.locator('input[aria-label="Input"]');
+  private readonly _inputNameVolumename = this.locator('input[name="volume.name"]');
+  private readonly _selectPersistentVolumeClaimBtn = this.locator(
+    'button:has-text("Select PersistentVolumeClaim")',
+  );
+  private readonly _selectProjectBtn = this.locator('button:has-text("Select Project")');
+  private readonly _storageClassSelect = this.locator('[data-test-id="storage-class-select"]');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Adds a disk in the sidebar editor wizard (template VM customize flow).
+   * Uses the .sidebar-editor button instead of .kv-configuration-vm-disk-list.
+   */
+  async addDiskInSidebarWizard(diskConfig: {
+    name: string;
+    diskType?: string;
+    diskSource?: {
+      sourceNs?: string;
+      sourcePvc?: string;
+      value?: string;
+    };
+    size?: string;
+    storageClass?: string;
+  }): Promise<void> {
+    const addButton = this.locator('.sidebar-editor button', { hasText: 'Add' });
+    await addButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(addButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    if (diskConfig.diskType) {
+      const diskTypeOption = this.locator(`text=${diskConfig.diskType}`);
+      await diskTypeOption.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+      await this.robustClick(diskTypeOption);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+
+    const nameInput = this._inputNameVolumename;
+    await nameInput.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await nameInput.clear();
+    await nameInput.fill(diskConfig.name);
+
+    if (diskConfig.diskType === 'Clone volume' && diskConfig.diskSource) {
+      if (diskConfig.diskSource.sourceNs) {
+        const selectPVCNS = this._selectProjectBtn;
+        await selectPVCNS.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(selectPVCNS);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+        const nsOption = this.locator(
+          `[role="listbox"] button:has-text("${diskConfig.diskSource.sourceNs}")`,
+        );
+        await nsOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(nsOption);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      }
+
+      if (diskConfig.diskSource.sourcePvc) {
+        const selectPVCName = this._selectPersistentVolumeClaimBtn;
+        await selectPVCName.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(selectPVCName);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+        const pvcOption = this.locator(
+          `[role="listbox"] button:has-text("${diskConfig.diskSource.sourcePvc}")`,
+        );
+        await pvcOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(pvcOption);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      }
+    }
+
+    if (diskConfig.size) {
+      const sizeInput = this._inputInput;
+      const sizeInputExists = await sizeInput
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_LONG })
+        .catch(() => false);
+      if (sizeInputExists) {
+        await sizeInput.clear();
+        const incrementButton = this._buttonIncrement;
+        for (let i = 0; i < parseInt(diskConfig.size); i++) {
+          await this.robustClick(incrementButton);
+        }
+      }
+    }
+
+    if (diskConfig.storageClass) {
+      const storageClassSelect = this._storageClassSelect;
+      await storageClassSelect.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(storageClassSelect);
+      const storageClassOption = this.locator(
+        `button#select-inline-filter-${diskConfig.storageClass}`,
+      );
+      await storageClassOption.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(storageClassOption);
+    }
+
+    await this.clickDialogSaveButton();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_LONG);
+  }
+
+  /**
+   * Adds a disk in the wizard Storage tab.
+   * Matches Cypress: catalog.addDisks(vmData) -> addDisk(disk)
+   *
+   * @param diskConfig - Disk configuration
+   */
+  async addDiskInWizard(diskConfig: {
+    name: string;
+    diskType?: string; // e.g., 'Empty disk (blank)', 'Ephemeral', 'Clone volume'
+    diskSource?: {
+      name?: string; // e.g., 'Blank', 'EphemeralDisk', 'cloneVolume'
+      selector?: string;
+      value?: string;
+    };
+    size?: string;
+    storageClass?: string;
+    type?: string; // e.g., 'lun'
+    shareDisk?: boolean;
+    scsiReservation?: boolean;
+  }): Promise<void> {
+    const addButton = this.locator('.kv-configuration-vm-disk-list button', { hasText: 'Add' });
+    await addButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(addButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const diskType = diskConfig.diskType || 'Empty disk (blank)';
+    const diskTypeOption = this.locator(`text=${diskType}`);
+    await diskTypeOption.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(diskTypeOption);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const nameInput = this._inputNameVolumename;
+    await nameInput.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await nameInput.clear();
+    await nameInput.fill(diskConfig.name);
+
+    if (diskConfig.diskSource) {
+      if (diskConfig.diskType === 'Clone volume') {
+        const selectPVCNS = this._selectProjectBtn;
+        await selectPVCNS.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(selectPVCNS);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+        const selectPVCName = this._selectPersistentVolumeClaimBtn;
+        await selectPVCName.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(selectPVCName);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      }
+
+      if (diskConfig.diskSource.value && diskConfig.diskType) {
+        const containerSourceInput = this.locator('[data-test-id="disk-source-container"]');
+        await containerSourceInput.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ACTION_COMPLETE,
+        });
+        await containerSourceInput.clear();
+        await containerSourceInput.fill(diskConfig.diskSource.value);
+      }
+    }
+
+    if (diskConfig.size) {
+      const sizeInput = this._inputInput;
+      const sizeInputExists = await sizeInput
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_LONG })
+        .catch(() => false);
+      if (sizeInputExists) {
+        await sizeInput.clear();
+        const incrementButton = this._buttonIncrement;
+        for (let i = 0; i < parseInt(diskConfig.size); i++) {
+          await this.robustClick(incrementButton);
+        }
+      }
+    }
+
+    if (diskConfig.type) {
+      const diskTypeSelect = this.locator('[data-test-id="disk-type-select"]');
+      await diskTypeSelect.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(diskTypeSelect);
+      const typeOption = this.locator(`[data-test-id="disk-type-select-${diskConfig.type}"]`);
+      await typeOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(typeOption);
+    }
+
+    if (diskConfig.storageClass) {
+      const storageClassSelect = this._storageClassSelect;
+      await storageClassSelect.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(storageClassSelect);
+      const storageClassOption = this.locator(
+        `button#select-inline-filter-${diskConfig.storageClass}`,
+      );
+      await storageClassOption.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(storageClassOption);
+    }
+
+    if (diskConfig.shareDisk) {
+      const advancedSettingsButton = this._advancedSettingsBtn;
+      await advancedSettingsButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(advancedSettingsButton);
+      const shareDiskCheckbox = this.locator('input[id="sharable-disk"]');
+      await shareDiskCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await shareDiskCheckbox.check({ force: true });
+    }
+
+    if (diskConfig.scsiReservation) {
+      const advancedSettingsButton = this._advancedSettingsBtn;
+      await advancedSettingsButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(advancedSettingsButton);
+      const scsiReservationCheckbox = this.locator('input[id="lun-reservation"]');
+      await scsiReservationCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await scsiReservationCheckbox.check({ force: true });
+    }
+
+    await this.clickDialogSaveButton();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_LONG);
+  }
+}
+
+export class CreateVmWizardTabsComponent extends BaseComponent {
+  private readonly _pfV6CModalBoxBody = this.locator('.pf-v6-c-modal-box__body');
+  private readonly _tabModal = this.locator('#tab-modal');
+
+  private readonly _wizardAnnotationsEditButton = this.locator(
+    '[data-test-id="wizard-metadata-annotations-edit"], button[data-test-id^="pw-vm-customize-it-"][data-test-id*="annotations"]',
+  );
+  private readonly _wizardCpuInput = this.locator('input[name="cpu-input"]');
+  private readonly _wizardCpuMemEditBtn = this.locator(
+    '[data-test-id="wizard-overview-cpu-memory-edit"]',
+  );
+  private readonly _wizardDedicatedResourcesCheckbox = this.locator('#dedicated-resources');
+  private readonly _wizardDedicatedResourcesEditBtn = this.locator(
+    '[data-test-id="dedicated-resources-edit"]',
+  );
+  private readonly _wizardDeschedulerCheckbox = this.locator('#descheduler');
+  private readonly _wizardDeschedulerEditBtn = this.locator('[data-test-id="descheduler-edit"]');
+
+  private readonly _wizardEvictionStrategyCheckbox = this.locator('#eviction-strategy');
+  private readonly _wizardEvictionStrategyEditBtn = this.locator(
+    '[data-test-id="eviction-strategy"] button',
+  );
+  private readonly _wizardHeadlessCheckbox = this.locator('#headless-mode');
+  private readonly _wizardHostnameEditBtn = this.locator(
+    '[data-test-id="wizard-overview-hostname-edit"], button[data-test-id^="pw-vm-customize-it-"][data-test-id*="hostname"]',
+  );
+  private readonly _wizardHostnameInput = this.locator('input#hostname');
+  private readonly _wizardLabelsEditButton = this.locator(
+    '[data-test-id="wizard-metadata-labels-edit"], button[data-test-id^="pw-vm-customize-it-"][data-test-id*="labels"]',
+  );
+
+  private readonly _wizardLabelsInput = this.locator('[data-test="tags-input"]');
+
+  private readonly _wizardMemInput = this.locator('input[name="memory-input"]');
+  private readonly _wizardNameInput = this.locator('#vm-name');
+  private readonly _wizardNicToggle = this.locator('#toggle-id-network');
+  private readonly _wizardNodeSelectorEditButton = this.locator(
+    '[data-test-id="node-selector-edit"], button[data-test-id^="pw-vm-customize-it-"][data-test-id*="node-selector"]',
+  );
+
+  private readonly _wizardSSHKeyEditButton = this.locator('[data-test-id="wizard-sshkey-edit"]');
+  private readonly _wizardStartInPauseCheckbox = this.locator('#start-in-pause-mode');
+  private readonly _wizardSysprepEditButton = this.locator('[data-test-id="wizard-sysprep-edit"]');
+  readonly disks: CreateVmWizardDisksComponent;
+  constructor(page: Page) {
+    super(page);
+    this.disks = new CreateVmWizardDisksComponent(page);
+  }
+
+  async addDiskInSidebarWizard(
+    ...args: Parameters<CreateVmWizardDisksComponent['addDiskInSidebarWizard']>
+  ): ReturnType<CreateVmWizardDisksComponent['addDiskInSidebarWizard']> {
+    return this.disks.addDiskInSidebarWizard(...args);
+  }
+
+  async addDiskInWizard(
+    ...args: Parameters<CreateVmWizardDisksComponent['addDiskInWizard']>
+  ): ReturnType<CreateVmWizardDisksComponent['addDiskInWizard']> {
+    return this.disks.addDiskInWizard(...args);
+  }
+
+  /**
+   * Clicks the Cancel button in the wizard.
+   * Matches Cypress: cy.clickCancelBtn()
+   */
+  async clickCancelButton(): Promise<void> {
+    const wizardCancelButton = this.locator('button:has-text("Cancel")');
+    await wizardCancelButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+    // Accept confirmation dialog that may appear when saving (e.g. after restore)
+    this.page.once('dialog', (dialog) => dialog.accept());
+    await this.robustClick(wizardCancelButton);
+  }
+
+  /**
+   * Clicks the final Create VirtualMachine button in the customize wizard.
+   */
+  async clickWizardCreateButton() {
+    const wizardCreateButton = this.locator('[data-test-id="create-virtual-machine"] button', {
+      hasText: 'Create VirtualMachine',
+    });
+    await wizardCreateButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(wizardCreateButton);
+  }
+
+  /**
+   * Fills the Metadata tab in the customize wizard with labels, annotations, and nodeSelector.
+   * Matches Cypress: fillMetadata(vmData) function
+   *
+   * @param config - Metadata configuration with labels, annotations, and nodeSelector
+   */
+  async fillWizardMetadata(config: {
+    labels?: string[]; // Array of strings like "key=value"
+    annotations?: Array<{ key: string; value: string }>; // Array of key-value pairs
+    expectedAnnotationsCount?: number; // Expected number of annotations shown on button (default: 1)
+  }): Promise<void> {
+    await this.navigateToWizardVerticalTab('Metadata');
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    if (config.labels && config.labels.length > 0) {
+      await this._wizardLabelsEditButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(this._wizardLabelsEditButton);
+
+      await this._wizardLabelsInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this._wizardLabelsInput.clear();
+
+      for (const label of config.labels) {
+        await this._wizardLabelsInput.fill(label);
+        await this.page.keyboard.press('Enter');
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      }
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        await this.clickSave();
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+
+    if (config.annotations && config.annotations.length > 0) {
+      const annotationsCount = config.expectedAnnotationsCount ?? 1;
+      const annotationsText =
+        annotationsCount === 1 ? '1 Annotation' : `${annotationsCount} Annotations`;
+      const annotationsBtn = this.locator(`button:has-text("${annotationsText}")`);
+
+      const annotationsBtnExists = await annotationsBtn
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (!annotationsBtnExists) {
+        const altAnnotationsBtn = this.locator('button[data-test-id*="annotation"]').first();
+        const altExists = await altAnnotationsBtn
+          .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+          .catch(() => false);
+        if (altExists) {
+          await this.robustClick(altAnnotationsBtn);
+        } else {
+          // Annotations section may not be available - silently continue
+          return;
+        }
+      } else {
+        await this.robustClick(annotationsBtn);
+      }
+
+      for (const annotation of config.annotations) {
+        const addButton = this.locator('button:has-text("Add more")');
+        await addButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(addButton);
+
+        const keyInput = this.locator('input[aria-label="annotation key"]').last();
+        const valueInput = this.locator('input[aria-label="annotation value"]').last();
+        await keyInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await keyInput.fill(annotation.key);
+        await valueInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await valueInput.fill(annotation.value);
+      }
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        await this.clickSave();
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+  }
+
+  /**
+   * Fills the Overview tab in the customize wizard.
+   *
+   * @param config - Overview configuration
+   */
+  async fillWizardOverview(config: {
+    name?: string;
+    description?: string;
+    cpu?: number;
+    memory?: number;
+    bootMode?: string;
+    workload?: string;
+    hostname?: string;
+    startInPause?: boolean;
+    headless?: boolean;
+  }) {
+    if (config.name) {
+      await this.locator('[data-test-id="wizard-overview-name-edit"]').click();
+      await this._wizardNameInput.clear();
+      await this._wizardNameInput.fill(config.name);
+      await this.clickSave();
+    }
+
+    if (config.description) {
+      await this.robustClick(
+        this.locator(
+          '[data-test-id="wizard-overview-description-edit"], button[data-test-id^="pw-vm-customize-it-"][data-test-id*="description"]',
+        ),
+      );
+      const tabModal = this._tabModal;
+      await tabModal.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      const descTextarea = tabModal.locator('[aria-label="description text area"]');
+      await descTextarea.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await descTextarea.clear();
+      await descTextarea.fill(config.description);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        await this.clickSave();
+      }
+    }
+
+    if (config.cpu || config.memory) {
+      await this._wizardCpuMemEditBtn.click();
+      if (config.cpu) {
+        await this._wizardCpuInput.clear();
+        await this._wizardCpuInput.fill(config.cpu.toString());
+      }
+      if (config.memory) {
+        await this._wizardMemInput.clear();
+        await this._wizardMemInput.fill(config.memory.toString());
+      }
+      await this.clickSave();
+    }
+
+    if (config.bootMode) {
+      await this.locator('[data-test-id="wizard-overview-boot-method-edit"]').click();
+      const modalBody = this._pfV6CModalBoxBody;
+      await modalBody.locator('button').first().click();
+      // Use exact text matching to avoid partial matches (e.g., "UEFI" vs "UEFI(secure)")
+      await this.clickElementByExactText('span', config.bootMode);
+      await this.clickButtonByText('Save');
+    }
+
+    if (config.workload) {
+      await this.locator('[data-test-id="wizard-overview-workload-profile-edit"]').click();
+      const modalBody = this._tabModal;
+      await modalBody.locator('button.pf-v6-c-menu-toggle').click();
+      await this.locator('button', { hasText: config.workload }).click();
+      await this.clickButtonByText('Save');
+    }
+
+    if (config.hostname) {
+      await this._wizardHostnameEditBtn.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.RESOURCE_CREATION,
+      });
+      await this.robustClick(this._wizardHostnameEditBtn);
+      await this._wizardHostnameInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this._wizardHostnameInput.fill(config.hostname);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        await this.clickSave();
+      }
+    }
+
+    if (config.startInPause !== undefined) {
+      await this._wizardStartInPauseCheckbox.waitFor({
+        state: 'attached',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      const startInPauseChecked = await this._wizardStartInPauseCheckbox
+        .isChecked()
+        .catch(() => false);
+      // Hidden PF switches: set `checked` and dispatch `change` (click may not reach the input).
+      if (config.startInPause && !startInPauseChecked) {
+        await this._wizardStartInPauseCheckbox.evaluate((el: HTMLInputElement) => {
+          el.checked = true;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      } else if (!config.startInPause && startInPauseChecked) {
+        await this._wizardStartInPauseCheckbox.evaluate((el: HTMLInputElement) => {
+          el.checked = false;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      }
+    }
+
+    if (config.headless) {
+      await this._wizardHeadlessCheckbox.waitFor({
+        state: 'attached',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      const headlessChecked = await this._wizardHeadlessCheckbox.isChecked().catch(() => false);
+      if (config.headless && !headlessChecked) {
+        await this._wizardHeadlessCheckbox.evaluate((el: HTMLInputElement) => {
+          el.checked = true;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      } else if (!config.headless && headlessChecked) {
+        await this._wizardHeadlessCheckbox.evaluate((el: HTMLInputElement) => {
+          el.checked = false;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      }
+    }
+  }
+  /**
+   * Fills the Scheduling tab in the customize wizard.
+   *
+   * @param config - Scheduling configuration
+   */
+  async fillWizardScheduling(config: {
+    descheduler?: boolean;
+    dedicatedResources?: boolean;
+    evictionStrategy?: boolean;
+    nodeSelector?: { key: string; value: string }; // Node selector key-value pair
+  }) {
+    await this.navigateToWizardVerticalTab('Scheduling');
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    if (config.descheduler !== undefined) {
+      await this._wizardDeschedulerEditBtn.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(this._wizardDeschedulerEditBtn);
+      const deschedulerChecked = await this._wizardDeschedulerCheckbox
+        .isChecked()
+        .catch(() => false);
+      if (config.descheduler && !deschedulerChecked) {
+        await this._wizardDeschedulerCheckbox.click({ force: true });
+      } else if (!config.descheduler && deschedulerChecked) {
+        await this._wizardDeschedulerCheckbox.click({ force: true });
+      }
+      await this.clickSave();
+    }
+
+    if (config.dedicatedResources !== undefined) {
+      await this._wizardDedicatedResourcesEditBtn.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(this._wizardDedicatedResourcesEditBtn);
+      const dedicatedResourcesChecked = await this._wizardDedicatedResourcesCheckbox
+        .isChecked()
+        .catch(() => false);
+      if (config.dedicatedResources && !dedicatedResourcesChecked) {
+        await this._wizardDedicatedResourcesCheckbox.click({ force: true });
+      } else if (!config.dedicatedResources && dedicatedResourcesChecked) {
+        await this._wizardDedicatedResourcesCheckbox.click({ force: true });
+      }
+      await this.clickSave();
+    }
+
+    if (config.evictionStrategy !== undefined) {
+      // Eviction controls may be absent depending on wizard context / cluster capabilities.
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const evictionBtnExists = await this._wizardEvictionStrategyEditBtn
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (evictionBtnExists) {
+        await this.robustClick(this._wizardEvictionStrategyEditBtn);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+        const evictionStrategyChecked = await this._wizardEvictionStrategyCheckbox
+          .isChecked()
+          .catch(() => false);
+        if (config.evictionStrategy && !evictionStrategyChecked) {
+          await this._wizardEvictionStrategyCheckbox.click({ force: true });
+        } else if (!config.evictionStrategy && evictionStrategyChecked) {
+          await this._wizardEvictionStrategyCheckbox.click({ force: true });
+        }
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+        await this.clickSave();
+      } else {
+        // Eviction strategy section may not be available - silently continue
+      }
+    }
+
+    if (config.nodeSelector) {
+      const noSelectorBtn = this.locator('button:has-text("No selector")');
+      await noSelectorBtn.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(noSelectorBtn);
+
+      const addSelectorBtn = this.locator('#vm-labels-list-add-btn');
+      await addSelectorBtn.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(addSelectorBtn);
+
+      const keyInput = this.locator('input[aria-label="selector key"]');
+      const valueInput = this.locator('input[aria-label="selector value"]');
+      await keyInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await keyInput.clear();
+      await keyInput.fill(config.nodeSelector.key);
+      await valueInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await valueInput.clear();
+      await valueInput.fill(config.nodeSelector.value);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        await this.clickSave();
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+  }
+
+  /**
+   * Fills the Scripts tab in the customize wizard with sysprep configuration.
+   * Matches Cypress: fillScripts(vmData) function for sysprep
+   *
+   * @param config - Scripts configuration with sysprep
+   */
+  async fillWizardScripts(config: {
+    sysprepName?: string; // Name of existing sysprep ConfigMap (e.g., "sysprep-vm-name")
+    // Note: sysprepFile upload would require file handling and is not implemented yet
+  }): Promise<void> {
+    await this.navigateToWizardHorizontalTab('Scripts');
+
+    if (config.sysprepName) {
+      const sysprepSection = this.locator('text=Sysprep').locator('..');
+      const editButton = sysprepSection.locator('button').first();
+      await editButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+      await this.robustClick(editButton);
+
+      const attachExistingButton = this.locator('button:has-text("Attach existing sysprep")');
+      await attachExistingButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(attachExistingButton);
+
+      const selectButton = this.locator('button:has-text("--- Select sysprep ---")');
+      await selectButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(selectButton);
+
+      const sysprepOption = this.locator(`button:has-text("sysprep-${config.sysprepName}")`);
+      await sysprepOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(sysprepOption);
+
+      await this.clickSave();
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+  }
+
+  /**
+   * Fills the SSH section in the Scripts tab of the customize wizard with a new secret.
+   * Matches Cypress: fillSSH(vmData) function for newSecret
+   * Note: SSH is part of the Scripts tab, not a separate tab
+   *
+   * @param secretName - The name for the new secret
+   * @param sshKeyFilePath - Path to the SSH key file to upload (default: './fixtures/rsa.pub')
+   */
+  async fillWizardSSH(secretName: string, sshKeyFilePath: string): Promise<void> {
+    await this.navigateToWizardHorizontalTab('Scripts');
+
+    const sshEditButton = this.locator('[data-test-id="wizard-sshkey-edit"]');
+    await sshEditButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(sshEditButton);
+
+    const addNewButton = this.locator('#addNew');
+    await this.robustClick(addNewButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    // File inputs stay hidden in PF; wait for attachment, not visibility.
+    const uploadInput = this.locator('input[type="file"]');
+    await uploadInput.waitFor({ state: 'attached', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    await uploadInput.setInputFiles(sshKeyFilePath);
+
+    const secretNameInput = this.locator('#new-secret-name');
+    await secretNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    await secretNameInput.clear();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    // Slow typing so reactive validation can enable Save.
+    await secretNameInput.type(secretName, { delay: 150 });
+
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const saveButton = this.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(saveButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async navigateToWizardHorizontalTab(
+    tabName:
+      | 'Overview'
+      | 'Scheduling'
+      | 'Environment'
+      | 'Network interfaces'
+      | 'Disks'
+      | 'Scripts'
+      | 'Metadata',
+  ) {
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const tabLocator = this.locator(`[data-test-id="horizontal-link-${tabName}"]`);
+    await this.robustClick(tabLocator);
+  }
+
+  /**
+   * Navigates to the Scripts tab in the customize wizard.
+   */
+  async navigateToWizardScriptsTab(): Promise<void> {
+    await this.navigateToWizardHorizontalTab('Scripts');
+  }
+
+  /**
+   * Navigates to a specific tab in the customize wizard using vertical tabs.
+   * Use this method when you explicitly need vertical tabs (instance type-based wizard).
+   *
+   * @param tabName - The tab name ('Details', 'Storage', 'Network', 'Scheduling', 'SSH', 'Initial run', 'Metadata')
+   */
+  async navigateToWizardVerticalTab(
+    tabName: 'Details' | 'Storage' | 'Network' | 'Scheduling' | 'SSH' | 'Initial run' | 'Metadata',
+  ) {
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const tabMapping: Record<typeof tabName, string> = {
+      Details: 'vm-configuration-details',
+      Storage: 'vm-configuration-storage',
+      Network: 'vm-configuration-network',
+      Scheduling: 'vm-configuration-scheduling',
+      SSH: 'vm-configuration-ssh',
+      'Initial run': 'vm-configuration-initial',
+      Metadata: 'vm-configuration-metadata',
+    };
+
+    const verticalTabId = tabMapping[tabName];
+    if (!verticalTabId) {
+      throw new Error(`Unknown tab name: ${tabName}`);
+    }
+
+    const tabLocator = this.locator(`[data-test-id="${verticalTabId}"]`);
+    await tabLocator.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(tabLocator);
+  }
+
+  /**
+   * Verifies that "Not found" message appears in the Networks tab (indicating no NICs).
+   * Matches Cypress: cy.contains('Not found').should('exist');
+   *
+   * @returns True if "Not found" message is visible or no NICs are present, false otherwise
+   */
+  async verifyNetworksTabNotFoundMessage(): Promise<boolean> {
+    try {
+      await this.navigateToWizardHorizontalTab('Network interfaces');
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_LONG);
+
+      const nicToggleCount = await this._wizardNicToggle.count();
+      if (nicToggleCount === 0) {
+        return true;
+      }
+
+      const notFoundSelectors = [
+        'text=Not found',
+        'text=/not found/i',
+        '[data-test="empty-state"]',
+        '.pf-v6-c-empty-state',
+        '.pf-v6-c-empty-state__body',
+        'text=No network interfaces',
+        'text=No network',
+      ];
+
+      for (const selector of notFoundSelectors) {
+        try {
+          const notFoundLocator = this.locator(selector).first();
+          const isVisible = await notFoundLocator.isVisible({
+            timeout: TestTimeouts.UI_DELAY_SHORT,
+          });
+          if (isVisible) {
+            const text = await notFoundLocator.textContent().catch(() => '');
+            if (
+              text?.toLowerCase().includes('not found') ||
+              text?.toLowerCase().includes('no network')
+            ) {
+              return true;
+            }
+          }
+        } catch {}
+      }
+
+      const networksTabContent = this.locator('[data-test-id="wizard-tab-Networks"]')
+        .locator('..')
+        .locator('..');
+      const tabText = await networksTabContent.textContent().catch(() => '');
+      if (
+        tabText?.toLowerCase().includes('not found') ||
+        tabText?.toLowerCase().includes('no network')
+      ) {
+        return true;
+      }
+
+      const toggleVisible = await this._wizardNicToggle
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      return !toggleVisible;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Verifies if the SSH key edit button is disabled in the Scripts tab.
+   * This button should be disabled for Windows templates.
+   * @returns true if disabled, false otherwise
+   */
+  async verifySSHKeyEditButtonDisabled(): Promise<boolean> {
+    try {
+      await this._wizardSSHKeyEditButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await this._wizardSSHKeyEditButton.isDisabled();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Verifies if the SSH key edit button is visible in the Scripts tab.
+   * This button should be visible for Linux templates.
+   * @returns true if visible, false otherwise
+   */
+  async verifySSHKeyEditButtonVisible(): Promise<boolean> {
+    try {
+      await this._wizardSSHKeyEditButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await this._wizardSSHKeyEditButton.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Verifies if the Sysprep edit button is enabled in the Scripts tab.
+   * @returns true if enabled, false otherwise
+   */
+  async verifySysprepEditButtonEnabled(): Promise<boolean> {
+    try {
+      await this._wizardSysprepEditButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await this._wizardSysprepEditButton.isEnabled();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Verifies if the Sysprep edit button is visible in the Scripts tab.
+   * This button should be visible for Windows templates.
+   * @returns true if visible, false otherwise
+   */
+  async verifySysprepEditButtonVisible(): Promise<boolean> {
+    try {
+      await this._wizardSysprepEditButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await this._wizardSysprepEditButton.isVisible();
+    } catch {
+      return false;
+    }
+  }
+}
+
+export class CreateVmWizardComponent extends BaseComponent {
+  private readonly _advancedSettingsBtn = this.locator('button:has-text("Advanced settings")');
+  private readonly _buttonIncrement = this.locator('button[aria-label="Increment"]');
+  private readonly _dedicatedResources = this.locator('#dedicated-resources');
+  private readonly _dedicatedResourcesEdit = this.locator(
+    '[data-test-id="dedicated-resources-edit"]',
+  );
+  private readonly _descheduler = this.locator('#descheduler');
+  private readonly _deschedulerEdit = this.locator('[data-test-id="descheduler-edit"]');
+  private readonly _evictionStrategy = this.locator('#eviction-strategy');
+  private readonly _evictionStrategyButton = this.locator(
+    '[data-test-id="eviction-strategy"] button',
+  );
+  private readonly _headlessMode = this.locator('#headless-mode');
+  private readonly _inputhostname = this.locator('input#hostname');
+  private readonly _inputInput = this.locator('input[aria-label="Input"]');
+  private readonly _inputNameCpuInput = this.locator('input[name="cpu-input"]');
+  private readonly _inputNameMemoryInput = this.locator('input[name="memory-input"]');
+  private readonly _inputNameVolumename = this.locator('input[name="volume.name"]');
+  private readonly _selectPersistentVolumeClaimBtn = this.locator(
+    'button:has-text("Select PersistentVolumeClaim")',
+  );
+  private readonly _selectProjectBtn = this.locator('button:has-text("Select Project")');
+  private readonly _startInPauseMode = this.locator('#start-in-pause-mode');
+  private readonly _storageClassSelect = this.locator('[data-test-id="storage-class-select"]');
+  private readonly _tabModal = this.locator('#tab-modal');
+  private readonly _tagsInput = this.locator('[data-test="tags-input"]');
+  private readonly _toggleIdNetwork = this.locator('#toggle-id-network');
+  private readonly _vmName = this.locator('#vm-name');
+  private readonly _wizardSSHKeyEditButton = this.locator('[data-test-id="wizard-sshkey-edit"]');
+  private readonly _wizardSysprepEditButton = this.locator('[data-test-id="wizard-sysprep-edit"]');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async addDiskInSidebarWizard(diskConfig: {
+    name: string;
+    diskType?: string;
+    diskSource?: {
+      sourceNs?: string;
+      sourcePvc?: string;
+      value?: string;
+    };
+    size?: string;
+    storageClass?: string;
+  }): Promise<void> {
+    const addButton = this.locator('.sidebar-editor button', { hasText: 'Add' });
+    await addButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(addButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    if (diskConfig.diskType) {
+      const diskTypeOption = this.locator(`text=${diskConfig.diskType}`);
+      await diskTypeOption.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+      await this.robustClick(diskTypeOption);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+
+    const nameInput = this._inputNameVolumename;
+    await nameInput.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await nameInput.clear();
+    await nameInput.fill(diskConfig.name);
+
+    if (diskConfig.diskType === 'Clone volume' && diskConfig.diskSource) {
+      if (diskConfig.diskSource.sourceNs) {
+        const selectPVCNS = this._selectProjectBtn;
+        await selectPVCNS.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(selectPVCNS);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+        const nsOption = this.locator(
+          `[role="listbox"] button:has-text("${diskConfig.diskSource.sourceNs}")`,
+        );
+        await nsOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(nsOption);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      }
+
+      if (diskConfig.diskSource.sourcePvc) {
+        const selectPVCName = this._selectPersistentVolumeClaimBtn;
+        await selectPVCName.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(selectPVCName);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+        const pvcOption = this.locator(
+          `[role="listbox"] button:has-text("${diskConfig.diskSource.sourcePvc}")`,
+        );
+        await pvcOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(pvcOption);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      }
+    }
+
+    if (diskConfig.size) {
+      const sizeInput = this._inputInput;
+      const sizeInputExists = await sizeInput
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_LONG })
+        .catch(() => false);
+      if (sizeInputExists) {
+        await sizeInput.clear();
+        const incrementButton = this._buttonIncrement;
+        for (let i = 0; i < parseInt(diskConfig.size); i++) {
+          await this.robustClick(incrementButton);
+        }
+      }
+    }
+
+    if (diskConfig.storageClass) {
+      const storageClassSelect = this._storageClassSelect;
+      await storageClassSelect.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(storageClassSelect);
+      const storageClassOption = this.locator(
+        `button#select-inline-filter-${diskConfig.storageClass}`,
+      );
+      await storageClassOption.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(storageClassOption);
+    }
+
+    await this.clickDialogSaveButton();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_LONG);
+  }
+
+  async addDiskInWizard(diskConfig: {
+    name: string;
+    diskType?: string;
+    diskSource?: {
+      name?: string;
+      selector?: string;
+      value?: string;
+    };
+    size?: string;
+    storageClass?: string;
+    type?: string;
+    shareDisk?: boolean;
+    scsiReservation?: boolean;
+  }): Promise<void> {
+    const addButton = this.locator('.kv-configuration-vm-disk-list button', { hasText: 'Add' });
+    await addButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(addButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const diskType = diskConfig.diskType || 'Empty disk (blank)';
+    const diskTypeOption = this.locator(`text=${diskType}`);
+    await diskTypeOption.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(diskTypeOption);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const nameInput = this._inputNameVolumename;
+    await nameInput.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await nameInput.clear();
+    await nameInput.fill(diskConfig.name);
+
+    if (diskConfig.diskSource) {
+      if (diskConfig.diskType === 'Clone volume') {
+        const selectPVCNS = this._selectProjectBtn;
+        await selectPVCNS.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(selectPVCNS);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+        const selectPVCName = this._selectPersistentVolumeClaimBtn;
+        await selectPVCName.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(selectPVCName);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      }
+
+      if (diskConfig.diskSource.value && diskConfig.diskType) {
+        const containerSourceInput = this.locator('[data-test-id="disk-source-container"]');
+        await containerSourceInput.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ACTION_COMPLETE,
+        });
+        await containerSourceInput.clear();
+        await containerSourceInput.fill(diskConfig.diskSource.value);
+      }
+    }
+
+    if (diskConfig.size) {
+      const sizeInput = this._inputInput;
+      const sizeInputExists = await sizeInput
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_LONG })
+        .catch(() => false);
+      if (sizeInputExists) {
+        await sizeInput.clear();
+        const incrementButton = this._buttonIncrement;
+        for (let i = 0; i < parseInt(diskConfig.size); i++) {
+          await this.robustClick(incrementButton);
+        }
+      }
+    }
+
+    if (diskConfig.type) {
+      const diskTypeSelect = this.locator('[data-test-id="disk-type-select"]');
+      await diskTypeSelect.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(diskTypeSelect);
+      const typeOption = this.locator(`[data-test-id="disk-type-select-${diskConfig.type}"]`);
+      await typeOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(typeOption);
+    }
+
+    if (diskConfig.storageClass) {
+      const storageClassSelect = this._storageClassSelect;
+      await storageClassSelect.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(storageClassSelect);
+      const storageClassOption = this.locator(
+        `button#select-inline-filter-${diskConfig.storageClass}`,
+      );
+      await storageClassOption.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(storageClassOption);
+    }
+
+    if (diskConfig.shareDisk) {
+      const advancedSettingsButton = this._advancedSettingsBtn;
+      await advancedSettingsButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(advancedSettingsButton);
+      const shareDiskCheckbox = this.locator('input[id="sharable-disk"]');
+      await shareDiskCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await shareDiskCheckbox.check({ force: true });
+    }
+
+    if (diskConfig.scsiReservation) {
+      const advancedSettingsButton = this._advancedSettingsBtn;
+      await advancedSettingsButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(advancedSettingsButton);
+      const scsiReservationCheckbox = this.locator('input[id="lun-reservation"]');
+      await scsiReservationCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await scsiReservationCheckbox.check({ force: true });
+    }
+
+    await this.clickDialogSaveButton();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_LONG);
+  }
+
+  async clickCancelButton(): Promise<void> {
+    const wizardCancelButton = this.locator('button:has-text("Cancel")');
+    await wizardCancelButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+
+    this.page.once('dialog', (dialog) => dialog.accept());
+    await this.robustClick(wizardCancelButton);
+  }
+
+  async fillWizardMetadata(config: {
+    labels?: string[];
+    annotations?: Array<{ key: string; value: string }>;
+    expectedAnnotationsCount?: number;
+  }): Promise<void> {
+    await this.navigateToWizardVerticalTab('Metadata');
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    if (config.labels && config.labels.length > 0) {
+      await this.locator(
+        '[data-test-id="wizard-metadata-labels-edit"], button[data-test-id^="pw-vm-customize-it-"][data-test-id*="labels"]',
+      ).waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(
+        this.locator(
+          '[data-test-id="wizard-metadata-labels-edit"], button[data-test-id^="pw-vm-customize-it-"][data-test-id*="labels"]',
+        ),
+      );
+
+      await this._tagsInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this._tagsInput.clear();
+
+      for (const label of config.labels) {
+        await this._tagsInput.fill(label);
+        await this.page.keyboard.press('Enter');
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      }
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        await this.clickSave();
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+
+    if (config.annotations && config.annotations.length > 0) {
+      const annotationsCount = config.expectedAnnotationsCount ?? 1;
+      const annotationsText =
+        annotationsCount === 1 ? '1 Annotation' : `${annotationsCount} Annotations`;
+      const annotationsBtn = this.locator(`button:has-text("${annotationsText}")`);
+
+      const annotationsBtnExists = await annotationsBtn
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (!annotationsBtnExists) {
+        const altAnnotationsBtn = this.locator('button[data-test-id*="annotation"]').first();
+        const altExists = await altAnnotationsBtn
+          .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+          .catch(() => false);
+        if (altExists) {
+          await this.robustClick(altAnnotationsBtn);
+        } else {
+          return;
+        }
+      } else {
+        await this.robustClick(annotationsBtn);
+      }
+
+      for (const annotation of config.annotations) {
+        const addButton = this.locator('button:has-text("Add more")');
+        await addButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(addButton);
+
+        const keyInput = this.locator('input[aria-label="annotation key"]').last();
+        const valueInput = this.locator('input[aria-label="annotation value"]').last();
+        await keyInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await keyInput.fill(annotation.key);
+        await valueInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await valueInput.fill(annotation.value);
+      }
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        await this.clickSave();
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+  }
+
+  async fillWizardOverview(config: {
+    name?: string;
+    description?: string;
+    cpu?: number;
+    memory?: number;
+    bootMode?: string;
+    workload?: string;
+    hostname?: string;
+    startInPause?: boolean;
+    headless?: boolean;
+  }) {
+    if (config.name) {
+      await this.locator('[data-test-id="wizard-overview-name-edit"]').click();
+      await this._vmName.clear();
+      await this._vmName.fill(config.name);
+      await this.clickSave();
+    }
+
+    if (config.description) {
+      await this.robustClick(
+        this.locator(
+          '[data-test-id="wizard-overview-description-edit"], button[data-test-id^="pw-vm-customize-it-"][data-test-id*="description"]',
+        ),
+      );
+      const tabModal = this._tabModal;
+      await tabModal.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      const descTextarea = tabModal.locator('[aria-label="description text area"]');
+      await descTextarea.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await descTextarea.clear();
+      await descTextarea.fill(config.description);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        await this.clickSave();
+      }
+    }
+
+    if (config.cpu || config.memory) {
+      await this.locator('[data-test-id="wizard-overview-cpu-memory-edit"]').click();
+      if (config.cpu) {
+        await this._inputNameCpuInput.clear();
+        await this._inputNameCpuInput.fill(config.cpu.toString());
+      }
+      if (config.memory) {
+        await this._inputNameMemoryInput.clear();
+        await this._inputNameMemoryInput.fill(config.memory.toString());
+      }
+      await this.clickSave();
+    }
+
+    if (config.bootMode) {
+      await this.locator('[data-test-id="wizard-overview-boot-method-edit"]').click();
+      const modalBody = this.locator('.pf-v6-c-modal-box__body');
+      await modalBody.locator('button').first().click();
+
+      await this.clickElementByExactText('span', config.bootMode);
+      await this.clickButtonByText('Save');
+    }
+
+    if (config.workload) {
+      await this.locator('[data-test-id="wizard-overview-workload-profile-edit"]').click();
+      const modalBody = this._tabModal;
+      await modalBody.locator('button.pf-v6-c-menu-toggle').click();
+      await this.locator('button', { hasText: config.workload }).click();
+      await this.clickButtonByText('Save');
+    }
+
+    if (config.hostname) {
+      await this.locator(
+        '[data-test-id="wizard-overview-hostname-edit"], button[data-test-id^="pw-vm-customize-it-"][data-test-id*="hostname"]',
+      ).waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.RESOURCE_CREATION,
+      });
+      await this.robustClick(
+        this.locator(
+          '[data-test-id="wizard-overview-hostname-edit"], button[data-test-id^="pw-vm-customize-it-"][data-test-id*="hostname"]',
+        ),
+      );
+      await this._inputhostname.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this._inputhostname.fill(config.hostname);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        await this.clickSave();
+      }
+    }
+
+    if (config.startInPause !== undefined) {
+      await this._startInPauseMode.waitFor({
+        state: 'attached',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      const startInPauseChecked = await this._startInPauseMode.isChecked().catch(() => false);
+      if (config.startInPause && !startInPauseChecked) {
+        await this._startInPauseMode.evaluate((el: HTMLInputElement) => {
+          el.checked = true;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      } else if (!config.startInPause && startInPauseChecked) {
+        await this._startInPauseMode.evaluate((el: HTMLInputElement) => {
+          el.checked = false;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      }
+    }
+
+    if (config.headless) {
+      await this._headlessMode.waitFor({
+        state: 'attached',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      const headlessChecked = await this._headlessMode.isChecked().catch(() => false);
+      if (config.headless && !headlessChecked) {
+        await this._headlessMode.evaluate((el: HTMLInputElement) => {
+          el.checked = true;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      } else if (!config.headless && headlessChecked) {
+        await this._headlessMode.evaluate((el: HTMLInputElement) => {
+          el.checked = false;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      }
+    }
+  }
+
+  async fillWizardScheduling(config: {
+    descheduler?: boolean;
+    dedicatedResources?: boolean;
+    evictionStrategy?: boolean;
+    nodeSelector?: { key: string; value: string };
+  }) {
+    await this.navigateToWizardVerticalTab('Scheduling');
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    if (config.descheduler !== undefined) {
+      await this._deschedulerEdit.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(this._deschedulerEdit);
+      const deschedulerChecked = await this._descheduler.isChecked().catch(() => false);
+      if (config.descheduler && !deschedulerChecked) {
+        await this._descheduler.click({ force: true });
+      } else if (!config.descheduler && deschedulerChecked) {
+        await this._descheduler.click({ force: true });
+      }
+      await this.clickSave();
+    }
+
+    if (config.dedicatedResources !== undefined) {
+      await this._dedicatedResourcesEdit.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(this._dedicatedResourcesEdit);
+      const dedicatedResourcesChecked = await this._dedicatedResources
+        .isChecked()
+        .catch(() => false);
+      if (config.dedicatedResources && !dedicatedResourcesChecked) {
+        await this._dedicatedResources.click({ force: true });
+      } else if (!config.dedicatedResources && dedicatedResourcesChecked) {
+        await this._dedicatedResources.click({ force: true });
+      }
+      await this.clickSave();
+    }
+
+    if (config.evictionStrategy !== undefined) {
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const evictionBtnExists = await this._evictionStrategyButton
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (evictionBtnExists) {
+        await this.robustClick(this._evictionStrategyButton);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+        const evictionStrategyChecked = await this._evictionStrategy.isChecked().catch(() => false);
+        if (config.evictionStrategy && !evictionStrategyChecked) {
+          await this._evictionStrategy.click({ force: true });
+        } else if (!config.evictionStrategy && evictionStrategyChecked) {
+          await this._evictionStrategy.click({ force: true });
+        }
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+        await this.clickSave();
+      }
+    }
+
+    if (config.nodeSelector) {
+      const noSelectorBtn = this.locator('button:has-text("No selector")');
+      await noSelectorBtn.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(noSelectorBtn);
+
+      const addSelectorBtn = this.locator('#vm-labels-list-add-btn');
+      await addSelectorBtn.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(addSelectorBtn);
+
+      const keyInput = this.locator('input[aria-label="selector key"]');
+      const valueInput = this.locator('input[aria-label="selector value"]');
+      await keyInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await keyInput.clear();
+      await keyInput.fill(config.nodeSelector.key);
+      await valueInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await valueInput.clear();
+      await valueInput.fill(config.nodeSelector.value);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        await this.clickSave();
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+  }
+
+  async fillWizardScripts(config: { sysprepName?: string }): Promise<void> {
+    await this.navigateToWizardHorizontalTab('Scripts');
+
+    if (config.sysprepName) {
+      const sysprepSection = this.locator('text=Sysprep').locator('..');
+      const editButton = sysprepSection.locator('button').first();
+      await editButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+      await this.robustClick(editButton);
+
+      const attachExistingButton = this.locator('button:has-text("Attach existing sysprep")');
+      await attachExistingButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(attachExistingButton);
+
+      const selectButton = this.locator('button:has-text("--- Select sysprep ---")');
+      await selectButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(selectButton);
+
+      const sysprepOption = this.locator(`button:has-text("sysprep-${config.sysprepName}")`);
+      await sysprepOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(sysprepOption);
+
+      await this.clickSave();
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+  }
+
+  async fillWizardSSH(secretName: string, sshKeyFilePath: string): Promise<void> {
+    await this.navigateToWizardHorizontalTab('Scripts');
+
+    const sshEditButton = this.locator('[data-test-id="wizard-sshkey-edit"]');
+    await sshEditButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(sshEditButton);
+
+    const addNewButton = this.locator('#addNew');
+    await this.robustClick(addNewButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const uploadInput = this.locator('input[type="file"]');
+    await uploadInput.waitFor({ state: 'attached', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    await uploadInput.setInputFiles(sshKeyFilePath);
+
+    const secretNameInput = this.locator('#new-secret-name');
+    await secretNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    await secretNameInput.clear();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    await secretNameInput.type(secretName, { delay: 150 });
+
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const saveButton = this.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(saveButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async navigateToWizardHorizontalTab(
+    tabName:
+      | 'Overview'
+      | 'Scheduling'
+      | 'Environment'
+      | 'Network interfaces'
+      | 'Disks'
+      | 'Scripts'
+      | 'Metadata',
+  ) {
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const tabLocator = this.locator(`[data-test-id="horizontal-link-${tabName}"]`);
+    await this.robustClick(tabLocator);
+  }
+
+  async navigateToWizardScriptsTab(): Promise<void> {
+    await this.navigateToWizardHorizontalTab('Scripts');
+  }
+
+  async navigateToWizardVerticalTab(
+    tabName: 'Details' | 'Storage' | 'Network' | 'Scheduling' | 'SSH' | 'Initial run' | 'Metadata',
+  ) {
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const tabMapping: Record<typeof tabName, string> = {
+      Details: 'vm-configuration-details',
+      Storage: 'vm-configuration-storage',
+      Network: 'vm-configuration-network',
+      Scheduling: 'vm-configuration-scheduling',
+      SSH: 'vm-configuration-ssh',
+      'Initial run': 'vm-configuration-initial',
+      Metadata: 'vm-configuration-metadata',
+    };
+
+    const verticalTabId = tabMapping[tabName];
+    if (!verticalTabId) {
+      throw new Error(`Unknown tab name: ${tabName}`);
+    }
+
+    const tabLocator = this.locator(`[data-test-id="${verticalTabId}"]`);
+    await tabLocator.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(tabLocator);
+  }
+
+  async verifyNetworksTabNotFoundMessage(): Promise<boolean> {
+    try {
+      await this.navigateToWizardHorizontalTab('Network interfaces');
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_LONG);
+
+      const nicToggleCount = await this._toggleIdNetwork.count();
+      if (nicToggleCount === 0) {
+        return true;
+      }
+
+      const notFoundSelectors = [
+        'text=Not found',
+        'text=/not found/i',
+        '[data-test="empty-state"]',
+        '.pf-v6-c-empty-state',
+        '.pf-v6-c-empty-state__body',
+        'text=No network interfaces',
+        'text=No network',
+      ];
+
+      for (const selector of notFoundSelectors) {
+        try {
+          const notFoundLocator = this.locator(selector).first();
+          const isVisible = await notFoundLocator.isVisible({
+            timeout: TestTimeouts.UI_DELAY_SHORT,
+          });
+          if (isVisible) {
+            const text = await notFoundLocator.textContent().catch(() => '');
+            if (
+              text?.toLowerCase().includes('not found') ||
+              text?.toLowerCase().includes('no network')
+            ) {
+              return true;
+            }
+          }
+        } catch {}
+      }
+
+      const networksTabContent = this.locator('[data-test-id="wizard-tab-Networks"]')
+        .locator('..')
+        .locator('..');
+      const tabText = await networksTabContent.textContent().catch(() => '');
+      if (
+        tabText?.toLowerCase().includes('not found') ||
+        tabText?.toLowerCase().includes('no network')
+      ) {
+        return true;
+      }
+
+      const toggleVisible = await this._toggleIdNetwork
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      return !toggleVisible;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifySSHKeyEditButtonDisabled(): Promise<boolean> {
+    try {
+      await this._wizardSSHKeyEditButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await this._wizardSSHKeyEditButton.isDisabled();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifySSHKeyEditButtonVisible(): Promise<boolean> {
+    try {
+      await this._wizardSSHKeyEditButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await this._wizardSSHKeyEditButton.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifySysprepEditButtonEnabled(): Promise<boolean> {
+    try {
+      await this._wizardSysprepEditButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await this._wizardSysprepEditButton.isEnabled();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifySysprepEditButtonVisible(): Promise<boolean> {
+    try {
+      await this._wizardSysprepEditButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await this._wizardSysprepEditButton.isVisible();
+    } catch {
+      return false;
+    }
+  }
+}

--- a/playwright/src/components/create-vm/create-vm-component.ts
+++ b/playwright/src/components/create-vm/create-vm-component.ts
@@ -1,0 +1,487 @@
+import { CreateVmInstanceTypesComponent } from '@/components/create-vm/bootable-volumes-actions-instance-components';
+import { CreateVmTemplateCatalogComponent } from '@/components/create-vm/catalog-template-components';
+import { CreateVmWizardTabsComponent } from '@/components/create-vm/catalog-wizard-tabs-components';
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+export default class CreateVmComponent extends BaseComponent {
+  readonly instanceType: CreateVmInstanceTypesComponent;
+  readonly templateCatalog: CreateVmTemplateCatalogComponent;
+  readonly wizardTabs: CreateVmWizardTabsComponent;
+
+  constructor(page: Page) {
+    super(page);
+    this.templateCatalog = new CreateVmTemplateCatalogComponent(page);
+    this.instanceType = new CreateVmInstanceTypesComponent(page);
+    this.wizardTabs = new CreateVmWizardTabsComponent(page);
+  }
+
+  private async clickDocumentationLinkAndVerifyUrl(
+    expectedUrl: string,
+    expectedHashFragment: string,
+    closeTab = true,
+  ): Promise<string> {
+    const newPagePromise = this.page.context().waitForEvent('page');
+
+    const link = this.locator(`a[href="${expectedUrl}"]`);
+    await link.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(link);
+
+    const newPage = await newPagePromise;
+
+    await newPage.waitForLoadState('networkidle');
+
+    const mainContent = newPage.locator('main, [role="main"], .main-content, nav, header');
+    await mainContent
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    const newTabUrl = newPage.url();
+
+    if (!newTabUrl.includes(expectedHashFragment)) {
+      throw new Error(`Expected URL to contain ${expectedHashFragment} but got ${newTabUrl}`);
+    }
+
+    if (closeTab) {
+      await newPage.close();
+    }
+
+    return newTabUrl;
+  }
+
+  async addDiskInSidebarWizard(
+    ...args: Parameters<CreateVmWizardTabsComponent['addDiskInSidebarWizard']>
+  ): ReturnType<CreateVmWizardTabsComponent['addDiskInSidebarWizard']> {
+    return this.wizardTabs.addDiskInSidebarWizard(...args);
+  }
+
+  async addDiskInWizard(
+    ...args: Parameters<CreateVmWizardTabsComponent['addDiskInWizard']>
+  ): ReturnType<CreateVmWizardTabsComponent['addDiskInWizard']> {
+    return this.wizardTabs.addDiskInWizard(...args);
+  }
+
+  async addVolumeViaRegistry(
+    ...args: Parameters<CreateVmInstanceTypesComponent['addVolumeViaRegistry']>
+  ): ReturnType<CreateVmInstanceTypesComponent['addVolumeViaRegistry']> {
+    return this.instanceType.addVolumeViaRegistry(...args);
+  }
+
+  async addVolumeViaUpload(
+    ...args: Parameters<CreateVmInstanceTypesComponent['addVolumeViaUpload']>
+  ): ReturnType<CreateVmInstanceTypesComponent['addVolumeViaUpload']> {
+    return this.instanceType.addVolumeViaUpload(...args);
+  }
+
+  async clearSecretsApiMock(namespace?: string): Promise<void> {
+    return this.instanceType.clearSecretsApiMock(namespace);
+  }
+
+  async clickAddConfigMapSecretOrServiceAccount(): Promise<void> {
+    return this.instanceType.clickAddConfigMapSecretOrServiceAccount();
+  }
+
+  async clickAddVolumeButton() {
+    return this.instanceType.clickAddVolumeButton();
+  }
+
+  async clickAllTemplatesButton() {
+    return this.templateCatalog.clickAllTemplatesButton();
+  }
+
+  async clickCancelButton(): Promise<void> {
+    return this.wizardTabs.clickCancelButton();
+  }
+
+  async clickCliTab(): Promise<void> {
+    return this.instanceType.clickCliTab();
+  }
+
+  async clickCreateVirtualMachine() {
+    return this.instanceType.clickCreateVirtualMachine();
+  }
+
+  async clickCustomizeVirtualMachineButton() {
+    return this.templateCatalog.clickCustomizeVirtualMachineButton();
+  }
+
+  async clickCustomizeVirtualMachineFooterButton() {
+    return this.templateCatalog.clickCustomizeVirtualMachineFooterButton();
+  }
+
+  async clickCustomizeVmButton() {
+    return this.templateCatalog.clickCustomizeVmButton();
+  }
+
+  async clickHugepages() {
+    return this.instanceType.clickHugepages();
+  }
+
+  async clickInstanceSize(sizeOption: string) {
+    return this.instanceType.clickInstanceSize(sizeOption);
+  }
+
+  async clickInstanceTypesTab() {
+    return this.instanceType.clickInstanceTypesTab();
+  }
+
+  async clickInstanceTypesVmDetailsSection() {
+    return this.instanceType.clickInstanceTypesVmDetailsSection();
+  }
+
+  async clickOperatingSystem(osName: string) {
+    return this.instanceType.clickOperatingSystem(osName);
+  }
+
+  async clickQuickCreateVmButton() {
+    return this.templateCatalog.clickQuickCreateVmButton();
+  }
+
+  async clickSeriesDropdown(seriesName: string) {
+    return this.instanceType.clickSeriesDropdown(seriesName);
+  }
+
+  async clickStartAfterCreationCheckbox() {
+    return this.templateCatalog.clickStartAfterCreationCheckbox();
+  }
+
+  async clickTemplateByMetadataName(templateMetadataName: string) {
+    return this.templateCatalog.clickTemplateByMetadataName(templateMetadataName);
+  }
+
+  async clickTemplatesTab() {
+    return this.templateCatalog.clickTemplatesTab();
+  }
+
+  async clickUserProvidedTab() {
+    return this.templateCatalog.clickUserProvidedTab();
+  }
+
+  async clickUserTemplatesTab() {
+    return this.templateCatalog.clickUserTemplatesTab();
+  }
+
+  async clickViewAllProjectsButton(): Promise<void> {
+    return this.templateCatalog.clickViewAllProjectsButton();
+  }
+
+  async clickViewYamlAndCli(): Promise<void> {
+    return this.instanceType.clickViewYamlAndCli();
+  }
+
+  async clickWizardCreateButton() {
+    return this.wizardTabs.clickWizardCreateButton();
+  }
+
+  async configureTlsCertificate(
+    ...args: Parameters<CreateVmTemplateCatalogComponent['configureTlsCertificate']>
+  ): ReturnType<CreateVmTemplateCatalogComponent['configureTlsCertificate']> {
+    return this.templateCatalog.configureTlsCertificate(...args);
+  }
+
+  async countTemplateCards(templateName: string): Promise<number> {
+    return this.templateCatalog.countTemplateCards(templateName);
+  }
+
+  async fillReviewAndCreateVmName(vmName: string) {
+    return this.templateCatalog.fillReviewAndCreateVmName(vmName);
+  }
+
+  async fillTemplateCatalogVmName(vmName: string) {
+    return this.templateCatalog.fillTemplateCatalogVmName(vmName);
+  }
+
+  async fillVmName(vmName: string) {
+    return this.instanceType.fillVmName(vmName);
+  }
+
+  async fillWizardMetadata(
+    ...args: Parameters<CreateVmWizardTabsComponent['fillWizardMetadata']>
+  ): ReturnType<CreateVmWizardTabsComponent['fillWizardMetadata']> {
+    return this.wizardTabs.fillWizardMetadata(...args);
+  }
+
+  async fillWizardOverview(
+    ...args: Parameters<CreateVmWizardTabsComponent['fillWizardOverview']>
+  ): ReturnType<CreateVmWizardTabsComponent['fillWizardOverview']> {
+    return this.wizardTabs.fillWizardOverview(...args);
+  }
+
+  async fillWizardScheduling(
+    ...args: Parameters<CreateVmWizardTabsComponent['fillWizardScheduling']>
+  ): ReturnType<CreateVmWizardTabsComponent['fillWizardScheduling']> {
+    return this.wizardTabs.fillWizardScheduling(...args);
+  }
+
+  async fillWizardScripts(
+    ...args: Parameters<CreateVmWizardTabsComponent['fillWizardScripts']>
+  ): ReturnType<CreateVmWizardTabsComponent['fillWizardScripts']> {
+    return this.wizardTabs.fillWizardScripts(...args);
+  }
+
+  async fillWizardSSH(secretName: string, sshKeyFilePath: string): Promise<void> {
+    return this.wizardTabs.fillWizardSSH(secretName, sshKeyFilePath);
+  }
+
+  async filterByBootSourceAvailable(check = true): Promise<void> {
+    return this.templateCatalog.filterByBootSourceAvailable(check);
+  }
+
+  async filterByOSName(
+    osName: 'RHEL' | 'Windows' | 'Fedora' | 'CentOS',
+    check = true,
+  ): Promise<void> {
+    return this.templateCatalog.filterByOSName(osName, check);
+  }
+
+  async filterByProvider(provider: 'Red Hat' | 'Other', check = true): Promise<void> {
+    return this.templateCatalog.filterByProvider(provider, check);
+  }
+
+  async filterByWorkload(workload: 'Desktop' | 'Server', check = true): Promise<void> {
+    return this.templateCatalog.filterByWorkload(workload, check);
+  }
+
+  async filterVolumeByName(volumeName = 'fedora'): Promise<boolean> {
+    return this.instanceType.filterVolumeByName(volumeName);
+  }
+
+  async filterVolumeByOS(osName = 'Fedora'): Promise<boolean> {
+    return this.instanceType.filterVolumeByOS(osName);
+  }
+
+  async getEnvironmentResourceGroupTitles(): Promise<string[]> {
+    return this.instanceType.getEnvironmentResourceGroupTitles();
+  }
+
+  async getInstanceTypeText(): Promise<string> {
+    return this.instanceType.getInstanceTypeText();
+  }
+
+  async getOperatingSystemText(): Promise<string> {
+    return this.instanceType.getOperatingSystemText();
+  }
+
+  async isAddConfigMapButtonVisible(): Promise<boolean> {
+    return this.instanceType.isAddConfigMapButtonVisible();
+  }
+
+  async isBootableVolumesSectionVisible(): Promise<boolean> {
+    return this.instanceType.isBootableVolumesSectionVisible();
+  }
+
+  async isCreateVmFromCatalogAvailable(): Promise<boolean> {
+    return this.templateCatalog.isCreateVmFromCatalogAvailable();
+  }
+
+  async isEnvironmentEditorVisible(): Promise<boolean> {
+    return this.instanceType.isEnvironmentEditorVisible();
+  }
+
+  async isEnvironmentErrorAlertVisible(waitMs = 3000): Promise<boolean> {
+    return this.instanceType.isEnvironmentErrorAlertVisible(waitMs);
+  }
+
+  async isInstanceTypesSectionVisible(): Promise<boolean> {
+    return this.instanceType.isInstanceTypesSectionVisible();
+  }
+
+  async isTemplateCatalogSectionVisible(): Promise<boolean> {
+    return this.templateCatalog.isTemplateCatalogSectionVisible();
+  }
+
+  async isTlsCertificateCheckboxVisible(timeout?: number): Promise<boolean> {
+    return this.templateCatalog.isTlsCertificateCheckboxVisible(timeout);
+  }
+
+  async isTlsCertificateChecked(): Promise<boolean> {
+    return this.templateCatalog.isTlsCertificateChecked();
+  }
+
+  async markVolumeFavorite(): Promise<boolean> {
+    return this.instanceType.markVolumeFavorite();
+  }
+
+  async markVolumeFavoriteWithUnfavorite(volumeName: string): Promise<boolean> {
+    return this.instanceType.markVolumeFavoriteWithUnfavorite(volumeName);
+  }
+
+  async mockSecretsApiWith403(namespace?: string): Promise<void> {
+    return this.instanceType.mockSecretsApiWith403(namespace);
+  }
+
+  async navigateToCatalogViaUI(): Promise<void> {
+    return this.templateCatalog.navigateToCatalogViaUI();
+  }
+
+  async navigateToInstanceTypeCatalogViaVmList(namespace?: string): Promise<void> {
+    return this.instanceType.navigateToInstanceTypeCatalogViaVmList(namespace);
+  }
+
+  /**
+   * @deprecated Use {@link navigateToWizardTemplateCatalog} on 4.22+.
+   */
+  async navigateToNamespaceCatalogViaUI(namespace?: string): Promise<void> {
+    return this.templateCatalog.navigateToNamespaceCatalogViaUI(namespace);
+  }
+
+  async navigateToProjectCatalog(projectName: string) {
+    return this.templateCatalog.navigateToProjectCatalog(projectName);
+  }
+
+  /**
+   * @deprecated Use {@link navigateToWizardTemplateCatalog} on 4.22+.
+   */
+  async navigateToTemplateCatalogViaVmList(namespace?: string): Promise<void> {
+    return this.templateCatalog.navigateToTemplateCatalogViaVmList(namespace);
+  }
+
+  async navigateToWizardHorizontalTab(
+    ...args: Parameters<CreateVmWizardTabsComponent['navigateToWizardHorizontalTab']>
+  ): ReturnType<CreateVmWizardTabsComponent['navigateToWizardHorizontalTab']> {
+    return this.wizardTabs.navigateToWizardHorizontalTab(...args);
+  }
+
+  async navigateToWizardScriptsTab(): Promise<void> {
+    return this.wizardTabs.navigateToWizardScriptsTab();
+  }
+
+  async navigateToWizardVerticalTab(
+    ...args: Parameters<CreateVmWizardTabsComponent['navigateToWizardVerticalTab']>
+  ): ReturnType<CreateVmWizardTabsComponent['navigateToWizardVerticalTab']> {
+    return this.wizardTabs.navigateToWizardVerticalTab(...args);
+  }
+
+  async searchTemplate(templateName: string) {
+    return this.templateCatalog.searchTemplate(templateName);
+  }
+
+  async selectBootableVolume(volumeName: string): Promise<boolean> {
+    return this.instanceType.selectBootableVolume(volumeName);
+  }
+
+  async selectBootSource(
+    ...args: Parameters<CreateVmTemplateCatalogComponent['selectBootSource']>
+  ): ReturnType<CreateVmTemplateCatalogComponent['selectBootSource']> {
+    return this.templateCatalog.selectBootSource(...args);
+  }
+
+  async selectDiskSource(
+    ...args: Parameters<CreateVmTemplateCatalogComponent['selectDiskSource']>
+  ): ReturnType<CreateVmTemplateCatalogComponent['selectDiskSource']> {
+    return this.templateCatalog.selectDiskSource(...args);
+  }
+
+  async selectFolderForInstanceType(folderName: string) {
+    return this.instanceType.selectFolderForInstanceType(folderName);
+  }
+
+  async selectFolderForTemplate(folderName: string, createNew = true) {
+    return this.templateCatalog.selectFolderForTemplate(folderName, createNew);
+  }
+
+  async selectNamespaceInProjectDropdown(namespace: string): Promise<void> {
+    return this.templateCatalog.selectNamespaceInProjectDropdown(namespace);
+  }
+
+  async selectProjectFromCatalog(projectName: string) {
+    return this.templateCatalog.selectProjectFromCatalog(projectName);
+  }
+
+  async setStartAfterCreationInstanceType(enabled: boolean): Promise<void> {
+    return this.instanceType.setStartAfterCreationInstanceType(enabled);
+  }
+
+  async setWindowsDrivers(mount = true) {
+    return this.templateCatalog.setWindowsDrivers(mount);
+  }
+
+  async switchView(view: 'grid' | 'list') {
+    return this.templateCatalog.switchView(view);
+  }
+
+  async uncheckStartAfterCreationCheckbox() {
+    return this.templateCatalog.uncheckStartAfterCreationCheckbox();
+  }
+
+  async verifyArchitectureFilterExists(): Promise<boolean> {
+    return this.templateCatalog.verifyArchitectureFilterExists();
+  }
+
+  async verifyCliCommandComponents(components: string[]): Promise<Record<string, boolean>> {
+    return this.instanceType.verifyCliCommandComponents(components);
+  }
+
+  async verifyCliCommandContains(expectedText: string): Promise<boolean> {
+    return this.instanceType.verifyCliCommandContains(expectedText);
+  }
+
+  async verifyEmptyProjectState(): Promise<boolean> {
+    return this.templateCatalog.verifyEmptyProjectState();
+  }
+
+  async verifyInstanceTypeHelpText(): Promise<boolean> {
+    return this.instanceType.verifyInstanceTypeHelpText();
+  }
+
+  async verifyInstanceTypeSeries(): Promise<boolean> {
+    return this.instanceType.verifyInstanceTypeSeries();
+  }
+
+  async verifyInstanceTypeText(expectedText: string): Promise<boolean> {
+    return this.instanceType.verifyInstanceTypeText(expectedText);
+  }
+
+  async verifyNetworksTabNotFoundMessage(): Promise<boolean> {
+    return this.wizardTabs.verifyNetworksTabNotFoundMessage();
+  }
+
+  async verifyNoErrorBoundary(waitMs = 3000): Promise<boolean> {
+    return this.templateCatalog.verifyNoErrorBoundary(waitMs);
+  }
+
+  async verifyOperatingSystemText(expectedText: string): Promise<boolean> {
+    return this.instanceType.verifyOperatingSystemText(expectedText);
+  }
+
+  async verifySSHKeyEditButtonDisabled(): Promise<boolean> {
+    return this.wizardTabs.verifySSHKeyEditButtonDisabled();
+  }
+
+  async verifySSHKeyEditButtonVisible(): Promise<boolean> {
+    return this.wizardTabs.verifySSHKeyEditButtonVisible();
+  }
+
+  async verifySysprepEditButtonEnabled(): Promise<boolean> {
+    return this.wizardTabs.verifySysprepEditButtonEnabled();
+  }
+
+  async verifySysprepEditButtonVisible(): Promise<boolean> {
+    return this.wizardTabs.verifySysprepEditButtonVisible();
+  }
+
+  async verifyTemplateCardVisible(templateName: string): Promise<boolean> {
+    return this.templateCatalog.verifyTemplateCardVisible(templateName);
+  }
+
+  async verifyTemplateVisibleInListView(templateName: string): Promise<boolean> {
+    return this.templateCatalog.verifyTemplateVisibleInListView(templateName);
+  }
+
+  async verifyVolumeExistsInList(volumeName: string): Promise<boolean> {
+    return this.instanceType.verifyVolumeExistsInList(volumeName);
+  }
+
+  async verifyVolumeNameInNameField(volumeName: string): Promise<boolean> {
+    return this.instanceType.verifyVolumeNameInNameField(volumeName);
+  }
+
+  async verifyWindowsDriversCheckbox(shouldBeChecked: boolean): Promise<boolean> {
+    return this.templateCatalog.verifyWindowsDriversCheckbox(shouldBeChecked);
+  }
+
+  override async waitForTemplateForm() {
+    return this.templateCatalog.waitForTemplateForm();
+  }
+}

--- a/playwright/src/components/create-vm/create-vm-create-component.ts
+++ b/playwright/src/components/create-vm/create-vm-create-component.ts
@@ -1,0 +1,392 @@
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+export default class CreateVmCreateComponent extends BaseComponent {
+  private readonly _bootCd = this.locator('[data-test-id="boot-cd"]');
+  private readonly _btnPlaceholderSelectProject = this.locator(
+    'button[placeholder="Select project..."]',
+  );
+  private readonly _btnPlaceholderSelectTLSCertificate = this.locator(
+    'button[placeholder="Select TLS certificate"]',
+  );
+  private readonly _cdBootSource = this.locator('[data-test-id="cd-boot-source"]');
+  private readonly _createFolderButton = this.locator('button:has-text("Create folder")');
+  private readonly _customizeVirtualMachineFooterButton = this.locator(
+    '.create-vm-instance-type-footer button',
+    { hasText: 'Customize VirtualMachine' },
+  );
+  private readonly _customizeVmBtn = this.locator('[data-test-id="customize-vm-btn"]');
+  private readonly _diskBootSource = this.locator('[data-test-id="disk-boot-source"]');
+  private readonly _diskBootSourceContainerSourceInput = this.locator(
+    '[data-test-id="disk-boot-source-container-source-input"]',
+  );
+  private readonly _diskBootSourceHttpSourceInput = this.locator(
+    '[data-test-id="disk-boot-source-http-source-input"]',
+  );
+  private readonly _idQuickCreateFormPlaceholderSearchFolder = this.locator(
+    '[id="quick-create-form"] [placeholder="Search folder"]',
+  );
+  private readonly _quickCreateVmBtn = this.locator('[data-test-id="quick-create-vm-btn"]');
+  private readonly _startAfterCreationCheckbox = this.locator(
+    '#start-after-create-checkbox',
+  ).first();
+  private readonly _templateCatalogVmNameInput = this.locator(
+    '[data-test-id="template-catalog-vm-name-input"]',
+  );
+  private readonly _tLSCertificate = this.locator('[aria-label="TLS certificate"]');
+  private readonly _tlsCertRequiredCheckbox = this.locator('#tls-certificate-required');
+
+  private readonly _windowsDriversCheckbox = this.locator('[data-test-id="cdrom-drivers"]');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async clickCustomizeVirtualMachineButton() {
+    await this._customizeVmBtn.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._customizeVmBtn);
+  }
+
+  async clickCustomizeVirtualMachineFooterButton() {
+    await this._customizeVirtualMachineFooterButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._customizeVirtualMachineFooterButton);
+  }
+  async clickCustomizeVmButton() {
+    await this._customizeVmBtn.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._customizeVmBtn);
+  }
+
+  async clickQuickCreateVmButton() {
+    await this._quickCreateVmBtn.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._quickCreateVmBtn);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_LONG);
+  }
+
+  async clickStartAfterCreationCheckbox() {
+    await this._startAfterCreationCheckbox.waitFor({
+      state: 'attached',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    const isChecked = await this._startAfterCreationCheckbox.isChecked().catch(() => false);
+    if (!isChecked) {
+      await this._startAfterCreationCheckbox.evaluate((el: HTMLInputElement) => {
+        el.checked = true;
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    }
+  }
+
+  async configureTlsCertificate(config: {
+    source: 'existing' | 'new';
+    certProject?: string;
+    configMapName?: string;
+    certificate?: string;
+  }) {
+    await this._tlsCertRequiredCheckbox.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    const isChecked = await this._tlsCertRequiredCheckbox.isChecked().catch(() => false);
+    if (!isChecked) {
+      await this.robustClick(this._tlsCertRequiredCheckbox);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+
+    if (config.source === 'existing') {
+      await this.robustClick(this.locator('#tls-use-existing'));
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+      if (config.certProject) {
+        await this._btnPlaceholderSelectProject.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        await this.robustClick(this._btnPlaceholderSelectProject);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+        const searchInput = this.page.locator('[role="listbox"]').locator('input');
+        const hasSearch = await searchInput.isVisible().catch(() => false);
+        if (hasSearch) {
+          await searchInput.fill(config.certProject);
+          await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+        }
+
+        const projectOption = this.page.locator('[role="option"]', {
+          hasText: config.certProject,
+        });
+        await projectOption.first().waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        await this.robustClick(projectOption.first());
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      }
+
+      if (config.configMapName) {
+        await this._btnPlaceholderSelectTLSCertificate.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        await this.robustClick(this._btnPlaceholderSelectTLSCertificate);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+        const certOption = this.page.locator('[role="option"]', {
+          hasText: config.configMapName,
+        });
+        await certOption.first().waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        await this.robustClick(certOption.first());
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      }
+    } else {
+      await this.robustClick(this.locator('#tls-add-new'));
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+      if (config.certificate) {
+        await this._tLSCertificate.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        await this._tLSCertificate.fill(config.certificate);
+      }
+    }
+  }
+
+  async fillReviewAndCreateVmName(vmName: string) {
+    await this._templateCatalogVmNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+
+    await this.page.waitForFunction(
+      (selector) => {
+        const el = document.querySelector(selector) as HTMLInputElement | null;
+        return el && !el.disabled && !el.readOnly;
+      },
+      '[data-test-id="template-catalog-vm-name-input"]',
+      { timeout: TestTimeouts.RESOURCE_CREATION },
+    );
+
+    await this._templateCatalogVmNameInput.clear();
+    await this._templateCatalogVmNameInput.fill(vmName);
+    await this._templateCatalogVmNameInput.press('Tab');
+  }
+  async fillTemplateCatalogVmName(vmName: string) {
+    await this._templateCatalogVmNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+    await this._templateCatalogVmNameInput.clear();
+    await this._templateCatalogVmNameInput.fill(vmName);
+    await this._templateCatalogVmNameInput.press('Tab');
+  }
+  async isTlsCertificateCheckboxVisible(timeout?: number): Promise<boolean> {
+    try {
+      await this._tlsCertRequiredCheckbox.waitFor({
+        state: 'visible',
+        timeout: timeout || TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isTlsCertificateChecked(): Promise<boolean> {
+    return await this._tlsCertRequiredCheckbox.isChecked().catch(() => false);
+  }
+
+  async navigateToCatalogViaUI(): Promise<void> {
+    await this.navigateToTemplateCatalogViaVmList();
+  }
+
+  /**
+   * @deprecated Use navigateToWizardTemplateCatalog on 4.22+.
+   */
+  async navigateToNamespaceCatalogViaUI(namespace?: string): Promise<void> {
+    await this.navigateToTemplateCatalogViaVmList(namespace);
+  }
+
+  async navigateToProjectCatalog(projectName: string) {
+    await this.goTo(`/k8s/ns/${projectName}/catalog`);
+  }
+
+  /**
+   * @deprecated Use navigateToWizardTemplateCatalog on 4.22+.
+   */
+  async navigateToTemplateCatalogViaVmList(namespace?: string): Promise<void> {
+    const ns = namespace || 'default';
+    await this.goTo(`/k8s/ns/${ns}/catalog`);
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  async selectBootSource(
+    _bootSource: 'ISO' | 'Registry' | 'URL' | 'PVC' | 'Upload',
+    _value?: string,
+  ) {
+    const isChecked = await this._bootCd.isChecked().catch(() => false);
+    if (!isChecked) {
+      await this._bootCd.check({ force: true });
+    }
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    await this._cdBootSource.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+    await this.robustClick(this._cdBootSource);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async selectDiskSource(
+    diskSource: 'URL' | 'Registry' | 'PVC' | 'Upload',
+    value?: string,
+    username?: string,
+    password?: string,
+  ) {
+    await this._diskBootSource.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+    await this.robustClick(this._diskBootSource);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    switch (diskSource) {
+      case 'URL':
+        await this.robustClick(this.locator('[data-test-id="http"]'));
+        if (value) {
+          await this._diskBootSourceHttpSourceInput.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          await this._diskBootSourceHttpSourceInput.fill(value);
+        }
+        break;
+      case 'Registry':
+        await this.robustClick(this.locator('[data-test-id="registry"]'));
+        if (value) {
+          await this._diskBootSourceContainerSourceInput.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          await this._diskBootSourceContainerSourceInput.fill(value);
+        }
+        if (username) {
+          await this.locator('[data-test-id="disk-boot-source-container-source-username"]').fill(
+            username,
+          );
+        }
+        if (password) {
+          await this.locator('[data-test-id="disk-boot-source-container-source-password"]').fill(
+            password,
+          );
+        }
+        break;
+      case 'PVC':
+        await this.robustClick(this.locator('[data-test-id="pvc-clone"]'));
+        break;
+      case 'Upload': {
+        const uploadMenuItem = this.locator('.pf-v6-c-menu__item-main', {
+          hasText: 'Upload (Upload a new file to a PVC)',
+        });
+        await uploadMenuItem.scrollIntoViewIfNeeded();
+        await this.robustClick(uploadMenuItem, { force: true });
+
+        if (value) {
+          await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+          const fileUploadInput = this.locator('.pf-v6-c-file-upload input[type="file"]');
+          const fileUploadArea = this.locator('.pf-v6-c-file-upload');
+          await fileUploadArea.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          await fileUploadInput.setInputFiles(value);
+          await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+        }
+        break;
+      }
+    }
+  }
+
+  async selectFolderForTemplate(folderName: string, createNew = true) {
+    try {
+      await this.locator('[id="quick-create-form"]').waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+
+      await this._idQuickCreateFormPlaceholderSearchFolder.focus();
+      await this._idQuickCreateFormPlaceholderSearchFolder.fill(folderName);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+      if (createNew) {
+        await this._idQuickCreateFormPlaceholderSearchFolder.press('Enter');
+        await this.robustClick(this._createFolderButton);
+      } else {
+        const folderOption = this.locator(`#select-typeahead-${folderName}`);
+        await this.robustClick(folderOption);
+      }
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async setWindowsDrivers(mount = true) {
+    const isChecked = await this._windowsDriversCheckbox.isChecked().catch(() => false);
+    if (mount && !isChecked) {
+      await this._windowsDriversCheckbox.check({ force: true });
+    } else if (!mount && isChecked) {
+      await this._windowsDriversCheckbox.uncheck({ force: true });
+    }
+  }
+
+  async uncheckStartAfterCreationCheckbox() {
+    await this._startAfterCreationCheckbox.waitFor({
+      state: 'attached',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    const isChecked = await this._startAfterCreationCheckbox.isChecked().catch(() => false);
+    if (isChecked) {
+      await this._startAfterCreationCheckbox.evaluate((el: HTMLInputElement) => {
+        el.checked = false;
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    }
+  }
+
+  async verifyWindowsDriversCheckbox(shouldBeChecked: boolean): Promise<boolean> {
+    try {
+      await this._windowsDriversCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.RESOURCE_CREATION,
+      });
+      const isChecked = await this._windowsDriversCheckbox.isChecked().catch(() => false);
+      return isChecked === shouldBeChecked;
+    } catch {
+      return false;
+    }
+  }
+
+  override async waitForTemplateForm() {
+    await super.waitForTemplateForm();
+  }
+}

--- a/playwright/src/components/create-vm/instance-type-customize-wizard-component.ts
+++ b/playwright/src/components/create-vm/instance-type-customize-wizard-component.ts
@@ -1,0 +1,833 @@
+/**
+ * Page object for the Instance Type-based VM customization wizard.
+ * Uses vertical tabs (vm-configuration-* pattern) for navigation between wizard sections.
+ * Handles VM configuration for name, description, CPU/memory, scheduling, networks, storage, scripts, and metadata.
+ */
+
+import BaseComponent from '@/components/shared/base-component';
+import { SSH_KEY_PATHS } from '@/data-models';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+export default class InstanceTypeCustomizeWizardComponent extends BaseComponent {
+  private readonly _advancedSettingsBtn = this.locator('button:has-text("Advanced settings")');
+  private readonly _inputKey = this.locator('input[aria-label="Key"]');
+  private readonly _inputValue = this.locator('input[aria-label="Value"]');
+  private readonly _tabModal = this.locator('#tab-modal');
+  private readonly _wizardHeadlessCheckbox = this.locator('#headless-mode');
+  private readonly _wizardNicToggle = this.locator('#toggle-id-network');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async addDisk(diskConfig: {
+    name: string;
+    diskType?: string;
+    diskSource?: {
+      name?: string;
+      selector?: string;
+      value?: string;
+    };
+    size?: string;
+    storageClass?: string;
+    type?: string;
+    shareDisk?: boolean;
+    scsiReservation?: boolean;
+  }): Promise<void> {
+    await this.navigateToWizardTab('Storage');
+
+    const addButton = this.locator('button:has-text("Add")');
+    await addButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(addButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const diskType = diskConfig.diskType || 'Empty disk (blank)';
+    const diskTypeOption = this.locator(`text=${diskType}`);
+    await diskTypeOption.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(diskTypeOption);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const nameInput = this.locator('input[aria-label="Disk name"]');
+    await nameInput.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await nameInput.clear();
+    await nameInput.fill(diskConfig.name);
+
+    if (diskConfig.diskSource) {
+      if (diskConfig.diskSource.name === 'cloneVolume') {
+        const selectPVCNS = this.locator('button:has-text("Select Project")');
+        await selectPVCNS.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(selectPVCNS);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+        const selectPVCName = this.locator('button:has-text("Select PersistentVolumeClaim")');
+        await selectPVCName.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(selectPVCName);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      }
+    }
+
+    if (diskConfig.size) {
+      const sizeInput = this.locator('input[aria-label="Input"]');
+      const sizeInputExists = await sizeInput
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_LONG })
+        .catch(() => false);
+      if (sizeInputExists) {
+        await sizeInput.clear();
+        const incrementButton = this.locator('button[aria-label="Increment"]');
+        for (let i = 0; i < parseInt(diskConfig.size); i++) {
+          await this.robustClick(incrementButton);
+        }
+      }
+    }
+
+    if (diskConfig.type) {
+      const diskTypeSelect = this.locator('[data-test-id="disk-type-select"]');
+      await diskTypeSelect.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(diskTypeSelect);
+      const typeOption = this.locator(`[data-test-id="disk-type-select-${diskConfig.type}"]`);
+      await typeOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(typeOption);
+    }
+
+    if (diskConfig.storageClass) {
+      const storageClassSelect = this.locator('[data-test-id="storage-class-select"]');
+      await storageClassSelect.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(storageClassSelect);
+      const storageClassOption = this.locator(
+        `button#select-inline-filter-${diskConfig.storageClass}`,
+      );
+      await storageClassOption.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(storageClassOption);
+    }
+
+    if (diskConfig.shareDisk) {
+      const advancedSettingsButton = this._advancedSettingsBtn;
+      await advancedSettingsButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(advancedSettingsButton);
+      const shareDiskCheckbox = this.locator('input[id="sharable-disk"]');
+      await shareDiskCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await shareDiskCheckbox.check({ force: true });
+    }
+
+    if (diskConfig.scsiReservation) {
+      const advancedSettingsButton = this._advancedSettingsBtn;
+      await advancedSettingsButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(advancedSettingsButton);
+      const scsiReservationCheckbox = this.locator('input[id="scsi-reservation"]');
+      await scsiReservationCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await scsiReservationCheckbox.check({ force: true });
+    }
+
+    await this.clickSave();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async addGpuDevice(gpuName = 'vgpu_test', gpuResourceName = 'nvidia.com'): Promise<void> {
+    const gpuDevicesButton = this.locator('button:has-text("GPU devices")');
+    await gpuDevicesButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(gpuDevicesButton);
+
+    const addGpuDeviceButton = this.locator('button:has-text("Add GPU device")');
+    await addGpuDeviceButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(addGpuDeviceButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const optionsMenuButton = this.locator('button[aria-label="Options menu"]');
+    await optionsMenuButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(optionsMenuButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const gpuResourceOption = this.locator(`button:has-text("${gpuResourceName}")`);
+    await gpuResourceOption.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(gpuResourceOption);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const gpuNameInput = this.locator('input#name');
+    await gpuNameInput.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await gpuNameInput.clear();
+    await gpuNameInput.fill(gpuName);
+
+    const saveButton = this.locator('button.pf-m-plain')
+      .locator('svg[viewBox="0 0 512 512"]')
+      .locator('..');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(saveButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const resourceRow = this.locator('[data-test-rows="resource-row"]');
+    const gpuRow = resourceRow.locator(`text=${gpuName}`);
+    await gpuRow.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+
+    await this.clickSave();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const hardwareDevicesTable = this.locator('.hardware-devices-table');
+    await hardwareDevicesTable.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+    const gpuInTable = hardwareDevicesTable.locator(`text=${gpuName}`);
+    await gpuInTable.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+  }
+
+  async clickCreateButton(): Promise<void> {
+    const wizardCreateButton = this.locator('[data-test-id="create-virtual-machine"] button', {
+      hasText: 'Create VirtualMachine',
+    });
+    await wizardCreateButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(wizardCreateButton);
+  }
+
+  async deleteNic(): Promise<void> {
+    await this.navigateToWizardTab('Network');
+
+    await this._wizardNicToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+    await this.robustClick(this._wizardNicToggle);
+
+    const wizardDeleteNicButton = this.locator('button:has-text("Delete")');
+    await wizardDeleteNicButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(wizardDeleteNicButton);
+
+    const tabModal = this._tabModal;
+    await tabModal.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+
+    await this.locator('text=Delete NIC?').waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+
+    const confirmDeleteButton = tabModal.locator('button:has-text("Delete")');
+    await confirmDeleteButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(confirmDeleteButton);
+
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async fillMetadata(config: {
+    labels?: string[];
+    annotations?: Array<{ key: string; value: string }>;
+    nodeSelector?: { key: string; value: string };
+  }): Promise<void> {
+    await this.navigateToWizardTab('Metadata');
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    if (config.labels && config.labels.length > 0) {
+      const wizardLabelsEditButton = this.locator(
+        'button[data-test-id^="pw-vm-customize-it-"][data-test-id*="labels"]',
+      );
+      await wizardLabelsEditButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(wizardLabelsEditButton);
+
+      const wizardLabelsInput = this.locator('[data-test="tags-input"]');
+      await wizardLabelsInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await wizardLabelsInput.clear();
+
+      for (const label of config.labels) {
+        await wizardLabelsInput.fill(label);
+        await this.page.keyboard.press('Enter');
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      }
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        await this.clickSave();
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+
+    if (config.annotations && config.annotations.length > 0) {
+      const wizardAnnotationsEditButton = this.locator(
+        'button[data-test-id^="pw-vm-customize-it-"][data-test-id*="annotations"]',
+      );
+      const annotationsBtnExists = await wizardAnnotationsEditButton
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (!annotationsBtnExists) {
+        const altAnnotationsBtn = this.locator('button[data-test-id*="annotation"]').first();
+        const altExists = await altAnnotationsBtn
+          .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+          .catch(() => false);
+        if (altExists) {
+          await this.robustClick(altAnnotationsBtn);
+        } else {
+          return;
+        }
+      } else {
+        await this.robustClick(wizardAnnotationsEditButton);
+      }
+
+      for (const annotation of config.annotations) {
+        const addButton = this.locator('button:has-text("Add annotation")');
+        await addButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(addButton);
+
+        const keyInput = this._inputKey.last();
+        const valueInput = this._inputValue.last();
+        await keyInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await keyInput.fill(annotation.key);
+        await valueInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await valueInput.fill(annotation.value);
+      }
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        await this.clickSave();
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+
+    if (config.nodeSelector) {
+      const wizardNodeSelectorEditButton = this.locator(
+        'button[data-test-id^="pw-vm-customize-it-"][data-test-id*="node-selector"]',
+      );
+      await wizardNodeSelectorEditButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(wizardNodeSelectorEditButton);
+
+      const keyInput = this._inputKey;
+      const valueInput = this._inputValue;
+      await keyInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await keyInput.clear();
+      await keyInput.fill(config.nodeSelector.key);
+      await valueInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await valueInput.clear();
+      await valueInput.fill(config.nodeSelector.value);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        await this.clickSave();
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+  }
+
+  async fillNetworks(config: {
+    nics?: Array<{
+      name?: string;
+      model?: string;
+      network?: string;
+      type?: string;
+    }>;
+  }) {
+    if (config.nics && config.nics.length > 0) {
+      await this.navigateToWizardTab('Network');
+
+      for (const nic of config.nics) {
+        const wizardAddNetworkInterfaceButton = this.locator(
+          'button:has-text("Add network interface")',
+        );
+        await wizardAddNetworkInterfaceButton.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.RESOURCE_CREATION,
+        });
+        await this.robustClick(wizardAddNetworkInterfaceButton);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+
+        if (nic.name) {
+          const wizardNicNameInput = this.locator('input[aria-label="Network interface name"]');
+          await wizardNicNameInput.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.RESOURCE_CREATION,
+          });
+          await wizardNicNameInput.clear();
+          await wizardNicNameInput.fill(nic.name);
+        }
+
+        if (nic.model) {
+          const wizardNicModelSelect = this.locator('[data-test-id="model-select"]');
+          await wizardNicModelSelect.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          await this.robustClick(wizardNicModelSelect);
+          const modelOption = this.locator(`[data-test-id="model-select-${nic.model}"]`);
+          await modelOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+          await this.robustClick(modelOption);
+        }
+
+        if (nic.network) {
+          const wizardNicNetworkSelect = this.locator(
+            '[data-test-id="network-attachment-definition-select"]',
+          );
+          await wizardNicNetworkSelect.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          const networkToggle = wizardNicNetworkSelect.locator(
+            'button.pf-v6-c-menu-toggle__button',
+          );
+          await networkToggle.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          await this.robustClick(networkToggle);
+          await this.clickButtonByText(nic.network);
+        }
+
+        if (nic.type) {
+          const wizardNicTypeSelect = this.locator(
+            '[data-test-id="network-interface-type-select"]',
+          );
+          await wizardNicTypeSelect.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          await this.robustClick(wizardNicTypeSelect);
+          const typeOption = this.locator(
+            `button[data-test-id="network-interface-type-select-${nic.type}"]`,
+          );
+          await typeOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+          await this.robustClick(typeOption);
+        }
+
+        await this.clickSave();
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+      }
+    }
+  }
+
+  async fillOverview(config: {
+    name?: string;
+    description?: string;
+    cpu?: number;
+    memory?: number;
+    bootMode?: string;
+    workload?: string;
+    hostname?: string;
+    startInPause?: boolean;
+    headless?: boolean;
+  }) {
+    if (config.name) {
+      await this.locator('[data-test-id="wizard-overview-name-edit"]').click();
+      const wizardNameInput = this.locator('#vm-name');
+      await wizardNameInput.clear();
+      await wizardNameInput.fill(config.name);
+      await this.clickSave();
+    }
+
+    if (config.description) {
+      await this.robustClick(
+        this.locator('button[data-test-id^="pw-vm-customize-it-"][data-test-id*="description"]'),
+      );
+      const tabModal = this._tabModal;
+      await tabModal.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      const descTextarea = tabModal.locator('[aria-label="description text area"]');
+      await descTextarea.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await descTextarea.clear();
+      await descTextarea.fill(config.description);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        // Fallback to global Save button selector
+        await this.clickSave();
+      }
+    }
+
+    if (config.cpu || config.memory) {
+      await this.locator('[data-test-id="wizard-overview-cpu-memory-edit"]').click();
+      const wizardCpuInput = this.locator('input[name="cpu-input"]');
+      const wizardMemInput = this.locator('input[name="memory-input"]');
+      if (config.cpu) {
+        await wizardCpuInput.clear();
+        await wizardCpuInput.fill(config.cpu.toString());
+      }
+      if (config.memory) {
+        await wizardMemInput.clear();
+        await wizardMemInput.fill(config.memory.toString());
+      }
+      await this.clickSave();
+    }
+
+    if (config.bootMode) {
+      await this.locator('[data-test-id="wizard-overview-boot-method-edit"]').click();
+      const modalBody = this.locator('.pf-v6-c-modal-box__body');
+      await modalBody.locator('button').first().click();
+      // Use exact text matching to avoid partial matches (e.g., "UEFI" vs "UEFI(secure)")
+      await this.clickElementByExactText('span', config.bootMode);
+      await this.clickButtonByText('Save');
+    }
+
+    if (config.workload) {
+      await this.locator('[data-test-id="wizard-overview-workload-profile-edit"]').click();
+      const modalBody = this._tabModal;
+      await modalBody.locator('button.pf-v6-c-menu-toggle').click();
+      await this.locator('button', { hasText: config.workload }).click();
+      await this.clickButtonByText('Save');
+    }
+
+    if (config.hostname) {
+      const wizardHostnameEditBtn = this.locator(
+        'button[data-test-id^="pw-vm-customize-it-"][data-test-id*="hostname"]',
+      );
+      await wizardHostnameEditBtn.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.RESOURCE_CREATION,
+      });
+      await this.robustClick(wizardHostnameEditBtn);
+      const wizardHostnameInput = this.locator('input#hostname');
+      await wizardHostnameInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await wizardHostnameInput.fill(config.hostname);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        // Fallback to global Save button selector
+        await this.clickSave();
+      }
+    }
+
+    if (config.startInPause !== undefined) {
+      const wizardStartInPauseCheckbox = this.locator('#start-in-pause-mode');
+      // Switch elements may be hidden but still interactable, so wait for attached state
+      await wizardStartInPauseCheckbox.waitFor({
+        state: 'attached',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      const startInPauseChecked = await wizardStartInPauseCheckbox.isChecked().catch(() => false);
+      if (config.startInPause && !startInPauseChecked) {
+        // Use evaluate to set checked state directly for hidden switches
+        await wizardStartInPauseCheckbox.evaluate((el: HTMLInputElement) => {
+          el.checked = true;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      } else if (!config.startInPause && startInPauseChecked) {
+        // Use evaluate to set checked state directly for hidden switches
+        await wizardStartInPauseCheckbox.evaluate((el: HTMLInputElement) => {
+          el.checked = false;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      }
+    }
+
+    if (config.headless !== undefined) {
+      // Switch elements may be hidden but still interactable, so wait for attached state
+      await this._wizardHeadlessCheckbox.waitFor({
+        state: 'attached',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      const headlessChecked = await this._wizardHeadlessCheckbox.isChecked().catch(() => false);
+      if (config.headless && !headlessChecked) {
+        // Use evaluate to set checked state directly for hidden switches
+        await this._wizardHeadlessCheckbox.evaluate((el: HTMLInputElement) => {
+          el.checked = true;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      } else if (!config.headless && headlessChecked) {
+        // Use evaluate to set checked state directly for hidden switches
+        await this._wizardHeadlessCheckbox.evaluate((el: HTMLInputElement) => {
+          el.checked = false;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      }
+    }
+  }
+
+  async fillScheduling(config: {
+    descheduler?: boolean;
+    dedicatedResources?: boolean;
+    evictionStrategy?: boolean;
+  }) {
+    await this.navigateToWizardTab('Scheduling');
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    if (config.descheduler !== undefined) {
+      const wizardDeschedulerEditBtn = this.locator('[data-test-id="descheduler-edit"]');
+      await wizardDeschedulerEditBtn.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(wizardDeschedulerEditBtn);
+      const wizardDeschedulerCheckbox = this.locator('#descheduler');
+      const deschedulerChecked = await wizardDeschedulerCheckbox.isChecked().catch(() => false);
+      if (config.descheduler && !deschedulerChecked) {
+        await wizardDeschedulerCheckbox.click({ force: true });
+      } else if (!config.descheduler && deschedulerChecked) {
+        await wizardDeschedulerCheckbox.click({ force: true });
+      }
+      await this.clickSave();
+    }
+
+    if (config.dedicatedResources !== undefined) {
+      const wizardDedicatedResourcesEditBtn = this.locator(
+        '[data-test-id="dedicated-resources-edit"]',
+      );
+      await wizardDedicatedResourcesEditBtn.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(wizardDedicatedResourcesEditBtn);
+      const wizardDedicatedResourcesCheckbox = this.locator('#dedicated-resources');
+      const dedicatedResourcesChecked = await wizardDedicatedResourcesCheckbox
+        .isChecked()
+        .catch(() => false);
+      if (config.dedicatedResources && !dedicatedResourcesChecked) {
+        await wizardDedicatedResourcesCheckbox.click({ force: true });
+      } else if (!config.dedicatedResources && dedicatedResourcesChecked) {
+        await wizardDedicatedResourcesCheckbox.click({ force: true });
+      }
+      await this.clickSave();
+    }
+
+    if (config.evictionStrategy !== undefined) {
+      const wizardEvictionStrategyEditBtn = this.locator(
+        '[data-test-id="eviction-strategy"] button',
+      );
+      // Check if eviction strategy edit button exists (may not be available in all contexts)
+      const evictionBtnExists = await wizardEvictionStrategyEditBtn
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (evictionBtnExists) {
+        await this.robustClick(wizardEvictionStrategyEditBtn);
+        const wizardEvictionStrategyCheckbox = this.locator('#eviction-strategy');
+        const evictionStrategyChecked = await wizardEvictionStrategyCheckbox
+          .isChecked()
+          .catch(() => false);
+        if (config.evictionStrategy && !evictionStrategyChecked) {
+          await wizardEvictionStrategyCheckbox.click({ force: true });
+        } else if (!config.evictionStrategy && evictionStrategyChecked) {
+          await wizardEvictionStrategyCheckbox.click({ force: true });
+        }
+        await this.clickSave();
+      }
+    }
+  }
+
+  async fillScripts(config: { sysprepName?: string }): Promise<void> {
+    await this.navigateToWizardTab('Initial run');
+
+    if (config.sysprepName) {
+      const sysprepSection = this.locator('text=Sysprep').locator('..');
+      const editButton = sysprepSection.locator('button').first();
+      await editButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+      await this.robustClick(editButton);
+
+      const attachExistingButton = this.locator('button:has-text("Attach existing sysprep")');
+      await attachExistingButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(attachExistingButton);
+
+      const selectButton = this.locator('button:has-text("--- Select sysprep ---")');
+      await selectButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(selectButton);
+      await this.clickButtonByText(config.sysprepName);
+      await this.clickSave();
+    }
+  }
+
+  async fillSSH(
+    secretName: string,
+    sshKeyFilePath: string = SSH_KEY_PATHS.PUBLIC_KEY,
+  ): Promise<void> {
+    await this.navigateToWizardTab('SSH');
+
+    const sshEditButton = this.locator('[data-test-id="wizard-sshkey-edit"]');
+    await sshEditButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(sshEditButton);
+
+    const addNewButton = this.locator('#addNew');
+    await this.robustClick(addNewButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const uploadInput = this.locator('input[type="file"]');
+    await uploadInput.waitFor({ state: 'attached', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    await uploadInput.setInputFiles(sshKeyFilePath);
+
+    const secretNameInput = this.locator('#new-secret-name');
+    await secretNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    await secretNameInput.clear();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    await secretNameInput.type(secretName, { delay: 150 });
+
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const saveButton = this.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(saveButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async navigateToWizardTab(
+    tabName: 'Details' | 'Storage' | 'Network' | 'Scheduling' | 'SSH' | 'Initial run' | 'Metadata',
+  ) {
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const tabMapping: Record<typeof tabName, string> = {
+      Details: 'vm-configuration-details',
+      Scheduling: 'vm-configuration-scheduling',
+      SSH: 'vm-configuration-ssh',
+      Network: 'vm-configuration-network',
+      Storage: 'vm-configuration-storage',
+      'Initial run': 'vm-configuration-initial',
+      Metadata: 'vm-configuration-metadata',
+    };
+
+    const verticalTabId = tabMapping[tabName];
+    if (!verticalTabId) {
+      throw new Error(`Unknown tab name: ${tabName}`);
+    }
+
+    const tabLocator = this.locator(`[data-test-id="${verticalTabId}"]`);
+    await this.robustClick(tabLocator);
+  }
+
+  async setHeadless(headless: boolean): Promise<void> {
+    await this._wizardHeadlessCheckbox.waitFor({
+      state: 'attached',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    const headlessChecked = await this._wizardHeadlessCheckbox.isChecked().catch(() => false);
+    if (headless && !headlessChecked) {
+      await this._wizardHeadlessCheckbox.evaluate((el: HTMLInputElement) => {
+        el.checked = true;
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    } else if (!headless && headlessChecked) {
+      await this._wizardHeadlessCheckbox.evaluate((el: HTMLInputElement) => {
+        el.checked = false;
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    }
+  }
+
+  async verifyNetworksTabNotFoundMessage(): Promise<boolean> {
+    try {
+      await this.navigateToWizardTab('Network');
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_LONG);
+
+      const nicToggleCount = await this._wizardNicToggle.count();
+      if (nicToggleCount === 0) {
+        return true;
+      }
+
+      const notFoundSelectors = [
+        'text=Not found',
+        'text=/not found/i',
+        '[data-test="empty-state"]',
+        '.pf-v6-c-empty-state',
+        '.pf-v6-c-empty-state__body',
+        'text=No network interfaces',
+        'text=No network',
+      ];
+
+      for (const selector of notFoundSelectors) {
+        try {
+          const notFoundLocator = this.locator(selector).first();
+          const isVisible = await notFoundLocator.isVisible({
+            timeout: TestTimeouts.UI_DELAY_SHORT,
+          });
+          if (isVisible) {
+            const text = await notFoundLocator.textContent().catch(() => '');
+            if (
+              text?.toLowerCase().includes('not found') ||
+              text?.toLowerCase().includes('no network')
+            ) {
+              return true;
+            }
+          }
+        } catch {
+          continue;
+        }
+      }
+
+      const networksTabContent = this.locator('[data-test-id="vm-configuration-network"]')
+        .locator('..')
+        .locator('..');
+      const tabText = await networksTabContent.textContent().catch(() => '');
+      if (
+        tabText?.toLowerCase().includes('not found') ||
+        tabText?.toLowerCase().includes('no network')
+      ) {
+        return true;
+      }
+
+      const toggleVisible = await this._wizardNicToggle
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      return !toggleVisible;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/playwright/src/components/create-vm/template-components.ts
+++ b/playwright/src/components/create-vm/template-components.ts
@@ -1,0 +1,1420 @@
+/**
+ * Template listing and template customization wizard components.
+ */
+
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import { waitForElementStable } from '@/utils/wait-helpers';
+import type { Page } from '@playwright/test';
+
+export class CreateVmTemplatesComponent extends BaseComponent {
+  private readonly _createVirtualMachineButton = this.locator('button', {
+    hasText: 'Create VirtualMachine',
+  });
+  private readonly _filterCategoryArchitecture = this.locator(
+    '[data-test-id="filter-category-Architecture"]',
+  );
+  private readonly _searchCatalogInput = this.locator('[data-test="search-catalog"] input');
+  private readonly _templatesTab = this.locator('[data-test="templates-tab"]');
+  private readonly _userTemplates = this.locator('#user-templates');
+  private readonly _vmCatalogGrid = this.locator('#vm-catalog-grid');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  private getTemplateCardTitleLocator(templateName: string) {
+    return this._vmCatalogGrid.locator('.vm-catalog-grid-tile .catalog-tile-pf-title', {
+      hasText: templateName,
+    });
+  }
+
+  async clickAllTemplatesButton() {
+    const allTemplatesButton = this.locator('[data-test-id="catalog-template-filter-all-items"]');
+    await this.robustClick(allTemplatesButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+  async clickTemplateByMetadataName(templateMetadataName: string) {
+    await super.clickTemplateByTestId(
+      templateMetadataName,
+      `div[data-test-id="${templateMetadataName}"]`,
+    );
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_LONG);
+  }
+  async clickTemplatesTab() {
+    await this._templatesTab.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._templatesTab);
+  }
+
+  async clickUserProvidedTab() {
+    await this._userTemplates.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._userTemplates);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+  async clickUserTemplatesTab() {
+    const userTemplatesTab = this._userTemplates;
+    await userTemplatesTab.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(userTemplatesTab);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async clickViewAllProjectsButton(): Promise<void> {
+    const viewAllButton = this.locator('button', { hasText: 'View all projects' });
+    await viewAllButton.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(viewAllButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async countTemplateCards(templateName: string): Promise<number> {
+    const templateCards = this._vmCatalogGrid.locator(
+      '.vm-catalog-grid-tile .catalog-tile-pf-title',
+      { hasText: templateName },
+    );
+    return await templateCards.count();
+  }
+
+  async filterByBootSourceAvailable(check = true) {
+    const bootSourceFilter = this.locator(
+      '[data-test-id="boot-source-available-Boot source available"]',
+    ).locator('input[type="checkbox"]');
+    if (check) {
+      await bootSourceFilter.check({ force: true });
+    } else {
+      await bootSourceFilter.uncheck({ force: true });
+    }
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+  async filterByOSName(osName: 'RHEL' | 'Windows' | 'Fedora' | 'CentOS', check = true) {
+    const osFilter = this.locator(`[data-test-id="osName-${osName}"]`).locator(
+      'input[type="checkbox"]',
+    );
+    await osFilter.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    if (check) {
+      await osFilter.check({ force: true });
+    } else {
+      await osFilter.uncheck({ force: true });
+    }
+    await this.page.waitForTimeout(TestTimeouts.UI_FILTER_APPLY / 3);
+    await this._vmCatalogGrid
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => {
+        return;
+      });
+  }
+
+  async filterByWorkload(workload: 'Desktop' | 'Server', check = true) {
+    const workloadFilter = this.locator(`[data-test-id="workload-${workload}"]`).locator(
+      'input[type="checkbox"]',
+    );
+    await workloadFilter.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    if (check) {
+      await workloadFilter.check({ force: true });
+    } else {
+      await workloadFilter.uncheck({ force: true });
+    }
+    await this.page.waitForTimeout(TestTimeouts.UI_FILTER_APPLY / 3);
+    await this._vmCatalogGrid
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => {
+        return;
+      });
+  }
+
+  async isCreateVmFromCatalogAvailable(): Promise<boolean> {
+    const createBtn = await this._createVirtualMachineButton
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+    if (createBtn) return true;
+    return await this._vmCatalogGrid
+      .isVisible({ timeout: TestTimeouts.RETRY_DELAY })
+      .catch(() => false);
+  }
+
+  async isTemplateCatalogSectionVisible(): Promise<boolean> {
+    const tabVisible = await this._templatesTab
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+    if (!tabVisible) return false;
+    const gridVisible = await this._vmCatalogGrid
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+    return gridVisible;
+  }
+
+  async searchTemplate(templateName: string) {
+    await this._searchCatalogInput.clear();
+    await this._searchCatalogInput.fill(templateName);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+  async selectNamespaceInProjectDropdown(namespace: string): Promise<void> {
+    const projectDropdown = this.locator('.project-dropdown').locator('button').first();
+    await projectDropdown.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(projectDropdown);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const filterInput = this.locator('#select-inline-filter input');
+    await filterInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await filterInput.clear();
+    await filterInput.pressSequentially(namespace, { delay: 100 });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const namespaceOption = this.locator(`[data-test-id="${namespace}"]`).first();
+    await namespaceOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(namespaceOption);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async selectProjectFromCatalog(projectName: string) {
+    const projectDropdown = this.locator('.templates-catalog-project-dropdown').locator('button');
+    await projectDropdown.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(projectDropdown);
+
+    const projectItem = this.locator('.pf-v6-c-menu__item-text', { hasText: projectName });
+    await projectItem.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_LONG });
+    await this.robustClick(projectItem);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async switchView(view: 'grid' | 'list') {
+    if (view === 'list') {
+      const listButton = this.locator('#template-list-btn');
+      await this.robustClick(listButton);
+    } else {
+      const gridButton = this.locator('#template-grid-btn');
+      await this.robustClick(gridButton);
+    }
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+  async verifyArchitectureFilterExists(): Promise<boolean> {
+    const maxRetries = 3;
+    let lastError: Error | undefined;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        await this.page.waitForLoadState('networkidle', {
+          timeout: TestTimeouts.UI_ACTION_COMPLETE,
+        });
+
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+        await waitForElementStable(
+          this._filterCategoryArchitecture,
+          TestTimeouts.UI_ELEMENT_VISIBILITY,
+        );
+
+        const hasCheckboxes = await this.waitForChildElements(
+          this._filterCategoryArchitecture,
+          'input[type="checkbox"]',
+          { timeout: TestTimeouts.UI_ELEMENT_VISIBILITY },
+        );
+
+        if (hasCheckboxes) {
+          return true;
+        }
+
+        throw new Error('No checkboxes found in architecture filter');
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+        if (attempt < maxRetries) {
+          console.warn(`Architecture filter verification attempt ${attempt} failed, retrying...`);
+          await this.page.waitForTimeout(TestTimeouts.RETRY_DELAY);
+        }
+      }
+    }
+
+    console.warn(
+      `Architecture filter verification failed after ${maxRetries} attempts: ${lastError?.message}`,
+    );
+    return false;
+  }
+
+  async verifyEmptyProjectState(): Promise<boolean> {
+    try {
+      const emptyStateTitle = this.locator('text=No templates found in this project');
+      await emptyStateTitle.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await emptyStateTitle.isVisible();
+    } catch {
+      return false;
+    }
+  }
+  async verifyNoErrorBoundary(waitMs = 3000): Promise<boolean> {
+    const errorIndicator = this.page.locator('text=Something wrong happened');
+    const hasError = await errorIndicator.isVisible({ timeout: waitMs }).catch(() => false);
+    return !hasError;
+  }
+  async verifyTemplateCardVisible(templateName: string): Promise<boolean> {
+    try {
+      await this._vmCatalogGrid.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+      const anyCardTile = this._vmCatalogGrid.locator('.vm-catalog-grid-tile').first();
+      const hasAnyCards = await anyCardTile
+        .isVisible({ timeout: TestTimeouts.UI_ACTION_COMPLETE })
+        .catch(() => false);
+
+      if (!hasAnyCards) {
+        await this.page.waitForTimeout(TestTimeouts.UI_FILTER_APPLY / 3);
+      }
+
+      const templateCardTitleLocator = this.getTemplateCardTitleLocator(templateName);
+
+      await templateCardTitleLocator
+        .first()
+        .waitFor({ state: 'visible', timeout: TestTimeouts.TEMPLATE_CREATION });
+
+      await this.page.waitForTimeout(TestTimeouts.POLLING_INTERVAL / 2);
+
+      const locators = await templateCardTitleLocator.all();
+      if (locators.length === 0) {
+        return false;
+      }
+      const visibilityChecks = await Promise.all(locators.map((locator) => locator.isVisible()));
+      return visibilityChecks.every((isVisible) => isVisible);
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyTemplateVisibleInListView(templateName: string): Promise<boolean> {
+    try {
+      const templateSpan = this.locator('.vm-catalog-table-container').locator('button span', {
+        hasText: templateName,
+      });
+      await templateSpan.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  override async waitForTemplateForm() {
+    await super.waitForTemplateForm();
+  }
+}
+
+/**
+ * Page object for the Template-based VM customization wizard.
+ * Uses horizontal tabs (horizontal-link-* pattern) for navigation between wizard sections.
+ * Handles VM configuration for name, description, CPU/memory, scheduling, networks, storage, scripts, and metadata.
+ */
+
+export class TemplateCustomizeWizardComponent extends BaseComponent {
+  private readonly _advancedSettingsBtn = this.locator('button:has-text("Advanced settings")');
+  private readonly _cDROMDiskTypeSelectCdrom = this.locator(
+    'text=CD-ROM, [data-test-id="disk-type-select-cdrom"]',
+  );
+  private readonly _inputKey = this.locator('input[aria-label="Key"]');
+  private readonly _inputname = this.locator('input#name');
+  private readonly _inputTypeFile = this.locator('input[type="file"]');
+  private readonly _inputValue = this.locator('input[aria-label="Value"]');
+  private readonly _tabModal = this.locator('#tab-modal');
+  private readonly _wizardCpuMemEditBtn = this.locator(
+    '[data-test-id="wizard-overview-cpu-memory-edit"]',
+  );
+  private readonly _wizardCreateButton = this.locator(
+    '[data-test-id="create-virtual-machine"] button',
+    { hasText: 'Create VirtualMachine' },
+  );
+  private readonly _wizardHeadlessCheckbox = this.locator('#headless-mode');
+  private readonly _wizardNicToggle = this.locator('#toggle-id-network');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async addCDROMDisk(
+    diskName: string,
+    cdromSource: 'Upload new ISO' | 'Use existing ISO' | 'Leave empty drive' = 'Upload new ISO',
+    sourceValue?: string,
+  ): Promise<boolean> {
+    await this.navigateToWizardTab('Disks');
+
+    const addButton = this.locator(
+      'button:has-text("Add"), [data-test-id="add-disk"], [data-test="add-disk"]',
+    );
+    await addButton.first().waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(addButton.first());
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    // Try multiple ways to find the CD-ROM option in the menu
+    const cdromMenuOption = this.page
+      .locator('.pf-v6-c-menu__item, .pf-c-dropdown__menu-item')
+      .filter({ hasText: 'CD-ROM' })
+      .first();
+    await cdromMenuOption
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => null);
+
+    if (await cdromMenuOption.isVisible()) {
+      await cdromMenuOption.click({ force: true });
+    } else {
+      const cdromOption = this._cDROMDiskTypeSelectCdrom;
+      await cdromOption
+        .first()
+        .waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+      await cdromOption.first().click({ force: true });
+    }
+
+    const nameInput = this.locator('input[aria-label="Disk name"], input[id="name"]');
+    await nameInput.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await nameInput.clear();
+    await nameInput.fill(diskName);
+
+    if (cdromSource === 'Upload new ISO' && sourceValue) {
+      const uploadRadio = this.page.locator(
+        'input[id="cdrom-source-upload"], input#cdrom-source-upload',
+      );
+      await uploadRadio.waitFor({ state: 'attached', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      await uploadRadio.check({ force: true });
+
+      await this.locator('input[id="simple-file-filename"]').waitFor({
+        state: 'attached',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+
+      // Use the actual hidden file input for the upload
+      const fileInput = this._inputTypeFile;
+      await fileInput.setInputFiles(sourceValue);
+
+      // Add a long explicit wait to allow the file upload processing and form validation to complete
+      await this.page.waitForTimeout(5000);
+    } else if (cdromSource === 'Use existing ISO' && sourceValue) {
+      const mountExistingRadio = this.page.locator(
+        'input[id="cdrom-source-existing"], input#cdrom-source-existing',
+      );
+      await mountExistingRadio.waitFor({
+        state: 'attached',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await mountExistingRadio.check({ force: true });
+
+      const selectIsoButton = this.locator('button[placeholder="Select ISO file"]');
+      await selectIsoButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await selectIsoButton.click();
+
+      const isoOption = this.locator(`button[id="select-inline-filter-${sourceValue}"]`);
+      await isoOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await isoOption.click();
+    } else if (cdromSource === 'Leave empty drive') {
+      const emptyRadio = this.page.locator(
+        'input[id="cdrom-source-empty"], input#cdrom-source-empty, label:has-text("Leave empty drive") input',
+      );
+      await emptyRadio.waitFor({ state: 'attached', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+      if (await emptyRadio.isDisabled()) {
+        await this.clickCancel();
+        return false;
+      }
+
+      await emptyRadio.check({ force: true });
+      // Small delay for UI to enable Save button
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const saveButton = this.locator(
+      '[role="dialog"] [data-test="save-button"], [role="dialog"] button:has-text("Save")',
+    );
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+
+    await saveButton.click();
+
+    const dialog = this.page.locator('#tab-modal, .pf-v6-c-modal-box').last();
+    await dialog.waitFor({ state: 'hidden', timeout: 60000 }).catch(async (e) => {
+      const errorAlert = dialog.locator('.pf-v6-c-alert.pf-m-danger, .pf-c-alert.pf-m-danger');
+      let errorText = 'None';
+      if (await errorAlert.isVisible()) {
+        errorText = (await errorAlert.textContent().catch(() => 'None')) || 'None';
+      }
+
+      const cancelButton = this.locator(
+        '#tab-modal [data-test="cancel-button"], #tab-modal button:has-text("Cancel")',
+      ).first();
+      if (await cancelButton.isVisible()) {
+        await cancelButton.click({ force: true });
+      }
+      throw new Error(
+        `CD-ROM modal failed to close in wizard. Error: ${errorText}. Original error: ${e.message}`,
+      );
+    });
+
+    return true;
+  }
+
+  async addDisk(diskConfig: {
+    name: string;
+    diskType?: string; // e.g., 'Empty disk (blank)', 'Ephemeral', 'Clone volume'
+    diskSource?: {
+      name?: string; // e.g., 'Blank', 'EphemeralDisk', 'cloneVolume'
+      selector?: string;
+      value?: string;
+    };
+    size?: string;
+    storageClass?: string;
+    type?: string; // e.g., 'lun'
+    shareDisk?: boolean;
+    scsiReservation?: boolean;
+  }): Promise<void> {
+    await this.navigateToWizardTab('Disks');
+
+    const addButton = this.locator('button:has-text("Add")');
+    await addButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(addButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const diskType = diskConfig.diskType || 'Empty disk (blank)';
+    const diskTypeOption = this.locator(`text=${diskType}`);
+    await diskTypeOption.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(diskTypeOption);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const nameInput = this.locator('input[aria-label="Disk name"]');
+    await nameInput.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await nameInput.clear();
+    await nameInput.fill(diskConfig.name);
+
+    if (diskConfig.diskSource) {
+      if (diskConfig.diskSource.name === 'cloneVolume') {
+        const selectPVCNS = this.locator('button:has-text("Select Project")');
+        await selectPVCNS.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(selectPVCNS);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+        const selectPVCName = this.locator('button:has-text("Select PersistentVolumeClaim")');
+        await selectPVCName.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(selectPVCName);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      }
+    }
+
+    if (diskConfig.size) {
+      const sizeInput = this.locator('input[aria-label="Input"]');
+      const sizeInputExists = await sizeInput
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_LONG })
+        .catch(() => false);
+      if (sizeInputExists) {
+        await sizeInput.clear();
+        // Use increment button to set size
+        const incrementButton = this.locator('button[aria-label="Increment"]');
+        for (let i = 0; i < parseInt(diskConfig.size); i++) {
+          await this.robustClick(incrementButton);
+        }
+      }
+    }
+
+    if (diskConfig.type) {
+      const diskTypeSelect = this.locator('[data-test-id="disk-type-select"]');
+      await diskTypeSelect.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(diskTypeSelect);
+      const typeOption = this.locator(`[data-test-id="disk-type-select-${diskConfig.type}"]`);
+      await typeOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(typeOption);
+    }
+
+    if (diskConfig.storageClass) {
+      const storageClassSelect = this.locator('[data-test-id="storage-class-select"]');
+      await storageClassSelect.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(storageClassSelect);
+      const storageClassOption = this.locator(
+        `button#select-inline-filter-${diskConfig.storageClass}`,
+      );
+      await storageClassOption.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(storageClassOption);
+    }
+
+    if (diskConfig.shareDisk) {
+      const advancedSettingsButton = this._advancedSettingsBtn;
+      await advancedSettingsButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(advancedSettingsButton);
+      const shareDiskCheckbox = this.locator('input[id="sharable-disk"]');
+      await shareDiskCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await shareDiskCheckbox.check({ force: true });
+    }
+
+    if (diskConfig.scsiReservation) {
+      const advancedSettingsButton = this._advancedSettingsBtn;
+      await advancedSettingsButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(advancedSettingsButton);
+      const scsiReservationCheckbox = this.locator('input[id="scsi-reservation"]');
+      await scsiReservationCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await scsiReservationCheckbox.check({ force: true });
+    }
+
+    await this.clickSave();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async addGpuDevice(gpuName = 'vgpu_test', gpuResourceName = 'nvidia.com'): Promise<void> {
+    const gpuDevicesButton = this.locator('button:has-text("GPU devices")');
+    await gpuDevicesButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(gpuDevicesButton);
+
+    const addGpuDeviceButton = this.locator('button:has-text("Add GPU device")');
+    await addGpuDeviceButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(addGpuDeviceButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const optionsMenuButton = this.locator('button[aria-label="Options menu"]');
+    await optionsMenuButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(optionsMenuButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const gpuResourceOption = this.locator(`button:has-text("${gpuResourceName}")`);
+    await gpuResourceOption.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(gpuResourceOption);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const gpuNameInput = this._inputname;
+    await gpuNameInput.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await gpuNameInput.clear();
+    await gpuNameInput.fill(gpuName);
+
+    // Click save button (button.pf-m-plain>svg[viewBox="0 0 512 512"])
+    const saveButton = this.locator('button.pf-m-plain')
+      .locator('svg[viewBox="0 0 512 512"]')
+      .locator('..');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(saveButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const resourceRow = this.locator('[data-test-rows="resource-row"]');
+    const gpuRow = resourceRow.locator(`text=${gpuName}`);
+    await gpuRow.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+
+    await this.clickSave();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const hardwareDevicesTable = this.locator('.hardware-devices-table');
+    await hardwareDevicesTable.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+    const gpuInTable = hardwareDevicesTable.locator(`text=${gpuName}`);
+    await gpuInTable.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+  }
+
+  async clickCancel(): Promise<void> {
+    await this.robustClick(this.locator('button:has-text("Cancel")'));
+  }
+
+  async clickCreateButton(): Promise<void> {
+    await this._wizardCreateButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(this._wizardCreateButton, { timeout: TestTimeouts.ELEMENT_WAIT });
+  }
+
+  async deleteNic(): Promise<void> {
+    await this.navigateToWizardTab('Network interfaces');
+
+    await this._wizardNicToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+    await this.robustClick(this._wizardNicToggle);
+
+    const wizardDeleteNicButton = this.locator('button:has-text("Delete")');
+    await wizardDeleteNicButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(wizardDeleteNicButton);
+
+    const tabModal = this._tabModal;
+    await tabModal.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+
+    await this.locator('text=Delete NIC?').waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+
+    const confirmDeleteButton = tabModal.locator('button:has-text("Delete")');
+    await confirmDeleteButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    await this.robustClick(confirmDeleteButton);
+
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async fillMetadata(config: {
+    labels?: string[]; // Array of strings like "key=value"
+    annotations?: Array<{ key: string; value: string }>; // Array of key-value pairs
+    nodeSelector?: { key: string; value: string }; // Single key-value pair
+  }): Promise<void> {
+    await this.navigateToWizardTab('Metadata');
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    if (config.labels && config.labels.length > 0) {
+      const wizardLabelsEditButton = this.locator('[data-test-id="wizard-metadata-labels-edit"]');
+      await wizardLabelsEditButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(wizardLabelsEditButton);
+
+      const wizardLabelsInput = this.locator('[data-test="tags-input"]');
+      await wizardLabelsInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await wizardLabelsInput.clear();
+
+      for (const label of config.labels) {
+        await wizardLabelsInput.fill(label);
+        await this.page.keyboard.press('Enter');
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      }
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        // Fallback to global Save button selector
+        await this.clickSave();
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+
+    if (config.annotations && config.annotations.length > 0) {
+      const wizardAnnotationsEditButton = this.locator(
+        '[data-test-id="wizard-metadata-annotations-edit"]',
+      );
+      // Check if annotations edit button exists (may have different selector pattern)
+      const annotationsBtnExists = await wizardAnnotationsEditButton
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (!annotationsBtnExists) {
+        // Try alternative selector pattern
+        const altAnnotationsBtn = this.locator('button[data-test-id*="annotation"]').first();
+        const altExists = await altAnnotationsBtn
+          .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+          .catch(() => false);
+        if (altExists) {
+          await this.robustClick(altAnnotationsBtn);
+        } else {
+          // Annotations section may not be available - silently continue
+          return;
+        }
+      } else {
+        await this.robustClick(wizardAnnotationsEditButton);
+      }
+
+      for (const annotation of config.annotations) {
+        const addButton = this.locator('button:has-text("Add annotation")');
+        await addButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(addButton);
+
+        const keyInput = this._inputKey.last();
+        const valueInput = this._inputValue.last();
+        await keyInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await keyInput.fill(annotation.key);
+        await valueInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await valueInput.fill(annotation.value);
+      }
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        // Fallback to global Save button selector
+        await this.clickSave();
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+
+    if (config.nodeSelector) {
+      const wizardNodeSelectorEditButton = this.locator('[data-test-id="node-selector-edit"]');
+      await wizardNodeSelectorEditButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(wizardNodeSelectorEditButton);
+
+      const keyInput = this._inputKey;
+      const valueInput = this._inputValue;
+      await keyInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await keyInput.clear();
+      await keyInput.fill(config.nodeSelector.key);
+      await valueInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await valueInput.clear();
+      await valueInput.fill(config.nodeSelector.value);
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        // Fallback to global Save button selector
+        await this.clickSave();
+      }
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+  }
+
+  async fillNetworks(config: {
+    nics?: Array<{
+      name?: string;
+      model?: string;
+      network?: string;
+      type?: string;
+    }>;
+  }) {
+    if (config.nics && config.nics.length > 0) {
+      await this.navigateToWizardTab('Network interfaces');
+
+      for (const nic of config.nics) {
+        const wizardAddNetworkInterfaceButton = this.locator(
+          'button:has-text("Add network interface")',
+        );
+        await wizardAddNetworkInterfaceButton.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.RESOURCE_CREATION,
+        });
+        await this.robustClick(wizardAddNetworkInterfaceButton);
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+
+        if (nic.name) {
+          const wizardNicNameInput = this._inputname;
+          await wizardNicNameInput.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.RESOURCE_CREATION,
+          });
+          await wizardNicNameInput.clear();
+          await wizardNicNameInput.fill(nic.name);
+        }
+
+        if (nic.model) {
+          const wizardNicModelSelect = this.locator('[data-test-id="model-select"]>button');
+          await wizardNicModelSelect.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          await this.robustClick(wizardNicModelSelect);
+          const modelOption = this.locator(`[data-test-id="model-select-${nic.model}"]>button`);
+          await modelOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+          await this.robustClick(modelOption);
+        }
+
+        if (nic.network) {
+          const wizardNicNetworkSelect = this.locator(
+            'input[placeholder="Select a NetworkAttachmentDefinition"]',
+          );
+          await wizardNicNetworkSelect.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          const networkToggle = wizardNicNetworkSelect;
+          await networkToggle.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          await networkToggle.fill(nic.network);
+          await this.clickButtonByText(nic.network);
+        }
+
+        if (nic.type) {
+          const wizardNicTypeSelect = this.locator(
+            '[data-test-id="network-interface-type-select"]',
+          );
+          await wizardNicTypeSelect.waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_ACTION_COMPLETE,
+          });
+          await this.robustClick(wizardNicTypeSelect);
+          const typeOption = this.locator(
+            `button[data-test-id="network-interface-type-select-${nic.type}"]`,
+          );
+          await typeOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+          await this.robustClick(typeOption);
+        }
+
+        await this.clickSaveByTestId();
+      }
+    }
+  }
+
+  async fillOverview(config: {
+    name?: string;
+    description?: string;
+    cpu?: number;
+    memory?: number;
+    bootMode?: string;
+    workload?: string;
+    hostname?: string;
+    startInPause?: boolean;
+    headless?: boolean;
+  }) {
+    if (config.name) {
+      await this.locator('[data-test-id="wizard-overview-name-edit"]').click();
+      const wizardNameInput = this.locator('#vm-name');
+      await wizardNameInput.clear();
+      await wizardNameInput.fill(config.name);
+      await this.clickSave();
+    }
+
+    if (config.description) {
+      await this.robustClick(this.locator('[data-test-id="wizard-overview-description-edit"]'));
+      // Wait for modal to appear and scope textarea to modal
+      const tabModal = this._tabModal;
+      await tabModal.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      const descTextarea = tabModal.locator('[aria-label="description text area"]');
+      await descTextarea.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await descTextarea.clear();
+      await descTextarea.fill(config.description);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        // Fallback to global Save button selector
+        await this.clickSave();
+      }
+    }
+
+    if (config.cpu || config.memory) {
+      await this._wizardCpuMemEditBtn.click();
+      const wizardCpuInput = this.locator('input[name="cpu-input"]');
+      const wizardMemInput = this.locator('input[name="memory-input"]');
+      if (config.cpu) {
+        await wizardCpuInput.clear();
+        await wizardCpuInput.fill(config.cpu.toString());
+      }
+      if (config.memory) {
+        await wizardMemInput.clear();
+        await wizardMemInput.fill(config.memory.toString());
+      }
+      await this.clickSave();
+    }
+
+    if (config.bootMode) {
+      await this.locator('[data-test-id="wizard-overview-boot-method-edit"]').click();
+      const modalBody = this.locator('.pf-v6-c-modal-box__body');
+      await modalBody.locator('button').first().click();
+      // Use exact text matching to avoid partial matches (e.g., "UEFI" vs "UEFI(secure)")
+      await this.clickElementByExactText('span', config.bootMode);
+      await this.clickButtonByText('Save');
+    }
+
+    if (config.workload) {
+      await this.locator('[data-test-id="wizard-overview-workload-profile-edit"]').click();
+      const modalBody = this._tabModal;
+      await modalBody.locator('button.pf-v6-c-menu-toggle').click();
+      await this.locator('button', { hasText: config.workload }).click();
+      await this.clickButtonByText('Save');
+    }
+
+    if (config.hostname) {
+      const wizardHostnameEditBtn = this.locator('[data-test-id="wizard-overview-hostname-edit"]');
+      await wizardHostnameEditBtn.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.RESOURCE_CREATION,
+      });
+      await this.robustClick(wizardHostnameEditBtn);
+      const wizardHostnameInput = this.locator('input#hostname');
+      await wizardHostnameInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await wizardHostnameInput.fill(config.hostname);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      const tabModal = this._tabModal;
+      const saveButtonInModal = tabModal.locator('button').filter({ hasText: 'Save' }).first();
+      const saveButtonVisible = await saveButtonInModal
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (saveButtonVisible) {
+        await this.robustClick(saveButtonInModal);
+      } else {
+        // Fallback to global Save button selector
+        await this.clickSave();
+      }
+    }
+
+    if (config.startInPause !== undefined) {
+      const wizardStartInPauseCheckbox = this.locator('#start-in-pause-mode');
+      // Switch elements may be hidden but still interactable, so wait for attached state
+      await wizardStartInPauseCheckbox.waitFor({
+        state: 'attached',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      const startInPauseChecked = await wizardStartInPauseCheckbox.isChecked().catch(() => false);
+      if (config.startInPause && !startInPauseChecked) {
+        // Use evaluate to set checked state directly for hidden switches
+        await wizardStartInPauseCheckbox.evaluate((el: HTMLInputElement) => {
+          el.checked = true;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      } else if (!config.startInPause && startInPauseChecked) {
+        // Use evaluate to set checked state directly for hidden switches
+        await wizardStartInPauseCheckbox.evaluate((el: HTMLInputElement) => {
+          el.checked = false;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      }
+    }
+
+    if (config.headless !== undefined) {
+      // Switch elements may be hidden but still interactable, so wait for attached state
+      await this._wizardHeadlessCheckbox.waitFor({
+        state: 'attached',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      const headlessChecked = await this._wizardHeadlessCheckbox.isChecked().catch(() => false);
+      if (config.headless && !headlessChecked) {
+        // Use evaluate to set checked state directly for hidden switches
+        await this._wizardHeadlessCheckbox.evaluate((el: HTMLInputElement) => {
+          el.checked = true;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      } else if (!config.headless && headlessChecked) {
+        // Use evaluate to set checked state directly for hidden switches
+        await this._wizardHeadlessCheckbox.evaluate((el: HTMLInputElement) => {
+          el.checked = false;
+          el.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+      }
+    }
+  }
+
+  async fillScheduling(config: {
+    descheduler?: boolean;
+    dedicatedResources?: boolean;
+    evictionStrategy?: boolean;
+  }) {
+    await this.navigateToWizardTab('Scheduling');
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    if (config.descheduler !== undefined) {
+      const wizardDeschedulerEditBtn = this.locator('[data-test-id="descheduler-edit"]');
+      await wizardDeschedulerEditBtn.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(wizardDeschedulerEditBtn);
+      const wizardDeschedulerCheckbox = this.locator('#descheduler');
+      const deschedulerChecked = await wizardDeschedulerCheckbox.isChecked().catch(() => false);
+      if (config.descheduler && !deschedulerChecked) {
+        await wizardDeschedulerCheckbox.click({ force: true });
+      } else if (!config.descheduler && deschedulerChecked) {
+        await wizardDeschedulerCheckbox.click({ force: true });
+      }
+      await this.clickSave();
+    }
+
+    if (config.dedicatedResources !== undefined) {
+      const wizardDedicatedResourcesEditBtn = this.locator(
+        '[data-test-id="dedicated-resources-edit"]',
+      );
+      await wizardDedicatedResourcesEditBtn.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(wizardDedicatedResourcesEditBtn);
+      const wizardDedicatedResourcesCheckbox = this.locator('#dedicated-resources');
+      const dedicatedResourcesChecked = await wizardDedicatedResourcesCheckbox
+        .isChecked()
+        .catch(() => false);
+      if (config.dedicatedResources && !dedicatedResourcesChecked) {
+        await wizardDedicatedResourcesCheckbox.click({ force: true });
+      } else if (!config.dedicatedResources && dedicatedResourcesChecked) {
+        await wizardDedicatedResourcesCheckbox.click({ force: true });
+      }
+      await this.clickSave();
+    }
+
+    if (config.evictionStrategy !== undefined) {
+      const wizardEvictionStrategyEditBtn = this.locator('[data-test-id="eviction-strategy-edit"]');
+      // Check if eviction strategy edit button exists (may not be available in all contexts)
+      const evictionBtnExists = await wizardEvictionStrategyEditBtn
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      if (evictionBtnExists) {
+        await this.robustClick(wizardEvictionStrategyEditBtn);
+        const wizardEvictionStrategyCheckbox = this.locator('#eviction-strategy');
+        const evictionStrategyChecked = await wizardEvictionStrategyCheckbox
+          .isChecked()
+          .catch(() => false);
+        if (config.evictionStrategy && !evictionStrategyChecked) {
+          await wizardEvictionStrategyCheckbox.click({ force: true });
+        } else if (!config.evictionStrategy && evictionStrategyChecked) {
+          await wizardEvictionStrategyCheckbox.click({ force: true });
+        }
+        await this.clickSave();
+      } else {
+        // Eviction strategy section may not be available - silently continue
+      }
+    }
+  }
+
+  async fillScripts(config: {
+    sysprepName?: string; // Name of existing sysprep ConfigMap (e.g., "sysprep-vm-name")
+    cloudInitNetwork?: {
+      ethernetName: string;
+      ipCidr: string;
+      gateway?: string;
+    };
+  }): Promise<void> {
+    if (!config.sysprepName && !config.cloudInitNetwork) {
+      return;
+    }
+    await this.navigateToWizardTab('Scripts');
+
+    if (config.sysprepName) {
+      const sysprepSection = this.locator('text=Sysprep').locator('..');
+      const editButton = sysprepSection.locator('button').first();
+      await editButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+      await this.robustClick(editButton);
+
+      const attachExistingButton = this.locator('button:has-text("Attach existing sysprep")');
+      await attachExistingButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(attachExistingButton);
+
+      const selectButton = this.locator('button:has-text("--- Select sysprep ---")');
+      await selectButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+      await this.robustClick(selectButton);
+      await this.clickButtonByText(config.sysprepName);
+      await this.clickSave();
+    }
+
+    if (config.cloudInitNetwork) {
+      const cloudInitEdit = this.locator('[data-test-id="wizard-cloudinit-edit"]');
+      await cloudInitEdit.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+      await this.robustClick(cloudInitEdit);
+
+      const { ethernetName, ipCidr, gateway } = config.cloudInitNetwork;
+      const cloudInitNetworkCheckbox = this.locator('input[id="custom-network-checkbox"]');
+      await cloudInitNetworkCheckbox.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_DELAY_MEDIUM,
+      });
+      await cloudInitNetworkCheckbox.check({ force: true });
+
+      const cloudInitEthNameInput = this.locator('input[id="ethernet-name"]');
+      await cloudInitEthNameInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_DELAY_MEDIUM,
+      });
+      await cloudInitEthNameInput.fill(ethernetName);
+
+      const cloudInitIpAddressInput = this.locator('input[id="address"]');
+      await cloudInitIpAddressInput.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_DELAY_MEDIUM,
+      });
+      await cloudInitIpAddressInput.fill(ipCidr);
+
+      if (gateway) {
+        const cloudInitGatewayInput = this.locator('input[id="gateway"]');
+        await cloudInitGatewayInput.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_DELAY_MEDIUM,
+        });
+        await cloudInitGatewayInput.fill(gateway);
+      }
+
+      const cloudInitApplyButton = this.locator('button:has-text("Apply")');
+      await cloudInitApplyButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_DELAY_MEDIUM,
+      });
+      await this.robustClick(cloudInitApplyButton);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+  }
+
+  async fillSSH(secretName: string, sshKeyFilePath: string): Promise<void> {
+    await this.navigateToWizardTab('Scripts');
+
+    const sshEditButton = this.locator('[data-test-id="wizard-sshkey-edit"]');
+    await sshEditButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(sshEditButton);
+
+    const addNewButton = this.locator('#addNew');
+    await this.robustClick(addNewButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    // Wait for upload input to be ready (file inputs are often hidden)
+    const uploadInput = this._inputTypeFile;
+    await uploadInput.waitFor({ state: 'attached', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    await uploadInput.setInputFiles(sshKeyFilePath);
+
+    const secretNameInput = this.locator('#new-secret-name');
+    await secretNameInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    // Enter secret name with delay between keystrokes to allow form validation to react
+    // Clear the input first in case there's a pre-filled value
+    await secretNameInput.clear();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    // Type the secret name with a small delay between keystrokes
+    // This allows the form validation to process each character and update the Save button state
+    await secretNameInput.type(secretName, { delay: 150 });
+
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const saveButton = this.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(saveButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async isSecretCopyWarningVisible(): Promise<boolean> {
+    try {
+      const warning = this.locator('text=This Secret will be copied to the destination project');
+      await warning.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async navigateToWizardTab(
+    tabName:
+      | 'Overview'
+      | 'Scheduling'
+      | 'Environment'
+      | 'Network interfaces'
+      | 'Disks'
+      | 'Scripts'
+      | 'Metadata',
+  ) {
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    const tabLocator = this.locator(`[data-test-id="horizontal-link-${tabName}"]`);
+    await this.robustClick(tabLocator);
+  }
+
+  async restoreCpuMemoryToDefaults(): Promise<void> {
+    await this.navigateToWizardTab('Overview');
+
+    await this._wizardCpuMemEditBtn.click();
+
+    const restoreButton = this.locator('button:has-text("Restore template settings")');
+    await restoreButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+    await this.robustClick(restoreButton);
+
+    await this.clickSave();
+  }
+
+  async setHeadless(headless: boolean): Promise<void> {
+    // Switch elements may be hidden but still interactable, so wait for attached state
+    await this._wizardHeadlessCheckbox.waitFor({
+      state: 'attached',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+    const headlessChecked = await this._wizardHeadlessCheckbox.isChecked().catch(() => false);
+    if (headless && !headlessChecked) {
+      // Use evaluate to set checked state directly for hidden switches
+      await this._wizardHeadlessCheckbox.evaluate((el: HTMLInputElement) => {
+        el.checked = true;
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    } else if (!headless && headlessChecked) {
+      // Use evaluate to set checked state directly for hidden switches
+      await this._wizardHeadlessCheckbox.evaluate((el: HTMLInputElement) => {
+        el.checked = false;
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    }
+  }
+
+  async verifyCdromSizeNotConstrainedByRootDisk(): Promise<boolean> {
+    await this.navigateToWizardTab('Disks');
+
+    const addButton = this.locator(
+      'button:has-text("Add"), [data-test-id="add-disk"], [data-test="add-disk"]',
+    );
+    await addButton.first().waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(addButton.first());
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const cdromMenuOption = this.page
+      .locator('.pf-v6-c-menu__item, .pf-c-dropdown__menu-item')
+      .filter({ hasText: 'CD-ROM' })
+      .first();
+    await cdromMenuOption
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => null);
+
+    if (await cdromMenuOption.isVisible()) {
+      await cdromMenuOption.click({ force: true });
+    } else {
+      const cdromOption = this._cDROMDiskTypeSelectCdrom;
+      await cdromOption
+        .first()
+        .waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+      await cdromOption.first().click({ force: true });
+    }
+
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+
+    const sizeValidationError = this.page.locator(
+      '.pf-v6-c-helper-text__item.pf-m-error, .pf-v6-c-form__helper-text.pf-m-error',
+    );
+    const hasError = await sizeValidationError
+      .filter({ hasText: /Size cannot be less than/ })
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+      .catch(() => false);
+
+    const cancelButton = this.locator(
+      '#tab-modal [data-test="cancel-button"], #tab-modal button:has-text("Cancel"), [role="dialog"] button:has-text("Cancel")',
+    ).first();
+    if (await cancelButton.isVisible()) {
+      await cancelButton.click({ force: true });
+    }
+
+    return !hasError;
+  }
+
+  async verifyCpuMemory(cpu: string, mem: string): Promise<boolean> {
+    try {
+      await this.navigateToWizardTab('Overview');
+      const cpuMemText = await this._wizardCpuMemEditBtn.textContent();
+      const containsCpu = cpuMemText?.includes(cpu) ?? false;
+      const containsMem = cpuMemText?.includes(mem) ?? false;
+      return containsCpu && containsMem;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyNetworksTabNotFoundMessage(): Promise<boolean> {
+    try {
+      await this.navigateToWizardTab('Network interfaces');
+      // Wait for the tab content to load - give extra time after NIC deletion
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_LONG);
+
+      // First, check if there are any NICs present (toggle elements)
+      // If no NICs are found, that's equivalent to "Not found"
+      const nicToggleCount = await this._wizardNicToggle.count();
+      if (nicToggleCount === 0) {
+        // No NICs present, which means "Not found" state
+        return true;
+      }
+
+      // Try multiple selectors for "Not found" message
+      // The message might be in different locations depending on the UI state
+      const notFoundSelectors = [
+        'text=Not found',
+        'text=/not found/i',
+        '[data-test="empty-state"]',
+        '.pf-v6-c-empty-state',
+        '.pf-v6-c-empty-state__body',
+        'text=No network interfaces',
+        'text=No network',
+      ];
+
+      for (const selector of notFoundSelectors) {
+        try {
+          const notFoundLocator = this.locator(selector).first();
+          const isVisible = await notFoundLocator.isVisible({
+            timeout: TestTimeouts.UI_DELAY_SHORT,
+          });
+          if (isVisible) {
+            // Check if it actually contains "not found" text
+            const text = await notFoundLocator.textContent().catch(() => '');
+            if (
+              text?.toLowerCase().includes('not found') ||
+              text?.toLowerCase().includes('no network')
+            ) {
+              return true;
+            }
+          }
+        } catch {}
+      }
+
+      // If none of the specific selectors worked, try a broader search in the Networks tab content
+      const networksTabContent = this.locator('[data-test-id="horizontal-link-Networks"]')
+        .locator('..')
+        .locator('..');
+      const tabText = await networksTabContent.textContent().catch(() => '');
+      if (
+        tabText?.toLowerCase().includes('not found') ||
+        tabText?.toLowerCase().includes('no network')
+      ) {
+        return true;
+      }
+
+      // Final check: if no NIC toggle is visible, consider it as "not found"
+      const toggleVisible = await this._wizardNicToggle
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+        .catch(() => false);
+      return !toggleVisible;
+    } catch {
+      return false;
+    }
+  }
+
+  async waitForWizardReady(): Promise<void> {
+    await this._wizardCreateButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.RESOURCE_CREATION,
+    });
+  }
+}

--- a/playwright/src/page-objects/create-vm/bootable-volume-detail-page.ts
+++ b/playwright/src/page-objects/create-vm/bootable-volume-detail-page.ts
@@ -1,0 +1,3 @@
+import { BootableVolumeDetailComponent } from '@/components/create-vm/bootable-volumes-actions-instance-components';
+
+export default class BootableVolumeDetailPage extends BootableVolumeDetailComponent {}

--- a/playwright/src/page-objects/create-vm/bootable-volumes-create-page.ts
+++ b/playwright/src/page-objects/create-vm/bootable-volumes-create-page.ts
@@ -1,0 +1,3 @@
+import { BootableVolumesCreateComponent } from '@/components/create-vm/bootable-volumes-create-components';
+
+export default class BootableVolumesCreatePage extends BootableVolumesCreateComponent {}

--- a/playwright/src/page-objects/create-vm/bootable-volumes-list-page.ts
+++ b/playwright/src/page-objects/create-vm/bootable-volumes-list-page.ts
@@ -1,0 +1,476 @@
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+import PageCommons from '../page-commons';
+
+export default class BootableVolumesListPage extends PageCommons {
+  private readonly _closeFilterLabelGroup = this.locator(
+    '[aria-label="Close label group"]',
+  ).first();
+  private readonly _clusterFilterButton = this.locator('#filter-toolbar').locator('button', {
+    hasText: 'Cluster',
+  });
+  private readonly _dataLabelCluster = this.locator('[data-label="Cluster"]');
+  private readonly _dataLabelNamespace = this.locator('[data-label="Namespace"]');
+  private readonly _dialogModal = this.locator('[data-test="dialog-modal"]');
+  private readonly _projectFilterButton = this.locator('#filter-toolbar').locator('button', {
+    hasText: 'Project',
+  });
+
+  private readonly _roleMenuitem = this.locator('[role="menuitem"]');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  private async clickMenuItemByText(label: string): Promise<void> {
+    const item = this.locator('[role="menuitem"]').filter({
+      has: this.locator('.pf-v6-c-menu__item-text', { hasText: label }),
+    });
+    await item.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(item);
+  }
+
+  private async openRowKebabMenu(volumeName: string): Promise<void> {
+    const byTestId = this.locator('tbody tr').filter({
+      has: this.locator(`[data-test-id="${volumeName}"]`),
+    });
+    const byLink = this.locator('tbody tr').filter({
+      has: this.page.locator(`a:has-text("${volumeName}")`),
+    });
+    const row = byTestId.or(byLink).first();
+    await row.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const kebabButton = row.locator('button.pf-v6-c-menu-toggle');
+    await kebabButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(kebabButton);
+    await this.locator('[role="menuitem"]')
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+  }
+
+  async addAnnotationInEditAnnotationsModalAndSave(
+    annotationKey: string,
+    annotationValue: string,
+  ): Promise<void> {
+    const dialog = this._dialogModal;
+    await dialog.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const addMoreButton = dialog.locator('button:has-text("Add more")');
+    await addMoreButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(addMoreButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    const keyInput = dialog.locator('[placeholder="annotation key"]').last();
+    const valueInput = dialog.locator('[placeholder="annotation value"]').last();
+    await keyInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await keyInput.fill(annotationKey);
+    await valueInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await valueInput.fill(annotationValue);
+    const saveButton = dialog.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(saveButton);
+  }
+
+  async addLabelInEditLabelsModalAndSave(labelTag: string): Promise<void> {
+    const tagsInput = this.locator('[data-test="tags-input"]');
+    await tagsInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await tagsInput.fill(labelTag);
+    await this.page.keyboard.press('Enter');
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    const saveButton = this.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(saveButton);
+  }
+
+  async checkDeletePvcCheckbox(): Promise<void> {
+    const dialog = this._dialogModal;
+    await dialog.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const checkbox = dialog.locator('#delete-pvc-checkbox');
+    await checkbox.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    if (!(await checkbox.isChecked())) await checkbox.click({ force: true });
+  }
+
+  async clickManageColumnsAndVerifyNamespaceAndClusterInModal(): Promise<boolean> {
+    try {
+      const manageColumnsBtn = this.locator('[data-test="manage-columns"]');
+      await manageColumnsBtn.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await manageColumnsBtn.click();
+      const nsVisible = await this.locator('#table-column-management-item-namespace')
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+        .catch(() => false);
+      const clVisible = await this.locator('#table-column-management-item-cluster')
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+        .catch(() => false);
+      return nsVisible && clVisible;
+    } catch {
+      return false;
+    }
+  }
+
+  async clickRowActionDelete(volumeName: string): Promise<void> {
+    await this.openRowKebabMenu(volumeName);
+    await this.clickMenuItemByText('Delete');
+  }
+
+  async clickRowActionEditAnnotations(volumeName: string): Promise<void> {
+    await this.openRowKebabMenu(volumeName);
+    await this.clickMenuItemByText('Edit annotations');
+  }
+
+  async clickRowActionEditLabels(volumeName: string): Promise<void> {
+    await this.openRowKebabMenu(volumeName);
+    await this.clickMenuItemByText('Edit labels');
+  }
+
+  async clickRowActionUploadToRegistry(volumeName: string): Promise<void> {
+    await this.openRowKebabMenu(volumeName);
+    await this.clickMenuItemByText('Upload to registry');
+  }
+
+  async clickSaveInDeleteModal(): Promise<void> {
+    const saveButton = this._dialogModal.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(saveButton);
+  }
+
+  async clickSaveInUploadToRegistryModal(): Promise<void> {
+    const saveButton = this._dialogModal.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(saveButton);
+  }
+
+  async clickVolumeNameToGoToDetail(volumeName: string): Promise<void> {
+    const row = this.locator('tbody tr').filter({
+      has: this.locator(`[data-test-id="${volumeName}"]`),
+    });
+    const nameLink = row.locator('a').filter({ hasText: volumeName }).first();
+    await nameLink.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(nameLink);
+  }
+
+  async closeFilterLabelGroup(): Promise<void> {
+    await this._closeFilterLabelGroup.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._closeFilterLabelGroup.click();
+  }
+
+  async fillUploadToRegistryForm(
+    registryName: string,
+    destination: string,
+    username: string,
+    password: string,
+  ): Promise<void> {
+    const dialog = this._dialogModal;
+    await dialog.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await dialog.locator('#registryName').fill(registryName);
+    await dialog.locator('#destination').fill(destination);
+    await dialog.locator('#username').fill(username);
+    await dialog.locator('#password').fill(password);
+  }
+
+  async getColumnHeaders(): Promise<string[]> {
+    const headerLocator = this.page.locator('th');
+    await headerLocator.first().waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    const count = await headerLocator.count();
+    const texts: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const text = (await headerLocator.nth(i).textContent())?.trim();
+      if (text) texts.push(text);
+    }
+    return texts;
+  }
+
+  async getUploadToRegistryModalButtonText(): Promise<string> {
+    const saveButton = this._dialogModal.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return (await saveButton.textContent())?.trim() ?? '';
+  }
+
+  async isClusterFilterButtonVisible(
+    timeout: number = TestTimeouts.UI_VISIBILITY_QUICK,
+  ): Promise<boolean> {
+    try {
+      await this._clusterFilterButton.waitFor({ state: 'visible', timeout });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isProjectFilterButtonVisible(timeout: number = TestTimeouts.DEFAULT): Promise<boolean> {
+    try {
+      await this._projectFilterButton.waitFor({ state: 'visible', timeout });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isUploadToRegistryModalButtonDisabled(): Promise<boolean> {
+    const saveButton = this._dialogModal.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return await saveButton.isDisabled();
+  }
+
+  async navigateToBootableVolumesViaUI(): Promise<void> {
+    try {
+      await this.clickNavBootableVolumes();
+    } catch {
+      await this.navigateToGeneralBootableVolumes();
+    }
+  }
+
+  async navigateToGeneralBootableVolumes() {
+    await this.goTo('/k8s/all-namespaces/bootablevolumes');
+  }
+
+  async navigateToNamespaceBootableVolumesViaUI(namespace: string): Promise<void> {
+    await this.switchToVirtualizationPerspective();
+    await this.clickNavBootableVolumes();
+    await this.page.waitForLoadState('domcontentloaded');
+    if (!this.page.url().includes(`/ns/${namespace}/`)) {
+      const path = `/k8s/ns/${namespace}/bootablevolumes`;
+      await this.page.evaluate((p) => {
+        window.history.pushState({}, '', p);
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      }, path);
+      await this.page.waitForFunction((p: string) => window.location.pathname === p, path, {
+        timeout: TestTimeouts.NAVIGATION,
+      });
+      await this.page.waitForLoadState('domcontentloaded');
+    }
+    await this.verifyPageLoaded([], true, TestTimeouts.UI_ELEMENT_VISIBILITY);
+  }
+
+  async navigateToProjectBootableVolumes(projectName: string) {
+    await this.goTo(`/k8s/ns/${projectName}/bootablevolumes`);
+  }
+
+  async openClusterFilter(): Promise<void> {
+    await this._clusterFilterButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._clusterFilterButton.click();
+  }
+
+  async openProjectFilter(): Promise<void> {
+    await this._projectFilterButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._projectFilterButton.click();
+  }
+
+  async selectClusterInFilterMenu(clusterName: string): Promise<void> {
+    const menuitem = this._roleMenuitem.filter({ hasText: clusterName }).first();
+    await menuitem.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await menuitem.click();
+  }
+
+  async selectNamespaceInFilterMenu(
+    namespaceName: string,
+    options?: { force?: boolean },
+  ): Promise<void> {
+    const menuitem = this._roleMenuitem.filter({ hasText: namespaceName }).first();
+    if (options?.force) {
+      await menuitem.click({ force: true });
+    } else {
+      await menuitem.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      await menuitem.click();
+    }
+  }
+
+  async verifyAnnotationsCountTextOnDetailPage(expectedText: string): Promise<boolean> {
+    await this.page.waitForLoadState('load', { timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+    return await this.page
+      .getByText(expectedText)
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+  }
+
+  async verifyAtLeastOneClusterIdentifierVisible(clusterNames: string[]): Promise<boolean> {
+    if (clusterNames.length === 0) return true;
+    const visibilityTimeout = TestTimeouts.UI_DELAY_MEDIUM;
+    try {
+      const localClusterIdentifier = this.locator('[data-test-id="local-cluster"]');
+      if (await localClusterIdentifier.isVisible({ timeout: visibilityTimeout }).catch(() => false))
+        return true;
+      for (const name of clusterNames) {
+        const cell = this._dataLabelCluster.filter({ hasText: name }).first();
+        if (await cell.isVisible({ timeout: visibilityTimeout }).catch(() => false)) return true;
+        const byTestId = this.locator(`[data-test-id="${name}"]`);
+        if ((await byTestId.count()) > 0) {
+          if (
+            await byTestId
+              .first()
+              .isVisible({ timeout: visibilityTimeout })
+              .catch(() => false)
+          )
+            return true;
+        }
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyAtLeastOneNamespaceIdentifierVisible(namespaceNames: string[]): Promise<boolean> {
+    if (namespaceNames.length === 0) return true;
+    const visibilityTimeout = TestTimeouts.UI_DELAY_MEDIUM;
+    try {
+      const osImagesIndicator = this.locator('[data-test="openshift-virtualization-os-images"]');
+      if (await osImagesIndicator.isVisible({ timeout: visibilityTimeout }).catch(() => false))
+        return true;
+      for (const name of namespaceNames) {
+        const cell = this._dataLabelNamespace.filter({ hasText: name }).first();
+        if (await cell.isVisible({ timeout: visibilityTimeout }).catch(() => false)) return true;
+        const byTestId = this.locator(`[data-test-id="${name}"]`);
+        if ((await byTestId.count()) > 0) {
+          if (
+            await byTestId
+              .first()
+              .isVisible({ timeout: visibilityTimeout })
+              .catch(() => false)
+          )
+            return true;
+        }
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyBootableVolumeDoesNotExist(volumeName: string, timeout = 60000): Promise<boolean> {
+    try {
+      await this.page.waitForLoadState('load', { timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+      const volumeRow = this.locator(`tr:has-text("${volumeName}")`);
+      return !(await volumeRow.isVisible({ timeout }).catch(() => false));
+    } catch {
+      return true;
+    }
+  }
+
+  async verifyBootableVolumeExistsInList(volumeName: string, timeout = 10000): Promise<boolean> {
+    try {
+      const volumeRow = this.locator(`tr:has-text("${volumeName}")`);
+      await volumeRow.waitFor({ state: 'visible', timeout });
+      return await volumeRow.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyClusterAndProjectFilterButtonsVisible(): Promise<boolean> {
+    try {
+      const filterToolbar = this.locator('#filter-toolbar');
+      await filterToolbar.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      await this._projectFilterButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      await this._clusterFilterButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyClusterColumnHeaderVisible(): Promise<boolean> {
+    try {
+      await this._dataLabelCluster.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyDataVolumeRowVisible(
+    volumeName: string,
+    timeout = TestTimeouts.DEFAULT,
+  ): Promise<boolean> {
+    try {
+      const byTestId = this.locator(`[data-test-id="${volumeName}"]`);
+      const byLink = this.locator(`table tbody tr`).filter({
+        has: this.page.locator(`a:has-text("${volumeName}")`),
+      });
+      const row = byTestId.or(byLink).first();
+      await row.waitFor({ state: 'visible', timeout });
+      return await row.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyFormCreatedVolumeRowVisible(timeout = 10000): Promise<boolean> {
+    try {
+      const row = this.locator(
+        '[data-test-id^="pw-bv-form-"], [data-test-id^="pw-bv-registry-"], [data-test-id^="pw-bv-http-"]',
+      );
+      await row.first().waitFor({ state: 'visible', timeout });
+      return await row.first().isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyLabelVisibleOnDetailPage(expectedLabelText: string): Promise<boolean> {
+    const labelsControl = this.locator('[data-test-id^="pw-bv-"][data-test-id$="-labels"]').first();
+    await labelsControl.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const isButton = (await labelsControl.evaluate((el) => el.tagName === 'BUTTON')) ?? false;
+    if (isButton) {
+      await this.robustClick(labelsControl);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+    return await this.locator(`text=${expectedLabelText}`)
+      .isVisible()
+      .catch(() => false);
+  }
+
+  async verifyNamespaceColumnHeaderVisible(): Promise<boolean> {
+    try {
+      await this._dataLabelNamespace.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  override async verifyPageLoaded(
+    indicatorSelectors: string[] = [],
+    includeCreateButton = true,
+    timeout = 10000,
+  ): Promise<boolean> {
+    return await super.verifyPageLoaded(indicatorSelectors, includeCreateButton, timeout);
+  }
+
+  async verifySearchFilterVisible(): Promise<boolean> {
+    try {
+      const filter = this.locator('[data-test-id="item-filter"]');
+      await filter.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyUploadStepsVisibleInUploadToRegistryModal(): Promise<boolean> {
+    await this.page.waitForLoadState('load', { timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+    return await this.locator('[aria-label="Upload steps"]')
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+  }
+
+  async waitForClusterFilterApplied(): Promise<void> {
+    await this._closeFilterLabelGroup.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.page.waitForTimeout(3000);
+  }
+}

--- a/playwright/src/page-objects/create-vm/bootable-volumes-page.ts
+++ b/playwright/src/page-objects/create-vm/bootable-volumes-page.ts
@@ -1,0 +1,681 @@
+/**
+ * Page object for the Bootable Volumes page.
+ */
+
+import type { CreateBootableVolumeFormOptions } from '@/components/create-vm/bootable-volumes-create-components';
+import {
+  BootableVolumesCreateFormsComponent,
+  BootableVolumesRowActionsComponent,
+} from '@/components/create-vm/bootable-volumes-create-components';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+import PageCommons from '../page-commons';
+
+export type { CreateBootableVolumeFormOptions } from '@/components/create-vm/bootable-volumes-create-components';
+
+export default class BootableVolumesPage extends PageCommons {
+  private readonly _addVolumeDialog = this.locator('#tab-modal');
+  private readonly _closeFilterLabelGroup = this.locator(
+    '[aria-label="Close label group"]',
+  ).first();
+
+  private readonly _clusterFilterButton = this.locator('#filter-toolbar').locator('button', {
+    hasText: 'Cluster',
+  });
+
+  private readonly _dataLabelCluster = this.locator('[data-label="Cluster"]');
+  private readonly _dataLabelNamespace = this.locator('[data-label="Namespace"]');
+  private readonly _projectFilterButton = this.locator('#filter-toolbar').locator('button', {
+    hasText: 'Project',
+  });
+  private readonly _roleMenuitem = this.locator('[role="menuitem"]');
+  protected override readonly _row = this.locator(
+    '[data-test-rows="resource-row"], .kubevirt-table tbody tr, [class*="c-table__tr"]:not([class*="control-row"])',
+  );
+  readonly createForms: BootableVolumesCreateFormsComponent;
+  readonly rowActions: BootableVolumesRowActionsComponent;
+
+  constructor(page: Page) {
+    super(page);
+    this.createForms = new BootableVolumesCreateFormsComponent(page);
+    this.rowActions = new BootableVolumesRowActionsComponent(page);
+  }
+
+  private async navigateToNamespaceClientSide(namespace: string): Promise<void> {
+    const path = `/k8s/ns/${namespace}/bootablevolumes`;
+    await this.page.evaluate((p) => {
+      window.history.pushState({}, '', p);
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    }, path);
+    await this.page.waitForFunction((p: string) => window.location.pathname === p, path, {
+      timeout: TestTimeouts.NAVIGATION,
+    });
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  async addAnnotationInEditAnnotationsModalAndSave(
+    annotationKey: string,
+    annotationValue: string,
+  ): Promise<void> {
+    return this.rowActions.addAnnotationInEditAnnotationsModalAndSave(
+      annotationKey,
+      annotationValue,
+    );
+  }
+
+  async addLabelInEditLabelsModalAndSave(labelTag: string): Promise<void> {
+    return this.rowActions.addLabelInEditLabelsModalAndSave(labelTag);
+  }
+
+  async applyRowFilter(filterValue: string): Promise<void> {
+    await this.openRowFilterDropdown();
+    await this.filterToolbar.toggleRowFilter(filterValue, true);
+    await this.closeRowFilterDropdown();
+    await this.filterToolbar.waitForFilterApplied();
+  }
+
+  async cancelManageSourceModal(): Promise<void> {
+    return this.rowActions.cancelManageSourceModal();
+  }
+
+  async checkDeletePvcCheckbox(): Promise<void> {
+    return this.rowActions.checkDeletePvcCheckbox();
+  }
+
+  async clearAllFilters(): Promise<void> {
+    await this.filterToolbar.clearAllFilters();
+  }
+
+  override async clickCreateAndSelectOption(option: 'With form' | 'With YAML') {
+    const optionSelectors = {
+      'With form': 'button[role="menuitem"]:has-text("With form")',
+      'With YAML': 'button[role="menuitem"]:has-text("With YAML")',
+    };
+    await super.clickCreateAndSelectOption('[data-test="item-create"]', optionSelectors[option]);
+  }
+
+  async clickManageColumnsAndVerifyNamespaceAndClusterInModal(): Promise<boolean> {
+    try {
+      const btn = this.locator('[data-test="manage-columns"]');
+      await btn.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      await btn.click();
+      const nsVis = await this.locator('#table-column-management-item-namespace')
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+        .catch(() => false);
+      const clVis = await this.locator('#table-column-management-item-cluster')
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+        .catch(() => false);
+      return nsVis && clVis;
+    } catch {
+      return false;
+    }
+  }
+
+  async clickRowActionDelete(volumeName: string): Promise<void> {
+    return this.rowActions.clickRowActionDelete(volumeName);
+  }
+
+  async clickRowActionEditAnnotations(volumeName: string): Promise<void> {
+    return this.rowActions.clickRowActionEditAnnotations(volumeName);
+  }
+
+  async clickRowActionEditLabels(volumeName: string): Promise<void> {
+    return this.rowActions.clickRowActionEditLabels(volumeName);
+  }
+
+  async clickRowActionManageSource(volumeName: string): Promise<void> {
+    return this.rowActions.clickRowActionManageSource(volumeName);
+  }
+
+  async clickRowActionUploadToRegistry(volumeName: string): Promise<void> {
+    return this.rowActions.clickRowActionUploadToRegistry(volumeName);
+  }
+
+  async clickSaveInDeleteModal(): Promise<void> {
+    return this.rowActions.clickSaveInDeleteModal();
+  }
+
+  async clickSaveInUploadToRegistryModal(): Promise<void> {
+    return this.rowActions.clickSaveInUploadToRegistryModal();
+  }
+
+  async clickVolumeNameToGoToDetail(volumeName: string): Promise<void> {
+    return this.rowActions.clickVolumeNameToGoToDetail(volumeName);
+  }
+
+  async clickVolumeNameToGoToDetailWithRetry(volumeName: string, namespace: string): Promise<void> {
+    try {
+      await this.clickVolumeNameToGoToDetail(volumeName);
+    } catch {
+      await this.navigateToBootableVolumesForNamespaceWithRetry(namespace);
+      await this.ensureDataVolumeRowVisibleWithReNav(volumeName, namespace);
+      await this.clickVolumeNameToGoToDetail(volumeName);
+    }
+  }
+
+  async closeFilterLabelGroup(): Promise<void> {
+    await this._closeFilterLabelGroup.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._closeFilterLabelGroup.click();
+  }
+
+  async closeRowFilterDropdown(): Promise<void> {
+    const toggle = this.locator('[data-test-id="filter-dropdown-toggle"]');
+    await toggle.click();
+  }
+
+  async ensureDataVolumeRowVisibleWithReNav(
+    volumeName: string,
+    namespace: string,
+    rowTimeout: number = TestTimeouts.DEFAULT,
+  ): Promise<boolean> {
+    let visible = await this.verifyDataVolumeRowVisible(volumeName, rowTimeout);
+    if (!visible) {
+      await this.navigateToBootableVolumesForNamespaceWithRetry(namespace);
+      visible = await this.verifyDataVolumeRowVisible(volumeName, rowTimeout);
+    }
+    return visible;
+  }
+
+  async executeRowActionWithRetry(
+    namespace: string,
+    volumeName: string,
+    action: () => Promise<void>,
+  ): Promise<void> {
+    try {
+      await action();
+    } catch {
+      await this.navigateToBootableVolumesForNamespaceWithRetry(namespace);
+      await this.ensureDataVolumeRowVisibleWithReNav(volumeName, namespace);
+      await action();
+    }
+  }
+
+  async fillCreateBootableVolumeFormAndSave(
+    volumeName: string,
+    imageFilePath: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    return this.createForms.fillCreateBootableVolumeFormAndSave(volumeName, imageFilePath, options);
+  }
+
+  async fillCreateBootableVolumeFormFromExistingAndSave(
+    volumeName: string,
+    existingVolumeName: string,
+    projectNamespace: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    return this.createForms.fillCreateBootableVolumeFormFromExistingAndSave(
+      volumeName,
+      existingVolumeName,
+      projectNamespace,
+      options,
+    );
+  }
+
+  async fillCreateBootableVolumeFormFromFirstSnapshotInNamespaceAndSave(
+    volumeName: string,
+    projectNamespace: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    return this.createForms.fillCreateBootableVolumeFormFromFirstSnapshotInNamespaceAndSave(
+      volumeName,
+      projectNamespace,
+      options,
+    );
+  }
+
+  async fillCreateBootableVolumeFormFromHttpAndSave(
+    volumeName: string,
+    imageUrl: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    return this.createForms.fillCreateBootableVolumeFormFromHttpAndSave(
+      volumeName,
+      imageUrl,
+      options,
+    );
+  }
+
+  async fillCreateBootableVolumeFormFromRegistryAndSave(
+    volumeName: string,
+    registryUrl: string,
+    cronExpression: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    return this.createForms.fillCreateBootableVolumeFormFromRegistryAndSave(
+      volumeName,
+      registryUrl,
+      cronExpression,
+      options,
+    );
+  }
+
+  async fillCreateBootableVolumeFormFromSnapshotAndSave(
+    volumeName: string,
+    snapshotName: string,
+    projectNamespace: string,
+    options: CreateBootableVolumeFormOptions = {},
+  ): Promise<void> {
+    return this.createForms.fillCreateBootableVolumeFormFromSnapshotAndSave(
+      volumeName,
+      snapshotName,
+      projectNamespace,
+      options,
+    );
+  }
+
+  async fillManageSourceCronExpression(cron: string): Promise<void> {
+    return this.rowActions.fillManageSourceCronExpression(cron);
+  }
+
+  async fillManageSourceRegistryUrl(url: string): Promise<void> {
+    return this.rowActions.fillManageSourceRegistryUrl(url);
+  }
+
+  async fillUploadToRegistryForm(
+    registryName: string,
+    destination: string,
+    username: string,
+    password: string,
+  ): Promise<void> {
+    return this.rowActions.fillUploadToRegistryForm(registryName, destination, username, password);
+  }
+
+  async getColumnHeaders(): Promise<string[]> {
+    const tableLocator = this.page.locator('.kubevirt-table, [class*="c-table"]').first();
+    await tableLocator
+      .waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT })
+      .catch(() => undefined);
+    const headerLocator = (await tableLocator.isVisible().catch(() => false))
+      ? tableLocator.locator('th')
+      : this.page.locator('th');
+    await headerLocator.first().waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+    const count = await headerLocator.count();
+    const texts: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const text = (await headerLocator.nth(i).textContent())?.trim();
+      if (text) texts.push(text);
+    }
+    return texts;
+  }
+
+  async getManageSourceRegistryUrl(): Promise<string> {
+    return this.rowActions.getManageSourceRegistryUrl();
+  }
+
+  async getRowCountByText(text: RegExp | string): Promise<number> {
+    const pattern = text instanceof RegExp ? text : new RegExp(text, 'i');
+    return this._row.filter({ hasText: pattern }).count();
+  }
+
+  async getUploadToRegistryModalButtonText(): Promise<string> {
+    return this.rowActions.getUploadToRegistryModalButtonText();
+  }
+  async getVisibleRowCount(): Promise<number> {
+    return this._row.count();
+  }
+  async isClusterFilterButtonVisible(
+    timeout: number = TestTimeouts.UI_VISIBILITY_QUICK,
+  ): Promise<boolean> {
+    try {
+      await this._clusterFilterButton.waitFor({ state: 'visible', timeout });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  async isManageSourceModalVisible(timeout?: number): Promise<boolean> {
+    return this.rowActions.isManageSourceModalVisible(timeout);
+  }
+  async isProjectFilterButtonVisible(timeout: number = TestTimeouts.DEFAULT): Promise<boolean> {
+    try {
+      await this._projectFilterButton.waitFor({ state: 'visible', timeout });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  async isUploadToRegistryModalButtonDisabled(): Promise<boolean> {
+    return this.rowActions.isUploadToRegistryModalButtonDisabled();
+  }
+  async navigateToBootableVolumesForNamespaceWithRetry(
+    namespace: string,
+    maxAttempts = 3,
+  ): Promise<boolean> {
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        await this.navigateToNamespaceBootableVolumesViaUI(namespace);
+        if (await this.verifyPageLoaded()) return true;
+      } catch {
+        /* retry */
+      }
+    }
+    return false;
+  }
+  async navigateToBootableVolumesViaUI(): Promise<void> {
+    await this.switchToVirtualizationPerspective();
+    await this.clickNavBootableVolumes();
+  }
+  async navigateToBootableVolumesWithParams(params: string): Promise<void> {
+    const basePath = '/k8s/all-namespaces/bootablevolumes';
+    await this.goTo(`${basePath}?${params}`);
+    await this.waitForTableData();
+  }
+  /** @deprecated Use navigateToBootableVolumesViaUI() */
+  async navigateToGeneralBootableVolumes() {
+    await this.goTo('/k8s/all-namespaces/bootablevolumes');
+  }
+  async navigateToNamespaceBootableVolumesViaUI(namespace: string): Promise<void> {
+    await this.switchToVirtualizationPerspective();
+    await this.clickNavBootableVolumes();
+    await this.page.waitForLoadState('domcontentloaded');
+    if (!this.page.url().includes(`/ns/${namespace}/`)) {
+      await this.navigateToNamespaceClientSide(namespace);
+    }
+    await this.verifyPageLoaded([], true, TestTimeouts.UI_ELEMENT_VISIBILITY);
+  }
+  /** @deprecated Use navigateToNamespaceBootableVolumesViaUI() */
+  async navigateToProjectBootableVolumes(projectName: string) {
+    await this.goTo(`/k8s/ns/${projectName}/bootablevolumes`);
+  }
+  async openClusterFilter(): Promise<void> {
+    await this._clusterFilterButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._clusterFilterButton.click();
+  }
+  async openProjectFilter(): Promise<void> {
+    await this._projectFilterButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._projectFilterButton.click();
+  }
+  async openRowFilterDropdown(): Promise<void> {
+    const toggle = this.locator('[data-test-id="filter-dropdown-toggle"]');
+    await toggle.waitFor({ state: 'visible', timeout: TestTimeouts.NAVIGATION });
+    await this.robustClick(toggle);
+    await this.locator('[data-test-row-filter]').first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+  }
+  async reloadAndWaitForTable(timeout = TestTimeouts.NAVIGATION): Promise<boolean> {
+    await this.reloadPage();
+    return this.waitForTableData(timeout);
+  }
+  async saveManageSourceModal(): Promise<void> {
+    return this.rowActions.saveManageSourceModal();
+  }
+  async selectClusterInFilterMenu(clusterName: string): Promise<void> {
+    const menuitem = this._roleMenuitem.filter({ hasText: clusterName }).first();
+    await menuitem.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await menuitem.click();
+  }
+  async selectNamespaceInFilterMenu(
+    namespaceName: string,
+    options?: { force?: boolean },
+  ): Promise<void> {
+    const menuitem = this._roleMenuitem.filter({ hasText: namespaceName }).first();
+    if (options?.force) {
+      await menuitem.click({ force: true });
+    } else {
+      await menuitem.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      await menuitem.click();
+    }
+  }
+  async selectRowFilter(filterValue: string): Promise<void> {
+    const option = this.locator(`[data-test-row-filter="${filterValue}"]`);
+    await option.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await option.click();
+  }
+  async selectSourceTypeInAddVolumeModal(
+    sourceType: 'URL' | 'Registry' | 'Volume' | 'Volume snapshot',
+  ): Promise<void> {
+    const sourceTypeMap: Record<string, string> = {
+      URL: '[data-test-id="use-http"]',
+      Registry: '[data-test-id="use-registry"]',
+      Volume: 'button[role="option"]:has-text("Volume"):not(:has-text("snapshot"))',
+      'Volume snapshot': 'button[role="option"]:has-text("Volume snapshot")',
+    };
+    await this._addVolumeDialog.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    const sourceTypeSelect = this._addVolumeDialog.locator('[data-test-id="source-type-select"]');
+    await sourceTypeSelect.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(sourceTypeSelect);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    const opt = this.locator(sourceTypeMap[sourceType]);
+    await opt.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+    await this.robustClick(opt);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+  async setManageSourceAllowAutoUpdate(enable: boolean): Promise<void> {
+    return this.rowActions.setManageSourceAllowAutoUpdate(enable);
+  }
+  async verifyAnnotationsCountTextOnDetailPage(expectedText: string): Promise<boolean> {
+    return this.rowActions.verifyAnnotationsCountTextOnDetailPage(expectedText);
+  }
+  async verifyAtLeastOneClusterIdentifierVisible(clusterNames: string[]): Promise<boolean> {
+    if (clusterNames.length === 0) return true;
+    const t = TestTimeouts.UI_DELAY_MEDIUM;
+    try {
+      if (
+        await this.locator('[data-test-id="local-cluster"]')
+          .isVisible({ timeout: t })
+          .catch(() => false)
+      )
+        return true;
+      for (const name of clusterNames) {
+        if (
+          await this._dataLabelCluster
+            .filter({ hasText: name })
+            .first()
+            .isVisible({ timeout: t })
+            .catch(() => false)
+        )
+          return true;
+        const byId = this.locator(`[data-test-id="${name}"]`);
+        if (
+          (await byId.count()) > 0 &&
+          (await byId
+            .first()
+            .isVisible({ timeout: t })
+            .catch(() => false))
+        )
+          return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyAtLeastOneNamespaceIdentifierVisible(namespaceNames: string[]): Promise<boolean> {
+    if (namespaceNames.length === 0) return true;
+    const t = TestTimeouts.UI_DELAY_MEDIUM;
+    try {
+      if (
+        await this.locator('[data-test="openshift-virtualization-os-images"]')
+          .isVisible({ timeout: t })
+          .catch(() => false)
+      )
+        return true;
+      for (const name of namespaceNames) {
+        if (
+          await this._dataLabelNamespace
+            .filter({ hasText: name })
+            .first()
+            .isVisible({ timeout: t })
+            .catch(() => false)
+        )
+          return true;
+        const byId = this.locator(`[data-test-id="${name}"]`);
+        if (
+          (await byId.count()) > 0 &&
+          (await byId
+            .first()
+            .isVisible({ timeout: t })
+            .catch(() => false))
+        )
+          return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyBootableVolumeDoesNotExist(volumeName: string, timeout = 60000): Promise<boolean> {
+    try {
+      await this.page.waitForLoadState('load', { timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+      return !(await this.locator(`tr:has-text("${volumeName}")`)
+        .isVisible({ timeout })
+        .catch(() => false));
+    } catch {
+      return true;
+    }
+  }
+
+  async verifyBootableVolumeExistsInList(volumeName: string, timeout = 10000): Promise<boolean> {
+    try {
+      const row = this.locator(`tr:has-text("${volumeName}")`);
+      await row.waitFor({ state: 'visible', timeout });
+      return await row.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyClusterAndProjectFilterButtonsVisible(): Promise<boolean> {
+    try {
+      await this.locator('#filter-toolbar').waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.DEFAULT,
+      });
+      await this._projectFilterButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      await this._clusterFilterButton.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyClusterColumnHeaderVisible(): Promise<boolean> {
+    try {
+      await this._dataLabelCluster.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyDataVolumeRowVisible(
+    volumeName: string,
+    timeout = TestTimeouts.DEFAULT,
+  ): Promise<boolean> {
+    try {
+      const byTestId = this.locator(`[data-test-id="${volumeName}"]`);
+      const byLink = this.locator(`table tbody tr`).filter({
+        has: this.page.locator(`a:has-text("${volumeName}")`),
+      });
+      const row = byTestId.or(byLink).first();
+      await row.waitFor({ state: 'visible', timeout });
+      return await row.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyFormCreatedVolumeRowVisible(timeout = 10000): Promise<boolean> {
+    try {
+      const row = this.locator(
+        '[data-test-id^="pw-bv-form-"], [data-test-id^="pw-bv-registry-"], [data-test-id^="pw-bv-http-"]',
+      );
+      await row.first().waitFor({ state: 'visible', timeout });
+      return await row.first().isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyLabelVisibleOnDetailPage(expectedLabelText: string): Promise<boolean> {
+    return this.rowActions.verifyLabelVisibleOnDetailPage(expectedLabelText);
+  }
+
+  async verifyNamespaceColumnHeaderVisible(): Promise<boolean> {
+    try {
+      await this._dataLabelNamespace.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  override async verifyPageLoaded(
+    indicatorSelectors: string[] = [],
+    _includeCreateButton = true,
+    timeout = 10000,
+  ): Promise<boolean> {
+    try {
+      await this.waitForLoadingComplete(Math.min(timeout / 2, TestTimeouts.UI_DELAY_MEDIUM));
+      const tableLocator = this.locator('.kubevirt-table, [class*="c-table"]').first();
+      const createButton = this.locator('[data-test="item-create"]');
+      let pageIndicator = tableLocator.or(createButton);
+      if (indicatorSelectors.length > 0) {
+        for (const name of indicatorSelectors) {
+          pageIndicator = pageIndicator.or(this.locator(`td, tr`, { hasText: name }));
+        }
+      }
+      await pageIndicator.first().waitFor({ state: 'visible', timeout });
+      return await pageIndicator
+        .first()
+        .isVisible()
+        .catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async verifySearchFilterVisible(): Promise<boolean> {
+    try {
+      await this.locator('[data-test-id="item-filter"]').waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyUploadStepsVisibleInUploadToRegistryModal(): Promise<boolean> {
+    return this.rowActions.verifyUploadStepsVisibleInUploadToRegistryModal();
+  }
+
+  async waitForClusterFilterApplied(): Promise<void> {
+    await this._closeFilterLabelGroup.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.page.waitForTimeout(3000);
+  }
+
+  async waitForTableData(timeout = TestTimeouts.NAVIGATION): Promise<boolean> {
+    return this._row
+      .first()
+      .waitFor({ state: 'visible', timeout })
+      .then(() => true)
+      .catch(() => false);
+  }
+}

--- a/playwright/src/page-objects/create-vm/create-vm-create-page.ts
+++ b/playwright/src/page-objects/create-vm/create-vm-create-page.ts
@@ -1,0 +1,3 @@
+import CreateVmCreateComponent from '@/components/create-vm/create-vm-create-component';
+
+export default class CreateVmCreatePage extends CreateVmCreateComponent {}

--- a/playwright/src/page-objects/create-vm/create-vm-instance-types-page.ts
+++ b/playwright/src/page-objects/create-vm/create-vm-instance-types-page.ts
@@ -1,0 +1,3 @@
+import { CreateVmInstanceTypesComponent } from '@/components/create-vm/bootable-volumes-actions-instance-components';
+
+export default class CreateVmInstanceTypesPage extends CreateVmInstanceTypesComponent {}

--- a/playwright/src/page-objects/create-vm/create-vm-page.ts
+++ b/playwright/src/page-objects/create-vm/create-vm-page.ts
@@ -1,0 +1,3 @@
+import CreateVmComponent from '@/components/create-vm/create-vm-component';
+
+export default class CreateVmPage extends CreateVmComponent {}

--- a/playwright/src/page-objects/create-vm/create-vm-template-catalog-page.ts
+++ b/playwright/src/page-objects/create-vm/create-vm-template-catalog-page.ts
@@ -1,0 +1,3 @@
+import { CreateVmTemplateCatalogComponent } from '@/components/create-vm/catalog-template-components';
+
+export default class CreateVmTemplateCatalogPage extends CreateVmTemplateCatalogComponent {}

--- a/playwright/src/page-objects/create-vm/create-vm-templates-page.ts
+++ b/playwright/src/page-objects/create-vm/create-vm-templates-page.ts
@@ -1,0 +1,3 @@
+import { CreateVmTemplatesComponent } from '@/components/create-vm/template-components';
+
+export default class CreateVmTemplatesPage extends CreateVmTemplatesComponent {}

--- a/playwright/src/page-objects/create-vm/create-vm-wizard-disks-page.ts
+++ b/playwright/src/page-objects/create-vm/create-vm-wizard-disks-page.ts
@@ -1,0 +1,3 @@
+import { CreateVmWizardDisksComponent } from '@/components/create-vm/catalog-wizard-tabs-components';
+
+export default class CreateVmWizardDisksPage extends CreateVmWizardDisksComponent {}

--- a/playwright/src/page-objects/create-vm/create-vm-wizard-page.ts
+++ b/playwright/src/page-objects/create-vm/create-vm-wizard-page.ts
@@ -1,0 +1,3 @@
+import { CreateVmWizardComponent } from '@/components/create-vm/catalog-wizard-tabs-components';
+
+export default class CreateVmWizardPage extends CreateVmWizardComponent {}

--- a/playwright/src/page-objects/create-vm/create-vm-wizard-tabs-page.ts
+++ b/playwright/src/page-objects/create-vm/create-vm-wizard-tabs-page.ts
@@ -1,0 +1,3 @@
+import { CreateVmWizardTabsComponent } from '@/components/create-vm/catalog-wizard-tabs-components';
+
+export default class CreateVmWizardTabsPage extends CreateVmWizardTabsComponent {}

--- a/playwright/src/page-objects/create-vm/index.ts
+++ b/playwright/src/page-objects/create-vm/index.ts
@@ -1,0 +1,17 @@
+export { default as BootableVolumeDetailPage } from './bootable-volume-detail-page';
+export { default as BootableVolumesCreatePage } from './bootable-volumes-create-page';
+export { default as BootableVolumesListPage } from './bootable-volumes-list-page';
+export { default as BootableVolumesPage } from './bootable-volumes-page';
+export { default as CreateVmCreatePage } from './create-vm-create-page';
+export { default as CreateVmInstanceTypesPage } from './create-vm-instance-types-page';
+export { default as CreateVmPage } from './create-vm-page';
+export { default as CreateVmTemplateCatalogPage } from './create-vm-template-catalog-page';
+export { default as CreateVmTemplatesPage } from './create-vm-templates-page';
+export { default as CreateVmWizardDisksPage } from './create-vm-wizard-disks-page';
+export { default as CreateVmWizardPage } from './create-vm-wizard-page';
+export { default as CreateVmWizardTabsPage } from './create-vm-wizard-tabs-page';
+export { default as InstanceTypeCustomizeWizardPage } from './instance-type-customize-wizard-page';
+export { default as InstanceTypesPage } from './instance-types-page';
+export { default as TemplateCustomizeWizardPage } from './template-customize-wizard-page';
+export { default as TemplateDetailPage } from './template-detail-page';
+export { default as TemplatesPage } from './templates-page';

--- a/playwright/src/page-objects/create-vm/instance-type-customize-wizard-page.ts
+++ b/playwright/src/page-objects/create-vm/instance-type-customize-wizard-page.ts
@@ -1,0 +1,3 @@
+import InstanceTypeCustomizeWizardComponent from '@/components/create-vm/instance-type-customize-wizard-component';
+
+export default class InstanceTypeCustomizeWizardPage extends InstanceTypeCustomizeWizardComponent {}

--- a/playwright/src/page-objects/create-vm/instance-types-page.ts
+++ b/playwright/src/page-objects/create-vm/instance-types-page.ts
@@ -1,0 +1,298 @@
+/**
+ * Page object for the InstanceTypes list and detail pages.
+ */
+
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+import PageCommons from '../page-commons';
+
+export default class InstanceTypesPage extends PageCommons {
+  private readonly _clusterInstanceTypesBtn = this.locator(
+    'button:has-text("Cluster InstanceTypes")',
+  );
+  private readonly _filterToolbarClusterButton = this.locator(
+    '[data-test="filter-toolbar"], #filter-toolbar',
+  )
+    .locator('button')
+    .filter({ hasText: 'Cluster' })
+    .first();
+  private readonly _inputnameFilterInput = this.locator('input[data-test="name-filter-input"]');
+  private readonly _noInstanceTypeMessage = this.locator('#no-instancetype-msg');
+  private readonly _userInstanceTypesTab = this.locator('button:has-text("User InstanceTypes")');
+  constructor(page: Page) {
+    super(page);
+  }
+
+  private userTabNameFilterInput() {
+    return this.page
+      .locator('[id^="pf-tab-section-1-"]')
+      .locator('input[data-test="name-filter-input"]');
+  }
+
+  async clickClusterInstanceTypesTab() {
+    await this._clusterInstanceTypesBtn.click();
+  }
+
+  override async clickCreate() {
+    await this.page.waitForLoadState('domcontentloaded');
+    const createLink = this.locator(
+      'a[href*="~new"] button, [data-test="item-create"], button:has-text("Create VirtualMachine")',
+    ).first();
+    await createLink.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(createLink);
+  }
+
+  async clickDetailsActions() {
+    const detailsActions = this.locator('[data-test-id="details-actions"]')
+      .locator('button')
+      .first();
+    await detailsActions.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(detailsActions);
+  }
+
+  override async clickSaveChanges() {
+    await this._saveChangesButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._saveChangesButton);
+  }
+
+  async clickUserInstanceTypesTab() {
+    await this._userInstanceTypesTab.click();
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  async deleteClusterInstanceTypeFromDetail(): Promise<void> {
+    const actionsBtn = this.locator('[data-test-id="actions-menu-button"]');
+    await actionsBtn.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(actionsBtn);
+    const deleteItem = this.page.locator(
+      '[role="menuitem"]:has-text("Delete VirtualMachineClusterInstancetype")',
+    );
+    await deleteItem.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await deleteItem.click();
+    const confirmBtn = this.page.locator('[data-test="confirm-action"]');
+    await confirmBtn.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await confirmBtn.click();
+    await this.page.waitForURL(/VirtualMachineClusterInstancetype(?!.*\/[^/]+$)/, {
+      timeout: TestTimeouts.DEFAULT,
+    });
+  }
+
+  async deleteUserInstanceTypeFromDetail(): Promise<void> {
+    const actionsBtn = this.locator('[data-test-id="actions-menu-button"]');
+    await actionsBtn.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(actionsBtn);
+    const deleteItem = this.page.locator(
+      '[role="menuitem"]:has-text("Delete VirtualMachineInstancetype")',
+    );
+    await deleteItem.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await deleteItem.click();
+    const confirmBtn = this.page.locator('[data-test="confirm-action"]');
+    await confirmBtn.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await confirmBtn.click();
+    await this.page.waitForURL(/VirtualMachineInstancetype(?!.*\/[^/]+$)/, {
+      timeout: TestTimeouts.DEFAULT,
+    });
+  }
+
+  override async filterByName(name: string) {
+    const visibleInput = this._inputnameFilterInput.first();
+    await visibleInput.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await visibleInput.clear();
+    await visibleInput.fill(name);
+  }
+
+  async filterByNameInUserTab(name: string) {
+    const input = await this.userTabNameFilterInput();
+    await input.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await input.clear();
+    await input.fill(name);
+  }
+
+  async getNameDetailsValue(): Promise<string> {
+    return (
+      (await this.locator('[data-test-selector="details-item-value__Name"]').textContent()) || ''
+    );
+  }
+
+  async navigateToClusterInstanceTypeDetail(name: string): Promise<void> {
+    await this.goTo(
+      `/k8s/cluster/instancetype.kubevirt.io~v1beta1~VirtualMachineClusterInstancetype/${name}`,
+    );
+    await this.page.waitForLoadState('load', { timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+  }
+
+  /** @deprecated Use navigateToInstanceTypesViaUI() for more reliable navigation */
+  async navigateToClusterInstanceTypes() {
+    await this.goTo(
+      '/k8s/cluster/instancetype.kubevirt.io~v1beta1~VirtualMachineClusterInstancetype',
+    );
+  }
+
+  async navigateToCrdPage(crdPlural: string): Promise<void> {
+    await this.goTo(`/k8s/cluster/customresourcedefinitions/${crdPlural}/instances`);
+    await this.page.waitForLoadState('load');
+  }
+
+  async navigateToInstanceTypesViaInstancetypeNavItem(): Promise<void> {
+    const instancetypeNavItem = this.locator('[data-test-id="instancetype-nav-item"]');
+    await instancetypeNavItem.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(instancetypeNavItem);
+    await this.page.waitForLoadState('load', { timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+  }
+
+  async navigateToInstanceTypesViaUI(): Promise<void> {
+    try {
+      await this.clickNavInstanceTypes();
+    } catch {
+      await this.navigateToClusterInstanceTypes();
+    }
+  }
+
+  async navigateToProjectInstanceTypes() {
+    const vmciNav = this.locator('[data-test-id="virtualmachineclusterinstancetypes-nav-item"]');
+    await vmciNav.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(vmciNav);
+  }
+
+  async navigateToUserInstanceTypeDetail(namespace: string, name: string): Promise<void> {
+    await this.goTo(
+      `/k8s/ns/${namespace}/instancetype.kubevirt.io~v1beta1~VirtualMachineInstancetype/${name}`,
+    );
+    await this.page.waitForLoadState('load', { timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+  }
+
+  async navigateToUserInstanceTypesAllNamespaces() {
+    await this.goTo(
+      '/k8s/all-namespaces/instancetype.kubevirt.io~v1beta1~VirtualMachineInstancetype',
+    );
+  }
+
+  async navigateToUserInstanceTypesProject(projectName: string) {
+    await this.goTo(
+      `/k8s/ns/${projectName}/instancetype.kubevirt.io~v1beta1~VirtualMachineInstancetype`,
+    );
+  }
+
+  async openClusterFilter(): Promise<void> {
+    await this._filterToolbarClusterButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._filterToolbarClusterButton);
+  }
+
+  async selectClusterInFilterMenu(clusterName: string): Promise<void> {
+    const clusterOption = this.locator('#checkbox-select li', { hasText: clusterName }).first();
+    await clusterOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(clusterOption);
+  }
+
+  async verifyClusterFilterButtonVisible(): Promise<boolean> {
+    try {
+      await this._filterToolbarClusterButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return await this._filterToolbarClusterButton.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  verifyCrdPageNotRedirected(expectedPathFragment: string): boolean {
+    const url = this.page.url();
+    const notRedirected = !url.includes('/dashboard') || url.includes(expectedPathFragment);
+    return notRedirected && url.includes(expectedPathFragment);
+  }
+
+  async verifyEmptyMessageVisible(): Promise<boolean> {
+    try {
+      const emptyIndicator = this._noInstanceTypeMessage.or(
+        this.locator('[data-test="empty-box-body"], .pf-v6-c-empty-state, .pf-c-empty-state'),
+      );
+      const emptyVisible = await emptyIndicator
+        .first()
+        .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .then(() => true)
+        .catch(() => false);
+      if (emptyVisible) {
+        const text = await emptyIndicator.first().textContent();
+        return (
+          text?.includes('No VirtualMachineClusterInstanceType found') ||
+          text?.includes('No resources found') ||
+          text?.includes('No results') ||
+          text?.includes('not found') ||
+          false
+        );
+      }
+      const tableBody = this.locator('table tbody, [class*="table"] tbody');
+      const rows = tableBody.locator('tr');
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      return (await rows.count()) === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyInstanceTypeExists(instanceTypeId: string): Promise<boolean> {
+    try {
+      const instanceType = this.locator(`[data-test-id="${instanceTypeId}"]`);
+      await instanceType.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return await instanceType.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyInstanceTypesPageLoaded(expectedInstanceType = 'cx1.2xlarge'): Promise<boolean> {
+    try {
+      const loc = this.locator(`text=${expectedInstanceType}`).first();
+      await loc.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return await loc.isVisible().catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyUserInstanceTypesTabReady(
+    timeout = TestTimeouts.UI_ELEMENT_VISIBILITY,
+  ): Promise<{ state: 'populated' | 'empty'; rowCount: number }> {
+    await this.waitForInstanceTypesListReady();
+    const emptyState = this.locator('.pf-v6-c-empty-state');
+    const hasEmpty = await emptyState
+      .waitFor({ state: 'visible', timeout })
+      .then(() => true)
+      .catch(() => false);
+    if (!hasEmpty) {
+      const rows = this.locator('tbody tr');
+      const rowCount = await rows.count().catch(() => 0);
+      if (rowCount > 0) return { state: 'populated', rowCount };
+    }
+    return { state: 'empty', rowCount: 0 };
+  }
+
+  async waitForInstanceTypesListReady(timeoutMs = TestTimeouts.UI_FILTER_APPLY): Promise<void> {
+    await this.waitForCondition(
+      async () => {
+        const tabsVisible = await this._clusterInstanceTypesBtn.isVisible().catch(() => false);
+        const emptyVisible = await this._noInstanceTypeMessage.isVisible().catch(() => false);
+        const nameFilterVisible = await this.locator(
+          'input[data-test="name-filter-input"], input[placeholder*="Search by name"]',
+        )
+          .first()
+          .isVisible()
+          .catch(() => false);
+        return tabsVisible || emptyVisible || nameFilterVisible;
+      },
+      timeoutMs,
+      TestTimeouts.POLLING_INTERVAL,
+    );
+  }
+}

--- a/playwright/src/page-objects/create-vm/template-customize-wizard-page.ts
+++ b/playwright/src/page-objects/create-vm/template-customize-wizard-page.ts
@@ -1,0 +1,3 @@
+import { TemplateCustomizeWizardComponent } from '@/components/create-vm/template-components';
+
+export default class TemplateCustomizeWizardPage extends TemplateCustomizeWizardComponent {}

--- a/playwright/src/page-objects/create-vm/template-detail-page.ts
+++ b/playwright/src/page-objects/create-vm/template-detail-page.ts
@@ -1,0 +1,3 @@
+import { TemplateDetailComponent } from '@/components/create-vm/catalog-template-components';
+
+export default class TemplateDetailPage extends TemplateDetailComponent {}

--- a/playwright/src/page-objects/create-vm/templates-page.ts
+++ b/playwright/src/page-objects/create-vm/templates-page.ts
@@ -1,0 +1,944 @@
+/**
+ * Page object for the Templates list page.
+ */
+
+import { TestTimeouts } from '@/utils/test-config';
+import type { Locator, Page } from '@playwright/test';
+
+import PageCommons from '../page-commons';
+
+export default class TemplatesPage extends PageCommons {
+  private readonly _btnPlaceholderSelectProject = this.locator(
+    'button[placeholder="Select project"]',
+  );
+  private readonly _closeFilterLabelGroup = this.locator(
+    '[aria-label="Close label group"]',
+  ).first();
+  private readonly _columnsSaveButton = this.locator('[data-test="save-button"]');
+  private readonly _filterToolbarClusterButton = this.locator(
+    '[data-test="filter-toolbar"] button.pf-v6-c-menu-toggle',
+  )
+    .filter({ hasText: 'Cluster' })
+    .first();
+  private readonly _filterToolbarProjectButton = this.locator(
+    '[data-test="filter-toolbar"] button.pf-v6-c-menu-toggle',
+  )
+    .filter({ hasText: 'Project' })
+    .first();
+  private readonly _footerSaveButton = this.locator('footer [data-test="save-button"]');
+
+  private readonly _inputSearchInput = this.locator('input[aria-label="Search input"]');
+  private readonly _provider = this.locator('#provider');
+  private readonly _roleMenuitem = this.locator('[role="menuitem"]');
+  private readonly _templateActionsDropdown = this.locator('[data-test="actions-dropdown"]');
+  private readonly _tr = this.locator('tr');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  private getTemplateActionsButton(templateName: string): Locator {
+    const row = this.getTemplateRow(templateName);
+    return row.locator('[data-test="actions-dropdown"] button').first();
+  }
+
+  private getTemplateRow(templateName: string): Locator {
+    return this.locator('tbody tr').filter({ hasText: templateName });
+  }
+
+  async areAllCreateOptionsVisibleAndEnabled(): Promise<boolean> {
+    const createTemplateButton = this.locator('[data-test="item-create"]');
+    await createTemplateButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(createTemplateButton);
+
+    const options = ['From an existing template', 'From a virtual machine', 'With YAML'];
+    try {
+      for (const option of options) {
+        const menuItem = this.page.getByRole('menuitem', { name: option });
+        const isVisible = await menuItem
+          .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+          .catch(() => false);
+        if (!isVisible) return false;
+
+        const isDisabled = await menuItem.getAttribute('aria-disabled');
+        if (isDisabled === 'true') return false;
+      }
+      return true;
+    } finally {
+      await this.page.keyboard.press('Escape');
+    }
+  }
+
+  async clickCloneModalCloneButton() {
+    await this.robustClick(this.locator('button:has-text("Clone")'));
+  }
+
+  async clickCloneTemplate(templateName: string) {
+    const actionsButton = this.getTemplateActionsButton(templateName);
+    await this.robustClick(actionsButton);
+    await this.robustClick(this.page.getByRole('menuitem', { name: 'Clone' }));
+  }
+
+  async clickCreateButtonInModal() {
+    const createButton = this.locator('[data-test="save-changes"], button:has-text("Create")');
+    await createButton.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_LONG });
+    await this.robustClick(createButton.first());
+    await this.page.waitForTimeout(TestTimeouts.RETRY_DELAY);
+  }
+
+  async clickCreateTemplate() {
+    const createTemplateButton = this.locator('[data-test="item-create"]');
+    await createTemplateButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(createTemplateButton);
+
+    const yamlOption = this.page.getByRole('menuitem', { name: 'With YAML' });
+    const hasDropdown = await yamlOption
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+    if (hasDropdown) {
+      await this.robustClick(yamlOption);
+    }
+  }
+
+  async clickCreateTemplateOption(
+    option: 'From an existing template' | 'From a virtual machine' | 'With YAML',
+  ): Promise<void> {
+    const createTemplateButton = this.locator('[data-test="item-create"]');
+    await createTemplateButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(createTemplateButton);
+
+    const menuItem = this.page.getByRole('menuitem', { name: option });
+    await menuItem.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+    await this.robustClick(menuItem);
+  }
+
+  async clickEditBootSourceReference(templateName: string) {
+    const actionsButton = this.getTemplateActionsButton(templateName);
+    await this.robustClick(actionsButton);
+    await this.robustClick(this.locator('button:has-text("Edit boot source reference")'));
+  }
+
+  async clickFooterSaveButton() {
+    await this.robustClick(this._footerSaveButton);
+  }
+
+  override async clickTemplateByTestId(templateName: string) {
+    const templateLink = this.locator(`[data-test-id="${templateName}"]`);
+
+    const loadingSpinner = this.locator('.pf-v6-c-spinner, .pf-c-spinner, [data-test="loading"]');
+    await loadingSpinner
+      .waitFor({ state: 'hidden', timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => {
+        return;
+      });
+
+    await templateLink.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    const urlBefore = this.page.url();
+    const maxAttempts = 3;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      await this.page.waitForTimeout(TestTimeouts.UI_ANIMATION_DELAY);
+
+      try {
+        await templateLink.click({ timeout: TestTimeouts.UI_DELAY_MEDIUM });
+      } catch {
+        await templateLink.dispatchEvent('click');
+      }
+
+      try {
+        await this.page.waitForURL((url) => url.href !== urlBefore, { timeout: 8000 });
+        await this.page.waitForLoadState('domcontentloaded');
+        return;
+      } catch {
+        if (attempt < maxAttempts) {
+          await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+        }
+      }
+    }
+
+    await this.robustClick(templateLink);
+  }
+
+  /**
+   * Clone a template via "Create → From an existing template" modal.
+   * Opens the modal, selects the source template, fills target fields, and submits.
+   */
+  async cloneTemplateFromExisting(opts: {
+    sourceTemplateName: string;
+    newTemplateName: string;
+    sourceProject?: string;
+    targetProject?: string;
+    displayName?: string;
+    provider?: string;
+  }): Promise<void> {
+    await this.clickCreateTemplateOption('From an existing template');
+
+    const dialog = this.page.getByRole('dialog');
+    await dialog.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    if (opts.sourceProject) {
+      const sourceProjectBtn = dialog
+        .locator('button')
+        .filter({ hasText: /Source template project/ });
+      if (await sourceProjectBtn.count()) {
+        await this.robustClick(
+          dialog
+            .locator('button')
+            .filter({ hasText: /Project/ })
+            .first(),
+        );
+        const searchInput = dialog.locator('[role="listbox"]').locator('input[type="text"]');
+        if (
+          await searchInput.isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT }).catch(() => false)
+        ) {
+          await searchInput.fill(opts.sourceProject);
+        }
+        await this.robustClick(
+          dialog.locator(`[role="option"]`).filter({ hasText: opts.sourceProject }),
+        );
+      }
+    }
+
+    const templateDropdown = dialog.locator('button').filter({ hasText: 'Select a template' });
+    await this.robustClick(templateDropdown);
+    await this.robustClick(
+      dialog.locator('[role="option"]').filter({ hasText: opts.sourceTemplateName }),
+    );
+
+    const nameInput = dialog.locator('#templateName');
+    await nameInput.clear();
+    await nameInput.fill(opts.newTemplateName);
+
+    if (opts.targetProject) {
+      const projectBtn = dialog.locator('button').filter({ hasText: 'Select project' });
+      await this.robustClick(projectBtn);
+      const searchInput = dialog.locator('[role="listbox"]').locator('input[type="text"]');
+      if (
+        await searchInput.isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT }).catch(() => false)
+      ) {
+        await searchInput.fill(opts.targetProject);
+      }
+      await this.robustClick(
+        dialog.locator('[role="option"]').filter({ hasText: opts.targetProject }),
+      );
+    }
+
+    if (opts.displayName) {
+      const displayInput = dialog.locator('#templateDisplayName');
+      await displayInput.clear();
+      await displayInput.fill(opts.displayName);
+    }
+
+    if (opts.provider) {
+      const providerInput = dialog.locator('#templateProvider');
+      await providerInput.clear();
+      await providerInput.fill(opts.provider);
+    }
+
+    const cloneBtn = dialog.locator('footer button').filter({ hasText: 'Clone' });
+    await this.robustClick(cloneBtn);
+  }
+
+  async closeFilterLabelGroup(): Promise<void> {
+    await this._closeFilterLabelGroup.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._closeFilterLabelGroup);
+  }
+
+  async deleteTemplate() {
+    await this.robustClick(this._templateActionsDropdown);
+    await this.robustClick(this.page.getByRole('menuitem', { name: 'Delete' }));
+    await this.robustClick(this._footerSaveButton);
+  }
+
+  async deleteTemplateFromList(templateName: string) {
+    const actionsButton = this.getTemplateActionsButton(templateName);
+    await this.robustClick(actionsButton);
+    await this.robustClick(this.page.getByRole('menuitem', { name: 'Delete' }));
+    await this.robustClick(this._footerSaveButton);
+  }
+
+  async editBootSourceForDisk(diskName: string) {
+    await this.robustClick(this._templateActionsDropdown);
+    await this.robustClick(this.locator('[data-test-id="edit-boot-source"]'));
+
+    const diskRow = this._tr.filter({ hasText: diskName });
+    const diskToggle = diskRow.locator('#toggle-id-disk');
+    await this.robustClick(diskToggle);
+
+    await this.robustClick(
+      this._roleMenuitem.filter({
+        hasText: 'Edit',
+      }),
+    );
+    await this.locator('#enable-bootsource').check({ force: true });
+    await this.robustClick(this._footerSaveButton);
+  }
+
+  async fillCloneTemplateModal(
+    metadataName: string,
+    displayName?: string,
+    provider?: string,
+    namespace?: string,
+  ) {
+    const dialog = this.page.getByRole('dialog');
+    await dialog.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    const nameInput = dialog.locator(
+      'input[id="name"], input[id="templateName"], input#clone-name',
+    );
+    await nameInput
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await nameInput.first().clear();
+    await nameInput.first().fill(metadataName);
+
+    if (displayName) {
+      const displayInput = dialog.locator(
+        'input[id="display-name"], input[id="templateDisplayName"]',
+      );
+      if (
+        await displayInput
+          .first()
+          .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+          .catch(() => false)
+      ) {
+        await displayInput.first().clear();
+        await displayInput.first().fill(displayName);
+      }
+    }
+
+    if (namespace) {
+      const projectBtn = dialog.locator('button').filter({ hasText: /Select project|Project/ });
+      if (
+        await projectBtn
+          .first()
+          .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+          .catch(() => false)
+      ) {
+        await this.robustClick(projectBtn.first());
+        const searchInput = dialog.locator('[role="listbox"]').locator('input[type="text"]');
+        if (
+          await searchInput.isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT }).catch(() => false)
+        ) {
+          await searchInput.fill(namespace);
+        }
+        await this.robustClick(dialog.locator('[role="option"]').filter({ hasText: namespace }));
+      }
+    }
+
+    if (provider) {
+      const providerInput = dialog.locator('input[id="provider"], input[id="templateProvider"]');
+      if (
+        await providerInput
+          .first()
+          .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+          .catch(() => false)
+      ) {
+        await providerInput.first().clear();
+        await providerInput.first().fill(provider);
+      }
+    }
+  }
+
+  async filterByDefaultTemplates() {
+    await this.openFilterDropdown();
+    const newRadio = this.locator('input[data-test-row-filter="default"]');
+    const oldCheckbox = this.locator('[data-test-row-filter="templates"] [type="checkbox"]');
+    const isNewVisible = await newRadio
+      .isVisible({ timeout: TestTimeouts.UI_STABILIZE })
+      .catch(() => false);
+    if (isNewVisible) {
+      const isChecked = await newRadio.isChecked().catch(() => false);
+      if (!isChecked) {
+        await newRadio.click({ force: true });
+      }
+      return;
+    }
+    const isOldVisible = await oldCheckbox
+      .isVisible({ timeout: TestTimeouts.UI_STABILIZE })
+      .catch(() => false);
+    if (!isOldVisible) {
+      await this.openFilterDropdown();
+    }
+    await oldCheckbox.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const isChecked = await oldCheckbox.isChecked();
+    if (!isChecked) {
+      await oldCheckbox.click({ force: true });
+    }
+  }
+
+  async filterByOS(os: 'rhel' | 'windows' | 'fedora' | 'centos') {
+    await this.openFilterDropdown();
+    const filterCheckbox = this.locator(`[data-test-row-filter="${os}"] [type="checkbox"]`).first();
+    const isVisible = await filterCheckbox
+      .isVisible({ timeout: TestTimeouts.UI_STABILIZE })
+      .catch(() => false);
+    if (!isVisible) {
+      await this.openFilterDropdown();
+    }
+    await filterCheckbox.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const isChecked = await filterCheckbox.isChecked();
+    if (!isChecked) {
+      await filterCheckbox.click({ force: true });
+    }
+  }
+
+  async filterByProvider(provider: string) {
+    await this.openFilterDropdown();
+    const filterCheckbox = this.locator(
+      `[data-test-row-filter="${provider}"] [type="checkbox"]`,
+    ).first();
+    const isVisible = await filterCheckbox
+      .isVisible({ timeout: TestTimeouts.UI_STABILIZE })
+      .catch(() => false);
+    if (!isVisible) {
+      await this.openFilterDropdown();
+    }
+    await filterCheckbox.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const isChecked = await filterCheckbox.isChecked();
+    if (!isChecked) {
+      await filterCheckbox.click({ force: true });
+    }
+  }
+
+  /**
+   * Filter by template type (OpenShift-provided vs user VirtualMachine templates).
+   */
+  async filterByType(type: 'templates' | 'vm-templates') {
+    await this.openFilterDropdown();
+    const filterCheckbox = this.locator(
+      `[data-test-row-filter="${type}"] [type="checkbox"]`,
+    ).first();
+    const isVisible = await filterCheckbox
+      .isVisible({ timeout: TestTimeouts.UI_STABILIZE })
+      .catch(() => false);
+    if (!isVisible) {
+      await this.openFilterDropdown();
+    }
+    await filterCheckbox.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const isChecked = await filterCheckbox.isChecked();
+    if (!isChecked) {
+      await filterCheckbox.click({ force: true });
+    }
+  }
+
+  async filterTemplatesByName(templateName: string) {
+    const templateNameFilter = this.locator('[data-test="name-filter-input"]');
+    await templateNameFilter.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await templateNameFilter.clear();
+    await templateNameFilter.fill(templateName);
+    await this.page.waitForTimeout(TestTimeouts.UI_FILTER_APPLY / 3);
+    await this.page
+      .waitForLoadState('domcontentloaded', { timeout: TestTimeouts.UI_ACTION_COMPLETE })
+      .catch(() => {
+        return;
+      });
+  }
+
+  async hasBadgeInTemplateRow(templateName: string, badgeText: string): Promise<boolean> {
+    const row = this.getTemplateRow(templateName);
+    const badge = row.locator(`text=${badgeText}`);
+    try {
+      await badge.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isBaseTemplateVisible(templateName: string): Promise<boolean> {
+    const baseTemplateElement = this.locator(`[data-test="${templateName}"]`);
+    await baseTemplateElement
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => {
+        return;
+      });
+    return await baseTemplateElement.isVisible().catch(() => false);
+  }
+
+  /**
+   * Opens the column manager and returns whether the given column checkbox is currently checked.
+   */
+  async isColumnEnabled(
+    columnName: 'namespace' | 'workload' | 'architecture' | 'cpu',
+  ): Promise<boolean> {
+    const columnManagementButton = this.locator('[data-test="manage-columns"]');
+    await columnManagementButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(columnManagementButton);
+    const idMap: Record<string, string> = {
+      namespace: '#data-list-namespace',
+      workload: '#data-list-workload',
+      architecture: '#data-list-architecture',
+      cpu: '#data-list-cpu',
+    };
+    const checkbox = this.locator(idMap[columnName]);
+    await checkbox.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const checked = await checkbox.isChecked();
+    await this.page.keyboard.press('Escape');
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    return checked;
+  }
+
+  /**
+   * Returns true if the create template modal shows visible cluster and namespace selection (Fleet ACM).
+   */
+  async isCreateTemplateModalShowingClusterAndNamespaceOptions(): Promise<boolean> {
+    try {
+      const clusterToggle = this.locator('[data-test="cluster-dropdown-menu-toggle"]').first();
+      const namespaceToggle = this.locator('[data-test="namespace-dropdown-menu-toggle"]').first();
+      await clusterToggle.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await namespaceToggle.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isDiskBootable(diskName: string): Promise<boolean> {
+    const diskRow = this._tr.filter({ hasText: diskName });
+    await diskRow.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    const bootableText = diskRow.locator('text=bootable');
+    await bootableText
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => {
+        return;
+      });
+    const isBootable = await bootableText.isVisible().catch(() => false);
+
+    return isBootable;
+  }
+
+  async isEmptyMessageVisible(): Promise<boolean> {
+    try {
+      const filterEmpty = this.page.getByText('No templates found');
+      const namespaceEmpty = this.page.getByText("You don't have any templates yet");
+      const combined = filterEmpty.or(namespaceEmpty);
+      await combined.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isTemplateNameLinkVisible(templateMetadataName: string): Promise<boolean> {
+    const templateLocator = this.locator(`[data-test-id="${templateMetadataName}-name"]`);
+    await templateLocator
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => {
+        return;
+      });
+    return await templateLocator.isVisible().catch(() => false);
+  }
+
+  async isTemplateVisible(templateMetadataName: string): Promise<boolean> {
+    const templateLocator = this.locator(`[data-test-id="${templateMetadataName}"]`);
+    try {
+      await templateLocator.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Navigates to the all-namespaces Templates list page via URL.
+   * @deprecated Use navigateToTemplatesViaUI() for more reliable navigation
+   */
+  async navigateToAllNamespacesTemplates() {
+    await this.goTo('/k8s/all-namespaces/template.openshift.io~v1~Template');
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  /**
+   * Navigates to Templates page for a specific namespace via sidebar UI click.
+   * @param namespace - The namespace to switch to
+   */
+  async navigateToNamespaceTemplatesViaUI(namespace: string): Promise<void> {
+    try {
+      await this.clickNavTemplates();
+    } catch {
+      await this.goTo(`/k8s/ns/${namespace}/template.openshift.io~v1~Template`);
+      await this.page.waitForLoadState('domcontentloaded');
+    }
+    await this.switchToNamespace(namespace);
+  }
+
+  async navigateToProjectTemplates(projectName: string) {
+    await this.goTo(`/k8s/ns/${projectName}/template.openshift.io~v1~Template`);
+  }
+
+  async navigateToTemplateDetail(templateName: string) {
+    const row = this.getTemplateRow(templateName);
+    const templateLink = row
+      .locator(`[data-test-id="${templateName}"], a`)
+      .filter({ hasText: templateName })
+      .first();
+    await this.robustClick(templateLink);
+  }
+
+  /**
+   * Navigates to Templates page by clicking [data-test-id="templates-nav-item"] (Fleet context).
+   * Expands the Virtualization nav section first so the item is visible.
+   */
+  async navigateToTemplatesViaTemplatesNavItem(): Promise<void> {
+    await this.expandVirtualizationNavSection();
+    const navItem = this.locator('[data-test-id="templates-nav-item"]');
+    await navItem.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(navItem);
+    await this.page.waitForLoadState('load', {
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+  }
+
+  /**
+   * Navigates to Templates page via sidebar UI click, falling back to URL navigation.
+   */
+  async navigateToTemplatesViaUI(): Promise<void> {
+    try {
+      await this.clickNavTemplates();
+    } catch {
+      await this.navigateToAllNamespacesTemplates();
+    }
+  }
+
+  async openClusterFilter(): Promise<void> {
+    await this._filterToolbarClusterButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._filterToolbarClusterButton);
+  }
+
+  async openFilterDropdown() {
+    const dropdownMenu = this.locator('[data-test-row-filter]').first();
+    const isVisible = await dropdownMenu
+      .isVisible({ timeout: TestTimeouts.UI_STABILIZE })
+      .catch(() => false);
+
+    if (!isVisible) {
+      await this.robustClick(
+        this.locator('[data-test="filter-toolbar"] [data-test-id="filter-dropdown-toggle"]'),
+      );
+      await dropdownMenu.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    }
+  }
+
+  async openProjectFilter(): Promise<void> {
+    await this._filterToolbarProjectButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._filterToolbarProjectButton);
+  }
+
+  async resetColumns() {
+    const columnManagementButton = this.locator('[data-test="manage-columns"]');
+    await columnManagementButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+    await this.robustClick(columnManagementButton);
+    const resetColumnsButton = this.locator('[data-test="reset-button"]');
+    await resetColumnsButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(resetColumnsButton);
+    await this.robustClick(this._columnsSaveButton);
+  }
+
+  async selectClusterInFilterMenu(clusterName: string): Promise<void> {
+    const checkboxOption = this.locator('#checkbox-select li', { hasText: clusterName }).first();
+    const menuitemOption = this._roleMenuitem.filter({ hasText: clusterName }).first();
+    const option = (await checkboxOption.isVisible().catch(() => false))
+      ? checkboxOption
+      : menuitemOption;
+    await option.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(option);
+  }
+
+  async selectNamespaceInFilterMenu(namespaceName: string): Promise<void> {
+    const menuitem = this._roleMenuitem.filter({ hasText: namespaceName }).first();
+    await menuitem.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(menuitem);
+  }
+
+  async selectPvcAsBootSource(projectName: string, pvcName: string) {
+    await this.robustClick(this.locator('button:has-text("Select boot source")'));
+    await this.robustClick(
+      this.locator('[data-test-id="disk-source-select-persistentVolumeClaim"]'),
+    );
+    await this.robustClick(this.locator('text=--- Select PVC project ---'));
+    await this.clickButtonByText(projectName);
+    await this.robustClick(this.locator('.pf-c-form-control.pf-c-select__toggle-typeahead'));
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+    await this.clickButtonByText(pvcName);
+  }
+
+  /**
+   * Sets the template name in the create-template-from-example YAML editor.
+   */
+  async setCreateTemplateExampleNameInYamlEditor(templateName: string): Promise<void> {
+    await this.page.waitForSelector('.monaco-editor', {
+      state: 'visible',
+      timeout: TestTimeouts.ELEMENT_WAIT,
+    });
+
+    await this.page.waitForFunction(
+      () => {
+        const w = window as unknown as {
+          monaco?: {
+            editor?: {
+              getEditors: () => Array<{
+                getModel: () => { getValue: () => string } | null | undefined;
+              }>;
+            };
+          };
+        };
+        const editors = w.monaco?.editor?.getEditors();
+        return Boolean(editors && editors.length > 0 && editors[0].getModel());
+      },
+      { timeout: TestTimeouts.UI_VISIBILITY_QUICK as number },
+    );
+
+    const content = await this.page.evaluate(() => {
+      try {
+        const w = window as unknown as {
+          monaco?: {
+            editor?: {
+              getEditors: () => Array<{
+                getModel: () => { getValue: () => string } | null | undefined;
+              }>;
+            };
+          };
+        };
+        const editors = w.monaco?.editor?.getEditors();
+        if (editors && editors.length > 0) {
+          const editor = editors[0];
+          const model = editor.getModel();
+          if (model) return model.getValue();
+        }
+      } catch {}
+      return null;
+    });
+
+    if (!content) {
+      throw new Error('Could not get create-template YAML editor content');
+    }
+
+    const updated = content
+      .replace(/\bname: example\b/, `name: ${templateName}`)
+      .replace(/vm\.kubevirt\.io\/template: example\b/, `vm.kubevirt.io/template: ${templateName}`);
+
+    await this.fillYamlEditor(updated);
+  }
+
+  async toggleColumn(columnName: 'namespace' | 'workload' | 'architecture' | 'cpu') {
+    const columnManagementButton = this.locator('[data-test="manage-columns"]');
+    await columnManagementButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+    await this.robustClick(columnManagementButton);
+    let checkbox;
+    switch (columnName) {
+      case 'namespace':
+        checkbox = this.locator('#data-list-namespace');
+        break;
+      case 'workload':
+        checkbox = this.locator('#data-list-workload');
+        break;
+      case 'architecture':
+        checkbox = this.locator('#data-list-architecture');
+        break;
+      case 'cpu':
+        checkbox = this.locator('#data-list-cpu');
+        break;
+    }
+    await checkbox.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await checkbox.click({ force: true });
+    await this.robustClick(this._columnsSaveButton);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+  }
+
+  /**
+   * Verifies the filter toolbar contains Cluster and Project filter buttons (Fleet ACM).
+   */
+  async verifyClusterAndProjectFilterButtonsVisible(): Promise<boolean> {
+    try {
+      await this._filterToolbarClusterButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      await this._filterToolbarProjectButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return (
+        (await this._filterToolbarClusterButton.isVisible()) &&
+        (await this._filterToolbarProjectButton.isVisible())
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  override async verifyPageLoaded(
+    templateNameOrIndicators?: string | string[],
+    includeCreateButton?: boolean,
+    timeout?: number,
+  ): Promise<boolean> {
+    if (typeof templateNameOrIndicators === 'string') {
+      const templateName = templateNameOrIndicators;
+      await this.page.waitForLoadState('domcontentloaded');
+      await this.page.waitForTimeout(TestTimeouts.UI_STABILIZE);
+
+      const templateNameLocator = this.locator(`[data-test-id="${templateName}"]`);
+      try {
+        await templateNameLocator.waitFor({
+          state: 'visible',
+          timeout: timeout || TestTimeouts.DEFAULT,
+        });
+        return await templateNameLocator.isVisible().catch(() => false);
+      } catch {
+        return false;
+      }
+    }
+    const indicators = Array.isArray(templateNameOrIndicators)
+      ? templateNameOrIndicators
+      : ['[data-test-id="template-name"]'];
+    return await super.verifyPageLoaded(indicators, includeCreateButton, timeout);
+  }
+
+  /**
+   * After submitting the create-template YAML form, waits for navigation away from the `~new`
+   * creation URL and verifies that the redirect lands on the correct fleet-virtualization templates
+   * detail URL.
+   */
+  async verifyRedirectAfterTemplateCreation(): Promise<{ isValid: boolean; url: string }> {
+    try {
+      await this.page.waitForURL(
+        (url) => !url.pathname.endsWith('~new') && !url.pathname.includes('~new'),
+        { timeout: TestTimeouts.ELEMENT_WAIT },
+      );
+      const currentUrl = this.page.url();
+      const isCorrectPath = currentUrl.includes('/fleet-virtualization/templates/cluster/');
+      const hasOldBrokenPath = currentUrl.includes('template.openshift.io~v1~Template');
+      return { isValid: isCorrectPath && !hasOldBrokenPath, url: currentUrl };
+    } catch {
+      return { isValid: false, url: this.page.url() };
+    }
+  }
+
+  async verifySourceAvailableTextDoesNotExist(): Promise<boolean> {
+    try {
+      const sourceAvailableLocator = this.locator('text=Source available');
+      const exists = await sourceAvailableLocator
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+        .catch(() => false);
+      return !exists;
+    } catch {
+      return true;
+    }
+  }
+
+  async verifyTableHeaderExists(
+    headerLabel: 'Namespace' | 'Architecture' | 'Workload profile' | 'CPU | Memory',
+    shouldExist: boolean,
+  ): Promise<boolean> {
+    const header = this.page.locator('table.kubevirt-table th', { hasText: headerLabel });
+    await header
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT })
+      .catch(() => {
+        return;
+      });
+    const exists = await header
+      .first()
+      .isVisible()
+      .catch(() => false);
+    return exists === shouldExist;
+  }
+
+  async verifyTemplateContains(expectedText: string): Promise<boolean> {
+    try {
+      const textLocator = this.locator(`text=${expectedText}`);
+      await textLocator.waitFor({ state: 'visible', timeout: TestTimeouts.UI_VISIBILITY_QUICK });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyTemplateCreationFromExample(expectedText: string): Promise<boolean> {
+    try {
+      const textLocator = this.locator(`text=${expectedText}`);
+      await textLocator.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyTemplateDetailsPage(): Promise<boolean> {
+    try {
+      const templateDetailsLocator = this.locator('text=Template details');
+      await templateDetailsLocator.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async waitForClusterFilterApplied(): Promise<void> {
+    await this._closeFilterLabelGroup.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+  }
+
+  async waitForTemplateRowDetached(
+    templateName: string,
+    timeout: number = TestTimeouts.DEFAULT,
+  ): Promise<void> {
+    const row = this.getTemplateRow(templateName);
+    await row.waitFor({ state: 'detached', timeout });
+  }
+}


### PR DESCRIPTION
## 📝 Description

add create-VM page objects and components

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-92538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive UI test coverage for creating and customizing virtual machines, including disks, networks, metadata, scheduling, scripts, SSH, GPUs, and instance types.
  * Added bootable volume creation, filtering, editing, upload, deletion, and detail-page workflows.
  * Added template catalog browsing, filtering, creation, cloning, customization, and detail-page verification.
  * Added page-object exports for streamlined Create VM, template, instance type, and bootable volume testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->