### PR TITLE
CNV-92616: Auto-retest open PRs' hot-cluster gating tests when main advances

### DIFF
--- a/.github/actions/publish-gating-check/action.yml
+++ b/.github/actions/publish-gating-check/action.yml
@@ -1,0 +1,75 @@
+name: Publish Run Gating Tests Check
+description: |
+  Creates a fresh "Run Gating Tests" check-run for a given SHA. Always
+  creates a new entry rather than updating an existing one -- GitHub removed
+  the ability to modify the status/conclusion of an Actions check-run via
+  the GITHUB_TOKEN from a workflow run
+  (https://github.blog/changelog/2025-02-12-notice-of-upcoming-deprecations-and-breaking-changes-for-github-actions/,
+  "Changes to check run status modification"), so a checks.update call would
+  fail regardless of which run originally created the target check-run. A
+  second "Run Gating Tests" entry for the same SHA is the normal,
+  GitHub-native way to represent a new check attempt -- the merge box shows
+  whichever check-run reported most recently for a given name.
+
+  Single source of truth for the check's name/shape, used by both
+  retest-stale-gating.yml's per-PR stale-marking and hot-cluster-e2e.yml's
+  retest-result publishing, so the two can't drift out of sync.
+
+inputs:
+  head-sha:
+    description: SHA to attach the check-run to
+    required: true
+  status:
+    description: queued | in_progress | completed
+    required: true
+  conclusion:
+    description: Required when status is completed (success | failure | neutral | ...)
+    required: false
+    default: ''
+  title:
+    description: Short check-run title shown on the PR
+    required: true
+  summary:
+    description: Longer check-run summary (markdown) shown on the PR
+    required: true
+  details-url:
+    description: Optional link to the workflow run for more detail
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Create check-run
+      uses: actions/github-script@v9
+      env:
+        CHECK_HEAD_SHA: ${{ inputs['head-sha'] }}
+        CHECK_STATUS: ${{ inputs.status }}
+        CHECK_CONCLUSION: ${{ inputs.conclusion }}
+        CHECK_TITLE: ${{ inputs.title }}
+        CHECK_SUMMARY: ${{ inputs.summary }}
+        CHECK_DETAILS_URL: ${{ inputs['details-url'] }}
+      with:
+        script: |
+          const payload = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            name: 'Run Gating Tests',
+            head_sha: process.env.CHECK_HEAD_SHA,
+            status: process.env.CHECK_STATUS,
+            output: {
+              title: process.env.CHECK_TITLE,
+              summary: process.env.CHECK_SUMMARY,
+            },
+          };
+
+          if (process.env.CHECK_STATUS === 'completed') {
+            payload.conclusion = process.env.CHECK_CONCLUSION;
+            payload.completed_at = new Date().toISOString();
+          }
+          if (process.env.CHECK_DETAILS_URL) {
+            payload.details_url = process.env.CHECK_DETAILS_URL;
+          }
+
+          const { data } = await github.rest.checks.create(payload);
+          core.info(`Created check-run ${data.id} ("${payload.status}") for ${payload.head_sha}.`);

--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -22,6 +22,16 @@ on:
         required: false
         default: ''
         type: string
