### PR TITLE
CNV-87133: restrict tab to admin

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -2767,8 +2767,6 @@
   "You don't have any volumes for the chosen OS yet": "You don't have any volumes for the chosen OS yet",
   "You don't have any volumes yet": "You don't have any volumes yet",
   "You don't have permission to perform this action": "You don't have permission to perform this action",
-  "You must be an administrator to install operators": "You must be an administrator to install operators",
-  "You must be an administrator to manage operators": "You must be an administrator to manage operators",
   "You must ensure that the configuration is correct before starting the VirtualMachine.": "You must ensure that the configuration is correct before starting the VirtualMachine.",
   "You're all set!": "You're all set!",
   "You're in view-only mode": "You're in view-only mode",

--- a/locales/es/plugin__kubevirt-plugin.json
+++ b/locales/es/plugin__kubevirt-plugin.json
@@ -2791,8 +2791,6 @@
   "You don't have any volumes for the chosen OS yet": "You don't have any volumes for the chosen OS yet",
   "You don't have any volumes yet": "You don't have any volumes yet",
   "You don't have permission to perform this action": "No tiene permiso para realizar esta acción.",
-  "You must be an administrator to install operators": "You must be an administrator to install operators",
-  "You must be an administrator to manage operators": "You must be an administrator to manage operators",
   "You must ensure that the configuration is correct before starting the VirtualMachine.": "Debe asegurarse de que la configuración sea correcta antes de iniciar la VirtualMachine.",
   "You're all set!": "¡Ya está todo listo!",
   "You're in view-only mode": "Está en modo de solo visualización.",

--- a/locales/fr/plugin__kubevirt-plugin.json
+++ b/locales/fr/plugin__kubevirt-plugin.json
@@ -2791,8 +2791,6 @@
   "You don't have any volumes for the chosen OS yet": "You don't have any volumes for the chosen OS yet",
   "You don't have any volumes yet": "You don't have any volumes yet",
   "You don't have permission to perform this action": "Vous n’êtes pas autorisé à effectuer cette action.",
-  "You must be an administrator to install operators": "You must be an administrator to install operators",
-  "You must be an administrator to manage operators": "You must be an administrator to manage operators",
   "You must ensure that the configuration is correct before starting the VirtualMachine.": "Vous devez vous assurer que la configuration est correcte avant de démarrer la machine virtuelle.",
   "You're all set!": "C'est tout bon !",
   "You're in view-only mode": "Vous êtes en mode lecture seule",

--- a/locales/ja/plugin__kubevirt-plugin.json
+++ b/locales/ja/plugin__kubevirt-plugin.json
@@ -2762,8 +2762,6 @@
   "You don't have any volumes for the chosen OS yet": "You don't have any volumes for the chosen OS yet",
   "You don't have any volumes yet": "You don't have any volumes yet",
   "You don't have permission to perform this action": "このアクションを実行する権限がありません",
-  "You must be an administrator to install operators": "You must be an administrator to install operators",
-  "You must be an administrator to manage operators": "You must be an administrator to manage operators",
   "You must ensure that the configuration is correct before starting the VirtualMachine.": "VirtualMachine を起動する前に、設定が正しいことを確認する必要があります。",
   "You're all set!": "準備が整いました!",
   "You're in view-only mode": "表示専用モードです",

--- a/locales/ko/plugin__kubevirt-plugin.json
+++ b/locales/ko/plugin__kubevirt-plugin.json
@@ -2762,8 +2762,6 @@
   "You don't have any volumes for the chosen OS yet": "You don't have any volumes for the chosen OS yet",
   "You don't have any volumes yet": "You don't have any volumes yet",
   "You don't have permission to perform this action": "이 작업을 수행할 수 있는 권한이 없습니다",
-  "You must be an administrator to install operators": "You must be an administrator to install operators",
-  "You must be an administrator to manage operators": "You must be an administrator to manage operators",
   "You must ensure that the configuration is correct before starting the VirtualMachine.": "VirtualMachine을 시작하기 전에 구성이 올바른지 확인해야 합니다.",
   "You're all set!": "모두 설정되어 있습니다!",
   "You're in view-only mode": "뷰 전용 모드입니다.",

