### PR TITLE
CNV-92989: Limit hot cluster concurrent jobs

### DIFF
--- a/.github/workflows/hold-e2e.yml
+++ b/.github/workflows/hold-e2e.yml
@@ -13,17 +13,12 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  issues: write
+  checks: write
 
 jobs:
-  # issues: write (reactions) added here, not at the workflow level -- a
-  # job-level permissions block fully replaces the workflow-level one for
-  # that job, so contents/pull-requests are restated too (both used below).
   check:
     name: Check Hold Request
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: >
@@ -94,9 +89,6 @@ jobs:
   # is-merge-pool-pr.cjs excludes it from the merge pool too.
   apply-hold-label:
     name: Apply Hold Label
-    # issues: write covers label read/create/add -- no contents/checkout needed.
-    permissions:
-      issues: write
     needs: [check]
     if: needs.check.result == 'success' && needs.check.outputs.trusted == 'true'
     runs-on: ubuntu-latest
@@ -137,9 +129,6 @@ jobs:
   # after the hold below.
   cancel-cluster-check:
     name: Cancel Cluster Check
-    # Entering the concurrency group below is the only thing this job does
-    # -- no API calls, so no permissions at all.
-    permissions: {}
     needs: [check]
     if: needs.check.result == 'success' && needs.check.outputs.trusted == 'true'
     runs-on: ubuntu-latest
@@ -154,8 +143,6 @@ jobs:
   # cluster/test time.
   cancel-run-e2e-tests:
     name: Cancel Run E2E Tests
-    # Same as cancel-cluster-check -- no API calls, no permissions needed.
-    permissions: {}
     needs: [check]
     if: needs.check.result == 'success' && needs.check.outputs.trusted == 'true'
     runs-on: ubuntu-latest
@@ -180,11 +167,6 @@ jobs:
   # the common case ordered correctly.
   mark-held:
     name: Mark Run Gating Tests Held
-    # checks: write for publish-gating-check (checks.create/update); contents:
-    # read since checkout is needed to resolve that local composite action.
-    permissions:
-      contents: read
-      checks: write
     needs: [check, cancel-cluster-check, cancel-run-e2e-tests]
     if: needs.check.result == 'success' && needs.check.outputs.trusted == 'true'
     runs-on: ubuntu-latest
@@ -212,9 +194,6 @@ jobs:
 
   report:
     name: Report Hold
-    # issues: write for the PR comment -- no checks calls in this job.
-    permissions:
-      issues: write
     needs: [check, apply-hold-label, cancel-cluster-check, cancel-run-e2e-tests, mark-held]
     if: always() && needs.check.result == 'success' && needs.check.outputs.trusted == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/ibmc-cluster-setup.yml
+++ b/.github/workflows/ibmc-cluster-setup.yml
@@ -38,6 +38,11 @@ on:
         required: true
         default: '2'
         type: string
+      max_runners:
+        description: 'Max concurrent ARC runner pods for this cluster (caps concurrent E2E + manual-console jobs; extra jobs queue)'
+        required: true
+        default: '2'
+        type: string
       kvm_emulation:
         description: 'KVM emulation (true for vpc/shared, false for bare metal)'
         required: true
@@ -101,6 +106,11 @@ on:
         type: string
       worker_count:
         description: 'Number of worker nodes (at least 2 so ingress is happy)'
+        required: false
+        default: '2'
+        type: string
+      max_runners:
+        description: 'Max concurrent ARC runner pods for this cluster (caps concurrent E2E + manual-console jobs; extra jobs queue)'
         required: false
         default: '2'
         type: string
@@ -631,6 +641,7 @@ jobs:
           ARC_RUNNER_IMAGE: ${{ steps.build_runner.outputs.image_ref }}
           ARC_VERSION: '0.14.0'
           RUNNER_SCALE_SET_NAME: ${{ env.CLUSTER_NAME }}
+          MAX_RUNNERS: ${{ inputs.max_runners }}
         run: |
           ./ci-scripts/hot-cluster/arc/install-arc-controller.sh
           ./ci-scripts/hot-cluster/arc/install-runner-scale-set.sh

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -240,6 +240,7 @@ Key defaults:
 - `RUNNER_SCALE_SET_NAME=kubevirt-plugin-ci` (the `runs-on:` label)
 - `ARC_CONTROLLER_INSTALL_NAME=arc` (Helm release for controller)
 - `ARC_VERSION=0.14.0` (pinned Helm chart version)
+- `MAX_RUNNERS=2` (max concurrent ARC runner pods per cluster -- caps concurrent E2E + manual-console jobs against that cluster; extra jobs queue for a free runner rather than overloading it. Independent per cluster, since each has its own scale set. Override via `ibmc-cluster-setup.yml`'s `max_runners` input, or re-provision to apply a changed default)
 
 ## Cost Control
 

--- a/ci-scripts/hot-cluster/arc/install-runner-scale-set.sh
+++ b/ci-scripts/hot-cluster/arc/install-runner-scale-set.sh
@@ -13,7 +13,9 @@
 #
 # Optional environment variables:
 #   RUNNER_SCALE_SET_NAME       (default: kubevirt-plugin-ci)
-#   MIN_RUNNERS / MAX_RUNNERS   (default: 0 / 5)
+#   MIN_RUNNERS / MAX_RUNNERS   (default: 0 / 2) -- MAX_RUNNERS caps how many
+#                               jobs (E2E + manual-console) can run at once
+#                               against this cluster; queues the rest.
 #   ARC_CONTROLLER_NS           (default: arc-systems) — must match controller install
 #   ARC_CONTROLLER_INSTALL_NAME (default: arc)
 #   ARC_RUNNERS_NS              (default: arc-runners)
@@ -45,7 +47,7 @@ ARC_HELM_REPO="oci://ghcr.io/actions/actions-runner-controller-charts"
 ARC_VERSION="${ARC_VERSION:-0.14.0}"
 RUNNER_SCALE_SET_NAME="${RUNNER_SCALE_SET_NAME:-kubevirt-plugin-ci}"
 MIN_RUNNERS="${MIN_RUNNERS:-0}"
-MAX_RUNNERS="${MAX_RUNNERS:-5}"
+MAX_RUNNERS="${MAX_RUNNERS:-2}"
 CONTROLLER_SA_NAME="${ARC_CONTROLLER_INSTALL_NAME}-gha-rs-controller"
 
 echo "=== ARC runner scale set installation (OpenShift) ==="


### PR DESCRIPTION
## 📝 Description

Cap the number of self-hosted-runner jobs (Hot Cluster E2E gating tests, plus manual-console deploys/redeploys) that can run concurrently against a single hot cluster to a small, easily-changeable number (default 2), to stop the cluster from being overloaded when many PRs test in parallel. 
The cap is be per cluster, not per repo -- a release-branch cluster's load has zero effect on how many PRs can test against the main-branch cluster.

## 🔗 Links

Jira ticket: [CNV-92989](https://redhat.atlassian.net/browse/CNV-92989)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable limit for the maximum number of concurrent CI runner pods.
  * Cluster setup workflows now accept a `max_runners` parameter (default: 2) to control runner scaling.

* **Documentation**
  * Updated configuration guidance to document the `MAX_RUNNERS` default (capping concurrent runner pods at 2) and how to override it.

* **Chores**
  * Updated E2E workflow permissions to be managed at the workflow level for consistent access across jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->