### PR TITLE
CNV-92722: Fix remaining issues on the Jira ticket

### DIFF
--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -35,6 +35,17 @@ on:
         required: false
         default: ''
         type: string
+      cnv_pin_version:
+        description: |
+          CNV version pinned for this cluster (e.g. 4.20, 4.21, 4.22), as
+          resolved by hot-cluster-e2e.yml's resolve-cluster-config job.
+          Only affects Cypress's TEST_NS/TEST_SECRET_NAME -- see this
+          workflow's TEST_NS/TEST_SECRET_NAME env for why. Leave empty for a
+          standalone dispatch (falls back to the fixed release-4.20-era
+          naming).
+        required: false
+        default: ''
+        type: string
       checkout_ref:
         description: |
           Ref/SHA to check out for the code under test. Leave empty for the
@@ -85,6 +96,17 @@ on:
         default: ''
       cluster_name:
         description: Cluster name for run tagging (defaults to runner_label)
+        type: string
+        required: false
+        default: ''
+      cnv_pin_version:
+        description: |
+          CNV version pinned for this cluster (e.g. 4.20, 4.21, 4.22), as
+          resolved by hot-cluster-e2e.yml's resolve-cluster-config job.
+          Only affects Cypress's TEST_NS/TEST_SECRET_NAME -- see this
+          workflow's TEST_NS/TEST_SECRET_NAME env for why. Leave empty for a
+          standalone dispatch (falls back to the fixed release-4.20-era
+          naming).
         type: string
         required: false
         default: ''
@@ -357,6 +379,39 @@ jobs:
     needs: [check-runner, build-kubevirt-plugin-image]
     runs-on: ${{ inputs.runner_label || 'kubevirt-plugin-ci' }}
     timeout-minutes: 120
+    # Only the fixed-namespace Cypress case (see TEST_NS/TEST_SECRET_NAME
+    # below -- release-4.20, any future/unknown cnv_pin_version, or a bare
+    # standalone dispatch) still shares auto-test-ns/auto-test-secret across
+    # runs, so serialize same-cluster runs of that case rather than let them
+    # clobber each other's namespace mid-run (CNV-92722 finding 6, part B).
+    # release-4.21/4.22 already got a genuine per-run namespace above, so
+    # they fall into the no-op `no-lock-<run_id>` group instead -- a group
+    # that's unique to this run and therefore never queues against anything.
+    # cancel-in-progress: false is deliberate: unlike the PR-vs-PR retest
+    # concurrency group in hot-cluster-e2e.yml (where cancelling a superseded
+    # run is correct), two different PRs sharing a fixed namespace must be
+    # queued one after another, not have one silently killed mid-run.
+    # queue: max is required for that "queued one after another" intent to
+    # actually hold: GitHub's default (queue: single) keeps only a single
+    # pending run per group and CANCELS an older pending run outright the
+    # moment a third one arrives in the same group -- silently defeating
+    # this lock for a 3rd/4th concurrent PR without it (confirmed via
+    # GitHub's own concurrency docs).
+    # inputs.cluster_name falls back to inputs.runner_label, matching
+    # run-gating-tests' own runs-on: above and this workflow's run-name --
+    # a bare cluster_name (e.g. a standalone dispatch that only set
+    # runner_label) must still land in the same group as an automated run
+    # targeting that same physical cluster, or this lock silently no-ops
+    # for exactly the case it's meant to protect.
+    concurrency:
+      group: >-
+        ${{
+          ((inputs.test_engine || 'playwright') == 'cypress' && inputs.cnv_pin_version != '4.21' && inputs.cnv_pin_version != '4.22') &&
+          format('cypress-fixed-ns-{0}', inputs.cluster_name || inputs.runner_label || 'kubevirt-plugin-ci') ||
+          format('no-lock-{0}', github.run_id)
+        }}
+      cancel-in-progress: false
+      queue: max
     env:
       PLUGIN_IMAGE: ${{ needs.build-kubevirt-plugin-image.outputs.kubevirt-plugin-image }}
       HEADLESS: 'true'
@@ -369,19 +424,39 @@ jobs:
       # dynamic per-run values below can't reach on every branch:
       #   - release-4.20's cypress/utils/const/index.ts hardcodes
       #     TEST_NS = 'auto-test-ns' as a literal string -- no mechanism
