### PR TITLE
CNV-94182: set Merge Gate success before merge API call

### DIFF
--- a/.github/scripts/src/merge/auto-merge.ts
+++ b/.github/scripts/src/merge/auto-merge.ts
@@ -12,8 +12,9 @@
  * merges via PUT /pulls/:number/merge using the bot token so that
  * post-merge workflows (deploy, etc.) are triggered.
  *
- * Publishes a "Merge Gate" commit status for visibility in the PR merge box.
- * The job itself always exits 0.
+ * Publishes a "Merge Gate" commit status (also a required branch-protection
+ * check). Success is set before the merge API call so GitHub does not reject
+ * the merge for a pending/failed Merge Gate. The job itself always exits 0.
  */
 
 import { Octokit } from '@octokit/rest';
@@ -299,18 +300,36 @@ const main = async (): Promise<void> => {
   }
 
   const botOctokit = new Octokit({ auth: botToken });
-  const merged = await tryMerge(botOctokit, owner, repo, prNumber, headSha);
-  addStepSummary(buildStepSummary(result, statusResult, merged));
 
+  // Merge Gate is required by branch protection. Mark it successful only after
+  // eligibility + other required checks pass, and before calling the merge API.
+  // Otherwise GitHub rejects the merge when Merge Gate is still pending/failed.
   await setCommitStatus(
     octokit,
     owner,
     repo,
     headSha,
-    merged ? 'success' : 'failure',
-    merged ? 'Merged' : 'Merge failed — see workflow log',
+    'success',
+    'Ready to merge',
     MERGE_GATE_CONTEXT,
   );
+
+  const merged = await tryMerge(botOctokit, owner, repo, prNumber, headSha);
+  addStepSummary(buildStepSummary(result, statusResult, merged));
+
+  if (!merged) {
+    await setCommitStatus(
+      octokit,
+      owner,
+      repo,
+      headSha,
+      'failure',
+      'Merge failed — see workflow log',
+      MERGE_GATE_CONTEXT,
+    );
+  } else {
+    await setCommitStatus(octokit, owner, repo, headSha, 'success', 'Merged', MERGE_GATE_CONTEXT);
+  }
 };
 
 void main().catch(async (err) => {


### PR DESCRIPTION
## Summary
- Auto-merge now publishes `Merge Gate` as `success` (`Ready to merge`) after eligibility and other required checks pass, **before** calling the merge API.
- On merge failure it still marks `Merge Gate` as failed; on success it updates the description to `Merged`.

This fixes the chicken-and-egg where branch protection blocked merges because `Merge Gate` was still pending/failed, then the script recorded another failure (seen on #4505).

## Test plan
- [ ] Merge this PR (may need admin/bypass once while the old bug is still on `main`)
- [ ] Re-run Auto Merge on a merge-pool-eligible PR (e.g. #4505) and confirm merge succeeds
- [ ] Confirm a non-eligible PR still gets a failing `Merge Gate` status


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Merge Gate is a required branch-protection check and must pass before merging.

* **Bug Fixes**
  * Added pre-merge validation for pull request status, draft state, updated commits, conflicts, mergeability, and branches behind the base.
  * Retryable conditions remain pending, while permanent failures are reported as unsuccessful.
  * Merge Gate now reports success before a merge is attempted and accurately updates to failure or success based on the merge result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->