### PR TITLE
CNV-93067: PR-validation GitHub Actions workflows can resolve local actions/scripts from the wrong ref

### DIFF
--- a/.github/workflows/hot-cluster-e2e-pr-gate.yml
+++ b/.github/workflows/hot-cluster-e2e-pr-gate.yml
@@ -1,27 +1,18 @@
 name: Hot Cluster E2E PR Gate
 
-# hot-cluster-e2e.yml used to listen for pull_request_target directly on
-# opened/synchronize/reopened, so every PR push landed the full multi-job
-# graph (Prepare, cluster-check, Run E2E, Verify, and every nested job from
-# their `uses:` reusable workflows) natively on the PR -- GitHub creates a
-# check-run per job the moment the workflow triggers, with no way to hide or
-# nest them under "Hot Cluster E2E Progress". This one-job gatekeeper is now
-# the only thing listening for those PR events, dispatching the real
-# workflow via workflow_dispatch instead so only its own row (plus the
-# API-posted Progress/Run Gating Tests checks) lands in the merge box. See
-# ci-scripts/README.md ("Check-Run & Retest Model").
+# Thin gatekeeper for PR events: dispatches hot-cluster-e2e.yml via
+# workflow_dispatch so only this job (plus API-posted Progress/Run Gating
+# Tests checks) appears in the merge box, instead of the full nested job
+# graph. See ci-scripts/README.md ("Check-Run & Retest Model").
 #
-# When e2e-hold is present, dispatch is skipped (no cluster run) but the
-# held "Run Gating Tests" marker is re-published onto the new HEAD -- a
-# push/force-push would otherwise leave the required check as "Expected --
-# waiting for status" on the new SHA while the neutral marker stayed on
-# the old one (confirmed live on PR #4349).
+# When e2e-hold is present, skip dispatch but re-publish the held
+# "Run Gating Tests" marker onto the new HEAD so the required check isn't
+# left as "Expected" on the new SHA.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-# checks: write -- republish-hold's publish-gating-check posts the held
-# marker via the ambient GITHUB_TOKEN (same as hold-e2e.yml's mark-held).
+# checks: write -- republish-hold posts the held marker via GITHUB_TOKEN.
 permissions:
   contents: read
   actions: write
@@ -30,10 +21,8 @@ permissions:
 jobs:
   dispatch:
     name: Dispatch Hot Cluster E2E
-    # Skipped while /hold-e2e is active -- e2e-hold is a durable label so
-    # this holds across every future push too, not just the current one.
-    # Only /retest-e2e removes it (see retest-e2e.yml). republish-hold
-    # covers the required-check side of the hold for those same events.
+    # Skip while e2e-hold is active (durable across pushes; only /retest-e2e
+    # removes it). republish-hold covers the required-check side.
     if: "!contains(github.event.pull_request.labels.*.name, 'e2e-hold')"
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -44,11 +33,10 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
 
-            // skip_pool_check: a plain PR open/sync/reopen isn't a
-            // merge-readiness signal, so gating must run regardless of
-            // lgtm/approved. base_ref: the PR's real base branch, so a
-            // release-branch PR resolves cluster/test-engine and merges
-            // against the right tip.
+            // skip_pool_check: open/sync/reopen isn't merge-readiness, so
+            // gating runs regardless of lgtm/approved.
+            // base_ref: PR's real base so release-branch PRs resolve the
+            // right cluster/test-engine tip.
             await github.rest.actions.createWorkflowDispatch({
               ...context.repo,
               workflow_id: 'hot-cluster-e2e.yml',
@@ -60,21 +48,20 @@ jobs:
               },
             });
 
-  # Re-attach the non-passing held marker to whatever HEAD this event
-  # brought in. Without this, skipping dispatch above leaves the new SHA
-  # with no "Run Gating Tests" result at all.
+  # Re-attach the held marker to the new HEAD when dispatch is skipped.
   republish-hold:
     name: Republish Held Gating Check
     if: contains(github.event.pull_request.labels.*.name, 'e2e-hold')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # Needed to resolve the local publish-gating-check action. Uses the
