### PR TITLE
CNV-92679: Detect and run Cypress tests for hot-cluster E2E on release-4.22 and earlier branches

### DIFF
--- a/.github/workflows/hot-cluster-check.yml
+++ b/.github/workflows/hot-cluster-check.yml
@@ -28,6 +28,16 @@ on:
         type: string
         required: false
         default: '4.22_openshift'
+      branch_name:
+        description: |
+          Branch identity to report in the "Hot cluster ready" Slack
+          notification if provisioning happens (main/release-4.X, or a
+          plain branch name for ad-hoc dispatches). Forwarded as-is to
+          ibmc-cluster-setup.yml -- see its own branch_name input for the
+          fallback used when this is left empty.
+        type: string
+        required: false
+        default: ''
       worker_flavor:
         description: Worker node flavor
         type: string
@@ -115,6 +125,7 @@ jobs:
       cluster_name: ${{ inputs.cluster_name }}
       zone: ${{ inputs.zone }}
       openshift_version: ${{ inputs.openshift_version }}
+      branch_name: ${{ inputs.branch_name }}
       worker_flavor: ${{ inputs.worker_flavor }}
       worker_count: ${{ inputs.worker_count }}
       # kvm_emulation is declared as a string here (matching workflow_call's

--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -313,9 +313,17 @@ jobs:
           ref: ${{ inputs.checkout_ref || github.event.pull_request.head.sha || github.ref }}
           allow-unsafe-pr-checkout: true
 
+      # Referenced by owner/repo/path@main rather than the local ./ path --
+      # checkout_ref can point at a release branch that predates this CI
+      # infra entirely (e.g. release-4.22 and earlier, before hot-cluster
+      # CI existed), so the composite action wouldn't exist in the checked-
+      # out tree. Both ci-env-request and ci-env-release are self-contained
+      # (pure oc/kubectl commands against the already-running ci-env-
+      # controller, no other local file references), so pinning to main
+      # here is safe regardless of what's checked out above.
       - name: Provision CI test environment
         id: ci-env
-        uses: ./.github/actions/ci-env-request
+        uses: kubevirt-ui/kubevirt-plugin/.github/actions/ci-env-request@main
         with:
           plugin-image: ${{ env.PLUGIN_IMAGE }}
           test-namespace: ${{ env.TEST_NS }}
@@ -373,6 +381,16 @@ jobs:
           TEST_PROJECT: ${{ inputs.test_project }}
         run: |
           if [[ "${TEST_ENGINE}" == "cypress" ]]; then
+            # Cypress only auto-exposes env vars to Cypress.env(...) when
+            # they carry the CYPRESS_ prefix (or via an explicit --env
+            # flag) -- the plain TEST_NS/OS_IMAGES_NS/CNV_NS/
+            # TEST_SECRET_NAME already set at the job level (used by
+            # Playwright and the oc/bash steps directly) are invisible to
+            # the test code's Cypress.env('TEST_NS') etc. otherwise.
+            export CYPRESS_TEST_NS="${TEST_NS}"
+            export CYPRESS_OS_IMAGES_NS="${OS_IMAGES_NS}"
+            export CYPRESS_CNV_NS="${CNV_NS}"
+            export CYPRESS_TEST_SECRET_NAME="${TEST_SECRET_NAME}"
             if [[ "${TEST_PROJECT}" == "features" ]]; then
               npm run test-cypress-headless -- --spec tests/tier1.cy.ts
             else
@@ -435,11 +453,15 @@ jobs:
         if: always()
         run: |
           echo "Cleaning test entities in ${TEST_NS}..."
-          bash ci-scripts/hot-cluster/test-cleanup.sh
+          # Fetched from main rather than run from the checked-out tree --
+          # same reasoning as the ci-env-request/ci-env-release uses:
+          # below, this script may not exist on whatever checkout_ref was
+          # used (e.g. a pre-hot-cluster-CI release branch).
+          curl -sL "https://raw.githubusercontent.com/kubevirt-ui/kubevirt-plugin/main/ci-scripts/hot-cluster/test-cleanup.sh" | bash
 
       - name: Release CI test environment
         if: always()
-        uses: ./.github/actions/ci-env-release
+        uses: kubevirt-ui/kubevirt-plugin/.github/actions/ci-env-release@main
         with:
           configmap-name: ${{ env.CI_ENV_CM }}
           ci-env-namespace: ${{ env.CI_ENV_NS }}

--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -5,13 +5,26 @@ on:
   workflow_dispatch:
     inputs:
       test_project:
-        description: Playwright project to run
+        description: Test project/suite to run (gating, or the features/tier1 equivalent)
         required: true
         default: gating
         type: choice
         options:
           - gating
           - features
+      test_engine:
+        description: |
+          E2E test engine to run against the checked-out code. Defaults to
+          playwright -- there's no base branch to auto-detect from outside
+          hot-cluster-e2e.yml's pull_request_target path, so set this
+          explicitly to cypress when manually testing a release-4.22-or-
+          earlier ref.
+        required: false
+        default: playwright
+        type: choice
+        options:
+          - playwright
+          - cypress
       runner_label:
         description: ARC runner label (defaults to kubevirt-plugin-ci)
         required: false
@@ -35,10 +48,18 @@ on:
   workflow_call:
     inputs:
       test_project:
-        description: Playwright project to run
+        description: Test project/suite to run (gating, or the features/tier1 equivalent)
         type: string
         required: false
         default: gating
+      test_engine:
+        description: |
+          E2E test engine to run against the checked-out code (playwright or
+          cypress). See hot-cluster-e2e.yml's resolve-cluster-config job for
+          how this is auto-detected from the target branch.
+        type: string
+        required: false
+        default: playwright
       runner_label:
         description: ARC runner label (defaults to kubevirt-plugin-ci)
         type: string
@@ -270,7 +291,7 @@ jobs:
           podman push ${KUBEVIRT_PLUGIN_IMAGE}
 
   run-gating-tests:
-    name: Playwright Gating Tests
+    name: Run Gating Tests
     needs: [check-runner, build-kubevirt-plugin-image]
     runs-on: ${{ inputs.runner_label || 'kubevirt-plugin-ci' }}
     timeout-minutes: 120
@@ -278,6 +299,9 @@ jobs:
       PLUGIN_IMAGE: ${{ needs.build-kubevirt-plugin-image.outputs.kubevirt-plugin-image }}
       HEADLESS: 'true'
       RUN_FEATURE_TESTS: ${{ inputs.test_project == 'features' && 'true' || 'false' }}
+      # Both playwright/fixtures/ and cypress/fixtures/ have a matching
+      # layout, so the engine name doubles as the fixtures directory name.
+      TEST_ENGINE: ${{ inputs.test_engine || 'playwright' }}
 
     steps:
       # See the build-kubevirt-plugin-image job's Checkout step above --
@@ -303,7 +327,7 @@ jobs:
           yq e '
             .metadata.name = strenv(TEST_SECRET_NAME) |
             .metadata.namespace = strenv(TEST_NS)
-          ' playwright/fixtures/secret.yaml | oc apply -f -
+          ' "${TEST_ENGINE}/fixtures/secret.yaml" | oc apply -f -
 
       - name: Seed kubevirt-user-settings ConfigMap
         run: |
@@ -334,25 +358,41 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci --ignore-scripts --no-audit
-          npm run playwright-install
 
-      - name: Run Playwright gating tests
+          if [[ "${TEST_ENGINE}" == "cypress" ]]; then
+            # --ignore-scripts above skips Cypress's normal postinstall
+            # binary download, so fetch it explicitly.
+            npx cypress install
+          else
+            npm run playwright-install
+          fi
+
+      - name: Run gating tests
         env:
           BRIDGE_BASE_ADDRESS: ${{ steps.ci-env.outputs.bridge-base-address }}
+          TEST_PROJECT: ${{ inputs.test_project }}
         run: |
-          if [[ "${{ inputs.test_project }}" == "features" ]]; then
-            npm run test-playwright-headless -- --project=features
+          if [[ "${TEST_ENGINE}" == "cypress" ]]; then
+            if [[ "${TEST_PROJECT}" == "features" ]]; then
+              npm run test-cypress-headless -- --spec tests/tier1.cy.ts
+            else
+              npm run test-cypress-headless -- --spec tests/gating.cy.ts
+            fi
           else
-            npm run test-playwright-headless -- --project=gating
+            if [[ "${TEST_PROJECT}" == "features" ]]; then
+              npm run test-playwright-headless -- --project=features
+            else
+              npm run test-playwright-headless -- --project=gating
+            fi
           fi
 
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-results-${{ github.run_id }}
+          name: ${{ env.TEST_ENGINE }}-results-${{ github.run_id }}
           path: |
-            playwright/test-results/
+            ${{ env.TEST_ENGINE == 'cypress' && 'cypress/gui-test-screenshots/' || 'playwright/test-results/' }}
           retention-days: 7
           if-no-files-found: ignore
 

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -131,6 +131,7 @@ jobs:
       cluster_name: ${{ steps.resolve.outputs.cluster_name }}
       openshift_version: ${{ steps.resolve.outputs.openshift_version }}
       test_engine: ${{ steps.resolve.outputs.test_engine }}
+      branch_name: ${{ steps.resolve.outputs.branch_name }}
     steps:
       # persist-credentials: false -- this job only reads files to resolve
       # cluster config, it never pushes, so there's no reason to leave
@@ -400,6 +401,13 @@ jobs:
       cluster_name: ${{ needs.resolve-cluster-config.outputs.cluster_name }}
       infrastructure_type: ${{ inputs.infrastructure_type || 'ipi' }}
       openshift_version: ${{ needs.resolve-cluster-config.outputs.openshift_version }}
+      # The resolved base branch (main/release-4.X) for pull_request_target
+      # and /retest-e2e's forwarded base_ref; falls back to whatever ref
+      # this run itself is on for a plain workflow_dispatch with no PR
+      # context (e.g. a manual test dispatched from a feature branch) --
+      # both feed the "Hot cluster ready [...]" Slack notification further
+      # down the provisioning chain.
+      branch_name: ${{ needs.resolve-cluster-config.outputs.branch_name || github.ref_name }}
       # Single-line plain scalar (same well-precedented `${{ ... }}` pattern
       # used for run-name/other with: values throughout this file) rather
       # than a multi-line expression wrapped in a literal block scalar --

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -42,10 +42,11 @@ on:
         description: |
           E2E test engine to run. 'auto' detects from the base branch
           (release-4.22 and earlier use Cypress, everything else uses
-          Playwright) for pull_request_target; for a plain workflow_dispatch
-          (no base branch to detect from) 'auto' defaults to Playwright, so
-          override this explicitly when manually testing a Cypress-era
-          release branch.
+          Playwright) for pull_request_target and for workflow_dispatch
+          when base_ref is provided (e.g. /retest-e2e fallback); for a
+          plain workflow_dispatch with no base_ref, 'auto' defaults to
+          Playwright, so override this explicitly when manually testing a
+          Cypress-era release branch.
         required: false
         default: auto
         type: choice
@@ -60,6 +61,16 @@ on:
           re-validate merge-pool PRs after main advances (the Tide-equivalent
           staleness guard -- see CNV-92616). Leave empty for a normal manual
           dispatch.
+        required: false
+        default: ''
+        type: string
+      base_ref:
+        description: |
+          PR base branch to use for cluster/test_engine auto-selection on
+          workflow_dispatch (e.g. release-4.20). Forwarded by retest-e2e.yml's
+          /retest-e2e fallback so release-4.22-and-earlier PRs get Cypress
+          and a version-matched cluster instead of defaulting to Playwright
+          on kubevirt-plugin-ci. Leave empty for a plain manual dispatch.
         required: false
         default: ''
         type: string
