### PR TITLE
CNV-92439: fix diagnostics tab misleading alert count

### DIFF
--- a/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
+++ b/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
@@ -113,12 +113,16 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
                   id={`horizontal-pageHeader-${item.name}`}
                 >
                   {item.name}
-                  {item.badge?.count > 0 && (
-                    <Badge
-                      className={`horizontal-navbar__badge horizontal-navbar__badge--${item.badge.color}`}
-                    >
-                      {item.badge.count}
-                    </Badge>
+                  {item.badges?.map(
+                    (badge) =>
+                      badge.count > 0 && (
+                        <Badge
+                          className={`horizontal-navbar__badge horizontal-navbar__badge--${badge.color}`}
+                          key={badge.color}
+                        >
+                          {badge.count}
+                        </Badge>
+                      ),
                   )}
                 </NavLink>
               </li>

--- a/src/utils/components/HorizontalNavbar/utils/utils.ts
+++ b/src/utils/components/HorizontalNavbar/utils/utils.ts
@@ -26,7 +26,7 @@ export type TabBadge = {
 };
 
 export type NavPageKubevirt = Omit<NavPage, 'component'> & {
-  badge?: TabBadge;
+  badges?: TabBadge[];
   component: ComponentType<PropsWithChildren<NavPageComponentProps>>;
   isHidden?: boolean;
 };

--- a/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
+++ b/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
@@ -7,7 +7,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 
 import VirtualMachineConfigurationTab from '../tabs/configuration/VirtualMachineConfigurationTab';
 import VirtualMachineConsolePage from '../tabs/console/VirtualMachineConsolePage';
-import { getDiagnosticBadge } from '../tabs/diagnostic/utils/utils';
+import useDiagnosticBadges from '../tabs/diagnostic/hooks/useDiagnosticBadges';
 import VirtualMachineDiagnosticTab from '../tabs/diagnostic/VirtualMachineDiagnosticTab';
 import VirtualMachinePageEventsTab from '../tabs/events/VirtualMachinePageEvents';
 import VirtualMachineMetricsTab from '../tabs/metrics/VirtualMachineMetricsTab';
@@ -20,7 +20,7 @@ export const useVirtualMachineTabs = (vm: V1VirtualMachine) => {
   const { t } = useKubevirtTranslation();
   const { hideYamlTab } = useHideYamlTab();
 
-  const diagnosticBadge = useMemo(() => getDiagnosticBadge(vm), [vm]);
+  const diagnosticBadges = useDiagnosticBadges(vm);
 
   const tabs = useMemo(
     () =>
@@ -90,7 +90,7 @@ export const useVirtualMachineTabs = (vm: V1VirtualMachine) => {
             ...getTabHrefAndName(VirtualMachineDetailsTab.Snapshots, t),
           },
           {
-            badge: diagnosticBadge,
+            badges: diagnosticBadges,
             component: VirtualMachineDiagnosticTab,
             ...getTabHrefAndName(VirtualMachineDetailsTab.Diagnostics, t),
           },
@@ -109,7 +109,7 @@ export const useVirtualMachineTabs = (vm: V1VirtualMachine) => {
         ],
         hideYamlTab,
       ),
-    [t, hideYamlTab, diagnosticBadge],
+    [t, hideYamlTab, diagnosticBadges],
   );
   return tabs;
 };

--- a/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticBadges.ts
+++ b/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticBadges.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+
+import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { TabBadge } from '@kubevirt-utils/components/HorizontalNavbar/utils/utils';
+
+import useDiagnosticCounts from './useDiagnosticCounts';
+import useDiagnosticData from './useDiagnosticData';
+
+const useDiagnosticBadges = (vm: V1VirtualMachine): TabBadge[] => {
+  const diagnosticData = useDiagnosticData(vm);
+  const { severityCounts } = useDiagnosticCounts(diagnosticData);
+
+  return useMemo(() => {
+    const badges: TabBadge[] = [];
+    if (severityCounts.critical > 0) badges.push({ color: 'red', count: severityCounts.critical });
+    if (severityCounts.warnings > 0)
+      badges.push({ color: 'yellow', count: severityCounts.warnings });
+    return badges;
+  }, [severityCounts.critical, severityCounts.warnings]);
+};
+
+export default useDiagnosticBadges;

--- a/src/views/virtualmachines/details/tabs/diagnostic/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/diagnostic/utils/utils.ts
@@ -1,7 +1,5 @@
 import { TFunction } from 'i18next';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { TabBadge } from '@kubevirt-utils/components/HorizontalNavbar/utils/utils';
 import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
 import { LabelProps } from '@patternfly/react-core';
 
@@ -52,24 +50,6 @@ export const getDVSeverity = (phase: string): DiagnosticSeverity => {
 
 export const getSnapshotSeverity = (enabled: boolean): DiagnosticSeverity =>
   enabled ? 'healthy' : 'warning';
-
-export const getDiagnosticBadge = (vm: V1VirtualMachine): TabBadge | undefined => {
-  const conditions = vm?.status?.conditions ?? [];
-  const volumeSnapshotStatuses = vm?.status?.volumeSnapshotStatuses ?? [];
-
-  const conditionSeverities = conditions.map((c) => getConditionSeverity(c.status, c.type));
-  const critical = conditionSeverities.filter((s) => s === 'critical').length;
-  const conditionWarnings = conditionSeverities.filter((s) => s === 'warning').length;
-  const snapshotWarnings = volumeSnapshotStatuses.filter((v) => !v.enabled).length;
-
-  const totalIssues = critical + conditionWarnings + snapshotWarnings;
-  if (totalIssues === 0) return undefined;
-
-  return {
-    color: critical > 0 ? 'red' : 'yellow',
-    count: totalIssues,
-  };
-};
 
 type StatusLabel = { color: LabelProps['color']; text: string };
 


### PR DESCRIPTION

## 📝 Description

splits the Diagnostics tab badge into two separate badges — a red badge for critical alerts and a yellow badge for warning alerts — instead of a single combined count. Also fixes a data source gap where the tab badge was not including `DataVolume` statuses, causing it to show a lower count than the in-tab overview cards.

## 🔗 Links

Jira ticket:https://redhat.atlassian.net/browse/CNV-92439

## 🎥 Demo

Before:
<img width="2060" height="504" alt="image" src="https://github.com/user-attachments/assets/b1730456-e4a8-4d8e-a8e2-0cd683732126" />

After:
<img width="1525" height="661" alt="Screenshot at Jul 13 17-56-00" src="https://github.com/user-attachments/assets/a16f85fe-dc59-4110-b3d9-eb373548eaa9" />
<img width="1473" height="566" alt="Screenshot at Jul 13 17-56-23" src="https://github.com/user-attachments/assets/633b8afc-ab17-42dd-90de-f12799e3c7e1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Virtual machine navigation tabs can now display multiple diagnostic badges simultaneously.
  - Diagnostic tabs show separate counts for critical issues and warnings when applicable.
  - Badge colors clearly distinguish critical issues from warnings.
- **Bug Fixes**
  - Improved diagnostic badge updates so tab indicators accurately reflect the latest virtual machine status and diagnostic counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->