### PR TITLE
CNV-94182: add missing checkout to cancel-on-close workflow

### DIFF
--- a/.github/workflows/hot-cluster-e2e-cancel-on-close.yml
+++ b/.github/workflows/hot-cluster-e2e-cancel-on-close.yml
@@ -19,6 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: .github
+
       - name: Setup scripts
         uses: ./.github/actions/setup-gh-scripts
         with:


### PR DESCRIPTION
## Summary
- The `Detect Pending E2E Runs` job in `cancel-on-close.yml` was missing an `actions/checkout` step before calling the local `setup-gh-scripts` action
- GitHub Actions needs the repo checked out to find local composite actions (`uses: ./.github/actions/...`)

## Test plan
- [ ] Close a PR and verify `Detect Pending E2E Runs` no longer fails with "Can't find action.yml"

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated workflow setup by retrieving the latest default-branch configuration before running cancellation checks.
  * Enhanced credential handling during workflow checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->