@@ -103,14 +114,15 @@ env:
 
 jobs:
   # Resolves cluster_name/openshift_version/test_engine for this run.
-  # workflow_dispatch always uses its own inputs unchanged. Automatic
-  # pull_request_target runs against a release-4.X branch get a dedicated,
+  # Automatic pull_request_target runs (and workflow_dispatch retests that
+  # forward base_ref) against a release-4.X branch get a dedicated,
   # version-matched cluster (kubevirt-plugin-<major><minor>) instead of
   # silently colliding with main's kubevirt-plugin-ci cluster; any other
-  # base branch falls back to the same default as today. test_engine
-  # follows the same release-branch detection -- release-4.22 and earlier
-  # predate the Cypress → Playwright migration on main, so PRs targeting
-  # them run the Cypress suite that still lives on those branches instead.
+  # base branch, and plain workflow_dispatch without base_ref, falls back
+  # to the provided inputs / defaults. test_engine follows the same
+  # release-branch detection -- release-4.22 and earlier predate the
+  # Cypress → Playwright migration on main, so PRs targeting them run the
+  # Cypress suite that still lives on those branches instead.
   resolve-cluster-config:
     name: Resolve Cluster Config
     runs-on: ubuntu-latest
@@ -131,8 +143,10 @@ jobs:
       - name: Resolve cluster_name/openshift_version/test_engine for this branch
         id: resolve
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_REF: ${{ github.base_ref }}
+          # workflow_dispatch has no github.base_ref -- retest-e2e.yml
+          # forwards the PR's base via inputs.base_ref so auto-selection
+          # still works for release-branch /retest-e2e fallbacks.
+          BASE_REF: ${{ inputs.base_ref || github.base_ref }}
           INPUT_CLUSTER_NAME: ${{ inputs.cluster_name }}
           INPUT_OPENSHIFT_VERSION: ${{ inputs.openshift_version }}
           INPUT_TEST_ENGINE: ${{ inputs.test_engine }}

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -38,6 +38,21 @@ on:
         required: false
         default: '4.22_openshift'
         type: string
+      test_engine:
+        description: |
+          E2E test engine to run. 'auto' detects from the base branch
+          (release-4.22 and earlier use Cypress, everything else uses
+          Playwright) for pull_request_target; for a plain workflow_dispatch
+          (no base branch to detect from) 'auto' defaults to Playwright, so
+          override this explicitly when manually testing a Cypress-era
+          release branch.
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - playwright
+          - cypress
       pr_number:
         description: |
           PR number to retest merged with the current base branch tip,
@@ -48,6 +63,18 @@ on:
         required: false
         default: ''
         type: string
+      skip_pool_check:
+        description: |
+          Skip the lgtm+approved (no hold) merge-pool requirement for a
+          pr_number retest. Used by retest-e2e.yml's /retest-e2e fallback
+          dispatch, which retests on demand for any PR regardless of review
+          state -- unlike retest-stale-gating.yml's dispatch, which only
+          ever retests merge-pool PRs and always leaves this false so that
+          check keeps meaning what it says. mergeable/trusted are still
+          re-checked either way.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -75,12 +102,15 @@ env:
   BASE_DOMAIN: cnv-ui.com
 
 jobs:
-  # Resolves cluster_name/openshift_version for this run. workflow_dispatch
-  # always uses its own inputs unchanged. Automatic pull_request_target runs
-  # against a release-4.X branch get a dedicated, version-matched cluster
-  # (kubevirt-plugin-<major><minor>) instead of silently colliding with
-  # main's kubevirt-plugin-ci cluster; any other base branch falls back to
-  # the same default as today.
+  # Resolves cluster_name/openshift_version/test_engine for this run.
+  # workflow_dispatch always uses its own inputs unchanged. Automatic
+  # pull_request_target runs against a release-4.X branch get a dedicated,
+  # version-matched cluster (kubevirt-plugin-<major><minor>) instead of
+  # silently colliding with main's kubevirt-plugin-ci cluster; any other
+  # base branch falls back to the same default as today. test_engine
+  # follows the same release-branch detection -- release-4.22 and earlier
+  # predate the Cypress → Playwright migration on main, so PRs targeting
+  # them run the Cypress suite that still lives on those branches instead.
   resolve-cluster-config:
     name: Resolve Cluster Config
     runs-on: ubuntu-latest
@@ -88,17 +118,24 @@ jobs:
     outputs:
       cluster_name: ${{ steps.resolve.outputs.cluster_name }}
       openshift_version: ${{ steps.resolve.outputs.openshift_version }}
+      test_engine: ${{ steps.resolve.outputs.test_engine }}
     steps:
+      # persist-credentials: false -- this job only reads files to resolve
+      # cluster config, it never pushes, so there's no reason to leave
+      # GITHUB_TOKEN sitting in .git/config for the rest of the job.
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
-      - name: Resolve cluster_name/openshift_version for this branch
+      - name: Resolve cluster_name/openshift_version/test_engine for this branch
         id: resolve
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
           INPUT_CLUSTER_NAME: ${{ inputs.cluster_name }}
           INPUT_OPENSHIFT_VERSION: ${{ inputs.openshift_version }}
+          INPUT_TEST_ENGINE: ${{ inputs.test_engine }}
         run: ./ci-scripts/hot-cluster/resolve-cluster-config.sh >> "$GITHUB_OUTPUT"
 
   # Resolves the PR being retested when this run was dispatched with
@@ -168,11 +205,13 @@ jobs:
         # workflow_dispatch input.
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
+          SKIP_POOL_CHECK: ${{ inputs.skip_pool_check }}
         with:
           script: |
             const fs = require('fs');
             const { isMergePoolPr } = require('./ci-scripts/hot-cluster/is-merge-pool-pr.cjs');
             const prNumber = Number(process.env.PR_NUMBER);
+            const skipPoolCheck = process.env.SKIP_POOL_CHECK === 'true';
 
             // mergeable/mergeable_state are computed asynchronously by
             // GitHub and can be null right after main moves -- retry
