### PR TITLE
CNV-92682: Fix hot-cluster E2E reliability for release branches (CNV/HCO pin, branch checkout, RBAC, cold-start, guided-tour modal)

### DIFF
--- a/.github/actions/ci-env-request/action.yml
+++ b/.github/actions/ci-env-request/action.yml
@@ -19,6 +19,17 @@ inputs:
   timeout:
     description: Max seconds to wait for environment to become ready
     default: '360'
+  user-settings-location:
+    description: |
+      Optional override for the console's BRIDGE_USER_SETTINGS_LOCATION
+      ("configmap" or "localstorage"). Leave empty (default) to keep the
+      ci-test-stack chart's own default (localstorage) -- e.g. Playwright's
+      seedGuidedTourState() relies on that default and would silently stop
+      working if this were changed globally. Only set to "configmap" for
+      callers (e.g. Cypress) that need CI to seed user-settings server-side
+      before the browser ever loads the console.
+    required: false
+    default: ''
 
 outputs:
   bridge-base-address:
@@ -46,6 +57,7 @@ runs:
           desired-state: "present"
           plugin-image: "${{ inputs.plugin-image }}"
           test-namespace: "${{ inputs.test-namespace }}"
+          user-settings-location: "${{ inputs.user-settings-location }}"
         EOF
         echo "Created trigger ConfigMap ${{ inputs.configmap-name }} in ${{ inputs.ci-env-namespace }}"
 

--- a/.github/workflows/deploy-manual-console.yml
+++ b/.github/workflows/deploy-manual-console.yml
@@ -10,12 +10,24 @@ run-name: "Deploy Manual Console [${{ inputs.cluster_name }}] @ ${{ inputs.pr_nu
 # Prerequisites: the target cluster must already be provisioned via
 # "IBM Cloud Hot Cluster Setup" (ibmc-cluster-setup.yml), which installs the
 # ARC runner scale set and the ci-env-controller this workflow depends on.
+#
+# Dispatch ref matters: whichever branch/ref you pick in the "Use workflow
+# from" dropdown (github.ref) is what gets checked out for CI scripts (the
+# "Checkout workflow scripts" step below has no ref: override), separately
+# from "branch"/pr_number below, which only selects the plugin source to
+# build. Dispatch from main (or another branch that carries current
+# ci-scripts/manual-console/) even when deploying an old release branch's
+# plugin -- dispatching from a ref that itself lacks those scripts will fail
+# the same way "branch" pointing at one would.
 
 on:
   workflow_dispatch:
     inputs:
       branch:
-        description: Git branch or ref to build the kubevirt-plugin image from. Ignored when pr_number is set.
+        description: >-
+          Git branch or ref to build the kubevirt-plugin image from (can be
+          an old release branch). Ignored when pr_number is set. Dispatch
+          this workflow itself from main/current -- see the header comment.
         required: true
         default: main
         type: string
@@ -140,11 +152,31 @@ jobs:
     runs-on: ${{ inputs.cluster_name }}
     timeout-minutes: 30
     steps:
-      # allow-unsafe-pr-checkout is not needed here: actions/checkout only
-      # enforces that guard for pull_request_target/workflow_run triggers,
-      # not workflow_dispatch. The OWNERS check above (resolve-pr) is this
-      # workflow's actual trust gate for fork PRs.
-      - name: Checkout
+      # Two checkouts, deliberately kept separate:
+      #   1. This repo's own dispatch ref (default actions/checkout behavior
+      #      with no ref: -- github.ref, i.e. whatever branch was selected
+      #      in the workflow_dispatch UI) into $GITHUB_WORKSPACE, so CI
+      #      scripts here (e.g. ci-scripts/manual-console/images/
+      #      setup-plugin-image.sh, added on main and not present on older
+      #      release branches) always match the workflow YAML that's
+      #      actually running.
+      #   2. The plugin source to actually build -- PR head, or inputs.branch
+      #      (which may be an old release branch lacking those same CI
+      #      scripts) -- into plugin-src/, used only as setup-plugin-
+      #      image.sh's BUILD_DIR below. Building main's plugin against a
+      #      release branch's console previously produced "Failed to load
+      #      scripts of plugin kubevirt-plugin" in the browser (SDK/
+      #      PatternFly version skew) -- confirmed live, CNV-92682 follow-up.
+      # allow-unsafe-pr-checkout is not needed for either: actions/checkout
+      # only enforces that guard for pull_request_target/workflow_run
+      # triggers, not workflow_dispatch. The OWNERS check above (resolve-pr)
+      # is this workflow's actual trust gate for fork PRs.
+      - name: Checkout workflow scripts
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Checkout plugin source
         uses: actions/checkout@v7
         with:
           # Falls back to the default repository (github.repository, actions/
@@ -155,6 +187,7 @@ jobs:
           # the '(source repository deleted)' sentinel as a repository name.
           repository: ${{ (needs.resolve-pr.outputs.head_repo != '' && needs.resolve-pr.outputs.head_repo != '(source repository deleted)') && needs.resolve-pr.outputs.head_repo || github.repository }}
           ref: ${{ needs.resolve-pr.outputs.head_sha || inputs.branch }}
+          path: plugin-src
           persist-credentials: false
 
       - name: Log environment summary
@@ -185,6 +218,11 @@ jobs:
         run: |
           NS="${MANUAL_CONSOLE_NS}"
           export NS
+          # BUILD_DIR points at the plugin-src/ checkout above, not the
+          # workflow-scripts checkout at $GITHUB_WORKSPACE -- see that
+          # checkout step's comment for why these must stay separate.
+          BUILD_DIR="${GITHUB_WORKSPACE}/plugin-src"
+          export BUILD_DIR
           OUTPUT_FILE="$(mktemp)"
           bash ci-scripts/manual-console/images/setup-plugin-image.sh | tee "${OUTPUT_FILE}"
           IMAGE_REF="$(grep '^IMAGE_REF=' "${OUTPUT_FILE}" | cut -d= -f2-)"

--- a/.github/workflows/deploy-plugin.yml
+++ b/.github/workflows/deploy-plugin.yml
@@ -11,12 +11,21 @@ run-name: 'Deploy Plugin [${{ inputs.cluster_name }}] @ ${{ inputs.branch }}'
 # Prerequisites: same as deploy-manual-console.yml -- the target cluster must
 # already be provisioned, and a manual console should already exist (though
 # this workflow works standalone too, it will just deploy fresh).
+#
+# Dispatch ref matters, same as deploy-manual-console.yml: dispatch this
+# workflow itself from main (or another ref carrying current
+# ci-scripts/manual-console/) even when "branch" below points at an old
+# release branch -- the "Checkout workflow scripts" step has no ref:
+# override, so it always uses whatever ref you pick in the dispatch UI.
 
 on:
   workflow_dispatch:
     inputs:
       branch:
-        description: Git branch or ref to build the kubevirt-plugin image from
+        description: >-
+          Git branch or ref to build the kubevirt-plugin image from (can be
+          an old release branch). Dispatch this workflow itself from
+          main/current -- see the header comment.
         required: true
         default: main
         type: string
@@ -45,10 +54,26 @@ jobs:
     runs-on: ${{ inputs.cluster_name }}
     timeout-minutes: 20
     steps:
-      - name: Checkout
+      # Two checkouts, deliberately kept separate -- see
+      # deploy-manual-console.yml's equivalent checkout steps for the full
+      # rationale (CNV-92682 follow-up: building main's plugin against an
+      # older release branch's console caused "Failed to load scripts of
+      # plugin kubevirt-plugin" in the browser).
+      #   1. This repo's own dispatch ref into $GITHUB_WORKSPACE, for CI
+      #      scripts (e.g. setup-plugin-image.sh) that may not exist on
+      #      inputs.branch.
+      #   2. inputs.branch itself into plugin-src/, used only as
+      #      setup-plugin-image.sh's BUILD_DIR below.
+      - name: Checkout workflow scripts
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Checkout plugin source
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.branch }}
+          path: plugin-src
           persist-credentials: false
 
       - name: Build kubevirt-plugin image in-cluster
@@ -56,6 +81,10 @@ jobs:
         run: |
           NS="${MANUAL_CONSOLE_NS}"
           export NS
+          # BUILD_DIR points at the plugin-src/ checkout above, not the
+          # workflow-scripts checkout at $GITHUB_WORKSPACE.
+          BUILD_DIR="${GITHUB_WORKSPACE}/plugin-src"
+          export BUILD_DIR
           OUTPUT_FILE="$(mktemp)"
           bash ci-scripts/manual-console/images/setup-plugin-image.sh | tee "${OUTPUT_FILE}"
           IMAGE_REF="$(grep '^IMAGE_REF=' "${OUTPUT_FILE}" | cut -d= -f2-)"

--- a/.github/workflows/hot-cluster-check.yml
+++ b/.github/workflows/hot-cluster-check.yml
@@ -47,6 +47,19 @@ on:
         type: string
         required: false
         default: 'stable'
