### PR TITLE
[DO NOT MERGE!] CNV-92829: Validating CI is working as expected - Break a Playwright test

### DIFF
--- a/playwright/tests/gating/template-clone.spec.ts
+++ b/playwright/tests/gating/template-clone.spec.ts
@@ -23,7 +23,10 @@ test.describe('Clone template modal', () => {
 
     const sourceTemplateToggle = templatesPage.sourceTemplateToggle;
     await expect(sourceTemplateToggle).toContainText(RHEL9, { timeout: SHORT_TIMEOUT });
-    await expect(sourceTemplateToggle).toBeDisabled();
+    // INTENTIONALLY BROKEN for Hot Cluster CI pipeline validation -- the
+    // toggle is actually disabled; this flips the assertion so the gating
+    // run fails on purpose. Will be fixed in a follow-up commit.
+    await expect(sourceTemplateToggle).toBeEnabled();
 
     await expect(templatesPage.saveButton).toBeEnabled();
 


### PR DESCRIPTION
## 📝 Description

Validating [CNV-92829](https://redhat.atlassian.net/browse/CNV-92829)

## 🔗 Links

Jira ticket: [CNV-92829](https://redhat.atlassian.net/browse/CNV-92829)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated coverage for cloning templates from the actions menu.
  * The validation now detects an incorrect template toggle state and blocks the CI release gate until the issue is resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->