### PR TITLE
[release-4.22] CNV-92871: Fix Fleet Virtualization Customization step hang

### DIFF
--- a/src/multicluster/hooks/useK8sWatchData.ts
+++ b/src/multicluster/hooks/useK8sWatchData.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useIsACMPage from '@multicluster/useIsACMPage';
+import { enrichFleetData } from '@multicluster/utils';
 import { useK8sWatchResource, WatchK8sResult } from '@openshift-console/dynamic-plugin-sdk';
 import {
   FleetWatchK8sResource,
@@ -24,6 +25,11 @@ const useK8sWatchData = <T>(resource: FleetWatchK8sResource | null): WatchK8sRes
     useFleet && !waitingForHubName ? requestWithNoLimit : null,
   );
 
+  const normalizedFleetData = useMemo(
+    () => enrichFleetData(fleetData, resource?.groupVersionKind),
+    [fleetData, resource?.groupVersionKind],
+  );
+
   const [k8sWatchData, k8sWatchLoaded, k8sWatchError] = useK8sWatchResource<T>(
     !useFleet ? resource : null,
   );
@@ -39,7 +45,7 @@ const useK8sWatchData = <T>(resource: FleetWatchK8sResource | null): WatchK8sRes
   if (waitingForHubName) return [defaultData, false, undefined];
 
   return useFleet
-    ? [isEmpty(fleetData) ? defaultData : fleetData, fleetLoaded, fleetError]
+    ? [isEmpty(normalizedFleetData) ? defaultData : normalizedFleetData, fleetLoaded, fleetError]
     : [isEmpty(k8sWatchData) ? defaultData : k8sWatchData, k8sWatchLoaded, k8sWatchError];
 };
 

--- a/src/multicluster/utils.ts
+++ b/src/multicluster/utils.ts
@@ -1,0 +1,32 @@
+import { K8sGroupVersionKind, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+const enrichResource = (
+  resource: K8sResourceCommon,
+  apiVersion: string,
+  kind: string,
+): K8sResourceCommon =>
+  resource.apiVersion && resource.kind ? resource : { apiVersion, kind, ...resource };
+
+const getApiVersion = (groupVersionKind: K8sGroupVersionKind) =>
+  groupVersionKind.group
+    ? `${groupVersionKind.group}/${groupVersionKind.version}`
+    : groupVersionKind.version;
+
+/**
+ * useFleetK8sWatchResource does not inject apiVersion/kind into list items
+ * (unlike fleetK8sList which does). This normalizes fleet data so that
+ * getGroupVersionKindForResource and kind-based type guards work correctly.
+ */
+export const enrichFleetData = <T>(data: T, groupVersionKind: K8sGroupVersionKind): T => {
+  if (!data || !groupVersionKind?.kind || !groupVersionKind?.version) return data;
+
+  const apiVersion = getApiVersion(groupVersionKind);
+
+  if (Array.isArray(data)) {
+    return data.map((item: K8sResourceCommon) =>
+      enrichResource(item, apiVersion, groupVersionKind.kind),
+    ) as T;
+  }
+
+  return enrichResource(data, apiVersion, groupVersionKind.kind) as T;
+};

--- a/src/views/templates/list/hooks/useOpenShiftTemplates.ts
+++ b/src/views/templates/list/hooks/useOpenShiftTemplates.ts
@@ -30,7 +30,6 @@ export const useOpenShiftTemplates: UseOpenShiftTemplates = ({
 }) => {
   const multiclusterFilters = useListMulticlusterFilters();
   const clusters = useListClusters();
-  const cluster = clusters?.length === 1 ? clusters[0] : undefined;
 
   const templateWatchNamespaces = useMemo(
     () => (namespace ? [OPENSHIFT_NAMESPACE, namespace] : [OPENSHIFT_NAMESPACE]),
@@ -56,7 +55,7 @@ export const useOpenShiftTemplates: UseOpenShiftTemplates = ({
     loadError,
     resources: templates,
   } = useAccessibleResources<V1Template>({
-    clusters: cluster ? [cluster] : undefined,
+    clusters,
     fieldSelector,
     groupVersionKind: TemplateModelGroupVersionKind,
     namespace,

--- a/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
+++ b/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
@@ -10,6 +10,7 @@ import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import {
   K8sGroupVersionKind,
+  K8sResourceCommon,
   Selector,
   useK8sWatchResources,
 } from '@openshift-console/dynamic-plugin-sdk';
@@ -29,15 +30,13 @@ type UseAccessibleResourcesArgs = {
   watchNamespaces?: string[];
 };
 
-type UseAccessibleResources = <T extends K8sResourceCommon>(
-  args: UseAccessibleResourcesArgs,
-) => {
+type UseAccessibleResourcesReturn<T> = {
   loaded: boolean;
   loadError?: any;
   resources: T[];
 };
 
-export const useAccessibleResources: UseAccessibleResources = <T>({
+export const useAccessibleResources = <T extends K8sResourceCommon>({
   clusters,
   fieldSelector,
   filterOptions,
@@ -47,11 +46,16 @@ export const useAccessibleResources: UseAccessibleResources = <T>({
   searchQueries,
   selector,
   watchNamespaces,
-}) => {
+}: UseAccessibleResourcesArgs): UseAccessibleResourcesReturn<T> => {
   const isAdmin = useIsAdmin();
   const isACMPage = useIsACMPage();
   const cluster = useClusterParam();
   const [projectNames, projectNamesLoaded, projectNamesError] = useProjects();
+
+  const clusterToWatch = useMemo(() => {
+    if (clusters?.length === 1) return clusters[0];
+    return clusters ? undefined : cluster;
+  }, [clusters, cluster]);
 
   const namespacesToWatch = useMemo(() => {
     if (watchNamespaces) return watchNamespaces;
@@ -65,7 +69,7 @@ export const useAccessibleResources: UseAccessibleResources = <T>({
   const [allResources, allResourcesLoaded] = useKubevirtWatchResource<T[]>(
     shouldFetchClusterWide
       ? {
-          cluster: clusters ? undefined : cluster,
+          cluster: clusterToWatch,
           fieldSelector,
           groupVersionKind,
           isList: true,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- On Fleet, Templates were loaded via multicluster search, which often omitted nested `objects`, so VM create could not resolve a VirtualMachine.
- When a single managed cluster is selected, load Templates with fleet k8s watch instead of search, and enrich watch results with `kind`/`apiVersion`

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-92871
## 🎥 Demo

before:


https://github.com/user-attachments/assets/ed22c5db-4be2-4a70-b89c-a139f66f3c9d



after:

https://github.com/user-attachments/assets/c813f58a-63b1-4bdf-9554-f0b263923922

