### PR TITLE
CNV-89223: Add clickable NAD links in VM network details tab

### DIFF
--- a/src/utils/resources/nad/utils.test.ts
+++ b/src/utils/resources/nad/utils.test.ts
@@ -1,0 +1,67 @@
+import { parseVMMultusIntoNAD } from './utils';
+
+describe('parseVMMultusIntoNAD', () => {
+  const VM_NAMESPACE = 'vm-namespace';
+
+  describe('when networkName has namespace/name format', () => {
+    it('should parse namespace and name from the value', () => {
+      expect(parseVMMultusIntoNAD('other-ns/my-nad', VM_NAMESPACE)).toEqual({
+        name: 'my-nad',
+        namespace: 'other-ns',
+      });
+    });
+
+    it('should handle same namespace as VM', () => {
+      expect(parseVMMultusIntoNAD('vm-namespace/my-nad', VM_NAMESPACE)).toEqual({
+        name: 'my-nad',
+        namespace: 'vm-namespace',
+      });
+    });
+  });
+
+  describe('when networkName has no slash (bare name)', () => {
+    it('should use the VM namespace as fallback', () => {
+      expect(parseVMMultusIntoNAD('my-nad', VM_NAMESPACE)).toEqual({
+        name: 'my-nad',
+        namespace: VM_NAMESPACE,
+      });
+    });
+
+    it('should handle single-word names', () => {
+      expect(parseVMMultusIntoNAD('default', VM_NAMESPACE)).toEqual({
+        name: 'default',
+        namespace: VM_NAMESPACE,
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return empty namespace for leading slash', () => {
+      expect(parseVMMultusIntoNAD('/my-nad', VM_NAMESPACE)).toEqual({
+        name: 'my-nad',
+        namespace: '',
+      });
+    });
+
+    it('should return empty name for trailing slash', () => {
+      expect(parseVMMultusIntoNAD('ns/', VM_NAMESPACE)).toEqual({
+        name: '',
+        namespace: 'ns',
+      });
+    });
+
+    it('should use first slash as separator when multiple exist', () => {
+      expect(parseVMMultusIntoNAD('ns/name/extra', VM_NAMESPACE)).toEqual({
+        name: 'name/extra',
+        namespace: 'ns',
+      });
+    });
+
+    it('should handle empty vmNamespace fallback', () => {
+      expect(parseVMMultusIntoNAD('my-nad', '')).toEqual({
+        name: 'my-nad',
+        namespace: '',
+      });
+    });
+  });
+});

--- a/src/utils/resources/nad/utils.ts
+++ b/src/utils/resources/nad/utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Parses a VM's multus networkName into NAD namespace and name components.
+ * The multus networkName format is "namespace/name" for cross-namespace NADs,
+ * or just "name" for NADs in the same namespace as the VM.
+ *
+ * @param networkName - The multus networkName value from the VM spec
+ * @param vmNamespace - Fallback namespace (the VM's namespace) when no namespace prefix is present
+ * @returns Object with parsed `name` and `namespace`. Empty strings indicate a malformed value.
+ */
+export const parseVMMultusIntoNAD = (
+  networkName: string,
+  vmNamespace: string,
+): { name: string; namespace: string } => {
+  const slashIndex = networkName.indexOf('/');
+  if (slashIndex === -1) {
+    return { name: networkName, namespace: vmNamespace };
+  }
+  return {
+    name: networkName.substring(slashIndex + 1),
+    namespace: networkName.substring(0, slashIndex),
+  };
+};

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkCell.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkCell.tsx
@@ -1,0 +1,48 @@
+import React, { type FC } from 'react';
+
+import { NetworkAttachmentDefinitionModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { parseVMMultusIntoNAD } from '@kubevirt-utils/resources/nad/utils';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
+import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+
+import { type SimpleNICPresentation } from '../../utils/types';
+import { type NetworkInterfaceListCallbacks } from './networkInterfaceListDefinition';
+
+type NetworkCellProps = {
+  callbacks: NetworkInterfaceListCallbacks;
+  row: SimpleNICPresentation;
+};
+
+const NetworkCell: FC<NetworkCellProps> = ({ callbacks, row }) => {
+  const { t } = useKubevirtTranslation();
+  const networkName = row.network?.multus?.networkName;
+
+  if (!networkName) {
+    return (
+      <span data-test={`nic-network-${row.network?.name}`}>
+        {row.network?.pod ? t('Pod networking') : NO_DATA_DASH}
+      </span>
+    );
+  }
+
+  const vmNamespace = getNamespace(callbacks.vm) ?? '';
+  const { name, namespace } = parseVMMultusIntoNAD(networkName, vmNamespace);
+
+  if (!name || !namespace) {
+    return <span data-test={`nic-network-${row.network?.name}`}>{networkName}</span>;
+  }
+
+  return (
+    <span data-test={`nic-network-${row.network?.name}`}>
+      <ResourceLink
+        groupVersionKind={NetworkAttachmentDefinitionModelGroupVersionKind}
+        name={name}
+        namespace={namespace}
+      />
+    </span>
+  );
+};
+
+export default NetworkCell;

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/networkInterfaceListDefinition.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/networkInterfaceListDefinition.tsx
@@ -1,19 +1,21 @@
-import React, { FC, ReactNode } from 'react';
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
+import React, { type FC, type ReactNode } from 'react';
 
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import EphemeralBadge from '@kubevirt-utils/components/badges/EphemeralBadge/EphemeralBadge';
 import PendingBadge from '@kubevirt-utils/components/badges/PendingBadge/PendingBadge';
 import NetworkIcon from '@kubevirt-utils/components/NetworkIcons/NetworkIcon';
-import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
+import { type ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
-import { getNetworkNameLabel } from '@kubevirt-utils/resources/vm/utils/network/network-columns';
 import { Label, Stack, StackItem } from '@patternfly/react-core';
 
-import { SimpleNICPresentation } from '../../utils/types';
+import { type SimpleNICPresentation } from '../../utils/types';
 import { getConfigInterfaceState, getRuntimeInterfaceState } from '../../utils/utils';
-
+import NetworkCell from './NetworkCell';
 import NetworkInterfaceActions from './NetworkInterfaceActions';
 
 export type NetworkInterfaceListCallbacks = {
@@ -64,19 +66,6 @@ const StateCell: FC<StateCellProps> = ({ row }) => {
   );
 };
 
-type NetworkCellProps = {
-  row: SimpleNICPresentation;
-};
-
-const NetworkCell: FC<NetworkCellProps> = ({ row }) => {
-  const { t } = useKubevirtTranslation();
-  return (
-    <span data-test={`nic-network-${row.network?.name}`}>
-      {getNetworkNameLabel(t, { network: row.network }) ?? NO_DATA_DASH}
-    </span>
-  );
-};
-
 const renderActionsCell = (
   row: SimpleNICPresentation,
   callbacks: NetworkInterfaceListCallbacks,
@@ -115,7 +104,7 @@ export const getNetworkInterfaceListColumns = (
     getValue: (row) => row.network?.multus?.networkName ?? '',
     key: 'network',
     label: t('Network'),
-    renderCell: (row) => <NetworkCell row={row} />,
+    renderCell: (row, callbacks) => <NetworkCell callbacks={callbacks} row={row} />,
     sortable: true,
   },
   {

--- a/src/views/virtualmachines/details/tabs/configuration/network/utils/types.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/network/utils/types.ts
@@ -9,7 +9,7 @@ export type SimpleNICPresentation = {
   isInterfaceEphemeral: boolean;
   isPending: boolean;
   isSRIOV: boolean;
-  network: { multus?: { networkName: string }; name: string };
+  network: { multus?: { networkName: string }; name: string; pod?: object };
   runtimeLinkState?: string;
   type: string;
 };


### PR DESCRIPTION
## 📝 Description

Replace plain-text NAD names in the VM details Configuration > Network tab with clickable `ResourceLink` components that navigate to the NetworkAttachmentDefinition detail page.

### Changes
- **NetworkCell**: New component that renders `ResourceLink` for multus networks, parsing `networkName` in `namespace/name` or bare `name` format
- **Pod networking**: Shown as plain text (no link) since pod networks don't reference external resources
- **Graceful fallback**: Malformed `networkName` values (empty name/namespace) fall back to plain text
- **Type update**: Added `pod?: object` to `SimpleNICPresentation.network` for proper pod network detection

## 🔗 Links
- JIRA: [CNV-89223](https://issues.redhat.com/browse/CNV-89223)
- Parent epic: [CNV-89211](https://issues.redhat.com/browse/CNV-89211)

## ✅ Verification
- [x] TypeScript compiles cleanly
- [x] ESLint passes (including max-lines rule)
- [x] Pre-commit hooks pass
- [x] Multi-perspective review (UX, QE, Security, KubeVirt Expert) — no blockers

## 📹 Demo
The "Network" column in the VM Configuration > Network tab now shows clickable links that navigate to the NAD detail page. Pod networking entries remain as plain text.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved NIC network display in virtual machine configuration tables.
  - When a Multus network name is available, it now links to the corresponding network attachment resource.
  - Supports network names with or without namespaces, with sensible fallbacks for malformed or missing values.
  - Shows pod networking when present; otherwise shows a “no data” placeholder.
- **Tests**
  - Added unit tests covering network-name parsing and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->