### PR TITLE
CNV-91407: fix default ssh key not applied in create vm wizard

### DIFF
--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/types.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/types.ts
@@ -16,6 +16,7 @@ type GenerateVMArgs = {
   pvcSource: IoK8sApiCoreV1PersistentVolumeClaim;
   selectedBootableVolume: BootableVolume;
   selectedInstanceType: { name: string; namespace: string };
+  sshSecretName?: string;
   targetNamespace: string;
   vmDescription?: string;
   vmName?: string;

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/useGenerateVM.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/useGenerateVM.ts
@@ -9,6 +9,8 @@ import {
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import useIsIPv6SingleStackCluster from '@kubevirt-utils/hooks/useIPStackType/useIsIPv6SingleStackCluster';
+import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import useRHELAutomaticSubscription from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/useRHELAutomaticSubscription';
 import { getLabel } from '@kubevirt-utils/resources/shared';
 import useNamespaceUDN from '@kubevirt-utils/resources/udn/hooks/useNamespaceUDN';
@@ -81,6 +83,10 @@ const useGenerateVM: UseGenerateVM = () => {
   );
   const generatedVMName = useMemo(() => generatePrettyName(osLabel), [osLabel]);
 
+  const [driversImage] = useDriversImage();
+  const [authorizedSSHKeys] = useKubevirtUserSettings(USER_SETTINGS_KEYS.ssh, cluster);
+  const defaultSSHSecretName = authorizedSSHKeys?.[namespace];
+
   const generatedVM = useMemo(() => {
     return generateVM({
       cluster,
@@ -94,6 +100,7 @@ const useGenerateVM: UseGenerateVM = () => {
       pvcSource,
       selectedBootableVolume,
       selectedInstanceType,
+      sshSecretName: defaultSSHSecretName,
       targetNamespace: namespace,
       vmDescription,
       vmName: vmName || generatedVMName,
@@ -101,6 +108,7 @@ const useGenerateVM: UseGenerateVM = () => {
   }, [
     cluster,
     customDiskSize,
+    defaultSSHSecretName,
     dvSource,
     enableMultiArchBootImageImport,
     folder,
@@ -116,11 +124,8 @@ const useGenerateVM: UseGenerateVM = () => {
     vmName,
   ]);
 
-  const [driversImage] = useDriversImage();
-
   return useMemo(() => {
     const isWindowsOSVolume = isWindowBootableVolume(selectedBootableVolume);
-
     return isWindowsOSVolume ? addWinDriverVolume(generatedVM, driversImage) : generatedVM;
   }, [driversImage, generatedVM, selectedBootableVolume]);
 };

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVM.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVM.ts
@@ -1,5 +1,7 @@
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { DYNAMIC_CREDENTIALS_SUPPORT } from '@kubevirt-utils/components/DynamicSSHKeyInjection/constants/constants';
+import { addSecretToVM } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import { DEFAULT_PREFERENCE_LABEL } from '@kubevirt-utils/constants/instancetypes-and-preferences';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { getLabel } from '@kubevirt-utils/resources/shared';
@@ -31,6 +33,7 @@ export const generateVM: GenerateVMCallback = ({
   pvcSource,
   selectedBootableVolume,
   selectedInstanceType,
+  sshSecretName,
   targetNamespace,
   vmDescription,
   vmName,
@@ -58,6 +61,11 @@ export const generateVM: GenerateVMCallback = ({
       isUDNManagedNamespace,
     }),
   };
+
+  if (sshSecretName) {
+    const isDynamic = getLabel(selectedBootableVolume, DYNAMIC_CREDENTIALS_SUPPORT) === 'true';
+    return addSecretToVM(generatedVM, sshSecretName, isDynamic);
+  }
 
   return generatedVM;
 };

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/hooks/useCreateVMFromTemplate.ts
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/hooks/useCreateVMFromTemplate.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { logTemplateFlowEvent } from '@kubevirt-utils/extensions/telemetry/telemetry';
 import {
@@ -6,6 +7,8 @@ import {
   CUSTOMIZE_VM_FAILED,
 } from '@kubevirt-utils/extensions/telemetry/utils/constants';
 import { logVMCreationFailedFromTemplate } from '@kubevirt-utils/extensions/telemetry/vm-creation';
+import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import { getResourceKey } from '@kubevirt-utils/resources/shared';
 import { customizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
@@ -25,11 +28,12 @@ type UseCreateVMFromTemplate = () => {
 
 const useCreateVMFromTemplate: UseCreateVMFromTemplate = () => {
   const [createError, setCreateError] = useState(undefined);
-  const { getValues, setValue } = useVMWizard();
+  const { control, getValues, setValue } = useVMWizard();
+  const cluster = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER });
+  const [authorizedSSHKeys] = useKubevirtUserSettings(USER_SETTINGS_KEYS.ssh, cluster);
 
   const createVMFromTemplate = async () => {
     const {
-      cluster,
       description,
       folder,
       name: vmName,
@@ -54,6 +58,7 @@ const useCreateVMFromTemplate: UseCreateVMFromTemplate = () => {
         folder,
         namespace,
         selectedTemplate,
+        sshSecretName: authorizedSSHKeys?.[namespace],
         vm,
       });
       setValue(CREATE_VM_FORM_FIELDS_UI_STATE.LAST_PROCESSED_TEMPLATE_KEY, selectedKey);

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/hooks/utils.ts
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/hooks/utils.ts
@@ -1,7 +1,9 @@
 import { produce } from 'immer';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { getName } from '@kubevirt-utils/resources/shared';
+import { DYNAMIC_CREDENTIALS_SUPPORT } from '@kubevirt-utils/components/DynamicSSHKeyInjection/constants/constants';
+import { addSecretToVM } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
+import { getLabel, getName } from '@kubevirt-utils/resources/shared';
 import {
   isVirtualMachineTemplate,
   LABEL_USED_TEMPLATE_NAME,
@@ -49,6 +51,7 @@ export const getVMObjectFromTemplate = ({
   folder,
   namespace,
   selectedTemplate,
+  sshSecretName,
   vm,
   vmName,
 }: {
@@ -56,10 +59,11 @@ export const getVMObjectFromTemplate = ({
   folder: string;
   namespace: string;
   selectedTemplate: null | Template;
+  sshSecretName?: string;
   vm: V1VirtualMachine;
   vmName?: string;
-}) =>
-  produce(vm, (draftVM) => {
+}) => {
+  const generatedVM = produce(vm, (draftVM) => {
     if (!isEmpty(description)) {
       draftVM.metadata.annotations.description = description;
     }
@@ -75,3 +79,11 @@ export const getVMObjectFromTemplate = ({
     draftVM.metadata.namespace = namespace;
     draftVM.spec.runStrategy = getDefaultRunningStrategy();
   });
+
+  if (sshSecretName) {
+    const isDynamic = getLabel(generatedVM, DYNAMIC_CREDENTIALS_SUPPORT) === 'true';
+    return addSecretToVM(generatedVM, sshSecretName, isDynamic);
+  }
+
+  return generatedVM;
+};


### PR DESCRIPTION

## 📝 Description

The new VM creation wizard was missing SSH key handling — default SSH keys configured in user settings were never applied to VMs created via either the instance-type or template flows. This fix integrates the default SSH key directly into the VM definition during generation, with proper detection of dynamic credentials support based on the boot volume label. It also fixes the template flow which was using the wrong hook to resolve the cluster value, causing the user settings lookup to silently fail and adds testing. 

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-91407

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/4f4efdd7-1875-4cc6-a54d-c700a4734996


After:

https://github.com/user-attachments/assets/db562fab-f4cf-4653-b1e4-75cc4753c945




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtual machines created through the wizard or from templates can now automatically use the authorized SSH key secret for the selected namespace.
  * SSH credentials are applied appropriately for workloads supporting dynamic credentials.
* **Bug Fixes**
  * Improved cluster selection handling when creating a virtual machine from a template.
  * Ensured driver information is available consistently during VM generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->