### PR TITLE
CNV-94182: verify VPC E2E flow after ROKS default switch

### DIFF
--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -70,7 +70,7 @@ Label name SSOT: [`.github/scripts/src/shared/merge-pool.ts`](../.github/scripts
 
 ### VPC ROKS (recommended)
 
-Uses standard IBM Cloud IAM (no SoftLayer/classic permissions). VPC, subnet, public gateway, and COS instance are auto-created and reused across runs.
+Uses standard IBM Cloud IAM (no SoftLayer/classic permissions). VPC, subnet, public gateway, and COS instance are auto-created and reused across runs. No public DNS (CIS) dependency — IBM Cloud DNS Services provides private resolution within the VPC automatically.
 
 - **Zone format**: `us-south-1`, `eu-de-1`
 - **Flavor**: `bx2.8x32`, `cx2.4x8` (list with `ibmcloud oc flavors --zone <zone> --provider vpc-gen2`)

--- a/ci-scripts/hot-cluster/check-roks-cluster-state.sh
+++ b/ci-scripts/hot-cluster/check-roks-cluster-state.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Polls IBM Cloud until the ROKS cluster is fully available.
-# The cluster is ready when .state is "normal" AND .ingressStatus is "healthy".
+# The cluster is ready when .state is "normal" AND .ingress.status is "healthy".
 #
 # Required env:
 #   CLUSTER_NAME   - name of the cluster to check
@@ -16,7 +16,7 @@ MAX_WAIT="${MAX_WAIT:-7200}"
 INTERVAL="${INTERVAL:-60}"
 
 echo "Waiting for cluster '${CLUSTER_NAME}' to be fully available..."
-echo "  Ready when: state=normal, ingressStatus=healthy"
+echo "  Ready when: state=normal, ingress.status=healthy"
 echo "  Timeout: ${MAX_WAIT}s, poll interval: ${INTERVAL}s"
 echo ""
 
@@ -26,10 +26,12 @@ while [[ ${ELAPSED} -lt ${MAX_WAIT} ]]; do
   CLUSTER_JSON=$(ibmcloud oc cluster get --cluster "${CLUSTER_NAME}" --output json 2>/dev/null || echo "{}")
 
   STATE=$(echo "${CLUSTER_JSON}" | jq -r '.state // "unknown"')
-  MASTER_STATE=$(echo "${CLUSTER_JSON}" | jq -r '.masterState // "unknown"')
-  INGRESS_STATUS=$(echo "${CLUSTER_JSON}" | jq -r '.ingressStatus // "unknown"')
+  MASTER_STATUS=$(echo "${CLUSTER_JSON}" | jq -r '.lifecycle.masterStatus // "unknown"')
+  MASTER_HEALTH=$(echo "${CLUSTER_JSON}" | jq -r '.lifecycle.masterHealth // "unknown"')
+  INGRESS_STATUS=$(echo "${CLUSTER_JSON}" | jq -r '.ingress.status // "unknown"')
+  INGRESS_HOSTNAME=$(echo "${CLUSTER_JSON}" | jq -r '.ingress.hostname // ""')
 
-  echo "[$(date '+%H:%M:%S')] state=${STATE}  masterState=${MASTER_STATE}  ingressStatus=${INGRESS_STATUS}  (${ELAPSED}s elapsed)"
+  echo "[$(date '+%H:%M:%S')] state=${STATE}  master=${MASTER_STATUS}/${MASTER_HEALTH}  ingress=${INGRESS_STATUS}  hostname=${INGRESS_HOSTNAME:-<empty>}  (${ELAPSED}s elapsed)"
 
   if [[ "${STATE}" == "critical" || "${STATE}" == "delete_failed" ]]; then
     echo "ERROR: Cluster entered '${STATE}' state"


### PR DESCRIPTION
## Summary

- Clarify in README that VPC ROKS has no CIS/public DNS dependency (uses IBM Cloud DNS Services for private resolution automatically)

Test PR to verify the full E2E flow works end-to-end with VPC as the default infrastructure type.

## Test plan

- [ ] PR validation passes
- [ ] Hot Cluster E2E dispatches correctly with `vpc` default


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that VPC resources are reused across runs.
  * Documented that public DNS (CIS) isn’t required, since private resolution is handled automatically within the VPC.
* **Operational Updates**
  * Improved ROKS cluster readiness checking and polling output by using the latest readiness and ingress fields and reporting more detailed lifecycle and ingress information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->