### PR TITLE
CNV-93565: Fix VMT drawer error by generating params client-side

### DIFF
--- a/src/utils/resources/template/utils/generateParameterValue.test.ts
+++ b/src/utils/resources/template/utils/generateParameterValue.test.ts
@@ -1,0 +1,22 @@
+import { generateParameterValueFromExpression } from './generateParameterValue';
+
+describe('generateParameterValueFromExpression', () => {
+  it('returns empty string for empty input', () => {
+    expect(generateParameterValueFromExpression('')).toBe('');
+  });
+
+  it('preserves literal prefixes', () => {
+    const value = generateParameterValueFromExpression('fedora-[a-z0-9]{4}');
+    expect(value).toMatch(/^fedora-[a-z0-9]{4}$/);
+  });
+
+  it('generates values for digit class', () => {
+    const value = generateParameterValueFromExpression('[0-9]{6}');
+    expect(value).toMatch(/^\d{6}$/);
+  });
+
+  it('supports escaped digit class', () => {
+    const value = generateParameterValueFromExpression('\\d{4}');
+    expect(value).toMatch(/^\d{4}$/);
+  });
+});

--- a/src/utils/resources/template/utils/generateParameterValue.ts
+++ b/src/utils/resources/template/utils/generateParameterValue.ts
@@ -1,0 +1,97 @@
+const CHAR_CLASSES: Record<string, string> = {
+  '\\A': 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+  '\\a': 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
+  '\\d': '0123456789',
+  '\\w': 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_',
+};
+
+const pickRandomChar = (chars: string): string =>
+  chars.charAt(Math.floor(Math.random() * chars.length));
+
+const expandCharClass = (charClass: string): string => {
+  if (CHAR_CLASSES[charClass]) {
+    return CHAR_CLASSES[charClass];
+  }
+
+  // Ranges like a-z, A-Z, 0-9 inside [...]
+  let chars = '';
+  for (let i = 0; i < charClass.length; i++) {
+    if (charClass[i + 1] === '-' && charClass[i + 2]) {
+      const start = charClass.charCodeAt(i);
+      const end = charClass.charCodeAt(i + 2);
+      for (let code = start; code <= end; code++) {
+        chars += String.fromCharCode(code);
+      }
+      i += 2;
+      continue;
+    }
+    chars += charClass[i];
+  }
+  return chars;
+};
+
+/**
+ * Generates a value from a virt-template / OpenShift-style expression.
+ * Supports character classes ([a-z], [A-Z0-9], \w, \d, \a, \A) and {n} repetition.
+ */
+export const generateParameterValueFromExpression = (from: string): string => {
+  if (!from) {
+    return '';
+  }
+
+  let result = '';
+  let i = 0;
+
+  while (i < from.length) {
+    if (from[i] === '[') {
+      const end = from.indexOf(']', i);
+      if (end === -1) {
+        result += from[i];
+        i += 1;
+        continue;
+      }
+
+      const chars = expandCharClass(from.slice(i + 1, end));
+      i = end + 1;
+
+      let count = 1;
+      const repeatMatch = from.slice(i).match(/^\{(\d+)\}/);
+      if (repeatMatch) {
+        count = Number(repeatMatch[1]);
+        i += repeatMatch[0].length;
+      }
+
+      for (let n = 0; n < count; n++) {
+        result += pickRandomChar(chars || 'x');
+      }
+      continue;
+    }
+
+    if (from[i] === '\\' && from[i + 1]) {
+      const escape = `\\${from[i + 1]}`;
+      const chars = CHAR_CLASSES[escape];
+      i += 2;
+
+      let count = 1;
+      const repeatMatch = from.slice(i).match(/^\{(\d+)\}/);
+      if (repeatMatch) {
+        count = Number(repeatMatch[1]);
+        i += repeatMatch[0].length;
+      }
+
+      if (chars) {
+        for (let n = 0; n < count; n++) {
+          result += pickRandomChar(chars);
+        }
+      } else {
+        result += escape.slice(1).repeat(count);
+      }
+      continue;
+    }
+
+    result += from[i];
+    i += 1;
+  }
+
+  return result;
+};

