### PR TITLE
test: verify ConfigMap seed, Quay push, and image build skip

### DIFF
--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -2,7 +2,7 @@
 
 This directory contains scripts and documentation for the **IBM Cloud hot cluster** CI stack: an OpenShift cluster used for KubeVirt plugin E2E testing, with **Hyperconverged Cluster Operator (HCO)** and **GitHub Actions Runner Controller (ARC)** for self-hosted runners (`kubevirt-plugin-ci`).
 
-Three infrastructure types are supported: **Classic ROKS**, **VPC ROKS** (recommended; OVN-Kubernetes CNI with Multus support), and **IPI** (self-managed OpenShift).
+Three infrastructure types are supported: **Classic ROKS**, **VPC ROKS** (recommended; OVN-Kubernetes CNI, Multus support), and **IPI** (self-managed OpenShift).
 
 **Prow/Tide are gone for this repo.** Gating E2E runs here; merge eligibility (`lgtm`/`approved`/`hold`/`needs-rebase`) and native auto-merge live in GitHub Actions. See [Prow/Tide → GitHub Actions Migration](#prowtide-github-actions-migration-complete-for-this-repo) below.
 

--- a/ci-scripts/hot-cluster/ts/src/scripts/seed-user-settings.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/seed-user-settings.ts
@@ -9,19 +9,23 @@ import * as k8s from '@kubernetes/client-node';
 
 import { KubeClient, requireEnv } from '../kube-client';
 
-const mergeConfigMapData = async (
-  api: k8s.CoreV1Api,
+const makePatchApi = (client: KubeClient): k8s.KubernetesObjectApi =>
+  k8s.KubernetesObjectApi.makeApiClient(client.kubeConfig);
+
+const patchConfigMapData = async (
+  patchApi: k8s.KubernetesObjectApi,
   name: string,
   namespace: string,
   data: Record<string, string>,
 ): Promise<void> => {
-  const cm = await api.readNamespacedConfigMap({ name, namespace });
-  const merged = { ...cm.data, ...data };
-  await api.replaceNamespacedConfigMap({
-    body: { ...cm, data: merged },
-    name,
-    namespace,
-  });
+  await patchApi.patch(
+    { apiVersion: 'v1', kind: 'ConfigMap', metadata: { name, namespace }, data },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    k8s.PatchStrategy.MergePatch,
+  );
 };
 
 const USER_SETTINGS = JSON.stringify({
@@ -43,6 +47,7 @@ const main = async (): Promise<void> => {
 
   const client = KubeClient.fromKubeconfig();
   const coreApi = client.coreV1;
+  const patchApi = makePatchApi(client);
 
   const saName = `${ciEnvCm}-console`;
 
@@ -77,7 +82,7 @@ const main = async (): Promise<void> => {
     patchData[saUid] = USER_SETTINGS;
   }
 
-  await mergeConfigMapData(coreApi, 'kubevirt-user-settings', cnvNs, patchData);
+  await patchConfigMapData(patchApi, 'kubevirt-user-settings', cnvNs, patchData);
 
   // Ensure kubevirt-ui-features ConfigMap exists
   try {
@@ -89,7 +94,7 @@ const main = async (): Promise<void> => {
     });
   }
 
-  await mergeConfigMapData(coreApi, 'kubevirt-ui-features', cnvNs, {
+  await patchConfigMapData(patchApi, 'kubevirt-ui-features', cnvNs, {
     advancedSearch: 'true',
     treeViewFolders: 'true',
   });
@@ -108,7 +113,7 @@ const main = async (): Promise<void> => {
       });
     }
 
-    await mergeConfigMapData(coreApi, cmName, cmNs, { 'console.guidedTour': GUIDED_TOUR });
+    await patchConfigMapData(patchApi, cmName, cmNs, { 'console.guidedTour': GUIDED_TOUR });
   }
 
   console.log('User settings seeded successfully.');


### PR DESCRIPTION
## Summary
- Test PR to verify all recent CI fixes end-to-end

## Test plan
- [ ] Quay.io push succeeds
- [ ] `seed-user-settings.ts` patches ConfigMaps without JSON Patch error
- [ ] `create-test-secret.ts` finds fixture at repo root
- [ ] ARC/ci-env image builds skipped when already present


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that VPC ROKS supports Multus in the infrastructure types documentation.

* **Bug Fixes**
  * Improved cluster configuration updates to better preserve existing settings and reduce conflicts when multiple changes occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->