+      cnv_pin_version:
+        description: |
+          "<major>.<minor>" to pin CNV to the newest matching CSV within
+          cnv_channel via startingCSV (e.g. for a release branch under
+          test); empty installs whatever cnv_channel currently resolves to.
+          If provisioning happens and no matching CSV can be found for this
+          version, the build fails rather than silently installing an
+          unpinned/newer CNV -- pass an explicit cnv_channel instead to
+          install unpinned deliberately. Forwarded as-is to
+          ibmc-cluster-setup.yml.
+        type: string
+        required: false
+        default: ''
       worker_flavor:
         description: Worker node flavor
         type: string
@@ -136,6 +149,7 @@ jobs:
       openshift_version: ${{ inputs.openshift_version }}
       branch_name: ${{ inputs.branch_name }}
       cnv_channel: ${{ inputs.cnv_channel }}
+      cnv_pin_version: ${{ inputs.cnv_pin_version }}
       worker_flavor: ${{ inputs.worker_flavor }}
       worker_count: ${{ inputs.worker_count }}
       # kvm_emulation is declared as a string here (matching workflow_call's

--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -346,6 +346,16 @@ jobs:
           test-namespace: ${{ env.TEST_NS }}
           configmap-name: ${{ env.CI_ENV_CM }}
           ci-env-namespace: ${{ env.CI_ENV_NS }}
+          # configmap only for Cypress: its before-all hook has no way to
+          # dismiss OpenShift Console's own "Welcome to the new OpenShift
+          # experience" guided-tour modal (unlike Playwright, which already
+          # seeds tour-completion into browser localStorage via
+          # seedGuidedTourState() -- see playwright/pages/LoginPage.ts).
+          # Left empty for Playwright so its console keeps the chart's
+          # default (localstorage) and that existing seeding keeps working
+          # unchanged. See the "Seed kubevirt-user-settings ConfigMap" step
+          # below for the matching server-side seed.
+          user-settings-location: ${{ env.TEST_ENGINE == 'cypress' && 'configmap' || '' }}
 
       - name: Create test secret
         run: |
@@ -379,6 +389,32 @@ jobs:
 
           oc patch configmap kubevirt-ui-features -n "${CNV_NS}" --type=merge \
             --patch '{"data":{"advancedSearch":"true","treeViewFolders":"true"}}'
+
+          # Only meaningful when TEST_ENGINE=cypress (see "Provision CI test
+          # environment" step above, which only sets user-settings-location=
+          # configmap for that engine) -- Playwright's console stays on
+          # localstorage and keeps working via its own browser-side
+          # seedGuidedTourState(), so this ConfigMap wouldn't even be read
+          # for a Playwright run. Seeds core OpenShift Console's own
+          # guided-tour completion state so the "Welcome to the new
+          # OpenShift experience" intro modal (a core console feature, not
+          # kubevirt-plugin's own onboarding above) never blocks the very
+          # first Cypress test. Mirrors playwright/pages/LoginPage.ts's
+          # seedGuidedTourState(), adapted for configmap instead of
+          # localStorage. ConfigMap name convention (user-settings-<uid>)
+          # per openshift/console's getConfigMapName() -- verify live if
+          # this ever silently stops working, since the naming convention
+          # has evolved across console versions.
+          if [[ "${TEST_ENGINE}" == "cypress" && -n "${SA_UID}" ]]; then
+            GUIDED_TOUR='{"admin":{"completed":true},"dev":{"completed":true},"virtualization-perspective":{"completed":true}}'
+            CONSOLE_CM_NAME="user-settings-${SA_UID}"
+
+            if ! oc get configmap "${CONSOLE_CM_NAME}" -n openshift-console-user-settings &>/dev/null; then
+              oc create configmap "${CONSOLE_CM_NAME}" -n openshift-console-user-settings
+            fi
+            oc patch configmap "${CONSOLE_CM_NAME}" -n openshift-console-user-settings \
+              --type merge -p "$(jq -cn --arg v "${GUIDED_TOUR}" '{data: {"console.guidedTour": $v}}')"
+          fi
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -80,6 +80,20 @@ on:
         type: string
         required: false
         default: ''
+      is_reusable_call:
+        description: |
+          Internal marker set only by hot-cluster-e2e.yml's own `uses:` call
+          -- never available on the workflow_dispatch trigger, so it's
+          reliably false for a standalone dispatch. Distinguishes that case
+          (whose "Run Gating Tests" job would otherwise be a top-level,
+          bare-named check-run that can collide with an unrelated open PR
+          sharing the same SHA -- confirmed live on CNV-92682/PR #4293) from
+          being called via `uses:` (where GitHub already composite-prefixes
+          the check name, e.g. "Run E2E Tests / Run Gating Tests", so no
+          collision is possible regardless of this flag).
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -291,7 +305,10 @@ jobs:
           podman push ${KUBEVIRT_PLUGIN_IMAGE}
 
   run-gating-tests:
-    name: Run Gating Tests
+    # inputs.is_reusable_call is only ever true when hot-cluster-e2e.yml
+    # calls this workflow via `uses:` -- see that input's own description
+    # for why a standalone dispatch needs a distinctly-named check here.
+    name: ${{ inputs.is_reusable_call && 'Run Gating Tests' || 'Run Gating Tests (standalone dispatch)' }}
     needs: [check-runner, build-kubevirt-plugin-image]
     runs-on: ${{ inputs.runner_label || 'kubevirt-plugin-ci' }}
     timeout-minutes: 120

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -458,8 +458,20 @@ jobs:
     needs: [cluster-check, resolve-cluster-config]
     # cluster-check now always runs (see comment above it) and quickly
     # reports 'success' even as a no-op, so gate on the actual readiness
-    # output rather than the job result.
-    if: github.event_name == 'workflow_dispatch' && needs.cluster-check.outputs.cluster_ready == 'true'
+    # output rather than the job result. always() is required despite that:
+    # a job's own custom `if:` is implicitly ANDed with success() unless it
+    # already includes a status-check function (documented GitHub Actions
+    # behavior, see actions/runner#491) -- and success() here needs
+    # cluster-check's own aggregate status, which reads as non-'success'
+    # whenever its internal provision job was skipped (cluster already
+    # existed), even though cluster-check's own cluster_ready OUTPUT is
+    # correctly 'true' in that exact case. Without always(), this job (and
+    # everything that needs it, i.e. run-e2e-tests) silently skips even
+    # though the cluster is genuinely ready -- confirmed live: dispatching
+    # against an existing cluster from hot-cluster-e2e.yml's own
+    # workflow_dispatch (CNV-92682 follow-up). run-e2e-tests below already
+    # guards against this same gotcha with its own always().
+    if: always() && github.event_name == 'workflow_dispatch' && needs.cluster-check.outputs.cluster_ready == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -1,5 +1,5 @@
 name: Hot Cluster E2E
-run-name: "Hot Cluster E2E [${{ inputs.cluster_name || github.base_ref || 'kubevirt-plugin-ci' }}] @ ${{ inputs.pr_number != '' && format('PR#{0} retest', inputs.pr_number) || github.head_ref || github.ref_name }}"
+run-name: "Hot Cluster E2E [${{ inputs.base_ref || inputs.cluster_name || github.base_ref || 'kubevirt-plugin-ci' }}] @ ${{ inputs.pr_number != '' && format('PR#{0} retest', inputs.pr_number) || github.head_ref || github.ref_name }}"
 
 on:
   pull_request_target:
@@ -58,7 +58,11 @@ on:
         description: |
           Explicit CNV OLM subscription channel override for provisioning.
           Leave empty to use the resolver default (catalog unversioned
-          'stable'). There is no automatic per-branch channel selection.
+          'stable'). There is no automatic per-branch channel selection --
+          but a release branch DOES get an automatic per-branch startingCSV
+          pin within that channel (see resolve-cluster-config.sh). Setting
+          this to any explicit value (even 'stable') clears that pin, e.g.
+          to deliberately install unpinned if the pin can't be resolved.
         required: false
         default: ''
         type: string
@@ -141,6 +145,7 @@ jobs:
       test_engine: ${{ steps.resolve.outputs.test_engine }}
       branch_name: ${{ steps.resolve.outputs.branch_name }}
       cnv_channel: ${{ steps.resolve.outputs.cnv_channel }}
+      cnv_pin_version: ${{ steps.resolve.outputs.cnv_pin_version }}
     steps:
       # persist-credentials: false -- this job only reads files to resolve
       # cluster config, it never pushes, so there's no reason to leave