+      checkout_ref:
+        description: |
+          Ref/SHA to check out for the code under test. Leave empty for the
+          default (PR head SHA, or the triggering ref for a plain manual
+          run). Set to refs/pull/<N>/merge to test a PR merged with the
+          current base tip instead of the PR's head commit in isolation
+          (used by hot-cluster-e2e.yml's pr_number retest path).
+        required: false
+        default: ''
+        type: string
   workflow_call:
     inputs:
       test_project:
@@ -36,6 +46,16 @@ on:
         default: ''
       cluster_name:
         description: Cluster name for run tagging (defaults to runner_label)
+        type: string
+        required: false
+        default: ''
+      checkout_ref:
+        description: |
+          Ref/SHA to check out for the code under test. Leave empty for the
+          default (PR head SHA, or the triggering ref for a plain manual
+          run). Set to refs/pull/<N>/merge to test a PR merged with the
+          current base tip instead of the PR's head commit in isolation
+          (used by hot-cluster-e2e.yml's pr_number retest path).
         type: string
         required: false
         default: ''
@@ -193,10 +213,14 @@ jobs:
     outputs:
       kubevirt-plugin-image: ${{ env.KUBEVIRT_PLUGIN_IMAGE }}
     steps:
+      # inputs.checkout_ref (set to refs/pull/<N>/merge for the main-push
+      # retest path in hot-cluster-e2e.yml) takes priority over the PR's own
+      # head SHA -- see the checkout_ref input above for why: testing the
+      # merge with the current base tip, not the PR's isolated head commit.
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          ref: ${{ inputs.checkout_ref || github.event.pull_request.head.sha || github.ref }}
           allow-unsafe-pr-checkout: true
 
       - name: Check if kubevirt-plugin image exists in registry
@@ -256,10 +280,13 @@ jobs:
       RUN_FEATURE_TESTS: ${{ inputs.test_project == 'features' && 'true' || 'false' }}
 
     steps:
+      # See the build-kubevirt-plugin-image job's Checkout step above --
+      # same checkout_ref precedence, so the image build and the test run
+      # always test the identical tree.
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          ref: ${{ inputs.checkout_ref || github.event.pull_request.head.sha || github.ref }}
           allow-unsafe-pr-checkout: true
 
       - name: Provision CI test environment

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -1,5 +1,5 @@
 name: Hot Cluster E2E
-run-name: "Hot Cluster E2E [${{ inputs.cluster_name || github.base_ref || 'kubevirt-plugin-ci' }}] @ ${{ github.head_ref || github.ref_name }}"
+run-name: "Hot Cluster E2E [${{ inputs.cluster_name || github.base_ref || 'kubevirt-plugin-ci' }}] @ ${{ inputs.pr_number != '' && format('PR#{0} retest', inputs.pr_number) || github.head_ref || github.ref_name }}"
 
 on:
   pull_request_target:
@@ -37,6 +37,16 @@ on:
         description: 'OpenShift version (e.g. 4.22_openshift)'
         required: false
         default: '4.22_openshift'
+        type: string
+      pr_number:
+        description: |
+          PR number to retest merged with the current base branch tip,
+          instead of a plain manual run. Used by retest-stale-gating.yml to
+          re-validate merge-pool PRs after main advances (the Tide-equivalent
+          staleness guard -- see CNV-92616). Leave empty for a normal manual
+          dispatch.
+        required: false
+        default: ''
         type: string
 
 permissions:
@@ -90,6 +100,120 @@ jobs:
           INPUT_CLUSTER_NAME: ${{ inputs.cluster_name }}
           INPUT_OPENSHIFT_VERSION: ${{ inputs.openshift_version }}
         run: ./ci-scripts/hot-cluster/resolve-cluster-config.sh >> "$GITHUB_OUTPUT"
+
+  # Resolves the PR being retested when this run was dispatched with
+  # pr_number (the merge-pool "real retest" path from retest-stale-gating.yml
+  # after main advances). Looked up fresh via the API rather than trusted
+  # from any caller-supplied SHA, so the checkout ref and the SHA that
+  # ultimately receives the "Run Gating Tests" result are always the PR's
+  # actual current state at run time, not whatever the caller observed
+  # earlier.
+  #
+  # Trust IS re-checked here, freshly -- the lgtm+approved+no-hold labels
+  # retest-stale-gating.yml saw when it decided to dispatch are only a
+  # snapshot from *before* this run was queued, and lgtm/approved are Tide's
+  # merge-readiness signal, not a CI-trust signal: they say nothing about
+  # whether this specific author/commit was ever cleared to run privileged
+  # CI (secrets: inherit, cloud credentials) on a fork's code. Unlike the
+  # normal pull_request_target path, this workflow_dispatch retest path has
+  # no pull_request payload for cluster-check's own should_run expression to
+  # gate on (github.event_name == 'workflow_dispatch' short-circuits that
+  # expression to true unconditionally) -- so this job is the only place
+  # that can re-verify actual CI trust before run-e2e-tests spends real
+  # cluster time. still_in_pool (merge-pool membership) is a separate check
+  # below.
+  #
+  # OWNERS (the approvers/reviewers list) is the single source of truth for
+  # trust here, exactly like check-trust above -- never author_association
+  # or collaborator/contributor/member status, which are unreliable proxies
+  # (can misreport private org membership, and don't reflect this repo's
+  # actual OWNERS-based review process). same-repo branches and a
+  # currently-present ok-to-test label are the same two supplementary
+  # trust signals cluster-check's own should_run already accepts for the
+  # normal path -- kept consistent here rather than inventing a stricter or
+  # looser bar for the retest path specifically.
+  resolve-pr-context:
+    name: Resolve PR Context
+    if: github.event_name == 'workflow_dispatch' && inputs.pr_number != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      pull-requests: read
+    outputs:
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+      mergeable: ${{ steps.resolve.outputs.mergeable }}
+      still_in_pool: ${{ steps.resolve.outputs.still_in_pool }}
+      trusted: ${{ steps.resolve.outputs.trusted }}
+    steps:
+      # No ref override: defaults to checking out the ref this run was
+      # dispatched against (main, per retest-stale-gating.yml), never the
+      # PR's own branch -- same reasoning as check-trust above, so a PR
+      # can't add itself to OWNERS to self-approve trust. Also needed to
+      # require() the shared is-merge-pool-pr.cjs predicate below.
+      #
+      # persist-credentials: false -- this job only reads files (OWNERS,
+      # the shared module), it never pushes, so there's no reason to leave
+      # GITHUB_TOKEN sitting in .git/config for the rest of the job.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Look up PR head SHA, mergeability, trust, and pool membership
+        id: resolve
+        uses: actions/github-script@v9
+        # inputs.pr_number is spliced as a literal into the script source if
+        # interpolated directly via ${{ }} -- passing it through env/
+        # process.env instead avoids arbitrary-code injection via a crafted
+        # workflow_dispatch input.
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const { isMergePoolPr } = require('./ci-scripts/hot-cluster/is-merge-pool-pr.cjs');
+            const prNumber = Number(process.env.PR_NUMBER);
+
+            // mergeable/mergeable_state are computed asynchronously by
+            // GitHub and can be null right after main moves -- retry
+            // briefly rather than mistaking "not computed yet" for a real
+            // conflict.
+            let pr;
+            for (let attempt = 0; attempt < 5; attempt++) {
+              const { data } = await github.rest.pulls.get({ ...context.repo, pull_number: prNumber });
+              pr = data;
+              if (pr.mergeable !== null) break;
+              core.info(`PR #${prNumber} mergeable state not yet computed, retrying...`);
+              await new Promise(r => setTimeout(r, 3000));
+            }
+
+            // Same OWNERS-based check as check-trust above, verbatim --
+            // deliberately not author_association/collaborator status. See
+            // this job's own header comment for why.
+            const author = pr.user.login;
+            let ownedByAuthor = false;
+            try {
+              const owners = fs.readFileSync('OWNERS', 'utf8');
+              ownedByAuthor = new RegExp(`^\\s*-\\s*${author}\\s*$`, 'm').test(owners);
+            } catch (err) {
+              core.warning(`Could not read OWNERS file: ${err.message}`);
+            }
+
+            const sameRepo = pr.head.repo?.full_name === pr.base.repo.full_name;
+            const hasOkToTest = pr.labels.some((label) => label.name === 'ok-to-test');
+            const trusted = ownedByAuthor || sameRepo || hasOkToTest;
+
+            const stillInPool = isMergePoolPr(pr.labels);
+            core.info(`PR #${prNumber}: head=${pr.head.sha}, mergeable=${pr.mergeable}, mergeable_state=${pr.mergeable_state}, still_in_pool=${stillInPool}`);
+            core.info(`PR #${prNumber}: author=${author}, ownedByAuthor=${ownedByAuthor}, sameRepo=${sameRepo}, hasOkToTest=${hasOkToTest}, trusted=${trusted}`);
+
+            core.setOutput('head_sha', pr.head.sha);
+            // Treat still-unknown (null) as mergeable rather than failing
+            // the retest on GitHub's own computation lag -- only an
+            // explicit `false` should block the run below.
+            core.setOutput('mergeable', pr.mergeable === false ? 'false' : 'true');
+            core.setOutput('still_in_pool', stillInPool ? 'true' : 'false');
+            core.setOutput('trusted', trusted ? 'true' : 'false');
 
   check-trust:
     name: Check Trusted Author
@@ -145,7 +269,7 @@ jobs:
   # own bare context name.
   progress-check-start:
     name: Start Progress Check
-    needs: [check-trust, resolve-cluster-config]
+    needs: [check-trust, resolve-cluster-config, resolve-pr-context]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -163,15 +287,21 @@ jobs:
       - name: Post progress status
         continue-on-error: true
         uses: actions/github-script@v9
+        env:
+          RESOLVED_HEAD_SHA: ${{ needs.resolve-pr-context.outputs.head_sha }}
         with:
           script: |
             // pull_request_target's github.sha/context.sha is the BASE
             // branch's commit, not the PR head -- posting the status
             // there would make it silently never appear in the PR's own
-            // Checks tab.
+            // Checks tab. The pr_number retest path (workflow_dispatch, no
+            // associated pull_request payload) has the same problem for a
+            // different reason: context.sha there is whatever ref the
+            // dispatch used (main's tip), not the PR being retested -- use
+            // resolve-pr-context's freshly-looked-up head SHA instead.
             const headSha = context.eventName === 'pull_request_target'
               ? context.payload.pull_request.head.sha
-              : context.sha;
+              : (process.env.RESOLVED_HEAD_SHA || context.sha);
 
             const isIrrelevantLabel = context.payload.action === 'labeled'
               && context.payload.label?.name !== 'ok-to-test';
@@ -311,7 +441,7 @@ jobs:
   # this posts a commit status rather than updating a check-run.
   progress-check-running-tests:
     name: Update Progress Check
-    needs: [progress-check-start, cluster-check, cluster-health-check]
+    needs: [progress-check-start, cluster-check, cluster-health-check, resolve-pr-context]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -324,6 +454,8 @@ jobs:
       - name: Post progress status
         continue-on-error: true
         uses: actions/github-script@v9
+        env:
+          RESOLVED_HEAD_SHA: ${{ needs.resolve-pr-context.outputs.head_sha }}
         with:
           script: |
             const isIrrelevantLabel = context.payload.action === 'labeled'
@@ -333,9 +465,11 @@ jobs:
               return;
             }
 
+            // See progress-check-start above for why the pr_number retest
+            // path also needs resolve-pr-context's head SHA here.
             const headSha = context.eventName === 'pull_request_target'
               ? context.payload.pull_request.head.sha
-              : context.sha;
+              : (process.env.RESOLVED_HEAD_SHA || context.sha);
 
             // cluster-health-check only ever runs for workflow_dispatch (its
             // own `if:` skips it otherwise) -- branch on event type here,
@@ -361,7 +495,7 @@ jobs:
 
   run-e2e-tests:
     name: Run E2E Tests
-    needs: [cluster-check, cluster-health-check, resolve-cluster-config]
+    needs: [cluster-check, cluster-health-check, resolve-cluster-config, resolve-pr-context]
     # See cluster-health-check above: key off cluster-check's cluster_ready
     # output, not its job result, now that a no-op event still reports
     # 'success' for cluster-check. cluster-health-check only ever runs for
@@ -369,16 +503,52 @@ jobs:
     # event type here -- rather than a plain `||` of the two -- is required:
     # an unconditional `||` would let a manual run with cluster_ready ==
     # 'true' proceed even if its own health check subsequently failed.
+    #
+    # The trailing mergeable/still_in_pool/trusted checks only ever block
+    # the pr_number retest path -- resolve-pr-context is skipped (empty
+    # outputs) for every other trigger, and empty != 'false'. A real
+    # conflict with the current base tip, labels no longer qualifying for
+    # the merge pool, or the author/commit no longer being CI-trusted (all
+    # re-checked fresh in resolve-pr-context, not trusted from
+    # retest-stale-gating.yml's earlier snapshot -- see that job's comments
+    # for why) must surface as a clear failure below, not a silently
+    # skipped run. `trusted` matters here specifically because this
+    # workflow_dispatch path bypasses cluster-check's own should_run trust
+    # gate entirely (see resolve-pr-context's header comment).
+    #
+    # resolve-pr-context.result not in [failure, cancelled] guards against
+    # the case where that job itself errors out or gets cancelled/times out
+    # (API outage, deleted PR, run cancellation, ...) rather than cleanly
+    # resolving mergeable/still_in_pool/trusted to 'false' -- without this,
+    # an empty output would read as "not false" and let a real cluster run
+    # proceed with no way to ever report its result (no head SHA to
+    # publish the check-run against), burning cluster time for a run whose
+    # outcome nobody can see. 'skipped' (the normal, expected result for
+    # every non-retest trigger, since resolve-pr-context's own `if:` is
+    # false then) is deliberately left out of this list -- it must keep
+    # reading as "proceed" for those paths. See verify-gating-tests below
+    # for the visible-failure fallback when resolve-pr-context ends in
+    # either of these states.
     if: |
       always() && (
         (github.event_name == 'workflow_dispatch' && needs.cluster-health-check.result == 'success') ||
         (github.event_name != 'workflow_dispatch' && needs.cluster-check.outputs.cluster_ready == 'true')
-      )
+      ) &&
+      needs.resolve-pr-context.result != 'failure' &&
+      needs.resolve-pr-context.result != 'cancelled' &&
+      needs.resolve-pr-context.outputs.mergeable != 'false' &&
+      needs.resolve-pr-context.outputs.still_in_pool != 'false' &&
+      needs.resolve-pr-context.outputs.trusted != 'false'
     uses: ./.github/workflows/hot-cluster-e2e-run.yml
     with:
       test_project: ${{ inputs.test_project || 'gating' }}
       runner_label: ${{ inputs.runner_label || needs.resolve-cluster-config.outputs.cluster_name }}
       cluster_name: ${{ needs.resolve-cluster-config.outputs.cluster_name }}
