### PR TITLE
CNV-92681: Fix stale cluster-scoped test cleanup and CNV channel version mismatch on hot-cluster E2E

### DIFF
--- a/.github/workflows/hot-cluster-check.yml
+++ b/.github/workflows/hot-cluster-check.yml
@@ -38,6 +38,15 @@ on:
         type: string
         required: false
         default: ''
+      cnv_channel:
+        description: |
+          CNV OLM subscription channel to install if provisioning happens.
+          Defaults to the catalog's unversioned 'stable' channel
+          (redhat-operators has no stable-4.X for kubevirt-hyperconverged).
+          Forwarded as-is to ibmc-cluster-setup.yml.
+        type: string
+        required: false
+        default: 'stable'
       worker_flavor:
         description: Worker node flavor
         type: string
@@ -126,6 +135,7 @@ jobs:
       zone: ${{ inputs.zone }}
       openshift_version: ${{ inputs.openshift_version }}
       branch_name: ${{ inputs.branch_name }}
+      cnv_channel: ${{ inputs.cnv_channel }}
       worker_flavor: ${{ inputs.worker_flavor }}
       worker_count: ${{ inputs.worker_count }}
       # kvm_emulation is declared as a string here (matching workflow_call's

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -54,6 +54,14 @@ on:
           - auto
           - playwright
           - cypress
+      cnv_channel:
+        description: |
+          Explicit CNV OLM subscription channel override for provisioning.
+          Leave empty to use the resolver default (catalog unversioned
+          'stable'). There is no automatic per-branch channel selection.
+        required: false
+        default: ''
+        type: string
       pr_number:
         description: |
           PR number to retest merged with the current base branch tip,
@@ -132,6 +140,7 @@ jobs:
       openshift_version: ${{ steps.resolve.outputs.openshift_version }}
       test_engine: ${{ steps.resolve.outputs.test_engine }}
       branch_name: ${{ steps.resolve.outputs.branch_name }}
+      cnv_channel: ${{ steps.resolve.outputs.cnv_channel }}
     steps:
       # persist-credentials: false -- this job only reads files to resolve
       # cluster config, it never pushes, so there's no reason to leave
@@ -151,6 +160,7 @@ jobs:
           INPUT_CLUSTER_NAME: ${{ inputs.cluster_name }}
           INPUT_OPENSHIFT_VERSION: ${{ inputs.openshift_version }}
           INPUT_TEST_ENGINE: ${{ inputs.test_engine }}
+          INPUT_CNV_CHANNEL: ${{ inputs.cnv_channel }}
         run: ./ci-scripts/hot-cluster/resolve-cluster-config.sh >> "$GITHUB_OUTPUT"
 
   # Resolves the PR being retested when this run was dispatched with
@@ -401,6 +411,11 @@ jobs:
       cluster_name: ${{ needs.resolve-cluster-config.outputs.cluster_name }}
       infrastructure_type: ${{ inputs.infrastructure_type || 'ipi' }}
       openshift_version: ${{ needs.resolve-cluster-config.outputs.openshift_version }}
+      # Resolver defaults to the catalog's unversioned 'stable' channel
+      # (redhat-operators has no stable-4.X for kubevirt-hyperconverged).
+      # Optional workflow_dispatch cnv_channel overrides that default.
+      # See resolve-cluster-config.sh for the full rationale.
+      cnv_channel: ${{ needs.resolve-cluster-config.outputs.cnv_channel }}
       # The resolved base branch (main/release-4.X) for pull_request_target
       # and /retest-e2e's forwarded base_ref; falls back to whatever ref
       # this run itself is on for a plain workflow_dispatch with no PR

--- a/ci-scripts/hot-cluster/arc/arc-runner-rbac.yaml
+++ b/ci-scripts/hot-cluster/arc/arc-runner-rbac.yaml
@@ -60,6 +60,20 @@ rules:
     resources: ['hyperconvergeds']
     verbs: ['get', 'list']
 
+  # --- test-cleanup.sh: delete cluster-scoped test leftovers created under
+  # a fixed "example" name by the Cypress suite's YAML-creation tests.
+  # ci-env-test-runner (bound per-run via a namespaced RoleBinding, see
+  # helm/ci-env-controller/templates/clusterrole-test-runner.yaml) only
+  # covers the namespaced virtualmachineinstancetypes/virtualmachine
+  # preferences kinds -- cluster-scoped resources need a real
+  # ClusterRoleBinding, which only this role has. ---
+  - apiGroups: ['instancetype.kubevirt.io']
+    resources: ['virtualmachineclusterinstancetypes', 'virtualmachineclusterpreferences']
+    verbs: ['get', 'list', 'delete']
+  - apiGroups: ['migrations.kubevirt.io']
+    resources: ['migrationpolicies']
+    verbs: ['get', 'list', 'delete']
+
   # --- check-runner job: HCO / operator version logging ---
   - apiGroups: ['operators.coreos.com']
     resources: ['clusterserviceversions']

