### PR TITLE
CNV-94182: verify CI workflows after sparse-checkout fix

### DIFF
--- a/.github/actions/create-bot-token/action.yml
+++ b/.github/actions/create-bot-token/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: Pull requests permission for the token (omit with empty string)
     required: false
     default: write
+  permission-checks:
+    description: Checks permission for the token (omit with empty string)
+    required: false
+    default: ''
 
 outputs:
   token:
@@ -36,3 +40,4 @@ runs:
         private-key: ${{ inputs.private-key }}
         permission-issues: ${{ inputs.permission-issues }}
         permission-pull-requests: ${{ inputs.permission-pull-requests }}
+        permission-checks: ${{ inputs.permission-checks }}

--- a/.github/scripts/src/commands/validation-handler.ts
+++ b/.github/scripts/src/commands/validation-handler.ts
@@ -6,6 +6,8 @@
 
 import type { CommandContext } from './dispatcher';
 
+import { main as runValidationCommands } from '../validation/commands/index';
+
 export const executeValidationCommand = async (ctx: CommandContext): Promise<void> => {
   const { data: pullRequest } = await ctx.octokit.pulls.get({
     owner: ctx.owner,
@@ -22,5 +24,5 @@ export const executeValidationCommand = async (ctx: CommandContext): Promise<voi
   process.env.PR_HEAD_SHA = pullRequest.head.sha;
   process.env.PR_AUTHOR = pullRequest.user?.login ?? '';
 
-  await import('../validation/commands/index');
+  await runValidationCommands();
 };

--- a/.github/scripts/src/label-sync/index.ts
+++ b/.github/scripts/src/label-sync/index.ts
@@ -25,15 +25,14 @@ import { dispatchWorkflow } from '../shared/dispatch';
 import { getRepoContext } from '../shared/actions-context';
 import type { GitHubConfig } from '../types/index';
 import { requireEnv, safeErrorMessage } from '../utils';
-import { verifyMergePoolHoldRemoval, verifyMergePoolLabel } from '../validation/verify-merge-pool-labels/verify';
+import {
+  verifyMergePoolHoldRemoval,
+  verifyMergePoolLabel,
+} from '../validation/verify-merge-pool-labels/verify';
 
 const VERIFY_ON_LABELED = new Set(['lgtm', 'approved', 'do-not-merge/hold']);
 const RETEST_ON_LABELED = new Set(['lgtm', 'approved']);
-const RETEST_ON_UNLABELED = new Set([
-  'do-not-merge/hold',
-  'hold',
-  'needs-rebase',
-]);
+const RETEST_ON_UNLABELED = new Set(['do-not-merge/hold', 'hold', 'needs-rebase']);
 
 type Route = { verify: boolean; retest: boolean };
 
@@ -157,9 +156,7 @@ const main = async (): Promise<void> => {
     token: requireEnv('GITHUB_TOKEN'),
   };
 
-  console.log(
-    `Label "${labelName}" (${action}) → verify=${route.verify}, retest=${route.retest}`,
-  );
+  console.log(`Label "${labelName}" (${action}) → verify=${route.verify}, retest=${route.retest}`);
 
   if (route.verify) {
     await runVerify(config, action);

--- a/.github/scripts/src/validation/commands/index.ts
+++ b/.github/scripts/src/validation/commands/index.ts
@@ -16,7 +16,7 @@ import { parseCommand } from './parse-command';
 import type { CommandHandlers, CommandOutcome } from './process';
 import { processCommands, reportCommandFailure } from './process';
 
-const main = async (): Promise<void> => {
+export const main = async (): Promise<void> => {
   const commands = parseCommand(requireEnv('COMMENT_BODY'));
 
   const config: GitHubConfig = {
@@ -94,29 +94,31 @@ const main = async (): Promise<void> => {
   }
 
   if (failures.length > 0) {
-    process.exit(1);
+    throw new Error(`${failures.length} command(s) failed`);
   }
 };
 
-void main().catch(async (err) => {
-  console.error(safeErrorMessage(err));
+if (require.main === module) {
+  void main().catch(async (err) => {
+    console.error(safeErrorMessage(err));
 
-  // Reaching here means something failed *before* the per-command loop even
-  // started (e.g. requireEnv('GITHUB_TOKEN') throwing because a bot-token
-  // generation step failed) -- nothing has been reported yet. Best-effort
-  // report it against every requested command via the ambient/status token,
-  // which doesn't depend on the credential that just failed.
-  const owner = process.env.REPO_OWNER;
-  const repo = process.env.REPO_NAME;
-  const statusToken = process.env.STATUS_GITHUB_TOKEN ?? process.env.GITHUB_TOKEN;
+    // Reaching here means something failed *before* the per-command loop even
+    // started (e.g. requireEnv('GITHUB_TOKEN') throwing because a bot-token
+    // generation step failed) -- nothing has been reported yet. Best-effort
+    // report it against every requested command via the ambient/status token,
+    // which doesn't depend on the credential that just failed.
+    const owner = process.env.REPO_OWNER;
+    const repo = process.env.REPO_NAME;
+    const statusToken = process.env.STATUS_GITHUB_TOKEN ?? process.env.GITHUB_TOKEN;
 
-  if (owner && repo && statusToken) {
-    const commands = parseCommand(process.env.COMMENT_BODY ?? '');
-    const config: GitHubConfig = { owner, repo, token: statusToken };
-    for (const command of commands) {
-      await reportCommandFailure({ command, error: err }, config, process.env.PR_HEAD_SHA);
+    if (owner && repo && statusToken) {
+      const commands = parseCommand(process.env.COMMENT_BODY ?? '');
+      const config: GitHubConfig = { owner, repo, token: statusToken };
+      for (const command of commands) {
+        await reportCommandFailure({ command, error: err }, config, process.env.PR_HEAD_SHA);
+      }
     }
-  }
 
-  process.exit(1);
-});
+    process.exit(1);
+  });
+}

--- a/.github/workflows/hot-cluster-e2e-pr-gate.yml
+++ b/.github/workflows/hot-cluster-e2e-pr-gate.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           app-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          permission-checks: write
 
       - name: Clear stale e2e-passed/e2e-failed on push
         if: github.event.action == 'synchronize'

--- a/README.md
+++ b/README.md
@@ -155,4 +155,3 @@ config to enable the plugin.
 oc patch consoles.operator.openshift.io cluster \
   --patch '{ "spec": { "plugins": ["kubevirt-plugin"] } }' --type=merge
 ```
-


### PR DESCRIPTION
Empty test PR to confirm all workflows run cleanly.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Deployment on cluster” instructions to correct the `oc patch` command example so the console operator plugin is enabled after deployment.
* **Chores**
  * Enhanced the pull request gating workflow to request additional “checks” permissions and made held/queued status publishing more resilient to transient failures.
  * Extended the bot-token action with an optional input to control “checks” permissions.
  * Improved validation command handling to properly surface command failures without auto-running when imported.
  * Updated label-sync retest routing logic and logging for more reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->