-      #     to read Cypress.env('TEST_NS') at all (release-4.21/4.22
-      #     already read it dynamically, so this is a no-op override
-      #     for them, not a fix).
+      #     to read Cypress.env('TEST_NS') at all.
       #   - release-4.20's TEST_SECRET_NAME is likewise hardcoded to
       #     'auto-test-secret', matching cypress/fixtures/secret.yaml's
-      #     own hardcoded metadata.name (release-4.21/4.22 already read
-      #     Cypress.env('TEST_SECRET_NAME') dynamically).
+      #     own hardcoded metadata.name.
+      #   - release-4.21/4.22, by contrast, already read both dynamically
+      #     via Cypress.env(...) -- confirmed live during CNV-92722
+      #     validation -- so they get a genuine per-run name below
+      #     instead of the fixed one, removing the cross-PR namespace-
+      #     collision risk entirely for those two (CNV-92722 finding 6):
+      #     two concurrent same-branch PRs on the same cluster no longer
+      #     share auto-test-ns/auto-test-secret and can't clobber each
+      #     other's console mid-run. release-4.20 (and any future/unknown
+      #     pin, including a bare standalone dispatch with no
+      #     cnv_pin_version at all) keeps the fixed fallback name -- see
+      #     the run-gating-tests job-level concurrency block below for
+      #     how that fixed-namespace case is instead serialized rather
+      #     than made collision-proof.
       # CYPRESS_TEST_NS/CYPRESS_TEST_SECRET_NAME are exported from these
       # further down but were never consumed by release-4.20's frozen
       # code -- override both here to match instead. Playwright keeps
       # the dynamic per-run values from the workflow-level env: above.
-      TEST_NS: ${{ (inputs.test_engine || 'playwright') == 'cypress' && 'auto-test-ns' || format('kubevirt-plugin-ci-test-{0}', github.run_id) }}
-      TEST_SECRET_NAME: ${{ (inputs.test_engine || 'playwright') == 'cypress' && 'auto-test-secret' || 'ci-test-secret' }}
+      TEST_NS: >-
+        ${{
+          (inputs.test_engine || 'playwright') != 'cypress' && format('kubevirt-plugin-ci-test-{0}', github.run_id) ||
+          (inputs.cnv_pin_version == '4.21' || inputs.cnv_pin_version == '4.22') && format('auto-test-ns-{0}', github.run_id) ||
+          'auto-test-ns'
+        }}
+      TEST_SECRET_NAME: >-
+        ${{
+          (inputs.test_engine || 'playwright') != 'cypress' && 'ci-test-secret' ||
+          (inputs.cnv_pin_version == '4.21' || inputs.cnv_pin_version == '4.22') && format('auto-test-secret-{0}', github.run_id) ||
+          'auto-test-secret'
+        }}
 
     steps:
       # See the build-kubevirt-plugin-image job's Checkout step above --
@@ -585,7 +660,16 @@ jobs:
           mkdir -p "${TMP}"
 
           HELM_RELEASE="$(oc get configmap "${CI_ENV_CM}" -n "${CI_ENV_NS}" \
-            -o jsonpath='{.data.helm-release}' 2>/dev/null || echo "${CI_ENV_CM}")"
+            -o jsonpath='{.data.helm-release}' 2>/dev/null || true)"
+          # The lookup above only falls back on a hard command failure (get
+          # 403/404) -- an empty-but-present helm-release field (observed
+          # live during PR #4298 attempt 3) succeeds with an empty string,
+          # silently turning the selector below into the invalid literal
+          # "app=-console" and returning zero logs with no error (CNV-92722
+          # finding 8). CI_ENV_CM (the trigger ConfigMap name) is always
+          # populated, so fall back to it explicitly whenever HELM_RELEASE
+          # comes back empty for either reason.
+          HELM_RELEASE="${HELM_RELEASE:-${CI_ENV_CM}}"
 
           oc logs -n "${TEST_NS}" -l "app=${HELM_RELEASE}-console" --tail=-1 \
             > "${TMP}/console.log" 2>&1 || true

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -736,6 +736,12 @@ jobs:
       test_engine: ${{ needs.resolve-cluster-config.outputs.test_engine }}
       runner_label: ${{ inputs.runner_label || needs.resolve-cluster-config.outputs.cluster_name }}
       cluster_name: ${{ needs.resolve-cluster-config.outputs.cluster_name }}
