### PR TITLE
CNV-92254: Use HyperConverged v1beta1 for all HCO watch and patch paths

### DIFF
--- a/src/utils/hooks/useHyperConvergeConfiguration.ts
+++ b/src/utils/hooks/useHyperConvergeConfiguration.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { HyperConvergedModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1ModelGroupVersionKind as HyperConvergedModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { V1LabelSelector } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import { V1MigrationConfiguration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { CalculationMethod } from '@kubevirt-utils/resources/quotas/types';

--- a/src/utils/hooks/usePasstFeatureFlag.ts
+++ b/src/utils/hooks/usePasstFeatureFlag.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';

--- a/src/utils/hooks/useVMTemplateFeatureFlag/constants.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/constants.ts
@@ -8,10 +8,3 @@ export const ADD_TEMPLATE_FEATURE_GATE_PATCH = {
   path: TEMPLATE_FEATURE_GATE_PATH,
   value: TEMPLATE_FEATURE_GATE,
 };
-
-/** GVK used to detect whether HCO v1 (slice-based featureGates) is available. */
-export const HYPERCONVERGED_V1_GROUP_VERSION_KIND = {
-  group: 'hco.kubevirt.io',
-  kind: 'HyperConverged',
-  version: 'v1',
-} as const;

--- a/src/utils/hooks/useVMTemplateFeatureFlag/useIsHyperConvergedV1Available.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/useIsHyperConvergedV1Available.ts
@@ -1,14 +1,14 @@
+import { HyperConvergedV1ModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
-
-import { HYPERCONVERGED_V1_GROUP_VERSION_KIND } from './constants';
 
 /**
  * HCO v1 exposes slice-based featureGates (Template is Beta / first-class).
  * HCO v1beta1 still needs the Preview Features jsonpatch toggle.
+ * Detection only — all HCO watch/patch paths use v1beta1.
  */
 const useIsHyperConvergedV1Available = (): { isHCOV1: boolean; loading: boolean } => {
-  const [hcoV1Model, inFlight] = useK8sModel(HYPERCONVERGED_V1_GROUP_VERSION_KIND);
+  const [hcoV1Model, inFlight] = useK8sModel(HyperConvergedV1ModelGroupVersionKind);
 
   return {
     isHCOV1: !inFlight && !isEmpty(hcoV1Model),

--- a/src/utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/useVMTemplateFeatureFlag.ts
@@ -1,4 +1,4 @@
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { K8S_OPS } from '@kubevirt-utils/constants/constants';
 import useHyperConvergeConfiguration, {
   type HyperConverged,

--- a/src/views/dashboard-extensions/KubevirtHealthPopup/components/Conditions/Conditions.tsx
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/components/Conditions/Conditions.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { Link } from 'react-router';
 
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { AlertType } from '@kubevirt-utils/components/AlertsCard/utils/types';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import useInfrastructureAlerts from '@kubevirt-utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts';

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/AdvancedCDROMFeatures/hooks/useAdvancedCDROMFeatureFlag.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/AdvancedCDROMFeatures/hooks/useAdvancedCDROMFeatureFlag.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { K8S_OPS } from '@kubevirt-utils/constants/constants';
 import useHyperConvergeConfiguration, {
   HyperConverged,

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/AutomaticallyGrantVirtualizationRoles/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/AutomaticallyGrantVirtualizationRoles/utils/utils.ts
@@ -1,4 +1,4 @@
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { K8S_OPS } from '@kubevirt-utils/constants/constants';
 import { HCO_MANUAL_ROLE_AGGREGATION_STRATEGY } from '@kubevirt-utils/flags/consts';
 import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/utils/utils.ts
@@ -1,4 +1,4 @@
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/MemoryDensity/components/KernelSamepageMerging/KernelSamepageMerging.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/MemoryDensity/components/KernelSamepageMerging/KernelSamepageMerging.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from 'react';
 
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
 import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/MemoryDensity/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/MemoryDensity/utils/utils.ts
@@ -1,6 +1,6 @@
 import { TFunction } from 'i18next';
 
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
 

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/AutomaticImagesDownload/AutomaticImagesDownload.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/AutomaticImagesDownload/AutomaticImagesDownload.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useCallback, useState } from 'react';
 
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
 import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/BootableVolumeProjectSection/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/BootableVolumeProjectSection/utils/utils.ts
@@ -1,4 +1,4 @@
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { OPENSHIFT_OS_IMAGES_NS } from '@kubevirt-utils/constants/constants';
 import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/TemplatesProjectSection/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/TemplatesProjectSection/utils/utils.ts
@@ -1,4 +1,4 @@
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { TemplateModel, V1Template } from '@kubevirt-utils/models';
 import { kubevirtK8sDelete, kubevirtK8sGet, kubevirtK8sPatch } from '@multicluster/k8sRequests';

--- a/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/GuestSystemLogsAccess/GuestSystemLogsAccess.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/GuestSystemLogsAccess/GuestSystemLogsAccess.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState } from 'react';
 
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
 import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';

--- a/src/views/settings/tabs/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState } from 'react';
 
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
 import {
   FEATURE_HCO_PERSISTENT_RESERVATION,

--- a/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/ApplicationAwareQuota/ApplicationAwareQuota.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/ApplicationAwareQuota/ApplicationAwareQuota.tsx
@@ -1,10 +1,10 @@
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { getQuotaListURL } from 'src/views/quotas/utils/url';
 
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
 import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { HyperConvergedModel } from '@kubevirt-utils/models';
 import { getAAQCalculationMethod } from '@kubevirt-utils/resources/hyperconverged/selectors';
 import { isAAQEnabled } from '@kubevirt-utils/resources/hyperconverged/utils';
 import { CalculationMethod } from '@kubevirt-utils/resources/quotas/types';

--- a/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/ApplicationAwareQuota/components/EditCalculationMethodModal.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/ApplicationAwareQuota/components/EditCalculationMethodModal.tsx
@@ -1,9 +1,9 @@
 import React, { FC, useState } from 'react';
 
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { HyperConvergedModel } from '@kubevirt-utils/models';
 import { CalculationMethod } from '@kubevirt-utils/resources/quotas/types';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
 import { FormGroup, Radio } from '@patternfly/react-core';

--- a/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/utils/utils.ts
@@ -1,4 +1,4 @@
-import { HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { K8S_OPS } from '@kubevirt-utils/constants/constants';
 import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';


### PR DESCRIPTION
## 📝 Description

`@kubevirt-ui-ext/kubevirt-api` now defaults `HyperConvergedModel` to HCO **v1**. This PR switches all HyperConverged watch and patch call sites to the explicit `HyperConvergedV1Beta1Model` / `HyperConvergedV1Beta1ModelGroupVersionKind` so the plugin keeps using `hco.kubevirt.io/v1beta1` until the HCO v1 migration is complete.

HCO v1 availability detection (`useIsHyperConvergedV1Available`) is unchanged and still used only to gate the Preview Features template toggle.

## 🔗 Links

- https://issues.redhat.com/browse/CNV-92254

## 🎥 Demo

N/A — import/model version change only; no UI behavior change on clusters that already expose HCO v1beta1.

## Test plan

- [ ] Virtualization Settings → Cluster: live migration, memory density, KSM, templates/images namespace, AAQ, auto CPU limits, guest logs, persistent reservation toggles still load and patch successfully
- [ ] Preview Features → Passt / native VM templates toggles still work on HCO v1beta1 clusters
- [ ] Health popup HyperConverged conditions link still resolves
- [ ] On a cluster with HCO v1 API available, Preview Features template toggle remains gated as before


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated HyperConverged resource handling to use the current API model consistently across cluster settings, feature flags, health checks, and configuration updates.
  - Improved compatibility for applying feature-gate and configuration changes.

- **New Features**
  - Added support for inserting the Template feature gate when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->