-      # base-branch workflow/action (pull_request_target), not the PR tip.
+      # Pin to default branch: pull_request_target checks out the PR base,
+      # which may lack publish-gating-check on older release branches.
       - name: Checkout
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Publish held marker for current HEAD
         uses: ./.github/actions/publish-gating-check

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -17,20 +17,21 @@ jobs:
       group: pr-validation-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
+      # Pin to default branch: pull_request_target checks out the PR base,
+      # which may lack setup-gh-scripts on older release branches.
       - name: Checkout
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Setup validation scripts
         uses: ./.github/actions/setup-gh-scripts
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.repository.default_branch }}
 
-      # Runs Jira, AI-config, and CI-scripts validation from one process --
-      # each still reports its own status/labels independently (jira-validation,
-      # ai-config-validation, ci-scripts-validation), fetching the PR's changed
-      # files once and sharing that between AI-config and CI-scripts.
+      # Runs Jira, AI-config, and CI-scripts validation; each reports its
+      # own status/labels. Changed files are fetched once and shared.
       - name: Run PR validation
         working-directory: .github/scripts
         env:

--- a/.github/workflows/pr_validation_commands.yml
+++ b/.github/workflows/pr_validation_commands.yml
@@ -7,9 +7,8 @@ on:
 jobs:
   command:
     name: pr-validation-command
-    # !endsWith(...'[bot]') -- report comments mention their own trigger
-    # command as guidance text (e.g. "then comment /recheck-jira"), which
-    # would otherwise re-trigger this job against the bot's own comments.
+    # Skip bot comments so report guidance that mentions trigger commands
+    # (e.g. "/recheck-jira") doesn't re-trigger this job.
     if: >-
       github.event.issue.pull_request != null &&
       !endsWith(github.event.comment.user.login, '[bot]') &&
@@ -39,23 +38,22 @@ jobs:
             core.setOutput('base_ref', pr.base.ref);
             core.setOutput('head_sha', pr.head.sha);
 
-      # Required to resolve the local setup-gh-scripts action below -- a
-      # uses: ./path reference can't be resolved until the repo is checked
-      # out. No ref override: issue_comment reads this workflow from the
-      # default branch, so the default checkout matches.
+      # Needed so the local setup-gh-scripts action can resolve. issue_comment
+      # already loads this workflow from the default branch.
       - name: Checkout
         uses: actions/checkout@v7
         with:
           persist-credentials: false
 
+      # Pin scripts to default branch; release-branch bases may predate the
+      # current layout. BASE_BRANCH below still carries the PR's real base.
       - name: Setup validation scripts
         uses: ./.github/actions/setup-gh-scripts
         with:
-          ref: ${{ steps.pr.outputs.base_ref }}
+          ref: ${{ github.event.repository.default_branch }}
 
-      # See ci-scripts/README.md ("Check-Run & Retest Model") for why this
-      # needs the bot app, not GITHUB_TOKEN. continue-on-error: a bad
-      # credential must still let the step below run and report what it can.
+      # Bot app token required (see ci-scripts/README.md). continue-on-error
+      # so a bad credential still lets the step below report what it can.
       - name: Generate bot token
         id: bot-token
         continue-on-error: true
@@ -66,10 +64,8 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
 
-      # GITHUB_TOKEN is the bot token (issues/pull-requests scope).
-      # STATUS_GITHUB_TOKEN is the ambient token -- for commit statuses and
-      # the .github/OWNERS read (needs contents: read), neither of which the
-      # bot app has or will get. See github-repo.ts's createStatusOctokit.
+      # GITHUB_TOKEN: bot (issues/PRs). STATUS_GITHUB_TOKEN: ambient token
+      # for commit statuses and OWNERS reads. See createStatusOctokit.
       - name: Run validation command
         working-directory: .github/scripts
         env:

--- a/.github/workflows/retest-on-pool-entry.yml
+++ b/.github/workflows/retest-on-pool-entry.yml
@@ -1,11 +1,9 @@
 name: Retest On Pool Entry
 
