### PR TITLE
CNV-94182: verify image build skip, secret path, and Quay push

### DIFF
--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -2,7 +2,7 @@
 
 This directory contains scripts and documentation for the **IBM Cloud hot cluster** CI stack: an OpenShift cluster used for KubeVirt plugin E2E testing, with **Hyperconverged Cluster Operator (HCO)** and **GitHub Actions Runner Controller (ARC)** for self-hosted runners (`kubevirt-plugin-ci`).
 
-Three infrastructure types are supported: **Classic ROKS**, **VPC ROKS** (recommended, OVN-Kubernetes CNI with Multus support), and **IPI** (self-managed OpenShift).
+Three infrastructure types are supported: **Classic ROKS**, **VPC ROKS** (recommended; OVN-Kubernetes CNI with Multus support), and **IPI** (self-managed OpenShift).
 
 **Prow/Tide are gone for this repo.** Gating E2E runs here; merge eligibility (`lgtm`/`approved`/`hold`/`needs-rebase`) and native auto-merge live in GitHub Actions. See [Prow/Tide → GitHub Actions Migration](#prowtide-github-actions-migration-complete-for-this-repo) below.
 

--- a/ci-scripts/hot-cluster/ts/src/scripts/seed-user-settings.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/seed-user-settings.ts
@@ -5,7 +5,24 @@
  * Env: CI_ENV_CM, TEST_NS, CNV_NS, TEST_ENGINE
  */
 
+import * as k8s from '@kubernetes/client-node';
+
 import { KubeClient, requireEnv } from '../kube-client';
+
+const mergeConfigMapData = async (
+  api: k8s.CoreV1Api,
+  name: string,
+  namespace: string,
+  data: Record<string, string>,
+): Promise<void> => {
+  const cm = await api.readNamespacedConfigMap({ name, namespace });
+  const merged = { ...cm.data, ...data };
+  await api.replaceNamespacedConfigMap({
+    body: { ...cm, data: merged },
+    name,
+    namespace,
+  });
+};
 
 const USER_SETTINGS = JSON.stringify({
   onboardingPopoversHidden: { catalog: true, createProject: true, navCollapse: true, vmsTab: true },
@@ -54,23 +71,27 @@ const main = async (): Promise<void> => {
     });
   }
 
-  // Patch user settings
+  // Merge user settings into ConfigMap via read + replace
   const patchData: Record<string, string> = { [sanitizedName]: USER_SETTINGS };
   if (saUid) {
     patchData[saUid] = USER_SETTINGS;
   }
 
-  await coreApi.patchNamespacedConfigMap({
-    body: { data: patchData },
-    name: 'kubevirt-user-settings',
-    namespace: cnvNs,
-  });
+  await mergeConfigMapData(coreApi, 'kubevirt-user-settings', cnvNs, patchData);
 
-  // Patch kubevirt-ui-features
-  await coreApi.patchNamespacedConfigMap({
-    body: { data: { advancedSearch: 'true', treeViewFolders: 'true' } },
-    name: 'kubevirt-ui-features',
-    namespace: cnvNs,
+  // Ensure kubevirt-ui-features ConfigMap exists
+  try {
+    await coreApi.readNamespacedConfigMap({ name: 'kubevirt-ui-features', namespace: cnvNs });
+  } catch {
+    await coreApi.createNamespacedConfigMap({
+      body: { metadata: { name: 'kubevirt-ui-features', namespace: cnvNs } },
+      namespace: cnvNs,
+    });
+  }
+
+  await mergeConfigMapData(coreApi, 'kubevirt-ui-features', cnvNs, {
+    advancedSearch: 'true',
+    treeViewFolders: 'true',
   });
 
   // Cypress-only: seed guided tour completion
@@ -87,11 +108,7 @@ const main = async (): Promise<void> => {
       });
     }
 
-    await coreApi.patchNamespacedConfigMap({
-      body: { data: { 'console.guidedTour': GUIDED_TOUR } },
-      name: cmName,
-      namespace: cmNs,
-    });
+    await mergeConfigMapData(coreApi, cmName, cmNs, { 'console.guidedTour': GUIDED_TOUR });
   }
 
   console.log('User settings seeded successfully.');


### PR DESCRIPTION
## Summary
- Test PR to verify all recent CI fixes end-to-end

## Test plan
- [ ] Plugin image pushes to Quay.io successfully
- [ ] ARC/ci-env runner image builds are skipped (already exist)
- [ ] `create-test-secret.ts` finds `secret.yaml` at repo root
- [ ] ci-env-request action installs dependencies


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization of user settings, UI feature flags, and guided-tour data to preserve existing configuration while updating specific values.
  * Ensured required configuration settings are created when missing.

* **Documentation**
  * Clarified the infrastructure-types description by improving punctuation in the VPC ROKS guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->