### PR TITLE
CNV-90313: CD-ROM drive not ejected when canceling upload during new VM creation

### DIFF
--- a/src/utils/components/DiskModal/utils/helpers.test.ts
+++ b/src/utils/components/DiskModal/utils/helpers.test.ts
@@ -1,6 +1,29 @@
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  getCustomizeWizardVM,
+  updateVMCustomizeIT,
+} from '@kubevirt-utils/signals/customizeWizardVMSignal';
+import { updateDisks } from '@virtualmachines/details/tabs/configuration/details/utils/utils';
+import { kubevirtK8sGet } from '@multicluster/k8sRequests';
 
-import { createDataVolumeName } from './helpers';
+import {
+  createDataVolumeName,
+  createDetachDiskCancelCleanup,
+  createEjectMountedDiskCancelCleanup,
+} from './helpers';
+
+jest.mock('@multicluster/k8sRequests', () => ({
+  kubevirtK8sGet: jest.fn(),
+}));
+
+jest.mock('@virtualmachines/details/tabs/configuration/details/utils/utils', () => ({
+  updateDisks: jest.fn(),
+}));
+
+jest.mock('@kubevirt-utils/signals/customizeWizardVMSignal', () => ({
+  getCustomizeWizardVM: jest.fn(),
+  updateVMCustomizeIT: jest.fn(),
+}));
 
 const vm = (name: string): V1VirtualMachine => ({ metadata: { name }, spec: { template: {} } });
 const RANDOM_CHARS = /[a-z0-9]/;
@@ -24,5 +47,74 @@ describe('Generate names for data volume', () => {
     expect(name).toHaveLength(9);
     expect(name.substring(0, 3)).toEqual('dv-');
     expect(name.substring(3, 9)).toMatch(RANDOM_CHARS);
+  });
+});
+
+describe('createEjectMountedDiskCancelCleanup / createDetachDiskCancelCleanup', () => {
+  const cdromName = 'cdrom-1';
+
+  const vmWithCdrom = (): V1VirtualMachine => ({
+    metadata: { name: 'test-vm', namespace: 'test-ns' },
+    spec: {
+      template: {
+        spec: {
+          domain: { devices: { disks: [{ cdrom: {}, name: cdromName }] } },
+          volumes: [{ dataVolume: { name: 'dv-1' }, name: cdromName }],
+        },
+      },
+    },
+  });
+
+  const mockKubevirtK8sGet = kubevirtK8sGet as jest.Mock;
+  const mockUpdateDisks = updateDisks as jest.Mock;
+  const mockGetCustomizeWizardVM = getCustomizeWizardVM as jest.Mock;
+  const mockUpdateVMCustomizeIT = updateVMCustomizeIT as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCustomizeWizardVM.mockReturnValue(null);
+  });
+
+  describe('without a wizard draft VM (persisted VM / details page)', () => {
+    it('re-fetches the VM from the cluster and patches it', async () => {
+      const freshVM = vmWithCdrom();
+      mockKubevirtK8sGet.mockResolvedValue(freshVM);
+
+      const cleanup = createEjectMountedDiskCancelCleanup(vmWithCdrom(), cdromName);
+      await cleanup();
+
+      expect(mockKubevirtK8sGet).toHaveBeenCalledTimes(1);
+      expect(mockUpdateDisks).toHaveBeenCalledTimes(1);
+      expect(mockUpdateVMCustomizeIT).not.toHaveBeenCalled();
+      const patchedVM = mockUpdateDisks.mock.calls[0][0] as V1VirtualMachine;
+      expect(patchedVM.spec.template.spec.volumes).toEqual([]);
+    });
+  });
+
+  describe('with a wizard draft VM (in-memory customize instance type wizard)', () => {
+    it('transforms the live signal VM and patches it via updateVMCustomizeIT', async () => {
+      const draftVM = vmWithCdrom();
+      mockGetCustomizeWizardVM.mockReturnValue(draftVM);
+
+      const cleanup = createEjectMountedDiskCancelCleanup(vmWithCdrom(), cdromName);
+      await cleanup();
+
+      expect(mockKubevirtK8sGet).not.toHaveBeenCalled();
+      expect(mockUpdateVMCustomizeIT).toHaveBeenCalledTimes(1);
+      const patchedVM = mockUpdateVMCustomizeIT.mock.calls[0][0] as V1VirtualMachine;
+      expect(patchedVM.spec.template.spec.volumes).toEqual([]);
+    });
+
+    it('detaches (rather than ejects) the disk when using createDetachDiskCancelCleanup', async () => {
+      const draftVM = vmWithCdrom();
+      mockGetCustomizeWizardVM.mockReturnValue(draftVM);
+
+      const cleanup = createDetachDiskCancelCleanup(vmWithCdrom(), cdromName);
+      await cleanup();
+
+      const patchedVM = mockUpdateVMCustomizeIT.mock.calls[0][0] as V1VirtualMachine;
+      expect(patchedVM.spec.template.spec.domain.devices.disks).toEqual([]);
+      expect(patchedVM.spec.template.spec.volumes).toEqual([]);
+    });
   });
 });

