### PR TITLE
[release-4.15] CNV-92658: Add Konflux hermetic build CI check

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -36,9 +36,22 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Detect package-lock.json changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            package-lock:
+              - package-lock.json
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -51,6 +64,28 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Prefetch npm dependencies with Hermeto
+        if: steps.filter.outputs.package-lock == 'true'
+        run: |
+          git checkout -- package.json package-lock.json
+          rm -rf node_modules hermeto-output
+          HERMETO_OUTPUT="${{ github.workspace }}/hermeto-output"
+          docker run --rm \
+            -v "${{ github.workspace }}:${{ github.workspace }}" \
+            -w "${{ github.workspace }}" \
+            ghcr.io/hermetoproject/hermeto:latest \
+            fetch-deps --source "${{ github.workspace }}" --output "$HERMETO_OUTPUT" npm
+          docker run --rm \
+            -v "${{ github.workspace }}:${{ github.workspace }}" \
+            -w "${{ github.workspace }}" \
+            ghcr.io/hermetoproject/hermeto:latest \
+            inject-files "$HERMETO_OUTPUT" --for-output-dir "$HERMETO_OUTPUT"
+
+      - name: Verify offline install
+        if: steps.filter.outputs.package-lock == 'true'
+        run: |
+          HUSKY=0 npm ci --offline --ignore-scripts --no-audit
 
   unit-test:
     name: unit-test

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,6 @@
         "@types/react-router-dom": "5.x",
         "@typescript-eslint/eslint-plugin": "^5.14.0",
         "@typescript-eslint/parser": "^5.14.0",
-        "ajv": "^8.11.0",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "6.6.0",
         "cypress": "9.5.x",
@@ -2091,22 +2090,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.17.0",
       "resolved": "https://registry.yarnpkg.com/globals/-/globals-13.17.0.tgz",
@@ -2121,12 +2104,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.10.4",
@@ -2619,6 +2596,24 @@
       "resolved": "https://registry.yarnpkg.com/@kubevirt-ui/kubevirt-api/-/kubevirt-api-0.0.35.tgz",
       "integrity": "sha1-mlZ+ooe2R803pH1wuH+9ddSZSok= sha512-3S374M9I8nHP+9lnBhL+Z3gMVssNk4vyK7uPI3lkAjal/X6zjR0+E9fWQEPv36K45KxRoUX9w/4pMGWQvVlDcQ=="
     },