@@ -203,8 +242,8 @@ jobs:
             const hasOkToTest = pr.labels.some((label) => label.name === 'ok-to-test');
             const trusted = ownedByAuthor || sameRepo || hasOkToTest;
 
-            const stillInPool = isMergePoolPr(pr.labels);
-            core.info(`PR #${prNumber}: head=${pr.head.sha}, mergeable=${pr.mergeable}, mergeable_state=${pr.mergeable_state}, still_in_pool=${stillInPool}`);
+            const stillInPool = skipPoolCheck || isMergePoolPr(pr.labels);
+            core.info(`PR #${prNumber}: head=${pr.head.sha}, mergeable=${pr.mergeable}, mergeable_state=${pr.mergeable_state}, still_in_pool=${stillInPool}${skipPoolCheck ? ' (pool check skipped)' : ''}`);
             core.info(`PR #${prNumber}: author=${author}, ownedByAuthor=${ownedByAuthor}, sameRepo=${sameRepo}, hasOkToTest=${hasOkToTest}, trusted=${trusted}`);
 
             core.setOutput('head_sha', pr.head.sha);
@@ -542,6 +581,7 @@ jobs:
     uses: ./.github/workflows/hot-cluster-e2e-run.yml
     with:
       test_project: ${{ inputs.test_project || 'gating' }}
+      test_engine: ${{ needs.resolve-cluster-config.outputs.test_engine }}
       runner_label: ${{ inputs.runner_label || needs.resolve-cluster-config.outputs.cluster_name }}
       cluster_name: ${{ needs.resolve-cluster-config.outputs.cluster_name }}
       # Merge the PR with the current base tip instead of testing its head

--- a/.github/workflows/ibmc-cluster-auto-teardown.yml
+++ b/.github/workflows/ibmc-cluster-auto-teardown.yml
@@ -151,17 +151,124 @@ jobs:
             echo "Release-branch cluster: 120 minutes (2h)"
           fi
 
+      # Listing self-hosted runners requires admin access to the repo, which
+      # GITHUB_TOKEN can never have regardless of the `permissions:` block
+      # above (there is no "administration" key for GITHUB_TOKEN) -- calling
+      # listSelfHostedRunnersForRepo with it always 403s. Reuse the existing
+      # kubevirt-plugin-arc GitHub App (see ibmc-cluster-teardown.yml) to mint
+      # a short-lived, read-only admin-scoped token instead.
+      - name: Generate ARC app token for runner-busy check
+        id: arc-app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.ARC_GITHUB_APP_ID }}
+          private-key: ${{ secrets.ARC_GITHUB_APP_PRIVATE_KEY }}
+          permission-administration: read
+
       - name: Check CI jobs for this cluster
         id: check_ci
         uses: actions/github-script@v9
         env:
           INCLUDE_WORKFLOWS: '[".github/workflows/hot-cluster-e2e.yml", ".github/workflows/hot-cluster-e2e-run.yml", ".github/workflows/ibmc-cluster-setup.yml"]'
           CLUSTER_NAME: ${{ matrix.cluster_name }}
+          RUNNER_ADMIN_TOKEN: ${{ steps.arc-app-token.outputs.token }}
         with:
           script: |
             const INCLUDE_WORKFLOWS = JSON.parse(process.env.INCLUDE_WORKFLOWS);
             const clusterName = process.env.CLUSTER_NAME;
             const clusterTag = `[${clusterName}]`;
+
+            // Authoritative, title-independent "is this cluster in use right
+            // now" signal: each cluster's ARC runner scale set Helm release
+            // is named after cluster_name (RUNNER_SCALE_SET_NAME in
+            // install-runner-scale-set.sh), and runs-on: <cluster_name>
+            // routes jobs to it -- so a registered self-hosted runner
+            // carrying that name as a label, with busy: true, means a job
+            // is actively executing against this cluster this very moment.
+            // Unlike the run-title matching below (which can only prove
+            // "was active as of its last recorded timestamp"), this can't
+            // be fooled by a run that hasn't reported/updated its title yet,
+            // is between steps, or any other title-matching edge case --
+            // it's checked first and short-circuits the rest of this step
+            // when true.
+            //
+            // This listing endpoint requires an admin-scoped token (the
+            // default GITHUB_TOKEN is rejected outright), so a dedicated
+            // Octokit client authenticated with the ARC app token from the
+            // previous step is used here instead of the ambient `github`
+            // client.
+            let runnerBusy = false;
+            try {
+              if (!process.env.RUNNER_ADMIN_TOKEN) {
+                throw new Error('ARC app token unavailable (see previous step)');
+              }
+              const runnerOctokit = require('@actions/github').getOctokit(process.env.RUNNER_ADMIN_TOKEN);
+              const runners = await runnerOctokit.paginate(runnerOctokit.rest.actions.listSelfHostedRunnersForRepo, {
+                ...context.repo,
+                per_page: 100,
+              });
+              runnerBusy = runners.some(
+                r => r.busy && r.labels?.some(l => l.name === clusterName)
+              );
+              core.info(`Runner pool for '${clusterName}': ${runnerBusy ? 'busy' : 'idle'} (${runners.length} total runners checked).`);
+            } catch (err) {
+              core.warning(`Failed to query self-hosted runners: ${err.message}`);
+            }
+
+            if (runnerBusy) {
+              core.setOutput('active_jobs', 'true');
+              core.setOutput('last_run_time', '');
+              core.summary.addList([
+                `Cluster: ${clusterName}`,
+                `Runner pool busy: true (skipping teardown -- job running right now)`,
+              ]);
+              await core.summary.write();
+              return;
+            }
+
+            // hot-cluster-e2e.yml's run-name falls back to the raw PR base
+            // branch (github.base_ref, e.g. "main"/"release-4.20") for
+            // automatic pull_request_target runs, since inputs.cluster_name
+            // is unset for that event -- it never shows the actually-
+            // resolved cluster name that resolve-cluster-config.sh computes.
+            // A naive substring match against clusterTag therefore silently
+            // never matches these runs (the overwhelming majority of real
+            // usage), making this checker blind to recent activity and
+            // causing premature teardown of clusters that are still warm
+            // (see the incident this comment was added for: a cluster
+            // finished a real gating run ~1h earlier but was reported as
+            // idle for 662 minutes). Re-derive the resolved cluster name
+            // from the bracketed token using the same release-branch
+            // mapping rule instead of trusting the token itself. The other
+            // two workflows never have this problem -- hot-cluster-e2e-
+            // run.yml and ibmc-cluster-setup.yml's run-names only ever use
+            // an explicit or defaulted cluster_name/runner_label input, no
+            // base_ref fallback -- so they keep the plain substring match.
+            function runMatchesCluster(run, workflow) {
+              const title = run.display_title || '';
+              if (workflow === '.github/workflows/hot-cluster-e2e.yml') {
+                const bracketed = title.match(/^Hot Cluster E2E \[([^\]]+)\]/);
+                if (!bracketed) return false;
+                const token = bracketed[1];
+                // The bracketed token is inputs.cluster_name || github.base_ref
+                // || 'kubevirt-plugin-ci' (see hot-cluster-e2e.yml's run-name).
+                // An explicit cluster_name input is already the resolved
+                // cluster name -- resolve-cluster-config.sh only remaps
+                // release-X.Y base_ref tokens (automatic pull_request_target
+                // runs with no cluster_name input); anything else falls back
+                // to the default cluster.
+                let resolved;
+                if (token.startsWith('kubevirt-plugin-')) {
+                  resolved = token;
+                } else {
+                  const release = token.match(/^release-(\d+)\.(\d+)$/);
+                  resolved = release ? `kubevirt-plugin-${release[1]}${release[2]}` : 'kubevirt-plugin-ci';
+                }
+                return resolved === clusterName;
+              }
+              return title.includes(clusterTag);
+            }
 
             let inProgress = 0;
             let queued = 0;