--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -25,6 +25,10 @@ import {
 import { ANNOTATIONS } from '@kubevirt-utils/resources/template';
 import { getBootDisk, getDataVolumeTemplates, getVolumes } from '@kubevirt-utils/resources/vm';
 import { getOperatingSystem } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
+import {
+  getCustomizeWizardVM,
+  updateVMCustomizeIT,
+} from '@kubevirt-utils/signals/customizeWizardVMSignal';
 import { ensurePath, getRandomChars, isEmpty } from '@kubevirt-utils/utils/utils';
 import { isDNS1123Label } from '@kubevirt-utils/utils/validation';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -399,6 +403,9 @@ export const detachDiskFromVM = (vm: V1VirtualMachine, diskName: string): V1Virt
   });
 };
 
+// If the VM only exists as an in-memory draft (the creation wizard), the wizard signal is
+// the live source of truth: patch it instead of re-fetching from the cluster, since the
+// draft VM has never been persisted and kubevirtK8sGet would fail.
 const createDiskCancelCleanup =
   (
     vm: V1VirtualMachine,
@@ -406,6 +413,13 @@ const createDiskCancelCleanup =
     transform: (vm: V1VirtualMachine, name: string) => V1VirtualMachine,
   ): (() => Promise<void>) =>
   async () => {
+    const draftVM = getCustomizeWizardVM();
+
+    if (draftVM) {
+      await updateVMCustomizeIT(transform(draftVM, diskName));
+      return;
+    }
+
     const freshVM = await kubevirtK8sGet<V1VirtualMachine>({
       cluster: getCluster(vm),
       model: VirtualMachineModel,

--- a/src/utils/components/DiskModal/utils/submitCDROM.test.ts
+++ b/src/utils/components/DiskModal/utils/submitCDROM.test.ts
@@ -1,0 +1,134 @@
+import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getCustomizeWizardVM } from '@kubevirt-utils/signals/customizeWizardVMSignal';
+import { isRunning } from '@virtualmachines/utils';
+
+import {
+  createDetachDiskCancelCleanup,
+  createEjectMountedDiskCancelCleanup,
+  mountISOToCDROM,
+} from './helpers';
+import { submitCDROM } from './submitCDROM';
+import { V1DiskFormState } from './types';
+import { runVmCdromBackgroundUpload } from './vmCdromBackgroundUpload';
+
+jest.mock('@virtualmachines/utils', () => ({
+  isRunning: jest.fn(),
+}));
+
+jest.mock('@kubevirt-utils/signals/customizeWizardVMSignal', () => ({
+  getCustomizeWizardVM: jest.fn(),
+}));
+
+jest.mock('./helpers', () => ({
+  createDetachDiskCancelCleanup: jest.fn(() => 'detach-cleanup'),
+  createEjectMountedDiskCancelCleanup: jest.fn(() => 'eject-cleanup'),
+  createMutableUploadData: jest.fn((data) => data),
+  mountISOToCDROM: jest.fn(async (vm) => vm),
+}));
+
+jest.mock('./submit', () => ({
+  addDisk: jest.fn((_data, vm) => vm),
+}));
+
+jest.mock('./bootDiskUtils', () => ({
+  reorderBootDisk: jest.fn((vm) => vm),
+}));
+
+jest.mock('./vmCdromBackgroundUpload', () => ({
+  logBackgroundUploadError: jest.fn(),
+  runVmCdromBackgroundUpload: jest.fn().mockResolvedValue(undefined),
+}));
+
+const baseVM: V1VirtualMachine = {
+  metadata: { name: 'test-vm', namespace: 'test-ns' },
+  spec: { running: false, template: { spec: { domain: { devices: {} } } } },
+};
+
+const buildData = (overrides: Partial<V1DiskFormState> = {}): V1DiskFormState => ({
+  disk: { cdrom: {}, name: 'cdrom-1' },
+  isBootSource: false,
+  uploadFile: { file: new File(['iso'], 'test.iso'), filename: 'test.iso' },
+  ...overrides,
+});
+
+describe('submitCDROM - cancel cleanup wiring', () => {
+  const onSubmit = jest.fn(async (vm: V1VirtualMachine) => vm);
+  const uploadData = jest.fn();
+  const t = ((key: string) => key) as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    onSubmit.mockImplementation(async (vm: V1VirtualMachine) => vm);
+    (isRunning as jest.Mock).mockReturnValue(false);
+    (getCustomizeWizardVM as jest.Mock).mockReturnValue(null);
+  });
+
+  it('builds an eject cancel cleanup (hotpluggable)', async () => {
+    await submitCDROM(buildData(), {
+      isHotPluggable: true,
+      onSubmit,
+      t,
+      uploadData,
+      uploadEnabled: true,
+      vm: baseVM,
+    } as any);
+
+    expect(createEjectMountedDiskCancelCleanup).toHaveBeenCalledWith(baseVM, 'cdrom-1');
+    expect(createDetachDiskCancelCleanup).not.toHaveBeenCalled();
+  });
+
+  it('builds a detach cancel cleanup (non-hotpluggable)', async () => {
+    await submitCDROM(buildData(), {
+      isHotPluggable: false,
+      onSubmit,
+      t,
+      uploadData,
+      uploadEnabled: true,
+      vm: baseVM,
+    } as any);
+
+    expect(createDetachDiskCancelCleanup).toHaveBeenCalledWith(baseVM, 'cdrom-1');
+    expect(createEjectMountedDiskCancelCleanup).not.toHaveBeenCalled();
+  });
+
+  it('mounts the ISO against the live wizard signal VM (not the stale closure) once the upload completes', async () => {
+    (isRunning as jest.Mock).mockReturnValue(true);
+    const liveVM: V1VirtualMachine = {
+      ...baseVM,
+      metadata: { ...baseVM.metadata, name: 'live-vm' },
+    };
+    (getCustomizeWizardVM as jest.Mock).mockReturnValue(liveVM);
+
+    await submitCDROM(buildData(), {
+      isHotPluggable: true,
+      onSubmit,
+      t,
+      uploadData,
+      uploadEnabled: true,
+      vm: baseVM,
+    } as any);
+
+    const backgroundUploadArgs = (runVmCdromBackgroundUpload as jest.Mock).mock.calls[0][0];
+    await backgroundUploadArgs.afterUpload();
+
+    expect(mountISOToCDROM).toHaveBeenCalledWith(liveVM, expect.anything(), true);
+  });
+
+  it('falls back to the closed-over VM for mounting when there is no wizard signal VM', async () => {
+    (isRunning as jest.Mock).mockReturnValue(true);
+
+    await submitCDROM(buildData(), {
+      isHotPluggable: true,
+      onSubmit,
+      t,
+      uploadData,
+      uploadEnabled: true,
+      vm: baseVM,
+    } as any);
+
+    const backgroundUploadArgs = (runVmCdromBackgroundUpload as jest.Mock).mock.calls[0][0];
+    await backgroundUploadArgs.afterUpload();
+
+    expect(mountISOToCDROM).toHaveBeenCalledWith(baseVM, expect.anything(), true);
+  });
+});