--- a/locales/zh/plugin__kubevirt-plugin.json
+++ b/locales/zh/plugin__kubevirt-plugin.json
@@ -2762,8 +2762,6 @@
   "You don't have any volumes for the chosen OS yet": "You don't have any volumes for the chosen OS yet",
   "You don't have any volumes yet": "You don't have any volumes yet",
   "You don't have permission to perform this action": "您没有执行此操作的权限",
-  "You must be an administrator to install operators": "You must be an administrator to install operators",
-  "You must be an administrator to manage operators": "You must be an administrator to manage operators",
   "You must ensure that the configuration is correct before starting the VirtualMachine.": "您必须确保在启动 VirtualMachine 前配置正确。",
   "You're all set!": "您已完成设置！",
   "You're in view-only mode": "您处于只读模式",

--- a/src/views/settings/SettingsPage.tsx
+++ b/src/views/settings/SettingsPage.tsx
@@ -5,6 +5,7 @@ import ClusterDropdown from '@kubevirt-utils/components/ClusterProjectDropdown/C
 import ConfigurationSearch from '@kubevirt-utils/components/ConfigurationSearch/ConfigurationSearch';
 import GuidedTour from '@kubevirt-utils/components/GuidedTour/GuidedTour';
 import LoadingEmptyState from '@kubevirt-utils/components/LoadingEmptyState/LoadingEmptyState';
+import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VirtualMachineModelRef } from '@kubevirt-utils/models';
 import { getNamespacePathSegment } from '@kubevirt-utils/utils/utils';
