### PR TITLE
CNV-92551: add API contract tests suite

### DIFF
--- a/.cursor/commands/create-test.md
+++ b/.cursor/commands/create-test.md
@@ -33,6 +33,7 @@ Without `--local`, locator discovery relies on the live UI via Playwright MCP (`
 | Tier 1   | `tests/tier1/<feature>/` | Per-feature fixture           | `Tier1`      | `@tier1`        | Single-resource CRUD lifecycle per module; VM tab configuration; must NOT overlap gating                 |
 | Tier 2   | `tests/tier2/<feature>/` | Per-feature fixture           | `Tier2`      | `@tier2`        | Cross-module integration (BV→VM wizard, snapshot→clone); VM live/storage migration; multi-step workflows |
 | Settings | `tests/settings/`        | `@/fixtures/settings-fixture` | `Settings`   | `@cnv-settings` | Cluster and user settings pages                                                                          |
+| API      | `tests/api/`             | `@/fixtures/api-test-fixture` | `API`        | `@api`          | API contract tests — CRUD lifecycle and endpoint validation via `RequestContextClient` (no browser UI)   |
 
 ### Where to place a new test
 
@@ -41,6 +42,7 @@ Without `--local`, locator discovery relies on the live UI via Playwright MCP (`
 3. **Does it test a single resource's lifecycle (create → configure → verify → delete)?** → **Tier 1** under `tests/tier1/<feature>/`
 4. **Does it test cross-module integration, multi-resource workflows, or migration?** → **Tier 2** under `tests/tier2/<feature>/`
 5. **Does it test cluster or user settings?** → **Settings** under `tests/settings/`
+6. **Does it validate API contracts (CRUD, list, subresources) without browser UI?** → **API** under `tests/api/`
 
 ### Current test file map
 
@@ -64,10 +66,18 @@ tests/
 │   ├── create-vm/                              # Clone wizard (clone existing VM)
 │   ├── migrations/                             # Live migration, storage migration
 │   └── virtualmachines/                        # Snapshots (take/restore/clone), VM clone
-└── settings/
-    ├── aaq-quotas.spec.ts                      # AAQ quota settings
-    ├── cluster-settings.spec.ts                # Cluster-level settings
-    └── user-settings.spec.ts                   # User preferences
+├── settings/
+│   ├── aaq-quotas.spec.ts                      # AAQ quota settings
+│   ├── cluster-settings.spec.ts                # Cluster-level settings
+│   └── user-settings.spec.ts                   # User preferences
+└── api/                                        # API contract tests (no browser UI)
+    ├── vm-vmi-lifecycle-api.spec.ts             # VM/VMI lifecycle (start/stop/restart/delete)
+    ├── vm-crud-api.spec.ts                      # VM CRUD operations
+    ├── bootable-volumes-crud-api.spec.ts        # BV DataVolume/DataSource CRUD
+    ├── instance-types-crud-api.spec.ts          # Instance type CRUD
+    ├── migration-policies-crud-api.spec.ts      # Migration policy CRUD
+    ├── snapshots-crud-api.spec.ts               # Snapshot CRUD
+    └── ...                                      # See tests/api/ for full list
 ```
 
 ### Fixture Pattern
@@ -328,7 +338,8 @@ playwright/
 │   ├── gating/                    # Gating specs (gating-fixture)
 │   ├── tier1/<feature>/           # Tier 1 specs (per-feature fixtures)
 │   ├── tier2/<feature>/           # Tier 2 specs (per-feature fixtures)
-│   └── settings/                  # Settings specs (settings-fixture)
+│   ├── settings/                  # Settings specs (settings-fixture)
+│   └── api/                       # API contract specs (api-test-fixture)
 ├── src/
 │   ├── components/                # UI components (extend BaseComponent)
 │   │   ├── shared/                # Base classes (base-component, navigation-component)
@@ -360,7 +371,7 @@ playwright/
 │   ├── data-factories/            # Test data generators (SSH keys, VM specs)
 │   └── utils/                     # Env vars, test config, random names, helpers
 ├── project-dependencies/          # Global setup/teardown + rule engine
-└── playwright.config.ts           # Projects: Gating, Tier1, Tier2, Settings
+└── playwright.config.ts           # Projects: Gating, Tier1, Tier2, Settings, API
 ```
 
 ## Rules
@@ -381,4 +392,4 @@ playwright/
 - **All API calls go through the console proxy** — `RequestContextClient` routes all requests through the console proxy with the authenticated user's permissions. Never use `oc` CLI, `@kubernetes/client-node`, or direct cluster access.
 - **No direct URL navigation** — never use `page.goto()` or `goTo()` in specs; always navigate through the Virtualization perspective switcher and sidebar
 - **Never put `ID(CNV-XXXXX)` in test names or step names** — use only in allure tags
-- **DO NOT commit or push** — the user handles git operations
+- **DO NOT commit, push, or create PRs** — never run `git commit`, `git push`, `gh pr create`, or any git write operation. The user handles all git operations manually. Only use git read commands (`git status`, `git diff`, `git log`) when needed for context.

--- a/.cursor/commands/test-fix.md
+++ b/.cursor/commands/test-fix.md
@@ -15,6 +15,7 @@ Run Playwright tests, analyze failures, fix test code issues, and re-run until s
 | `tier1`       | Tier 1 tests (`npx playwright test --project=Tier1`)                  |
 | `tier2`       | Tier 2 tests (`npx playwright test --project=Tier2`)                  |
 | `settings`    | Settings tests (`npx playwright test --project=Settings`)             |
+| `api`         | API contract tests (`npx playwright test --project=API`)              |
 | `<file-path>` | Specific spec file (`npx playwright test <path>`)                     |
 | `<test-name>` | Specific test by name (`npx playwright test -g "<name>" --workers=1`) |
 
@@ -24,7 +25,7 @@ Run Playwright tests, analyze failures, fix test code issues, and re-run until s
 
 1. Verify the environment is configured:
    ```bash
-   echo "Console URL: $(grep -m1 '^WEB_CONSOLE_URL=' .env 2>/dev/null | cut -d= -f2- || echo 'not set')"
+   echo "Console URL: ${WEB_CONSOLE_URL:-not set}"
    ```
 2. Check for stale test namespaces (if `oc` is available):
    ```bash
@@ -186,6 +187,7 @@ Remaining failures: <list with classification>
 | Tier 1   | Single-resource CRUD lifecycle for each module; VM tab configuration; does NOT overlap gating                     | `tests/tier1/<feature>/` |
 | Tier 2   | Cross-module integration (e.g. BV → VM wizard, snapshot → clone); VM live/storage migration; multi-step workflows | `tests/tier2/<feature>/` |
 | Settings | Cluster and user settings                                                                                         | `tests/settings/`        |
+| API      | API contract tests — CRUD lifecycle and endpoint validation via `RequestContextClient` (no browser UI)            | `tests/api/`             |
 
 ### Current test file map
 
@@ -209,10 +211,27 @@ tests/
 │   ├── create-vm/                              # Clone wizard (clone existing VM)
 │   ├── migrations/                             # Live migration, storage migration
 │   └── virtualmachines/                        # Snapshots (take/restore/clone), VM clone
-└── settings/
-    ├── aaq-quotas.spec.ts                      # AAQ quota settings
-    ├── cluster-settings.spec.ts                # Cluster-level settings
-    └── user-settings.spec.ts                   # User preferences
+├── settings/
+│   ├── aaq-quotas.spec.ts                      # AAQ quota settings
+│   ├── cluster-settings.spec.ts                # Cluster-level settings
+│   └── user-settings.spec.ts                   # User preferences
+└── api/                                        # API contract tests (no browser UI)
+    ├── vm-vmi-lifecycle-api.spec.ts             # VM/VMI lifecycle (start/stop/restart/delete)
+    ├── vm-crud-api.spec.ts                      # VM CRUD operations
+    ├── vm-list-api.spec.ts                      # VM list endpoints
+    ├── vm-detail-api.spec.ts                    # VM detail page endpoints
+    ├── vm-migration-api.spec.ts                 # VMIM CRUD
+    ├── vm-snapshots-extended-api.spec.ts        # Snapshot/restore full lifecycle
+    ├── vm-save-as-template-api.spec.ts          # Save VM as template
+    ├── vm-folders-api.spec.ts                   # VM folder operations
+    ├── bootable-volumes-api.spec.ts             # BV read endpoints
+    ├── bootable-volumes-crud-api.spec.ts        # BV DataVolume/DataSource CRUD
+    ├── create-vm-api.spec.ts                    # VM creation page endpoints
+    ├── instance-types-crud-api.spec.ts          # Instance type CRUD
+    ├── migration-policies-crud-api.spec.ts      # Migration policy CRUD
+    ├── snapshots-crud-api.spec.ts               # Snapshot CRUD
+    ├── storage-migration-plan-crud-api.spec.ts  # Storage migration plan CRUD
+    └── templates-crud-api.spec.ts               # Template CRUD
 ```
 
 ## Project Structure Reference
@@ -223,7 +242,8 @@ playwright/
 │   ├── gating/                    # Gating specs (gating-fixture)
 │   ├── tier1/<feature>/           # Tier 1 specs (per-feature fixtures)
 │   ├── tier2/<feature>/           # Tier 2 specs (per-feature fixtures)
-│   └── settings/                  # Settings specs (settings-fixture)
+│   ├── settings/                  # Settings specs (settings-fixture)
+│   └── api/                       # API contract specs (api-test-fixture)
 ├── src/
 │   ├── components/                # UI components (extend BaseComponent)
 │   ├── page-objects/              # Page objects (extend BasePage/PageCommons)
@@ -234,7 +254,7 @@ playwright/
 │   ├── data-factories/            # Test data generators
 │   └── utils/                     # Env vars, test config, random names
 ├── project-dependencies/          # Global setup/teardown + rule engine
-├── playwright.config.ts           # Projects: Gating, Tier1, Tier2, Settings
+├── playwright.config.ts           # Projects: Gating, Tier1, Tier2, Settings, API
 ├── playwright-runner.sh           # Local runner script
 └── playwright-runner-hc-e2e.sh    # CI/hot-cluster runner script
 ```
@@ -252,4 +272,4 @@ playwright/
 - **Single process only** — use `--workers=N`, never concurrent test invocations
 - Report `product_bug` findings without modifying the test — the test is correct, the app is wrong
 - Always run `npm run check-types:playwright` after changes
-- **DO NOT commit or push** — the user handles git operations
+- **DO NOT commit, push, or create PRs** — never run `git commit`, `git push`, `gh pr create`, or any git write operation. The user handles all git operations manually. Only use git read commands (`git status`, `git diff`, `git log`) when needed for context.

--- a/playwright-runner.sh
+++ b/playwright-runner.sh
@@ -52,6 +52,7 @@ if [[ -z "${PROJECT}" ]]; then
   echo "  Tier1                  Tier 1 specs (scenario infrastructure)"
   echo "  Tier2                  Tier 2 specs (scenario infrastructure)"
   echo "  Settings               Settings specs (scenario infrastructure)"
+  echo "  API                    API contract tests (browserless)"
   echo "  migration-gating       Migration gating specs"
   echo "  migration-tier1        Migration tier 1 specs"
   echo "  migration-tier2        Tier 2 specs"
@@ -80,6 +81,7 @@ if [[ "${PROJECT}" == "all" ]]; then
     Tier1
     Tier2
     Settings
+    API
     migration-gating
     migration-tier1
     migration-tier2

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -84,6 +84,15 @@ export default defineConfig({
       use: migrationUse,
     },
 
+    // ── API contract tests (browserless, console proxy) ────────────────
+    {
+      fullyParallel: false,
+      name: 'API',
+      retries: 0,
+      testDir: './playwright/tests/api',
+      use: migrationUse,
+    },
+
     // ── Migration projects (use global setup/teardown) ───────────────
     {
       fullyParallel: true,

--- a/playwright/project-dependencies/rule-engine/setup-rules.ts
+++ b/playwright/project-dependencies/rule-engine/setup-rules.ts
@@ -384,46 +384,6 @@ export function getSetupRules(): SetupRule[] {
       },
     },
     {
-      id: 'set-default-storage-class',
-      name: 'Set default StorageClass for VirtualMachines',
-      phase: SetupPhase.CLUSTER,
-      guard: () => !EnvVariables.isHcE2e && !EnvVariables.isNonPrivUser,
-      onError: 'warn',
-      run: async (ctx) => {
-        const apiClient = ctx.apiClient;
-        if (!apiClient) {
-          throw new Error('RequestContextClient not initialized');
-        }
-        const defaultVmStorageClass = EnvVariables.storageClass;
-        logger.info(
-          `📦 Setting default StorageClass for VirtualMachines: ${defaultVmStorageClass}...`,
-        );
-
-        const scList = await apiClient.getStorageClasses();
-        for (const sc of scList.items ?? []) {
-          const scName = sc.metadata?.name;
-          if (!scName) continue;
-          await apiClient.mergePatchResource('storage.k8s.io', 'v1', 'storageclasses', scName, {
-            metadata: {
-              annotations: { 'storageclass.kubevirt.io/is-default-virt-class': 'false' },
-            },
-          });
-        }
-        await apiClient.mergePatchResource(
-          'storage.k8s.io',
-          'v1',
-          'storageclasses',
-          defaultVmStorageClass,
-          {
-            metadata: {
-              annotations: { 'storageclass.kubevirt.io/is-default-virt-class': 'true' },
-            },
-          },
-        );
-        logger.success(`✓ Default for VirtualMachines set to ${defaultVmStorageClass}`);
-      },
-    },
-    {
       id: 'save-config',
       name: 'Persist shared test configuration',
       phase: SetupPhase.CLUSTER,

--- a/playwright/src/clients/proxy-handlers/infra-proxy-handler.ts
+++ b/playwright/src/clients/proxy-handlers/infra-proxy-handler.ts
@@ -182,11 +182,12 @@ export class InfraProxyHandler {
   async isStorageMigrationAvailable(): Promise<boolean> {
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
-        await this.ctx.listResources(
+        const result = await this.ctx.listResources(
           InfraProxyHandler._MIGRATION_GROUP,
           InfraProxyHandler._MIGRATION_VERSION,
           InfraProxyHandler._MIGRATION_PLAN_PLURAL,
         );
+        if (!result) throw new Error('listResources returned falsy');
         return true;
       } catch {
         if (attempt === 0) await new Promise((r) => setTimeout(r, 2_000));

--- a/playwright/src/fixtures/api-test-fixture.ts
+++ b/playwright/src/fixtures/api-test-fixture.ts
@@ -1,24 +1,15 @@
 /**
  * API Test Fixture
  *
- * Provides a lightweight, browser-less test context for API contract tests that
- * target the same OpenShift console proxy endpoints used by the kubevirt UI.
+ * Provides a lightweight test context for API contract tests that target the
+ * same OpenShift console proxy endpoints used by the kubevirt UI.
  *
- * Auth strategy (two-layer):
- *  1. **Session cookies** — the `request` fixture inherits the storage state written
- *     by global setup's `browser-login` rule. The OpenShift console proxy requires
- *     these cookies (`openshift-session-token`) for all requests; Bearer token alone
- *     is not accepted by the console proxy.
- *  2. **Bearer token** (added via `Authorization` header) — provides an additional
- *     explicit credential, read from `.test-config.json`. It is belt-and-suspenders on
- *     top of the session cookies.
- *  3. **CSRF token** — the console proxy sets a `csrf-token` cookie on the first
- *     response; `_buildTokenAuthOptions` reads it back via `storageState()` and
- *     echoes it as `X-CSRFToken` on mutating (POST/PATCH/DELETE) requests.
- *
- * Because the `browser-login` rule must run, `SKIP_BROWSER_SETUP=1` only skips
- * the UI-navigation steps (perspective switch, welcome modal, project selection),
- * NOT the login itself.
+ * Fixtures provided:
+ *  - `apiClient` — RequestContextClient authenticated via session cookies +
+ *    optional Bearer token from `.test-config.json`. All API calls go through
+ *    the console proxy.
+ *  - `testNamespace` — resolved from `.test-config.json` or `TEST_NS` env var.
+ *  - `utils` — shared test utilities, factories, and constants.
  *
  * Usage:
  * ```typescript
@@ -32,7 +23,6 @@
  */
 
 import RequestContextClient from '@/clients/request-context-client';
-import { createApiClientFromToken } from '@/clients/rcc-singleton';
 import { ALLURE_API_FEATURE, withAllure } from '@/utils/allure';
 import { EnvVariables } from '@/utils/env-variables';
 import { TestConfigManager } from '@/utils/test-config';
@@ -47,17 +37,6 @@ export { ALLURE_API_FEATURE, expect };
 interface ApiTestFixtures {
   /** Pre-configured RequestContextClient using Bearer token auth (no browser). */
   apiClient: RequestContextClient;
-  /**
-   * RequestContextClient authenticated as the non-privileged test user
-   * (`TEST_USERNAME` / `TEST_USER_PASSWORD`, default `test` / `test`).
-   *
-   * Only available when `NON_PRIV=1` is set. Tests that use this fixture should
-   * guard with `test.skip(!utils.EnvVariables.isNonPrivUser, ...)`.
-   *
-   * The token is obtained via OAuth HTTP flow during fixture setup
-   * so no external CLI tools are required.
-   */
-  nonPrivApiClient: RequestContextClient;
   /** @internal — auto-applied Allure metadata; not used directly in specs. */
   _allureSetup: void;
   /** Shared test utilities, factories, and constants (same aggregator as UI tests). */
@@ -67,17 +46,8 @@ interface ApiTestFixtures {
 /**
  * Worker-scoped fixtures — one instance per worker, shared by all tests and
  * all beforeAll/afterAll hooks within that worker.
- *
- * Making `testNamespace` and `ocClient` worker-scoped ensures that the
- * namespace resolved in beforeAll is the same instance seen in individual
- * tests and afterAll — preventing stale or mismatched namespace values.
  */
 interface ApiWorkerFixtures {
-  /**
-   * RequestContextClient for API operations (wait/poll operations after writes).
-   * Created in token mode — no browser required.
-   */
-  ocClient: RequestContextClient;
   /**
    * Target namespace for test resources. Resolution order:
    *   1. `testNamespace` from `.test-config.json` (set by global setup, includes shard suffix)
@@ -110,12 +80,6 @@ export const test = base.extend<ApiTestFixtures, ApiWorkerFixtures>({
   apiClient: async ({ request }, use) => {
     const config = TestConfigManager.getConfig();
 
-    if (!config?.authToken) {
-      console.warn(
-        '[apiClient] No authToken in .test-config.json — relying on storage state cookies for auth.',
-      );
-    }
-
     const client = new RequestContextClient(request, {
       baseUrl: EnvVariables.webConsoleUrl,
       username: EnvVariables.username,
@@ -123,51 +87,10 @@ export const test = base.extend<ApiTestFixtures, ApiWorkerFixtures>({
       ...(config?.authToken ? { token: config.authToken } : {}),
     });
 
-    // Prime the csrf-token cookie by fetching the console root page.
-    // The OpenShift console only sets csrf-token on HTML responses, not API endpoints.
     await client.primeCsrfToken();
 
     await use(client);
   },
-
-  // Test-scoped: authenticates as the non-priv test user and returns a
-  // RequestContextClient scoped to that identity.
-  nonPrivApiClient: async ({ request }, use) => {
-    const username = EnvVariables.testUsername;
-    const password = EnvVariables.testUserPassword;
-
-    const { fetchOAuthToken } = await import('@/utils/oauth-token');
-    let token: string;
-    try {
-      token = await fetchOAuthToken(EnvVariables.clusterUrl, username, password);
-    } catch (err) {
-      throw new Error(
-        `nonPrivApiClient: could not obtain token for user "${username}". ` +
-          `Ensure the user exists in the cluster IDP (run the test suite with NON_PRIV=1 ` +
-          `so global setup provisions the htpasswd user). Original error: ${String(err)}`,
-      );
-    }
-
-    const client = new RequestContextClient(request, {
-      baseUrl: EnvVariables.webConsoleUrl,
-      username,
-      password,
-      token,
-    });
-
-    // Prime the csrf-token cookie by fetching the console root page.
-    await client.primeCsrfToken();
-
-    await use(client);
-  },
-
-  ocClient: [
-    async ({}, use) => {
-      const client = await createApiClientFromToken();
-      await use(client);
-    },
-    { scope: 'worker' },
-  ],
 
   // Worker-scoped: resolved once per worker from config or env fallback.
   testNamespace: [

--- a/playwright/src/utils/api-poll.ts
+++ b/playwright/src/utils/api-poll.ts
@@ -14,6 +14,17 @@ function isTransientError(error: unknown): boolean {
   return typeof statusCode === 'number' && TRANSIENT_STATUS_CODES.has(statusCode);
 }
 
+function is404(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  if (/\b404\b/.test(msg)) return true;
+  if (/not found/i.test(msg)) return true;
+  const statusCode =
+    (error as { statusCode?: number })?.statusCode ??
+    (error as { response?: { statusCode?: number } })?.response?.statusCode ??
+    (error as { code?: number })?.code;
+  return statusCode === 404;
+}
+
 /**
  * Generic polling loop. Calls `condition` every POLL_INTERVAL_MS until it returns true
  * or `timeoutMs` elapses. Transient errors (404, 503) are suppressed; persistent errors
@@ -40,7 +51,7 @@ async function pollUntil(
 // VMI pollers
 // ---------------------------------------------------------------------------
 
-/** Polls until the VMI no longer exists (404). */
+/** Polls until the VMI no longer exists (null return or 404 error). */
 export async function pollUntilVmiGone(
   apiClient: { getVirtualMachineInstance: (ns: string, name: string) => Promise<unknown> },
   namespace: string,
@@ -50,12 +61,12 @@ export async function pollUntilVmiGone(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
-      await apiClient.getVirtualMachineInstance(namespace, vmName);
+      const result = await apiClient.getVirtualMachineInstance(namespace, vmName);
+      if (result == null) return;
       await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      if (msg.includes('404') || msg.toLowerCase().includes('not found')) return;
-      throw e;
+      if (is404(e)) return;
+      if (!isTransientError(e)) throw e;
     }
   }
   throw new Error(`VMI ${vmName} still exists after ${timeoutMs}ms`);
@@ -67,7 +78,7 @@ export async function pollUntilVmiUidChanged(
     getVirtualMachineInstance: (
       ns: string,
       name: string,
-    ) => Promise<{ metadata?: { uid?: string } }>;
+    ) => Promise<{ metadata?: { uid?: string } } | null>;
   },
   namespace: string,
   vmName: string,
@@ -77,6 +88,7 @@ export async function pollUntilVmiUidChanged(
   await pollUntil(
     async () => {
       const vmi = await apiClient.getVirtualMachineInstance(namespace, vmName);
+      if (!vmi) return false;
       return vmi.metadata?.uid !== oldUid;
     },
     timeoutMs,
@@ -90,7 +102,7 @@ export async function pollUntilVmiRunning(
     getVirtualMachineInstance: (
       ns: string,
       name: string,
-    ) => Promise<{ status?: { phase?: string } }>;
+    ) => Promise<{ status?: { phase?: string } } | null>;
   },
   namespace: string,
   vmName: string,
@@ -99,6 +111,7 @@ export async function pollUntilVmiRunning(
   await pollUntil(
     async () => {
       const vmi = await apiClient.getVirtualMachineInstance(namespace, vmName);
+      if (!vmi) return false;
       return vmi.status?.phase === 'Running';
     },
     timeoutMs,
@@ -116,7 +129,7 @@ export async function pollUntilSnapshotReady(
     getVirtualMachineSnapshot: (
       ns: string,
       name: string,
-    ) => Promise<{ status?: { readyToUse?: boolean } }>;
+    ) => Promise<{ status?: { readyToUse?: boolean } } | null>;
   },
   namespace: string,
   snapshotName: string,
@@ -125,6 +138,7 @@ export async function pollUntilSnapshotReady(
   await pollUntil(
     async () => {
       const snap = await apiClient.getVirtualMachineSnapshot(namespace, snapshotName);
+      if (!snap) return false;
       return snap.status?.readyToUse === true;
     },
     timeoutMs,
@@ -138,7 +152,7 @@ export async function pollUntilRestoreComplete(
     getVirtualMachineRestore: (
       ns: string,
       name: string,
-    ) => Promise<{ status?: { complete?: boolean } }>;
+    ) => Promise<{ status?: { complete?: boolean } } | null>;
   },
   namespace: string,
   restoreName: string,
@@ -147,9 +161,60 @@ export async function pollUntilRestoreComplete(
   await pollUntil(
     async () => {
       const restore = await apiClient.getVirtualMachineRestore(namespace, restoreName);
+      if (!restore) return false;
       return restore.status?.complete === true;
     },
     timeoutMs,
     `Restore ${restoreName} did not complete`,
   );
+}
+
+// ---------------------------------------------------------------------------
+// Deletion pollers (wait for 404)
+// ---------------------------------------------------------------------------
+
+/** Polls until the VirtualMachineSnapshot no longer exists (null return or 404 error). */
+export async function pollUntilSnapshotDeleted(
+  apiClient: {
+    getVirtualMachineSnapshot: (ns: string, name: string) => Promise<unknown>;
+  },
+  namespace: string,
+  snapshotName: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const result = await apiClient.getVirtualMachineSnapshot(namespace, snapshotName);
+      if (result == null) return;
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    } catch (e: unknown) {
+      if (is404(e)) return;
+      if (!isTransientError(e)) throw e;
+    }
+  }
+  throw new Error(`Snapshot ${snapshotName} still exists after ${timeoutMs}ms`);
+}
+
+/** Polls until the VirtualMachineRestore no longer exists (null return or 404 error). */
+export async function pollUntilRestoreDeleted(
+  apiClient: {
+    getVirtualMachineRestore: (ns: string, name: string) => Promise<unknown>;
+  },
+  namespace: string,
+  restoreName: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const result = await apiClient.getVirtualMachineRestore(namespace, restoreName);
+      if (result == null) return;
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    } catch (e: unknown) {
+      if (is404(e)) return;
+      if (!isTransientError(e)) throw e;
+    }
+  }
+  throw new Error(`Restore ${restoreName} still exists after ${timeoutMs}ms`);
 }

--- a/playwright/tests/api/bootable-volumes-api.spec.ts
+++ b/playwright/tests/api/bootable-volumes-api.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@/fixtures/api-test-fixture';
+import { assertList } from '@/utils/api-assertions';
+
+test.describe('Bootable volumes page — API endpoints', { tag: ['@api'] }, () => {
+  test('GET DataSources (ns-scoped) with default-preference label returns list', async ({
+    apiClient,
+    testNamespace,
+  }) => {
+    const body = await apiClient.getDataSources(
+      testNamespace,
+      'instancetype.kubevirt.io/default-preference',
+    );
+    assertList(body, 'DataSourceList');
+  });
+
+  test('GET DataImportCrons (ns-scoped) returns list', async ({ apiClient, testNamespace }) => {
+    const body = await apiClient.getDataImportCrons(testNamespace);
+    assertList(body, 'DataImportCronList');
+  });
+
+  test('GET DataVolumes (ns-scoped) returns list', async ({ apiClient, testNamespace }) => {
+    const body = await apiClient.getDataVolumes(testNamespace);
+    assertList(body, 'DataVolumeList');
+  });
+
+  test('GET PersistentVolumeClaims (ns-scoped) returns list', async ({
+    apiClient,
+    testNamespace,
+  }) => {
+    const body = await apiClient.getPersistentVolumeClaims(testNamespace);
+    assertList(body, 'PersistentVolumeClaimList');
+  });
+
+  test('GET VolumeSnapshots (ns-scoped) returns list', async ({ apiClient, testNamespace }) => {
+    const body = await apiClient.getVolumeSnapshots(testNamespace);
+    assertList(body, 'VolumeSnapshotList');
+  });
+
+  test('GET VirtualMachineClusterPreferences returns list', async ({ apiClient }) => {
+    const body = await apiClient.getVirtualMachineClusterPreferences();
+    assertList(body, 'VirtualMachineClusterPreferenceList');
+  });
+
+  test('GET CDI config singleton is readable', async ({ apiClient }) => {
+    const body = await apiClient.getCdiConfig();
+    expect(body.kind, 'kind must be CDIConfig').toBe('CDIConfig');
+    expect(body.metadata?.name, 'name must be config').toBe('config');
+  });
+});

--- a/playwright/tests/api/bootable-volumes-crud-api.spec.ts
+++ b/playwright/tests/api/bootable-volumes-crud-api.spec.ts
@@ -1,0 +1,160 @@
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/api-test-fixture';
+
+test.describe('Bootable Volume — DataVolume CRUD API', { tag: ['@api'] }, () => {
+  let dvName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    dvName = utils.generateRandomDataVolumeName('bv-dv');
+
+    const spec = utils.DataVolumeFactory.createResourceObject({
+      name: dvName,
+      namespace: testNamespace,
+      defaultInstanceType: 'u1.medium',
+      defaultPreference: 'fedora',
+      source: { registry: { url: 'docker://quay.io/containerdisks/fedora:latest' } },
+      storage: { requests: { storage: '5Gi' } },
+    });
+
+    await test.step('CREATE DataVolume via console proxy', async () => {
+      const created = await apiClient.createDataVolume(testNamespace, spec);
+      expect(created.kind).toBe('DataVolume');
+      expect(created.metadata.name).toBe(dvName);
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (dvName) {
+      await apiClient.deleteDataVolume(testNamespace, dvName).catch(() => undefined);
+    }
+  });
+
+  test('READ: GET DataVolume returns correct metadata and instancetype labels', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const dv = await apiClient.getDataVolume(testNamespace, dvName);
+    expect(dv.kind).toBe('DataVolume');
+    expect(dv.metadata.name).toBe(dvName);
+    expect(dv.metadata.labels?.['instancetype.kubevirt.io/default-instancetype']).toBe('u1.medium');
+    expect(dv.metadata.labels?.['instancetype.kubevirt.io/default-preference']).toBe('fedora');
+    expect(
+      (dv.spec?.['source'] as { registry?: { url?: string } } | undefined)?.registry?.url,
+    ).toBe('docker://quay.io/containerdisks/fedora:latest');
+  });
+
+  test('READ: DataVolume appears in namespace list', async ({ testNamespace, apiClient }) => {
+    const list = await apiClient.getDataVolumes(testNamespace);
+    expect(list.kind).toBe('DataVolumeList');
+    const found = list.items.find((dv: KubernetesResource) => dv.metadata?.name === dvName);
+    expect(found, `DataVolume ${dvName} must appear in namespace list`).toBeDefined();
+  });
+
+  test('PATCH: add label to DataVolume', async ({ testNamespace, apiClient }) => {
+    await apiClient.patchDataVolume(testNamespace, dvName, [
+      { op: 'add', path: '/metadata/labels/api-test', value: 'bv-crud' },
+    ]);
+    const updated = await apiClient.getDataVolume(testNamespace, dvName);
+    expect(updated.metadata.labels?.['api-test']).toBe('bv-crud');
+  });
+
+  test('DELETE: remove DataVolume and verify response', async ({ testNamespace, apiClient }) => {
+    const result = await apiClient.deleteDataVolume(testNamespace, dvName);
+    expect(['DataVolume', 'Status']).toContain(result.kind);
+    dvName = '';
+  });
+});
+
+test.describe('Bootable Volume — DataSource CRUD API', { tag: ['@api'] }, () => {
+  let dsName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    dsName = utils.generateRandomName('bv-ds');
+
+    const spec = {
+      apiVersion: 'cdi.kubevirt.io/v1beta1',
+      kind: 'DataSource',
+      metadata: {
+        name: dsName,
+        namespace: testNamespace,
+        labels: {
+          'instancetype.kubevirt.io/default-preference': 'fedora',
+          'instancetype.kubevirt.io/default-instancetype': 'u1.medium',
+        },
+        annotations: {
+          'cdi.kubevirt.io/architecture': 'amd64',
+          description: 'API test DataSource for bootable volume CRUD',
+        },
+      },
+      spec: {
+        source: {
+          pvc: { name: dsName, namespace: testNamespace },
+        },
+      },
+    };
+
+    await test.step('CREATE DataSource via console proxy', async () => {
+      const created = await apiClient.createDataSource(testNamespace, spec);
+      expect(created.kind).toBe('DataSource');
+      expect(created.metadata.name).toBe(dsName);
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (dsName) {
+      await apiClient.deleteDataSource(testNamespace, dsName).catch(() => undefined);
+    }
+  });
+
+  test('READ: GET DataSource returns correct metadata and instancetype labels', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const ds = await apiClient.getDataSource(testNamespace, dsName);
+    expect(ds.kind).toBe('DataSource');
+    expect(ds.metadata.name).toBe(dsName);
+    expect(ds.metadata.labels?.['instancetype.kubevirt.io/default-preference']).toBe('fedora');
+    expect(ds.metadata.labels?.['instancetype.kubevirt.io/default-instancetype']).toBe('u1.medium');
+    expect(ds.metadata.annotations?.['cdi.kubevirt.io/architecture']).toBe('amd64');
+  });
+
+  test('READ: DataSource appears in namespace list', async ({ testNamespace, apiClient }) => {
+    const list = await apiClient.getDataSources(testNamespace);
+    expect(list.kind).toBe('DataSourceList');
+    const found = list.items.find((ds: KubernetesResource) => ds.metadata?.name === dsName);
+    expect(found, `DataSource ${dsName} must appear in namespace list`).toBeDefined();
+  });
+
+  test('READ: DataSource returned by default-preference label filter', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const list = await apiClient.getDataSources(
+      testNamespace,
+      'instancetype.kubevirt.io/default-preference',
+    );
+    const found = list.items.find((ds: KubernetesResource) => ds.metadata?.name === dsName);
+    expect(
+      found,
+      `DataSource ${dsName} must appear when filtering by default-preference label`,
+    ).toBeDefined();
+  });
+
+  test('PATCH: update DataSource description annotation', async ({ testNamespace, apiClient }) => {
+    await apiClient.patchDataSource(testNamespace, dsName, [
+      {
+        op: 'replace',
+        path: '/metadata/annotations/description',
+        value: 'patched-by-api-test',
+      },
+    ]);
+    const updated = await apiClient.getDataSource(testNamespace, dsName);
+    expect(updated.metadata.annotations?.description).toBe('patched-by-api-test');
+  });
+
+  test('DELETE: remove DataSource and verify response', async ({ testNamespace, apiClient }) => {
+    const result = await apiClient.deleteDataSource(testNamespace, dsName);
+    expect(['DataSource', 'Status']).toContain(result.kind);
+    dsName = '';
+  });
+});

