### PR TITLE
CNV-93498: add data-test attributes to remaining plugin views

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -1367,6 +1367,7 @@
   "Mount point": "Mount point",
   "Mount Windows drivers disk": "Mount Windows drivers disk",
   "Move <1>{getName(vm)}</1> VirtualMachine to group": "Move <1>{getName(vm)}</1> VirtualMachine to group",
+  "Move to folder": "Move to folder",
   "Move to group": "Move to group",
   "Move virtual machine_one": "Move virtual machine",
   "Move virtual machine_other": "Move virtual machine",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -1384,6 +1384,7 @@
   "Mount point": "Punto de montaje",
   "Mount Windows drivers disk": "Montar disco de controladores de Windows",
   "Move <1>{getName(vm)}</1> VirtualMachine to group": "Move <1>{getName(vm)}</1> VirtualMachine to group",
+  "Move to folder": "Move to folder",
   "Move to group": "Move to group",
   "Move virtual machine_one": "Mover máquina virtual_one",
   "Move virtual machine_many": "Move virtual machine",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -1384,6 +1384,7 @@
   "Mount point": "Point de montage",
   "Mount Windows drivers disk": "Monter le disque des pilotes Windows",
   "Move <1>{getName(vm)}</1> VirtualMachine to group": "Move <1>{getName(vm)}</1> VirtualMachine to group",
+  "Move to folder": "Move to folder",
   "Move to group": "Move to group",
   "Move virtual machine_one": "Déplacer la machine virtuelle_one",
   "Move virtual machine_many": "Move virtual machine",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -1363,6 +1363,7 @@
   "Mount point": "マウントポイント",
   "Mount Windows drivers disk": "Windows ドライバーディスクのマウント",
   "Move <1>{getName(vm)}</1> VirtualMachine to group": "Move <1>{getName(vm)}</1> VirtualMachine to group",
+  "Move to folder": "Move to folder",
   "Move to group": "Move to group",
   "Move virtual machine_one": "仮想マシンを移動する",
   "Move virtual machine_other": "仮想マシンを移動する",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -1363,6 +1363,7 @@
   "Mount point": "마운트 지점",
   "Mount Windows drivers disk": "Windows 드라이버 디스크 마운트",
   "Move <1>{getName(vm)}</1> VirtualMachine to group": "Move <1>{getName(vm)}</1> VirtualMachine to group",
+  "Move to folder": "Move to folder",
   "Move to group": "Move to group",
   "Move virtual machine_one": "가상 머신 이동",
   "Move virtual machine_other": "가상 머신 이동",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -1363,6 +1363,7 @@
   "Mount point": "挂载点",
   "Mount Windows drivers disk": "挂载 Windows 驱动器磁盘",
   "Move <1>{getName(vm)}</1> VirtualMachine to group": "Move <1>{getName(vm)}</1> VirtualMachine to group",
+  "Move to folder": "Move to folder",
   "Move to group": "Move to group",
   "Move virtual machine_one": "移动虚拟机",
   "Move virtual machine_other": "移动虚拟机",

--- a/src/multicluster/extensions.ts
+++ b/src/multicluster/extensions.ts
@@ -65,7 +65,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-virtualmachines',
-        'data-test-id': 'virtualmachines-nav-item',
+        'data-test': 'virtualmachines-nav-item',
       },
       href: `${FLEET_VIRTUAL_MACHINES_PATH}/all-clusters/all-namespaces`,
       id: 'virtualmachines-virt-perspective',
@@ -79,7 +79,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-templates',
-        'data-test-id': 'templates-nav-item',
+        'data-test': 'templates-nav-item',
       },
       href: `${FLEET_TEMPLATES_PATH}/all-clusters/all-namespaces`,
       id: 'templates-virt-perspective',
@@ -94,7 +94,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-bootablevolumes',
-        'data-test-id': 'bootablevolumes-nav-item',
+        'data-test': 'bootablevolumes-nav-item',
       },
       href: `${FLEET_BOOTABLE_VOLUMES_PATH}/all-clusters/all-namespaces`,
       id: 'bootablevolumes-virt-perspective',
@@ -119,7 +119,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-instancetype',
-        'data-test-id': 'instancetype-nav-item',
+        'data-test': 'instancetype-nav-item',
       },
       href: `${FLEET_INSTANCETYPES_PATH}/all-clusters/all-namespaces`,
       id: 'instancetype-virt-perspective',
@@ -144,7 +144,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-migrationpolicies',
-        'data-test-id': 'migrationpolicies-nav-item',
+        'data-test': 'migrationpolicies-nav-item',
       },
       href: `${FLEET_MIGRATION_POLICIES_PATH}/all-clusters`,
       id: 'migrationpolicies-virt-perspective',
@@ -159,7 +159,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-checkups',
-        'data-test-id': 'checkups-nav-item',
+        'data-test': 'checkups-nav-item',
       },
       href: `${FLEET_CHECKUPS_PATH}/all-clusters/all-namespaces/storage`,
       id: 'checkups-virt-perspective',

--- a/src/perspective/navigation/clusterSection.ts
+++ b/src/perspective/navigation/clusterSection.ts
@@ -10,7 +10,7 @@ export const clusterSection: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-sec-cluster-virt-perspective',
-        'data-test-id': 'cluster-virt-perspective-nav-item',
+        'data-test': 'cluster-virt-perspective-nav-item',
       },
       id: 'cluster-virt-perspective',
       insertAfter: suffixId(NAV_ID.SETTINGS),
@@ -24,7 +24,7 @@ export const clusterSection: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-cluster-overview',
-        'data-test-id': 'cluster-overview-nav-item',
+        'data-test': 'cluster-overview-nav-item',
       },
       href: '/dashboards',
       id: 'overview-virt-perspective',

--- a/src/perspective/navigation/migrationSection.ts
+++ b/src/perspective/navigation/migrationSection.ts
@@ -11,7 +11,7 @@ export const migrationSection: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-sec-migration-virt-perspective',
-        'data-testid': 'migration-virt-perspective-nav-item',
+        'data-test': 'migration-virt-perspective-nav-item',
       },
       id: 'migration-virt-perspective',
       insertAfter: 'cluster-virt-perspective',
@@ -27,7 +27,7 @@ export const migrationSection: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-storagemigrations-virt-perspective',
-        'data-test-id': 'storagemigrations-virt-perspective-nav-item',
+        'data-test': 'storagemigrations-virt-perspective-nav-item',
       },
       href: 'storagemigrations',
       id: 'storagemigrations-virt-perspective',

--- a/src/perspective/navigation/networkingSection.ts
+++ b/src/perspective/navigation/networkingSection.ts
@@ -18,7 +18,7 @@ export const networkingSection: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-services',
-        'data-test-id': 'services-nav-item',
+        'data-test': 'services-nav-item',
       },
       id: 'services-virt-perspective',
       model: {
@@ -36,7 +36,7 @@ export const networkingSection: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-routes',
-        'data-test-id': 'routes-nav-item',
+        'data-test': 'routes-nav-item',
       },
       id: 'routes-virt-perspective',
       insertAfter: 'services-virt-perspective',
@@ -55,7 +55,7 @@ export const networkingSection: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-ingresses',
-        'data-test-id': 'ingresses-nav-item',
+        'data-test': 'ingresses-nav-item',
       },
       id: 'ingresses-virt-perspective',
       insertAfter: 'routes-virt-perspective',
@@ -74,7 +74,7 @@ export const networkingSection: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-networkpolicies',
-        'data-test-id': 'networkpolicies-nav-item',
+        'data-test': 'networkpolicies-nav-item',
       },
       id: 'networkpolicies-virt-perspective',
       insertAfter: 'ingresses-virt-perspective',
@@ -94,7 +94,7 @@ export const networkingSection: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-multinetworkpolicies',
-        'data-test-id': 'multinetworkpolicies-nav-item',
+        'data-test': 'multinetworkpolicies-nav-item',
       },
       id: 'multinetworkpolicies-virt-perspective',
       insertAfter: 'networkpolicies-virt-perspective',
