### PR TITLE
CNV-92941: Modify deploy-manual-console PR command with cluster auto-detection / add cleanup

### DIFF
--- a/.github/actions/hot-cluster/resolve-trusted-pr/action.yml
+++ b/.github/actions/hot-cluster/resolve-trusted-pr/action.yml
@@ -1,0 +1,87 @@
+name: Resolve Trusted PR
+description: >
+  Resolve a PR's head SHA/repo and verify its author is listed in OWNERS
+  before any in-cluster build touches their code. Shared by every
+  manual-console workflow that builds + runs arbitrary PR source on a
+  self-hosted runner, so this security-sensitive check can't drift between
+  callers.
+
+inputs:
+  pr-number:
+    description: PR number to resolve and check
+    required: true
+  github-token:
+    description: Token for the GitHub API call
+    required: true
+
+outputs:
+  head-sha:
+    description: PR head commit SHA
+    value: ${{ steps.resolve.outputs.head_sha }}
+  head-repo:
+    description: >
+      PR head repository full_name, or the literal string
+      "(source repository deleted)" if the fork no longer exists
+    value: ${{ steps.resolve.outputs.head_repo }}
+
+runs:
+  using: composite
+  steps:
+    # Pinned to the default branch explicitly: without a ref:, checkout
+    # falls back to github.ref, which for workflow_dispatch is whatever
+    # branch was selected in the dispatch UI -- not necessarily the default
+    # branch. Reading OWNERS from an unpinned, dispatcher-chosen branch
+    # would let a modified OWNERS file on that branch self-approve trust for
+    # a fork PR.
+    - name: Checkout default branch
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+        persist-credentials: false
+
+    - name: Resolve PR and verify author is a trusted repo owner
+      id: resolve
+      uses: actions/github-script@v9
+      env:
+        # Passed via env, not interpolated into the script string below:
+        # pr-number is a raw, unvalidated caller-supplied string, and
+        # substituting it directly into the JS source would let a crafted
+        # value break out of the string literal and inject arbitrary script.
+        PR_NUMBER: ${{ inputs.pr-number }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const fs = require('fs');
+
+          const prNumber = parseInt(process.env.PR_NUMBER, 10);
+          if (!Number.isInteger(prNumber) || prNumber <= 0) {
+            core.setFailed(`pr-number must be a positive integer, got '${process.env.PR_NUMBER}'`);
+            return;
+          }
+
+          const { data: pr } = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: prNumber,
+          });
+
+          const author = pr.user.login;
+          const headSha = pr.head.sha;
+          const headRepo = pr.head.repo ? pr.head.repo.full_name : '(source repository deleted)';
+          core.info(`PR #${prNumber}: author=${author}, head=${headRepo}@${headSha}`);
+
+          let trusted = false;
+          try {
+            const owners = fs.readFileSync('OWNERS', 'utf8');
+            trusted = new RegExp(`^\\s*-\\s*${author}\\s*$`, 'm').test(owners);
+          } catch (err) {
+            core.warning(`Could not read OWNERS file: ${err.message}`);
+          }
+
+          core.info(`${author} is ${trusted ? '' : 'not '}listed in OWNERS (approvers/reviewers) — ${trusted ? 'trusted' : 'untrusted'}.`);
+          core.setOutput('head_sha', headSha);
+          core.setOutput('head_repo', headRepo);
+
+          if (!trusted) {
+            core.setFailed(`PR #${prNumber}'s author '${author}' is not listed in OWNERS (approvers/reviewers). Only PRs from trusted repo owners can be built on a self-hosted runner via this workflow. To use this PR's changes anyway, push its branch to this repository directly and use the "branch" input instead.`);
+          }

--- a/.github/actions/manual-console-request/action.yml
+++ b/.github/actions/manual-console-request/action.yml
@@ -18,6 +18,11 @@ inputs:
   configmap-name:
     description: Name of the trigger ConfigMap
     default: manual-console
+  helm-release:
+    description: >
+      Helm release name. Defaults to configmap-name (this action's
+      historical behavior) when left empty.
+    default: ''
   ci-env-namespace:
     description: Namespace where ci-env-controller runs
     default: ci-env
@@ -67,7 +72,7 @@ runs:
           desired-state: "present"
           plugin-image: "${{ inputs.plugin-image }}"
           test-namespace: "${{ inputs.test-namespace }}"
-          helm-release: "manual-console"
+          helm-release: "${{ inputs.helm-release || inputs.configmap-name }}"
           auth-mode: "openshift"
           htpasswd-user: "${{ inputs.htpasswd-user }}"
           htpasswd-secret-name: "${{ inputs.htpasswd-secret-name }}"
@@ -130,6 +135,7 @@ runs:
       env:
         CM_NAME: ${{ inputs.configmap-name }}
         CM_NS: ${{ inputs.ci-env-namespace }}
+        HELM_RELEASE: ${{ inputs.helm-release || inputs.configmap-name }}
         PLUGIN_IMAGE: ${{ inputs.plugin-image }}
         TEST_NS: ${{ inputs.test-namespace }}
         HTPASSWD_USER: ${{ inputs.htpasswd-user }}
@@ -141,6 +147,7 @@ runs:
           echo "| Input Parameter | Value |"
           echo "|------|-------|"
           echo "| ConfigMap | \`${CM_NS}/${CM_NAME}\` |"
+          echo "| Helm release | \`${HELM_RELEASE}\` |"
           echo "| Plugin image | \`${PLUGIN_IMAGE}\` |"
           echo "| Namespace | \`${TEST_NS}\` |"
           echo "| Login username | \`${HTPASSWD_USER}\` |"

