### PR TITLE
CNV-93496: surface Playwright test failures in Run Gating Tests check-run

### DIFF
--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -146,6 +146,10 @@ on:
         type: string
         required: false
         default: ''
+    outputs:
+      test_failure_summary:
+        description: Markdown summary of Playwright test failures parsed from JUnit XML (empty when all tests pass or XML is unavailable)
+        value: ${{ jobs.run-gating-tests.outputs.test_failure_summary }}
 
 permissions:
   contents: read
@@ -269,6 +273,8 @@ jobs:
           (inputs.cnv_pin_version == '4.21' || inputs.cnv_pin_version == '4.22') && format('auto-test-secret-{0}', github.run_id) ||
           'auto-test-secret'
         }}
+    outputs:
+      test_failure_summary: ${{ steps.test-summary.outputs.test_summary }}
 
     steps:
       # Folded in from a former standalone "Check Runner Image" job (same
@@ -525,6 +531,84 @@ jobs:
             # features is Cypress-only on release branches; Playwright on main has no features project.
             ./playwright-runner-hc-e2e.sh Gating
           fi
+
+      - name: Extract test failure summary
+        id: test-summary
+        if: always()
+        run: |
+          RESULTS_FILE="playwright/test-results/results.xml"
+          if [[ "${TEST_ENGINE}" != "playwright" || ! -f "${RESULTS_FILE}" ]]; then
+            echo "test_summary=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          SUMMARY=$(node << 'NODESCRIPT'
+          const fs = require('fs');
+          try {
+            const xml = fs.readFileSync('playwright/test-results/results.xml', 'utf8');
+
+            const decode = (s) => s
+              .replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+              .replace(/&quot;/g, '"').replace(/&apos;/g, "'")
+              .replace(/&#10;/g, ' ').replace(/&#13;/g, '');
+
+            const attr = (el, name) => {
+              const m = el.match(new RegExp(name + '="([^"]*)"'));
+              return m ? decode(m[1]) : '';
+            };
+
+            const root = xml.match(/<testsuites[^>]*>/);
+            const total = root ? attr(root[0], 'tests') : '?';
+            const failed = root ? attr(root[0], 'failures') : '?';
+            const skipped = root ? attr(root[0], 'skipped') : '0';
+            const passed = (total !== '?' && failed !== '?')
+              ? String(Number(total) - Number(failed) - Number(skipped))
+              : '?';
+
+            if (failed === '0') process.exit(0);
+
+            const failures = [];
+            const re = /<testcase\s+([\s\S]*?)>([\s\S]*?)<\/testcase>/g;
+            let m;
+            while ((m = re.exec(xml)) !== null) {
+              if (!m[2].includes('<failure')) continue;
+              const failTag = m[2].match(/<failure\s+([\s\S]*?)(?:\/>|>[\s\S]*?<\/failure>)/);
+              failures.push({
+                name: attr(m[1], 'name'),
+                suite: attr(m[1], 'classname'),
+                msg: failTag ? attr(failTag[1], 'message') : '',
+              });
+            }
+
+            if (failures.length === 0) process.exit(0);
+
+            const MAX = 25;
+            let out = `**${failed}** of **${total}** tests failed, **${passed}** passed`;
+            if (skipped !== '0') out += `, ${skipped} skipped`;
+            out += '\n\n| Test | Error |\n| --- | --- |\n';
+            for (const f of failures.slice(0, MAX)) {
+              const name = f.name.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+              const msg = f.msg.replace(/\|/g, '\\|').replace(/\n/g, ' ').substring(0, 200);
+              out += `| ${name} | ${msg} |\n`;
+            }
+            if (failures.length > MAX) {
+              out += `\n_...and ${failures.length - MAX} more failures (see workflow artifacts for full report)_\n`;
+            }
+            if (out.length > 60000) {
+              out = out.substring(0, 60000) + '\n\n_...truncated_\n';
+            }
+            process.stdout.write(out);
+          } catch (e) {
+            process.exit(0);
+          }
+          NODESCRIPT
+          )
+
+          {
+            echo 'test_summary<<SUMMARY_DELIM'
+            echo "${SUMMARY}"
+            echo 'SUMMARY_DELIM'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload test artifacts
         if: always()

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -519,18 +519,12 @@ jobs:
               fi
 
               if [[ -n "${TEST_FAILURE_SUMMARY}" ]]; then
-                FAIL_MSG="${FAIL_MSG}
-
----
-
-### Failed Tests
-
-${TEST_FAILURE_SUMMARY}"
+                # Keep --- off column 0 -- a bare --- line is a YAML document separator
+                # and breaks prettier/YAML parsing of this workflow file.
+                FAIL_MSG="${FAIL_MSG}"$'\n\n---\n\n### Failed Tests\n\n'"${TEST_FAILURE_SUMMARY}"
               fi
 
-              FAIL_MSG="${FAIL_MSG}
-
-See the [workflow run](${WORKFLOW_RUN_URL}) for full details, or comment \`/retest-e2e\` once fixed."
+              FAIL_MSG="${FAIL_MSG}"$'\n\n'"See the [workflow run](${WORKFLOW_RUN_URL}) for full details, or comment \`/retest-e2e\` once fixed."
 
               {
                 echo 'summary<<SUMMARY_DELIM'

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -450,6 +450,8 @@ jobs:
           MAIN_SHA: ${{ github.sha }}
           IS_POOL_RETEST: ${{ inputs.is_pool_retest }}
           HELD: ${{ steps.check-hold.outputs.held }}
+          TEST_FAILURE_SUMMARY: ${{ needs.run-e2e-tests.outputs.test_failure_summary }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           # Held wins over any real result -- re-checked live here rather
           # than trusted from earlier in this run, since the hold may have
@@ -510,11 +512,31 @@ jobs:
               echo "conclusion=failure" >> "$GITHUB_OUTPUT"
               if [[ "${IS_POOL_RETEST}" == "true" ]]; then
                 echo "title=Hot Cluster E2E: gating tests did not pass (retest after main advanced)" >> "$GITHUB_OUTPUT"
-                echo "summary=Re-validated PR #${PR_NUMBER} merged with the current main tip (${MAIN_SHA}) after main advanced -- tests did not pass. See the workflow run for details." >> "$GITHUB_OUTPUT"
+                FAIL_MSG="Re-validated PR #${PR_NUMBER} merged with the current main tip (${MAIN_SHA}) after main advanced -- tests did not pass."
               else
                 echo "title=Hot Cluster E2E: gating tests did not pass" >> "$GITHUB_OUTPUT"
-                echo "summary=Hot cluster gating tests did not pass for PR #${PR_NUMBER} (reason: \`${REASON}\`). See the Run E2E Tests job for details, or comment /retest-e2e once fixed." >> "$GITHUB_OUTPUT"
+                FAIL_MSG="Hot cluster gating tests did not pass for PR #${PR_NUMBER} (reason: \`${REASON}\`)."
               fi
+
+              if [[ -n "${TEST_FAILURE_SUMMARY}" ]]; then
+                FAIL_MSG="${FAIL_MSG}
+
+---
+
+### Failed Tests
+
+${TEST_FAILURE_SUMMARY}"
+              fi
+
+              FAIL_MSG="${FAIL_MSG}
+
+See the [workflow run](${WORKFLOW_RUN_URL}) for full details, or comment \`/retest-e2e\` once fixed."
+
+              {
+                echo 'summary<<SUMMARY_DELIM'
+                echo "${FAIL_MSG}"
+                echo 'SUMMARY_DELIM'
+              } >> "$GITHUB_OUTPUT"
               ;;
           esac
 


### PR DESCRIPTION
## Summary

- Parse Playwright JUnit XML (`results.xml`) after E2E tests finish and extract a markdown summary of failed test names and error messages
- Embed the failure table directly in the "Run Gating Tests" check-run summary so developers see which tests broke without navigating to workflow logs
- Add `test_failure_summary` output to `hot-cluster-e2e-run.yml` and consume it in `hot-cluster-e2e.yml`'s `verify-gating-tests` job

### Before
The "Run Gating Tests" check showed a generic one-liner:
> Hot cluster gating tests did not pass for PR #123 (reason: `test-failed`). See the Run E2E Tests job for details.

### After
The check-run now renders a table of failures directly in the PR checks panel:
> Hot cluster gating tests did not pass for PR #123 (reason: `test-failed`).
>
> ---
> ### Failed Tests
> **3** of **15** tests failed, **12** passed
>
> | Test | Error |
> | --- | --- |
> | VM creation test | expect(received).toBeVisible() — element not found |
> | Disk attach test | Timeout 60000ms exceeded |

## Implementation Details

- **JUnit XML parsing** uses a lightweight inline Node.js script (no new deps) with regex-based extraction
- Capped at **25 failures** and **60KB** to stay within GitHub's check-run summary limits
- Fails silently on parse errors — the summary is best-effort, never blocks the pipeline
- Only runs for **Playwright** (skips Cypress, which has its own path)

## Test plan

- [ ] Verify `hot-cluster-e2e-run.yml` YAML is valid (actionlint in CI)
- [ ] Trigger a PR with a known test failure and confirm the check-run shows the failure table
- [ ] Trigger a PR with all tests passing and confirm the summary remains clean (no empty table)
- [ ] Verify Cypress-branch dispatches still work (skips the extraction step cleanly)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed end-to-end test failure summaries, including pass, fail, and skip counts.
  * Failure notifications now include a formatted list of failed tests with their failure messages, along with a link to the originating workflow run and clear retest guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->