### PR TITLE
CNV-92846: VM list sort with no usage data (-)

### DIFF
--- a/src/views/virtualmachines/list/vmSortFunctions.ts
+++ b/src/views/virtualmachines/list/vmSortFunctions.ts
@@ -11,6 +11,9 @@ import {
 } from './metrics';
 import { VMCallbacks } from './virtualMachinesDefinition';
 
+const EMPTY_STRING_VALUE = '';
+const EMPTY_NUMBER_VALUE = 0;
+
 const createVMSort = (
   compareFn: (a: V1VirtualMachine, b: V1VirtualMachine, callbacks?: VMCallbacks) => number,
 ) => {
@@ -31,20 +34,15 @@ const createNullSafeSort = (
   isString = false,
 ) => {
   return createVMSort((a, b, callbacks) => {
-    const valA = extractor(a, callbacks);
-    const valB = extractor(b, callbacks);
-
-    // Use nullish checks for numbers (preserves 0), falsy checks for strings
-    const aEmpty = isString ? !valA : valA == null;
-    const bEmpty = isString ? !valB : valB == null;
-
-    if (aEmpty && bEmpty) return 0;
-    if (aEmpty) return 1;
-    if (bEmpty) return -1;
+    const firstValue = extractor(a, callbacks);
+    const secondValue = extractor(b, callbacks);
 
     return isString
-      ? (valA as string).localeCompare(valB as string)
-      : (valA as number) - (valB as number);
+      ? ((firstValue as string) ?? EMPTY_STRING_VALUE).localeCompare(
+          (secondValue as string) ?? EMPTY_STRING_VALUE,
+        )
+      : ((firstValue as number) ?? EMPTY_NUMBER_VALUE) -
+          ((secondValue as number) ?? EMPTY_NUMBER_VALUE);
   });
 };
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes sorting in the VM list so that VMs with no usage data (-) are treated as zero/empty instead of being placed inconsistently depending on sort direction

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-92846
## 🎥 Demo

Before: When sorting by Memory, CPU, Network, Node, or Storage class, VMs with - (no data) appeared at the top in descending order and at the bottom in ascending order

https://github.com/user-attachments/assets/62c2013e-ae02-434a-9155-6556c775742f





After: Empty values are treated as 0 (numbers) or "" (strings), so they sort naturally alongside real values — appearing first in ascending order and last in descending order


https://github.com/user-attachments/assets/12ce0907-b335-4724-a924-bcdd0b63b7ee



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual machine list sorting when values are missing or empty.
  * Ensured consistent ordering for both text and numeric fields without unexpected comparison behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->