@@ -116,7 +116,7 @@ export const networkingSection: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-nads',
-        'data-test-id': 'nads-nav-item',
+        'data-test': 'nads-nav-item',
       },
       id: 'networkattachmentdefinitions-virt-perspective',
       model: {
@@ -137,7 +137,7 @@ export const networkingSection: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-udns',
-        'data-test-id': 'udns-nav-item',
+        'data-test': 'udns-nav-item',
       },
       id: 'udns-virt-perspective',
       model: {

--- a/src/views/bootablevolumes/list/cells/BootableVolumeNameCell.tsx
+++ b/src/views/bootablevolumes/list/cells/BootableVolumeNameCell.tsx
@@ -94,11 +94,11 @@ const BootableVolumeNameCell: FC<BootableVolumeNameCellProps> = ({ callbacks, ro
   }, [isDataSource, cluster, row, bootableVolumeName, bootableVolumeNamespace]);
 
   return (
-    <>
+    <span data-test={bootableVolumeName}>
       {resourceLink}
       {isDeprecated(bootableVolumeName) && <DeprecatedBadge />}
       {isDataSource && isCloning && <Label>{t('Clone in progress')}</Label>}
-    </>
+    </span>
   );
 };
 

--- a/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCFormMode.tsx
+++ b/src/views/cdi-upload-provider/upload-pvc-form/UploadPVCFormMode.tsx
@@ -19,7 +19,7 @@ const UploadPVCFormMode = ({
   const provisioner =
     storageClasses?.find((sc) => sc.metadata.name === storageClassName)?.provisioner || '';
   return applySP ? (
-    <div data-test="sp-default-settings">
+    <div>
       {t('Access mode: {{accessMode}} / Volume mode: {{volumeMode}}', {
         accessMode,
         volumeMode,

--- a/src/views/checkups/self-validation/components/form/components/WindowsEulaCheckbox.tsx
+++ b/src/views/checkups/self-validation/components/form/components/WindowsEulaCheckbox.tsx
@@ -30,7 +30,6 @@ const WindowsEulaCheckbox: FC<WindowsEulaCheckboxProps> = ({
             for each deployment or installation for the Microsoft product(s).
           </Trans>
         }
-        data-test="windows-eula-checkbox"
         id="windows-eula-checkbox"
         isChecked={isEulaConfirmed}
         onChange={(_event, checked) => setIsEulaConfirmed(checked)}

--- a/src/views/checkups/self-validation/components/form/components/WindowsTestingSwitch.tsx
+++ b/src/views/checkups/self-validation/components/form/components/WindowsTestingSwitch.tsx
@@ -32,7 +32,6 @@ const WindowsTestingSwitch: FC<WindowsTestingSwitchProps> = ({
         </>
       }
       className="pf-v6-u-mb-sm"
-      data-test="windows-eula-switch"
       id="accept-windows-eula"
       isChecked={acceptWindowsEula}
       isDisabled={!isTier2Selected}

--- a/src/views/checkups/self-validation/list/checkupsSelfValidationCells.tsx
+++ b/src/views/checkups/self-validation/list/checkupsSelfValidationCells.tsx
@@ -38,7 +38,10 @@ export const NameCell: FC<{ row: IoK8sApiCoreV1ConfigMap }> = ({ row }) => {
   }
 
   return (
-    <Link to={getSelfValidationCheckupURL(name, namespace, isACMPage ? cluster : undefined)}>
+    <Link
+      data-test={name}
+      to={getSelfValidationCheckupURL(name, namespace, isACMPage ? cluster : undefined)}
+    >
       {name}
     </Link>
   );

--- a/src/views/checkups/storage/list/checkupsStorageCells.tsx
+++ b/src/views/checkups/storage/list/checkupsStorageCells.tsx
@@ -35,7 +35,12 @@ export const NameCell: FC<{ row: IoK8sApiCoreV1ConfigMap }> = ({ row }) => {
   }
 
   return (
-    <Link to={getStorageCheckupURL(name, namespace, isACMPage ? cluster : undefined)}>{name}</Link>
+    <Link
+      data-test={name}
+      to={getStorageCheckupURL(name, namespace, isACMPage ? cluster : undefined)}
+    >
+      {name}
+    </Link>
   );
 };
 

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/MigrationsCells.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/MigrationsCells.tsx
@@ -39,7 +39,7 @@ export const VMNameCell: FC<CellProps> = ({ row }) => {
   const cluster = getCluster(vmiObj) ?? getCluster(vmim);
 
   if (!vmName) {
-    return <span data-test="migration-vm-name-unknown">{NO_DATA_DASH}</span>;
+    return <span>{NO_DATA_DASH}</span>;
   }
 
   return (
@@ -61,7 +61,7 @@ export const NamespaceCell: FC<CellProps> = ({ row }) => {
   const cluster = getCluster(vmiObj) ?? getCluster(vmim);
 
   if (!namespace) {
-    return <span data-test="migration-namespace-unknown">{NO_DATA_DASH}</span>;
+    return <span>{NO_DATA_DASH}</span>;
   }
 
   return (

--- a/src/views/clusteroverview/OverviewTab/activity-card/ActivityCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/activity-card/ActivityCard.tsx
@@ -12,7 +12,7 @@ import RecentEvent from './utils/RecentEvent';
 const ActivityCard: FC = memo(() => {
   const { t } = useKubevirtTranslation();
   return (
-    <Card className="co-overview-card--gradient" data-test-id="kv-activity-card">
+    <Card className="co-overview-card--gradient">
       <CardHeader
         actions={{
           actions: <Link to={VIEW_EVENTS_PATH}>{t('View events')}</Link>,

--- a/src/views/clusteroverview/OverviewTab/getting-started-card/utils/getting-started-content/GettingStartedSectionContents.tsx
+++ b/src/views/clusteroverview/OverviewTab/getting-started-card/utils/getting-started-content/GettingStartedSectionContents.tsx
@@ -51,11 +51,7 @@ const GettingStartedSectionContents: FC<GettingStartedSectionContentsProps> = ({
         {title}
       </Title>
 
-      {description ? (
-        <Content component={ContentVariants.small} data-test="description">
-          {description}
-        </Content>
-      ) : null}
+      {description ? <Content component={ContentVariants.small}>{description}</Content> : null}
 
       <Flex direction={{ default: 'column' }} grow={{ default: 'grow' }}>
         {links?.length > 0 ? (

--- a/src/views/clusteroverview/OverviewTab/inventory-card/InventoryCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/inventory-card/InventoryCard.tsx
@@ -25,7 +25,7 @@ const InventoryCard: FC = () => {
   const vms = isAdmin ? resources?.vms : getAllowedResourceData(resources, VirtualMachineModel);
 
   return (
-    <Card data-test-id="kv-running-inventory-card">
+    <Card data-test="inventory-card">
       <CardHeader>
         <CardTitle>{t('Inventory')}</CardTitle>
       </CardHeader>

--- a/src/views/clusteroverview/OverviewTab/resources-inventory-card/ResourcesInventoryCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/resources-inventory-card/ResourcesInventoryCard.tsx
@@ -21,7 +21,7 @@ const ResourcesInventoryCard: FC = () => {
   const [activeNamespace] = useActiveNamespace();
 
   return (
-    <div className="resources-inventory-card" data-test-id="resources-inventory-card">
+    <div className="resources-inventory-card">
       <Grid className="resources-inventory-card__grid" hasGutter>
         <GridItem>
           <Card className="resources-inventory-card__grid-item">

--- a/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusesCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusesCard.tsx
@@ -71,7 +71,7 @@ const VMStatusesCard: FC = () => {
   const isLoaded = loaded && observabilityLoaded;
 
   return (
-    <Card className="vm-statuses-card" data-test-id="vm-statuses-card">
+    <Card className="vm-statuses-card" data-test="vm-statuses-card">
       <CardHeader className="vm-statuses-card__header">
         <CardTitle>{t('VirtualMachine statuses')}</CardTitle>
       </CardHeader>

--- a/src/views/clusteroverview/OverviewTab/vms-per-resource-card/VMsPerResourceCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/vms-per-resource-card/VMsPerResourceCard.tsx
@@ -21,7 +21,7 @@ const VMsPerResourceCard = () => {
   };
 
   return (
-    <Card data-test-id="vms-per-template-card">
+    <Card data-test="vms-per-template-card">
       <CardHeader
         actions={{
           actions: (

--- a/src/views/datasources/actions/DataSourceActions.tsx
+++ b/src/views/datasources/actions/DataSourceActions.tsx
@@ -58,7 +58,6 @@ const DataSourceActions: FC<DataSourceActionProps> = ({
   return (
     <Dropdown
       className="kubevirt-data-source-actions"
-      data-test-id="data-source-actions"
       isOpen={isOpen}
       onOpenChange={setIsOpen}
       popperProps={{ appendTo: getContentScrollableElement, position: 'right' }}
@@ -71,7 +70,7 @@ const DataSourceActions: FC<DataSourceActionProps> = ({
         >
           {dsActions?.map((action) => (
             <DropdownItem
-              data-test-id={action?.id}
+              data-test={action?.id}
               description={action?.description}
               isDisabled={action?.disabled}
               key={action?.id}
@@ -84,7 +83,6 @@ const DataSourceActions: FC<DataSourceActionProps> = ({
         <Divider key="divider" />
         <DropdownGroup key="datasource-manage" label={t('DataImportCron')}>
           <DropdownItem
-            data-test-id="datasource-manage"
             description={manageAction?.description}
             isDisabled={manageAction?.disabled}
             key="datasource-manage"

--- a/src/views/datasources/dataimportcron/details/DataImportCronManageDetails/DataImportCronManageDetails.tsx
+++ b/src/views/datasources/dataimportcron/details/DataImportCronManageDetails/DataImportCronManageDetails.tsx
@@ -61,7 +61,6 @@ export const DataImportCronManageDetails: FC<DataImportCronManageDetailsProps> =
                   <DescriptionListDescription>
                     <ClipboardCopy
                       clickTip={t('Copied')}
-                      data-test="cron-copy-command"
                       hoverTip={t('Copy to clipboard')}
                       isReadOnly
                     >
@@ -75,7 +74,6 @@ export const DataImportCronManageDetails: FC<DataImportCronManageDetailsProps> =
           />
         </DescriptionList>
       }
-      data-test-id="dataimportcron-manage-details"
       descriptionHeader={t('Automatic update and scheduling')}
       isEdit={!isOwnedBySSP}
       onEditClick={onEditClick}

--- a/src/views/datasources/dataimportcron/details/DataImportCronManageModal/DataImportCronManageModal.tsx
+++ b/src/views/datasources/dataimportcron/details/DataImportCronManageModal/DataImportCronManageModal.tsx
@@ -102,7 +102,7 @@ export const DataImportCronManageModal: FC<DataImportCronManageModalProps> = ({
               <FormTextInput
                 {...register('url', { required: true })}
                 aria-label={t('Registry URL')}
-                data-test-id={'dataimportcron-manage-source-url'}
+                data-test={'dataimportcron-manage-source-url'}
                 defaultValue={dataImportCron?.spec?.template.spec?.source?.registry?.url}
                 id={'dataimportcron-manage-source-url'}
                 type="text"
@@ -194,7 +194,7 @@ export const DataImportCronManageModal: FC<DataImportCronManageModalProps> = ({
                       errors?.['schedule'] ? ValidatedOptions.error : ValidatedOptions.default
                     }
                     aria-label={t('Cron expression')}
-                    data-test-id={'dataimportcron-manage-cron'}
+                    data-test={'dataimportcron-manage-cron'}
                     defaultValue={dataImportCron?.spec?.schedule}
                     id={'dataimportcron-manage-source-cron'}
                     type="text"

--- a/src/views/datasources/dataimportcron/details/DataImportCronPageTitle.tsx
+++ b/src/views/datasources/dataimportcron/details/DataImportCronPageTitle.tsx
@@ -40,7 +40,7 @@ const DataImportCronPageTitle: FC<DataImportCronPageTitleProps> = ({
       <PaneHeading>
         <Title className="co-resource-item" headingLevel="h1">
           <span className="co-m-resource-icon co-m-resource-icon--lg">{t('DIC')}</span>
-          <span data-test-id="resource-title">{name ?? dataImportCron?.metadata?.name} </span>
+          <span data-test="resource-title">{name ?? dataImportCron?.metadata?.name} </span>
         </Title>
         <DataImportCronActions dataImportCron={dataImportCron} />
       </PaneHeading>

--- a/src/views/datasources/details/DataSourcePageTitle.tsx
+++ b/src/views/datasources/details/DataSourcePageTitle.tsx
@@ -48,7 +48,7 @@ const DataSourcePageTitle: FC<DataSourcePageTitleProps> = ({ dataSource, name, n
       <PaneHeading>
         <Title className="co-resource-item" headingLevel="h1">
           <span className="co-m-resource-icon co-m-resource-icon--lg">{t('DS')}</span>
-          <span data-test-id="resource-title">{name ?? dataSource?.metadata?.name} </span>
+          <span data-test="resource-title">{name ?? dataSource?.metadata?.name} </span>
           {isDataSourceReady(dataSource) && (
             <span className="dps-resource-item__resource-status pf-v6-u-display-none pf-v6-u-display-inline-on-md">
               <Label isCompact>{t('Ready')}</Label>

--- a/src/views/datasources/list/CreateDataSourceModal/CreateDataSourceForm.tsx
+++ b/src/views/datasources/list/CreateDataSourceModal/CreateDataSourceForm.tsx
@@ -45,7 +45,6 @@ export const CreateDataSourceForm: FC<CreateDataSourceFormProps> = ({
         <FormTextInput
           {...register('name', { required: true })}
           aria-label={t('Name')}
-          data-test-id="datasource-create-name"
           id="datasource-create-name"
           type="text"
           validated={errors?.['name'] ? ValidatedOptions.error : ValidatedOptions.default}
@@ -65,7 +64,7 @@ export const CreateDataSourceForm: FC<CreateDataSourceFormProps> = ({
         <FormTextInput
           {...register('url', { required: true })}
           aria-label={t('Registry URL')}
-          data-test-id={'datasource-create-source-url'}
+          data-test={'datasource-create-source-url'}
           id={'datasource-create-source-url'}
           type="text"
           validated={errors?.['url'] ? ValidatedOptions.error : ValidatedOptions.default}
@@ -140,7 +139,7 @@ export const CreateDataSourceForm: FC<CreateDataSourceFormProps> = ({
             },
           })}
           aria-label={t('Cron expression')}
-          data-test-id={'datasource-create-cron'}
+          data-test={'datasource-create-cron'}
           id={'datasource-create-source-cron'}
           isRequired
           type="text"

--- a/src/views/instancetypes/list/InstanceTypePage.tsx
+++ b/src/views/instancetypes/list/InstanceTypePage.tsx
@@ -115,19 +115,13 @@ const InstanceTypePage: FC<ListPageProps> = (props) => {
         usePageInsets
       >
         <Tab
-          title={
-            <TabTitleText data-test="cluster-instancetype-tab">
-              {t('Cluster InstanceTypes')}
-            </TabTitleText>
-          }
+          title={<TabTitleText>{t('Cluster InstanceTypes')}</TabTitleText>}
           eventKey={CLUSTER_INSTANCETYPE_TAB_INDEX}
         >
           <ClusterInstancetypeList {...props} />
         </Tab>
         <Tab
-          title={
-            <TabTitleText data-test="user-instancetype-tab">{t('User InstanceTypes')}</TabTitleText>
-          }
+          title={<TabTitleText>{t('User InstanceTypes')}</TabTitleText>}
           eventKey={USER_INSTANCETYPE_TAB_INDEX}
         >
           <UserInstancetypeList

--- a/src/views/instancetypes/list/clusterInstancetypeDefinition.tsx
+++ b/src/views/instancetypes/list/clusterInstancetypeDefinition.tsx
@@ -17,7 +17,7 @@ import { getCluster } from '@multicluster/helpers/selectors';
 import ClusterInstancetypeActions from '../actions/ClusterInstancetypeActions';
 
 const NameCell = ({ row }: { row: V1beta1VirtualMachineClusterInstancetype }) => (
-  <>
+  <span data-test={getName(row)}>
     <MulticlusterResourceLink
       cluster={getCluster(row)}
       groupVersionKind={VirtualMachineClusterInstancetypeModelGroupVersionKind}
@@ -25,7 +25,7 @@ const NameCell = ({ row }: { row: V1beta1VirtualMachineClusterInstancetype }) =>
       name={getName(row)}
     />
     <RedHatLabel obj={row} />
-  </>
+  </span>
 );
 
 const ClusterCell = ({ row }: { row: V1beta1VirtualMachineClusterInstancetype }) => (

--- a/src/views/instancetypes/list/userInstancetypeDefinition.tsx
+++ b/src/views/instancetypes/list/userInstancetypeDefinition.tsx
@@ -17,7 +17,7 @@ import { getCluster } from '@multicluster/helpers/selectors';
 import UserInstancetypeActions from '../actions/UserInstancetypeActions';
 
 const NameCell = ({ row }: { row: V1beta1VirtualMachineInstancetype }) => (
-  <>
+  <span data-test={getName(row)}>
     <MulticlusterResourceLink
       cluster={getCluster(row)}
       groupVersionKind={VirtualMachineInstancetypeModelGroupVersionKind}
@@ -26,7 +26,7 @@ const NameCell = ({ row }: { row: V1beta1VirtualMachineInstancetype }) => (
       namespace={getNamespace(row)}
     />
     <RedHatLabel obj={row} />
-  </>
+  </span>
 );
 
 const ClusterCell = ({ row }: { row: V1beta1VirtualMachineInstancetype }) => (

--- a/src/views/migrationpolicies/components/MigrationPolicyConfigurations/MigrationPolicyConfigurations.tsx
+++ b/src/views/migrationpolicies/components/MigrationPolicyConfigurations/MigrationPolicyConfigurations.tsx
@@ -42,7 +42,7 @@ const MigrationPolicyConfigurations: FC<MigrationPolicyConfigurationsProps> = ({
             ([key, { component: Component, label }]) =>
               key in state && (
                 <FormGroup
-                  data-test-id={`${key}-selected`}
+                  data-test={`${key}-selected`}
                   fieldId={key}
                   hasNoPaddingTop
                   key={key}

--- a/src/views/migrationpolicies/components/MigrationPolicyConfigurations/compnents/CompletionTimeout/CompletionTimeout.tsx
+++ b/src/views/migrationpolicies/components/MigrationPolicyConfigurations/compnents/CompletionTimeout/CompletionTimeout.tsx
@@ -19,7 +19,6 @@ const CompletionTimeout: FC<CompletionTimeoutProps> = ({
       onChange={(event: ChangeEvent<HTMLInputElement>) =>
         +event?.target?.value >= 0 && setState(+event.target.value)
       }
-      data-test-id="migration-policy-completion-timeout-input"
       id="migration-policy-completion-timeout-input"
       min={0}
       minusBtnAriaLabel={t('Decrement')}

--- a/src/views/migrationpolicies/components/MigrationPolicyConfigurations/compnents/MigrationPolicyConfigurationDropdown/MigrationPolicyConfigurationDropdown.tsx
+++ b/src/views/migrationpolicies/components/MigrationPolicyConfigurations/compnents/MigrationPolicyConfigurationDropdown/MigrationPolicyConfigurationDropdown.tsx
@@ -42,14 +42,13 @@ const MigrationPolicyConfigurationDropdown: FC<MigrationPolicyConfigurationDropd
         onClick: onToggle,
       })}
       className="migration-policy__form-config-dropdown"
-      data-test-id="migration-policies-configurations"
       isOpen={isOpen}
       onOpenChange={setIsOpen}
     >
       <DropdownList>
         {Object.entries(options).map(([key, { defaultValue, description, label }]) => (
           <DropdownItem
-            data-test-id={key}
+            data-test={key}
             description={description}
             isDisabled={key in state}
             key={key}

--- a/src/views/migrationpolicies/details/components/MigrationPolicyBreadcrumb/MigrationPolicyBreadcrumb.tsx
+++ b/src/views/migrationpolicies/details/components/MigrationPolicyBreadcrumb/MigrationPolicyBreadcrumb.tsx
@@ -13,7 +13,7 @@ export const MigrationPolicyBreadcrumb: FC = () => {
 
   return (
     <Breadcrumb>
-      <BreadcrumbItem data-test-id="breadcrumb-link-0">
+      <BreadcrumbItem>
         <Link to={migrationPoliciesClusterListPage}>{t('MigrationPolicies')}</Link>
       </BreadcrumbItem>
       <BreadcrumbItem>{t('MigrationPolicy details')}</BreadcrumbItem>

--- a/src/views/migrationpolicies/list/MigrationPoliciesCells.tsx
+++ b/src/views/migrationpolicies/list/MigrationPoliciesCells.tsx
@@ -27,11 +27,13 @@ export const NameCell: FC<CellProps> = ({ row }) => {
 
   return (
     <span data-test={`migration-policy-name-${getName(row)}`}>
-      <MulticlusterResourceLink
-        cluster={isACMPage ? cluster : undefined}
-        groupVersionKind={MigrationPolicyModelGroupVersionKind}
-        name={getName(row)}
-      />
+      <span data-test={`policy-${getName(row)}`}>
+        <MulticlusterResourceLink
+          cluster={isACMPage ? cluster : undefined}
+          groupVersionKind={MigrationPolicyModelGroupVersionKind}
+          name={getName(row)}
+        />
+      </span>
     </span>
   );
 };

--- a/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/copmonents/MigrationPolicyFormFooter/MigrationPolicyFormFooter.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/copmonents/MigrationPolicyFormFooter/MigrationPolicyFormFooter.tsx
@@ -79,7 +79,11 @@ const MigrationPolicyFormFooter: FC<MigrationPolicyFormFooterProps> = ({ migrati
             </Button>
           </ActionListItem>
           <ActionListItem>
-            <Button onClick={closeModal} variant={ButtonVariant.link}>
+            <Button
+              data-test="modal-cancel-action"
+              onClick={closeModal}
+              variant={ButtonVariant.link}
+            >
               {t('Cancel')}
             </Button>
           </ActionListItem>

--- a/src/views/navigation/virtualizationSection.ts
+++ b/src/views/navigation/virtualizationSection.ts
@@ -33,7 +33,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-sec-virtualization',
-        'data-test-id': 'virtualization-nav-item',
+        'data-test': 'virtualization-nav-item',
       },
       id: VIRT_SECTION_ID,
       insertAfter: 'workloads',
@@ -45,7 +45,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-virtualmachines',
-        'data-test-id': 'virtualmachines-nav-item',
+        'data-test': 'virtualmachines-nav-item',
       },
       id: NAV_ID.VIRTUAL_MACHINES,
       insertAfter: VIRT_SECTION_ID,
@@ -63,7 +63,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-templates',
-        'data-test-id': 'templates-nav-item',
+        'data-test': 'templates-nav-item',
       },
       href: 'templates',
       id: NAV_ID.TEMPLATES,
@@ -78,7 +78,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-bootablevolumes',
-        'data-test-id': 'bootablevolumes-nav-item',
+        'data-test': 'bootablevolumes-nav-item',
       },
       href: 'bootablevolumes',
       id: NAV_ID.BOOTABLE_VOLUMES,
@@ -107,7 +107,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-virtualmachineclusterinstancetypes',
-        'data-test-id': 'virtualmachineclusterinstancetypes-nav-item',
+        'data-test': 'virtualmachineclusterinstancetypes-nav-item',
       },
       id: NAV_ID.INSTANCE_TYPES,
       insertAfter: NAV_ID.SEPARATOR_1,
@@ -128,7 +128,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-vmnetwork',
-        'data-test-id': 'vmnetwork-nav-item',
+        'data-test': 'vmnetwork-nav-item',
       },
       href: '/k8s/cluster/virtualmachine-networks',
       id: NAV_ID.VM_NETWORKS,
@@ -154,7 +154,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-migrationpolicies',
-        'data-test-id': 'migrationpolicies-nav-item',
+        'data-test': 'migrationpolicies-nav-item',
       },
       id: NAV_ID.MIGRATION_POLICIES,
       insertAfter: NAV_ID.SEPARATOR_2,
@@ -175,7 +175,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-quotas',
-        'data-test-id': 'quotas-nav-item',
+        'data-test': 'quotas-nav-item',
       },
       href: 'quotas',
       id: NAV_ID.QUOTAS,
@@ -194,7 +194,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-virtualization-checkups',
-        'data-test-id': 'virtualization-checkups-nav-item',
+        'data-test': 'virtualization-checkups-nav-item',
       },
       href: 'checkups',
       id: NAV_ID.CHECKUPS,
@@ -219,7 +219,7 @@ export const extensions: EncodedExtension[] = [
   {
     properties: {
       dataAttributes: {
-        'data-test-id': 'virtualization-settings-nav-item',
+        'data-test': 'virtualization-settings-nav-item',
       },
       href: 'virtualization-settings',
       id: NAV_ID.SETTINGS,

--- a/src/views/preferences/list/PreferencePage.tsx
+++ b/src/views/preferences/list/PreferencePage.tsx
@@ -99,22 +99,10 @@ const PreferencePage: FC<ListPageProps> = (props) => {
         activeKey={activeTabKey}
         style={{ flexShrink: 0 }}
       >
-        <Tab
-          title={
-            <TabTitleText data-test="cluster-preferences-tab">
-              {t('Cluster Preferences')}
-            </TabTitleText>
-          }
-          eventKey={0}
-        >
+        <Tab title={<TabTitleText>{t('Cluster Preferences')}</TabTitleText>} eventKey={0}>
           <ClusterPreferenceList {...props} />
         </Tab>
-        <Tab
-          title={
-            <TabTitleText data-test="user-preferences-tab">{t('User Preferences')}</TabTitleText>
-          }
-          eventKey={1}
-        >
+        <Tab title={<TabTitleText>{t('User Preferences')}</TabTitleText>} eventKey={1}>
           <UserPreferenceList {...props} />
         </Tab>
       </Tabs>

--- a/src/views/quotas/details/QuotaPageTitle.tsx
+++ b/src/views/quotas/details/QuotaPageTitle.tsx
@@ -37,7 +37,7 @@ const QuotaPageTitle: FC<QuotaPageTitleProps> = ({ name, namespace, quota }) => 
     >
       <PaneHeading>
         <Title className="co-resource-item" headingLevel="h1">
-          <span data-test-id="resource-title">{name ?? quota?.metadata?.name}</span>
+          <span data-test="resource-title">{name ?? quota?.metadata?.name}</span>
         </Title>
         <QuotaActions quota={quota} />
       </PaneHeading>

--- a/src/views/search/components/AdvancedSearchModal/AdvancedSearchModal.tsx
+++ b/src/views/search/components/AdvancedSearchModal/AdvancedSearchModal.tsx
@@ -103,7 +103,7 @@ const AdvancedSearchModal: FC<AdvancedSearchModalProps> = ({
     >
       <ModalHeader title={t('Advanced search')} />
       <ModalBody>
-        <div data-test="adv-search-details">
+        <div>
           <ModalExpandableSection title={t('Details')}>
             <Form isHorizontal>
               <NameField />

--- a/src/views/search/components/AdvancedSearchModal/formFields/ArchitectureField.tsx
+++ b/src/views/search/components/AdvancedSearchModal/formFields/ArchitectureField.tsx
@@ -30,7 +30,6 @@ const ArchitectureField: FC<ArchitectureFieldProps> = ({ vms }) => {
     <FormGroup label={t('Architecture type')}>
       <MultiSelectTypeahead
         allResourceNames={allArchitectures}
-        data-test="adv-search-vm-architecture-type"
         selectedResourceNames={value}
         selectPlaceholder={t('Select architecture type')}
         setSelectedResourceNames={setValue}

--- a/src/views/search/components/AdvancedSearchModal/formFields/CPUField.tsx
+++ b/src/views/search/components/AdvancedSearchModal/formFields/CPUField.tsx
@@ -18,7 +18,6 @@ const CPUField: FC = () => {
     <FormGroup label={t('vCPU')}>
       <InputGroup>
         <NumberOperatorSelect
-          data-test="adv-search-vcpu-operator"
           onSelect={(operator) => setVCPU({ ...vCPU, operator })}
           selected={vCPU.operator}
         />

--- a/src/views/search/components/AdvancedSearchModal/formFields/ClusterField.tsx
+++ b/src/views/search/components/AdvancedSearchModal/formFields/ClusterField.tsx
@@ -18,7 +18,6 @@ const ClusterField: FC = () => {
     <FormGroup label={t('Cluster')}>
       <MultiSelectTypeahead
         allResourceNames={clusterNames}
-        data-test="adv-search-vm-cluster"
         emptyValuePlaceholder={t('All clusters')}
         selectedResourceNames={value}
         selectPlaceholder={t('Select cluster')}

--- a/src/views/search/components/AdvancedSearchModal/formFields/DateCreatedField.tsx
+++ b/src/views/search/components/AdvancedSearchModal/formFields/DateCreatedField.tsx
@@ -37,7 +37,6 @@ const DateCreatedField: FC = () => {
       {effectiveDateOption === DateSelectOption.Custom && (
         <div className="pf-v6-u-mt-sm">
           <DateFromToPicker
-            data-test="adv-search-date"
             dateFromString={dateFromString}
             dateToString={dateToString}
             setDateFromString={setDateFromString}

--- a/src/views/search/components/AdvancedSearchModal/formFields/LabelsField.tsx
+++ b/src/views/search/components/AdvancedSearchModal/formFields/LabelsField.tsx
@@ -24,7 +24,6 @@ const LabelsField: FC<LabelsFieldProps> = ({ vms }) => {
     <FormGroup label={t('Labels')}>
       <MultiSelectTypeahead
         allResourceNames={allLabels}
-        data-test="adv-search-vm-labels"
         initialInputValue={labelInputValue}
         selectedResourceNames={value}
         selectPlaceholder={t('Add label')}

--- a/src/views/search/components/AdvancedSearchModal/formFields/MemoryField.tsx
+++ b/src/views/search/components/AdvancedSearchModal/formFields/MemoryField.tsx
@@ -19,7 +19,6 @@ const MemoryField: FC = () => {
     <FormGroup label={t('Memory')}>
       <InputGroup>
         <NumberOperatorSelect
-          data-test="adv-search-mem-operator"
           onSelect={(operator) => setMemory({ ...memory, operator })}
           selected={memory.operator}
         />
@@ -31,7 +30,6 @@ const MemoryField: FC = () => {
           />
         </InputGroupItem>
         <MemoryUnitSelect
-          data-test="adv-search-mem-unit"
           onSelect={(unit) => setMemory({ ...memory, unit })}
           selected={memory.unit}
         />

--- a/src/views/search/components/AdvancedSearchModal/formFields/ProjectField.tsx
+++ b/src/views/search/components/AdvancedSearchModal/formFields/ProjectField.tsx
@@ -23,7 +23,6 @@ const ProjectField: FC<ProjectFieldProps> = ({ vms }) => {
     <FormGroup label={t('Project')}>
       <MultiSelectTypeahead
         allResourceNames={allProjectNames}
-        data-test="adv-search-vm-project"
         emptyValuePlaceholder={t('All projects')}
         selectedResourceNames={value}
         selectPlaceholder={t('Select project')}

--- a/src/views/search/components/AdvancedSearchModal/formFields/StatusField.tsx
+++ b/src/views/search/components/AdvancedSearchModal/formFields/StatusField.tsx
@@ -16,7 +16,6 @@ const StatusField: FC = () => {
     <FormGroup label={t('Status')}>
       <MultiSelectTypeahead
         allResourceNames={statusFilterItems?.map((item) => item.title)}
-        data-test="adv-search-vm-status"
         selectedResourceNames={value}
         setSelectedResourceNames={setValue}
       />

--- a/src/views/settings/ExpandSection/ExpandSection.tsx
+++ b/src/views/settings/ExpandSection/ExpandSection.tsx
@@ -45,7 +45,7 @@ const ExpandSection: FC<ExpandSectionProps> = ({
         { 'expand-section__disabled': isDisabled, isHighlighted },
         'ExpandSection',
       )}
-      data-test-id={dataTestID}
+      data-test={dataTestID}
       id={id}
       isExpanded={isExpanded}
       isIndented={isIndented}

--- a/src/views/settings/SettingsTab.tsx
+++ b/src/views/settings/SettingsTab.tsx
@@ -17,6 +17,7 @@ const SettingsTab: FC = () => {
         <Tabs activeKey={activeTab} className="settings-tab__tabs">
           {tabs.map(({ name, title }) => (
             <Tab
+              data-test={`settings-tab-${name}`}
               eventKey={name}
               key={name}
               onClick={() => redirectTab(name)}

--- a/src/views/settings/tabs/ClusterTab/components/GeneralInformation/GeneralInformation.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralInformation/GeneralInformation.tsx
@@ -52,7 +52,7 @@ const GeneralInformation: FC<GeneralInformationProps> = ({
       <SplitItem>
         <DescriptionList>
           <DescriptionItem
-            data-test-id="general-information-installed-version"
+            data-test="general-information-installed-version"
             descriptionData={loaded ? version : <Skeleton />}
             descriptionHeader={t('Installed version')}
           />
@@ -62,7 +62,7 @@ const GeneralInformation: FC<GeneralInformationProps> = ({
       <SplitItem>
         <DescriptionList>
           <DescriptionItem
-            data-test-id="general-information-update-status"
+            data-test="general-information-update-status"
             descriptionData={getUpdateStatusContent()}
             descriptionHeader={t('Update status')}
           />

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/AdvancedCDROMFeatures/AdvancedCDROMFeatures.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/AdvancedCDROMFeatures/AdvancedCDROMFeatures.tsx
@@ -23,6 +23,7 @@ const AdvancedCDROMFeatures: FC<AdvancedCDROMFeaturesProps> = ({ newBadge }) => 
 
   return (
     <ExpandSection
+      dataTestID="advanced-cdrom-features-section"
       searchItemId={CLUSTER_TAB_IDS.advancedCDROMFeatures}
       toggleText={getGeneralSettingsLabels(t).advancedCDROMFeatures}
     >

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/GeneralSettings.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/GeneralSettings.tsx
@@ -18,6 +18,7 @@ const GeneralSettings: FC<GeneralSettingsProps> = ({ hyperConvergeConfiguration,
 
   return (
     <ExpandSection
+      dataTestID="general-settings"
       searchItemId={CLUSTER_TAB_IDS.generalSettings}
       toggleText={t('General settings')}
     >

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/HideYamlTab/HideYamlTab.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/HideYamlTab/HideYamlTab.tsx
@@ -10,8 +10,6 @@ import { useSettingsCluster } from '@settings/context/SettingsClusterContext';
 import ExpandSection from '@settings/ExpandSection/ExpandSection';
 import { CLUSTER_TAB_IDS } from '@settings/search/constants';
 
-import { getGeneralSettingsLabels } from '../consts/consts';
-
 type HideYamlTabProps = {
   newBadge?: boolean;
 };
@@ -30,8 +28,9 @@ const HideYamlTab: FC<HideYamlTabProps> = ({ newBadge = false }) => {
 
   return (
     <ExpandSection
+      dataTestID="yaml-tab-visibility"
       searchItemId={CLUSTER_TAB_IDS.hideYamlTab}
-      toggleText={getGeneralSettingsLabels(t).yamlTabVisibility}
+      toggleText={t('YAML tab visibility')}
     >
       <SectionWithSwitch
         helpTextIconContent={t(

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/Limits/MigrationNumberInput.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/Limits/MigrationNumberInput.tsx
@@ -74,6 +74,7 @@ const MigrationNumberInput: FC<MigrationNumberInputProps> = ({
               return newValue;
             })
           }
+          data-test={`${inputName}-input`}
           inputName={inputName}
           min={minValue}
           value={value}

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/LiveMigrationSection.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/LiveMigrationSection.tsx
@@ -23,6 +23,7 @@ const LiveMigrationSection: FC<LiveMigrationSectionProps> = ({ hyperConvergeConf
   return (
     <ExpandSection
       className="live-migration-tab"
+      dataTestID="live-migration"
       searchItemId={CLUSTER_TAB_IDS.liveMigration}
       toggleText={getGeneralSettingsLabels(t).liveMigration}
     >

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/MemoryDensity/components/MemoryRequestRatioInput.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/MemoryDensity/components/MemoryRequestRatioInput.tsx
@@ -62,7 +62,6 @@ const MemoryRequestRatioInput: FC<MemoryRequestRatioInputProps> = ({
         <Stack hasGutter>
           <StackItem>
             <NumberInput
-              data-test-id="memory-request-ratio-input"
               inputAriaLabel={t('Memory request ratio percentage')}
               inputName="memory-request-ratio"
               isDisabled={isLoading}
@@ -111,7 +110,6 @@ const MemoryRequestRatioInput: FC<MemoryRequestRatioInputProps> = ({
               <Split hasGutter>
                 <SplitItem>
                   <Button
-                    data-test-id="memory-request-ratio-save"
                     isDisabled={isLoading || !isValid}
                     isLoading={isLoading}
                     onClick={onSave}
@@ -122,7 +120,6 @@ const MemoryRequestRatioInput: FC<MemoryRequestRatioInputProps> = ({
                 </SplitItem>
                 <SplitItem>
                   <Button
-                    data-test-id="memory-request-ratio-restore"
                     isDisabled={isLoading}
                     onClick={onRestoreDefault}
                     variant={ButtonVariant.link}

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/SSHConfiguration/SSHConfiguration.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/SSHConfiguration/SSHConfiguration.tsx
@@ -68,6 +68,7 @@ const SSHConfiguration: FC<SSHConfigurationProps> = ({ newBadge }) => {
 
   return (
     <ExpandSection
+      dataTestID="ssh-configurations"
       searchItemId={CLUSTER_TAB_IDS.sshConfiguration}
       toggleText={getGeneralSettingsLabels(t).sshConfigurations}
     >

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/TemplatesAndImagesManagement.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/TemplatesAndImagesManagement.tsx
@@ -34,6 +34,7 @@ const TemplatesAndImagesManagement: FC<TemplatesAndImagesManagementProps> = ({
 
   return (
     <ExpandSection
+      dataTestID="templates-and-images-management"
       searchItemId={CLUSTER_TAB_IDS.templatesManagement}
       toggleText={getGeneralSettingsLabels(t).templatesAndImagesManagement}
     >

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/AutomaticImagesDownload/AutomaticImagesDownload.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/AutomaticImagesDownload/AutomaticImagesDownload.tsx
@@ -94,6 +94,7 @@ const AutomaticImagesDownload: FC<AutomaticImagesDownloadProps> = ({
 
   return (
     <ExpandSection
+      dataTestID="automatic-images-download"
       searchItemId={CLUSTER_TAB_IDS.automaticImagesDownload}
       toggleText={t('Automatic images download')}
     >

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/VMActionsConfirmation/VMActionsConfirmation.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/VMActionsConfirmation/VMActionsConfirmation.tsx
@@ -28,6 +28,7 @@ const VMActionsConfirmation: FC<VMActionsConfirmationProps> = ({ newBadge }) => 
 
   return (
     <ExpandSection
+      dataTestID="vm-actions-confirmation"
       searchItemId={CLUSTER_TAB_IDS.vmActionsConfirmation}
       toggleText={getGeneralSettingsLabels(t).virtualMachineActionsConfirmation}
     >

--- a/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/AutomaticSubscriptionRHELGuests.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/AutomaticSubscriptionRHELGuests.tsx
@@ -61,6 +61,7 @@ const AutomaticSubscriptionRHELGuests: FC<AutomaticSubscriptionRHELGuestsProps> 
           {newBadge && <NewBadge />}
         </>
       }
+      dataTestID="automatic-subscription-rhel"
       id={CLUSTER_TAB_IDS.automaticSubscriptionRhel}
       searchItemId={CLUSTER_TAB_IDS.automaticSubscriptionRhel}
     >

--- a/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/GuestManagementSection.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/GuestManagementSection.tsx
@@ -23,6 +23,7 @@ const GuestManagementSection: FC<GuestManagementSectionProps> = ({
 
   return (
     <ExpandSection
+      dataTestID="guest-management"
       searchItemId={CLUSTER_TAB_IDS.guestManagement}
       toggleText={t('Guest management')}
     >

--- a/src/views/settings/tabs/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
@@ -65,6 +65,7 @@ const PersistentReservationSection: FC<PersistentReservationSectionProps> = ({
 
   return (
     <ExpandSection
+      dataTestID="persistent-reservation-section"
       searchItemId={CLUSTER_TAB_IDS.persistentReservation}
       toggleText={t('SCSI persistent reservation')}
     >

--- a/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/ResourceManagementSection.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/ResourceManagementSection.tsx
@@ -22,6 +22,7 @@ const ResourceManagementSection: FC<ResourceManagementSectionProps> = ({
 
   return (
     <ExpandSection
+      dataTestID="resource-management"
       searchItemId={CLUSTER_TAB_IDS.resourceManagement}
       toggleText={t('Resource management')}
     >

--- a/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/ApplicationAwareQuota/ApplicationAwareQuota.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/ApplicationAwareQuota/ApplicationAwareQuota.tsx
@@ -76,6 +76,7 @@ const ApplicationAwareQuota: FC<ApplicationAwareQuotaProps> = ({
         helpTextIconContent={t(
           'Extends ResourceQuota by managing quotas for VM workloads as well as pods and other resource limits. AAQ is virtualization-aware and helps prevent issues such as failing live migrations due to quota limits.',
         )}
+        dataTestID="application-aware-quota"
         isDisabled={!hyperLoaded}
         isLoading={isLoading}
         newBadge={newBadge}

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/FeaturedOperatorItem.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesList/components/FeaturedOperatorItem.tsx
@@ -31,7 +31,7 @@ const FeaturedOperatorItem: FC<FeaturedOperatorItemProps> = ({
   const Icon = getInstallStateIcon(installState);
 
   return (
-    <Split className="featured-operator-item" hasGutter>
+    <Split className="featured-operator-item" data-test={operatorName} hasGutter>
       <SplitItem>
         <span className="featured-operator-item__title">
           {title}

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/HighAvailabilityConfigurationSection/components/HighAvailabilityToggleContent/SwitchWithTooltip.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/HighAvailabilityConfigurationSection/components/HighAvailabilityToggleContent/SwitchWithTooltip.tsx
@@ -20,7 +20,7 @@ const SwitchWithTooltip: FC<SwitchWithTooltipProps> = ({
   switchIsDisabled ? (
     <Tooltip content={disabledTooltipContent}>
       <Switch
-        data-test-id={dataTestID}
+        data-test={dataTestID}
         isChecked={switchState}
         isDisabled={switchIsDisabled}
         onChange={(_, checked: boolean) => onSwitchChange(checked)}
@@ -28,7 +28,7 @@ const SwitchWithTooltip: FC<SwitchWithTooltipProps> = ({
     </Tooltip>
   ) : (
     <Switch
-      data-test-id={dataTestID}
+      data-test={dataTestID}
       isChecked={switchState}
       onChange={(_, checked: boolean) => onSwitchChange(checked)}
     />

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/LoadBalanceConfigurationSection/components/LoadBalanceToggleContent/LoadBalanceToggleContent.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/LoadBalanceConfigurationSection/components/LoadBalanceToggleContent/LoadBalanceToggleContent.tsx
@@ -45,7 +45,6 @@ const LoadBalanceToggleContent: FC<LoadBalanceToggleContentProps> = ({ alternati
           <InstalledIconWithTooltip />
         ) : (
           <Switch
-            data-test-id="load-balance"
             isChecked={switchState}
             onChange={(_event, newSwitchState) => handleSwitchChange(newSwitchState)}
           />

--- a/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/VirtFeatureConfigurationItem/VirtFeatureConfigurationItem.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/VirtualizationFeaturesWizard/components/ConfigurationStep/components/VirtFeatureConfigurationItem/VirtFeatureConfigurationItem.tsx
@@ -79,7 +79,7 @@ const VirtFeatureConfigurationItem: FC<VirtFeatureConfigurationItemProps> = ({
               <Icon />
             ) : (
               <Switch
-                data-test-id={operatorName}
+                data-test={operatorName}
                 isChecked={switchState}
                 onChange={(_, checked: boolean) => handleSwitchChange(checked)}
               />

--- a/src/views/settings/tabs/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/components/SSHAuthKeyRow/SSHAuthKeyRow.tsx
+++ b/src/views/settings/tabs/UserTab/components/ManageSSHKeySection/SSHAuthKeysList/components/SSHAuthKeyRow/SSHAuthKeyRow.tsx
@@ -98,7 +98,7 @@ const SSHAuthKeyRow: FC<SSHAuthKeyRowProps> = ({
         )}
       </GridItem>
       <GridItem span={1} />
-      <GridItem className="ssh-auth-row__edit-button" data-test="configure-ssh-key" span={5}>
+      <GridItem className="ssh-auth-row__edit-button" span={5}>
         <AddProjectAuthKeyButton
           cluster={cluster}
           onSubmit={onSubmit}

--- a/src/views/storagemigrations/extensions.ts
+++ b/src/views/storagemigrations/extensions.ts
@@ -27,7 +27,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-sec-migration',
-        'data-testid': 'migration-nav-item',
+        'data-test': 'migration-nav-item',
       },
       id: 'migration',
       insertAfter: ['virtualization', 'workloads'],
@@ -50,7 +50,7 @@ export const extensions: EncodedExtension[] = [
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-storagemigrations',
-        'data-test-id': 'storagemigrations-nav-item',
+        'data-test': 'storagemigrations-nav-item',
       },
       href: 'storagemigrations',
       id: 'storagemigrations',

--- a/src/views/templates/actions/components/SelectSourceOption.tsx
+++ b/src/views/templates/actions/components/SelectSourceOption.tsx
@@ -18,7 +18,7 @@ const getSourceOption = (source: SOURCE_OPTIONS_IDS, ns: string, t: TFunction) =
           description={t('Use the default Template disk source')}
           value={SOURCE_TYPES.defaultSource}
         >
-          <span data-test-id={SOURCE_TYPES.defaultSource}>{t('Default')}</span>
+          <span data-test={SOURCE_TYPES.defaultSource}>{t('Default')}</span>
         </SelectOption>
       );
     case SOURCE_TYPES.pvcSource:
@@ -29,7 +29,7 @@ const getSourceOption = (source: SOURCE_OPTIONS_IDS, ns: string, t: TFunction) =
           )}
           value={SOURCE_TYPES.pvcSource}
         >
-          <span data-test-id={SOURCE_TYPES.pvcSource}>{t('PVC (clone PVC)')}</span>
+          <span data-test={SOURCE_TYPES.pvcSource}>{t('PVC (clone PVC)')}</span>
         </SelectOption>
       );
     case SOURCE_TYPES.httpSource:
@@ -38,7 +38,7 @@ const getSourceOption = (source: SOURCE_OPTIONS_IDS, ns: string, t: TFunction) =
           description={t('Import content via URL (HTTP or HTTPS endpoint).')}
           value={SOURCE_TYPES.httpSource}
         >
-          <span data-test-id={SOURCE_TYPES.httpSource}>{t('URL (creates PVC)')}</span>
+          <span data-test={SOURCE_TYPES.httpSource}>{t('URL (creates PVC)')}</span>
         </SelectOption>
       );
     case SOURCE_TYPES.registrySource:
@@ -47,7 +47,7 @@ const getSourceOption = (source: SOURCE_OPTIONS_IDS, ns: string, t: TFunction) =
           description={t('Import content via container registry.')}
           value={SOURCE_TYPES.registrySource}
         >
-          <span data-test-id={SOURCE_TYPES.registrySource}>{t('Registry (ContainerDisk)')}</span>
+          <span data-test={SOURCE_TYPES.registrySource}>{t('Registry (ContainerDisk)')}</span>
         </SelectOption>
       );
     case SOURCE_TYPES.uploadSource:

--- a/src/views/templates/details/TemplatePageTitle.tsx
+++ b/src/views/templates/details/TemplatePageTitle.tsx
@@ -77,7 +77,7 @@ const TemplatePageTitle: FC<TemplatePageTitleTitleProps> = ({ template }) => {
           <span className="co-m-resource-icon co-m-resource-icon--lg">
             {isOSTemplate ? TemplateModel.abbr : VirtualMachineTemplateModel.abbr}
           </span>
-          <span>
+          <span data-test="resource-title">
             {templateName}{' '}
             {isDeprecatedTemplate(template) && <Label isCompact>{t('Deprecated')}</Label>}
           </span>

--- a/src/views/templates/details/tabs/parameters/ParameterValueEditor.tsx
+++ b/src/views/templates/details/tabs/parameters/ParameterValueEditor.tsx
@@ -56,18 +56,16 @@ const SelectParameterValueType: FC<ParameterValueEditorProps> = ({
             description={t('Value generated using an expression')}
             value={PARAMETER_VALUE_TYPES.GENERATED}
           >
-            <span data-test-id={PARAMETER_VALUE_TYPES.GENERATED}>
-              {t('Generated (expression)')}
-            </span>
+            <span data-test={PARAMETER_VALUE_TYPES.GENERATED}>{t('Generated (expression)')}</span>
           </SelectOption>
           <SelectOption
             description={t('Default value for this parameter')}
             value={PARAMETER_VALUE_TYPES.VALUE}
           >
-            <span data-test-id={PARAMETER_VALUE_TYPES.VALUE}>{t('Value')}</span>
+            <span data-test={PARAMETER_VALUE_TYPES.VALUE}>{t('Value')}</span>
           </SelectOption>
           <SelectOption description={t('No default value')} value={PARAMETER_VALUE_TYPES.NONE}>
-            <span data-test-id={PARAMETER_VALUE_TYPES.NONE}>{t('None')}</span>
+            <span data-test={PARAMETER_VALUE_TYPES.NONE}>{t('None')}</span>
           </SelectOption>
         </FormPFSelect>
       </FormGroup>

--- a/src/views/templates/details/tabs/scripts/components/SSHKey/SSHKey.tsx
+++ b/src/views/templates/details/tabs/scripts/components/SSHKey/SSHKey.tsx
@@ -109,7 +109,7 @@ const SSHKey: FC<SSHKeyProps> = ({ template }) => {
     <DescriptionItem
       descriptionData={
         <Stack hasGutter>
-          <div data-test="ssh-popover">
+          <div>
             <Content component={ContentVariants.p}>{t('Select an available secret')}</Content>
           </div>
           <SecretNameLabel secretName={vmAttachedSecretName} />

--- a/src/views/templates/list/cells/TemplateActionsCell.tsx
+++ b/src/views/templates/list/cells/TemplateActionsCell.tsx
@@ -23,9 +23,7 @@ const TemplateActionsCell: FC<TemplateActionsCellProps> = ({ row }) => {
     return <VirtualMachineTemplateActions isKebabToggle vmTemplate={row} />;
   }
 
-  return (
-    <VirtualMachineTemplatesActions data-test="template-row-actions" isKebabToggle template={row} />
-  );
+  return <VirtualMachineTemplatesActions isKebabToggle template={row} />;
 };
 
 export default TemplateActionsCell;

--- a/src/views/templates/list/cells/TemplateNameCell.tsx
+++ b/src/views/templates/list/cells/TemplateNameCell.tsx
@@ -36,7 +36,6 @@ const TemplateNameCell: FC<TemplateNameCellProps> = ({ row }) => {
           <MulticlusterResourceLink
             cluster={cluster}
             data-test={name}
-            data-test-id={name}
             groupVersionKind={getGroupVersionKindForResource(row)}
             name={name}
             namespace={namespace}

--- a/src/views/virtualmachines/actions/BulkVirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/BulkVirtualMachineActionFactory.tsx
@@ -287,8 +287,8 @@ export const createBulkVirtualMachineActionFactory = (
         />
       )),
     disabled: !haveSameCluster(vms) || !haveSameNamespace(vms) || isEmpty(vms),
-    id: ACTIONS_ID.MOVE_TO_FOLDER,
-    label: t('Move to group'),
+    id: BULK_ACTIONS_ID.MOVE_TO_FOLDER,
+    label: t('Move to folder'),
   }),
   pause: (
     vms: V1VirtualMachine[],

--- a/src/views/virtualmachines/hooks/useAutoHideNavigation/constants.ts
+++ b/src/views/virtualmachines/hooks/useAutoHideNavigation/constants.ts
@@ -6,7 +6,6 @@ export const NAV_TOGGLE_BUTTON_SELECTORS = [
   '#nav-toggle',
   'button.pf-v6-c-masthead__toggle',
   '.pf-v6-c-masthead__toggle button',
-  '[]',
 ];
 
 export const AUTO_HIDE_NAV_DEFAULT = true;

--- a/src/views/vmnetworks/details/tabs/ConnectedProjects/cells/ProjectNameCell.tsx
+++ b/src/views/vmnetworks/details/tabs/ConnectedProjects/cells/ProjectNameCell.tsx
@@ -14,7 +14,7 @@ const ProjectNameCell: FC<ProjectNameCellProps> = ({ row }) => {
   const { projectName } = row;
 
   if (!projectName) {
-    return <span data-test="project-name">{NO_DATA_DASH}</span>;
+    return <span>{NO_DATA_DASH}</span>;
   }
 
   return (

--- a/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/cells/VMNameCell.tsx
+++ b/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/cells/VMNameCell.tsx
@@ -15,7 +15,7 @@ const VMNameCell: FC<VMNameCellProps> = ({ row }) => {
   const namespace = getNamespace(row);
 
   if (!name || !namespace) {
-    return <span data-test="vm-name">{NO_DATA_DASH}</span>;
+    return <span>{NO_DATA_DASH}</span>;
   }
 
   return (

--- a/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/cells/VMNamespaceCell.tsx
+++ b/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/cells/VMNamespaceCell.tsx
@@ -14,7 +14,7 @@ const VMNamespaceCell: FC<VMNamespaceCellProps> = ({ row }) => {
   const namespace = getNamespace(row);
 
   if (!namespace) {
-    return <span data-test="vm-namespace">{NO_DATA_DASH}</span>;
+    return <span>{NO_DATA_DASH}</span>;
   }
 
   return (

--- a/src/views/vmnetworks/details/tabs/NetworkDetailPage.tsx
+++ b/src/views/vmnetworks/details/tabs/NetworkDetailPage.tsx
@@ -43,7 +43,7 @@ const NetworkDetailsPage: FC<NetworkDetailsPageProps> = ({ obj: network }) => {
           <Title className="pf-v6-u-mb-md" headingLevel="h2">
             {t('Virtual machine network details')}
           </Title>
-          <DL className="co-m-pane__details" data-test-id="resource-summary">
+          <DL className="co-m-pane__details">
             <DescriptionItemName
               label={t('Name')}
               model={ClusterUserDefinedNetworkModel}

--- a/src/views/vmnetworks/list/vmNetworkListDefinition.tsx
+++ b/src/views/vmnetworks/list/vmNetworkListDefinition.tsx
@@ -23,11 +23,11 @@ const MTUCell: FC<MTUCellProps> = ({ obj }) => {
   const mtu = getMTU(obj);
 
   if (mtu) {
-    return <span data-test-id={`vmnetwork-mtu-${getName(obj)}`}>{mtu}</span>;
+    return <span data-test={`vmnetwork-mtu-${getName(obj)}`}>{mtu}</span>;
   }
 
   return (
-    <span className="pf-v6-u-text-color-subtle" data-test-id={`vmnetwork-mtu-${getName(obj)}`}>
+    <span className="pf-v6-u-text-color-subtle" data-test={`vmnetwork-mtu-${getName(obj)}`}>
       {t('Not available')}
     </span>
   );
@@ -47,7 +47,7 @@ export const getVMNetworkListColumns = (
     renderCell: (row) => {
       const name = getName(row);
       return (
-        <span data-test-id={`vmnetwork-name-${name}`}>
+        <span data-test={`vmnetwork-name-${name}`}>
           <Link to={`${VM_NETWORKS_PATH}/${name}`}>{name}</Link>
         </span>
       );
@@ -64,7 +64,7 @@ export const getVMNetworkListColumns = (
     key: 'physicalNetworkName',
     label: t('Physical network name'),
     renderCell: (row) => (
-      <span data-test-id={`vmnetwork-physicalnetwork-${getName(row)}`}>
+      <span data-test={`vmnetwork-physicalnetwork-${getName(row)}`}>
         {getLocalnet(row)?.physicalNetworkName ?? NO_DATA_DASH}
       </span>
     ),
@@ -75,9 +75,7 @@ export const getVMNetworkListColumns = (
     key: 'vlanID',
     label: t('VLAN ID'),
     renderCell: (row) => (
-      <span data-test-id={`vmnetwork-vlanid-${getName(row)}`}>
-        {getVLANID(row) ?? NO_DATA_DASH}
-      </span>
+      <span data-test={`vmnetwork-vlanid-${getName(row)}`}>{getVLANID(row) ?? NO_DATA_DASH}</span>
     ),
     sortable: true,
   },


### PR DESCRIPTION
## 📝 Description

Add data-test attributes to remaining plugin views

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-93498


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bulk virtual machine action label to “Move to folder” to match the correct action.
  * Improved automatic navigation hiding by reliably detecting navigation toggle controls.

* **Refactor**
  * Standardized UI test/automation selectors across navigation, cards, tables, dialogs, settings, and resource pages by switching from `data-test-id`/removing older selectors to `data-test` (or adding missing `data-test` attributes where applicable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->