### PR TITLE
CNV-92722: harden cancel-e2e comment posting against transient failures

### DIFF
--- a/.github/workflows/cancel-e2e.yml
+++ b/.github/workflows/cancel-e2e.yml
@@ -179,11 +179,17 @@ jobs:
             const body = wasRunning
               ? '🛑 Cancelled the in-progress Hot Cluster E2E run for this PR -- comment `/retest-e2e` for a fresh result.'
               : 'ℹ️ No Hot Cluster E2E run was in progress for this PR -- nothing to cancel.';
-            await github.rest.issues.createComment({
-              ...context.repo,
-              issue_number: context.issue.number,
-              body,
-            });
+            // Wrapped like react() above -- a transient comment-post failure shouldn't
+            // hard-fail this step and skip the progress-status update that follows.
+            try {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            } catch (err) {
+              core.warning(`Could not comment cancellation outcome: ${err.message || err}`);
+            }
 
       # Only touches the informational progress status, never "Run Gating
       # Tests" -- a cancellation isn't a test result. cluster-check/


### PR DESCRIPTION
## 📝 Description

Fix /cancel-e2e command

## 🔗 Links

Jira ticket: [CNV-92722](https://redhat.atlassian.net/browse/CNV-92722)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow resilience when posting cancellation status comments.
  * Comment-posting failures now generate a warning without causing the workflow step to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->