### PR TITLE
CNV-91016: store table sorting in URL

### DIFF
--- a/src/utils/components/KubevirtTable/KubevirtTable.tsx
+++ b/src/utils/components/KubevirtTable/KubevirtTable.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, ReactNode, useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router';
 
 import { PF_TABLE_CHECK_CLASS } from '@kubevirt-utils/hooks/useDataViewTableSort/constants';
 import { useDataViewTableSort } from '@kubevirt-utils/hooks/useDataViewTableSort/useDataViewTableSort';
@@ -12,8 +13,8 @@ import MutedTextSpan from '../MutedTextSpan/MutedTextSpan';
 import StateHandler from '../StateHandler/StateHandler';
 
 import { useTableSelection } from './hooks/useTableSelection';
-import { getActiveColumns } from './utils/getActiveColumns';
 import { KubevirtTableProps } from './types';
+import { getActiveColumns } from './utils/getActiveColumns';
 
 import './KubevirtTable.scss';
 
@@ -55,8 +56,11 @@ const KubevirtTable = <TData, TCallbacks = undefined>(
     noDataMsg,
     noFilteredDataMsg,
     pagination,
+    persistSortInUrl,
     unfilteredData,
   } = props;
+
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const isSelectable = props.selectable === true;
   const onSelect = isSelectable ? props.onSelect : undefined;
