### PR TITLE
CNV-94151: remove i18n check from GitHub Actions CI

### DIFF
--- a/.cursor/commands/review.md
+++ b/.cursor/commands/review.md
@@ -112,6 +112,6 @@ Based on user choice:
 
 After implementing fixes:
 
-- Run `npm run i18n` if any strings were added or changed
+- Verify all new/changed user-facing strings are correctly wrapped in `t()`
 - Run `npm run check-types` to verify no type errors
 - Run `npm run lint` to verify linting passes

--- a/.cursor/rules/agents/developer.mdc
+++ b/.cursor/rules/agents/developer.mdc
@@ -103,7 +103,6 @@ Your approach:
 - Never define custom types like `(key: string) => string` for the translation function
 - No string concatenation with `t()` results -- use interpolation: `t('Delete {{name}}', { name })`
 - No comment-only `// t('...')` patterns -- they do NOT wire up translations. **Exception**: `src/utils/i18n.ts` uses comment-only `// t('...')` intentionally for `i18next-parser` string extraction (see `.cursor/rules/i18n.mdc` Section 4); do not flag those
-- `npm run i18n` must be run after adding or changing any user-facing string
 - For non-React code (constants, configs), always accept `t: TFunction` as a parameter -- never import `{ t }` directly
 - Flag hardcoded user-facing strings (JSX text, button labels, placeholders) as blockers
 

--- a/.cursor/rules/coding-standards.mdc
+++ b/.cursor/rules/coding-standards.mdc
@@ -317,7 +317,6 @@ Before completing any code generation or review, verify **all** of the following
 - [ ] Utility functions use `t: TFunction` from `i18next` (not custom types)
 - [ ] No string concatenation with `t()` results -- use interpolation
 - [ ] No comment-only `// t('...')` patterns
-- [ ] `npm run i18n` run after adding/changing strings
 
 ### Code Quality
 - [ ] Check for existing similar components before creating new ones

--- a/.cursor/rules/common-commands.mdc
+++ b/.cursor/rules/common-commands.mdc
@@ -98,7 +98,7 @@ npm run cypress-postreport   # Full report pipeline
 ## 5. Internationalization (i18n)
 
 ```bash
-npm run i18n                 # Extract strings and update translations
+npm run i18n                 # Extract strings and update locale files
 npm run i18n:verbose         # Verbose output
 npm run i18n-dummy-locale    # Create dummy locale for testing
 npm run i18n-to-po           # Convert i18n to PO format
@@ -172,7 +172,6 @@ npm run check-types && npm run lint      # Quick quality check
 ### Before Commit
 ```bash
 npm run check-types && npm run lint && npm test
-npm run i18n                             # If strings changed
 ```
 
 ### Troubleshooting

--- a/.cursor/rules/i18n.mdc
+++ b/.cursor/rules/i18n.mdc
@@ -250,21 +250,12 @@ Add a comment in `src/utils/i18n.ts` for the parser. This is the **only** file w
 
 ## 7. Updating Translations
 
-### After Adding Strings
-```bash
-# Extract new strings to translation files
-npm run i18n
-```
+When to run `npm run i18n` and the Memsource upload flow are documented in [INTERNATIONALIZATION.md](../../INTERNATIONALIZATION.md).
 
-### What This Does
+### What `npm run i18n` Does
 1. Scans source files for `t()` calls
 2. Extracts strings to `locales/en/plugin__kubevirt-plugin.json`
 3. Syncs with other language files (adds missing keys)
-
-### Commit Translation Changes
-- Always commit translation file updates
-- Run `npm run i18n` before PR
-- lint-staged runs this automatically for src changes
 
 ---
 
@@ -291,12 +282,14 @@ npm run i18n
 
 ## 9. Testing Translations
 
-### Verify All Strings Translated
-```bash
-# Check for missing translations
-npm run i18n
+### Verify Translation Usage in Code
+- Review PRs for hardcoded strings and incorrect `t()` patterns (see Section 12)
+- English UI works with key-as-text even when locale JSON is not yet refreshed
 
-# Look for changes in translation files
+### Before Translation Upload
+```bash
+# Extract strings, then inspect locale diffs
+npm run i18n
 git diff locales/
 ```
 
@@ -371,15 +364,16 @@ These rules are mandatory for AI agents when generating or reviewing code:
 - **Never** import `{ t }` directly from `useKubevirtTranslation` -- always pass `t` as a parameter
 - Never invent custom types for the translation function
 - Use interpolation for dynamic values: `t('{{count}} items', { count })` -- never concatenate
