### PR TITLE
CNV-93073: Clarify Merge Gate PR check display

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,9 +6,15 @@ name: Auto Merge
 #
 # The GraphQL enable/disable calls are convenience only, not the actual
 # enforcement -- if either silently fails, a held/ineligible PR must still
-# be blocked. The "Merge Gate" check-run below is the real backstop: it's a
-# required status check (like Run Gating Tests), so branch protection alone
-# keeps blocking merge regardless of whether the auto-merge toggle succeeds.
+# be blocked. The required "Merge Gate" check is this job's own native
+# check-run (job name below), so branch protection alone keeps blocking
+# merge regardless of whether the auto-merge toggle succeeds. Deliberately
+# NOT published via publish-gating-check/checks.create() -- an API-created
+# check-run isn't attached to this workflow run, so GitHub parks it under
+# whichever other check suite happens to exist for the SHA (often "Needs
+# Rebase"), showing the confusing "Needs Rebase / Merge Gate" in the merge
+# box. The native job check-run is always correctly attributed to "Auto
+# Merge / Merge Gate" instead.
 on:
   pull_request_target:
     # opened -- so a brand-new PR gets an immediate, explicit "Merge Gate:
@@ -19,11 +25,10 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  checks: write
 
 jobs:
   sync-auto-merge:
-    name: Sync Auto-Merge State
+    name: Merge Gate
     runs-on: ubuntu-latest
     timeout-minutes: 2
     # Serialize per PR so out-of-order concurrent label events can't leave
@@ -64,9 +69,9 @@ jobs:
                 `PR #${prNumber} labels: [${pr.data.labels.map((l) => l.name).join(', ')}] -- merge-pool eligible: ${eligible}`,
               );
             } catch (err) {
-              // Fail closed: publish a failing Merge Gate for this event's
-              // head SHA rather than silently leaving a possibly-stale
-              // check in place, or guessing at eligibility.
+              // Fail closed: fail this job for this event's head SHA
+              // rather than silently leaving a possibly-stale Merge Gate
+              // conclusion in place, or guessing at eligibility.
               determined = false;
               eligible = false;
               headSha = context.payload.pull_request.head.sha;
@@ -98,19 +103,6 @@ jobs:
                   : 'PR is missing lgtm/approved, or carries a hold/do-not-merge label. This check blocks merge independently of auto-merge state.',
             );
 
-      # The actual merge gate: a required check, independent of whether the
-      # GraphQL toggle below succeeds. Not eligible -> failure, which alone
-      # is enough for branch protection to keep blocking merge.
-      - name: Publish merge gate check
-        uses: ./.github/actions/publish-gating-check
-        with:
-          name: 'Merge Gate'
-          head-sha: ${{ steps.eligibility.outputs.head_sha }}
-          status: completed
-          conclusion: ${{ steps.eligibility.outputs.conclusion }}
-          title: ${{ steps.eligibility.outputs.title }}
-          summary: ${{ steps.eligibility.outputs.summary }}
-
       # enablePullRequestAutoMerge/disablePullRequestAutoMerge reject the
       # default GITHUB_TOKEN with "Resource not accessible by integration"
       # regardless of permissions: -- use the same bot App token other
@@ -134,9 +126,9 @@ jobs:
             const prNumber = '${{ steps.eligibility.outputs.number }}';
 
             if (!determined) {
-              // Eligibility is unknown -- the Merge Gate check above
-              // already failed closed. Don't guess by toggling auto-merge
-              // either way; a later event will retry this.
+              // Eligibility is unknown -- this job will fail closed below
+              // regardless. Don't guess by toggling auto-merge either way;
+              // a later event will retry this.
               core.info(`Skipping auto-merge toggle for PR #${prNumber} -- eligibility could not be determined this run.`);
               return;
             }
@@ -157,8 +149,9 @@ jobs:
                 core.info(`Enabled auto-merge for PR #${prNumber}.`);
               } catch (err) {
                 // Draft/already-merged PRs and similar edge cases surface
-                // as GraphQL errors here -- the Merge Gate check already
-                // reflects eligibility regardless, so this is UX only.
+                // as GraphQL errors here -- this job's own Merge Gate
+                // conclusion already reflects eligibility regardless, so
+                // this is UX only.
                 core.warning(`Could not enable auto-merge for PR #${prNumber}: ${err.message}`);
               }
               return;
