### PR TITLE
CNV-94182: restore path validation error commit status

### DIFF
--- a/.github/scripts/src/validation/pr-path-validation/execute.test.ts
+++ b/.github/scripts/src/validation/pr-path-validation/execute.test.ts
@@ -22,19 +22,68 @@ const TEST_CONFIG: PathValidationConfig = {
 
 const buildStatusDescription = (): string => 'unused';
 
+type Call = { args: unknown; method: string };
+
+type FakeOptions = {
+  /** Reject createCommitStatus starting from this call number onward (1-indexed). Ignored when unset. */
+  rejectCommitStatusFromCall?: number;
+};
+
 /** issues.listLabelsOnIssue throws -- simulating a genuinely unexpected failure inside runPathValidation. */
-const fakeOctokitThrowing = (): Octokit =>
+const fakeOctokitThrowingAfterPending = (calls: Call[], options: FakeOptions = {}): Octokit =>
   ({
     issues: {
       listLabelsOnIssue: async () => {
+        calls.push({ args: {}, method: 'issues.listLabelsOnIssue' });
         throw new Error('API rate limit exceeded');
+      },
+    },
+    repos: {
+      createCommitStatus: async (args: unknown) => {
+        const callNumber = calls.filter((c) => c.method === 'createCommitStatus').length + 1;
+        calls.push({ args, method: 'createCommitStatus' });
+        if (
+          options.rejectCommitStatusFromCall !== undefined &&
+          callNumber >= options.rejectCommitStatusFromCall
+        ) {
+          throw new Error('secondary outage: statuses unavailable');
+        }
       },
     },
   }) as unknown as Octokit;
 
 describe('executePathValidation', () => {
-  it('wraps unexpected errors in HandledValidationError', async () => {
-    const octokit = fakeOctokitThrowing();
+  it('reports a final "error" status when an unexpected error occurs', async () => {
+    const calls: Call[] = [];
+    const octokit = fakeOctokitThrowingAfterPending(calls);
+
+    await assert.rejects(
+      executePathValidation(
+        {
+          baseBranch: 'main',
+          config: { owner: 'kubevirt-ui', repo: 'kubevirt-plugin', token: 'x' },
+          files: [{ filename: 'protected/foo.ts' }],
+          headSha: 'abc123',
+          octokit,
+          prNumber: 1,
+          statusOctokit: octokit,
+        },
+        TEST_CONFIG,
+        buildStatusDescription,
+      ),
+      HandledValidationError,
+    );
+
+    const statuses = calls
+      .filter((c) => c.method === 'createCommitStatus')
+      .map((c) => c.args as { context: string; state: string });
+    assert.equal(statuses.at(-1)?.state, 'error');
+    assert.equal(statuses.at(-1)?.context, 'test-validation');
+  });
+
+  it('still rethrows HandledValidationError even when the error status publish itself rejects', async () => {
+    const calls: Call[] = [];
+    const octokit = fakeOctokitThrowingAfterPending(calls, { rejectCommitStatusFromCall: 1 });
 
     await assert.rejects(
       executePathValidation(
@@ -60,7 +109,7 @@ describe('reportPathValidationError', () => {
     await assert.doesNotReject(
       reportPathValidationError(
         { owner: 'kubevirt-ui', repo: 'kubevirt-plugin', token: 'x' },
-        'abc123',
+        undefined,
         TEST_CONFIG,
         new Error('boom'),
       ),

--- a/.github/scripts/src/validation/pr-path-validation/execute.ts
+++ b/.github/scripts/src/validation/pr-path-validation/execute.ts
@@ -1,5 +1,6 @@
 import type { Octokit } from '@octokit/rest';
 
+import { setCommitStatus } from '../../github-comments';
 import { createOctokit, createStatusOctokit } from '../../github-repo';
 import type { GitHubConfig } from '../../types/index';
 import { safeErrorMessage } from '../../utils';
@@ -38,24 +39,44 @@ export const executePathValidation = async (
   const octokit = input.octokit ?? createOctokit(config);
   const statusOctokit = input.statusOctokit ?? createStatusOctokit(config);
 
-  const outcome: PathValidationOutcome = await runPathValidation(
-    {
-      baseBranch,
-      config,
-      event: { action: eventAction },
-      files,
-      headSha,
-      octokit,
-      prNumber,
-      statusOctokit,
-    },
-    pathConfig,
-    buildStatusDescription,
-    onFilesFetched,
-  ).catch((err) => {
+  let outcome: PathValidationOutcome;
+  try {
+    outcome = await runPathValidation(
+      {
+        baseBranch,
+        config,
+        event: { action: eventAction },
+        files,
+        headSha,
+        octokit,
+        prNumber,
+        statusOctokit,
+      },
+      pathConfig,
+      buildStatusDescription,
+      onFilesFetched,
+    );
+  } catch (err) {
     const message = `${pathConfig.displayName} encountered an unexpected error`;
+    // Best-effort -- a rejected status publish must not prevent rethrowing
+    // as HandledValidationError below.
+    if (headSha) {
+      await setCommitStatus(
+        statusOctokit,
+        config.owner,
+        config.repo,
+        headSha,
+        'error',
+        message,
+        pathConfig.statusContext,
+      ).catch((statusErr) => {
+        console.error(`Failed to report error status: ${safeErrorMessage(statusErr)}`);
+      });
+    }
+    // Already reported above -- wrap as HandledValidationError so the
+    // caller's isolation loop doesn't report this same error again.
     throw new HandledValidationError(`${message}: ${safeErrorMessage(err)}`);
-  });
+  }
 
   if (outcome.kind === 'failed') {
     throw new HandledValidationError(
@@ -66,14 +87,33 @@ export const executePathValidation = async (
   return outcome;
 };
 
-/** Best-effort "something broke" handler -- logs the error, never throws. */
+/** Best-effort "something broke" handler -- posts an error commit status, never throws. */
 export const reportPathValidationError = async (
-  _config: GitHubConfig,
-  _headSha: string | undefined,
-  _pathConfig: Pick<PathValidationConfig, 'displayName' | 'statusContext'>,
+  config: GitHubConfig,
+  headSha: string | undefined,
+  pathConfig: Pick<PathValidationConfig, 'displayName' | 'statusContext'>,
   err: unknown,
 ): Promise<void> => {
   console.error('Unexpected error:', safeErrorMessage(err));
+  if (!headSha) {
+    return;
+  }
+
+  const message = `${pathConfig.displayName} encountered an unexpected error`;
+  try {
+    const statusOctokit = createStatusOctokit(config);
+    await setCommitStatus(
+      statusOctokit,
+      config.owner,
+      config.repo,
+      headSha,
+      'error',
+      message,
+      pathConfig.statusContext,
+    );
+  } catch (statusErr) {
+    console.error(`Failed to report error status: ${safeErrorMessage(statusErr)}`);
+  }
 };
 
 const logSuspiciousMatches = (files: Array<{ filename: string; patch?: string }>): void => {


### PR DESCRIPTION
## 📝 Description

Restore commit-status reporting for unexpected path-validation failures.

`reportPathValidationError` and `executePathValidation`'s unexpected-error path were reduced to `console.error` in #4443, so AI/CI config check contexts no longer flipped to `error` when something broke. This restores posting `error` via `setCommitStatus` (best-effort; never throws).

## 🔗 Links

- https://issues.redhat.com/browse/CNV-94182
- Related regression: https://github.com/kubevirt-ui/kubevirt-plugin/pull/4443

## 🎥 Demo

N/A — CI validation scripting change.

## Test plan

- [ ] Unexpected failure during AI/CI path validation posts `error` on the corresponding status context
- [ ] Missing `headSha` still only logs (no status API call)
- [ ] Status API failure does not crash the workflow step


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation failure handling by publishing an error status when unexpected failures occur.
  * Ensured status publishing failures do not mask the original validation error.
  * Preserved consistent error reporting when commit status updates fail.

* **Tests**
  * Expanded coverage for unexpected validation errors and failed status updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->