@@ -32,6 +33,7 @@ const SettingsPage: FC = () => {
   useSignals();
 
   const { t } = useKubevirtTranslation();
+  const isAdmin = useIsAdmin();
   const [activeNamespace] = useActiveNamespace();
   const [clusterNames, clustersLoaded] = useFleetClusterNames();
   const [hubClusterName] = useHubClusterName();
@@ -92,7 +94,7 @@ const SettingsPage: FC = () => {
                 <ConfigurationSearch
                   createSearchURL={createSettingsSearchURL}
                   placeholder={showClusterDropdown ? t('Find in selected cluster') : undefined}
-                  searchItems={getSearchItems(t)}
+                  searchItems={getSearchItems(t, isAdmin)}
                 />
               </GridItem>
             </Grid>

--- a/src/views/settings/search/search.ts
+++ b/src/views/settings/search/search.ts
@@ -80,13 +80,15 @@ const getDownloadsTabIds = (t: TFunction): SearchItem[] => [
   { id: DOWNLOADS_TAB_IDS.virtioDriversWindows, title: t('VirtIO drivers for Windows') },
 ];
 
-export const getSearchItems = (t: TFunction): SearchItemWithTab[] => {
+export const getSearchItems = (t: TFunction, isAdmin: boolean): SearchItemWithTab[] => {
   const tabsIds: { [key: string]: SearchItem[] } = {
-    cluster: getClusterTabIds(t),
     downloads: getDownloadsTabIds(t),
-    features: getPreviewFeaturesTabIds(t),
-    recommended: getRecommendedTabIds(t),
     user: getUserTabIds(t),
+    ...(isAdmin && {
+      cluster: getClusterTabIds(t),
+      features: getPreviewFeaturesTabIds(t),
+      recommended: getRecommendedTabIds(t),
+    }),
   };
 
   return Object.entries(tabsIds)

--- a/src/views/settings/tabs.ts
+++ b/src/views/settings/tabs.ts
@@ -46,7 +46,7 @@ export const getTabs = (isAdmin: boolean, t: TFunction): SettingsTabConfig[] => 
   {
     Component: RecommendedCapabilitiesTab,
     dataTest: 'recommended-capabilities',
-    isEnabled: true,
+    isEnabled: isAdmin,
     isFullWidth: true,
     name: SETTINGS_TABS.RECOMMENDED,
     title: t('Recommended capabilities'),

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/CustomSelectionView.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/CustomSelectionView.tsx
@@ -2,7 +2,6 @@ import React, { FC, useMemo } from 'react';
 import { useNavigate } from 'react-router';
 
 import StateHandler from '@kubevirt-utils/components/StateHandler/StateHandler';
-import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Alert, Stack, StackItem } from '@patternfly/react-core';
@@ -21,7 +20,6 @@ import { isCapabilitySelectable, sortFeatures } from './utils';
 const CustomSelectionView: FC = () => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
-  const isAdmin = useIsAdmin();
   const { detailsMap, features, getCapabilityInstallState, loadErrors, resourcesLoaded } =
     useCapabilitiesData();
   const { capabilitySelection, installFeature, installingFeatures } = useCapabilitiesActions();
@@ -45,7 +43,6 @@ const CustomSelectionView: FC = () => {
         getCapabilityInstallState,
         installFeature,
         installingFeatures,
-        isAdmin,
         navigate,
         t,
       }),
@@ -54,7 +51,6 @@ const CustomSelectionView: FC = () => {
       getCapabilityInstallState,
       installFeature,
       installingFeatures,
-      isAdmin,
       navigate,
       sortedFeatures,
       t,

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/actions.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/actions.ts
@@ -7,21 +7,15 @@ import { type CapabilityFeature, CapabilityInstallState } from '../../utils/type
 export const getCapabilityRowActions = (
   feature: CapabilityFeature,
   installState: CapabilityInstallState,
-  isAdmin: boolean,
   isFeatureInstalling: boolean,
   installFeature: (feature: CapabilityFeature) => Promise<void>,
-  notAdminTooltip: string,
   t: TFunction,
 ): ActionDropdownItemType[] => {
-  const isDisabled = !isAdmin || isFeatureInstalling;
-  const disabledTooltip = !isAdmin ? notAdminTooltip : undefined;
-
   if (installState === CapabilityInstallState.NotInstalled) {
     return [
       {
         cta: () => void installFeature(feature),
-        disabled: isDisabled,
-        disabledTooltip,
+        disabled: isFeatureInstalling,
         id: `install-all-${feature.id}`,
         label: t('Install all operators'),
       },
@@ -32,8 +26,7 @@ export const getCapabilityRowActions = (
     return [
       {
         cta: () => void installFeature(feature),
-        disabled: isDisabled,
-        disabledTooltip,
+        disabled: isFeatureInstalling,
         id: `install-missing-${feature.id}`,
         label: t('Install missing operators'),
       },

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildTreeRows.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildTreeRows.tsx
@@ -19,7 +19,6 @@ type BuildTreeRowsParams = {
   getCapabilityInstallState: (feature: CapabilityFeature) => CapabilityInstallState;
   installFeature: (feature: CapabilityFeature) => Promise<void>;
   installingFeatures: Set<string>;
-  isAdmin: boolean;
   navigate: (path: string) => void;
   t: TFunction;
 };
@@ -30,23 +29,18 @@ export const buildTreeRows = ({
   getCapabilityInstallState,
   installFeature,
   installingFeatures,
-  isAdmin,
   navigate,
   t,
-}: BuildTreeRowsParams): DataViewTrTree[] => {
-  const notAdminTooltip = t('You must be an administrator to manage operators');
-
-  return features.map((feature) => {
+}: BuildTreeRowsParams): DataViewTrTree[] =>
+  features.map((feature) => {
     const installState = getCapabilityInstallState(feature);
     const isFeatureInstalling =
       installingFeatures.has(feature.id) || hasOperatorsInstalling(feature, detailsMap);
     const actions = getCapabilityRowActions(
       feature,
       installState,
-      isAdmin,
       isFeatureInstalling,
       installFeature,
-      notAdminTooltip,
       t,
     );
 
@@ -58,4 +52,3 @@ export const buildTreeRows = ({
       row: buildCapabilityRow(feature, installState, isFeatureInstalling, actions, t),
     };
   });
-};

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/InstallBundleButton/InstallBundleButton.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/InstallBundleButton/InstallBundleButton.tsx
@@ -2,7 +2,6 @@ import React, { FC } from 'react';
 
 import { type TFunction } from 'i18next';
 
-import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Button, Skeleton, Tooltip } from '@patternfly/react-core';
@@ -13,12 +12,10 @@ import { useCapabilitiesData } from '../../context/useCapabilitiesData';
 import { countInstalledCapabilities, getBundleFeatures } from '../../utils/utils';
 
 const getInstallBundleTooltipContent = (
-  isAdmin: boolean,
   allBundleCapabilitiesInstalled: boolean,
   hasLoadErrors: boolean,
   t: TFunction,
 ): string | undefined => {
-  if (!isAdmin) return t('You must be an administrator to install operators');
   if (hasLoadErrors) return t('Cannot install while operator data failed to load');
   if (allBundleCapabilitiesInstalled) return t('All bundle capabilities are already installed');
   return undefined;
@@ -26,7 +23,6 @@ const getInstallBundleTooltipContent = (
 
 const InstallBundleButton: FC = () => {
   const { t } = useKubevirtTranslation();
-  const isAdmin = useIsAdmin();
   const { detailsMap, features, loadErrors, resourcesLoaded } = useCapabilitiesData();
   const { installBundle, installResourcesLoaded, isInstalling } = useCapabilitiesActions();
 
@@ -49,14 +45,9 @@ const InstallBundleButton: FC = () => {
   const hasLoadErrors = !isEmpty(loadErrors);
 
   const isDisabled =
-    !isAdmin ||
-    isInstalling ||
-    isBundleInstallInProgress ||
-    allBundleCapabilitiesInstalled ||
-    hasLoadErrors;
+    isInstalling || isBundleInstallInProgress || allBundleCapabilitiesInstalled || hasLoadErrors;
 
   const tooltipContent = getInstallBundleTooltipContent(
-    isAdmin,
     allBundleCapabilitiesInstalled,
     hasLoadErrors,
     t,

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/InstallSelectedButton/InstallSelectedButton.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/InstallSelectedButton/InstallSelectedButton.tsx
@@ -2,7 +2,6 @@ import React, { FC, useCallback, useMemo } from 'react';
 
 import { type TFunction } from 'i18next';
 
-import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Button, Skeleton, Tooltip } from '@patternfly/react-core';
@@ -13,12 +12,10 @@ import { CapabilityInstallState } from '../../utils/types';
 import { hasOperatorsInstalling } from '../CustomSelectionView/utils';
 
 const getTooltipContent = (
-  isAdmin: boolean,
   hasSelection: boolean,
   hasLoadErrors: boolean,
   t: TFunction,
 ): string | undefined => {
-  if (!isAdmin) return t('You must be an administrator to install operators');
   if (hasLoadErrors) return t('Cannot install while operator data failed to load');
   if (!hasSelection) return t('Select capabilities to install');
   return undefined;
@@ -26,7 +23,6 @@ const getTooltipContent = (
 
 const InstallSelectedButton: FC = () => {
   const { t } = useKubevirtTranslation();
-  const isAdmin = useIsAdmin();
   const { detailsMap, features, getCapabilityInstallState, loadErrors, resourcesLoaded } =
     useCapabilitiesData();
   const {
@@ -62,9 +58,9 @@ const InstallSelectedButton: FC = () => {
   const hasSelection = !isEmpty(installableSelectedFeatures);
   const hasLoadErrors = !isEmpty(loadErrors);
   const isAnyInstalling = isInstalling || installingFeatures.size > 0;
-  const isDisabled = !isAdmin || !hasSelection || isAnyInstalling || hasLoadErrors;
+  const isDisabled = !hasSelection || isAnyInstalling || hasLoadErrors;
 
-  const tooltipContent = getTooltipContent(isAdmin, hasSelection, hasLoadErrors, t);
+  const tooltipContent = getTooltipContent(hasSelection, hasLoadErrors, t);
 
   const button = (
     <Button


### PR DESCRIPTION

## 📝 Description

restrict access to recommended capabilities tab to admin only 

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-87133

## 🎥 Demo


https://github.com/user-attachments/assets/95ddc77a-e86d-4e74-89b8-aeb60a945753




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Restricted the “Recommended capabilities” settings tab and related search options to administrators.
- **Bug Fixes**
  - Updated capability installation controls to enable actions based on installation state, selections, and errors rather than administrator status.
  - Improved tooltips by removing unnecessary administrator-specific restrictions and messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->