### PR TITLE
CNV-92412: Add Playwright coverage and wait for project default NAD

### DIFF
--- a/eslintv10.config.js
+++ b/eslintv10.config.js
@@ -211,7 +211,14 @@ const tsConfigs = tseslint.configs.recommended.map((config) => ({
         varsIgnorePattern: '^_',
       },
     ],
-    '@typescript-eslint/prefer-nullish-coalescing': 'error',
+    '@typescript-eslint/prefer-nullish-coalescing': [
+      'error',
+      {
+        ignorePrimitives: {
+          boolean: true,
+        },
+      },
+    ],
     '@typescript-eslint/prefer-optional-chain': 'error',
     '@typescript-eslint/restrict-template-expressions': [
       'error',

--- a/playwright/src/components/vm-wizard/vm-wizard-compute-customization-component.ts
+++ b/playwright/src/components/vm-wizard/vm-wizard-compute-customization-component.ts
@@ -42,12 +42,34 @@ export default class VmWizardComputeCustomizationComponent extends BaseComponent
     }
   }
 
+  private networkInterfaceModal() {
+    return this.page
+      .locator('[role="dialog"]')
+      .filter({ hasText: /network interface/i })
+      .first();
+  }
+
   private async toggleSwitch(switchId: string): Promise<void> {
     await this.dismissOverlayIfPresent();
     const label = this.page.locator(`label:has(#${switchId})`);
     await label.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
     await label.click();
     await this.page.waitForTimeout(300);
+  }
+
+  async cancelNetworkInterfaceModal(): Promise<void> {
+    const modal = this.networkInterfaceModal();
+    const cancelButton = modal.getByTestId('cancel-button');
+    if (
+      await cancelButton.isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM }).catch(() => false)
+    ) {
+      await this.robustClick(cancelButton);
+    } else {
+      await this.page.keyboard.press('Escape');
+    }
+    await modal
+      .waitFor({ state: 'hidden', timeout: TestTimeouts.ELEMENT_WAIT })
+      .catch(() => undefined);
   }
 
   async clearReviewVmName(): Promise<void> {
@@ -117,6 +139,17 @@ export default class VmWizardComputeCustomizationComponent extends BaseComponent
     } catch {
       return '';
     }
+  }
+
+  /** Selected Network typeahead display value in the Add/Edit network interface modal. */
+  async getAddNetworkInterfaceSelectedNetwork(): Promise<string> {
+    const modal = this.networkInterfaceModal();
+    const selectRoot = modal.getByTestId('network-attachment-definition-select');
+    await selectRoot.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    const input = selectRoot.locator('input[role="combobox"]').first();
+    await input.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+    return ((await input.inputValue()) ?? '').trim();
   }
 
   async getComputeSizeDropdownText(): Promise<string> {
@@ -275,6 +308,17 @@ export default class VmWizardComputeCustomizationComponent extends BaseComponent
     return disks;
   }
 
