### PR TITLE
CNV-93632: Add Virt cluster validation to self validation test suites

### DIFF
--- a/src/views/checkups/self-validation/components/form/CheckupsSelfValidationForm.tsx
+++ b/src/views/checkups/self-validation/components/form/CheckupsSelfValidationForm.tsx
@@ -27,10 +27,10 @@ import {
 } from '@patternfly/react-core';
 
 import {
+  DEFAULT_TEST_SUITES,
   SELF_VALIDATION_NAME,
   selfValidationCheckupImageSettings,
   TEST_SUITE_OPTIONS,
-  TEST_SUITES,
 } from '../../utils';
 import { calculatePVCStorageSize } from '../../utils/selfValidationJob/resourceTemplates';
 
@@ -55,7 +55,7 @@ const CheckupsSelfValidationForm = () => {
   const [name, setName] = useState<string>(generatePrettyName(SELF_VALIDATION_NAME));
   const [checkupImage, checkupImageLoaded, checkupImageLoadError, checkupImageIsFallback] =
     useRelatedImage(selfValidationCheckupImageSettings);
-  const [selectedTestSuites, setSelectedTestSuites] = useState<string[]>(TEST_SUITES);
+  const [selectedTestSuites, setSelectedTestSuites] = useState<string[]>(DEFAULT_TEST_SUITES);
   const [isDryRun, setIsDryRun] = useState<boolean>(false);
   const [storageClass, setStorageClass] = useState<string>('');
   const [testSkips, setTestSkips] = useState<string>('');

--- a/src/views/checkups/self-validation/utils/constants.ts
+++ b/src/views/checkups/self-validation/utils/constants.ts
@@ -55,8 +55,18 @@ export const TEST_SUITE_NETWORK = 'network';
 export const TEST_SUITE_STORAGE = 'storage';
 export const TEST_SUITE_SSP = 'ssp';
 export const TEST_SUITE_TIER2 = 'tier2';
+export const TEST_SUITE_VIRT_CLUSTER_VALIDATE = 'virt-cluster-validate';
 
 export const TEST_SUITES = [
+  TEST_SUITE_COMPUTE,
+  TEST_SUITE_NETWORK,
+  TEST_SUITE_STORAGE,
+  TEST_SUITE_SSP,
+  TEST_SUITE_TIER2,
+  TEST_SUITE_VIRT_CLUSTER_VALIDATE,
+];
+
+export const DEFAULT_TEST_SUITES = [
   TEST_SUITE_COMPUTE,
   TEST_SUITE_NETWORK,
   TEST_SUITE_STORAGE,
@@ -70,6 +80,7 @@ export const TEST_SUITE_OPTIONS = [
   { label: 'Storage', value: TEST_SUITE_STORAGE },
   { label: 'SSP', value: TEST_SUITE_SSP },
   { label: 'Tier2', value: TEST_SUITE_TIER2 },
+  { label: 'Virt cluster validation', value: TEST_SUITE_VIRT_CLUSTER_VALIDATE },
 ];
 
 type SelfValidationTestSuiteName =
@@ -77,7 +88,8 @@ type SelfValidationTestSuiteName =
   | typeof TEST_SUITE_NETWORK
   | typeof TEST_SUITE_SSP
   | typeof TEST_SUITE_STORAGE
-  | typeof TEST_SUITE_TIER2;
+  | typeof TEST_SUITE_TIER2
+  | typeof TEST_SUITE_VIRT_CLUSTER_VALIDATE;
 
 type SelfValidationSuiteResult = {
   failed_tests?: string[];


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add Virt Cluster Validate [1] to Self Validation test suites.
Depends on [2]
Default is disabled.

[1] https://github.com/openshift-cnv/virt-cluster-validate
[2] https://github.com/openshift-cnv/ocp-virt-validation-checkup/pull/94

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-93632

## 🎥 Demo

<img width="269" height="313" alt="image" src="https://github.com/user-attachments/assets/8ca0d5ef-a936-40c4-9d89-e3895cd8fe35" />