+    "node_modules/@kubevirt-ui/components/node_modules/@patternfly/react-core": {
+      "version": "4.231.8",
+      "resolved": "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.231.8.tgz",
+      "integrity": "sha1-L53jjs3S/FPGOv9VQzmE/Pk6X+Y= sha512-2ClqlYCvSADppMfVfkUGIA/8XlO6jX8batoClXLxZDwqGoOfr61XyUgQ6SSlE4w60czoNeX4Nf6cfQKUH4RIKw==",
+      "dependencies": {
+        "@patternfly/react-icons": "^4.82.8",
+        "@patternfly/react-styles": "^4.81.8",
+        "@patternfly/react-tokens": "^4.83.8",
+        "focus-trap": "6.9.2",
+        "react-dropzone": "9.0.0",
+        "tippy.js": "5.1.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
     "node_modules/@kubevirt-ui/kubevirt-api": {
       "version": "1.2.0",
       "resolved": "https://registry.yarnpkg.com/@kubevirt-ui/kubevirt-api/-/kubevirt-api-1.2.0.tgz",
@@ -2895,15 +2890,6 @@
       "integrity": "sha1-undMYUvg8BbaEFyFjnFZ6ujnaHs= sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "dev": true
     },
-    "node_modules/@openshift-console/dynamic-plugin-sdk-internal/node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
-      "dev": true,
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
     "node_modules/@openshift-console/dynamic-plugin-sdk-internal/node_modules/react-router-dom": {
       "version": "5.2.0",
       "resolved": "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz",
@@ -2942,22 +2928,6 @@
         "read-pkg": "5.x",
         "semver": "6.x",
         "webpack": "^5.73.0"
-      }
-    },
-    "node_modules/@openshift-console/dynamic-plugin-sdk-webpack/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@openshift-console/dynamic-plugin-sdk-webpack/node_modules/ansi-styles": {
@@ -3018,12 +2988,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@openshift-console/dynamic-plugin-sdk-webpack/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
     },
     "node_modules/@openshift-console/dynamic-plugin-sdk-webpack/node_modules/semver": {
       "version": "6.3.0",
@@ -3205,15 +3169,6 @@
       "integrity": "sha1-R8cVchrT3TFaUj81K6Gg3isD8Lw= sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q==",
       "dev": true
     },
-    "node_modules/@openshift-console/dynamic-plugin-sdk/node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
-      "dev": true,
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
     "node_modules/@openshift-console/dynamic-plugin-sdk/node_modules/react-router": {
       "version": "5.3.4",
       "resolved": "https://registry.yarnpkg.com/react-router/-/react-router-5.3.4.tgz",
@@ -3347,6 +3302,11 @@
       "resolved": "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha1-undMYUvg8BbaEFyFjnFZ6ujnaHs= sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
+    "node_modules/@patternfly/quickstarts/node_modules/dompurify": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.9.tgz",
+      "integrity": "sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA=="
+    },
     "node_modules/@patternfly/quickstarts/node_modules/history": {
       "version": "5.3.0",
       "resolved": "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz",
@@ -3368,6 +3328,24 @@
         "@patternfly/patternfly": "4.206.3",
         "@patternfly/react-core": "^4.231.8",
         "@patternfly/react-styles": "^4.81.8"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@patternfly/react-catalog-view-extension/node_modules/@patternfly/react-core": {
+      "version": "4.231.8",
+      "resolved": "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.231.8.tgz",
+      "integrity": "sha1-L53jjs3S/FPGOv9VQzmE/Pk6X+Y= sha512-2ClqlYCvSADppMfVfkUGIA/8XlO6jX8batoClXLxZDwqGoOfr61XyUgQ6SSlE4w60czoNeX4Nf6cfQKUH4RIKw==",
+      "dependencies": {
+        "@patternfly/react-icons": "^4.82.8",
+        "@patternfly/react-styles": "^4.81.8",
+        "@patternfly/react-tokens": "^4.83.8",
+        "focus-trap": "6.9.2",
+        "react-dropzone": "9.0.0",
+        "tippy.js": "5.1.2",
+        "tslib": "^2.0.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
@@ -3423,13 +3401,23 @@
         "react-dom": "^16.8 || ^17 || ^18"
       }
     },
+    "node_modules/@patternfly/react-core/node_modules/@patternfly/react-styles": {
+      "version": "4.92.6",
+      "resolved": "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.92.6.tgz",
+      "integrity": "sha1-pyxfC3iWzhxBnR23n445umYyBX0= sha512-b8uQdEReMyeoMzjpMri845QxqtupY/tIFFYfVeKoB2neno8gkcW1RvDdDe62LF88q45OktCwAe/8A99ker10Iw=="
+    },
+    "node_modules/@patternfly/react-core/node_modules/@patternfly/react-tokens": {
+      "version": "4.94.6",
+      "resolved": "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.94.6.tgz",
+      "integrity": "sha1-R8cVchrT3TFaUj81K6Gg3isD8Lw= sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q=="
+    },
     "node_modules/@patternfly/react-icons": {
-      "version": "4.93.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.93.7.tgz",
-      "integrity": "sha512-3kr35dgba7Qz5CSzmfH0rIjSvBC5xkmiknf3SvVUVxaiVA7KRowID8viYHeZlf3v/Oa3sEewaH830Q0t+nWsZQ==",
+      "version": "4.82.8",
+      "resolved": "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.82.8.tgz",
+      "integrity": "sha1-WasaE50/xYb9OEpYgW5GCKBg7jI= sha512-cKixprTiMLZRe/+kmdZ5suvYb9ly9p1f/HjlcNiWBfsiA8ZDEPmxJnVdend/YsafelC8YC9QGcQf97ay5PNhcw==",
       "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@patternfly/react-log-viewer": {
@@ -3459,24 +3447,6 @@
         "react-dropzone": "^14.2.3",
         "tslib": "^2.5.0"
       },
-      "peerDependencies": {
-        "react": "^17 || ^18",
-        "react-dom": "^17 || ^18"
-      }
-    },
-    "node_modules/@patternfly/react-log-viewer/node_modules/@patternfly/react-core/node_modules/@patternfly/react-icons": {
-      "version": "4.93.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.93.7.tgz",
-      "integrity": "sha512-3kr35dgba7Qz5CSzmfH0rIjSvBC5xkmiknf3SvVUVxaiVA7KRowID8viYHeZlf3v/Oa3sEewaH830Q0t+nWsZQ==",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
-      }
-    },
-    "node_modules/@patternfly/react-log-viewer/node_modules/@patternfly/react-icons": {
-      "version": "5.4.2",
-      "resolved": "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-5.4.2.tgz",
-      "integrity": "sha1-iTenFnoLOr3DwXlST0VrTL2PDDk= sha512-CMQ5oHYzW6TPVTs2jpNJmP2vGCAKR/YeTPwHGO9dLkAUej1IcIxtCCWK2Fdo2UJsnBjuZihasyw2b6ehvbUm9Q==",
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
@@ -3540,6 +3510,11 @@
       "resolved": "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz",
       "integrity": "sha1-cy+2K8AXXPzsJXMwvhh9z7ofO5c= sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
+    "node_modules/@patternfly/react-log-viewer/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha1-cDrClCXns3zW/UVukkBNRtHz5K4= sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
     "node_modules/@patternfly/react-styles": {
       "version": "4.92.8",
       "resolved": "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.92.8.tgz",
@@ -3555,6 +3530,24 @@
         "@patternfly/react-styles": "^4.81.8",
         "@patternfly/react-tokens": "^4.83.8",
         "lodash": "^4.17.19",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@patternfly/react-table/node_modules/@patternfly/react-core": {
+      "version": "4.231.8",
+      "resolved": "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.231.8.tgz",
+      "integrity": "sha1-L53jjs3S/FPGOv9VQzmE/Pk6X+Y= sha512-2ClqlYCvSADppMfVfkUGIA/8XlO6jX8batoClXLxZDwqGoOfr61XyUgQ6SSlE4w60czoNeX4Nf6cfQKUH4RIKw==",
+      "dependencies": {
+        "@patternfly/react-icons": "^4.82.8",
+        "@patternfly/react-styles": "^4.81.8",
+        "@patternfly/react-tokens": "^4.83.8",
+        "focus-trap": "6.9.2",
+        "react-dropzone": "9.0.0",
+        "tippy.js": "5.1.2",
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
@@ -4434,8 +4427,8 @@
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "resolved": "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha1-usywepcLkXB986PoumiWxX6tLRE= sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
       "optional": true
     },
@@ -4999,15 +4992,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk= sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "version": "6.12.6",
+      "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       },
       "funding": {
         "type": "github",
@@ -5022,30 +5015,6 @@
       "peerDependencies": {
         "ajv": "^6.9.1"
       }
-    },
-    "node_modules/ajv-keywords/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-keywords/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "peer": true
     },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
@@ -5401,30 +5370,6 @@
         "webpack": ">=2"
       }
     },
