### PR TITLE
CNV-93564: Fix template breadcrumb navigating to /k8s/ns/all-namespaces

### DIFF
--- a/src/utils/resources/template/utils/url.ts
+++ b/src/utils/resources/template/utils/url.ts
@@ -1,4 +1,5 @@
 import { VirtualMachineTemplateModelRef } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { ALL_NAMESPACES, ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { FLEET_TEMPLATES_PATH } from '@multicluster/constants';
 import { getFleetTemplatesURL } from '@multicluster/urls';
 
@@ -12,8 +13,13 @@ export const getVMTemplateURL = (name: string, namespace: string, cluster?: stri
     ? `${getFleetTemplatesURL(cluster, namespace)}/vmt/${name}`
     : `/k8s/ns/${namespace}/${VirtualMachineTemplateModelRef}/${name}`;
 
-export const getTemplateListURL = (namespace?: string): string =>
-  namespace ? `/k8s/ns/${namespace}/templates` : `/k8s/all-namespaces/templates`;
+export const getTemplateListURL = (namespace?: string): string => {
+  if (!namespace || namespace === ALL_NAMESPACES || namespace === ALL_NAMESPACES_SESSION_KEY) {
+    return `/k8s/all-namespaces/templates`;
+  }
+
+  return `/k8s/ns/${namespace}/templates`;
+};
 
 export const getACMTemplateListURL = (): string =>
   `${FLEET_TEMPLATES_PATH}/all-clusters/all-namespaces`;

--- a/src/views/templates/details/TemplatePageTitle.tsx
+++ b/src/views/templates/details/TemplatePageTitle.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import { TemplateModel, VirtualMachineTemplateModel } from '@kubevirt-ui-ext/kubevirt-api/console';
@@ -6,18 +6,16 @@ import DetailsPageTitle from '@kubevirt-utils/components/DetailsPageTitle/Detail
 import PaneHeading from '@kubevirt-utils/components/PaneHeading/PaneHeading';
 import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
-import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { useLastNamespacePath } from '@kubevirt-utils/hooks/useLastNamespacePath';
 import { getName } from '@kubevirt-utils/resources/shared';
 import {
   getACMTemplateListURL,
-  getTemplateListURL,
   isDeprecatedTemplate,
   isOpenShiftTemplate,
-  Template,
+  type Template,
 } from '@kubevirt-utils/resources/template';
 import useIsACMPage from '@multicluster/useIsACMPage';
-import { useLastNamespace } from '@openshift-console/dynamic-plugin-sdk-internal';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -29,9 +27,8 @@ import {
 } from '@patternfly/react-core';
 
 import VirtualMachineTemplatesActions from '../actions/VirtualMachineTemplatesActions';
-
-import useEditTemplateAccessReview from './hooks/useIsTemplateEditable';
 import CommonTemplateAlert from './CommonTemplateAlert';
+import useEditTemplateAccessReview from './hooks/useIsTemplateEditable';
 import NoPermissionTemplateAlert from './NoPermissionTemplateAlert';
 
 type TemplatePageTitleTitleProps = {
@@ -42,7 +39,7 @@ const TemplatePageTitle: FC<TemplatePageTitleTitleProps> = ({ template }) => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
   const location = useLocation();
-  const [lastNamespace] = useLastNamespace();
+  const lastNamespacePath = useLastNamespacePath();
   const isACMPage = useIsACMPage();
   const { hasEditPermission, isCommonTemplate } = useEditTemplateAccessReview(template);
 
@@ -60,16 +57,12 @@ const TemplatePageTitle: FC<TemplatePageTitleTitleProps> = ({ template }) => {
         <Breadcrumb>
           <BreadcrumbItem>
             <Button
+              isInline
               onClick={() =>
                 navigate(
-                  isACMPage
-                    ? getACMTemplateListURL()
-                    : getTemplateListURL(
-                        lastNamespace === ALL_NAMESPACES_SESSION_KEY ? undefined : lastNamespace,
-                      ),
+                  isACMPage ? getACMTemplateListURL() : `/k8s/${lastNamespacePath}/templates`,
                 )
               }
-              isInline
               variant={ButtonVariant.link}
             >
               {t('Templates')}


### PR DESCRIPTION
## 📝 Description

The Templates breadcrumb on the template details page incorrectly navigated to `/k8s/ns/all-namespaces/templates` when the project scope was All projects.

`useLastNamespace()` can return `all-namespaces` (or `#ALL_NS#`), but the breadcrumb only treated `#ALL_NS#` as all-namespaces, so it built an `ns/...` URL.

This change:
- Uses `useLastNamespacePath()` for the breadcrumb (same pattern as VMI breadcrumbs)
- Hardens `getTemplateListURL` to treat both `all-namespaces` and `#ALL_NS#` as the all-namespaces list URL

## 🔗 Links

- https://issues.redhat.com/browse/CNV-93564

## 🎥 Demo

> N/A

## Test plan
- [ ] Open a template details page while project scope is **All projects**
- [ ] Click the **Templates** breadcrumb
- [ ] Confirm navigation goes to `/k8s/all-namespaces/templates` (not `/k8s/ns/all-namespaces/templates`)
- [ ] With a specific project selected, confirm breadcrumb still goes to `/k8s/ns/<project>/templates`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation between template details and template lists across namespace contexts.
  * Corrected template list routing when viewing all namespaces or a specific namespace.
  * Simplified breadcrumb navigation for non-ACM template views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->