+      # Merge the PR with the current base tip instead of testing its head
+      # commit in isolation -- see hot-cluster-e2e-run.yml's checkout_ref
+      # input for why this matters (a plain workflow re-run would otherwise
+      # keep re-testing the same stale commit forever).
+      checkout_ref: ${{ inputs.pr_number != '' && format('refs/pull/{0}/merge', inputs.pr_number) || '' }}
     secrets: inherit
 
   # Single source of truth for the "Run Gating Tests" required status check.
@@ -432,39 +602,83 @@ jobs:
         run-e2e-tests,
         progress-check-start,
         progress-check-running-tests,
+        resolve-pr-context,
       ]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Scoped here (rather than at the workflow level) -- needed by the
-    # "Complete progress status" step's createCommitStatus call below. See
-    # progress-check-start above.
+    # Scoped here (rather than at the workflow level) -- statuses: write is
+    # needed by the "Complete progress status" step's createCommitStatus
+    # call below (see progress-check-start above). checks: write is needed
+    # by "Publish result for retested PR" below -- the pr_number retest path
+    # has no pull_request payload for GitHub Actions to auto-associate this
+    # job's own check-run with, so that step manually posts/updates the
+    # "Run Gating Tests" check-run on the PR's real head SHA instead.
+    # issues: write is needed by "Report unresolvable PR context on the PR"
+    # -- PR comments are issue comments under the hood.
     permissions:
       statuses: write
