### PR TITLE
CNV-92666:[release-4.17] Updating js-yaml to 4.3.0 as a fix for CVE-2026-59869

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "global": "^4.4.0",
         "immer": "^9.0.12",
         "js-abbreviation-number": "^1.4.0",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "4.3.0",
         "lodash.clonedeepwith": "^4.5.0",
         "lodash.shuffle": "^4.2.0",
         "mochawesome-report-generator": "^6.0.1",
@@ -2367,34 +2367,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE= sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc= sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw= sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
@@ -11832,9 +11804,20 @@
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk= sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI= sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2368,6 +2368,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -10300,6 +10328,18 @@
       "resolved": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM= sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
+    },
+    "node_modules/i18next-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/i18next-parser/node_modules/lilconfig": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "global": "^4.4.0",
         "immer": "^9.0.12",
         "js-abbreviation-number": "^1.4.0",
-        "js-yaml": "4.3.0",
+        "js-yaml": "^4.3.0",
         "lodash.clonedeepwith": "^4.5.0",
         "lodash.shuffle": "^4.2.0",
         "mochawesome-report-generator": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "global": "^4.4.0",
     "immer": "^9.0.12",
     "js-abbreviation-number": "^1.4.0",
-    "js-yaml": "4.3.0",
+    "js-yaml": "^4.3.0",
     "lodash.clonedeepwith": "^4.5.0",
     "lodash.shuffle": "^4.2.0",
     "mochawesome-report-generator": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     },
     "@types/react": "^17.0.40",
     "@types/react-dom": "^17.0.0",
-    "js-yaml": "4.3.0",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "global": "^4.4.0",
     "immer": "^9.0.12",
     "js-abbreviation-number": "^1.4.0",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "4.3.0",
     "lodash.clonedeepwith": "^4.5.0",
     "lodash.shuffle": "^4.2.0",
     "mochawesome-report-generator": "^6.0.1",
@@ -124,6 +124,7 @@
     },
     "@types/react": "^17.0.40",
     "@types/react-dom": "^17.0.0",
+    "js-yaml": "4.3.0",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   },


### PR DESCRIPTION
## Summary
- Updates `js-yaml` from `^4.1.0` to `4.3.0` to fix CVE-2026-59869
- **CVE-2026-59869**: js-yaml can spend quadratic CPU time parsing a document whose size grows only linearly when a chain of mappings uses merge keys where each mapping merges the previous one
- Fixed in js-yaml versions 3.15.0 and 4.3.0

## Jira
- [CNV-92666](https://redhat.atlassian.net/browse/CNV-92666)