--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -20,6 +20,12 @@
       "workflow": ".github/workflows/deploy-manual-console-command.yml"
     },
     {
+      "command": "/cleanup-manual-console",
+      "description": "Tear down this PR's manual console + kubevirt-plugin instance (Helm release, trigger ConfigMap, and OAuth user).",
+      "trust": "owners",
+      "workflow": ".github/workflows/cleanup-manual-console-command.yml"
+    },
+    {
       "command": "/recheck-jira",
       "description": "Re-run Jira ticket validation for this PR.",
       "trust": "none",

--- a/.github/workflows/cleanup-manual-console-command.yml
+++ b/.github/workflows/cleanup-manual-console-command.yml
@@ -1,0 +1,148 @@
+name: Cleanup Manual Console Command
+run-name: 'Cleanup Manual Console Command @ PR#${{ github.event.issue.number }}'
+
+# Lets an OWNERS-listed maintainer comment /cleanup-manual-console on a PR
+# to tear down its manual console (Helm release, trigger ConfigMap, OAuth
+# user). Resolves the cluster the same way deploy-manual-console-command.yml
+# does, then dispatches deploy-manual-console.yml with action: teardown.
+# issue_comment only, so this never becomes a PR check.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  actions: write
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: cleanup-manual-console-cmd-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch Cleanup Manual Console
+    if: >
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/cleanup-manual-console')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # No ref override: reads OWNERS from the default branch, not the commenter's PR.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # The job-level if: above is just a cheap substring prefilter -- it
+      # would still fire for e.g. "I ran /cleanup-manual-console yesterday".
+      # This step re-checks with a word-boundary match; every step below
+      # requires it, so mentioning the command in passing is a silent no-op.
+      - name: Match exact command
+        id: match
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const body = context.payload.comment.body || '';
+            const matched = /(^|\s)\/cleanup-manual-console(\s|$)/.test(body);
+            core.setOutput('matched', matched ? 'true' : 'false');
+
+      # OWNERS is the trust source, same as /deploy-manual-console -- no
+      # ok-to-test escape hatch. This is the only trust gate for teardown:
+      # deploy-manual-console.yml's own resolve-pr check doesn't run for it.
+      - name: Check trusted commenter
+        id: check-trust
+        if: steps.match.outputs.matched == 'true'
+        uses: ./.github/actions/hot-cluster/check-trust
+        with:
+          author: ${{ github.event.comment.user.login }}
+
+      - name: Reject untrusted commenter
+        if: steps.match.outputs.matched == 'true' && steps.check-trust.outputs.trusted != 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const author = context.payload.comment.user.login;
+            await github.rest.reactions.createForIssueComment({
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              content: '-1',
+            }).catch((err) => core.warning(`Could not react: ${err.message || err}`));
+            core.setFailed(`${author} is not authorized to use /cleanup-manual-console`);
+
+      - name: Resolve PR context
+        id: pr
+        if: steps.match.outputs.matched == 'true' && steps.check-trust.outputs.trusted == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('number', String(pr.number));
+            core.setOutput('base_ref', pr.base.ref);
+
+      # Same resolution deploy-manual-console-command.yml uses, so teardown
+      # targets the same cluster a prior /deploy-manual-console would have.
+      - name: Resolve cluster config
+        id: resolve-config
+        if: steps.match.outputs.matched == 'true' && steps.check-trust.outputs.trusted == 'true'
+        uses: ./.github/actions/hot-cluster/resolve-cluster-config
+        with:
+          base-ref: ${{ steps.pr.outputs.base_ref }}
+
+      - name: Dispatch deploy-manual-console.yml (teardown)
+        id: dispatch
+        if: steps.match.outputs.matched == 'true' && steps.check-trust.outputs.trusted == 'true'
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          CLUSTER_NAME: ${{ steps.resolve-config.outputs.cluster-name }}
+        with:
+          script: |
+            const clusterName = process.env.CLUSTER_NAME;
+
+            await github.rest.actions.createWorkflowDispatch({
+              ...context.repo,
+              workflow_id: 'deploy-manual-console.yml',
+              ref: context.payload.repository.default_branch,
+              inputs: {
+                action: 'teardown',
+                pr_number: process.env.PR_NUMBER,
+                // Ignored by teardown logic -- kept so the required
+                // "branch" input is non-empty.
+                branch: process.env.BASE_REF,
+                cluster_name: clusterName,
+              },
+            });
+
+            core.info(`Dispatched deploy-manual-console.yml teardown for PR #${process.env.PR_NUMBER} (cluster=${clusterName}).`);
+            core.setOutput('cluster_name', clusterName);
+
+      - name: React and comment on the PR
+        if: steps.match.outputs.matched == 'true' && steps.check-trust.outputs.trusted == 'true' && steps.dispatch.outcome == 'success'
+        uses: actions/github-script@v9
+        env:
+          CLUSTER_NAME: ${{ steps.dispatch.outputs.cluster_name }}
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            }).catch((err) => core.warning(`Could not react: ${err.message || err}`));
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/workflows/deploy-manual-console.yml`;
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: [
+                `🧹 Dispatched a manual console teardown for this PR (cluster \`${process.env.CLUSTER_NAME}\`).`,
+                '',
+                `If no manual console exists for this PR, the teardown run is a harmless no-op -- check the [Actions tab](${runUrl}) for progress.`,
+              ].join('\n'),
+            });

--- a/.github/workflows/deploy-manual-console.yml
+++ b/.github/workflows/deploy-manual-console.yml
@@ -1,5 +1,5 @@
 name: Deploy Manual Console
-run-name: "Deploy Manual Console [${{ inputs.cluster_name }}] @ ${{ inputs.pr_number && format('PR#{0}', inputs.pr_number) || inputs.branch }}"
+run-name: "${{ inputs.action == 'teardown' && 'Teardown' || 'Deploy' }} Manual Console [${{ inputs.cluster_name }}] @ ${{ inputs.pr_number && format('PR#{0}', inputs.pr_number) || inputs.branch }}"
 
 # Deploys a standalone, OAuth-protected console + kubevirt-plugin stack to an
 # existing hot cluster for manual UI testing. Entirely separate from the E2E
@@ -21,6 +21,18 @@ run-name: "Deploy Manual Console [${{ inputs.cluster_name }}] @ ${{ inputs.pr_nu
 on:
   workflow_dispatch:
     inputs:
+      action:
+        description: >-
+          "deploy" provisions a new instance for the given PR/branch;
+          "teardown" removes an existing one. For teardown, only
+          pr_number/branch and cluster_name matter -- other inputs are
+          ignored.
+        required: false
+        default: deploy
+        type: choice
+        options:
+          - deploy
+          - teardown
       branch:
         description: >-
           Git branch or ref to build the kubevirt-plugin image from (can be
@@ -71,86 +83,88 @@ permissions:
   contents: read
   pull-requests: read
 
-# Persistent environment: never cancel an in-flight deploy for the same
-# cluster, since that could leave the manual console mid-provision.
+# Persistent environment: never cancel an in-flight run, since that could
+# leave the manual console mid-operation. Scoped by pr_number/branch (not
+# just cluster_name) -- each PR gets its own instance now, so distinct PRs
+# no longer queue behind each other.
 concurrency:
-  group: deploy-manual-console-${{ inputs.cluster_name }}
+  group: deploy-manual-console-${{ inputs.cluster_name }}-${{ inputs.pr_number || inputs.branch }}
   cancel-in-progress: false
 
 env:
   CI_ENV_NS: ci-env
-  MANUAL_CONSOLE_CM: manual-console
   MANUAL_CONSOLE_NS: manual-console
-  MANUAL_CONSOLE_USER: manual-console
 
 jobs:
-  # Only runs when pr_number is set (deploying a PR, possibly from a fork).
-  # Mirrors hot-cluster-e2e.yml's check-trust: only PR authors listed in
-  # OWNERS can have their PR deployed here, with no "ok-to-test" escape
-  # hatch -- push the branch directly and use "branch" instead if needed.
+  # Shared by deploy and teardown so both address the same instance:
+  # pr-<number> when pr_number is set, otherwise a sanitized/truncated
+  # branch name (DNS-safe once "manual-console-" is prefixed).
+  instance-key:
+    name: Compute Instance Key
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      key: ${{ steps.compute.outputs.key }}
+    steps:
+      - name: Compute instance key
+        id: compute
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          if [[ -n "${PR_NUMBER}" ]]; then
+            if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+              echo "::error::pr_number must be numeric, got '${PR_NUMBER}'"
+              exit 1
+            fi
+            KEY="pr-${PR_NUMBER}"
+          else
+            # Budget: this becomes "console-manual-console-<key>", the first
+            # label of the console Route host, which must stay <=63 chars
+            # (DNS-1123) -- 24 of those are already spent on that fixed
+            # prefix. Truncating the sanitized branch name alone isn't
+            # collision-safe (two different branches sharing the same first
+            # 11 chars would silently overwrite each other's instance), so
+            # pair a short prefix with an 8-hex-char hash of the *full*
+            # branch name -- deterministic (same branch always yields the
+            # same key, for Deploy Plugin redeploys) and distinct whenever
+            # the full names differ, even beyond the truncated prefix.
+            PREFIX="$(echo -n "${BRANCH}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g' | cut -c1-11 | sed -E 's/^-+//; s/-+$//')"
+            HASH="$(echo -n "${BRANCH}" | sha256sum | cut -c1-8)"
+            KEY="${PREFIX:-branch}-${HASH}"
+          fi
+          echo "key=${KEY}" >> "${GITHUB_OUTPUT}"
+          echo "Computed instance key: ${KEY}"
+
+  # Only runs for the "deploy" action when pr_number is set (deploying a PR,
+  # possibly from a fork). Mirrors hot-cluster-e2e.yml's check-trust: only PR
+  # authors listed in OWNERS can have their PR deployed here, with no
+  # "ok-to-test" escape hatch -- push the branch directly and use "branch"
+  # instead if needed. Teardown skips this: it doesn't build the PR's code,
+  # and /cleanup-manual-console already gates who can trigger it.
   resolve-pr:
     name: Resolve PR
-    if: inputs.pr_number != ''
+    if: inputs.pr_number != '' && inputs.action != 'teardown'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      head_sha: ${{ steps.resolve.outputs.head_sha }}
-      head_repo: ${{ steps.resolve.outputs.head_repo }}
+      head_sha: ${{ steps.resolve.outputs.head-sha }}
+      head_repo: ${{ steps.resolve.outputs.head-repo }}
     steps:
-      # Pinned to the default branch explicitly: without a ref:, checkout
-      # falls back to github.ref, which for workflow_dispatch is whatever
-      # branch was selected in the dispatch UI -- not necessarily the
-      # default branch. Reading OWNERS from an unpinned, dispatcher-chosen
-      # branch would let a modified OWNERS file on that branch self-approve
-      # trust for a fork PR.
+      # Needed to resolve the local composite action below -- its own
+      # internal checkout (pinned to the default branch) is what actually
+      # matters for reading OWNERS safely.
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Resolve PR and verify author is a trusted repo owner
         id: resolve
-        uses: actions/github-script@v9
-        env:
-          # Passed via env, not interpolated into the script string below:
-          # inputs.pr_number is a raw, unvalidated workflow_dispatch string
-          # input, and substituting it directly into the JS source would let
-          # a crafted value break out of the string literal and inject
-          # arbitrary script.
-          PR_NUMBER: ${{ inputs.pr_number }}
+        uses: ./.github/actions/hot-cluster/resolve-trusted-pr
         with:
+          pr-number: ${{ inputs.pr_number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const prNumber = parseInt(process.env.PR_NUMBER, 10);
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
-
-            const author = pr.user.login;
-            const headSha = pr.head.sha;
-            const headRepo = pr.head.repo ? pr.head.repo.full_name : '(source repository deleted)';
-            core.info(`PR #${prNumber}: author=${author}, head=${headRepo}@${headSha}`);
-
-            let trusted = false;
-            try {
-              const owners = fs.readFileSync('OWNERS', 'utf8');
-              trusted = new RegExp(`^\\s*-\\s*${author}\\s*$`, 'm').test(owners);
-            } catch (err) {
-              core.warning(`Could not read OWNERS file: ${err.message}`);
-            }
-
-            core.info(`${author} is ${trusted ? '' : 'not '}listed in OWNERS (approvers/reviewers) — ${trusted ? 'trusted' : 'untrusted'}.`);
-            core.setOutput('head_sha', headSha);
-            core.setOutput('head_repo', headRepo);
-
-            if (!trusted) {
-              core.setFailed(`PR #${prNumber}'s author '${author}' is not listed in OWNERS (approvers/reviewers). Only PRs from trusted repo owners can be deployed via this workflow. To deploy this PR's changes anyway, push its branch to this repository directly and use the "branch" input instead.`);
-            }
 
   # Probes the target cluster and provisions it if it isn't up yet -- same
   # reusable workflow hot-cluster-e2e.yml already uses for this. Gated on
@@ -162,7 +176,7 @@ jobs:
   cluster-check:
     name: Cluster Check
     needs: resolve-pr
-    if: always() && needs.resolve-pr.result != 'failure'
+    if: always() && needs.resolve-pr.result != 'failure' && inputs.action != 'teardown'
     uses: ./.github/workflows/hot-cluster-check.yml
     with:
       cluster_name: ${{ inputs.cluster_name }}
@@ -181,9 +195,11 @@ jobs:
   # case).
   deploy:
     name: Deploy Manual Console
-    needs: [resolve-pr, cluster-check]
+    needs: [instance-key, resolve-pr, cluster-check]
     if: |
-      always() && needs.resolve-pr.result != 'failure' &&
+      always() && inputs.action != 'teardown' &&
+      needs.instance-key.result == 'success' &&
+      needs.resolve-pr.result != 'failure' &&
       needs.cluster-check.outputs.cluster_ready == 'true'
     runs-on: ${{ inputs.cluster_name }}
     timeout-minutes: 30
@@ -223,6 +239,7 @@ jobs:
           HEAD_REPO: ${{ needs.resolve-pr.outputs.head_repo }}
           HEAD_SHA: ${{ needs.resolve-pr.outputs.head_sha }}
           CLUSTER_NAME: ${{ inputs.cluster_name }}
+          INSTANCE_KEY: ${{ needs.instance-key.outputs.key }}
         run: |
           {
             echo "## Manual Console Deploy"
@@ -235,15 +252,24 @@ jobs:
               echo "| Branch | \`${BRANCH}\` |"
             fi
             echo "| Cluster | \`${CLUSTER_NAME}\` |"
+            echo "| Instance key | \`${INSTANCE_KEY}\` |"
             echo "| Infrastructure | \`${{ inputs.infrastructure_type }}\` |"
             echo "| Triggered by | @${{ github.actor }} |"
           } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Build kubevirt-plugin image in-cluster
         id: build
+        env:
+          INSTANCE_KEY: ${{ needs.instance-key.outputs.key }}
         run: |
           NS="${MANUAL_CONSOLE_NS}"
           export NS
+          # Per-instance ImageStream/BuildConfig name: the default
+          # "kubevirt-plugin" is shared across the whole namespace, so two
+          # PRs building concurrently would race on the same BuildConfig and
+          # stomp each other's ":latest" ImageStreamTag.
+          IMAGE_NAME="kubevirt-plugin-${INSTANCE_KEY}"
+          export IMAGE_NAME
           # BUILD_DIR points at the plugin-src/ checkout above, not the
           # workflow-scripts checkout at $GITHUB_WORKSPACE -- see that
           # checkout step's comment for why these must stay separate.
@@ -284,9 +310,10 @@ jobs:
         with:
           plugin-image: ${{ steps.build.outputs.image }}
           test-namespace: ${{ env.MANUAL_CONSOLE_NS }}
-          configmap-name: ${{ env.MANUAL_CONSOLE_CM }}
+          configmap-name: manual-console-${{ needs.instance-key.outputs.key }}
+          helm-release: manual-console-${{ needs.instance-key.outputs.key }}
           ci-env-namespace: ${{ env.CI_ENV_NS }}
-          htpasswd-user: ${{ env.MANUAL_CONSOLE_USER }}
+          htpasswd-user: manual-console-${{ needs.instance-key.outputs.key }}
           htpasswd-secret-name: ${{ steps.secret.outputs.name }}
 
       - name: Send manual console credentials to Slack
@@ -295,6 +322,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           CONSOLE_URL: ${{ steps.deploy.outputs.console-route }}
           MANUAL_CONSOLE_PASSWORD: ${{ steps.creds.outputs.password }}
+          MANUAL_CONSOLE_USER: manual-console-${{ needs.instance-key.outputs.key }}
           ACTOR: ${{ github.actor }}
           BRANCH: ${{ inputs.branch }}
           PR_NUMBER: ${{ inputs.pr_number }}
@@ -309,8 +337,10 @@ jobs:
 
           if [[ -n "${PR_NUMBER}" ]]; then
             SOURCE_LINE="*PR:* <https://github.com/${{ github.repository }}/pull/${PR_NUMBER}|#${PR_NUMBER}> (\`${HEAD_REPO}\`)"
+            CLEANUP_LINE=$'\n'"Done with it? Comment \`/cleanup-manual-console\` on the PR."
           else
             SOURCE_LINE="*Branch:* \`${BRANCH}\`"
+            CLEANUP_LINE=""
           fi
 
           TEXT=":rocket: *Manual console ready*"
@@ -320,6 +350,7 @@ jobs:
           TEXT+=$'\n'"*Password:* \`${MANUAL_CONSOLE_PASSWORD}\`"
           TEXT+=$'\n'"${SOURCE_LINE}"
           TEXT+=$'\n'"*Run:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>"
+          TEXT+="${CLEANUP_LINE}"
 
           PAYLOAD=$(jq -n --arg text "${TEXT}" '{text: $text}')
 
@@ -357,3 +388,61 @@ jobs:
         run: |
           SECRET_NAME="manual-console-creds-${{ github.run_id }}"
           oc delete secret "${SECRET_NAME}" --namespace="${CI_ENV_NS}" --ignore-not-found
+
+  # Triggered by /cleanup-manual-console. Runs on the target cluster's own
+  # runner (same as deploy) and just flips the trigger ConfigMap's
+  # desired-state to "absent" -- ci-env-controller's existing reconciliation
+  # loop (also used by the TTL reaper) does the actual cleanup from there.
+  teardown:
+    name: Teardown Manual Console
+    needs: instance-key
+    if: inputs.action == 'teardown' && needs.instance-key.result == 'success'
+    runs-on: ${{ inputs.cluster_name }}
+    timeout-minutes: 10
+    env:
+      CLUSTER_NAME: ${{ inputs.cluster_name }}
+    steps:
+      - name: Mark manual console for teardown
+        id: teardown
+        env:
+          CM_NAME: manual-console-${{ needs.instance-key.outputs.key }}
+        run: |
+          # --ignore-not-found: absent ConfigMap → exit 0 + empty output
+          # (treat as nothing to tear down). Auth/RBAC/API failures still
+          # exit non-zero so we fail instead of silently skipping cleanup.
+          CM_REF="$(oc get configmap "${CM_NAME}" -n "${CI_ENV_NS}" --ignore-not-found -o name)"
+          if [[ -z "${CM_REF}" ]]; then
+            echo "::warning::No manual console ConfigMap ${CI_ENV_NS}/${CM_NAME} found on ${CLUSTER_NAME} -- nothing to tear down."
+            echo "found=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          oc patch configmap "${CM_NAME}" -n "${CI_ENV_NS}" \
+            --type merge -p '{"data":{"desired-state":"absent"}}'
+          echo "found=true" >> "${GITHUB_OUTPUT}"
+          echo "Marked ${CI_ENV_NS}/${CM_NAME} for teardown (desired-state=absent); ci-env-controller will remove its Helm release, namespace resources, and OAuth user shortly."
+
+      - name: Write job summary
+        if: always()
+        env:
+          FOUND: ${{ steps.teardown.outputs.found }}
+          INSTANCE_KEY: ${{ needs.instance-key.outputs.key }}
+        run: |
+          {
+            echo "## Manual Console Teardown"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Instance key | \`${INSTANCE_KEY}\` |"
+            echo "| ConfigMap | \`${CI_ENV_NS}/manual-console-${INSTANCE_KEY}\` |"
+            echo "| Cluster | \`${CLUSTER_NAME}\` |"
+            echo "| Triggered by | @${{ github.actor }} |"
+            echo ""
+            if [[ "${FOUND}" == "true" ]]; then
+              echo "Teardown requested; ci-env-controller reconciles this asynchronously."
+            elif [[ "${FOUND}" == "false" ]]; then
+              echo "No matching manual console was found -- nothing to tear down."
+            else
+              echo ":x: Teardown request failed -- see logs above."
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-plugin.yml
+++ b/.github/workflows/deploy-plugin.yml
@@ -1,16 +1,17 @@
 name: Deploy Plugin (Manual Console Quick Redeploy)
-run-name: 'Deploy Plugin [${{ inputs.cluster_name }}] @ ${{ inputs.branch }}'
+run-name: "Deploy Plugin [${{ inputs.cluster_name }}] @ ${{ inputs.pr_number && format('PR#{0}', inputs.pr_number) || inputs.branch }}"
 
 # Lightweight companion to deploy-manual-console.yml for quickly
 # iterating on UI changes against an already-deployed manual console: builds
-# a fresh plugin image and re-provisions the same "manual-console" release,
+# a fresh plugin image and re-provisions the same per-instance release,
 # without repeating the full job summary / Slack notification of the main
 # workflow. Use deploy-manual-console.yml for the first deploy, or whenever
 # you need a fresh URL/credentials reminder.
 #
 # Prerequisites: same as deploy-manual-console.yml -- the target cluster must
-# already be provisioned, and a manual console should already exist (though
-# this workflow works standalone too, it will just deploy fresh).
+# already be provisioned, and a manual console for this pr_number/branch
+# should already exist (though this workflow works standalone too, it will
+# just deploy a fresh instance under the same instance-key naming).
 #
 # Dispatch ref matters, same as deploy-manual-console.yml: dispatch this
 # workflow itself from main (or another ref carrying current
@@ -24,10 +25,18 @@ on:
       branch:
         description: >-
           Git branch or ref to build the kubevirt-plugin image from (can be
-          an old release branch). Dispatch this workflow itself from
-          main/current -- see the header comment.
+          an old release branch). Ignored when pr_number is set.
         required: true
         default: main
+        type: string
+      pr_number:
+        description: >-
+          PR number to redeploy instead (works with PRs from forks -- the
+          OWNERS-listed author check below still applies). Takes precedence
+          over "branch" when set. Must match the pr_number the console was
+          originally deployed with, or this targets a different instance.
+        required: false
+        default: ''
         type: string
       cluster_name:
         description: ARC runner label / hot cluster name (must already be provisioned)
@@ -37,20 +46,81 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: deploy-manual-console-${{ inputs.cluster_name }}
+  group: deploy-manual-console-${{ inputs.cluster_name }}-${{ inputs.pr_number || inputs.branch }}
   cancel-in-progress: false
 
 env:
   CI_ENV_NS: ci-env
-  MANUAL_CONSOLE_CM: manual-console
   MANUAL_CONSOLE_NS: manual-console
-  MANUAL_CONSOLE_USER: manual-console
 
 jobs:
+  # Mirrors deploy-manual-console.yml's instance-key job -- keep both in
+  # sync. Kept inline here (not factored into a reusable workflow) since
+  # this is meant to stay a small, single-purpose quick-redeploy path.
+  instance-key:
+    name: Compute Instance Key
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      key: ${{ steps.compute.outputs.key }}
+    steps:
+      - name: Compute instance key
+        id: compute
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          if [[ -n "${PR_NUMBER}" ]]; then
+            if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+              echo "::error::pr_number must be numeric, got '${PR_NUMBER}'"
+              exit 1
+            fi
+            KEY="pr-${PR_NUMBER}"
+          else
+            # Mirrors deploy-manual-console.yml's instance-key job exactly --
+            # same prefix+hash scheme, so the same branch always resolves to
+            # the same key on both sides. See that job's comment for the
+            # DNS-1123 budget and collision-resistance rationale.
+            PREFIX="$(echo -n "${BRANCH}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g' | cut -c1-11 | sed -E 's/^-+//; s/-+$//')"
+            HASH="$(echo -n "${BRANCH}" | sha256sum | cut -c1-8)"
+            KEY="${PREFIX:-branch}-${HASH}"
+          fi
+          echo "key=${KEY}" >> "${GITHUB_OUTPUT}"
+          echo "Computed instance key: ${KEY}"
+
+  # Same OWNERS trust gate deploy-manual-console.yml uses -- required here
+  # too, since this job builds arbitrary PR source on a self-hosted runner.
+  resolve-pr:
+    name: Resolve PR
+    if: inputs.pr_number != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      head_sha: ${{ steps.resolve.outputs.head-sha }}
+      head_repo: ${{ steps.resolve.outputs.head-repo }}
+    steps:
+      # Needed to resolve the local composite action below -- its own
+      # internal checkout (pinned to the default branch) is what actually
+      # matters for reading OWNERS safely.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Resolve PR and verify author is a trusted repo owner
+        id: resolve
+        uses: ./.github/actions/hot-cluster/resolve-trusted-pr
+        with:
+          pr-number: ${{ inputs.pr_number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   redeploy:
     name: Redeploy Plugin
+    needs: [instance-key, resolve-pr]
+    if: always() && needs.instance-key.result == 'success' && needs.resolve-pr.result != 'failure'
     runs-on: ${{ inputs.cluster_name }}
     timeout-minutes: 20
     steps:
@@ -59,7 +129,8 @@ jobs:
       #   1. This repo's own dispatch ref into $GITHUB_WORKSPACE, for CI
       #      scripts (e.g. setup-plugin-image.sh) that may not exist on
       #      inputs.branch.
-      #   2. inputs.branch itself into plugin-src/, used only as
+      #   2. The plugin source to actually build -- PR head, or
+      #      inputs.branch -- into plugin-src/, used only as
       #      setup-plugin-image.sh's BUILD_DIR below.
       - name: Checkout workflow scripts
         uses: actions/checkout@v7
@@ -69,15 +140,24 @@ jobs:
       - name: Checkout plugin source
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.branch }}
+          repository: ${{ (needs.resolve-pr.outputs.head_repo != '' && needs.resolve-pr.outputs.head_repo != '(source repository deleted)') && needs.resolve-pr.outputs.head_repo || github.repository }}
+          ref: ${{ needs.resolve-pr.outputs.head_sha || inputs.branch }}
           path: plugin-src
           persist-credentials: false
 
       - name: Build kubevirt-plugin image in-cluster
         id: build
+        env:
+          INSTANCE_KEY: ${{ needs.instance-key.outputs.key }}
         run: |
           NS="${MANUAL_CONSOLE_NS}"
           export NS
+          # Per-instance name, matching deploy-manual-console.yml -- the
+          # default "kubevirt-plugin" is shared across the whole namespace,
+          # so redeploying one instance would race any other instance's
+          # concurrent build on the same BuildConfig/ImageStreamTag.
+          IMAGE_NAME="kubevirt-plugin-${INSTANCE_KEY}"
+          export IMAGE_NAME
           # BUILD_DIR points at the plugin-src/ checkout above, not the
           # workflow-scripts checkout at $GITHUB_WORKSPACE.
           BUILD_DIR="${GITHUB_WORKSPACE}/plugin-src"
@@ -121,9 +201,10 @@ jobs:
         with:
           plugin-image: ${{ steps.build.outputs.image }}
           test-namespace: ${{ env.MANUAL_CONSOLE_NS }}
-          configmap-name: ${{ env.MANUAL_CONSOLE_CM }}
+          configmap-name: manual-console-${{ needs.instance-key.outputs.key }}
+          helm-release: manual-console-${{ needs.instance-key.outputs.key }}
           ci-env-namespace: ${{ env.CI_ENV_NS }}
-          htpasswd-user: ${{ env.MANUAL_CONSOLE_USER }}
+          htpasswd-user: manual-console-${{ needs.instance-key.outputs.key }}
           htpasswd-secret-name: ${{ steps.secret.outputs.name }}
 
       # ci-env-controller re-applies the htpasswd user on every provision, so
@@ -136,8 +217,10 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           CONSOLE_URL: ${{ steps.deploy.outputs.console-route }}
           MANUAL_CONSOLE_PASSWORD: ${{ steps.creds.outputs.password }}
+          MANUAL_CONSOLE_USER: manual-console-${{ needs.instance-key.outputs.key }}
           ACTOR: ${{ github.actor }}
           BRANCH: ${{ inputs.branch }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
             echo "::warning::SLACK_WEBHOOK_URL not set — skipping Slack notification"
@@ -146,12 +229,18 @@ jobs:
 
           echo "::add-mask::${MANUAL_CONSOLE_PASSWORD}"
 
+          if [[ -n "${PR_NUMBER}" ]]; then
+            SOURCE_LINE="*PR:* <https://github.com/${{ github.repository }}/pull/${PR_NUMBER}|#${PR_NUMBER}>"
+          else
+            SOURCE_LINE="*Branch:* \`${BRANCH}\`"
+          fi
+
           TEXT=":arrows_counterclockwise: *Manual console plugin redeployed*"
           TEXT+=$'\n'"*Triggered by:* @${ACTOR}"
           TEXT+=$'\n'"*URL:* <${CONSOLE_URL}>"
           TEXT+=$'\n'"*User:* \`${MANUAL_CONSOLE_USER}\`"
           TEXT+=$'\n'"*Password (rotated):* \`${MANUAL_CONSOLE_PASSWORD}\`"
-          TEXT+=$'\n'"*Branch:* \`${BRANCH}\`"
+          TEXT+=$'\n'"${SOURCE_LINE}"
 
           PAYLOAD=$(jq -n --arg text "${TEXT}" '{text: $text}')
 

--- a/ci-scripts/hot-cluster/helm/ci-env-controller/scripts/ci-env-controller.sh
+++ b/ci-scripts/hot-cluster/helm/ci-env-controller/scripts/ci-env-controller.sh
@@ -15,9 +15,9 @@
 #   HELM_CHART_PATH        Path to the ci-test-stack Helm chart inside the container
 #   ENSURE_MANUAL_CONSOLE_USER_SCRIPT
 #                          Path to ensure-manual-console-user.sh inside the
-#                          container; only invoked when a ConfigMap sets
-#                          auth-mode=openshift (default:
-#                          /opt/ci-env/manual-console/ensure-manual-console-user.sh)
+#                          container; only invoked (to add or, on teardown,
+#                          --remove) when a ConfigMap sets auth-mode=openshift
+#                          (default: /opt/ci-env/manual-console/ensure-manual-console-user.sh)
 #
 # Trigger ConfigMap data field (per-request, optional):
 #   user-settings-location  Overrides the console's BRIDGE_USER_SETTINGS_LOCATION
@@ -181,6 +181,21 @@ ensure_manual_console_auth() {
     log "ERROR: ensure-manual-console-user.sh did not produce a CA_CERT_FILE"
     return 1
   fi
+}
+
+# --------------------------------------------------------------------------- #
+#  Remove an htpasswd user provisioned for a manual-console instance
+# --------------------------------------------------------------------------- #
+remove_manual_console_auth() {
+  local htpasswd_user="$1"
+
+  log "Removing htpasswd user ${htpasswd_user} via ${ENSURE_MANUAL_CONSOLE_USER_SCRIPT}..."
+  local remove_output
+  if ! remove_output="$(bash "${ENSURE_MANUAL_CONSOLE_USER_SCRIPT}" --remove "${htpasswd_user}" 2>&1)"; then
+    log "ERROR: failed to remove htpasswd user ${htpasswd_user}: ${remove_output}"
+    return 1
+  fi
+  log "${remove_output}"
 }
 
 # --------------------------------------------------------------------------- #
@@ -377,13 +392,50 @@ teardown() {
   local cm_name="$1"
   local test_ns="$2"
   local helm_release="${3:-${cm_name}}"
+  local auth_mode="${4:-disabled}"
+  local htpasswd_user="${5:-}"
 
   log "Tearing down: cm=${cm_name} ns=${test_ns} release=${helm_release}"
   patch_cm "${cm_name}" '{"data":{"status":"cleaning"}}'
 
   helm uninstall "${helm_release}" -n "${test_ns}" --wait 2>/dev/null || true
 
-  oc delete namespace "${test_ns}" --wait=false 2>/dev/null || true
+  # A failure here must not be silently swallowed into "cleaned": that
+  # status stops reconcile_one from ever retrying (see its absent-branch
+  # check), which would leave a cluster-admin htpasswd user stranded
+  # indefinitely. Setting status=error instead keeps this CM eligible for
+  # another teardown attempt next reconciliation cycle.
+  if [[ "${auth_mode}" == "openshift" && -n "${htpasswd_user}" ]]; then
+    if ! remove_manual_console_auth "${htpasswd_user}"; then
+      local err="failed to remove htpasswd user ${htpasswd_user}; will retry"
+      log "ERROR: ${err}"
+      patch_cm "${cm_name}" "{\"data\":{\"status\":\"error\",\"error-message\":\"${err}\"}}"
+      return 1
+    fi
+  fi
+
+  # auth-mode=openshift is the manual-console signal (never set for E2E --
+  # see provision()'s comment above). Its namespace is declared-shared by
+  # design: concurrent instances from distinct Helm releases, plus a
+  # one-time RBAC bootstrap (install-manual-console-rbac.sh) that must
+  # survive between deploys. Never auto-delete it here based on a
+  # point-in-time `helm list` snapshot -- that's both racy (a concurrent
+  # provision() elsewhere in the same reconciliation pass may not have
+  # registered its release yet) and wrong even when accurate (it would
+  # destroy the RBAC bootstrap too). Every namespace on the E2E path is
+  # either exclusively per-run/ephemeral or GitHub Actions-concurrency-
+  # serialized, so deleting it once its own release is gone stays safe.
+  if [[ "${auth_mode}" == "openshift" ]]; then
+    log "${test_ns} is a manual-console namespace; not auto-deleting it"
+  else
+    local remaining
+    remaining="$(helm list -n "${test_ns}" -q 2>/dev/null | wc -l | tr -d ' ')"
+    if [[ "${remaining}" == "0" ]]; then
+      oc delete namespace "${test_ns}" --wait=false 2>/dev/null || true
+    else
+      log "${remaining} other Helm release(s) still in ${test_ns}; leaving namespace in place"
+    fi
+  fi
 
   log "Teardown complete for ${cm_name}"
   patch_cm "${cm_name}" '{"data":{"status":"cleaned"}}'
@@ -433,7 +485,7 @@ reconcile_one() {
       patch_cm "${cm_name}" '{"data":{"status":"cleaned"}}'
       return
     fi
-    teardown "${cm_name}" "${test_ns}" "${helm_release}" || \
+    teardown "${cm_name}" "${test_ns}" "${helm_release}" "${auth_mode}" "${htpasswd_user}" || \
       log "WARN: teardown encountered errors for ${cm_name} (non-fatal)"
   fi
 }

--- a/ci-scripts/hot-cluster/helm/ci-test-stack/templates/_helpers.tpl
+++ b/ci-scripts/hot-cluster/helm/ci-test-stack/templates/_helpers.tpl
@@ -38,6 +38,15 @@ collisions between manual-console and any concurrent E2E test releases).
 {{- end }}
 
 {{/*
+Test-runner RoleBinding name (namespace-scoped, so it's release-namespaced
+to avoid a Helm ownership conflict between concurrent releases sharing one
+namespace, e.g. multiple manual-console instances).
+*/}}
+{{- define "ci-test-stack.testRunnerRoleBindingName" -}}
+{{ .Release.Name }}-ci-env-test-runner
+{{- end }}
+
+{{/*
 NOTE: there is deliberately no "oauthClientSecret" helper here. A helper
 that falls back to a random value (e.g. randAlphaNum) when no existing
 OAuthClient/Secret is found would re-evaluate that randomness independently

--- a/ci-scripts/hot-cluster/helm/ci-test-stack/templates/runner-rolebinding.yaml
+++ b/ci-scripts/hot-cluster/helm/ci-test-stack/templates/runner-rolebinding.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: ci-env-test-runner
+  name: {{ include "ci-test-stack.testRunnerRoleBindingName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ci-test-stack.labels" . | nindent 4 }}

--- a/ci-scripts/manual-console/README.md
+++ b/ci-scripts/manual-console/README.md
@@ -52,12 +52,36 @@ subject never matches a release cluster's runner SA.
 
 Actions -> **Deploy Manual Console** -> Run workflow, with:
 
-- `branch` -- the branch to build the plugin image from
+- `branch` -- the branch to build the plugin image from (ignored if `pr_number` is set)
+- `pr_number` -- deploy a PR instead, or comment `/deploy-manual-console` on it
 - `cluster_name` -- the ARC runner label / hot cluster name (default `kubevirt-plugin-ci`)
 - `infrastructure_type` -- informational only, no kubeconfig is downloaded
 
-For UI-only iteration afterwards, **Deploy Plugin** rebuilds and
-redeploys just the plugin image against the same release.
+For UI-only iteration afterwards, **Deploy Plugin** rebuilds and redeploys
+just the plugin image against the same instance -- it takes the same
+`branch`/`pr_number` inputs and must be given the same one used for the
+original deploy, or it targets a different (and possibly nonexistent)
+instance.
+
+Every deploy is scoped to an **instance key** -- `pr-<number>` when
+`pr_number` is set, otherwise a truncated, normalized `branch` prefix plus
+an 8-character hash of the full branch name (so two branches that happen to
+share the same prefix still get distinct keys) -- so different PRs (or
+branches) on the same cluster each get their own trigger ConfigMap, Helm
+release, OAuth user, and console route (`console-manual-console-<key>.<apps
+domain>`) instead of overwriting each other. The namespace
+(`manual-console`) stays shared across all of them.
+
+## Tearing down
+
+Manual-console ConfigMaps are exempt from the TTL reaper, so nothing removes
+a deployed instance automatically. Once done with it, either comment
+`/cleanup-manual-console` on the PR, or run **Deploy Manual Console** with
+`action: teardown` and the same `pr_number`/`branch` + `cluster_name` used to
+deploy it. This flips the trigger ConfigMap's `desired-state` to `absent`;
+`ci-env-controller` then removes that instance's Helm release and htpasswd
+user asynchronously. The shared `manual-console` namespace itself is only
+deleted once no other instance's Helm release remains in it.
 
 ## How it works
 
@@ -95,15 +119,19 @@ required beyond `SLACK_WEBHOOK_URL`:
 2. It writes that password into a short-lived Kubernetes `Secret` in the
    `ci-env` namespace (never into the trigger ConfigMap).
 3. `ci-env-controller` reads the Secret, upserts an htpasswd identity
-   provider user named `manual-console` with that password, grants it
-   `cluster-admin`, and **deletes the Secret immediately** -- the password
-   never persists in the cluster.
+   provider user named after that deploy's instance key (e.g.
+   `manual-console-pr-1234`) with that password, grants it `cluster-admin`,
+   and **deletes the Secret immediately** -- the password never persists in
+   the cluster.
 4. The workflow posts the console URL, username, and password to Slack
    (`SLACK_WEBHOOK_URL`), along with the GitHub user who triggered the
    deploy and a link to the run.
 
 Redeploying (either workflow) rotates the password; the previous one stops
 working. **Deploy Plugin** sends its own Slack reminder for this reason.
+
+Tearing down an instance (see above) removes that htpasswd user and revokes
+its `cluster-admin` grant, in addition to uninstalling its Helm release.
 
 If `SLACK_WEBHOOK_URL` isn't configured, the workflow logs a warning and
 skips notification -- the deploy still succeeds, but credentials must be

--- a/ci-scripts/manual-console/ensure-manual-console-user.sh
+++ b/ci-scripts/manual-console/ensure-manual-console-user.sh
@@ -10,7 +10,9 @@
 # only when a ConfigMap's auth-mode=openshift; never touched by the default
 # E2E provisioning path.
 #
-# Usage: echo <password> | ensure-manual-console-user.sh <username>
+# Usage:
+#   echo <password> | ensure-manual-console-user.sh <username>   # add/update
+#   ensure-manual-console-user.sh --remove <username>             # remove
 #
 # The password is read from stdin, not argv -- CLI arguments persist for the
 # process's whole lifetime and are visible to any co-located process via
@@ -20,14 +22,46 @@
 # username replaces that user's password hash; other users already present
 # in the htpasswd secret (e.g. cluster setup's "admin") are preserved.
 #
-# Output (stdout): CA_CERT_FILE=<path to a temp file with the PEM CA bundle>
-#   Caller is responsible for deleting this file after use.
+# Output (stdout, add/update mode only): CA_CERT_FILE=<path to a temp file
+#   with the PEM CA bundle>. Caller is responsible for deleting this file
+#   after use.
 #
 # Requires: oc logged in with cluster-admin (or equivalent) permissions to
 # manage openshift-config secrets, the cluster OAuth config, and
 # cluster-admin ClusterRoleBindings. Also requires the `htpasswd` CLI
 # (httpd-tools / apache2-utils).
 set -euo pipefail
+
+if [[ "${1:-}" == "--remove" ]]; then
+  USERNAME="${2:?Usage: ensure-manual-console-user.sh --remove <username>}"
+
+  echo "Removing htpasswd user '${USERNAME}'..."
+
+  if oc get secret htpass-secret -n openshift-config &>/dev/null; then
+    EXISTING_HTPASSWD="$(oc get secret htpass-secret -n openshift-config \
+      -o jsonpath='{.data.htpasswd}' | base64 -d)"
+    # Same literal (not regex) field match as the add/update path below.
+    UPDATED_HTPASSWD="$(printf '%s\n' "${EXISTING_HTPASSWD}" \
+      | awk -F: -v u="${USERNAME}" '$1 != u && NF')"
+    oc create secret generic htpass-secret \
+      --from-literal=htpasswd="${UPDATED_HTPASSWD}" \
+      -n openshift-config --dry-run=client -o yaml | oc apply -f -
+  else
+    echo "htpass-secret not found; nothing to remove from it."
+  fi
+
+  # Not `|| true`: a real failure here (permissions, API hiccup, etc.) must
+  # be visible so ci-env-controller can retry instead of marking teardown
+  # "cleaned". This command is already a no-op (exits 0) when the user
+  # isn't currently bound, so it only ever fails on a genuine error.
+  if ! oc adm policy remove-cluster-role-from-user cluster-admin "${USERNAME}"; then
+    echo "ERROR: failed to revoke cluster-admin from ${USERNAME}" >&2
+    exit 1
+  fi
+
+  echo "User '${USERNAME}' removed."
+  exit 0
+fi
 
 USERNAME="${1:?Usage: ensure-manual-console-user.sh <username> (password via stdin)}"
 


### PR DESCRIPTION
## 📝 Description

### Per-PR isolation + `/cleanup-manual-console` teardown 

- Fixes a collision bug in the above: every deploy reused the same fixed ConfigMap/Helm release/OAuth user name (manual-console), so a second PR's deploy on the same cluster silently overwrote the first PR's whole environment (route, Helm release, everything) instead of coexisting

- deploy-manual-console.yml now computes an instance-key (pr-<number> when pr_number is set, otherwise a sanitized branch) and uses manual-console-<key> for the trigger ConfigMap, Helm release, and htpasswd user -- the namespace (manual-console) stays shared, no new RBAC needed

- manual-console-request composite action gets a new helm-release input (previously hardcoded to "manual-console")

- Concurrency group is now scoped by cluster_name + pr_number/branch instead of just cluster_name, so distinct PRs on the same cluster no longer queue behind each other

- **New action**: deploy|teardown input on deploy-manual-console.yml; teardown flips the instance's trigger ConfigMap desired-state to absent, reusing ci-env-controller's existing reconciliation path (same one used for the TTL reaper) to remove the Helm release, namespace resources, and htpasswd user

- New OWNERS-gated /cleanup-manual-console PR command (cleanup-manual-console-command.yml), same shape as /deploy-manual-console, dispatching the new teardown action -- registered in .github/pr-commands.json so it shows up in /help automatically

## 🔗 Links

Jira ticket: [CNV-92941](https://redhat.atlassian.net/browse/CNV-92941)

## 🎥 Demo

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added instance-scoped manual console deployments (per PR/branch) with configurable Helm release naming.
  - Added OWNERS-trusted `/cleanup-manual-console` teardown via comment command, with deploy/teardown dispatch support.
  - Added plugin “quick redeploy” for PR/branch, with instance-specific build identifiers.
- **Bug Fixes**
  - Improved teardown safety: removes htpasswd user and revokes access; avoids deleting shared namespaces when other releases exist.
  - Hardened workflow trust checks and per-instance teardown behavior.
- **Documentation**
  - Expanded manual console README with updated teardown flow and credential/htpasswd behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->