+      checks: write
+      issues: write
     steps:
+      # id: verify -- its `reason` output drives both the PR-facing check
+      # summary below (so *why* a retest didn't pass reaches the PR, not
+      # just this job's own logs) and the resolve-context-failed fallback
+      # comment further down.
       - name: Verify hot cluster E2E ran and passed
+        id: verify
         env:
           TRUSTED: ${{ needs.check-trust.outputs.trusted }}
           E2E_RESULT: ${{ needs.run-e2e-tests.result }}
+          RESOLVE_PR_CONTEXT_RESULT: ${{ needs.resolve-pr-context.result }}
           IS_IRRELEVANT_LABEL: ${{ github.event.action == 'labeled' && github.event.label.name != 'ok-to-test' }}
           LABEL_NAME: ${{ github.event.label.name }}
+          IS_RETEST: ${{ inputs.pr_number != '' }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          MERGEABLE: ${{ needs.resolve-pr-context.outputs.mergeable }}
+          STILL_IN_POOL: ${{ needs.resolve-pr-context.outputs.still_in_pool }}
+          RETEST_TRUSTED: ${{ needs.resolve-pr-context.outputs.trusted }}
         run: |
           if [[ "${IS_IRRELEVANT_LABEL}" == "true" ]]; then
             echo "Irrelevant label event ('${LABEL_NAME}') — this run does not represent a real gating-test outcome."
+            echo "reason=irrelevant-label" >> "$GITHUB_OUTPUT"
             exit 0
+          fi
+
+          # resolve-pr-context erroring out or getting cancelled/timing out
+          # (not just resolving mergeable/still_in_pool to false) leaves no
+          # head SHA to publish a check-run against -- see the fallback PR
+          # comment step below, which is the only visible signal possible
+          # in either case.
+          if [[ "${IS_RETEST}" == "true" && ( "${RESOLVE_PR_CONTEXT_RESULT}" == "failure" || "${RESOLVE_PR_CONTEXT_RESULT}" == "cancelled" ) ]]; then
+            echo "::error::Could not resolve PR #${PR_NUMBER}'s context (head SHA / labels / mergeability) -- resolve-pr-context ended in '${RESOLVE_PR_CONTEXT_RESULT}'. See the 'Resolve PR Context' job for details."
+            echo "reason=resolve-context-failed" >> "$GITHUB_OUTPUT"
+            exit 1
           fi
 
           echo "run-e2e-tests result: ${E2E_RESULT}"
 
           if [[ "${E2E_RESULT}" == "success" ]]; then
             echo "Hot cluster gating tests passed."
+            echo "reason=passed" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if [[ "${{ github.event_name }}" == "pull_request_target" && "${TRUSTED}" != "true" ]]; then
+          if [[ "${IS_RETEST}" == "true" && "${MERGEABLE}" == "false" ]]; then
+            echo "::error::PR #${PR_NUMBER} no longer merges cleanly with the current base branch tip -- resolve the conflict and push an update (this will trigger a normal gating run)."
+            echo "reason=merge-conflict" >> "$GITHUB_OUTPUT"
+          elif [[ "${IS_RETEST}" == "true" && "${STILL_IN_POOL}" == "false" ]]; then
+            echo "::error::PR #${PR_NUMBER} no longer carries the lgtm+approved (no hold) labels required for the merge pool, re-checked fresh at run time -- skipping the retest."
+            echo "reason=left-pool" >> "$GITHUB_OUTPUT"
+          elif [[ "${IS_RETEST}" == "true" && "${RETEST_TRUSTED}" == "false" ]]; then
+            echo "::error::PR #${PR_NUMBER} is not from OWNERS, not from a same-repo branch, and does not currently carry the 'ok-to-test' label -- skipping the retest (re-checked fresh at run time)."
+            echo "reason=untrusted-retest" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "pull_request_target" && "${TRUSTED}" != "true" ]]; then
             echo "::error::Hot cluster E2E has not run for this PR because the author is not listed in OWNERS. A maintainer must add the 'ok-to-test' label to trigger it (it is removed again on each new push)."
