### PR TITLE
CNV-87123: Testing for VSOCK toggle feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/js-yaml": "^4.0.5",
         "@types/node": "^22.x",
         "@types/react": "^18.3.28",
@@ -6806,6 +6807,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/js-yaml": "^4.0.5",
     "@types/node": "^22.x",
     "@types/react": "^18.3.28",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -101,6 +101,26 @@ export default defineConfig({
         ]
       : []),
 
+    // ── Scenario project (new tests, uses global setup/teardown) ─────
+    ...(process.env.USE_SCENARIO_INFRA === 'true'
+      ? [
+          {
+            fullyParallel: false,
+            name: 'scenario',
+            retries: 0,
+            testDir: './playwright/tests/scenario',
+            use: {
+              ...devices['Desktop Chrome'],
+              launchOptions: {
+                args: chromeArgs,
+                headless: !process.env.DEBUG_MODE && !process.env.HEADED,
+              },
+              viewport: { height: 1080, width: 1920 },
+            },
+          },
+        ]
+      : []),
+
     // ── Migration projects (use global setup/teardown) ───────────────
     {
       fullyParallel: true,

--- a/playwright/src/fixtures/scenario-fixture.ts
+++ b/playwright/src/fixtures/scenario-fixture.ts
@@ -1,6 +1,7 @@
 import { KubernetesClient } from '@/clients/kubernetes-client';
 import { CheckupsPage } from '@/page-objects/checkups-page';
 import { OverviewPage } from '@/page-objects/overview-page';
+import { PreviewFeaturesSettingsPage } from '@/page-objects/settings/preview-features-settings-page';
 import { VirtualMachinesPage } from '@/page-objects/virtual-machines-page';
 import { getStorageStatePath } from '@/utils/file-utils';
 import { TestConfigManager } from '@/utils/test-config';
@@ -10,6 +11,7 @@ interface ScenarioFixtures {
   checkupsPage: CheckupsPage;
   k8sClient: KubernetesClient;
   overviewPage: OverviewPage;
+  previewFeaturesSettingsPage: PreviewFeaturesSettingsPage;
   virtualMachinesPage: VirtualMachinesPage;
 }
 
@@ -33,6 +35,10 @@ export const scenarioTest = base.extend<ScenarioFixtures>({
 
   overviewPage: async ({ page }, use) => {
     await use(new OverviewPage(page));
+  },
+
+  previewFeaturesSettingsPage: async ({ page }, use) => {
+    await use(new PreviewFeaturesSettingsPage(page));
   },
 
   virtualMachinesPage: async ({ page }, use) => {

--- a/playwright/src/page-objects/settings/preview-features-settings-page.ts
+++ b/playwright/src/page-objects/settings/preview-features-settings-page.ts
@@ -1,0 +1,59 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { SECOND } from 'utils/constants';
+import { env } from '../../../utils/env';
+
+const PREVIEW_FEATURES_TAB = 'Preview features';
+const VSOCK_FEATURE_ID = 'vsockEnabled';
+const WAIT_VSOCK_TOGGLE = SECOND;
+
+/**
+ * Page object for the Virtualization Settings page.
+ * Covers navigation and interaction with the Preview Features tab,
+ * specifically the VSOCK toggle.
+ */
+export class PreviewFeaturesSettingsPage {
+  readonly heading: Locator;
+  readonly previewFeaturesTab: Locator;
+  readonly vsockSwitch: Locator;
+
+  constructor(private readonly page: Page) {
+    this.heading = page.getByRole('heading', { level: 1, name: 'Settings' });
+    this.previewFeaturesTab = page.getByRole('tab', {
+      exact: true,
+      name: PREVIEW_FEATURES_TAB,
+    });
+    this.vsockSwitch = page.locator(`[data-test-id="${VSOCK_FEATURE_ID}"]`);
+  }
+
+  async disableVsock(): Promise<void> {
+    await this.navigateToPreviewFeatures();
+    const isOn = await this.vsockSwitch.isChecked();
+    if (isOn) {
+      await this.vsockSwitch.locator('..').click();
+      await this.page.waitForTimeout(WAIT_VSOCK_TOGGLE);
+    }
+  }
+
+  async enableVsock(): Promise<void> {
+    await this.navigateToPreviewFeatures();
+    const isOn = await this.vsockSwitch.isChecked();
+    if (!isOn) {
+      await this.vsockSwitch.locator('..').click();
+      await this.page.waitForTimeout(WAIT_VSOCK_TOGGLE);
+    }
+  }
+
+  async navigate(): Promise<void> {
+    await this.page.goto(`/k8s/ns/${env.cnvNamespace}/virtualization-settings`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await this.heading.waitFor({ state: 'visible', timeout: 30_000 });
+  }
+
+  async navigateToPreviewFeatures(): Promise<void> {
+    await this.navigate();
+    await this.previewFeaturesTab.click();
+    await this.vsockSwitch.waitFor({ state: 'visible', timeout: 30_000 });
+  }
+}

--- a/playwright/tests/scenario/vsock-toggle.spec.ts
+++ b/playwright/tests/scenario/vsock-toggle.spec.ts
@@ -1,0 +1,147 @@
+import { expect, scenarioTest as test } from '@/fixtures/scenario-fixture';
+import { SECOND } from 'utils/constants';
+
+const VSOCK_SWITCH_ID = '#enable-vsock';
+const NS = process.env.TEST_NS || 'default';
+const WIZARD_URL = '/vm-wizard';
+const WAIT_VSOCK_TOGGLE = SECOND;
+
+async function handleWizardFourFirstSteps(page: import('@playwright/test').Page) {
+  await page.goto(WIZARD_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle');
+
+  // Step 1: Deployment details — generate name and click Next
+  const generateNameBtn = page.locator('[data-test="generate-vm-name-button"]');
+  await generateNameBtn.waitFor({ state: 'visible', timeout: 30_000 });
+  await generateNameBtn.click();
+
+  const nameInput = page.locator('#vm-name');
+  await nameInput.waitFor({ state: 'visible', timeout: 5_000 });
+  const vmName = await nameInput.inputValue();
+
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+  // Step 2: Guest OS — select RHEL
+  const rhelTile = page.getByText('RHEL', { exact: true });
+  await rhelTile.waitFor({ state: 'visible', timeout: 30_000 });
+  await rhelTile.click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+  // Step 3: Boot source — select first available volume
+  const bootSourceRow = page.locator('table tbody tr').first();
+  await bootSourceRow.waitFor({ state: 'visible', timeout: 60_000 });
+  await bootSourceRow.click();
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+  // Step 4: Compute resources — use default
+  await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+  // Return generated vm name so we can use it in the next steps
+  return vmName;
+}
+
+test.skip('VSOCK toggle — full end-to-end flow', async ({
+  page,
+  previewFeaturesSettingsPage: settingsPage,
+}) => {
+  let vmName: string;
+
+  // ── Step 0: Enable VSOCK in Settings ──────────────────────────────────
+  await test.step('Enable VSOCK in Settings → Preview features', async () => {
+    await settingsPage.enableVsock();
+    await expect(settingsPage.vsockSwitch).toBeChecked({ timeout: 10_000 });
+  });
+
+  // ── Steps 1-6: Create VM through wizard with VSOCK enabled ────────────
+  await test.step('Create VM through wizard with VSOCK enabled', async () => {
+    // Step 1-4: Create VM through wizard
+    vmName = await handleWizardFourFirstSteps(page);
+
+    // Step 5: Customization — enable VSOCK
+    const vsockSwitch = page.locator(VSOCK_SWITCH_ID);
+    await vsockSwitch.waitFor({ state: 'visible', timeout: 30_000 });
+    await expect(vsockSwitch).not.toBeDisabled();
+
+    const isChecked = await vsockSwitch.isChecked();
+    if (!isChecked) {
+      await vsockSwitch.locator('..').click();
+      await page.waitForTimeout(WAIT_VSOCK_TOGGLE);
+    }
+    await expect(vsockSwitch).toBeChecked({ timeout: 10_000 });
+    await page.waitForTimeout(WAIT_VSOCK_TOGGLE);
+
+    // Step 6: Review and create
+    await page.getByRole('button', { name: 'Next', exact: true }).click();
+
+    const createVmBtn = page.getByRole('button', { name: /Create VirtualMachine/i });
+    await createVmBtn.waitFor({ state: 'visible', timeout: 30_000 });
+    await expect(createVmBtn).not.toHaveAttribute('aria-disabled', 'true', { timeout: 10_000 });
+    await createVmBtn.click();
+
+    // Wait for redirect to VM details page
+    await page.waitForURL(/kubevirt\.io~v1~VirtualMachine\/[^/]+$/, { timeout: 60_000 });
+    await page.waitForLoadState('networkidle');
+  });
+
+  // ── Step 7: Navigate to created VM — toggle VSOCK off then on ─────────
+  await test.step('VM details — Configuration — toggle VSOCK off then on', async () => {
+    await page.goto(`/k8s/ns/${NS}/kubevirt.io~v1~VirtualMachine/${vmName}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('[data-test-id="horizontal-link-Configuration"]').click();
+    await page.waitForLoadState('networkidle');
+
+    const vsockSwitch = page.locator(VSOCK_SWITCH_ID);
+    await vsockSwitch.scrollIntoViewIfNeeded();
+    await vsockSwitch.waitFor({ state: 'visible', timeout: 30_000 });
+    await expect(vsockSwitch).not.toBeDisabled();
+
+    // Turn off
+    if (await vsockSwitch.isChecked()) {
+      await vsockSwitch.locator('..').click();
+    }
+    await expect(vsockSwitch).not.toBeChecked({ timeout: 10_000 });
+    await page.waitForTimeout(WAIT_VSOCK_TOGGLE);
+
+    // Turn on
+    await vsockSwitch.locator('..').click();
+    await expect(vsockSwitch).toBeChecked({ timeout: 10_000 });
+    await page.waitForTimeout(WAIT_VSOCK_TOGGLE);
+  });
+
+  // ── Step 8: Disable VSOCK in Settings ─────────────────────────────────
+  await test.step('Disable VSOCK in Settings → Preview features', async () => {
+    await settingsPage.disableVsock();
+    await expect(settingsPage.vsockSwitch).not.toBeChecked({ timeout: 10_000 });
+  });
+
+  // ── Step 9: Navigate back to created VM — verify VSOCK is disabled ────
+  await test.step('VM details — VSOCK toggle is disabled when feature gate is off', async () => {
+    await page.goto(`/k8s/ns/${NS}/kubevirt.io~v1~VirtualMachine/${vmName}`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.waitForLoadState('networkidle');
+
+    await page.locator('[data-test-id="horizontal-link-Configuration"]').click();
+    await page.waitForLoadState('networkidle');
+
+    const vsockSwitch = page.locator(VSOCK_SWITCH_ID);
+    await vsockSwitch.scrollIntoViewIfNeeded();
+    await vsockSwitch.waitFor({ state: 'visible', timeout: 30_000 });
+    await expect(vsockSwitch).toBeDisabled();
+    await page.waitForTimeout(WAIT_VSOCK_TOGGLE);
+  });
+
+  // ── Step 10: Go through wizard again — verify VSOCK is disabled ───────
+  await test.step('Wizard — VSOCK toggle is disabled when feature gate is off', async () => {
+    await handleWizardFourFirstSteps(page);
+
+    // Step 5: verify VSOCK is disabled
+    const vsockSwitch = page.locator(VSOCK_SWITCH_ID);
+    await vsockSwitch.waitFor({ state: 'visible', timeout: 30_000 });
+    await expect(vsockSwitch).toBeDisabled();
+    await page.waitForTimeout(WAIT_VSOCK_TOGGLE);
+  });
+});

--- a/src/utils/components/EnableVSOCK/EnableVSOCK.tsx
+++ b/src/utils/components/EnableVSOCK/EnableVSOCK.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useMemo, useState } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useIsVSOCKFeatureEnabled from '@kubevirt-utils/hooks/useVSOCKFeatureFlag/useIsVSOCKFeatureEnabled';
 import { isVSOCKEnabled } from '@kubevirt-utils/resources/vm';
 import { Switch } from '@patternfly/react-core';
@@ -11,6 +12,7 @@ type EnableVSOCKProps = {
 };
 
 const EnableVSOCK: FC<EnableVSOCKProps> = ({ updateVSOCK, vm }) => {
+  const { t } = useKubevirtTranslation();
   const [isChecked, setIsChecked] = useState<boolean>(isVSOCKEnabled(vm));
 
   const { featureEnabled: isVSOCKFeatureGateEnabled, isLoading } = useIsVSOCKFeatureEnabled();
@@ -26,6 +28,7 @@ const EnableVSOCK: FC<EnableVSOCKProps> = ({ updateVSOCK, vm }) => {
         setIsChecked(checked);
         updateVSOCK(checked);
       }}
+      aria-label={t('Enable VSOCK')}
       checked={isChecked}
       id="enable-vsock"
       isDisabled={isDisabled}

--- a/src/utils/hooks/useVSOCKFeatureFlag/tests/enableVSOCK.test.tsx
+++ b/src/utils/hooks/useVSOCKFeatureFlag/tests/enableVSOCK.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import EnableVSOCK from '../../../components/EnableVSOCK/EnableVSOCK';
+
+import { createVM, mockFeatureEnabled, resetVSOCKMocks } from './mocks';
+
+jest.mock('@kubevirt-utils/hooks/useVSOCKFeatureFlag/useIsVSOCKFeatureEnabled', () => ({
+  __esModule: true,
+  default: () => mockFeatureEnabled(),
+}));
+
+jest.mock('@kubevirt-utils/hooks/useKubevirtTranslation', () => ({
+  useKubevirtTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('EnableVSOCK — editing VSOCK on an existing VM', () => {
+  const updateVSOCK = jest.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    resetVSOCKMocks();
+    updateVSOCK.mockClear();
+  });
+
+  it('should render OFF for a VM without VSOCK', () => {
+    render(<EnableVSOCK updateVSOCK={updateVSOCK} vm={createVM()} />);
+    expect(screen.getByRole('switch')).not.toBeChecked();
+  });
+
+  it('should render ON for a VM with VSOCK', () => {
+    render(<EnableVSOCK updateVSOCK={updateVSOCK} vm={createVM({ autoattachVSOCK: true })} />);
+    expect(screen.getByRole('switch')).toBeChecked();
+  });
+
+  it('should turn VSOCK ON when user clicks the toggle', async () => {
+    render(<EnableVSOCK updateVSOCK={updateVSOCK} vm={createVM()} />);
+
+    await userEvent.click(screen.getByRole('switch'));
+
+    expect(updateVSOCK).toHaveBeenCalledWith(true);
+    expect(screen.getByRole('switch')).toBeChecked();
+  });
+
+  it('should turn VSOCK OFF when user clicks the toggle', async () => {
+    render(<EnableVSOCK updateVSOCK={updateVSOCK} vm={createVM({ autoattachVSOCK: true })} />);
+
+    await userEvent.click(screen.getByRole('switch'));
+
+    expect(updateVSOCK).toHaveBeenCalledWith(false);
+    expect(screen.getByRole('switch')).not.toBeChecked();
+  });
+
+  it('should allow toggling ON then OFF consecutively', async () => {
+    render(<EnableVSOCK updateVSOCK={updateVSOCK} vm={createVM()} />);
+    const toggle = screen.getByRole('switch');
+
+    await userEvent.click(toggle);
+    expect(updateVSOCK).toHaveBeenLastCalledWith(true);
+
+    await userEvent.click(toggle);
+    expect(updateVSOCK).toHaveBeenLastCalledWith(false);
+
+    expect(updateVSOCK).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('EnableVSOCK — when feature gate is not enabled', () => {
+  const updateVSOCK = jest.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    resetVSOCKMocks();
+    updateVSOCK.mockClear();
+  });
+
+  it('should disable the toggle when the feature gate is OFF', () => {
+    mockFeatureEnabled.mockReturnValue({ featureEnabled: false, isLoading: false });
+
+    render(<EnableVSOCK updateVSOCK={updateVSOCK} vm={createVM()} />);
+
+    expect(screen.getByRole('switch')).toBeDisabled();
+  });
+
+  it('should not allow interaction when the toggle is disabled', async () => {
+    mockFeatureEnabled.mockReturnValue({ featureEnabled: false, isLoading: false });
+
+    render(<EnableVSOCK updateVSOCK={updateVSOCK} vm={createVM()} />);
+
+    const toggle = screen.getByRole('switch');
+    expect(toggle).toBeDisabled();
+    expect(toggle).not.toBeChecked();
+
+    await userEvent.click(toggle);
+    expect(updateVSOCK).not.toHaveBeenCalled();
+  });
+
+  it('should show VSOCK as checked but disabled if VM already has it but gate is OFF', () => {
+    mockFeatureEnabled.mockReturnValue({ featureEnabled: false, isLoading: false });
+
+    render(<EnableVSOCK updateVSOCK={updateVSOCK} vm={createVM({ autoattachVSOCK: true })} />);
+
+    const toggle = screen.getByRole('switch');
+    expect(toggle).toBeChecked();
+    expect(toggle).toBeDisabled();
+  });
+
+  it('should keep the toggle enabled while feature gate is still loading', () => {
+    mockFeatureEnabled.mockReturnValue({ featureEnabled: false, isLoading: true });
+
+    render(<EnableVSOCK updateVSOCK={updateVSOCK} vm={createVM()} />);
+
+    expect(screen.getByRole('switch')).not.toBeDisabled();
+  });
+
+  it('should enable the toggle once the feature gate is ON', () => {
+    mockFeatureEnabled.mockReturnValue({ featureEnabled: true, isLoading: false });
+
+    render(<EnableVSOCK updateVSOCK={updateVSOCK} vm={createVM()} />);
+
+    expect(screen.getByRole('switch')).not.toBeDisabled();
+  });
+});

--- a/src/utils/hooks/useVSOCKFeatureFlag/tests/getChangedVSOCK.test.ts
+++ b/src/utils/hooks/useVSOCKFeatureFlag/tests/getChangedVSOCK.test.ts
@@ -1,0 +1,51 @@
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+
+import { getChangedVSOCK } from '../../../components/PendingChanges/utils/helpers';
+
+import { createVM, createVMI } from './mocks';
+
+describe('getChangedVSOCK — pending changes between VM and VMI', () => {
+  it('should detect no change when both have VSOCK enabled', () => {
+    expect(
+      getChangedVSOCK(createVM({ autoattachVSOCK: true }), createVMI({ autoattachVSOCK: true })),
+    ).toBe(false);
+  });
+
+  it('should detect no change when both have VSOCK disabled', () => {
+    expect(
+      getChangedVSOCK(createVM({ autoattachVSOCK: false }), createVMI({ autoattachVSOCK: false })),
+    ).toBe(false);
+  });
+
+  it('should detect no change when neither has VSOCK set', () => {
+    expect(getChangedVSOCK(createVM(), createVMI())).toBe(false);
+  });
+
+  it('should detect a change when VM enables VSOCK but VMI does not', () => {
+    expect(
+      getChangedVSOCK(createVM({ autoattachVSOCK: true }), createVMI({ autoattachVSOCK: false })),
+    ).toBe(true);
+  });
+
+  it('should detect a change when VM disables VSOCK but VMI has it enabled', () => {
+    expect(
+      getChangedVSOCK(createVM({ autoattachVSOCK: false }), createVMI({ autoattachVSOCK: true })),
+    ).toBe(true);
+  });
+
+  it('should detect a change when VM has VSOCK enabled but VMI has it unset', () => {
+    expect(getChangedVSOCK(createVM({ autoattachVSOCK: true }), createVMI())).toBe(true);
+  });
+
+  it('should return false when VM is empty', () => {
+    expect(getChangedVSOCK({} as V1VirtualMachine, createVMI({ autoattachVSOCK: true }))).toBe(
+      false,
+    );
+  });
+
+  it('should return false when VMI is empty', () => {
+    expect(
+      getChangedVSOCK(createVM({ autoattachVSOCK: true }), {} as V1VirtualMachineInstance),
+    ).toBe(false);
+  });
+});

--- a/src/utils/hooks/useVSOCKFeatureFlag/tests/isVSOCKEnabled.test.ts
+++ b/src/utils/hooks/useVSOCKFeatureFlag/tests/isVSOCKEnabled.test.ts
@@ -1,0 +1,35 @@
+import { isVSOCKEnabled } from '../../../resources/vm/utils/selectors';
+
+import { createVM, createVMI } from './mocks';
+
+describe('isVSOCKEnabled', () => {
+  it('should detect VSOCK on a VM created with autoattachVSOCK=true', () => {
+    expect(isVSOCKEnabled(createVM({ autoattachVSOCK: true }))).toBe(true);
+  });
+
+  it('should not detect VSOCK on a VM created without the field', () => {
+    expect(isVSOCKEnabled(createVM())).toBe(false);
+  });
+
+  it('should not detect VSOCK on a VM created with autoattachVSOCK=false', () => {
+    expect(isVSOCKEnabled(createVM({ autoattachVSOCK: false }))).toBe(false);
+  });
+
+  it('should handle a VM with no devices block', () => {
+    const vmWithoutDevices = createVM();
+    delete vmWithoutDevices?.spec?.template?.spec?.domain?.devices;
+    expect(isVSOCKEnabled(vmWithoutDevices)).toBe(false);
+  });
+
+  it('should handle undefined input', () => {
+    expect(isVSOCKEnabled(undefined)).toBe(false);
+  });
+
+  it('should detect VSOCK on a running VMI with autoattachVSOCK=true', () => {
+    expect(isVSOCKEnabled(createVMI({ autoattachVSOCK: true }))).toBe(true);
+  });
+
+  it('should not detect VSOCK on a running VMI without the field', () => {
+    expect(isVSOCKEnabled(createVMI())).toBe(false);
+  });
+});

--- a/src/utils/hooks/useVSOCKFeatureFlag/tests/mocks.ts
+++ b/src/utils/hooks/useVSOCKFeatureFlag/tests/mocks.ts
@@ -1,0 +1,80 @@
+import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+import { KUBEVIRT_JSONPATCH_ANNOTATION } from '../../utils/featureGateAnnotation';
+
+export const escapedAnnotationKey = KUBEVIRT_JSONPATCH_ANNOTATION.replace(/\//g, '~1');
+export const annotationPath = `/metadata/annotations/${escapedAnnotationKey}`;
+
+export const mockHCConfig = jest.fn();
+export const mockHCConfiguration = jest.fn();
+export const mockFeatureEnabled = jest.fn();
+export const mockKubevirtK8sPatch = jest.fn().mockResolvedValue({});
+
+export const resetVSOCKMocks = () => {
+  jest.clearAllMocks();
+  mockFeatureEnabled.mockReturnValue({ featureEnabled: true, isLoading: false });
+  mockHCConfig.mockReturnValue({ featureGates: ['VSOCK'], hcLoaded: true });
+};
+
+export const createVM = (
+  overrides: {
+    autoattachVSOCK?: boolean;
+    cluster?: string;
+    name?: string;
+    namespace?: string;
+  } = {},
+): V1VirtualMachine => {
+  const { autoattachVSOCK, cluster, name = 'test-vm', namespace = 'default' } = overrides;
+  const vm: V1VirtualMachine = {
+    apiVersion: 'kubevirt.io/v1',
+    kind: 'VirtualMachine',
+    metadata: { name, namespace },
+    spec: {
+      template: {
+        spec: {
+          domain: {
+            devices: {
+              ...(autoattachVSOCK !== undefined && { autoattachVSOCK }),
+            },
+          },
+        },
+      },
+    },
+  };
+  if (cluster) (vm as V1VirtualMachine & { cluster: string }).cluster = cluster;
+  return vm;
+};
+
+export const createVMI = (
+  overrides: {
+    autoattachVSOCK?: boolean;
+    name?: string;
+    namespace?: string;
+  } = {},
+): V1VirtualMachineInstance => {
+  const { autoattachVSOCK, name = 'test-vmi', namespace = 'default' } = overrides;
+  return {
+    apiVersion: 'kubevirt.io/v1',
+    kind: 'VirtualMachineInstance',
+    metadata: { name, namespace },
+    spec: {
+      domain: {
+        devices: {
+          ...(autoattachVSOCK !== undefined && { autoattachVSOCK }),
+        },
+      },
+    },
+    status: {},
+  };
+};
+
+export const createHyperConverged = (annotations?: Record<string, string>): K8sResourceCommon => ({
+  apiVersion: 'hco.kubevirt.io/v1beta1',
+  kind: 'HyperConverged',
+  metadata: {
+    name: 'kubevirt-hyperconverged',
+    namespace: 'openshift-cnv',
+    ...(annotations && { annotations }),
+  },
+});

--- a/src/utils/hooks/useVSOCKFeatureFlag/tests/useVSOCKFeatureFlag.test.ts
+++ b/src/utils/hooks/useVSOCKFeatureFlag/tests/useVSOCKFeatureFlag.test.ts
@@ -1,0 +1,182 @@
+import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { renderHook } from '@testing-library/react';
+
+import { KUBEVIRT_JSONPATCH_ANNOTATION } from '../../utils/featureGateAnnotation';
+
+import { ADD_VSOCK_FEATURE_GATE_PATCH } from '../constants';
+
+import {
+  annotationPath,
+  createHyperConverged,
+  mockFeatureEnabled,
+  mockHCConfiguration,
+  mockKubevirtK8sPatch,
+  resetVSOCKMocks,
+} from './mocks';
+
+jest.mock('@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration', () => ({
+  __esModule: true,
+  default: () => ({}),
+}));
+
+jest.mock('@kubevirt-utils/hooks/useHyperConvergeConfiguration', () => ({
+  __esModule: true,
+  default: () => mockHCConfiguration(),
+}));
+
+jest.mock('@kubevirt-utils/hooks/useIsAdmin', () => ({
+  useIsAdmin: () => true,
+}));
+
+jest.mock('@kubevirt-utils/hooks/useVSOCKFeatureFlag/useIsVSOCKFeatureEnabled', () => ({
+  __esModule: true,
+  default: () => mockFeatureEnabled(),
+}));
+
+jest.mock('@multicluster/hooks/useClusterParam', () => ({
+  __esModule: true,
+  default: () => '',
+}));
+
+jest.mock('@multicluster/k8sRequests', () => ({
+  kubevirtK8sPatch: (...args: unknown[]) => mockKubevirtK8sPatch(...args),
+}));
+
+describe('useVSOCKFeatureFlag — toggling the feature gate ON/OFF', () => {
+  let useVSOCKFeatureFlag: typeof import('../useVSOCKFeatureFlag').default;
+
+  beforeEach(() => {
+    resetVSOCKMocks();
+    useVSOCKFeatureFlag = jest.requireActual('../useVSOCKFeatureFlag').default;
+  });
+
+  it('should produce the correct HC patch when toggled ON from a clean HC', async () => {
+    const hc = createHyperConverged();
+    mockHCConfiguration.mockReturnValue([hc, true, null]);
+    mockFeatureEnabled.mockReturnValue({ featureEnabled: false, isLoading: false });
+
+    const { result } = renderHook(() => useVSOCKFeatureFlag());
+    await result.current.toggleFeature(true);
+
+    expect(mockKubevirtK8sPatch).toHaveBeenCalledTimes(1);
+
+    const { model, resource, data } = mockKubevirtK8sPatch.mock.calls[0][0];
+
+    expect(model).toBe(HyperConvergedModel);
+    expect(resource).toBe(hc);
+
+    expect(data).toEqual([
+      { op: 'add', path: '/metadata/annotations', value: {} },
+      {
+        op: 'add',
+        path: annotationPath,
+        value: JSON.stringify([
+          {
+            op: 'add',
+            path: '/spec/configuration/developerConfiguration/featureGates/-',
+            value: 'VSOCK',
+          },
+        ]),
+      },
+    ]);
+  });
+
+  it('should produce the correct HC patch when toggled OFF', async () => {
+    const hc = createHyperConverged({
+      [KUBEVIRT_JSONPATCH_ANNOTATION]: JSON.stringify([ADD_VSOCK_FEATURE_GATE_PATCH]),
+    });
+    mockHCConfiguration.mockReturnValue([hc, true, null]);
+    mockFeatureEnabled.mockReturnValue({ featureEnabled: true, isLoading: false });
+
+    const { result } = renderHook(() => useVSOCKFeatureFlag());
+    await result.current.toggleFeature(false);
+
+    const { model, resource, data } = mockKubevirtK8sPatch.mock.calls[0][0];
+
+    expect(model).toBe(HyperConvergedModel);
+    expect(resource).toBe(hc);
+
+    expect(data).toEqual([{ op: 'replace', path: annotationPath, value: JSON.stringify([]) }]);
+  });
+
+  it('should not duplicate the VSOCK entry if already present', async () => {
+    const hc = createHyperConverged({
+      [KUBEVIRT_JSONPATCH_ANNOTATION]: JSON.stringify([ADD_VSOCK_FEATURE_GATE_PATCH]),
+    });
+    mockHCConfiguration.mockReturnValue([hc, true, null]);
+    mockFeatureEnabled.mockReturnValue({ featureEnabled: true, isLoading: false });
+
+    const { result } = renderHook(() => useVSOCKFeatureFlag());
+    await result.current.toggleFeature(true);
+
+    const { data } = mockKubevirtK8sPatch.mock.calls[0][0];
+    const annotationValue = JSON.parse(
+      data.find((p: { path: string }) => p.path === annotationPath).value,
+    );
+
+    expect(annotationValue).toHaveLength(1);
+    expect(annotationValue[0]).toEqual({
+      op: 'add',
+      path: '/spec/configuration/developerConfiguration/featureGates/-',
+      value: 'VSOCK',
+    });
+  });
+
+  it('should keep other feature gates intact when adding VSOCK', async () => {
+    const otherPatch = { op: 'add', path: '/some/other/path', value: 'OtherFeature' };
+    const hc = createHyperConverged({
+      [KUBEVIRT_JSONPATCH_ANNOTATION]: JSON.stringify([otherPatch]),
+    });
+    mockHCConfiguration.mockReturnValue([hc, true, null]);
+    mockFeatureEnabled.mockReturnValue({ featureEnabled: false, isLoading: false });
+
+    const { result } = renderHook(() => useVSOCKFeatureFlag());
+    await result.current.toggleFeature(true);
+
+    const { data } = mockKubevirtK8sPatch.mock.calls[0][0];
+    const annotationValue = JSON.parse(
+      data.find((p: { path: string }) => p.path === annotationPath).value,
+    );
+
+    expect(annotationValue).toEqual([
+      otherPatch,
+      {
+        op: 'add',
+        path: '/spec/configuration/developerConfiguration/featureGates/-',
+        value: 'VSOCK',
+      },
+    ]);
+  });
+
+  it('should keep other feature gates intact when removing VSOCK', async () => {
+    const otherPatch = { op: 'add', path: '/some/other/path', value: 'OtherFeature' };
+    const hc = createHyperConverged({
+      [KUBEVIRT_JSONPATCH_ANNOTATION]: JSON.stringify([otherPatch, ADD_VSOCK_FEATURE_GATE_PATCH]),
+    });
+    mockHCConfiguration.mockReturnValue([hc, true, null]);
+    mockFeatureEnabled.mockReturnValue({ featureEnabled: true, isLoading: false });
+
+    const { result } = renderHook(() => useVSOCKFeatureFlag());
+    await result.current.toggleFeature(false);
+
+    const { data } = mockKubevirtK8sPatch.mock.calls[0][0];
+    const annotationValue = JSON.parse(
+      data.find((p: { path: string }) => p.path === annotationPath).value,
+    );
+
+    expect(annotationValue).toEqual([otherPatch]);
+  });
+
+  it('should reject when HC configuration is not loaded', async () => {
+    mockHCConfiguration.mockReturnValue([undefined, false, null]);
+    mockFeatureEnabled.mockReturnValue({ featureEnabled: false, isLoading: true });
+
+    const { result } = renderHook(() => useVSOCKFeatureFlag());
+
+    await expect(result.current.toggleFeature(true)).rejects.toThrow(
+      'HyperConverged configuration is not loaded',
+    );
+
+    expect(mockKubevirtK8sPatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/resources/vm/utils/selectors.ts
+++ b/src/utils/resources/vm/utils/selectors.ts
@@ -418,7 +418,8 @@ export const getArchitecture = (vm: V1VirtualMachine): string =>
 export const getVMTemplateAnnotations = (vm: V1VirtualMachine): { [key: string]: string } =>
   vm?.spec?.template?.metadata?.annotations;
 
-export const isVSOCKEnabled = (vm: V1VirtualMachine | V1VirtualMachineInstance) => {
+export const isVSOCKEnabled = (vm: V1VirtualMachine | V1VirtualMachineInstance | undefined) => {
+  if (!vm) return false;
   const devices = isVM(vm) ? getDevices(vm) : getVMIDevices(vm);
   return Boolean(devices?.autoattachVSOCK);
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add comprehensive unit tests for the VSOCK toggle feature covering:
* VM creation with/without VSOCK
* editing VSOCK configuration via the EnableVSOCK component
* pending changes detection between VM and VMI
* toggling the feature gate ON/OFF through useVSOCKFeatureFlag
* verifying the toggle is disabled when the feature gate is not enabled.

## 🔗 Links
Jira ticket: https://redhat.atlassian.net/browse/CNV-87123
## 🎥 Demo

<img width="827" height="660" alt="image" src="https://github.com/user-attachments/assets/295a2445-30c4-4032-b59b-0d339dcc4fc7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved accessibility for the VSOCK enablement switch by providing a translated aria-label.
* **Tests**
  * Added coverage for enabling/disabling VSOCK and correctly reflecting VM/device state in the UI.
  * Added feature-flag behavior tests (disabled, loading, and enabled states) and verified toggle interactions.
  * Added unit tests for VSOCK detection and change detection between VM and VMI, including edge cases.
  * Added comprehensive hook tests for JSON-patch updates, preservation of existing feature gates, idempotency, and safe failure when configuration isn’t loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->