### PR TITLE
CNV-92668:[release-4.22] Updating js-yaml to 4.3.0 as a fix for CVE-2026-59869

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "immer": "^9.0.12",
         "ipaddr.js": "2.2.0",
         "js-abbreviation-number": "^1.4.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "4.3.0",
         "lodash": "^4.18.1",
         "mochawesome-report-generator": "^6.2.0",
         "murmurhash-js": "1.0.0",
@@ -3033,30 +3033,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -3066,13 +3042,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
@@ -20274,9 +20243,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3033,6 +3033,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -3042,6 +3066,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "immer": "^9.0.12",
     "ipaddr.js": "2.2.0",
     "js-abbreviation-number": "^1.4.0",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "4.3.0",
     "lodash": "^4.18.1",
     "mochawesome-report-generator": "^6.2.0",
     "murmurhash-js": "1.0.0",
@@ -147,7 +147,8 @@
       "react-i18next": "~16.5.8"
     },
     "eslint": "^8.57.1",
-    "delaunator": "4.0.1"
+    "delaunator": "4.0.1",
+    "js-yaml": "4.3.0"
   },
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "immer": "^9.0.12",
     "ipaddr.js": "2.2.0",
     "js-abbreviation-number": "^1.4.0",
-    "js-yaml": "4.3.0",
+    "js-yaml": "^4.3.0",
     "lodash": "^4.18.1",
     "mochawesome-report-generator": "^6.2.0",
     "murmurhash-js": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -147,8 +147,7 @@
       "react-i18next": "~16.5.8"
     },
     "eslint": "^8.57.1",
-    "delaunator": "4.0.1",
-    "js-yaml": "4.3.0"
+    "delaunator": "4.0.1"
   },
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- Updates `js-yaml` from `^4.1.1` to `4.3.0` to fix CVE-2026-59869
- **CVE-2026-59869**: js-yaml can spend quadratic CPU time parsing a document whose size grows only linearly when a chain of mappings uses merge keys where each mapping merges the previous one
- Fixed in js-yaml versions 3.15.0 and 4.3.0

## Jira
- [CNV-92668](https://redhat.atlassian.net/browse/CNV-92668)