### PR TITLE
test: fix playwright-runner-hc-e2e.sh path in run-gating-tests

### DIFF
--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -2,7 +2,7 @@
 
 This directory contains scripts and documentation for the **IBM Cloud hot cluster** CI stack: an OpenShift cluster used for KubeVirt plugin E2E testing, with **Hyperconverged Cluster Operator (HCO)** and **GitHub Actions Runner Controller (ARC)** for self-hosted runners (`kubevirt-plugin-ci`).
 
-Three infrastructure types are supported: **Classic ROKS**, **VPC ROKS** (recommended; OVN-Kubernetes CNI, Multus support), and **IPI** (self-managed OpenShift).
+Three infrastructure types are supported: **Classic ROKS**, **VPC ROKS** (recommended; OVN-Kubernetes CNI, Multus), and **IPI** (self-managed OpenShift).
 
 **Prow/Tide are gone for this repo.** Gating E2E runs here; merge eligibility (`lgtm`/`approved`/`hold`/`needs-rebase`) and native auto-merge live in GitHub Actions. See [Prow/Tide → GitHub Actions Migration](#prowtide-github-actions-migration-complete-for-this-repo) below.
 

--- a/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
@@ -5,7 +5,7 @@
  * Cypress-specific env: TEST_NS, OS_IMAGES_NS, CNV_NS, TEST_SECRET_NAME
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 
 import { requireEnv } from '../utils';
 
@@ -32,7 +32,10 @@ const main = async (): Promise<void> => {
     const spec = testProject === 'features' ? 'tests/tier1.cy.ts' : 'tests/gating.cy.ts';
     execSync(`npm run test-cypress-headless -- --spec ${spec}`, { env, stdio: 'inherit' });
   } else {
-    execSync('./playwright-runner-hc-e2e.sh Gating', { stdio: 'inherit' });
+    const repoRoot =
+      process.env.GITHUB_WORKSPACE ??
+      execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+    execSync('./playwright-runner-hc-e2e.sh Gating', { cwd: repoRoot, stdio: 'inherit' });
   }
 };
 


### PR DESCRIPTION
## Summary
- Fix `./playwright-runner-hc-e2e.sh: not found` error in CI by setting `cwd` to repo root when invoking the script from `run-gating-tests.ts` (same CWD-vs-repo-root issue as previous Dockerfile and secret.yaml fixes)

## Test plan
- [ ] CI gating tests run successfully without the "not found" error


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the VPC ROKS description to clarify its use of OVN-Kubernetes CNI and Multus.

* **Bug Fixes**
  * Improved gating test execution by ensuring tests run from the correct repository root in supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->