### PR TITLE
CNV-92722: Hot Cluster E2E progress status and /retest-e2e don't reflect the real run state

### DIFF
--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -45,6 +45,24 @@ on:
         required: false
         default: ''
         type: string
+      progress_status_sha:
+        description: |
+          Commit SHA to post the "Running gating tests" progress status
+          against once the actual test command starts (passed by
+          hot-cluster-e2e.yml). Leave empty to skip -- e.g. a standalone
+          workflow_dispatch test run of this file alone.
+        required: false
+        default: ''
+        type: string
+      progress_status_context:
+        description: |
+          Commit-status context name to post the above under. Must match
+          hot-cluster-e2e.yml's "Hot Cluster E2E Progress" naming
+          convention (including its manual-dispatch variant) -- see that
+          workflow's progress-check-running-tests job.
+        required: false
+        default: ''
+        type: string
   workflow_call:
     inputs:
       test_project:
@@ -94,10 +112,29 @@ on:
         type: boolean
         required: false
         default: false
+      progress_status_sha:
+        description: |
+          Commit SHA to post the "Running gating tests" progress status
+          against once the actual test command starts (passed by
+          hot-cluster-e2e.yml). Leave empty to skip -- e.g. a standalone
+          workflow_dispatch test run of this file alone.
+        type: string
+        required: false
+        default: ''
+      progress_status_context:
+        description: |
+          Commit-status context name to post the above under. Must match
+          hot-cluster-e2e.yml's "Hot Cluster E2E Progress" naming
+          convention (including its manual-dispatch variant) -- see that
+          workflow's progress-check-running-tests job.
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
   actions: read
+  statuses: write
 
 env:
   CNV_NS: openshift-cnv
@@ -257,6 +294,14 @@ jobs:
         with:
           ref: ${{ inputs.checkout_ref || github.event.pull_request.head.sha || github.ref }}
           allow-unsafe-pr-checkout: true
+          # This job's token now carries statuses: write (see
+          # hot-cluster-e2e.yml's run-e2e-tests job) -- persisting it to
+          # .git/config would let PR-controlled code checked out below
+          # (e.g. a malicious test-suite change) read it straight off
+          # disk and post arbitrary commit statuses repo-wide. Checkout
+          # itself doesn't need the credential to persist afterward (no
+          # further git operations happen in this job).
+          persist-credentials: false
 
       - name: Check if kubevirt-plugin image exists in registry
         id: check_image
@@ -347,6 +392,14 @@ jobs:
         with:
           ref: ${{ inputs.checkout_ref || github.event.pull_request.head.sha || github.ref }}
           allow-unsafe-pr-checkout: true
+          # This job's token now carries statuses: write (see
+          # hot-cluster-e2e.yml's run-e2e-tests job) -- persisting it to
+          # .git/config would let PR-controlled code checked out below
+          # (e.g. a malicious test-suite change) read it straight off
+          # disk and post arbitrary commit statuses repo-wide. Checkout
+          # itself doesn't need the credential to persist afterward (no
+          # further git operations happen in this job).
+          persist-credentials: false
 
       # Referenced by owner/repo/path@main rather than the local ./ path --
       # checkout_ref can point at a release branch that predates this CI
@@ -445,6 +498,33 @@ jobs:
           else
             npm run playwright-install
           fi
+
+      # Best-effort follow-up to hot-cluster-e2e.yml's own progress-check-
+      # running-tests job, which already posted "Building plugin image"
+      # against the same SHA/context before this reusable workflow even
+      # started (that checkpoint covers check-runner + build-kubevirt-
+      # plugin-image + everything up to here). Only hot-cluster-e2e.yml's
+      # `uses:` call ever sets progress_status_sha -- a standalone
+      # workflow_dispatch of this file alone leaves it empty, so this is
+      # a no-op then.
+      - name: Update progress status
+        if: inputs.progress_status_sha != '' && inputs.progress_status_context != ''
+        continue-on-error: true
+        uses: actions/github-script@v9
+        env:
+          STATUS_SHA: ${{ inputs.progress_status_sha }}
+          STATUS_CONTEXT: ${{ inputs.progress_status_context }}
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.STATUS_SHA,
+              context: process.env.STATUS_CONTEXT,
+              state: 'pending',
+              description: 'Running gating tests',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
 
       - name: Run gating tests
         env:

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -559,9 +559,20 @@ jobs:
     # progress-check-start above.
     permissions:
       statuses: write
+    outputs:
+      # Threaded into run-e2e-tests below (and from there, into
+      # hot-cluster-e2e-run.yml) so it can post its own follow-up
+      # "Running gating tests" progress update once the actual test
+      # command starts, reusing this job's already-resolved SHA/context
+      # rather than recomputing the same logic a third time. Empty for
+      # an irrelevant-label event (the script returns before setting
+      # them), but run-e2e-tests never runs in that case anyway.
+      head-sha: ${{ steps.post-status.outputs.head-sha }}
+      status-context: ${{ steps.post-status.outputs.status-context }}
     steps:
       # Best-effort, same as progress-check-start above.
       - name: Post progress status
