### PR TITLE
[DO NOT MERGE!] CNV-92829: Validate Run Gating Tests fix - break a Playwright test

### DIFF
--- a/.github/actions/hot-cluster/resolve-progress-context/action.yml
+++ b/.github/actions/hot-cluster/resolve-progress-context/action.yml
@@ -3,13 +3,10 @@ description: |
   Computes the head SHA and commit-status context name that every "Hot
   Cluster E2E Progress" posting in this pipeline must agree on, so all
   phase updates (waiting / building / running / done) land on the same
-  commit-status entry. Also reports whether this event is an
-  irrelevant-label no-op (a bot label like lgtm/approved that doesn't
-  represent a real code change) or an ad-hoc dispatch (bare
-  workflow_dispatch, no pr_number) -- callers use is-irrelevant-label to
-  skip posting entirely (the real context's last state stands untouched)
-  and is-adhoc-dispatch to post under a distinct context so it can't
-  collide with a real PR's own status.
+  commit-status entry. Also reports whether this is an ad-hoc dispatch
+  (bare workflow_dispatch, no pr_number) -- callers use is-adhoc-dispatch
+  to post under a distinct context so it can't collide with a real PR's
+  own status.
 
 inputs:
   resolved-head-sha:
@@ -33,9 +30,6 @@ outputs:
   status-context:
     description: Commit-status context name to post under
     value: ${{ steps.resolve.outputs.status_context }}
-  is-irrelevant-label:
-    description: "'true' if this run was triggered by a bot label that doesn't represent a real gating-test outcome"
-    value: ${{ steps.resolve.outputs.is_irrelevant_label }}
   is-adhoc-dispatch:
     description: "'true' if this is a bare workflow_dispatch with no pr_number"
     value: ${{ steps.resolve.outputs.is_adhoc_dispatch }}
@@ -58,15 +52,9 @@ runs:
             ? context.payload.pull_request.head.sha
             : (process.env.RESOLVED_HEAD_SHA || context.sha);
 
-          const isIrrelevantLabel = context.payload.action === 'labeled'
-            && context.payload.label?.name !== 'ok-to-test';
-
           // An ad-hoc dispatch doesn't represent any specific PR -- give it
           // a distinct context so it can't collide with (and obscure, per
           // GitHub's "most recent wins" display) a real PR's own status.
-          // isIrrelevantLabel doesn't need its own context: callers skip
-          // posting entirely for that case, so the real context (below)
-          // simply keeps its last real state.
           const isAdHocDispatch = context.eventName === 'workflow_dispatch' && !process.env.PR_NUMBER;
 
           const statusContext = isAdHocDispatch
@@ -75,5 +63,4 @@ runs:
 
           core.setOutput('head_sha', headSha);
           core.setOutput('status_context', statusContext);
-          core.setOutput('is_irrelevant_label', isIrrelevantLabel ? 'true' : 'false');
           core.setOutput('is_adhoc_dispatch', isAdHocDispatch ? 'true' : 'false');

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -113,10 +113,15 @@ jobs:
   # Resolves cluster config, CI trust, PR context, and progress status as
   # steps of one job (not four) since every top-level job is its own
   # merge-box row. Each step after Checkout has its own always() +
-  # continue-on-error so one failure can't skip the others.
+  # continue-on-error so one failure can't skip the others. Skipped
+  # entirely for an irrelevant-label no-op, same as every job below --
+  # "is this irrelevant" is computable directly from github.event.* here,
+  # without needing anything this job itself would resolve, so there's no
+  # chicken-and-egg problem gating it at this level too. Turns the last
+  # remaining "successful but did nothing" row into a skip as well.
   prepare:
     name: Prepare
-    if: always()
+    if: always() && !(github.event.action == 'labeled' && github.event.label.name != 'ok-to-test')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -143,7 +148,6 @@ jobs:
       # Single source of truth for "Hot Cluster E2E Progress" postings this run.
       progress_head_sha: ${{ steps.resolve-progress.outputs.head-sha }}
       progress_status_context: ${{ steps.resolve-progress.outputs.status-context }}
-      is_irrelevant_label: ${{ steps.resolve-progress.outputs.is-irrelevant-label }}
     steps:
       # No ref override -- checks out the base branch so a PR can't
       # self-approve OWNERS trust.
@@ -194,11 +198,10 @@ jobs:
           resolved-head-sha: ${{ steps.resolve-pr-context.outputs.head-sha }}
           pr-number: ${{ inputs.pr_number }}
 
-      # No posting for the irrelevant-label no-op -- the status simply
-      # keeps its last real state; a differently-named entry here would
-      # just add a permanent extra row to nearly every PR.
+      # Irrelevant-label events never reach this job at all (see if: above)
+      # -- no separate check needed here.
       - name: Post initial progress status (waiting for cluster)
-        if: always() && steps.resolve-progress.outputs.is-irrelevant-label != 'true'
+        if: always()
         uses: ./.github/actions/hot-cluster/post-progress-status
         with:
           head-sha: ${{ steps.resolve-progress.outputs.head-sha }}
@@ -215,7 +218,6 @@ jobs:
       - name: Supersede stale "Run Gating Tests" check for this run
         if: |
           always() &&
-          steps.resolve-progress.outputs.is-irrelevant-label != 'true' &&
           steps.resolve-progress.outputs.head-sha != '' &&
           !(github.event_name == 'workflow_dispatch' && inputs.pr_number == '') &&
           steps.resolve-pr-context.outcome != 'failure' &&
@@ -279,14 +281,8 @@ jobs:
         env:
           HEAD_SHA: ${{ needs.prepare.outputs.progress_head_sha }}
           STATUS_CONTEXT: ${{ needs.prepare.outputs.progress_status_context }}
-          IS_IRRELEVANT_LABEL: ${{ needs.prepare.outputs.is_irrelevant_label }}
         with:
           script: |
-            if (process.env.IS_IRRELEVANT_LABEL === 'true') {
-              core.info('Irrelevant label event — progress status already completed as a no-op.');
-              return;
-            }
-
             const headSha = process.env.HEAD_SHA;
             const statusContext = process.env.STATUS_CONTEXT;
 

--- a/playwright/tests/gating/template-clone.spec.ts
+++ b/playwright/tests/gating/template-clone.spec.ts
@@ -23,7 +23,10 @@ test.describe('Clone template modal', () => {
 
     const sourceTemplateToggle = templatesPage.sourceTemplateToggle;
     await expect(sourceTemplateToggle).toContainText(RHEL9, { timeout: SHORT_TIMEOUT });
-    await expect(sourceTemplateToggle).toBeDisabled();
+    // INTENTIONALLY BROKEN for Hot Cluster CI pipeline validation -- the
+    // toggle is actually disabled; this flips the assertion so the gating
+    // run fails on purpose. Will be fixed in a follow-up commit.
+    await expect(sourceTemplateToggle).toBeEnabled();
 
     await expect(templatesPage.saveButton).toBeEnabled();
 


### PR DESCRIPTION
## 📝 Description

Re-validating the "Run Gating Tests" fix from #4314 (Checkout step + permissions gap) against a real gating-test failure, using the same throwaway breakage from #4313 (now closed).

Expected: "Run Gating Tests" required check should now be published correctly (as a failure) instead of getting stuck at "Expected -- waiting for status to be reported".

Will be closed once validated -- not for merging.

## 🔗 Links

Jira ticket: [CNV-92829](https://redhat.atlassian.net/browse/CNV-92829)

## 🎥 Demo

N/A

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated template cloning validation to confirm the source template option is enabled for RHEL9 templates.
  * Adjusted hot-cluster CI progress reporting and gating to better distinguish ad-hoc runs from normal PR/status updates, and removed irrelevant-label handling from progress-context logic.
  * Refined workflow job/step conditions so progress checks run consistently where intended, without early exits for irrelevant-label scenarios.
* **Tests**
  * Extended end-to-end coverage for hot-cluster CI pipeline validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->