### PR TITLE
CNV-93050: Fix infinite Templates list loading without permissions

### DIFF
--- a/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
+++ b/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
@@ -65,7 +65,7 @@ export const useAccessibleResources = <T>({
   const loadPerNamespace = !isACMPage && projectNamesLoaded && !isAdmin;
 
   const shouldFetchClusterWide = isAdmin || isACMPage;
-  const [allResources, allResourcesLoaded] = useKubevirtWatchResource<T[]>(
+  const [allResources, allResourcesLoaded, allResourcesLoadError] = useKubevirtWatchResource<T[]>(
     shouldFetchClusterWide
       ? {
           cluster: clusterToWatch,
@@ -107,13 +107,12 @@ export const useAccessibleResources = <T>({
   }, [allResources, allowedResources, loadPerNamespace]);
 
   const loaded = shouldFetchClusterWide
-    ? allResourcesLoaded
+    ? allResourcesLoaded || !!allResourcesLoadError
     : projectNamesLoaded &&
       (isEmpty(allowedResources) ||
         Object.values(allowedResources).some((resource) => resource.loaded || resource.loadError));
 
-  // Cluster-wide watches do not need OpenShift Project discovery.
-  const loadError = shouldFetchClusterWide ? undefined : projectNamesError;
+  const loadError = shouldFetchClusterWide ? allResourcesLoadError : projectNamesError;
 
   return { loaded, loadError, resources };
 };


### PR DESCRIPTION
## 📝 Description

When a user without list permissions opens **Virtualization → Templates** (especially Fleet/ACM), the page stayed on the loading skeleton forever instead of showing an access error.

`useAccessibleResources` fetched cluster-wide resources but discarded the watch `loadError` and never treated a failed watch as loaded. This change:

- Captures `allResourcesLoadError` from `useKubevirtWatchResource`
- Marks the query loaded when a watch error occurs (`loaded || !!loadError`)
- Returns that watch error for cluster-wide/ACM fetches so list pages can show AccessDenied

Callers that already pass through `loadError` (Templates list, VM list, Overview, etc.) pick this up with no further changes. Project discovery errors remain ignored for cluster-wide watches.

## 🔗 Links

- https://issues.redhat.com/browse/CNV-93050

## 🎥 Demo

> N/A — error-state fix (AccessDenied / empty of skeleton)

## Test plan
- [ ] As a user without Template list permission on Fleet → Templates: page finishes loading and shows AccessDenied (or equivalent error), not infinite skeleton
- [ ] As an admin on Fleet → Templates: list still loads normally
- [ ] Cluster-wide VM list still works when Project API is unavailable (regression for “Ignore missing Project API”)
- [ ] Namespaced Templates/VM list paths unchanged for permitted users


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster-wide resource loading errors are now detected and surfaced.
  * Loading state correctly completes when the resource load either succeeds or fails.
  * Error information is now available instead of being silently omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->