+        id: post-status
         continue-on-error: true
         uses: actions/github-script@v9
         env:
@@ -598,6 +609,28 @@ jobs:
               ? '${{ needs.cluster-health-check.result }}' === 'success'
               : '${{ needs.cluster-check.outputs.cluster_ready }}' === 'true';
 
+            // Set before the API call below (not after) -- if
+            // createCommitStatus throws (transient API error), this step's
+            // continue-on-error keeps the job "successful" but the script
+            // stops here, and outputs already set survive that. Setting
+            // them after the call would instead leave run-e2e-tests with
+            // an empty head-sha/status-context on any such failure, so its
+            // own follow-up "Running gating tests" post inside
+            // hot-cluster-e2e-run.yml would silently never fire, stranding
+            // the status on whatever progress-check-start posted earlier
+            // ("Waiting for cluster to be built") until the terminal
+            // update.
+            if (clusterReady) {
+              core.setOutput('head-sha', headSha);
+              core.setOutput('status-context', statusContext);
+            }
+
+            // "Running gating tests" is posted later, from within
+            // hot-cluster-e2e-run.yml itself once the actual test command
+            // is about to run (see its "Update progress status" step) --
+            // this checkpoint only covers up to the point where that
+            // reusable workflow starts, whose first real jobs are
+            // check-runner + build-kubevirt-plugin-image.
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -605,14 +638,43 @@ jobs:
               context: statusContext,
               state: clusterReady ? 'pending' : 'failure',
               description: clusterReady
-                ? 'Running gating tests'
+                ? 'Building plugin image'
                 : 'Cluster not ready -- gating tests not run',
               target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             });
 
   run-e2e-tests:
     name: Run E2E Tests
-    needs: [cluster-check, cluster-health-check, resolve-cluster-config, resolve-pr-context]
+    # progress-check-running-tests added solely so its head-sha/status-
+    # context outputs (below) are available here -- it doesn't gate
+    # whether this job runs (the explicit `if: always() && (...)` below
+    # already bypasses the implicit "all needs succeeded" default).
+    needs:
+      [
+        cluster-check,
+        cluster-health-check,
+        resolve-cluster-config,
+        resolve-pr-context,
+        progress-check-running-tests,
+      ]
+    # Job-level permissions here OVERRIDE (not add to) the workflow-level
+    # defaults for this specific job, and also become the ceiling for
+    # whatever the called reusable workflow's own jobs can use -- so this
+    # must keep everything the workflow-level block already granted
+    # (contents: read, actions: write) rather than just adding the new
+    # statuses: write on its own, which would otherwise silently strip
+    # the other two from this job and everything it calls into (e.g.
+    # hot-cluster-e2e-run.yml's own actions/checkout steps need
+    # contents: read). statuses: write is threaded into
+    # hot-cluster-e2e-run.yml so it can post its own follow-up "Running
+    # gating tests" progress update once the actual test command starts
+    # -- see progress-check-running-tests above for where these are
+    # computed, and that reusable workflow's own "Update progress
+    # status" step for where they're consumed.
+    permissions:
+      contents: read
+      actions: write
+      statuses: write
     # See cluster-health-check above: key off cluster-check's cluster_ready
     # output, not its job result, now that a no-op event still reports
     # 'success' for cluster-check. cluster-health-check only ever runs for
@@ -689,6 +751,11 @@ jobs:
       # Always true for this `uses:` call -- see hot-cluster-e2e-run.yml's
       # is_reusable_call input for why.
       is_reusable_call: true
+      # Empty when progress-check-running-tests didn't run/set them (e.g.
+      # an irrelevant-label event) -- hot-cluster-e2e-run.yml's own
+      # "Update progress status" step already no-ops on an empty SHA.
+      progress_status_sha: ${{ needs.progress-check-running-tests.outputs.head-sha }}
+      progress_status_context: ${{ needs.progress-check-running-tests.outputs.status-context }}
     secrets: inherit
 
   # Single source of truth for the "Run Gating Tests" required status check.
@@ -739,6 +806,11 @@ jobs:
     # "Run Gating Tests" required check for the same SHA when someone
     # ad-hoc-dispatches this workflow against a branch that also has an
     # open PR (confirmed live on CNV-92682/PR #4293).