--- a/src/utils/resources/template/utils/helpers.ts
+++ b/src/utils/resources/template/utils/helpers.ts
@@ -7,7 +7,6 @@ import {
   TemplateParameter,
   V1Template,
   VirtualMachineTemplateModel,
-  VirtualMachineTemplateRequestModel,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
@@ -32,6 +31,7 @@ import {
   TEMPLATE_TYPE_BASE,
   TEMPLATE_TYPE_LABEL,
 } from './constants';
+import { generateParameterValueFromExpression } from './generateParameterValue';
 import { getTemplatePVCName, getTemplateVirtualMachineObject } from './selectors';
 
 // Only used for replacing parameters in the template, do not use for anything else
@@ -179,6 +179,23 @@ export const updateTemplate = async (template: Template) => {
   return result;
 };
 
+const generateVirtualMachineTemplateParameters = (
+  template: Template,
+  excludedParameters: TemplateParameter[],
+): (TemplateParameter | V1alpha1VirtualMachineTemplateSpecParameters)[] => {
+  const generatedParameters = (getParameters(template) ?? []).map((parameter) => {
+    if (parameter.generate === 'expression' && parameter.from && !parameter.value) {
+      return {
+        ...parameter,
+        value: generateParameterValueFromExpression(parameter.from),
+      };
+    }
+    return parameter;
+  });
+
+  return [...generatedParameters, ...excludedParameters];
+};
+
 export const createProcessedTemplate = <T extends Template>(
   template: T,
   cluster: string,
@@ -188,12 +205,29 @@ export const createProcessedTemplate = <T extends Template>(
   setError: (value: SetStateAction<Error>) => void,
   setLoading: (value: SetStateAction<boolean>) => void,
 ) => {
+  // VirtualMachineTemplateRequest creates a template from a VM — it is not a process API.
+  // Generate expression parameters client-side for VMTs (matches virt-template expression syntax).
+  if (isVirtualMachineTemplate(template)) {
+    try {
+      const mergedParameters = generateVirtualMachineTemplateParameters(
+        template,
+        excludedParameters,
+      );
+      setTemplateWithGeneratedValues(replaceTemplateParameters(template, mergedParameters));
+      setError(null);
+    } catch (apiError) {
+      setTemplateWithGeneratedValues(template);
+      setError(apiError instanceof Error ? apiError : new Error(String(apiError)));
+    } finally {
+      setLoading(false);
+    }
+    return;
+  }
+
   kubevirtK8sCreate<T>({
     cluster,
     data: template,
-    model: isOpenShiftTemplate(template)
-      ? ProcessedTemplatesModel
-      : VirtualMachineTemplateRequestModel,
+    model: ProcessedTemplatesModel,
     ns: namespace,
     queryParams: {
       dryRun: 'All',


### PR DESCRIPTION
## 📝 Description

Selecting a VirtualMachineTemplate in the Create VM wizard caused the template details drawer to fail with:

`Invalid value: "VirtualMachineTemplate": must be VirtualMachineTemplateRequest`

**Cause:** `createProcessedTemplate` sent VMTs to `VirtualMachineTemplateRequest`, which creates a template from a VM — it is not a process/parameter-generation API.

**Fix:**
- Generate `expression` parameters client-side for VirtualMachineTemplates
- Keep using OpenShift `ProcessedTemplates` for OpenShift Templates
- Add unit tests for expression generation

## 🔗 Links

- https://issues.redhat.com/browse/CNV-93565

## 🎥 Demo

**BEFORE**

<img width="1863" height="1085" alt="Screenshot 2026-07-21 at 11 18 06" src="https://github.com/user-attachments/assets/b27c9c3c-f544-4044-b2a1-1b95b7781e3d" />


## Test plan
- [ ] Create VM → Template step → select a **VirtualMachineTemplate** with generated parameters
- [ ] Confirm the details drawer loads without the kind validation error
- [ ] Confirm OpenShift Templates still process parameters correctly
- [ ] Unit tests: `npm test -- --testPathPattern=generateParameterValue`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Virtual machine templates can now automatically generate parameter values from supported expressions, including character classes, ranges, repetitions, and escaped patterns.
  * Generated values preserve literal text and support excluded parameters during template processing.

* **Bug Fixes**
  * Improved template processing error handling and loading-state cleanup when parameter replacement fails.

* **Tests**
  * Added coverage for empty expressions, literal prefixes, numeric patterns, and escaped digit patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->