-# retest-stale-gating.yml only re-evaluates merge-pool membership on a push
-# to main. A PR that gains lgtm+approved (or loses hold) afterward, while
-# its "Run Gating Tests" check is still that push's stale marker, gets no
-# further trigger until main next advances or someone manually intervenes.
-# This closes that gap for the pool-entry transition itself. See
-# ci-scripts/README.md ("Check-Run & Retest Model").
+# retest-stale-gating.yml only re-evaluates the merge pool on main pushes.
+# This covers the gap when a PR becomes pool-eligible (lgtm+approved, or
+# hold removed) while its "Run Gating Tests" check is still the stale
+# marker. See ci-scripts/README.md ("Check-Run & Retest Model").
 on:
   pull_request_target:
     types: [labeled, unlabeled]
@@ -25,12 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      # No ref override: reads the merge-pool helper from the base branch,
-      # same as every other hot-cluster pull_request_target job.
+      # Pin to default branch: pull_request_target checks out the PR base,
+      # which may lack ci-scripts/hot-cluster/ on older release branches.
       - name: Checkout
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Dispatch retest if now pool-eligible and check is stale
         uses: actions/github-script@v9
@@ -42,17 +41,14 @@ jobs:
             const pr = context.payload.pull_request;
             const prNumber = pr.number;
 
-            // labels here already reflect the post-event state.
+            // labels already reflect the post-event state.
             if (!isMergePoolPr(pr.labels)) {
               core.info(`PR #${prNumber} is not merge-pool eligible yet (needs lgtm+approved, no hold) -- nothing to do.`);
               return;
             }
 
-            // lgtm+approved is Tide's merge-readiness signal, not a CI-trust
-            // one -- same distinction and same three signals resolve-pr-context
-            // re-checks fresh right before the credentialed run. Checking here
-            // too just avoids a dispatch that would only fail on this same
-            // check downstream.
+            // Pre-check CI trust (OWNERS / same-repo / ok-to-test) to avoid
+            // a dispatch that would only fail the same check downstream.
             const author = pr.user.login;
             let ownedByAuthor = false;
             try {
@@ -91,10 +87,7 @@ jobs:
             }
 
             core.info(`PR #${prNumber} just became merge-pool eligible while its check was stale -- dispatching a fresh retest against main.`);
-            // base_ref required for the same reason as retest-stale-gating.yml's
-            // dispatch -- without it a release-branch PR's retest would
-            // resolve the wrong cluster/test-engine and merge onto main
-            // instead of its own base tip.
+            // base_ref so release-branch retests resolve the right tip.
             await github.rest.actions.createWorkflowDispatch({
               ...context.repo,
               workflow_id: 'hot-cluster-e2e.yml',


### PR DESCRIPTION
## 📝 Description

pull_request_target workflows that resolve a local action (uses: ./.github/actions/...) or require() a script from ci-scripts/ do a plain actions/checkout with no ref: override. For pull_request_target, that defaults to the PR's own base ref, not always the default branch -- two related failure modes found live:

1. Wrong branch entirely. A PR targeting an older release branch (e.g. release-4.22) checks out that branch, which predates .github/actions/setup-gh-scripts / .github/scripts' current layout entirely → Can't find 'action.yml' ... under .github/actions/setup-gh-scripts. Confirmed on https://github.com/kubevirt-ui/kubevirt-plugin/pull/4358.

2. Stale workflow snapshot vs. live inner checkout. A job's own workflow-YAML snapshot is pinned at trigger time, but setup-gh-scripts' internal checkout used a live branch-name ref: (re-resolved at actual run/re-run time). After the src/validation/... consolidation ([CNV-92998](https://redhat.atlassian.net/browse/CNV-92998)) landed on main, re-running an older pre-consolidation run reused the old job name/commands (npx tsx src/ai-config-validation/index.ts) while the inner checkout fetched the now-refactored main → ERR_MODULE_NOT_FOUND. Confirmed on https://github.com/kubevirt-ui/kubevirt-plugin/pull/4357. This check-run can never self-heal: the old job name (ai-config-validation) no longer exists in any current workflow, so no future run can supersede it -- only a fresh commit (new SHA) clears it.

## 🔗 Links

Jira ticket: [CNV-93067](https://redhat.atlassian.net/browse/CNV-93067)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request validation reliability across branches, including older release branches.
  - Ensured required gating checks remain visible when testing is temporarily on hold.
  - Improved automatic retesting when pull requests become eligible for the merge pool.

- **Chores**
  - Clarified validation and testing behavior for automated and manually triggered checks.
  - Improved consistency of scripts and checks used across pull request workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->