+    #
+    # The literal 'skipped - irrelevant label event' suffix below is a
+    # string contract with retest-e2e.yml, which greps every candidate
+    # run's job names for that exact substring to tell a real run apart
+    # from a bot-label no-op -- keep both in sync if this naming changes.
     name: ${{ (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test') && ((github.event_name == 'workflow_dispatch' && inputs.pr_number == '' && 'Run Gating Tests (manual dispatch)') || 'Run Gating Tests') || 'Run Gating Tests (skipped - irrelevant label event)' }}
     needs:
       [

--- a/.github/workflows/retest-e2e.yml
+++ b/.github/workflows/retest-e2e.yml
@@ -127,7 +127,7 @@ jobs:
                 per_page: 100,
               });
 
-              const prRun = runs.find(r => {
+              const candidates = runs.filter(r => {
                 const prMatch = r.pull_requests?.some(p => p.number === prNumber);
                 const shaMatch = r.head_sha === headSha;
                 // Branch name alone isn't unique across forks -- a same-named
@@ -137,6 +137,48 @@ jobs:
                   r.head_repository?.id === pr.data.head.repo?.id;
                 return prMatch || shaMatch || branchMatch;
               });
+
+              // Bot labels (jira/valid-reference, approved, lgtm, ...) land
+              // on a PR seconds after it's opened, and each one triggers its
+              // own hot-cluster-e2e.yml run that internally no-ops as
+              // "Run Gating Tests (skipped - irrelevant label event)" since
+              // it doesn't represent a real code change. A bot can only
+              // react to a PR that already exists, so these no-op runs are
+              // always *newer* than the real "opened"-triggered run --
+              // picking the newest match alone (the original approach here)
+              // would almost always grab the no-op instead of the real run.
+              // Confirmed live on PR #4298: /retest-e2e re-ran the
+              // "approved"-label no-op run while the genuinely-failed real
+              // run sat untouched, with no visible sign anything was wrong.
+              // Walk newest-to-oldest (still preferring the most recent
+              // match when there's a genuine tie) and skip any candidate
+              // whose jobs show that no-op marker.
+              //
+              // 'skipped - irrelevant label event' is a string contract
+              // with hot-cluster-e2e.yml's verify-gating-tests job, whose
+              // dynamic `name:` is the only place that exact suffix comes
+              // from -- if that naming ever changes, this check must
+              // change with it (and vice versa).
+              let prRun = null;
+              for (const candidate of candidates) {
+                // A single run realistically has on the order of ~10-15
+                // jobs here (well under the API's default page size), but
+                // paginate defensively rather than assume that holds
+                // forever -- a truncated jobs list could otherwise miss
+                // the no-op marker and misclassify a skip run as real.
+                const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                  ...context.repo,
+                  run_id: candidate.id,
+                  per_page: 100,
+                });
+                const isIrrelevantLabelNoop = jobs.some(
+                  j => j.name.includes('skipped - irrelevant label event'),
+                );
+                if (!isIrrelevantLabelNoop) {
+                  prRun = candidate;
+                  break;
+                }
+              }
 
               if (prRun) {
                 core.info(`Re-running workflow run ${prRun.id} (attempt ${prRun.run_attempt})...`);
@@ -171,7 +213,7 @@ jobs:
               // version-matched cluster for release-4.22-and-earlier PRs
               // (workflow_dispatch has no github.base_ref of its own).
               const baseRef = pr.data.base.ref;
-              core.warning(`No recent Hot Cluster E2E workflow run found for PR #${prNumber} (base: ${baseRef}). Dispatching a fresh run instead.`);
+              core.warning(`No recent Hot Cluster E2E workflow run with real gating-test results found for PR #${prNumber} (base: ${baseRef}) -- only irrelevant-label no-ops, if anything, matched. Dispatching a fresh run instead.`);
               await react('rocket');
 
               await github.rest.actions.createWorkflowDispatch({
@@ -211,7 +253,7 @@ jobs:
               ...context.repo,
               issue_number: context.issue.number,
               body: [
-                '🚀 No recent Hot Cluster E2E run was found to re-run, so `/retest-e2e` dispatched a fresh one instead ' +
+                '🚀 No recent Hot Cluster E2E run with real gating-test results was found to re-run (bot-label events don\'t count), so `/retest-e2e` dispatched a fresh one instead ' +
                   '(this also re-provisions the cluster automatically if it was torn down).',
                 '',
                 `See the [Actions tab](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/hot-cluster-e2e.yml) for progress.`,


### PR DESCRIPTION
## 📝 Description

Hot Cluster E2E progress status and /retest-e2e don't reflect the real run state

## 🔗 Links

Jira ticket: [CNV-92722](https://redhat.atlassian.net/browse/CNV-92722)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progress status updates during end-to-end testing, including clearer indications when plugin images are being built.
  * Added support for controlling progress status details when triggering test workflows.

* **Bug Fixes**
  * Improved `/retest-e2e` reliability by identifying the correct prior test run and ignoring irrelevant no-op runs.
  * Updated fallback messaging when no suitable prior run is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->