-    "node_modules/babel-loader/node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/babel-loader/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/babel-loader/node_modules/schema-utils": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
@@ -5592,9 +5537,9 @@
       ]
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "dev": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -5807,9 +5752,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "dev": true,
       "funding": [
         {
@@ -5826,10 +5771,10 @@
         }
       ],
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -6072,9 +6017,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001800",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
-      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "version": "1.0.30001805",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
       "dev": true,
       "funding": [
         {
@@ -7482,9 +7427,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.9",
-      "resolved": "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.9.tgz",
-      "integrity": "sha1-gEgewi36xnKFzCdMtRpFwen6nEI= sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA=="
+      "version": "3.4.0",
+      "resolved": "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha1-sfwz69rbNzJBYh4KMOStgVc9/Qs= sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "dev": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/domutils": {
       "version": "3.0.1",
@@ -7556,9 +7505,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.384",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.384.tgz",
-      "integrity": "sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==",
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -8477,22 +8426,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/eslint/node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz",
@@ -8560,12 +8493,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/eslint/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
@@ -8923,22 +8850,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc= sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha1-9pWkDwBqulBWMVc6ACHdshGUrRE= sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ]
-    },
     "node_modules/fast-xml-builder": {
       "version": "1.1.4",
       "resolved": "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
@@ -9273,28 +9184,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
       "version": "2.7.0",
@@ -10175,6 +10064,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/http-proxy/node_modules/follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha1-DKakUjBsmyduTTEnSD4pV14getU= sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/http-signature": {
@@ -11914,9 +11823,9 @@
       "dev": true
     },
     "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI= sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "version": "0.4.1",
+      "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -12532,6 +12441,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lint-staged/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha1-fOyqfwc85oCgWEeqd76UEJjzbcM= sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
     },
     "node_modules/listr2": {
       "version": "3.14.0",
@@ -13567,9 +13482,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -15582,6 +15497,12 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha1-fOyqfwc85oCgWEeqd76UEJjzbcM= sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -15709,6 +15630,22 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha1-l36R3ZbKZp9UoR4j43jjO4hKVl8= sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/schema-utils/node_modules/ajv-formats": {
       "version": "2.1.1",
       "resolved": "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -15737,6 +15674,12 @@
       "peerDependencies": {
         "ajv": "^8.8.2"
       }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI= sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -16757,28 +16700,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
       "version": "3.1.1",
@@ -18234,28 +18155,6 @@
       "version": "0.0.51",
       "resolved": "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha1-z9cJJKJaP9MrIY5eQg5ol+GsT0A= sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-      "dev": true
-    },
-    "node_modules/webpack/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "node_modules/webpack/node_modules/schema-utils": {
@@ -20049,18 +19948,6 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "globals": {
           "version": "13.17.0",
           "resolved": "https://registry.yarnpkg.com/globals/-/globals-13.17.0.tgz",
@@ -20069,12 +19956,6 @@
           "requires": {
             "type-fest": "^0.20.2"
           }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
         }
       }
     },
