### PR TITLE
CNV-94182: trust openshift-ci[bot] labels and preserve approved for OWNERS authors

### DIFF
--- a/.github/scripts/src/validation/pr-path-validation/owners.ts
+++ b/.github/scripts/src/validation/pr-path-validation/owners.ts
@@ -1,7 +1,13 @@
+import { Buffer } from 'buffer';
+
 import type { Octokit } from '@octokit/rest';
 
-/** The only identity commands/approve.ts uses to add reviewed/skip labels -- any other bot/app with label-write access must still pass the OWNERS check below. */
+/** The primary identity commands/approve.ts uses to add reviewed/skip labels. */
 export const APPROVAL_BOT_LOGIN = 'kubevirt-plugin-bot[bot]';
+
+const TRUSTED_BOT_LOGINS: ReadonlySet<string> = new Set([APPROVAL_BOT_LOGIN, 'openshift-ci[bot]']);
+
+export const isTrustedBot = (login: string): boolean => TRUSTED_BOT_LOGINS.has(login);
 
 const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
@@ -93,7 +99,7 @@ export const isLabelAppliedByTrustedActor = async (
       return false;
     }
 
-    if (actor === APPROVAL_BOT_LOGIN) {
+    if (isTrustedBot(actor)) {
       return true;
     }
     return await isListedInOwners(octokit, owner, repo, baseRef, actor);

--- a/.github/scripts/src/validation/verify-merge-pool-labels/verify-hold-removal.ts
+++ b/.github/scripts/src/validation/verify-merge-pool-labels/verify-hold-removal.ts
@@ -5,7 +5,7 @@ import { DO_NOT_MERGE_HOLD_LABEL } from '../../shared/merge-pool';
 import type { GitHubConfig } from '../../types/index';
 import { sameGitHubLogin } from '../../utils';
 import { isWriteCollaborator } from '../commands/collaborator-trust';
-import { APPROVAL_BOT_LOGIN } from '../pr-path-validation/owners';
+import { isTrustedBot } from '../pr-path-validation/owners';
 
 export type VerifyHoldRemovalContext = {
   config: GitHubConfig;
@@ -21,8 +21,8 @@ export type VerifyHoldRemovalContext = {
 export const verifyMergePoolHoldRemoval = async (ctx: VerifyHoldRemovalContext): Promise<void> => {
   const { config, octokit, prNumber, sender } = ctx;
 
-  if (sameGitHubLogin(sender, APPROVAL_BOT_LOGIN)) {
-    console.log(`Hold removal by bot ${APPROVAL_BOT_LOGIN} — trusted.`);
+  if (isTrustedBot(sender)) {
+    console.log(`Hold removal by bot ${sender} — trusted.`);
     return;
   }
 

--- a/.github/scripts/src/validation/verify-merge-pool-labels/verify-hold-removal.ts
+++ b/.github/scripts/src/validation/verify-merge-pool-labels/verify-hold-removal.ts
@@ -3,7 +3,6 @@ import type { Octokit } from '@octokit/rest';
 import { addLabel } from '../../github-comments';
 import { DO_NOT_MERGE_HOLD_LABEL } from '../../shared/merge-pool';
 import type { GitHubConfig } from '../../types/index';
-import { sameGitHubLogin } from '../../utils';
 import { isWriteCollaborator } from '../commands/collaborator-trust';
 import { isTrustedBot } from '../pr-path-validation/owners';
 

--- a/.github/scripts/src/validation/verify-merge-pool-labels/verify.ts
+++ b/.github/scripts/src/validation/verify-merge-pool-labels/verify.ts
@@ -5,7 +5,7 @@ import { APPROVED_LABEL, DO_NOT_MERGE_HOLD_LABEL, LGTM_LABEL } from '../../share
 import type { GitHubConfig } from '../../types/index';
 import { sameGitHubLogin } from '../../utils';
 import { isWriteCollaborator } from '../commands/collaborator-trust';
-import { APPROVAL_BOT_LOGIN, isListedInOwners } from '../pr-path-validation/owners';
+import { isListedInOwners, isTrustedBot } from '../pr-path-validation/owners';
 
 /** Pool-facing labels whose presence must match the slash-command trust model. */
 export const MERGE_POOL_WATCHED_LABELS = new Set<string>([
@@ -67,7 +67,7 @@ export const isTrustedMergePoolLabelActor = async (
   actor: string,
   prAuthor: string,
 ): Promise<boolean> => {
-  if (actor === APPROVAL_BOT_LOGIN) {
+  if (isTrustedBot(actor)) {
     return true;
   }
 
@@ -79,6 +79,9 @@ export const isTrustedMergePoolLabelActor = async (
   }
 
   if (labelName === APPROVED_LABEL) {
+    if (await isListedInOwners(octokit, owner, repo, baseBranch, prAuthor, 'OWNERS')) {
+      return true;
+    }
     if (sameGitHubLogin(actor, prAuthor)) {
       return false;
     }

--- a/.github/scripts/src/validation/verify-review-labels/verify.ts
+++ b/.github/scripts/src/validation/verify-review-labels/verify.ts
@@ -10,9 +10,9 @@ import {
   executeCiScriptsValidation,
 } from '../pr-path-validation/execute';
 import {
-  APPROVAL_BOT_LOGIN,
   isLabelAppliedByTrustedActor,
   isListedInOwners,
+  isTrustedBot,
 } from '../pr-path-validation/owners';
 
 export const AI_LABELS = new Set<string>([AI_CONFIG.labels.reviewed, AI_CONFIG.labels.skip]);
@@ -59,7 +59,7 @@ const isEventSenderTrusted = async (ctx: VerifyReviewLabelContext): Promise<bool
   // the bot adds the label -- that labeled event's sender is the bot, so
   // without this exemption verify would strip valid bot-applied approvals.
   // Exact match only: trusting every *[bot] would let any label-write app bypass.
-  if (ctx.sender === APPROVAL_BOT_LOGIN) {
+  if (isTrustedBot(ctx.sender)) {
     return true;
   }
   return isListedInOwners(

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,8 @@
       "devDependencies": {
         "@commitlint/cli": "^21.0.2",
         "@eslint-react/eslint-plugin": "^5.9.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/rest": "^21.1.1",
         "@openshift-console/dynamic-plugin-sdk": "4.23.0-prerelease.4",
         "@openshift-console/dynamic-plugin-sdk-internal": "4.23.0-prerelease.4",
         "@openshift-console/dynamic-plugin-sdk-webpack": "4.23.0-prerelease.4",
@@ -4872,6 +4874,297 @@
       "integrity": "sha512-4yGHOtUCnEJUCsgEt/L78eeJu00kthurLBWXFiaXfonNx0pzbs6R/3gJb1byZe6iAE8V9MF0syQb0xIL8MSOtQ==",
       "license": "MPL-2.0"
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
+      "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.2.2",
+        "@octokit/request": "^9.2.3",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/endpoint": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/graphql": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
+      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/request": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^10.1.4",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/request-error": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
+      "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.11.tgz",
+      "integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
+      "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^6.1.4",
+        "@octokit/plugin-paginate-rest": "^11.4.2",
+        "@octokit/plugin-request-log": "^5.3.1",
+        "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
     "node_modules/@openshift-console/dynamic-plugin-sdk": {
       "version": "4.23.0-prerelease.4",
       "resolved": "https://registry.npmjs.org/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-4.23.0-prerelease.4.tgz",
@@ -9116,6 +9409,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -13029,6 +13329,23 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -19768,6 +20085,13 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC"
     },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.10.tgz",
+      "integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -26205,6 +26529,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
   "devDependencies": {
     "@commitlint/cli": "^21.0.2",
     "@eslint-react/eslint-plugin": "^5.9.0",
+    "@octokit/graphql": "^9.0.3",
+    "@octokit/rest": "^21.1.1",
     "@openshift-console/dynamic-plugin-sdk": "4.23.0-prerelease.4",
     "@openshift-console/dynamic-plugin-sdk-internal": "4.23.0-prerelease.4",
     "@openshift-console/dynamic-plugin-sdk-webpack": "4.23.0-prerelease.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
     "plugin-metadata.ts",
     "plugin-extensions.ts",
     "knip.config.ts",
-    "@types/**/*"
+    "@types/**/*",
+    ".github/scripts/src/**/*.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,6 @@
     "plugin-metadata.ts",
     "plugin-extensions.ts",
     "knip.config.ts",
-    "@types/**/*",
-    ".github/scripts/src/**/*.ts"
+    "@types/**/*"
   ]
 }


### PR DESCRIPTION
## Summary

- Add `openshift-ci[bot]` to the trusted bot set so its `lgtm`/`approved` labels are not stripped by label verification
- Never strip the `approved` label when the PR author is listed in the OWNERS file (they have inherent approval rights)
- Add `@octokit` deps to root `devDependencies` and `.github/scripts/src/` to root `tsconfig.json` include for IDE resolution

## Background

`openshift-ci[bot]` applies `lgtm`/`approved` labels when a reviewer approves, but the label verification system only trusted `kubevirt-plugin-bot[bot]`. This caused a race condition:

1. `openshift-ci[bot]` adds labels
2. Label verification strips them (untrusted actor)
3. `kubevirt-plugin-bot[bot]` re-adds them from the review pathway
4. During the brief gap, `auto-merge.yml` evaluates eligibility and fails
5. Old failed check runs persist in GitHub's status rollup, blocking auto-merge indefinitely

## Test plan

- [ ] PR opened by an OWNERS-listed author retains `approved` label when applied by `openshift-ci[bot]`
- [ ] Auto-merge is not blocked by stale failed check runs from label race conditions
- [ ] Label verification still strips `lgtm`/`approved` from untrusted actors


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request label validation to recognize approved automation bots consistently.
  * Allowed authorized code owners to apply approval labels on their own pull requests.
  * Updated hold-label removal and review-label checks to correctly trust approved automated actions.
  * Preserved existing collaborator verification and safeguards when labels are removed or reapplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->