@@ -190,9 +297,7 @@ jobs:
                   // outside the first page.
                   const runs = await github.paginate(github.rest.actions.listWorkflowRuns, params);
 
-                  const matching = runs.filter(
-                    r => r.display_title && r.display_title.includes(clusterTag)
-                  );
+                  const matching = runs.filter(r => runMatchesCluster(r, workflow));
 
                   if (status === 'in_progress') inProgress += matching.length;
                   if (status === 'queued') queued += matching.length;

--- a/.github/workflows/ibmc-cluster-setup.yml
+++ b/.github/workflows/ibmc-cluster-setup.yml
@@ -53,6 +53,14 @@ on:
         required: false
         default: 'stable'
         type: string
+      branch_name:
+        description: |
+          Branch identity to report in the "Hot cluster ready" Slack
+          notification. Leave empty for a direct manual dispatch -- falls
+          back to github.ref_name (the branch this run itself is on).
+        required: false
+        default: ''
+        type: string
   workflow_call:
     inputs:
       infrastructure_type:
@@ -99,6 +107,14 @@ on:
         description: 'CNV OLM subscription channel (e.g. stable, stable-4.17)'
         required: false
         default: 'stable'
+        type: string
+      branch_name:
+        description: |
+          Branch identity to report in the "Hot cluster ready" Slack
+          notification (main/release-4.X, or a plain branch name). Falls
+          back to github.ref_name when left empty.
+        required: false
+        default: ''
         type: string
     secrets:
       IC_KEY:
@@ -663,12 +679,15 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           ADMIN_PASSWORD: ${{ secrets.CLUSTER_ADMIN_PASSWORD }}
           INSTALL_DIR: ${{ runner.temp }}/ipi-install
-          # github.head_ref is only set for pull_request*/pull_request_target
-          # events (the PR's source branch); github.ref_name would otherwise
-          # resolve to the *base* branch for pull_request_target (e.g. this
-          # workflow reached via hot-cluster-e2e.yml's auto-provision chain),
-          # misreporting the branch in the Slack message below.
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          # inputs.branch_name is threaded down from hot-cluster-e2e.yml's
+          # resolve-cluster-config job (main/release-4.X for the
+          # auto-provision chain, or that job's own ref_name fallback for a
+          # plain workflow_dispatch with no PR context) -- see its
+          # branch_name output for the full resolution logic. Falls back to
+          # this run's own ref_name for a direct dispatch of just this
+          # workflow (skipping the chain above entirely, so inputs.branch_name
+          # is left at its default empty string).
+          BRANCH_NAME: ${{ inputs.branch_name || github.ref_name }}
         run: |
           CONSOLE_URL=$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}' 2>/dev/null || echo "unknown")
 

--- a/.github/workflows/retest-e2e.yml
+++ b/.github/workflows/retest-e2e.yml
@@ -38,6 +38,11 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
+          # app-id is deprecated in favor of client-id (the action now warns
+          # about it at runtime), but actionlint pins its bundled action
+          # metadata to v1.7.12 here, which predates that input -- switching
+          # would fail the actionlint CI check over a harmless warning. Revisit
+          # once actionlint's metadata (or this repo's pinned version) catches up.
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
@@ -104,37 +109,79 @@ jobs:
 
               core.info(`/retest-e2e requested by ${author} on PR #${prNumber} (HEAD: ${headSha})`);
 
-              const runs = await github.rest.actions.listWorkflowRuns({
+              // A flat per_page: 10 (the original approach here) only looks
+              // at the 10 most recent pull_request_target runs of
+              // hot-cluster-e2e.yml *repo-wide* -- on an active repo, other
+              // PRs' pushes/labels routinely push this PR's own run out of
+              // that window within the hour (confirmed on PR #4143: its run
+              // had fallen to position 12 by the time /retest-e2e ran).
+              // Paginate further, bounded by a recent lookback window so
+              // this stays cheap -- if the PR's own run is older than that,
+              // the fallback dispatch below still guarantees correctness.
+              const lookbackDate = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
                 ...context.repo,
                 workflow_id: 'hot-cluster-e2e.yml',
                 event: 'pull_request_target',
-                per_page: 10,
+                created: `>=${lookbackDate}`,
+                per_page: 100,
               });
 