@@ -20494,6 +20375,20 @@
           "version": "0.0.35",
           "resolved": "https://registry.yarnpkg.com/@kubevirt-ui/kubevirt-api/-/kubevirt-api-0.0.35.tgz",
           "integrity": "sha1-mlZ+ooe2R803pH1wuH+9ddSZSok= sha512-3S374M9I8nHP+9lnBhL+Z3gMVssNk4vyK7uPI3lkAjal/X6zjR0+E9fWQEPv36K45KxRoUX9w/4pMGWQvVlDcQ=="
+        },
+        "@patternfly/react-core": {
+          "version": "4.231.8",
+          "resolved": "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.231.8.tgz",
+          "integrity": "sha1-L53jjs3S/FPGOv9VQzmE/Pk6X+Y= sha512-2ClqlYCvSADppMfVfkUGIA/8XlO6jX8batoClXLxZDwqGoOfr61XyUgQ6SSlE4w60czoNeX4Nf6cfQKUH4RIKw==",
+          "requires": {
+            "@patternfly/react-icons": "^4.82.8",
+            "@patternfly/react-styles": "^4.81.8",
+            "@patternfly/react-tokens": "^4.83.8",
+            "focus-trap": "6.9.2",
+            "react-dropzone": "9.0.0",
+            "tippy.js": "5.1.2",
+            "tslib": "^2.0.0"
+          }
         }
       }
     },
@@ -20703,15 +20598,6 @@
           "resolved": "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.94.6.tgz",
           "integrity": "sha1-R8cVchrT3TFaUj81K6Gg3isD8Lw= sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q==",
           "dev": true
-        },
-        "dompurify": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-          "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
-          "dev": true,
-          "requires": {
-            "@types/trusted-types": "^2.0.7"
-          }
         },
         "react-router": {
           "version": "5.3.4",
@@ -20930,15 +20816,6 @@
           "integrity": "sha1-undMYUvg8BbaEFyFjnFZ6ujnaHs= sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
           "dev": true
         },
