### PR TITLE
CNV-92722: Fix merging latest code

### DIFF
--- a/.github/actions/hot-cluster/checkout-for-retest/action.yml
+++ b/.github/actions/hot-cluster/checkout-for-retest/action.yml
@@ -35,7 +35,7 @@ runs:
             inputs.pr-number != '' && (inputs.checkout-ref || github.sha) ||
             inputs.checkout-ref || github.event.pull_request.head.sha || github.ref
           }}
-        fetch-depth: ${{ inputs.pr-number != '' && 0 || 1 }}
+        fetch-depth: ${{ inputs.pr-number != '' && '0' || '1' }}
         allow-unsafe-pr-checkout: true
         persist-credentials: false
 


### PR DESCRIPTION
## 📝 Description

The fetch-depth: ${{ inputs.pr-number != '' && 0 || 1 }} line is a classic GitHub Actions expression pitfall — this language follows JavaScript-style truthy/falsy rules, and the numeric 0 is falsy. So true && 0 evaluates to 0, and then 0 || 1 falls through to 1 because 0 is falsy — the expression collapses to 1 no matter what the condition is. The job log proved it: fetch-depth: 1 was used even though pr-number was set, so the checkout stayed shallow (single commit), had no shared history with the separately-fetched refs/pull/4322/head, and git merge correctly refused with "unrelated histories".


## 🔗 Links

Jira ticket: [CNV-92722](https://redhat.atlassian.net/browse/CNV-92722)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request retesting by ensuring the complete history is available when needed.
  * Kept shallow checkouts for standard runs, preserving existing performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->