### PR TITLE
CNV-92254: Make HCO v1 availability check ACM-aware

### DIFF
--- a/src/utils/hooks/useVMTemplateFeatureFlag/constants.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/constants.ts
@@ -1,3 +1,5 @@
+import { HyperConvergedModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+
 export const KUBEVIRT_JSONPATCH_ANNOTATION = 'kubevirt.kubevirt.io/jsonpatch';
 export const TEMPLATE_FEATURE_GATE = 'Template';
 export const TEMPLATE_FEATURE_GATE_PATH =
@@ -9,9 +11,11 @@ export const ADD_TEMPLATE_FEATURE_GATE_PATCH = {
   value: TEMPLATE_FEATURE_GATE,
 };
 
-/** GVK used to detect whether HCO v1 (slice-based featureGates) is available. */
-export const HYPERCONVERGED_V1_GROUP_VERSION_KIND = {
-  group: 'hco.kubevirt.io',
-  kind: 'HyperConverged',
+/**
+ * Pinned to HCO v1 for availability detection (slice-based featureGates).
+ * HyperConvergedModelGroupVersionKind is v1beta1.
+ */
+export const HyperConvergedV1GroupVersionKind = {
+  ...HyperConvergedModelGroupVersionKind,
   version: 'v1',
 } as const;

--- a/src/utils/hooks/useVMTemplateFeatureFlag/tests/useIsHyperConvergedV1Available.test.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/tests/useIsHyperConvergedV1Available.test.ts
@@ -1,0 +1,105 @@
+import { operatorNamespaceSignal } from '@kubevirt-utils/store/operatorNamespace';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { HyperConvergedV1GroupVersionKind } from '../constants';
+import useIsHyperConvergedV1Available from '../useIsHyperConvergedV1Available';
+
+jest.mock('@kubevirt-utils/store/operatorNamespace', () => ({
+  operatorNamespaceSignal: { value: 'openshift-cnv' },
+}));
+
+jest.mock('@multicluster/hooks/useClusterParam', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('@multicluster/hooks/useK8sWatchData', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockUseClusterParam = useClusterParam as jest.Mock;
+const mockUseK8sWatchData = useK8sWatchData as jest.Mock;
+
+describe('useIsHyperConvergedV1Available', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    operatorNamespaceSignal.value = 'openshift-cnv';
+    mockUseClusterParam.mockReturnValue(undefined);
+  });
+
+  it('passes the default cluster to useK8sWatchData', () => {
+    mockUseClusterParam.mockReturnValue('hub');
+    mockUseK8sWatchData.mockReturnValue([[], true, undefined]);
+
+    renderHook(() => useIsHyperConvergedV1Available());
+
+    expect(mockUseK8sWatchData).toHaveBeenCalledWith({
+      cluster: 'hub',
+      groupVersionKind: HyperConvergedV1GroupVersionKind,
+      isList: true,
+      namespace: 'openshift-cnv',
+    });
+  });
+
+  it('passes an explicit clusterOverride to useK8sWatchData', () => {
+    mockUseClusterParam.mockReturnValue('hub');
+    mockUseK8sWatchData.mockReturnValue([[], true, undefined]);
+
+    renderHook(() => useIsHyperConvergedV1Available('spoke-a'));
+
+    expect(mockUseK8sWatchData).toHaveBeenCalledWith({
+      cluster: 'spoke-a',
+      groupVersionKind: HyperConvergedV1GroupVersionKind,
+      isList: true,
+      namespace: 'openshift-cnv',
+    });
+  });
+
+  it('should update availability after the HCO v1 probe completes', async () => {
+    mockUseK8sWatchData.mockReturnValue([[], false, undefined]);
+
+    const { rerender, result } = renderHook(() => useIsHyperConvergedV1Available());
+
+    expect(result.current).toEqual({ isHCOV1: false, loading: true });
+
+    mockUseK8sWatchData.mockReturnValue([[], true, undefined]);
+    rerender();
+
+    await waitFor(() => expect(result.current).toEqual({ isHCOV1: true, loading: false }));
+  });
+
+  it('returns available when the watch succeeds', () => {
+    mockUseK8sWatchData.mockReturnValue([[], true, undefined]);
+
+    const { result } = renderHook(() => useIsHyperConvergedV1Available());
+
+    expect(result.current).toEqual({ isHCOV1: true, loading: false });
+  });
+
+  it('returns unavailable for 404 responses', () => {
+    mockUseK8sWatchData.mockReturnValue([[], true, { code: 404 }]);
+
+    const { result } = renderHook(() => useIsHyperConvergedV1Available());
+
+    expect(result.current).toEqual({ isHCOV1: false, loading: false });
+  });
+
+  it('returns available for 403 responses', () => {
+    mockUseK8sWatchData.mockReturnValue([[], true, { response: { status: 403 } }]);
+
+    const { result } = renderHook(() => useIsHyperConvergedV1Available());
+
+    expect(result.current).toEqual({ isHCOV1: true, loading: false });
+  });
+
+  it('returns unavailable for indeterminate non-HTTP failures', () => {
+    mockUseK8sWatchData.mockReturnValue([[], true, new Error('Network Error')]);
+
+    const { result } = renderHook(() => useIsHyperConvergedV1Available());
+
+    expect(result.current).toEqual({ isHCOV1: false, loading: false });
+  });
+});

--- a/src/utils/hooks/useVMTemplateFeatureFlag/useIsHyperConvergedV1Available.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/useIsHyperConvergedV1Available.ts
@@ -1,19 +1,58 @@
+import {
+  isK8sForbiddenError,
+  isK8sNotFoundError,
+} from '@kubevirt-utils/resources/errorStatusChecks';
+import { operatorNamespaceSignal } from '@kubevirt-utils/store/operatorNamespace';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
-import { HYPERCONVERGED_V1_GROUP_VERSION_KIND } from './constants';
+import { HyperConvergedV1GroupVersionKind } from './constants';
+
+type UseIsHyperConvergedV1Available = (clusterOverride?: string) => {
+  isHCOV1: boolean;
+  loading: boolean;
+};
 
 /**
  * HCO v1 exposes slice-based featureGates (Template is Beta / first-class).
  * HCO v1beta1 still needs the Preview Features jsonpatch toggle.
+ * Probes the target cluster (ACM-aware) via a shared watch; does not use useK8sModel.
+ * @param clusterOverride
  */
-const useIsHyperConvergedV1Available = (): { isHCOV1: boolean; loading: boolean } => {
-  const [hcoV1Model, inFlight] = useK8sModel(HYPERCONVERGED_V1_GROUP_VERSION_KIND);
+const useIsHyperConvergedV1Available: UseIsHyperConvergedV1Available = (clusterOverride) => {
+  const clusterParam = useClusterParam();
+  const cluster = clusterOverride ?? clusterParam;
+  const operatorNamespace = operatorNamespaceSignal.value;
 
-  return {
-    isHCOV1: !inFlight && !isEmpty(hcoV1Model),
-    loading: inFlight,
-  };
+  const [, loaded, loadError] = useK8sWatchData<K8sResourceCommon[]>(
+    operatorNamespace
+      ? {
+          cluster,
+          groupVersionKind: HyperConvergedV1GroupVersionKind,
+          isList: true,
+          namespace: operatorNamespace,
+        }
+      : null,
+  );
+
+  if (isEmpty(operatorNamespace) || !loaded) {
+    return { isHCOV1: false, loading: true };
+  }
+
+  // 404 means HCO v1 is not served on the target cluster.
+  if (isK8sNotFoundError(loadError)) {
+    return { isHCOV1: false, loading: false };
+  }
+
+  // Successful watch, or 403 (API exists but LIST/WATCH is denied).
+  if (!loadError || isK8sForbiddenError(loadError)) {
+    return { isHCOV1: true, loading: false };
+  }
+
+  // Timeouts, transport failures, and 5xx are indeterminate — keep the toggle.
+  return { isHCOV1: false, loading: false };
 };
 
 export default useIsHyperConvergedV1Available;

--- a/src/utils/resources/errorStatusChecks.test.ts
+++ b/src/utils/resources/errorStatusChecks.test.ts
@@ -1,0 +1,35 @@
+import { isK8sForbiddenError, isK8sNotFoundError } from './errorStatusChecks';
+
+describe('errorStatusChecks', () => {
+  describe('isK8sNotFoundError', () => {
+    it.each([[{ code: 404 }], [{ response: { status: 404 } }], [{ json: { code: 404 } }]])(
+      'returns true for %j',
+      (error) => {
+        expect(isK8sNotFoundError(error)).toBe(true);
+      },
+    );
+
+    it.each([null, undefined, 'not found', { code: 403 }, { response: { status: 500 } }])(
+      'returns false for %j',
+      (error) => {
+        expect(isK8sNotFoundError(error)).toBe(false);
+      },
+    );
+  });
+
+  describe('isK8sForbiddenError', () => {
+    it.each([[{ code: 403 }], [{ response: { status: 403 } }], [{ json: { code: 403 } }]])(
+      'returns true for %j',
+      (error) => {
+        expect(isK8sForbiddenError(error)).toBe(true);
+      },
+    );
+
+    it.each([null, undefined, { code: 404 }, { response: { status: 500 } }])(
+      'returns false for %j',
+      (error) => {
+        expect(isK8sForbiddenError(error)).toBe(false);
+      },
+    );
+  });
+});

--- a/src/utils/resources/errorStatusChecks.ts
+++ b/src/utils/resources/errorStatusChecks.ts
@@ -1,16 +1,32 @@
+const HTTP_FORBIDDEN = 403;
 const HTTP_NOT_FOUND = 404;
 
-type K8sError = {
-  code?: number;
-  json?: { code?: number };
-  response?: { status?: number };
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const getK8sErrorStatus = (error: unknown): number | undefined => {
+  if (!isRecord(error)) return undefined;
+
+  if (typeof error.code === 'number') {
+    return error.code;
+  }
+
+  if (isRecord(error.response) && typeof error.response.status === 'number') {
+    return error.response.status;
+  }
+
+  if (isRecord(error.json) && typeof error.json.code === 'number') {
+    return error.json.code;
+  }
+
+  return undefined;
 };
 
-export const isK8sNotFoundError = (error: unknown): boolean => {
-  const err = error as K8sError | null | undefined;
-  return (
-    err?.code === HTTP_NOT_FOUND ||
-    err?.response?.status === HTTP_NOT_FOUND ||
-    err?.json?.code === HTTP_NOT_FOUND
-  );
-};
+const isK8sStatusError = (error: unknown, status: number): boolean =>
+  getK8sErrorStatus(error) === status;
+
+export const isK8sNotFoundError = (error: unknown): boolean =>
+  isK8sStatusError(error, HTTP_NOT_FOUND);
+
+export const isK8sForbiddenError = (error: unknown): boolean =>
+  isK8sStatusError(error, HTTP_FORBIDDEN);

--- a/src/views/settings/tabs/PreviewFeaturesTab/hooks/usePreviewFeaturesData.tsx
+++ b/src/views/settings/tabs/PreviewFeaturesTab/hooks/usePreviewFeaturesData.tsx
@@ -50,7 +50,7 @@ const usePreviewFeaturesData: UsePreviewFeaturesData = (cluster) => {
   );
   // HCO v1: Template is Beta / first-class — hide jsonpatch toggle.
   // HCO v1beta1 only: keep Preview Features toggle.
-  const { isHCOV1, loading: hcoV1Loading } = useIsHyperConvergedV1Available();
+  const { isHCOV1, loading: hcoV1Loading } = useIsHyperConvergedV1Available(cluster);
 
   const features: Feature[] = [
     {


### PR DESCRIPTION
## Summary
- Replace `useK8sModel` in `useIsHyperConvergedV1Available` with a cluster-aware `useK8sListData` probe against pinned `HyperConvergedV1Model` (`hco.kubevirt.io/v1`)
- Accept optional cluster override (ACM cluster param fallback) and pass `cluster` from `usePreviewFeaturesData`
- Keeps Preview Features VMT toggle hidden only when HCO v1 is available on the target cluster

## Links
- https://issues.redhat.com/browse/CNV-92254
- Follow-up to #4379

## Test plan
- [ ] Single-cluster / HCO v1: Preview Features does **not** show “Enable native VirtualMachine templates”
- [ ] Single-cluster / HCO v1beta1 only: toggle is still shown
- [ ] ACM: open Preview Features for a spoke with HCO v1 → toggle hidden for that cluster
- [ ] ACM: spoke with HCO v1beta1 only → toggle still shown


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection of HyperConverged v1 availability on a per-cluster basis.
  * VM Templates preview availability now reflects the selected cluster.
  * Clusters where access is restricted but the feature is present are handled as available.

* **Bug Fixes**
  * Improved handling of missing, forbidden, and unexpected cluster API responses.

* **Tests**
  * Added coverage for cluster selection, availability states, and Kubernetes error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->