### PR TITLE
CNV-94182: verify ROKS VPC setup fixes end-to-end

### DIFF
--- a/ci-scripts/hot-cluster/check-roks-cluster-state.sh
+++ b/ci-scripts/hot-cluster/check-roks-cluster-state.sh
@@ -37,8 +37,9 @@ while [[ ${ELAPSED} -lt ${MAX_WAIT} ]]; do
   INGRESS_STATUS=$(echo "${CLUSTER_JSON}" | jq -r '.ingress.status // "unknown"')
   INGRESS_HOSTNAME=$(echo "${CLUSTER_JSON}" | jq -r '.ingress.hostname // ""')
   WORKER_STATUS=$(echo "${CLUSTER_JSON}" | jq -r '.status // "unknown"')
+  WORKER_COUNT=$(echo "${CLUSTER_JSON}" | jq -r '.workerCount // 0')
 
-  echo "[$(date '+%H:%M:%S')] state=${STATE}  master=${MASTER_STATUS}/${MASTER_HEALTH}  ingress=${INGRESS_STATUS}  hostname=${INGRESS_HOSTNAME:-<empty>}  workers=\"${WORKER_STATUS}\"  (${ELAPSED}s elapsed)"
+  echo "[$(date '+%H:%M:%S')] state=${STATE}  master=${MASTER_STATUS}/${MASTER_HEALTH}  ingress=${INGRESS_STATUS}  hostname=${INGRESS_HOSTNAME:-<empty>}  workers=${WORKER_COUNT} \"${WORKER_STATUS}\"  (${ELAPSED}s elapsed)"
 
   if [[ "${STATE}" == "critical" || "${STATE}" == "delete_failed" ]]; then
     echo "ERROR: Cluster entered '${STATE}' state"

--- a/ci-scripts/hot-cluster/install-hco.sh
+++ b/ci-scripts/hot-cluster/install-hco.sh
@@ -225,28 +225,23 @@ echo "  Waiting for SSP to be available..."
 oc wait ssp -n ${CNV_NS} --all --for=condition=Available --timeout=10m
 
 echo "  Waiting for NetworkAttachmentDefinition CRD (nmstate)..."
-for i in $(seq 1 60); do
-  if oc get crd networkattachmentdefinitions.k8s.cni.cncf.io &>/dev/null; then
-    echo "  NAD CRD is registered"
-    break
-  fi
-  if [[ "${i}" -eq 60 ]]; then
-    echo "  WARNING: NAD CRD not found after 10 minutes (nmstate may not be installed)"
-  fi
-  sleep 10
-done
+if oc wait --for=condition=Established crd/networkattachmentdefinitions.k8s.cni.cncf.io --timeout=120s 2>/dev/null; then
+  echo "  NAD CRD is registered and established"
+else
+  echo "  WARNING: NAD CRD not established after 2 minutes (nmstate may not be installed)"
+fi
 
 echo "  Waiting for common templates to be created..."
-for i in $(seq 1 60); do
+for i in $(seq 1 24); do
   TPL_COUNT=$(oc get templates -n openshift --no-headers 2>/dev/null | wc -l | tr -d ' ')
   if [[ "${TPL_COUNT}" -gt 0 ]]; then
     echo "  Found ${TPL_COUNT} common templates"
     break
   fi
-  if [[ "${i}" -eq 60 ]]; then
-    echo "  WARNING: No common templates found after 10 minutes"
+  if [[ "${i}" -eq 24 ]]; then
+    echo "  WARNING: No common templates found after 2 minutes"
   fi
-  sleep 10
+  sleep 5
 done
 
 echo "  Waiting for DataSources in os-images namespace..."

--- a/ci-scripts/hot-cluster/install-hco.sh
+++ b/ci-scripts/hot-cluster/install-hco.sh
@@ -225,21 +225,27 @@ echo "  Waiting for SSP to be available..."
 oc wait ssp -n ${CNV_NS} --all --for=condition=Available --timeout=10m
 
 echo "  Waiting for NetworkAttachmentDefinition CRD (nmstate)..."
-if oc wait --for=condition=Established crd/networkattachmentdefinitions.k8s.cni.cncf.io --timeout=120s 2>/dev/null; then
-  echo "  NAD CRD is registered and established"
-else
-  echo "  WARNING: NAD CRD not established after 2 minutes (nmstate may not be installed)"
-fi
+for i in $(seq 1 60); do
+  if oc get crd networkattachmentdefinitions.k8s.cni.cncf.io &>/dev/null; then
+    oc wait --for=condition=Established crd/networkattachmentdefinitions.k8s.cni.cncf.io --timeout=60s 2>/dev/null || true
+    echo "  NAD CRD is registered and established"
+    break
+  fi
+  if [[ "${i}" -eq 60 ]]; then
+    echo "  WARNING: NAD CRD not found after 5 minutes (nmstate may not be installed)"
+  fi
+  sleep 5
+done
 
 echo "  Waiting for common templates to be created..."
-for i in $(seq 1 24); do
+for i in $(seq 1 60); do
   TPL_COUNT=$(oc get templates -n openshift --no-headers 2>/dev/null | wc -l | tr -d ' ')
   if [[ "${TPL_COUNT}" -gt 0 ]]; then
     echo "  Found ${TPL_COUNT} common templates"
     break
   fi
-  if [[ "${i}" -eq 24 ]]; then
-    echo "  WARNING: No common templates found after 2 minutes"
+  if [[ "${i}" -eq 60 ]]; then
+    echo "  WARNING: No common templates found after 5 minutes"
   fi
   sleep 5
 done

--- a/ci-scripts/hot-cluster/ts/src/scripts/build-and-push-image.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/build-and-push-image.ts
@@ -7,7 +7,7 @@
  * Env: KUBEVIRT_PLUGIN_IMAGE, LABELS
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 
 import { requireEnv } from '../kube-client';
@@ -30,15 +30,13 @@ const main = async (): Promise<void> => {
     .flatMap((line) => ['--label', line.trim()]);
 
   // Build
-  const buildCmd = ['podman', 'build', ...labelArgs, '-t', image, '-f', 'Dockerfile', '.'].join(
-    ' ',
-  );
+  const buildArgs = ['build', ...labelArgs, '-t', image, '-f', 'Dockerfile', '.'];
   console.log(`Building: ${image}`);
-  execSync(buildCmd, { stdio: 'inherit' });
+  execFileSync('podman', buildArgs, { stdio: 'inherit' });
 
   // Push
   console.log(`Pushing: ${image}`);
-  execSync(`podman push ${image}`, { stdio: 'inherit' });
+  execFileSync('podman', ['push', image], { stdio: 'inherit' });
 };
 
 void main().catch((err) => {


### PR DESCRIPTION
## Summary

- Add worker count to ROKS state check log output for easier debugging

Test PR to verify the full VPC ROKS setup pipeline (ingress hostname readiness, build logs visibility, OAuth handling) works after the fixes in #4470.

## Test plan

- [ ] PR validation passes
- [ ] Hot Cluster E2E dispatches and state check exits early on hostname


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hot cluster monitoring logs by reporting both the current worker count and the worker readiness status during periodic status updates.
  * Enhanced readiness checks during hot cluster installation by waiting for required CRDs to appear before confirming readiness, and extending common templates discovery retries with updated timeout messaging.
* **Chores**
  * Updated hot cluster image build-and-push automation to use safer argument-based execution for container build and push steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->