-- After adding or changing any user-facing string, run `npm run i18n`
 
 ### When Reviewing Code
+Reviewers (and AI review agents) must carefully verify translation correctness in source:
 - Verify every user-facing string is wrapped in `t()`
 - Verify `TFunction` is imported from `i18next`, not defined inline
 - Flag any string concatenation with `t()` results as a **blocker**
 - Flag any `// t('...')` comment-only patterns as a **blocker** -- these do not wire up translations. **Exception**: `src/utils/i18n.ts` uses comment-only `// t('...')` intentionally for `i18next-parser` string extraction (see Section 4)
 - Flag any hardcoded user-facing strings (JSX text content, button labels, etc.) as a **blocker**
-- Verify locale diffs are present in the PR when user-facing strings change
+- Flag split sentences / multiple adjacent `t()` calls that lose translator context as a **blocker**
+- Confirm console extension labels use `%plugin__kubevirt-plugin~...%` and are registered in `src/utils/i18n.ts` when applicable
 
 ### Common Mistakes to Catch
 ```tsx
@@ -398,6 +392,9 @@ const getLabel = (t: (key: string) => string) => t('Name');
 
 // BLOCKER: template literal with t()
 `${t('Make persistent disk')} - (${names.join(', ')})`
+
+// BLOCKER: split sentence loses context for translators
+{t('Click')} {t('here')} {t('to continue')}
 ```
 
 ---
@@ -409,8 +406,6 @@ const getLabel = (t: (key: string) => string) => t('Name');
 - [ ] `TFunction` imported from `i18next` (no custom types)
 - [ ] Dynamic values use interpolation `{{variable}}`
 - [ ] No string concatenation for translated text
-- [ ] No comment-only `// t('...')` patterns
+- [ ] No comment-only `// t('...')` patterns (except `src/utils/i18n.ts`)
 - [ ] Console extensions use `%plugin__...%` format
 - [ ] Extension strings registered in `utils/i18n.ts`
-- [ ] `npm run i18n` run before commit
-- [ ] Translation file changes committed

--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -213,8 +213,7 @@ import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 
 ### i18n
 - Use `useKubevirtTranslation` hook
-- All user-facing strings must be translated
-- Run `npm run i18n` after adding strings
+- All user-facing strings must be wrapped in `t()`
 
 ### Styling
 - Use PatternFly components and variables (tokens)

--- a/.cursor/rules/team-review.mdc
+++ b/.cursor/rules/team-review.mdc
@@ -62,7 +62,6 @@ Use *"/review"* to run **all six review agents in parallel** on the current chan
 - No string concatenation with `t()` results; use interpolation: `t('Delete {{name}}', { name })`
 - No comment-only `// t('...')` patterns -- they do NOT wire up translations. **Exception**: `src/utils/i18n.ts` uses comment-only `// t('...')` intentionally for `i18next-parser` string extraction
 - For non-React code (constants, configs), always accept `t: TFunction` as a parameter -- never import `{ t }` directly
-- `npm run i18n` must be run after adding or changing any user-facing string
 
 ### Code Standards
 - One exported component per file (exception: unexported helpers in `*Definition.tsx` and `*Cells.tsx`)
@@ -111,8 +110,9 @@ Use *"/review"* to run **all six review agents in parallel** on the current chan
 ✅ [Selectors used correctly]
 
 ### 🌐 i18n Compliance
-🔴 [Untranslated string / wrong TFunction type]
-✅ [All strings properly translated]
+🔴 [Hardcoded / untranslated string, concatenation, or wrong TFunction type]
+🟡 [Split sentences or weak translator context]
+✅ [All strings properly wrapped in `t()` with correct patterns]
 
 ### 📏 Code Standards
 🟡 [File structure / naming issue]
@@ -149,9 +149,7 @@ For thorough analysis from a single perspective, invoke a specific agent:
 - [ ] **UX**: Accessibility, states, consistency
 - [ ] **QE**: Edge cases, tests, async issues
 - [ ] **Security**: Input validation, auth, XSS
-- [ ] **KubeVirt**: K8s patterns, VM lifecycle, API usage
-- [ ] **Selectors**: Field access via selectors, no unnecessary inline property chains
-- [ ] **i18n**: All strings translated, `TFunction` from `i18next`, no concatenation
+- [ ] **i18n**: All user-facing strings wrapped in `t()`, `TFunction` from `i18next`, no concatenation / hardcoded text
 - [ ] **Standards**: One component per file, filename matches, files under 150 lines
 
 ### After Review