+      # Fed through to hot-cluster-e2e-run.yml so it can tell whether the
+      # Cypress content it's about to run reads TEST_NS/TEST_SECRET_NAME
+      # dynamically (release-4.21/4.22) or still hardcodes them
+      # (release-4.20) -- see that workflow's TEST_NS/TEST_SECRET_NAME env
+      # for the full rationale (CNV-92722 finding 6).
+      cnv_pin_version: ${{ needs.resolve-cluster-config.outputs.cnv_pin_version }}
       # Three cases, in priority order:
       #   1. pr_number set (merge-pool retest path): merge the PR with the
       #      current base tip instead of testing its head commit in
@@ -977,27 +983,27 @@ jobs:
           case "${REASON}" in
             passed)
               echo "conclusion=success" >> "$GITHUB_OUTPUT"
-              echo "title=Hot cluster gating tests passed (retest after main advanced)" >> "$GITHUB_OUTPUT"
+              echo "title=Hot Cluster E2E: gating tests passed (retest after main advanced)" >> "$GITHUB_OUTPUT"
               echo "summary=Re-validated PR #${PR_NUMBER} merged with the current main tip (${MAIN_SHA}) after main advanced (see CNV-92616)." >> "$GITHUB_OUTPUT"
               ;;
             merge-conflict)
               echo "conclusion=failure" >> "$GITHUB_OUTPUT"
-              echo "title=PR no longer merges cleanly with main (retest after main advanced)" >> "$GITHUB_OUTPUT"
+              echo "title=Hot Cluster E2E: PR no longer merges cleanly with main (retest after main advanced)" >> "$GITHUB_OUTPUT"
               echo "summary=PR #${PR_NUMBER} no longer merges cleanly with the current main tip (${MAIN_SHA}) -- resolve the conflict and push an update, which will trigger a normal gating run." >> "$GITHUB_OUTPUT"
               ;;
             left-pool)
               echo "conclusion=failure" >> "$GITHUB_OUTPUT"
-              echo "title=No longer in the merge pool (retest after main advanced)" >> "$GITHUB_OUTPUT"
+              echo "title=Hot Cluster E2E: no longer in the merge pool (retest after main advanced)" >> "$GITHUB_OUTPUT"
               echo "summary=PR #${PR_NUMBER} no longer carries the lgtm+approved (no hold) labels required for the merge pool, re-checked fresh when this retest ran against main tip ${MAIN_SHA} -- the cluster run was skipped." >> "$GITHUB_OUTPUT"
               ;;
             untrusted-retest)
               echo "conclusion=failure" >> "$GITHUB_OUTPUT"
-              echo "title=Not CI-trusted for a retest (retest after main advanced)" >> "$GITHUB_OUTPUT"
+              echo "title=Hot Cluster E2E: not CI-trusted for a retest (retest after main advanced)" >> "$GITHUB_OUTPUT"
               echo "summary=PR #${PR_NUMBER} is not from OWNERS, not from a same-repo branch, and does not currently carry 'ok-to-test' (re-checked fresh when this retest ran against main tip ${MAIN_SHA}) -- the cluster run was skipped. A maintainer can add 'ok-to-test' to allow it." >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "conclusion=failure" >> "$GITHUB_OUTPUT"
-              echo "title=Hot cluster gating tests did not pass (retest after main advanced)" >> "$GITHUB_OUTPUT"
+              echo "title=Hot Cluster E2E: gating tests did not pass (retest after main advanced)" >> "$GITHUB_OUTPUT"
               echo "summary=Re-validated PR #${PR_NUMBER} merged with the current main tip (${MAIN_SHA}) after main advanced (see CNV-92616) -- tests did not pass. See the workflow run for details." >> "$GITHUB_OUTPUT"
               ;;
           esac

--- a/.github/workflows/retest-stale-gating.yml
+++ b/.github/workflows/retest-stale-gating.yml
@@ -110,7 +110,17 @@ jobs:
         env:
           PR_NUMBER: ${{ matrix.pr_number }}
           POOL_PR_NUMBERS: ${{ needs.list-open-prs.outputs.pool_pr_numbers }}
