### PR TITLE
CNV-92539: add VM wizard and settings page objects

### DIFF
--- a/playwright/src/components/vm-wizard/vm-creation-wizard-component.ts
+++ b/playwright/src/components/vm-wizard/vm-creation-wizard-component.ts
@@ -1,0 +1,979 @@
+import BaseComponent from '@/components/shared/base-component';
+import {
+  VmCreationWizardDeploymentComponent,
+  VmCreationWizardReviewComponent,
+} from '@/components/vm-wizard/wizard-deploy-review-components';
+import {
+  VmCreationWizardCloneComponent,
+  VmCreationWizardNavigationComponent,
+  VmCreationWizardTemplateCatalogComponent,
+} from '@/components/vm-wizard/wizard-navigation-components';
+import {
+  VmCreationWizardBootSourceComponent,
+  VmCreationWizardComputeComponent,
+  VmCreationWizardLocationComponent,
+} from '@/components/vm-wizard/wizard-step-components';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+export default class VmCreationWizardComponent extends BaseComponent {
+  private static readonly _strategyLabels: Record<string, string> = {
+    Always: 'Always',
+    Halted: 'Halted',
+    Manual: 'Manual',
+    RerunOnFailure: 'Rerun on failure',
+  };
+  private readonly _button = this.locator('button');
+  private readonly _pfV6CWizardInputPlaceholderFindSettings = this.locator(
+    '.pf-v6-c-wizard input[placeholder="Find settings"]',
+  );
+  private readonly _roleTabpanel = this.locator('[role="tabpanel"]');
+  readonly bootSource: VmCreationWizardBootSourceComponent;
+  readonly clone: VmCreationWizardCloneComponent;
+  readonly compute: VmCreationWizardComputeComponent;
+  readonly deployment: VmCreationWizardDeploymentComponent;
+
+  readonly location: VmCreationWizardLocationComponent;
+
+  readonly navigation: VmCreationWizardNavigationComponent;
+  readonly review: VmCreationWizardReviewComponent;
+  readonly templateCatalog: VmCreationWizardTemplateCatalogComponent;
+
+  constructor(page: Page) {
+    super(page);
+    this.bootSource = new VmCreationWizardBootSourceComponent(page);
+    this.clone = new VmCreationWizardCloneComponent(page);
+    this.compute = new VmCreationWizardComputeComponent(page);
+    this.deployment = new VmCreationWizardDeploymentComponent(page);
+    this.location = new VmCreationWizardLocationComponent(page);
+    this.navigation = new VmCreationWizardNavigationComponent(page);
+    this.review = new VmCreationWizardReviewComponent(page);
+    this.templateCatalog = new VmCreationWizardTemplateCatalogComponent(page);
+  }
+
+  private async _dismissOverlayIfPresent(): Promise<void> {
+    const backdrop = this.page.locator('.pf-v6-c-backdrop');
+    if (await backdrop.isVisible({ timeout: 1000 }).catch(() => false)) {
+      const closeBtn = this.page.locator('.pf-v6-c-backdrop [aria-label="Close"]');
+      if (await closeBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
+        await closeBtn.click();
+        await this.page.waitForTimeout(500);
+      } else {
+        await this.page.keyboard.press('Escape');
+        await this.page.waitForTimeout(500);
+      }
+    }
+  }
+
+  private async _toggleSwitch(switchId: string): Promise<void> {
+    await this._dismissOverlayIfPresent();
+    const label = this.page.locator(`label:has(#${switchId})`);
+    await label.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await label.click();
+    await this.page.waitForTimeout(300);
+  }
+
+  async applyWorkloadFilter(workload: string): Promise<void> {
+    return this.templateCatalog.applyWorkloadFilter(workload);
+  }
+
+  async cancelAddVolumeModal(): Promise<void> {
+    return this.bootSource.cancelAddVolumeModal();
+  }
+
+  async cancelWizard(): Promise<void> {
+    return this.navigation.cancelWizard();
+  }
+
+  async clearCloneSourceFilters(): Promise<void> {
+    return this.clone.clearCloneSourceFilters();
+  }
+
+  async clearReviewVmName(): Promise<void> {
+    return this.review.clearReviewVmName();
+  }
+
+  async clickAddVolumeButton(): Promise<void> {
+    return this.bootSource.clickAddVolumeButton();
+  }
+
+  async clickBack(): Promise<void> {
+    return this.navigation.clickBack();
+  }
+
+  async clickClearAllFiltersInCatalog(): Promise<void> {
+    return this.templateCatalog.clickClearAllFiltersInCatalog();
+  }
+
+  async clickCreateVm(): Promise<void> {
+    return this.review.clickCreateVm();
+  }
+
+  async clickNext(): Promise<void> {
+    return this.navigation.clickNext();
+  }
+
+  async clickViewAllProjectsInCatalog(): Promise<void> {
+    return this.templateCatalog.clickViewAllProjectsInCatalog();
+  }
+
+  async closeEditLocationPanel(): Promise<void> {
+    return this.location.closeEditLocationPanel();
+  }
+
+  async closeTemplateDrawer(): Promise<void> {
+    return this.templateCatalog.closeTemplateDrawer();
+  }
+
+  async editSchedulingRunStrategy(strategy: string): Promise<boolean> {
+    try {
+      const editButton = this.locator('button[data-test-id="run-strategy"]');
+      await editButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+      });
+      await this.robustClick(editButton);
+
+      const modal = this.page.locator('[role="dialog"]').filter({ hasText: 'Edit run strategy' });
+      await modal.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.INSTANCE_TYPE_VERIFICATION,
+      });
+
+      const selectToggle = modal.locator('.pf-v6-c-menu-toggle');
+      await selectToggle.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      await this.robustClick(selectToggle);
+
+      const label = VmCreationWizardComponent._strategyLabels[strategy] || strategy;
+      const option = this.page
+        .locator('button[role="option"]')
+        .filter({ has: this.page.locator('.pf-v6-c-menu__item-text', { hasText: label }) });
+      await option.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      await this.robustClick(option);
+
+      const saveButton = modal.locator('button').filter({ hasText: 'Save' }).first();
+      await this.robustClick(saveButton);
+      await modal.waitFor({
+        state: 'hidden',
+        timeout: TestTimeouts.ELEMENT_WAIT,
+      });
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async enableUserTemplatesFilter(): Promise<void> {
+    return this.templateCatalog.enableUserTemplatesFilter();
+  }
+
+  // ============================================================================
+  // Step 1 — Deployment Details: Location section
+  // ============================================================================
+
+  /**
+   * Ensures the deployment step has a valid VM name before proceeding.
+   * If the name field is empty, auto-generates one via the dice button.
+   * No-op if the name input is not visible (e.g. on Clone step).
+   */
+  async ensureVmNameFilled(): Promise<void> {
+    if (await this.deployment.isVmNameEmpty()) {
+      await this.deployment.generateVmName();
+    }
+  }
+
+  async fillReviewDescription(text: string): Promise<void> {
+    return this.review.fillReviewDescription(text);
+  }
+
+  async fillReviewVmName(name: string): Promise<void> {
+    return this.review.fillReviewVmName(name);
+  }
+
+  async fillVmName(name: string): Promise<void> {
+    return this.deployment.fillVmName(name);
+  }
+
+  async filterTemplateCatalog(keyword: string): Promise<void> {
+    return this.templateCatalog.filterTemplateCatalog(keyword);
+  }
+
+  // ============================================================================
+  // Step 3 — Boot Source
+  // ============================================================================
+
+  /** Click the dice icon to auto-generate a unique VM name (required on 4.99+ before Next). */
+  async generateVmName(): Promise<void> {
+    return this.deployment.generateVmName();
+  }
+
+  async getActiveComputeTab(): Promise<string> {
+    return this.compute.getActiveComputeTab();
+  }
+
+  async getAddVolumeModalSaveButtonText(): Promise<string> {
+    return this.bootSource.getAddVolumeModalSaveButtonText();
+  }
+
+  async getAddVolumePreferenceHelperText(): Promise<string> {
+    return this.bootSource.getAddVolumePreferenceHelperText();
+  }
+
+  async getAddVolumePreferenceValue(): Promise<string> {
+    return this.bootSource.getAddVolumePreferenceValue();
+  }
+
+  async getBootSourceEmptyStateBodyText(): Promise<string> {
+    return this.bootSource.getBootSourceEmptyStateBodyText();
+  }
+
+  async getBootSourceEmptyStateHeading(): Promise<string> {
+    return this.bootSource.getBootSourceEmptyStateHeading();
+  }
+
+  async getBootVolumeCount(): Promise<number> {
+    return this.bootSource.getBootVolumeCount();
+  }
+
+  async getBootVolumeOsColumnValues(): Promise<string[]> {
+    return this.bootSource.getBootVolumeOsColumnValues();
+  }
+
+  async getCloneWizardStepIds(): Promise<string[]> {
+    return this.clone.getCloneWizardStepIds();
+  }
+
+  async getComputeSizeDropdownText(): Promise<string> {
+    return this.compute.getComputeSizeDropdownText();
+  }
+
+  async getComputeSizeOptions(): Promise<string[]> {
+    return this.compute.getComputeSizeOptions();
+  }
+
+  async getCreateButtonText(): Promise<string> {
+    return this.review.getCreateButtonText();
+  }
+
+  async getCreatedVmNameFromUrl(): Promise<string> {
+    const url = this.page.url();
+    const match = url.match(/kubevirt\.io~v1~VirtualMachine\/([^/?#]+)/);
+    return match?.[1] || '';
+  }
+
+  async getCreatedVmNamespaceFromUrl(): Promise<string> {
+    const url = this.page.url();
+    const match = url.match(/\/ns\/([^/]+)\//);
+    return match?.[1] || '';
+  }
+
+  async getCustomizationVmName(): Promise<string> {
+    try {
+      const hostname = this._button.filter({ hasText: /^[a-z0-9-]+$/ });
+      const detailsRegion = this._roleTabpanel;
+      const hostnameValue = detailsRegion.locator('dt:has-text("Hostname") + dd button');
+      const text = await hostnameValue.first().textContent({ timeout: TestTimeouts.SHORT_WAIT });
+      return text?.trim() || (await hostname.first().textContent()) || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getDeploymentVmName(): Promise<string> {
+    return this.deployment.getVmName();
+  }
+
+  async getLocationProject(): Promise<string> {
+    return this.location.getLocationProject();
+  }
+
+  async getReviewDescription(): Promise<string> {
+    return this.review.getReviewDescription();
+  }
+
+  async getReviewDescriptionText(): Promise<string> {
+    return this.review.getReviewDescriptionText();
+  }
+
+  async getReviewNameValidationError(): Promise<string> {
+    return this.review.getReviewNameValidationError();
+  }
+
+  async getReviewVmName(): Promise<string> {
+    return this.review.getReviewVmName();
+  }
+
+  async getSchedulingRunStrategy(): Promise<string> {
+    try {
+      const panel = this._roleTabpanel;
+      const dd = panel.locator('[data-test-id="run-strategy"]').first();
+      return (await dd.textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getSelectedInstanceTypeSeries(): Promise<string> {
+    return this.compute.getSelectedInstanceTypeSeries();
+  }
+
+  // ============================================================================
+  // Step 4 — Compute Resources
+  // ============================================================================
+
+  async getSelectedOsType(): Promise<string> {
+    return this.deployment.getSelectedOsType();
+  }
+
+  async getSelectedTemplateCardTitle(templateTestId: string): Promise<string> {
+    return this.templateCatalog.getSelectedTemplateCardTitle(templateTestId);
+  }
+
+  async getStartAfterCreationLabel(): Promise<string> {
+    return this.review.getStartAfterCreationLabel();
+  }
+
+  async getStorageTabDisks(): Promise<string[]> {
+    const panel = this._roleTabpanel;
+    const diskList = panel.locator('[data-test="vm-disk-list"]');
+    await diskList.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const firstDisk = diskList.locator('[data-test-id^="disk-"]').first();
+    await firstDisk.waitFor({ state: 'attached', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    const allDiskEls = diskList.locator('[data-test-id]');
+    const count = await allDiskEls.count();
+    const disks: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const testId = await allDiskEls.nth(i).getAttribute('data-test-id');
+      if (
+        testId &&
+        testId.startsWith('disk-') &&
+        !testId.includes('-source-') &&
+        !testId.includes('-size-') &&
+        !testId.includes('-drive-') &&
+        !testId.includes('-interface-') &&
+        !testId.includes('-storage-class-')
+      ) {
+        const text = await allDiskEls.nth(i).textContent();
+        if (text?.trim()) disks.push(text.trim());
+      }
+    }
+    return disks;
+  }
+
+  async getTemplateCardFields(templateTestId: string): Promise<string[]> {
+    return this.templateCatalog.getTemplateCardFields(templateTestId);
+  }
+
+  async getTemplateCatalogCount(): Promise<number> {
+    return this.templateCatalog.getTemplateCatalogCount();
+  }
+
+  async getTemplateDrawerFields(): Promise<string[]> {
+    return this.templateCatalog.getTemplateDrawerFields();
+  }
+
+  async getTemplateDrawerTitle(): Promise<string> {
+    return this.templateCatalog.getTemplateDrawerTitle();
+  }
+
+  async isAddVolumeModalSaveButtonDisabled(): Promise<boolean> {
+    return this.bootSource.isAddVolumeModalSaveButtonDisabled();
+  }
+
+  async isAddVolumePreferenceDisabled(): Promise<boolean> {
+    return this.bootSource.isAddVolumePreferenceDisabled();
+  }
+
+  async isBootVolumeOsFilterVisible(): Promise<boolean> {
+    return this.bootSource.isBootVolumeOsFilterVisible();
+  }
+
+  async isBootVolumeStarred(volumeName: string): Promise<boolean> {
+    return this.bootSource.isBootVolumeStarred(volumeName);
+  }
+
+  // ============================================================================
+  // Step 6 — Customization
+  // ============================================================================
+
+  async isCreateButtonDisabled(): Promise<boolean> {
+    return this.review.isCreateButtonDisabled();
+  }
+
+  async isDeletionProtectionEnabled(): Promise<boolean> {
+    return await this.locator('#deletion-protection').isChecked();
+  }
+
+  async isGuestSystemLogAccessEnabled(): Promise<boolean> {
+    return await this.locator('#guest-system-log-access').isChecked();
+  }
+
+  async isHeadlessModeEnabled(): Promise<boolean> {
+    return await this.locator('#headless-mode').isChecked();
+  }
+
+  async isNextButtonDisabled(): Promise<boolean> {
+    return this.navigation.isNextButtonDisabled();
+  }
+
+  async isStartAfterCreationChecked(): Promise<boolean> {
+    return this.review.isStartAfterCreationChecked();
+  }
+
+  async isVmNameEmpty(): Promise<boolean> {
+    return this.deployment.isVmNameEmpty();
+  }
+
+  async navigateToStepByName(stepName: string): Promise<void> {
+    return this.navigation.navigateToStepByName(stepName);
+  }
+
+  async navigateToWizardInNamespace(namespace: string): Promise<void> {
+    return this.deployment.navigateToWizardInNamespace(namespace);
+  }
+
+  async openEditLocationPanel(): Promise<void> {
+    return this.location.openEditLocationPanel();
+  }
+
+  async openWizardFromCreateDropdown(): Promise<void> {
+    return this.deployment.openWizardFromCreateDropdown();
+  }
+
+  async searchBootVolumeByName(name: string): Promise<void> {
+    return this.bootSource.searchBootVolumeByName(name);
+  }
+
+  async searchCloneSourceByName(name: string): Promise<void> {
+    return this.clone.searchCloneSourceByName(name);
+  }
+
+  async searchCustomizationSettings(query: string): Promise<void> {
+    const searchInput = this._pfV6CWizardInputPlaceholderFindSettings;
+    await searchInput.clear();
+    await searchInput.fill(query);
+    await this.page.waitForTimeout(500);
+  }
+
+  async selectBootVolumeByName(volumeName: string): Promise<void> {
+    return this.bootSource.selectBootVolumeByName(volumeName);
+  }
+
+  async selectCloneSourceVm(vmName: string): Promise<void> {
+    return this.clone.selectCloneSourceVm(vmName);
+  }
+
+  // ============================================================================
+  // Step 8 — Review and Create
+  // ============================================================================
+
+  async selectComputeSize(sizeName: string): Promise<void> {
+    return this.compute.selectComputeSize(sizeName);
+  }
+
+  async selectComputeTab(tab: 'redhat' | 'user'): Promise<void> {
+    return this.compute.selectComputeTab(tab);
+  }
+
+  async selectCreationMethod(method: 'newVm' | 'fromTemplate' | 'cloneVm'): Promise<void> {
+    return this.deployment.selectCreationMethod(method);
+  }
+
+  async selectCustomizationTab(
+    tabName: 'Details' | 'Storage' | 'Network' | 'Scheduling' | 'SSH' | 'Initial run' | 'Metadata',
+  ): Promise<void> {
+    const tab = this.locator(`button[role="tab"]:has-text("${tabName}")`);
+    await this.robustClick(tab.first());
+  }
+
+  async selectInstanceTypeSeries(series: 'cx' | 'd' | 'u' | 'm' | 'n' | 'o' | 'rt'): Promise<void> {
+    return this.compute.selectInstanceTypeSeries(series);
+  }
+
+  async selectNoBootSource(): Promise<void> {
+    return this.bootSource.selectNoBootSource();
+  }
+
+  async selectOperatingSystem(os: 'rhel' | 'windows' | 'otherLinux'): Promise<void> {
+    return this.deployment.selectOperatingSystem(os);
+  }
+
+  async selectOsType(osType: string): Promise<void> {
+    return this.deployment.selectOsType(osType);
+  }
+
+  async selectTemplateByTestId(templateTestId: string): Promise<void> {
+    return this.templateCatalog.selectTemplateByTestId(templateTestId);
+  }
+
+  async selectTemplateCatalogProject(projectName: string): Promise<void> {
+    return this.templateCatalog.selectTemplateCatalogProject(projectName);
+  }
+
+  async selectUserProvidedInstanceTypeByName(name: string): Promise<void> {
+    return this.compute.selectUserProvidedInstanceTypeByName(name);
+  }
+
+  async selectVolumesProject(projectName: string): Promise<void> {
+    return this.bootSource.selectVolumesProject(projectName);
+  }
+
+  async setCloneSourceProjectFilter(namespace: string): Promise<void> {
+    return this.clone.setCloneSourceProjectFilter(namespace);
+  }
+
+  async toggleBootVolumeStar(volumeName: string): Promise<void> {
+    return this.bootSource.toggleBootVolumeStar(volumeName);
+  }
+
+  async toggleDeletionProtection(): Promise<void> {
+    await this._toggleSwitch('deletion-protection');
+    const modal = this.page.locator('.deletion-protection-modal');
+    if (await modal.isVisible({ timeout: 2000 }).catch(() => false)) {
+      const confirmBtn = modal.locator('button:has-text("Enable"), button:has-text("Disable")');
+      await confirmBtn.first().click();
+      await modal
+        .waitFor({ state: 'hidden', timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => undefined);
+    }
+  }
+
+  async toggleGuestSystemLogAccess(): Promise<void> {
+    await this._toggleSwitch('guest-system-log-access');
+  }
+
+  async toggleHeadlessMode(): Promise<void> {
+    await this._toggleSwitch('headless-mode');
+  }
+
+  // ============================================================================
+  // Step 5 — Template catalog (From Template flow)
+  // ============================================================================
+
+  async toggleStartAfterCreation(): Promise<void> {
+    return this.review.toggleStartAfterCreation();
+  }
+
+  async toggleTemplateCatalogView(view: 'grid' | 'list'): Promise<void> {
+    return this.templateCatalog.toggleTemplateCatalogView(view);
+  }
+
+  async typeReviewVmName(name: string): Promise<void> {
+    return this.review.typeReviewVmName(name);
+  }
+
+  async verifyAddVolumeButtonVisible(): Promise<boolean> {
+    return this.bootSource.verifyAddVolumeButtonVisible();
+  }
+
+  async verifyAllInstanceTypeSeriesVisible(): Promise<string[]> {
+    return this.compute.verifyAllInstanceTypeSeriesVisible();
+  }
+
+  async verifyBootSourceStepVisible(): Promise<boolean> {
+    return this.bootSource.verifyBootSourceStepVisible();
+  }
+
+  async verifyBootVolumeTableColumnsVisible(): Promise<boolean> {
+    return this.bootSource.verifyBootVolumeTableColumnsVisible();
+  }
+
+  async verifyBootVolumeTableOrEmptyState(): Promise<boolean> {
+    return this.bootSource.verifyBootVolumeTableOrEmptyState();
+  }
+
+  async verifyBootVolumeTableVisible(): Promise<boolean> {
+    return this.bootSource.verifyBootVolumeTableVisible();
+  }
+
+  async verifyCloneSourceDescription(): Promise<boolean> {
+    return this.clone.verifyCloneSourceDescription();
+  }
+
+  async verifyCloneSourceStepVisible(): Promise<boolean> {
+    return this.clone.verifyCloneSourceStepVisible();
+  }
+
+  async verifyCloneVmListVisible(): Promise<boolean> {
+    return this.clone.verifyCloneVmListVisible();
+  }
+
+  async verifyComputeResourcesStepVisible(): Promise<boolean> {
+    return this.compute.verifyComputeResourcesStepVisible();
+  }
+
+  async verifyComputeTabsVisible(): Promise<boolean> {
+    return this.compute.verifyComputeTabsVisible();
+  }
+
+  async verifyCreationMethodCardSelected(
+    method: 'newVm' | 'fromTemplate' | 'cloneVm',
+  ): Promise<boolean> {
+    return this.deployment.verifyCreationMethodCardSelected(method);
+  }
+
+  async verifyCreationMethodTilesVisible(): Promise<boolean> {
+    return this.deployment.verifyCreationMethodTilesVisible();
+  }
+
+  async verifyCustomizationDetailsFields(): Promise<string[]> {
+    const expectedFields = [
+      'Description',
+      'Folder',
+      'Hostname',
+      'Headless mode',
+      'Guest system log access',
+      'Deletion protection',
+    ];
+    const found: string[] = [];
+    const panel = this._roleTabpanel;
+    for (const field of expectedFields) {
+      const term = panel.locator(`text=${field}`).first();
+      if (await term.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false)) {
+        found.push(field);
+      }
+    }
+    return found;
+  }
+
+  async verifyCustomizationExpandableSections(): Promise<string[]> {
+    const expectedSections = ['Hardware devices', 'Boot management'];
+    const found: string[] = [];
+    for (const section of expectedSections) {
+      const btn = this.locator(`.pf-v6-c-wizard button:has-text("${section}")`);
+      if (
+        await btn
+          .first()
+          .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+          .catch(() => false)
+      ) {
+        found.push(section);
+      }
+    }
+    return found;
+  }
+
+  async verifyCustomizationSearchInputVisible(): Promise<boolean> {
+    try {
+      const input = this._pfV6CWizardInputPlaceholderFindSettings;
+      return await input.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCustomizationStepVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Customization")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCustomizationTabsVisible(): Promise<boolean> {
+    const expectedTabs = [
+      'Details',
+      'Storage',
+      'Network',
+      'Scheduling',
+      'SSH',
+      'Initial run',
+      'Metadata',
+    ];
+    try {
+      for (const tabName of expectedTabs) {
+        const tab = this.locator(`button[role="tab"]:has-text("${tabName}")`);
+        await tab.first().waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.SHORT_WAIT,
+        });
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyEditLocationButtonVisible(): Promise<boolean> {
+    return this.location.verifyEditLocationButtonVisible();
+  }
+
+  async verifyEditLocationPanelFields(): Promise<{
+    projectDropdown: boolean;
+    folderCombobox: boolean;
+  }> {
+    return this.location.verifyEditLocationPanelFields();
+  }
+
+  // ============================================================================
+  // Step 6 — Customization sub-tabs content validation
+  // ============================================================================
+
+  async verifyEmptyProjectStateInCatalog(): Promise<boolean> {
+    return this.templateCatalog.verifyEmptyProjectStateInCatalog();
+  }
+
+  async verifyInitialRunTabContent(): Promise<{
+    cloudInitEditButton: boolean;
+    sysprepSection: boolean;
+  }> {
+    await this.selectCustomizationTab('Initial run');
+    await this.page.waitForTimeout(1000);
+    const panel = this._roleTabpanel;
+    await panel.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return {
+      cloudInitEditButton: await panel
+        .locator('button:has-text("Edit")')
+        .first()
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false),
+      sysprepSection: await panel
+        .locator('[data-test-id="sysprep-button"]')
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false),
+    };
+  }
+
+  async verifyInstanceTypeSeriesVisible(): Promise<boolean> {
+    return this.compute.verifyInstanceTypeSeriesVisible();
+  }
+
+  async verifyLocationSectionVisible(): Promise<boolean> {
+    return this.location.verifyLocationSectionVisible();
+  }
+
+  async verifyMetadataTabContent(): Promise<{
+    labelsEditButton: boolean;
+    annotationsButton: boolean;
+  }> {
+    await this.selectCustomizationTab('Metadata');
+    await this.page.waitForTimeout(1000);
+    const panel = this._roleTabpanel;
+    await panel.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return {
+      labelsEditButton: await panel
+        .locator('[data-test-id$="-labels-edit"]')
+        .first()
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false),
+      annotationsButton: await panel
+        .locator('button:has-text("Annotations")')
+        .first()
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false),
+    };
+  }
+
+  async verifyNetworkTabContent(): Promise<{
+    interfaceTable: boolean;
+    addButton: boolean;
+    filterToolbar: boolean;
+  }> {
+    await this.selectCustomizationTab('Network');
+    await this.page.waitForTimeout(500);
+    const panel = this._roleTabpanel;
+    return {
+      interfaceTable: await panel
+        .locator('[data-test="wizard-network-interfaces-table"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      addButton: await panel
+        .locator('[data-test="item-create"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      filterToolbar: await panel
+        .locator('[data-test="filter-toolbar"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+    };
+  }
+
+  async verifyNoBootSourceOptionVisible(): Promise<boolean> {
+    return this.bootSource.verifyNoBootSourceOptionVisible();
+  }
+
+  async verifyNoErrorBoundary(waitMs = 3000): Promise<boolean> {
+    return this.templateCatalog.verifyNoErrorBoundary(waitMs);
+  }
+
+  async verifyNoHeaderProjectSelector(): Promise<boolean> {
+    return this.location.verifyNoHeaderProjectSelector();
+  }
+
+  async verifyOsTilesVisible(): Promise<boolean> {
+    return this.deployment.verifyOsTilesVisible();
+  }
+
+  async verifyOsTypeDropdownVisible(): Promise<boolean> {
+    return this.deployment.verifyOsTypeDropdownVisible();
+  }
+
+  // ============================================================================
+  // Clone flow — Source step
+  // ============================================================================
+
+  async verifyRedirectedToVmDetails(): Promise<boolean> {
+    try {
+      await this.page.waitForURL(/kubevirt\.io~v1~VirtualMachine\/[a-z0-9][a-z0-9-]*[a-z0-9]$/, {
+        timeout: TestTimeouts.VM_OPERATION,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyRedirectedToVmList(): Promise<boolean> {
+    try {
+      await this.page.waitForURL(/kubevirt\.io~v1~VirtualMachine|\/vms/, {
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyReviewNameEditable(): Promise<boolean> {
+    return this.review.verifyReviewNameEditable();
+  }
+
+  async verifyReviewNameLabelRequired(): Promise<boolean> {
+    return this.review.verifyReviewNameLabelRequired();
+  }
+
+  async verifyReviewSectionsVisible(): Promise<boolean> {
+    return this.review.verifyReviewSectionsVisible();
+  }
+
+  async verifyReviewStepVisible(): Promise<boolean> {
+    return this.review.verifyReviewStepVisible();
+  }
+
+  async verifySchedulingTabContent(): Promise<string[]> {
+    await this.selectCustomizationTab('Scheduling');
+    await this.page.waitForTimeout(500);
+    const panel = this._roleTabpanel;
+    const expectedFields = [
+      'Node selector',
+      'Tolerations',
+      'Affinity rules',
+      'Descheduler',
+      'Dedicated resources',
+      'Eviction strategy',
+      'Run strategy',
+    ];
+    const found: string[] = [];
+    for (const field of expectedFields) {
+      const el = panel.locator(`text=${field}`).first();
+      if (await el.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false)) {
+        found.push(field);
+      }
+    }
+    return found;
+  }
+
+  async verifySSHTabContent(): Promise<{
+    sshAccessField: boolean;
+    publicKeyEditButton: boolean;
+  }> {
+    await this.selectCustomizationTab('SSH');
+    await this.page.waitForTimeout(1000);
+    const panel = this._roleTabpanel;
+    await panel.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return {
+      sshAccessField: await panel
+        .locator('[data-test-id="ssh-access"]')
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false),
+      publicKeyEditButton: await panel
+        .locator('[data-test-id="public-ssh-key-edit"]')
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false),
+    };
+  }
+
+  // ============================================================================
+  // Create action
+  // ============================================================================
+
+  async verifyStartAfterCreationCheckbox(): Promise<boolean> {
+    return this.review.verifyStartAfterCreationCheckbox();
+  }
+
+  async verifyStepActive(stepId: string): Promise<boolean> {
+    return this.deployment.verifyStepActive(stepId);
+  }
+
+  async verifyStorageTabContent(): Promise<{
+    diskList: boolean;
+    addButton: boolean;
+    environmentSection: boolean;
+    windowsDriversCheckbox: boolean;
+  }> {
+    await this.selectCustomizationTab('Storage');
+    await this.page.waitForTimeout(500);
+    const panel = this._roleTabpanel;
+    return {
+      diskList: await panel
+        .locator('[data-test="vm-disk-list"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      addButton: await panel
+        .locator('button:has-text("Add")')
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      environmentSection: await panel
+        .locator('h2:has-text("Environment")')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      windowsDriversCheckbox: await panel
+        .locator('[data-test-id="cdrom-drivers"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+    };
+  }
+
+  async verifyTemplateCatalogHasCards(): Promise<boolean> {
+    return this.templateCatalog.verifyTemplateCatalogHasCards();
+  }
+
+  async verifyTemplateCatalogStepVisible(): Promise<boolean> {
+    return this.templateCatalog.verifyTemplateCatalogStepVisible();
+  }
+
+  // ============================================================================
+  // Wizard Navigation
+  // ============================================================================
+
+  async verifyTemplateCatalogToolbar(): Promise<{
+    filterInput: boolean;
+    gridToggle: boolean;
+    listToggle: boolean;
+    projectDropdown: boolean;
+  }> {
+    return this.templateCatalog.verifyTemplateCatalogToolbar();
+  }
+
+  async verifyTemplateDrawerVisible(): Promise<boolean> {
+    return this.templateCatalog.verifyTemplateDrawerVisible();
+  }
+
+  async verifyWizardCloseButtonHidden(): Promise<boolean> {
+    return this.location.verifyWizardCloseButtonHidden();
+  }
+
+  async verifyWizardClosed(): Promise<boolean> {
+    return this.deployment.verifyWizardClosed();
+  }
+
+  async verifyWizardVisible(): Promise<boolean> {
+    return this.deployment.verifyWizardVisible();
+  }
+}

--- a/playwright/src/components/vm-wizard/vm-wizard-boot-source-component.ts
+++ b/playwright/src/components/vm-wizard/vm-wizard-boot-source-component.ts
@@ -1,0 +1,367 @@
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+export default class VmWizardBootSourceComponent extends BaseComponent {
+  private readonly _dialogModalTabModal = this.locator('[data-test="dialog-modal"], #tab-modal');
+  private readonly _noBootSource = this.locator('text=No boot source');
+  private readonly _pfV6CWizardAddVolumeBtn = this.locator(
+    '.pf-v6-c-wizard button:has-text("Add volume")',
+  );
+  private readonly _pfV6CWizardInputnameFilterInput = this.locator(
+    '.pf-v6-c-wizard input[data-test="name-filter-input"]',
+  );
+  private readonly _pfV6CWizardTableTbodyTr = this.locator('.pf-v6-c-wizard table tbody tr');
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async cancelAddVolumeModal(): Promise<void> {
+    const dialog = this._dialogModalTabModal;
+    const cancelButton = dialog.locator('[data-test="cancel-button"]');
+    await cancelButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(cancelButton);
+  }
+
+  async clickAddVolumeButton(): Promise<void> {
+    const addBtn = this._pfV6CWizardAddVolumeBtn;
+    await addBtn.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(addBtn.first());
+    const dialog = this._dialogModalTabModal;
+    await dialog.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+  }
+
+  async getAddVolumeModalSaveButtonText(): Promise<string> {
+    const dialog = this._dialogModalTabModal;
+    const saveButton = dialog.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return (await saveButton.textContent())?.trim() ?? '';
+  }
+
+  async getAddVolumePreferenceHelperText(): Promise<string> {
+    const dialog = this._dialogModalTabModal;
+    const labels = dialog.locator('.pf-v6-c-form__label');
+    const prefLabel = labels.filter({ hasText: 'Preference' });
+    const group = prefLabel.locator('..').locator('..');
+    const helperText = group.locator('.pf-v6-c-helper-text');
+    try {
+      await helperText.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return (await helperText.first().textContent())?.trim() ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getAddVolumePreferenceValue(): Promise<string> {
+    const dialog = this._dialogModalTabModal;
+    const labels = dialog.locator('.pf-v6-c-form__label');
+    const prefLabel = labels.filter({ hasText: 'Preference' });
+    const group = prefLabel.locator('..').locator('..');
+    const toggle = group.locator('.pf-v6-c-menu-toggle');
+    try {
+      await toggle.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return (await toggle.first().textContent())?.trim() ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getBootSourceEmptyStateBodyText(): Promise<string> {
+    try {
+      const emptyState = this.locator('.bootable-volume-empty-state').or(
+        this.locator('.pf-v6-c-empty-state__body'),
+      );
+      await emptyState.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return (await emptyState.first().textContent())?.trim() ?? '';
+    } catch {
+      const bodyByText = this.page.getByText(/to get started.*add volume/i);
+      return (await bodyByText.first().textContent())?.trim() ?? '';
+    }
+  }
+
+  async getBootSourceEmptyStateHeading(): Promise<string> {
+    try {
+      const heading = this.locator(
+        '.bootable-volume-empty-state__title, .bootable-volume-empty-state h3',
+      );
+      await heading.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return (await heading.first().textContent())?.trim() ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getBootVolumeCount(): Promise<number> {
+    const paginationText = this.locator('button').filter({ hasText: /of \d+/ });
+    try {
+      const text = await paginationText.first().textContent({ timeout: TestTimeouts.SHORT_WAIT });
+      const match = text?.match(/of (\d+)/);
+      return match ? parseInt(match[1], 10) : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  async getBootVolumeOsColumnValues(): Promise<string[]> {
+    const rows = this._pfV6CWizardTableTbodyTr;
+    await rows.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const count = await rows.count();
+    const osValues: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const osCell = rows.nth(i).locator('td:nth-child(4)');
+      const text = (await osCell.textContent())?.trim() ?? '';
+      if (text) osValues.push(text);
+    }
+    return osValues;
+  }
+
+  async isAddVolumeModalSaveButtonDisabled(): Promise<boolean> {
+    const dialog = this._dialogModalTabModal;
+    const saveButton = dialog.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return await saveButton.isDisabled();
+  }
+
+  async isAddVolumePreferenceDisabled(): Promise<boolean> {
+    const dialog = this._dialogModalTabModal;
+    const labels = dialog.locator('.pf-v6-c-form__label');
+    const prefLabel = labels.filter({ hasText: 'Preference' });
+    const group = prefLabel.locator('..').locator('..');
+    const toggle = group.locator('.pf-v6-c-menu-toggle');
+    try {
+      await toggle.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      const isDisabled = await toggle.first().getAttribute('class');
+      return isDisabled?.includes('pf-m-disabled') ?? false;
+    } catch {
+      return false;
+    }
+  }
+
+  async isBootVolumeEmptyStateVisible(): Promise<boolean> {
+    try {
+      await this.waitForLoadingComplete(TestTimeouts.ELEMENT_WAIT);
+
+      const byEmptyState = this.locator(
+        '.pf-v6-c-empty-state h3, .pf-v6-c-empty-state h4, .pf-v6-c-empty-state__title',
+      ).filter({ hasText: /no.*volumes|don.*t have any volumes/i });
+
+      const byText = this.page.getByText(/you don.t have any volumes/i);
+
+      const match = byEmptyState.or(byText);
+      await match.first().waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isBootVolumeOsFilterVisible(): Promise<boolean> {
+    try {
+      const osFilter = this.locator(
+        '.pf-v6-c-wizard [data-test="os-filter"], .pf-v6-c-wizard [data-test-row-filter="operating-system"]',
+      );
+      return await osFilter
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async isBootVolumeStarred(volumeName: string): Promise<boolean> {
+    try {
+      const row = this.page.getByRole('row').filter({ hasText: volumeName });
+      return await row
+        .locator('button[aria-label="Starred"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async searchBootVolumeByName(name: string): Promise<void> {
+    const searchInput = this._pfV6CWizardInputnameFilterInput;
+    await searchInput.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await searchInput.first().clear();
+    await searchInput.first().fill(name);
+    await this.page.waitForTimeout(500);
+  }
+
+  async selectBootVolumeByName(volumeName: string): Promise<void> {
+    const table = this.locator('.pf-v6-c-wizard table, .pf-v6-c-wizard [role="grid"]');
+    await table.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    const searchInput = this._pfV6CWizardInputnameFilterInput;
+    if (await searchInput.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false)) {
+      await searchInput.clear();
+      await searchInput.fill(volumeName);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const row = this._pfV6CWizardTableTbodyTr.filter({ hasText: volumeName });
+    await row.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(row.first());
+
+    if (await searchInput.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await searchInput.clear();
+      await this.page.waitForTimeout(300);
+    }
+  }
+
+  async selectNoBootSource(): Promise<void> {
+    const radio = this.locator('input[type="radio"][value="no-boot-source"]').or(
+      this._noBootSource.locator('..').locator('input[type="radio"]'),
+    );
+    if (
+      await radio
+        .first()
+        .isVisible()
+        .catch(() => false)
+    ) {
+      await this.robustClick(radio.first());
+    } else {
+      await this.robustClick(this._noBootSource);
+    }
+  }
+
+  async selectVolumesProject(projectName: string): Promise<void> {
+    const projectToggle = this.locator(
+      '.pf-v6-c-wizard button:has-text("All projects"), .pf-v6-c-wizard button:has-text("Project"), .pf-v6-c-wizard .pf-v6-c-menu-toggle:has-text("project")',
+    ).first();
+    await projectToggle.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(projectToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const vmFilterCheckbox = this.page.locator(
+      'input[type="checkbox"] + label:has-text("Show only projects with VirtualMachines"), label:has-text("Show only projects with") input[type="checkbox"]',
+    );
+    const filterVisible = await vmFilterCheckbox
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+      .catch(() => false);
+    if (filterVisible) {
+      const isChecked = await vmFilterCheckbox.isChecked().catch(() => false);
+      if (isChecked) {
+        await vmFilterCheckbox.uncheck({ force: true });
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      }
+    }
+
+    const searchInput = this.page.locator(
+      '[role="listbox"] input[type="search"], .pf-v6-c-menu input[type="search"], input[placeholder*="project"], input[placeholder*="Project"]',
+    );
+    if (await searchInput.isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT }).catch(() => false)) {
+      await searchInput.fill(projectName);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const option = this.page.locator(
+      `[role="option"]:has-text("${projectName}"), .pf-v6-c-menu__item-text:text-is("${projectName}")`,
+    );
+    await option.first().waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(option.first());
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async toggleBootVolumeStar(volumeName: string): Promise<void> {
+    const row = this.page.getByRole('row').filter({ hasText: volumeName });
+    const starBtn = row.locator('button[aria-label="Not starred"], button[aria-label="Starred"]');
+    await this.robustClick(starBtn.first());
+    // Wait for aria-label to flip before returning
+    await this.page.waitForTimeout(500);
+  }
+
+  async verifyAddVolumeButtonVisible(): Promise<boolean> {
+    try {
+      const addBtn = this._pfV6CWizardAddVolumeBtn;
+      return await addBtn
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Verifies the boot source step description hint is visible.
+   * The hint reads "Select a boot source (volume or ISO) now or configure it later."
+   * CNV-84916: this hint was missing from the Boot source step before the fix.
+   */
+  async verifyBootSourceDescriptionVisible(): Promise<boolean> {
+    try {
+      const description = this.page.getByText('Select a boot source (volume or ISO)', {
+        exact: false,
+      });
+      await description.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyBootSourceStepVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Boot source")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyBootVolumeTableColumnsVisible(): Promise<boolean> {
+    const expectedColumns = [
+      'Volume name',
+      'Architecture',
+      'Operating system',
+      'Storage class',
+      'Size',
+      'Description',
+    ];
+    try {
+      for (const col of expectedColumns) {
+        const header = this.page.getByRole('columnheader', { name: col });
+        await header.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyBootVolumeTableOrEmptyState(): Promise<boolean> {
+    if (await this.verifyBootVolumeTableVisible()) return true;
+    if (await this.isBootVolumeEmptyStateVisible()) return true;
+
+    const noBootSourceForOs = this.locator(
+      'h3:has-text("No volumes found for the chosen OS"), .pf-v6-c-empty-state',
+    );
+    return await noBootSourceForOs
+      .first()
+      .isVisible()
+      .catch(() => false);
+  }
+
+  async verifyBootVolumeTableVisible(): Promise<boolean> {
+    try {
+      const table = this.locator('table.BootableVolumeList-table, .pf-v6-c-wizard table');
+      await table.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyNoBootSourceOptionVisible(): Promise<boolean> {
+    try {
+      await this.verifyBootVolumeTableOrEmptyState();
+      const noBootRadio = this._noBootSource;
+      await noBootRadio.first().scrollIntoViewIfNeeded({ timeout: TestTimeouts.SHORT_WAIT });
+      return await noBootRadio.first().isVisible({ timeout: TestTimeouts.SHORT_WAIT });
+    } catch {
+      return false;
+    }
+  }
+}

--- a/playwright/src/components/vm-wizard/vm-wizard-compute-customization-component.ts
+++ b/playwright/src/components/vm-wizard/vm-wizard-compute-customization-component.ts
@@ -1,0 +1,740 @@
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+export default class VmWizardComputeCustomizationComponent extends BaseComponent {
+  private static readonly strategyLabels: Record<string, string> = {
+    Always: 'Always',
+    Halted: 'Halted',
+    Manual: 'Manual',
+    RerunOnFailure: 'Rerun on failure',
+  };
+  private readonly _inputTypeText = this.locator('input[type="text"]');
+  private readonly _pfV6CMenuToggle = this.locator('.pf-v6-c-menu-toggle');
+  private readonly _pfV6CWizardButtonpfV6CButtonpfMPrimary = this.locator(
+    '.pf-v6-c-wizard button.pf-v6-c-button.pf-m-primary',
+  );
+  private readonly _pfV6CWizardInputPlaceholderFindSettings = this.locator(
+    '.pf-v6-c-wizard input[placeholder="Find settings"]',
+  );
+  private readonly _pfV6CWizardInputTypeText = this.locator('.pf-v6-c-wizard input[type="text"]');
+  private readonly _roleTabpanel = this.locator('[role="tabpanel"]');
+  private readonly _startAfterCreateCheckbox = this.locator('#start-after-create-checkbox');
+  private readonly _startThisVirtualMachineAfterCreation = this.locator(
+    'text=Start this VirtualMachine after creation',
+  );
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  private async dismissOverlayIfPresent(): Promise<void> {
+    const backdrop = this.page.locator('.pf-v6-c-backdrop');
+    if (await backdrop.isVisible({ timeout: 1000 }).catch(() => false)) {
+      const closeBtn = this.page.locator('.pf-v6-c-backdrop [aria-label="Close"]');
+      if (await closeBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
+        await closeBtn.click();
+        await this.page.waitForTimeout(500);
+      } else {
+        await this.page.keyboard.press('Escape');
+        await this.page.waitForTimeout(500);
+      }
+    }
+  }
+
+  private async toggleSwitch(switchId: string): Promise<void> {
+    await this.dismissOverlayIfPresent();
+    const label = this.page.locator(`label:has(#${switchId})`);
+    await label.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await label.click();
+    await this.page.waitForTimeout(300);
+  }
+
+  async clearReviewVmName(): Promise<void> {
+    const nameInput = this._pfV6CWizardInputTypeText.first();
+    await nameInput.clear();
+    await this.page.waitForTimeout(300);
+  }
+
+  async editSchedulingRunStrategy(strategy: string): Promise<boolean> {
+    try {
+      const editButton = this.locator('button[data-test-id="run-strategy"]');
+      await editButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_VISIBILITY_QUICK,
+      });
+      await this.robustClick(editButton);
+
+      const modal = this.page.locator('[role="dialog"]').filter({ hasText: 'Edit run strategy' });
+      await modal.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.INSTANCE_TYPE_VERIFICATION,
+      });
+
+      const selectToggle = modal.locator('.pf-v6-c-menu-toggle');
+      await selectToggle.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      await this.robustClick(selectToggle);
+
+      const label = VmWizardComputeCustomizationComponent.strategyLabels[strategy] || strategy;
+      const option = this.page
+        .locator('button[role="option"]')
+        .filter({ has: this.page.locator('.pf-v6-c-menu__item-text', { hasText: label }) });
+      await option.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      await this.robustClick(option);
+
+      const saveButton = modal.locator('button').filter({ hasText: 'Save' }).first();
+      await this.robustClick(saveButton);
+      await modal.waitFor({
+        state: 'hidden',
+        timeout: TestTimeouts.ELEMENT_WAIT,
+      });
+
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async fillReviewDescription(text: string): Promise<void> {
+    const descInput = this._pfV6CWizardInputTypeText.nth(1);
+    await descInput.clear();
+    await descInput.fill(text);
+  }
+
+  async fillReviewVmName(name: string): Promise<void> {
+    const nameInput = this._inputTypeText.first();
+    await nameInput.clear();
+    await nameInput.fill(name);
+    await nameInput.press('Tab');
+  }
+
+  async getActiveComputeTab(): Promise<string> {
+    try {
+      const activeTab = this.locator('button[role="tab"][aria-selected="true"]');
+      const text = await activeTab.first().textContent({ timeout: TestTimeouts.SHORT_WAIT });
+      return text?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getComputeSizeDropdownText(): Promise<string> {
+    try {
+      const sizeBtn = this._pfV6CMenuToggle.filter({
+        hasText: /CPUs.*Memory/,
+      });
+      return (
+        (await sizeBtn.first().textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || ''
+      );
+    } catch {
+      return '';
+    }
+  }
+
+  async getComputeSizeOptions(): Promise<string[]> {
+    const sizeBtn = this._pfV6CMenuToggle.filter({
+      hasText: /CPUs.*Memory/,
+    });
+    await this.robustClick(sizeBtn.first());
+    await this.page.waitForTimeout(500);
+
+    const options: string[] = [];
+    const menuItems = this.page.getByRole('menuitem');
+    const count = await menuItems.count();
+    for (let i = 0; i < count; i++) {
+      const text = await menuItems.nth(i).textContent();
+      if (text?.trim()) options.push(text.trim());
+    }
+
+    await this.page.keyboard.press('Escape');
+    return options;
+  }
+
+  async getCreateButtonText(): Promise<string> {
+    try {
+      const createBtn = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
+      return (
+        (await createBtn.first().textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || ''
+      );
+    } catch {
+      return '';
+    }
+  }
+
+  async getCustomizationVmName(): Promise<string> {
+    try {
+      const hostname = this.locator('button').filter({ hasText: /^[a-z0-9-]+$/ });
+      const detailsRegion = this._roleTabpanel;
+      const hostnameValue = detailsRegion.locator('dt:has-text("Hostname") + dd button');
+      const text = await hostnameValue.first().textContent({ timeout: TestTimeouts.SHORT_WAIT });
+      return text?.trim() || (await hostname.first().textContent()) || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getReviewDescription(): Promise<string> {
+    try {
+      const descInput = this._pfV6CWizardInputTypeText.nth(1);
+      return (await descInput.inputValue()) || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getReviewDescriptionText(): Promise<string> {
+    try {
+      const region = this.locator(
+        '.pf-v6-c-wizard [class*="review"] strong:has-text("Create VirtualMachine")',
+      )
+        .locator('..')
+        .first();
+      return (await region.textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getReviewNameValidationError(): Promise<string> {
+    try {
+      const error = this.locator('.pf-v6-c-helper-text__item.pf-m-error');
+      await error.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return (await error.first().textContent())?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getReviewVmName(): Promise<string> {
+    try {
+      const nameInput = this._inputTypeText.first();
+      return (await nameInput.inputValue()) || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getSchedulingRunStrategy(): Promise<string> {
+    try {
+      const panel = this._roleTabpanel;
+      const dd = panel.locator('[data-test-id="run-strategy"]').first();
+      return (await dd.textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getSelectedInstanceTypeSeries(): Promise<string> {
+    try {
+      const pressed = this.locator(
+        '.instance-type-series-menu-card__toggle-card[aria-pressed="true"]',
+      );
+      const text = await pressed.first().textContent({ timeout: TestTimeouts.SHORT_WAIT });
+      return text?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getStartAfterCreationLabel(): Promise<string> {
+    try {
+      const checkbox = this._startAfterCreateCheckbox;
+      const label = checkbox.locator('..').locator('label, .pf-v6-c-check__label').first();
+      return (await label.textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getStorageTabDisks(): Promise<string[]> {
+    const panel = this._roleTabpanel;
+    const diskList = panel.locator('[data-test="vm-disk-list"]');
+    await diskList.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const firstDisk = diskList.locator('[data-test-id^="disk-"]').first();
+    await firstDisk.waitFor({ state: 'attached', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    const allDiskEls = diskList.locator('[data-test-id]');
+    const count = await allDiskEls.count();
+    const disks: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const testId = await allDiskEls.nth(i).getAttribute('data-test-id');
+      if (
+        testId &&
+        testId.startsWith('disk-') &&
+        !testId.includes('-source-') &&
+        !testId.includes('-size-') &&
+        !testId.includes('-drive-') &&
+        !testId.includes('-interface-') &&
+        !testId.includes('-storage-class-')
+      ) {
+        const text = await allDiskEls.nth(i).textContent();
+        if (text?.trim()) disks.push(text.trim());
+      }
+    }
+    return disks;
+  }
+
+  async isCreateButtonDisabled(): Promise<boolean> {
+    try {
+      const createBtn = this._pfV6CWizardButtonpfV6CButtonpfMPrimary.first();
+      await createBtn.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return createBtn.isDisabled();
+    } catch {
+      return true;
+    }
+  }
+
+  async isDeletionProtectionEnabled(): Promise<boolean> {
+    return await this.locator('#deletion-protection').isChecked();
+  }
+
+  async isGuestSystemLogAccessEnabled(): Promise<boolean> {
+    return await this.locator('#guest-system-log-access').isChecked();
+  }
+
+  async isHeadlessModeEnabled(): Promise<boolean> {
+    return await this.locator('#headless-mode').isChecked();
+  }
+
+  async isStartAfterCreationChecked(): Promise<boolean> {
+    try {
+      const checkbox = this._startAfterCreateCheckbox;
+      await checkbox.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return checkbox.isChecked();
+    } catch {
+      return false;
+    }
+  }
+
+  async searchCustomizationSettings(query: string): Promise<void> {
+    const searchInput = this._pfV6CWizardInputPlaceholderFindSettings;
+    await searchInput.clear();
+    await searchInput.fill(query);
+    await this.page.waitForTimeout(500);
+  }
+
+  async selectComputeSize(sizeName: string): Promise<void> {
+    const sizeToggle = this.locator('button.pf-v6-c-menu-toggle').filter({
+      hasText: /Select size|CPUs.*Memory/,
+    });
+    await this.robustClick(sizeToggle.first());
+    await this.page.waitForTimeout(500);
+
+    const sizeOption = this.page.getByRole('menuitem').filter({ hasText: sizeName });
+    await this.robustClick(sizeOption.first());
+  }
+
+  async selectComputeTab(tab: 'redhat' | 'user'): Promise<void> {
+    const tabText = tab === 'redhat' ? 'Red Hat provided' : 'User provided';
+    const tabButton = this.locator(`button[role="tab"]:has-text("${tabText}")`);
+    await this.robustClick(tabButton.first());
+  }
+
+  async selectCustomizationTab(
+    tabName: 'Details' | 'Storage' | 'Network' | 'Scheduling' | 'SSH' | 'Initial run' | 'Metadata',
+  ): Promise<void> {
+    const tab = this.locator(`button[role="tab"]:has-text("${tabName}")`);
+    await this.robustClick(tab.first());
+  }
+
+  async selectInstanceTypeSeries(series: 'cx' | 'd' | 'u' | 'm' | 'n' | 'o' | 'rt'): Promise<void> {
+    const seriesMap: Record<string, string> = {
+      cx: 'Compute Exclusive',
+      d: 'Dedicated vCPU',
+      u: 'General Purpose',
+      m: 'Memory Intensive',
+      n: 'Network',
+      o: 'Overcommitted',
+      rt: 'Realtime',
+    };
+    const card = this.locator(
+      `.instance-type-series-menu-card__toggle-card:has-text("${seriesMap[series]}")`,
+    );
+    await this.robustClick(card.first());
+  }
+
+  async selectUserProvidedInstanceTypeByName(name: string): Promise<void> {
+    const row = this.locator('tbody tr.pf-m-clickable').filter({
+      has: this.locator(`[data-test-id="${name}"]`),
+    });
+    await row.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(row.first());
+  }
+
+  async toggleDeletionProtection(): Promise<void> {
+    await this.toggleSwitch('deletion-protection');
+    const modal = this.page.locator('.deletion-protection-modal');
+    if (await modal.isVisible({ timeout: 2000 }).catch(() => false)) {
+      const confirmBtn = modal.locator('button:has-text("Enable"), button:has-text("Disable")');
+      await confirmBtn.first().click();
+      await modal
+        .waitFor({ state: 'hidden', timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => undefined);
+    }
+  }
+
+  async toggleGuestSystemLogAccess(): Promise<void> {
+    await this.toggleSwitch('guest-system-log-access');
+  }
+
+  async toggleHeadlessMode(): Promise<void> {
+    await this.toggleSwitch('headless-mode');
+  }
+
+  async toggleStartAfterCreation(): Promise<void> {
+    const checkbox = this.locator('input[type="checkbox"]').or(
+      this._startThisVirtualMachineAfterCreation,
+    );
+    await this.robustClick(checkbox.first());
+  }
+
+  async typeReviewVmName(name: string): Promise<void> {
+    const nameInput = this._pfV6CWizardInputTypeText.first();
+    await nameInput.clear();
+    await nameInput.fill(name);
+    await this.page.waitForTimeout(200);
+  }
+
+  async verifyAllInstanceTypeSeriesVisible(): Promise<string[]> {
+    const expectedSeries = [
+      'Compute Exclusive',
+      'Dedicated vCPU',
+      'General Purpose',
+      'Memory Intensive',
+      'Network',
+      'Overcommitted',
+      'Realtime',
+    ];
+    const found: string[] = [];
+    for (const series of expectedSeries) {
+      const card = this.locator(
+        `.instance-type-series-menu-card__toggle-card:has-text("${series}")`,
+      );
+      if (
+        await card
+          .first()
+          .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+          .catch(() => false)
+      ) {
+        found.push(series);
+      }
+    }
+    return found;
+  }
+
+  async verifyComputeResourcesStepVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Compute resources")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyComputeTabsVisible(): Promise<boolean> {
+    try {
+      const rhProvided = this.locator('button[role="tab"]:has-text("Red Hat provided")');
+      const userProvided = this.locator('button[role="tab"]:has-text("User provided")');
+      await rhProvided.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.SHORT_WAIT,
+      });
+      await userProvided.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.SHORT_WAIT,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCustomizationDetailsFields(): Promise<string[]> {
+    const expectedFields = [
+      'Description',
+      'Folder',
+      'Hostname',
+      'Headless mode',
+      'Guest system log access',
+      'Deletion protection',
+    ];
+    const found: string[] = [];
+    const panel = this._roleTabpanel;
+    for (const field of expectedFields) {
+      const term = panel.locator(`text=${field}`).first();
+      if (await term.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false)) {
+        found.push(field);
+      }
+    }
+    return found;
+  }
+
+  async verifyCustomizationExpandableSections(): Promise<string[]> {
+    const expectedSections = ['Hardware devices', 'Boot management'];
+    const found: string[] = [];
+    for (const section of expectedSections) {
+      const btn = this.locator(`.pf-v6-c-wizard button:has-text("${section}")`);
+      if (
+        await btn
+          .first()
+          .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+          .catch(() => false)
+      ) {
+        found.push(section);
+      }
+    }
+    return found;
+  }
+
+  async verifyCustomizationSearchInputVisible(): Promise<boolean> {
+    try {
+      const input = this._pfV6CWizardInputPlaceholderFindSettings;
+      return await input.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCustomizationStepVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Customization")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCustomizationTabsVisible(): Promise<boolean> {
+    const expectedTabs = [
+      'Details',
+      'Storage',
+      'Network',
+      'Scheduling',
+      'SSH',
+      'Initial run',
+      'Metadata',
+    ];
+    try {
+      for (const tabName of expectedTabs) {
+        const tab = this.locator(`button[role="tab"]:has-text("${tabName}")`);
+        await tab.first().waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.SHORT_WAIT,
+        });
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyInitialRunTabContent(): Promise<{
+    cloudInitEditButton: boolean;
+    sysprepSection: boolean;
+  }> {
+    await this.selectCustomizationTab('Initial run');
+    await this.page.waitForTimeout(1000);
+    const panel = this._roleTabpanel;
+    await panel.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return {
+      cloudInitEditButton: await panel
+        .locator('button:has-text("Edit")')
+        .first()
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false),
+      sysprepSection: await panel
+        .locator('[data-test-id="sysprep-button"]')
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false),
+    };
+  }
+
+  async verifyInstanceTypeSeriesVisible(): Promise<boolean> {
+    try {
+      const uSeries = this.locator('.instance-type-series-menu-card__toggle-card');
+      await uSeries.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyMetadataTabContent(): Promise<{
+    labelsEditButton: boolean;
+    annotationsButton: boolean;
+  }> {
+    await this.selectCustomizationTab('Metadata');
+    await this.page.waitForTimeout(1000);
+    const panel = this._roleTabpanel;
+    await panel.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return {
+      labelsEditButton: await panel
+        .locator('[data-test-id$="-labels-edit"]')
+        .first()
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false),
+      annotationsButton: await panel
+        .locator('button:has-text("Annotations")')
+        .first()
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false),
+    };
+  }
+
+  async verifyNetworkTabContent(): Promise<{
+    interfaceTable: boolean;
+    addButton: boolean;
+    filterToolbar: boolean;
+  }> {
+    await this.selectCustomizationTab('Network');
+    await this.page.waitForTimeout(500);
+    const panel = this._roleTabpanel;
+    return {
+      interfaceTable: await panel
+        .locator('[data-test="wizard-network-interfaces-table"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      addButton: await panel
+        .locator('[data-test="item-create"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      filterToolbar: await panel
+        .locator('[data-test="filter-toolbar"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+    };
+  }
+
+  async verifyReviewNameEditable(): Promise<boolean> {
+    try {
+      const nameInput = this._pfV6CWizardInputTypeText.first();
+      const isEditable = await nameInput.isEditable({ timeout: TestTimeouts.SHORT_WAIT });
+      return isEditable;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyReviewNameLabelRequired(): Promise<boolean> {
+    try {
+      const nameFormGroup = this.locator('.pf-v6-c-wizard .pf-v6-c-form__group').first();
+      const requiredIndicator = nameFormGroup.locator('.pf-v6-c-form__label-required');
+      await requiredIndicator.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyReviewSectionsVisible(): Promise<boolean> {
+    const sections = ['Details', 'Storage', 'Network', 'Hardware devices'];
+    try {
+      for (const section of sections) {
+        const btn = this.locator(`.pf-v6-c-wizard button:has-text("${section}")`);
+        await btn.first().waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.SHORT_WAIT,
+        });
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyReviewStepVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Review and create")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifySchedulingTabContent(): Promise<string[]> {
+    await this.selectCustomizationTab('Scheduling');
+    await this.page.waitForTimeout(500);
+    const panel = this._roleTabpanel;
+    const expectedFields = [
+      'Node selector',
+      'Tolerations',
+      'Affinity rules',
+      'Descheduler',
+      'Dedicated resources',
+      'Eviction strategy',
+      'Run strategy',
+    ];
+    const found: string[] = [];
+    for (const field of expectedFields) {
+      const el = panel.locator(`text=${field}`).first();
+      if (await el.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false)) {
+        found.push(field);
+      }
+    }
+    return found;
+  }
+
+  async verifySSHTabContent(): Promise<{
+    sshAccessField: boolean;
+    publicKeyEditButton: boolean;
+  }> {
+    await this.selectCustomizationTab('SSH');
+    await this.page.waitForTimeout(1000);
+    const panel = this._roleTabpanel;
+    await panel.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return {
+      sshAccessField: await panel
+        .locator('[data-test-id="ssh-access"]')
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false),
+      publicKeyEditButton: await panel
+        .locator('[data-test-id="public-ssh-key-edit"]')
+        .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .catch(() => false),
+    };
+  }
+
+  async verifyStartAfterCreationCheckbox(): Promise<boolean> {
+    try {
+      const checkbox = this._startThisVirtualMachineAfterCreation;
+      await checkbox.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyStorageTabContent(): Promise<{
+    diskList: boolean;
+    addButton: boolean;
+    environmentSection: boolean;
+    windowsDriversCheckbox: boolean;
+  }> {
+    await this.selectCustomizationTab('Storage');
+    await this.page.waitForTimeout(500);
+    const panel = this._roleTabpanel;
+    return {
+      diskList: await panel
+        .locator('[data-test="vm-disk-list"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      addButton: await panel
+        .locator('button:has-text("Add")')
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      environmentSection: await panel
+        .locator('h2:has-text("Environment")')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      windowsDriversCheckbox: await panel
+        .locator('[data-test-id="cdrom-drivers"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+    };
+  }
+}

--- a/playwright/src/components/vm-wizard/vm-wizard-navigation-component.ts
+++ b/playwright/src/components/vm-wizard/vm-wizard-navigation-component.ts
@@ -1,0 +1,841 @@
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+export default class VmWizardNavigationComponent extends BaseComponent {
+  private readonly _buttonEditVMCreationLocation = this.locator(
+    'button[aria-label="Edit VM creation location"]',
+  );
+  private readonly _cloneVmRadio = this.locator(
+    '.vm-creation-method-tile:has(#clone-radio-button), #clone',
+  );
+  private readonly _fromTemplateRadio = this.locator(
+    '.vm-creation-method-tile:has(#template-radio-button), #template',
+  );
+  private readonly _generateVmNameButton = this.locator(
+    '.vm-creation-wizard [data-test="generate-vm-name-button"]',
+  );
+  private readonly _newVmRadio = this.locator(
+    '.vm-creation-method-tile:has(#instance-type-radio-button), #instance-type',
+  );
+  private readonly _otherLinuxTile = this.locator('.operating-system-tile:has-text("Other Linux")');
+
+  private readonly _pfV6CMenuToggle = this.locator('.pf-v6-c-menu-toggle');
+
+  private readonly _pfV6CWizardButtonpfV6CButtonpfMPrimary = this.locator(
+    '.pf-v6-c-wizard button.pf-v6-c-button.pf-m-primary',
+  );
+  private readonly _pfV6CWizardMain = this.locator('.pf-v6-c-wizard__main');
+  private readonly _pfV6CWizardTemplatesCatalogTile = this.locator(
+    '.pf-v6-c-wizard .templates-catalog-tile',
+  );
+
+  private readonly _rhelTile = this.locator('.operating-system-tile:has-text("RHEL")');
+  private readonly _vmNameInput = this.locator('.vm-creation-wizard #vm-name');
+
+  private readonly _windowsTile = this.locator(
+    '.operating-system-tile:has-text("Microsoft Windows")',
+  );
+  private readonly _wizardContainer = this.locator('.pf-v6-c-wizard.vm-creation-wizard');
+  constructor(page: Page) {
+    super(page);
+  }
+
+  private get _osTypeDropdown() {
+    return this.locator('.pf-v6-c-form__group')
+      .filter({ has: this.page.locator('label:has-text("Guest operating system type")') })
+      .locator('.pf-v6-c-menu-toggle');
+  }
+
+  async applyWorkloadFilter(workload: string): Promise<void> {
+    const filterBtn = this.page.getByRole('button', { name: 'Filter', exact: true });
+    await this.robustClick(filterBtn);
+    await this.page.waitForTimeout(300);
+
+    const workloadItem = this.page.locator(
+      `.pf-v6-c-menu__list .pf-v6-c-menu__item-text:text-is("${workload}")`,
+    );
+    await workloadItem.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await workloadItem.click();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async cancelWizard(): Promise<void> {
+    await this.robustClick(
+      this.locator('.pf-v6-c-wizard button.pf-v6-c-button.pf-m-link:has-text("Cancel")').first(),
+    );
+  }
+
+  async clearCloneSourceFilters(): Promise<void> {
+    const wizard = this._pfV6CWizardMain;
+    const chipCloseButtons = wizard.locator(
+      '.pf-v6-c-label .pf-v6-c-label__actions button, .pf-v6-c-chip button',
+    );
+    const count = await chipCloseButtons.count();
+    for (let i = count - 1; i >= 0; i--) {
+      await chipCloseButtons.nth(i).click();
+      await this.page.waitForTimeout(300);
+    }
+    if (count > 0) {
+      await this.page.waitForTimeout(1000);
+    }
+  }
+
+  async clickBack(): Promise<void> {
+    await this.robustClick(
+      this.locator('.pf-v6-c-wizard button.pf-v6-c-button.pf-m-secondary:has-text("Back")').first(),
+    );
+  }
+
+  async clickClearAllFiltersInCatalog(): Promise<void> {
+    const clearLink = this._pfV6CWizardMain.locator('button', {
+      hasText: 'Clear all filters',
+    });
+    await clearLink.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(clearLink);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async clickCreateVm(): Promise<void> {
+    const createBtn = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
+    await createBtn.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.SHORT_WAIT,
+    });
+
+    if (await createBtn.first().isDisabled()) {
+      const nameInput = this._vmNameInput.first();
+      if ((await nameInput.count()) > 0) {
+        await nameInput.press('Tab');
+        await this.page.waitForTimeout(300);
+      }
+    }
+
+    await this.robustClick(createBtn.first());
+    await this.page.waitForTimeout(2000);
+  }
+
+  async clickNext(): Promise<void> {
+    const nextButton = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
+    await nextButton.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.SHORT_WAIT,
+    });
+    await this.robustClick(nextButton.first());
+    await this.page.waitForTimeout(1000);
+  }
+
+  async clickViewAllProjectsInCatalog(): Promise<void> {
+    const viewAllBtn = this._pfV6CWizardMain.locator('button', {
+      hasText: 'View all projects',
+    });
+    await viewAllBtn.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(viewAllBtn);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async closeEditLocationPanel(): Promise<void> {
+    const editBtn = this._buttonEditVMCreationLocation;
+    await this.robustClick(editBtn);
+    await this.page.waitForTimeout(300);
+  }
+
+  async closeTemplateDrawer(): Promise<void> {
+    const closeBtn = this.locator(
+      '.pf-v6-c-modal-box__close button[aria-label="Close"], button[aria-label="Close drawer panel"]',
+    ).first();
+    if (await closeBtn.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false)) {
+      await this.robustClick(closeBtn);
+      await this.page.waitForTimeout(500);
+    }
+  }
+
+  async enableUserTemplatesFilter(): Promise<void> {
+    const filterBtn = this.page.getByRole('button', { name: 'Filter', exact: true });
+    const userTemplatesCheckbox = this.page.locator(
+      '.pf-v6-c-menu__item:has(.pf-v6-c-menu__item-text:text-is("User templates")) input[type="checkbox"]',
+    );
+
+    await this.robustClick(filterBtn);
+    await filterBtn.and(this.page.locator('[aria-expanded="true"]')).waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.ELEMENT_WAIT,
+    });
+    await userTemplatesCheckbox.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+
+    if (!(await userTemplatesCheckbox.isChecked())) {
+      await userTemplatesCheckbox.evaluate((el) => (el as HTMLInputElement).click());
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    }
+
+    await this.locator('.pf-v6-c-wizard h1, .pf-v6-c-wizard__main').first().click();
+    await filterBtn.and(this.page.locator('[aria-expanded="false"]')).waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.ELEMENT_WAIT,
+    });
+  }
+
+  async ensureVmNameFilled(): Promise<void> {
+    const isVisible = await this._vmNameInput
+      .first()
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+    if (!isVisible) return;
+    const value = await this._vmNameInput
+      .first()
+      .inputValue()
+      .catch(() => '');
+    if (value.trim().length === 0) {
+      await this.generateVmName();
+    }
+  }
+
+  async fillVmName(name: string): Promise<void> {
+    await this._vmNameInput.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.SHORT_WAIT,
+    });
+    await this._vmNameInput.first().fill(name);
+  }
+
+  async filterTemplateCatalog(keyword: string): Promise<void> {
+    const input = this.locator('.pf-v6-c-wizard__main input[placeholder*="Filter"]');
+    await input.clear();
+    await input.fill(keyword);
+    await this.page.waitForTimeout(500);
+  }
+
+  /** Click the dice icon to auto-generate a unique VM name (required on 4.99+ before Next). */
+  async generateVmName(): Promise<void> {
+    await this._generateVmNameButton.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.SHORT_WAIT,
+    });
+    await this.robustClick(this._generateVmNameButton.first());
+    await this.page.waitForTimeout(500);
+  }
+
+  async getCloneWizardStepIds(): Promise<string[]> {
+    return await this.page.evaluate(() => {
+      const links = document.querySelectorAll('.pf-v6-c-wizard__nav-link');
+      return Array.from(links)
+        .map((el) => el.closest('[id]')?.id || '')
+        .filter(Boolean);
+    });
+  }
+
+  async getCreatedVmNameFromUrl(): Promise<string> {
+    const url = this.page.url();
+    const match = url.match(/kubevirt\.io~v1~VirtualMachine\/([^/?#]+)/);
+    return match?.[1] || '';
+  }
+
+  async getCreatedVmNamespaceFromUrl(): Promise<string> {
+    const url = this.page.url();
+    const match = url.match(/\/ns\/([^/]+)\//);
+    return match?.[1] || '';
+  }
+
+  async getLocationProject(): Promise<string> {
+    try {
+      const projectText = this.locator('.pf-v6-c-wizard').getByText('Project').first();
+      const container = projectText.locator('..');
+      const text = await container.textContent({ timeout: TestTimeouts.SHORT_WAIT });
+      const match = text?.match(/Project\s*(.+?)(?:>|$)/);
+      return match?.[1]?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getSelectedOsType(): Promise<string> {
+    try {
+      const text = this._osTypeDropdown.locator('.pf-v6-c-menu-toggle__text');
+      return (await text.first().textContent())?.trim() ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getSelectedTemplateCardTitle(templateTestId: string): Promise<string> {
+    try {
+      const card = this.locator(`[data-test-id="${templateTestId}"]`);
+      return (await card.textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getTemplateCardFields(templateTestId: string): Promise<string[]> {
+    const card = this.locator(`[data-test-id="${templateTestId}"]`);
+    const text = (await card.textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || '';
+    const knownFields = ['Architecture', 'Project', 'Boot source', 'Workload', 'CPU', 'Memory'];
+    return knownFields.filter((field) => text.includes(field));
+  }
+
+  async getTemplateCatalogCount(): Promise<number> {
+    const gridCards = this._pfV6CWizardTemplatesCatalogTile;
+    const gridCount = await gridCards.count();
+    if (gridCount > 0) return gridCount;
+
+    const listRows = this.locator('.pf-v6-c-wizard tr.pf-m-clickable');
+    return await listRows.count();
+  }
+
+  async getTemplateDrawerFields(): Promise<string[]> {
+    await this.page.waitForTimeout(2000);
+    const overlay = this.locator(
+      '.co-catalog-page__overlay, .pf-v6-c-drawer__panel.template-catalog-drawer',
+    ).first();
+    await overlay.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const text = (await overlay.textContent({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })) || '';
+    const knownFields = [
+      'Operating system',
+      'Workload type',
+      'Description',
+      'CPU | Memory',
+      'Network interfaces',
+      'Disks',
+    ];
+    return knownFields.filter((field) => text.includes(field));
+  }
+
+  async getTemplateDrawerTitle(): Promise<string> {
+    try {
+      return await this.page.evaluate(() => {
+        const h1 =
+          document.querySelector('.template-catalog-drawer h1') ||
+          document.querySelector('.co-catalog-page__overlay h1');
+        return h1?.textContent?.trim() || '';
+      });
+    } catch {
+      return '';
+    }
+  }
+
+  async isNextButtonDisabled(): Promise<boolean> {
+    const nextButton = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
+    await nextButton.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.SHORT_WAIT,
+    });
+    return await nextButton.first().isDisabled();
+  }
+
+  async navigateToStepByName(stepName: string): Promise<void> {
+    const toggle = this.locator('button:has-text("Wizard toggle")');
+    await this.robustClick(toggle.first());
+    const stepButton = this.locator(
+      `nav[aria-label="Wizard steps"] button:has-text("${stepName}")`,
+    );
+    await this.robustClick(stepButton.first());
+  }
+
+  async navigateToWizardInNamespace(_namespace: string): Promise<void> {
+    await this.page.goto('/vm-wizard');
+    await this._wizardContainer.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+  }
+
+  async openEditLocationPanel(): Promise<void> {
+    const editBtn = this._buttonEditVMCreationLocation;
+    await this.robustClick(editBtn);
+    await this.page.waitForTimeout(500);
+  }
+
+  async openWizardFromCreateDropdown(): Promise<void> {
+    const welcomeModal = this.page
+      .getByRole('dialog', { name: /Welcome/i })
+      .or(this.locator('#guided-tour-modal'));
+
+    const dismissWelcomeModal = async (): Promise<boolean> => {
+      try {
+        await welcomeModal.first().waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_DELAY_MEDIUM,
+        });
+      } catch {
+        return false;
+      }
+      const closeBtn = welcomeModal.first().locator('button[aria-label="Close"]');
+      if (await closeBtn.isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM }).catch(() => false)) {
+        await this.robustClick(closeBtn);
+      } else {
+        await this.page.keyboard.press('Escape');
+      }
+      await welcomeModal
+        .first()
+        .waitFor({ state: 'hidden', timeout: TestTimeouts.UI_ACTION_COMPLETE })
+        .catch(() => undefined);
+      await this.page.waitForTimeout(500);
+      return true;
+    };
+
+    await dismissWelcomeModal();
+
+    const createButton = this.locator(
+      '[data-test="item-create"].pf-m-primary, .pf-m-primary > [data-test="item-create"], [data-test="vms-treeview"] [data-test="item-create"], button[aria-label="Create VirtualMachine"]',
+    ).first();
+    await createButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(createButton);
+
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const wizardVisible = await this._wizardContainer
+        .first()
+        .waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT })
+        .then(() => true)
+        .catch(() => false);
+
+      if (wizardVisible) return;
+
+      const dismissed = await dismissWelcomeModal();
+      if (dismissed) {
+        await createButton.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        await this.robustClick(createButton);
+      }
+    }
+
+    await this._wizardContainer.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.DEFAULT,
+    });
+  }
+
+  async searchCloneSourceByName(name: string): Promise<void> {
+    const searchInput = this.locator('.pf-v6-c-wizard input[placeholder*="Search by name"]');
+    await searchInput.first().clear();
+    await searchInput.first().fill(name);
+    await this.page.waitForTimeout(1000);
+  }
+
+  async selectCloneSourceVm(vmName: string): Promise<void> {
+    const row = this.locator('.pf-v6-c-wizard tr, .pf-v6-c-wizard [role="row"]').filter({
+      hasText: vmName,
+    });
+    await row.first().waitFor({ state: 'visible', timeout: TestTimeouts.VM_OPERATION });
+    await this.robustClick(row.first());
+  }
+
+  async selectCreationMethod(method: 'newVm' | 'fromTemplate' | 'cloneVm'): Promise<void> {
+    const radioMap = {
+      newVm: this._newVmRadio,
+      fromTemplate: this._fromTemplateRadio,
+      cloneVm: this._cloneVmRadio,
+    };
+    await this.robustClick(radioMap[method].first());
+  }
+
+  async selectOperatingSystem(os: 'rhel' | 'windows' | 'otherLinux'): Promise<void> {
+    const osMap = {
+      rhel: this._rhelTile,
+      windows: this._windowsTile,
+      otherLinux: this._otherLinuxTile,
+    };
+    await this.robustClick(osMap[os].first());
+  }
+
+  async selectOsType(osType: string): Promise<void> {
+    await this.robustClick(this._osTypeDropdown.first());
+    await this.page.waitForTimeout(500);
+
+    const preferredOption = this.locator(`[role="option"]:has-text("${osType}")`).first();
+    if (
+      await preferredOption.isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM }).catch(() => false)
+    ) {
+      await this.robustClick(preferredOption);
+    } else {
+      const firstOption = this.locator('[role="option"]').first();
+      await this.robustClick(firstOption);
+    }
+  }
+
+  async selectTemplateByTestId(templateTestId: string): Promise<void> {
+    const card = this.locator(`[data-test-id="${templateTestId}"]`);
+    await card.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(card);
+
+    await card.evaluate(
+      (el) =>
+        new Promise<void>((resolve) => {
+          if (el.classList.contains('pf-m-selected')) {
+            resolve();
+            return;
+          }
+          const obs = new MutationObserver(() => {
+            if (el.classList.contains('pf-m-selected')) {
+              obs.disconnect();
+              resolve();
+            }
+          });
+          obs.observe(el, { attributes: true });
+          setTimeout(() => {
+            obs.disconnect();
+            resolve();
+          }, 3000);
+        }),
+    );
+  }
+
+  async selectTemplateCatalogProject(projectName: string): Promise<void> {
+    const wizMain = this._pfV6CWizardMain;
+    const projectToggle = wizMain.locator('.templates-catalog-project-dropdown button').first();
+    await projectToggle.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(projectToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const option = this.page.locator('.pf-v6-c-menu__item-text', { hasText: projectName });
+    await option.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(option);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async setCloneSourceProjectFilter(namespace: string): Promise<void> {
+    await this.clearCloneSourceFilters();
+    await this.page.waitForTimeout(1000);
+
+    const projectBtn = this.locator(
+      '.pf-v6-c-wizard [data-ouia-component-type="PF6/MenuToggle"]',
+    ).filter({ hasText: 'Project' });
+    await this.robustClick(projectBtn.first());
+    await this.page.waitForTimeout(500);
+
+    const option = this.page.getByRole('menuitem', { name: namespace, exact: true });
+    await option.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await option.click();
+    await this.page.waitForTimeout(2000);
+
+    await projectBtn.first().click();
+    await this.page.waitForTimeout(500);
+  }
+
+  async toggleTemplateCatalogView(view: 'grid' | 'list'): Promise<void> {
+    const btn = this.locator(`button[aria-label="template ${view} button"]`);
+    await this.robustClick(btn);
+    await this.page.waitForTimeout(1000);
+  }
+
+  async verifyCloneSourceDescription(): Promise<boolean> {
+    try {
+      const desc = this.locator('text=/Select a V(irtual)?M(achine)? to clone/');
+      await desc.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCloneSourceStepVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Source")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCloneVmListVisible(): Promise<boolean> {
+    try {
+      const byClass = this.locator(
+        '.pf-v6-c-wizard .vm-listpagebody, .pf-v6-c-wizard [class*="listpage"], .pf-v6-c-wizard table',
+      );
+      const byRole = this.locator('.pf-v6-c-wizard').locator('[role="grid"], [role="table"]');
+      const vmList = byClass.or(byRole).first();
+      await vmList.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCreationMethodCardSelected(
+    method: 'newVm' | 'fromTemplate' | 'cloneVm',
+  ): Promise<boolean> {
+    const idMap = {
+      newVm: 'instance-type',
+      fromTemplate: 'template',
+      cloneVm: 'clone',
+    };
+    const card = this.locator(
+      `.vm-creation-method-tile:has(#${idMap[method]}-radio-button), #${idMap[method]}.pf-m-selectable`,
+    );
+    try {
+      await card.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return await card
+        .first()
+        .evaluate(
+          (el) => el.classList.contains('pf-m-current') || el.classList.contains('pf-m-selected'),
+        );
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCreationMethodTilesVisible(): Promise<boolean> {
+    try {
+      const newVmVisible = await this._newVmRadio
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+      const templateVisible = await this._fromTemplateRadio
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+      const cloneVisible = await this._cloneVmRadio
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+      return newVmVisible && templateVisible && cloneVisible;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyEditLocationButtonVisible(): Promise<boolean> {
+    try {
+      const editBtn = this._buttonEditVMCreationLocation;
+      return await editBtn.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyEditLocationPanelFields(): Promise<{
+    projectDropdown: boolean;
+    folderCombobox: boolean;
+  }> {
+    return {
+      projectDropdown: await this.locator(
+        '.pf-v6-c-wizard [data-test="namespace-dropdown-menu-toggle"]',
+      )
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      folderCombobox: await this.locator(
+        '.pf-v6-c-wizard input[role="combobox"][placeholder*="folder"]',
+      )
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+    };
+  }
+
+  async verifyEmptyProjectStateInCatalog(): Promise<boolean> {
+    try {
+      const emptyPatterns = [
+        'No templates found',
+        'No results found',
+        'No results match',
+        'No templates available',
+      ];
+      for (const pattern of emptyPatterns) {
+        const emptyTitle = this._pfV6CWizardMain.getByText(pattern, { exact: false });
+        if (
+          await emptyTitle.isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM }).catch(() => false)
+        ) {
+          return true;
+        }
+      }
+      const cards = this._pfV6CWizardMain.locator('.templates-catalog-tile');
+      const count = await cards.count();
+      return count === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyLocationSectionVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Location")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyNoErrorBoundary(waitMs = 3000): Promise<boolean> {
+    const errorIndicator = this.page.locator('text=Something wrong happened');
+    const hasError = await errorIndicator.isVisible({ timeout: waitMs }).catch(() => false);
+    return !hasError;
+  }
+
+  async verifyNoHeaderProjectSelector(): Promise<boolean> {
+    const headerSelector = this.locator('[data-test-id="namespace-bar-dropdown"]');
+    try {
+      await headerSelector.waitFor({ state: 'visible', timeout: 3000 });
+      return false;
+    } catch {
+      return true;
+    }
+  }
+
+  async verifyOsTilesVisible(): Promise<boolean> {
+    try {
+      const rhelVisible = await this._rhelTile
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+      const windowsVisible = await this._windowsTile
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+      const otherLinuxVisible = await this._otherLinuxTile
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+      return rhelVisible && windowsVisible && otherLinuxVisible;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyOsTypeDropdownVisible(): Promise<boolean> {
+    try {
+      return await this._osTypeDropdown
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyRedirectedToVmDetails(): Promise<boolean> {
+    try {
+      await this.page.waitForURL(/kubevirt\.io~v1~VirtualMachine\/[a-z0-9][a-z0-9-]*[a-z0-9]$/, {
+        timeout: TestTimeouts.VM_OPERATION,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyRedirectedToVmList(): Promise<boolean> {
+    try {
+      await this.page.waitForURL(/kubevirt\.io~v1~VirtualMachine|\/vms/, {
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyStepActive(stepId: string): Promise<boolean> {
+    try {
+      const step = this.locator(`#${stepId}`);
+      const isCurrent = await step.getAttribute('aria-current');
+      return isCurrent === 'step';
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyTemplateCatalogHasCards(): Promise<boolean> {
+    try {
+      const cards = this._pfV6CWizardTemplatesCatalogTile;
+      await cards.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return (await cards.count()) > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyTemplateCatalogStepVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Templates")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyTemplateCatalogToolbar(): Promise<{
+    filterInput: boolean;
+    gridToggle: boolean;
+    listToggle: boolean;
+    projectDropdown: boolean;
+  }> {
+    const wizMain = this._pfV6CWizardMain;
+    const filterInput = wizMain.locator('input[placeholder*="Filter"]');
+    await filterInput
+      .waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT })
+      .catch(() => undefined);
+    return {
+      filterInput: await filterInput.isVisible().catch(() => false),
+      gridToggle: await wizMain
+        .locator('button[aria-label="template grid button"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      listToggle: await wizMain
+        .locator('button[aria-label="template list button"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      projectDropdown: await wizMain
+        .locator('.pf-v6-c-menu-toggle')
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+    };
+  }
+
+  async verifyTemplateDrawerVisible(): Promise<boolean> {
+    try {
+      const drawer = this.locator(
+        '.co-catalog-page__overlay, .pf-v6-c-drawer__panel.template-catalog-drawer',
+      );
+      await drawer.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyWizardCloseButtonHidden(): Promise<boolean> {
+    const closeBtn = this.locator('.pf-v6-c-wizard__close');
+    try {
+      await closeBtn.waitFor({ state: 'visible', timeout: 3000 });
+      return false;
+    } catch {
+      return true;
+    }
+  }
+
+  async verifyWizardClosed(): Promise<boolean> {
+    try {
+      await this._wizardContainer.first().waitFor({
+        state: 'hidden',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyWizardVisible(): Promise<boolean> {
+    try {
+      await this._wizardContainer.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/playwright/src/components/vm-wizard/wizard-deploy-review-components.ts
+++ b/playwright/src/components/vm-wizard/wizard-deploy-review-components.ts
@@ -1,0 +1,448 @@
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+export class VmCreationWizardReviewComponent extends BaseComponent {
+  private readonly _inputTypeText = this.locator('input[type="text"]');
+
+  private readonly _pfV6CWizardButtonpfV6CButtonpfMPrimary = this.locator(
+    '.pf-v6-c-wizard button.pf-v6-c-button.pf-m-primary',
+  );
+  private readonly _pfV6CWizardInputTypeText = this.locator('.pf-v6-c-wizard input[type="text"]');
+  private readonly _startAfterCreateCheckbox = this.locator('#start-after-create-checkbox');
+  private readonly _startThisVirtualMachineAfterCreation = this.locator(
+    'text=Start this VirtualMachine after creation',
+  );
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async clearReviewVmName(): Promise<void> {
+    const nameInput = this._pfV6CWizardInputTypeText.first();
+    await nameInput.clear();
+    await this.page.waitForTimeout(300);
+  }
+
+  async clickCreateVm(): Promise<void> {
+    const createBtn = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
+    await createBtn.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.SHORT_WAIT,
+    });
+
+    if (await createBtn.first().isDisabled()) {
+      const nameInput = this.locator('#vm-name');
+      if ((await nameInput.count()) > 0) {
+        await nameInput.press('Tab');
+        await this.page.waitForTimeout(300);
+      }
+    }
+
+    await this.robustClick(createBtn.first());
+    await this.page.waitForTimeout(2000);
+  }
+
+  async fillReviewDescription(text: string): Promise<void> {
+    const descInput = this._pfV6CWizardInputTypeText.nth(1);
+    await descInput.clear();
+    await descInput.fill(text);
+  }
+
+  async fillReviewVmName(name: string): Promise<void> {
+    const nameInput = this._inputTypeText.first();
+    await nameInput.clear();
+    await nameInput.fill(name);
+    await nameInput.press('Tab');
+  }
+
+  async getCreateButtonText(): Promise<string> {
+    try {
+      const createBtn = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
+      return (
+        (await createBtn.first().textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || ''
+      );
+    } catch {
+      return '';
+    }
+  }
+
+  async getReviewDescription(): Promise<string> {
+    try {
+      const descInput = this._pfV6CWizardInputTypeText.nth(1);
+      return (await descInput.inputValue()) || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getReviewDescriptionText(): Promise<string> {
+    try {
+      const region = this.locator(
+        '.pf-v6-c-wizard [class*="review"] strong:has-text("Create VirtualMachine")',
+      )
+        .locator('..')
+        .first();
+      return (await region.textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getReviewNameValidationError(): Promise<string> {
+    try {
+      const error = this.locator('.pf-v6-c-helper-text__item.pf-m-error');
+      await error.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return (await error.first().textContent())?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getReviewVmName(): Promise<string> {
+    try {
+      const nameInput = this._inputTypeText.first();
+      return (await nameInput.inputValue()) || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getStartAfterCreationLabel(): Promise<string> {
+    try {
+      const checkbox = this._startAfterCreateCheckbox;
+      const label = checkbox.locator('..').locator('label, .pf-v6-c-check__label').first();
+      return (await label.textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async isCreateButtonDisabled(): Promise<boolean> {
+    try {
+      const createBtn = this._pfV6CWizardButtonpfV6CButtonpfMPrimary.first();
+      await createBtn.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return createBtn.isDisabled();
+    } catch {
+      return true;
+    }
+  }
+
+  async isStartAfterCreationChecked(): Promise<boolean> {
+    try {
+      const checkbox = this._startAfterCreateCheckbox;
+      await checkbox.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return checkbox.isChecked();
+    } catch {
+      return false;
+    }
+  }
+
+  async toggleStartAfterCreation(): Promise<void> {
+    const checkbox = this.locator('input[type="checkbox"]').or(
+      this._startThisVirtualMachineAfterCreation,
+    );
+    await this.robustClick(checkbox.first());
+  }
+
+  async typeReviewVmName(name: string): Promise<void> {
+    const nameInput = this._pfV6CWizardInputTypeText.first();
+    await nameInput.clear();
+    await nameInput.fill(name);
+    await this.page.waitForTimeout(200);
+  }
+
+  async verifyReviewNameEditable(): Promise<boolean> {
+    try {
+      const nameInput = this._pfV6CWizardInputTypeText.first();
+      const isEditable = await nameInput.isEditable({ timeout: TestTimeouts.SHORT_WAIT });
+      return isEditable;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyReviewNameLabelRequired(): Promise<boolean> {
+    try {
+      const nameFormGroup = this.locator('.pf-v6-c-wizard .pf-v6-c-form__group').first();
+      const requiredIndicator = nameFormGroup.locator('.pf-v6-c-form__label-required');
+      await requiredIndicator.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyReviewSectionsVisible(): Promise<boolean> {
+    const sections = ['Details', 'Storage', 'Network', 'Hardware devices'];
+    try {
+      for (const section of sections) {
+        const btn = this.locator(`.pf-v6-c-wizard button:has-text("${section}")`);
+        await btn.first().waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.SHORT_WAIT,
+        });
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyReviewStepVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Review and create")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyStartAfterCreationCheckbox(): Promise<boolean> {
+    try {
+      const checkbox = this._startThisVirtualMachineAfterCreation;
+      await checkbox.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export class VmCreationWizardDeploymentComponent extends BaseComponent {
+  private readonly _cloneVmRadio = this.page.getByRole('radio', {
+    name: /Clone existing VirtualMachine/,
+  });
+
+  private readonly _fromTemplateRadio = this.page.getByRole('radio', {
+    name: /Create from Template/,
+  });
+
+  private readonly _generateVmNameButton = this.locator(
+    '.vm-creation-wizard [data-test="generate-vm-name-button"]',
+  );
+  private readonly _newVmRadio = this.page.getByRole('radio', {
+    name: /Custom configuration/,
+  });
+  private readonly _otherLinuxTile = this.locator('.operating-system-tile:has-text("Other Linux")');
+
+  private readonly _rhelTile = this.locator('.operating-system-tile:has-text("RHEL")');
+  private readonly _vmNameInput = this.locator('.vm-creation-wizard #vm-name');
+
+  private readonly _windowsTile = this.locator(
+    '.operating-system-tile:has-text("Microsoft Windows")',
+  );
+  private readonly _wizardContainer = this.locator('.pf-v6-c-wizard.vm-creation-wizard');
+  constructor(page: Page) {
+    super(page);
+  }
+
+  private get _osTypeDropdown() {
+    return this.locator('.pf-v6-c-form__group')
+      .filter({ has: this.page.locator('label:has-text("Guest operating system type")') })
+      .locator('.pf-v6-c-menu-toggle');
+  }
+
+  async fillVmName(name: string): Promise<void> {
+    await this._vmNameInput.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.SHORT_WAIT,
+    });
+    await this._vmNameInput.first().fill(name);
+  }
+
+  /** Click the dice icon to auto-generate a unique VM name. */
+  async generateVmName(): Promise<void> {
+    await this._generateVmNameButton.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.SHORT_WAIT,
+    });
+    await this.robustClick(this._generateVmNameButton.first());
+    await this.page.waitForTimeout(500);
+  }
+
+  async getSelectedOsType(): Promise<string> {
+    try {
+      const text = this._osTypeDropdown.locator('.pf-v6-c-menu-toggle__text');
+      return (await text.first().textContent())?.trim() ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getVmName(): Promise<string> {
+    return (await this._vmNameInput.first().inputValue()) || '';
+  }
+
+  /** Returns true if the Name field is empty or not visible (4.99+: required before Next). */
+  async isVmNameEmpty(): Promise<boolean> {
+    try {
+      const isVisible = await this._vmNameInput
+        .first()
+        .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+        .catch(() => false);
+      if (!isVisible) return false;
+      const value = await this.getVmName();
+      return value.trim().length === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async navigateToWizardInNamespace(_namespace: string): Promise<void> {
+    await this.page.goto('/vm-wizard');
+    await this._wizardContainer.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+  }
+
+  async openWizardFromCreateDropdown(): Promise<void> {
+    const createButton = this.locator(
+      'button[aria-label="Create VirtualMachine"], [data-test="item-create"].pf-m-primary, .pf-m-primary > [data-test="item-create"], [data-test="vms-treeview"] [data-test="item-create"]',
+    ).first();
+    await createButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(createButton);
+    await this._wizardContainer.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.DEFAULT,
+    });
+  }
+
+  async selectCreationMethod(method: 'newVm' | 'fromTemplate' | 'cloneVm'): Promise<void> {
+    const radioMap = {
+      newVm: this._newVmRadio,
+      fromTemplate: this._fromTemplateRadio,
+      cloneVm: this._cloneVmRadio,
+    };
+    await this.robustClick(radioMap[method].first());
+  }
+
+  async selectOperatingSystem(os: 'rhel' | 'windows' | 'otherLinux'): Promise<void> {
+    const osMap = {
+      rhel: this._rhelTile,
+      windows: this._windowsTile,
+      otherLinux: this._otherLinuxTile,
+    };
+    await this.robustClick(osMap[os].first());
+  }
+
+  async selectOsType(osType: string): Promise<void> {
+    await this.robustClick(this._osTypeDropdown.first());
+    await this.page.waitForTimeout(500);
+
+    const preferredOption = this.locator(`[role="option"]:has-text("${osType}")`).first();
+    if (
+      await preferredOption.isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM }).catch(() => false)
+    ) {
+      await this.robustClick(preferredOption);
+    } else {
+      const firstOption = this.locator('[role="option"]').first();
+      await this.robustClick(firstOption);
+    }
+  }
+
+  async verifyCreationMethodCardSelected(
+    method: 'newVm' | 'fromTemplate' | 'cloneVm',
+  ): Promise<boolean> {
+    const idMap = {
+      newVm: 'instance-type',
+      fromTemplate: 'template',
+      cloneVm: 'clone',
+    };
+    const card = this.locator(`#${idMap[method]}.pf-m-selectable`);
+    try {
+      await card.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return await card.evaluate(
+        (el) => el.classList.contains('pf-m-current') || el.classList.contains('pf-m-selected'),
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCreationMethodTilesVisible(): Promise<boolean> {
+    try {
+      const newVmVisible = await this._newVmRadio
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+      const templateVisible = await this._fromTemplateRadio
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+      const cloneVisible = await this._cloneVmRadio
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+      return newVmVisible && templateVisible && cloneVisible;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyOsTilesVisible(): Promise<boolean> {
+    try {
+      const rhelVisible = await this._rhelTile
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+      const windowsVisible = await this._windowsTile
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+      const otherLinuxVisible = await this._otherLinuxTile
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+      return rhelVisible && windowsVisible && otherLinuxVisible;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyOsTypeDropdownVisible(): Promise<boolean> {
+    try {
+      return await this._osTypeDropdown
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyStepActive(stepId: string): Promise<boolean> {
+    try {
+      const step = this.locator(`#${stepId}`);
+      const isCurrent = await step.getAttribute('aria-current');
+      return isCurrent === 'step';
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyWizardClosed(): Promise<boolean> {
+    try {
+      await this._wizardContainer.first().waitFor({
+        state: 'hidden',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyWizardVisible(): Promise<boolean> {
+    try {
+      await this._wizardContainer.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/playwright/src/components/vm-wizard/wizard-navigation-components.ts
+++ b/playwright/src/components/vm-wizard/wizard-navigation-components.ts
@@ -1,0 +1,440 @@
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+export class VmCreationWizardNavigationComponent extends BaseComponent {
+  private readonly _pfV6CWizardButtonpfV6CButtonpfMPrimary = this.locator(
+    '.pf-v6-c-wizard button.pf-v6-c-button.pf-m-primary',
+  );
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async cancelWizard(): Promise<void> {
+    await this.robustClick(
+      this.locator('.pf-v6-c-wizard button.pf-v6-c-button.pf-m-link:has-text("Cancel")').first(),
+    );
+  }
+
+  async clickBack(): Promise<void> {
+    await this.robustClick(
+      this.locator('.pf-v6-c-wizard button.pf-v6-c-button.pf-m-secondary:has-text("Back")').first(),
+    );
+  }
+
+  async clickNext(): Promise<void> {
+    const nextButton = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
+    await nextButton.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.SHORT_WAIT,
+    });
+    await this.robustClick(nextButton.first());
+    await this.page.waitForTimeout(1000);
+  }
+
+  async isBackButtonDisabled(): Promise<boolean> {
+    const backButton = this.locator(
+      '.pf-v6-c-wizard button.pf-v6-c-button.pf-m-secondary:has-text("Back")',
+    ).first();
+    const visible = await backButton
+      .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+      .catch(() => false);
+    if (!visible) return true;
+    return await backButton.isDisabled();
+  }
+
+  async isNextButtonDisabled(): Promise<boolean> {
+    const nextButton = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
+    await nextButton.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.SHORT_WAIT,
+    });
+    return await nextButton.first().isDisabled();
+  }
+
+  async navigateToStepByName(stepName: string): Promise<void> {
+    const toggle = this.locator('button:has-text("Wizard toggle")');
+    await this.robustClick(toggle.first());
+    const stepButton = this.locator(
+      `nav[aria-label="Wizard steps"] button:has-text("${stepName}")`,
+    );
+    await this.robustClick(stepButton.first());
+  }
+}
+
+export class VmCreationWizardCloneComponent extends BaseComponent {
+  private readonly _pfV6CWizardMain = this.locator('.pf-v6-c-wizard__main');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async clearCloneSourceFilters(): Promise<void> {
+    const wizard = this._pfV6CWizardMain;
+    const chipCloseButtons = wizard.locator(
+      '.pf-v6-c-label .pf-v6-c-label__actions button, .pf-v6-c-chip button',
+    );
+    const count = await chipCloseButtons.count();
+    for (let i = count - 1; i >= 0; i--) {
+      await chipCloseButtons.nth(i).click();
+      await this.page.waitForTimeout(300);
+    }
+    if (count > 0) {
+      await this.page.waitForTimeout(1000);
+    }
+  }
+
+  async getCloneWizardStepIds(): Promise<string[]> {
+    return await this.page.evaluate(() => {
+      const links = document.querySelectorAll('.pf-v6-c-wizard__nav-link');
+      return Array.from(links)
+        .map((el) => el.closest('[id]')?.id || '')
+        .filter(Boolean);
+    });
+  }
+
+  async searchCloneSourceByName(name: string): Promise<void> {
+    const searchInput = this.locator('.pf-v6-c-wizard input[placeholder*="Search by name"]');
+    await searchInput.first().clear();
+    await searchInput.first().fill(name);
+    await this.page.waitForTimeout(1000);
+  }
+
+  async selectCloneSourceVm(vmName: string): Promise<void> {
+    const row = this.locator('.pf-v6-c-wizard tr, .pf-v6-c-wizard [role="row"]').filter({
+      hasText: vmName,
+    });
+    await row.first().waitFor({ state: 'visible', timeout: TestTimeouts.VM_OPERATION });
+    await this.robustClick(row.first());
+  }
+
+  async setCloneSourceProjectFilter(namespace: string): Promise<void> {
+    await this.clearCloneSourceFilters();
+    await this.page.waitForTimeout(1000);
+
+    const projectBtn = this.locator(
+      '.pf-v6-c-wizard [data-ouia-component-type="PF6/MenuToggle"]',
+    ).filter({ hasText: 'Project' });
+    await this.robustClick(projectBtn.first());
+    await this.page.waitForTimeout(500);
+
+    const option = this.page.getByRole('menuitem', { name: namespace, exact: true });
+    await option.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await option.click();
+    await this.page.waitForTimeout(2000);
+
+    await projectBtn.first().click();
+    await this.page.waitForTimeout(500);
+  }
+
+  async verifyCloneSourceDescription(): Promise<boolean> {
+    try {
+      const desc = this.locator('text=/Select a V(irtual)?M(achine)? to clone/');
+      await desc.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCloneSourceStepVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Source")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyCloneVmListVisible(): Promise<boolean> {
+    try {
+      const byClass = this.locator(
+        '.pf-v6-c-wizard .vm-listpagebody, .pf-v6-c-wizard [class*="listpage"], .pf-v6-c-wizard table',
+      );
+      const byRole = this.locator('.pf-v6-c-wizard').locator('[role="grid"], [role="table"]');
+      const vmList = byClass.or(byRole).first();
+      await vmList.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export class VmCreationWizardTemplateCatalogComponent extends BaseComponent {
+  private readonly _pfV6CWizardMain = this.locator('.pf-v6-c-wizard__main');
+
+  private readonly _pfV6CWizardTemplatesCatalogTile = this.locator(
+    '.pf-v6-c-wizard .templates-catalog-tile',
+  );
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async applyWorkloadFilter(workload: string): Promise<void> {
+    const filterBtn = this.page.getByRole('button', { name: 'Filter', exact: true });
+    await this.robustClick(filterBtn);
+    await this.page.waitForTimeout(300);
+
+    const workloadItem = this.page.locator(
+      `.pf-v6-c-menu__list .pf-v6-c-menu__item-text:text-is("${workload}")`,
+    );
+    await workloadItem.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await workloadItem.click();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async clickClearAllFiltersInCatalog(): Promise<void> {
+    const clearLink = this._pfV6CWizardMain.locator('button', {
+      hasText: 'Clear all filters',
+    });
+    await clearLink.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(clearLink);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async clickViewAllProjectsInCatalog(): Promise<void> {
+    const viewAllBtn = this._pfV6CWizardMain.locator('button', {
+      hasText: 'View all projects',
+    });
+    await viewAllBtn.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(viewAllBtn);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async closeTemplateDrawer(): Promise<void> {
+    const closeBtn = this.locator(
+      '.pf-v6-c-modal-box__close button[aria-label="Close"], button[aria-label="Close drawer panel"]',
+    ).first();
+    if (await closeBtn.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false)) {
+      await this.robustClick(closeBtn);
+      await this.page.waitForTimeout(500);
+    }
+  }
+
+  async enableUserTemplatesFilter(): Promise<void> {
+    const filterBtn = this.page.getByRole('button', { name: 'Filter', exact: true });
+    await this.robustClick(filterBtn);
+    await this.page.waitForTimeout(300);
+
+    const userTemplatesItem = this.page.locator(
+      '.pf-v6-c-menu__list .pf-v6-c-menu__item-text:text-is("User templates")',
+    );
+    await userTemplatesItem.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.ELEMENT_WAIT,
+    });
+    await userTemplatesItem.click();
+
+    await this.page.waitForTimeout(300);
+    await filterBtn.click();
+    await this.page.waitForTimeout(500);
+  }
+
+  async filterTemplateCatalog(keyword: string): Promise<void> {
+    const input = this.locator('.pf-v6-c-wizard__main input[placeholder*="Filter"]');
+    await input.clear();
+    await input.fill(keyword);
+    await this.page.waitForTimeout(500);
+  }
+
+  async getSelectedTemplateCardTitle(templateTestId: string): Promise<string> {
+    try {
+      const card = this.locator(`[data-test-id="${templateTestId}"]`);
+      return (await card.textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getTemplateCardFields(templateTestId: string): Promise<string[]> {
+    const card = this.locator(`[data-test-id="${templateTestId}"]`);
+    const text = (await card.textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || '';
+    const knownFields = ['Architecture', 'Project', 'Boot source', 'Workload', 'CPU', 'Memory'];
+    return knownFields.filter((field) => text.includes(field));
+  }
+
+  async getTemplateCatalogCount(): Promise<number> {
+    const gridCards = this._pfV6CWizardTemplatesCatalogTile;
+    const gridCount = await gridCards.count();
+    if (gridCount > 0) return gridCount;
+
+    const listRows = this.locator('.pf-v6-c-wizard tr.pf-m-clickable');
+    return await listRows.count();
+  }
+
+  async getTemplateDrawerFields(): Promise<string[]> {
+    await this.page.waitForTimeout(2000);
+    const overlay = this.locator(
+      '.co-catalog-page__overlay, .pf-v6-c-drawer__panel.template-catalog-drawer',
+    ).first();
+    await overlay.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const text = (await overlay.textContent({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })) || '';
+    const knownFields = [
+      'Operating system',
+      'Workload type',
+      'Description',
+      'CPU | Memory',
+      'Network interfaces',
+      'Disks',
+    ];
+    return knownFields.filter((field) => text.includes(field));
+  }
+
+  async getTemplateDrawerTitle(): Promise<string> {
+    try {
+      return await this.page.evaluate(() => {
+        const h1 =
+          document.querySelector('.template-catalog-drawer h1') ||
+          document.querySelector('.co-catalog-page__overlay h1');
+        return h1?.textContent?.trim() || '';
+      });
+    } catch {
+      return '';
+    }
+  }
+
+  async selectTemplateByTestId(templateTestId: string): Promise<void> {
+    const card = this.locator(`[data-test-id="${templateTestId}"]`);
+    await card.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(card);
+    await card.evaluate(
+      (el) =>
+        new Promise<void>((resolve) => {
+          if (el.classList.contains('pf-m-selected')) {
+            resolve();
+            return;
+          }
+          const obs = new MutationObserver(() => {
+            if (el.classList.contains('pf-m-selected')) {
+              obs.disconnect();
+              resolve();
+            }
+          });
+          obs.observe(el, { attributes: true });
+          setTimeout(() => {
+            obs.disconnect();
+            resolve();
+          }, 3000);
+        }),
+    );
+  }
+
+  async selectTemplateCatalogProject(projectName: string): Promise<void> {
+    const wizMain = this._pfV6CWizardMain;
+    const projectToggle = wizMain.locator('.templates-catalog-project-dropdown button').first();
+    await projectToggle.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(projectToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const option = this.page.locator('.pf-v6-c-menu__item-text', { hasText: projectName });
+    await option.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(option);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async toggleTemplateCatalogView(view: 'grid' | 'list'): Promise<void> {
+    const btn = this.locator(`button[aria-label="template ${view} button"]`);
+    await this.robustClick(btn);
+    await this.page.waitForTimeout(1000);
+  }
+
+  async verifyEmptyProjectStateInCatalog(): Promise<boolean> {
+    try {
+      const emptyPatterns = [
+        'No templates found',
+        'No results found',
+        'No results match',
+        'No templates available',
+      ];
+      for (const pattern of emptyPatterns) {
+        const emptyTitle = this._pfV6CWizardMain.getByText(pattern, { exact: false });
+        if (
+          await emptyTitle.isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM }).catch(() => false)
+        ) {
+          return true;
+        }
+      }
+      const cards = this._pfV6CWizardMain.locator('.templates-catalog-tile');
+      const count = await cards.count();
+      return count === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyNoErrorBoundary(waitMs = 3000): Promise<boolean> {
+    const errorIndicator = this.page.locator('text=Something wrong happened');
+    const hasError = await errorIndicator.isVisible({ timeout: waitMs }).catch(() => false);
+    return !hasError;
+  }
+
+  async verifyTemplateCatalogHasCards(): Promise<boolean> {
+    try {
+      const cards = this._pfV6CWizardTemplatesCatalogTile;
+      await cards.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return (await cards.count()) > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyTemplateCatalogStepVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Templates")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyTemplateCatalogToolbar(): Promise<{
+    filterInput: boolean;
+    gridToggle: boolean;
+    listToggle: boolean;
+    projectDropdown: boolean;
+  }> {
+    const wizMain = this._pfV6CWizardMain;
+    const filterInput = wizMain.locator('input[placeholder*="Filter"]');
+    await filterInput
+      .waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT })
+      .catch(() => undefined);
+    return {
+      filterInput: await filterInput.isVisible().catch(() => false),
+      gridToggle: await wizMain
+        .locator('button[aria-label="template grid button"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      listToggle: await wizMain
+        .locator('button[aria-label="template list button"]')
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      projectDropdown: await wizMain
+        .locator('.pf-v6-c-menu-toggle')
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+    };
+  }
+
+  async verifyTemplateDrawerVisible(): Promise<boolean> {
+    try {
+      const drawer = this.locator(
+        '.co-catalog-page__overlay, .pf-v6-c-drawer__panel.template-catalog-drawer',
+      );
+      await drawer.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/playwright/src/components/vm-wizard/wizard-step-components.ts
+++ b/playwright/src/components/vm-wizard/wizard-step-components.ts
@@ -1,0 +1,614 @@
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+export class VmCreationWizardLocationComponent extends BaseComponent {
+  private readonly _buttonEditVMCreationLocation = this.locator(
+    'button[aria-label="Edit VM creation location"]',
+  );
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async closeEditLocationPanel(): Promise<void> {
+    const editBtn = this._buttonEditVMCreationLocation;
+    await this.robustClick(editBtn);
+    await this.page.waitForTimeout(300);
+  }
+
+  async getLocationProject(): Promise<string> {
+    try {
+      const projectText = this.locator('.pf-v6-c-wizard').getByText('Project').first();
+      const container = projectText.locator('..');
+      const text = await container.textContent({ timeout: TestTimeouts.SHORT_WAIT });
+      const match = text?.match(/Project\s*(.+?)(?:>|$)/);
+      return match?.[1]?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async openEditLocationPanel(): Promise<void> {
+    const editBtn = this._buttonEditVMCreationLocation;
+    await this.robustClick(editBtn);
+    await this.page.waitForTimeout(500);
+  }
+
+  async verifyEditLocationButtonVisible(): Promise<boolean> {
+    try {
+      const editBtn = this._buttonEditVMCreationLocation;
+      return await editBtn.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyEditLocationPanelFields(): Promise<{
+    projectDropdown: boolean;
+    folderCombobox: boolean;
+  }> {
+    return {
+      projectDropdown: await this.locator(
+        '.pf-v6-c-wizard [data-test="namespace-dropdown-menu-toggle"]',
+      )
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+      folderCombobox: await this.locator(
+        '.pf-v6-c-wizard input[role="combobox"][placeholder*="folder"]',
+      )
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false),
+    };
+  }
+
+  async verifyLocationSectionVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Location")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyNoHeaderProjectSelector(): Promise<boolean> {
+    const headerSelector = this.locator('[data-test-id="namespace-bar-dropdown"]');
+    try {
+      await headerSelector.waitFor({ state: 'visible', timeout: 3000 });
+      return false;
+    } catch {
+      return true;
+    }
+  }
+
+  async verifyWizardCloseButtonHidden(): Promise<boolean> {
+    const closeBtn = this.locator('.pf-v6-c-wizard__close');
+    try {
+      await closeBtn.waitFor({ state: 'visible', timeout: 3000 });
+      return false;
+    } catch {
+      return true;
+    }
+  }
+}
+
+export class VmCreationWizardComputeComponent extends BaseComponent {
+  private readonly _pfV6CMenuToggle = this.locator('.pf-v6-c-menu-toggle');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Returns the text of the currently active (selected) compute resources tab.
+   * Used to verify the "User provided" tab was not reverted after row selection (CNV-85868).
+   */
+  async getActiveComputeTab(): Promise<string> {
+    try {
+      const activeTab = this.locator('button[role="tab"][aria-selected="true"]');
+      const text = await activeTab.first().textContent({ timeout: TestTimeouts.SHORT_WAIT });
+      return text?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getComputeSizeDropdownText(): Promise<string> {
+    try {
+      const sizeBtn = this._pfV6CMenuToggle.filter({
+        hasText: /CPUs.*Memory/,
+      });
+      return (
+        (await sizeBtn.first().textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || ''
+      );
+    } catch {
+      return '';
+    }
+  }
+
+  async getComputeSizeOptions(): Promise<string[]> {
+    const sizeBtn = this._pfV6CMenuToggle.filter({
+      hasText: /CPUs.*Memory/,
+    });
+    await this.robustClick(sizeBtn.first());
+    await this.page.waitForTimeout(500);
+
+    const options: string[] = [];
+    const menuItems = this.page.getByRole('menuitem');
+    const count = await menuItems.count();
+    for (let i = 0; i < count; i++) {
+      const text = await menuItems.nth(i).textContent();
+      if (text?.trim()) options.push(text.trim());
+    }
+
+    await this.page.keyboard.press('Escape');
+    return options;
+  }
+
+  async getSelectedInstanceTypeSeries(): Promise<string> {
+    try {
+      const pressed = this.locator(
+        '.instance-type-series-menu-card__toggle-card[aria-pressed="true"]',
+      );
+      const text = await pressed.first().textContent({ timeout: TestTimeouts.SHORT_WAIT });
+      return text?.trim() || '';
+    } catch {
+      return '';
+    }
+  }
+
+  async selectComputeSize(sizeName: string): Promise<void> {
+    const sizeToggle = this.locator('button.pf-v6-c-menu-toggle').filter({
+      hasText: /Select size|CPUs.*Memory/,
+    });
+    await this.robustClick(sizeToggle.first());
+    await this.page.waitForTimeout(500);
+
+    const sizeOption = this.page.getByRole('menuitem').filter({ hasText: sizeName });
+    await this.robustClick(sizeOption.first());
+  }
+
+  async selectComputeTab(tab: 'redhat' | 'user'): Promise<void> {
+    const tabText = tab === 'redhat' ? 'Red Hat provided' : 'User provided';
+    const tabButton = this.locator(`button[role="tab"]:has-text("${tabText}")`);
+    await this.robustClick(tabButton.first());
+  }
+
+  async selectInstanceTypeSeries(series: 'cx' | 'd' | 'u' | 'm' | 'n' | 'o' | 'rt'): Promise<void> {
+    const seriesMap: Record<string, string> = {
+      cx: 'Compute Exclusive',
+      d: 'Dedicated vCPU',
+      u: 'General Purpose',
+      m: 'Memory Intensive',
+      n: 'Network',
+      o: 'Overcommitted',
+      rt: 'Realtime',
+    };
+    const card = this.locator(
+      `.instance-type-series-menu-card__toggle-card:has-text("${seriesMap[series]}")`,
+    );
+    await this.robustClick(card.first());
+  }
+
+  /**
+   * Clicks a row in the User provided instance type table matching the given name.
+   * The row is a clickable <tr> containing a resource name cell with data-test-id="${name}".
+   */
+  async selectUserProvidedInstanceTypeByName(name: string): Promise<void> {
+    const row = this.locator('tbody tr.pf-m-clickable').filter({
+      has: this.locator(`[data-test-id="${name}"]`),
+    });
+    await row.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(row.first());
+  }
+
+  async verifyAllInstanceTypeSeriesVisible(): Promise<string[]> {
+    const expectedSeries = [
+      'Compute Exclusive',
+      'Dedicated vCPU',
+      'General Purpose',
+      'Memory Intensive',
+      'Network',
+      'Overcommitted',
+      'Realtime',
+    ];
+    const found: string[] = [];
+    for (const series of expectedSeries) {
+      const card = this.locator(
+        `.instance-type-series-menu-card__toggle-card:has-text("${series}")`,
+      );
+      if (
+        await card
+          .first()
+          .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+          .catch(() => false)
+      ) {
+        found.push(series);
+      }
+    }
+    return found;
+  }
+
+  async verifyComputeResourcesStepVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Compute resources")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyComputeTabsVisible(): Promise<boolean> {
+    try {
+      const rhProvided = this.locator('button[role="tab"]:has-text("Red Hat provided")');
+      const userProvided = this.locator('button[role="tab"]:has-text("User provided")');
+      await rhProvided.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.SHORT_WAIT,
+      });
+      await userProvided.first().waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.SHORT_WAIT,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyInstanceTypeSeriesVisible(): Promise<boolean> {
+    try {
+      const uSeries = this.locator('.instance-type-series-menu-card__toggle-card');
+      await uSeries.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export class VmCreationWizardBootSourceComponent extends BaseComponent {
+  private readonly _dialogModalTabModal = this.locator('[data-test="dialog-modal"], #tab-modal');
+
+  private readonly _noBootSource = this.locator('text=No boot source');
+  private readonly _pfV6CWizardAddVolumeBtn = this.locator(
+    '.pf-v6-c-wizard button:has-text("Add volume")',
+  );
+  private readonly _pfV6CWizardInputnameFilterInput = this.locator(
+    '.pf-v6-c-wizard input[data-test="name-filter-input"]',
+  );
+  private readonly _pfV6CWizardTableTbodyTr = this.locator('.pf-v6-c-wizard table tbody tr');
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async cancelAddVolumeModal(): Promise<void> {
+    const dialog = this._dialogModalTabModal;
+    const cancelButton = dialog.locator('[data-test="cancel-button"]');
+    await cancelButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(cancelButton);
+  }
+
+  async clickAddVolumeButton(): Promise<void> {
+    const addBtn = this._pfV6CWizardAddVolumeBtn;
+    await addBtn.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(addBtn.first());
+    const dialog = this._dialogModalTabModal;
+    await dialog.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+  }
+
+  /**
+   * Returns the text of the Save button in the Add Volume modal (CNV-82477).
+   */
+  async getAddVolumeModalSaveButtonText(): Promise<string> {
+    const dialog = this._dialogModalTabModal;
+    const saveButton = dialog.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return (await saveButton.textContent())?.trim() ?? '';
+  }
+
+  async getAddVolumePreferenceHelperText(): Promise<string> {
+    const dialog = this._dialogModalTabModal;
+    const labels = dialog.locator('.pf-v6-c-form__label');
+    const prefLabel = labels.filter({ hasText: 'Preference' });
+    const group = prefLabel.locator('..').locator('..');
+    const helperText = group.locator('.pf-v6-c-helper-text');
+    try {
+      await helperText.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return (await helperText.first().textContent())?.trim() ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getAddVolumePreferenceValue(): Promise<string> {
+    const dialog = this._dialogModalTabModal;
+    const labels = dialog.locator('.pf-v6-c-form__label');
+    const prefLabel = labels.filter({ hasText: 'Preference' });
+    const group = prefLabel.locator('..').locator('..');
+    const toggle = group.locator('.pf-v6-c-menu-toggle');
+    try {
+      await toggle.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return (await toggle.first().textContent())?.trim() ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getBootSourceEmptyStateBodyText(): Promise<string> {
+    try {
+      const emptyState = this.locator('.bootable-volume-empty-state').or(
+        this.locator('.pf-v6-c-empty-state__body'),
+      );
+      await emptyState.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return (await emptyState.first().textContent())?.trim() ?? '';
+    } catch {
+      const bodyByText = this.page.getByText(/to get started.*add volume/i);
+      return (await bodyByText.first().textContent())?.trim() ?? '';
+    }
+  }
+
+  async getBootSourceEmptyStateHeading(): Promise<string> {
+    try {
+      const heading = this.locator(
+        '.bootable-volume-empty-state__title, .bootable-volume-empty-state h3',
+      );
+      await heading.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return (await heading.first().textContent())?.trim() ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  async getBootVolumeCount(): Promise<number> {
+    const paginationText = this.locator('button').filter({ hasText: /of \d+/ });
+    try {
+      const text = await paginationText.first().textContent({ timeout: TestTimeouts.SHORT_WAIT });
+      const match = text?.match(/of (\d+)/);
+      return match ? parseInt(match[1], 10) : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  async getBootVolumeOsColumnValues(): Promise<string[]> {
+    const rows = this._pfV6CWizardTableTbodyTr;
+    await rows.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const count = await rows.count();
+    const osValues: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const osCell = rows.nth(i).locator('td:nth-child(4)');
+      const text = (await osCell.textContent())?.trim() ?? '';
+      if (text) osValues.push(text);
+    }
+    return osValues;
+  }
+
+  /**
+   * Returns whether the Save button is disabled in the Add Volume modal (CNV-82477).
+   */
+  async isAddVolumeModalSaveButtonDisabled(): Promise<boolean> {
+    const dialog = this._dialogModalTabModal;
+    const saveButton = dialog.locator('[data-test="save-button"]');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return await saveButton.isDisabled();
+  }
+
+  async isAddVolumePreferenceDisabled(): Promise<boolean> {
+    const dialog = this._dialogModalTabModal;
+    const labels = dialog.locator('.pf-v6-c-form__label');
+    const prefLabel = labels.filter({ hasText: 'Preference' });
+    const group = prefLabel.locator('..').locator('..');
+    const toggle = group.locator('.pf-v6-c-menu-toggle');
+    try {
+      await toggle.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      const isDisabled = await toggle.first().getAttribute('class');
+      return isDisabled?.includes('pf-m-disabled') ?? false;
+    } catch {
+      return false;
+    }
+  }
+
+  async isBootVolumeEmptyStateVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('h3:has-text("No volumes found")');
+      return await heading.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async isBootVolumeOsFilterVisible(): Promise<boolean> {
+    try {
+      const osFilter = this.locator(
+        '.pf-v6-c-wizard [data-test="os-filter"], .pf-v6-c-wizard [data-test-row-filter="operating-system"]',
+      );
+      return await osFilter
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async isBootVolumeStarred(volumeName: string): Promise<boolean> {
+    try {
+      const row = this.page.getByRole('row').filter({ hasText: volumeName });
+      const starred = row.locator('button[aria-label="Starred"]');
+      return await starred.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async searchBootVolumeByName(name: string): Promise<void> {
+    const searchInput = this._pfV6CWizardInputnameFilterInput;
+    await searchInput.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await searchInput.first().clear();
+    await searchInput.first().fill(name);
+    await this.page.waitForTimeout(500);
+  }
+
+  async selectBootVolumeByName(volumeName: string): Promise<void> {
+    const table = this.locator('.pf-v6-c-wizard table, .pf-v6-c-wizard [role="grid"]');
+    await table.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    const searchInput = this._pfV6CWizardInputnameFilterInput;
+    if (await searchInput.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false)) {
+      await searchInput.clear();
+      await searchInput.fill(volumeName);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const row = this._pfV6CWizardTableTbodyTr.filter({ hasText: volumeName });
+    await row.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(row.first());
+
+    if (await searchInput.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await searchInput.clear();
+      await this.page.waitForTimeout(300);
+    }
+  }
+
+  async selectNoBootSource(): Promise<void> {
+    const radio = this.locator('input[type="radio"][value="no-boot-source"]').or(
+      this._noBootSource.locator('..').locator('input[type="radio"]'),
+    );
+    if (
+      await radio
+        .first()
+        .isVisible()
+        .catch(() => false)
+    ) {
+      await this.robustClick(radio.first());
+    } else {
+      await this.robustClick(this._noBootSource);
+    }
+  }
+
+  async selectVolumesProject(projectName: string): Promise<void> {
+    const projectToggle = this.locator(
+      '.pf-v6-c-wizard button:has-text("All projects"), .pf-v6-c-wizard button:has-text("Project"), .pf-v6-c-wizard .pf-v6-c-menu-toggle:has-text("project")',
+    ).first();
+    await projectToggle.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(projectToggle);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+
+    const vmFilterCheckbox = this.page.locator(
+      'input[type="checkbox"] + label:has-text("Show only projects with VirtualMachines"), label:has-text("Show only projects with") input[type="checkbox"]',
+    );
+    const filterVisible = await vmFilterCheckbox
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT })
+      .catch(() => false);
+    if (filterVisible) {
+      const isChecked = await vmFilterCheckbox.isChecked().catch(() => false);
+      if (isChecked) {
+        await vmFilterCheckbox.uncheck({ force: true });
+        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      }
+    }
+
+    const searchInput = this.page.locator(
+      '[role="listbox"] input[type="search"], .pf-v6-c-menu input[type="search"], input[placeholder*="project"], input[placeholder*="Project"]',
+    );
+    if (await searchInput.isVisible({ timeout: TestTimeouts.UI_DELAY_SHORT }).catch(() => false)) {
+      await searchInput.fill(projectName);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const option = this.page.locator(
+      `[role="option"]:has-text("${projectName}"), .pf-v6-c-menu__item-text:text-is("${projectName}")`,
+    );
+    await option.first().waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(option.first());
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async toggleBootVolumeStar(volumeName: string): Promise<void> {
+    const row = this.page.getByRole('row').filter({ hasText: volumeName });
+    const starBtn = row.locator('button[aria-label="Not starred"], button[aria-label="Starred"]');
+    await this.robustClick(starBtn.first());
+    await this.page.waitForTimeout(300);
+  }
+
+  async verifyAddVolumeButtonVisible(): Promise<boolean> {
+    try {
+      const addBtn = this._pfV6CWizardAddVolumeBtn;
+      return await addBtn
+        .first()
+        .isVisible({ timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyBootSourceStepVisible(): Promise<boolean> {
+    try {
+      const heading = this.locator('.pf-v6-c-wizard h1:has-text("Boot source")');
+      await heading.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyBootVolumeTableColumnsVisible(): Promise<boolean> {
+    const expectedColumns = [
+      'Volume name',
+      'Architecture',
+      'Operating system',
+      'Storage class',
+      'Size',
+      'Description',
+    ];
+    try {
+      for (const col of expectedColumns) {
+        const header = this.page.getByRole('columnheader', { name: col });
+        await header.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      }
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyBootVolumeTableOrEmptyState(): Promise<boolean> {
+    if (await this.verifyBootVolumeTableVisible()) return true;
+    if (await this.isBootVolumeEmptyStateVisible()) return true;
+
+    const noBootSourceForOs = this.locator(
+      'h3:has-text("No volumes found for the chosen OS"), .pf-v6-c-empty-state',
+    );
+    return await noBootSourceForOs
+      .first()
+      .isVisible()
+      .catch(() => false);
+  }
+
+  async verifyBootVolumeTableVisible(): Promise<boolean> {
+    try {
+      const table = this.locator('table.BootableVolumeList-table, .pf-v6-c-wizard table');
+      await table.first().waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyNoBootSourceOptionVisible(): Promise<boolean> {
+    try {
+      await this.verifyBootVolumeTableOrEmptyState();
+      const noBootRadio = this._noBootSource;
+      await noBootRadio.first().scrollIntoViewIfNeeded({ timeout: TestTimeouts.SHORT_WAIT });
+      return await noBootRadio.first().isVisible({ timeout: TestTimeouts.SHORT_WAIT });
+    } catch {
+      return false;
+    }
+  }
+}

--- a/playwright/src/page-objects/settings/settings-page.ts
+++ b/playwright/src/page-objects/settings/settings-page.ts
@@ -1,0 +1,461 @@
+/**
+ * SettingsPage — standalone page object for the Virtualization Settings area.
+ *
+ * Covers all three tabs reachable from Virtualization → Settings:
+ *   /k8s/all-namespaces/virtualization-settings/cluster
+ *   /k8s/all-namespaces/virtualization-settings/user
+ *   /k8s/all-namespaces/virtualization-settings/features
+ *
+ * Composes the existing sub-page-objects without going through OverviewPage.
+ */
+
+import BasePage from '@/page-objects/base-page';
+import OverviewMigrationsPage from '@/page-objects/overview/overview-migrations-page';
+import OverviewSettingsPage from '@/page-objects/overview/overview-settings-page';
+import OverviewSshKeysPage from '@/page-objects/overview/overview-ssh-keys-page';
+import OverviewVirtualizationFeaturesPage from '@/page-objects/overview/overview-virtualization-features-page';
+import type { Page } from '@playwright/test';
+
+export default class SettingsPage extends BasePage {
+  private readonly _features: OverviewVirtualizationFeaturesPage;
+  private readonly _migrations: OverviewMigrationsPage;
+  private readonly _settings: OverviewSettingsPage;
+  private readonly _sshKeys: OverviewSshKeysPage;
+
+  constructor(page: Page) {
+    super(page);
+    this._settings = new OverviewSettingsPage(page);
+    this._sshKeys = new OverviewSshKeysPage(page);
+    this._features = new OverviewVirtualizationFeaturesPage(page);
+    this._migrations = new OverviewMigrationsPage(page);
+  }
+
+  // ── Navigation ──────────────────────────────────────────────────────────────
+
+  disableAdvancedCdromFeatures(
+    ...args: Parameters<OverviewSettingsPage['disableAdvancedCdromFeatures']>
+  ): ReturnType<OverviewSettingsPage['disableAdvancedCdromFeatures']> {
+    return this._settings.disableAdvancedCdromFeatures(...args);
+  }
+
+  disableCentosStream9ImageCron(
+    ...args: Parameters<OverviewSettingsPage['disableCentosStream9ImageCron']>
+  ): ReturnType<OverviewSettingsPage['disableCentosStream9ImageCron']> {
+    return this._settings.disableCentosStream9ImageCron(...args);
+  }
+
+  disableMemoryDensity(
+    ...args: Parameters<OverviewMigrationsPage['disableMemoryDensity']>
+  ): ReturnType<OverviewMigrationsPage['disableMemoryDensity']> {
+    return this._migrations.disableMemoryDensity(...args);
+  }
+
+  // ── Cluster tab — top-level ──────────────────────────────────────────────────
+
+  disableVmTemplatesPreviewFeature(
+    ...args: Parameters<OverviewSettingsPage['disableVmTemplatesPreviewFeature']>
+  ): ReturnType<OverviewSettingsPage['disableVmTemplatesPreviewFeature']> {
+    return this._settings.disableVmTemplatesPreviewFeature(...args);
+  }
+
+  enableAaq(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['enableAaq']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['enableAaq']> {
+    return this._features.enableAaq(...args);
+  }
+
+  enableAdvancedCdromFeatures(
+    ...args: Parameters<OverviewSettingsPage['enableAdvancedCdromFeatures']>
+  ): ReturnType<OverviewSettingsPage['enableAdvancedCdromFeatures']> {
+    return this._settings.enableAdvancedCdromFeatures(...args);
+  }
+
+  enableCentosStream9ImageCron(
+    ...args: Parameters<OverviewSettingsPage['enableCentosStream9ImageCron']>
+  ): ReturnType<OverviewSettingsPage['enableCentosStream9ImageCron']> {
+    return this._settings.enableCentosStream9ImageCron(...args);
+  }
+
+  enableGuidedTour(
+    ...args: Parameters<OverviewSettingsPage['enableGuidedTour']>
+  ): ReturnType<OverviewSettingsPage['enableGuidedTour']> {
+    return this._settings.enableGuidedTour(...args);
+  }
+
+  // ── Cluster tab — Virtualization features section ────────────────────────────
+
+  enableKSM(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['enableKSM']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['enableKSM']> {
+    return this._features.enableKSM(...args);
+  }
+
+  enableMemoryDensity(
+    ...args: Parameters<OverviewMigrationsPage['enableMemoryDensity']>
+  ): ReturnType<OverviewMigrationsPage['enableMemoryDensity']> {
+    return this._migrations.enableMemoryDensity(...args);
+  }
+
+  enablePersistentReservation(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['enablePersistentReservation']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['enablePersistentReservation']> {
+    return this._features.enablePersistentReservation(...args);
+  }
+
+  enableSSHOverNodePort(
+    ...args: Parameters<OverviewSettingsPage['enableSSHOverNodePort']>
+  ): ReturnType<OverviewSettingsPage['enableSSHOverNodePort']> {
+    return this._settings.enableSSHOverNodePort(...args);
+  }
+
+  // SSH configurations
+  enableSSHUsingLoadBalancer(
+    ...args: Parameters<OverviewSettingsPage['enableSSHUsingLoadBalancer']>
+  ): ReturnType<OverviewSettingsPage['enableSSHUsingLoadBalancer']> {
+    return this._settings.enableSSHUsingLoadBalancer(...args);
+  }
+
+  // ── Cluster tab — General settings section ───────────────────────────────────
+
+  enableVmTemplatesPreviewFeature(
+    ...args: Parameters<OverviewSettingsPage['enableVmTemplatesPreviewFeature']>
+  ): ReturnType<OverviewSettingsPage['enableVmTemplatesPreviewFeature']> {
+    return this._settings.enableVmTemplatesPreviewFeature(...args);
+  }
+
+  enableWelcomeInformation(
+    ...args: Parameters<OverviewSettingsPage['enableWelcomeInformation']>
+  ): ReturnType<OverviewSettingsPage['enableWelcomeInformation']> {
+    return this._settings.enableWelcomeInformation(...args);
+  }
+
+  fillActivationKey(
+    ...args: Parameters<OverviewSettingsPage['fillActivationKey']>
+  ): ReturnType<OverviewSettingsPage['fillActivationKey']> {
+    return this._settings.fillActivationKey(...args);
+  }
+
+  fillConfigurationSearchInput(
+    ...args: Parameters<OverviewSettingsPage['fillConfigurationSearchInput']>
+  ): ReturnType<OverviewSettingsPage['fillConfigurationSearchInput']> {
+    return this._settings.fillConfigurationSearchInput(...args);
+  }
+
+  getClusterSettingsSectionNames(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['getClusterSettingsSectionNames']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['getClusterSettingsSectionNames']> {
+    return this._features.getClusterSettingsSectionNames(...args);
+  }
+
+  getGeneralSettingsSubSections(
+    ...args: Parameters<OverviewSettingsPage['getGeneralSettingsSubSections']>
+  ): ReturnType<OverviewSettingsPage['getGeneralSettingsSubSections']> {
+    return this._settings.getGeneralSettingsSubSections(...args);
+  }
+
+  getMemoryDensityToggleState(
+    ...args: Parameters<OverviewMigrationsPage['getMemoryDensityToggleState']>
+  ): ReturnType<OverviewMigrationsPage['getMemoryDensityToggleState']> {
+    return this._migrations.getMemoryDensityToggleState(...args);
+  }
+
+  getPreviewFeatureLabels(
+    ...args: Parameters<OverviewSettingsPage['getPreviewFeatureLabels']>
+  ): ReturnType<OverviewSettingsPage['getPreviewFeatureLabels']> {
+    return this._settings.getPreviewFeatureLabels(...args);
+  }
+
+  getSettingsTabNames(
+    ...args: Parameters<OverviewSettingsPage['getSettingsTabNames']>
+  ): ReturnType<OverviewSettingsPage['getSettingsTabNames']> {
+    return this._settings.getSettingsTabNames(...args);
+  }
+
+  getVirtualizationFeatureItems(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['getVirtualizationFeatureItems']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['getVirtualizationFeatureItems']> {
+    return this._features.getVirtualizationFeatureItems(...args);
+  }
+
+  // VirtualMachine actions confirmation
+  getVmActionsConfirmationState(
+    ...args: Parameters<OverviewSettingsPage['getVmActionsConfirmationState']>
+  ): ReturnType<OverviewSettingsPage['getVmActionsConfirmationState']> {
+    return this._settings.getVmActionsConfirmationState(...args);
+  }
+
+  hideGuestCredentials(
+    ...args: Parameters<OverviewSettingsPage['hideGuestCredentials']>
+  ): ReturnType<OverviewSettingsPage['hideGuestCredentials']> {
+    return this._settings.hideGuestCredentials(...args);
+  }
+
+  isAaqControlVisible(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['isAaqControlVisible']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['isAaqControlVisible']> {
+    return this._features.isAaqControlVisible(...args);
+  }
+
+  isAaqEnabled(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['isAaqEnabled']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['isAaqEnabled']> {
+    return this._features.isAaqEnabled(...args);
+  }
+
+  isAdvancedCdromFeaturesEnabled(
+    ...args: Parameters<OverviewSettingsPage['isAdvancedCdromFeaturesEnabled']>
+  ): ReturnType<OverviewSettingsPage['isAdvancedCdromFeaturesEnabled']> {
+    return this._settings.isAdvancedCdromFeaturesEnabled(...args);
+  }
+
+  isConfigureFeaturesButtonVisible(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['isConfigureFeaturesButtonVisible']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['isConfigureFeaturesButtonVisible']> {
+    return this._features.isConfigureFeaturesButtonVisible(...args);
+  }
+
+  isKsmControlVisible(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['isKsmControlVisible']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['isKsmControlVisible']> {
+    return this._features.isKsmControlVisible(...args);
+  }
+
+  isManageQuotasLinkVisible(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['isManageQuotasLinkVisible']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['isManageQuotasLinkVisible']> {
+    return this._features.isManageQuotasLinkVisible(...args);
+  }
+
+  isPasstBindingChecked(
+    ...args: Parameters<OverviewSettingsPage['isPasstBindingChecked']>
+  ): ReturnType<OverviewSettingsPage['isPasstBindingChecked']> {
+    return this._settings.isPasstBindingChecked(...args);
+  }
+
+  navigateToAutomaticImagesDownload(
+    ...args: Parameters<OverviewSettingsPage['navigateToAutomaticImagesDownload']>
+  ): ReturnType<OverviewSettingsPage['navigateToAutomaticImagesDownload']> {
+    return this._settings.navigateToAutomaticImagesDownload(...args);
+  }
+
+  navigateToAutomaticSubscription(
+    ...args: Parameters<OverviewSettingsPage['navigateToAutomaticSubscription']>
+  ): ReturnType<OverviewSettingsPage['navigateToAutomaticSubscription']> {
+    return this._settings.navigateToAutomaticSubscription(...args);
+  }
+
+  navigateToGeneralSettings(
+    ...args: Parameters<OverviewSettingsPage['navigateToGeneralSettings']>
+  ): ReturnType<OverviewSettingsPage['navigateToGeneralSettings']> {
+    return this._settings.navigateToGeneralSettings(...args);
+  }
+
+  navigateToGettingStartedResources(
+    ...args: Parameters<OverviewSettingsPage['navigateToGettingStartedResources']>
+  ): ReturnType<OverviewSettingsPage['navigateToGettingStartedResources']> {
+    return this._settings.navigateToGettingStartedResources(...args);
+  }
+
+  // ── Cluster tab — Guest management section ───────────────────────────────────
+
+  navigateToGuestManagement(
+    ...args: Parameters<OverviewSettingsPage['navigateToGuestManagement']>
+  ): ReturnType<OverviewSettingsPage['navigateToGuestManagement']> {
+    return this._settings.navigateToGuestManagement(...args);
+  }
+
+  navigateToPermissions(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['navigateToPermissions']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['navigateToPermissions']> {
+    return this._features.navigateToPermissions(...args);
+  }
+
+  navigateToPreviewFeatures(
+    ...args: Parameters<OverviewSettingsPage['navigateToPreviewFeatures']>
+  ): ReturnType<OverviewSettingsPage['navigateToPreviewFeatures']> {
+    return this._settings.navigateToPreviewFeatures(...args);
+  }
+
+  navigateToResourceManagement(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['navigateToResourceManagement']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['navigateToResourceManagement']> {
+    return this._features.navigateToResourceManagement(...args);
+  }
+
+  navigateToSettings(
+    ...args: Parameters<OverviewSettingsPage['navigateToSettings']>
+  ): ReturnType<OverviewSettingsPage['navigateToSettings']> {
+    return this._settings.navigateToSettings(...args);
+  }
+
+  // ── Cluster tab — Resource management section ────────────────────────────────
+
+  navigateToSettingsViaSidebar(
+    ...args: Parameters<OverviewSettingsPage['navigateToSettingsViaSidebar']>
+  ): ReturnType<OverviewSettingsPage['navigateToSettingsViaSidebar']> {
+    return this._settings.navigateToSettingsViaSidebar(...args);
+  }
+
+  navigateToSettingsViaUI(
+    ...args: Parameters<OverviewSettingsPage['navigateToSettingsViaUI']>
+  ): ReturnType<OverviewSettingsPage['navigateToSettingsViaUI']> {
+    return this._settings.navigateToSettingsViaUI(...args);
+  }
+
+  navigateToSSHKeysManagement(
+    ...args: Parameters<OverviewSshKeysPage['navigateToSSHKeysManagement']>
+  ): ReturnType<OverviewSshKeysPage['navigateToSSHKeysManagement']> {
+    return this._sshKeys.navigateToSSHKeysManagement(...args);
+  }
+
+  // Templates and images management
+  navigateToTemplatesAndImagesManagement(
+    ...args: Parameters<OverviewSettingsPage['navigateToTemplatesAndImagesManagement']>
+  ): ReturnType<OverviewSettingsPage['navigateToTemplatesAndImagesManagement']> {
+    return this._settings.navigateToTemplatesAndImagesManagement(...args);
+  }
+
+  navigateToVirtualizationFeatures(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['navigateToVirtualizationFeatures']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['navigateToVirtualizationFeatures']> {
+    return this._features.navigateToVirtualizationFeatures(...args);
+  }
+
+  // Advanced CD-ROM features
+  openAdvancedCdromFeaturesSettings(
+    ...args: Parameters<OverviewSettingsPage['openAdvancedCdromFeaturesSettings']>
+  ): ReturnType<OverviewSettingsPage['openAdvancedCdromFeaturesSettings']> {
+    return this._settings.openAdvancedCdromFeaturesSettings(...args);
+  }
+
+  // Memory density
+  openMemoryDensitySettings(
+    ...args: Parameters<OverviewMigrationsPage['openMemoryDensitySettings']>
+  ): ReturnType<OverviewMigrationsPage['openMemoryDensitySettings']> {
+    return this._migrations.openMemoryDensitySettings(...args);
+  }
+
+  saveSSHKey(
+    ...args: Parameters<OverviewSshKeysPage['saveSSHKey']>
+  ): ReturnType<OverviewSshKeysPage['saveSSHKey']> {
+    return this._sshKeys.saveSSHKey(...args);
+  }
+
+  // ── Cluster tab — SCSI persistent reservation section ───────────────────────
+
+  selectProjectInSSHSettings(
+    ...args: Parameters<OverviewSshKeysPage['selectProjectInSSHSettings']>
+  ): ReturnType<OverviewSshKeysPage['selectProjectInSSHSettings']> {
+    return this._sshKeys.selectProjectInSSHSettings(...args);
+  }
+
+  setGuestSystemLog(
+    ...args: Parameters<OverviewSettingsPage['setGuestSystemLog']>
+  ): ReturnType<OverviewSettingsPage['setGuestSystemLog']> {
+    return this._settings.setGuestSystemLog(...args);
+  }
+
+  // ── User tab ─────────────────────────────────────────────────────────────────
+
+  // YAML tab visibility
+  setHideYamlTab(
+    ...args: Parameters<OverviewSettingsPage['setHideYamlTab']>
+  ): ReturnType<OverviewSettingsPage['setHideYamlTab']> {
+    return this._settings.setHideYamlTab(...args);
+  }
+
+  // Live migration
+  setLiveMigrationLimits(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['setLiveMigrationLimits']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['setLiveMigrationLimits']> {
+    return this._features.setLiveMigrationLimits(...args);
+  }
+
+  setMemoryDensityPercentage(
+    ...args: Parameters<OverviewMigrationsPage['setMemoryDensityPercentage']>
+  ): ReturnType<OverviewMigrationsPage['setMemoryDensityPercentage']> {
+    return this._migrations.setMemoryDensityPercentage(...args);
+  }
+
+  setVmActionsConfirmation(
+    ...args: Parameters<OverviewSettingsPage['setVmActionsConfirmation']>
+  ): ReturnType<OverviewSettingsPage['setVmActionsConfirmation']> {
+    return this._settings.setVmActionsConfirmation(...args);
+  }
+
+  testPasstBindingSetting(
+    ...args: Parameters<OverviewSettingsPage['testPasstBindingSetting']>
+  ): ReturnType<OverviewSettingsPage['testPasstBindingSetting']> {
+    return this._settings.testPasstBindingSetting(...args);
+  }
+
+  testVmFoldersSetting(
+    ...args: Parameters<OverviewSettingsPage['testVmFoldersSetting']>
+  ): ReturnType<OverviewSettingsPage['testVmFoldersSetting']> {
+    return this._settings.testVmFoldersSetting(...args);
+  }
+
+  // ── User tab — Getting started resources section ──────────────────────────────
+
+  verifyCentosStream9ImageCronEnabled(
+    ...args: Parameters<OverviewSettingsPage['verifyCentosStream9ImageCronEnabled']>
+  ): ReturnType<OverviewSettingsPage['verifyCentosStream9ImageCronEnabled']> {
+    return this._settings.verifyCentosStream9ImageCronEnabled(...args);
+  }
+
+  verifyHighlightedSearchResultsVisible(
+    ...args: Parameters<OverviewSettingsPage['verifyHighlightedSearchResultsVisible']>
+  ): ReturnType<OverviewSettingsPage['verifyHighlightedSearchResultsVisible']> {
+    return this._settings.verifyHighlightedSearchResultsVisible(...args);
+  }
+
+  verifyInstalledVersion(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['verifyInstalledVersion']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['verifyInstalledVersion']> {
+    return this._features.verifyInstalledVersion(...args);
+  }
+
+  // ── Preview features tab ─────────────────────────────────────────────────────
+
+  verifyKSMEnabled(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['verifyKSMEnabled']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['verifyKSMEnabled']> {
+    return this._features.verifyKSMEnabled(...args);
+  }
+
+  verifyLiveMigrationSettings(
+    ...args: Parameters<OverviewMigrationsPage['verifyLiveMigrationSettings']>
+  ): ReturnType<OverviewMigrationsPage['verifyLiveMigrationSettings']> {
+    return this._migrations.verifyLiveMigrationSettings(...args);
+  }
+
+  verifyPersistentReservationEnabled(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['verifyPersistentReservationEnabled']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['verifyPersistentReservationEnabled']> {
+    return this._features.verifyPersistentReservationEnabled(...args);
+  }
+
+  verifyPublicSSHKeyVisible(
+    ...args: Parameters<OverviewSshKeysPage['verifyPublicSSHKeyVisible']>
+  ): ReturnType<OverviewSshKeysPage['verifyPublicSSHKeyVisible']> {
+    return this._sshKeys.verifyPublicSSHKeyVisible(...args);
+  }
+
+  verifySettingsTabLoaded(
+    ...args: Parameters<OverviewSettingsPage['verifySettingsTabLoaded']>
+  ): ReturnType<OverviewSettingsPage['verifySettingsTabLoaded']> {
+    return this._settings.verifySettingsTabLoaded(...args);
+  }
+
+  verifyUserPermissions(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['verifyUserPermissions']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['verifyUserPermissions']> {
+    return this._features.verifyUserPermissions(...args);
+  }
+
+  verifyVirtualizationFeatures(
+    ...args: Parameters<OverviewVirtualizationFeaturesPage['verifyVirtualizationFeatures']>
+  ): ReturnType<OverviewVirtualizationFeaturesPage['verifyVirtualizationFeatures']> {
+    return this._features.verifyVirtualizationFeatures(...args);
+  }
+}

--- a/playwright/src/page-objects/vm-wizard/index.ts
+++ b/playwright/src/page-objects/vm-wizard/index.ts
@@ -1,0 +1,4 @@
+export { default as VmCreationWizardPage } from './vm-creation-wizard-page';
+export { default as VmWizardBootSourcePage } from './vm-wizard-boot-source-page';
+export { default as VmWizardComputeCustomizationPage } from './vm-wizard-compute-customization-page';
+export { default as VmWizardNavigationPage } from './vm-wizard-navigation-page';

--- a/playwright/src/page-objects/vm-wizard/vm-creation-wizard-page.ts
+++ b/playwright/src/page-objects/vm-wizard/vm-creation-wizard-page.ts
@@ -1,0 +1,3 @@
+import VmCreationWizardComponent from '@/components/vm-wizard/vm-creation-wizard-component';
+
+export default class VmCreationWizardPage extends VmCreationWizardComponent {}

--- a/playwright/src/page-objects/vm-wizard/vm-wizard-boot-source-page.ts
+++ b/playwright/src/page-objects/vm-wizard/vm-wizard-boot-source-page.ts
@@ -1,0 +1,3 @@
+import VmWizardBootSourceComponent from '@/components/vm-wizard/vm-wizard-boot-source-component';
+
+export default class VmWizardBootSourcePage extends VmWizardBootSourceComponent {}

--- a/playwright/src/page-objects/vm-wizard/vm-wizard-compute-customization-page.ts
+++ b/playwright/src/page-objects/vm-wizard/vm-wizard-compute-customization-page.ts
@@ -1,0 +1,3 @@
+import VmWizardComputeCustomizationComponent from '@/components/vm-wizard/vm-wizard-compute-customization-component';
+
+export default class VmWizardComputeCustomizationPage extends VmWizardComputeCustomizationComponent {}

--- a/playwright/src/page-objects/vm-wizard/vm-wizard-navigation-page.ts
+++ b/playwright/src/page-objects/vm-wizard/vm-wizard-navigation-page.ts
@@ -1,0 +1,3 @@
+import VmWizardNavigationComponent from '@/components/vm-wizard/vm-wizard-navigation-component';
+
+export default class VmWizardNavigationPage extends VmWizardNavigationComponent {}


### PR DESCRIPTION
## 📝 Description

VM wizard and settings page objects

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-92539


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive automated coverage for the virtual machine creation wizard, including boot source, compute, customization, deployment, review, location, cloning, and template catalog workflows.
  - Added validation for wizard navigation, fields, controls, dialogs, tables, tabs, redirects, and empty states.
  - Added automated page objects for virtualization settings and wizard pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->