### PR TITLE
CNV-93066: Run auto merge gate on open

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,7 +12,10 @@ name: Auto Merge
 # keeps blocking merge regardless of whether the auto-merge toggle succeeds.
 on:
   pull_request_target:
-    types: [labeled, unlabeled, reopened, synchronize]
+    # opened -- so a brand-new PR gets an immediate, explicit "Merge Gate:
+    # failure" instead of sitting as "Expected -- waiting for status" until
+    # its first label/push event
+    types: [opened, labeled, unlabeled, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
## 📝 Description

Run auto merge gate when a new PR is opened. 

## 🔗 Links

Jira ticket: [CNV-93066](https://redhat.atlassian.net/browse/CNV-93066)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Merge checks now run automatically when a new pull request is opened, providing immediate validation instead of waiting for another activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->