### PR TITLE
CNV-93072: Validate prow migrations and readme files update

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,79 @@
+# GitHub Actions Workflows
+
+Index of workflows in this directory. Deep design notes (check-run model, merge pool, secrets, troubleshooting) live in [`ci-scripts/README.md`](../../ci-scripts/README.md). Slash-command help text is SSOT in [`../pr-commands.json`](../pr-commands.json) (`/help`).
+
+**Prow/Tide are not used for this repo.** Gating E2E and merge automation run here.
+
+## Hot Cluster E2E
+
+| Workflow                              | Trigger                                | Role                                                            |
+| ------------------------------------- | -------------------------------------- | --------------------------------------------------------------- |
+| `hot-cluster-e2e.yml`                 | `workflow_dispatch` only               | Full E2E graph; publishes required **Run Gating Tests**         |
+| `hot-cluster-e2e-run.yml`             | `workflow_call`                        | Build plugin image + run Playwright on ARC                      |
+| `hot-cluster-check.yml`               | `workflow_call` (+ manual health)      | Cluster readiness / health                                      |
+| `hot-cluster-e2e-pr-gate.yml`         | PR opened / synchronize / reopened     | Thin gate → dispatch `hot-cluster-e2e.yml`                      |
+| `ok-to-test-gate.yml`                 | `ok-to-test` labeled                   | Thin gate for fork PRs                                          |
+| `ok-to-test-reset.yml`                | synchronize while `ok-to-test` present | Remove `ok-to-test` when head moves                             |
+| `retest-e2e.yml`                      | `/retest-e2e`                          | Cancel in-flight via concurrency groups; dispatch fresh run     |
+| `cancel-e2e.yml`                      | `/cancel-e2e`                          | Cancel in-flight E2E without a new result                       |
+| `hold-e2e.yml`                        | `/hold-e2e`                            | `e2e-hold` + neutral gating check; pauses dispatch              |
+| `hot-cluster-e2e-cancel-on-close.yml` | PR closed                              | Cancel in-flight when PR closes                                 |
+| `retest-stale-gating.yml`             | push to `main`                         | Mark checks stale; retest merge-pool PRs                        |
+| `retest-on-pool-entry.yml`            | pool label add / blocking label remove | Retest when a PR newly becomes pool-eligible with a stale check |
+
+## Merge automation (Prow / Tide replacements)
+
+| Workflow                       | Trigger                       | Role                                                                                      |
+| ------------------------------ | ----------------------------- | ----------------------------------------------------------------------------------------- |
+| `auto-merge.yml`               | label / review / synchronize… | Required **Merge Gate** + enable/disable GitHub auto-merge                                |
+| `pr_validation_commands.yml`   | issue comment                 | `/lgtm`, `/approve`, `/hold` (+ cancel), `/ai-approved`, `/ci-approved`, `/recheck-jira`  |
+| `pr_review_commands.yml`       | review submitted              | Approve / Request changes ↔ `lgtm` (+ `approved` for root OWNERS)                         |
+| `needs-rebase.yml`             | PR events + push to `main`    | Sync `needs-rebase` from GitHub `mergeable`                                               |
+| `verify-merge-pool-labels.yml` | labeled / unlabeled           | Strip untrusted UI `lgtm`/`approved`/`do-not-merge/hold`; restore untrusted hold removals |
+| `pr_help_command.yml`          | `/help`                       | Comment command list from `pr-commands.json`                                              |
+
+Pool eligibility (`isMergePoolPr`): `lgtm` + `approved`, and no blockers (`hold`, `e2e-hold`, `needs-rebase`, any `do-not-merge/*`). Label names: [`ci-scripts/hot-cluster/js/merge-pool-labels.cjs`](../../ci-scripts/hot-cluster/js/merge-pool-labels.cjs).
+
+`/hold` blocks merge; `/hold-e2e` only pauses Hot Cluster E2E (different label: `do-not-merge/hold` vs `e2e-hold`).
+
+## PR validation (OWNERS-gated paths)
+
+| Workflow                   | Trigger                 | Role                                                  |
+| -------------------------- | ----------------------- | ----------------------------------------------------- |
+| `pr_validation.yml`        | `pull_request_target`   | Jira + AI-config + CI-scripts validation statuses     |
+| `verify-review-labels.yml` | labeled (reviewed/skip) | Strip untrusted UI adds of AI/CI reviewed/skip labels |
+
+Sensitive-path review uses `/ai-approved` and `/ci-approved` (`.github/OWNERS`), not `/approve`.
+
+## Cluster lifecycle & manual console
+
+| Workflow                             | Role                                                |
+| ------------------------------------ | --------------------------------------------------- |
+| `ibmc-cluster-setup.yml`             | Provision hot cluster (classic / vpc / ipi)         |
+| `ibmc-cluster-teardown.yml`          | Tear down hot cluster                               |
+| `ibmc-cluster-auto-teardown.yml`     | Cron: tear down idle clusters (~2h)                 |
+| `ibmc-cleanup-all.yml`               | Aggressive cleanup of leftover IBM Cloud resources  |
+| `deploy-manual-console.yml`          | Deploy OAuth console + plugin for manual UI testing |
+| `deploy-manual-console-command.yml`  | `/deploy-manual-console`                            |
+| `cleanup-manual-console-command.yml` | `/cleanup-manual-console`                           |
+| `deploy-plugin.yml`                  | Rebuild/redeploy plugin only against manual console |
+
+See [`ci-scripts/manual-console/README.md`](../../ci-scripts/manual-console/README.md).
+
+## Other
+
+| Workflow         | Role                                          |
+| ---------------- | --------------------------------------------- |
+| `ci_checks.yml`  | Unit tests, build, i18n, actionlint           |
+| `deploy.yml`     | Build/push multi-arch Quay image on main/tags |
+| `jira_clone.yml` | Jira clone helper                             |
+
+## Shared helpers
+
+| Path                                                                         | Used for                                                                      |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [`.github/actions/setup-gh-scripts`](../actions/setup-gh-scripts/action.yml) | Checkout validation scripts (+ `ci-scripts/hot-cluster/js` SSOT) and `npm ci` |
+| [`.github/actions/create-bot-token`](../actions/create-bot-token/action.yml) | `kubevirt-plugin-bot` App token for label/comment/auto-merge writes           |
+| [`.github/scripts/`](../scripts/)                                            | TypeScript for validation commands, merge-pool verify, Jira/AI/CI checks      |
+
+Bot secrets: `BOT_APP_ID`, `BOT_APP_PRIVATE_KEY` (Issues + Pull requests write on the App). Details: [`ci-scripts/README.md`](../../ci-scripts/README.md#kubevirt-plugin-bot-required-for-prow-replacement-merge-automation).

--- a/ci-scripts/hot-cluster/arc/README.md
+++ b/ci-scripts/hot-cluster/arc/README.md
@@ -37,7 +37,7 @@ Details are in each script’s header comments.
 ## GitHub configuration
 
 - **GitHub App** (recommended): repository **Administration: Read and write**, organization **Self-hosted runners: Read and write**. Install the app on the target repo/org; use App ID, installation ID, and private key PEM.
-- **PAT**: fine-grained or classic with sufficient repo + runner permissions (see [HOT_CLUSTER_CI.md](../HOT_CLUSTER_CI.md)).
+- **PAT**: fine-grained or classic with sufficient repo + runner permissions (see [ci-scripts/README.md](../../README.md) Required GitHub Secrets).
 
 Workflows must use `runs-on:` labels that match **`RUNNER_SCALE_SET_NAME`** (default **`kubevirt-plugin-ci`**).
 
@@ -62,6 +62,6 @@ The custom runner image and its `Dockerfile` live in [`../images/`](../images/) 
 
 ## Further reading
 
-- [ci-scripts/README.md](../README.md) — secrets, multilabel, experimental chart notes.
+- [ci-scripts/README.md](../../README.md) — secrets, E2E check-run model, Prow→GHA migration.
 - [Red Hat: ARC on OpenShift](https://developers.redhat.com/articles/2025/02/17/how-securely-deploy-github-arc-openshift)
 - Upstream chart: `oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set`

--- a/ci-scripts/hot-cluster/ci-env/README.md
+++ b/ci-scripts/hot-cluster/ci-env/README.md
@@ -31,7 +31,7 @@ ARC Runner                ci-env namespace              Test namespace
 2. The **controller** discovers cluster endpoints, resolves the console image,
    creates the test namespace, deploys the Helm chart, and waits for readiness.
 3. The controller patches the ConfigMap with `status: ready` and the
-   `bridge-base-address` the runner needs for Cypress.
+   `bridge-base-address` the runner needs for Playwright (or Cypress on older release branches).
 4. After tests, the runner sets `desired-state: absent` and the controller
    tears down the environment.
 
@@ -52,12 +52,14 @@ ARC Runner                ci-env namespace              Test namespace
 | `console-image` | Override console image (auto-resolved from cluster version if empty) |
 | `helm-release`  | Override Helm release name (defaults to ConfigMap name)              |
 
+Manual-console deploys (label `ci.kubevirt-plugin/type: manual-console`) also pass optional OAuth fields (`auth-mode`, `htpasswd-user`, `htpasswd-secret-name`) and are exempt from the TTL reaper. See [`manual-console/README.md`](../../manual-console/README.md).
+
 ### Controller populates (read-only for runner)
 
 | Field                 | Description                                                             |
 | --------------------- | ----------------------------------------------------------------------- |
 | `status`              | `pending` / `provisioning` / `ready` / `error` / `cleaning` / `cleaned` |
-| `bridge-base-address` | In-cluster console URL for Cypress                                      |
+| `bridge-base-address` | In-cluster console URL for Playwright / Cypress E2E                     |
 | `console-route`       | External Route URL for debugging                                        |
 | `error-message`       | Error details (only when `status=error`)                                |
 
@@ -149,9 +151,10 @@ The `ci-console` ClusterRole (required by the ci-test-stack chart) is also
 owned by this chart, so the ci-env-controller must be installed before any
 test runs.
 
-## Future Work
+## Related
 
-- **Authenticated console mode**: Return a login Secret in the ConfigMap so the
-  console can run with `BRIDGE_USER_AUTH` enabled for production-like testing.
-- **CRD evolution**: Replace ConfigMaps with a proper `CITestEnvironment` CRD
-  for structured status and validation webhooks.
+- **Authenticated (OAuth) console for humans**: implemented by
+  [manual-console](../../manual-console/README.md) (`auth-mode=openshift`), not
+  by the E2E path (`BRIDGE_USER_AUTH=disabled`).
+- **CRD evolution** (future): Replace ConfigMaps with a proper
+  `CITestEnvironment` CRD for structured status and validation webhooks.


### PR DESCRIPTION
## 📝 Description

Validating CNV-93072 by updating the readme file. 

## 🔗 Links

Jira ticket: [CNV-93072](https://redhat.atlassian.net/browse/CNV-93072)

## 🎥 Demo

[Demo](https://github.com/kubevirt-ui/kubevirt-plugin/pull/4366)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a structured guide to available GitHub Actions workflows, including testing, deployment, merge automation, approvals, labels, and manual operations.
  * Updated hot-cluster setup documentation with current GitHub authentication and E2E testing references.
  * Clarified console configuration for Playwright and Cypress, including manual-console OAuth settings and lifecycle behavior.
  * Revised related-resource guidance to better describe current authentication and CRD documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->