### PR TITLE
CNV-92977: Checkout default branch in hot-cluster-e2e PR gate

### DIFF
--- a/.github/workflows/hot-cluster-e2e-pr-gate.yml
+++ b/.github/workflows/hot-cluster-e2e-pr-gate.yml
@@ -26,6 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
       # e2e-passed/e2e-failed mirror the *last real* result -- only clear on
       # synchronize, since neither label reflects the new HEAD until the
       # fresh dispatch below reports one (opened/reopened have no prior diff


### PR DESCRIPTION
## 📝 Description

Follow-up fix for the Hot Cluster E2E PR gate: the dispatch job uses local composite actions (`create-bot-token`, `clear-e2e-result-labels`) under `pull_request_target`, but had no checkout step, so those actions could not resolve.

Adds `actions/checkout` of the repository **default branch** (not the PR head) with `persist-credentials: false` before the bot-token / label-clear steps.

## 🔗 Links

- Jira: https://redhat.atlassian.net/browse/CNV-92977

## 🎥 Demo

N/A — CI workflow change

## Test plan

- [ ] On a PR without `e2e-hold`, synchronize a commit and confirm Dispatch Hot Cluster E2E can run `create-bot-token` / clear stale e2e labels
- [ ] Confirm checkout uses `default_branch` (not PR head) for `pull_request_target` safety
- [ ] Confirm held PRs (`e2e-hold`) still republish the held check as before


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request validation workflows to ensure end-to-end checks run against the correct repository state.
  * Increased reliability of automated testing before changes are integrated.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->