### PR TITLE
CNV-85806: fix isInstalled import in manual operator actions

### DIFF
--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ManualCapabilitiesTable/manualOperatorActions.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ManualCapabilitiesTable/manualOperatorActions.ts
@@ -1,9 +1,9 @@
 import { type TFunction } from 'i18next';
 
 import { type ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
-import { isInstalled } from '@settings/tabs/ClusterTab/components/VirtualizationFeaturesSection/utils/utils';
 
 import { type RecommendedCapabilityOperatorDetails } from '../../utils/types';
+import { isInstalled } from '../../utils/utils';
 
 export const getManualOperatorActions = (
   details: RecommendedCapabilityOperatorDetails | undefined,


### PR DESCRIPTION
## 📝 Description

Fix a broken import in `manualOperatorActions.ts` after the Recommended Capabilities redesign. `isInstalled` is now imported from the local Recommended Capabilities utils instead of the removed VirtualizationFeaturesSection path, so the OperatorHub Install/Manage action label resolves against the correct `InstallState`.

## 🔗 Links

https://issues.redhat.com/browse/CNV-85806

## 🎥 Demo

N/A — import-only fix

## Test plan
- [ ] Open Settings → Recommended capabilities
- [ ] For a manual operator capability, open the kebab/actions menu
- [ ] Confirm Install/Manage in OperatorHub action appears with the correct label based on install state
- [ ] Confirm navigating to OperatorHub still works


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of manual capability status checks without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->