### PR TITLE
CNV-94182: verify unified PR validation always runs

### DIFF
--- a/.github/scripts/src/e2e/resolve-pr-context.ts
+++ b/.github/scripts/src/e2e/resolve-pr-context.ts
@@ -32,7 +32,7 @@ const fetchPrWithMergeability = async (
   const attempts = Array.from({ length: MERGEABLE_RETRIES });
   const result = await attempts.reduce<Promise<PullData | undefined>>(async (prev, _attempt, i) => {
     const current = await prev;
-    if (current?.mergeable !== null) {
+    if (current !== undefined && current.mergeable !== null) {
       return current;
     }
     if (i > 0) {

--- a/TEST_CI.md
+++ b/TEST_CI.md
@@ -1,1 +1,0 @@
-# Test: verify unified PR validation always runs

--- a/TEST_CI.md
+++ b/TEST_CI.md
@@ -1,0 +1,1 @@
+# Test: verify unified PR validation always runs


### PR DESCRIPTION
## Summary
- Test PR to confirm the unified PR Validation dispatcher always runs validation checks
- Fixes `resolve-pr-context.ts` bug: the reduce's initial `undefined` accumulator caused `current?.mergeable !== null` to always early-return without fetching the PR

## Changes
1. **`pr-validation/dispatcher.ts`** — always runs full validation after label handlers, so exit code reflects true PR state
2. **`e2e/resolve-pr-context.ts`** — fix condition to `current !== undefined && current.mergeable !== null` so the PR is actually fetched

## Test plan
- [ ] PR Validation workflow triggers on open and reports correct status
- [ ] Hot Cluster E2E `resolve-pr-context` step successfully fetches the PR
- [ ] Adding a label re-runs validation and reflects correct state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI testing documentation to indicate that unified pull request validation should always run.
* **Chores**
  * Adjusted end-to-end PR mergeability polling logic to more explicitly handle cases where previously fetched PR data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->