--- a/.cursor/rules/workflows/ci-triage.mdc
+++ b/.cursor/rules/workflows/ci-triage.mdc
@@ -33,7 +33,7 @@ If the user provided a raw build URL, extract `job_name` and `build_id` from the
 Match the failure output against the three categories using the patterns below:
 
 - **INFRASTRUCTURE**: Registry timeouts, image pull failures, cluster provisioning errors, network flakes, Docker build container errors. These are transient and safe to retest.
-- **CODE**: TypeScript/webpack build errors, lint failures, unit test failures, i18n drift, e2e test assertion failures. These require developer action.
+- **CODE**: TypeScript/webpack build errors, lint failures, unit test failures, e2e test assertion failures. These require developer action.
 - **FLAKY_TEST**: Known intermittent test failures, timeout-only failures in test steps.
 
 When classifying:
@@ -190,9 +190,6 @@ In PR comments, prefer sentence case for classification labels (e.g. "Infrastruc
 - `FAIL\s+src/` — Jest test failure
 - `Test Suites:.*failed` — Jest suite failure summary
 - `Expected:.*Received:` — Jest assertion mismatch
-
-**i18n:**
-- `i18n files are not up to date` — i18n extraction drift
 
 **E2E assertion (test logic failure):**
 - `AssertionError:` — Assertion failure in test

--- a/.cursor/rules/workflows/feature-development.mdc
+++ b/.cursor/rules/workflows/feature-development.mdc
@@ -219,7 +219,7 @@ Address any blockers or suggestions before moving on.
 
 Following `pr-preparation.mdc`:
 - [ ] All checks pass (types, lint, test)
-- [ ] i18n updated (`npm run i18n`)
+- [ ] User-facing strings correctly wrapped in `t()`
 - [ ] No debug code
 - [ ] Self-reviewed
 

--- a/.cursor/rules/workflows/new-component.mdc
+++ b/.cursor/rules/workflows/new-component.mdc
@@ -293,8 +293,7 @@ src/views/{feature}/components/{component-name}/
 
 ### i18n
 - [ ] Uses `useKubevirtTranslation`
-- [ ] All strings translated
-- [ ] `npm run i18n` run
+- [ ] All strings wrapped in `t()` with correct patterns
 
 ### Styling
 - [ ] SCSS file created

--- a/.cursor/rules/workflows/pr-preparation.mdc
+++ b/.cursor/rules/workflows/pr-preparation.mdc
@@ -58,18 +58,13 @@ npm run check-types && npm run lint && npm test
 
 ## 3. i18n Verification
 
-### Run i18n
-```bash
-npm run i18n
-```
-
 ### Translation Checklist
 - [ ] All user-facing strings use `t()` function
-- [ ] `npm run i18n` has been run
-- [ ] Translation file changes committed
 - [ ] No hardcoded strings in UI
 - [ ] Proper interpolation for dynamic values
 - [ ] Pluralization handled correctly
+- [ ] `TFunction` from `i18next` (no custom types / no direct `{ t }` import)
+- [ ] No string concatenation or split sentences that lose translator context
 
 ---
 
@@ -309,7 +304,7 @@ See `AI_README.md` for the full merge policy. Do not use PR comments to approve;
 
 ### Code
 - [ ] All checks pass (types, lint, test)
-- [ ] i18n updated
+- [ ] User-facing strings correctly wrapped in `t()`
 - [ ] No debug code
 - [ ] Self-reviewed
 
@@ -336,9 +331,6 @@ npm run check-types && npm run lint && npm test
 
 # Fix lint issues
 npm run lint:fix
-
-# Update translations
-npm run i18n
 
 # Run specific test
 npm test path/to/file.test.ts

--- a/.github/scripts/src/shared/check-step-results.ts
+++ b/.github/scripts/src/shared/check-step-results.ts
@@ -3,7 +3,7 @@
  * Entry point: npx tsx src/shared/check-step-results.ts
  *
  * Env: STEP_RESULTS — JSON object mapping step names to outcomes
- *      e.g. {"i18n":"success","lint":"failure","build":"success"}
+ *      e.g. {"lint":"failure","build":"success"}
  */
 
 import { requireEnv } from '../utils';

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -56,7 +56,7 @@ See [`ci-scripts/manual-console/README.md`](../../ci-scripts/manual-console/READ
 
 | Workflow        | Role                                          |
 | --------------- | --------------------------------------------- |
-| `ci_checks.yml` | Unit tests, build, i18n, actionlint           |
+| `ci_checks.yml` | Unit tests, build, lint, actionlint           |
 | `deploy.yml`    | Build/push multi-arch Quay image on main/tags |
 
 ## Shared helpers

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -37,20 +37,6 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      # ── i18n ──────────────────────────────────────────────
-      - name: Check i18n
-        id: i18n
-        continue-on-error: true
-        shell: bash
-        run: |
-          npm run i18n
-          GIT_STATUS="$(git status --short --untracked-files locales)"
-          if [ -n "$GIT_STATUS" ]; then
-            echo "i18n files are not up to date. Commit them to fix."
-            git diff
-            exit 1
-          fi
-
       # ── actionlint ────────────────────────────────────────
       - name: Install actionlint
         run: |
@@ -132,7 +118,6 @@ jobs:
         env:
           STEP_RESULTS: >-
             {
-              "i18n": "${{ steps.i18n.outcome }}",
               "actionlint": "${{ steps.actionlint.outcome }}",
               "lint": "${{ steps.lint.outcome }}",
               "build": "${{ steps.build.outcome }}",

--- a/INTERNATIONALIZATION.md
+++ b/INTERNATIONALIZATION.md
@@ -13,6 +13,8 @@ Internationalized text and translations are located in JSON files in a locales f
 In general, these files shouldn't be manually updated, though sometimes plurals will need to be adjusted manually
 after files are generated.
 
+There is no need to run `npm run i18n` on every commit or PR. Locale files are updated when preparing to upload strings for translation (`npm run memsource-upload` runs extraction automatically). Feature work should wrap user-facing strings in `t()` correctly; PR review should verify translation patterns in source.
+
 To generate and update text files:
 
 ```

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ add the message from console extensions files to your message catalog as follows
 // t('plugin__kubevirt-plugin~VirtualMachines')
 ```
 
-Run `npm run i18n` to update the JSON files in the `locales` folder of the
-dynamic plugin when adding or changing messages.
+See [INTERNATIONALIZATION.md](./INTERNATIONALIZATION.md) for when to update
+locale files.
 
 ## Docker image
 

--- a/i18n-scripts/README.md
+++ b/i18n-scripts/README.md
@@ -21,6 +21,8 @@ Example CLI usage for upload script: `npm run memsource-upload -- -v 4.8 -s 200`
 * -v is the current OpenShift version
 * -s is the current sprint number
 
+`memsource-upload` runs `npm run i18n` first to extract strings from source.
+
 Example CLI usage for download script: `npm run memsource-download -- -p 6sB6qwpbRkGCeBQq4hUyK1`
 * -p is the project ID in Memsource. The project ID can be obtained from the Memsource project URL (it's the series of numbers and letters after /show/, i.e. https://cloud.memsource.com/web/project2/show/FBfZeTEWPYaC4VXhgrW0R2).
 

--- a/i18n-scripts/memsource-upload.sh
+++ b/i18n-scripts/memsource-upload.sh
@@ -18,6 +18,10 @@ BRANCH=$(git branch  --show-current)
 
 echo "Creating project with title \"[CNV $VERSION] UI Localization - Sprint $SPRINT/Branch $BRANCH\""
 
+echo "Extracting i18n strings from source"
+npm run i18n
+echo "i18n extraction complete"
+
 echo "Exporting PO files"
 npm run export-pos
 echo "Exported all PO files"

--- a/package.json
+++ b/package.json
@@ -132,9 +132,6 @@
     "node": ">=22.0.0"
   },
   "lint-staged": {
-    "src/**/*.{js,ts,tsx,jsx,json}": [
-      "npm run i18n"
-    ],
     "*.{js,ts,tsx,jsx}": [
       "eslint --config eslintv10.config.js --no-warn-ignored --fix"
     ],


### PR DESCRIPTION
## 📝 Description

Remove the automated `npm run i18n` / locale drift check from GitHub Actions so CI no longer blocks PRs on i18n file freshness.

- Remove the dedicated `i18n` job from `.github/workflows/ci_checks.yml`
- Stop running `npm run i18n` via lint-staged on every `src` change
- Document that locale extraction is intentional (via `memsource-upload`, which now runs `npm run i18n` first)
- Update contributor / agent docs to emphasize correct `t()` usage in source instead of committing locale diffs on every PR

## 🔗 Links

> https://issues.redhat.com/browse/CNV-94151

## 🎥 Demo

> N/A — CI / docs process change only

## Test plan

- [ ] Confirm CI no longer runs an `i18n` job on this PR
- [ ] Confirm `build` and `unit-test` jobs still run
- [ ] Confirm `npm run memsource-upload` extracts strings before exporting PO files
- [ ] Confirm docs (`INTERNATIONALIZATION.md`, `README.md`, i18n-scripts README) describe the new process


Made with [Cursor](https://cursor.com)