### PR TITLE
CNV-93073: Validate auto-merge and update readme file

### DIFF
--- a/.github/scripts/src/validation/pr-path-validation/label-sync.test.ts
+++ b/.github/scripts/src/validation/pr-path-validation/label-sync.test.ts
@@ -103,7 +103,7 @@ describe('reportCommitStatus', () => {
     assert.equal(calls.length, 0);
   });
 
-  it('publishes only a commit status, not a check-run -- an API-created check-run isn\'t attached to the calling workflow run and gets parked under an unrelated check suite in the merge box', async () => {
+  it("publishes only a commit status, not a check-run -- an API-created check-run isn't attached to the calling workflow run and gets parked under an unrelated check suite in the merge box", async () => {
     const calls: Call[] = [];
     const octokit = fakeOctokit(calls, 'main');
     await reportCommitStatus(baseCtx(octokit), TEST_CONFIG, 'pending', 'in progress');

--- a/.github/scripts/src/validation/pr-path-validation/run-validation.test.ts
+++ b/.github/scripts/src/validation/pr-path-validation/run-validation.test.ts
@@ -357,5 +357,4 @@ describe('runPathValidation', () => {
     const statuses = statusesOf(calls);
     assert.equal(statuses[0]?.state, 'pending');
   });
-
 });

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -120,7 +120,7 @@ Uses `openshift-install` to create a fully self-managed OpenShift cluster on IBM
 | `BOT_APP_ID`          | GitHub App ID for `kubevirt-plugin-bot` |
 | `BOT_APP_PRIVATE_KEY` | GitHub App private key                  |
 
-Used by `/lgtm`/`/approve`/`/hold`, review sync, `needs-rebase`, auto-merge GraphQL, e2e result labels, and related PR comment/label writes. The App installation must have **Issues: Read & write** and **Pull requests: Read & write**. Shared helper: [`.github/actions/create-bot-token`](../.github/actions/create-bot-token/action.yml).
+Used by `/lgtm`/`/approve`/`/hold`, review sync, `needs-rebase`, auto-merge GraphQL, e2e result labels, and related PR comment/label writes. The App installation must have **Issues: Read & write**, **Pull requests: Read & write**, and **Contents: Read & write** (the last one specifically for `enablePullRequestAutoMerge`/`disablePullRequestAutoMerge` -- see below). Shared helper: [`.github/actions/create-bot-token`](../.github/actions/create-bot-token/action.yml).
 
 Ghost runner cleanup reuses the ARC Authentication GitHub App credentials above (`ARC_GITHUB_APP_ID` + `ARC_GITHUB_APP_PRIVATE_KEY`) — no separate secret needed, since that app is already scoped to `administration: write`, exactly what deregistering offline runners requires.
 
@@ -357,9 +357,11 @@ Per-PR concurrency (`needs-rebase-<PR#>`, `cancel-in-progress: false`) avoids ra
 
 Purely informational, PR-list-visible mirror of Hot Cluster E2E's latest _real_ result -- **not** a merge gate (`isMergePoolPr` doesn't read these; the required "Run Gating Tests" check-run is still the actual gate). Added by a new step in `hot-cluster-e2e.yml`'s `verify-gating-tests` job, right after "Publish result for PR": `success` -> `e2e-passed` (+ remove `e2e-failed`); `failure` -> `e2e-failed` (+ remove `e2e-passed`); `neutral` (held/stale/non-real results) -> skipped entirely, leaving whichever label already reflects the last real result untouched. Label writes go through the `kubevirt-plugin-bot` App token (`permission-issues: write` + `permission-pull-requests: write`), same reason as `/hold-e2e`'s `e2e-hold` -- not `GITHUB_TOKEN`.
 
-### `enablePullRequestAutoMerge` needs the bot token, not `GITHUB_TOKEN`
+### `enablePullRequestAutoMerge` needs the bot token, not `GITHUB_TOKEN` -- and needs `contents:write` on that token too
 
 Confirmed live on PR #4363: even with `Merge Gate` correctly reporting `success`, `auto-merge.yml`'s GraphQL call to `enablePullRequestAutoMerge` failed with `Resource not accessible by integration` -- **regardless of the workflow's `permissions:` block**. `enablePullRequestAutoMerge`/`disablePullRequestAutoMerge` are two of a small set of mutations GitHub blocks for the default Actions bot identity as a platform restriction, not a scope you can widen your way around. Fixed by generating a `kubevirt-plugin-bot` App token (via [`.github/actions/create-bot-token`](../.github/actions/create-bot-token/action.yml) or `actions/create-github-app-token@v3` directly) and passing it as `github-token:` to that GraphQL step -- the eligibility-check step stays on the default token.
+
+**Granting the App "Contents: Read & write" in its installation settings is not enough on its own.** `actions/create-github-app-token@v3`'s `permission-*` inputs narrow the generated token to exactly what's requested, regardless of what the App's own installation permissions allow -- requesting only `permission-pull-requests: write` still 403'd with the same error even after the App was granted Contents access, because the token itself never carried a `contents` scope. The `Generate bot token` step in `auto-merge.yml` requests both `permission-contents: write` and `permission-pull-requests: write` for this reason.
 
 ### Known limitations
 


### PR DESCRIPTION
## 📝 Description

Validating CNV-93073 and auto merge functionality

## 🔗 Links

Jira ticket: [CNV-93073](https://redhat.atlassian.net/browse/CNV-93073)

## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the GitHub App permissions required for pull request auto-merge operations, including the explicit need for repository contents read/write access.
  * Added guidance that contents access alone isn’t sufficient unless the generated bot token is created with the proper contents write scope.
* **Tests**
  * Improved validation coverage to ensure an initial pending commit status is published before subsequent success/failure updates.
  * Adjusted a test description for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->