+            echo "reason=untrusted" >> "$GITHUB_OUTPUT"
           else
             echo "::error::Hot cluster gating tests did not pass (run-e2e-tests result: '${E2E_RESULT}'). See the 'Run E2E Tests' job for details, or use /retest-e2e once fixed."
+            echo "reason=test-failed" >> "$GITHUB_OUTPUT"
           fi
           exit 1
 
@@ -478,6 +692,9 @@ jobs:
         if: always()
         continue-on-error: true
         uses: actions/github-script@v9
+        env:
+          RESOLVED_HEAD_SHA: ${{ needs.resolve-pr-context.outputs.head_sha }}
+          JOB_STATUS: ${{ job.status }}
         with:
           script: |
             const isIrrelevantLabel = context.payload.action === 'labeled'
@@ -487,11 +704,13 @@ jobs:
               return;
             }
 
+            // See progress-check-start above for why the pr_number retest
+            // path also needs resolve-pr-context's head SHA here.
             const headSha = context.eventName === 'pull_request_target'
               ? context.payload.pull_request.head.sha
-              : context.sha;
+              : (process.env.RESOLVED_HEAD_SHA || context.sha);
 
-            const passed = '${{ job.status }}' === 'success';
+            const passed = process.env.JOB_STATUS === 'success';
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
@@ -503,4 +722,112 @@ jobs:
                 ? 'Hot cluster gating tests passed'
                 : 'Hot cluster gating tests did not pass',
               target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