+  /** Returns the Network column text for a NIC row on the customization Network tab. */
+  async getWizardNetworkInterfaceNetworkName(nicName: string): Promise<string> {
+    await this.selectCustomizationTab('Network');
+    const table = this.page.getByTestId('wizard-network-interfaces-table');
+    await table.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    const networkCell = table.getByTestId(`nic-network-${nicName}`);
+    await networkCell.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return ((await networkCell.textContent()) ?? '').trim();
+  }
+
   async isCreateButtonDisabled(): Promise<boolean> {
     try {
       const createBtn = this._pfV6CWizardButtonpfV6CButtonpfMPrimary.first();
@@ -297,6 +341,26 @@ export default class VmWizardComputeCustomizationComponent extends BaseComponent
     return await this.locator('#headless-mode').isChecked();
   }
 
+  async isPodNetworkingOptionVisibleInAddNetworkModal(): Promise<boolean> {
+    const modal = this.networkInterfaceModal();
+    const selectRoot = modal.getByTestId('network-attachment-definition-select');
+    await selectRoot.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    // Opening via the typeahead input avoids PF MenuToggle class selectors.
+    const input = selectRoot.locator('input[role="combobox"]').first();
+    await input.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+    await this.robustClick(input);
+
+    const podOption = this.page.getByTestId('network-option-pod-networking');
+    const visible = await podOption
+      .isVisible({ timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .catch(() => false);
+
+    await this.page.keyboard.press('Escape');
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    return visible;
+  }
+
   async isStartAfterCreationChecked(): Promise<boolean> {
     try {
       const checkbox = this._startAfterCreateCheckbox;
@@ -305,6 +369,21 @@ export default class VmWizardComputeCustomizationComponent extends BaseComponent
     } catch {
       return false;
     }
+  }
+
+  async openAddNetworkInterfaceModal(): Promise<void> {
+    await this.selectCustomizationTab('Network');
+    const addButton = this._roleTabpanel
+      .locator('[data-test="item-create"], button:has-text("Add network interface")')
+      .first();
+    await addButton.waitFor({ state: 'visible', timeout: TestTimeouts.RESOURCE_CREATION });
+    await this.robustClick(addButton);
+
+    await this.page
+      .locator('[role="dialog"]')
+      .filter({ hasText: /network interface/i })
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.INSTANCE_TYPE_VERIFICATION });
   }
 
   async searchCustomizationSettings(query: string): Promise<void> {

--- a/playwright/src/fixtures/gating-fixture.ts
+++ b/playwright/src/fixtures/gating-fixture.ts
@@ -27,6 +27,7 @@ import VmOverviewTabPage from '@/page-objects/vm/vm-overview-tab-page';
 import VmTreePage from '@/page-objects/vm/vm-tree-page';
 import VmCreationWizardPage from '@/page-objects/vm-wizard/vm-creation-wizard-page';
 import VmWizardBootSourcePage from '@/page-objects/vm-wizard/vm-wizard-boot-source-page';
+import VmWizardComputeCustomizationPage from '@/page-objects/vm-wizard/vm-wizard-compute-customization-page';
 import VmWizardNavigationPage from '@/page-objects/vm-wizard/vm-wizard-navigation-page';
 import { EnvVariables } from '@/utils/env-variables';
 import { TestTimeouts } from '@/utils/test-config';
@@ -53,6 +54,7 @@ interface GatingFixtures {
   virtualizationOverviewPage: VirtualizationOverviewPage;
   vmCreationWizardPage: VmCreationWizardPage;
   vmWizardBootSourcePage: VmWizardBootSourcePage;
+  vmWizardComputePage: VmWizardComputeCustomizationPage;
   vmWizardNavigationPage: VmWizardNavigationPage;
 }
 
@@ -176,6 +178,9 @@ const test = baseTest.extend<GatingFixtures>({
   },
   vmWizardBootSourcePage: async ({ page }, use) => {
     await use(new VmWizardBootSourcePage(page));
+  },
+  vmWizardComputePage: async ({ page }, use) => {
+    await use(new VmWizardComputeCustomizationPage(page));
   },
   vmWizardNavigationPage: async ({ page }, use) => {
     await use(new VmWizardNavigationPage(page));

--- a/playwright/src/utils/test-setup-helpers.ts
+++ b/playwright/src/utils/test-setup-helpers.ts
@@ -159,3 +159,60 @@ export async function setupTestNamespace(
   client.trackResource('Namespace', namespace);
   return namespace;
 }
+
+export type ProjectNetworkSettingsAnnotations = {
+  /** Value for kubevirt.io/default-network (NAD name in the project). */
+  defaultNetwork?: string;
+  /**
+   * When false, sets kubevirt.io/allow-pod-network to "false".
+   * When true/undefined, the annotation is omitted (pod networking allowed by default).
+   */
+  allowPodNetwork?: boolean;
+};
+
+/** Creates a bridge NetworkAttachmentDefinition for project-network UI tests. */
+export async function createBridgeNetworkAttachmentDefinition(
+  client: RequestContextClient,
+  name: string,
+  namespace: string,
+  bridge = 'br1',
+): Promise<void> {
+  await client.createResourceByKind(
+    'NetworkAttachmentDefinition',
+    {
+      apiVersion: 'k8s.cni.cncf.io/v1',
+      kind: 'NetworkAttachmentDefinition',
+      metadata: { name, namespace },
+      spec: {
+        config: JSON.stringify({
+          cniVersion: '0.3.1',
+          name,
+          type: 'bridge',
+          bridge,
+        }),
+      },
+    },
+    namespace,
+  );
+  client.trackResource('NetworkAttachmentDefinition', name, namespace);
+}
+
+/**
+ * Sets project-level KubeVirt network annotations on a Namespace.
+ * Always writes both annotation keys; omitted/undefined values are cleared via
+ * JSON merge-patch nulls so configs can be replaced cleanly.
+ */
+export async function setProjectNetworkSettings(
+  client: RequestContextClient,
+  namespace: string,
+  settings: ProjectNetworkSettingsAnnotations = {},
+): Promise<void> {
+  const annotations: Record<string, string | null> = {
+    'kubevirt.io/default-network': settings.defaultNetwork ?? null,
+    'kubevirt.io/allow-pod-network': settings.allowPodNetwork === false ? 'false' : null,
+  };
+
+  await client.mergePatchResource('', 'v1', 'namespaces', namespace, {
+    metadata: { annotations },
+  });
+}

--- a/playwright/tests/gating/project-network-settings.spec.ts
+++ b/playwright/tests/gating/project-network-settings.spec.ts
@@ -1,0 +1,300 @@
+import type RequestContextClient from '@/clients/request-context-client';
+import {
+  ADMIN_ONLY_TAG,
+  GATING,
+  GATING_TAG,
+  NETWORKING_TAG_LABEL,
+} from '@/data-models/allure-constants';
+import { expect, test } from '@/fixtures/gating-fixture';
+import type VmWizardBootSourcePage from '@/page-objects/vm-wizard/vm-wizard-boot-source-page';
+import type VmWizardComputeCustomizationPage from '@/page-objects/vm-wizard/vm-wizard-compute-customization-page';
+import type VmWizardNavigationPage from '@/page-objects/vm-wizard/vm-wizard-navigation-page';
+import type VmTreePage from '@/page-objects/vm/vm-tree-page';
+import { TestTimeouts } from '@/utils/test-config';
+import {
+  createBridgeNetworkAttachmentDefinition,
+  type ProjectNetworkSettingsAnnotations,
+  setProjectNetworkSettings,
+  setupTestNamespace,
+} from '@/utils/test-setup-helpers';
+
+const SUITE = 'Project network settings';
+const DEFAULT_NIC_NAME = 'default';
+
+/**
+ * API-only project setup. Must complete before any VirtualMachines UI navigation
+ * so the wizard loads with the intended project network annotations applied.
+ */
+async function setupProjectNetworkNamespace(
+  apiClient: RequestContextClient,
+  prefix: string,
+  options: {
+    nadName?: string;
+    settings?: ProjectNetworkSettingsAnnotations;
+  } = {},
+): Promise<string> {
+  const namespace = await setupTestNamespace(apiClient, prefix);
+
+  if (options.nadName) {
+    await createBridgeNetworkAttachmentDefinition(apiClient, options.nadName, namespace);
+  }
+
+  if (options.settings) {
+    await setProjectNetworkSettings(apiClient, namespace, options.settings);
+  }
+
+  return namespace;
+}
+
+async function navigateWizardToCustomizationNetwork(args: {
+  vmTreePage: VmTreePage;
+  vmWizardNavigationPage: VmWizardNavigationPage;
+  vmWizardBootSourcePage: VmWizardBootSourcePage;
+  vmWizardComputePage: VmWizardComputeCustomizationPage;
+  namespace: string;
+}): Promise<void> {
+  const {
+    vmTreePage,
+    vmWizardNavigationPage,
+    vmWizardBootSourcePage,
+    vmWizardComputePage,
+    namespace,
+  } = args;
+
+  // Namespace/NAD/annotations must already exist before this UI entry point.
+  await vmTreePage.switchToVirtualizationPerspective();
+  await vmTreePage.navigateToProjectVmListViaUI(namespace);
+  await vmWizardNavigationPage.openWizardFromCreateDropdown();
+
+  await vmWizardNavigationPage.generateVmName();
+  await vmWizardNavigationPage.clickNext();
+  await vmWizardNavigationPage.clickNext();
+
+  await vmWizardBootSourcePage.verifyBootSourceStepVisible();
+  const volumeCount = await vmWizardBootSourcePage.getBootVolumeCount();
+  if (volumeCount > 0) {
+    await vmWizardBootSourcePage.selectBootVolumeByName('rhel');
+  } else {
+    await vmWizardBootSourcePage.selectNoBootSource();
+  }
+  await vmWizardNavigationPage.clickNext();
+
+  await vmWizardComputePage.verifyComputeResourcesStepVisible();
+  // Give namespace/NAD watches time to settle before Compute → Next snapshots the VM.
+  await vmWizardNavigationPage.page.waitForTimeout(TestTimeouts.CLUSTER_STATE_PROPAGATION);
+  await vmWizardNavigationPage.clickNext();
+
+  const customizationVisible = await vmWizardComputePage.verifyCustomizationStepVisible();
+  expect(customizationVisible, 'Customization step should be visible').toBe(true);
+}
+
+async function assertDefaultNicUsesNetwork(
+  vmWizardComputePage: VmWizardComputeCustomizationPage,
+  expectedNetwork: string,
+  timeout: number,
+): Promise<void> {
+  await expect
+    .poll(async () => vmWizardComputePage.getWizardNetworkInterfaceNetworkName(DEFAULT_NIC_NAME), {
+      message: `Default NIC should use ${expectedNetwork}`,
+      timeout,
+    })
+    .toContain(expectedNetwork);
+
+  const networkName =
+    await vmWizardComputePage.getWizardNetworkInterfaceNetworkName(DEFAULT_NIC_NAME);
+  expect(networkName, 'Default NIC must not fall back to Pod networking').not.toBe(
+    'Pod networking',
+  );
+}
+
+async function assertAddNicModalHidesPodAndSelectsNad(
+  vmWizardComputePage: VmWizardComputeCustomizationPage,
+  timeout: number,
+): Promise<void> {
+  await vmWizardComputePage.openAddNetworkInterfaceModal();
+
+  // When pod networking is disallowed, the modal preselects the first available NAD
+  // option (sorted alphabetically) — not necessarily the project default-network.
+  await expect
+    .poll(async () => vmWizardComputePage.getAddNetworkInterfaceSelectedNetwork(), {
+      message: 'Add NIC modal should auto-select a NAD when pod networking is disallowed',
+      timeout,
+    })
+    .not.toBe('');
+
+  const selectedNetwork = await vmWizardComputePage.getAddNetworkInterfaceSelectedNetwork();
+  expect(selectedNetwork, 'Selected network must not be Pod networking').not.toContain(
+    'Pod networking',
+  );
+
+  const podVisible = await vmWizardComputePage.isPodNetworkingOptionVisibleInAddNetworkModal();
+  expect(podVisible, 'Pod networking option should be hidden when disallowed').toBe(false);
+
+  await vmWizardComputePage.cancelNetworkInterfaceModal();
+}
+
+test.describe(SUITE, { tag: [GATING_TAG, '@catalog-wizard', ADMIN_ONLY_TAG] }, () => {
+  test.beforeEach(async ({ utils }) => {
+    await utils.withAllure({
+      suite: SUITE,
+      feature: GATING,
+      tags: [GATING_TAG, NETWORKING_TAG_LABEL, ADMIN_ONLY_TAG],
+    });
+  });
+
+  test('uses Pod networking when project has no network annotations', async ({
+    apiClient,
+    vmTreePage,
+    vmWizardNavigationPage,
+    vmWizardBootSourcePage,
+    vmWizardComputePage,
+    utils,
+  }) => {
+    test.setTimeout(utils.TestTimeouts.TEST_VM_CREATION);
+
+    const namespace = await setupProjectNetworkNamespace(apiClient, 'proj-net-baseline');
+
+    await navigateWizardToCustomizationNetwork({
+      vmTreePage,
+      vmWizardNavigationPage,
+      vmWizardBootSourcePage,
+      vmWizardComputePage,
+      namespace,
+    });
+
+    await expect
+      .poll(
+        async () => vmWizardComputePage.getWizardNetworkInterfaceNetworkName(DEFAULT_NIC_NAME),
+        {
+          message: 'Default NIC should use Pod networking without project annotations',
+          timeout: utils.TestTimeouts.ELEMENT_WAIT,
+        },
+      )
+      .toBe('Pod networking');
+  });
+
+  test('uses project default-network for default NIC while Pod networking stays allowed', async ({
+    apiClient,
+    vmTreePage,
+    vmWizardNavigationPage,
+    vmWizardBootSourcePage,
+    vmWizardComputePage,
+    utils,
+  }) => {
+    test.setTimeout(utils.TestTimeouts.TEST_VM_CREATION);
+
+    const nadName = utils.generateRandomNadName('proj-nad');
+    const namespace = await setupProjectNetworkNamespace(apiClient, 'proj-net-default-only', {
+      nadName,
+      settings: { defaultNetwork: nadName },
+    });
+
+    await navigateWizardToCustomizationNetwork({
+      vmTreePage,
+      vmWizardNavigationPage,
+      vmWizardBootSourcePage,
+      vmWizardComputePage,
+      namespace,
+    });
+
+    await test.step('VM creation uses the project default NAD', async () => {
+      await assertDefaultNicUsesNetwork(
+        vmWizardComputePage,
+        nadName,
+        utils.TestTimeouts.TEST_MEDIUM,
+      );
+    });
+
+    await test.step('Add NIC modal still offers Pod networking', async () => {
+      await vmWizardComputePage.openAddNetworkInterfaceModal();
+
+      const podVisible = await vmWizardComputePage.isPodNetworkingOptionVisibleInAddNetworkModal();
+      expect(podVisible, 'Pod networking option should remain available').toBe(true);
+
+      await vmWizardComputePage.cancelNetworkInterfaceModal();
+    });
+  });
+
+  test('hides Pod networking and selects available NAD when pod network is disallowed', async ({
+    apiClient,
+    vmTreePage,
+    vmWizardNavigationPage,
+    vmWizardBootSourcePage,
+    vmWizardComputePage,
+    utils,
+  }) => {
+    test.setTimeout(utils.TestTimeouts.TEST_VM_CREATION);
+
+    const nadName = utils.generateRandomNadName('proj-nad');
+    const namespace = await setupProjectNetworkNamespace(apiClient, 'proj-net-no-pod', {
+      nadName,
+      settings: { allowPodNetwork: false },
+    });
+
+    await navigateWizardToCustomizationNetwork({
+      vmTreePage,
+      vmWizardNavigationPage,
+      vmWizardBootSourcePage,
+      vmWizardComputePage,
+      namespace,
+    });
+
+    await test.step('VM creation falls back to the available project NAD', async () => {
+      await assertDefaultNicUsesNetwork(
+        vmWizardComputePage,
+        nadName,
+        utils.TestTimeouts.TEST_MEDIUM,
+      );
+    });
+
+    await test.step('Add NIC modal hides Pod networking and auto-selects a NAD', async () => {
+      await assertAddNicModalHidesPodAndSelectsNad(
+        vmWizardComputePage,
+        utils.TestTimeouts.ELEMENT_WAIT,
+      );
+    });
+  });
+
+  test('honors default-network and hides Pod networking when disallowed', async ({
+    apiClient,
+    vmTreePage,
+    vmWizardNavigationPage,
+    vmWizardBootSourcePage,
+    vmWizardComputePage,
+    utils,
+  }) => {
+    test.setTimeout(utils.TestTimeouts.TEST_VM_CREATION);
+
+    const nadName = utils.generateRandomNadName('proj-nad');
+    const namespace = await setupProjectNetworkNamespace(apiClient, 'proj-net-nad', {
+      nadName,
+      settings: {
+        defaultNetwork: nadName,
+        allowPodNetwork: false,
+      },
+    });
+
+    await navigateWizardToCustomizationNetwork({
+      vmTreePage,
+      vmWizardNavigationPage,
+      vmWizardBootSourcePage,
+      vmWizardComputePage,
+      namespace,
+    });
+
+    await test.step('VM creation uses the project default NAD', async () => {
+      await assertDefaultNicUsesNetwork(
+        vmWizardComputePage,
+        nadName,
+        utils.TestTimeouts.TEST_MEDIUM,
+      );
+    });
+
+    await test.step('Add NIC modal hides Pod networking and auto-selects a NAD', async () => {
+      await assertAddNicModalHidesPodAndSelectsNad(
+        vmWizardComputePage,
+        utils.TestTimeouts.ELEMENT_WAIT,
+      );
+    });
+  });
+});

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/buildNetworkOptions.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/buildNetworkOptions.tsx
@@ -98,12 +98,12 @@ export const buildNetworkSelectOptions = ({
       label: podNetworkingText,
       optionProps: {
         children: (
-          <>
+          <span data-test="network-option-pod-networking">
             {podNetworkingText}{' '}
             <Label isCompact>
               {podNetworkType} {t('Binding')}
             </Label>
-          </>
+          </span>
         ),
         key: POD_NETWORK,
       },

--- a/src/utils/resources/namespace/hooks/useProjectDefaultNad.ts
+++ b/src/utils/resources/namespace/hooks/useProjectDefaultNad.ts
@@ -14,6 +14,7 @@ type UseProjectDefaultNadArgs = {
 };
 
 type UseProjectDefaultNadReturn = {
+  loaded: boolean;
   vmCreationNad?: NetworkAttachmentDefinitionKind;
 };
 
@@ -21,14 +22,18 @@ const useProjectDefaultNad = ({
   cluster,
   namespaceName,
 }: UseProjectDefaultNadArgs): UseProjectDefaultNadReturn => {
-  const { defaultNadName, isPodNetworkAllowed } = useProjectNetworkSettings({
+  const {
+    defaultNadName,
+    isPodNetworkAllowed,
+    loaded: networkSettingsLoaded,
+  } = useProjectNetworkSettings({
     cluster,
     namespaceName,
   });
 
-  const [nads] = useFetchNADs(namespaceName ?? '', cluster);
+  const [nads, nadsLoaded] = useFetchNADs(namespaceName ?? '', cluster);
 
-  const [annotatedNad] = useK8sWatchData<NetworkAttachmentDefinitionKind>(
+  const [annotatedNad, annotatedNadLoaded] = useK8sWatchData<NetworkAttachmentDefinitionKind>(
     defaultNadName && namespaceName
       ? {
           cluster,
@@ -59,7 +64,12 @@ const useProjectDefaultNad = ({
     return undefined;
   }, [annotatedNad, defaultNadName, firstAvailableNad, isPodNetworkAllowed]);
 
+  const vmCreationNadLoaded = defaultNadName
+    ? annotatedNadLoaded
+    : isPodNetworkAllowed || nadsLoaded;
+
   return {
+    loaded: networkSettingsLoaded && vmCreationNadLoaded,
     vmCreationNad,
   };
 };

--- a/src/views/virtualmachines/wizard/components/VMGenerationWizardNavItem/VMGenerationWizardNavItem.tsx
+++ b/src/views/virtualmachines/wizard/components/VMGenerationWizardNavItem/VMGenerationWizardNavItem.tsx
@@ -1,13 +1,14 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { WizardNavItem, WizardStepType } from '@patternfly/react-core';
-import { VMGenerationNavItemClickHandler } from '@virtualmachines/wizard/utils/types';
+import { WizardNavItem, type WizardStepType } from '@patternfly/react-core';
+import { type VMGenerationNavItemClickHandler } from '@virtualmachines/wizard/utils/types';
 
 type VMGenerationWizardNavItemProps = {
   activeStep: WizardStepType;
   goToStepByIndex: (index: number) => void;
   handleNavItemClick: VMGenerationNavItemClickHandler;
   isGeneratingVM: boolean;
+  loaded: boolean;
   step: WizardStepType;
 };
 
@@ -16,13 +17,14 @@ const VMGenerationWizardNavItem: FC<VMGenerationWizardNavItemProps> = ({
   goToStepByIndex,
   handleNavItemClick,
   isGeneratingVM,
+  loaded = true,
   step,
 }) => (
   <WizardNavItem
     content={step.name}
     id={step.id}
     isCurrent={step.id === activeStep?.id}
-    isDisabled={step.isDisabled || isGeneratingVM}
+    isDisabled={step.isDisabled || isGeneratingVM || !loaded}
     onClick={() => handleNavItemClick(step, activeStep, goToStepByIndex)}
     stepIndex={step.index}
   />

--- a/src/views/virtualmachines/wizard/hooks/useVMGenerationNavClick.ts
+++ b/src/views/virtualmachines/wizard/hooks/useVMGenerationNavClick.ts
@@ -1,19 +1,22 @@
 import { useState } from 'react';
 
 import { setCustomizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
-import { WizardStepType } from '@patternfly/react-core';
+import { type WizardStepType } from '@patternfly/react-core';
 import useCreateVMFromTemplate from '@virtualmachines/wizard/steps/TemplateStep/hooks/useCreateVMFromTemplate';
-import { VM_GENERATION_STEPS, VMCreationMethod } from '@virtualmachines/wizard/utils/constants';
+import {
+  VM_GENERATION_STEPS,
+  type VMCreationMethod,
+} from '@virtualmachines/wizard/utils/constants';
 import {
   isInstanceTypeCreationMethod,
   isTemplateCreationMethod,
 } from '@virtualmachines/wizard/utils/utils';
 
 import useGenerateVM from '../steps/InstanceTypesSteps/hooks/useGenerateVM/useGenerateVM';
-import { WizardStepNavItemConfig } from '../utils/types';
+import { type WizardStepNavItemConfig } from '../utils/types';
 
 const useVMGenerationNavClick = (creationMethod: VMCreationMethod): WizardStepNavItemConfig => {
-  const generatedVM = useGenerateVM();
+  const { generatedVM, loaded } = useGenerateVM();
   const { createVMFromTemplate } = useCreateVMFromTemplate();
   const [isGeneratingVM, setIsGeneratingVM] = useState(false);
 
@@ -21,7 +24,7 @@ const useVMGenerationNavClick = (creationMethod: VMCreationMethod): WizardStepNa
     step: WizardStepType,
     activeStep: WizardStepType,
     goToStepByIndex: (index: number) => void,
-  ) => {
+  ): Promise<void> => {
     if (VM_GENERATION_STEPS.has(activeStep?.id)) {
       setIsGeneratingVM(true);
       try {
@@ -36,7 +39,7 @@ const useVMGenerationNavClick = (creationMethod: VMCreationMethod): WizardStepNa
     goToStepByIndex(step.index);
   };
 
-  return { handleNavItemClick, isGeneratingVM };
+  return { handleNavItemClick, isGeneratingVM, loaded };
 };
 
 export default useVMGenerationNavClick;

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/network/NetworkCell.tsx
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/network/NetworkCell.tsx
@@ -1,8 +1,8 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
-import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { type NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { getNetworkNameLabel } from '@kubevirt-utils/resources/vm/utils/network/network-columns';
 
 type NetworkCellProps = {
@@ -11,7 +11,11 @@ type NetworkCellProps = {
 
 const NetworkCell: FC<NetworkCellProps> = ({ row }) => {
   const { t } = useKubevirtTranslation();
-  return <>{getNetworkNameLabel(t, { network: row.network }) ?? NO_DATA_DASH}</>;
+  return (
+    <span data-test={`nic-network-${row.network?.name}`}>
+      {getNetworkNameLabel(t, { network: row.network }) ?? NO_DATA_DASH}
+    </span>
+  );
 };
 
 export default NetworkCell;

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/ComputeResourcesStepFooter.tsx
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/ComputeResourcesStepFooter.tsx
@@ -1,31 +1,34 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { setCustomizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
-import { useWizardContext, WizardFooter } from '@patternfly/react-core';
+import { type ButtonProps, useWizardContext, WizardFooter } from '@patternfly/react-core';
 import useCloseWizard from '@virtualmachines/wizard/hooks/useCloseWizard';
 import useWizardStepValidation from '@virtualmachines/wizard/hooks/useWizardStepValidation';
 import { VMWizardStep } from '@virtualmachines/wizard/utils/constants';
+
 import useGenerateVM from '../../hooks/useGenerateVM/useGenerateVM';
 
 const ComputeResourcesStepFooter: FC = () => {
   const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
-  const generatedVM = useGenerateVM();
+  const { generatedVM, loaded } = useGenerateVM();
   const closeWizard = useCloseWizard();
   const { isNextDisabledForStep } = useWizardStepValidation();
 
-  const handleGoToNextStep = () => {
+  const handleGoToNextStep = (): void => {
     setCustomizeWizardVMSignal(generatedVM);
-    goToNextStep();
+    void goToNextStep();
   };
 
   return (
     <WizardFooter
       activeStep={activeStep}
-      backButtonProps={{ 'data-test': 'wizard-back-button' } as any}
-      cancelButtonProps={{ 'data-test': 'wizard-cancel-button' } as any}
+      backButtonProps={{ 'data-test': 'wizard-back-button' } as Omit<ButtonProps, 'children'>}
+      cancelButtonProps={{ 'data-test': 'wizard-cancel-button' } as Omit<ButtonProps, 'children'>}
       isBackDisabled={activeStep.index === 1}
-      isNextDisabled={isNextDisabledForStep(VMWizardStep.COMPUTE_RESOURCES)}
-      nextButtonProps={{ 'data-test': 'wizard-next-button' } as any}
+      isNextDisabled={isNextDisabledForStep(VMWizardStep.COMPUTE_RESOURCES) || !loaded}
+      nextButtonProps={
+        { 'data-test': 'wizard-next-button', isLoading: !loaded } as Omit<ButtonProps, 'children'>
+      }
       onBack={goToPrevStep}
       onClose={closeWizard}
       onNext={handleGoToNextStep}

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/useGenerateVM.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/useGenerateVM.ts
@@ -32,9 +32,12 @@ import {
 
 import { createPopulatedCloudInitYAML } from './utils/generateVM';
 
-export type UseGenerateVM = () => V1VirtualMachine;
+export type UseGenerateVMResult = {
+  generatedVM: V1VirtualMachine;
+  loaded: boolean;
+};
 
-const useGenerateVM: UseGenerateVM = () => {
+const useGenerateVM = (): UseGenerateVMResult => {
   const { control } = useVMWizard();
   const [
     cluster,
@@ -79,7 +82,10 @@ const useGenerateVM: UseGenerateVM = () => {
 
   const validNamespace = getValidNamespace(namespace);
   const [isUDNManagedNamespace] = useNamespaceUDN(validNamespace);
-  const { vmCreationNad } = useProjectDefaultNad({ cluster, namespaceName: validNamespace });
+  const { loaded, vmCreationNad } = useProjectDefaultNad({
+    cluster,
+    namespaceName: validNamespace,
+  });
   const isIPv6SingleStack = useIsIPv6SingleStackCluster(cluster);
   const [hyperConverge] = useHyperConvergeConfiguration();
   const enableMultiArchBootImageImport =
@@ -101,7 +107,10 @@ const useGenerateVM: UseGenerateVM = () => {
 
   const [driversImage] = useDriversImage(cluster);
   const [authorizedSSHKeys] = useKubevirtUserSettings(USER_SETTINGS_KEYS.ssh, cluster);
-  const defaultSSHSecretName = authorizedSSHKeys?.[namespace];
+  const defaultSSHSecretName =
+    typeof authorizedSSHKeys?.[namespace] === 'string'
+      ? (authorizedSSHKeys[namespace] as string)
+      : undefined;
 
   const generatedVM = useMemo(() => {
     return generateVM({
@@ -142,10 +151,12 @@ const useGenerateVM: UseGenerateVM = () => {
     vmName,
   ]);
 
-  return useMemo(() => {
+  const vmWithDrivers = useMemo(() => {
     const isWindowsOSVolume = isWindowBootableVolume(selectedBootableVolume);
     return isWindowsOSVolume ? addWinDriverVolume(generatedVM, driversImage) : generatedVM;
   }, [driversImage, generatedVM, selectedBootableVolume]);
+
+  return { generatedVM: vmWithDrivers, loaded };
 };
 
 export default useGenerateVM;

--- a/src/views/virtualmachines/wizard/utils/steps.tsx
+++ b/src/views/virtualmachines/wizard/utils/steps.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { CustomWizardNavItemFunction } from '@patternfly/react-core';
+import { type CustomWizardNavItemFunction } from '@patternfly/react-core';
 import VMGenerationWizardNavItem from '@virtualmachines/wizard/components/VMGenerationWizardNavItem/VMGenerationWizardNavItem';
 
-import { WizardStepNavItemConfig } from './types';
+import { type WizardStepNavItemConfig } from './types';
 
 export const getVMGenerationNavItem =
   (navItemConfig: WizardStepNavItemConfig): CustomWizardNavItemFunction =>
@@ -13,6 +13,7 @@ export const getVMGenerationNavItem =
       goToStepByIndex={goToStepByIndex}
       handleNavItemClick={navItemConfig.handleNavItemClick}
       isGeneratingVM={navItemConfig.isGeneratingVM}
+      loaded={navItemConfig.loaded}
       step={step}
     />
   );

--- a/src/views/virtualmachines/wizard/utils/types.ts
+++ b/src/views/virtualmachines/wizard/utils/types.ts
@@ -1,26 +1,26 @@
-import { TFunction } from 'i18next';
-import { FC, ReactNode } from 'react';
-import { UseFormGetValues, UseFormSetValue } from 'react-hook-form';
-import { NavigateFunction } from 'react-router';
+import { type FC, type ReactNode } from 'react';
+import { type UseFormGetValues, type UseFormSetValue } from 'react-hook-form';
+import { type NavigateFunction } from 'react-router';
+import { type TFunction } from 'i18next';
 
 import {
-  V1beta1DataImportCron,
-  V1beta1DataVolume,
+  type V1beta1DataImportCron,
+  type V1beta1DataVolume,
 } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import {
-  V1beta1VirtualMachineClone,
-  V1beta1VirtualMachineClusterInstancetype,
-  V1beta1VirtualMachineClusterPreference,
-  V1beta1VirtualMachineInstancetype,
+  type V1beta1VirtualMachineClone,
+  type V1beta1VirtualMachineClusterInstancetype,
+  type V1beta1VirtualMachineClusterPreference,
+  type V1beta1VirtualMachineInstancetype,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
-import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
-import { ClusterNamespacedResourceMap } from '@kubevirt-utils/resources/shared';
-import { WizardStepProps, WizardStepType } from '@patternfly/react-core';
-import { VMWizardStep } from '@virtualmachines/wizard/utils/constants';
+import { type VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
+import { type BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { type ClusterNamespacedResourceMap } from '@kubevirt-utils/resources/shared';
+import { type WizardStepProps, type WizardStepType } from '@patternfly/react-core';
+import { type VMWizardStep } from '@virtualmachines/wizard/utils/constants';
 
-import { VMWizardFormValues } from '../state/vm-wizard-form/types';
+import { type VMWizardFormValues } from '../state/vm-wizard-form/types';
 
 export type VMGenerationNavItemClickHandler = (
   step: WizardStepType,
@@ -31,6 +31,7 @@ export type VMGenerationNavItemClickHandler = (
 export type WizardStepNavItemConfig = {
   handleNavItemClick: VMGenerationNavItemClickHandler;
   isGeneratingVM: boolean;
+  loaded: boolean;
 };
 
 export type VMWizardStepDisplay = WizardStepProps & {
@@ -54,7 +55,7 @@ export type UseInstanceTypeAndPreferencesValues = {
   allInstanceTypes: InstanceTypes;
   clusterInstanceTypes: V1beta1VirtualMachineClusterInstancetype[];
   loaded: boolean;
-  loadError: any;
+  loadError: Error | undefined;
   preferences: V1beta1VirtualMachineClusterPreference[];
 };
 
@@ -101,7 +102,7 @@ export type HandleCloneRequestPhaseChangeParams = {
   navigate: NavigateFunction;
   setError: (error: unknown) => void;
   setIsSubmitting: (isSubmitting: boolean) => void;
-  submittedCloneRequest: undefined | V1beta1VirtualMachineClone;
   setSubmittedCloneRequest: (cloneRequest: undefined | V1beta1VirtualMachineClone) => void;
+  submittedCloneRequest: undefined | V1beta1VirtualMachineClone;
   t: TFunction;
 };


### PR DESCRIPTION
## 📝 Description

Squashed follow-up for project network settings:

- Gate VM generation (Compute Next / generation nav) until project default NAD / network settings are loaded
- Add Playwright coverage verifying VM creation honors `kubevirt.io/default-network` and Add NIC hides Pod networking when `allow-pod-network` is false

## 🔗 Links

- Jira: https://issues.redhat.com/browse/CNV-92422
- Related (merged): https://github.com/kubevirt-ui/kubevirt-plugin/pull/4321

## 🎥 Demo

> N/A — E2E + loading-gate follow-up; covered by Playwright suite `project-network-settings.spec.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VM creation now honors project network annotations for default NIC network selection.
  * The Add Network Interface flow opens with the correct network selected when pod networking is disallowed.
  * Pod networking option is hidden when prohibited by project settings.
  * Wizard navigation and Next button now reflect network loading readiness.
* **Bug Fixes**
  * Improved network fallback behavior to prevent pod networking from being used when disallowed.
* **Tests**
  * Added Playwright gating coverage for project network settings and resulting wizard network/NIC behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->