### PR TITLE
CNV-92722: Fix stale merges - release branches

### DIFF
--- a/.github/actions/hot-cluster/checkout-for-retest/action.yml
+++ b/.github/actions/hot-cluster/checkout-for-retest/action.yml
@@ -2,19 +2,25 @@ name: Checkout for Hot Cluster E2E
 description: |
   Checks out the code under test. For a plain dispatch, behaves like a
   normal checkout (checkout-ref, PR head, or the triggering ref). For a
-  pr_number retest, checks out the current base tip (always fresh --
-  see hot-cluster-e2e.yml) and merges the PR's actual head on top via a
+  pr_number retest, checks out the PR's actual base branch tip -- from
+  checkout-ref (base_ref) when the PR doesn't target main, else
+  github.sha, since hot-cluster-e2e.yml's pr_number dispatches always
+  run against ref: main -- and merges the PR's actual head on top via a
   local git merge, deliberately bypassing GitHub's own
   refs/pull/<N>/merge ref, which is only recomputed reactively and can
-  go stale for an idle PR while main advances.
+  go stale for an idle PR while the base branch advances.
 
 inputs:
   checkout-ref:
-    description: Ref/SHA to check out when not doing a pr_number retest.
+    description: |
+      Ref/SHA to check out. For a pr_number retest, this must be the
+      PR's own base branch (e.g. release-4.22) when it isn't main --
+      github.sha is only correct for a main-targeting PR, since that's
+      the only ref hot-cluster-e2e.yml ever dispatches pr_number against.
     required: false
     default: ''
   pr-number:
-    description: PR number to merge fresh on top of the current base tip.
+    description: PR number to merge fresh on top of the checked-out base tip.
     required: false
     default: ''
 
@@ -24,7 +30,11 @@ runs:
     - name: Checkout
       uses: actions/checkout@v7
       with:
-        ref: ${{ inputs.pr-number == '' && (inputs.checkout-ref || github.event.pull_request.head.sha || github.ref) || github.sha }}
+        ref: >-
+          ${{
+            inputs.pr-number != '' && (inputs.checkout-ref || github.sha) ||
+            inputs.checkout-ref || github.event.pull_request.head.sha || github.ref
+          }}
         fetch-depth: ${{ inputs.pr-number != '' && 0 || 1 }}
         allow-unsafe-pr-checkout: true
         persist-credentials: false


### PR DESCRIPTION
## 📝 Description

Bug: The checkout-for-retest action's checkout step unconditionally used github.sha for any pr-number retest, ignoring checkout-ref (which carries the PR's real base_ref). Since hot-cluster-e2e.yml always dispatches with ref: 'main' (that only selects which version of the workflow file runs, not the branch to test against), github.sha is always main's tip — so a release-branch PR like #4323 (release-4.22) would have been silently tested merged onto main instead of release-4.22.

## 🔗 Links

Jira ticket: [CNV-92722](https://redhat.atlassian.net/browse/CNV-92722)

## 🎥 Demo

N/A