-        "dompurify": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-          "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
-          "dev": true,
-          "requires": {
-            "@types/trusted-types": "^2.0.7"
-          }
-        },
         "react-router-dom": {
           "version": "5.2.0",
           "resolved": "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz",
@@ -20978,18 +20855,6 @@
         "webpack": "5.74.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -21035,12 +20900,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0= sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "semver": {
@@ -21130,6 +20989,11 @@
           "resolved": "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz",
           "integrity": "sha1-undMYUvg8BbaEFyFjnFZ6ujnaHs= sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
         },
+        "dompurify": {
+          "version": "2.5.9",
+          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.9.tgz",
+          "integrity": "sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA=="
+        },
         "history": {
           "version": "5.3.0",
           "resolved": "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz",
@@ -21153,6 +21017,22 @@
         "@patternfly/patternfly": "4.206.3",
         "@patternfly/react-core": "^4.231.8",
         "@patternfly/react-styles": "^4.81.8"
+      },
+      "dependencies": {
+        "@patternfly/react-core": {
+          "version": "4.231.8",
+          "resolved": "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.231.8.tgz",
+          "integrity": "sha1-L53jjs3S/FPGOv9VQzmE/Pk6X+Y= sha512-2ClqlYCvSADppMfVfkUGIA/8XlO6jX8batoClXLxZDwqGoOfr61XyUgQ6SSlE4w60czoNeX4Nf6cfQKUH4RIKw==",
+          "requires": {
+            "@patternfly/react-icons": "^4.82.8",
+            "@patternfly/react-styles": "^4.81.8",
+            "@patternfly/react-tokens": "^4.83.8",
+            "focus-trap": "6.9.2",
+            "react-dropzone": "9.0.0",
+            "tippy.js": "5.1.2",
+            "tslib": "^2.0.0"
+          }
+        }
       }
     },
     "@patternfly/react-charts": {
@@ -21194,12 +21074,24 @@
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
         "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@patternfly/react-styles": {
+          "version": "4.92.6",
+          "resolved": "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.92.6.tgz",
+          "integrity": "sha1-pyxfC3iWzhxBnR23n445umYyBX0= sha512-b8uQdEReMyeoMzjpMri845QxqtupY/tIFFYfVeKoB2neno8gkcW1RvDdDe62LF88q45OktCwAe/8A99ker10Iw=="
+        },
+        "@patternfly/react-tokens": {
+          "version": "4.94.6",
+          "resolved": "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.94.6.tgz",
+          "integrity": "sha1-R8cVchrT3TFaUj81K6Gg3isD8Lw= sha512-tm7C6nat+uKMr1hrapis7hS3rN9cr41tpcCKhx6cod6FLU8KwF2Yt5KUxakhIOCEcE/M/EhXhAw/qejp8w0r7Q=="
+        }
       }
     },
     "@patternfly/react-icons": {
-      "version": "4.93.7",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.93.7.tgz",
-      "integrity": "sha512-3kr35dgba7Qz5CSzmfH0rIjSvBC5xkmiknf3SvVUVxaiVA7KRowID8viYHeZlf3v/Oa3sEewaH830Q0t+nWsZQ==",
+      "version": "4.82.8",
+      "resolved": "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.82.8.tgz",
+      "integrity": "sha1-WasaE50/xYb9OEpYgW5GCKBg7jI= sha512-cKixprTiMLZRe/+kmdZ5suvYb9ly9p1f/HjlcNiWBfsiA8ZDEPmxJnVdend/YsafelC8YC9QGcQf97ay5PNhcw==",
       "requires": {}
     },
     "@patternfly/react-log-viewer": {
@@ -21224,20 +21116,7 @@
             "focus-trap": "7.5.2",
             "react-dropzone": "^14.2.3",
             "tslib": "^2.5.0"
-          },
-          "dependencies": {
-            "@patternfly/react-icons": {
-              "version": "4.93.7",
-              "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.93.7.tgz",
-              "integrity": "sha512-3kr35dgba7Qz5CSzmfH0rIjSvBC5xkmiknf3SvVUVxaiVA7KRowID8viYHeZlf3v/Oa3sEewaH830Q0t+nWsZQ==",
-              "requires": {}
-            }
           }