+      # Maps verify's `reason` output to a PR-facing title/summary so
+      # *why* a retest didn't pass reaches the check-run's own output, not
+      # just this job's Actions log (a generic "did not pass" doesn't tell
+      # a PR author whether they have a merge conflict, dropped out of the
+      # pool, or the tests genuinely failed).
+      - name: Determine retest result details
+        id: result-details
+        if: always() && inputs.pr_number != '' && needs.resolve-pr-context.outputs.head_sha != ''
+        env:
+          REASON: ${{ steps.verify.outputs.reason }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          MAIN_SHA: ${{ github.sha }}
+        run: |
+          case "${REASON}" in
+            passed)
+              echo "conclusion=success" >> "$GITHUB_OUTPUT"
+              echo "title=Hot cluster gating tests passed (retest after main advanced)" >> "$GITHUB_OUTPUT"
+              echo "summary=Re-validated PR #${PR_NUMBER} merged with the current main tip (${MAIN_SHA}) after main advanced (see CNV-92616)." >> "$GITHUB_OUTPUT"
+              ;;
+            merge-conflict)
+              echo "conclusion=failure" >> "$GITHUB_OUTPUT"
+              echo "title=PR no longer merges cleanly with main (retest after main advanced)" >> "$GITHUB_OUTPUT"
+              echo "summary=PR #${PR_NUMBER} no longer merges cleanly with the current main tip (${MAIN_SHA}) -- resolve the conflict and push an update, which will trigger a normal gating run." >> "$GITHUB_OUTPUT"
+              ;;
+            left-pool)
+              echo "conclusion=failure" >> "$GITHUB_OUTPUT"
+              echo "title=No longer in the merge pool (retest after main advanced)" >> "$GITHUB_OUTPUT"
+              echo "summary=PR #${PR_NUMBER} no longer carries the lgtm+approved (no hold) labels required for the merge pool, re-checked fresh when this retest ran against main tip ${MAIN_SHA} -- the cluster run was skipped." >> "$GITHUB_OUTPUT"
+              ;;
+            untrusted-retest)
+              echo "conclusion=failure" >> "$GITHUB_OUTPUT"
+              echo "title=Not CI-trusted for a retest (retest after main advanced)" >> "$GITHUB_OUTPUT"
+              echo "summary=PR #${PR_NUMBER} is not from OWNERS, not from a same-repo branch, and does not currently carry 'ok-to-test' (re-checked fresh when this retest ran against main tip ${MAIN_SHA}) -- the cluster run was skipped. A maintainer can add 'ok-to-test' to allow it." >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "conclusion=failure" >> "$GITHUB_OUTPUT"
+              echo "title=Hot cluster gating tests did not pass (retest after main advanced)" >> "$GITHUB_OUTPUT"
+              echo "summary=Re-validated PR #${PR_NUMBER} merged with the current main tip (${MAIN_SHA}) after main advanced (see CNV-92616) -- tests did not pass. See the workflow run for details." >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      # The pr_number retest path (workflow_dispatch, dispatched against
+      # main's own tip -- see run-e2e-tests's checkout_ref above) has no
+      # pull_request payload, so unlike the normal pull_request_target
+      # path, GitHub Actions has nothing to auto-associate this job's own
+      # check-run with the PR being retested -- it would otherwise land on
+      # main's tip commit and never show up on the PR at all. This step
+      # manually publishes the "Run Gating Tests" result onto the PR's real
+      # head SHA instead (via the shared publish-gating-check composite
+      # action -- see that action for why it always creates a fresh
+      # check-run rather than updating an existing one).
+      # persist-credentials: false -- this checkout exists solely so the
+      # local ./.github/actions/publish-gating-check composite action below
+      # is available on disk; it never pushes, so GITHUB_TOKEN doesn't need
+      # to persist in .git/config afterwards.
+      - name: Checkout
+        if: always() && inputs.pr_number != '' && needs.resolve-pr-context.outputs.head_sha != ''
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Publish result for retested PR
+        if: always() && inputs.pr_number != '' && needs.resolve-pr-context.outputs.head_sha != ''
+        continue-on-error: true
+        uses: ./.github/actions/publish-gating-check
+        with:
+          head-sha: ${{ needs.resolve-pr-context.outputs.head_sha }}
+          status: completed
+          conclusion: ${{ steps.result-details.outputs.conclusion }}
+          title: ${{ steps.result-details.outputs.title }}
+          summary: ${{ steps.result-details.outputs.summary }}
+          details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      # resolve-pr-context erroring out or getting cancelled/timing out (as
+      # opposed to cleanly resolving mergeable/still_in_pool to false)
+      # leaves no head SHA at all, so the step above can't publish
+      # anything -- without this, the guard would silently do nothing
+      # visible on the PR while still having burned (or skipped, per
+      # run-e2e-tests's guard) cluster time. A PR comment only needs the PR
+      # number, not a head SHA, so it's the one channel still available
+      # here for either outcome.
+      - name: Report unresolvable PR context on the PR
+        if: |
+          always() && inputs.pr_number != '' && (
+            needs.resolve-pr-context.result == 'failure' ||
+            needs.resolve-pr-context.result == 'cancelled'
+          )
+        continue-on-error: true
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              body: [
+                '⚠️ The automatic retest triggered after `main` advanced could not resolve this PR\'s context ' +
+                  '(head SHA / labels / mergeability) and did not run.',
+                '',
+                'The existing "Run Gating Tests" result may be stale -- please comment `/retest-e2e` for a fresh result before merging.',
+                '',
+                `See the failed run for details: ${runUrl}`,
+              ].join('\n'),
             });

