### PR TITLE
CNV-92422: Honor project network settings in VM creation and add-NIC flows

### DIFF
--- a/src/multicluster/components/CrossClusterMigration/components/NetworkMapping.tsx
+++ b/src/multicluster/components/CrossClusterMigration/components/NetworkMapping.tsx
@@ -3,7 +3,7 @@ import React, { FC, useMemo } from 'react';
 import { V1beta1NetworkMap } from '@forklift-ui/types';
 import { NetworkAttachmentDefinitionModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
-import { NetworkAttachmentDefinition } from '@kubevirt-utils/components/NetworkInterfaceModal/components/hooks/types';
+import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind } from '@kubevirt-utils/models';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
@@ -15,7 +15,7 @@ import { getNADNameAndNamespace } from '../utils';
 
 type NetworkMappingProps = {
   changeNetworkMap: UseNetworkReadinessReturnType['changeNetworkMap'];
-  nads: NetworkAttachmentDefinition[];
+  nads: NetworkAttachmentDefinitionKind[];
   networkMap: V1beta1NetworkMap;
 };
 

--- a/src/multicluster/components/CrossClusterMigration/hooks/useNetworkReadiness.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useNetworkReadiness.ts
@@ -3,7 +3,7 @@ import { Updater } from 'use-immer';
 
 import { V1beta1NetworkMap, V1beta1NetworkMapSpecMapDestination } from '@forklift-ui/types';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { NetworkAttachmentDefinition } from '@kubevirt-utils/components/NetworkInterfaceModal/components/hooks/types';