--- a/ci-scripts/hot-cluster/resolve-cluster-config.sh
+++ b/ci-scripts/hot-cluster/resolve-cluster-config.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Emits cluster_name=..., openshift_version=..., test_engine=..., and
-# branch_name=... for GITHUB_OUTPUT.
+# Emits cluster_name=..., openshift_version=..., test_engine=...,
+# branch_name=..., and cnv_channel=... for GITHUB_OUTPUT.
 #
 # Runs against a release-<major>.<minor> base branch get a dedicated,
 # version-matched cluster (kubevirt-plugin-<major><minor>) instead of
@@ -18,12 +18,25 @@ set -euo pipefail
 # Everything else (main, any future release-4.23+, non-release bases) is
 # Playwright-only.
 #
+# cnv_channel always resolves to the catalog's real channel, 'stable' --
+# the redhat-operators catalog for kubevirt-hyperconverged only ever
+# exposes a single unversioned 'stable' channel (per Red Hat's own install
+# docs); there is no 'stable-4.X' per-version channel. A prior version of
+# this script constructed one anyway, which created a Subscription OLM
+# could never resolve an InstallPlan for (confirmed live: cluster
+# provisioning hung for 10+ minutes then failed outright). Actually
+# version-pinning old CNV releases would need startingCSV + Manual
+# approval on the Subscription, not a differently-named channel -- out of
+# scope here; INPUT_CNV_CHANNEL below remains available as an explicit
+# override for anyone who wants to try that separately.
+#
 # Env:
 #   BASE_REF                - PR target branch (e.g. release-4.20), from
 #                             github.base_ref or workflow_dispatch inputs.base_ref
 #   INPUT_CLUSTER_NAME       - workflow_dispatch inputs.cluster_name, if set
 #   INPUT_OPENSHIFT_VERSION  - workflow_dispatch inputs.openshift_version, if set
 #   INPUT_TEST_ENGINE        - workflow_dispatch inputs.test_engine ('auto'/'playwright'/'cypress'), if set
+#   INPUT_CNV_CHANNEL        - workflow_dispatch inputs.cnv_channel, if set
 #
 # Usage (from a workflow step):
 #   ./ci-scripts/hot-cluster/resolve-cluster-config.sh >> "$GITHUB_OUTPUT"
@@ -31,6 +44,7 @@ set -euo pipefail
 DEFAULT_CLUSTER_NAME="kubevirt-plugin-ci"
 DEFAULT_OPENSHIFT_VERSION="4.22_openshift"
 DEFAULT_TEST_ENGINE="playwright"
+DEFAULT_CNV_CHANNEL="stable"
 
 # Last release branch still on the pre-migration Cypress suite. Any branch
 # release-<major>.<minor> with major.minor <= this threshold uses Cypress.
@@ -41,13 +55,15 @@ BASE_REF="${BASE_REF:-}"
 INPUT_CLUSTER_NAME="${INPUT_CLUSTER_NAME:-}"
 INPUT_OPENSHIFT_VERSION="${INPUT_OPENSHIFT_VERSION:-}"
 INPUT_TEST_ENGINE="${INPUT_TEST_ENGINE:-}"
+INPUT_CNV_CHANNEL="${INPUT_CNV_CHANNEL:-}"
 
 if [[ "${BASE_REF}" =~ ^release-([0-9]+)\.([0-9]+)$ ]]; then
   MAJOR="${BASH_REMATCH[1]}"
   MINOR="${BASH_REMATCH[2]}"
   CLUSTER_NAME="kubevirt-plugin-${MAJOR}${MINOR}"
   OPENSHIFT_VERSION="${MAJOR}.${MINOR}_openshift"
-  echo "Base branch '${BASE_REF}' is a release branch → cluster '${CLUSTER_NAME}' (${OPENSHIFT_VERSION})" >&2
+  CNV_CHANNEL="${DEFAULT_CNV_CHANNEL}"
+  echo "Base branch '${BASE_REF}' is a release branch → cluster '${CLUSTER_NAME}' (${OPENSHIFT_VERSION}, CNV channel '${CNV_CHANNEL}')" >&2
 
   if (( MAJOR * 1000 + MINOR <= LAST_CYPRESS_MAJOR * 1000 + LAST_CYPRESS_MINOR )); then
     TEST_ENGINE="cypress"
