### PR TITLE
CNV-94182: squash-merge PRs via Merge Gate

### DIFF
--- a/.github/scripts/src/merge/auto-merge.ts
+++ b/.github/scripts/src/merge/auto-merge.ts
@@ -9,7 +9,7 @@
  * the platform's mergeStateStatus evaluation is unreliable — it can report
  * BLOCKED even when all required checks pass (known GitHub bug). Instead,
  * this script checks label eligibility + required statuses itself, then
- * merges via PUT /pulls/:number/merge using the bot token so that
+ * squash-merges via PUT /pulls/:number/merge using the bot token so that
  * post-merge workflows (deploy, etc.) are triggered.
  *
  * Publishes a "Merge Gate" commit status (also a required branch-protection
@@ -153,13 +153,13 @@ const tryMerge = async (
 ): Promise<boolean> => {
   try {
     await botOctokit.pulls.merge({
-      merge_method: 'merge',
+      merge_method: 'squash',
       owner,
       pull_number: prNumber,
       repo,
       sha,
     });
-    console.log(`Merged PR #${prNumber} via API.`);
+    console.log(`Squash-merged PR #${prNumber} via API.`);
     return true;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Change auto-merge from `merge_method: 'merge'` to `'squash'` so Merge Gate lands one commit per PR instead of a merge commit with the full branch history.

## Test plan
- [ ] Confirm repo still has squash merge enabled (already true)
- [ ] After merge, verify next Merge Gate success squash-merges a pool PR
- [ ] Confirm squash commit title/message follow repo settings (`COMMIT_OR_PR_TITLE` / `COMMIT_MESSAGES`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that pull requests are merged using squash mode.

* **Chores**
  * Updated merge reporting to accurately reflect squash merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->