@@ -82,6 +86,8 @@ const KubevirtTable = <TData, TCallbacks = undefined>(
     effectiveInitialSortKey,
     initialSortDirection,
     callbacks,
+    persistSortInUrl ? searchParams : undefined,
+    persistSortInUrl ? setSearchParams : undefined,
   );
 
   const paginatedData = useMemo(() => {

--- a/src/utils/components/KubevirtTable/types.ts
+++ b/src/utils/components/KubevirtTable/types.ts
@@ -38,6 +38,8 @@ type BaseKubevirtTableProps<TData, TCallbacks = undefined> = {
   noFilteredDataMsg?: ReactNode;
   /** Pagination state from usePagination hook. When provided, table will slice sorted data accordingly */
   pagination?: PaginationState;
+  /** When true, sort state (column and direction) is persisted in URL search params */
+  persistSortInUrl?: boolean;
   unfilteredData?: TData[];
 };
 

--- a/src/utils/hooks/useDataViewTableSort/useDataViewTableSort.ts
+++ b/src/utils/hooks/useDataViewTableSort/useDataViewTableSort.ts
@@ -15,6 +15,8 @@ export const useDataViewTableSort = <TData, TCallbacks = undefined>(
   initialSortKey?: string,
   initialSortDirection: 'asc' | 'desc' = 'asc',
   callbacks?: TCallbacks,
+  searchParams?: URLSearchParams,
+  setSearchParams?: (params: URLSearchParams) => void,
 ): {
   sortedData: TData[];
   tableColumns: DataViewTh[];
@@ -24,6 +26,8 @@ export const useDataViewTableSort = <TData, TCallbacks = undefined>(
 
   const { direction, onSort, sortBy } = useDataViewSort({
     initialSort: { direction: initialSortDirection, sortBy: initialSortKey ?? columns[0]?.key },
+    searchParams,
+    setSearchParams,
   });
 
   const sortByIndex = useMemo(

--- a/src/views/bootablevolumes/list/BootableVolumesList.tsx
+++ b/src/views/bootablevolumes/list/BootableVolumesList.tsx
@@ -163,6 +163,7 @@ const BootableVolumesList: FC = () => {
             loadError={error}
             noDataMsg={t("You don't have any bootable volumes yet")}
             pagination={pagination}
+            persistSortInUrl
             unfilteredData={bootableVolumes}
           />
         </Stack>

--- a/src/views/checkups/self-validation/list/CheckupsSelfValidationList.tsx
+++ b/src/views/checkups/self-validation/list/CheckupsSelfValidationList.tsx
@@ -150,6 +150,7 @@ const CheckupsSelfValidationList: FC = () => {
         loadError={error}
         noDataMsg={t('No self validation checkups found')}
         pagination={pagination}
+        persistSortInUrl
         unfilteredData={unfilteredData}
       />
     </ListPageBody>

--- a/src/views/checkups/storage/list/CheckupsStorageList.tsx
+++ b/src/views/checkups/storage/list/CheckupsStorageList.tsx
@@ -151,6 +151,7 @@ const CheckupsStorageList = () => {
         loadError={error}
         noDataMsg={t('No storage checkups found')}
         pagination={pagination}
+        persistSortInUrl
         unfilteredData={unfilteredData}
       />
     </ListPageBody>

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/MigrationsTable.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/MigrationsTable.tsx
@@ -106,6 +106,7 @@ const MigrationTable: FC<MigrationTableProps> = ({ tableData }) => {
         loadError={loadErrors}
         noDataMsg={t('No migrations found')}
         pagination={pagination}
+        persistSortInUrl
         unfilteredData={migrationsTableUnfilteredData}
       />
     </ListPageBody>

--- a/src/views/datasources/list/DataSourcesList.tsx
+++ b/src/views/datasources/list/DataSourcesList.tsx
@@ -132,6 +132,7 @@ const DataSourcesList: FC<DataSourcesListProps> = ({ kind, namespace }) => {
           loadError={loadError}
           noDataMsg={t("You don't have any DataSources yet")}
           pagination={pagination}
+          persistSortInUrl
           unfilteredData={unfilteredData}
         />
       </ListPageBody>

--- a/src/views/instancetypes/list/ClusterInstancetypeList.tsx
+++ b/src/views/instancetypes/list/ClusterInstancetypeList.tsx
@@ -118,6 +118,7 @@ const ClusterInstancetypeList: FC<ListPageProps> = ({
         loadError={loadError}
         noDataMsg={t("You don't have any VirtualMachineClusterInstanceTypes yet")}
         pagination={pagination}
+        persistSortInUrl
         unfilteredData={instanceTypes}
       />
     </ListPageBody>

--- a/src/views/instancetypes/list/UserInstancetypeList.tsx
+++ b/src/views/instancetypes/list/UserInstancetypeList.tsx
@@ -136,6 +136,7 @@ const UserInstancetypeList: FC<UserInstancetypeListProps> = ({
         loadError={loadError}
         noDataMsg={t("You don't have any VirtualMachineInstanceTypes yet")}
         pagination={pagination}
+        persistSortInUrl
         unfilteredData={instanceTypes}
       />
     </ListPageBody>

--- a/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
+++ b/src/views/migrationpolicies/list/MigrationPoliciesList.tsx
@@ -108,6 +108,7 @@ const MigrationPoliciesList: FC<ListPageProps> = ({
           loaded={isLoaded}
           loadError={loadError}
           noDataMsg={t("You don't have any MigrationPolicies yet")}
+          persistSortInUrl
           unfilteredData={mps}
         />
       </ListPageBody>

--- a/src/views/preferences/list/ClusterPreferenceList.tsx
+++ b/src/views/preferences/list/ClusterPreferenceList.tsx
@@ -91,6 +91,7 @@ const ClusterPreferenceList: FC<ListPageProps> = ({
         loadError={loadError}
         noDataMsg={t('No preferences found')}
         pagination={pagination}
+        persistSortInUrl
         unfilteredData={preferences}
       />
     </ListPageBody>

--- a/src/views/preferences/list/UserPreferenceList.tsx
+++ b/src/views/preferences/list/UserPreferenceList.tsx
@@ -106,6 +106,7 @@ const UserPreferenceList: FC<ListPageProps> = ({
         loadError={loadError}
         noDataMsg={t("You don't have any VirtualMachinePreferences yet")}
         pagination={pagination}
+        persistSortInUrl
         unfilteredData={preferences}
       />
     </ListPageBody>

--- a/src/views/quotas/list/QuotasList.tsx
+++ b/src/views/quotas/list/QuotasList.tsx
@@ -190,6 +190,7 @@ const QuotasList: FC = () => {
               noDataMsg={t("You don't have any application-aware quotas yet")}
               noFilteredDataMsg={t('No application-aware quotas found')}
               pagination={pagination}
+              persistSortInUrl
               unfilteredData={unfilteredData}
             />
           </>

--- a/src/views/storagemigrations/list/StorageMigrationList.tsx
+++ b/src/views/storagemigrations/list/StorageMigrationList.tsx
@@ -105,6 +105,7 @@ const StorageMigrationList: FC = () => {
           loadError={loadError}
           noDataMsg={t("You don't have any storage migrations yet")}
           pagination={pagination}
+          persistSortInUrl
           unfilteredData={unfilteredData}
         />
       </ListPageBody>

--- a/src/views/templates/list/VirtualMachineTemplatesList.tsx
+++ b/src/views/templates/list/VirtualMachineTemplatesList.tsx
@@ -123,6 +123,7 @@ const VirtualMachineTemplatesList: FC<ListPageProps> = ({
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- hook error typed as any
           loadError={error}
           noFilteredDataMsg={t('No templates found')}
+          persistSortInUrl
           unfilteredData={allTemplatesWithRequests}
         />
       </ListPageBody>

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -283,6 +283,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({
                   />
                 }
                 pagination={pagination}
+                persistSortInUrl
                 unfilteredData={allVMsInNamespace}
               />
             </>

--- a/src/views/virtualmachinesinstance/list/VirtualMachinesInstancesList.tsx
+++ b/src/views/virtualmachinesinstance/list/VirtualMachinesInstancesList.tsx
@@ -64,6 +64,7 @@ const VirtualMachinesInstancesList: FC<VirtualMachinesInstancesListProps> = ({ n
               namespace={namespace || DEFAULT_NAMESPACE}
             />
           }
+          persistSortInUrl
           unfilteredData={vmis}
         />
       </ListPageBody>

--- a/src/views/vmnetworks/list/VMNetworkList.tsx
+++ b/src/views/vmnetworks/list/VMNetworkList.tsx
@@ -42,6 +42,7 @@ const VMNetworkList: FC<VMNetworkListProps> = ({ onCreate }) => {
             initialSortKey="name"
             loaded={loaded}
             loadError={error}
+            persistSortInUrl
             unfilteredData={data}
           />
         </ListPageBody>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Stores `sortBy` and `direction` params in URL (by passing `searchParams` and `setSearchParams` props to `useDataViewTableSort` -> `useDataViewSort`), so sorting is kept on page refresh.

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-91016

## 🎥 Demo

After:

https://github.com/user-attachments/assets/6b808239-955a-4cb0-8517-4e17a365a87a





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table sorting can now be saved in the URL across supported resource lists.
  * Sort column and direction are preserved when refreshing, sharing, or navigating back to a list.
  * URL-based sort persistence is enabled across virtual machines, templates, volumes, migrations, preferences, quotas, networks, and related views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->