### PR TITLE
CNV-93098: [release-4.22]  DOMPurify: Cross-site scripting vulnerability allows code execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11590,9 +11590,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
       "react-i18next": "~16.5.8"
     },
     "eslint": "^8.57.1",
-    "delaunator": "4.0.1"
+    "delaunator": "4.0.1",
+    "dompurify": "^3.4.6"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
Fix raised to bump the vulnerable dompurify package to patched version and mentioned the package in overrides since it is a transitive dependency