### PR TITLE
CNV-92941: Add help and deploy manual steps

### DIFF
--- a/.cursor/OWNERS
+++ b/.cursor/OWNERS
@@ -4,5 +4,6 @@
 approvers:
   - upalatucci
   - metalice
+  - galkremer1
 options:
   no_parent_owners: true

--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -3,5 +3,6 @@
 approvers:
   - upalatucci
   - metalice
+  - galkremer1
 options:
   no_parent_owners: true

--- a/.github/actions/hot-cluster/detect-cluster-infra/action.yml
+++ b/.github/actions/hot-cluster/detect-cluster-infra/action.yml
@@ -1,0 +1,82 @@
+name: Detect Hot Cluster Infrastructure Type
+description: |
+  Best-effort detection of whether a named hot cluster already exists, and
+  if so, its infrastructure type (ipi/vpc/classic) -- adapted from the
+  detection already proven in ibmc-cluster-auto-teardown.yml's own "Check
+  if cluster exists" step. ROKS clusters (vpc/classic) are checked via the
+  IBM Cloud CLI; IPI clusters have no IBM Cloud CLI concept of their own,
+  so they're detected via DNS instead. Used only to pick informational/
+  provisioning defaults -- never a substitute for hot-cluster-check.yml's
+  own readiness probe.
+
+inputs:
+  cluster-name:
+    description: Cluster name to probe
+    required: true
+  ic-api-key:
+    description: |
+      IBM Cloud API key for the ROKS (vpc/classic) check. Composite actions
+      can't read the secrets context directly, so the caller must pass
+      secrets.IC_KEY explicitly (same as IBM/actions-ibmcloud-cli's own
+      api_key: input).
+    required: true
+  ibm-region:
+    description: IBM Cloud region for the CLI setup
+    required: false
+    default: eu-de
+  ibm-resource-group:
+    description: IBM Cloud resource group for the CLI setup
+    required: false
+    default: cnv-ui
+  base-domain:
+    description: Base domain for IPI cluster DNS
+    required: false
+    default: cnv-ui.com
+
+outputs:
+  exists:
+    description: "'true' if a cluster with this name was found (ROKS or IPI)"
+    value: ${{ steps.detect.outputs.exists }}
+  infrastructure-type:
+    description: "'ipi' | 'vpc' | 'classic', empty when exists is 'false'"
+    value: ${{ steps.detect.outputs.infrastructure_type }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup IBM Cloud CLI
+      uses: IBM/actions-ibmcloud-cli@v2
+      with:
+        api_key: ${{ inputs.ic-api-key }}
+        region: ${{ inputs.ibm-region }}
+        group: ${{ inputs.ibm-resource-group }}
+        plugins: kubernetes-service
+
+    - name: Detect cluster existence and infrastructure type
+      id: detect
+      shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster-name }}
+        BASE_DOMAIN: ${{ inputs.base-domain }}
+      run: |
+        INFRA_TYPE=""
+
+        if ibmcloud oc cluster get --cluster "${CLUSTER_NAME}" &>/dev/null; then
+          PROVIDER=$(ibmcloud oc cluster get --cluster "${CLUSTER_NAME}" --output json 2>/dev/null | jq -r '.provider // "classic"')
+          echo "ROKS cluster '${CLUSTER_NAME}' exists (provider: ${PROVIDER})"
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+          if [[ "${PROVIDER}" == "vpc-gen2" ]]; then
+            INFRA_TYPE="vpc"
+          else
+            INFRA_TYPE="classic"
+          fi
+        elif dig +short "api.${CLUSTER_NAME}.${BASE_DOMAIN}" 2>/dev/null | grep -q .; then
+          echo "IPI cluster detected via DNS (api.${CLUSTER_NAME}.${BASE_DOMAIN} resolves)"
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+          INFRA_TYPE="ipi"
+        else
+          echo "No cluster '${CLUSTER_NAME}' found (ROKS or IPI)"
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        echo "infrastructure_type=${INFRA_TYPE}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-gh-scripts/action.yml
+++ b/.github/actions/setup-gh-scripts/action.yml
@@ -13,7 +13,9 @@ runs:
       uses: actions/checkout@v7
       with:
         ref: ${{ inputs.ref }}
-        sparse-checkout: .github/scripts
+        sparse-checkout: |
+          .github/scripts
+          .github/actions/setup-gh-scripts
         persist-credentials: false
 
     - name: Setup Node

