### PR TITLE
CNV-85806: Autopilot data-layer

### DIFF
--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/context/CapabilitiesDataProvider.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/context/CapabilitiesDataProvider.tsx
@@ -6,6 +6,7 @@ import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { useDataViewSelection } from '@patternfly/react-data-view';
 import useOperatorResources from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/hooks/useOperatorResources/useOperatorResources';
 
+import useAutopilotStatus from '../hooks/useAutopilotStatus';
 import useInstallBundle from '../hooks/useInstallBundle';
 import useInstallFeature from '../hooks/useInstallFeature';
 import { getRecommendedCapabilityFeatures } from '../utils/capabilityFeatures';
@@ -29,6 +30,8 @@ export const CapabilitiesDataProvider: FC<{ children?: ReactNode }> = ({ childre
   const validNamespace = getValidNamespace(activeNamespace);
 
   const features = useMemo(() => getRecommendedCapabilityFeatures(t), [t]);
+
+  const { autopilotEnabled, autopilotLoaded, autopilotStatusMap } = useAutopilotStatus();
 
   const [alternativeState, setAlternativeState] = useState<AlternativeStateMap>({});
 
@@ -93,14 +96,19 @@ export const CapabilitiesDataProvider: FC<{ children?: ReactNode }> = ({ childre
   const dataValue: CapabilitiesDataValue = useMemo(
     () => ({
       alternativeState,
+      autopilotEnabled,
+      autopilotStatusMap,
       detailsMap,
       features,
       getCapabilityInstallState,
       loadErrors,
-      resourcesLoaded: operatorResourcesLoaded,
+      resourcesLoaded: operatorResourcesLoaded && autopilotLoaded,
     }),
     [
       alternativeState,
+      autopilotEnabled,
+      autopilotLoaded,
+      autopilotStatusMap,
       detailsMap,
       features,
       getCapabilityInstallState,

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/context/useCapabilitiesData.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/context/useCapabilitiesData.ts
@@ -2,6 +2,7 @@ import { createContext, useContext } from 'react';
 
 import {
   type AlternativeStateMap,
+  type AutopilotStatusMap,
   type CapabilityFeature,
   CapabilityInstallState,
   type RecommendedCapabilityDetailsMap,
@@ -9,6 +10,8 @@ import {
 
 export type CapabilitiesDataValue = {
   alternativeState: AlternativeStateMap;
+  autopilotEnabled: boolean;
+  autopilotStatusMap: AutopilotStatusMap;
   detailsMap: RecommendedCapabilityDetailsMap;
   features: CapabilityFeature[];
   getCapabilityInstallState: (feature: CapabilityFeature) => CapabilityInstallState;
@@ -18,6 +21,8 @@ export type CapabilitiesDataValue = {
 
 const defaultDataValue: CapabilitiesDataValue = {
   alternativeState: {},
+  autopilotEnabled: false,
+  autopilotStatusMap: {},
   detailsMap: {},
   features: [],
   getCapabilityInstallState: () => CapabilityInstallState.NotInstalled,

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/hooks/useAutopilotStatus.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/hooks/useAutopilotStatus.ts
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+
+import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { getAnnotation } from '@kubevirt-utils/resources/shared';
+import useKubevirtWatchResources from '@multicluster/hooks/useKubevirtWatchResources';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+import { HCO_AUTOPILOT_ANNOTATION } from '../utils/autopilotConstants';
+import { AUTOPILOT_REGISTRY } from '../utils/autopilotRegistry';
+import { deriveConfigStatus, watchAutopilotResources } from '../utils/autopilotUtils';
+import { type AutopilotStatusMap } from '../utils/types';
+
+type UseAutopilotStatusResult = {
+  autopilotEnabled: boolean;
+  autopilotLoaded: boolean;
+  autopilotStatusMap: AutopilotStatusMap;
+};
+
+const useAutopilotStatus = (): UseAutopilotStatusResult => {
+  const [hco, hcoLoaded] = useHyperConvergeConfiguration();
+
+  const autopilotEnabled = hcoLoaded && getAnnotation(hco, HCO_AUTOPILOT_ANNOTATION) === 'true';
+
+  const results =
+    useKubevirtWatchResources<Record<string, K8sResourceCommon>>(watchAutopilotResources);
+
+  const autopilotLoaded =
+    hcoLoaded && Object.values(results).every((result) => result.loaded || !!result.loadError);
+
+  const autopilotStatusMap = useMemo<AutopilotStatusMap>(
+    () =>
+      AUTOPILOT_REGISTRY.reduce<AutopilotStatusMap>((statusMap, entry) => {
+        const result = results[entry.operatorPackageName];
+        const resource = result?.data;
+
+        statusMap[entry.operatorPackageName] = {
+          configStatus: result?.loaded ? deriveConfigStatus(resource) : undefined,
+          managedCR: resource || undefined,
+          recommendedYAML: entry.recommendedYAML,
+        };
+
+        return statusMap;
+      }, {}),
+    [results],
+  );
+
+  return { autopilotEnabled, autopilotLoaded, autopilotStatusMap };
+};
+
+export default useAutopilotStatus;

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotConstants.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotConstants.ts
@@ -1,0 +1,46 @@
+import { type K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
+
+export const AUTOPILOT_MANAGED_BY_LABEL = 'platform.kubevirt.io/managed-by';
+export const AUTOPILOT_MANAGED_BY_VALUE = 'virt-platform-autopilot';
+export const AUTOPILOT_MODE_ANNOTATION = 'platform.kubevirt.io/mode';
+export const AUTOPILOT_MODE_UNMANAGED = 'unmanaged';
+export const HCO_AUTOPILOT_ANNOTATION = 'platform.kubevirt.io/autopilot';
+
+export const DESCHEDULER_OPERATOR_PACKAGE = 'cluster-kube-descheduler-operator';
+export const CLUSTER_OBSERVABILITY_OPERATOR_PACKAGE = 'cluster-observability-operator';
+
+export const KubeDeschedulerGVK: K8sGroupVersionKind = {
+  group: 'operator.openshift.io',
+  kind: 'KubeDescheduler',
+  version: 'v1',
+};
+
+export const MetalLBGVK: K8sGroupVersionKind = {
+  group: 'metallb.io',
+  kind: 'MetalLB',
+  version: 'v1beta1',
+};
+
+export const ForkliftControllerGVK: K8sGroupVersionKind = {
+  group: 'forklift.konveyor.io',
+  kind: 'ForkliftController',
+  version: 'v1beta1',
+};
+
+export const UIPluginGVK: K8sGroupVersionKind = {
+  group: 'observability.openshift.io',
+  kind: 'UIPlugin',
+  version: 'v1alpha1',
+};
+
+export const LokiStackGVK: K8sGroupVersionKind = {
+  group: 'loki.grafana.com',
+  kind: 'LokiStack',
+  version: 'v1',
+};
+
+export const ClusterLogForwarderGVK: K8sGroupVersionKind = {
+  group: 'observability.openshift.io',
+  kind: 'ClusterLogForwarder',
+  version: 'v1',
+};

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotRecommendedYaml.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotRecommendedYaml.ts
@@ -1,0 +1,75 @@
+/**
+ * Static recommended YAML for autopilot-managed operator CRs.
+ * Used for read-only display in the ReviewRecommendationModal.
+ */
+
+export const KUBE_DESCHEDULER_RECOMMENDED_YAML = `apiVersion: operator.openshift.io/v1
+kind: KubeDescheduler
+metadata:
+  name: cluster
+  namespace: openshift-kube-descheduler-operator
+spec:
+  mode: Predictive
+  deschedulingIntervalSeconds: 3600
+  profiles:
+    - KubeVirtRelieveAndMigrate
+  managementState: Managed`;
+
+export const METALLB_RECOMMENDED_YAML = `apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+  namespace: metallb-system`;
+
+export const FORKLIFT_CONTROLLER_RECOMMENDED_YAML = `apiVersion: forklift.konveyor.io/v1beta1
+kind: ForkliftController
+metadata:
+  name: forklift-controller
+  namespace: openshift-mtv
+spec:
+  feature_must_gather_api: true
+  feature_volume_populator: true`;
+
+export const UI_PLUGIN_RECOMMENDED_YAML = `apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: monitoring
+spec:
+  type: Monitoring`;
+
+export const LOKI_STACK_RECOMMENDED_YAML = `apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  size: 1x.extra-small
+  storage:
+    schemas:
+      - effectiveDate: "2024-10-01"
+        version: v13
+  tenants:
+    mode: openshift-logging`;
+
+export const CLUSTER_LOG_FORWARDER_RECOMMENDED_YAML = `apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: collector
+  namespace: openshift-logging
+spec:
+  managementState: Managed
+  outputs:
+    - lokiStack:
+        target:
+          name: logging-loki
+          namespace: openshift-logging
+      name: default-lokistack
+      type: LokiStack
+  pipelines:
+    - inputRefs:
+        - infrastructure
+        - application
+        - audit
+      name: default-logstore
+      outputRefs:
+        - default-lokistack`;

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotRegistry.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotRegistry.ts
@@ -1,0 +1,78 @@
+import { type K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
+
+import {
+  CLUSTER_OBSERVABILITY_OPERATOR_PACKAGE,
+  ClusterLogForwarderGVK,
+  DESCHEDULER_OPERATOR_PACKAGE,
+  ForkliftControllerGVK,
+  KubeDeschedulerGVK,
+  LokiStackGVK,
+  MetalLBGVK,
+  UIPluginGVK,
+} from './autopilotConstants';
+import {
+  CLUSTER_LOG_FORWARDER_RECOMMENDED_YAML,
+  FORKLIFT_CONTROLLER_RECOMMENDED_YAML,
+  KUBE_DESCHEDULER_RECOMMENDED_YAML,
+  LOKI_STACK_RECOMMENDED_YAML,
+  METALLB_RECOMMENDED_YAML,
+  UI_PLUGIN_RECOMMENDED_YAML,
+} from './autopilotRecommendedYaml';
+import {
+  CLUSTER_LOGGING_OPERATOR_NAME,
+  LOKI_OPERATOR_NAME,
+  METALLB_OPERATOR_NAME,
+  MTV_OPERATOR_NAME,
+} from './operatorNames';
+
+export type AutopilotRegistryEntry = {
+  crGVK: K8sGroupVersionKind;
+  crName: string;
+  crNamespace?: string;
+  operatorPackageName: string;
+  recommendedYAML: string;
+};
+
+export const AUTOPILOT_REGISTRY: AutopilotRegistryEntry[] = [
+  {
+    crGVK: KubeDeschedulerGVK,
+    crName: 'cluster',
+    crNamespace: 'openshift-kube-descheduler-operator',
+    operatorPackageName: DESCHEDULER_OPERATOR_PACKAGE,
+    recommendedYAML: KUBE_DESCHEDULER_RECOMMENDED_YAML,
+  },
+  {
+    crGVK: MetalLBGVK,
+    crName: 'metallb',
+    crNamespace: 'metallb-system',
+    operatorPackageName: METALLB_OPERATOR_NAME,
+    recommendedYAML: METALLB_RECOMMENDED_YAML,
+  },
+  {
+    crGVK: ForkliftControllerGVK,
+    crName: 'forklift-controller',
+    crNamespace: 'openshift-mtv',
+    operatorPackageName: MTV_OPERATOR_NAME,
+    recommendedYAML: FORKLIFT_CONTROLLER_RECOMMENDED_YAML,
+  },
+  {
+    crGVK: UIPluginGVK,
+    crName: 'monitoring',
+    operatorPackageName: CLUSTER_OBSERVABILITY_OPERATOR_PACKAGE,
+    recommendedYAML: UI_PLUGIN_RECOMMENDED_YAML,
+  },
+  {
+    crGVK: LokiStackGVK,
+    crName: 'logging-loki',
+    crNamespace: 'openshift-logging',
+    operatorPackageName: LOKI_OPERATOR_NAME,
+    recommendedYAML: LOKI_STACK_RECOMMENDED_YAML,
+  },
+  {
+    crGVK: ClusterLogForwarderGVK,
+    crName: 'collector',
+    crNamespace: 'openshift-logging',
+    operatorPackageName: CLUSTER_LOGGING_OPERATOR_NAME,
+    recommendedYAML: CLUSTER_LOG_FORWARDER_RECOMMENDED_YAML,
+  },
+];

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotUtils.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotUtils.ts
@@ -1,0 +1,42 @@
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { getAnnotation, getLabel } from '@kubevirt-utils/resources/shared';
+
+import {
+  AUTOPILOT_MANAGED_BY_LABEL,
+  AUTOPILOT_MANAGED_BY_VALUE,
+  AUTOPILOT_MODE_ANNOTATION,
+  AUTOPILOT_MODE_UNMANAGED,
+} from './autopilotConstants';
+import { AUTOPILOT_REGISTRY, type AutopilotRegistryEntry } from './autopilotRegistry';
+import { ConfigurationStatus } from './types';
+
+export const watchAutopilotResources = Object.fromEntries(
+  AUTOPILOT_REGISTRY.map((entry) => [
+    entry.operatorPackageName,
+    {
+      groupVersionKind: entry.crGVK,
+      name: entry.crName,
+      ...(entry.crNamespace && { namespace: entry.crNamespace }),
+    },
+  ]),
+);
+
+export const deriveConfigStatus = (
+  resource: K8sResourceCommon | undefined,
+): ConfigurationStatus | undefined => {
+  if (!resource) return undefined;
+
+  const managedBy = getLabel(resource, AUTOPILOT_MANAGED_BY_LABEL);
+  const mode = getAnnotation(resource, AUTOPILOT_MODE_ANNOTATION);
+
+  if (managedBy === AUTOPILOT_MANAGED_BY_VALUE && mode !== AUTOPILOT_MODE_UNMANAGED) {
+    return ConfigurationStatus.Recommended;
+  }
+
+  return ConfigurationStatus.Manual;
+};
+
+export const getRegistryEntryByPackageName = (
+  packageName: string,
+): AutopilotRegistryEntry | undefined =>
+  AUTOPILOT_REGISTRY.find((entry) => entry.operatorPackageName === packageName);

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/types.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/types.ts
@@ -1,4 +1,5 @@
 import { OLSPromptType } from '@lightspeed/utils/prompts';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import {
   type OperatorGroupKind,
   type PackageManifestKind,
@@ -46,6 +47,19 @@ export type SelectionCardConfig = {
   label: string;
   showRecommendedBadge: boolean;
 };
+
+export enum ConfigurationStatus {
+  Manual = 'Manual',
+  Recommended = 'Recommended',
+}
+
+export type AutopilotOperatorStatus = {
+  configStatus?: ConfigurationStatus;
+  managedCR?: K8sResourceCommon;
+  recommendedYAML: string;
+};
+
+export type AutopilotStatusMap = Record<string, AutopilotOperatorStatus>;
 
 export type AlternativeStateMap = Record<string, boolean>;
 


### PR DESCRIPTION

## 📝 Description

adds the autopilot data layer for the configuration column in the recommended capabilities table (future pr)
- static registry mapping 6 autopilot supported operators to their CRs and recommended YAML (autopilot doesn't currently expose)
- hook to watch managed CRs and get configuration status (Recommended/Manual)


## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-85806




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Autopilot status tracking to the Recommended Capabilities tab, including an enabled/loaded state and per-capability status.
  * Introduced recommended YAML templates for supported capabilities (descheduler, MetalLB, forklift, monitoring, logging, and collection).
  * Added automatic configuration status detection (recommended vs manual) based on Autopilot-related metadata.
* **Bug Fixes / Improvements**
  * Updated capability data loading so it becomes available only after Autopilot status is resolved, with load errors treated as non-blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->