+import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
@@ -21,7 +21,7 @@ export type UseNetworkReadinessReturnType = {
   isReady: boolean;
   loaded: boolean;
   networkMap: V1beta1NetworkMap;
-  targetNADs: NetworkAttachmentDefinition[];
+  targetNADs: NetworkAttachmentDefinitionKind[];
 };
 
 const useNetworkReadiness = (

--- a/src/multicluster/components/CrossClusterMigration/hooks/useProviderNADs.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useProviderNADs.ts
@@ -1,5 +1,5 @@
 import { NetworkAttachmentDefinitionModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { NetworkAttachmentDefinition } from '@kubevirt-utils/components/NetworkInterfaceModal/components/hooks/types';
+import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import {
   DEFAULT_NAMESPACE,
   OPENSHIFT_MULTUS_NS,
@@ -10,7 +10,7 @@ import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
 const useProviderNADs = (targetCluster: string, namespace: string) => {
   const [namespaceNADs, namespaceNADsLoaded, namespaceNADsError] = useK8sWatchData<
-    NetworkAttachmentDefinition[]
+    NetworkAttachmentDefinitionKind[]
   >({
     cluster: targetCluster,
     groupVersionKind: modelToGroupVersionKind(NetworkAttachmentDefinitionModel),
@@ -18,21 +18,21 @@ const useProviderNADs = (targetCluster: string, namespace: string) => {
     namespace,
   });
 
-  const [defaultNADs, defaultNADsLoaded] = useK8sWatchData<NetworkAttachmentDefinition[]>({
+  const [defaultNADs, defaultNADsLoaded] = useK8sWatchData<NetworkAttachmentDefinitionKind[]>({
     cluster: targetCluster,
     groupVersionKind: modelToGroupVersionKind(NetworkAttachmentDefinitionModel),
     isList: true,
     namespace: DEFAULT_NAMESPACE,
   });
 
-  const [multusNADs, multusNADsLoaded] = useK8sWatchData<NetworkAttachmentDefinition[]>({
+  const [multusNADs, multusNADsLoaded] = useK8sWatchData<NetworkAttachmentDefinitionKind[]>({
     cluster: targetCluster,
     groupVersionKind: modelToGroupVersionKind(NetworkAttachmentDefinitionModel),
     isList: true,
     namespace: OPENSHIFT_MULTUS_NS,
   });
 
-  const [sriovNADs, sriovNADsLoaded] = useK8sWatchData<NetworkAttachmentDefinition[]>({
+  const [sriovNADs, sriovNADsLoaded] = useK8sWatchData<NetworkAttachmentDefinitionKind[]>({
     cluster: targetCluster,
     groupVersionKind: modelToGroupVersionKind(NetworkAttachmentDefinitionModel),
     isList: true,

--- a/src/multicluster/components/CrossClusterMigration/utils.ts
+++ b/src/multicluster/components/CrossClusterMigration/utils.ts
@@ -11,7 +11,7 @@ import {
   V1beta1StorageMapSpecMap,
 } from '@forklift-ui/types';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { NetworkAttachmentDefinition } from '@kubevirt-utils/components/NetworkInterfaceModal/components/hooks/types';
+import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import { getName, getNamespace, getUID } from '@kubevirt-utils/resources/shared';
 import { getNetworks, getVolumes } from '@kubevirt-utils/resources/vm';
 import { getRandomChars } from '@kubevirt-utils/utils/utils';
@@ -76,7 +76,7 @@ export const getNADNameAndNamespace = (nad: string, defaultNamespace?: string) =
 
 export const getInitialNetworkMap = (
   vms: V1VirtualMachine[],
-  targetNADs: NetworkAttachmentDefinition[],
+  targetNADs: NetworkAttachmentDefinitionKind[],
 ): V1beta1NetworkMap => {
   const sourceNamespace = getNamespace(vms?.[0]);
   const networks = vms

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/editNetworkSelectUtils.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/editNetworkSelectUtils.tsx
@@ -1,4 +1,5 @@
 import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getNetworks } from '@kubevirt-utils/resources/vm';
 
@@ -9,7 +10,6 @@ import {
   isOvnOverlayNad,
   isPodNetworkName,
 } from '../../utils/helpers';
-import { type NetworkAttachmentDefinition } from '../hooks/types';
 import type {
   FilterNADsForSelectArgs,
   GetSelectTypeaheadKeyArgs,
@@ -17,7 +17,7 @@ import type {
 } from './types';
 
 export const getNadOptionValue = (
-  nad: NetworkAttachmentDefinition,
+  nad: NetworkAttachmentDefinitionKind,
   vmiNamespace: string,
 ): string => {
   const { name, namespace: nadNamespace } = nad.metadata;
@@ -26,7 +26,7 @@ export const getNadOptionValue = (
 };
 
 export const nadMatchesNetworkName = (
-  nad: NetworkAttachmentDefinition,
+  nad: NetworkAttachmentDefinitionKind,
   networkName: string,
   vmiNamespace: string,
 ): boolean => {
@@ -47,7 +47,7 @@ export const nadMatchesNetworkName = (
 
 export const getSelectNetworkName = (
   networkName: string,
-  nads: NetworkAttachmentDefinition[],
+  nads: NetworkAttachmentDefinitionKind[],
   vmiNamespace: string,
 ): string => {
   if (!networkName) {
@@ -75,7 +75,7 @@ export const filterNADsForSelect = ({
   isEditing,
   nads,
   vmiNamespace,
-}: FilterNADsForSelectArgs): NetworkAttachmentDefinition[] =>
+}: FilterNADsForSelectArgs): NetworkAttachmentDefinitionKind[] =>
   nads?.filter((nad) => {
     if (
       isEditing &&
@@ -94,8 +94,9 @@ export const getShowPodNetworkingOption = ({
   hasPodNetwork,
   isEditing,
   isIPv6SingleStack,
+  isPodNetworkAllowed = true,
 }: GetShowPodNetworkingOptionArgs): boolean => {
-  if (isIPv6SingleStack) {
+  if (isIPv6SingleStack || !isPodNetworkAllowed) {
     return false;
   }
 

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/types.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/types.ts
@@ -5,7 +5,7 @@ import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { type SelectTypeaheadOptionProps } from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
 import { type ValidatedOptions } from '@patternfly/react-core';
 
-import { type NetworkAttachmentDefinition } from '../hooks/types';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 
 export type NetworkSelectTypeaheadOptionProps = SelectTypeaheadOptionProps & {
   type: string;
@@ -39,13 +39,14 @@ export type GetShowPodNetworkingOptionArgs = {
   hasPodNetwork: boolean;
   isEditing?: boolean;
   isIPv6SingleStack: boolean;
+  isPodNetworkAllowed?: boolean;
 };
 
 export type FilterNADsForSelectArgs = {
   currentlyUsedNADFullNames: string[];
   editInitValueNetworkName?: string;
   isEditing?: boolean;
-  nads: NetworkAttachmentDefinition[];
+  nads: NetworkAttachmentDefinitionKind[];
   vmiNamespace: string;
 };
 
@@ -67,7 +68,7 @@ export type GetEditingNetworkOptionIfMissingArgs = {
 export type BuildNetworkSelectOptionsArgs = {
   createdNetworkOptions: NetworkSelectTypeaheadOptionProps[];
   editInitValueNetworkName?: string;
-  filteredNADs: NetworkAttachmentDefinition[];
+  filteredNADs: NetworkAttachmentDefinitionKind[];
   isEditing?: boolean;
   podNetworkingText: string;
   podNetworkType: string;

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useEditNetworkSelect.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useEditNetworkSelect.ts
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 
-import { NetworkAttachmentDefinition } from '../hooks/types';
+import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 
 import {
   filterNADsForSelect,
@@ -13,7 +13,7 @@ type UseEditNetworkSelectArgs = {
   editInitValueNetworkName?: string;
   isEditing?: boolean;
   loaded: boolean;
-  nads: NetworkAttachmentDefinition[];
+  nads: NetworkAttachmentDefinitionKind[];
   networkName: string;
   setSubmitDisabled: Dispatch<SetStateAction<boolean>>;
   vmiNamespace: string;

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useNetworkAutoSelect.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useNetworkAutoSelect.ts
@@ -1,5 +1,6 @@
 import { type Dispatch, type SetStateAction, useCallback, useEffect } from 'react';
 
+import { resolveProjectDefaultNetworkSelectValue } from '@kubevirt-utils/resources/namespace/networkDefault';
 import { POD_NETWORK } from '@kubevirt-utils/resources/vm';
 
 import { type NetworkSelectTypeaheadOptionProps } from './types';
@@ -7,6 +8,7 @@ import { type NetworkSelectTypeaheadOptionProps } from './types';
 type UseNetworkAutoSelectArgs = {
   canCreateNetworkInterface: boolean;
   isEditing?: boolean;
+  isPodNetworkAllowed?: boolean;
   loaded: boolean;
   loadError: unknown;
   networkName: string;
@@ -22,6 +24,7 @@ type UseNetworkAutoSelectArgs = {
 export const useNetworkAutoSelect = ({
   canCreateNetworkInterface,
   isEditing,
+  isPodNetworkAllowed = true,
   loaded,
   loadError,
   networkName,
@@ -54,7 +57,10 @@ export const useNetworkAutoSelect = ({
 
     if (loaded && !loadError && !selectedFirstOnLoad) {
       setSelectedFirstOnLoad(true);
-      const networkToPreselect = networkOptions?.[0]?.value;
+      const networkToPreselect = resolveProjectDefaultNetworkSelectValue(
+        isPodNetworkAllowed,
+        networkOptions,
+      );
       if (networkToPreselect) handleChange(networkToPreselect);
       return;
     }
@@ -66,6 +72,7 @@ export const useNetworkAutoSelect = ({
     loadError,
     canCreateNetworkInterface,
     isEditing,
+    isPodNetworkAllowed,
     loaded,
     networkName,
     networkOptions,

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useNetworkInterfaceData.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useNetworkInterfaceData.ts
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 
 import useIsIPv6SingleStackCluster from '@kubevirt-utils/hooks/useIPStackType/useIsIPv6SingleStackCluster';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useProjectNetworkSettings from '@kubevirt-utils/resources/namespace/hooks/useProjectNetworkSettings';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
 import { interfaceTypesProxy } from '@kubevirt-utils/resources/vm/utils/network/constants';
@@ -50,6 +51,10 @@ export default function useNetworkInterfaceData({
   const isIPv6SingleStack = useIsIPv6SingleStackCluster(getCluster(vm));
   const vmiNamespace = getNamespace(vm) ?? namespace;
   const { loaded, loadError, nads, primaryNADs } = useNADsData(vmiNamespace, getCluster(vm));
+  const { isPodNetworkAllowed, loaded: projectNetworkLoaded } = useProjectNetworkSettings({
+    cluster: getCluster(vm),
+    namespaceName: vmiNamespace,
+  });
   const [isNamespaceManagedByUDN] = useNamespaceUDN(vmiNamespace);
   const podNetworkType = isNamespaceManagedByUDN
     ? interfaceTypesProxy.l2bridge
@@ -91,6 +96,7 @@ export default function useNetworkInterfaceData({
     hasPodNetwork,
     isEditing,
     isIPv6SingleStack,
+    isPodNetworkAllowed,
   });
   const canCreateNetworkInterface = filteredNADs?.length > 0 || !hasPodNetwork;
 
@@ -124,7 +130,8 @@ export default function useNetworkInterfaceData({
   const handleChange = useNetworkAutoSelect({
     canCreateNetworkInterface,
     isEditing,
-    loaded,
+    isPodNetworkAllowed,
+    loaded: loaded && projectNetworkLoaded,
     loadError,
     networkName,
     networkOptions,

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/utils.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/utils.tsx
@@ -9,7 +9,7 @@ import { HelperText, HelperTextItem, Label, type SelectOptionProps } from '@patt
 import { InfoIcon } from '@patternfly/react-icons';
 
 import { getNadFullName, getNameAndNs, isNadFullName, isOvnOverlayNad } from '../../utils/helpers';
-import { type NetworkAttachmentDefinition } from '../hooks/types';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import InvalidNADNamespace from './components/InvalidNADNamespace';
 import { type NetworkSelectTypeaheadOptionProps } from './types';
 
@@ -97,8 +97,8 @@ export const buildValidators = ({
   vmiNamespace,
 }: {
   currentlyUsedNADFullNames: string[];
-  nads: NetworkAttachmentDefinition[];
-  primaryNADs: NetworkAttachmentDefinition[];
+  nads: NetworkAttachmentDefinitionKind[];
+  primaryNADs: NetworkAttachmentDefinitionKind[];
   t: TFunction;
   vmiNamespace: string;
 }): ((fullName: string) => ReactNode)[] => {

--- a/src/utils/components/NetworkInterfaceModal/components/hooks/types.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/hooks/types.ts
@@ -1,6 +1,4 @@
-import { NetworkAttachmentDefinitionSpec } from 'src/views/clusteroverview/OverviewTab/inventory-card/utils/types';
-
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 
 export enum ExtraNADNamespaces {
   default = 'default',
@@ -10,16 +8,12 @@ export enum ExtraNADNamespaces {
 
 export type NADListPermissionsMap = { [key in ExtraNADNamespaces]: boolean };
 
-export type NetworkAttachmentDefinition = K8sResourceCommon & {
-  spec: NetworkAttachmentDefinitionSpec;
-};
-
 export type UseNADsData = (
   namespace: string,
   cluster?: string,
 ) => {
   loaded: boolean;
   loadError: string;
-  nads: NetworkAttachmentDefinition[];
-  primaryNADs: NetworkAttachmentDefinition[];
+  nads: NetworkAttachmentDefinitionKind[];
+  primaryNADs: NetworkAttachmentDefinitionKind[];
 };

--- a/src/utils/components/NetworkInterfaceModal/components/hooks/useFetchNADs.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/hooks/useFetchNADs.ts
@@ -2,19 +2,21 @@ import { useMemo } from 'react';
 
 import { GLOBAL_NAD_NAMESPACES } from '@kubevirt-utils/constants/constants';
 import { NetworkAttachmentDefinitionModelGroupVersionKind } from '@kubevirt-utils/models';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-import { NetworkAttachmentDefinition } from './types';
 import useNADListPermissions from './useNADListPermissions';
 import { resources, watchResourceIfAllowed } from './utils';
 
 export const useFetchNADs = (
   namespace: string,
   cluster: string,
-): [data: NetworkAttachmentDefinition[], loaded: boolean, error: any] => {
+  // K8s watch errors are untyped from the Console SDK.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- propagated to useNADsData consumers
+): [data: NetworkAttachmentDefinitionKind[], loaded: boolean, error: any] => {
   const allowMap = useNADListPermissions(cluster);
   const [namespaceData, namespaceLoaded, namespaceLoadError] = useK8sWatchData<
-    NetworkAttachmentDefinition[]
+    NetworkAttachmentDefinitionKind[]
   >(
     watchResourceIfAllowed(
       {
@@ -28,14 +30,16 @@ export const useFetchNADs = (
   );
 
   const [defaultData, defaultLoaded, defaultLoadError] = useK8sWatchData<
-    NetworkAttachmentDefinition[]
+    NetworkAttachmentDefinitionKind[]
   >(watchResourceIfAllowed(resources.default, allowMap.default, cluster));
 
   const [multusData, multusLoaded, multusLoadError] = useK8sWatchData<
-    NetworkAttachmentDefinition[]
+    NetworkAttachmentDefinitionKind[]
   >(watchResourceIfAllowed(resources.OPENSHIFT_MULTUS_NS, allowMap.OPENSHIFT_MULTUS_NS, cluster));
 
-  const [sriovData, sriovLoaded, sriovLoadError] = useK8sWatchData<NetworkAttachmentDefinition[]>(
+  const [sriovData, sriovLoaded, sriovLoadError] = useK8sWatchData<
+    NetworkAttachmentDefinitionKind[]
+  >(
     watchResourceIfAllowed(
       resources.OPENSHIFT_SRIOV_NETWORK_OPERATOR_NS,
       allowMap.OPENSHIFT_SRIOV_NETWORK_OPERATOR_NS,

--- a/src/utils/components/NetworkInterfaceModal/components/hooks/utils.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/hooks/utils.ts
@@ -1,7 +1,7 @@
 import partition from 'lodash/partition';
 
 import { NetworkAttachmentDefinitionModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { NetworkAttachmentDefinition } from '@kubevirt-utils/components/NetworkInterfaceModal/components/hooks/types';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import {
   DEFAULT_NAMESPACE,
   OPENSHIFT_MULTUS_NS,
@@ -32,7 +32,7 @@ export const resources = {
   },
 };
 
-export const filterUDNNads = (nads: NetworkAttachmentDefinition[]) => {
+export const filterUDNNads = (nads: NetworkAttachmentDefinitionKind[]) => {
   const vmAvailableNADs = (nads ?? []).filter(
     (nad) => getName(nad) !== PRIMARY_UDN_KUBEVIRT_BINDING,
   );

--- a/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
+++ b/src/utils/components/NetworkInterfaceModal/utils/helpers.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import {
-  V1Disk,
-  V1Interface,
-  V1Network,
-  V1VirtualMachine,
+  type V1Disk,
+  type V1Interface,
+  type V1Network,
+  type V1VirtualMachine,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import TechPreviewBadge from '@kubevirt-utils/components/TechPreviewBadge/TechPreviewBadge';
-import { NetworkAttachmentDefinitionConfig } from '@kubevirt-utils/resources/nad/types';
+import {
+  type NetworkAttachmentDefinitionConfig,
+  type NetworkAttachmentDefinitionKind,
+} from '@kubevirt-utils/resources/nad/types';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getDisks, getInterface, getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
 import {
@@ -20,7 +23,7 @@ import {
 import {
   interfaceLabelsProxy,
   interfaceTypesProxy,
-  NetworkPresentation,
+  type NetworkPresentation,
 } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import {
   patchVM,
@@ -32,13 +35,10 @@ import {
   hasAutoAttachedPodNetwork,
   isPodNetwork,
 } from '@kubevirt-utils/resources/vm/utils/network/selectors';
-import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
+import { type NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
-import { NetworkAttachmentDefinitionKind } from '@overview/OverviewTab/inventory-card/utils/types';
 import { ABSENT } from '@virtualmachines/details/tabs/configuration/network/utils/constants';
 import { isRunning, isStopped } from '@virtualmachines/utils';
-
-import { NetworkAttachmentDefinition } from '../components/hooks/types';
 
 export const hasExplicitlyDefinedPodNetwork = (vm: V1VirtualMachine): boolean =>
   getNetworks(vm)?.some(isPodNetwork);
@@ -162,9 +162,9 @@ export const prepareNICBootOrder = (vm: V1VirtualMachine): NICBootOrderPreparati
   };
 };
 
-type NADTypes = NetworkAttachmentDefinition | NetworkAttachmentDefinitionKind;
-
-export const parseNADConfig = (nad?: NADTypes): NetworkAttachmentDefinitionConfig | null => {
+export const parseNADConfig = (
+  nad?: NetworkAttachmentDefinitionKind,
+): NetworkAttachmentDefinitionConfig | null => {
   if (!nad?.spec?.config) return null;
 
   try {
@@ -175,18 +175,18 @@ export const parseNADConfig = (nad?: NADTypes): NetworkAttachmentDefinitionConfi
   }
 };
 
-const getRawNadConfigType = (nad: NetworkAttachmentDefinition): string | undefined => {
+const getRawNadConfigType = (nad: NetworkAttachmentDefinitionKind): string | undefined => {
   const config = parseNADConfig(nad);
   //can be config.type or config.plugin first element only!
   return config?.type || config?.plugins?.[0]?.type;
 };
 
-export const getNadType = (nad: NetworkAttachmentDefinition): string => {
+export const getNadType = (nad: NetworkAttachmentDefinitionKind): string => {
   const rawType = getRawNadConfigType(nad);
   return interfaceTypesProxy?.[rawType];
 };
 
-export const getNADRole = (nad: NetworkAttachmentDefinition): string => {
+export const getNADRole = (nad: NetworkAttachmentDefinitionKind): string => {
   const config = parseNADConfig(nad);
   return config?.role;
 };
@@ -194,7 +194,7 @@ export const getNADRole = (nad: NetworkAttachmentDefinition): string => {
 export const getNadFullName = ({ name, namespace }: { name: string; namespace: string }) =>
   `${namespace}/${name}`;
 
-export const getNameAndNs = (nad: NetworkAttachmentDefinition) => ({
+export const getNameAndNs = (nad: NetworkAttachmentDefinitionKind) => ({
   name: getName(nad) ?? '',
   namespace: getNamespace(nad) ?? '',
 });
@@ -202,14 +202,14 @@ export const getNameAndNs = (nad: NetworkAttachmentDefinition) => ({
 export const isNadFullName = (name: string) => name?.split('/').length === 2;
 
 export const isNADUsedInVM = (
-  nad: NetworkAttachmentDefinition,
+  nad: NetworkAttachmentDefinitionKind,
   currentlyUsedNADsNames: string[],
 ): boolean => {
   const nadFullName = getNadFullName(getNameAndNs(nad));
   return currentlyUsedNADsNames.includes(nadFullName);
 };
 
-export const isOvnOverlayNad = (nad: NetworkAttachmentDefinition): boolean => {
+export const isOvnOverlayNad = (nad: NetworkAttachmentDefinitionKind): boolean => {
   const rawType = getRawNadConfigType(nad);
   return rawType === NAD_TYPE_OVN_K8S_CNI_OVERLAY;
 };

--- a/src/utils/resources/nad/types.ts
+++ b/src/utils/resources/nad/types.ts
@@ -1,4 +1,15 @@
+import { K8sResourceKind } from '@openshift-console/dynamic-plugin-sdk';
+
 import { NADTopology } from './constants';
+
+// The config is a JSON object with the NetworkAttachmentDefinitionConfig type stored as a string
+export type NetworkAttachmentDefinitionSpec = {
+  config: string;
+};
+
+export type NetworkAttachmentDefinitionKind = {
+  spec?: NetworkAttachmentDefinitionSpec;
+} & K8sResourceKind;
 
 type IPAMConfig = {
   dataDir?: string;

--- a/src/utils/resources/namespace/constants.ts
+++ b/src/utils/resources/namespace/constants.ts
@@ -1,2 +1,6 @@
 export const SYSTEM_NAMESPACES_PREFIX = ['kube-', 'openshift-', 'kubernetes-'];
 export const SYSTEM_NAMESPACES = ['openshift'];
+
+export const PROJECT_DEFAULT_NETWORK_ANNOTATION = 'kubevirt.io/default-network';
+export const PROJECT_ALLOW_POD_NETWORK_ANNOTATION = 'kubevirt.io/allow-pod-network';
+export const PROJECT_ALLOW_POD_NETWORK_FALSE_VALUE = 'false';

--- a/src/utils/resources/namespace/hooks/useProjectDefaultNad.ts
+++ b/src/utils/resources/namespace/hooks/useProjectDefaultNad.ts
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+
+import { useFetchNADs } from '@kubevirt-utils/components/NetworkInterfaceModal/components/hooks/useFetchNADs';
+import { filterUDNNads } from '@kubevirt-utils/components/NetworkInterfaceModal/components/hooks/utils';
+import { NetworkAttachmentDefinitionModelGroupVersionKind } from '@kubevirt-utils/models';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+
+import useProjectNetworkSettings from './useProjectNetworkSettings';
+
+type UseProjectDefaultNadArgs = {
+  cluster?: string;
+  namespaceName?: string;
+};
+
+type UseProjectDefaultNadReturn = {
+  vmCreationNad?: NetworkAttachmentDefinitionKind;
+};
+
+const useProjectDefaultNad = ({
+  cluster,
+  namespaceName,
+}: UseProjectDefaultNadArgs): UseProjectDefaultNadReturn => {
+  const { defaultNadName, isPodNetworkAllowed } = useProjectNetworkSettings({
+    cluster,
+    namespaceName,
+  });
+
+  const [nads] = useFetchNADs(namespaceName ?? '', cluster);
+
+  const [annotatedNad] = useK8sWatchData<NetworkAttachmentDefinitionKind>(
+    defaultNadName && namespaceName
+      ? {
+          cluster,
+          groupVersionKind: NetworkAttachmentDefinitionModelGroupVersionKind,
+          name: defaultNadName,
+          namespace: namespaceName,
+        }
+      : null,
+  );
+
+  const firstAvailableNad = useMemo((): NetworkAttachmentDefinitionKind | undefined => {
+    const { regular } = filterUDNNads(nads) as {
+      primary: NetworkAttachmentDefinitionKind[];
+      regular: NetworkAttachmentDefinitionKind[];
+    };
+    return regular?.[0];
+  }, [nads]);
+
+  const vmCreationNad = useMemo((): NetworkAttachmentDefinitionKind | undefined => {
+    if (defaultNadName) {
+      return annotatedNad;
+    }
+
+    if (!isPodNetworkAllowed) {
+      return firstAvailableNad;
+    }
+
+    return undefined;
+  }, [annotatedNad, defaultNadName, firstAvailableNad, isPodNetworkAllowed]);
+
+  return {
+    vmCreationNad,
+  };
+};
+
+export default useProjectDefaultNad;

--- a/src/utils/resources/namespace/hooks/useProjectNetworkSettings.ts
+++ b/src/utils/resources/namespace/hooks/useProjectNetworkSettings.ts
@@ -1,0 +1,41 @@
+import { modelToGroupVersionKind, NamespaceModel } from '@kubevirt-utils/models';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+import { getProjectNetworkSettings, type ProjectNetworkSettings } from '../selectors';
+
+type UseProjectNetworkSettingsArgs = {
+  cluster?: string;
+  namespaceName?: string;
+};
+
+type UseProjectNetworkSettingsReturn = ProjectNetworkSettings & {
+  error: unknown;
+  loaded: boolean;
+};
+
+const useProjectNetworkSettings = ({
+  cluster,
+  namespaceName,
+}: UseProjectNetworkSettingsArgs): UseProjectNetworkSettingsReturn => {
+  const [namespace, loaded, error] = useK8sWatchData<K8sResourceCommon>(
+    namespaceName
+      ? {
+          cluster,
+          groupVersionKind: modelToGroupVersionKind(NamespaceModel),
+          name: namespaceName,
+        }
+      : null,
+  );
+
+  const { defaultNadName, isPodNetworkAllowed } = getProjectNetworkSettings(namespace);
+
+  return {
+    defaultNadName,
+    error,
+    isPodNetworkAllowed,
+    loaded,
+  };
+};
+
+export default useProjectNetworkSettings;

--- a/src/utils/resources/namespace/networkDefault.ts
+++ b/src/utils/resources/namespace/networkDefault.ts
@@ -1,0 +1,79 @@
+import { type V1Interface, type V1Network } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  createInterface,
+  createNetwork,
+  getNadType,
+} from '@kubevirt-utils/components/NetworkInterfaceModal/utils/helpers';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
+import { getName } from '@kubevirt-utils/resources/shared';
+import {
+  DEFAULT_NETWORK,
+  DEFAULT_NETWORK_INTERFACE,
+  POD_NETWORK,
+  UDN_BINDING_NAME,
+} from '@kubevirt-utils/resources/vm';
+
+type NetworkSelectOption = {
+  value: string;
+};
+
+export const resolveProjectDefaultNetworkSelectValue = (
+  isPodNetworkAllowed: boolean,
+  networkOptions: NetworkSelectOption[],
+): string | undefined => {
+  if (!networkOptions?.length) {
+    return undefined;
+  }
+
+  if (isPodNetworkAllowed) {
+    const podOption = networkOptions.find((option) => option.value === POD_NETWORK);
+    return podOption?.value ?? networkOptions?.[0]?.value;
+  }
+
+  return (
+    networkOptions.find((option) => option.value !== POD_NETWORK)?.value ??
+    networkOptions?.[0]?.value
+  );
+};
+
+type BuildDefaultNetworkInterfaceArgs = {
+  isUDNManagedNamespace?: boolean;
+  vmCreationNad?: NetworkAttachmentDefinitionKind;
+};
+
+export const buildDefaultNetworkInterface = ({
+  isUDNManagedNamespace,
+  vmCreationNad,
+}: BuildDefaultNetworkInterfaceArgs): V1Interface => {
+  if (isUDNManagedNamespace) {
+    return {
+      binding: { name: UDN_BINDING_NAME },
+      name: DEFAULT_NETWORK_INTERFACE.name,
+    } as V1Interface;
+  }
+
+  if (!vmCreationNad) {
+    return DEFAULT_NETWORK_INTERFACE;
+  }
+
+  return createInterface({
+    interfaceMACAddress: '',
+    interfaceModel: 'virtio',
+    interfaceType: getNadType(vmCreationNad),
+    nicName: DEFAULT_NETWORK_INTERFACE.name,
+  });
+};
+
+type BuildDefaultNetworkArgs = {
+  vmCreationNad?: NetworkAttachmentDefinitionKind;
+};
+
+export const buildDefaultNetwork = ({ vmCreationNad }: BuildDefaultNetworkArgs): V1Network => {
+  if (!vmCreationNad) {
+    return DEFAULT_NETWORK;
+  }
+
+  const vmCreationNadName = getName(vmCreationNad);
+
+  return createNetwork(DEFAULT_NETWORK_INTERFACE.name, vmCreationNadName);
+};

--- a/src/utils/resources/namespace/selectors.ts
+++ b/src/utils/resources/namespace/selectors.ts
@@ -1,0 +1,30 @@
+import { getAnnotation } from '@kubevirt-utils/resources/shared';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+import {
+  PROJECT_ALLOW_POD_NETWORK_ANNOTATION,
+  PROJECT_ALLOW_POD_NETWORK_FALSE_VALUE,
+  PROJECT_DEFAULT_NETWORK_ANNOTATION,
+} from './constants';
+
+export type ProjectNetworkSettings = {
+  defaultNadName?: string;
+  isPodNetworkAllowed: boolean;
+};
+
+const getProjectDefaultNadName = (namespace?: K8sResourceCommon): string | undefined => {
+  const value = getAnnotation(namespace, PROJECT_DEFAULT_NETWORK_ANNOTATION);
+  return value || undefined;
+};
+
+const isPodNetworkAllowed = (namespace?: K8sResourceCommon): boolean => {
+  const value = getAnnotation(namespace, PROJECT_ALLOW_POD_NETWORK_ANNOTATION);
+  return value !== PROJECT_ALLOW_POD_NETWORK_FALSE_VALUE;
+};
+
+export const getProjectNetworkSettings = (
+  namespace?: K8sResourceCommon,
+): ProjectNetworkSettings => ({
+  defaultNadName: getProjectDefaultNadName(namespace),
+  isPodNetworkAllowed: isPodNetworkAllowed(namespace),
+});

--- a/src/utils/resources/udn/hooks/useNamespaceUDN.ts
+++ b/src/utils/resources/udn/hooks/useNamespaceUDN.ts
@@ -5,7 +5,7 @@ import { NetworkAttachmentDefinitionModelGroupVersionKind } from '@kubevirt-util
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
-import { NetworkAttachmentDefinitionKind } from '@overview/OverviewTab/inventory-card/utils/types';
+import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 
 import { NADRole, NADTopology, PrimaryTopologies } from '../../nad/constants';
 

--- a/src/views/clusteroverview/OverviewTab/inventory-card/utils/types.ts
+++ b/src/views/clusteroverview/OverviewTab/inventory-card/utils/types.ts
@@ -7,16 +7,7 @@ import {
   WatchK8sResults,
 } from '@openshift-console/dynamic-plugin-sdk';
 
-import { K8sResourceKind } from '../../../utils/types';
-
-// The config is a JSON object with the NetworkAttachmentDefinitionConfig type stored as a string
-export type NetworkAttachmentDefinitionSpec = {
-  config: string;
-};
-
-export type NetworkAttachmentDefinitionKind = {
-  spec?: NetworkAttachmentDefinitionSpec;
-} & K8sResourceKind;
+import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 
 export type InventoryCardResources = {
   nads: NetworkAttachmentDefinitionKind[];

--- a/src/views/search/components/AdvancedSearchModal/formFields/NetworkAttachmentDefinitionsField.tsx
+++ b/src/views/search/components/AdvancedSearchModal/formFields/NetworkAttachmentDefinitionsField.tsx
@@ -2,7 +2,7 @@ import React, { FC, useMemo } from 'react';
 
 import { NetworkAttachmentDefinitionModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import MultiSelectTypeahead from '@kubevirt-utils/components/MultiSelectTypeahead/MultiSelectTypeahead';
-import { NetworkAttachmentDefinition } from '@kubevirt-utils/components/NetworkInterfaceModal/components/hooks/types';
+import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
@@ -15,7 +15,7 @@ const NetworkAttachmentDefinitionsField: FC = () => {
   const { t } = useKubevirtTranslation();
   const { setValue, value } = useAdvancedSearchField(VirtualMachineRowFilterType.NAD);
 
-  const [allNetworkAttachmentDefinitions] = useK8sWatchResource<NetworkAttachmentDefinition[]>({
+  const [allNetworkAttachmentDefinitions] = useK8sWatchResource<NetworkAttachmentDefinitionKind[]>({
     groupVersionKind: NetworkAttachmentDefinitionModelGroupVersionKind,
     isList: true,
   });

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/Network/Network.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/Network/Network.tsx
@@ -6,7 +6,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
-import { NetworkAttachmentDefinitionKind } from '@overview/OverviewTab/inventory-card/utils/types';
+import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import {
   Alert,
   AlertVariant,

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/types.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/types.ts
@@ -1,8 +1,9 @@
-import { V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
-import { VMWizardFormValues } from '@virtualmachines/wizard/state/vm-wizard-form/types';
+import { type V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
+import { type VMWizardFormValues } from '@virtualmachines/wizard/state/vm-wizard-form/types';
 
 type GenerateVMArgs = {
   cluster?: string;
@@ -17,6 +18,7 @@ type GenerateVMArgs = {
   selectedBootableVolume: BootableVolume;
   selectedInstanceType: { name: string; namespace: string };
   targetNamespace: string;
+  vmCreationNad?: NetworkAttachmentDefinitionKind;
   vmDescription?: string;
   vmName?: string;
 };
@@ -24,37 +26,39 @@ type GenerateVMArgs = {
 export type GenerateVMCallback = (props: GenerateVMArgs) => V1VirtualMachine;
 
 export type GenerateVMSpecConfiguration = {
-  selectedBootableVolume: BootableVolume;
-  dvSource: VMWizardFormValues['instanceTypeData']['dvSource'];
-  pvcSource: VMWizardFormValues['instanceTypeData']['pvcSource'];
   customDiskSize: string;
-  vmName: string;
-  selectedInstanceType: VMWizardFormValues['instanceTypeData']['selectedInstanceType'];
+  dvSource: VMWizardFormValues['instanceTypeData']['dvSource'];
   enableMultiArchBootImageImport: boolean;
   isIPv6SingleStack: boolean;
-  populatedCloudInitYAML: string;
   isUDNManagedNamespace: boolean;
+  populatedCloudInitYAML: string;
+  pvcSource: VMWizardFormValues['instanceTypeData']['pvcSource'];
+  selectedBootableVolume: BootableVolume;
+  selectedInstanceType: VMWizardFormValues['instanceTypeData']['selectedInstanceType'];
+  vmCreationNad?: NetworkAttachmentDefinitionKind;
+  vmName: string;
 };
 
 export type GenerateVMSpecTemplateConfiguration = {
-  isUDNManagedNamespace: boolean;
   enableMultiArchBootImageImport: boolean;
   isIPv6SingleStack: boolean;
   isIso: boolean;
-  vmName: string;
+  isUDNManagedNamespace: boolean;
   populatedCloudInitYAML: string;
-  volumeName: string;
-  selectedPreference: string;
   selectedBootableVolume: BootableVolume;
+  selectedPreference: string;
+  vmCreationNad?: NetworkAttachmentDefinitionKind;
+  vmName: string;
+  volumeName: string;
 };
 
 export type GenerateVMSpecDataVolumeTemplates = {
-  volumeName: string;
-  selectedBootableVolume: BootableVolume;
-  dvSource: Parameters<GenerateVMCallback>[0]['dvSource'];
-  pvcSource: Parameters<GenerateVMCallback>[0]['pvcSource'];
   customDiskSize: string | undefined;
+  dvSource: Parameters<GenerateVMCallback>[0]['dvSource'];
   isIso: boolean;
+  pvcSource: Parameters<GenerateVMCallback>[0]['pvcSource'];
+  selectedBootableVolume: BootableVolume;
   storageClassName: string;
   vmName: string;
+  volumeName: string;
 };

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/useGenerateVM.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/useGenerateVM.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useWatch } from 'react-hook-form';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
   DEFAULT_PREFERENCE_LABEL,
   KUBEVIRT_OS,
@@ -10,6 +10,7 @@ import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import useIsIPv6SingleStackCluster from '@kubevirt-utils/hooks/useIPStackType/useIsIPv6SingleStackCluster';
 import useRHELAutomaticSubscription from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription';
+import useProjectDefaultNad from '@kubevirt-utils/resources/namespace/hooks/useProjectDefaultNad';
 import { getLabel } from '@kubevirt-utils/resources/shared';
 import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
 import { addWinDriverVolume } from '@kubevirt-utils/resources/vm/utils/disk/drivers';
@@ -21,10 +22,12 @@ import {
   CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA,
   CREATE_VM_FORM_FIELDS_VM_DATA,
 } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
+import { type VMWizardFormValues } from '@virtualmachines/wizard/state/vm-wizard-form/types';
 import {
   generateVM,
   isWindowBootableVolume,
 } from '@virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVM';
+
 import { createPopulatedCloudInitYAML } from './utils/generateVM';
 
 export type UseGenerateVM = () => V1VirtualMachine;
@@ -56,12 +59,25 @@ const useGenerateVM: UseGenerateVM = () => {
       CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.PVC_SOURCE,
       CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.SELECTED_INSTANCE_TYPE,
     ],
-  });
+  }) as [
+    VMWizardFormValues['vmData']['cluster'],
+    VMWizardFormValues['vmData']['project'],
+    VMWizardFormValues['instanceTypeData']['selectedBootableVolume'],
+    VMWizardFormValues['vmData']['description'],
+    VMWizardFormValues['vmData']['folder'],
+    VMWizardFormValues['vmData']['name'],
+    VMWizardFormValues['instanceTypeData']['customDiskSize'],
+    VMWizardFormValues['instanceTypeData']['dvSource'],
+    VMWizardFormValues['instanceTypeData']['pvcSource'],
+    VMWizardFormValues['instanceTypeData']['selectedInstanceType'],
+  ];
   const { featureEnabled: autoUpdateEnabled } = useFeatures(AUTOMATIC_UPDATE_FEATURE_NAME);
 
   const { subscriptionData } = useRHELAutomaticSubscription();
 
-  const [isUDNManagedNamespace] = useNamespaceUDN(getValidNamespace(namespace));
+  const validNamespace = getValidNamespace(namespace);
+  const [isUDNManagedNamespace] = useNamespaceUDN(validNamespace);
+  const { vmCreationNad } = useProjectDefaultNad({ cluster, namespaceName: validNamespace });
   const isIPv6SingleStack = useIsIPv6SingleStackCluster(cluster);
   const [hyperConverge] = useHyperConvergeConfiguration();
   const enableMultiArchBootImageImport =
@@ -95,8 +111,9 @@ const useGenerateVM: UseGenerateVM = () => {
       selectedBootableVolume,
       selectedInstanceType,
       targetNamespace: namespace,
+      vmCreationNad,
       vmDescription,
-      vmName: vmName || generatedVMName,
+      vmName: vmName ?? generatedVMName,
     });
   }, [
     cluster,
@@ -108,6 +125,7 @@ const useGenerateVM: UseGenerateVM = () => {
     isIPv6SingleStack,
     isUDNManagedNamespace,
     populatedCloudInitYAML,
+    vmCreationNad,
     pvcSource,
     selectedBootableVolume,
     selectedInstanceType,

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVM.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVM.ts
@@ -28,6 +28,7 @@ export const generateVM: GenerateVMCallback = ({
   isIPv6SingleStack,
   isUDNManagedNamespace,
   populatedCloudInitYAML,
+  vmCreationNad,
   pvcSource,
   selectedBootableVolume,
   selectedInstanceType,
@@ -56,6 +57,7 @@ export const generateVM: GenerateVMCallback = ({
       isIPv6SingleStack,
       populatedCloudInitYAML,
       isUDNManagedNamespace,
+      vmCreationNad,
     }),
   };
 

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVMSpecConfig.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVMSpecConfig.ts
@@ -1,4 +1,4 @@
-import { V1Interface } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
   DEFAULT_INSTANCETYPE_LABEL,
   DEFAULT_PREFERENCE_KIND_LABEL,
@@ -7,17 +7,13 @@ import {
 import { VirtualMachineInstancetypeModel } from '@kubevirt-utils/models';
 import { isBootableVolumeISO } from '@kubevirt-utils/resources/bootableresources/helpers';
 import { getPVCStorageClassName } from '@kubevirt-utils/resources/bootableresources/selectors';
-import { getLabel, getLabels } from '@kubevirt-utils/resources/shared';
 import {
-  DEFAULT_NETWORK_INTERFACE,
-  getDefaultRunningStrategy,
-  UDN_BINDING_NAME,
-} from '@kubevirt-utils/resources/vm';
+  buildDefaultNetwork,
+  buildDefaultNetworkInterface,
+} from '@kubevirt-utils/resources/namespace/networkDefault';
+import { getLabel, getLabels } from '@kubevirt-utils/resources/shared';
+import { getDefaultRunningStrategy } from '@kubevirt-utils/resources/vm';
 import { OS_WINDOWS_PREFIX } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
-import { GenerateVMSpecConfiguration, GenerateVMSpecTemplateConfiguration } from '../types';
-import { getDataVolumeTemplates } from './generateVMSpecTemplateConfig';
-
-import { DEFAULT_NETWORK } from '@kubevirt-utils/resources/vm';
 import { getArchitecture } from '@kubevirt-utils/utils/architecture';
 import {
   HEADLESS_SERVICE_LABEL,
@@ -25,22 +21,31 @@ import {
 } from '@kubevirt-utils/utils/headless-service';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
+import {
+  type GenerateVMSpecConfiguration,
+  type GenerateVMSpecTemplateConfiguration,
+} from '../types';
+
+import { getDataVolumeTemplates } from './generateVMSpecTemplateConfig';
 import { getDomainDisks, getTemplateVolumes } from './templateVolumeAndDisk';
 
+type VMSpecTemplate = NonNullable<NonNullable<V1VirtualMachine['spec']>['template']>;
+type VMSpec = NonNullable<V1VirtualMachine['spec']>;
+
 const getSpecTemplateConfiguration = ({
-  isUDNManagedNamespace,
   enableMultiArchBootImageImport,
   isIPv6SingleStack,
   isIso,
-  vmName,
-  selectedPreference,
+  isUDNManagedNamespace,
   populatedCloudInitYAML,
-  volumeName,
   selectedBootableVolume,
-}: GenerateVMSpecTemplateConfiguration) => {
-  const defaultInterface = isUDNManagedNamespace
-    ? ({ binding: { name: UDN_BINDING_NAME }, name: DEFAULT_NETWORK_INTERFACE.name } as V1Interface)
-    : DEFAULT_NETWORK_INTERFACE;
+  selectedPreference,
+  vmCreationNad,
+  vmName,
+  volumeName,
+}: GenerateVMSpecTemplateConfiguration): VMSpecTemplate => {
+  const defaultInterface = buildDefaultNetworkInterface({ isUDNManagedNamespace, vmCreationNad });
+  const defaultNetwork = buildDefaultNetwork({ vmCreationNad });
 
   const isWindowsVM = selectedPreference?.startsWith(OS_WINDOWS_PREFIX);
 
@@ -66,7 +71,7 @@ const getSpecTemplateConfiguration = ({
           interfaces: isIPv6SingleStack ? [] : [defaultInterface],
         },
       },
-      networks: isIPv6SingleStack ? [] : [DEFAULT_NETWORK],
+      networks: isIPv6SingleStack ? [] : [defaultNetwork],
       subdomain: HEADLESS_SERVICE_NAME,
       volumes: getTemplateVolumes(volumeName, isIso, vmName, isWindowsVM, populatedCloudInitYAML),
     },
@@ -74,17 +79,18 @@ const getSpecTemplateConfiguration = ({
 };
 
 export const getSpecConfiguration = ({
-  selectedBootableVolume,
-  dvSource,
-  pvcSource,
   customDiskSize,
-  vmName,
-  selectedInstanceType,
+  dvSource,
   enableMultiArchBootImageImport,
   isIPv6SingleStack,
-  populatedCloudInitYAML,
   isUDNManagedNamespace,
-}: GenerateVMSpecConfiguration) => {
+  populatedCloudInitYAML,
+  pvcSource,
+  selectedBootableVolume,
+  selectedInstanceType,
+  vmCreationNad,
+  vmName,
+}: GenerateVMSpecConfiguration): VMSpec => {
   const selectedPreference = getLabel(selectedBootableVolume, DEFAULT_PREFERENCE_LABEL);
   const selectPreferenceKind = getLabel(
     selectedBootableVolume,
@@ -97,21 +103,21 @@ export const getSpecConfiguration = ({
 
   return {
     dataVolumeTemplates: getDataVolumeTemplates({
-      volumeName,
-      selectedBootableVolume,
-      dvSource,
-      pvcSource,
       customDiskSize,
+      dvSource,
       isIso,
+      pvcSource,
+      selectedBootableVolume,
       storageClassName,
       vmName,
+      volumeName,
     }),
     instancetype: {
       ...(selectedInstanceType?.namespace && {
         kind: VirtualMachineInstancetypeModel.kind,
       }),
       name:
-        selectedInstanceType?.name ||
+        selectedInstanceType?.name ??
         getLabels(selectedBootableVolume)?.[DEFAULT_INSTANCETYPE_LABEL],
     },
     preference: {
@@ -123,12 +129,13 @@ export const getSpecConfiguration = ({
       enableMultiArchBootImageImport,
       isIPv6SingleStack,
       isIso,
-      vmName,
-      selectedPreference,
+      isUDNManagedNamespace,
       populatedCloudInitYAML,
       selectedBootableVolume,
+      selectedPreference,
+      vmCreationNad,
+      vmName,
       volumeName,
-      isUDNManagedNamespace,
     }),
   };
 };

--- a/src/views/vmnetworks/list/hooks/useOtherVMNetworks.ts
+++ b/src/views/vmnetworks/list/hooks/useOtherVMNetworks.ts
@@ -10,7 +10,7 @@ import {
   UserDefinedNetworkKind,
 } from '@kubevirt-utils/resources/udn/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { NetworkAttachmentDefinitionKind } from '@overview/OverviewTab/inventory-card/utils/types';
+import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 
 import { VALID_OTHER_VM_NETWORK_TYPES } from '../constants';
 import { OtherVMNetwork, OtherVMNetworkWithType } from '../types';

--- a/src/views/vmnetworks/list/types.ts
+++ b/src/views/vmnetworks/list/types.ts
@@ -2,7 +2,7 @@ import {
   ClusterUserDefinedNetworkKind,
   UserDefinedNetworkKind,
 } from '@kubevirt-utils/resources/udn/types';
-import { NetworkAttachmentDefinitionKind } from '@overview/OverviewTab/inventory-card/utils/types';
+import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 
 export enum VMNetworkType {
   INVALID = 'invalid',

--- a/src/views/vmnetworks/list/utils.ts
+++ b/src/views/vmnetworks/list/utils.ts
@@ -14,7 +14,7 @@ import {
   UserDefinedNetworkKind,
 } from '@kubevirt-utils/resources/udn/types';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm';
-import { NetworkAttachmentDefinitionKind } from '@overview/OverviewTab/inventory-card/utils/types';
+import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 
 import { OtherVMNetwork, VMNetworkType } from './types';
 


### PR DESCRIPTION
## Summary

- Add namespace annotation support for per-project network policy via `kubevirt.io/allow-pod-network` and `kubevirt.io/default-network`
- VM creation wizard uses project default NAD when configured; pod network is hidden and first NAD auto-selected when pod networking is disabled
- Add-NIC modal respects `allow-pod-network` for pod visibility and auto-selection
- Consolidate `NetworkAttachmentDefinition` types under `src/utils/resources/nad/types.ts`

## Behavior matrix

| `allow-pod-network` | `default-network` | VM creation | Add NIC |
|---|---|---|---|
| unset | unset | Pod network | Pod auto-selected |
| `false` | unset | First NAD | Pod hidden, first NAD auto-selected |
| unset | set | Configured NAD | Pod auto-selected |
| `false` | set | Configured NAD | Pod hidden, first NAD auto-selected |

## Test plan

- [ ] Create VM in project with no annotations — pod network is used
- [ ] Set `kubevirt.io/default-network` to a NAD name — VM creation uses that NAD
- [ ] Set `kubevirt.io/allow-pod-network: "false"` — pod option hidden in Add NIC modal, first NAD auto-selected
- [ ] Combine both annotations — VM uses configured NAD, pod hidden on Add NIC
- [ ] Verify UDN-managed namespaces still use UDN binding
- [ ] Verify IPv6 single-stack clusters skip network config


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project-level network settings to drive default NAD/network selection and control whether pod networking is allowed.
  * VM creation now uses the selected project default NAD to generate the default network interface and network.
* **Bug Fixes**
  * “Pod networking” option is hidden when disallowed by project settings.
  * Network auto-selection now respects pod-network permissions instead of defaulting to the first option.
  * Improved consistency of NAD handling across migration, VM networking, and search workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->