-        },
-        "@patternfly/react-icons": {
-          "version": "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-5.4.2.tgz",
-          "integrity": "sha1-iTenFnoLOr3DwXlST0VrTL2PDDk= sha512-CMQ5oHYzW6TPVTs2jpNJmP2vGCAKR/YeTPwHGO9dLkAUej1IcIxtCCWK2Fdo2UJsnBjuZihasyw2b6ehvbUm9Q==",
-          "requires": {}
         },
         "@patternfly/react-styles": {
           "version": "5.1.1",
@@ -21284,6 +21163,11 @@
           "version": "6.2.0",
           "resolved": "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz",
           "integrity": "sha1-cy+2K8AXXPzsJXMwvhh9z7ofO5c= sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+        },
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha1-cDrClCXns3zW/UVukkBNRtHz5K4= sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
@@ -21303,6 +21187,22 @@
         "@patternfly/react-tokens": "^4.83.8",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@patternfly/react-core": {
+          "version": "4.231.8",
+          "resolved": "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.231.8.tgz",
+          "integrity": "sha1-L53jjs3S/FPGOv9VQzmE/Pk6X+Y= sha512-2ClqlYCvSADppMfVfkUGIA/8XlO6jX8batoClXLxZDwqGoOfr61XyUgQ6SSlE4w60czoNeX4Nf6cfQKUH4RIKw==",
+          "requires": {
+            "@patternfly/react-icons": "^4.82.8",
+            "@patternfly/react-styles": "^4.81.8",
+            "@patternfly/react-tokens": "^4.83.8",
+            "focus-trap": "6.9.2",
+            "react-dropzone": "9.0.0",
+            "tippy.js": "5.1.2",
+            "tslib": "^2.0.0"
+          }
+        }
       }
     },
     "@patternfly/react-tokens": {
@@ -22119,8 +22019,8 @@
     },
     "@types/trusted-types": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "resolved": "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha1-usywepcLkXB986PoumiWxX6tLRE= sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
       "optional": true
     },
@@ -22552,15 +22452,15 @@
       }
     },
     "ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk= sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "version": "6.12.6",
+      "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ajv-keywords": {
@@ -22568,28 +22468,7 @@
       "resolved": "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0= sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
-      "requires": {},
-      "dependencies": {
-        "ajv": {
-          "version": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true,
-          "peer": true
-        }
-      }
+      "requires": {}
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -22841,26 +22720,6 @@
         "schema-utils": "^2.6.5"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.15.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-          "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true,
-          "peer": true
-        },
         "schema-utils": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
@@ -22984,9 +22843,9 @@
       "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo= sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "dev": true
     },
     "batch": {
@@ -23174,15 +23033,15 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "dev": true,
       "requires": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       }
     },