-              const prRun = runs.data.workflow_runs.find(r => {
+              const prRun = runs.find(r => {
                 const prMatch = r.pull_requests?.some(p => p.number === prNumber);
                 const shaMatch = r.head_sha === headSha;
-                return prMatch || shaMatch;
+                // Branch name alone isn't unique across forks -- a same-named
+                // branch in a different fork must not be mistaken for this
+                // PR's run, so also require the run's head repo to match.
+                const branchMatch = r.head_branch === pr.data.head.ref &&
+                  r.head_repository?.id === pr.data.head.repo?.id;
+                return prMatch || shaMatch || branchMatch;
               });
 
-              if (!prRun) {
-                const msg = `No Hot Cluster E2E workflow run found for PR #${prNumber}. ` +
-                  `Push a commit to trigger the initial run.`;
-                core.warning(msg);
-                await react('confused');
+              if (prRun) {
+                core.info(`Re-running workflow run ${prRun.id} (attempt ${prRun.run_attempt})...`);
+
+                await react('rocket');
+
+                await github.rest.actions.reRunWorkflow({
+                  ...context.repo,
+                  run_id: prRun.id,
+                });
+
+                core.info(`Re-run triggered: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${prRun.id}`);
                 return;
               }
 
-              core.info(`Re-running workflow run ${prRun.id} (attempt ${prRun.run_attempt})...`);
-
+              // No existing run to re-run within the lookback window --
+              // rather than silently giving up (the original behavior:
+              // just a job log warning and a best-effort reaction, which
+              // itself silently fails since this bot lacks issues: write --
+              // see react() above), dispatch a fresh run instead. This is
+              // the same workflow_dispatch + pr_number mechanism
+              // retest-stale-gating.yml already uses for merge-pool PRs,
+              // which already provisions the cluster if it's down or queues
+              // behind an in-progress provision (ibmc-cluster-setup.yml's
+              // hot-cluster-provision-<cluster_name> concurrency group) --
+              // no new queueing logic needed here. skip_pool_check: true
+              // because /retest-e2e must work for any PR on demand,
+              // regardless of lgtm/approved review state -- unlike
+              // retest-stale-gating.yml's dispatch, which intentionally
+              // only retests merge-pool PRs.
+              core.warning(`No recent Hot Cluster E2E workflow run found for PR #${prNumber}. Dispatching a fresh run instead.`);
               await react('rocket');
 
-              await github.rest.actions.reRunWorkflow({
+              await github.rest.actions.createWorkflowDispatch({
                 ...context.repo,
-                run_id: prRun.id,
+                workflow_id: 'hot-cluster-e2e.yml',
+                ref: 'main',
+                inputs: {
+                  pr_number: String(prNumber),
+                  skip_pool_check: 'true',
+                },
               });
 
-              core.info(`Re-run triggered: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${prRun.id}`);
+              core.info(`Fresh run dispatched for PR #${prNumber}.`);
+              core.setOutput('fallback_dispatched', 'true');
             } catch (err) {
               // Distinct from the expected "not authorized" rejection above:
               // this is an unforeseen failure (bad bot token, API outage,
@@ -144,6 +191,27 @@ jobs:
               core.setOutput('error_message', err.message || String(err));
               core.setFailed(`Unexpected error while processing /retest-e2e: ${err.message || err}`);
             }
+
+      # Reactions on this bot's token silently fail (see react() above), so
+      # a fallback dispatch needs its own visible confirmation on the PR --
+      # otherwise the author sees no difference between "a fresh run was
+      # just dispatched" and "nothing happened at all".
+      - name: Report fallback retest dispatch on the PR
+        if: steps.retest.outputs.fallback_dispatched == 'true'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: [
+                '🚀 No recent Hot Cluster E2E run was found to re-run, so `/retest-e2e` dispatched a fresh one instead ' +
+                  '(this also re-provisions the cluster automatically if it was torn down).',
+                '',
+                `See the [Actions tab](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/hot-cluster-e2e.yml) for progress.`,
+              ].join('\n'),
+            });
 
       - name: Report unexpected retest failure on the PR
         if: steps.retest.outputs.unexpected_error == 'true'

--- a/.github/workflows/retest-e2e.yml
+++ b/.github/workflows/retest-e2e.yml
@@ -166,8 +166,12 @@ jobs:
               // because /retest-e2e must work for any PR on demand,
               // regardless of lgtm/approved review state -- unlike
               // retest-stale-gating.yml's dispatch, which intentionally
-              // only retests merge-pool PRs.
-              core.warning(`No recent Hot Cluster E2E workflow run found for PR #${prNumber}. Dispatching a fresh run instead.`);
+              // only retests merge-pool PRs. base_ref is required so
+              // resolve-cluster-config can auto-select Cypress + a
+              // version-matched cluster for release-4.22-and-earlier PRs
+              // (workflow_dispatch has no github.base_ref of its own).
+              const baseRef = pr.data.base.ref;
+              core.warning(`No recent Hot Cluster E2E workflow run found for PR #${prNumber} (base: ${baseRef}). Dispatching a fresh run instead.`);
               await react('rocket');
 
               await github.rest.actions.createWorkflowDispatch({
@@ -176,11 +180,12 @@ jobs:
                 ref: 'main',
                 inputs: {
                   pr_number: String(prNumber),
+                  base_ref: baseRef,
                   skip_pool_check: 'true',
                 },
               });
 
-              core.info(`Fresh run dispatched for PR #${prNumber}.`);
+              core.info(`Fresh run dispatched for PR #${prNumber} (base_ref=${baseRef}).`);
               core.setOutput('fallback_dispatched', 'true');
             } catch (err) {
               // Distinct from the expected "not authorized" rejection above:

--- a/ci-scripts/hot-cluster/arc/arc-runner-rbac.yaml
+++ b/ci-scripts/hot-cluster/arc/arc-runner-rbac.yaml
@@ -54,6 +54,12 @@ rules:
     resources: ['configmaps']
     verbs: ['get', 'list', 'create', 'patch']
 
+  # --- Cypress settings tests: cy.exec('oc get hyperconverged ...') reads
+  # HCO's spec directly (e.g. liveMigrationConfig, higherWorkloadDensity) ---
+  - apiGroups: ['hco.kubevirt.io']
+    resources: ['hyperconvergeds']
+    verbs: ['get', 'list']
+
   # --- check-runner job: HCO / operator version logging ---
   - apiGroups: ['operators.coreos.com']
     resources: ['clusterserviceversions']

--- a/ci-scripts/hot-cluster/resolve-cluster-config.sh
+++ b/ci-scripts/hot-cluster/resolve-cluster-config.sh
@@ -4,11 +4,13 @@ set -euo pipefail
 # Emits cluster_name=..., openshift_version=..., and test_engine=... for
 # GITHUB_OUTPUT.
 #
-# Automatic pull_request_target runs against a release-<major>.<minor>
-# branch get a dedicated, version-matched cluster (kubevirt-plugin-<major><minor>)
-# instead of silently colliding with main's kubevirt-plugin-ci cluster. Any
-# other base branch, and every workflow_dispatch run, falls back to the
-# provided input (or the repo's long-standing default).
+# Runs against a release-<major>.<minor> base branch get a dedicated,
+# version-matched cluster (kubevirt-plugin-<major><minor>) instead of
+# silently colliding with main's kubevirt-plugin-ci cluster. BASE_REF comes
+# from github.base_ref on pull_request_target, or from the workflow_dispatch
+# base_ref input (forwarded by /retest-e2e for PR retests). Any other base
+# branch, and every workflow_dispatch without a release base_ref, falls
+# back to the provided input (or the repo's long-standing default).
 #
 # test_engine follows the same release-branch detection: release-4.22 and
 # earlier predate the Cypress → Playwright migration on main (see
@@ -17,8 +19,8 @@ set -euo pipefail
 # Playwright-only.
 #
 # Env:
-#   EVENT_NAME              - github.event_name (e.g. pull_request_target, workflow_dispatch)
-#   BASE_REF                - github.base_ref (PR target branch, e.g. release-4.20)
+#   BASE_REF                - PR target branch (e.g. release-4.20), from
+#                             github.base_ref or workflow_dispatch inputs.base_ref
 #   INPUT_CLUSTER_NAME       - workflow_dispatch inputs.cluster_name, if set
 #   INPUT_OPENSHIFT_VERSION  - workflow_dispatch inputs.openshift_version, if set
 #   INPUT_TEST_ENGINE        - workflow_dispatch inputs.test_engine ('auto'/'playwright'/'cypress'), if set
@@ -35,13 +37,12 @@ DEFAULT_TEST_ENGINE="playwright"
 LAST_CYPRESS_MAJOR=4
 LAST_CYPRESS_MINOR=22
 
-EVENT_NAME="${EVENT_NAME:-}"
 BASE_REF="${BASE_REF:-}"
 INPUT_CLUSTER_NAME="${INPUT_CLUSTER_NAME:-}"
 INPUT_OPENSHIFT_VERSION="${INPUT_OPENSHIFT_VERSION:-}"
 INPUT_TEST_ENGINE="${INPUT_TEST_ENGINE:-}"
 
-if [[ "${EVENT_NAME}" == "pull_request_target" && "${BASE_REF}" =~ ^release-([0-9]+)\.([0-9]+)$ ]]; then
+if [[ "${BASE_REF}" =~ ^release-([0-9]+)\.([0-9]+)$ ]]; then
   MAJOR="${BASH_REMATCH[1]}"
   MINOR="${BASH_REMATCH[2]}"
   CLUSTER_NAME="kubevirt-plugin-${MAJOR}${MINOR}"
@@ -61,8 +62,8 @@ else
   TEST_ENGINE="${DEFAULT_TEST_ENGINE}"
 fi
 
-# An explicit, non-'auto' workflow_dispatch override always wins -- there's
-# no reliable base_ref to detect from outside pull_request_target.
+# An explicit, non-'auto' workflow_dispatch override always wins over
+# base_ref auto-detection.
 if [[ -n "${INPUT_TEST_ENGINE}" && "${INPUT_TEST_ENGINE}" != "auto" ]]; then
   TEST_ENGINE="${INPUT_TEST_ENGINE}"
   echo "Overriding test engine from input: '${TEST_ENGINE}'" >&2

--- a/ci-scripts/hot-cluster/resolve-cluster-config.sh
+++ b/ci-scripts/hot-cluster/resolve-cluster-config.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Emits cluster_name=..., openshift_version=..., and test_engine=... for
-# GITHUB_OUTPUT.
+# Emits cluster_name=..., openshift_version=..., test_engine=..., and
+# branch_name=... for GITHUB_OUTPUT.
 #
 # Runs against a release-<major>.<minor> base branch get a dedicated,
 # version-matched cluster (kubevirt-plugin-<major><minor>) instead of
@@ -72,3 +72,9 @@ fi
 echo "cluster_name=${CLUSTER_NAME}"
 echo "openshift_version=${OPENSHIFT_VERSION}"
 echo "test_engine=${TEST_ENGINE}"
+# Raw resolved base branch (e.g. "main", "release-4.20"), or empty when
+# there's none (plain workflow_dispatch with no PR context) -- callers
+# combine this with a ref_name fallback for display purposes (e.g. the
+# "Hot cluster ready [...]" Slack notification), since resolving that
+# fallback needs the github context, not available inside this script.
+echo "branch_name=${BASE_REF}"

--- a/ci-scripts/hot-cluster/resolve-cluster-config.sh
+++ b/ci-scripts/hot-cluster/resolve-cluster-config.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Emits cluster_name=... and openshift_version=... for GITHUB_OUTPUT.
+# Emits cluster_name=..., openshift_version=..., and test_engine=... for
+# GITHUB_OUTPUT.
 #
 # Automatic pull_request_target runs against a release-<major>.<minor>
 # branch get a dedicated, version-matched cluster (kubevirt-plugin-<major><minor>)
@@ -9,22 +10,36 @@ set -euo pipefail
 # other base branch, and every workflow_dispatch run, falls back to the
 # provided input (or the repo's long-standing default).
 #
+# test_engine follows the same release-branch detection: release-4.22 and
+# earlier predate the Cypress → Playwright migration on main (see
+# 9d7fe93c6), so they still carry a cypress/ suite instead of playwright/.
+# Everything else (main, any future release-4.23+, non-release bases) is
+# Playwright-only.
+#
 # Env:
 #   EVENT_NAME              - github.event_name (e.g. pull_request_target, workflow_dispatch)
 #   BASE_REF                - github.base_ref (PR target branch, e.g. release-4.20)
 #   INPUT_CLUSTER_NAME       - workflow_dispatch inputs.cluster_name, if set
 #   INPUT_OPENSHIFT_VERSION  - workflow_dispatch inputs.openshift_version, if set
+#   INPUT_TEST_ENGINE        - workflow_dispatch inputs.test_engine ('auto'/'playwright'/'cypress'), if set
 #
 # Usage (from a workflow step):
 #   ./ci-scripts/hot-cluster/resolve-cluster-config.sh >> "$GITHUB_OUTPUT"
 
 DEFAULT_CLUSTER_NAME="kubevirt-plugin-ci"
 DEFAULT_OPENSHIFT_VERSION="4.22_openshift"
+DEFAULT_TEST_ENGINE="playwright"
+
+# Last release branch still on the pre-migration Cypress suite. Any branch
+# release-<major>.<minor> with major.minor <= this threshold uses Cypress.
+LAST_CYPRESS_MAJOR=4
+LAST_CYPRESS_MINOR=22
 
 EVENT_NAME="${EVENT_NAME:-}"
 BASE_REF="${BASE_REF:-}"
 INPUT_CLUSTER_NAME="${INPUT_CLUSTER_NAME:-}"
 INPUT_OPENSHIFT_VERSION="${INPUT_OPENSHIFT_VERSION:-}"
+INPUT_TEST_ENGINE="${INPUT_TEST_ENGINE:-}"
 
 if [[ "${EVENT_NAME}" == "pull_request_target" && "${BASE_REF}" =~ ^release-([0-9]+)\.([0-9]+)$ ]]; then
   MAJOR="${BASH_REMATCH[1]}"
@@ -32,11 +47,27 @@ if [[ "${EVENT_NAME}" == "pull_request_target" && "${BASE_REF}" =~ ^release-([0-
   CLUSTER_NAME="kubevirt-plugin-${MAJOR}${MINOR}"
   OPENSHIFT_VERSION="${MAJOR}.${MINOR}_openshift"
   echo "Base branch '${BASE_REF}' is a release branch → cluster '${CLUSTER_NAME}' (${OPENSHIFT_VERSION})" >&2
+
+  if (( MAJOR * 1000 + MINOR <= LAST_CYPRESS_MAJOR * 1000 + LAST_CYPRESS_MINOR )); then
+    TEST_ENGINE="cypress"
+  else
+    TEST_ENGINE="playwright"
+  fi
+  echo "Base branch '${BASE_REF}' → test engine '${TEST_ENGINE}'" >&2
 else
   CLUSTER_NAME="${INPUT_CLUSTER_NAME:-${DEFAULT_CLUSTER_NAME}}"
   OPENSHIFT_VERSION="${INPUT_OPENSHIFT_VERSION:-${DEFAULT_OPENSHIFT_VERSION}}"
   echo "Using default/workflow_dispatch cluster config: '${CLUSTER_NAME}' (${OPENSHIFT_VERSION})" >&2
+  TEST_ENGINE="${DEFAULT_TEST_ENGINE}"
+fi
+
+# An explicit, non-'auto' workflow_dispatch override always wins -- there's
+# no reliable base_ref to detect from outside pull_request_target.
+if [[ -n "${INPUT_TEST_ENGINE}" && "${INPUT_TEST_ENGINE}" != "auto" ]]; then
+  TEST_ENGINE="${INPUT_TEST_ENGINE}"
+  echo "Overriding test engine from input: '${TEST_ENGINE}'" >&2
 fi
 
 echo "cluster_name=${CLUSTER_NAME}"
 echo "openshift_version=${OPENSHIFT_VERSION}"
+echo "test_engine=${TEST_ENGINE}"


### PR DESCRIPTION
## 📝 Description

The hot-cluster E2E pipeline (`hot-cluster-e2e.yml` / `hot-cluster-e2e-run.yml`) only exists on main, but since `pull_request_target` always resolves the workflow file from the default branch, it already runs against PRs targeting release branches too. It currently assumes the checked-out code has a Playwright suite (`playwright/`), which is only true on main. 

`release-4.22` and earlier branches still carry the pre-migration Cypress suite (`cypress/`,` test-cypress-headless`) and have no Playwright tests, so hot-cluster E2E effectively cannot run gating tests for PRs against those branches today.

## 🔗 Links

Jira ticket: [CNV-92679](https://redhat.atlassian.net/browse/CNV-92679)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for hot-cluster E2E gating tests to run with either Playwright or Cypress, selectable via a `test_engine` option (defaulting to Playwright) and with updated `test_project` labeling.
  * Extended hot-cluster E2E and retest workflows with `test_engine`, `base_ref`, and `skip_pool_check` inputs for more flexible dispatch behavior.

* **Improvements**
  * Enhanced retest run discovery to match prior runs more reliably (by PR/head SHA or branch and repo) and added visible reporting when a fresh dispatch is triggered.
  * Improved teardown activity detection and workflow/run matching using refined cluster/run correlation logic and busy-runner checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->