### PR TITLE
CNV-92845: Fix VM list selection not updating in the UI

### DIFF
--- a/src/views/virtualmachines/list/cells/VMSelectionCell.tsx
+++ b/src/views/virtualmachines/list/cells/VMSelectionCell.tsx
@@ -1,14 +1,16 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { Checkbox } from '@patternfly/react-core';
+import { useSignals } from '@preact/signals-react/runtime';
 
 import { deselectVM, isVMSelected, selectVM } from '../selectedVMs';
 
-import { VMCellProps } from './types';
+import { type VMCellProps } from './types';
 
 const VMSelectionCell: FC<VMCellProps> = ({ row }) => {
+  useSignals();
   const { t } = useKubevirtTranslation();
 
   if (!row) return null;
@@ -16,6 +18,7 @@ const VMSelectionCell: FC<VMCellProps> = ({ row }) => {
   const selected = isVMSelected(row);
   const name = getName(row);
   const namespace = getNamespace(row);
+  const checkboxId = row?.metadata?.uid ?? `${namespace}-${name}`;
 
   return (
     <Checkbox
@@ -24,7 +27,7 @@ const VMSelectionCell: FC<VMCellProps> = ({ row }) => {
         namespace,
       })}
       data-test={`select-vm-${name}`}
-      id={`select-${row?.metadata?.uid ?? `${namespace}-${name}`}`}
+      id={`select-${checkboxId}`}
       isChecked={selected}
       onChange={() => (selected ? deselectVM(row) : selectVM(row))}
     />

--- a/src/views/virtualmachines/list/hooks/useExistingSelectedVMs.ts
+++ b/src/views/virtualmachines/list/hooks/useExistingSelectedVMs.ts
@@ -1,28 +1,25 @@
 import { useMemo } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
 import { convertResourceArrayToMapWithCluster } from '@kubevirt-utils/resources/shared';
+import { useSignals } from '@preact/signals-react/runtime';
 
 import { selectedVMs } from '../selectedVMs';
 
-const useExistingSelectedVMs = (vms: V1VirtualMachine[]) => {
+const useExistingSelectedVMs = (vms: V1VirtualMachine[]): V1VirtualMachine[] => {
+  useSignals();
+
   const vmsMapper = useMemo(() => convertResourceArrayToMapWithCluster(vms, true), [vms]);
 
-  const existingSelectedVirtualMachines = useMemo(
-    () =>
-      selectedVMs.value
-        .map(
-          (selectedVM) =>
-            vmsMapper?.[selectedVM.cluster || SINGLE_CLUSTER_KEY]?.[selectedVM.namespace]?.[
-              selectedVM.name
-            ],
-        )
-        .filter(Boolean),
-    [vmsMapper],
-  );
-
-  return existingSelectedVirtualMachines;
+  return selectedVMs.value
+    .map(
+      (selectedVM) =>
+        vmsMapper?.[selectedVM.cluster ?? SINGLE_CLUSTER_KEY]?.[selectedVM.namespace]?.[
+          selectedVM.name
+        ],
+    )
+    .filter(Boolean);
 };
 
 export default useExistingSelectedVMs;


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/CNV-92845

## Summary
- Subscribe `VMSelectionCell` and `useExistingSelectedVMs` to the `selectedVMs` signal via `useSignals()` so row checkboxes and bulk selection/actions update immediately.
- Avoid stale selection state that previously only refreshed when unrelated VM list updates forced a re-render.

## Test plan
- [ ] Open Virtualization → Virtual Machines
- [ ] Select a VM via the row checkbox — checkbox should check immediately
- [ ] Use bulk select (page / all) — selected count and Actions should update immediately
- [ ] Deselect via checkbox and bulk select none — UI should clear selection immediately
- [ ] Delete a selected VM — it should be removed from the selection set


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual machine selection updates so checkbox states stay synchronized with the latest selection data.
  * Ensured selection identifiers remain stable, including for virtual machines without a UID.
  * Improved handling of empty or undefined cluster values when restoring selected virtual machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->