@@ -23346,9 +23205,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001800",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
-      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "version": "1.0.30001805",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
       "dev": true
     },
     "caseless": {
@@ -24398,9 +24257,13 @@
       }
     },
     "dompurify": {
-      "version": "2.5.9",
-      "resolved": "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.9.tgz",
-      "integrity": "sha1-gEgewi36xnKFzCdMtRpFwen6nEI= sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA=="
+      "version": "3.4.0",
+      "resolved": "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha1-sfwz69rbNzJBYh4KMOStgVc9/Qs= sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "domutils": {
       "version": "3.0.1",
@@ -24463,9 +24326,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.5.384",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.384.tgz",
-      "integrity": "sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==",
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true
     },
     "emittery": {
@@ -24807,18 +24670,6 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "doctrine": {
           "version": "3.0.0",
           "resolved": "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz",
@@ -24865,12 +24716,6 @@
           "requires": {
             "type-fest": "^0.20.2"
           }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
         },
         "locate-path": {
           "version": "6.0.0",
@@ -25480,12 +25325,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc= sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha1-9pWkDwBqulBWMVc6ACHdshGUrRE= sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
-      "dev": true
-    },
     "fast-xml-builder": {
       "version": "1.1.4",
       "resolved": "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
@@ -25730,24 +25569,6 @@
         "tapable": "^1.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
-        },
         "schema-utils": {
           "version": "2.7.0",
           "resolved": "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.0.tgz",
@@ -26419,6 +26240,14 @@
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.15.1",
+          "resolved": "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz",
+          "integrity": "sha1-DKakUjBsmyduTTEnSD4pV14getU= sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+          "dev": true
+        }
       }
     },
     "http-proxy-agent": {
@@ -27766,9 +27595,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI= sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "version": "0.4.1",
+      "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
@@ -28187,6 +28016,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
           "integrity": "sha1-UolMMT+/8xiDUoCu1g/3Hr8SuP0= sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha1-fOyqfwc85oCgWEeqd76UEJjzbcM= sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
@@ -28999,9 +28834,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true
     },
     "normalize-package-data": {
@@ -30493,6 +30328,14 @@
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha1-fOyqfwc85oCgWEeqd76UEJjzbcM= sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -30566,6 +30409,18 @@
         "ajv-keywords": "^5.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha1-l36R3ZbKZp9UoR4j43jjO4hKVl8= sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ajv-formats": {
           "version": "2.1.1",
           "resolved": "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz",
@@ -30583,6 +30438,12 @@
           "requires": {
             "fast-deep-equal": "^3.1.3"
           }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI= sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
         }
       }
     },
@@ -31400,24 +31261,6 @@
         "terser": "^5.14.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
-        },
         "schema-utils": {
           "version": "3.1.1",
           "resolved": "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -32418,24 +32261,6 @@
           "version": "0.0.51",
           "resolved": "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz",
           "integrity": "sha1-z9cJJKJaP9MrIY5eQg5ol+GsT0A= sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-          "dev": true
-        },
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ= sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA= sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "schema-utils": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "@types/react-router-dom": "5.x",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
-    "ajv": "^8.11.0",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "6.6.0",
     "cypress": "9.5.x",

--- a/src/utils/resources/instancetype/helper.ts
+++ b/src/utils/resources/instancetype/helper.ts
@@ -6,6 +6,6 @@ import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 export const getInstanceTypeModelFromMatcher = (
   instanceTypeMatcher: V1InstancetypeMatcher,
 ): K8sModel =>
-  instanceTypeMatcher.kind.includes('Cluster')
-    ? VirtualMachineClusterInstancetypeModel
-    : VirtualMachineInstancetypeModel;
+  instanceTypeMatcher?.kind && !instanceTypeMatcher.kind.includes('Cluster')
+    ? VirtualMachineInstancetypeModel
+    : VirtualMachineClusterInstancetypeModel;


### PR DESCRIPTION
## Summary

Backport of #4173 to `release-4.15`.

Adds Hermeto prefetch/offline `npm ci` verification to CI when `package-lock.json` changes.

Replaces the npm-migration lockfile with **synp** conversion from pre-migration `yarn.lock` (`19d7df9c1^`), upgraded to **lockfileVersion 2** for Hermeto.

### Bug fix: `Cannot read properties of undefined (reading 'includes')` in `InstanceTypeDescription`

`getInstanceTypeModelFromMatcher` accessed `instanceTypeMatcher.kind.includes('Cluster')` without guarding against a missing `kind` field. When a VM has an instance type matcher but `kind` is `undefined`, this throws at render time.

Fix: added optional chaining and flipped the condition so that a missing `kind` defaults to `VirtualMachineClusterInstancetypeModel` — the correct fallback since all built-in instance types are cluster-scoped.


<img width="1860" height="879" alt="Screenshot 2026-07-13 at 12 55 18" src="https://github.com/user-attachments/assets/68bdc4b8-f1ff-4baf-be64-cbfb6f6ea0f1" />



## Test plan

* CI build job runs Hermeto prefetch + offline install
* `npm ci` and `npm run build` pass
* `InstanceTypeDescription` no longer crashes when `kind` is undefined on the instance type matcher

Made with Cursor