--- a/playwright/tests/api/create-vm-api.spec.ts
+++ b/playwright/tests/api/create-vm-api.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@/fixtures/api-test-fixture';
+import { assertList } from '@/utils/api-assertions';
+
+const OS_IMAGES_NS = 'openshift-virtualization-os-images';
+
+const WELL_KNOWN_OS_DATASOURCES = ['fedora', 'rhel9', 'rhel8', 'centos-stream9'] as const;
+
+test.describe('VM Creation — API endpoints', { tag: ['@api'] }, () => {
+  test('GET VirtualMachineClusterInstanceTypes returns list', async ({ apiClient }) => {
+    const body = await apiClient.getVirtualMachineClusterInstanceTypes();
+    assertList(body, 'VirtualMachineClusterInstancetypeList');
+    expect(body.items.length, 'at least one cluster instance type must exist').toBeGreaterThan(0);
+  });
+
+  test('GET VirtualMachineClusterPreferences returns list', async ({ apiClient }) => {
+    const body = await apiClient.getVirtualMachineClusterPreferences();
+    assertList(body, 'VirtualMachineClusterPreferenceList');
+    expect(body.items.length, 'at least one cluster preference must exist').toBeGreaterThan(0);
+  });
+
+  test('GET VirtualMachineInstanceTypes (ns-scoped) returns list', async ({
+    apiClient,
+    testNamespace,
+  }) => {
+    const body = await apiClient.getVirtualMachineInstanceTypes(testNamespace);
+    assertList(body, 'VirtualMachineInstancetypeList');
+  });
+
+  test('GET VirtualMachinePreferences (ns-scoped) returns list', async ({
+    apiClient,
+    testNamespace,
+  }) => {
+    const body = await apiClient.getVirtualMachinePreferences(testNamespace);
+    assertList(body, 'VirtualMachinePreferenceList');
+  });
+
+  test('GET templates with catalog label selector returns TemplateList', async ({ apiClient }) => {
+    const body = await apiClient.getTemplates(undefined, 'template.kubevirt.io/type in (base,vm)');
+    assertList(body, 'TemplateList');
+  });
+
+  test('GET DataSources filtered by default-preference label returns list', async ({
+    apiClient,
+  }) => {
+    const body = await apiClient.getDataSources(
+      undefined,
+      'instancetype.kubevirt.io/default-preference',
+    );
+    assertList(body, 'DataSourceList');
+  });
+
+  test('GET DataImportCrons (cluster-wide) returns list', async ({ apiClient }) => {
+    const body = await apiClient.getDataImportCrons();
+    assertList(body, 'DataImportCronList');
+  });
+
+  test('GET DataVolumes (cluster-wide) returns list', async ({ apiClient }) => {
+    const body = await apiClient.getDataVolumes();
+    assertList(body, 'DataVolumeList');
+  });
+
+  test('GET StorageProfiles returns list', async ({ apiClient }) => {
+    const body = await apiClient.getStorageProfiles();
+    assertList(body, 'StorageProfileList');
+  });
+
+  for (const osName of WELL_KNOWN_OS_DATASOURCES) {
+    test(`GET DataSource ${osName} from os-images namespace is readable`, async ({ apiClient }) => {
+      const body = await apiClient.getDataSource(OS_IMAGES_NS, osName);
+      expect(body.kind, 'kind must be DataSource').toBe('DataSource');
+      expect(body.metadata?.name, `name must be ${osName}`).toBe(osName);
+    });
+  }
+});

