### PR TITLE
CNV-94182: verify Quay.io CI image push and Dockerfile path fix

### DIFF
--- a/.github/actions/ci-env-request/action.yml
+++ b/.github/actions/ci-env-request/action.yml
@@ -38,6 +38,11 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Install infra script dependencies
+      shell: bash
+      working-directory: ci-scripts/hot-cluster/ts
+      run: npm ci --ignore-scripts --no-audit
+
     - name: Request and wait for test environment
       id: request
       shell: bash

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -2,7 +2,7 @@
 
 This directory contains scripts and documentation for the **IBM Cloud hot cluster** CI stack: an OpenShift cluster used for KubeVirt plugin E2E testing, with **Hyperconverged Cluster Operator (HCO)** and **GitHub Actions Runner Controller (ARC)** for self-hosted runners (`kubevirt-plugin-ci`).
 
-Three infrastructure types are supported: **Classic ROKS**, **VPC ROKS** (recommended, OVN-Kubernetes CNI), and **IPI** (self-managed OpenShift).
+Three infrastructure types are supported: **Classic ROKS**, **VPC ROKS** (recommended, OVN-Kubernetes CNI with Multus), and **IPI** (self-managed OpenShift).
 
 **Prow/Tide are gone for this repo.** Gating E2E runs here; merge eligibility (`lgtm`/`approved`/`hold`/`needs-rebase`) and native auto-merge live in GitHub Actions. See [Prow/Tide → GitHub Actions Migration](#prowtide-github-actions-migration-complete-for-this-repo) below.
 


### PR DESCRIPTION
## Summary
- Test PR to verify Quay.io migration for CI plugin images (replaces ttl.sh)
- Verifies Dockerfile path resolution from `ci-scripts/hot-cluster/ts/` working directory

## Test plan
- [ ] `podman login quay.io` succeeds with repo secrets
- [ ] `build-and-push-image.ts` builds and pushes to `quay.io/kubevirt-ui/kubevirt-ui-ci`
- [ ] Image tagged with `quay.expires-after=2h` for auto-expiry
- [ ] `check-image-exists.ts` detects the pushed image


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated infrastructure documentation to note that VPC ROKS supports Multus alongside OVN-Kubernetes CNI.

* **Chores**
  * Improved test environment setup by installing required infrastructure script dependencies automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->