--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -1,0 +1,47 @@
+{
+  "_note": "Single source of truth for every PR-comment slash command in this repo, read by pr_help_command.yml (/help). Add an entry here whenever a new PR command is added -- same manual-sync convention as RELATED_AUTOMATION_PATHS in .github/scripts/src/ai-config-validation/constants.ts. trust values: 'owners' = root OWNERS approvers/reviewers; 'ai-config-owners' = the narrower .github/OWNERS (kept in sync with .cursor/OWNERS) approvers gating /ai-approved; 'member-or-owner' = GitHub author_association; 'none' = no trust gate.",
+  "commands": [
+    {
+      "command": "/retest-e2e",
+      "description": "Retest Hot Cluster E2E for this PR, merged with the current base branch tip. Cancels an in-progress run for this PR first, if any.",
+      "trust": "owners",
+      "workflow": ".github/workflows/retest-e2e.yml"
+    },
+    {
+      "command": "/cancel-e2e",
+      "description": "Cancel an in-progress Hot Cluster E2E run for this PR.",
+      "trust": "owners",
+      "workflow": ".github/workflows/cancel-e2e.yml"
+    },
+    {
+      "command": "/deploy-manual-console",
+      "description": "Deploy a manual console + kubevirt-plugin instance for this PR. Cluster name/infra type are auto-resolved from the PR's base branch; the cluster is provisioned automatically if not already up. Credentials are sent to Slack.",
+      "trust": "owners",
+      "workflow": ".github/workflows/deploy-manual-console-command.yml"
+    },
+    {
+      "command": "/recheck-jira",
+      "description": "Re-run Jira ticket validation for this PR.",
+      "trust": "none",
+      "workflow": ".github/workflows/pr_validation_commands.yml"
+    },
+    {
+      "command": "/ai-approved",
+      "description": "Mark AI/editor configuration changes on this PR as security-reviewed.",
+      "trust": "ai-config-owners",
+      "workflow": ".github/workflows/pr_validation_commands.yml"
+    },
+    {
+      "command": "/clone",
+      "description": "Cherry-pick this PR to another release branch once merged.",
+      "trust": "member-or-owner",
+      "workflow": ".github/workflows/jira_clone.yml"
+    },
+    {
+      "command": "/help",
+      "description": "List all available PR commands.",
+      "trust": "none",
+      "workflow": ".github/workflows/pr_help_command.yml"
+    }
+  ]
+}

--- a/.github/scripts/src/commands/index.ts
+++ b/.github/scripts/src/commands/index.ts
@@ -5,7 +5,7 @@ import { AI_CONFIG } from '../ai-config-validation/constants';
 import { addLabel, setCommitStatus } from '../github-comments';
 import { createOctokit } from '../github-repo';
 import { executeJiraValidation } from '../jira-validation/execute';
-import { isListedInOwners } from './owners';
+import { isListedInAiConfigOwners } from './owners';
 import { parseCommand } from './parse-command';
 import { requireEnv, safeErrorMessage } from '../utils';
 import type { GitHubConfig } from '../types/index';
