### PR TITLE
CNV-92679: Detect and run Cypress tests for hot-cluster E2E

### DIFF
--- a/.github/actions/hot-cluster/resolve-cypress-env-vars/action.yml
+++ b/.github/actions/hot-cluster/resolve-cypress-env-vars/action.yml
@@ -1,0 +1,49 @@
+name: Resolve Cypress Env Vars
+description: |
+  Thin wrapper around ci-scripts/hot-cluster/resolve-cypress-env-vars.sh --
+  resolves the Cypress TEST_NS/TEST_SECRET_NAME (and whether same-cluster
+  runs must be serialized), whether a test secret fixture exists, and which
+  --spec to run, for a CNV pin version. Assumes the caller has already
+  checked out the repo.
+
+inputs:
+  cnv-pin-version:
+    description: CNV version pinned for this cluster (e.g. 4.20, 4.21, 4.22), empty for unpinned
+    required: false
+    default: ''
+  run-id:
+    description: Unique run identifier used to build a genuinely unique namespace/secret name
+    required: true
+  test-project:
+    description: "'gating' or 'features' -- only affects spec selection on release-4.20 and later"
+    required: false
+    default: 'gating'
+
+outputs:
+  test-ns:
+    description: Resolved Cypress TEST_NS for this run
+    value: ${{ steps.resolve.outputs.test_ns }}
+  test-secret-name:
+    description: Resolved Cypress TEST_SECRET_NAME for this run
+    value: ${{ steps.resolve.outputs.test_secret_name }}
+  needs-lock:
+    description: "'true' if same-cluster Cypress runs of this CNV pin must be serialized (fixed namespace)"
+    value: ${{ steps.resolve.outputs.needs_lock }}
+  needs-secret:
+    description: "'true' if this CNV pin's checked-out content has a cypress/fixtures/secret.yaml to create"
+    value: ${{ steps.resolve.outputs.needs_secret }}
+  spec:
+    description: Resolved --spec value for this CNV pin's checked-out test layout (empty to omit the flag)
+    value: ${{ steps.resolve.outputs.spec }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve TEST_NS/TEST_SECRET_NAME/needs-lock/needs-secret/spec for this CNV pin
+      id: resolve
+      shell: bash
+      env:
+        CNV_PIN_VERSION: ${{ inputs.cnv-pin-version }}
+        RUN_ID: ${{ inputs.run-id }}
+        TEST_PROJECT: ${{ inputs.test-project }}
+      run: ./ci-scripts/hot-cluster/resolve-cypress-env-vars.sh >> "$GITHUB_OUTPUT"

--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -37,9 +37,9 @@ on:
       cnv_pin_version:
         description: |
           CNV version pinned for this cluster (e.g. 4.20, 4.21, 4.22), as
-          resolved by hot-cluster-e2e.yml's prepare job. Only affects
-          Cypress's TEST_NS/TEST_SECRET_NAME (see that env below). Leave
-          empty for a standalone dispatch.
+          resolved by hot-cluster-e2e.yml's prepare job. Fed into the
+          resolve-cypress-env-vars job below. Leave empty for a
+          standalone dispatch.
         required: false
         default: ''
         type: string
@@ -91,9 +91,9 @@ on:
       cnv_pin_version:
         description: |
           CNV version pinned for this cluster (e.g. 4.20, 4.21, 4.22), as
-          resolved by hot-cluster-e2e.yml's prepare job. Only affects
-          Cypress's TEST_NS/TEST_SECRET_NAME (see that env below). Leave
-          empty for a standalone dispatch.
+          resolved by hot-cluster-e2e.yml's prepare job. Fed into the
+          resolve-cypress-env-vars job below. Leave empty for a
+          standalone dispatch.
         type: string
         required: false
         default: ''
@@ -150,6 +150,36 @@ env:
   CI_ENV_CM: ci-env-${{ github.run_id }}
 
 jobs:
+  # Resolves Cypress's TEST_NS/TEST_SECRET_NAME/lock-need for this CNV pin
+  # via a dedicated script (see ci-scripts/hot-cluster/resolve-cypress-
+  # env-vars.sh) instead of inlining version checks directly in
+  # run-gating-tests below. A separate job (not a step of that job) since
+  # concurrency: is evaluated before any step runs and can only read
+  # needs.*.outputs, not step outputs from within the same job.
+  resolve-cypress-env-vars:
+    name: Resolve Cypress Env Vars
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      test_ns: ${{ steps.resolve.outputs.test-ns }}
+      test_secret_name: ${{ steps.resolve.outputs.test-secret-name }}
+      needs_lock: ${{ steps.resolve.outputs.needs-lock }}
+      needs_secret: ${{ steps.resolve.outputs.needs-secret }}
+      spec: ${{ steps.resolve.outputs.spec }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Resolve TEST_NS/TEST_SECRET_NAME/needs-lock/needs-secret/spec for this CNV pin
+        id: resolve
+        uses: ./.github/actions/hot-cluster/resolve-cypress-env-vars
+        with:
+          cnv-pin-version: ${{ inputs.cnv_pin_version }}
+          run-id: ${{ github.run_id }}
+          test-project: ${{ inputs.test_project || 'gating' }}
+
   build-kubevirt-plugin-image:
     name: Build Kubevirt Plugin Image
     runs-on: ubuntu-latest
@@ -213,20 +243,21 @@ jobs:
 
   run-gating-tests:
     name: ${{ inputs.is_reusable_call && 'Execute tests' || 'Execute tests (standalone dispatch)' }}
-    needs: [build-kubevirt-plugin-image]
+    needs: [build-kubevirt-plugin-image, resolve-cypress-env-vars]
     runs-on: ${{ inputs.runner_label || 'kubevirt-plugin-ci' }}
     timeout-minutes: 120
-    # Cypress on release-4.20 (or any unknown cnv_pin_version) still
-    # hardcodes a fixed auto-test-ns/auto-test-secret name, so same-cluster
-    # runs of that case are serialized here instead of made namespace-safe.
-    # release-4.21/4.22 get a genuine per-run namespace (see TEST_NS below)
-    # and fall into the unique no-lock-<run_id> group instead.
-    # cancel-in-progress: false + queue: max queue same-namespace runs one
-    # after another rather than cancelling or dropping a pending one.
+    # Cypress runs whose CNV pin's checked-out content still hardcodes a
+    # fixed auto-test-ns/auto-test-secret name (see resolve-cypress-
+    # env-vars job -- needs_lock) are serialized here instead of made
+    # namespace-safe. Every other run (Playwright, or a CNV pin whose
+    # content reads namespaces dynamically) gets the unique
+    # no-lock-<run_id> group instead. cancel-in-progress: false +
+    # queue: max queue same-namespace runs one after another rather than
+    # cancelling or dropping a pending one.
     concurrency:
       group: >-
         ${{
-          ((inputs.test_engine || 'playwright') == 'cypress' && inputs.cnv_pin_version != '4.21' && inputs.cnv_pin_version != '4.22') &&
+          ((inputs.test_engine || 'playwright') == 'cypress' && needs.resolve-cypress-env-vars.outputs.needs_lock == 'true') &&
           format('cypress-fixed-ns-{0}', inputs.cluster_name || inputs.runner_label || 'kubevirt-plugin-ci') ||
           format('no-lock-{0}', github.run_id)
         }}
@@ -237,22 +268,19 @@ jobs:
       HEADLESS: 'true'
       RUN_FEATURE_TESTS: ${{ inputs.test_project == 'features' && 'true' || 'false' }}
       TEST_ENGINE: ${{ inputs.test_engine || 'playwright' }}
-      # release-4.20's Cypress content hardcodes TEST_NS=auto-test-ns and
-      # TEST_SECRET_NAME=auto-test-secret; release-4.21/4.22 read both
-      # dynamically, so they get a genuine per-run name instead (avoiding
-      # cross-PR collisions on a shared cluster). Playwright always gets a
-      # per-run name.
+      # Cypress's TEST_NS/TEST_SECRET_NAME come from resolve-cypress-
+      # env-vars (see ci-scripts/hot-cluster/resolve-cypress-env-vars.sh
+      # for the fixed-vs-dynamic-per-CNV-pin rule). Playwright always
+      # gets a per-run name.
       TEST_NS: >-
         ${{
           (inputs.test_engine || 'playwright') != 'cypress' && format('kubevirt-plugin-ci-test-{0}', github.run_id) ||
-          (inputs.cnv_pin_version == '4.21' || inputs.cnv_pin_version == '4.22') && format('auto-test-ns-{0}', github.run_id) ||
-          'auto-test-ns'
+          needs.resolve-cypress-env-vars.outputs.test_ns
         }}
       TEST_SECRET_NAME: >-
         ${{
           (inputs.test_engine || 'playwright') != 'cypress' && 'ci-test-secret' ||
-          (inputs.cnv_pin_version == '4.21' || inputs.cnv_pin_version == '4.22') && format('auto-test-secret-{0}', github.run_id) ||
-          'auto-test-secret'
+          needs.resolve-cypress-env-vars.outputs.test_secret_name
         }}
 
     steps:
@@ -407,7 +435,14 @@ jobs:
           # (configmap); Playwright already seeds this client-side.
           user-settings-location: ${{ env.TEST_ENGINE == 'cypress' && 'configmap' || '' }}
 
+      # Playwright always has playwright/fixtures/secret.yaml; Cypress only
+      # has cypress/fixtures/secret.yaml from release-4.19 onward (see
+      # resolve-cypress-env-vars job -- needs_secret). Earlier branches have
+      # no secret fixture or concept in their checked-out Cypress content.
       - name: Create test secret
+        if: |
+          (inputs.test_engine || 'playwright') != 'cypress' ||
+          needs.resolve-cypress-env-vars.outputs.needs_secret == 'true'
         run: |
           yq e '
             .metadata.name = strenv(TEST_SECRET_NAME) |
@@ -489,6 +524,7 @@ jobs:
         env:
           BRIDGE_BASE_ADDRESS: ${{ steps.ci-env.outputs.bridge-base-address }}
           TEST_PROJECT: ${{ inputs.test_project }}
+          CYPRESS_SPEC: ${{ needs.resolve-cypress-env-vars.outputs.spec }}
         run: |
           if [[ "${TEST_ENGINE}" == "cypress" ]]; then
             # Cypress only exposes CYPRESS_-prefixed env vars to Cypress.env(...).
@@ -500,10 +536,14 @@ jobs:
             # release-4.20/4.21's VM patch/stop commands rely on the
             # runner's current oc project, not an explicit -n flag.
             oc project "${TEST_NS}"
-            if [[ "${TEST_PROJECT}" == "features" ]]; then
-              npm run test-cypress-headless -- --spec tests/tier1.cy.ts
+            # CYPRESS_SPEC is resolved per CNV pin (see resolve-cypress-env-
+            # vars job) -- empty on release-4.11-4.17, which have no single
+            # aggregator spec file; omit --spec there and let cypress.json's
+            # default pick up all specs.
+            if [[ -n "${CYPRESS_SPEC}" ]]; then
+              npm run test-cypress-headless -- --spec "${CYPRESS_SPEC}"
             else
-              npm run test-cypress-headless -- --spec tests/gating.cy.ts
+              npm run test-cypress-headless
             fi
           else
             if [[ "${TEST_PROJECT}" == "features" ]]; then

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -193,6 +193,14 @@ See [`hot-cluster/arc/README.md`](hot-cluster/arc/README.md) for ARC-specific de
 - **Test engine**: `release-4.22` and earlier predate the Cypress-to-Playwright migration and still carry a `cypress/` suite; everything else (main, future releases, non-release bases) uses Playwright. An explicit `workflow_dispatch` override always wins over this auto-detection.
 - **CNV channel**: always resolves to the catalog's real `stable` channel (there is no per-version `stable-4.X` channel); version pinning happens via `startingCSV`, not a different channel name.
 
+Separately, `resolve-cypress-env-vars.sh` resolves everything `hot-cluster-e2e-run.yml`'s `run-gating-tests` job needs to run Cypress against a given `cnv_pin_version`'s actual checked-out content, since the `cypress/` layout has changed several times across release branches:
+
+- **Namespace**: CNV pins at or before 4.20 (or unpinned) hardcode `auto-test-ns`/`auto-test-secret` as literal constants rather than reading `Cypress.env(...)`, so those runs get the fixed name and are serialized via a concurrency lock (`needs_lock=true`); 4.21 and later read both dynamically and get a genuine per-run name instead (`needs_lock=false`).
+- **Secret fixture**: `cypress/fixtures/secret.yaml` only exists from 4.19 onward; earlier branches have no secret concept in their Cypress content at all (`needs_secret=false` -- the caller skips creating one).
+- **Spec entrypoint**: the aggregator file differs by era -- 4.11-4.17 have no aggregator (omit `--spec`, let `cypress.json`'s default pick up all `.spec.ts` files), 4.18 has `tests/all.cy.ts`, 4.19 has `tests/gating.cy.ts` with no tier1 split, and 4.20+ have both `tests/gating.cy.ts` and `tests/tier1.cy.ts` (selected via `test_project`).
+
+This mirrors `resolve-cluster-config.sh`'s pattern (script + thin composite-action wrapper) rather than inlining version checks directly in the workflow YAML. Named generically (env vars, not namespace) so another repo with similar per-branch Cypress quirks can adopt the same script/action pattern for whatever env vars it needs to resolve.
+
 ## Check-Run & Retest Model
 
 The hot-cluster pipeline manages its own required check ("Run Gating Tests") and an informational "Hot Cluster E2E Progress" status across several workflows (`hot-cluster-e2e.yml`, `retest-e2e.yml`, `cancel-e2e.yml`, `retest-stale-gating.yml`, `retest-on-pool-entry.yml`) and the `publish-gating-check` action. A few GitHub behaviors drive the design:

--- a/ci-scripts/hot-cluster/resolve-cypress-env-vars.sh
+++ b/ci-scripts/hot-cluster/resolve-cypress-env-vars.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolves everything hot-cluster-e2e-run.yml needs to run Cypress against a
+# given CNV pin version's checked-out content: TEST_NS/TEST_SECRET_NAME (and
+# whether same-cluster runs must be serialized), whether a test secret
+# fixture exists to create, and which --spec to pass. See ci-scripts/
+# README.md ("Cluster & Test-Engine Resolution") for the cluster/test-engine
+# side of this resolution.
+#
+# Every threshold below reflects an actual difference in each CNV pin
+# version's own checked-out cypress/ tree, not a guess:
+#
+# - release-4.20 and any unknown/unpinned CNV version hardcode TEST_NS/
+#   TEST_SECRET_NAME as literal constants (not read from Cypress.env(...)),
+#   so same-cluster runs of that case must share one fixed namespace and are
+#   serialized by the caller's concurrency lock (needs_lock=true).
+#   release-4.21 and later read both dynamically, so they get a genuine
+#   per-run namespace and no lock (needs_lock=false).
+# - cypress/fixtures/secret.yaml only exists from release-4.19 onward;
+#   earlier branches have no secret concept in their Cypress content at all
+#   (needs_secret=false -- the caller should skip creating one).
+# - The Cypress spec entrypoint layout differs by era: release-4.11-4.17
+#   have no aggregator file (plain .spec.ts files -- omit --spec and let
+#   cypress.json's default pick them all up); release-4.18 has
+#   tests/all.cy.ts; release-4.19 has tests/gating.cy.ts with no tier1
+#   split; release-4.20 and later have both tests/gating.cy.ts and
+#   tests/tier1.cy.ts, selected via TEST_PROJECT.
+#
+# Env:
+#   CNV_PIN_VERSION - CNV version pinned for this cluster (e.g. 4.20,
+#                     4.21, 4.22), from hot-cluster-e2e.yml's prepare job.
+#                     Empty for an unpinned/standalone dispatch.
+#   RUN_ID          - Unique run identifier (github.run_id) used to build
+#                     a genuinely unique namespace/secret name.
+#   TEST_PROJECT    - 'gating' or 'features'. Only affects spec selection
+#                     on release-4.20 and later. Defaults to 'gating'.
+#
+# Usage: CNV_PIN_VERSION=4.21 RUN_ID=123 TEST_PROJECT=gating ./ci-scripts/hot-cluster/resolve-cypress-env-vars.sh >> "$GITHUB_OUTPUT"
+
+CNV_PIN_VERSION="${CNV_PIN_VERSION:-}"
+RUN_ID="${RUN_ID:?RUN_ID is required}"
+TEST_PROJECT="${TEST_PROJECT:-gating}"
+
+# 0 for unpinned/garbage input -- falls into the oldest (safest) band for
+# every threshold below.
+VERSION_NUM=0
+if [[ "${CNV_PIN_VERSION}" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
+  VERSION_NUM=$(( 10#${BASH_REMATCH[1]} * 1000 + 10#${BASH_REMATCH[2]} ))
+fi
+
+# First CNV pin version whose checked-out Cypress content reads TEST_NS/
+# TEST_SECRET_NAME dynamically via Cypress.env(...).
+FIRST_DYNAMIC_NS=$(( 4 * 1000 + 21 ))
+
+if (( VERSION_NUM >= FIRST_DYNAMIC_NS )); then
+  TEST_NS="auto-test-ns-${RUN_ID}"
+  TEST_SECRET_NAME="auto-test-secret-${RUN_ID}"
+  NEEDS_LOCK="false"
+  echo "CNV pin '${CNV_PIN_VERSION}' reads Cypress namespaces dynamically -> unique '${TEST_NS}', unlocked" >&2
+else
+  TEST_NS="auto-test-ns"
+  TEST_SECRET_NAME="auto-test-secret"
+  NEEDS_LOCK="true"
+  echo "CNV pin '${CNV_PIN_VERSION:-unpinned}' predates dynamic Cypress namespaces -> fixed '${TEST_NS}', locked" >&2
+fi
+
+# cypress/fixtures/secret.yaml exists from 4.19 onward.
+FIRST_WITH_SECRET=$(( 4 * 1000 + 19 ))
+if (( VERSION_NUM >= FIRST_WITH_SECRET )); then
+  NEEDS_SECRET="true"
+else
+  NEEDS_SECRET="false"
+fi
+
+# Spec entrypoint, oldest to newest checked-out layout.
+FIRST_WITH_ALL_FILE=$(( 4 * 1000 + 18 ))
+FIRST_WITH_GATING_FILE=$(( 4 * 1000 + 19 ))
+FIRST_WITH_TIER1_SPLIT=$(( 4 * 1000 + 20 ))
+
+if (( VERSION_NUM >= FIRST_WITH_TIER1_SPLIT )); then
+  SPEC="tests/gating.cy.ts"
+  [[ "${TEST_PROJECT}" == "features" ]] && SPEC="tests/tier1.cy.ts"
+elif (( VERSION_NUM >= FIRST_WITH_GATING_FILE )); then
+  SPEC="tests/gating.cy.ts"
+elif (( VERSION_NUM >= FIRST_WITH_ALL_FILE )); then
+  SPEC="tests/all.cy.ts"
+else
+  SPEC=""
+fi
+echo "CNV pin '${CNV_PIN_VERSION:-unpinned}' -> needs_secret=${NEEDS_SECRET}, spec='${SPEC:-<none>}'" >&2
+
+echo "test_ns=${TEST_NS}"
+echo "test_secret_name=${TEST_SECRET_NAME}"
+echo "needs_lock=${NEEDS_LOCK}"
+echo "needs_secret=${NEEDS_SECRET}"
+echo "spec=${SPEC}"


### PR DESCRIPTION
## 📝 Description

Detect and run Cypress tests for hot-cluster E2E on release-4.22 and earlier branches

## 🔗 Links

Jira ticket: [CNV-92679](https://redhat.atlassian.net/browse/CNV-92679)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Cypress end-to-end tests now resolve the correct test namespace, secret name, and related gating flags automatically based on the CNV version.
  * Cypress spec selection is now driven by a resolved value, simplifying how the correct tests are executed per run.
  * Older CNV versions continue to use serialized execution to avoid conflicts; newer versions run in isolated per-run environments.
  * Playwright test behavior remains unchanged.

* **Documentation**
  * Updated CI documentation to describe how Cypress environment inputs and spec selection are determined for different CNV versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->