@@ -58,7 +74,8 @@ if [[ "${BASE_REF}" =~ ^release-([0-9]+)\.([0-9]+)$ ]]; then
 else
   CLUSTER_NAME="${INPUT_CLUSTER_NAME:-${DEFAULT_CLUSTER_NAME}}"
   OPENSHIFT_VERSION="${INPUT_OPENSHIFT_VERSION:-${DEFAULT_OPENSHIFT_VERSION}}"
-  echo "Using default/workflow_dispatch cluster config: '${CLUSTER_NAME}' (${OPENSHIFT_VERSION})" >&2
+  CNV_CHANNEL="${DEFAULT_CNV_CHANNEL}"
+  echo "Using default/workflow_dispatch cluster config: '${CLUSTER_NAME}' (${OPENSHIFT_VERSION}, CNV channel '${CNV_CHANNEL}')" >&2
   TEST_ENGINE="${DEFAULT_TEST_ENGINE}"
 fi
 
@@ -69,9 +86,18 @@ if [[ -n "${INPUT_TEST_ENGINE}" && "${INPUT_TEST_ENGINE}" != "auto" ]]; then
   echo "Overriding test engine from input: '${TEST_ENGINE}'" >&2
 fi
 
+# An explicit workflow_dispatch override always wins over the default
+# unversioned 'stable' channel (e.g. experimenting with startingCSV /
+# Manual approval for an older CSV -- not versioned channel names).
+if [[ -n "${INPUT_CNV_CHANNEL}" ]]; then
+  CNV_CHANNEL="${INPUT_CNV_CHANNEL}"
+  echo "Overriding CNV channel from input: '${CNV_CHANNEL}'" >&2
+fi
+
 echo "cluster_name=${CLUSTER_NAME}"
 echo "openshift_version=${OPENSHIFT_VERSION}"
 echo "test_engine=${TEST_ENGINE}"
+echo "cnv_channel=${CNV_CHANNEL}"
 # Raw resolved base branch (e.g. "main", "release-4.20"), or empty when
 # there's none (plain workflow_dispatch with no PR context) -- callers
 # combine this with a ref_name fallback for display purposes (e.g. the

--- a/ci-scripts/hot-cluster/test-cleanup.sh
+++ b/ci-scripts/hot-cluster/test-cleanup.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 #
 # Deletes test-created VM/template/storage resources from the e2e run's test
-# namespace only (TEST_NS), leaving cluster-wide resources untouched.
+# namespace (TEST_NS), plus a handful of fixed-name cluster-scoped resources
+# the test suites also create (see below) -- everything else cluster-wide is
+# left untouched.
 #
 export TEST_NS=${TEST_NS:-${CYPRESS_TEST_NS:-'auto-test-ns'}}
 
@@ -15,3 +17,13 @@ oc -n ${TEST_NS} delete secret --all --ignore-not-found --wait=false || true
 oc -n ${TEST_NS} delete net-attach-def --all --ignore-not-found --wait=false || true
 oc -n ${TEST_NS} delete VirtualMachineInstancetype example --ignore-not-found --wait=false || true
 oc -n ${TEST_NS} delete VirtualMachinePreference example --ignore-not-found --wait=false || true
+
+# Cluster-scoped counterparts of the above, created under the same fixed
+# "example" name by the Cypress suite's YAML-creation tests. Unlike TEST_NS
+# (destroyed fresh each run), these persist across runs on a long-lived
+# cluster and collide with the next run's attempt to create them, e.g.
+# `virtualmachineclusterinstancetypes.instancetype.kubevirt.io "example"
+# already exists` -- confirmed live via CNV-92679's Cypress verification.
+oc delete virtualmachineclusterinstancetype example --ignore-not-found --wait=false || true
+oc delete virtualmachineclusterpreference example --ignore-not-found --wait=false || true
+oc delete migrationpolicy example --ignore-not-found --wait=false || true


### PR DESCRIPTION
## 📝 Description

Fix stale cluster-scoped test cleanup and CNV channel version mismatch on hot-cluster E2E

## 🔗 Links

Jira ticket: [CNV-92681](https://redhat.atlassian.net/browse/CNV-92681)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable CNV operator subscription channel support for hot-cluster provisioning, including a default (`stable`) and a manual override for end-to-end runs.
* **Bug Fixes**
  * Improved CI cleanup to remove additional fixed-name cluster-scoped leftovers created by YAML-based tests.
  * Updated CI runner permissions to allow deletion of the new cluster-scoped cleanup targets.
* **CI Improvements**
  * Propagated the resolved CNV channel through the end-to-end workflow chain and into downstream cluster checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->