@@ -353,6 +358,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           RESOLVED_HEAD_SHA: ${{ needs.resolve-pr-context.outputs.head_sha }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         with:
           script: |
             // pull_request_target's github.sha/context.sha is the BASE
@@ -370,6 +376,16 @@ jobs:
             const isIrrelevantLabel = context.payload.action === 'labeled'
               && context.payload.label?.name !== 'ok-to-test';
 
+            // A bare workflow_dispatch with no pr_number doesn't represent
+            // any specific PR -- if dispatched against a branch/SHA that
+            // happens to also have an open PR (e.g. ad-hoc manual testing
+            // on a feature branch, confirmed live on CNV-92682/PR #4293),
+            // posting under the same context as the real PR-driven status
+            // would collide with (and, per GitHub's "most recent wins"
+            // display behavior, obscure) that PR's own genuine result --
+            // same reasoning as isIrrelevantLabel below.
+            const isAdHocDispatch = context.eventName === 'workflow_dispatch' && !process.env.PR_NUMBER;
+
             // A distinct context for no-op runs prevents them from posting
             // a same-context, same-SHA status that could collide with (and,
             // per GitHub's "most recent wins" display behavior, obscure) an
@@ -378,7 +394,9 @@ jobs:
             // "Run Gating Tests" on verify-gating-tests below.
             const statusContext = isIrrelevantLabel
               ? 'Hot Cluster E2E Progress (skipped - irrelevant label event)'
-              : 'Hot Cluster E2E Progress';
+              : isAdHocDispatch
+                ? 'Hot Cluster E2E Progress (manual dispatch)'
+                : 'Hot Cluster E2E Progress';
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
@@ -416,6 +434,10 @@ jobs:
       # Optional workflow_dispatch cnv_channel overrides that default.
       # See resolve-cluster-config.sh for the full rationale.
       cnv_channel: ${{ needs.resolve-cluster-config.outputs.cnv_channel }}
+      # Empty for main/default; "<major>.<minor>" for a release branch --
+      # ibmc-cluster-setup.yml resolves this to a pinned startingCSV within
+      # cnv_channel. See resolve-cluster-config.sh for the full rationale.
+      cnv_pin_version: ${{ needs.resolve-cluster-config.outputs.cnv_pin_version }}
       # The resolved base branch (main/release-4.X) for pull_request_target
       # and /retest-e2e's forwarded base_ref; falls back to whatever ref
       # this run itself is on for a plain workflow_dispatch with no PR
@@ -532,6 +554,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           RESOLVED_HEAD_SHA: ${{ needs.resolve-pr-context.outputs.head_sha }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         with:
           script: |
             const isIrrelevantLabel = context.payload.action === 'labeled'
@@ -542,10 +565,16 @@ jobs:
             }
 
             // See progress-check-start above for why the pr_number retest
-            // path also needs resolve-pr-context's head SHA here.
+            // path also needs resolve-pr-context's head SHA here, and for
+            // why a bare ad-hoc dispatch needs its own distinct context.
             const headSha = context.eventName === 'pull_request_target'
               ? context.payload.pull_request.head.sha
               : (process.env.RESOLVED_HEAD_SHA || context.sha);
+
+            const isAdHocDispatch = context.eventName === 'workflow_dispatch' && !process.env.PR_NUMBER;
+            const statusContext = isAdHocDispatch
+              ? 'Hot Cluster E2E Progress (manual dispatch)'
+              : 'Hot Cluster E2E Progress';
 
             // cluster-health-check only ever runs for workflow_dispatch (its
             // own `if:` skips it otherwise) -- branch on event type here,
@@ -561,7 +590,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: headSha,
-              context: 'Hot Cluster E2E Progress',
+              context: statusContext,
               state: clusterReady ? 'pending' : 'failure',
               description: clusterReady
                 ? 'Running gating tests'
@@ -626,6 +655,9 @@ jobs:
       # input for why this matters (a plain workflow re-run would otherwise
       # keep re-testing the same stale commit forever).
       checkout_ref: ${{ inputs.pr_number != '' && format('refs/pull/{0}/merge', inputs.pr_number) || '' }}
+      # Always true for this `uses:` call -- see hot-cluster-e2e-run.yml's
+      # is_reusable_call input for why.
+      is_reusable_call: true
     secrets: inherit
 
   # Single source of truth for the "Run Gating Tests" required status check.
@@ -670,7 +702,13 @@ jobs:
   # pending update to land afterwards and permanently strand the progress
   # status as "pending" on an already-finished run.
   verify-gating-tests:
-    name: ${{ (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test') && 'Run Gating Tests' || 'Run Gating Tests (skipped - irrelevant label event)' }}
+    # Bare workflow_dispatch (no pr_number) doesn't represent any specific
+    # PR -- naming it distinctly here (mirroring the irrelevant-label case
+    # below) stops it from colliding with, and obscuring, a real PR's own
+    # "Run Gating Tests" required check for the same SHA when someone
+    # ad-hoc-dispatches this workflow against a branch that also has an
+    # open PR (confirmed live on CNV-92682/PR #4293).
+    name: ${{ (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test') && ((github.event_name == 'workflow_dispatch' && inputs.pr_number == '' && 'Run Gating Tests (manual dispatch)') || 'Run Gating Tests') || 'Run Gating Tests (skipped - irrelevant label event)' }}
     needs:
       [
         check-trust,
@@ -772,6 +810,7 @@ jobs:
         env:
           RESOLVED_HEAD_SHA: ${{ needs.resolve-pr-context.outputs.head_sha }}
           JOB_STATUS: ${{ job.status }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         with:
           script: |
             const isIrrelevantLabel = context.payload.action === 'labeled'
@@ -782,10 +821,16 @@ jobs:
             }
 
             // See progress-check-start above for why the pr_number retest
-            // path also needs resolve-pr-context's head SHA here.
+            // path also needs resolve-pr-context's head SHA here, and for
+            // why a bare ad-hoc dispatch needs its own distinct context.
             const headSha = context.eventName === 'pull_request_target'
               ? context.payload.pull_request.head.sha
               : (process.env.RESOLVED_HEAD_SHA || context.sha);
+
+            const isAdHocDispatch = context.eventName === 'workflow_dispatch' && !process.env.PR_NUMBER;
+            const statusContext = isAdHocDispatch
+              ? 'Hot Cluster E2E Progress (manual dispatch)'
+              : 'Hot Cluster E2E Progress';
 
             const passed = process.env.JOB_STATUS === 'success';
 
@@ -793,7 +838,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: headSha,
-              context: 'Hot Cluster E2E Progress',
+              context: statusContext,
               state: passed ? 'success' : 'failure',
               description: passed
                 ? 'Hot cluster gating tests passed'

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -650,11 +650,30 @@ jobs:
       test_engine: ${{ needs.resolve-cluster-config.outputs.test_engine }}
       runner_label: ${{ inputs.runner_label || needs.resolve-cluster-config.outputs.cluster_name }}
       cluster_name: ${{ needs.resolve-cluster-config.outputs.cluster_name }}
-      # Merge the PR with the current base tip instead of testing its head
-      # commit in isolation -- see hot-cluster-e2e-run.yml's checkout_ref
-      # input for why this matters (a plain workflow re-run would otherwise
-      # keep re-testing the same stale commit forever).
-      checkout_ref: ${{ inputs.pr_number != '' && format('refs/pull/{0}/merge', inputs.pr_number) || '' }}
+      # Three cases, in priority order:
+      #   1. pr_number set (merge-pool retest path): merge the PR with the
+      #      current base tip instead of testing its head commit in
+      #      isolation -- see hot-cluster-e2e-run.yml's checkout_ref input
+      #      for why this matters (a plain workflow re-run would otherwise
+      #      keep re-testing the same stale commit forever).
+      #   2. inputs.base_ref set, no pr_number (manual/ /retest-e2e
+      #      release-branch dispatch): build and test that release branch
+      #      itself. Without this, only cluster/engine/CNV-pin selection
+      #      followed base_ref (via resolve-cluster-config's own BASE_REF
+      #      env, fed by this same input) while the actual plugin image and
+      #      test checkout silently fell through to github.ref -- i.e. this
+      #      workflow's own ref (often main) -- so a "release-4.20" dispatch
+      #      could build main's plugin and run Playwright against a
+      #      Cypress-era release cluster/console. Confirmed live: CNV-92682
+      #      follow-up. Deliberately reads inputs.base_ref directly rather
+      #      than resolve-cluster-config's branch_name output -- branch_name
+      #      also carries github.base_ref for ordinary pull_request_target
+      #      runs, where this checkout_ref must stay empty (PR head, not the
+      #      PR's base branch). inputs.base_ref is only ever populated on
+      #      workflow_dispatch, so this case can never fire for a PR event.
+      #   3. Neither set (plain PR / bare dispatch): empty, falls through to
+      #      hot-cluster-e2e-run.yml's own PR-head/github.ref default.
+      checkout_ref: ${{ inputs.pr_number != '' && format('refs/pull/{0}/merge', inputs.pr_number) || inputs.base_ref || '' }}
       # Always true for this `uses:` call -- see hot-cluster-e2e-run.yml's
       # is_reusable_call input for why.
       is_reusable_call: true

--- a/.github/workflows/ibmc-cluster-setup.yml
+++ b/.github/workflows/ibmc-cluster-setup.yml
@@ -53,6 +53,17 @@ on:
         required: false
         default: 'stable'
         type: string
+      cnv_pin_version:
+        description: |
+          "<major>.<minor>" to pin CNV to the newest matching CSV within
+          cnv_channel via startingCSV. Leave empty to install whatever
+          cnv_channel currently resolves to. If set and no matching CSV is
+          found in the channel's entries, install-hco.sh fails the build
+          rather than silently falling back to an unpinned/newer install --
+          pass an explicit cnv_channel instead to opt into that.
+        required: false
+        default: ''
+        type: string
       branch_name:
         description: |
           Branch identity to report in the "Hot cluster ready" Slack
@@ -107,6 +118,17 @@ on:
         description: 'CNV OLM subscription channel (e.g. stable, stable-4.17)'
         required: false
         default: 'stable'
+        type: string
+      cnv_pin_version:
+        description: |
+          "<major>.<minor>" to pin CNV to the newest matching CSV within
+          cnv_channel via startingCSV. Leave empty to install whatever
+          cnv_channel currently resolves to. If set and no matching CSV is
+          found in the channel's entries, install-hco.sh fails the build
+          rather than silently falling back to an unpinned/newer install --
+          pass an explicit cnv_channel instead to opt into that.
+        required: false
+        default: ''
         type: string
       branch_name:
         description: |
@@ -575,12 +597,15 @@ jobs:
           fi
 
       - name: Install OpenShift Virtualization (CNV)
+        id: install_cnv
         env:
           KVM_EMULATION: ${{ steps.kvm_check.outputs.kvm_emulation || inputs.kvm_emulation }}
           CNV_CHANNEL: ${{ inputs.cnv_channel || 'stable' }}
+          CNV_PIN_VERSION: ${{ inputs.cnv_pin_version }}
         run: |
           echo "KVM_EMULATION=${KVM_EMULATION} (auto-detected)"
           echo "CNV_CHANNEL=${CNV_CHANNEL}"
+          echo "CNV_PIN_VERSION=${CNV_PIN_VERSION:-<none, unpinned>}"
           ./ci-scripts/hot-cluster/install-hco.sh
 
       - name: Configure internal image registry
@@ -757,6 +782,15 @@ jobs:
 
       - name: Setup summary
         if: always()
+        env:
+          CNV_PIN_VERSION_REQUESTED: ${{ inputs.cnv_pin_version || 'unpinned' }}
+          # Resolved from the live PackageManifest by install-hco.sh -- distinct
+          # from the requested pin above so this can never look "pinned" when
+          # the pin actually failed. Genuinely unpinned (no pin requested) and
+          # "pin requested but install-hco.sh failed before resolving it" both
+          # show this same empty fallback -- always check job status/logs for
+          # the latter, never infer success from this table alone.
+          CNV_INSTALLED_CSV: ${{ steps.install_cnv.outputs.starting_csv || 'unpinned, or pin failed -- check job status' }}
         run: |
           echo "## Hot Cluster Setup Summary" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -770,6 +804,8 @@ jobs:
           echo "| Workers | \`${{ inputs.worker_count }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| KVM Emulation | \`${{ inputs.kvm_emulation }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| CNV Channel | \`${{ inputs.cnv_channel || 'stable' }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| CNV Pin Version (requested) | \`${CNV_PIN_VERSION_REQUESTED}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| CNV Installed CSV | \`${CNV_INSTALLED_CSV}\` |" >> "$GITHUB_STEP_SUMMARY"
           CONSOLE_URL=$(oc get consoles.config.openshift.io cluster -o jsonpath='{.status.consoleURL}' 2>/dev/null || echo "")
           if [[ -n "${CONSOLE_URL}" ]]; then
             echo "| Console | [${CONSOLE_URL}](${CONSOLE_URL}) |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ibmc-cluster-setup.yml
+++ b/.github/workflows/ibmc-cluster-setup.yml
@@ -647,6 +647,17 @@ jobs:
           ./ci-scripts/hot-cluster/arc/install-arc-controller.sh
           ./ci-scripts/hot-cluster/arc/install-runner-scale-set.sh
 
+      - name: Bootstrap manual-console RBAC
+        # Optional feature (CNV-92150) -- unlike ARC/ci-env-controller above,
+        # E2E does not depend on this. continue-on-error so a hiccup here
+        # never fails the (multi-hour) cluster provisioning job; GitHub
+        # Actions still surfaces a warning annotation on failure.
+        continue-on-error: true
+        env:
+          RUNNER_SCALE_SET_NAME: ${{ env.CLUSTER_NAME }}
+        run: |
+          ./ci-scripts/manual-console/install-manual-console-rbac.sh
+
       - name: Install CI environment controller
         env:
           RUNNER_SCALE_SET_NAME: ${{ env.CLUSTER_NAME }}

--- a/ci-scripts/hot-cluster/arc/arc-runner-rbac.yaml
+++ b/ci-scripts/hot-cluster/arc/arc-runner-rbac.yaml
@@ -31,9 +31,28 @@ rules:
     verbs: ['get', 'list']
 
   # --- Playwright test setup: create/delete temporary namespaces ---
+  # Unrestricted (no resourceNames) because these dynamically-named test
+  # namespaces aren't known ahead of time.
   - apiGroups: ['']
     resources: ['namespaces']
     verbs: ['get', 'list', 'create', 'delete']
+
+  # --- deploy-manual-console.yml's setup-plugin-image.sh: idempotent re-apply
+  # of its one long-lived "manual-console" namespace. Only the very first
+  # run hits the create path above; every later run needs to patch the
+  # already-existing object instead (confirmed live: cluster provisioning
+  # succeeded, but a second manual-console deploy 403'd on "cannot patch
+  # resource namespaces" once the object existed -- CNV-92682 follow-up).
+  # This is deliberately its own rule with resourceNames, NOT folded into
+  # the unrestricted rule above -- this ClusterRole is bound cluster-wide
+  # via ClusterRoleBinding below, so an unscoped patch/update on namespaces
+  # would let the runner SA mutate ANY namespace (labels, annotations,
+  # finalizers), including openshift-*. `update` (full PUT) is omitted --
+  # `oc apply`'s 3-way merge only ever issues a PATCH, never a PUT.
+  - apiGroups: ['']
+    resources: ['namespaces']
+    verbs: ['patch']
+    resourceNames: ['manual-console']
   - apiGroups: ['config.openshift.io']
     resources: ['consoles', 'clusterversions', 'ingresses']
     verbs: ['get', 'list']

--- a/ci-scripts/hot-cluster/helm/ci-env-controller/scripts/ci-env-controller.sh
+++ b/ci-scripts/hot-cluster/helm/ci-env-controller/scripts/ci-env-controller.sh
@@ -18,6 +18,14 @@
 #                          container; only invoked when a ConfigMap sets
 #                          auth-mode=openshift (default:
 #                          /opt/ci-env/manual-console/ensure-manual-console-user.sh)
+#
+# Trigger ConfigMap data field (per-request, optional):
+#   user-settings-location  Overrides the console's BRIDGE_USER_SETTINGS_LOCATION
+#                            ("configmap" or "localstorage"). Empty (every
+#                            existing caller except Cypress E2E) keeps the
+#                            ci-test-stack chart's own default -- see
+#                            provision()'s own comment for why this must
+#                            stay opt-in.
 
 set -uo pipefail
 
@@ -190,6 +198,7 @@ provision() {
   local auth_mode="${6:-disabled}"
   local htpasswd_user="${7:-}"
   local htpasswd_secret_name="${8:-}"
+  local user_settings_location="${9:-}"
 
   local helm_release="${helm_release_override:-${cm_name}}"
 
@@ -221,6 +230,27 @@ provision() {
     fi
     extra_helm_args+=(--set "console.auth.mode=openshift")
     extra_helm_args+=(--set-file "console.auth.caCert=${MANUAL_AUTH_CA_CERT_FILE}")
+  fi
+
+  # Opt-in only: empty (every existing caller except Cypress E2E) means
+  # "don't override" -- the chart's own default (localstorage) applies, so
+  # this never changes behavior for callers that don't explicitly ask for
+  # it. Playwright's seedGuidedTourState() (browser localStorage) and
+  # manual-console both rely on that default; only flip this to "configmap"
+  # for a caller that also seeds server-side user-settings state to match
+  # (see hot-cluster-e2e-run.yml's "Seed kubevirt-user-settings ConfigMap"
+  # step) -- confirmed live: release-4.20 Cypress's before-all hook blocked
+  # on OpenShift Console's own "Welcome to the new OpenShift experience"
+  # guided-tour modal, which only browser-side localStorage seeding (not
+  # available to a GitHub Actions step) can normally suppress.
+  if [[ -n "${user_settings_location}" ]]; then
+    if [[ "${user_settings_location}" != "configmap" && "${user_settings_location}" != "localstorage" ]]; then
+      local err="invalid user-settings-location '${user_settings_location}' (must be 'configmap' or 'localstorage')"
+      log "ERROR: ${err}"
+      patch_cm "${cm_name}" "{\"data\":{\"status\":\"error\",\"error-message\":\"${err}\"}}"
+      return 1
+    fi
+    extra_helm_args+=(--set "console.userSettingsLocation=${user_settings_location}")
   fi
 
   log "Running helm upgrade --install ${helm_release}..."
@@ -281,7 +311,14 @@ provision() {
   log "Waiting for plugin bundle at ${plugin_base}..."
   local plugin_ready=false
   for i in $(seq 1 60); do
-    if curl -s "${plugin_base}/plugin-manifest.json" 2>/dev/null | grep -q '"name"'; then
+    # --max-time bounds each individual attempt so a hung connection can't
+    # stall past the 5-minute retry budget below; --fail rejects HTTP error
+    # responses (e.g. a 503 from a not-yet-ready backend) instead of
+    # treating any response body as success. jq validates the body is
+    # actually the plugin manifest (a non-empty "name" field), not just any
+    # JSON-ish text that happens to contain the substring "name".
+    if curl -s --max-time 5 --fail "${plugin_base}/plugin-manifest.json" 2>/dev/null \
+      | jq -e '(.name // "") | length > 0' &>/dev/null; then
       plugin_ready=true
       break
     fi
@@ -326,7 +363,7 @@ reconcile_one() {
   local cm_json="$1"
 
   local cm_name desired status plugin_image test_ns console_image helm_release
-  local auth_mode htpasswd_user htpasswd_secret_name
+  local auth_mode htpasswd_user htpasswd_secret_name user_settings_location
   cm_name="$(echo "${cm_json}" | jq -r '.metadata.name')"
   desired="$(echo "${cm_json}" | jq -r '.data["desired-state"] // "unknown"')"
   status="$(echo "${cm_json}" | jq -r '.data["status"] // ""')"
@@ -339,6 +376,10 @@ reconcile_one() {
   auth_mode="$(echo "${cm_json}" | jq -r '.data["auth-mode"] // "disabled"')"
   htpasswd_user="$(echo "${cm_json}" | jq -r '.data["htpasswd-user"] // ""')"
   htpasswd_secret_name="$(echo "${cm_json}" | jq -r '.data["htpasswd-secret-name"] // ""')"
+  # Opt-in override (empty for every existing caller, which keeps
+  # provision() on the chart's own default -- see provision()'s own comment
+  # for why this must never change unconditionally for every caller.
+  user_settings_location="$(echo "${cm_json}" | jq -r '.data["user-settings-location"] // ""')"
 
   if [[ "${desired}" == "present" && "${status}" != "ready" && "${status}" != "provisioning" ]]; then
     if [[ -z "${plugin_image}" || -z "${test_ns}" ]]; then
@@ -347,7 +388,7 @@ reconcile_one() {
       return
     fi
     if ! provision "${cm_name}" "${plugin_image}" "${test_ns}" "${console_image}" "${helm_release}" \
-      "${auth_mode}" "${htpasswd_user}" "${htpasswd_secret_name}"; then
+      "${auth_mode}" "${htpasswd_user}" "${htpasswd_secret_name}" "${user_settings_location}"; then
       log "ERROR: provision failed for ${cm_name}, ensuring status=error"
       local cur_status
       cur_status="$(oc get configmap "${cm_name}" -n "${CI_ENV_NS}" -o jsonpath='{.data.status}' 2>/dev/null || echo "")"

--- a/ci-scripts/hot-cluster/helm/ci-env-controller/scripts/ci-env-controller.sh
+++ b/ci-scripts/hot-cluster/helm/ci-env-controller/scripts/ci-env-controller.sh
@@ -266,6 +266,35 @@ provision() {
     return 1
   fi
 
+  # The console backend answering HTTP only proves the bridge process is up
+  # -- it says nothing about whether the plugin's own bundle (served by its
+  # own Deployment/Service, per ci-test-stack's plugin.port) is actually
+  # fetchable yet. Every E2E run gets a brand-new plugin pod scoped to this
+  # run's ID, so this is a cold start every single time regardless of how
+  # long the underlying cluster has existed -- without this check, tests can
+  # start clicking around the console while it's still showing a loading
+  # overlay for the not-yet-servable Virtualization perspective, which
+  # cascades into a total suite failure on suites without per-test isolation
+  # (confirmed live: release-4.20 Cypress, 0/37 passing, root cause traced to
+  # exactly this race).
+  local plugin_base="http://${helm_release}-plugin.${test_ns}.svc.cluster.local:9080"
+  log "Waiting for plugin bundle at ${plugin_base}..."
+  local plugin_ready=false
+  for i in $(seq 1 60); do
+    if curl -s "${plugin_base}/plugin-manifest.json" 2>/dev/null | grep -q '"name"'; then
+      plugin_ready=true
+      break
+    fi
+    sleep 5
+  done
+
+  if [[ "${plugin_ready}" != "true" ]]; then
+    local err="plugin bundle did not become ready within 5 minutes"
+    log "ERROR: ${err}"
+    patch_cm "${cm_name}" "{\"data\":{\"status\":\"error\",\"error-message\":\"${err}\"}}"
+    return 1
+  fi
+
   local console_route="https://${route_host}"
   log "Environment ready: bridge=${bridge_base} route=${console_route}"
   patch_cm "${cm_name}" "{\"data\":{\"status\":\"ready\",\"bridge-base-address\":\"${bridge_base}\",\"console-route\":\"${console_route}\"}}"

--- a/ci-scripts/hot-cluster/helm/ci-test-stack/templates/console-deployment.yaml
+++ b/ci-scripts/hot-cluster/helm/ci-test-stack/templates/console-deployment.yaml
@@ -75,7 +75,7 @@ spec:
 
             # Customization settings
             - name: BRIDGE_USER_SETTINGS_LOCATION
-              value: "localstorage"
+              value: {{ .Values.console.userSettingsLocation | default "localstorage" | quote }}
 
             # Plugins
             - name: BRIDGE_PLUGINS

--- a/ci-scripts/hot-cluster/helm/ci-test-stack/values.yaml
+++ b/ci-scripts/hot-cluster/helm/ci-test-stack/values.yaml
@@ -36,6 +36,16 @@ console:
     # auth.mode=openshift; ci-env-controller passes this via --set-file.
     caCert: ''
 
+  # BRIDGE_USER_SETTINGS_LOCATION. "localstorage" (default) keeps user
+  # settings (guided-tour completion, quickstart dismissal, column prefs,
+  # ...) purely in the browser -- what Playwright's seedGuidedTourState()
+  # relies on. ci-env-controller only ever overrides this to "configmap" for
+  # a caller that also seeds the equivalent server-side ConfigMap itself
+  # (Cypress E2E, via hot-cluster-e2e-run.yml's "Seed kubevirt-user-settings
+  # ConfigMap" step) -- never change this default unconditionally, or
+  # Playwright's browser-side seeding silently stops having any effect.
+  userSettingsLocation: localstorage
+
 # ClusterRole created by the ci-env-controller Helm chart (clusterrole-console.yaml).
 rbac:
   consoleClusterRole: cluster-admin

--- a/ci-scripts/hot-cluster/install-hco.sh
+++ b/ci-scripts/hot-cluster/install-hco.sh
@@ -8,6 +8,32 @@
 # Environment variables (all have defaults):
 #   KVM_EMULATION          - "true" or "false" (default: "true", only bare metal nodes have real KVM)
 #   CNV_CHANNEL            - OLM subscription channel (default: "stable")
+#   CNV_PIN_VERSION        - "<major>.<minor>" to pin CNV to the newest matching CSV
+#                            within CNV_CHANNEL via startingCSV, instead of installing
+#                            whatever the channel head currently resolves to (default:
+#                            empty/unpinned). Resolved dynamically against the live
+#                            PackageManifest at install time -- if no CSV matching this
+#                            version prefix is found (e.g. pruned from the channel's
+#                            entry graph), this is a hard failure (exit 1), NOT a
+#                            silent fallback to the latest channel head: installing an
+#                            unexpectedly newer CNV than the pin requested is a worse
+#                            outcome than failing the build, since it can make release
+#                            CI pass against the wrong product version without anyone
+#                            noticing. To deliberately install unpinned, override
+#                            cnv_channel explicitly on the workflow dispatch instead
+#                            (any explicit cnv_channel override clears the pin -- see
+#                            resolve-cluster-config.sh). Pinning also switches
+#                            installPlanApproval to Manual and approves only the
+#                            initial InstallPlan (after verifying it actually targets
+#                            STARTING_CSV -- guards against re-running this script
+#                            against an already-provisioned Subscription that has
+#                            since advanced to a later upgrade InstallPlan), so later
+#                            channel upgrades don't silently move the cluster off the
+#                            pinned version. Pinning only takes effect at Subscription
+#                            creation time -- it cannot re-pin or downgrade a cluster
+#                            that already has CNV installed (this script only ever
+#                            runs once per cluster's lifetime; see hot-cluster-check.yml
+#                            and ibmc-cluster-setup.yml's precheck job).
 #   HCO_CR_PATH            - Path to HCO CR yaml (default: playwright/fixtures/hco.yaml)
 #   SKIP_HPP               - Set to "true" to skip HPP installation
 #   HPP_VERSION            - HostPath Provisioner release branch
@@ -16,6 +42,7 @@ set -euo pipefail
 
 export KVM_EMULATION="${KVM_EMULATION:-true}"
 export CNV_CHANNEL="${CNV_CHANNEL:-stable}"
+CNV_PIN_VERSION="${CNV_PIN_VERSION:-}"
 HCO_CR_PATH="${HCO_CR_PATH:-playwright/fixtures/hco.yaml}"
 SKIP_HPP="${SKIP_HPP:-false}"
 HPP_VERSION="${HPP_VERSION:-release-v0.21}"
@@ -26,14 +53,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 echo "=== OpenShift Virtualization (CNV) Installation ==="
-echo "  KVM_EMULATION: ${KVM_EMULATION}"
-echo "  CNV_CHANNEL:   ${CNV_CHANNEL}"
-echo "  CNV_NS:        ${CNV_NS}"
-echo "  SKIP_HPP:      ${SKIP_HPP}"
+echo "  KVM_EMULATION:   ${KVM_EMULATION}"
+echo "  CNV_CHANNEL:     ${CNV_CHANNEL}"
+echo "  CNV_PIN_VERSION: ${CNV_PIN_VERSION:-<none, unpinned>}"
+echo "  CNV_NS:          ${CNV_NS}"
+echo "  SKIP_HPP:        ${SKIP_HPP}"
 echo ""
 
-# --- Namespace + OperatorGroup + Subscription ---
-echo "Creating CNV Namespace, OperatorGroup, and Subscription..."
+# --- Namespace + OperatorGroup ---
+echo "Creating CNV Namespace and OperatorGroup..."
 oc apply -f - <<EOF
 apiVersion: v1
 kind: Namespace
@@ -48,8 +76,70 @@ metadata:
 spec:
   targetNamespaces:
     - ${CNV_NS}
----
-apiVersion: operators.coreos.com/v1alpha1
+EOF
+
+# --- Resolve a pinned startingCSV, if requested ---
+# Only the channel head can be selected by name -- version-matching an old
+# release branch's CNV needs a specific CSV pinned via startingCSV, looked
+# up dynamically against the live catalog (no static version table to
+# maintain, and it naturally tracks z-stream bumps).
+STARTING_CSV=""
+INSTALL_PLAN_APPROVAL="Automatic"
+
+if [[ -n "${CNV_PIN_VERSION}" ]]; then
+  # Validate defensively -- a malformed value (bad override, upstream bug)
+  # must fail loudly here, not silently produce a meaningless jq/sort -V
+  # comparison below that could match nothing (or, worse, everything).
+  if [[ ! "${CNV_PIN_VERSION}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    echo "ERROR: CNV_PIN_VERSION='${CNV_PIN_VERSION}' is not a valid \"<major>.<minor>\" version (e.g. \"4.20\")."
+    exit 1
+  fi
+
+  echo "Resolving pinned CSV for CNV_PIN_VERSION=${CNV_PIN_VERSION} from channel '${CNV_CHANNEL}'..."
+  # Query the full list (not `oc get packagemanifest kubevirt-hyperconverged`
+  # by name) and filter by catalogSource explicitly -- a PackageManifest's
+  # .metadata.name isn't guaranteed unique across catalog sources, so
+  # fetching by name alone risks an ambiguous/wrong match if another source
+  # happens to expose a same-named package. Matching catalogSource ==
+  # redhat-operators keeps this in lockstep with the Subscription below,
+  # which pins to that exact source.
+  #
+  # Retried like the HPP/HCO CR applies below -- with `pipefail` active, a
+  # transient `oc get` failure (plausible right after cluster creation,
+  # while the API/catalog operator may still be stabilizing) would
+  # otherwise trip `set -e` and abort the whole script immediately, instead
+  # of just this one lookup. A genuine "no match" result still exits 0 (jq/
+  # sort/tail/awk all succeed on empty input), so this only retries real
+  # command failures -- the empty-result handling below is unaffected.
+  for attempt in 1 2 3; do
+    if STARTING_CSV="$(oc get packagemanifest -n openshift-marketplace -o json 2>/dev/null \
+      | jq -r --arg ch "${CNV_CHANNEL}" --arg ver "${CNV_PIN_VERSION}." \
+        '.items[]? | select(.metadata.name == "kubevirt-hyperconverged" and .status.catalogSource == "redhat-operators") | .status.channels[]? | select(.name == $ch) | .entries[]? | select((.version // "") | startswith($ver)) | "\(.version) \(.name)"' \
+      | sort -V | tail -1 | awk '{print $2}')"; then
+      break
+    fi
+    echo "  Retry ${attempt}/3 for packagemanifest lookup (API may be transiently unavailable)..."
+    sleep 10
+  done
+
+  if [[ -z "${STARTING_CSV}" ]]; then
+    echo "ERROR: No CSV matching version prefix '${CNV_PIN_VERSION}.' found in channel '${CNV_CHANNEL}' (redhat-operators)."
+    echo "This branch's CNV version may have aged out of the channel's retained entry graph, or something else is wrong -- investigate before proceeding."
+    echo "This is a hard failure rather than a silent fallback to the latest '${CNV_CHANNEL}' head: installing an unexpectedly newer CNV than requested could make this branch's CI pass against the wrong product version without anyone noticing."
+    echo "To deliberately install unpinned, override cnv_channel explicitly on the workflow dispatch (any explicit cnv_channel override clears the pin)."
+    exit 1
+  fi
+
+  echo "Resolved pinned CSV: ${STARTING_CSV}"
+  INSTALL_PLAN_APPROVAL="Manual"
+fi
+
+# --- Subscription ---
+# installPlanApproval stays Manual (never re-approved beyond the one plan
+# below) when pinned, so a later upgrade InstallPlan the channel generates
+# is intentionally left pending instead of silently moving the cluster off
+# STARTING_CSV.
+SUBSCRIPTION_YAML="apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: hco-operatorhub
@@ -58,12 +148,23 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   name: kubevirt-hyperconverged
-  channel: "${CNV_CHANNEL}"
-  installPlanApproval: Automatic
+  channel: \"${CNV_CHANNEL}\"
+  installPlanApproval: ${INSTALL_PLAN_APPROVAL}"
+
+if [[ -n "${STARTING_CSV}" ]]; then
+  SUBSCRIPTION_YAML="${SUBSCRIPTION_YAML}
+  startingCSV: \"${STARTING_CSV}\""
+fi
+
+SUBSCRIPTION_YAML="${SUBSCRIPTION_YAML}
   config:
     env:
     - name: KVM_EMULATION
-      value: "${KVM_EMULATION}"
+      value: \"${KVM_EMULATION}\""
+
+echo "Creating CNV Subscription..."
+oc apply -f - <<EOF
+${SUBSCRIPTION_YAML}
 EOF
 
 echo "Waiting for Subscription to have an InstallPlan..."
@@ -81,6 +182,29 @@ for i in $(seq 1 120); do
   echo "Waiting for InstallPlan... (${i}/120)"
   sleep 5
 done
+
+if [[ "${INSTALL_PLAN_APPROVAL}" == "Manual" ]]; then
+  # Guard against approving the wrong plan if this script is ever re-run
+  # against an already-provisioned Subscription (e.g. a retry after a
+  # transient failure earlier in this same job, before the cluster's own
+  # DNS/API is up) -- installPlanRef can have moved on to a later upgrade
+  # InstallPlan by then, and blindly approving it would silently unpin the
+  # cluster to whatever the channel head is at that point.
+  PLAN_CSVS="$(oc get installplan "${INSTALL_PLAN}" -n ${CNV_NS} -o jsonpath='{.spec.clusterServiceVersionNames[*]}' 2>/dev/null || true)"
+  if [[ " ${PLAN_CSVS} " != *" ${STARTING_CSV} "* ]]; then
+    echo "ERROR: InstallPlan ${INSTALL_PLAN} does not target the pinned CSV ${STARTING_CSV} (it targets: ${PLAN_CSVS:-<none>})."
+    echo "Refusing to approve it -- this would silently move the cluster off the pinned version. Investigate manually (a stale Subscription from a prior run is the most likely cause)."
+    exit 1
+  fi
+
+  echo "Approving the initial InstallPlan (${INSTALL_PLAN}) for pinned CSV ${STARTING_CSV}..."
+  echo "This is the only InstallPlan this script will ever approve -- installPlanApproval stays Manual, so any later upgrade InstallPlan the channel generates is intentionally left pending (harmless -- it never installs without a further explicit approval this script never gives), keeping CNV pinned at this version."
+  oc patch installplan "${INSTALL_PLAN}" -n ${CNV_NS} --type merge -p '{"spec":{"approved":true}}'
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "starting_csv=${STARTING_CSV}" >> "$GITHUB_OUTPUT"
+fi
 
 # --- Wait for HCO operator deployment ---
 echo "Waiting for HCO operator deployment to be created..."
@@ -133,6 +257,22 @@ echo "Waiting for HCO to report Available..."
 oc wait -n ${CNV_NS} hyperconverged kubevirt-hyperconverged \
   --for=condition=Available \
   --timeout=15m
+
+# --- Confirm the installed CSV actually matches the pin, if requested ---
+# Belt-and-suspenders check: the InstallPlan-targeting guard above should
+# already guarantee this, but confirming what's actually running (not just
+# what was approved) catches anything unexpected between approval and now.
+# Hard failure, not a warning -- same fail-closed reasoning as the
+# resolution step above: letting the build succeed while quietly running an
+# unexpected CNV version is worse than failing it outright.
+if [[ -n "${STARTING_CSV}" ]]; then
+  ACTUAL_CSV="$(oc get subscription hco-operatorhub -n ${CNV_NS} -o jsonpath='{.status.currentCSV}' 2>/dev/null || true)"
+  if [[ "${ACTUAL_CSV}" != "${STARTING_CSV}" ]]; then
+    echo "ERROR: Installed CSV '${ACTUAL_CSV:-<none>}' does not match pinned CSV '${STARTING_CSV}' -- the cluster is not running the expected CNV version."
+    exit 1
+  fi
+  echo "Confirmed installed CSV matches pin: ${ACTUAL_CSV}"
+fi
 
 # --- Wait for operands to be fully ready ---
 echo "Waiting for CNV operands to finish deploying..."
@@ -209,6 +349,11 @@ fi
 
 echo ""
 echo "=== OpenShift Virtualization Installation Complete ==="
-echo "  Namespace: ${CNV_NS}"
-echo "  Channel:   ${CNV_CHANNEL}"
-echo "  nmstate:   bundled (installed as CNV operand)"
+echo "  Namespace:   ${CNV_NS}"
+echo "  Channel:     ${CNV_CHANNEL}"
+if [[ -n "${STARTING_CSV}" ]]; then
+  echo "  Pinned CSV:  ${STARTING_CSV} (installPlanApproval: Manual)"
+else
+  echo "  Pinned CSV:  <none, unpinned>"
+fi
+echo "  nmstate:     bundled (installed as CNV operand)"

--- a/ci-scripts/hot-cluster/resolve-cluster-config.sh
+++ b/ci-scripts/hot-cluster/resolve-cluster-config.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 # Emits cluster_name=..., openshift_version=..., test_engine=...,
-# branch_name=..., and cnv_channel=... for GITHUB_OUTPUT.
+# branch_name=..., cnv_channel=..., and cnv_pin_version=... for
+# GITHUB_OUTPUT.
 #
 # Runs against a release-<major>.<minor> base branch get a dedicated,
 # version-matched cluster (kubevirt-plugin-<major><minor>) instead of
@@ -26,9 +27,23 @@ set -euo pipefail
 # could never resolve an InstallPlan for (confirmed live: cluster
 # provisioning hung for 10+ minutes then failed outright). Actually
 # version-pinning old CNV releases would need startingCSV + Manual
-# approval on the Subscription, not a differently-named channel -- out of
-# scope here; INPUT_CNV_CHANNEL below remains available as an explicit
-# override for anyone who wants to try that separately.
+# approval on the Subscription, not a differently-named channel --
+# INPUT_CNV_CHANNEL below remains available as an explicit override for
+# anyone who wants to try a different channel directly.
+#
+# cnv_pin_version carries that startingCSV pinning: for a release branch,
+# it resolves to "<major>.<minor>" (e.g. "4.20") -- install-hco.sh queries
+# the live PackageManifest for the 'stable' channel's newest CSV whose
+# version starts with that prefix, and pins the Subscription to it via
+# startingCSV + installPlanApproval: Manual. If that version can't be
+# found (e.g. pruned from the channel's entry graph), install-hco.sh fails
+# the build rather than silently falling back to the latest 'stable' head
+# -- installing an unexpectedly newer CNV than requested could make a
+# release branch's CI pass against the wrong product version unnoticed.
+# INPUT_CNV_CHANNEL below remains the explicit escape hatch for anyone who
+# wants to deliberately install unpinned instead. Left empty for
+# main/default/workflow_dispatch, which keep installing whatever 'stable'
+# currently resolves to, same as before.
 #
 # Env:
 #   BASE_REF                - PR target branch (e.g. release-4.20), from
@@ -63,7 +78,8 @@ if [[ "${BASE_REF}" =~ ^release-([0-9]+)\.([0-9]+)$ ]]; then
   CLUSTER_NAME="kubevirt-plugin-${MAJOR}${MINOR}"
   OPENSHIFT_VERSION="${MAJOR}.${MINOR}_openshift"
   CNV_CHANNEL="${DEFAULT_CNV_CHANNEL}"
-  echo "Base branch '${BASE_REF}' is a release branch → cluster '${CLUSTER_NAME}' (${OPENSHIFT_VERSION}, CNV channel '${CNV_CHANNEL}')" >&2
+  CNV_PIN_VERSION="${MAJOR}.${MINOR}"
+  echo "Base branch '${BASE_REF}' is a release branch → cluster '${CLUSTER_NAME}' (${OPENSHIFT_VERSION}, CNV channel '${CNV_CHANNEL}', pinned to CNV ${CNV_PIN_VERSION}.x)" >&2
 
   if (( MAJOR * 1000 + MINOR <= LAST_CYPRESS_MAJOR * 1000 + LAST_CYPRESS_MINOR )); then
     TEST_ENGINE="cypress"
@@ -75,6 +91,7 @@ else
   CLUSTER_NAME="${INPUT_CLUSTER_NAME:-${DEFAULT_CLUSTER_NAME}}"
   OPENSHIFT_VERSION="${INPUT_OPENSHIFT_VERSION:-${DEFAULT_OPENSHIFT_VERSION}}"
   CNV_CHANNEL="${DEFAULT_CNV_CHANNEL}"
+  CNV_PIN_VERSION=""
   echo "Using default/workflow_dispatch cluster config: '${CLUSTER_NAME}' (${OPENSHIFT_VERSION}, CNV channel '${CNV_CHANNEL}')" >&2
   TEST_ENGINE="${DEFAULT_TEST_ENGINE}"
 fi
@@ -91,13 +108,15 @@ fi
 # Manual approval for an older CSV -- not versioned channel names).
 if [[ -n "${INPUT_CNV_CHANNEL}" ]]; then
   CNV_CHANNEL="${INPUT_CNV_CHANNEL}"
-  echo "Overriding CNV channel from input: '${CNV_CHANNEL}'" >&2
+  CNV_PIN_VERSION=""
+  echo "Overriding CNV channel from input: '${CNV_CHANNEL}' (clearing auto-pinned CNV version -- an explicit channel override takes full manual control)" >&2
 fi
 
 echo "cluster_name=${CLUSTER_NAME}"
 echo "openshift_version=${OPENSHIFT_VERSION}"
 echo "test_engine=${TEST_ENGINE}"
 echo "cnv_channel=${CNV_CHANNEL}"
+echo "cnv_pin_version=${CNV_PIN_VERSION}"
 # Raw resolved base branch (e.g. "main", "release-4.20"), or empty when
 # there's none (plain workflow_dispatch with no PR context) -- callers
 # combine this with a ref_name fallback for display purposes (e.g. the

--- a/ci-scripts/manual-console/README.md
+++ b/ci-scripts/manual-console/README.md
@@ -36,14 +36,17 @@ permission out of the cluster-wide E2E RBAC, so it's granted separately and
 scoped to just this namespace:
 
 ```bash
-oc create namespace manual-console --dry-run=client -o yaml | oc apply -f -
-oc apply -f ci-scripts/manual-console/manual-console-rbac.yaml
+./ci-scripts/manual-console/install-manual-console-rbac.sh
 ```
 
-If your cluster uses a custom `RUNNER_SCALE_SET_NAME` or `ARC_RUNNERS_NS` (see
-[`arc/README.md`](../hot-cluster/arc/README.md)), edit the `ServiceAccount`
-subject in `manual-console-rbac.yaml` first -- it hardcodes the default
-`kubevirt-plugin-ci-gha-rs-no-permission` / `arc-runners`.
+Set `RUNNER_SCALE_SET_NAME` / `ARC_RUNNERS_NS` first if your cluster uses a
+custom runner scale set name (see [`arc/README.md`](../hot-cluster/arc/README.md))
+-- the script substitutes the `ServiceAccount` subject in
+`manual-console-rbac.yaml` for you (default `kubevirt-plugin-ci`, e.g.
+`RUNNER_SCALE_SET_NAME=kubevirt-plugin-420` for that release cluster). Do
+not `oc apply -f manual-console-rbac.yaml` directly unless your runner
+scale set is actually named `kubevirt-plugin-ci` -- the raw manifest's
+subject never matches a release cluster's runner SA.
 
 ## Deploying
 
@@ -135,11 +138,12 @@ TTL reaper** that force-cleans stale E2E environments.
 
 ## Files
 
-| File                            | Purpose                                                                                                                                         |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `images/setup-plugin-image.sh`  | Builds the kubevirt-plugin image in-cluster via an OpenShift BuildConfig                                                                        |
-| `ensure-manual-console-user.sh` | Upserts the htpasswd user + extracts the cluster CA bundle; invoked by `ci-env-controller` (embedded into its image -- see below)               |
-| `manual-console-rbac.yaml`      | One-time, per-cluster Role/RoleBinding granting the ARC runner SA ImageStream/BuildConfig access, scoped to the `manual-console` namespace only |
+| File                             | Purpose                                                                                                                                         |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `images/setup-plugin-image.sh`   | Builds the kubevirt-plugin image in-cluster via an OpenShift BuildConfig                                                                        |
+| `ensure-manual-console-user.sh`  | Upserts the htpasswd user + extracts the cluster CA bundle; invoked by `ci-env-controller` (embedded into its image -- see below)               |
+| `manual-console-rbac.yaml`       | One-time, per-cluster Role/RoleBinding granting the ARC runner SA ImageStream/BuildConfig access, scoped to the `manual-console` namespace only |
+| `install-manual-console-rbac.sh` | Applies `manual-console-rbac.yaml` with the ServiceAccount subject substituted for the cluster's actual runner scale set name                   |
 
 `ensure-manual-console-user.sh` is embedded into the `ci-env-runner` image at
 build time (via a symlink in

--- a/ci-scripts/manual-console/install-manual-console-rbac.sh
+++ b/ci-scripts/manual-console/install-manual-console-rbac.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# One-time, per-cluster bootstrap of the ARC runner ServiceAccount's
+# ImageStream/BuildConfig RBAC inside the manual-console namespace
+# (CNV-92150). Creates the namespace if needed, then applies
+# manual-console-rbac.yaml with its ServiceAccount subject substituted for
+# the cluster's actual runner scale set name -- mirrors
+# ../hot-cluster/arc/install-runner-scale-set.sh's own substitution of
+# arc-runner-rbac.yaml, for the same reason: the raw manifest hardcodes the
+# "kubevirt-plugin-ci" default, which never matches a release cluster's
+# runner SA (e.g. "kubevirt-plugin-420-gha-rs-no-permission").
+#
+# Optional environment variables:
+#   RUNNER_SCALE_SET_NAME (default: kubevirt-plugin-ci)
+#   ARC_RUNNERS_NS         (default: arc-runners)
+#   MANUAL_CONSOLE_NS      (default: manual-console)
+#
+# Requires: oc logged into the target cluster as a cluster-admin.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+source "${REPO_ROOT}/ci-scripts/_cluster-helpers.sh"
+verify_oc
+
+RUNNER_SCALE_SET_NAME="${RUNNER_SCALE_SET_NAME:-kubevirt-plugin-ci}"
+ARC_RUNNERS_NS="${ARC_RUNNERS_NS:-arc-runners}"
+MANUAL_CONSOLE_NS="${MANUAL_CONSOLE_NS:-manual-console}"
+RUNNER_SA="${RUNNER_SCALE_SET_NAME}-gha-rs-no-permission"
+RBAC_MANIFEST="${SCRIPT_DIR}/manual-console-rbac.yaml"
+
+echo "=== Manual console RBAC bootstrap ==="
+echo "  RUNNER_SCALE_SET_NAME: ${RUNNER_SCALE_SET_NAME}"
+echo "  ARC_RUNNERS_NS:        ${ARC_RUNNERS_NS}"
+echo "  MANUAL_CONSOLE_NS:     ${MANUAL_CONSOLE_NS}"
+echo "  Runner SA:             ${RUNNER_SA}"
+echo ""
+
+if [[ ! -f "${RBAC_MANIFEST}" ]]; then
+  echo "ERROR: Missing ${RBAC_MANIFEST}"
+  exit 1
+fi
+
+echo "Creating namespace ${MANUAL_CONSOLE_NS}..."
+oc create namespace "${MANUAL_CONSOLE_NS}" --dry-run=client -o yaml | oc apply -f -
+
+echo "Applying manual-console RBAC (Role manual-console-image-build → ${RUNNER_SA} in ${ARC_RUNNERS_NS})..."
+RENDERED="$(sed \
+  -e "s/^  namespace: manual-console\$/  namespace: ${MANUAL_CONSOLE_NS}/" \
+  -e "s/^    name: kubevirt-plugin-ci-gha-rs-no-permission\$/    name: ${RUNNER_SA}/" \
+  -e "s/^    namespace: arc-runners\$/    namespace: ${ARC_RUNNERS_NS}/" \
+  "${RBAC_MANIFEST}")"
+
+# Guard against a silent no-op sed: if manual-console-rbac.yaml's indentation
+# or literal text ever drifts from what these patterns match, sed exits 0
+# but leaves the defaults untouched -- applying RBAC for the wrong SA/
+# namespace without any error (exactly the class of bug this script exists
+# to fix elsewhere). Fail loudly instead.
+if ! grep -q "name: ${RUNNER_SA}\$" <<<"${RENDERED}" || ! grep -q "namespace: ${ARC_RUNNERS_NS}\$" <<<"${RENDERED}"; then
+  echo "ERROR: sed substitution did not produce the expected ServiceAccount subject" >&2
+  echo "  (expected 'name: ${RUNNER_SA}' and 'namespace: ${ARC_RUNNERS_NS}' in the rendered manifest)." >&2
+  echo "  manual-console-rbac.yaml's format likely changed -- update this script's sed patterns." >&2
+  exit 1
+fi
+if [[ "${MANUAL_CONSOLE_NS}" != "manual-console" ]] && ! grep -q "namespace: ${MANUAL_CONSOLE_NS}\$" <<<"${RENDERED}"; then
+  echo "ERROR: sed substitution did not rename the manual-console namespace to '${MANUAL_CONSOLE_NS}'." >&2
+  exit 1
+fi
+
+oc apply -f - <<<"${RENDERED}"
+
+echo ""
+echo "=== Manual console RBAC bootstrap complete ==="

--- a/ci-scripts/manual-console/manual-console-rbac.yaml
+++ b/ci-scripts/manual-console/manual-console-rbac.yaml
@@ -5,13 +5,17 @@
 # keep the E2E path's RBAC surface minimal; this file is additive and only
 # takes effect inside the manual-console namespace.
 #
-# Idempotent, one-time bootstrap per cluster (namespace must already exist,
-# or be created first -- see below). Apply manually:
-#   oc create namespace manual-console --dry-run=client -o yaml | oc apply -f -
-#   oc apply -f ci-scripts/manual-console/manual-console-rbac.yaml
+# Idempotent, one-time bootstrap per cluster. Apply via:
+#   ./ci-scripts/manual-console/install-manual-console-rbac.sh
 #
-# If RUNNER_SCALE_SET_NAME / ARC_RUNNERS_NS differ from defaults, edit the
-# subject below (see arc-runner-rbac.yaml for the same caveat).
+# That script substitutes the ServiceAccount subject below from
+# RUNNER_SCALE_SET_NAME / ARC_RUNNERS_NS (same convention as
+# arc-runner-rbac.yaml / install-runner-scale-set.sh) -- do not apply this
+# file directly with `oc apply -f` unless your cluster's runner scale set
+# is actually named "kubevirt-plugin-ci" (the default). A release cluster's
+# runner is named "<RUNNER_SCALE_SET_NAME>-gha-rs-no-permission" (e.g.
+# "kubevirt-plugin-420-gha-rs-no-permission"), which the raw subject below
+# never matches -- confirmed live, CNV-92682 follow-up.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
## 📝 Description

**CNV/HCO version pin**: pin CNV/HCO to the release branch's major.minor via startingCSV (fail-closed if no matching CSV), instead of the unversioned stable channel silently resolving to latest GA.

**Wrong branch built/tested**: hot-cluster-e2e.yml's checkout_ref now follows base_ref for release-branch dispatches (workflow_dispatch//retest-e2e) instead of silently falling back to the workflow's own ref -- previously a "release-4.20" dispatch could build main's plugin and run Playwright against a Cypress-era cluster.

**Cold-start race**: ci-env-controller.sh now also waits for the plugin bundle (not just the console) to be servable before marking a test environment ready.

**Status/check-run collisions**: ad-hoc workflow_dispatch runs (no pr_number) now post distinctly-named status/check contexts so they no longer clobber a real PR's "Run Gating Tests"/progress status on the same SHA.

**RBAC**: arc-runner-ci's namespaces patch is now scoped via resourceNames (was cluster-wide); manual-console RBAC subject is parameterized per cluster (install-manual-console-rbac.sh) and auto-bootstrapped during cluster provisioning.

**Manual-console wrong plugin version**: deploy-manual-console.yml/deploy-plugin.yml now checkout workflow scripts and plugin source separately, so an old release branch's plugin is no longer built against a newer console incompatibly.

**Guided-tour modal blocking Cypress**: OpenShift Console's own "Welcome to the new OpenShift experience" tour modal blocked the first Cypress test on old release branches (console feature absent from their frozen test content). Fixed via a test-engine-conditional BRIDGE_USER_SETTINGS_LOCATION=configmap + server-side tour-completion seed, scoped to Cypress only -- Playwright's existing localStorage-based seeding is untouched.

## 🔗 Links

Jira ticket: [CNV-92682](https://redhat.atlassian.net/browse/CNV-92682)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Optional CNV pinning (`<major>.<minor>`) for hot-cluster provisioning, with release-branch auto-selection and reporting of requested vs installed CNV CSV.
  * Improved E2E run naming/context for reusable calls and ad-hoc manual dispatches; E2E now supports console user-settings override for Cypress runs.
  * Added manual-console RBAC bootstrap support and clarified plugin deploy/redeploy checkout behavior.
* **Bug Fixes**
  * Hot-cluster provisioning now fails fast when pinned CNV doesn’t match the installed `currentCSV`.
  * Readiness now waits for plugin bundle availability before marking environments ready.
* **Documentation**
  * Updated manual-console README plus console/plugin deploy/redeploy guidance for the new RBAC bootstrap and ref behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->