@@ -176,7 +169,18 @@ jobs:
               core.info(`Disabled auto-merge for PR #${prNumber} (not merge-pool eligible).`);
             } catch (err) {
               // Most common case: auto-merge was never enabled to begin
-              // with. Either way, the failing Merge Gate check published
-              // above is what actually blocks merge here, not this call.
+              // with. Either way, this job's own failing conclusion (next
+              // step) is what actually blocks merge here, not this call.
               core.info(`No auto-merge to disable for PR #${prNumber} (${err.message}).`);
             }
+
+      # Runs after the auto-merge toggle above so a disable still happens
+      # for an ineligible PR before the job fails. Failing this job (rather
+      # than an API-created check-run) is what makes "Merge Gate" a native,
+      # correctly-attributed check-run under this workflow -- see the
+      # top-of-file comment for why that matters.
+      - name: Fail if not merge-pool eligible
+        if: steps.eligibility.outputs.conclusion == 'failure'
+        run: |
+          echo "::error title=${{ steps.eligibility.outputs.title }}::${{ steps.eligibility.outputs.summary }}"
+          exit 1

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -293,7 +293,7 @@ A PR is merge-pool eligible when **all** of the following hold (`isMergePoolPr`)
 
 `auto-merge.yml` then:
 
-- Publishes required check **`Merge Gate`** (`success` iff eligible, else `failure` -- the real merge backstop)
+- Its own job -- named **`Merge Gate`** -- fails when the PR isn't eligible and succeeds when it is; that native job check-run (shown in the merge box as **`Auto Merge / Merge Gate`**) is the required check, i.e. the real merge backstop. Deliberately **not** published via `publish-gating-check`/`checks.create()` -- an API-created check-run isn't attached to this workflow run, so GitHub parks it under whichever other check suite happens to exist for the SHA (often "Needs Rebase"), which used to show the confusing "Needs Rebase / Merge Gate" in the merge box.
 - Enables/disables GitHub native auto-merge via the bot App (GraphQL; `GITHUB_TOKEN` cannot do this)
 
 Branch protection must require **`Merge Gate`** and **`Run Gating Tests`** (plus build/test as before).
@@ -359,7 +359,7 @@ Purely informational, PR-list-visible mirror of Hot Cluster E2E's latest _real_ 
 
 ### `enablePullRequestAutoMerge` needs the bot token, not `GITHUB_TOKEN`
 
-Confirmed live on PR #4363: even with `Merge Gate` correctly reporting `success`, `auto-merge.yml`'s GraphQL call to `enablePullRequestAutoMerge` failed with `Resource not accessible by integration` -- **regardless of the workflow's `permissions:` block**. `enablePullRequestAutoMerge`/`disablePullRequestAutoMerge` are two of a small set of mutations GitHub blocks for the default Actions bot identity as a platform restriction, not a scope you can widen your way around. Fixed by generating a `kubevirt-plugin-bot` App token (via [`.github/actions/create-bot-token`](../.github/actions/create-bot-token/action.yml) or `actions/create-github-app-token@v3` directly) and passing it as `github-token:` to that GraphQL step -- eligibility-check and Merge-Gate-publishing steps stay on the default token.
+Confirmed live on PR #4363: even with `Merge Gate` correctly reporting `success`, `auto-merge.yml`'s GraphQL call to `enablePullRequestAutoMerge` failed with `Resource not accessible by integration` -- **regardless of the workflow's `permissions:` block**. `enablePullRequestAutoMerge`/`disablePullRequestAutoMerge` are two of a small set of mutations GitHub blocks for the default Actions bot identity as a platform restriction, not a scope you can widen your way around. Fixed by generating a `kubevirt-plugin-bot` App token (via [`.github/actions/create-bot-token`](../.github/actions/create-bot-token/action.yml) or `actions/create-github-app-token@v3` directly) and passing it as `github-token:` to that GraphQL step -- the eligibility-check step stays on the default token.
 
 ### Known limitations
 


### PR DESCRIPTION
## 📝 Description

Clarify Merge Gate PR check display (stop nesting under `Needs Rebase`)

## 🔗 Links

Jira ticket: [CNV-93073](https://redhat.atlassian.net/browse/CNV-93073)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge-gate behavior so blocked pull requests are clearly reported through the workflow’s native status.
  * Preserved fail-closed behavior when merge eligibility cannot be determined.
  * Prevented auto-merge settings from being changed when eligibility is unknown.

* **Documentation**
  * Clarified how the Merge Gate status is generated.
  * Updated guidance for enabling auto-merge with the required authentication token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->