--- a/.github/workflows/retest-stale-gating.yml
+++ b/.github/workflows/retest-stale-gating.yml
@@ -1,0 +1,213 @@
+name: Retest Stale Gating Checks
+
+# Tide-equivalent staleness guard (CNV-92616): when main advances, any open
+# PR's already-completed "Run Gating Tests" check was validated against a
+# base branch tip that no longer exists. Prow's Tide used to re-test every
+# merge-pool PR against the latest base commit before merge; that guarantee
+# doesn't exist for this repo's externally-triggered hot-cluster workflow,
+# since it only reacts to the PR's own push/relabel/comment events (see
+# hot-cluster-e2e.yml) and branch protection has strict: false.
+#
+# Two tiers, bounded for cost on the single shared hot cluster:
+#   - Cheap pass (every open PR targeting main): mark the existing "Run
+#     Gating Tests" check as stale/queued -- a plain Checks API call, no
+#     cluster time spent.
+#   - Real retest (merge-pool PRs only -- lgtm + approved, no hold/do-not-
+#     merge): dispatch hot-cluster-e2e.yml's pr_number path, which tests the
+#     PR merged with the new main tip (not a no-op re-run of the old
+#     head-only commit) and publishes the result onto the same check.
+#     Pool membership is re-verified fresh inside that dispatched run
+#     (resolve-pr-context) rather than trusted from this workflow's earlier
+#     snapshot -- see is-merge-pool-pr.cjs for why.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+  actions: write
+
+jobs:
+  list-open-prs:
+    name: List Open PRs Targeting main
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      pool_pr_numbers: ${{ steps.list.outputs.pool_pr_numbers }}
+      all_pr_numbers: ${{ steps.list.outputs.all_pr_numbers }}
+    steps:
+      # Needed to require() the shared is-merge-pool-pr.cjs predicate below.
+      # persist-credentials: false -- read-only usage, never pushes.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: List open PRs and classify merge-pool membership
+        id: list
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { isMergePoolPr } = require('./ci-scripts/hot-cluster/is-merge-pool-pr.cjs');
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              ...context.repo,
+              state: 'open',
+              base: 'main',
+              per_page: 100,
+            });
+
+            const all = prs.map((pr) => pr.number);
+            const pool = prs.filter((pr) => isMergePoolPr(pr.labels)).map((pr) => pr.number);
+
+            core.info(`Open PRs targeting main: ${all.length} total, ${pool.length} in the merge pool.`);
+            core.info(`Pool PRs: ${pool.join(', ') || '(none)'}`);
+
+            core.setOutput('all_pr_numbers', JSON.stringify(all));
+            core.setOutput('pool_pr_numbers', JSON.stringify(pool));
+
+  # Marks every open PR's "Run Gating Tests" check as stale by creating a
+  # fresh queued check-run, instead of leaving a now-invalid "success"
+  # visible as the most recent (and thus authoritative -- GitHub's merge
+  # box shows whichever check-run reported most recently for a given name)
+  # result on that SHA.
+  #
+  # One matrix job per PR (rather than one job looping over all PRs in a
+  # single script) so the shared publish-gating-check composite action can
+  # be invoked as a normal step, and so one PR's failure (e.g. a deleted
+  # fork branch) shows up as its own isolated, individually-visible job
+  # instead of a swallowed try/catch inside a bigger loop.
+  mark-stale:
+    name: Mark Stale (PR #${{ matrix.pr_number }})
+    needs: list-open-prs
+    if: needs.list-open-prs.outputs.all_pr_numbers != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        pr_number: ${{ fromJson(needs.list-open-prs.outputs.all_pr_numbers) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Needed to reference the local ./.github/actions/publish-gating-check
+      # composite action below. persist-credentials: false -- never pushes.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # Skips PRs whose most recent check-run is still in flight from a
+      # genuine run (status other than 'completed', and not one of our own
+      # prior stale markers -- identified by STALE_MARKER_TITLE below).
+      # Refreshes our own prior stale marker (rather than leaving it frozen
+      # on the first-ever push that made it stale) so its "main advanced
+      # to <SHA>" text reflects the current tip on every subsequent push
+      # too, as long as the PR still hasn't gotten a fresh real result.
+      - name: Determine whether to (re-)mark this PR stale
+        id: check
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ matrix.pr_number }}
+          POOL_PR_NUMBERS: ${{ needs.list-open-prs.outputs.pool_pr_numbers }}
+          STALE_MARKER_TITLE: 'Stale -- main has advanced since this ran'
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const { data: pr } = await github.rest.pulls.get({ ...context.repo, pull_number: prNumber });
+            core.setOutput('head_sha', pr.head.sha);
+
+            const inPool = JSON.parse(process.env.POOL_PR_NUMBERS).includes(prNumber);
+            core.setOutput('summary', [
+              `\`main\` advanced to ${context.sha} since this check last completed.`,
+              inPool
+                ? 'This PR is in the merge pool -- a real retest against the new base tip has been dispatched separately.'
+                : "This PR is not currently in the merge pool (needs both 'lgtm' and 'approved', no hold) -- push a commit, relabel, or comment `/retest-e2e` for a fresh result before merging.",
+            ].join('\n\n'));
+
+            const { data: existing } = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref: pr.head.sha,
+              check_name: 'Run Gating Tests',
+            });
+            const [latest] = existing.check_runs.sort(
+              (a, b) => new Date(b.started_at) - new Date(a.started_at),
+            );
+
+            if (!latest) {
+              core.info(`PR #${prNumber}: no existing "Run Gating Tests" check-run yet, nothing to mark stale.`);
+              core.setOutput('should_mark', 'false');
+              return;
+            }
+
+            const isOwnStaleMarker = latest.output?.title === process.env.STALE_MARKER_TITLE;
+            if (latest.status !== 'completed' && !isOwnStaleMarker) {
+              core.info(`PR #${prNumber}: check-run ${latest.id} is ${latest.status} from a real run -- leaving it alone.`);
+              core.setOutput('should_mark', 'false');
+              return;
+            }
+
+            core.info(`PR #${prNumber}: marking stale (superseding check-run ${latest.id}, isOwnStaleMarker=${isOwnStaleMarker}).`);
+            core.setOutput('should_mark', 'true');
+
+      - name: Mark check stale
+        if: steps.check.outputs.should_mark == 'true'
+        uses: ./.github/actions/publish-gating-check
+        with:
+          head-sha: ${{ steps.check.outputs.head_sha }}
+          status: queued
+          title: 'Stale -- main has advanced since this ran'
+          summary: ${{ steps.check.outputs.summary }}
+
+  # Real retest, merge-pool PRs only. Dispatches hot-cluster-e2e.yml's
+  # pr_number path (against main, so it always uses the just-pushed
+  # workflow definition) rather than reusing /retest-e2e's plain
+  # reRunWorkflow -- a re-run reuses the original cached event payload
+  # (same head SHA, no merge with the new base), so it would silently
+  # re-test the exact same commit and never actually validate the pool PR
+  # against whatever just merged. See hot-cluster-e2e.yml's checkout_ref /
+  # resolve-pr-context for how the fresh dispatch tests the PR merged with
+  # the new main tip instead.
+  #
+  # needs: mark-stale (not just list-open-prs) so every stale marker is
+  # fully created before any retest is dispatched -- otherwise, if
+  # mark-stale were ever delayed past a fast real retest completing, its
+  # "queued" marker could land *after* the real result and mask it as the
+  # most-recently-reported (and thus displayed) entry.
+  #
+  # if: always() is deliberate -- it's needed so one PR's stale-marking
+  # failure in the mark-stale matrix doesn't block retesting the other,
+  # unrelated pool PRs. But always() also disables GitHub's normal implicit
+  # `success()` wrapping entirely (it's not added unless the expression
+  # omits all status-check functions), so list-open-prs's own success is no
+  # longer required either -- explicitly checking its result here closes
+  # that gap: if list-open-prs itself failed, pool_pr_numbers is unset, and
+  # `!= '[]'` on an empty/undefined output would otherwise still read as
+  # "not empty", feeding invalid JSON into the matrix's fromJson() below.
+  retest-pool-prs:
+    name: Retest Merge-Pool PRs (PR #${{ matrix.pr_number }})
+    needs: [list-open-prs, mark-stale]
+    if: |
+      always() &&
+      needs.list-open-prs.result == 'success' &&
+      needs.list-open-prs.outputs.pool_pr_numbers != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        pr_number: ${{ fromJson(needs.list-open-prs.outputs.pool_pr_numbers) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Dispatch hot-cluster-e2e.yml retest
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ matrix.pr_number }}
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              ...context.repo,
+              workflow_id: 'hot-cluster-e2e.yml',
+              ref: 'main',
+              inputs: { pr_number: process.env.PR_NUMBER },
+            });
+            core.info(`PR #${process.env.PR_NUMBER}: dispatched a real retest against the new main tip.`);

