### PR TITLE
CNV-93066: Replace Tide auto-merge with native GitHub auto-merge

### DIFF
--- a/.github/actions/publish-gating-check/action.yml
+++ b/.github/actions/publish-gating-check/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: Optional link to the workflow run for more detail
     required: false
     default: ''
+  name:
+    description: Check-run name (only used when creating a fresh check-run)
+    required: false
+    default: 'Run Gating Tests'
 
 outputs:
   check-run-id:
@@ -63,6 +67,7 @@ runs:
         CHECK_TITLE: ${{ inputs.title }}
         CHECK_SUMMARY: ${{ inputs.summary }}
         CHECK_DETAILS_URL: ${{ inputs['details-url'] }}
+        CHECK_NAME: ${{ inputs.name }}
       with:
         script: |
           const output = {
@@ -111,7 +116,7 @@ runs:
           } else {
             ({ data } = await github.rest.checks.create({
               ...payload,
-              name: 'Run Gating Tests',
+              name: process.env.CHECK_NAME,
               head_sha: headSha,
             }));
             core.info(`Created check-run ${data.id} ("${payload.status}") for ${headSha}.`);

--- a/.github/scripts/src/validation/pr-path-validation/execute.test.ts
+++ b/.github/scripts/src/validation/pr-path-validation/execute.test.ts
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { Octokit } from '@octokit/rest';
+
+import { executePathValidation, reportPathValidationError } from './execute';
+import { HandledValidationError } from './errors';
+import type { PathValidationConfig } from './types';
+
+const TEST_CONFIG: PathValidationConfig = {
+  exactPaths: [],
+  pathPrefixes: ['protected/'],
+  labels: { alert: 'alert', block: 'block', reviewed: 'reviewed', skip: 'skip' },
+  labelMeta: {
+    alert: { color: 'f59e0b', description: 'alert' },
+    block: { color: 'b60205', description: 'block' },
+  },
+  statusContext: 'test-validation',
+  displayName: 'Test validation',
+  commandName: '/test-approved',
+};
+
+const buildStatusDescription = (): string => 'unused';
+
+type Call = { method: string; args: unknown };
+
+let nextCheckRunId = 2000;
+
+type FakeOptions = {
+  /** Reject createCommitStatus starting from this call number onward (1-indexed). Ignored when unset. */
+  rejectCommitStatusFromCall?: number;
+};
+
+/** issues.listLabelsOnIssue throws -- simulating a genuinely unexpected failure after runPathValidation has already published its pending check-run. */
+const fakeOctokitThrowingAfterPending = (
+  calls: Call[],
+  createdIds: number[],
+  options: FakeOptions = {},
+): Octokit =>
+  ({
+    checks: {
+      create: async (args: unknown) => {
+        const id = nextCheckRunId++;
+        createdIds.push(id);
+        calls.push({ method: 'checks.create', args });
+        return { data: { id } };
+      },
+      update: async (args: unknown) => {
+        calls.push({ method: 'checks.update', args });
+        return { data: { id: (args as { check_run_id: number }).check_run_id } };
+      },
+    },
+    issues: {
+      listLabelsOnIssue: async () => {
+        calls.push({ method: 'issues.listLabelsOnIssue', args: {} });
+        throw new Error('API rate limit exceeded');
+      },
+    },
+    repos: {
+      createCommitStatus: async (args: unknown) => {
+        const callNumber = calls.filter((c) => c.method === 'createCommitStatus').length + 1;
+        calls.push({ method: 'createCommitStatus', args });
+        if (
+          options.rejectCommitStatusFromCall !== undefined &&
+          callNumber >= options.rejectCommitStatusFromCall
+        ) {
+          throw new Error('secondary outage: statuses unavailable');
+        }
+      },
+    },
+  }) as unknown as Octokit;
+
+describe('executePathValidation', () => {
+  it('finalizes the same check-run (update, not a second create) when an unexpected error occurs after the pending check-run is published', async () => {
+    const calls: Call[] = [];
+    const createdIds: number[] = [];
+    const octokit = fakeOctokitThrowingAfterPending(calls, createdIds);
+
+    await assert.rejects(
+      executePathValidation(
+        {
+          baseBranch: 'main',
+          config: { token: 'x', owner: 'kubevirt-ui', repo: 'kubevirt-plugin' },
+          files: [{ filename: 'protected/foo.ts' }],
+          headSha: 'abc123',
+          octokit,
+          prNumber: 1,
+          statusOctokit: octokit,
+        },
+        TEST_CONFIG,
+        buildStatusDescription,
+      ),
+      HandledValidationError,
+    );
+
+    const created = calls.filter((c) => c.method === 'checks.create');
+    const updated = calls.filter((c) => c.method === 'checks.update');
+    assert.equal(created.length, 1, 'exactly one check-run should be created (the pending one)');
+    assert.equal(
+      updated.length,
+      1,
+      'the error path must update that same check-run, not create a second one',
+    );
+    assert.equal((updated[0].args as { check_run_id: number }).check_run_id, createdIds[0]);
+    assert.equal((updated[0].args as { conclusion: string }).conclusion, 'failure');
+
+    const statuses = calls
+      .filter((c) => c.method === 'createCommitStatus')
+      .map((c) => c.args as { state: string });
+    assert.equal(statuses.at(-1)?.state, 'error');
+  });
+
+  it('still finalizes the check-run and rethrows HandledValidationError even when the status publish itself rejects', async () => {
+    const calls: Call[] = [];
+    const createdIds: number[] = [];
+    // The first (pending) status call must succeed so a check-run actually
+    // exists before the error path's own status publish is the one that
+    // rejects -- this is what distinguishes "update the existing check-run"
+    // from "nothing existed yet, so create one" (already covered above).
+    const octokit = fakeOctokitThrowingAfterPending(calls, createdIds, {
+      rejectCommitStatusFromCall: 2,
+    });
+
+    await assert.rejects(
+      executePathValidation(
+        {
+          baseBranch: 'main',
+          config: { token: 'x', owner: 'kubevirt-ui', repo: 'kubevirt-plugin' },
+          files: [{ filename: 'protected/foo.ts' }],
+          headSha: 'abc123',
+          octokit,
+          prNumber: 1,
+          statusOctokit: octokit,
+        },
+        TEST_CONFIG,
+        buildStatusDescription,
+      ),
+      HandledValidationError,
+    );
+
+    const updated = calls.filter((c) => c.method === 'checks.update');
+    assert.equal(
+      updated.length,
+      1,
+      'the check-run must still be finalized even though the status publish rejected',
+    );
+    assert.equal((updated[0].args as { conclusion: string }).conclusion, 'failure');
+  });
+});
+
+describe('reportPathValidationError', () => {
+  it('still publishes the check-run when the status publish rejects', async () => {
+    const calls: Call[] = [];
+    const createdIds: number[] = [];
+    const octokit = fakeOctokitThrowingAfterPending(calls, createdIds, {
+      rejectCommitStatusFromCall: 1,
+    });
+
+    await assert.doesNotReject(
+      reportPathValidationError(
+        { token: 'x', owner: 'kubevirt-ui', repo: 'kubevirt-plugin' },
+        'abc123',
+        TEST_CONFIG,
+        new Error('boom'),
+        octokit,
+      ),
+    );
+
+    assert.equal(
+      calls.some((c) => c.method === 'checks.create'),
+      true,
+      'a check-run must still be published even though the status publish rejected',
+    );
+    assert.equal(
+      calls.some((c) => c.method === 'createCommitStatus'),
+      true,
+      'the status publish must still be attempted (even though it rejects)',
+    );
+  });
+});

--- a/.github/scripts/src/validation/pr-path-validation/execute.ts
+++ b/.github/scripts/src/validation/pr-path-validation/execute.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+import type { Octokit } from '@octokit/rest';
+
 import { runPathValidation } from './run-validation';
 import type { BuildStatusDescription, PathValidationOutcome } from './run-validation';
 import { HandledValidationError } from './errors';
@@ -7,6 +9,7 @@ import { AI_CONFIG } from '../ai-config-validation/constants';
 import { buildStatusDescription as buildAiConfigStatusDescription } from '../ai-config-validation/utils';
 import { CI_SCRIPTS_CONFIG } from '../ci-scripts-validation/constants';
 import { buildStatusDescription as buildCiScriptsStatusDescription } from '../ci-scripts-validation/utils';
+import { publishCheckRun } from './label-sync';
 import { createOctokit, createStatusOctokit } from '../../github-repo';
 import { setCommitStatus } from '../../github-comments';
 import { safeErrorMessage } from '../../utils';
@@ -22,6 +25,9 @@ export type PathValidationInput = {
   baseBranch: string;
   /** Pre-fetched changed files -- lets a caller running multiple path validations for the same PR share one fetch instead of each doing its own. */
   files?: Array<{ filename: string; patch?: string }>;
+  /** Injectable for tests; default to real Octokit clients built from config. */
+  octokit?: Octokit;
+  statusOctokit?: Octokit;
 };
 
 /** Run path-based validation; throws HandledValidationError on failure (already reported via label/status). */
@@ -32,24 +38,61 @@ export const executePathValidation = async (
   onFilesFetched?: (files: Array<{ filename: string; patch?: string }>) => void,
 ): Promise<PathValidationOutcome> => {
   const { config, prNumber, headSha, eventAction, baseBranch, files } = input;
-  const octokit = createOctokit(config);
-  const statusOctokit = createStatusOctokit(config);
+  const octokit = input.octokit ?? createOctokit(config);
+  const statusOctokit = input.statusOctokit ?? createStatusOctokit(config);
+  // Shared with runPathValidation so a throw after it publishes the pending
+  // check-run can finalize that same check-run here instead of leaving it
+  // stuck in_progress and creating an unrelated duplicate.
+  const checkRunId: { current?: number } = {};
 
-  const outcome = await runPathValidation(
-    {
-      baseBranch,
-      config,
-      event: { action: eventAction },
-      files,
-      headSha,
-      octokit,
-      prNumber,
-      statusOctokit,
-    },
-    pathConfig,
-    buildStatusDescription,
-    onFilesFetched,
-  );
+  let outcome: PathValidationOutcome;
+  try {
+    outcome = await runPathValidation(
+      {
+        baseBranch,
+        checkRunId,
+        config,
+        event: { action: eventAction },
+        files,
+        headSha,
+        octokit,
+        prNumber,
+        statusOctokit,
+      },
+      pathConfig,
+      buildStatusDescription,
+      onFilesFetched,
+    );
+  } catch (err) {
+    const message = `${pathConfig.displayName} encountered an unexpected error`;
+    // Independent best-effort boundaries -- a rejected status publish must
+    // not skip finalizing the check-run (or vice versa), and neither must
+    // prevent rethrowing as HandledValidationError below.
+    if (headSha) {
+      await setCommitStatus(
+        statusOctokit,
+        config.owner,
+        config.repo,
+        headSha,
+        'error',
+        message,
+        pathConfig.statusContext,
+      ).catch((statusErr) => {
+        console.error(`Failed to report error status: ${safeErrorMessage(statusErr)}`);
+      });
+    }
+    await publishCheckRun(
+      { checkRunId, config, headSha, octokit: statusOctokit, prNumber },
+      pathConfig,
+      'error',
+      pathConfig.displayName,
+      message,
+    );
+    // Already reported above (status + check-run) -- wrap as
+    // HandledValidationError so the caller's isolation loop doesn't report
+    // this same error again and create a second, duplicate check-run.
+    throw new HandledValidationError(`${message}: ${safeErrorMessage(err)}`);
+  }
 
   if (outcome.kind === 'failed') {
     throw new HandledValidationError(
@@ -66,26 +109,36 @@ export const reportPathValidationError = async (
   headSha: string | undefined,
   pathConfig: Pick<PathValidationConfig, 'statusContext' | 'displayName'>,
   err: unknown,
+  /** Injectable for tests; defaults to a real Octokit client built from config. */
+  statusOctokitOverride?: Octokit,
 ): Promise<void> => {
   console.error('Unexpected error:', safeErrorMessage(err));
   if (!headSha) {
     return;
   }
 
-  try {
-    const statusOctokit = createStatusOctokit(config);
-    await setCommitStatus(
-      statusOctokit,
-      config.owner,
-      config.repo,
-      headSha,
-      'error',
-      `${pathConfig.displayName} encountered an unexpected error`,
-      pathConfig.statusContext,
-    );
-  } catch {
-    // best-effort
-  }
+  const message = `${pathConfig.displayName} encountered an unexpected error`;
+  const statusOctokit = statusOctokitOverride ?? createStatusOctokit(config);
+  // Independent best-effort boundaries -- a rejected status publish must
+  // not skip the check-run publish, or vice versa.
+  await setCommitStatus(
+    statusOctokit,
+    config.owner,
+    config.repo,
+    headSha,
+    'error',
+    message,
+    pathConfig.statusContext,
+  ).catch((statusErr) => {
+    console.error(`Failed to report error status: ${safeErrorMessage(statusErr)}`);
+  });
+  await publishCheckRun(
+    { config, headSha, octokit: statusOctokit, prNumber: -1 },
+    pathConfig,
+    'error',
+    pathConfig.displayName,
+    message,
+  );
 };
 
 const logSuspiciousMatches = (files: Array<{ filename: string; patch?: string }>): void => {

--- a/.github/scripts/src/validation/pr-path-validation/label-sync.test.ts
+++ b/.github/scripts/src/validation/pr-path-validation/label-sync.test.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'node:test';
 import type { Octokit } from '@octokit/rest';
 
 import type { LabelSyncContext } from './label-sync';
-import { reportCommitStatus, syncValidationLabels } from './label-sync';
+import { publishCheckRun, reportCommitStatus, syncValidationLabels } from './label-sync';
 import type { PathValidationConfig } from './types';
 
 const TEST_CONFIG: PathValidationConfig = {
@@ -22,6 +22,8 @@ const TEST_CONFIG: PathValidationConfig = {
 
 type Call = { method: string; args: unknown };
 
+let nextCheckRunId = 1000;
+
 const fakeOctokit = (calls: Call[], id: string): Octokit =>
   ({
     repos: {
@@ -38,6 +40,16 @@ const fakeOctokit = (calls: Call[], id: string): Octokit =>
         calls.push({ method: `removeLabel:${id}`, args });
       },
     },
+    checks: {
+      create: async (args: unknown) => {
+        calls.push({ method: `checks.create:${id}`, args });
+        return { data: { id: nextCheckRunId++ } };
+      },
+      update: async (args: unknown) => {
+        calls.push({ method: `checks.update:${id}`, args });
+        return { data: { id: (args as { check_run_id: number }).check_run_id } };
+      },
+    },
   }) as unknown as Octokit;
 
 const baseCtx = (octokit: Octokit, statusOctokit?: Octokit): LabelSyncContext => ({
@@ -46,6 +58,7 @@ const baseCtx = (octokit: Octokit, statusOctokit?: Octokit): LabelSyncContext =>
   config: { token: 'x', owner: 'kubevirt-ui', repo: 'kubevirt-plugin' },
   prNumber: 1,
   headSha: 'abc123',
+  checkRunId: {},
 });
 
 describe('reportCommitStatus', () => {
@@ -101,6 +114,85 @@ describe('reportCommitStatus', () => {
     const ctx = { ...baseCtx(octokit), headSha: undefined };
     await reportCommitStatus(ctx, TEST_CONFIG, 'success', 'ok');
     assert.equal(calls.length, 0);
+  });
+
+  it('also publishes a check-run alongside the plain status, under the same context name', async () => {
+    const calls: Call[] = [];
+    const octokit = fakeOctokit(calls, 'main');
+    await reportCommitStatus(baseCtx(octokit), TEST_CONFIG, 'pending', 'in progress');
+    const created = calls.find((c) => c.method === 'checks.create:main');
+    assert.ok(created);
+    assert.equal((created?.args as { name: string }).name, TEST_CONFIG.statusContext);
+    assert.equal((created?.args as { status: string }).status, 'in_progress');
+  });
+});
+
+describe('publishCheckRun', () => {
+  it('creates a check-run on the first call, then updates that same check-run on a later call in the same context', async () => {
+    const calls: Call[] = [];
+    const octokit = fakeOctokit(calls, 'main');
+    const ctx = baseCtx(octokit);
+
+    await publishCheckRun(ctx, TEST_CONFIG, 'pending', 'title', 'in progress');
+    await publishCheckRun(ctx, TEST_CONFIG, 'success', 'title', 'done');
+
+    const created = calls.find((c) => c.method === 'checks.create:main');
+    const updated = calls.find((c) => c.method === 'checks.update:main');
+    assert.ok(created);
+    assert.ok(updated);
+    assert.equal((updated?.args as { check_run_id: number }).check_run_id, ctx.checkRunId?.current);
+    assert.equal((updated?.args as { conclusion: string }).conclusion, 'success');
+  });
+
+  it('uses statusOctokit for the check-run when provided, not octokit', async () => {
+    const mainCalls: Call[] = [];
+    const statusCalls: Call[] = [];
+    const octokit = fakeOctokit(mainCalls, 'main');
+    const statusOctokit = fakeOctokit(statusCalls, 'status');
+
+    await publishCheckRun(baseCtx(octokit, statusOctokit), TEST_CONFIG, 'success', 'title', 'ok');
+
+    assert.equal(
+      statusCalls.some((c) => c.method === 'checks.create:status'),
+      true,
+    );
+    assert.equal(
+      mainCalls.some((c) => c.method === 'checks.create:main'),
+      false,
+    );
+  });
+
+  it('does not throw when the check-run API is unavailable -- best-effort only', async () => {
+    const ctx: LabelSyncContext = {
+      config: { token: 'x', owner: 'kubevirt-ui', repo: 'kubevirt-plugin' },
+      headSha: 'abc123',
+      octokit: {} as Octokit,
+      prNumber: 1,
+    };
+    await assert.doesNotReject(publishCheckRun(ctx, TEST_CONFIG, 'success', 'title', 'ok'));
+  });
+
+  it('is a no-op without a headSha', async () => {
+    const calls: Call[] = [];
+    const octokit = fakeOctokit(calls, 'main');
+    await publishCheckRun(
+      { ...baseCtx(octokit), headSha: undefined },
+      TEST_CONFIG,
+      'success',
+      't',
+      's',
+    );
+    assert.equal(calls.length, 0);
+  });
+
+  it('maps an unexpected error to a completed check-run with a blocking "failure" conclusion, not "neutral"', async () => {
+    const calls: Call[] = [];
+    const octokit = fakeOctokit(calls, 'main');
+    await publishCheckRun(baseCtx(octokit), TEST_CONFIG, 'error', 'title', 'unexpected error');
+    const created = calls.find((c) => c.method === 'checks.create:main');
+    assert.ok(created);
+    assert.equal((created?.args as { status: string }).status, 'completed');
+    assert.equal((created?.args as { conclusion: string }).conclusion, 'failure');
   });
 });
 

--- a/.github/scripts/src/validation/pr-path-validation/label-sync.ts
+++ b/.github/scripts/src/validation/pr-path-validation/label-sync.ts
@@ -10,11 +10,84 @@ export type PathValidationEvent = {
 
 export type LabelSyncContext = {
   octokit: Octokit;
-  /** Commit statuses need a separate permission scope -- defaults to `octokit` when the caller has just one token. */
+  /** Commit statuses / check-runs need a separate permission scope -- defaults to `octokit` when the caller has just one token. */
   statusOctokit?: Octokit;
   config: GitHubConfig;
   prNumber: number;
   headSha?: string;
+  /** Holds the check-run id created by the first publishCheckRun call in this run, so later calls update it in place instead of creating a new one. */
+  checkRunId?: { current?: number };
+};
+
+const STATUS_TO_CHECK_STATE: Record<
+  'pending' | 'success' | 'failure' | 'error',
+  { status: 'in_progress' | 'completed'; conclusion?: 'success' | 'failure' | 'neutral' }
+> = {
+  pending: { status: 'in_progress' },
+  success: { status: 'completed', conclusion: 'success' },
+  failure: { status: 'completed', conclusion: 'failure' },
+  // 'neutral' does not block merging on GitHub -- an unexpected error must
+  // fail closed the same as a real failure, not silently pass the check.
+  error: { status: 'completed', conclusion: 'failure' },
+};
+
+/**
+ * Explicitly create/update a check-run for this validation, rather than
+ * relying on whatever incidental check-run the surrounding job's own name
+ * produces (which a future job rename could orphan). Same pattern as
+ * publish-gating-check for "Run Gating Tests". Best-effort: the plain
+ * status still reports the result even if this call fails.
+ */
+export const publishCheckRun = async (
+  ctx: LabelSyncContext,
+  pathConfig: Pick<PathValidationConfig, 'statusContext'>,
+  state: 'pending' | 'success' | 'failure' | 'error',
+  title: string,
+  summary: string,
+): Promise<void> => {
+  if (!ctx.headSha) return;
+
+  const octokit = ctx.statusOctokit ?? ctx.octokit;
+  const { status, conclusion } = STATUS_TO_CHECK_STATE[state];
+  const headSha = ctx.headSha;
+
+  const output = { summary, title };
+  const completedAt = status === 'completed' ? new Date().toISOString() : undefined;
+
+  try {
+    const existingId = ctx.checkRunId?.current;
+    if (existingId) {
+      await octokit.checks.update({
+        check_run_id: existingId,
+        completed_at: completedAt,
+        conclusion,
+        output,
+        owner: ctx.config.owner,
+        repo: ctx.config.repo,
+        status,
+      });
+      return;
+    }
+
+    const { data } = await octokit.checks.create({
+      completed_at: completedAt,
+      conclusion,
+      head_sha: headSha,
+      name: pathConfig.statusContext,
+      output,
+      owner: ctx.config.owner,
+      repo: ctx.config.repo,
+      status,
+    });
+    if (ctx.checkRunId) {
+      ctx.checkRunId.current = data.id;
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Could not publish "${pathConfig.statusContext}" check-run: ${(err as Error)?.message ?? err}`,
+    );
+  }
 };
 
 export const reportCommitStatus = async (
@@ -34,6 +107,7 @@ export const reportCommitStatus = async (
     description,
     pathConfig.statusContext,
   );
+  await publishCheckRun(ctx, pathConfig, state, pathConfig.displayName, description);
 };
 
 export const syncValidationLabels = async (

--- a/.github/scripts/src/validation/pr-path-validation/run-validation.test.ts
+++ b/.github/scripts/src/validation/pr-path-validation/run-validation.test.ts
@@ -86,6 +86,16 @@ const fakeOctokit = (options: FakeOctokitOptions, calls: Call[]): Octokit => {
         throw new Error('Not Found');
       },
     },
+    checks: {
+      create: async (args: unknown) => {
+        calls.push({ method: 'checks.create', args });
+        return { data: { id: 1000 } };
+      },
+      update: async (args: unknown) => {
+        calls.push({ method: 'checks.update', args });
+        return { data: { id: (args as { check_run_id: number }).check_run_id } };
+      },
+    },
   } as unknown as Octokit;
 };
 
@@ -356,5 +366,15 @@ describe('runPathValidation', () => {
 
     const statuses = statusesOf(calls);
     assert.equal(statuses[0]?.state, 'pending');
+  });
+
+  it('publishes one check-run per run -- pending creates it, the final status updates the same one', async () => {
+    const calls: Call[] = [];
+    const octokit = fakeOctokit({ files: [{ filename: 'src/App.tsx' }], labels: [] }, calls);
+
+    await runPathValidation(buildCtx(octokit), TEST_CONFIG, buildStatusDescription);
+
+    assert.equal(calls.filter((c) => c.method === 'checks.create').length, 1);
+    assert.equal(calls.filter((c) => c.method === 'checks.update').length, 1);
   });
 });

--- a/.github/scripts/src/validation/pr-path-validation/run-validation.ts
+++ b/.github/scripts/src/validation/pr-path-validation/run-validation.ts
@@ -20,6 +20,8 @@ export type PathValidationContext = {
   baseBranch: string;
   /** Pre-fetched changed files -- skips the internal getPullRequestFiles call so callers running multiple path validations for the same PR can share one fetch. */
   files?: Array<{ filename: string; patch?: string }>;
+  /** Shared with the caller so an error thrown after the pending check-run is created can still update that same check-run instead of creating a duplicate. Defaults to a fresh holder when omitted. */
+  checkRunId?: { current?: number };
 };
 
 export type PathValidationOutcome =
@@ -47,6 +49,9 @@ export const runPathValidation = async (
     config: ctx.config,
     prNumber: ctx.prNumber,
     headSha: ctx.headSha,
+    // Shared across this run's reportCommitStatus calls so the final
+    // status updates the same check-run created by the pending one.
+    checkRunId: ctx.checkRunId ?? {},
   };
 
   await reportCommitStatus(

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,165 @@
+name: Auto Merge
+
+# Toggles GitHub's native auto-merge instead of merging PRs ourselves --
+# GitHub then merges automatically once branch protection's required checks
+# pass and there are no conflicts. See ci-scripts/README.md ("Tide Removal &
+# Native Auto-Merge").
+#
+# The GraphQL enable/disable calls are convenience only, not the actual
+# enforcement -- if either silently fails, a held/ineligible PR must still
+# be blocked. The "Merge Gate" check-run below is the real backstop: it's a
+# required status check (like Run Gating Tests), so branch protection alone
+# keeps blocking merge regardless of whether the auto-merge toggle succeeds.
+on:
+  pull_request_target:
+    types: [labeled, unlabeled, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  sync-auto-merge:
+    name: Sync Auto-Merge State
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    # Serialize per PR so out-of-order concurrent label events can't leave
+    # auto-merge/the merge gate reflecting a stale label state.
+    concurrency:
+      group: auto-merge-${{ github.event.pull_request.number }}
+    steps:
+      # Pin to default branch: pull_request_target checks out the PR base,
+      # which may lack ci-scripts/hot-cluster/ on older release branches.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Determine merge-pool eligibility
+        id: eligibility
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { isMergePoolPr } = require('./ci-scripts/hot-cluster/is-merge-pool-pr.cjs');
+
+            // Re-read labels fresh instead of trusting the event payload --
+            // closes the race where a queued run's payload could be stale
+            // by the time it's this run's turn.
+            let eligible;
+            let headSha;
+            let nodeId = '';
+            let determined = true;
+            const prNumber = context.payload.pull_request.number;
+
+            try {
+              const pr = await github.rest.pulls.get({ ...context.repo, pull_number: prNumber });
+              eligible = isMergePoolPr(pr.data.labels);
+              headSha = pr.data.head.sha;
+              nodeId = pr.data.node_id;
+              core.info(
+                `PR #${prNumber} labels: [${pr.data.labels.map((l) => l.name).join(', ')}] -- merge-pool eligible: ${eligible}`,
+              );
+            } catch (err) {
+              // Fail closed: publish a failing Merge Gate for this event's
+              // head SHA rather than silently leaving a possibly-stale
+              // check in place, or guessing at eligibility.
+              determined = false;
+              eligible = false;
+              headSha = context.payload.pull_request.head.sha;
+              core.warning(
+                `Could not determine merge-pool eligibility for PR #${prNumber}: ${err.message} -- failing the Merge Gate check closed.`,
+              );
+            }
+
+            core.setOutput('determined', String(determined));
+            core.setOutput('eligible', String(eligible));
+            core.setOutput('node_id', nodeId);
+            core.setOutput('number', String(prNumber));
+            core.setOutput('head_sha', headSha);
+            core.setOutput('conclusion', eligible ? 'success' : 'failure');
+            core.setOutput(
+              'title',
+              !determined
+                ? 'Could not determine eligibility'
+                : eligible
+                  ? 'Merge-pool eligible'
+                  : 'Not merge-pool eligible',
+            );
+            core.setOutput(
+              'summary',
+              !determined
+                ? 'Failed to read current PR labels -- failing closed until a later event retries.'
+                : eligible
+                  ? 'PR carries lgtm+approved with no hold/do-not-merge label.'
+                  : 'PR is missing lgtm/approved, or carries a hold/do-not-merge label. This check blocks merge independently of auto-merge state.',
+            );
+
+      # The actual merge gate: a required check, independent of whether the
+      # GraphQL toggle below succeeds. Not eligible -> failure, which alone
+      # is enough for branch protection to keep blocking merge.
+      - name: Publish merge gate check
+        uses: ./.github/actions/publish-gating-check
+        with:
+          name: 'Merge Gate'
+          head-sha: ${{ steps.eligibility.outputs.head_sha }}
+          status: completed
+          conclusion: ${{ steps.eligibility.outputs.conclusion }}
+          title: ${{ steps.eligibility.outputs.title }}
+          summary: ${{ steps.eligibility.outputs.summary }}
+
+      - name: Enable or disable native auto-merge
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const determined = '${{ steps.eligibility.outputs.determined }}' === 'true';
+            const prNumber = '${{ steps.eligibility.outputs.number }}';
+
+            if (!determined) {
+              // Eligibility is unknown -- the Merge Gate check above
+              // already failed closed. Don't guess by toggling auto-merge
+              // either way; a later event will retry this.
+              core.info(`Skipping auto-merge toggle for PR #${prNumber} -- eligibility could not be determined this run.`);
+              return;
+            }
+
+            const eligible = '${{ steps.eligibility.outputs.eligible }}' === 'true';
+            const nodeId = '${{ steps.eligibility.outputs.node_id }}';
+
+            if (eligible) {
+              try {
+                await github.graphql(
+                  `mutation($id: ID!) {
+                    enablePullRequestAutoMerge(input: { pullRequestId: $id, mergeMethod: MERGE }) {
+                      pullRequest { autoMergeRequest { enabledAt } }
+                    }
+                  }`,
+                  { id: nodeId },
+                );
+                core.info(`Enabled auto-merge for PR #${prNumber}.`);
+              } catch (err) {
+                // Draft/already-merged PRs and similar edge cases surface
+                // as GraphQL errors here -- the Merge Gate check already
+                // reflects eligibility regardless, so this is UX only.
+                core.warning(`Could not enable auto-merge for PR #${prNumber}: ${err.message}`);
+              }
+              return;
+            }
+
+            try {
+              await github.graphql(
+                `mutation($id: ID!) {
+                  disablePullRequestAutoMerge(input: { pullRequestId: $id }) {
+                    pullRequest { autoMergeRequest { enabledAt } }
+                  }
+                }`,
+                { id: nodeId },
+              );
+              core.info(`Disabled auto-merge for PR #${prNumber} (not merge-pool eligible).`);
+            } catch (err) {
+              // Most common case: auto-merge was never enabled to begin
+              // with. Either way, the failing Merge Gate check published
+              // above is what actually blocks merge here, not this call.
+              core.info(`No auto-merge to disable for PR #${prNumber} (${err.message}).`);
+            }

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -12,6 +12,7 @@ jobs:
       pull-requests: write
       issues: write
       statuses: write
+      checks: write
     runs-on: ubuntu-latest
     concurrency:
       group: pr-validation-${{ github.event.pull_request.number }}

--- a/.github/workflows/pr_validation_commands.yml
+++ b/.github/workflows/pr_validation_commands.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: read
       statuses: write
+      checks: write
     runs-on: ubuntu-latest
     concurrency:
       group: pr-validation-cmd-${{ github.event.issue.number }}

--- a/.github/workflows/verify-review-labels.yml
+++ b/.github/workflows/verify-review-labels.yml
@@ -15,6 +15,7 @@ permissions:
   pull-requests: write
   issues: write
   statuses: write
+  checks: write
 
 jobs:
   verify:


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/auto-merge.yml`: toggles GitHub's native `enablePullRequestAutoMerge`/`disablePullRequestAutoMerge` from the existing `lgtm`/`approved`/hold labels (reusing `ci-scripts/hot-cluster/is-merge-pool-pr.cjs`), instead of re-implementing "are all required checks green" ourselves. GitHub's own branch-protection engine already evaluates this correctly -- the same engine that produces `mergeStateStatus: BLOCKED` for an unmet required check.
- Explicitly publishes `ai-config-validation`/`ci-scripts-validation` via the Checks API (`checks.create`/`checks.update`), matching the pattern `publish-gating-check` already uses for "Run Gating Tests". Prevents a future job rename/consolidation from permanently orphaning either required check the way PR #4357's `ai-config-validation` check-run got stuck after CNV-92998.
- Adds `checks: write` permission to the three workflows that run this validation path (`pr_validation.yml`, `pr_validation_commands.yml`, `verify-review-labels.yml`).

## Context
Part of [CNV-93066](https://redhat.atlassian.net/browse/CNV-93066): removing Tide as the merge mechanism for this repo and relying solely on GitHub's own required-checks + auto-merge, since Tide requires config parity in a separate repo (`openshift/release`) that has repeatedly drifted out of sync (missing labels/contexts -- see PR #4356, #4349).

Repo-level prerequisites already applied directly (not code, no PR needed):
- `main` branch protection now also requires `build`, `test`, `i18n`, `actionlint` (previously only `Run Gating Tests`/`ai-config-validation`/`ci-scripts-validation` were required).
- `allow_auto_merge` enabled on the repo.

## Test plan
- [x] `.github/scripts` unit tests pass (116/116)
- [x] `.github/scripts` typecheck clean
- [x] All edited/new workflow YAML validated
- [ ] Re-verify the PR #4356 / #4349 scenarios (held/failing required check + `lgtm`+`approved`) against this setup once merged
- [ ] Coordinate the `openshift/release` PR removing Tide's `tide:` block for this repo after this lands

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub Check Runs for PR path validation (pending → success/failure/error) alongside existing commit statuses.
  * Reuse a single check run per validation run, updating it instead of creating duplicates.
  * Introduced automated PR auto-merge management using a required “Merge Gate” check; now also reacts to new commits via **synchronize**.
* **Bug Fixes**
  * Improved unexpected-error handling to finalize the existing check run (not create a second one) and keep reporting commit statuses even if the Checks API is unavailable.
* **Chores**
  * Updated GitHub Action permissions to allow creating/updating check runs, and added a configurable check-run name for the gating check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->