### PR TITLE
ACM-37335 - MTV Advisor route namespace is hardcoded to open-cluster-management in kubevirt-plugin

### DIFF
--- a/src/multicluster/components/CrossClusterMigration/hooks/useAdvisorRouteURL.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useAdvisorRouteURL.ts
@@ -1,9 +1,15 @@
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
+const ACM_CONSOLE_PLUGIN_NAME = 'acm';
 const MTV_ADVISOR_ROUTE_NAME = 'mtv-advisor-route';
-const MTV_ADVISOR_NAMESPACE = 'open-cluster-management';
 
 const PROXY_KUBEVIRT_MTV_ADVISOR = '/api/proxy/plugin/kubevirt-plugin/mtv-advisor';
+
+const ConsolePluginGroupVersionKind = {
+  group: 'console.openshift.io',
+  kind: 'ConsolePlugin',
+  version: 'v1',
+};
 
 const RouteGroupVersionKind = {
   group: 'route.openshift.io',
@@ -12,12 +18,25 @@ const RouteGroupVersionKind = {
 };
 
 const useAdvisorRouteURL = (): [null | string, boolean, Error] => {
-  const [route, loaded, error] = useK8sWatchResource({
-    groupVersionKind: RouteGroupVersionKind,
-    name: MTV_ADVISOR_ROUTE_NAME,
-    namespace: MTV_ADVISOR_NAMESPACE,
+  const [acmPlugin, acmLoaded, acmError] = useK8sWatchResource({
+    groupVersionKind: ConsolePluginGroupVersionKind,
+    name: ACM_CONSOLE_PLUGIN_NAME,
   });
 
+  const acmNamespace = (acmPlugin as any)?.spec?.backend?.service?.namespace;
+
+  const [route, routeLoaded, routeError] = useK8sWatchResource(
+    acmNamespace
+      ? {
+          groupVersionKind: RouteGroupVersionKind,
+          name: MTV_ADVISOR_ROUTE_NAME,
+          namespace: acmNamespace,
+        }
+      : null,
+  );
+
+  const loaded = acmLoaded && routeLoaded;
+  const error = acmError || routeError;
   const isAvailable = loaded && !error && !!(route as any)?.spec?.host;
 
   return [isAvailable ? PROXY_KUBEVIRT_MTV_ADVISOR : null, loaded, error];


### PR DESCRIPTION
## 📝 Description

Resolve the MTV advisor route namespace dynamically instead of hardcoding `open-cluster-management`.

The `useAdvisorRouteURL` hook now watches the cluster-scoped `ConsolePlugin/acm` resource to extract `spec.backend.service.namespace`, then uses that namespace to watch the `mtv-advisor-route` Route. This supports environments where ACM is installed in a non-default namespace.

**Before:** Route namespace hardcoded to `open-cluster-management` — advisor feature silently unavailable if ACM is in a different namespace.

**After:** Two-step watch pattern — `ConsolePlugin/acm` → dynamic namespace → `Route/mtv-advisor-route`. Gracefully handles ACM not installed or mtv-advisor not deployed.

## 🔗 Links

- [ACM-37335](https://issues.redhat.com/browse/ACM-37335) — MTV Advisor route namespace is hardcoded to open-cluster-management in kubevirt-plugin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved advisor route detection across different namespaces.
  * Prevented invalid advisor URLs from being displayed while required route information is still loading or unavailable.
  * Enhanced error handling when advisor configuration resources cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->