-          STALE_MARKER_TITLE: 'Stale -- main has advanced since this ran'
+          STALE_MARKER_TITLE: 'Hot Cluster E2E: stale -- main has advanced since this ran'
+          # A marker posted by this job *before* the "Hot Cluster E2E: " prefix
+          # was added (CNV-92722 finding 5) still sits, unrefreshed, on any PR
+          # that hasn't gotten a fresh real result since that rollout. Matching
+          # only the current title would make isOwnStaleMarker permanently
+          # false for those, misreading our own queued marker as "a real run
+          # still in flight" (see the `latest.status !== 'completed'` check
+          # below) and freezing it on a stale SHA forever. Recognize both so a
+          # legacy marker still gets refreshed/superseded like normal until it
+          # naturally ages out.
+          STALE_MARKER_TITLE_LEGACY: 'Stale -- main has advanced since this ran'
         with:
           script: |
             const prNumber = Number(process.env.PR_NUMBER);
@@ -140,7 +150,8 @@ jobs:
               return;
             }
 
-            const isOwnStaleMarker = latest.output?.title === process.env.STALE_MARKER_TITLE;
+            const isOwnStaleMarker = latest.output?.title === process.env.STALE_MARKER_TITLE ||
+              latest.output?.title === process.env.STALE_MARKER_TITLE_LEGACY;
             if (latest.status !== 'completed' && !isOwnStaleMarker) {
               core.info(`PR #${prNumber}: check-run ${latest.id} is ${latest.status} from a real run -- leaving it alone.`);
               core.setOutput('should_mark', 'false');
@@ -150,13 +161,27 @@ jobs:
             core.info(`PR #${prNumber}: marking stale (superseding check-run ${latest.id}, isOwnStaleMarker=${isOwnStaleMarker}).`);
             core.setOutput('should_mark', 'true');
 
+      # status: completed/neutral (not queued) is deliberate. publish-gating-
+      # check always creates a brand-new check-run (see its own header
+      # comment on why -- GitHub blocks cross-run status updates), so a
+      # `queued` marker can NEVER be transitioned to any other state by a
+      # later real result -- it just sits there forever looking like an
+      # active, still-pending block, even after a genuinely newer success
+      # posts under the same name. Confirmed live on PR #4268: a marker
+      # queued at 12:22 was still shown as an unresolved "Required" pending
+      # check in the merge box at 13:12, a full hour after a real retest had
+      # already completed successfully. `completed`/`neutral` is a proper
+      # terminal state -- non-passing (so it can't be mistaken for a real
+      # success by a required-status-check gate expecting `success`) but not
+      # eternally "in flight" either.
       - name: Mark check stale
         if: steps.check.outputs.should_mark == 'true'
         uses: ./.github/actions/publish-gating-check
         with:
           head-sha: ${{ steps.check.outputs.head_sha }}
-          status: queued
-          title: 'Stale -- main has advanced since this ran'
+          status: completed
+          conclusion: neutral
+          title: 'Hot Cluster E2E: stale -- main has advanced since this ran'
           summary: ${{ steps.check.outputs.summary }}
 
   # Real retest, merge-pool PRs only. Dispatches hot-cluster-e2e.yml's

--- a/ci-scripts/hot-cluster/arc/arc-runner-rbac.yaml
+++ b/ci-scripts/hot-cluster/arc/arc-runner-rbac.yaml
@@ -81,6 +81,58 @@ rules:
     resources: ['virtualmachines']
     verbs: ['get', 'list', 'watch', 'patch', 'create', 'delete']
 
+  # NOTE on secrets: test-cleanup.sh's `oc delete secret "${TEST_SECRET_NAME}"`
+  # is deliberately NOT granted here as a ClusterRole rule, even a
+  # resourceNames-restricted one -- a get/list/delete on a named secret is
+  # still a credential-exposure risk if it applies cluster-wide (every
+  # namespace has its own 'ci-test-secret'/'auto-test-secret'-named objects
+  # for entirely unrelated purposes). For the one case that genuinely needs
+  # a persistent, non-per-run grant -- the fixed 'auto-test-ns' Cypress
+  # namespace (release-4.20/unknown pin/bare dispatch) -- ci-env-controller.sh's
+  # provision() applies a namespace-scoped Role+RoleBinding directly into
+  # that one namespace instead (see its "Ensure auto-test-ns secret-cleanup
+  # RBAC" step), re-applied fresh on every single run immediately after that
+  # namespace is (re)created, rather than relying on anything from a prior
+  # run surviving. Scoped to just 'auto-test-secret' -- Playwright's
+  # 'ci-test-secret' needs no equivalent here at all: it only ever runs in a
+  # fresh per-run dynamic namespace that already gets its own live
+  # ci-env-test-runner RoleBinding (see below).
+
+  # NOTE on PVCs/VirtualMachineSnapshots/DataVolumes/DataSources/Templates/
+  # net-attach-defs/VM instancetypes&preferences: test-cleanup.sh's delete
+  # calls for these rely ENTIRELY on the per-run, namespace-scoped
+  # ci-env-test-runner RoleBinding (helm/ci-env-controller/templates/
+  # clusterrole-test-runner.yaml, applied per-run by the ci-test-stack Helm
+  # release into the run's own ${TEST_NS}) -- deliberately NOT duplicated
+  # here as an unrestricted cluster-wide ClusterRole grant. An earlier
+  # version of this file added exactly that as a fallback after seeing
+  # Forbidden errors during cleanup live (CNV-92722 finding 7), but the
+  # actual root cause was two concurrent runs sharing the same *fixed*
+  # 'auto-test-ns' namespace (release-4.20's Cypress content still hardcodes
+  # that name) racing each other's Helm install/uninstall of that
+  # RoleBinding -- not a fundamentally missing permission. That race is now
+  # closed by CNV-92722 finding 6's job-level `concurrency:` lock on
+  # run-gating-tests (hot-cluster-e2e-run.yml), which serializes every run
+  # sharing a fixed-namespace cluster end-to-end (provision through
+  # cleanup through release), so a run's own RoleBinding can no longer be
+  # torn down mid-flight by a competing run. Granting this cluster-wide
+  # instead would let the runner SA -- exposed to PR-triggered job steps --
+  # delete these kinds in ANY namespace on the cluster (including shared
+  # golden-image DataSources/Templates), a real blast-radius regression for
+  # an availability-only benefit that the concurrency fix already provides.
+  # If this RoleBinding is ever legitimately unavailable for some other
+  # reason, test-cleanup.sh's `|| true` on every line degrades that specific
+  # delete to a no-op rather than failing the run -- but that's not truly
+  # "harmless": the un-deleted resource is left behind in ${TEST_NS} for
+  # whatever's left of this run (only reclaimed once the namespace itself is
+  # later deleted), and the underlying permissions gap producing the
+  # Forbidden goes unnoticed rather than surfacing anywhere. Unlike the
+  # dedicated auto-test-ns secret-cleanup RBAC above (which retries and
+  # fails provisioning outright rather than silently degrading), there's no
+  # equivalent hard-failure guard for this RoleBinding today -- a genuine,
+  # persistent gap here would need to be diagnosed from leftover test
+  # resources piling up in a run's namespace, not from an explicit error.
+
   # --- E2E test setup: user-settings and feature-flag configmaps in HCO namespace ---
   - apiGroups: ['']
     resources: ['configmaps']

--- a/ci-scripts/hot-cluster/helm/ci-env-controller/scripts/ci-env-controller.sh
+++ b/ci-scripts/hot-cluster/helm/ci-env-controller/scripts/ci-env-controller.sh
@@ -219,6 +219,73 @@ provision() {
   log "Creating namespace ${test_ns}..."
   oc create namespace "${test_ns}" --dry-run=client -o yaml | oc apply -f - || true
 
+  # Namespace-scoped (NOT cluster-wide) fallback so test-cleanup.sh's secret
+  # delete can't be Forbidden in the one namespace that isn't torn down and
+  # recreated by a fresh per-run Helm release each time: the fixed
+  # 'auto-test-ns' Cypress namespace (release-4.20/unknown pin/bare
+  # dispatch -- see hot-cluster-e2e-run.yml's TEST_SECRET_NAME). Applied
+  # directly here (not via the ci-test-stack Helm chart) so it's idempotent
+  # and unowned by any one run's Helm release -- since `oc create namespace`
+  # above recreates this namespace from scratch on every run (deleting
+  # anything that was in it, including these two objects), this step
+  # re-applies them fresh immediately afterward on every single run, rather
+  # than depending on Helm's release-ownership semantics (see
+  # arc-runner-rbac.yaml for the full rationale on why a ClusterRole grant
+  # was rejected in favor of this). Every other test namespace (all
+  # dynamically named, one per run) already gets equivalent secret access
+  # from its own live ci-env-test-runner RoleBinding below, so this is
+  # deliberately scoped to just this one fixed name, not applied
+  # unconditionally.
+  if [[ "${test_ns}" == "auto-test-ns" ]]; then
+    log "Ensuring auto-test-ns secret-cleanup RBAC..."
+    local secret_rbac_applied="false"
+    for attempt in 1 2 3; do
+      if cat <<EOF | oc apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ci-env-secret-cleanup
+  namespace: ${test_ns}
+rules:
+  - apiGroups: ['']
+    resources: ['secrets']
+    verbs: ['get', 'list', 'delete']
+    resourceNames: ['auto-test-secret']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ci-env-secret-cleanup
+  namespace: ${test_ns}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ci-env-secret-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: ${RUNNER_SA_NAME}
+    namespace: ${RUNNER_SA_NS}
+EOF
+      then
+        secret_rbac_applied="true"
+        break
+      fi
+      log "  Retry ${attempt}/3 for auto-test-ns secret-cleanup RBAC apply (API may be transiently unavailable)..."
+      sleep 5
+    done
+    # Not `|| true`: silently swallowing this would let a run's own
+    # test-cleanup.sh Forbidden-fail on the exact secret this exists for,
+    # with nothing surfacing why -- fail the run visibly instead so a
+    # persistent (not transient) problem gets noticed and fixed, rather than
+    # rediscovered live the way the original CNV-92722 finding 7 was.
+    if [[ "${secret_rbac_applied}" != "true" ]]; then
+      local err="failed to apply auto-test-ns secret-cleanup RBAC after 3 attempts"
+      log "ERROR: ${err}"
+      patch_cm "${cm_name}" "{\"data\":{\"status\":\"error\",\"error-message\":\"${err}\"}}"
+      return 1
+    fi
+  fi
+
   # Opt-in only: unset/disabled auth-mode (the default for every existing E2E
   # ConfigMap) skips this block entirely and behaves exactly as before.
   local extra_helm_args=()

--- a/ci-scripts/hot-cluster/test-cleanup.sh
+++ b/ci-scripts/hot-cluster/test-cleanup.sh
@@ -6,6 +6,13 @@
 # left untouched.
 #
 export TEST_NS=${TEST_NS:-${CYPRESS_TEST_NS:-'auto-test-ns'}}
+# Only test-created secrets go here -- NOT --all. The test namespace also
+# holds ci-env-controller's own console/Helm-release secrets (e.g. the
+# console's TLS/session secrets, pull-secret copies), which `delete secret
+# --all` was wiping alongside the test-created one, tearing down the
+# in-flight console mid-run. Confirmed live as a contributing factor in
+# PR #4298 attempt 3's cascading failure (CNV-92722 finding 7).
+export TEST_SECRET_NAME=${TEST_SECRET_NAME:-${CYPRESS_TEST_SECRET_NAME:-'auto-test-secret'}}
 
 oc -n ${TEST_NS} delete vm --all --wait=false || true
 oc -n ${TEST_NS} delete template --all --wait=false || true
@@ -13,7 +20,7 @@ oc -n ${TEST_NS} delete VirtualMachineSnapshot --all --ignore-not-found || true
 oc -n ${TEST_NS} delete datavolume --all --wait=false || true
 oc -n ${TEST_NS} delete datasource --all --wait=false || true
 oc -n ${TEST_NS} delete pvc --all --wait=false || true
-oc -n ${TEST_NS} delete secret --all --ignore-not-found --wait=false || true
+oc -n ${TEST_NS} delete secret "${TEST_SECRET_NAME}" --ignore-not-found --wait=false || true
 oc -n ${TEST_NS} delete net-attach-def --all --ignore-not-found --wait=false || true
 oc -n ${TEST_NS} delete VirtualMachineInstancetype example --ignore-not-found --wait=false || true
 oc -n ${TEST_NS} delete VirtualMachinePreference example --ignore-not-found --wait=false || true


### PR DESCRIPTION
## 📝 Description

Fixes remaining issues in [CNV-92722](https://redhat.atlassian.net/browse/CNV-92722)

## 🔗 Links

Jira ticket: [CNV-92722](https://redhat.atlassian.net/browse/CNV-92722)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved E2E/gating test isolation to prevent concurrent runs from clobbering fixed namespaces and shared secrets.
  * Test cleanup now deletes only the intended secret in the E2E namespace.
  * Updated stale-marker detection so both legacy and new stale check titles are handled correctly.
  * More robust CI diagnostics when deployment fields are present but empty.
* **CI Improvements**
  * Added a configurable pinned CNV version option and passed it through the hot-cluster E2E workflow.
  * Refined retest-related check-run titles/summaries for clearer PR feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->