@@ -37,10 +37,16 @@ const approveAiConfig = async (
   commentId: number,
 ): Promise<void> => {
   const octokit = createOctokit(config);
-  const trusted = await isListedInOwners(octokit, config.owner, config.repo, baseBranch, author);
+  const trusted = await isListedInAiConfigOwners(
+    octokit,
+    config.owner,
+    config.repo,
+    baseBranch,
+    author,
+  );
 
   console.log(
-    `${author} is ${trusted ? '' : 'not '}listed in OWNERS — ${trusted ? 'trusted' : 'untrusted, ignoring /ai-approved'}.`,
+    `${author} is ${trusted ? '' : 'not '}listed in .github/OWNERS (AI-config approvers) — ${trusted ? 'trusted' : 'untrusted, ignoring /ai-approved'}.`,
   );
 
   if (!trusted) {

--- a/.github/scripts/src/commands/owners.test.ts
+++ b/.github/scripts/src/commands/owners.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { Octokit } from '@octokit/rest';
+
+import { isListedInAiConfigOwners } from './owners';
+
+const OWNERS_CONTENT = [
+  'approvers:',
+  '  - alice-approver',
+  '  - bob-approver',
+  'options:',
+  '  no_parent_owners: true',
+].join('\n');
+
+const fakeOctokit = (content: string | null): Octokit =>
+  ({
+    repos: {
+      getContent: async () => {
+        if (content === null) {
+          throw new Error('Not Found');
+        }
+        return { data: { content: Buffer.from(content, 'utf8').toString('base64') } };
+      },
+    },
+  }) as unknown as Octokit;
+
+describe('isListedInAiConfigOwners', () => {
+  it('trusts an approver listed in .github/OWNERS', async () => {
+    const trusted = await isListedInAiConfigOwners(
+      fakeOctokit(OWNERS_CONTENT),
+      'kubevirt-ui',
+      'kubevirt-plugin',
+      'main',
+      'alice-approver',
+    );
+    assert.equal(trusted, true);
+  });
+
+  it('does not trust a user not listed in .github/OWNERS', async () => {
+    const trusted = await isListedInAiConfigOwners(
+      fakeOctokit(OWNERS_CONTENT),
+      'kubevirt-ui',
+      'kubevirt-plugin',
+      'main',
+      'random-contributor',
+    );
+    assert.equal(trusted, false);
+  });
+
+  it('does not partially match a username that is a substring of an approver', async () => {
+    const trusted = await isListedInAiConfigOwners(
+      fakeOctokit(OWNERS_CONTENT),
+      'kubevirt-ui',
+      'kubevirt-plugin',
+      'main',
+      'alice',
+    );
+    assert.equal(trusted, false);
+  });
+
+  it('fails closed when .github/OWNERS cannot be read', async () => {
+    const trusted = await isListedInAiConfigOwners(
+      fakeOctokit(null),
+      'kubevirt-ui',
+      'kubevirt-plugin',
+      'main',
+      'alice-approver',
+    );
+    assert.equal(trusted, false);
+  });
+});

--- a/.github/scripts/src/commands/owners.ts
+++ b/.github/scripts/src/commands/owners.ts
@@ -1,7 +1,14 @@
 import type { Octokit } from '@octokit/rest';
 
-/** Return true when the user is listed in OWNERS approvers or reviewers. */
-export const isListedInOwners = async (
+/**
+ * Return true when the user is listed as an approver of .github/OWNERS --
+ * the narrower, security-sensitive OWNERS file (no_parent_owners: true)
+ * that gates AI/editor config changes, not the root OWNERS file. Using the
+ * root OWNERS here would let every general repo approver use /ai-approved,
+ * not just the smaller group trusted for AI-config review (kept in sync
+ * with .cursor/OWNERS, which covers the same path set).
+ */
+export const isListedInAiConfigOwners = async (
   octokit: Octokit,
   owner: string,
   repo: string,
@@ -9,7 +16,7 @@ export const isListedInOwners = async (
   username: string,
 ): Promise<boolean> => {
   try {
-    const { data } = await octokit.repos.getContent({ owner, path: 'OWNERS', ref, repo });
+    const { data } = await octokit.repos.getContent({ owner, path: '.github/OWNERS', ref, repo });
     if (!('content' in data) || typeof data.content !== 'string') {
       return false;
     }

--- a/.github/workflows/deploy-manual-console-command.yml
+++ b/.github/workflows/deploy-manual-console-command.yml
@@ -1,0 +1,196 @@
+name: Deploy Manual Console Command
+run-name: 'Deploy Manual Console Command @ PR#${{ github.event.issue.number }}'
+
+# Lets an OWNERS-listed maintainer comment /deploy-manual-console on a PR to
+# spin up a manual console + kubevirt-plugin instance for it, without having
+# to manually pick cluster_name/infrastructure_type -- both are resolved
+# here from the PR's base branch (and the target cluster's actual state)
+# before dispatching deploy-manual-console.yml. issue_comment only, so this
+# never becomes a PR check -- see ci-scripts/README.md ("Check-Run & Retest
+# Model") for why that matters.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  actions: write
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: deploy-manual-console-cmd-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch Deploy Manual Console
+    if: >
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/deploy-manual-console')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # No ref override: reads OWNERS from the default branch, not the commenter's PR.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # The job-level if: above is a cheap substring prefilter only (avoids
+      # running this job at all for a totally unrelated comment) -- it would
+      # still fire for e.g. "I tested /deploy-manual-console last week" and
+      # trigger a real deploy for a trusted commenter. This step re-checks
+      # with a word-boundary match, and every step below requires it, so a
+      # comment merely mentioning the command in passing is a silent no-op.
+      - name: Match exact command
+        id: match
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const body = context.payload.comment.body || '';
+            const matched = /(^|\s)\/deploy-manual-console(\s|$)/.test(body);
+            core.setOutput('matched', matched ? 'true' : 'false');
+
+      # OWNERS is the single source of truth for trust, same as /retest-e2e
+      # and /cancel-e2e -- no ok-to-test escape hatch, matching
+      # deploy-manual-console.yml's own resolve-pr trust model for the PR
+      # author. That check still applies independently once pr_number is
+      # forwarded below -- this only gates who can trigger the dispatch.
+      - name: Check trusted commenter
+        id: check-trust
+        if: steps.match.outputs.matched == 'true'
+        uses: ./.github/actions/hot-cluster/check-trust
+        with:
+          author: ${{ github.event.comment.user.login }}
+
+      - name: Reject untrusted commenter
+        if: steps.match.outputs.matched == 'true' && steps.check-trust.outputs.trusted != 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const author = context.payload.comment.user.login;
+            await github.rest.reactions.createForIssueComment({
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              content: '-1',
+            }).catch((err) => core.warning(`Could not react: ${err.message || err}`));
+            core.setFailed(`${author} is not authorized to use /deploy-manual-console`);
+
+      - name: Resolve PR context
+        id: pr
+        if: steps.match.outputs.matched == 'true' && steps.check-trust.outputs.trusted == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('number', String(pr.number));
+            core.setOutput('base_ref', pr.base.ref);
+
+      # Same resolution every other hot-cluster workflow uses, so the
+      # deployed cluster always matches this PR's actual base branch
+      # (kubevirt-plugin-ci for main, kubevirt-plugin-MM for release-4.M).
+      - name: Resolve cluster config
+        id: resolve-config
+        if: steps.match.outputs.matched == 'true' && steps.check-trust.outputs.trusted == 'true'
+        uses: ./.github/actions/hot-cluster/resolve-cluster-config
+        with:
+          base-ref: ${{ steps.pr.outputs.base_ref }}
+
+      # Best-effort: continue-on-error so a probe failure (e.g. IBM Cloud
+      # API hiccup) doesn't block the dispatch -- the fallback below covers
+      # both a genuine "not found" and a failed probe the same way. Fine
+      # while every hot cluster today is ipi; would need to distinguish
+      # "probe failed" from "genuinely not found" if a vpc/classic cluster
+      # is ever provisioned under one of these names.
+      - name: Detect target cluster infrastructure type
+        id: detect-infra
+        if: steps.match.outputs.matched == 'true' && steps.check-trust.outputs.trusted == 'true'
+        continue-on-error: true
+        uses: ./.github/actions/hot-cluster/detect-cluster-infra
+        with:
+          cluster-name: ${{ steps.resolve-config.outputs.cluster-name }}
+          ic-api-key: ${{ secrets.IC_KEY }}
+
+      - name: Dispatch deploy-manual-console.yml
+        id: dispatch
+        if: steps.match.outputs.matched == 'true' && steps.check-trust.outputs.trusted == 'true'
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          CLUSTER_NAME: ${{ steps.resolve-config.outputs.cluster-name }}
+          INFRA_TYPE: ${{ steps.detect-infra.outputs.infrastructure-type }}
+          DETECT_OUTCOME: ${{ steps.detect-infra.outcome }}
+          OPENSHIFT_VERSION: ${{ steps.resolve-config.outputs.openshift-version }}
+          CNV_CHANNEL: ${{ steps.resolve-config.outputs.cnv-channel }}
+          CNV_PIN_VERSION: ${{ steps.resolve-config.outputs.cnv-pin-version }}
+        with:
+          script: |
+            const clusterName = process.env.CLUSTER_NAME;
+            // detect-cluster-infra is best-effort -- an empty result (probe
+            // failed, or the cluster doesn't exist yet) falls back to
+            // 'ipi', the default for every hot cluster provisioned today.
+            // Logged distinctly so a probe failure (vs. a clean "not found")
+            // is visible in the run log for debugging.
+            if (process.env.DETECT_OUTCOME === 'failure') {
+              core.warning(`Cluster infra detection for '${clusterName}' failed -- falling back to 'ipi'.`);
+            }
+            const infraType = process.env.INFRA_TYPE || 'ipi';
+
+            await github.rest.actions.createWorkflowDispatch({
+              ...context.repo,
+              workflow_id: 'deploy-manual-console.yml',
+              ref: 'main',
+              inputs: {
+                pr_number: process.env.PR_NUMBER,
+                // Ignored for plugin source (pr_number takes priority) --
+                // only used here so cluster-check's provisioning Slack
+                // notification, if it fires, reports the PR's real base
+                // branch instead of always saying "main".
+                branch: process.env.BASE_REF,
+                cluster_name: clusterName,
+                infrastructure_type: infraType,
+                openshift_version: process.env.OPENSHIFT_VERSION,
+                cnv_channel: process.env.CNV_CHANNEL,
+                cnv_pin_version: process.env.CNV_PIN_VERSION,
+              },
+            });
+
+            core.info(`Dispatched deploy-manual-console.yml for PR #${process.env.PR_NUMBER} (cluster=${clusterName}, infra=${infraType}).`);
+            core.setOutput('cluster_name', clusterName);
+            core.setOutput('infra_type', infraType);
+
+      # Credentials are never posted here -- deploy-manual-console.yml's own
+      # existing step still delivers them to Slack only, unchanged.
+      - name: React and comment on the PR
+        if: steps.match.outputs.matched == 'true' && steps.check-trust.outputs.trusted == 'true'
+        uses: actions/github-script@v9
+        env:
+          CLUSTER_NAME: ${{ steps.dispatch.outputs.cluster_name }}
+          INFRA_TYPE: ${{ steps.dispatch.outputs.infra_type }}
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            }).catch((err) => core.warning(`Could not react: ${err.message || err}`));
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/deploy-manual-console.yml`;
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: [
+                `🚀 Dispatched a manual console deploy for this PR (cluster \`${process.env.CLUSTER_NAME}\`, infrastructure \`${process.env.INFRA_TYPE}\`).`,
+                '',
+                "If that cluster isn't already up, it will be provisioned first, which can take a while -- check the Actions run for progress.",
+                'Login credentials will be sent to Slack once the console is ready.',
+                '',
+                `If the PR author isn't listed in OWNERS, this dispatch will fail at its own trust check -- see the [Actions tab](${runUrl}) if nothing shows up.`,
+              ].join('\n'),
+            });

--- a/.github/workflows/deploy-manual-console.yml
+++ b/.github/workflows/deploy-manual-console.yml
@@ -6,8 +6,11 @@ run-name: "Deploy Manual Console [${{ inputs.cluster_name }}] @ ${{ inputs.pr_nu
 # path: it builds its own in-cluster plugin image, uses its own trigger
 # ConfigMap/action, and does not touch the CNV-managed console, HCO, or SSP.
 #
-# Prerequisites: the target cluster must already be provisioned via
-# "IBM Cloud Hot Cluster Setup" (ibmc-cluster-setup.yml).
+# cluster-check below provisions the target cluster via "IBM Cloud Hot
+# Cluster Setup" (ibmc-cluster-setup.yml) if it isn't already up -- without
+# that, dispatching against a cluster with no matching ARC runner would
+# leave the deploy job hanging until its own timeout instead of failing
+# fast or self-provisioning.
 #
 # Dispatch ref matters: the dispatch branch/ref (github.ref) is what gets
 # checked out for CI scripts, separately from "branch"/pr_number below,
@@ -32,12 +35,12 @@ on:
         default: ''
         type: string
       cluster_name:
-        description: ARC runner label / hot cluster name (must already be provisioned)
+        description: ARC runner label / hot cluster name (provisioned automatically if not already up)
         required: true
         default: kubevirt-plugin-ci
         type: string
       infrastructure_type:
-        description: Infrastructure type of the target cluster (informational only)
+        description: Infrastructure type of the target cluster (used to provision if not already up)
         required: false
         default: ipi
         type: choice
@@ -45,6 +48,24 @@ on:
           - ipi
           - vpc
           - classic
+      openshift_version:
+        description: 'OpenShift version to provision if the cluster is not already up (e.g. 4.22_openshift)'
+        required: false
+        default: '4.22_openshift'
+        type: string
+      cnv_channel:
+        description: CNV OLM subscription channel to install if the cluster is not already up
+        required: false
+        default: stable
+        type: string
+      cnv_pin_version:
+        description: |
+          "<major>.<minor>" to pin CNV to if the cluster is not already up
+          (e.g. for a release branch under test). Leave empty to install
+          whatever cnv_channel currently resolves to.
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -131,13 +152,39 @@ jobs:
               core.setFailed(`PR #${prNumber}'s author '${author}' is not listed in OWNERS (approvers/reviewers). Only PRs from trusted repo owners can be deployed via this workflow. To deploy this PR's changes anyway, push its branch to this repository directly and use the "branch" input instead.`);
             }
 
-  # if: always() so this still runs when resolve-pr was skipped (no
-  # pr_number given -- the plain "branch" input path), but not when
-  # resolve-pr ran and failed the trust check.
-  deploy:
-    name: Deploy Manual Console
+  # Probes the target cluster and provisions it if it isn't up yet -- same
+  # reusable workflow hot-cluster-e2e.yml already uses for this. Gated on
+  # resolve-pr the same way deploy is below -- an untrusted PR author must
+  # not be able to trigger real cluster provisioning (secrets: inherit)
+  # just because deploy itself will later be skipped; skipped resolve-pr
+  # (the plain "branch" input path, no pr_number) still runs this normally.
+  # run_health_check stays false -- this isn't an E2E gating context.
+  cluster-check:
+    name: Cluster Check
     needs: resolve-pr
     if: always() && needs.resolve-pr.result != 'failure'
+    uses: ./.github/workflows/hot-cluster-check.yml
+    with:
+      cluster_name: ${{ inputs.cluster_name }}
+      infrastructure_type: ${{ inputs.infrastructure_type }}
+      openshift_version: ${{ inputs.openshift_version }}
+      cnv_channel: ${{ inputs.cnv_channel }}
+      cnv_pin_version: ${{ inputs.cnv_pin_version }}
+      branch_name: ${{ inputs.branch }}
+    secrets: inherit
+
+  # if: always() so this still runs when resolve-pr was skipped (no
+  # pr_number given -- the plain "branch" input path), but not when
+  # resolve-pr ran and failed the trust check, or the cluster never became
+  # ready (cluster-check provisions it if needed; a cluster already up
+  # returns ready almost immediately, so this adds no delay for the common
+  # case).
+  deploy:
+    name: Deploy Manual Console
+    needs: [resolve-pr, cluster-check]
+    if: |
+      always() && needs.resolve-pr.result != 'failure' &&
+      needs.cluster-check.outputs.cluster_ready == 'true'
     runs-on: ${{ inputs.cluster_name }}
     timeout-minutes: 30
     steps:

--- a/.github/workflows/pr_help_command.yml
+++ b/.github/workflows/pr_help_command.yml
@@ -1,0 +1,78 @@
+name: PR Help Command
+run-name: 'PR Help Command @ PR#${{ github.event.issue.number }}'
+
+# Lets anyone comment /help on a PR to list every available PR-comment
+# command, read from the single-source-of-truth registry at
+# .github/pr-commands.json. Purely informational -- no trust gate, matching
+# /recheck-jira's existing precedent for a read-only command.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: pr-help-cmd-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  help:
+    name: Post Command List
+    if: >
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/help')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # The job-level if: above is a cheap substring prefilter only -- it
+      # would still fire for e.g. a comment linking "docs.foo.com/help/".
+      # Re-check with a word-boundary match before posting anything.
+      - name: Match exact command
+        id: match
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const body = context.payload.comment.body || '';
+            const matched = /(^|\s)\/help(\s|$)/.test(body);
+            core.setOutput('matched', matched ? 'true' : 'false');
+
+      - name: Post available commands
+        if: steps.match.outputs.matched == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const { commands } = JSON.parse(fs.readFileSync('.github/pr-commands.json', 'utf8'));
+
+            const trustLabel = {
+              owners: 'OWNERS only',
+              'ai-config-owners': 'AI-config OWNERS only (.github/OWNERS)',
+              'member-or-owner': 'Member/owner/collaborator',
+              none: 'Anyone',
+            };
+
+            const rows = commands.map(
+              (c) => `| \`${c.command}\` | ${c.description} | ${trustLabel[c.trust] ?? c.trust} |`,
+            );
+
+            const body = [
+              '### Available PR commands',
+              '',
+              '| Command | Description | Who can use it |',
+              '|---|---|---|',
+              ...rows,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body,
+            });


### PR DESCRIPTION
## 📝 Description

Add an OWNERS-gated `/deploy-manual-console` PR-comment command that lets a trusted maintainer spin up a manual console + kubevirt-plugin instance for a PR without manually picking cluster/infra parameters, plus a single-source-of-truth PR-commands registry and a `/help` command.

## 🔗 Links

Jira ticket: [CNV-92941](https://redhat.atlassian.net/browse/CNV-92941)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **/help** support to list available pull request commands.
  * Introduced a trusted **/deploy-manual-console** command to trigger manual console deployments.
  * Deployments can now **automatically provision hot clusters** when needed.
  * Added **best-effort detection** of existing cluster infrastructure type (IPI, VPC, classic).

* **Security**
  * Tightened **AI approval** authorization to use the dedicated AI-config approvers list.
  * Added an additional trusted AI configuration approver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->