### PR TITLE
CNV-94182: verify unified PR validation always runs checks

### DIFF
--- a/.github/scripts/src/pr-validation/dispatcher.ts
+++ b/.github/scripts/src/pr-validation/dispatcher.ts
@@ -1,12 +1,9 @@
 /**
  * Unified PR Validation Dispatcher.
  *
- * Single entry point for ALL pull_request_target events. Routes to the
- * appropriate handler based on the event action:
- *
- *   - opened / synchronize / reopened / edited → PR push validation
- *   - labeled → label gate (review trust, E2E dispatch) + label sync
- *   - unlabeled → label sync
+ * Single entry point for ALL pull_request_target events. For label
+ * events, runs the label-specific handlers first, then ALWAYS runs the
+ * full push validation so the workflow exit code reflects true PR state.
  *
  * Entry point: npx tsx src/pr-validation/dispatcher.ts
  *
@@ -21,32 +18,21 @@ import { main as runPrValidation } from '../validation/pr-validation/index';
 
 type EventAction = 'edited' | 'labeled' | 'opened' | 'reopened' | 'synchronize' | 'unlabeled';
 
-const PUSH_ACTIONS = new Set<EventAction>(['opened', 'synchronize', 'reopened', 'edited']);
-
 const main = async (): Promise<void> => {
   const action = requireEnv('EVENT_ACTION') as EventAction;
-
-  if (PUSH_ACTIONS.has(action)) {
-    console.log(`Event: ${action} → running PR push validation`);
-    process.env.GITHUB_EVENT_ACTION = action;
-    await runPrValidation();
-    return;
-  }
 
   if (action === 'labeled') {
     console.log(`Event: labeled "${process.env.LABEL_NAME}" → running label gate + label sync`);
     await runLabelGate();
     await runLabelSync();
-    return;
-  }
-
-  if (action === 'unlabeled') {
+  } else if (action === 'unlabeled') {
     console.log(`Event: unlabeled "${process.env.LABEL_NAME}" → running label sync`);
     await runLabelSync();
-    return;
   }
 
-  console.log(`Event: ${action} → no handler, exiting cleanly.`);
+  console.log(`Running PR validation (event: ${action})`);
+  process.env.GITHUB_EVENT_ACTION = action;
+  await runPrValidation();
 };
 
 void main().catch((err) => {

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -153,6 +153,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: .github/scripts/package-lock.json
+
+      - name: Install script dependencies
+        shell: bash
+        working-directory: .github/scripts
+        run: npm ci
+
       - name: Resolve cluster config
         id: resolve-config
         if: always()


### PR DESCRIPTION
## Summary
- Test PR to verify the unified PR Validation dispatcher always runs validation regardless of event type
- Label events now run gate/sync first, then re-run full validation so the exit code reflects true PR state

## Test plan
- [ ] Verify PR Validation workflow runs on PR open
- [ ] Verify adding a label still shows correct validation status

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pull request validation now runs consistently for supported pull request events.
  - Label-related actions continue to apply their required checks and synchronization steps before validation.

- **Chores**
  - Hot Cluster end-to-end testing now automatically sets up Node.js and installs required script dependencies, improving reliability of automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->