### PR TITLE
fix: View storage migrations 404 — route to MultiNamespaceVirtualMachineStorageMigrationPlan

### DIFF
--- a/src/perspective/extensions.ts
+++ b/src/perspective/extensions.ts
@@ -194,6 +194,9 @@ const migrationSection = [
     type: 'console.navigation/section',
   } as EncodedExtension<NavSection>,
   {
+    flags: {
+      required: ['SHOW_MIGRATION_SECTION'],
+    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-storagemigrations-virt-perspective',
@@ -201,8 +204,8 @@ const migrationSection = [
       },
       id: 'storagemigrations-virt-perspective',
       model: {
-        group: 'migration.openshift.io',
-        kind: 'MigPlan',
+        group: 'migrations.kubevirt.io',
+        kind: 'MultiNamespaceVirtualMachineStorageMigrationPlan',
         version: 'v1alpha1',
       },
       name: '%plugin__kubevirt-plugin~Storage migrations%',

--- a/src/views/storagemigrations/actions/useStorageMigrationActions.tsx
+++ b/src/views/storagemigrations/actions/useStorageMigrationActions.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 
 import DeleteModal from '@kubevirt-utils/components/DeleteModal/DeleteModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import { ALL_NAMESPACES } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
 import {
@@ -21,6 +20,7 @@ import {
   useK8sModel,
   useLabelsModal,
 } from '@openshift-console/dynamic-plugin-sdk';
+import { getStorageMigrationsListUrl } from '../utils/urls';
 
 const useStorageMigrationActions: ExtensionHook<
   Action[],
@@ -34,9 +34,7 @@ const useStorageMigrationActions: ExtensionHook<
   const model = isMigPlan ? MigPlanModel : MultiNamespaceVirtualMachineStorageMigrationPlanModel;
 
   const currentNamespace = useNamespaceParam();
-  const storageMigrationsRedirectUrl = currentNamespace
-    ? `/k8s/ns/${currentNamespace}/storagemigrations`
-    : `/k8s/${ALL_NAMESPACES}/storagemigrations`;
+  const storageMigrationsRedirectUrl = getStorageMigrationsListUrl(currentNamespace);
 
   const [, inFlight] = useK8sModel(
     modelToRef(MultiNamespaceVirtualMachineStorageMigrationPlanModel),

--- a/src/views/storagemigrations/extensions.ts
+++ b/src/views/storagemigrations/extensions.ts
@@ -1,8 +1,8 @@
 import { EncodedExtension } from '@openshift/dynamic-plugin-sdk-webpack';
 import {
   FeatureFlagHookProvider,
-  HrefNavItem,
   NavSection,
+  ResourceNSNavItem,
   RoutePage,
 } from '@openshift-console/dynamic-plugin-sdk';
 import type { ConsolePluginBuildMetadata } from '@openshift-console/dynamic-plugin-sdk-webpack';
@@ -11,6 +11,12 @@ export const exposedModules: ConsolePluginBuildMetadata['exposedModules'] = {
   StorageMigrationList: './views/storagemigrations/list/StorageMigrationList.tsx',
   useStorageMigrationActionsProvider:
     './views/storagemigrations/actions/useStorageMigrationActions.tsx',
+};
+
+const multiNamespaceStorageMigrationPlanModel = {
+  group: 'migrations.kubevirt.io',
+  kind: 'MultiNamespaceVirtualMachineStorageMigrationPlan',
+  version: 'v1alpha1',
 };
 
 export const extensions: EncodedExtension[] = [
@@ -46,6 +52,14 @@ export const extensions: EncodedExtension[] = [
     type: 'console.page/route',
   } as EncodedExtension<RoutePage>,
   {
+    properties: {
+      component: { $codeRef: 'StorageMigrationList' },
+      model: multiNamespaceStorageMigrationPlanModel,
+      prefixNamespaced: true,
+    },
+    type: 'console.page/resource/list',
+  },
+  {
     flags: {
       required: ['SHOW_MIGRATION_SECTION'],
     },
@@ -54,22 +68,17 @@ export const extensions: EncodedExtension[] = [
         'data-quickstart-id': 'qs-nav-storagemigrations',
         'data-test-id': 'storagemigrations-nav-item',
       },
-      href: 'storagemigrations',
       id: 'storagemigrations',
+      model: multiNamespaceStorageMigrationPlanModel,
       name: '%plugin__kubevirt-plugin~Storage migrations%',
-      prefixNamespaced: true,
       section: 'migration',
     },
-    type: 'console.navigation/href',
-  } as EncodedExtension<HrefNavItem>,
+    type: 'console.navigation/resource-ns',
+  } as EncodedExtension<ResourceNSNavItem>,
 
   {
     properties: {
-      model: {
-        group: 'migrations.kubevirt.io',
-        kind: 'MultiNamespaceVirtualMachineStorageMigrationPlan',
-        version: 'v1alpha1',
-      },
+      model: multiNamespaceStorageMigrationPlanModel,
       provider: {
         $codeRef: 'useStorageMigrationActionsProvider',
       },

--- a/src/views/storagemigrations/utils/urls.test.ts
+++ b/src/views/storagemigrations/utils/urls.test.ts
@@ -1,0 +1,44 @@
+import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import { MultiNamespaceVirtualMachineStorageMigrationPlanModel } from '@kubevirt-utils/models';
+import { getResourceUrl } from '@kubevirt-utils/resources/shared';
+
+import { getStorageMigrationsListUrl } from './urls';
+
+jest.mock('@kubevirt-utils/resources/shared', () => ({
+  getResourceUrl: jest.fn(),
+}));
+
+const getResourceUrlMock = getResourceUrl as jest.MockedFunction<typeof getResourceUrl>;
+
+describe('getStorageMigrationsListUrl', () => {
+  beforeEach(() => {
+    getResourceUrlMock.mockReset();
+    getResourceUrlMock.mockImplementation(({ activeNamespace, model }) => {
+      const ns =
+        activeNamespace && activeNamespace !== ALL_NAMESPACES_SESSION_KEY
+          ? `ns/${activeNamespace}`
+          : 'all-namespaces';
+      return `/k8s/${ns}/${model.apiGroup}~${model.apiVersion}~${model.kind}`;
+    });
+  });
+
+  it('uses the MultiNamespaceVirtualMachineStorageMigrationPlan GVK path for a namespace', () => {
+    expect(getStorageMigrationsListUrl('my-ns')).toBe(
+      '/k8s/ns/my-ns/migrations.kubevirt.io~v1alpha1~MultiNamespaceVirtualMachineStorageMigrationPlan',
+    );
+    expect(getResourceUrlMock).toHaveBeenCalledWith({
+      activeNamespace: 'my-ns',
+      model: MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+    });
+  });
+
+  it('uses all-namespaces when namespace is omitted', () => {
+    expect(getStorageMigrationsListUrl()).toBe(
+      '/k8s/all-namespaces/migrations.kubevirt.io~v1alpha1~MultiNamespaceVirtualMachineStorageMigrationPlan',
+    );
+    expect(getResourceUrlMock).toHaveBeenCalledWith({
+      activeNamespace: ALL_NAMESPACES_SESSION_KEY,
+      model: MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+    });
+  });
+});

--- a/src/views/storagemigrations/utils/urls.ts
+++ b/src/views/storagemigrations/utils/urls.ts
@@ -1,0 +1,15 @@
+import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import { MultiNamespaceVirtualMachineStorageMigrationPlanModel } from '@kubevirt-utils/models';
+import { getResourceUrl } from '@kubevirt-utils/resources/shared';
+
+/**
+ * List URL for native storage migration plans.
+ * Uses the CRD GVK path so OpenShift Console resolves a real resource type
+ * instead of the synthetic "storagemigrations" plural (which 404s when the
+ * custom console.page/route is not active).
+ */
+export const getStorageMigrationsListUrl = (namespace?: string): string =>
+  getResourceUrl({
+    activeNamespace: namespace || ALL_NAMESPACES_SESSION_KEY,
+    model: MultiNamespaceVirtualMachineStorageMigrationPlanModel,
+  });

--- a/src/views/storagemigrations/utils/urls.ts
+++ b/src/views/storagemigrations/utils/urls.ts
@@ -3,10 +3,12 @@ import { MultiNamespaceVirtualMachineStorageMigrationPlanModel } from '@kubevirt
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
 
 /**
- * List URL for native storage migration plans.
- * Uses the CRD GVK path so OpenShift Console resolves a real resource type
- * instead of the synthetic "storagemigrations" plural (which 404s when the
- * custom console.page/route is not active).
+ * Console list URL for native live storage class migration plans
+ * (`MultiNamespaceVirtualMachineStorageMigrationPlan`).
+ *
+ * On 4.20 the UI previously linked to the synthetic plural `/storagemigrations`,
+ * which 404s ("resource type storagemigrations") because that is not a real CRD.
+ * Route via the CRD GVK instead — the same fallback 4.22 uses for CNV < 4.23.
  */
 export const getStorageMigrationsListUrl = (namespace?: string): string =>
   getResourceUrl({

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationStatus.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationStatus.tsx
@@ -2,7 +2,6 @@ import React, { FC } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
-import { ALL_NAMESPACES } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
 import { STATUS_COMPLETED } from '@kubevirt-utils/resources/migrations/constants';
@@ -18,6 +17,7 @@ import {
   DescriptionListTerm,
 } from '@patternfly/react-core';
 import { CloseIcon } from '@patternfly/react-icons';
+import { getStorageMigrationsListUrl } from '../../../../storagemigrations/utils/urls';
 
 import useProgressMigration from './hooks/useProgressMigration';
 import { getStorageMigrationStatusLabel } from './utils/utils';
@@ -34,9 +34,7 @@ const VirtualMachineMigrationStatus: FC<VirtualMachineMigrationStatusProps> = ({
   vmNamespace,
 }) => {
   const { t } = useKubevirtTranslation();
-  const storageMigrationsUrl = vmNamespace
-    ? `/k8s/ns/${vmNamespace}/storagemigrations`
-    : `/k8s/${ALL_NAMESPACES}/storagemigrations`;
+  const storageMigrationsUrl = getStorageMigrationsListUrl(vmNamespace);
 
   const {
     completedMigrationTimestamp,

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationStatusMtc.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/VirtualMachineMigrationStatusMtc.tsx
@@ -2,7 +2,6 @@ import React, { FC } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
-import { ALL_NAMESPACES } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   MigMigration,
@@ -20,6 +19,7 @@ import {
   DescriptionListTerm,
 } from '@patternfly/react-core';
 import { CloseIcon } from '@patternfly/react-icons';
+import { getStorageMigrationsListUrl } from '../../../../storagemigrations/utils/urls';
 
 import useProgressMigrationMtc from './hooks/useProgressMigrationMtc';
 
@@ -41,9 +41,7 @@ const VirtualMachineMigrationStatusMtc: FC<VirtualMachineMigrationStatusMtcProps
   vmNamespace,
 }) => {
   const { t } = useKubevirtTranslation();
-  const storageMigrationsUrl = vmNamespace
-    ? `/k8s/ns/${vmNamespace}/storagemigrations`
-    : `/k8s/${ALL_NAMESPACES}/storagemigrations`;
+  const storageMigrationsUrl = getStorageMigrationsListUrl(vmNamespace);
 
   const {
     completedMigrationTimestamp,


### PR DESCRIPTION
## 📝 Description

**Context:** From OpenShift Virtualization 4.20, live storage class migration uses the **native** API (`MultiNamespaceVirtualMachineStorageMigrationPlan`). MTC is decommissioned for this flow — the bug reproduces with **MTC uninstalled**.

**Bug (4.20.15):** After initiating Migration → Storage on a running VM, the status popup shows **View storage migrations**. Clicking it navigates to `/k8s/.../storagemigrations`. That plural is not a CRD, so the console shows:

> 404: Page Not Found  
> The server doesn't have a resource type "storagemigrations".

**Expected (works on 4.22):** Open the native `MultiNamespaceVirtualMachineStorageMigrationPlan` list / workflow.

**Fix:** Build the list URL from the native plan model GVK via `getResourceUrl` (same approach 4.22 uses when the custom `/storagemigrations` route is not available — spokes / CNV < 4.23). Register `console.page/resource/list` for that model so the existing Storage Migration list page still renders. Point Migration nav (admin + virt perspective) at the native model instead of the synthetic `storagemigrations` href / legacy MigPlan.

### Changes
- `getStorageMigrationsListUrl()` → native `MultiNamespaceVirtualMachineStorageMigrationPlan` GVK path
- **View storage migrations** (post-initiate popup) uses that URL
- Nav + `console.page/resource/list` for the native plan model
- Legacy `/storagemigrations` `console.page/route` kept for old bookmarks only

### Duplicate check
No other open PR covers this. Related historical work (#3977 / CNV-88330) only ungated the custom route and is **not** in `v4.20.15-rc.0`; this PR fixes the link target itself for the native path.

## 🔗 Links

Jira: _please add CNV ticket_ (PR currently blocked by `do-not-merge/jira-invalid`)

## Test plan

- [ ] Cluster: OCP/CNV **4.20.x**, native live storage migration enabled, **MTC not installed**
- [ ] VM Actions → Migration → Storage → complete initiate flow until status popup
- [ ] Click **View storage migrations** → opens `MultiNamespaceVirtualMachineStorageMigrationPlan` list (no 404)
- [ ] Migration → Storage migrations nav opens the same native list
- [ ] Confirm behavior matches 4.22 for this link