### PR TITLE
CNV-89750: Fix resolve a local uses

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -17,6 +17,11 @@ jobs:
       group: jira-check-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - name: Setup validation scripts
         uses: ./.github/actions/setup-gh-scripts
         with:
@@ -47,6 +52,11 @@ jobs:
       group: ai-config-check-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - name: Setup validation scripts
         uses: ./.github/actions/setup-gh-scripts
         with:

--- a/.github/workflows/pr_validation_commands.yml
+++ b/.github/workflows/pr_validation_commands.yml
@@ -35,6 +35,15 @@ jobs:
             core.setOutput('base_ref', pr.base.ref);
             core.setOutput('head_sha', pr.head.sha);
 
+      # Required to resolve the local setup-gh-scripts action below -- a
+      # uses: ./path reference can't be resolved until the repo is checked
+      # out. No ref override: issue_comment reads this workflow from the
+      # default branch, so the default checkout matches.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
       - name: Setup validation scripts
         uses: ./.github/actions/setup-gh-scripts
         with:


### PR DESCRIPTION
## 📝 Description

Added a bootstrap actions/checkout step (no ref: override — matches the default branch these workflows already read from, so it's a plain, minimal checkout just to make the local action resolvable) before each Setup validation scripts step in all three jobs.

## 🔗 Links

Jira ticket: [CNV-89750](https://redhat.atlassian.net/browse/CNV-89750)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request validation workflows by explicitly checking out repository content before running validation and command checks.
  * Enhanced workflow security by disabling persisted checkout credentials.
  * Preserved existing validation behavior and triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->