--- a/src/utils/components/DiskModal/utils/submitCDROM.ts
+++ b/src/utils/components/DiskModal/utils/submitCDROM.ts
@@ -2,6 +2,7 @@ import produce from 'immer';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getVmCdromUploadKeyFromVm } from '@kubevirt-utils/hooks/useUploadProgressToast/keys/uploadKeys';
+import { getCustomizeWizardVM } from '@kubevirt-utils/signals/customizeWizardVMSignal';
 import { generateUploadDiskName } from '@kubevirt-utils/utils/utils';
 import { isRunning } from '@virtualmachines/utils';
 
@@ -55,6 +56,7 @@ export const submitCDROM = async (
     const diskName = data.disk.name;
     const file = data?.uploadFile?.file;
     const uploadKey = getVmCdromUploadKeyFromVm(vm, diskName);
+
     const createCancelCleanup = isHotPluggable
       ? createEjectMountedDiskCancelCleanup
       : createDetachDiskCancelCleanup;
@@ -87,7 +89,8 @@ export const submitCDROM = async (
             delete draft.dataVolumeTemplate;
           });
 
-          const mountedVm = await mountISOToCDROM(vmAfterEmptyAdd, dataWithVolume, isHotPluggable);
+          const vmForMount = getCustomizeWizardVM() ?? vmAfterEmptyAdd;
+          const mountedVm = await mountISOToCDROM(vmForMount, dataWithVolume, isHotPluggable);
           await onSubmit(mountedVm);
         },
         diskState: mutableData,

--- a/src/utils/signals/customizeWizardVMSignal.ts
+++ b/src/utils/signals/customizeWizardVMSignal.ts
@@ -6,6 +6,8 @@ import { signal } from '@preact/signals-react';
 
 export const customizeWizardVMSignal = signal<V1VirtualMachine>(null);
 
