### PR TITLE
CNV-93076: Native review sync silently fails on fork PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,14 +23,15 @@ Index of workflows in this directory. Deep design notes (check-run model, merge 
 
 ## Merge automation (Prow / Tide replacements)
 
-| Workflow                       | Trigger                       | Role                                                                                      |
-| ------------------------------ | ----------------------------- | ----------------------------------------------------------------------------------------- |
-| `auto-merge.yml`               | label / review / synchronize… | Required **Merge Gate** + enable/disable GitHub auto-merge                                |
-| `pr_validation_commands.yml`   | issue comment                 | `/lgtm`, `/approve`, `/hold` (+ cancel), `/ai-approved`, `/ci-approved`, `/recheck-jira`  |
-| `pr_review_commands.yml`       | review submitted              | Approve / Request changes ↔ `lgtm` (+ `approved` for root OWNERS)                         |
-| `needs-rebase.yml`             | PR events + push to `main`    | Sync `needs-rebase` from GitHub `mergeable`                                               |
-| `verify-merge-pool-labels.yml` | labeled / unlabeled           | Strip untrusted UI `lgtm`/`approved`/`do-not-merge/hold`; restore untrusted hold removals |
-| `pr_help_command.yml`          | `/help`                       | Comment command list from `pr-commands.json`                                              |
+| Workflow                       | Trigger                       | Role                                                                                                                                   |
+| ------------------------------ | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `auto-merge.yml`               | label / review / synchronize… | Required **Merge Gate** + enable/disable GitHub auto-merge                                                                             |
+| `pr_validation_commands.yml`   | issue comment                 | `/lgtm`, `/approve`, `/hold` (+ cancel), `/ai-approved`, `/ci-approved`, `/recheck-jira`                                               |
+| `pr_review_commands.yml`       | review submitted              | Captures review data only (no secrets -- see below), uploads artifact                                                                  |
+| `pr_review_commands_sync.yml`  | `workflow_run` (after above)  | Approve / Request changes ↔ `lgtm` (+ `approved` for root OWNERS); split out since `pull_request_review` withholds secrets on fork PRs |
+| `needs-rebase.yml`             | PR events + push to `main`    | Sync `needs-rebase` from GitHub `mergeable`                                                                                            |
+| `verify-merge-pool-labels.yml` | labeled / unlabeled           | Strip untrusted UI `lgtm`/`approved`/`do-not-merge/hold`; restore untrusted hold removals                                              |
+| `pr_help_command.yml`          | `/help`                       | Comment command list from `pr-commands.json`                                                                                           |
 
 Pool eligibility (`isMergePoolPr`): `lgtm` + `approved`, and no blockers (`hold`, `e2e-hold`, `needs-rebase`, any `do-not-merge/*`). Label names: [`ci-scripts/hot-cluster/js/merge-pool-labels.cjs`](../../ci-scripts/hot-cluster/js/merge-pool-labels.cjs).
 

--- a/.github/workflows/pr_review_commands.yml
+++ b/.github/workflows/pr_review_commands.yml
@@ -3,65 +3,54 @@ name: PR Review Commands
 # A native GitHub Approve/Request-changes review toggles lgtm/approved the
 # same way the /lgtm command does. Always honors the review's state,
 # regardless of any command text in its body. See ci-scripts/README.md.
+#
+# Split into two workflows because GitHub withholds repository/organization
+# secrets (and gives only a read-only GITHUB_TOKEN) from pull_request_review
+# when the PR head is a fork -- confirmed live, and true for essentially
+# every PR in this repo, since contributors (including maintainers) push
+# from personal forks rather than branches on this repo directly. This half
+# never touches secrets or the API; it only captures the review's
+# already-trustworthy event-payload data (GitHub-computed, not something a
+# fork PR author can fake) and hands it to pr_review_commands_sync.yml via
+# an artifact. That workflow_run-triggered workflow always runs with full
+# base-repo secrets regardless of what triggered the upstream run -- the one
+# event type immune to the fork restriction -- and does the actual sync.
 on:
   pull_request_review:
     types: [submitted]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  sync-from-review:
-    name: Sync Lgtm/Approved From Review
+  capture-review:
+    name: Capture Review Event
     if: >-
       !endsWith(github.event.review.user.login, '[bot]') &&
       (github.event.review.state == 'approved' || github.event.review.state == 'changes_requested')
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    # Not cancel-in-progress: two reviews landing close together (e.g. an
-    # Approve immediately followed by Request-changes from someone else)
-    # must both apply in order, not race/clobber each other.
-    concurrency:
-      group: pr-review-cmd-${{ github.event.pull_request.number }}
     steps:
-      # Pin to default branch: this workflow's own definition already loads
-      # from there for a pull_request_review event, but the scripts it
-      # calls into need the same explicit pin other workflows use.
-      - name: Checkout
-        uses: actions/checkout@v7
+      # No checkout, no API calls, no secrets -- just the review's own
+      # event-payload fields, which are GitHub-computed and safe to trust
+      # even though this event can come from a fork PR.
+      - name: Write review data
+        uses: actions/github-script@v9
         with:
-          persist-credentials: false
-          ref: ${{ github.event.repository.default_branch }}
+          script: |
+            const fs = require('fs');
+            const data = {
+              prNumber: context.payload.pull_request.number,
+              reviewState: context.payload.review.state === 'approved' ? 'APPROVED' : 'CHANGES_REQUESTED',
+              reviewAuthor: context.payload.review.user.login,
+              prAuthor: context.payload.pull_request.user.login,
+              baseBranch: context.payload.pull_request.base.ref,
+            };
+            fs.writeFileSync('review-data.json', JSON.stringify(data));
+            core.info(`Captured review data: ${JSON.stringify(data)}`);
 
-      - name: Setup validation scripts
-        uses: ./.github/actions/setup-gh-scripts
+      - name: Upload review data
+        uses: actions/upload-artifact@v4
         with:
-          ref: ${{ github.event.repository.default_branch }}
-
-      # Bot app token required (see ci-scripts/README.md). continue-on-error
-      # so a bad credential still lets the step below report what it can.
-      - name: Generate bot token
-        id: bot-token
-        continue-on-error: true
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.BOT_APP_ID }}
-          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-          permission-issues: write
-          permission-pull-requests: write
-
-      # GITHUB_TOKEN: bot (labels). STATUS_GITHUB_TOKEN: ambient token for
-      # reading OWNERS. See createStatusOctokit.
-      - name: Sync lgtm/approved from review state
-        working-directory: .github/scripts
-        env:
-          GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
-          STATUS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REVIEW_STATE: ${{ github.event.review.state == 'approved' && 'APPROVED' || 'CHANGES_REQUESTED' }}
-          REVIEW_AUTHOR: ${{ github.event.review.user.login }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
-          REPO_OWNER: ${{ github.repository_owner }}
-          REPO_NAME: ${{ github.event.repository.name }}
-        run: npx tsx src/validation/commands/review-event.ts
+          name: review-data
+          path: review-data.json
+          retention-days: 1

--- a/.github/workflows/pr_review_commands_sync.yml
+++ b/.github/workflows/pr_review_commands_sync.yml
@@ -1,0 +1,108 @@
+name: PR Review Commands Sync
+
+# Second half of the pr_review_commands.yml split -- see that file's
+# top-of-file comment for why this is split in two. workflow_run always runs
+# with full base-repo secrets and a write GITHUB_TOKEN regardless of what
+# triggered the upstream run (including a fork PR's pull_request_review),
+# so this is where the actual lgtm/approved sync happens. See
+# ci-scripts/README.md.
+on:
+  workflow_run:
+    workflows: ['PR Review Commands']
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  sync-from-review:
+    name: Sync Lgtm/Approved From Review
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    # Not cancel-in-progress: two reviews landing close together (e.g. an
+    # Approve immediately followed by Request-changes from someone else)
+    # must both apply in order, not race/clobber each other. Can't key this
+    # on PR number directly -- that would need either the artifact (not
+    # downloaded until a step runs, too late for a concurrency: expression)
+    # or workflow_run.pull_requests[0].number, which GitHub deliberately
+    # leaves empty for fork-originated runs, i.e. exactly the runs this
+    # workflow exists for. head_repository/head_branch are separate,
+    # always-populated top-level fields on workflow_run (unlike
+    # pull_requests), and together uniquely identify the same PR across
+    # multiple reviews.
+    concurrency:
+      group: pr-review-cmd-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+    steps:
+      # Pin to default branch: the scripts this calls into need the same
+      # explicit pin other workflows use.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Setup validation scripts
+        uses: ./.github/actions/setup-gh-scripts
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Download review data
+        uses: actions/download-artifact@v4
+        with:
+          name: review-data
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Parse review data
+        id: review
+        run: |
+          node -e "
+            const data = require('./review-data.json');
+            const fs = require('fs');
+            const lines = [
+              'pr_number=' + data.prNumber,
+              'review_state=' + data.reviewState,
+              'review_author=' + data.reviewAuthor,
+              'pr_author=' + data.prAuthor,
+              'base_branch=' + data.baseBranch,
+            ];
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, lines.join('\n') + '\n');
+          "
+
+      # Bot app token required (see ci-scripts/README.md). continue-on-error
+      # so a genuinely bad credential (App uninstalled, secrets rotated --
+      # unrelated to the fork restriction this split already solves) still
+      # lets the step below report what it can instead of crashing.
+      - name: Generate bot token
+        id: bot-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-pull-requests: write
+
+      # GITHUB_TOKEN: bot (labels). STATUS_GITHUB_TOKEN: ambient token for
+      # reading OWNERS. See createStatusOctokit.
+      - name: Sync lgtm/approved from review state
+        if: steps.bot-token.outputs.token != ''
+        working-directory: .github/scripts
+        env:
+          GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}
+          STATUS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEW_STATE: ${{ steps.review.outputs.review_state }}
+          REVIEW_AUTHOR: ${{ steps.review.outputs.review_author }}
+          PR_AUTHOR: ${{ steps.review.outputs.pr_author }}
+          PR_NUMBER: ${{ steps.review.outputs.pr_number }}
+          BASE_BRANCH: ${{ steps.review.outputs.base_branch }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: npx tsx src/validation/commands/review-event.ts
+
+      - name: Note bot token failure
+        if: steps.bot-token.outputs.token == ''
+        run: |
+          echo "::warning title=Could not sync lgtm/approved from this review::The kubevirt-plugin-bot token could not be generated (BOT_APP_ID/BOT_APP_PRIVATE_KEY misconfigured, or the App was uninstalled) -- this review's Approve/Request-changes state was not synced to the lgtm/approved labels. Comment /lgtm or /approve on the PR instead."

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -274,7 +274,7 @@ Hot Cluster E2E already replaced Prow's **gating test execution**. The pieces be
 | Tide pool eligibility (`lgtm`+`approved`) | `isMergePoolPr` in [`hot-cluster/js/is-merge-pool-pr.cjs`](hot-cluster/js/is-merge-pool-pr.cjs)            |
 | Label name SSOT                           | [`hot-cluster/js/merge-pool-labels.cjs`](hot-cluster/js/merge-pool-labels.cjs)                             |
 | `/lgtm`, `/approve`, `/hold` (+ cancel)   | `pr_validation_commands.yml` + `.github/scripts/.../commands/{lgtm,approve,hold}.ts`                       |
-| Review acts as lgtm                       | `pr_review_commands.yml` + `commands/review-event.ts`                                                      |
+| Review acts as lgtm                       | `pr_review_commands.yml` + `pr_review_commands_sync.yml` + `commands/review-event.ts`                      |
 | `needs-rebase` plugin                     | `needs-rebase.yml` + `hot-cluster/js/sync-needs-rebase-label.cjs`                                          |
 | Anti-bypass for pool labels               | `verify-merge-pool-labels.yml` (strips untrusted UI adds; restores untrusted `do-not-merge/hold` removals) |
 | Presubmit / gating E2E                    | Hot Cluster E2E (`hot-cluster-e2e.yml` via thin PR gates) + required **`Run Gating Tests`** check          |
@@ -328,11 +328,18 @@ Commands in `pr_validation_commands.yml` (`.github/scripts/src/validation/comman
 
 ### Native GitHub reviews also toggle `lgtm`/`approved`
 
-`pr_review_commands.yml` (`pull_request_review: [submitted]`, entrypoint `commands/review-event.ts`) mirrors Prow's `review_acts_as_lgtm` convenience: an "Approve" review grants `lgtm` (+ `approved` if the reviewer is a root OWNERS approver); a "Request changes" review always removes both `lgtm` and `approved`, regardless of the reviewer's own OWNERS status -- same reasoning as `/lgtm cancel` above. Same write-collaborator check as the comment commands, and the same self-review restriction (a PR author's own review never toggles anything).
+An "Approve" review grants `lgtm` (+ `approved` if the reviewer is a root OWNERS approver); a "Request changes" review always removes both `lgtm` and `approved`, regardless of the reviewer's own OWNERS status -- same reasoning as `/lgtm cancel` above. Same write-collaborator check as the comment commands, and the same self-review restriction (a PR author's own review never toggles anything). Mirrors Prow's `review_acts_as_lgtm` convenience.
 
 **Deliberately simpler than Prow's original behavior**: Prow's real `lgtm` plugin skips handling a review entirely if its body text contains `/lgtm` or `/lgtm cancel` -- a genuinely confusing interaction (an "Approve" review with `/lgtm` typed in the body did _nothing_, neither the literal command nor the review-state auto-behavior), which is exactly what made the PR #4363 investigation so confusing in the first place. This implementation has no such special case: the review's **state** (`APPROVED`/`CHANGES_REQUESTED`) is always honored, regardless of anything typed in its body.
 
 No PR comment or reaction is posted for a review-triggered change (reviews don't support reactions the way issue comments do) -- a routine skip (non-collaborator, self-review) just logs and exits normally. Dismissing a review (as opposed to submitting a new one) is not handled -- see Known limitations below.
+
+**Split across two workflows because GitHub withholds secrets from `pull_request_review` on fork PRs.** `pull_request_review` gives only a read-only `GITHUB_TOKEN` and withholds all repository/organization secrets when the PR head is a fork -- confirmed live, and true for essentially every PR in this repo, since contributors (including maintainers) push from personal forks rather than branches on this repo directly. A single-workflow version of this feature would silently fail to generate the `kubevirt-plugin-bot` token on every such PR.
+
+- [`pr_review_commands.yml`](../.github/workflows/pr_review_commands.yml) (`pull_request_review: [submitted]`) does no checkout and touches no secrets or API at all -- it only captures the review's event-payload fields (`review.state`/`.user.login`, `pull_request.number`/`.user.login`/`.base.ref`; GitHub-computed, not something a fork PR author can fake) and uploads them as a `review-data` artifact.
+- [`pr_review_commands_sync.yml`](../.github/workflows/pr_review_commands_sync.yml) (`workflow_run: {workflows: ['PR Review Commands'], types: [completed]}`) does the actual work. `workflow_run` always runs with full base-repo secrets and a write `GITHUB_TOKEN`, regardless of what triggered the upstream run -- the one event type immune to the fork restriction. It downloads the artifact (`actions/download-artifact@v4` with `run-id: ${{ github.event.workflow_run.id }}` + an explicit `github-token`, required for a cross-run download), generates the bot token, and runs `commands/review-event.ts` exactly as before -- that script itself needed no changes, since it already only reads env vars.
+- `pr_review_commands_sync.yml` only runs `if: github.event.workflow_run.conclusion == 'success'`, so a skipped or failed capture (bot comment, non-Approve/Request-changes state, etc.) never triggers a spurious sync.
+- The bot-token step still keeps its own `continue-on-error` + a `::warning::` fallback for a genuinely broken App (uninstalled, rotated secrets) -- unrelated to the fork restriction this split solves, but worth failing gracefully for too.
 
 ### A new push clears stale `lgtm`/`approved`
 


### PR DESCRIPTION
## 📝 Description

Enable clicking GitHub's native "Approve"/"Request changes" button on a PR to toggle lgtm/approved, so that native reviews aren't a silent no-op that only appears to work.

## 🔗 Links

Jira ticket: [CNV-93076](https://redhat.atlassian.net/browse/CNV-93076)

## 🎥 Demo

N/A