### PR TITLE
CNV-94182: verify Quay.io push and ci-env-request npm ci fix

### DIFF
--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -2,7 +2,7 @@
 
 This directory contains scripts and documentation for the **IBM Cloud hot cluster** CI stack: an OpenShift cluster used for KubeVirt plugin E2E testing, with **Hyperconverged Cluster Operator (HCO)** and **GitHub Actions Runner Controller (ARC)** for self-hosted runners (`kubevirt-plugin-ci`).
 
-Three infrastructure types are supported: **Classic ROKS**, **VPC ROKS** (recommended, OVN-Kubernetes CNI with Multus), and **IPI** (self-managed OpenShift).
+Three infrastructure types are supported: **Classic ROKS**, **VPC ROKS** (recommended, OVN-Kubernetes CNI with Multus support), and **IPI** (self-managed OpenShift).
 
 **Prow/Tide are gone for this repo.** Gating E2E runs here; merge eligibility (`lgtm`/`approved`/`hold`/`needs-rebase`) and native auto-merge live in GitHub Actions. See [Prow/Tide → GitHub Actions Migration](#prowtide-github-actions-migration-complete-for-this-repo) below.
 

--- a/ci-scripts/hot-cluster/images/setup-arc-runner-image.sh
+++ b/ci-scripts/hot-cluster/images/setup-arc-runner-image.sh
@@ -50,7 +50,25 @@ echo "  YQ_VERSION:      ${YQ_VERSION}"
 echo "  OC_URL:          ${OC_URL:-(fallback to mirror.openshift.com)}"
 echo "  VIRTCTL_URL:     ${VIRTCTL_URL:-(fallback to GitHub releases)}"
 echo "  HELM_URL:        ${HELM_URL:-(fallback to get.helm.sh)}"
+echo "  FORCE_BUILD:     ${FORCE_BUILD:-false}"
 echo ""
+
+# Skip build if the ImageStream already has a :latest tag and FORCE_BUILD is not set
+if [[ "${FORCE_BUILD:-false}" != "true" ]]; then
+  EXISTING_REF=$(oc get imagestreamtag "${IMAGE_NAME}:latest" -n "${NS}" -o jsonpath='{.image.dockerImageReference}' 2>/dev/null || echo "")
+  if [[ -n "${EXISTING_REF}" ]]; then
+    resolve_internal_registry
+    IMAGE_REF="${INTERNAL_REGISTRY}/${NS}/${IMAGE_NAME}:latest"
+    echo "Image already exists, skipping build: ${IMAGE_REF}"
+    echo ""
+    if [[ -n "${ARC_RUNNER_IMAGE_FILE:-}" ]]; then
+      printf '%s\n' "${IMAGE_REF}" > "${ARC_RUNNER_IMAGE_FILE}"
+      echo "Wrote ${ARC_RUNNER_IMAGE_FILE}"
+    fi
+    echo "IMAGE_REF=${IMAGE_REF}"
+    exit 0
+  fi
+fi
 
 if [[ ! -f "${IMAGE_DIR}/Dockerfile" ]]; then
   echo "ERROR: Dockerfile not found at ${IMAGE_DIR}/Dockerfile"

--- a/ci-scripts/hot-cluster/images/setup-ci-env-runner-image.sh
+++ b/ci-scripts/hot-cluster/images/setup-ci-env-runner-image.sh
@@ -46,7 +46,25 @@ echo "  HELM_VERSION:         ${HELM_VERSION}"
 echo "  YQ_VERSION:           ${YQ_VERSION}"
 echo "  OC_URL:               ${OC_URL:-(fallback to mirror.openshift.com)}"
 echo "  HELM_URL:             ${HELM_URL:-(fallback to get.helm.sh)}"
+echo "  FORCE_BUILD:          ${FORCE_BUILD:-false}"
 echo ""
+
+# Skip build if the ImageStream already has a :latest tag and FORCE_BUILD is not set
+if [[ "${FORCE_BUILD:-false}" != "true" ]]; then
+  EXISTING_REF=$(oc get imagestreamtag "${IMAGE_NAME}:latest" -n "${NS}" -o jsonpath='{.image.dockerImageReference}' 2>/dev/null || echo "")
+  if [[ -n "${EXISTING_REF}" ]]; then
+    resolve_internal_registry
+    IMAGE_REF="${INTERNAL_REGISTRY}/${NS}/${IMAGE_NAME}:latest"
+    echo "Image already exists, skipping build: ${IMAGE_REF}"
+    echo ""
+    if [[ -n "${CI_ENV_RUNNER_IMAGE_FILE:-}" ]]; then
+      printf '%s\n' "${IMAGE_REF}" > "${CI_ENV_RUNNER_IMAGE_FILE}"
+      echo "Wrote ${CI_ENV_RUNNER_IMAGE_FILE}"
+    fi
+    echo "IMAGE_REF=${IMAGE_REF}"
+    exit 0
+  fi
+fi
 
 if [[ ! -f "${IMAGE_DIR}/Dockerfile" ]]; then
   echo "ERROR: Dockerfile not found at ${IMAGE_DIR}/Dockerfile"

--- a/ci-scripts/hot-cluster/ts/src/scripts/create-test-secret.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/create-test-secret.ts
@@ -6,6 +6,7 @@
  */
 
 import * as yaml from 'js-yaml';
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
@@ -16,7 +17,10 @@ const main = async (): Promise<void> => {
   const testNs = requireEnv('TEST_NS');
   const testEngine = process.env.TEST_ENGINE ?? 'playwright';
 
-  const fixturePath = resolve(testEngine, 'fixtures', 'secret.yaml');
+  const repoRoot =
+    process.env.GITHUB_WORKSPACE ??
+    execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+  const fixturePath = resolve(repoRoot, testEngine, 'fixtures', 'secret.yaml');
   const content = yaml.load(readFileSync(fixturePath, 'utf8')) as Record<string, unknown>;
 
   const metadata = content.metadata as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Test PR to verify Quay.io CI image push and ci-env-request action with npm ci fix

## Test plan
- [ ] Plugin image builds and pushes to `quay.io/kubevirt-ui/kubevirt-ui-ci`
- [ ] `ci-env-request` action installs dependencies before running
- [ ] Test environment provisions successfully


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Multus support for VPC ROKS is provided through the OVN-Kubernetes CNI.
* **Performance**
  * Reduced CI setup time by reusing existing runner images instead of rebuilding them unnecessarily.
* **Reliability**
  * Improved test environment setup by locating secret fixtures consistently across different working directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->