### PR TITLE
CNV-92013: Descheduler status loading

### DIFF
--- a/src/utils/hooks/useDeschedulerStatus/useDeschedulerStatus.ts
+++ b/src/utils/hooks/useDeschedulerStatus/useDeschedulerStatus.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { SubscriptionModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
-  DeschedulerStatus,
+  type DeschedulerStatus,
   useDeschedulerInstalled,
 } from '@kubevirt-utils/hooks/useDeschedulerInstalled';
 import { getDeschedulerStatus } from '@kubevirt-utils/hooks/useDeschedulerStatus/utils';
@@ -10,9 +10,10 @@ import {
   DESCHEDULER_OPERATOR_NAME,
   KUBE_DESCHEDULER_NAMESPACE,
 } from '@kubevirt-utils/resources/descheduler/constants';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
-import { SubscriptionKind } from '@overview/utils/types';
+import { type SubscriptionKind } from '@overview/utils/types';
 
 type UseDeschedulerStatusResult = {
   loaded: boolean;
@@ -22,13 +23,14 @@ type UseDeschedulerStatusResult = {
 /**
  * Resolves descheduler status for overview and cluster widgets.
  * Uses KubeDescheduler CR presence for enabled state and operator subscription for install state.
+ * @param cluster
  */
 export const useDeschedulerStatus = (cluster?: string): UseDeschedulerStatusResult => {
   const clusterParam = useClusterParam();
   const resolvedCluster = cluster ?? clusterParam;
 
   const { isDeschedulerInstalled, loaded: crLoaded } = useDeschedulerInstalled(resolvedCluster);
-  const [subscription, subscriptionLoaded] = useK8sWatchData<SubscriptionKind>({
+  const [subscription, subscriptionLoaded, subscriptionError] = useK8sWatchData<SubscriptionKind>({
     cluster: resolvedCluster,
     groupVersionKind: SubscriptionModelGroupVersionKind,
     isList: false,
@@ -36,7 +38,8 @@ export const useDeschedulerStatus = (cluster?: string): UseDeschedulerStatusResu
     namespace: KUBE_DESCHEDULER_NAMESPACE,
   });
 
-  const loaded = crLoaded && subscriptionLoaded;
+  const subscriptionResolved = subscriptionLoaded || !isEmpty(subscriptionError);
+  const loaded = crLoaded && subscriptionResolved;
   const status = useMemo(
     () =>
       getDeschedulerStatus({


### PR DESCRIPTION
## 📝 Description

Follow-up fix for #4326 / [CNV-92013](https://redhat.atlassian.net/browse/CNV-92013).

When the descheduler operator Subscription is not installed, the watch returns 404 and `subscriptionLoaded` stays `false`, so `useDeschedulerStatus` never finishes loading and descheduler status remains unknown indefinitely.

Treat a non-empty subscription watch error as loaded (same pattern used elsewhere in the plugin), so a missing Subscription correctly resolves to `DESCHEDULER_NOT_INSTALLED`.

## 🎥 Demo

N/A — loading-state fix when Subscription resource is absent (404).

## Test plan
- [ ] Open VM list / overview where descheduler status is shown on a cluster **without** the descheduler operator Subscription
- [ ] Confirm descheduler status settles (not stuck loading) and shows not installed
- [ ] Confirm status still works correctly when the Subscription exists and descheduler is enabled/disabled


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved descheduler status loading so it no longer waits indefinitely when subscription data can’t be retrieved.
  * The status now completes loading when subscription watch data is ready **or** when there is no meaningful subscription error, avoiding stuck/partial UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->