### PR TITLE
CNV-94392: show Code Checks step failures and keep running checks

### DIFF
--- a/.github/scripts/src/shared/check-step-results.ts
+++ b/.github/scripts/src/shared/check-step-results.ts
@@ -1,9 +1,12 @@
 /**
- * Aggregate step outcomes and fail if any failed.
+ * Aggregate step outcomes and fail if any failed or were skipped.
  * Entry point: npx tsx src/shared/check-step-results.ts
  *
  * Env: STEP_RESULTS — JSON object mapping step names to outcomes
  *      e.g. {"i18n":"success","lint":"failure","build":"success"}
+ *
+ * Skipped checks count as failures so a missing setup step cannot hide
+ * behind an empty "All checks passed" summary.
  */
 
 import { requireEnv } from '../utils';
@@ -15,15 +18,26 @@ const main = (): void => {
   const results = JSON.parse(raw) as Record<string, string>;
 
   const failed: string[] = [];
+  const skipped: string[] = [];
   const names = Object.keys(results);
   for (const name of names) {
-    if (results[name] === 'failure') {
+    const outcome = results[name];
+    if (outcome === 'failure') {
       failed.push(name);
+    } else if (outcome === 'skipped' || outcome === '') {
+      skipped.push(name);
     }
   }
 
+  const problems: string[] = [];
   if (failed.length > 0) {
-    failStep(`Failed checks: ${failed.join(', ')}`);
+    problems.push(`Failed checks: ${failed.join(', ')}`);
+  }
+  if (skipped.length > 0) {
+    problems.push(`Skipped checks: ${skipped.join(', ')}`);
+  }
+  if (problems.length > 0) {
+    failStep(problems.join('; '));
   }
 
   console.log('All checks passed');

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -24,6 +24,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout
+        id: checkout
         uses: actions/checkout@v7
         with:
           persist-credentials: false
@@ -35,12 +36,17 @@ jobs:
           cache: npm
 
       - name: Install dependencies
+        id: npm_ci
         run: npm ci --ignore-scripts
+
+      # Check steps intentionally omit continue-on-error so failures show as red
+      # in the Actions UI. Each step uses if: !cancelled() && <setup ok> so later
+      # checks still run after an earlier check fails.
 
       # ── i18n ──────────────────────────────────────────────
       - name: Check i18n
         id: i18n
-        continue-on-error: true
+        if: ${{ !cancelled() && steps.npm_ci.outcome == 'success' }}
         shell: bash
         run: |
           npm run i18n
@@ -53,30 +59,32 @@ jobs:
 
       # ── actionlint ────────────────────────────────────────
       - name: Install actionlint
+        id: actionlint_install
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         run: |
           go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run actionlint
         id: actionlint
-        continue-on-error: true
+        if: ${{ !cancelled() && steps.actionlint_install.outcome == 'success' }}
         run: actionlint -color -shellcheck= -pyflakes=
 
       # ── lint + build ──────────────────────────────────────
       - name: Lint
         id: lint
-        continue-on-error: true
+        if: ${{ !cancelled() && steps.npm_ci.outcome == 'success' }}
         run: npm run lint
 
       - name: Build
         id: build
-        continue-on-error: true
+        if: ${{ !cancelled() && steps.npm_ci.outcome == 'success' }}
         run: npm run build
 
       # ── Hermeto offline install verification ──────────────
       - name: Prefetch npm dependencies with Hermeto
         id: hermeto
-        continue-on-error: true
+        if: ${{ !cancelled() && steps.npm_ci.outcome == 'success' }}
         run: |
           git checkout -- package.json package-lock.json
           rm -rf node_modules hermeto-output
@@ -94,13 +102,13 @@ jobs:
 
       - name: Verify offline install
         id: offline
-        continue-on-error: true
+        if: ${{ !cancelled() && steps.npm_ci.outcome == 'success' }}
         run: HUSKY=0 npm ci --offline --ignore-scripts --no-audit
 
       # ── unit tests ────────────────────────────────────────
       - name: Run unit tests
         id: test
-        continue-on-error: true
+        if: ${{ !cancelled() && steps.npm_ci.outcome == 'success' }}
         run: npm run test-cov
 
       - name: Coverage upload
@@ -111,18 +119,20 @@ jobs:
 
       # ── workflow script checks ────────────────────────────
       - name: Install workflow script dependencies
+        id: script_deps
+        if: ${{ !cancelled() && steps.checkout.outcome == 'success' }}
         working-directory: .github/scripts
         run: npm ci
 
       - name: Check workflow script types
         id: script_types
-        continue-on-error: true
+        if: ${{ !cancelled() && steps.script_deps.outcome == 'success' }}
         working-directory: .github/scripts
         run: npm run check-types
 
       - name: Run workflow script tests
         id: script_tests
-        continue-on-error: true
+        if: ${{ !cancelled() && steps.script_deps.outcome == 'success' }}
         working-directory: .github/scripts
         run: npm test
 
@@ -143,4 +153,8 @@ jobs:
               "script-tests": "${{ steps.script_tests.outcome }}"
             }
         working-directory: .github/scripts
-        run: npx tsx src/shared/check-step-results.ts
+        run: |
+          if [ ! -d node_modules ]; then
+            npm ci --ignore-scripts
+          fi
+          npx tsx src/shared/check-step-results.ts


### PR DESCRIPTION
## Summary
- Remove `continue-on-error` from Code Checks so failed steps show as red failures in the Actions UI (instead of warning/success-looking outcomes).
- Gate each check on setup success (`npm ci` / checkout / install helpers) with `if: !cancelled() && …` so later steps still run when an earlier check like i18n fails.
- Treat skipped check outcomes as failures in the aggregate step, and ensure that step can install `.github/scripts` deps if needed.

## Links
- https://redhat.atlassian.net/browse/CNV-94392

## Test plan
- [ ] Open this PR and confirm Code Checks runs all check steps
- [ ] (Optional) Temporarily break i18n locally on a follow-up push and confirm i18n is red while lint/build/tests still execute
- [ ] Confirm the final "Check all results" step fails the job when any check failed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation reporting by clearly distinguishing failed and skipped checks.
  * Skipped or incomplete checks are now included in the final result.
  * Remaining checks continue to run when an earlier validation fails, providing more complete feedback.
  * Final workflow results are now reported more consistently, including when setup steps are cancelled or prerequisites do not succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->