### PR TITLE
CNV-0: Fail fast on CIS DNS and bad OCP versions for hot-cluster IPI

### DIFF
--- a/.github/workflows/ibmc-cluster-setup.yml
+++ b/.github/workflows/ibmc-cluster-setup.yml
@@ -217,6 +217,11 @@ jobs:
     if: needs.precheck.outputs.already_ready != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 360
+    # One provision at a time per cluster name. Cancel stale manual/E2E
+    # races that would otherwise fight over the same CIS DNS + VPC resources.
+    concurrency:
+      group: hot-cluster-setup-${{ inputs.cluster_name || 'kubevirt-plugin-ci' }}
+      cancel-in-progress: true
     steps:
       - name: Validate cluster_name format
         run: |
@@ -408,26 +413,49 @@ jobs:
           OC_VERSION_INPUT: ${{ inputs.openshift_version }}
         run: |
           OCP_BASE="${OC_VERSION_INPUT%%_*}"
+          OCP_CHANNEL=""
 
           if [[ "${OCP_BASE}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Using pinned OCP version: ${OCP_BASE}"
             MIRROR="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OCP_BASE}"
+            MIRROR_LABEL="${OCP_BASE}"
           else
             OCP_CHANNEL="stable-${OCP_BASE}"
             echo "Resolving ${OCP_CHANNEL} to latest patch version..."
             MIRROR="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OCP_CHANNEL}"
+            MIRROR_LABEL="${OCP_CHANNEL}"
           fi
 
+          download_ocp_tarball() {
+            local url="$1"
+            local dest="$2"
+            local label="$3"
+            local http_code
+            http_code=$(curl -sL -o "${dest}" -w "%{http_code}" "${url}")
+            if [[ "${http_code}" != "200" ]] || ! gzip -t "${dest}" 2>/dev/null; then
+              echo "::error::OpenShift client download failed for '${label}' (HTTP ${http_code}). '${OC_VERSION_INPUT}' is not available under mirror.openshift.com .../clients/ocp/. Use a GA channel such as 4.22_openshift. OCP 5.0 early builds live under ocp-dev-preview and are not supported by this workflow yet."
+              rm -f "${dest}"
+              exit 1
+            fi
+          }
+
           echo "Downloading openshift-install..."
-          curl -sL "${MIRROR}/openshift-install-linux.tar.gz" | tar -xz -C /usr/local/bin openshift-install
+          download_ocp_tarball "${MIRROR}/openshift-install-linux.tar.gz" "${RUNNER_TEMP}/openshift-install-linux.tar.gz" "${MIRROR_LABEL}"
+          tar -xz -C /usr/local/bin -f "${RUNNER_TEMP}/openshift-install-linux.tar.gz" openshift-install
           openshift-install version
 
           echo "Downloading oc + kubectl..."
-          curl -sL "${MIRROR}/openshift-client-linux.tar.gz" | tar -xz -C /usr/local/bin oc kubectl
+          download_ocp_tarball "${MIRROR}/openshift-client-linux.tar.gz" "${RUNNER_TEMP}/openshift-client-linux.tar.gz" "${MIRROR_LABEL}"
+          tar -xz -C /usr/local/bin -f "${RUNNER_TEMP}/openshift-client-linux.tar.gz" oc kubectl
           oc version --client
 
           echo "Downloading ccoctl..."
-          curl -sL "${MIRROR}/ccoctl-linux.tar.gz" | tar -xz -C /usr/local/bin ccoctl 2>/dev/null || echo "ccoctl not available for this version"
+          CCOCTL_CODE=$(curl -sL -o "${RUNNER_TEMP}/ccoctl-linux.tar.gz" -w "%{http_code}" "${MIRROR}/ccoctl-linux.tar.gz" || true)
+          if [[ "${CCOCTL_CODE}" == "200" ]] && gzip -t "${RUNNER_TEMP}/ccoctl-linux.tar.gz" 2>/dev/null; then
+            tar -xz -C /usr/local/bin -f "${RUNNER_TEMP}/ccoctl-linux.tar.gz" ccoctl
+          else
+            echo "ccoctl not available for this version"
+          fi
 
           RESOLVED_VERSION=$(openshift-install version | head -1 | awk '{print $2}')
           echo "ocp_channel=${OCP_CHANNEL}" >> "$GITHUB_OUTPUT"
@@ -461,6 +489,15 @@ jobs:
           echo "::endgroup::"
 
           cp "${INSTALL_DIR}/install-config.yaml" "${INSTALL_DIR}/install-config.yaml.bak"
+
+      # Fail in minutes (not after 5×90m install attempts) when CIS cannot
+      # create DNS records — the same failure mode as openshift-install's
+      # "Method Not Allowed" on api*.<cluster>.<base_domain>.
+      - name: Preflight CIS DNS write access
+        if: inputs.infrastructure_type == 'ipi'
+        env:
+          IC_API_KEY: ${{ secrets.IC_KEY }}
+        run: bash ./ci-scripts/hot-cluster/preflight-cis-dns.sh
 
       - name: Create IPI cluster (with retry)
         id: ipi_create

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -92,6 +92,7 @@ Uses `openshift-install` to create a fully self-managed OpenShift cluster on IBM
 - **Flavor**: `bx2-8x32` (hyphen format, auto-converted from dot format)
 - **Base domain**: `cnv-ui.com` (registered in IBM Cloud CIS)
 - **Required**: VPC Admin, COS Manager, DNS/CIS access, IAM Identity Admin, `OPENSHIFT_PULL_SECRET` GitHub secret
+- **CIS write preflight**: before `openshift-install`, setup runs [`preflight-cis-dns.sh`](hot-cluster/preflight-cis-dns.sh) (create+delete a throwaway A record). A 403/405 here means CIS plan/IAM must be fixed — do not expect IPI to succeed until that passes. CIS needs at least **Standard Next**, and `IC_KEY` needs Internet Services Administrator/Writer on the CIS instance.
 
 ## Required GitHub Secrets
 

--- a/ci-scripts/hot-cluster/preflight-cis-dns.sh
+++ b/ci-scripts/hot-cluster/preflight-cis-dns.sh
@@ -64,7 +64,9 @@ CREATE_RC="${CREATE_RC:-0}"
 
 if [[ "${CREATE_RC}" -ne 0 ]]; then
   echo "${CREATE_OUT}"
-  if echo "${CREATE_OUT}" | grep -qiE 'Method Not Allowed|405|not authorized|forbidden|403|not permitted'; then
+  if echo "${CREATE_OUT}" | grep -qiE 'Trial period has expired'; then
+    echo "::error::CIS DNS create failed because the CIS instance trial has expired (API code 10002 / HTTP 405). Upgrade cnv-cis (or the CIS instance for ${BASE_DOMAIN}) to at least Standard Next, then re-run setup. openshift-install hits the same failure creating api.${CLUSTER_NAME}.${BASE_DOMAIN}."
+  elif echo "${CREATE_OUT}" | grep -qiE 'Method Not Allowed|405|not authorized|forbidden|403|not permitted'; then
     echo "::error::CIS DNS create failed (HTTP 403/405 or auth). openshift-install will hit the same error creating api.${CLUSTER_NAME}.${BASE_DOMAIN}. Fix: CIS plan must be Standard Next (or higher), and IC_KEY needs Internet Services Administrator/Writer on the CIS instance / resource group. Then re-run setup."
   else
     echo "::error::CIS DNS create failed during preflight. Fix CIS permissions/zone before running IPI install."

--- a/ci-scripts/hot-cluster/preflight-cis-dns.sh
+++ b/ci-scripts/hot-cluster/preflight-cis-dns.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Prove the IBM Cloud API key can create+delete CIS DNS records for BASE_DOMAIN
+# before openshift-install spends hours on IPI. Failures here are the same class
+# as "Method Not Allowed" during install DNS create.
+#
+# Required env:
+#   IC_API_KEY     IBM Cloud API key (same as GitHub secret IC_KEY)
+#   BASE_DOMAIN    CIS-managed zone (e.g. cnv-ui.com)
+#   CLUSTER_NAME   Used in the throwaway record name for easy identification
+#
+# Optional env:
+#   CIS_INSTANCE   CIS instance name or CRN (default: first instance returned)
+
+set -euo pipefail
+
+IC_API_KEY="${IC_API_KEY:?IC_API_KEY must be set}"
+BASE_DOMAIN="${BASE_DOMAIN:?BASE_DOMAIN must be set}"
+CLUSTER_NAME="${CLUSTER_NAME:?CLUSTER_NAME must be set}"
+CIS_INSTANCE="${CIS_INSTANCE:-}"
+
+export IC_API_KEY
+
+echo "=== CIS DNS write preflight (zone=${BASE_DOMAIN}, cluster=${CLUSTER_NAME}) ==="
+
+ibmcloud plugin install cis -f 2>&1 | tail -3 || true
+
+if [[ -z "${CIS_INSTANCE}" ]]; then
+  CIS_INSTANCE=$(ibmcloud cis instances --output json 2>/dev/null | jq -r '.[0].crn // empty' || true)
+fi
+
+if [[ -z "${CIS_INSTANCE}" ]]; then
+  echo "::error::No IBM Cloud Internet Services (CIS) instance found. IPI public clusters require CIS with an authoritative zone for '${BASE_DOMAIN}'. See https://docs.okd.io/4.22/installing/installing_ibm_cloud/installing-ibm-cloud-account.html"
+  exit 1
+fi
+
+echo "Using CIS instance: ${CIS_INSTANCE}"
+ibmcloud cis instance-set "${CIS_INSTANCE}"
+
+ZONE_ID=$(ibmcloud cis domains --output json 2>/dev/null \
+  | jq -r --arg d "${BASE_DOMAIN}" '.[] | select(.name == $d) | .id // empty' | head -1 || true)
+
+if [[ -z "${ZONE_ID}" ]]; then
+  echo "::error::CIS zone '${BASE_DOMAIN}' not found on the targeted CIS instance. Confirm the domain is active and authoritative for IPI DNS."
+  echo "Domains on this instance:"
+  ibmcloud cis domains --output json 2>/dev/null | jq -r '.[].name // empty' || true
+  exit 1
+fi
+
+echo "Found zone '${BASE_DOMAIN}' (id=${ZONE_ID})"
+
+# Unique short-lived name so concurrent preflights do not collide.
+RECORD_LABEL="preflight-${CLUSTER_NAME}-$(date +%s)"
+RECORD_FQDN="${RECORD_LABEL}.${BASE_DOMAIN}"
+
+echo "Creating throwaway A record '${RECORD_FQDN}'..."
+CREATE_OUT=$(ibmcloud cis dns-record-create "${ZONE_ID}" \
+  --type A \
+  --name "${RECORD_LABEL}" \
+  --content 1.2.3.4 \
+  --ttl 120 \
+  --output json 2>&1) || CREATE_RC=$?
+CREATE_RC="${CREATE_RC:-0}"
+
+if [[ "${CREATE_RC}" -ne 0 ]]; then
+  echo "${CREATE_OUT}"
+  if echo "${CREATE_OUT}" | grep -qiE 'Method Not Allowed|405|not authorized|forbidden|403|not permitted'; then
+    echo "::error::CIS DNS create failed (HTTP 403/405 or auth). openshift-install will hit the same error creating api.${CLUSTER_NAME}.${BASE_DOMAIN}. Fix: CIS plan must be Standard Next (or higher), and IC_KEY needs Internet Services Administrator/Writer on the CIS instance / resource group. Then re-run setup."
+  else
+    echo "::error::CIS DNS create failed during preflight. Fix CIS permissions/zone before running IPI install."
+  fi
+  exit 1
+fi
+
+RECORD_ID=$(echo "${CREATE_OUT}" | jq -r '.id // empty' 2>/dev/null || true)
+if [[ -z "${RECORD_ID}" ]]; then
+  # Some CLI versions print a table; fall back to lookup by name.
+  RECORD_ID=$(ibmcloud cis dns-records "${ZONE_ID}" --output json 2>/dev/null \
+    | jq -r --arg n "${RECORD_FQDN}" --arg short "${RECORD_LABEL}" \
+      '.[] | select(.name == $n or .name == $short or (.name | endswith($n))) | .id' \
+    | head -1 || true)
+fi
+
+if [[ -z "${RECORD_ID}" ]]; then
+  echo "::error::Created CIS DNS record but could not resolve its id for cleanup. Check CIS console for '${RECORD_FQDN}'."
+  echo "${CREATE_OUT}"
+  exit 1
+fi
+
+echo "Created record id=${RECORD_ID}; deleting..."
+if ! ibmcloud cis dns-record-delete "${ZONE_ID}" "${RECORD_ID}"; then
+  echo "::warning::Failed to delete preflight record ${RECORD_ID} (${RECORD_FQDN}). Delete it manually from CIS."
+fi
+
+echo "CIS DNS write preflight succeeded."


### PR DESCRIPTION
## Summary
- Add per-cluster concurrency on hot-cluster IPI setup so dual provisions cannot race the same CIS DNS / VPC resources.
- Add a CIS DNS write preflight (create+delete throwaway A record) before `openshift-install`, so Method Not Allowed / 403 fails in minutes with an actionable error.
- Fail fast when `openshift_version` resolves to a missing mirror path (e.g. `stable-5.0`).

## Context
IPI was failing after VPC/LB ready with:
`failed to create dns record api-int.kubevirt-plugin-ci.cnv-ui.com: Method Not Allowed`

That is CIS plan/IAM — this PR does not fix IBM Cloud itself, but stops burning ~3h of retries and blocks unsupported OCP channels.

## Test plan
- [ ] Cancel any in-progress setups for `kubevirt-plugin-ci`
- [ ] Fix CIS (Standard Next + IC_KEY Writer/Admin) and prove `ibmcloud cis dns-record-create` works
- [ ] Dispatch Teardown (`ipi` / `kubevirt-plugin-ci`, force if needed)
- [ ] Dispatch Setup from this branch: `ipi`, `4.22_openshift`, `kubevirt-plugin-ci`
- [ ] Confirm preflight passes (or fails fast with clear CIS error)
- [ ] Dispatch with `5.0_openshift` and confirm install-tools fails immediately on mirror 404


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CIS DNS “write/delete” preflight check to fail early before IPI OpenShift installation.
* **Bug Fixes**
  * Prevented simultaneous cluster setup runs for the same cluster resources.
  * Improved validation of downloaded OpenShift client tools and failure messaging for invalid/unsupported downloads.
  * Tightened `ccoctl` download/extraction handling.
* **Documentation**
  * Updated IPI prerequisites with CIS DNS permission requirements and troubleshooting guidance for common 403/405 failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->