### PR TITLE
CNV-92254: Remove native VM templates Preview Features jsonpatch toggle

### DIFF
--- a/playwright/project-dependencies/rule-engine/setup-rules.ts
+++ b/playwright/project-dependencies/rule-engine/setup-rules.ts
@@ -324,66 +324,6 @@ export function getSetupRules(): SetupRule[] {
       },
     },
     {
-      id: 'enable-native-vm-templates',
-      name: 'Enable native VM template feature gate on HCO',
-      phase: SetupPhase.CLUSTER,
-      guard: () => !EnvVariables.isNonPrivUser,
-      onError: 'warn',
-      run: async (ctx) => {
-        const apiClient = ctx.apiClient;
-        if (!apiClient) {
-          throw new Error('RequestContextClient not initialized');
-        }
-
-        const kubevirt = await apiClient.getResourceByKind(
-          'kubevirt',
-          'kubevirt-kubevirt-hyperconverged',
-          'openshift-cnv',
-        );
-        const devConfig = (
-          (kubevirt?.spec as Record<string, unknown>)?.configuration as Record<string, unknown>
-        )?.developerConfiguration as Record<string, unknown> | undefined;
-        const featureGates = (devConfig?.featureGates as string[]) ?? [];
-        const disabledFeatureGates = (devConfig?.disabledFeatureGates as string[]) ?? [];
-
-        if (featureGates.includes('Template')) {
-          logger.success('✓ Native VM template feature gate already enabled');
-          return;
-        }
-
-        const jsonPatchOps: Array<Record<string, unknown>> = [];
-
-        const disabledIndex = disabledFeatureGates.indexOf('Template');
-        if (disabledIndex >= 0) {
-          jsonPatchOps.push({
-            op: 'remove',
-            path: `/spec/configuration/developerConfiguration/disabledFeatureGates/${disabledIndex}`,
-          });
-        }
-
-        jsonPatchOps.push({
-          op: 'add',
-          path: '/spec/configuration/developerConfiguration/featureGates/-',
-          value: 'Template',
-        });
-
-        await apiClient.patchResourceByKind(
-          'HyperConverged',
-          'kubevirt-hyperconverged',
-          {
-            metadata: {
-              annotations: {
-                'kubevirt.kubevirt.io/jsonpatch': JSON.stringify(jsonPatchOps),
-              },
-            },
-          },
-          'openshift-cnv',
-          'merge',
-        );
-        logger.success('✓ Native VM template feature gate enabled on HCO');
-      },
-    },
-    {
       id: 'save-config',
       name: 'Persist shared test configuration',
       phase: SetupPhase.CLUSTER,

--- a/playwright/project-dependencies/rule-engine/teardown-rules-cluster.ts
+++ b/playwright/project-dependencies/rule-engine/teardown-rules-cluster.ts
@@ -204,16 +204,6 @@ export function getClusterTeardownRules(): TeardownRule[] {
           } else {
             logger.info('No hyperconverged settings to restore');
           }
-
-          if (await apiClient.isNativeVmTemplateFeatureGateEnabled(namespace)) {
-            await apiClient.patchResourceByKind(
-              'hyperconverged',
-              hcoName,
-              [{ op: 'remove', path: '/spec/featureGates/deployNativeVMTemplate' }],
-              namespace,
-            );
-            logger.success('✓ Removed native VM template feature gate from HCO');
-          }
         } catch (error: unknown) {
           const err = error as { statusCode?: number; message?: string };
           if (err.statusCode === 404 || err.message?.includes('404')) {

--- a/playwright/src/clients/proxy-handlers/infra-proxy-handler.ts
+++ b/playwright/src/clients/proxy-handlers/infra-proxy-handler.ts
@@ -166,19 +166,6 @@ export class InfraProxyHandler {
     );
   }
 
-  async isNativeVmTemplateFeatureGateEnabled(
-    namespace = 'openshift-cnv',
-    kubevirtName = 'kubevirt-kubevirt-hyperconverged',
-  ): Promise<boolean> {
-    const kv = await this.getKubeVirt(namespace, kubevirtName);
-    const spec = kv?.spec as Record<string, unknown> | undefined;
-    const config = spec?.configuration as Record<string, unknown> | undefined;
-    const devConfig = config?.developerConfiguration as Record<string, unknown> | undefined;
-    const featureGates = (devConfig?.featureGates as string[]) ?? [];
-    const disabledFeatureGates = (devConfig?.disabledFeatureGates as string[]) ?? [];
-    return featureGates.includes('Template') && !disabledFeatureGates.includes('Template');
-  }
-
   async isStorageMigrationAvailable(): Promise<boolean> {
     for (let attempt = 0; attempt < 2; attempt++) {
       try {

--- a/playwright/src/clients/request-context-client.ts
+++ b/playwright/src/clients/request-context-client.ts
@@ -753,10 +753,6 @@ export default class RequestContextClient extends BaseClient implements ProxyApi
     return this.vm.hotplugVolumeToVm(namespace, vmName, volumeName, diskName);
   }
 
-  isNativeVmTemplateFeatureGateEnabled(namespace?: string, kubevirtName?: string) {
-    return this.infra.isNativeVmTemplateFeatureGateEnabled(namespace, kubevirtName);
-  }
-
   isStorageMigrationAvailable() {
     return this.infra.isStorageMigrationAvailable();
   }

--- a/playwright/src/components/overview/overview-component.ts
+++ b/playwright/src/components/overview/overview-component.ts
@@ -131,11 +131,6 @@ export default class OverviewComponent extends BaseComponent {
   ): ReturnType<OverviewMigrationsPage['disableMemoryDensity']> {
     return this.migrations.disableMemoryDensity(...args);
   }
-  disableVmTemplatesPreviewFeature(
-    ...args: Parameters<OverviewSettingsPage['disableVmTemplatesPreviewFeature']>
-  ): ReturnType<OverviewSettingsPage['disableVmTemplatesPreviewFeature']> {
-    return this._settings.disableVmTemplatesPreviewFeature(...args);
-  }
   dismissWelcomeModalCheckbox(
     ...args: Parameters<OverviewSettingsPage['dismissWelcomeModalCheckbox']>
   ): ReturnType<OverviewSettingsPage['dismissWelcomeModalCheckbox']> {
@@ -201,11 +196,6 @@ export default class OverviewComponent extends BaseComponent {
     return this.virtualizationFeatures.enableVirtualizationOptimizedAndCooLoggingMonitoring(
       ...args,
     );
-  }
-  enableVmTemplatesPreviewFeature(
-    ...args: Parameters<OverviewSettingsPage['enableVmTemplatesPreviewFeature']>
-  ): ReturnType<OverviewSettingsPage['enableVmTemplatesPreviewFeature']> {
-    return this._settings.enableVmTemplatesPreviewFeature(...args);
   }
   enableWelcomeInformation(
     ...args: Parameters<OverviewSettingsPage['enableWelcomeInformation']>

--- a/playwright/src/components/overview/overview-settings-component.ts
+++ b/playwright/src/components/overview/overview-settings-component.ts
@@ -79,7 +79,6 @@ export default class OverviewSettingsComponent extends BaseComponent {
   private readonly _vmActionsConfirmationToggle = this.locator(
     '[id="confirm-vm-actions"] [role="switch"]',
   );
-  private readonly _vmTemplates = this.locator('[data-test-id="vmTemplates"]');
   private readonly _yAMLTabVisibilityBtn = this.locator('button:has-text("YAML tab visibility")');
   protected readonly nav = new NavigationComponent(this.page);
 
@@ -199,33 +198,6 @@ export default class OverviewSettingsComponent extends BaseComponent {
       await guidedTourSwitch.uncheck({ force: true });
       await this.page.waitForTimeout(TestTimeouts.UI_STABILIZE);
       return true;
-    } catch {
-      return false;
-    }
-  }
-
-  async disableVmTemplatesPreviewFeature(): Promise<boolean> {
-    try {
-      const toggle = this._vmTemplates;
-      await toggle.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
-
-      if (!(await toggle.isChecked())) {
-        return true;
-      }
-
-      const patchPromise = this.page.waitForResponse(
-        (resp) =>
-          (resp.url().includes(KUBEVIRT_UI_FEATURES_RESOURCE) ||
-            resp.url().includes('kubevirt-user-settings')) &&
-          isPatchOrPutRequest(resp) &&
-          isSuccessResponse(resp),
-        { timeout: TestTimeouts.DEFAULT },
-      );
-      await toggle.click({ force: true });
-      await patchPromise.catch(() => void 0);
-
-      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
-      return !(await toggle.isChecked().catch(() => true));
     } catch {
       return false;
     }
@@ -371,40 +343,6 @@ export default class OverviewSettingsComponent extends BaseComponent {
       await this._loadBalancerFeatureInputTypeCheckbox.check({ force: true });
 
       return true;
-    } catch {
-      return false;
-    }
-  }
-
-  async enableVmTemplatesPreviewFeature(): Promise<boolean> {
-    try {
-      const toggle = this._vmTemplates;
-      await toggle.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
-
-      if (await toggle.isChecked()) {
-        return true;
-      }
-
-      const patchPromise = this.page.waitForResponse(
-        (resp) =>
-          (resp.url().includes(KUBEVIRT_UI_FEATURES_RESOURCE) ||
-            resp.url().includes('kubevirt-user-settings')) &&
-          isPatchOrPutRequest(resp) &&
-          isSuccessResponse(resp),
-        { timeout: TestTimeouts.DEFAULT },
-      );
-      await toggle.click({ force: true });
-      await patchPromise.catch(() => void 0);
-
-      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
-
-      for (let i = 0; i < 10; i++) {
-        const state = await toggle.isChecked().catch(() => false);
-        if (state) return true;
-        await this.page.waitForTimeout(500);
-      }
-
-      return await toggle.isChecked().catch(() => false);
     } catch {
       return false;
     }

--- a/playwright/src/page-objects/overview/overview-page.ts
+++ b/playwright/src/page-objects/overview/overview-page.ts
@@ -131,11 +131,6 @@ export default class OverviewPage extends PageCommons {
   ): ReturnType<OverviewMigrationsPage['disableMemoryDensity']> {
     return this.migrations.disableMemoryDensity(...args);
   }
-  disableVmTemplatesPreviewFeature(
-    ...args: Parameters<OverviewSettingsPage['disableVmTemplatesPreviewFeature']>
-  ): ReturnType<OverviewSettingsPage['disableVmTemplatesPreviewFeature']> {
-    return this._settings.disableVmTemplatesPreviewFeature(...args);
-  }
   dismissWelcomeModalCheckbox(
     ...args: Parameters<OverviewSettingsPage['dismissWelcomeModalCheckbox']>
   ): ReturnType<OverviewSettingsPage['dismissWelcomeModalCheckbox']> {
@@ -201,11 +196,6 @@ export default class OverviewPage extends PageCommons {
     return this.virtualizationFeatures.enableVirtualizationOptimizedAndCooLoggingMonitoring(
       ...args,
     );
-  }
-  enableVmTemplatesPreviewFeature(
-    ...args: Parameters<OverviewSettingsPage['enableVmTemplatesPreviewFeature']>
-  ): ReturnType<OverviewSettingsPage['enableVmTemplatesPreviewFeature']> {
-    return this._settings.enableVmTemplatesPreviewFeature(...args);
   }
   enableWelcomeInformation(
     ...args: Parameters<OverviewSettingsPage['enableWelcomeInformation']>

--- a/playwright/src/page-objects/settings/settings-page.ts
+++ b/playwright/src/page-objects/settings/settings-page.ts
@@ -76,12 +76,6 @@ export default class SettingsPage extends BasePage {
     return this._migrations.disableMemoryDensity(...args);
   }
 
-  disableVmTemplatesPreviewFeature(
-    ...args: Parameters<OverviewSettingsPage['disableVmTemplatesPreviewFeature']>
-  ): ReturnType<OverviewSettingsPage['disableVmTemplatesPreviewFeature']> {
-    return this._settings.disableVmTemplatesPreviewFeature(...args);
-  }
-
   disableWelcomeInformation(
     ...args: Parameters<OverviewSettingsPage['disableWelcomeInformation']>
   ): ReturnType<OverviewSettingsPage['disableWelcomeInformation']> {
@@ -151,12 +145,6 @@ export default class SettingsPage extends BasePage {
     ...args: Parameters<OverviewSettingsPage['enableSSHUsingLoadBalancer']>
   ): ReturnType<OverviewSettingsPage['enableSSHUsingLoadBalancer']> {
     return this._settings.enableSSHUsingLoadBalancer(...args);
-  }
-
-  enableVmTemplatesPreviewFeature(
-    ...args: Parameters<OverviewSettingsPage['enableVmTemplatesPreviewFeature']>
-  ): ReturnType<OverviewSettingsPage['enableVmTemplatesPreviewFeature']> {
-    return this._settings.enableVmTemplatesPreviewFeature(...args);
   }
 
   enableWelcomeInformation(

--- a/playwright/tests/settings/cluster-settings.spec.ts
+++ b/playwright/tests/settings/cluster-settings.spec.ts
@@ -370,7 +370,7 @@ test.describe('Cluster Settings', { tag: [CNV_SETTINGS_TAG, '@adminOnly'] }, () 
 
   // ── Preview features tab ────────────────────────────────────────────────────────
 
-  test('Preview features tab shows VM folders, Passt binding, and native VM templates options', async ({
+  test('Preview features tab shows VM folders and Passt binding options', async ({
     settingsPage,
     utils,
   }) => {
@@ -397,13 +397,21 @@ test.describe('Cluster Settings', { tag: [CNV_SETTINGS_TAG, '@adminOnly'] }, () 
       expect.soft(hasPasst, 'Passt binding preview feature should be listed').toBe(true);
     });
 
-    await test.step('Native VirtualMachine templates feature flag is present', async () => {
+    // Assumes HCO v1 (OCP 4.23+): Template is Beta / first-class, so the
+    // Preview Features jsonpatch toggle is hidden. HCO v1beta1 still shows it
+    // and is not covered here.
+    await test.step('Native VirtualMachine templates feature flag is absent (HCO v1)', async () => {
       const hasNativeTemplates = labels.some(
-        (l) => l.toLowerCase().includes('template') || l.toLowerCase().includes('native'),
+        (l) =>
+          l.toLowerCase().includes('native virtualmachine template') ||
+          l.toLowerCase().includes('enable native'),
       );
       expect
-        .soft(hasNativeTemplates, 'Native VM templates preview feature should be listed')
-        .toBe(true);
+        .soft(
+          hasNativeTemplates,
+          'Native VM templates should not appear in preview features on HCO v1 (CNV-92254)',
+        )
+        .toBe(false);
     });
   });
 

--- a/src/utils/hooks/useKubevirtHyperconvergeConfiguration/index.ts
+++ b/src/utils/hooks/useKubevirtHyperconvergeConfiguration/index.ts
@@ -18,6 +18,7 @@ export type KubevirtHyperconverged = K8sResourceCommon & {
 const useKubevirtHyperconvergeConfiguration = (
   cluster?: string,
 ): {
+  disabledFeatureGates: string[];
   featureGates: string[];
   hcConfig: KubevirtHyperconverged;
   hcError: any;
@@ -36,11 +37,18 @@ const useKubevirtHyperconvergeConfiguration = (
 
   const hcLoaded = _hcLoaded && !isEmpty(operatorNamespace);
 
-  const featureGates = useMemo(() => {
-    return getHyperconvergedConfiguration(hcConfig)?.developerConfiguration?.featureGates;
+  const developerConfiguration = useMemo(() => {
+    return getHyperconvergedConfiguration(hcConfig)?.developerConfiguration;
   }, [hcConfig]);
 
-  return { featureGates, hcConfig, hcError, hcLoaded };
+  const featureGates = developerConfiguration?.featureGates;
+
+  // Not yet in kubevirt-api types; present on KubeVirt 1.8+/1.9+ for Beta opt-out.
+  const disabledFeatureGates = (
+    developerConfiguration as { disabledFeatureGates?: string[] } | undefined
+  )?.disabledFeatureGates;
+
+  return { disabledFeatureGates, featureGates, hcConfig, hcError, hcLoaded };
 };
 
 export default useKubevirtHyperconvergeConfiguration;

--- a/src/utils/hooks/useVMTemplateFeatureFlag/constants.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/constants.ts
@@ -8,3 +8,10 @@ export const ADD_TEMPLATE_FEATURE_GATE_PATCH = {
   path: TEMPLATE_FEATURE_GATE_PATH,
   value: TEMPLATE_FEATURE_GATE,
 };
+
+/** GVK used to detect whether HCO v1 (slice-based featureGates) is available. */
+export const HYPERCONVERGED_V1_GROUP_VERSION_KIND = {
+  group: 'hco.kubevirt.io',
+  kind: 'HyperConverged',
+  version: 'v1',
+} as const;

--- a/src/utils/hooks/useVMTemplateFeatureFlag/tests/isTemplateFeatureGateEnabled.test.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/tests/isTemplateFeatureGateEnabled.test.ts
@@ -1,0 +1,23 @@
+import { isTemplateFeatureGateEnabled } from '../utils';
+
+describe('isTemplateFeatureGateEnabled', () => {
+  it('should return true when Template is explicitly in featureGates', () => {
+    expect(isTemplateFeatureGateEnabled(['Template'], undefined)).toBe(true);
+    expect(isTemplateFeatureGateEnabled(['Template'], ['Template'])).toBe(true);
+  });
+
+  it('should return true when disabledFeatureGates is present and Template is absent', () => {
+    expect(isTemplateFeatureGateEnabled([], [])).toBe(true);
+    expect(isTemplateFeatureGateEnabled(undefined, ['PasstBinding'])).toBe(true);
+  });
+
+  it('should return false when Template is in disabledFeatureGates', () => {
+    expect(isTemplateFeatureGateEnabled([], ['Template'])).toBe(false);
+    expect(isTemplateFeatureGateEnabled(undefined, ['Template', 'PasstBinding'])).toBe(false);
+  });
+
+  it('should return false when neither list indicates Template is available', () => {
+    expect(isTemplateFeatureGateEnabled(undefined, undefined)).toBe(false);
+    expect(isTemplateFeatureGateEnabled([], undefined)).toBe(false);
+  });
+});

--- a/src/utils/hooks/useVMTemplateFeatureFlag/useIsHyperConvergedV1Available.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/useIsHyperConvergedV1Available.ts
@@ -1,0 +1,19 @@
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+
+import { HYPERCONVERGED_V1_GROUP_VERSION_KIND } from './constants';
+
+/**
+ * HCO v1 exposes slice-based featureGates (Template is Beta / first-class).
+ * HCO v1beta1 still needs the Preview Features jsonpatch toggle.
+ */
+const useIsHyperConvergedV1Available = (): { isHCOV1: boolean; loading: boolean } => {
+  const [hcoV1Model, inFlight] = useK8sModel(HYPERCONVERGED_V1_GROUP_VERSION_KIND);
+
+  return {
+    isHCOV1: !inFlight && !isEmpty(hcoV1Model),
+    loading: inFlight,
+  };
+};
+
+export default useIsHyperConvergedV1Available;

--- a/src/utils/hooks/useVMTemplateFeatureFlag/useIsVMTemplateFeatureEnabled.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/useIsVMTemplateFeatureEnabled.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 
-import { TEMPLATE_FEATURE_GATE } from './constants';
+import { isTemplateFeatureGateEnabled } from './utils';
 
 type UseIsVMTemplateFeatureEnabled = (clusterOverride?: string) => {
   featureEnabled: boolean;
@@ -12,13 +12,14 @@ type UseIsVMTemplateFeatureEnabled = (clusterOverride?: string) => {
 
 const useIsVMTemplateFeatureEnabled: UseIsVMTemplateFeatureEnabled = (clusterOverride) => {
   const clusterParam = useClusterParam();
-  const cluster = clusterOverride || clusterParam;
+  const cluster = clusterOverride ?? clusterParam;
 
-  const { featureGates, hcLoaded } = useKubevirtHyperconvergeConfiguration(cluster);
+  const { disabledFeatureGates, featureGates, hcLoaded } =
+    useKubevirtHyperconvergeConfiguration(cluster);
 
   const featureEnabled = useMemo(
-    () => featureGates?.includes(TEMPLATE_FEATURE_GATE) ?? false,
-    [featureGates],
+    () => isTemplateFeatureGateEnabled(featureGates, disabledFeatureGates),
+    [disabledFeatureGates, featureGates],
   );
 
   return { featureEnabled, loading: !hcLoaded };

--- a/src/utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag.ts
@@ -1,39 +1,46 @@
 import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { K8S_OPS } from '@kubevirt-utils/constants/constants';
-import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import useHyperConvergeConfiguration, {
+  type HyperConverged,
+} from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { getAnnotations } from '@kubevirt-utils/resources/shared';
 import { escapeJsonPointerToken, isEmpty } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
-import { Patch } from '@openshift-console/dynamic-plugin-sdk';
+import { type Patch } from '@openshift-console/dynamic-plugin-sdk';
 
 import { ADD_TEMPLATE_FEATURE_GATE_PATCH, KUBEVIRT_JSONPATCH_ANNOTATION } from './constants';
 import useIsVMTemplateFeatureEnabled from './useIsVMTemplateFeatureEnabled';
 import { isTemplatePatch, parseJsonPatchAnnotation } from './utils';
 
-const useVMTemplateFeatureFlag = (clusterOverride?: string) => {
+type UseVMTemplateFeatureFlag = (clusterOverride?: string) => {
+  canEdit: boolean;
+  featureEnabled: boolean;
+  loading: boolean;
+  toggleFeature: (isChecked: boolean) => Promise<HyperConverged>;
+};
+
+const useVMTemplateFeatureFlag: UseVMTemplateFeatureFlag = (clusterOverride) => {
   const clusterParam = useClusterParam();
-  const cluster = clusterOverride || clusterParam;
+  const cluster = clusterOverride ?? clusterParam;
 
   const { featureEnabled, loading: featureEnabledLoading } = useIsVMTemplateFeatureEnabled(cluster);
 
-  const [hyperConvergeConfiguration, hcConfigLoaded, hcConfigError] =
-    useHyperConvergeConfiguration(cluster);
+  const [hyperConvergeConfiguration, hcConfigLoaded] = useHyperConvergeConfiguration(cluster);
 
   const isAdmin = useIsAdmin();
 
   return {
     canEdit: isAdmin,
-    error: hcConfigError,
     featureEnabled,
     loading: featureEnabledLoading || !hcConfigLoaded,
-    toggleFeature: (isChecked: boolean) => {
+    toggleFeature: (isChecked: boolean): Promise<HyperConverged> => {
       if (!hyperConvergeConfiguration) {
         return Promise.reject(new Error('HyperConverged configuration is not loaded'));
       }
 
-      const annotations = getAnnotations(hyperConvergeConfiguration) || {};
+      const annotations = getAnnotations(hyperConvergeConfiguration) ?? {};
       const currentValue = annotations[KUBEVIRT_JSONPATCH_ANNOTATION];
       let operations = parseJsonPatchAnnotation(currentValue);
 
@@ -42,7 +49,7 @@ const useVMTemplateFeatureFlag = (clusterOverride?: string) => {
           operations.push(ADD_TEMPLATE_FEATURE_GATE_PATCH);
         }
       } else {
-        operations = operations.filter((p) => !isTemplatePatch(p));
+        operations = operations.filter((patch) => !isTemplatePatch(patch));
       }
 
       const hasAnnotations = !isEmpty(annotations);

--- a/src/utils/hooks/useVMTemplateFeatureFlag/utils.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/utils.ts
@@ -1,18 +1,39 @@
-import { Patch } from '@openshift-console/dynamic-plugin-sdk';
+import { type Patch } from '@openshift-console/dynamic-plugin-sdk';
 
-import { ADD_TEMPLATE_FEATURE_GATE_PATCH } from './constants';
+import { ADD_TEMPLATE_FEATURE_GATE_PATCH, TEMPLATE_FEATURE_GATE } from './constants';
 
-export const isTemplatePatch = (p: Patch) =>
-  p?.op === ADD_TEMPLATE_FEATURE_GATE_PATCH.op &&
-  p?.path === ADD_TEMPLATE_FEATURE_GATE_PATCH.path &&
-  p?.value === ADD_TEMPLATE_FEATURE_GATE_PATCH.value;
+export const isTemplatePatch = (patch: Patch): boolean =>
+  patch?.op === ADD_TEMPLATE_FEATURE_GATE_PATCH.op &&
+  patch?.path === ADD_TEMPLATE_FEATURE_GATE_PATCH.path &&
+  patch?.value === ADD_TEMPLATE_FEATURE_GATE_PATCH.value;
 
 export const parseJsonPatchAnnotation = (annotationValue: string): Patch[] => {
   try {
     if (!annotationValue) return [];
-    const parsed = JSON.parse(annotationValue);
+    const parsed: unknown = JSON.parse(annotationValue);
     return Array.isArray(parsed) ? (parsed as Patch[]) : [];
   } catch {
     return [];
   }
+};
+
+/**
+ * Template is a KubeVirt Beta feature gate (enabled by default unless listed in
+ * disabledFeatureGates). Older clusters may only expose it via featureGates.
+ * @param featureGates
+ * @param disabledFeatureGates
+ */
+export const isTemplateFeatureGateEnabled = (
+  featureGates: string[] | undefined,
+  disabledFeatureGates: string[] | undefined,
+): boolean => {
+  if (featureGates?.includes(TEMPLATE_FEATURE_GATE)) {
+    return true;
+  }
+
+  if (Array.isArray(disabledFeatureGates)) {
+    return !disabledFeatureGates.includes(TEMPLATE_FEATURE_GATE);
+  }
+
+  return false;
 };

--- a/src/views/settings/search/search.ts
+++ b/src/views/settings/search/search.ts
@@ -1,10 +1,10 @@
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import { idIsHighlighted } from '@kubevirt-utils/components/SearchItem/useIsHighlighted';
 import { VIRTUALIZATION_PATHS } from '@kubevirt-utils/constants/constants';
 import {
-  SearchItem,
-  SearchItemWithTab,
+  type SearchItem,
+  type SearchItemWithTab,
 } from '@virtualmachines/details/tabs/configuration/utils/search';
 
 import {
@@ -64,7 +64,12 @@ const getPreviewFeaturesTabIds = (t: TFunction): SearchItem[] => [
   },
   {
     id: PREVIEW_FEATURES_TAB_IDS.vmTemplates,
+    // Shown only on HCO v1beta1; HCO v1 hides the Preview Features toggle.
     title: t('Enable native VirtualMachine templates'),
+  },
+  {
+    id: PREVIEW_FEATURES_TAB_IDS.controlDefaultVirtualizationPermissions,
+    title: t('Control default Virtualization permissions'),
   },
 ];
 
@@ -100,6 +105,6 @@ export const isSearchItemChildrenHighlighted = (itemId: string, hash: string): b
   if (!childrenIds) return false;
 
   return childrenIds.some(
-    (id) => idIsHighlighted(id, hash) || isSearchItemChildrenHighlighted(id, hash),
+    (childId) => idIsHighlighted(childId, hash) || isSearchItemChildrenHighlighted(childId, hash),
   );
 };

--- a/src/views/settings/tabs/PreviewFeaturesTab/hooks/usePreviewFeaturesData.tsx
+++ b/src/views/settings/tabs/PreviewFeaturesTab/hooks/usePreviewFeaturesData.tsx
@@ -1,6 +1,6 @@
-import React, { ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import {
   CONTROL_DEFAULT_VIRTUALIZATION_PERMISSIONS,
   PASST_UDN_NETWORK,
@@ -10,6 +10,7 @@ import {
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import usePasstFeatureFlag from '@kubevirt-utils/hooks/usePasstFeatureFlag';
+import useIsHyperConvergedV1Available from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useIsHyperConvergedV1Available';
 import useVMTemplateFeatureFlag from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import { PREVIEW_FEATURES_TAB_IDS } from '@settings/search/constants';
@@ -47,8 +48,11 @@ const usePreviewFeaturesData: UsePreviewFeaturesData = (cluster) => {
     CONTROL_DEFAULT_VIRTUALIZATION_PERMISSIONS,
     cluster,
   );
+  // HCO v1: Template is Beta / first-class — hide jsonpatch toggle.
+  // HCO v1beta1 only: keep Preview Features toggle.
+  const { isHCOV1, loading: hcoV1Loading } = useIsHyperConvergedV1Available();
 
-  const features = [
+  const features: Feature[] = [
     {
       externalLink: null,
       id: TREE_VIEW_FOLDERS,
@@ -65,14 +69,17 @@ const usePreviewFeaturesData: UsePreviewFeaturesData = (cluster) => {
       searchItemId: PREVIEW_FEATURES_TAB_IDS.passtUDNNetwork,
       ...passtFeatureFlag,
     },
-    {
-      externalLink: 'https://kubevirt.io/user-guide/user_workloads/vm_templates/',
-      id: VM_TEMPLATES,
-      label: t('Enable native VirtualMachine templates'),
-      searchItemId: PREVIEW_FEATURES_TAB_IDS.vmTemplates,
-      ...templateFeatureFlag,
-    },
-
+    ...(!hcoV1Loading && !isHCOV1
+      ? [
+          {
+            externalLink: 'https://kubevirt.io/user-guide/user_workloads/vm_templates/',
+            id: VM_TEMPLATES,
+            label: t('Enable native VirtualMachine templates'),
+            searchItemId: PREVIEW_FEATURES_TAB_IDS.vmTemplates,
+            ...templateFeatureFlag,
+          } satisfies Feature,
+        ]
+      : []),
     {
       externalLink: null,
       helpPopoverContent: t(
@@ -96,7 +103,7 @@ const usePreviewFeaturesData: UsePreviewFeaturesData = (cluster) => {
     {
       canEditAll: true,
       isEnabledAll: true,
-      loading: false,
+      loading: hcoV1Loading,
       togglers: [],
     },
   );

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useTemplates.ts
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useTemplates.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import useVMTemplateFeatureFlag from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag';
+import useIsVMTemplateFeatureEnabled from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useIsVMTemplateFeatureEnabled';
 import { Template } from '@kubevirt-utils/resources/template';
 import { useOpenShiftTemplates } from '@templates/list/hooks/useOpenShiftTemplates';
 import useVirtualMachineTemplates from '@templates/list/hooks/useVirtualMachineTemplates';
@@ -13,7 +13,7 @@ type UseTemplates = (namespace?: string) => {
 
 const useTemplates: UseTemplates = (namespace) => {
   const { featureEnabled: vmTemplatesEnabled, loading: vmTemplatesFeatureLoading } =
-    useVMTemplateFeatureFlag();
+    useIsVMTemplateFeatureEnabled();
 
   const {
     error: templatesError,


### PR DESCRIPTION
## 📝 Description

Updates Preview Features handling for native VirtualMachine templates now that Template is Beta on HCO v1.

- **HCO v1 available**: hide the Preview Features toggle “Enable native VirtualMachine templates” (jsonpatch path is no longer needed; Template is first-class / enabled by default)
- **HCO v1beta1 only**: keep showing the Preview Features toggle so older clusters can still enable Template via the unsafe HCO `kubevirt.kubevirt.io/jsonpatch` annotation
- Feature detection uses KubeVirt `featureGates` / `disabledFeatureGates` via `useIsVMTemplateFeatureEnabled`
- Playwright assumes HCO v1 (toggle not listed); no v1beta1 scenario coverage
- Cleans up Playwright setup/teardown helpers that depended on the jsonpatch enable path

## 🔗 Links

- Jira: https://redhat.atlassian.net/browse/CNV-92254
- Related: KubeVirt Template → Beta ([kubevirt#18065](https://github.com/kubevirt/kubevirt/pull/18065)), HCO featureGates v1 ([HCO#4079](https://github.com/kubevirt/hyperconverged-cluster-operator/pull/4079))

## 🎥 Demo

> N/A

## Test plan

- [ ] On HCO v1: Preview Features does **not** show “Enable native VirtualMachine templates”
- [ ] On HCO v1beta1: Preview Features still shows the toggle
- [ ] Native VM templates appear when Template is enabled (default on HCO v1)
- [ ] When Template is in `disabledFeatureGates`, native VM templates are not used
- [ ] Playwright setup no longer patches HCO jsonpatch for Template
- [ ] Unit tests for `isTemplateFeatureGateEnabled` pass