--- a/ci-scripts/hot-cluster/is-merge-pool-pr.cjs
+++ b/ci-scripts/hot-cluster/is-merge-pool-pr.cjs
@@ -1,0 +1,19 @@
+// Single source of truth for "is this PR in the hot-cluster-e2e merge pool"
+// (lgtm + approved, no hold/do-not-merge/*). Shared by:
+//   - .github/workflows/retest-stale-gating.yml's list-open-prs job (initial
+//     classification, decides which PRs get a real retest dispatched)
+//   - .github/workflows/hot-cluster-e2e.yml's resolve-pr-context job (fresh
+//     re-verification at execution time, right before the credentialed
+//     cluster run -- closes the gap between "labels were checked" and
+//     "cluster time was spent" so a label removed in between is caught)
+//
+// Keeping this in one file (rather than duplicating the predicate inline in
+// two separate workflow scripts) means the trust boundary can't silently
+// drift out of sync between the two check points.
+function isMergePoolPr(labels) {
+  const names = (labels || []).map((label) => (typeof label === 'string' ? label : label.name));
+  const hasHold = names.some((name) => name === 'hold' || name.startsWith('do-not-merge/'));
+  return names.includes('lgtm') && names.includes('approved') && !hasHold;
+}
+
+module.exports = { isMergePoolPr };


### PR DESCRIPTION
## 📝 Description

Auto-retest open PRs' hot-cluster gating tests when main advances (Tide-equivalent staleness guard)

Today, if PR A's gating tests pass and then PR B merges to main, PR A's passing result goes stale and nothing re-validates it -- hot-cluster-e2e.yml only triggers on PR A's own push/relabel/comment events (pull_request_target: [opened, synchronize, reopened, labeled]), and branch protection has strict: false. This is a real regression from the previous Prow/Tide setup, where Tide automatically re-tested every pool PR against the latest base commit before merge -- a guarantee Tide can only provide for Prow-native jobs, not externally-triggered GitHub Actions workflows.


## 🔗 Links

Jira ticket: [CNV-92616](https://redhat.atlassian.net/browse/CNV-92616)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled retesting pull requests after `main` advances, with a retest run name, consistent check publishing, and shared results tied to the resolved PR head.
  * Added automatic stale-gating detection to queue an updated gating check and trigger real retests for eligible merge-pool PRs.
* **Improvements**
  * Enhanced retest context resolution (mergeability, pool membership, trust) with clearer retest-specific failure reasons and PR comments when context can’t be determined.
  * Added a configurable checkout ref for E2E runs to ensure both image builds and tests use the same code.
  * Consolidated merge-pool eligibility rules using required approvals/labels, excluding held and `do-not-merge` cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->