--- a/playwright/tests/api/instance-types-crud-api.spec.ts
+++ b/playwright/tests/api/instance-types-crud-api.spec.ts
@@ -1,0 +1,126 @@
+import { load as yamlLoad } from 'js-yaml';
+
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/api-test-fixture';
+
+test.describe('VirtualMachineInstanceType CRUD — API', { tag: ['@api'] }, () => {
+  let instanceTypeName: string;
+  let clusterInstanceTypeName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    instanceTypeName = utils.generateRandomInstanceTypeName('test');
+    clusterInstanceTypeName = utils.generateRandomInstanceTypeName('cluster-test');
+
+    await test.step('CREATE VirtualMachineInstanceType (namespaced) via API', async () => {
+      const yaml = utils.InstanceTypeFactory.createNamespaced(
+        instanceTypeName,
+        testNamespace,
+        1,
+        '512Mi',
+      );
+      const created = await apiClient.createVirtualMachineInstanceType(
+        testNamespace,
+        yamlLoad(yaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('VirtualMachineInstancetype');
+      expect(created.metadata.name).toBe(instanceTypeName);
+    });
+
+    await test.step('CREATE VirtualMachineClusterInstancetype via API', async () => {
+      const yaml = utils.InstanceTypeFactory.createClusterScoped(
+        clusterInstanceTypeName,
+        1,
+        '512Mi',
+      );
+      const created = await apiClient.createVirtualMachineClusterInstanceType(
+        yamlLoad(yaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('VirtualMachineClusterInstancetype');
+      expect(created.metadata.name).toBe(clusterInstanceTypeName);
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (instanceTypeName) {
+      await apiClient
+        .deleteVirtualMachineInstanceType(testNamespace, instanceTypeName)
+        .catch(() => undefined);
+    }
+    if (clusterInstanceTypeName) {
+      await apiClient
+        .deleteVirtualMachineClusterInstanceType(clusterInstanceTypeName)
+        .catch(() => undefined);
+    }
+  });
+
+  test('READ: GET instance types in namespace includes created type', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const list = await apiClient.getVirtualMachineInstanceTypes(testNamespace);
+    expect(list.kind).toBe('VirtualMachineInstancetypeList');
+    const found = list.items.find(
+      (it: KubernetesResource) => it.metadata?.name === instanceTypeName,
+    );
+    expect(found, `instance type ${instanceTypeName} must appear in list`).toBeDefined();
+    const spec = (found as KubernetesResource).spec as {
+      cpu?: { guest?: number };
+      memory?: { guest?: string };
+    };
+    expect(spec.cpu?.guest).toBe(1);
+    expect(spec.memory?.guest).toBe('512Mi');
+  });
+
+  test('READ: GET cluster instance types list is non-empty', async ({ apiClient }) => {
+    const list = await apiClient.getVirtualMachineClusterInstanceTypes();
+    expect(list.kind).toBe('VirtualMachineClusterInstancetypeList');
+    expect(list.items.length, 'built-in cluster instance types must exist').toBeGreaterThan(0);
+  });
+
+  test('PATCH: update CPU guest count via JSON Patch', async ({ testNamespace, apiClient }) => {
+    await apiClient.patchResource(
+      'instancetype.kubevirt.io',
+      'v1beta1',
+      'virtualmachineinstancetypes',
+      instanceTypeName,
+      [{ op: 'replace', path: '/spec/cpu/guest', value: 2 }],
+      testNamespace,
+    );
+
+    const list = await apiClient.getVirtualMachineInstanceTypes(testNamespace);
+    const updated = list.items.find(
+      (it: KubernetesResource) => it.metadata?.name === instanceTypeName,
+    );
+    expect((updated?.spec as { cpu?: { guest?: number } })?.cpu?.guest).toBe(2);
+  });
+
+  test('DELETE: remove namespaced instance type via API', async ({ testNamespace, apiClient }) => {
+    await apiClient.deleteVirtualMachineInstanceType(testNamespace, instanceTypeName);
+
+    const list = await apiClient.getVirtualMachineInstanceTypes(testNamespace);
+    const found = list.items.find(
+      (it: KubernetesResource) => it.metadata?.name === instanceTypeName,
+    );
+    expect(
+      found,
+      'namespaced instance type must no longer appear in list after deletion',
+    ).toBeUndefined();
+
+    instanceTypeName = '';
+  });
+
+  test('DELETE: remove cluster instance type via API', async ({ apiClient }) => {
+    await apiClient.deleteVirtualMachineClusterInstanceType(clusterInstanceTypeName);
+
+    const list = await apiClient.getVirtualMachineClusterInstanceTypes();
+    const found = list.items.find(
+      (it: KubernetesResource) => it.metadata?.name === clusterInstanceTypeName,
+    );
+    expect(
+      found,
+      'cluster instance type must no longer appear in list after deletion',
+    ).toBeUndefined();
+
+    clusterInstanceTypeName = '';
+  });
+});

--- a/playwright/tests/api/migration-policies-crud-api.spec.ts
+++ b/playwright/tests/api/migration-policies-crud-api.spec.ts
@@ -1,0 +1,105 @@
+import { load as yamlLoad } from 'js-yaml';
+
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/api-test-fixture';
+
+test.describe('MigrationPolicy CRUD — API', { tag: ['@api'] }, () => {
+  let policyName: string;
+  let fullPolicyName: string;
+
+  test.beforeAll(async ({ apiClient, utils }) => {
+    policyName = utils.generateRandomMigrationPolicyName('test');
+    fullPolicyName = utils.generateRandomMigrationPolicyName('test-full');
+
+    await test.step('CREATE minimal MigrationPolicy via API', async () => {
+      const yaml = utils.MigrationPolicyFactory.createMinimal(policyName);
+      const created = await apiClient.createMigrationPolicy(yamlLoad(yaml) as KubernetesResource);
+      expect(created.kind).toBe('MigrationPolicy');
+      expect(created.metadata.name).toBe(policyName);
+    });
+
+    await test.step('CREATE full-config MigrationPolicy via API', async () => {
+      const yaml = utils.MigrationPolicyFactory.createFullConfig(
+        fullPolicyName,
+        true,
+        false,
+        '1Gi',
+        1,
+      );
+      const created = await apiClient.createMigrationPolicy(yamlLoad(yaml) as KubernetesResource);
+      expect(created.kind).toBe('MigrationPolicy');
+      expect(created.spec.allowAutoConverge).toBe(true);
+      expect(created.spec.bandwidthPerMigration).toBe('1Gi');
+    });
+  });
+
+  test.afterAll(async ({ apiClient }) => {
+    for (const name of [policyName, fullPolicyName]) {
+      if (name) await apiClient.deleteMigrationPolicy(name).catch(() => undefined);
+    }
+  });
+
+  test('READ: GET migration policies list includes created policies', async ({ apiClient }) => {
+    const list = await apiClient.getMigrationPolicies();
+    expect(list.kind).toBe('MigrationPolicyList');
+
+    const foundMinimal = list.items.find(
+      (p: KubernetesResource) => p.metadata?.name === policyName,
+    );
+    expect(foundMinimal, `policy ${policyName} must appear in list`).toBeDefined();
+
+    const foundFull = list.items.find(
+      (p: KubernetesResource) => p.metadata?.name === fullPolicyName,
+    );
+    expect(foundFull, `policy ${fullPolicyName} must appear in list`).toBeDefined();
+    expect(
+      ((foundFull as KubernetesResource)?.spec as { allowAutoConverge?: boolean } | undefined)
+        ?.allowAutoConverge,
+    ).toBe(true);
+  });
+
+  test('PATCH: update bandwidthPerMigration via JSON Patch', async ({ apiClient }) => {
+    await apiClient.patchMigrationPolicy(fullPolicyName, [
+      { op: 'replace', path: '/spec/bandwidthPerMigration', value: '2Gi' },
+    ]);
+
+    const list = await apiClient.getMigrationPolicies();
+    const updated = list.items.find((p: KubernetesResource) => p.metadata?.name === fullPolicyName);
+    expect(
+      (updated?.spec as { bandwidthPerMigration?: string } | undefined)?.bandwidthPerMigration,
+    ).toBe('2Gi');
+  });
+
+  test('CREATE: policy with namespace selector using factory', async ({ apiClient, utils }) => {
+    const selectorPolicyName = utils.generateRandomMigrationPolicyName('test-ns');
+    const yaml = utils.MigrationPolicyFactory.createWithNamespaceSelector(selectorPolicyName, {
+      'kubernetes.io/metadata.name': 'default',
+    });
+
+    try {
+      const created = await apiClient.createMigrationPolicy(yamlLoad(yaml) as KubernetesResource);
+      expect(created.kind).toBe('MigrationPolicy');
+      expect(
+        (created.spec as { selectors?: { namespaceSelector?: unknown } } | undefined)?.selectors
+          ?.namespaceSelector,
+      ).toBeDefined();
+    } finally {
+      await apiClient.deleteMigrationPolicy(selectorPolicyName).catch(() => undefined);
+    }
+  });
+
+  test('DELETE: remove both policies via API', async ({ apiClient }) => {
+    for (const [name, label] of [
+      [policyName, 'minimal'],
+      [fullPolicyName, 'full-config'],
+    ] as const) {
+      await apiClient.deleteMigrationPolicy(name);
+      const list = await apiClient.getMigrationPolicies();
+      const found = list.items.find((p: KubernetesResource) => p.metadata?.name === name);
+      expect(found, `${label} policy must not appear after deletion`).toBeUndefined();
+    }
+
+    policyName = '';
+    fullPolicyName = '';
+  });
+});

--- a/playwright/tests/api/snapshots-crud-api.spec.ts
+++ b/playwright/tests/api/snapshots-crud-api.spec.ts
@@ -1,0 +1,89 @@
+import { load as yamlLoad } from 'js-yaml';
+
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/api-test-fixture';
+
+test.describe('VirtualMachineSnapshot CRUD — API', { tag: ['@api'] }, () => {
+  let vmName: string;
+  let snapshotName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    vmName = utils.generateRandomVmName('test-snap-vm');
+    snapshotName = utils.generateRandomSnapshotName('test-snap');
+
+    await test.step('CREATE backing VirtualMachine', async () => {
+      const vmYaml = utils.VirtualMachineFactory.create({
+        name: vmName,
+        namespace: testNamespace,
+        runStrategy: 'Halted',
+        cpuCores: 1,
+        memory: '512Mi',
+      });
+      const created = await apiClient.createVirtualMachine(
+        testNamespace,
+        yamlLoad(vmYaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('VirtualMachine');
+    });
+
+    await test.step('WAIT: VM exists before snapshotting', async () => {
+      const ready = await apiClient.waitForVmExists(vmName, testNamespace);
+      expect(ready, 'VM must exist before snapshot can be taken').toBe(true);
+    });
+
+    await test.step('CREATE VirtualMachineSnapshot via console proxy', async () => {
+      const snapYaml = utils.createMinimalVirtualMachineSnapshotYaml({
+        name: snapshotName,
+        namespace: testNamespace,
+        vmName,
+      });
+      const created = await apiClient.createVirtualMachineSnapshot(
+        testNamespace,
+        yamlLoad(snapYaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('VirtualMachineSnapshot');
+      expect(created.metadata.name).toBe(snapshotName);
+    });
+
+    await test.step('WAIT: snapshot reaches Ready state', async () => {
+      const ready = await apiClient.waitForSnapshotReady(snapshotName, testNamespace);
+      expect(ready, 'snapshot must reach Ready=true before assertions').toBe(true);
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (snapshotName) {
+      await apiClient
+        .deleteVirtualMachineSnapshot(testNamespace, snapshotName)
+        .catch(() => undefined);
+    }
+    if (vmName) {
+      await apiClient.deleteVirtualMachine(testNamespace, vmName).catch(() => undefined);
+      await apiClient.waitForVmDeleted(vmName, testNamespace).catch(() => undefined);
+    }
+  });
+
+  test('READ: snapshot appears in namespace snapshot list', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const list = await apiClient.getVirtualMachineSnapshots(testNamespace);
+    expect(list.kind).toBe('VirtualMachineSnapshotList');
+    const found = list.items.find((s: KubernetesResource) => s.metadata?.name === snapshotName);
+    expect(found, `snapshot ${snapshotName} must appear in list`).toBeDefined();
+    expect(
+      ((found as KubernetesResource)?.spec as { source?: { name?: string } } | undefined)?.source
+        ?.name,
+    ).toBe(vmName);
+  });
+
+  test('DELETE: remove snapshot via API', async ({ testNamespace, apiClient }) => {
+    await apiClient.deleteVirtualMachineSnapshot(testNamespace, snapshotName);
+
+    const list = await apiClient.getVirtualMachineSnapshots(testNamespace);
+    const found = list.items.find((s: KubernetesResource) => s.metadata?.name === snapshotName);
+    expect(found, 'snapshot must no longer appear in list after deletion').toBeUndefined();
+
+    snapshotName = '';
+  });
+});

--- a/playwright/tests/api/storage-migration-plan-crud-api.spec.ts
+++ b/playwright/tests/api/storage-migration-plan-crud-api.spec.ts
@@ -1,0 +1,141 @@
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/api-test-fixture';
+
+function buildMultiNsPlanSpec(
+  name: string,
+  namespace: string,
+  vmName: string,
+  volumeName: string,
+  sourcePvcName: string,
+  destinationStorageClass: string,
+  retentionPolicy: 'keepSource' | 'deleteSource' = 'keepSource',
+): KubernetesResource {
+  return {
+    apiVersion: 'migrations.kubevirt.io/v1alpha1',
+    kind: 'MultiNamespaceVirtualMachineStorageMigrationPlan',
+    metadata: { name, namespace },
+    spec: {
+      namespaces: [
+        {
+          name: namespace,
+          retentionPolicy,
+          virtualMachines: [
+            {
+              name: vmName,
+              targetMigrationPVCs: [
+                {
+                  volumeName,
+                  sourcePVC: { name: sourcePvcName },
+                  destinationPVC: {
+                    storageClassName: destinationStorageClass,
+                    accessModes: ['Auto'],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  } as unknown as KubernetesResource;
+}
+
+test.describe('Storage Migration Plan CRUD — API', { tag: ['@api'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let planName: string;
+  let testNs: string;
+  let storageClassName: string;
+  const dummyVmName = 'pw-smig-api-dummy';
+  const dummyPvcName = 'pw-smig-api-dummy';
+
+  test.beforeAll(async ({ apiClient, testNamespace, utils }) => {
+    testNs = testNamespace;
+
+    const scList = await apiClient.getStorageClasses();
+    const scItems = (scList?.items as Array<{ metadata?: { name?: string } }>) ?? [];
+    storageClassName = scItems[0]?.metadata?.name ?? 'ocs-storagecluster-ceph-rbd';
+
+    planName = utils.generateRandomName('migplan');
+  });
+
+  test.afterAll(async ({ apiClient }) => {
+    if (planName) {
+      await apiClient.deleteMultiNsStorageMigrationPlan(planName, testNs).catch(() => undefined);
+    }
+  });
+
+  test('CREATE: multi-namespace storage migration plan', async ({ apiClient }) => {
+    const spec = buildMultiNsPlanSpec(
+      planName,
+      testNs,
+      dummyVmName,
+      'rootdisk',
+      dummyPvcName,
+      storageClassName,
+    );
+
+    const created = await apiClient.createMultiNsStorageMigrationPlan(spec, testNs);
+    expect(created, 'Plan creation must return a resource').not.toBeNull();
+    expect(created?.kind).toBe('MultiNamespaceVirtualMachineStorageMigrationPlan');
+    expect(created?.metadata.name).toBe(planName);
+  });
+
+  test('READ: GET single multi-ns plan returns correct spec', async ({ apiClient }) => {
+    const plan = await apiClient.getMultiNsStorageMigrationPlan(planName, testNs);
+    expect(plan, 'Plan must be retrievable by name').not.toBeNull();
+    expect(plan?.kind).toBe('MultiNamespaceVirtualMachineStorageMigrationPlan');
+    expect(plan?.metadata.name).toBe(planName);
+
+    const spec = plan?.spec as {
+      namespaces?: Array<{
+        name?: string;
+        retentionPolicy?: string;
+        virtualMachines?: Array<{ name?: string }>;
+      }>;
+    };
+    expect(spec.namespaces?.[0]?.retentionPolicy).toBe('keepSource');
+    expect(spec.namespaces?.[0]?.virtualMachines?.[0]?.name).toBe(dummyVmName);
+  });
+
+  test('READ: plan appears in multi-ns listing (UI endpoint)', async ({ apiClient }) => {
+    const list = await apiClient.getStorageMigrationPlans(testNs);
+    expect(list.kind).toContain('List');
+
+    const found = list.items.find((p: KubernetesResource) => p.metadata?.name === planName);
+    expect(found, `Plan ${planName} must appear in multi-ns list`).toBeDefined();
+  });
+
+  test('READ: auto-created child plan exists in namespaced list', async ({ apiClient, utils }) => {
+    const childName = `${planName}-${testNs}`;
+
+    await expect
+      .poll(
+        async () => {
+          const list = await apiClient.getNamespacedStorageMigrationPlans(testNs);
+          return list.items.find((p: KubernetesResource) => p.metadata?.name === childName);
+        },
+        {
+          timeout: utils.TestTimeouts.TEST_SHORT,
+          intervals: [3_000],
+          message: `Child plan ${childName} must exist`,
+        },
+      )
+      .toBeDefined();
+
+    const list = await apiClient.getNamespacedStorageMigrationPlans(testNs);
+    const found = list.items.find((p: KubernetesResource) => p.metadata?.name === childName);
+    expect(found?.kind).toBe('VirtualMachineStorageMigrationPlan');
+  });
+
+  test('DELETE: remove multi-ns plan and verify absence', async ({ apiClient }) => {
+    const result = await apiClient.deleteMultiNsStorageMigrationPlan(planName, testNs);
+    expect(result).not.toBeNull();
+
+    const list = await apiClient.getStorageMigrationPlans(testNs);
+    const found = list.items.find((p: KubernetesResource) => p.metadata?.name === planName);
+    expect(found, 'Plan must not appear after deletion').toBeUndefined();
+
+    planName = '';
+  });
+});

--- a/playwright/tests/api/templates-crud-api.spec.ts
+++ b/playwright/tests/api/templates-crud-api.spec.ts
@@ -1,0 +1,344 @@
+import { load as yamlLoad } from 'js-yaml';
+
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/api-test-fixture';
+
+const RH_TEMPLATES_NS = 'openshift';
+
+const RHEL9_TEMPLATE_NAME = 'rhel9-server-small';
+
+interface NestedVmTemplateSpec {
+  template?: {
+    spec?: {
+      domain?: {
+        cpu?: { cores?: number; dedicatedCpuPlacement?: boolean };
+        memory?: { guest?: string };
+      };
+      evictionStrategy?: string;
+    };
+  };
+}
+
+function templateObjects(tmpl: KubernetesResource): KubernetesResource[] {
+  const raw = tmpl['objects'];
+  return Array.isArray(raw) ? (raw as KubernetesResource[]) : [];
+}
+
+function templateParameters(tmpl: KubernetesResource): KubernetesResource[] {
+  const raw = tmpl['parameters'];
+  return Array.isArray(raw) ? (raw as KubernetesResource[]) : [];
+}
+
+test.describe('Template — user template lifecycle API', { tag: ['@api'] }, () => {
+  let templateName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    templateName = utils.generateRandomTemplateName('tmpl-lc');
+
+    const yaml = utils.TemplateFactory.create({
+      name: templateName,
+      namespace: testNamespace,
+      displayName: 'API Test Template',
+      cpuCores: 1,
+      memory: '512Mi',
+      workload: 'server',
+    });
+
+    await test.step('CREATE template via console proxy', async () => {
+      const created = await apiClient.createTemplate(
+        testNamespace,
+        yamlLoad(yaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('Template');
+      expect(created.metadata.name).toBe(templateName);
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (templateName) {
+      await apiClient.deleteTemplate(testNamespace, templateName).catch(() => undefined);
+    }
+  });
+
+  test('READ: GET single template returns correct spec', async ({ testNamespace, apiClient }) => {
+    const tmpl = await apiClient.getTemplate(testNamespace, templateName);
+    expect(tmpl.kind).toBe('Template');
+    expect(tmpl.metadata.name).toBe(templateName);
+    expect(tmpl.metadata.labels?.['template.kubevirt.io/type']).toBe('vm');
+  });
+
+  test('READ: template appears in namespace list', async ({ testNamespace, apiClient }) => {
+    const list = await apiClient.getTemplates(testNamespace);
+    expect(list.kind).toBe('TemplateList');
+    const found = list.items.find((t: KubernetesResource) => t.metadata?.name === templateName);
+    expect(found, `template ${templateName} must appear in namespace list`).toBeDefined();
+  });
+
+  test('READ: template returned by kubevirt type label filter', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const list = await apiClient.getTemplates(
+      testNamespace,
+      'template.kubevirt.io/type in (base,vm)',
+    );
+    const found = list.items.find((t: KubernetesResource) => t.metadata?.name === templateName);
+    expect(found, 'template must appear in vm-type filtered list').toBeDefined();
+  });
+
+  test('READ: template has NAME and CLOUD_USER_PASSWORD parameters', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const tmpl = await apiClient.getTemplate(testNamespace, templateName);
+    const params: string[] = templateParameters(tmpl).map((p) => String(p['name']));
+    expect(params, 'must contain NAME parameter').toContain('NAME');
+    expect(params, 'must contain CLOUD_USER_PASSWORD parameter').toContain('CLOUD_USER_PASSWORD');
+  });
+
+  test('READ: template objects array contains a VirtualMachine', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const tmpl = await apiClient.getTemplate(testNamespace, templateName);
+    expect(templateObjects(tmpl).length > 0, 'objects must be non-empty').toBe(true);
+    const vm = templateObjects(tmpl).find((o) => o.kind === 'VirtualMachine');
+    expect(vm, 'objects must contain a VirtualMachine').toBeDefined();
+  });
+
+  test('PATCH: update cpu.cores via JSON Patch', async ({ testNamespace, apiClient }) => {
+    await apiClient.patchTemplate(testNamespace, templateName, [
+      {
+        op: 'replace',
+        path: '/objects/0/spec/template/spec/domain/cpu/cores',
+        value: 2,
+      },
+    ]);
+    const updated = await apiClient.getTemplate(testNamespace, templateName);
+    const vmObj = templateObjects(updated)[0];
+    expect((vmObj?.spec as NestedVmTemplateSpec)?.template?.spec?.domain?.cpu?.cores).toBe(2);
+  });
+
+  test('PATCH: update memory via JSON Patch', async ({ testNamespace, apiClient }) => {
+    await apiClient.patchTemplate(testNamespace, templateName, [
+      {
+        op: 'replace',
+        path: '/objects/0/spec/template/spec/domain/memory/guest',
+        value: '1Gi',
+      },
+    ]);
+    const updated = await apiClient.getTemplate(testNamespace, templateName);
+    const vmObjMem = templateObjects(updated)[0];
+    expect((vmObjMem?.spec as NestedVmTemplateSpec)?.template?.spec?.domain?.memory?.guest).toBe(
+      '1Gi',
+    );
+  });
+
+  test('PATCH: add custom label to template metadata', async ({ testNamespace, apiClient }) => {
+    await apiClient.patchTemplate(testNamespace, templateName, [
+      { op: 'add', path: '/metadata/labels/api-test', value: 'template-crud' },
+    ]);
+    const updated = await apiClient.getTemplate(testNamespace, templateName);
+    expect(updated.metadata.labels?.['api-test']).toBe('template-crud');
+  });
+
+  test('DELETE: remove template and confirm it leaves the list', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const result = await apiClient.deleteTemplate(testNamespace, templateName);
+    expect(['Template', 'Status']).toContain(result.kind);
+
+    const list = await apiClient.getTemplates(testNamespace);
+    const found = list.items.find((t: KubernetesResource) => t.metadata?.name === templateName);
+    expect(found, 'template must not appear in list after deletion').toBeUndefined();
+
+    templateName = '';
+  });
+});
+
+test.describe('Template — dedicated resources API', { tag: ['@api'] }, () => {
+  let templateName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    templateName = utils.generateRandomTemplateName('tmpl-ded');
+
+    const yaml = utils.TemplateFactory.create({
+      name: templateName,
+      namespace: testNamespace,
+      displayName: 'Dedicated CPU Template',
+      workload: 'highperformance',
+      workloadLabel: 'highperformance',
+      dedicatedCpuPlacement: true,
+      evictionStrategy: 'LiveMigrate',
+      cpuCores: 2,
+      memory: '1Gi',
+    });
+
+    await test.step('CREATE dedicated-resources template', async () => {
+      const created = await apiClient.createTemplate(
+        testNamespace,
+        yamlLoad(yaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('Template');
+      expect(created.metadata.name).toBe(templateName);
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (templateName) {
+      await apiClient.deleteTemplate(testNamespace, templateName).catch(() => undefined);
+    }
+  });
+
+  test('READ: template has highperformance workload label', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const tmpl = await apiClient.getTemplate(testNamespace, templateName);
+    expect(tmpl.metadata.labels?.['workload.template.kubevirt.io/highperformance']).toBe('true');
+  });
+
+  test('READ: nested VM has dedicatedCpuPlacement=true', async ({ testNamespace, apiClient }) => {
+    const tmpl = await apiClient.getTemplate(testNamespace, templateName);
+    const vm = templateObjects(tmpl).find((o) => o.kind === 'VirtualMachine');
+    expect(
+      (vm?.spec as NestedVmTemplateSpec)?.template?.spec?.domain?.cpu?.dedicatedCpuPlacement,
+    ).toBe(true);
+  });
+
+  test('READ: nested VM has LiveMigrate eviction strategy', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const tmpl = await apiClient.getTemplate(testNamespace, templateName);
+    const vm = templateObjects(tmpl).find((o) => o.kind === 'VirtualMachine');
+    expect((vm?.spec as NestedVmTemplateSpec)?.template?.spec?.evictionStrategy).toBe(
+      'LiveMigrate',
+    );
+  });
+});
+
+test.describe('Template — clone API', { tag: ['@api'] }, () => {
+  let sourceName: string;
+  let cloneName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    sourceName = utils.generateRandomTemplateName('tmpl-src');
+    cloneName = utils.generateRandomTemplateName('tmpl-clone');
+
+    const yaml = utils.TemplateFactory.create({
+      name: sourceName,
+      namespace: testNamespace,
+      cpuCores: 2,
+      memory: '1Gi',
+    });
+
+    await test.step('CREATE source template', async () => {
+      const created = await apiClient.createTemplate(
+        testNamespace,
+        yamlLoad(yaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('Template');
+    });
+
+    await test.step('CLONE: GET source and re-POST under new name', async () => {
+      const source = await apiClient.getTemplate(testNamespace, sourceName);
+      const clone = {
+        ...source,
+        metadata: {
+          ...source.metadata,
+          name: cloneName,
+          resourceVersion: undefined,
+          uid: undefined,
+          creationTimestamp: undefined,
+          generation: undefined,
+          managedFields: undefined,
+        },
+      };
+      const created = await apiClient.createTemplate(testNamespace, clone);
+      expect(created.kind).toBe('Template');
+      expect(created.metadata.name).toBe(cloneName);
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    await Promise.all([
+      apiClient.deleteTemplate(testNamespace, sourceName).catch(() => undefined),
+      apiClient.deleteTemplate(testNamespace, cloneName).catch(() => undefined),
+    ]);
+  });
+
+  test('READ: clone exists in namespace list', async ({ testNamespace, apiClient }) => {
+    const list = await apiClient.getTemplates(testNamespace);
+    const found = list.items.find((t: KubernetesResource) => t.metadata?.name === cloneName);
+    expect(found, `cloned template ${cloneName} must appear in namespace list`).toBeDefined();
+  });
+
+  test('READ: clone has same CPU and memory spec as source', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const [source, clone] = await Promise.all([
+      apiClient.getTemplate(testNamespace, sourceName),
+      apiClient.getTemplate(testNamespace, cloneName),
+    ]);
+    const srcVm = templateObjects(source).find((o) => o.kind === 'VirtualMachine');
+    const cloneVm = templateObjects(clone as KubernetesResource).find(
+      (o) => o.kind === 'VirtualMachine',
+    );
+    expect((cloneVm?.spec as NestedVmTemplateSpec)?.template?.spec?.domain?.cpu?.cores).toBe(
+      (srcVm?.spec as NestedVmTemplateSpec)?.template?.spec?.domain?.cpu?.cores,
+    );
+    expect((cloneVm?.spec as NestedVmTemplateSpec)?.template?.spec?.domain?.memory?.guest).toBe(
+      (srcVm?.spec as NestedVmTemplateSpec)?.template?.spec?.domain?.memory?.guest,
+    );
+  });
+});
+
+test.describe('Template — Red Hat templates read-only API', { tag: ['@api'] }, () => {
+  test('GET: openshift namespace has VM templates', async ({ apiClient }) => {
+    const list = await apiClient.getTemplates(
+      RH_TEMPLATES_NS,
+      'template.kubevirt.io/type in (base,vm)',
+    );
+    expect(list.kind).toBe('TemplateList');
+    expect(
+      list.items.length,
+      'Red Hat VM templates must exist in openshift namespace',
+    ).toBeGreaterThan(0);
+  });
+
+  test('GET: RHEL9 template exists and has expected structure', async ({ apiClient }) => {
+    const tmpl = await apiClient.getTemplate(RH_TEMPLATES_NS, RHEL9_TEMPLATE_NAME);
+    expect(tmpl.kind).toBe('Template');
+    expect(
+      templateParameters(tmpl).length > 0,
+      'RHEL9 template must have at least one parameter',
+    ).toBe(true);
+    expect(templateObjects(tmpl).length > 0, 'RHEL9 template must have objects').toBe(true);
+    const vm = templateObjects(tmpl).find((o) => o.kind === 'VirtualMachine');
+    expect(vm, 'RHEL9 template objects must include a VirtualMachine').toBeDefined();
+  });
+
+  test('GET: RHEL9 template has os and type labels', async ({ apiClient }) => {
+    const tmpl = await apiClient.getTemplate(RH_TEMPLATES_NS, RHEL9_TEMPLATE_NAME);
+    expect(tmpl.metadata.labels?.['template.kubevirt.io/type']).toMatch(/^(base|vm)$/);
+    const hasOsLabel = Object.keys(tmpl.metadata.labels ?? {}).some((k) =>
+      k.startsWith('os.template.kubevirt.io/'),
+    );
+    expect(hasOsLabel, 'RHEL9 template must have an os.template.kubevirt.io/* label').toBe(true);
+  });
+
+  test('GET: template list returns all-namespaces results when namespace omitted', async ({
+    apiClient,
+  }) => {
+    const list = await apiClient.getTemplates(undefined, 'template.kubevirt.io/type in (base,vm)');
+    expect(list.kind).toBe('TemplateList');
+    expect(list.items.length).toBeGreaterThan(0);
+    const namespaces = new Set(list.items.map((t: KubernetesResource) => t.metadata?.namespace));
+    expect(namespaces.has(RH_TEMPLATES_NS), 'cross-namespace list must include openshift ns').toBe(
+      true,
+    );
+  });
+});

--- a/playwright/tests/api/vm-crud-api.spec.ts
+++ b/playwright/tests/api/vm-crud-api.spec.ts
@@ -1,0 +1,97 @@
+import { load as yamlLoad } from 'js-yaml';
+
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/api-test-fixture';
+
+test.describe('VirtualMachine CRUD — API', { tag: ['@api'] }, () => {
+  let vmName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    vmName = utils.generateRandomVmName('test-vm');
+
+    const yaml = utils.VirtualMachineFactory.create({
+      name: vmName,
+      namespace: testNamespace,
+      runStrategy: 'Halted',
+      cpuCores: 1,
+      memory: '512Mi',
+    });
+
+    await test.step('CREATE VirtualMachine via console proxy', async () => {
+      const created = await apiClient.createVirtualMachine(
+        testNamespace,
+        yamlLoad(yaml) as KubernetesResource,
+      );
+      expect(created.metadata.name).toBe(vmName);
+      expect(created.kind).toBe('VirtualMachine');
+    });
+
+    await test.step('WAIT: VM exists in cluster', async () => {
+      const ready = await apiClient.waitForVmExists(vmName, testNamespace);
+      expect(ready, 'VM must exist in cluster after creation').toBe(true);
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (vmName) {
+      await apiClient.deleteVirtualMachine(testNamespace, vmName).catch(() => undefined);
+    }
+  });
+
+  test('READ: GET single VirtualMachine returns the created VM', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const vm = await apiClient.getVirtualMachine(testNamespace, vmName);
+    expect(vm.kind).toBe('VirtualMachine');
+    expect(vm.metadata.name).toBe(vmName);
+    expect(vm.spec.runStrategy).toBe('Halted');
+  });
+
+  test('PATCH: update CPU cores via JSON Patch', async ({ testNamespace, apiClient }) => {
+    await apiClient.patchVirtualMachine(testNamespace, vmName, [
+      { op: 'replace', path: '/spec/template/spec/domain/cpu/cores', value: 2 },
+    ]);
+
+    const updated = (await apiClient.getVirtualMachine(
+      testNamespace,
+      vmName,
+    )) as KubernetesResource;
+    const updatedSpec = updated.spec as Record<string, unknown>;
+    const template = updatedSpec?.template as Record<string, unknown>;
+    const templateSpec = template?.spec as Record<string, unknown>;
+    const domain = templateSpec?.domain as Record<string, unknown>;
+    const cpu = domain?.cpu as Record<string, unknown>;
+    expect(cpu?.cores).toBe(2);
+  });
+
+  test('PATCH: update memory via JSON Patch', async ({ testNamespace, apiClient }) => {
+    await apiClient.patchVirtualMachine(testNamespace, vmName, [
+      { op: 'replace', path: '/spec/template/spec/domain/memory/guest', value: '1Gi' },
+    ]);
+
+    const updated = (await apiClient.getVirtualMachine(
+      testNamespace,
+      vmName,
+    )) as KubernetesResource;
+    const updatedSpec = updated.spec as Record<string, unknown>;
+    const template = updatedSpec?.template as Record<string, unknown>;
+    const templateSpec = template?.spec as Record<string, unknown>;
+    const domain = templateSpec?.domain as Record<string, unknown>;
+    const memory = domain?.memory as Record<string, unknown>;
+    expect(memory?.guest).toBe('1Gi');
+  });
+
+  test('DELETE: remove VirtualMachine and wait for deletion', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const result = await apiClient.deleteVirtualMachine(testNamespace, vmName);
+    expect(['VirtualMachine', 'Status']).toContain(result.kind);
+
+    const deleted = await apiClient.waitForVmDeleted(vmName, testNamespace);
+    expect(deleted, 'VM must be fully removed from cluster').toBe(true);
+
+    vmName = '';
+  });
+});

--- a/playwright/tests/api/vm-detail-api.spec.ts
+++ b/playwright/tests/api/vm-detail-api.spec.ts
@@ -1,0 +1,110 @@
+import { load as yamlLoad } from 'js-yaml';
+
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/api-test-fixture';
+import { assertList } from '@/utils/api-assertions';
+
+test.describe('VM detail page — API endpoints', { tag: ['@api'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let vmName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    vmName = utils.generateRandomVmName('detail-vm');
+
+    const yaml = utils.VirtualMachineFactory.create({
+      name: vmName,
+      namespace: testNamespace,
+      runStrategy: 'Always',
+      cpuCores: 1,
+      memory: '512Mi',
+      rootDiskImage: utils.REGISTRY_URLS.FEDORA_LATEST,
+    });
+
+    await test.step('CREATE: VirtualMachine via console proxy', async () => {
+      const created = await apiClient.createVirtualMachine(
+        testNamespace,
+        yamlLoad(yaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('VirtualMachine');
+      expect(created.metadata?.name).toBe(vmName);
+    });
+
+    await test.step('WAIT: VM reaches Running state', async () => {
+      const running = await apiClient.waitForVmRunning(
+        vmName,
+        testNamespace,
+        utils.TestTimeouts.VM_RUNNING,
+      );
+      expect(running, `VM ${vmName} did not reach Running within timeout`).toBe(true);
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (vmName) {
+      await apiClient.stopVirtualMachine(testNamespace, vmName).catch(() => undefined);
+      await apiClient.deleteVirtualMachine(testNamespace, vmName).catch(() => undefined);
+    }
+  });
+
+  test('GET VirtualMachines (ns-scoped) returns list', async ({ apiClient, testNamespace }) => {
+    const body = await apiClient.getVirtualMachines(testNamespace);
+    assertList(body, 'VirtualMachineList');
+  });
+
+  test('GET single VirtualMachine returns correct object', async ({ apiClient, testNamespace }) => {
+    const body = await apiClient.getVirtualMachine(testNamespace, vmName);
+    expect(body.kind, 'kind must be VirtualMachine').toBe('VirtualMachine');
+    expect(body.metadata?.name, 'name must match').toBe(vmName);
+    expect(body.spec, 'spec must be present').toBeDefined();
+    expect(body.spec?.runStrategy, 'runStrategy must be Always').toBe('Always');
+  });
+
+  test('GET VirtualMachineInstanceMigrations filtered by VM name returns list', async ({
+    apiClient,
+    testNamespace,
+  }) => {
+    const body = await apiClient.getVirtualMachineInstanceMigrations(testNamespace, {
+      labelSelector: `kubevirt.io/vmi-name=${vmName}`,
+    });
+    assertList(body, 'VirtualMachineInstanceMigrationList');
+  });
+
+  test('GET VirtualMachineSnapshots (ns-scoped) returns list', async ({
+    apiClient,
+    testNamespace,
+  }) => {
+    const body = await apiClient.getVirtualMachineSnapshots(testNamespace);
+    assertList(body, 'VirtualMachineSnapshotList');
+  });
+
+  test('GET VirtualMachineRestores (ns-scoped) returns list', async ({
+    apiClient,
+    testNamespace,
+  }) => {
+    const body = await apiClient.getVirtualMachineRestores(testNamespace);
+    assertList(body, 'VirtualMachineRestoreList');
+  });
+
+  test('GET NetworkAttachmentDefinitions (ns-scoped) returns list', async ({
+    apiClient,
+    testNamespace,
+  }) => {
+    const body = await apiClient.getNetworkAttachmentDefinitions(testNamespace);
+    assertList(body, 'NetworkAttachmentDefinitionList');
+  });
+
+  test('GET CDI config singleton is readable', async ({ apiClient }) => {
+    const body = await apiClient.getCdiConfig();
+    expect(body.kind, 'kind must be CDIConfig').toBe('CDIConfig');
+    expect(body.metadata?.name, 'name must be config').toBe('config');
+  });
+
+  test('GET storage migration plans (ns-scoped) returns list', async ({
+    apiClient,
+    testNamespace,
+  }) => {
+    const body = await apiClient.getStorageMigrationPlans(testNamespace);
+    assertList(body, 'MultiNamespaceVirtualMachineStorageMigrationPlanList');
+  });
+});

--- a/playwright/tests/api/vm-folders-api.spec.ts
+++ b/playwright/tests/api/vm-folders-api.spec.ts
@@ -1,0 +1,205 @@
+import { load as yamlLoad } from 'js-yaml';
+
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/api-test-fixture';
+import { FOLDER_LABEL, listVmsInFolder } from '@/utils/api-builders';
+
+test.describe('VM folders — single folder CRUD API', { tag: ['@api'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let vm1Name: string;
+  let vm2Name: string;
+  let folderA: string;
+  let folderB: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    folderA = utils.generateRandomFolderName('folder-a');
+    folderB = utils.generateRandomFolderName('folder-b');
+    vm1Name = utils.generateRandomVmName('folder-f1');
+    vm2Name = utils.generateRandomVmName('folder-f2');
+
+    for (const [vmName] of [[vm1Name], [vm2Name]]) {
+      const yaml = utils.VirtualMachineFactory.create({
+        name: vmName,
+        namespace: testNamespace,
+        runStrategy: 'Halted',
+        cpuCores: 1,
+        memory: '256Mi',
+      });
+      const payload = yamlLoad(yaml) as KubernetesResource;
+      payload.metadata = {
+        ...(payload.metadata ?? {}),
+        labels: {
+          ...(payload.metadata?.labels ?? {}),
+          [FOLDER_LABEL]: folderA,
+        },
+      };
+      await test.step(`CREATE ${vmName} in folder "${folderA}"`, async () => {
+        const created = await apiClient.createVirtualMachine(testNamespace, payload);
+        expect(created.kind).toBe('VirtualMachine');
+      });
+      await apiClient.waitForVmExists(vmName, testNamespace);
+    }
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    for (const name of [vm1Name, vm2Name]) {
+      if (name) {
+        await apiClient.deleteVirtualMachine(testNamespace, name).catch(() => undefined);
+        await apiClient.waitForVmDeleted(name, testNamespace).catch(() => undefined);
+      }
+    }
+  });
+
+  test('READ: both VMs appear when listing by folder label', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const vms = await listVmsInFolder(apiClient, testNamespace, folderA);
+    const names = vms.map((v) => v.metadata.name);
+    expect(names).toContain(vm1Name);
+    expect(names).toContain(vm2Name);
+  });
+
+  test('PATCH: move VM1 to a new folder (mirrors folder rename/move in UI)', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    await apiClient.patchVirtualMachine(testNamespace, vm1Name, [
+      {
+        op: 'add',
+        path: `/metadata/labels/${FOLDER_LABEL.replace(/\//g, '~1')}`,
+        value: folderB,
+      },
+    ]);
+    const updated = await apiClient.getVirtualMachine(testNamespace, vm1Name);
+    expect(updated.metadata.labels?.[FOLDER_LABEL]).toBe(folderB);
+  });
+
+  test('READ: VM1 no longer in folder A after move', async ({ testNamespace, apiClient }) => {
+    const vmsInA = await listVmsInFolder(apiClient, testNamespace, folderA);
+    const names = vmsInA.map((v) => v.metadata.name);
+    expect(names, `${vm1Name} must not be in folder A after move`).not.toContain(vm1Name);
+  });
+
+  test('READ: VM2 still in folder A after VM1 move', async ({ testNamespace, apiClient }) => {
+    const vmsInA = await listVmsInFolder(apiClient, testNamespace, folderA);
+    const names = vmsInA.map((v) => v.metadata.name);
+    expect(names, `${vm2Name} must remain in folder A`).toContain(vm2Name);
+  });
+
+  test('READ: VM1 now in folder B', async ({ testNamespace, apiClient }) => {
+    const vmsInB = await listVmsInFolder(apiClient, testNamespace, folderB);
+    const names = vmsInB.map((v) => v.metadata.name);
+    expect(names).toContain(vm1Name);
+  });
+
+  test('PATCH: remove folder label from VM2 (mirrors "remove from folder")', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    await apiClient.patchVirtualMachine(testNamespace, vm2Name, [
+      { op: 'remove', path: `/metadata/labels/${FOLDER_LABEL.replace(/\//g, '~1')}` },
+    ]);
+    const updated = await apiClient.getVirtualMachine(testNamespace, vm2Name);
+    expect(updated.metadata.labels?.[FOLDER_LABEL]).toBeUndefined();
+  });
+
+  test('READ: folder A is now empty (mirrors "delete folder")', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const vms = await listVmsInFolder(apiClient, testNamespace, folderA);
+    expect(vms.length, `folder "${folderA}" must have 0 VMs after removing all members`).toBe(0);
+  });
+});
+
+test.describe('VM folders — multi-folder bulk operations API', { tag: ['@api'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let vmNames: string[];
+  let folderX: string;
+  let folderY: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    folderX = utils.generateRandomFolderName('folder-x');
+    folderY = utils.generateRandomFolderName('folder-y');
+    vmNames = [
+      utils.generateRandomVmName('folder-mx0'),
+      utils.generateRandomVmName('folder-mx1'),
+      utils.generateRandomVmName('folder-my2'),
+    ];
+    const folderAssignments = [folderX, folderX, folderY];
+
+    for (let i = 0; i < vmNames.length; i++) {
+      const yaml = utils.VirtualMachineFactory.create({
+        name: vmNames[i],
+        namespace: testNamespace,
+        runStrategy: 'Halted',
+        cpuCores: 1,
+        memory: '256Mi',
+      });
+      const payload = yamlLoad(yaml) as KubernetesResource;
+      payload.metadata = {
+        ...(payload.metadata ?? {}),
+        labels: {
+          ...(payload.metadata?.labels ?? {}),
+          [FOLDER_LABEL]: folderAssignments[i],
+        },
+      };
+      await test.step(`CREATE ${vmNames[i]} in folder "${folderAssignments[i]}"`, async () => {
+        const created = await apiClient.createVirtualMachine(testNamespace, payload);
+        expect(created.kind).toBe('VirtualMachine');
+      });
+      await apiClient.waitForVmExists(vmNames[i], testNamespace);
+    }
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    for (const name of vmNames ?? []) {
+      await apiClient.deleteVirtualMachine(testNamespace, name).catch(() => undefined);
+      await apiClient.waitForVmDeleted(name, testNamespace).catch(() => undefined);
+    }
+  });
+
+  test('READ: folder X has 2 VMs, folder Y has 1 VM', async ({ testNamespace, apiClient }) => {
+    const [xVms, yVms] = await Promise.all([
+      listVmsInFolder(apiClient, testNamespace, folderX),
+      listVmsInFolder(apiClient, testNamespace, folderY),
+    ]);
+    expect(xVms.length, 'folder X must have 2 VMs').toBe(2);
+    expect(yVms.length, 'folder Y must have 1 VM').toBe(1);
+  });
+
+  test('PATCH: bulk-move folder-X VMs to folder-Y (mirrors bulk folder action)', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const xVms = await listVmsInFolder(apiClient, testNamespace, folderX);
+    await Promise.all(
+      xVms.map((vm) =>
+        apiClient.patchVirtualMachine(testNamespace, vm.metadata.name, [
+          {
+            op: 'add',
+            path: `/metadata/labels/${FOLDER_LABEL.replace(/\//g, '~1')}`,
+            value: folderY,
+          },
+        ]),
+      ),
+    );
+  });
+
+  test('READ: folder X is empty after bulk move', async ({ testNamespace, apiClient }) => {
+    const vms = await listVmsInFolder(apiClient, testNamespace, folderX);
+    expect(vms.length, 'folder X must be empty after bulk move').toBe(0);
+  });
+
+  test('READ: folder Y has all 3 VMs after bulk move', async ({ testNamespace, apiClient }) => {
+    const vms = await listVmsInFolder(apiClient, testNamespace, folderY);
+    expect(vms.length, 'folder Y must have all 3 VMs after bulk move').toBe(3);
+    const names = vms.map((v) => v.metadata.name);
+    for (const n of vmNames) {
+      expect(names).toContain(n);
+    }
+  });
+});

--- a/playwright/tests/api/vm-list-api.spec.ts
+++ b/playwright/tests/api/vm-list-api.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@/fixtures/api-test-fixture';
+import { assertList } from '@/utils/api-assertions';
+
+test.describe('VirtualMachines list page — API endpoints', { tag: ['@api'] }, () => {
+  test('GET virtualmachines (cluster-wide) returns VirtualMachineList', async ({ apiClient }) => {
+    const body = await apiClient.getVirtualMachines();
+    assertList(body, 'VirtualMachineList');
+  });
+
+  test('GET virtualmachineinstances (cluster-wide) returns VirtualMachineInstanceList', async ({
+    apiClient,
+  }) => {
+    const body = await apiClient.getVirtualMachineInstances();
+    assertList(body, 'VirtualMachineInstanceList');
+  });
+
+  test('GET virtualmachineinstancemigrations (cluster-wide) returns VirtualMachineInstanceMigrationList', async ({
+    apiClient,
+  }) => {
+    const body = await apiClient.getVirtualMachineInstanceMigrations();
+    assertList(body, 'VirtualMachineInstanceMigrationList');
+  });
+
+  test('GET hyperconvergeds returns HyperConvergedList with at least one item', async ({
+    apiClient,
+  }) => {
+    const body = await apiClient.getHyperConvergeds();
+    assertList(body, 'HyperConvergedList');
+    expect(body.items.length, 'at least one HyperConverged CR must exist').toBeGreaterThan(0);
+  });
+
+  test('GET kubevirt CR returns KubeVirt object', async ({ apiClient }) => {
+    const body = await apiClient.getKubeVirt();
+    expect(body.kind, 'kind must be KubeVirt').toBe('KubeVirt');
+    expect(body.metadata?.name, 'name must be kubevirt-kubevirt-hyperconverged').toBe(
+      'kubevirt-kubevirt-hyperconverged',
+    );
+    expect(body.status?.phase, 'phase must be Deployed').toBe('Deployed');
+  });
+
+  test('GET kubevirt-ui-features configmap is readable', async ({ apiClient }) => {
+    const body = await apiClient.getKubeVirtUiFeatures();
+    expect(body.kind, 'kind must be ConfigMap').toBe('ConfigMap');
+    expect(body.metadata?.name, 'name must match').toBe('kubevirt-ui-features');
+  });
+
+  test('GET kubevirt-user-settings configmap is readable', async ({ apiClient }) => {
+    const body = await apiClient.getKubeVirtUserSettings();
+    expect(body.kind, 'kind must be ConfigMap').toBe('ConfigMap');
+    expect(body.metadata?.name, 'name must match').toBe('kubevirt-user-settings');
+  });
+
+  test('GET migration policies returns MigrationPolicyList', async ({ apiClient }) => {
+    const body = await apiClient.getMigrationPolicies();
+    assertList(body, 'MigrationPolicyList');
+  });
+
+  test('GET storage migration plans (cluster-wide) returns MultiNamespaceVirtualMachineStorageMigrationPlanList', async ({
+    apiClient,
+  }) => {
+    const body = await apiClient.getStorageMigrationPlans();
+    assertList(body, 'MultiNamespaceVirtualMachineStorageMigrationPlanList');
+  });
+
+  test('GET templates with kubevirt label selector returns TemplateList', async ({ apiClient }) => {
+    const body = await apiClient.getTemplates(undefined, 'template.kubevirt.io/type');
+    assertList(body, 'TemplateList');
+  });
+
+  test('GET plugin health endpoint returns 200', async ({ apiClient }) => {
+    const healthy = await apiClient.checkPluginHealth();
+    expect(healthy, 'kubevirt-plugin apiserver proxy must be healthy').toBe(true);
+  });
+});

--- a/playwright/tests/api/vm-migration-api.spec.ts
+++ b/playwright/tests/api/vm-migration-api.spec.ts
@@ -1,0 +1,111 @@
+import { load as yamlLoad } from 'js-yaml';
+
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/api-test-fixture';
+
+test.describe('VirtualMachineInstanceMigration — API', { tag: ['@api'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let vmName: string;
+  let vmimName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    vmName = utils.generateRandomVmName('mig-vm');
+    vmimName = utils.generateRandomName('mig');
+
+    await test.step('CREATE VM with containerDisk (no PVC needed)', async () => {
+      const yaml = utils.VirtualMachineFactory.create({
+        name: vmName,
+        namespace: testNamespace,
+        runStrategy: 'Always',
+        cpuCores: 1,
+        memory: '512Mi',
+      });
+      const created = await apiClient.createVirtualMachine(
+        testNamespace,
+        yamlLoad(yaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('VirtualMachine');
+    });
+
+    await test.step('WAIT: VM reaches Running state', async () => {
+      const running = await apiClient.waitForVmRunning(
+        vmName,
+        testNamespace,
+        utils.TestTimeouts.VM_RUNNING,
+      );
+      expect(running, 'VM must be Running before migration can be triggered').toBe(true);
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (vmimName) {
+      await apiClient
+        .deleteVirtualMachineInstanceMigration(testNamespace, vmimName)
+        .catch(() => undefined);
+    }
+    if (vmName) {
+      await apiClient.stopVirtualMachine(testNamespace, vmName).catch(() => undefined);
+      await apiClient.deleteVirtualMachine(testNamespace, vmName).catch(() => undefined);
+      await apiClient.waitForVmDeleted(vmName, testNamespace).catch(() => undefined);
+    }
+  });
+
+  test('CREATE: trigger compute migration via VMIM resource', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const spec = {
+      apiVersion: 'kubevirt.io/v1',
+      kind: 'VirtualMachineInstanceMigration',
+      metadata: {
+        name: vmimName,
+        namespace: testNamespace,
+      },
+      spec: {
+        vmiName: vmName,
+      },
+    };
+    const created = await apiClient.createVirtualMachineInstanceMigration(testNamespace, spec);
+    expect(created.kind).toBe('VirtualMachineInstanceMigration');
+    expect(created.metadata.name).toBe(vmimName);
+    expect((created.spec as { vmiName?: string } | undefined)?.vmiName).toBe(vmName);
+  });
+
+  test('READ: GET single VMIM returns correct spec', async ({ testNamespace, apiClient }) => {
+    const vmim = await apiClient.getVirtualMachineInstanceMigration(testNamespace, vmimName);
+    expect(vmim.kind).toBe('VirtualMachineInstanceMigration');
+    expect(vmim.metadata.name).toBe(vmimName);
+    expect((vmim.spec as { vmiName?: string } | undefined)?.vmiName).toBe(vmName);
+  });
+
+  test('READ: VMIM appears in namespace migration list', async ({ testNamespace, apiClient }) => {
+    const list = await apiClient.getVirtualMachineInstanceMigrations(testNamespace);
+    expect(list.kind).toBe('VirtualMachineInstanceMigrationList');
+    const found = list.items.find((m: KubernetesResource) => m.metadata?.name === vmimName);
+    expect(found, `VMIM ${vmimName} must appear in namespace list`).toBeDefined();
+    expect(((found as KubernetesResource)?.spec as { vmiName?: string } | undefined)?.vmiName).toBe(
+      vmName,
+    );
+  });
+
+  test('READ: VMIM list filtered by vmiName label selector', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const list = await apiClient.getVirtualMachineInstanceMigrations(testNamespace, {
+      labelSelector: `kubevirt.io/vmi-name=${vmName}`,
+    });
+    const found = list.items.find((m: KubernetesResource) => m.metadata?.name === vmimName);
+    expect(found, 'VMIM must appear when filtering by vmi-name label').toBeDefined();
+  });
+
+  test('DELETE: cancel in-progress migration and verify removal', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const result = await apiClient.deleteVirtualMachineInstanceMigration(testNamespace, vmimName);
+    expect(['VirtualMachineInstanceMigration', 'Status']).toContain(result.kind);
+    vmimName = '';
+  });
+});

--- a/playwright/tests/api/vm-save-as-template-api.spec.ts
+++ b/playwright/tests/api/vm-save-as-template-api.spec.ts
@@ -1,0 +1,234 @@
+import { load as yamlLoad } from 'js-yaml';
+
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/api-test-fixture';
+import { buildTemplateFromVm } from '@/utils/api-builders';
+
+interface ProxyVmSpec {
+  template?: {
+    spec?: {
+      domain?: {
+        cpu?: { cores?: number };
+        memory?: { guest?: string };
+        devices?: { disks?: KubernetesResource[] };
+      };
+    };
+  };
+}
+
+function templateObjects(tmpl: KubernetesResource): KubernetesResource[] {
+  const raw = tmpl['objects'];
+  return Array.isArray(raw) ? (raw as KubernetesResource[]) : [];
+}
+
+function templateParameters(tmpl: KubernetesResource): KubernetesResource[] {
+  const raw = tmpl['parameters'];
+  return Array.isArray(raw) ? (raw as KubernetesResource[]) : [];
+}
+
+test.describe('VM save-as-template — spec parity API', { tag: ['@api'] }, () => {
+  let vmName: string;
+  let templateName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    vmName = utils.generateRandomVmName('sat-vm-sp');
+    templateName = utils.generateRandomTemplateName('sat-tpl-sp');
+
+    await test.step('CREATE source VM (Halted, 2 cores, 1Gi)', async () => {
+      const yaml = utils.VirtualMachineFactory.create({
+        name: vmName,
+        namespace: testNamespace,
+        runStrategy: 'Halted',
+        cpuCores: 2,
+        memory: '1Gi',
+      });
+      const created = await apiClient.createVirtualMachine(
+        testNamespace,
+        yamlLoad(yaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('VirtualMachine');
+    });
+
+    await test.step('WAIT: VM exists in cluster', async () => {
+      const ready = await apiClient.waitForVmExists(vmName, testNamespace);
+      expect(ready, 'source VM must exist before building template').toBe(true);
+    });
+
+    await test.step('GET VM spec + BUILD template + POST template', async () => {
+      const vm = await apiClient.getVirtualMachine(testNamespace, vmName);
+      const tmpl = buildTemplateFromVm(vm, templateName, `Saved from ${vmName}`);
+      const created = await apiClient.createTemplate(testNamespace, tmpl);
+      expect(created.kind).toBe('Template');
+      expect(created.metadata.name).toBe(templateName);
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (templateName) {
+      await apiClient.deleteTemplate(testNamespace, templateName).catch(() => undefined);
+    }
+    if (vmName) {
+      await apiClient.deleteVirtualMachine(testNamespace, vmName).catch(() => undefined);
+      await apiClient.waitForVmDeleted(vmName, testNamespace).catch(() => undefined);
+    }
+  });
+
+  test('READ: template exists and wraps a VirtualMachine object', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const tmpl = await apiClient.getTemplate(testNamespace, templateName);
+    expect(tmpl.kind).toBe('Template');
+    const vm = templateObjects(tmpl).find((o) => o.kind === 'VirtualMachine');
+    expect(vm, 'template objects must contain a VirtualMachine').toBeDefined();
+  });
+
+  test('READ: template CPU cores match source VM', async ({ testNamespace, apiClient }) => {
+    const [sourceVm, tmpl] = await Promise.all([
+      apiClient.getVirtualMachine(testNamespace, vmName),
+      apiClient.getTemplate(testNamespace, templateName),
+    ]);
+    const sourceCores = (sourceVm.spec as ProxyVmSpec | undefined)?.template?.spec?.domain?.cpu
+      ?.cores;
+    const tmplVm = templateObjects(tmpl).find((o) => o.kind === 'VirtualMachine');
+    const tmplCores = (tmplVm?.spec as ProxyVmSpec | undefined)?.template?.spec?.domain?.cpu?.cores;
+    expect(tmplCores).toBe(sourceCores);
+  });
+
+  test('READ: template memory matches source VM', async ({ testNamespace, apiClient }) => {
+    const [sourceVm, tmpl] = await Promise.all([
+      apiClient.getVirtualMachine(testNamespace, vmName),
+      apiClient.getTemplate(testNamespace, templateName),
+    ]);
+    const sourceMemory = (sourceVm.spec as ProxyVmSpec | undefined)?.template?.spec?.domain?.memory
+      ?.guest;
+    const tmplVm = templateObjects(tmpl).find((o) => o.kind === 'VirtualMachine');
+    const tmplMemory = (tmplVm?.spec as ProxyVmSpec | undefined)?.template?.spec?.domain?.memory
+      ?.guest;
+    expect(tmplMemory).toBe(sourceMemory);
+  });
+
+  test('READ: template disk list matches source VM volumes', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const [sourceVm, tmpl] = await Promise.all([
+      apiClient.getVirtualMachine(testNamespace, vmName),
+      apiClient.getTemplate(testNamespace, templateName),
+    ]);
+    const sourceDisks: string[] = (
+      (sourceVm.spec as ProxyVmSpec | undefined)?.template?.spec?.domain?.devices?.disks ?? []
+    ).map((d: KubernetesResource) => String(d['name']));
+
+    const tmplVm = templateObjects(tmpl).find((o) => o.kind === 'VirtualMachine');
+    const tmplDisks: string[] = (
+      (tmplVm?.spec as ProxyVmSpec | undefined)?.template?.spec?.domain?.devices?.disks ?? []
+    ).map((d: KubernetesResource) => String(d['name']));
+
+    expect(tmplDisks.sort(), 'template disks must exactly match source VM disks').toEqual(
+      sourceDisks.sort(),
+    );
+  });
+
+  test('READ: template has NAME parameter', async ({ testNamespace, apiClient }) => {
+    const tmpl = await apiClient.getTemplate(testNamespace, templateName);
+    const paramNames = templateParameters(tmpl).map((p) => String(p['name']));
+    expect(paramNames).toContain('NAME');
+  });
+
+  test('DELETE: remove saved template and confirm it leaves the list', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const result = await apiClient.deleteTemplate(testNamespace, templateName);
+    expect(['Template', 'Status']).toContain(result.kind);
+
+    const list = await apiClient.getTemplates(testNamespace);
+    const found = list.items.find((t: KubernetesResource) => t.metadata?.name === templateName);
+    expect(found, 'saved template must not appear after deletion').toBeUndefined();
+    templateName = '';
+  });
+});
+
+test.describe('VM save-as-template — label propagation API', { tag: ['@api'] }, () => {
+  let vmName: string;
+  let templateName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    vmName = utils.generateRandomVmName('sat-vm-lb');
+    templateName = utils.generateRandomTemplateName('sat-tpl-lb');
+
+    await test.step('CREATE source VM with OS and workload labels', async () => {
+      const yaml = utils.VirtualMachineFactory.create({
+        name: vmName,
+        namespace: testNamespace,
+        runStrategy: 'Halted',
+        cpuCores: 1,
+        memory: '512Mi',
+      });
+      const vmPayload = yamlLoad(yaml) as KubernetesResource;
+      vmPayload.metadata = {
+        ...(vmPayload.metadata ?? {}),
+        labels: {
+          ...(vmPayload.metadata?.labels ?? {}),
+          'vm.kubevirt.io/os': 'fedora',
+          'vm.kubevirt.io/workload': 'server',
+        },
+      };
+      const created = await apiClient.createVirtualMachine(testNamespace, vmPayload);
+      expect(created.kind).toBe('VirtualMachine');
+    });
+
+    await test.step('WAIT: VM exists', async () => {
+      await apiClient.waitForVmExists(vmName, testNamespace);
+    });
+
+    await test.step('GET VM + build template + POST', async () => {
+      const vm = await apiClient.getVirtualMachine(testNamespace, vmName);
+      const tmpl = buildTemplateFromVm(vm, templateName, `Label test from ${vmName}`);
+      const osLabel = vm.metadata.labels?.['vm.kubevirt.io/os'];
+      const workloadLabel = vm.metadata.labels?.['vm.kubevirt.io/workload'];
+      if (osLabel) tmpl.metadata.labels[`os.template.kubevirt.io/${osLabel}`] = 'true';
+      if (workloadLabel)
+        tmpl.metadata.labels[`workload.template.kubevirt.io/${workloadLabel}`] = 'true';
+
+      const created = await apiClient.createTemplate(testNamespace, tmpl);
+      expect(created.kind).toBe('Template');
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (templateName) {
+      await apiClient.deleteTemplate(testNamespace, templateName).catch(() => undefined);
+    }
+    if (vmName) {
+      await apiClient.deleteVirtualMachine(testNamespace, vmName).catch(() => undefined);
+      await apiClient.waitForVmDeleted(vmName, testNamespace).catch(() => undefined);
+    }
+  });
+
+  test('READ: saved template has os.template.kubevirt.io/* label', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const tmpl = await apiClient.getTemplate(testNamespace, templateName);
+    const hasOsLabel = Object.keys(tmpl.metadata.labels ?? {}).some((k) =>
+      k.startsWith('os.template.kubevirt.io/'),
+    );
+    expect(hasOsLabel, 'saved template must have an os.template.kubevirt.io/* label').toBe(true);
+  });
+
+  test('READ: saved template has workload.template.kubevirt.io/* label', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const tmpl = await apiClient.getTemplate(testNamespace, templateName);
+    const hasWorkloadLabel = Object.keys(tmpl.metadata.labels ?? {}).some((k) =>
+      k.startsWith('workload.template.kubevirt.io/'),
+    );
+    expect(
+      hasWorkloadLabel,
+      'saved template must have a workload.template.kubevirt.io/* label',
+    ).toBe(true);
+  });
+});

--- a/playwright/tests/api/vm-snapshots-extended-api.spec.ts
+++ b/playwright/tests/api/vm-snapshots-extended-api.spec.ts
@@ -1,0 +1,286 @@
+import { load as yamlLoad } from 'js-yaml';
+
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/api-test-fixture';
+import {
+  pollUntilRestoreComplete,
+  pollUntilRestoreDeleted,
+  pollUntilSnapshotDeleted,
+  pollUntilSnapshotReady,
+} from '@/utils/api-poll';
+
+interface SnapshotSourceRef {
+  apiGroup?: string;
+  kind?: string;
+  name?: string;
+}
+
+test.describe('VirtualMachineSnapshot — full lifecycle API', { tag: ['@api'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let vmName: string;
+  let snapshotName: string;
+  let restoreName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    vmName = utils.generateRandomVmName('snap-vm-lc');
+    snapshotName = utils.generateRandomSnapshotName('snap-lc');
+    restoreName = utils.generateRandomName('restore-lc');
+
+    await test.step('CREATE halted VM (containerDisk, no PVC)', async () => {
+      const yaml = utils.VirtualMachineFactory.create({
+        name: vmName,
+        namespace: testNamespace,
+        runStrategy: 'Halted',
+        cpuCores: 1,
+        memory: '512Mi',
+      });
+      const created = await apiClient.createVirtualMachine(
+        testNamespace,
+        yamlLoad(yaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('VirtualMachine');
+    });
+
+    await test.step('WAIT: VM exists before snapshotting', async () => {
+      const ready = await apiClient.waitForVmExists(vmName, testNamespace);
+      expect(ready, 'VM must exist before snapshot').toBe(true);
+    });
+
+    await test.step('CREATE snapshot via console proxy', async () => {
+      const snapYaml = utils.createMinimalVirtualMachineSnapshotYaml({
+        name: snapshotName,
+        namespace: testNamespace,
+        vmName,
+      });
+      const created = await apiClient.createVirtualMachineSnapshot(
+        testNamespace,
+        yamlLoad(snapYaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('VirtualMachineSnapshot');
+    });
+
+    await test.step('WAIT: snapshot reaches readyToUse=true', async () => {
+      await pollUntilSnapshotReady(
+        apiClient,
+        testNamespace,
+        snapshotName,
+        utils.TestTimeouts.TEST_MEDIUM,
+      );
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (restoreName) {
+      await apiClient
+        .deleteVirtualMachineRestore(testNamespace, restoreName)
+        .catch(() => undefined);
+    }
+    if (snapshotName) {
+      await apiClient
+        .deleteVirtualMachineSnapshot(testNamespace, snapshotName)
+        .catch(() => undefined);
+    }
+    if (vmName) {
+      await apiClient.deleteVirtualMachine(testNamespace, vmName).catch(() => undefined);
+      await apiClient.waitForVmDeleted(vmName, testNamespace).catch(() => undefined);
+    }
+  });
+
+  test('READ: GET single snapshot returns correct spec', async ({ testNamespace, apiClient }) => {
+    const snap = await apiClient.getVirtualMachineSnapshot(testNamespace, snapshotName);
+    expect(snap.kind).toBe('VirtualMachineSnapshot');
+    expect(snap.metadata.name).toBe(snapshotName);
+    expect((snap.spec as { source?: { name?: string } } | undefined)?.source?.name).toBe(vmName);
+    expect(snap.status?.readyToUse).toBe(true);
+  });
+
+  test('READ: snapshot appears in namespace list', async ({ testNamespace, apiClient }) => {
+    const list = await apiClient.getVirtualMachineSnapshots(testNamespace);
+    expect(list.kind).toBe('VirtualMachineSnapshotList');
+    const found = list.items.find((s: KubernetesResource) => s.metadata?.name === snapshotName);
+    expect(found, `snapshot ${snapshotName} must appear in list`).toBeDefined();
+  });
+
+  test('PATCH: add label to snapshot metadata via merge-patch', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    await apiClient.mergePatchResource(
+      'snapshot.kubevirt.io',
+      'v1beta1',
+      'virtualmachinesnapshots',
+      snapshotName,
+      { metadata: { labels: { 'api-test': 'snap-lifecycle' } } },
+      testNamespace,
+    );
+    const updated = await apiClient.getVirtualMachineSnapshot(testNamespace, snapshotName);
+    expect(updated.metadata.labels?.['api-test']).toBe('snap-lifecycle');
+  });
+
+  test('CREATE restore: restore VM from snapshot', async ({ testNamespace, apiClient }) => {
+    const spec = {
+      apiVersion: 'snapshot.kubevirt.io/v1beta1',
+      kind: 'VirtualMachineRestore',
+      metadata: {
+        name: restoreName,
+        namespace: testNamespace,
+      },
+      spec: {
+        target: {
+          apiGroup: 'kubevirt.io',
+          kind: 'VirtualMachine',
+          name: vmName,
+        },
+        virtualMachineSnapshotName: snapshotName,
+      },
+    };
+    const created = await apiClient.createVirtualMachineRestore(testNamespace, spec);
+    expect(created.kind).toBe('VirtualMachineRestore');
+    expect(created.metadata.name).toBe(restoreName);
+    expect(created.spec.virtualMachineSnapshotName).toBe(snapshotName);
+  });
+
+  test('WAIT + READ: restore completes and GET single returns correct state', async ({
+    testNamespace,
+    apiClient,
+    utils,
+  }) => {
+    await pollUntilRestoreComplete(
+      apiClient,
+      testNamespace,
+      restoreName,
+      utils.TestTimeouts.TEST_MEDIUM,
+    );
+
+    const restore = await apiClient.getVirtualMachineRestore(testNamespace, restoreName);
+    expect(restore.kind).toBe('VirtualMachineRestore');
+    expect(restore.status?.complete).toBe(true);
+    expect(restore.spec.virtualMachineSnapshotName).toBe(snapshotName);
+  });
+
+  test('READ: restore appears in namespace restore list', async ({ testNamespace, apiClient }) => {
+    const list = await apiClient.getVirtualMachineRestores(testNamespace);
+    expect(list.kind).toBe('VirtualMachineRestoreList');
+    const found = list.items.find((r: KubernetesResource) => r.metadata?.name === restoreName);
+    expect(found, `restore ${restoreName} must appear in list`).toBeDefined();
+  });
+
+  test('DELETE restore: remove restore and confirm it leaves the list', async ({
+    testNamespace,
+    apiClient,
+    utils,
+  }) => {
+    const result = await apiClient.deleteVirtualMachineRestore(testNamespace, restoreName);
+    expect(['VirtualMachineRestore', 'Status']).toContain(result.kind);
+
+    await pollUntilRestoreDeleted(
+      apiClient,
+      testNamespace,
+      restoreName,
+      utils.TestTimeouts.TEST_SHORT,
+    );
+
+    const list = await apiClient.getVirtualMachineRestores(testNamespace);
+    const found = list.items.find((r: KubernetesResource) => r.metadata?.name === restoreName);
+    expect(found, 'restore must not appear in list after deletion').toBeUndefined();
+    restoreName = '';
+  });
+
+  test('DELETE snapshot: remove snapshot and confirm it leaves the list', async ({
+    testNamespace,
+    apiClient,
+    utils,
+  }) => {
+    const result = await apiClient.deleteVirtualMachineSnapshot(testNamespace, snapshotName);
+    expect(['VirtualMachineSnapshot', 'Status']).toContain(result.kind);
+
+    await pollUntilSnapshotDeleted(
+      apiClient,
+      testNamespace,
+      snapshotName,
+      utils.TestTimeouts.TEST_SHORT,
+    );
+
+    const list = await apiClient.getVirtualMachineSnapshots(testNamespace);
+    const found = list.items.find((s: KubernetesResource) => s.metadata?.name === snapshotName);
+    expect(found, 'snapshot must not appear in list after deletion').toBeUndefined();
+    snapshotName = '';
+  });
+});
+
+test.describe('VirtualMachineSnapshot — metadata API', { tag: ['@api'] }, () => {
+  let vmName: string;
+  let snapshotName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    vmName = utils.generateRandomVmName('snap-vm-md');
+    snapshotName = utils.generateRandomSnapshotName('snap-md');
+
+    const yaml = utils.VirtualMachineFactory.create({
+      name: vmName,
+      namespace: testNamespace,
+      runStrategy: 'Halted',
+      cpuCores: 1,
+      memory: '512Mi',
+    });
+    await test.step('CREATE VM', async () => {
+      const created = await apiClient.createVirtualMachine(
+        testNamespace,
+        yamlLoad(yaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('VirtualMachine');
+    });
+    await test.step('WAIT: VM exists', async () => {
+      await apiClient.waitForVmExists(vmName, testNamespace);
+    });
+    await test.step('CREATE snapshot', async () => {
+      const snapYaml = utils.createMinimalVirtualMachineSnapshotYaml({
+        name: snapshotName,
+        namespace: testNamespace,
+        vmName,
+      });
+      await apiClient.createVirtualMachineSnapshot(
+        testNamespace,
+        yamlLoad(snapYaml) as KubernetesResource,
+      );
+    });
+    await test.step('WAIT: snapshot readyToUse', async () => {
+      await pollUntilSnapshotReady(
+        apiClient,
+        testNamespace,
+        snapshotName,
+        utils.TestTimeouts.TEST_MEDIUM,
+      );
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (snapshotName) {
+      await apiClient
+        .deleteVirtualMachineSnapshot(testNamespace, snapshotName)
+        .catch(() => undefined);
+    }
+    if (vmName) {
+      await apiClient.deleteVirtualMachine(testNamespace, vmName).catch(() => undefined);
+      await apiClient.waitForVmDeleted(vmName, testNamespace).catch(() => undefined);
+    }
+  });
+
+  test('READ: snapshot spec references correct VM', async ({ testNamespace, apiClient }) => {
+    const snap = await apiClient.getVirtualMachineSnapshot(testNamespace, snapshotName);
+    const source = (snap.spec as { source?: SnapshotSourceRef } | undefined)?.source;
+    expect(source?.apiGroup).toBe('kubevirt.io');
+    expect(source?.kind).toBe('VirtualMachine');
+    expect(source?.name).toBe(vmName);
+  });
+
+  test('READ: snapshot status has readyToUse and creationTime', async ({
+    testNamespace,
+    apiClient,
+  }) => {
+    const snap = await apiClient.getVirtualMachineSnapshot(testNamespace, snapshotName);
+    expect(snap.status?.readyToUse).toBe(true);
+    expect(snap.status?.creationTime, 'snapshot must have a creationTime').toBeTruthy();
+  });
+});

--- a/playwright/tests/api/vm-vmi-lifecycle-api.spec.ts
+++ b/playwright/tests/api/vm-vmi-lifecycle-api.spec.ts
@@ -1,0 +1,205 @@
+import { load as yamlLoad } from 'js-yaml';
+
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/api-test-fixture';
+import { pollUntilVmiGone, pollUntilVmiRunning, pollUntilVmiUidChanged } from '@/utils/api-poll';
+
+interface ProxyVmSpec {
+  runStrategy?: string;
+  template?: {
+    spec?: {
+      domain?: {
+        cpu?: { cores?: number };
+        memory?: { guest?: string };
+      };
+    };
+  };
+}
+
+interface VmiGuestSpec {
+  domain?: {
+    cpu?: { cores?: number };
+  };
+}
+
+test.describe('VirtualMachine and VMI lifecycle — API', { tag: ['@api'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let vmName: string;
+
+  test.beforeAll(async ({ testNamespace, apiClient, utils }) => {
+    vmName = utils.generateRandomVmName('lc-vm');
+
+    const yaml = utils.VirtualMachineFactory.create({
+      name: vmName,
+      namespace: testNamespace,
+      runStrategy: 'Halted',
+      cpuCores: 1,
+      memory: '512Mi',
+      rootDiskImage: utils.REGISTRY_URLS.FEDORA_LATEST,
+    });
+
+    await test.step('CREATE: VirtualMachine via console proxy (Halted)', async () => {
+      const created = await apiClient.createVirtualMachine(
+        testNamespace,
+        yamlLoad(yaml) as KubernetesResource,
+      );
+      expect(created.kind).toBe('VirtualMachine');
+      expect(created.metadata.name).toBe(vmName);
+    });
+
+    await test.step('WAIT: VM exists in cluster', async () => {
+      const exists = await apiClient.waitForVmExists(vmName, testNamespace);
+      expect(exists).toBe(true);
+    });
+  });
+
+  test.afterAll(async ({ testNamespace, apiClient }) => {
+    if (vmName) {
+      await apiClient.stopVirtualMachine(testNamespace, vmName).catch(() => undefined);
+      await apiClient.deleteVirtualMachine(testNamespace, vmName).catch(() => undefined);
+    }
+  });
+
+  test('READ: GET VM returns correct initial spec', async ({ testNamespace, apiClient }) => {
+    const vm = await apiClient.getVirtualMachine(testNamespace, vmName);
+    expect(vm.kind).toBe('VirtualMachine');
+    expect(vm.metadata.name).toBe(vmName);
+    expect((vm.spec as ProxyVmSpec | undefined)?.runStrategy).toBe('Halted');
+    expect((vm.spec as ProxyVmSpec | undefined)?.template?.spec?.domain?.cpu?.cores).toBe(1);
+    expect((vm.spec as ProxyVmSpec | undefined)?.template?.spec?.domain?.memory?.guest).toBe(
+      '512Mi',
+    );
+  });
+
+  test('PATCH: add label to VM while halted', async ({ testNamespace, apiClient }) => {
+    await apiClient.patchVirtualMachine(testNamespace, vmName, [
+      { op: 'add', path: '/metadata/labels/api-test', value: 'halted-patch' },
+    ]);
+    const updated = await apiClient.getVirtualMachine(testNamespace, vmName);
+    expect(updated.metadata.labels?.['api-test']).toBe('halted-patch');
+  });
+
+  test('PATCH: update CPU cores while halted', async ({ testNamespace, apiClient }) => {
+    await apiClient.patchVirtualMachine(testNamespace, vmName, [
+      { op: 'replace', path: '/spec/template/spec/domain/cpu/cores', value: 2 },
+    ]);
+    const updated = await apiClient.getVirtualMachine(testNamespace, vmName);
+    expect((updated.spec as ProxyVmSpec | undefined)?.template?.spec?.domain?.cpu?.cores).toBe(2);
+  });
+
+  test('START: call start subresource and wait for Running', async ({
+    testNamespace,
+    apiClient,
+    utils,
+  }) => {
+    await apiClient.startVirtualMachine(testNamespace, vmName);
+    const running = await apiClient.waitForVmRunning(
+      vmName,
+      testNamespace,
+      utils.TestTimeouts.VM_BOOTUP,
+    );
+    expect(running).toBe(true);
+    await pollUntilVmiRunning(apiClient, testNamespace, vmName, utils.TestTimeouts.VM_BOOTUP);
+  });
+
+  test('READ VMI: exists in namespace after start', async ({ testNamespace, apiClient }) => {
+    const list = await apiClient.getVirtualMachineInstances(testNamespace);
+    const vmi = list.items.find((v: KubernetesResource) => v.metadata?.name === vmName);
+    expect(vmi, `VMI ${vmName} must be present in namespace`).toBeDefined();
+    expect(vmi.status?.phase).toBe('Running');
+  });
+
+  test('READ VMI: GET single VMI returns Running phase', async ({ testNamespace, apiClient }) => {
+    const vmi = await apiClient.getVirtualMachineInstance(testNamespace, vmName);
+    expect(vmi.kind).toBe('VirtualMachineInstance');
+    expect(vmi.metadata.name).toBe(vmName);
+    expect(vmi.status?.phase).toBe('Running');
+  });
+
+  test('READ VMI: has owner reference pointing to VM', async ({ testNamespace, apiClient }) => {
+    const vmi = await apiClient.getVirtualMachineInstance(testNamespace, vmName);
+    const ownerRef = vmi.metadata?.ownerReferences?.find((ref) => ref.kind === 'VirtualMachine');
+    expect(ownerRef, 'VMI must have ownerReference to its VM').toBeDefined();
+    expect(ownerRef.name).toBe(vmName);
+  });
+
+  test('READ VMI: inherits CPU cores patched on VM', async ({ testNamespace, apiClient }) => {
+    const vmi = await apiClient.getVirtualMachineInstance(testNamespace, vmName);
+    expect((vmi.spec as VmiGuestSpec | undefined)?.domain?.cpu?.cores).toBe(2);
+  });
+
+  test('PATCH: update VM annotation while running', async ({ testNamespace, apiClient }) => {
+    await apiClient.patchVirtualMachine(testNamespace, vmName, [
+      {
+        op: 'add',
+        path: '/metadata/annotations/api-test-running',
+        value: 'patched-while-running',
+      },
+    ]);
+    const updated = await apiClient.getVirtualMachine(testNamespace, vmName);
+    expect(updated.metadata.annotations?.['api-test-running']).toBe('patched-while-running');
+  });
+
+  test('RESTART: call restart subresource and wait for Running again', async ({
+    testNamespace,
+    apiClient,
+    utils,
+  }) => {
+    const vmiBefore = await apiClient.getVirtualMachineInstance(testNamespace, vmName);
+    const oldUid = vmiBefore.metadata?.uid;
+
+    await apiClient.restartVirtualMachine(testNamespace, vmName);
+
+    await pollUntilVmiUidChanged(
+      apiClient,
+      testNamespace,
+      vmName,
+      oldUid,
+      utils.TestTimeouts.VM_BOOTUP,
+    );
+    const running = await apiClient.waitForVmRunning(
+      vmName,
+      testNamespace,
+      utils.TestTimeouts.VM_BOOTUP,
+    );
+    expect(running).toBe(true);
+    await pollUntilVmiRunning(apiClient, testNamespace, vmName, utils.TestTimeouts.VM_BOOTUP);
+  });
+
+  test('READ VMI: still Running after restart', async ({ testNamespace, apiClient }) => {
+    const vmi = await apiClient.getVirtualMachineInstance(testNamespace, vmName);
+    expect(vmi.status?.phase).toBe('Running');
+  });
+
+  test('STOP: stop VM and confirm VMI is removed', async ({ testNamespace, apiClient, utils }) => {
+    await apiClient.stopVirtualMachine(testNamespace, vmName);
+    await pollUntilVmiGone(apiClient, testNamespace, vmName, utils.TestTimeouts.TEST_VM_CREATION);
+
+    const list = await apiClient.getVirtualMachineInstances(testNamespace);
+    const vmi = list.items.find((v: KubernetesResource) => v.metadata?.name === vmName);
+    expect(vmi, `VMI ${vmName} must be gone after stop`).toBeUndefined();
+  });
+
+  test('STOP: VM status shows Halted after stop', async ({ testNamespace, apiClient, utils }) => {
+    await expect
+      .poll(
+        async () => {
+          const vm = await apiClient.getVirtualMachine(testNamespace, vmName);
+          return (vm?.spec as ProxyVmSpec | undefined)?.runStrategy;
+        },
+        { timeout: utils.TestTimeouts.TEST_SHORT, intervals: [3_000] },
+      )
+      .toBe('Halted');
+  });
+
+  test('DELETE: remove VM via API and wait for deletion', async ({ testNamespace, apiClient }) => {
+    const result = await apiClient.deleteVirtualMachine(testNamespace, vmName);
+    expect(['VirtualMachine', 'Status']).toContain(result.kind);
+
+    const deleted = await apiClient.waitForVmDeleted(vmName, testNamespace);
+    expect(deleted).toBe(true);
+
+    vmName = '';
+  });
+});

--- a/playwright/tests/gating/scenario-resource-creation.spec.ts
+++ b/playwright/tests/gating/scenario-resource-creation.spec.ts
@@ -80,11 +80,19 @@ test.describe('Resource creation (gating)', { tag: [GATING_TAG, '@resource-creat
     apiClient.trackResource('VirtualMachine', vmName, testConfig.testNamespace);
 
     await vmTreePage.navigateToNamespaceVirtualMachinesViaUI(testConfig.testNamespace);
-    await vmListPage.clickCreateAndSelectOption('With YAML');
 
-    await vmListPage.page
-      .getByRole('heading', { name: 'Create VirtualMachine', level: 1 })
-      .waitFor({ state: 'visible', timeout: utils.TestTimeouts.UI_ELEMENT_VISIBILITY });
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      try {
+        await vmListPage.clickCreateAndSelectOption('With YAML');
+        await vmListPage.page
+          .getByRole('heading', { name: 'Create VirtualMachine', level: 1 })
+          .waitFor({ state: 'visible', timeout: utils.TestTimeouts.UI_ELEMENT_VISIBILITY });
+        break;
+      } catch {
+        if (attempt === 2) throw new Error('YAML editor heading not visible after 2 attempts');
+        await vmTreePage.navigateToNamespaceVirtualMachinesViaUI(testConfig.testNamespace);
+      }
+    }
 
     await vmListPage.fillYamlEditor(vmYaml);
     await vmListPage.page.getByRole('button', { name: 'Create', exact: true }).click();

--- a/playwright/tests/tier1/virtualmachines/vm-actions/vm-lifecycle.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-actions/vm-lifecycle.spec.ts
@@ -50,11 +50,13 @@ test.describe(
           expect.soft(isStopped, 'VM should reach Stopped status after stop').toBe(true);
         });
 
-        await test.step('Restart VM and verify Running status again', async () => {
+        await test.step('Start VM again and verify Running status', async () => {
           await vmDetailPage.startVmFromActionsDropdown();
           await vmDetailPage.waitForVmOverviewStatusContains('Running', TestTimeouts.VM_BOOTUP);
           const isRunningAgain = await vmDetailPage.verifyVmOverviewStatus('Running');
-          expect.soft(isRunningAgain, 'VM should reach Running status after restart').toBe(true);
+          expect
+            .soft(isRunningAgain, 'VM should reach Running status after second start')
+            .toBe(true);
         });
       },
     );

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-configuration-storage.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-configuration-storage.spec.ts
@@ -151,6 +151,17 @@ test.describe.serial(
       expect(diskVisible, 'Hotplugged disk should be visible on Configuration > Storage').toBe(
         true,
       );
+
+      const madePersistent = await vmDetailPage.makeDiskPersistent(diskName);
+      expect.soft(madePersistent, 'Make persistent action should succeed').toBe(true);
+
+      await expect
+        .poll(() => apiClient.isVmDiskPersistent(vmName, ns, diskName), {
+          timeout: 30_000,
+          intervals: [3_000],
+          message: 'Disk should be persistent after Make persistent action',
+        })
+        .toBe(true);
     });
   },
 );


### PR DESCRIPTION
## 📝 Description

Add API contract test suite and fix poll utilities

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-92551


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API contract test tier/project (browserless) for CRUD and endpoint validation, and included it in the Playwright runner and configuration.
  * Introduced multiple new API-focused Playwright specs (VMs, templates, snapshots, migrations, storage, and related list/endpoints).

* **Bug Fixes**
  * Improved API polling to treat missing resources/404 as expected outcomes and added deletion pollers for snapshots and restores.
  * Added retry handling for a YAML import UI heading, and strengthened disk “Make persistent” validation with API polling.

* **Documentation**
  * Updated test creation and troubleshooting guidance with the new API tier, directory mapping, and stricter git write restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->