+export const getCustomizeWizardVM = (): V1VirtualMachine | null => customizeWizardVMSignal.value;
+
 export const mergeVMData = (currentData: any, updateData: any) => {
   // Handle null/undefined cases
   if (currentData == null && updateData == null) {

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/EjectCDROMModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/EjectCDROMModal.tsx
@@ -5,6 +5,7 @@ import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { ejectISOFromCDROM } from '@kubevirt-utils/components/DiskModal/utils/helpers';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getCustomizeWizardVM } from '@kubevirt-utils/signals/customizeWizardVMSignal';
 import { ButtonVariant } from '@patternfly/react-core';
 
 import { updateDisks } from '../../../details/utils/utils';
@@ -29,7 +30,8 @@ const EjectCDROMModal: FC<EjectCDROMModalProps> = ({
   const { t } = useKubevirtTranslation();
 
   const handleEject = () => {
-    const updatedVM = ejectISOFromCDROM(vm, cdromName);
+    const currentVM = getCustomizeWizardVM() ?? vm;
+    const updatedVM = ejectISOFromCDROM(currentVM, cdromName);
 
     if (onSubmit) {
       return onSubmit(updatedVM);

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
@@ -25,6 +25,7 @@ import {
   isCDROMDisk,
 } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
 import { isEmptyContainerDiskImage } from '@kubevirt-utils/resources/vm/utils/disk/utils';
+import { getVMIVolumes } from '@kubevirt-utils/resources/vmi';
 import { getContentScrollableElement } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import {
@@ -80,7 +81,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
   );
 
   const { isCDROMMountedState, volume } = useMemo(() => {
-    const vols = isVMRunning && !isCDROM ? vmi?.spec?.volumes : getVolumes(vm);
+    const vols = isVMRunning && !isCDROM ? getVMIVolumes(vmi) : getVolumes(vm);
     const vol = vols?.find(({ name }) => name === diskName);
 
     const isMountedVolume = (targetVolume: undefined | V1Volume): boolean => {

--- a/src/views/virtualmachines/wizard/utils/utils.test.ts
+++ b/src/views/virtualmachines/wizard/utils/utils.test.ts
@@ -1,0 +1,42 @@
+import { cancelAllWizardPendingUploads } from '@kubevirt-utils/hooks/useUploadProgressToast';
+import { setCustomizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
+
+import { clearVMPendingUploadsAndSignal } from './utils';
+
+jest.mock('@kubevirt-utils/hooks/useUploadProgressToast', () => ({
+  cancelAllWizardPendingUploads: jest.fn(),
+}));
+
+jest.mock('@kubevirt-utils/signals/customizeWizardVMSignal', () => ({
+  setCustomizeWizardVMSignal: jest.fn(),
+}));
+
+describe('clearVMPendingUploadsAndSignal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('nulls the wizard VM signal before cancelling pending uploads', () => {
+    const callOrder: string[] = [];
+    (setCustomizeWizardVMSignal as jest.Mock).mockImplementation(() => callOrder.push('setSignal'));
+    (cancelAllWizardPendingUploads as jest.Mock).mockImplementation(() =>
+      callOrder.push('cancelUploads'),
+    );
+
+    clearVMPendingUploadsAndSignal();
+
+    expect(callOrder).toEqual(['setSignal', 'cancelUploads']);
+  });
+
+  it('clears the signal with null', () => {
+    clearVMPendingUploadsAndSignal();
+
+    expect(setCustomizeWizardVMSignal).toHaveBeenCalledWith(null);
+  });
+
+  it('cancels all pending wizard uploads', () => {
+    clearVMPendingUploadsAndSignal();
+
+    expect(cancelAllWizardPendingUploads).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 📝 Description

When a user cancels a CD-ROM upload during new VM creation (customize instance type wizard), the CD-ROM drive is not ejected from the draft VM (When advanced CD-ROM features are enabled). 
This works correctly when adding a CD-ROM to an existing VM.

## 🔗 Links

Jira ticket: [CNV-90313](https://redhat.atlassian.net/browse/CNV-90313)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/05a1660a-20a3-4189-a442-b783f7426ecc


After:

https://github.com/user-attachments/assets/7a8d829c-a855-4413-b848-f25204f9972d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved disk and CD-ROM cleanup when canceling customization changes.
  - Preserved unsaved wizard changes when ejecting media or completing ISO uploads.
  - Ensured disk removal clears associated storage volumes correctly.
  - Improved storage volume handling for running virtual machines.

- **Tests**
  - Added coverage for disk cleanup, CD-ROM upload and eject flows, and wizard state reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->