### PR TITLE
CNV-93086: Support MCOA ClusterManagementAddOn for fleet observability

### DIFF
--- a/src/utils/hooks/useAlerts/utils/useMCOInstalled.ts
+++ b/src/utils/hooks/useAlerts/utils/useMCOInstalled.ts
@@ -1,16 +1,15 @@
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { OBSERVABILITY_CMA_NAMES } from '@kubevirt-utils/hooks/useVirtualizationObservabilityLink/constants';
+import { isObservabilityCMA } from '@kubevirt-utils/hooks/useVirtualizationObservabilityLink/utils';
 import {
   ClusterManagementAddOnModel,
+  modelToGroupVersionKind,
   MultiClusterObservabilityModel,
 } from '@kubevirt-utils/models';
-import { getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import useIsACMPage from '@multicluster/useIsACMPage';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import { useHubClusterName } from '@stolostron/multicluster-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 export const getMCONotInstalledTooltip = (t: TFunction): string =>
   t(
@@ -32,44 +31,25 @@ type UseMCOInstalledResult = {
  * When MCO is not installed, only the hub cluster should be shown and spoke clusters
  * should be disabled with a tooltip.
  *
- * Detection accepts either:
- * - a MultiClusterObservability CR, or
- * - a ClusterManagementAddOn named observability-controller (legacy) or
- *   multicluster-observability-addon (MCOA) — see CNV-93086.
+ * Detection accepts either a MultiClusterObservability CR or a matching
+ * ClusterManagementAddOn (legacy observability-controller or MCOA).
  */
 export const useMCOInstalled = (): UseMCOInstalledResult => {
   const isACMPage = useIsACMPage();
-  const [hubClusterName] = useHubClusterName();
-
-  const watchOnHub = isACMPage
-    ? {
-        cluster: hubClusterName,
-      }
-    : null;
 
   const [mcoResource, mcoLoaded, mcoError] = useK8sWatchData<K8sResourceCommon[]>(
-    watchOnHub
+    isACMPage
       ? {
-          ...watchOnHub,
-          groupVersionKind: {
-            group: MultiClusterObservabilityModel.apiGroup,
-            kind: MultiClusterObservabilityModel.kind,
-            version: MultiClusterObservabilityModel.apiVersion,
-          },
+          groupVersionKind: modelToGroupVersionKind(MultiClusterObservabilityModel),
           isList: true,
         }
       : null,
   );
 
   const [observabilityAddOns, cmaLoaded, cmaError] = useK8sWatchData<K8sResourceCommon[]>(
-    watchOnHub
+    isACMPage
       ? {
-          ...watchOnHub,
-          groupVersionKind: {
-            group: ClusterManagementAddOnModel.apiGroup,
-            kind: ClusterManagementAddOnModel.kind,
-            version: ClusterManagementAddOnModel.apiVersion,
-          },
+          groupVersionKind: modelToGroupVersionKind(ClusterManagementAddOnModel),
           isList: true,
         }
       : null,
@@ -83,11 +63,7 @@ export const useMCOInstalled = (): UseMCOInstalledResult => {
     };
   }
 
-  const hasObservabilityCMA = observabilityAddOns?.some((addon) => {
-    const name = getName(addon);
-    return Boolean(name && (OBSERVABILITY_CMA_NAMES as readonly string[]).includes(name));
-  });
-
+  const hasObservabilityCMA = observabilityAddOns?.some(isObservabilityCMA);
   const mcoInstalled = !isEmpty(mcoResource) || Boolean(hasObservabilityCMA);
 
   return {

--- a/src/utils/hooks/useAlerts/utils/useMCOInstalled.ts
+++ b/src/utils/hooks/useAlerts/utils/useMCOInstalled.ts
@@ -1,6 +1,11 @@
 import { TFunction } from 'i18next';
 
-import { MultiClusterObservabilityModel } from '@kubevirt-utils/models';
+import { OBSERVABILITY_CMA_NAMES } from '@kubevirt-utils/hooks/useVirtualizationObservabilityLink/constants';
+import {
+  ClusterManagementAddOnModel,
+  MultiClusterObservabilityModel,
+} from '@kubevirt-utils/models';
+import { getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import useIsACMPage from '@multicluster/useIsACMPage';
@@ -26,19 +31,44 @@ type UseMCOInstalledResult = {
  * MCO is required for fleet-wide Prometheus metrics polling.
  * When MCO is not installed, only the hub cluster should be shown and spoke clusters
  * should be disabled with a tooltip.
+ *
+ * Detection accepts either:
+ * - a MultiClusterObservability CR, or
+ * - a ClusterManagementAddOn named observability-controller (legacy) or
+ *   multicluster-observability-addon (MCOA) — see CNV-93086.
  */
 export const useMCOInstalled = (): UseMCOInstalledResult => {
   const isACMPage = useIsACMPage();
   const [hubClusterName] = useHubClusterName();
 
-  const [mcoResource, loaded, error] = useK8sWatchData<K8sResourceCommon[]>(
-    isACMPage
+  const watchOnHub = isACMPage
+    ? {
+        cluster: hubClusterName,
+      }
+    : null;
+
+  const [mcoResource, mcoLoaded, mcoError] = useK8sWatchData<K8sResourceCommon[]>(
+    watchOnHub
       ? {
-          cluster: hubClusterName,
+          ...watchOnHub,
           groupVersionKind: {
             group: MultiClusterObservabilityModel.apiGroup,
             kind: MultiClusterObservabilityModel.kind,
             version: MultiClusterObservabilityModel.apiVersion,
+          },
+          isList: true,
+        }
+      : null,
+  );
+
+  const [observabilityAddOns, cmaLoaded, cmaError] = useK8sWatchData<K8sResourceCommon[]>(
+    watchOnHub
+      ? {
+          ...watchOnHub,
+          groupVersionKind: {
+            group: ClusterManagementAddOnModel.apiGroup,
+            kind: ClusterManagementAddOnModel.kind,
+            version: ClusterManagementAddOnModel.apiVersion,
           },
           isList: true,
         }
@@ -52,11 +82,17 @@ export const useMCOInstalled = (): UseMCOInstalledResult => {
       mcoInstalled: true,
     };
   }
-  const mcoInstalled = !isEmpty(mcoResource);
+
+  const hasObservabilityCMA = observabilityAddOns?.some((addon) => {
+    const name = getName(addon);
+    return Boolean(name && (OBSERVABILITY_CMA_NAMES as readonly string[]).includes(name));
+  });
+
+  const mcoInstalled = !isEmpty(mcoResource) || Boolean(hasObservabilityCMA);
 
   return {
-    error,
-    loaded,
+    error: mcoError || cmaError,
+    loaded: mcoLoaded && cmaLoaded,
     mcoInstalled,
   };
 };

--- a/src/utils/hooks/useVirtualizationObservabilityLink/constants.ts
+++ b/src/utils/hooks/useVirtualizationObservabilityLink/constants.ts
@@ -4,7 +4,20 @@ export const VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAME =
 export const VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAMESPACE =
   'open-cluster-management-observability';
 
+/** Legacy Multicluster Observability ClusterManagementAddOn name. */
 export const OBSERVABILITY_CONTROLLER_NAME = 'observability-controller';
+
+/**
+ * MCOA (Multicluster Observability Addon) ClusterManagementAddOn name.
+ * Replaces the legacy observability-controller CMA when MCOA is enabled.
+ */
+export const MULTICLUSTER_OBSERVABILITY_ADDON_NAME = 'multicluster-observability-addon';
+
+/** CMA names that indicate ACM observability collection is available. */
+export const OBSERVABILITY_CMA_NAMES = [
+  OBSERVABILITY_CONTROLLER_NAME,
+  MULTICLUSTER_OBSERVABILITY_ADDON_NAME,
+] as const;
 
 export const VIRTUALIZATION_OBSERVABILITY_DASHBOARD_JSON_NAME =
   'acm-openshift-virtualization-clusters-overview.json';

--- a/src/utils/hooks/useVirtualizationObservabilityLink/constants.ts
+++ b/src/utils/hooks/useVirtualizationObservabilityLink/constants.ts
@@ -3,17 +3,10 @@ export const VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAME =
 
 export const VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAMESPACE =
   'open-cluster-management-observability';
+const OBSERVABILITY_CONTROLLER_NAME = 'observability-controller';
 
-/** Legacy Multicluster Observability ClusterManagementAddOn name. */
-export const OBSERVABILITY_CONTROLLER_NAME = 'observability-controller';
+const MULTICLUSTER_OBSERVABILITY_ADDON_NAME = 'multicluster-observability-addon';
 
-/**
- * MCOA (Multicluster Observability Addon) ClusterManagementAddOn name.
- * Replaces the legacy observability-controller CMA when MCOA is enabled.
- */
-export const MULTICLUSTER_OBSERVABILITY_ADDON_NAME = 'multicluster-observability-addon';
-
-/** CMA names that indicate ACM observability collection is available. */
 export const OBSERVABILITY_CMA_NAMES = [
   OBSERVABILITY_CONTROLLER_NAME,
   MULTICLUSTER_OBSERVABILITY_ADDON_NAME,

--- a/src/utils/hooks/useVirtualizationObservabilityLink/useVirtualizationObservabilityLink.ts
+++ b/src/utils/hooks/useVirtualizationObservabilityLink/useVirtualizationObservabilityLink.ts
@@ -4,28 +4,47 @@ import {
   ConfigMapModel,
   modelToGroupVersionKind,
 } from '@kubevirt-utils/models';
-import { getAnnotation } from '@kubevirt-utils/resources/shared';
+import { getAnnotation, getName } from '@kubevirt-utils/resources/shared';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import {
-  OBSERVABILITY_CONTROLLER_NAME,
+  OBSERVABILITY_CMA_NAMES,
   VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAME,
   VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAMESPACE,
   VIRTUALIZATION_OBSERVABILITY_DASHBOARD_ANNOTATION,
   VIRTUALIZATION_OBSERVABILITY_DASHBOARD_JSON_NAME,
 } from './constants';
 
+const isObservabilityCMA = (addon: K8sResourceCommon): boolean => {
+  const name = getName(addon);
+  return Boolean(name && (OBSERVABILITY_CMA_NAMES as readonly string[]).includes(name));
+};
+
 export const useVirtualizationObservabilityLink = () => {
+  const [hubClusterName] = useHubClusterName();
+
   const [virtObservabilityConfigMap] = useK8sWatchData<IoK8sApiCoreV1ConfigMap>({
+    cluster: hubClusterName,
     groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
     name: VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAME,
     namespace: VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAMESPACE,
   });
 
-  const [observabilityController] = useK8sWatchData({
+  // Watch all CMAs and accept either the legacy observability-controller or
+  // MCOA's multicluster-observability-addon (CNV-93086).
+  const [observabilityAddOns] = useK8sWatchData<K8sResourceCommon[]>({
+    cluster: hubClusterName,
     groupVersionKind: modelToGroupVersionKind(ClusterManagementAddOnModel),
-    name: OBSERVABILITY_CONTROLLER_NAME,
+    isList: true,
   });
+
+  const observabilityAddon = observabilityAddOns?.find(
+    (addon) =>
+      isObservabilityCMA(addon) &&
+      getAnnotation(addon, VIRTUALIZATION_OBSERVABILITY_DASHBOARD_ANNOTATION),
+  );
 
   const parsedDashboardData = JSON.parse(
     virtObservabilityConfigMap?.data?.[VIRTUALIZATION_OBSERVABILITY_DASHBOARD_JSON_NAME] || '{}',
@@ -34,7 +53,7 @@ export const useVirtualizationObservabilityLink = () => {
   const dashboardId = parsedDashboardData?.uid;
 
   const grafanaLink = getAnnotation(
-    observabilityController,
+    observabilityAddon,
     VIRTUALIZATION_OBSERVABILITY_DASHBOARD_ANNOTATION,
   );
 

--- a/src/utils/hooks/useVirtualizationObservabilityLink/useVirtualizationObservabilityLink.ts
+++ b/src/utils/hooks/useVirtualizationObservabilityLink/useVirtualizationObservabilityLink.ts
@@ -1,41 +1,29 @@
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import {
   ClusterManagementAddOnModel,
   ConfigMapModel,
   modelToGroupVersionKind,
 } from '@kubevirt-utils/models';
-import { getAnnotation, getName } from '@kubevirt-utils/resources/shared';
+import { getAnnotation } from '@kubevirt-utils/resources/shared';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import { useHubClusterName } from '@stolostron/multicluster-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 import {
-  OBSERVABILITY_CMA_NAMES,
   VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAME,
   VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAMESPACE,
   VIRTUALIZATION_OBSERVABILITY_DASHBOARD_ANNOTATION,
   VIRTUALIZATION_OBSERVABILITY_DASHBOARD_JSON_NAME,
 } from './constants';
+import { isObservabilityCMA, parseDashboardData } from './utils';
 
-const isObservabilityCMA = (addon: K8sResourceCommon): boolean => {
-  const name = getName(addon);
-  return Boolean(name && (OBSERVABILITY_CMA_NAMES as readonly string[]).includes(name));
-};
-
-export const useVirtualizationObservabilityLink = () => {
-  const [hubClusterName] = useHubClusterName();
-
+export const useVirtualizationObservabilityLink = (): null | string => {
   const [virtObservabilityConfigMap] = useK8sWatchData<IoK8sApiCoreV1ConfigMap>({
-    cluster: hubClusterName,
     groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
     name: VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAME,
     namespace: VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAMESPACE,
   });
 
-  // Watch all CMAs and accept either the legacy observability-controller or
-  // MCOA's multicluster-observability-addon (CNV-93086).
   const [observabilityAddOns] = useK8sWatchData<K8sResourceCommon[]>({
-    cluster: hubClusterName,
     groupVersionKind: modelToGroupVersionKind(ClusterManagementAddOnModel),
     isList: true,
   });
@@ -46,11 +34,11 @@ export const useVirtualizationObservabilityLink = () => {
       getAnnotation(addon, VIRTUALIZATION_OBSERVABILITY_DASHBOARD_ANNOTATION),
   );
 
-  const parsedDashboardData = JSON.parse(
-    virtObservabilityConfigMap?.data?.[VIRTUALIZATION_OBSERVABILITY_DASHBOARD_JSON_NAME] || '{}',
+  const parsedDashboardData = parseDashboardData(
+    virtObservabilityConfigMap?.data?.[VIRTUALIZATION_OBSERVABILITY_DASHBOARD_JSON_NAME],
   );
 
-  const dashboardId = parsedDashboardData?.uid;
+  const dashboardId = parsedDashboardData.uid;
 
   const grafanaLink = getAnnotation(
     observabilityAddon,
@@ -59,6 +47,10 @@ export const useVirtualizationObservabilityLink = () => {
 
   if (!grafanaLink || !dashboardId) return null;
 
-  const grafanaOrigin = new URL(grafanaLink).origin;
-  return `${grafanaOrigin}/d/${dashboardId}/executive-dashboards-clusters-overview?orgId=1`;
+  try {
+    const grafanaOrigin = new URL(grafanaLink).origin;
+    return `${grafanaOrigin}/d/${dashboardId}/executive-dashboards-clusters-overview?orgId=1`;
+  } catch {
+    return null;
+  }
 };

--- a/src/utils/hooks/useVirtualizationObservabilityLink/utils.ts
+++ b/src/utils/hooks/useVirtualizationObservabilityLink/utils.ts
@@ -1,0 +1,27 @@
+import { getName } from '@kubevirt-utils/resources/shared';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+import { OBSERVABILITY_CMA_NAMES } from './constants';
+
+type GrafanaDashboardData = {
+  uid?: string;
+};
+
+export const isObservabilityCMA = (addon: K8sResourceCommon): boolean => {
+  const name = getName(addon);
+  return Boolean(name && (OBSERVABILITY_CMA_NAMES as readonly string[]).includes(name));
+};
+
+export const parseDashboardData = (raw: string | undefined): GrafanaDashboardData => {
+  try {
+    const parsed: unknown = JSON.parse(raw ?? '{}');
+    if (typeof parsed !== 'object' || parsed === null) {
+      return {};
+    }
+
+    const uid = (parsed as { uid?: unknown }).uid;
+    return typeof uid === 'string' ? { uid } : {};
+  } catch {
+    return {};
+  }
+};

--- a/src/utils/models/index.ts
+++ b/src/utils/models/index.ts
@@ -62,7 +62,6 @@ export const ClusterManagementAddOnModel: K8sModel = {
   kind: 'ClusterManagementAddOn',
   label: 'ClusterManagementAddOn',
   labelPlural: 'ClusterManagementAddOns',
-  // ClusterManagementAddOn is a cluster-scoped OCM resource.
   namespaced: false,
   plural: 'clustermanagementaddons',
 };

--- a/src/utils/models/index.ts
+++ b/src/utils/models/index.ts
@@ -62,7 +62,8 @@ export const ClusterManagementAddOnModel: K8sModel = {
   kind: 'ClusterManagementAddOn',
   label: 'ClusterManagementAddOn',
   labelPlural: 'ClusterManagementAddOns',
-  namespaced: true,
+  // ClusterManagementAddOn is a cluster-scoped OCM resource.
+  namespaced: false,
   plural: 'clustermanagementaddons',
 };
 


### PR DESCRIPTION
## 📝 Description

When MCOA is enabled, the legacy `observability-controller` ClusterManagementAddOn is removed and replaced by `multicluster-observability-addon`. Fleet Virtualization only looked for the old CMA name, so observability looked unavailable (Hub-only metrics/alerts, missing Virtualization dashboard link).

This change:
- Accepts either CMA name when resolving the Grafana launch-link
- Treats either CMA (or a `MultiClusterObservability` CR) as MCO installed for fleet metrics/alerts
- Marks `ClusterManagementAddOn` as cluster-scoped so watches resolve correctly

## 🔗 Links

- JIRA: https://issues.redhat.com/browse/CNV-93086
- Related RCA: MCO intentionally removes legacy CMA when MCOA takes over ([stolostron/multicluster-observability-operator#2575](https://github.com/stolostron/multicluster-observability-operator/pull/2575))

## 🎥 Demo
**BEFORE**
<img width="1936" height="1005" alt="image (4)" src="https://github.com/user-attachments/assets/62a7cdd9-3ec4-4c92-b21b-fc6445d2f39b" />


**AFTER**

<img width="1905" height="1084" alt="Screenshot 2026-07-28 at 12 08 55" src="https://github.com/user-attachments/assets/dd8d3a34-53a3-491b-9088-29007425d49d" />


## Test plan
- [ ] ACM fleet with **MCOA enabled**: spoke metrics/alerts appear; Virtualization dashboard link works
- [ ] ACM fleet with **legacy** `observability-controller`: existing behavior unchanged
- [ ] ACM fleet with observability not installed: Hub-only / MCO-not-installed messaging still correct
- [ ] Non-ACM (single cluster): no regression


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Expanded observability detection to recognize Multicluster Observability through supported resource and add-on configurations.
  * Improved virtualization observability dashboard link discovery across supported observability add-ons.

* **Bug Fixes**
  * Prevented failures from malformed dashboard data and invalid Grafana links with graceful fallbacks.
  * Corrected observability add-on scope handling to improve detection accuracy.
  * Improved loading and error handling when checking multiple observability sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->