### PR TITLE
CNV-94182: use client-id for create-github-app-token

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -11,3 +11,9 @@ paths:
       # actionlint v1.7.12's schema doesn't recognize yet -- not a bug in
       # our workflows. Safe to drop once actionlint's schema catches up.
       - 'unexpected key "queue" for "concurrency" section'
+      # create-github-app-token@v3 now uses client-id (app-id deprecated), but
+      # actionlint v1.7.12's bundled popular_actions schema still requires
+      # app-id and doesn't know client-id. Fixed upstream in
+      # https://github.com/rhysd/actionlint/pull/668 — drop once released.
+      - 'missing input "app-id" which is required by action "actions/create-github-app-token@'
+      - 'input "client-id" is not defined in action "actions/create-github-app-token@'

--- a/.github/actions/create-bot-token/action.yml
+++ b/.github/actions/create-bot-token/action.yml
@@ -4,8 +4,10 @@ description: >
   continue-on-error so a bad credential still lets callers fall back to github.token.
 
 inputs:
-  app-id:
-    description: GitHub App ID (BOT_APP_ID secret)
+  client-id:
+    description: >
+      GitHub App Client ID (preferred). The BOT_APP_ID secret may hold either the
+      Client ID or legacy numeric App ID — both work as the JWT issuer.
     required: true
   private-key:
     description: GitHub App private key (BOT_APP_PRIVATE_KEY secret)
@@ -36,7 +38,7 @@ runs:
       continue-on-error: true
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.app-id }}
+        client-id: ${{ inputs.client-id }}
         private-key: ${{ inputs.private-key }}
         permission-issues: ${{ inputs.permission-issues }}
         permission-pull-requests: ${{ inputs.permission-pull-requests }}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,16 +6,16 @@ Index of workflows in this directory. Deep design notes (check-run model, merge 
 
 ## Hot Cluster E2E
 
-| Workflow                              | Trigger                                | Role                                                            |
-| ------------------------------------- | -------------------------------------- | --------------------------------------------------------------- |
-| `hot-cluster-e2e.yml`                 | `workflow_dispatch` only               | Full E2E graph; publishes required **Run Gating Tests**         |
-| `hot-cluster-e2e-run.yml`             | `workflow_call`                        | Build plugin image + run Playwright on ARC                      |
-| `hot-cluster-check.yml`               | `workflow_call` (+ manual health)      | Cluster readiness / health                                      |
-| `hot-cluster-e2e-pr-gate.yml`         | PR opened / synchronize / reopened     | Thin gate → dispatch `hot-cluster-e2e.yml`                      |
+| Workflow                              | Trigger                                | Role                                                                                   |
+| ------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------- |
+| `hot-cluster-e2e.yml`                 | `workflow_dispatch` only               | Full E2E graph; publishes required **Run Gating Tests**                                |
+| `hot-cluster-e2e-run.yml`             | `workflow_call`                        | Build plugin image + run Playwright on ARC                                             |
+| `hot-cluster-check.yml`               | `workflow_call` (+ manual health)      | Cluster readiness / health                                                             |
+| `hot-cluster-e2e-pr-gate.yml`         | PR opened / synchronize / reopened     | Thin gate → dispatch `hot-cluster-e2e.yml`                                             |
 | `pr-validation.yml`                   | All PR events (push + label)           | Unified PR validation: Jira, path checks, review labels, E2E dispatch, merge-pool sync |
-| `ok-to-test-reset.yml`                | synchronize while `ok-to-test` present | Remove `ok-to-test` when head moves                             |
-| `hot-cluster-e2e-cancel-on-close.yml` | PR closed                              | Cancel in-flight when PR closes                                 |
-| `on-main-push.yml`                    | push to `main`                         | Mark checks stale; retest merge-pool PRs; sync needs-rebase     |
+| `ok-to-test-reset.yml`                | synchronize while `ok-to-test` present | Remove `ok-to-test` when head moves                                                    |
+| `hot-cluster-e2e-cancel-on-close.yml` | PR closed                              | Cancel in-flight when PR closes                                                        |
+| `on-main-push.yml`                    | push to `main`                         | Mark checks stale; retest merge-pool PRs; sync needs-rebase                            |
 
 ## Merge automation (Prow / Tide replacements)
 
@@ -34,7 +34,7 @@ Pool eligibility (`isMergePoolPr`): `lgtm` + `approved`, and no blockers (`hold`
 ## PR validation (OWNERS-gated paths)
 
 | Workflow            | Trigger               | Role                                              |
-| ------------------- | --------------------- | -------------------------------------------------- |
+| ------------------- | --------------------- | ------------------------------------------------- |
 | `pr-validation.yml` | `pull_request_target` | Jira + AI-config + CI-scripts validation statuses |
 
 Sensitive-path review uses `/ai-approved` and `/ci-approved` (`.github/OWNERS`), not `/approve`. Review label trust enforcement is handled by the label-gate route in `pr-validation.yml`.
@@ -68,4 +68,4 @@ See [`ci-scripts/manual-console/README.md`](../../ci-scripts/manual-console/READ
 | [`.github/actions/clear-e2e-result-labels`](../actions/clear-e2e-result-labels/action.yml) | Remove `e2e-passed`/`e2e-failed` (shared by PR gate + on-main-push)           |
 | [`.github/scripts/`](../scripts/)                                                          | TypeScript for validation commands, merge-pool verify, Jira/AI/CI checks      |
 
-Bot secrets: `BOT_APP_ID`, `BOT_APP_PRIVATE_KEY` (Issues + Pull requests write on the App). Details: [`ci-scripts/README.md`](../../ci-scripts/README.md#kubevirt-plugin-bot-required-for-prow-replacement-merge-automation).
+Bot secrets: `BOT_APP_ID` (App Client ID preferred; numeric App ID still works), `BOT_APP_PRIVATE_KEY` (Issues + Pull requests write on the App). Details: [`ci-scripts/README.md`](../../ci-scripts/README.md#kubevirt-plugin-bot-required-for-prow-replacement-merge-automation).

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -37,7 +37,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/hot-cluster-e2e-pr-gate.yml
+++ b/.github/workflows/hot-cluster-e2e-pr-gate.yml
@@ -36,7 +36,7 @@ jobs:
         id: bot-token
         uses: ./.github/actions/create-bot-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-checks: write
 

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -215,7 +215,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/create-bot-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-checks: write
 
@@ -391,7 +391,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/create-bot-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-checks: write
 
@@ -427,7 +427,7 @@ jobs:
           )
         uses: ./.github/actions/create-bot-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Report unresolvable PR context on the PR
@@ -476,7 +476,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/create-bot-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-checks: write
 

--- a/.github/workflows/ibmc-cleanup-all.yml
+++ b/.github/workflows/ibmc-cleanup-all.yml
@@ -126,7 +126,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.ARC_GITHUB_APP_ID }}
+          client-id: ${{ secrets.ARC_GITHUB_APP_ID }}
           private-key: ${{ secrets.ARC_GITHUB_APP_PRIVATE_KEY }}
           permission-administration: write
 

--- a/.github/workflows/ibmc-cluster-auto-teardown.yml
+++ b/.github/workflows/ibmc-cluster-auto-teardown.yml
@@ -145,7 +145,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.ARC_GITHUB_APP_ID }}
+          client-id: ${{ secrets.ARC_GITHUB_APP_ID }}
           private-key: ${{ secrets.ARC_GITHUB_APP_PRIVATE_KEY }}
           permission-administration: read
 

--- a/.github/workflows/ibmc-cluster-teardown.yml
+++ b/.github/workflows/ibmc-cluster-teardown.yml
@@ -190,7 +190,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.ARC_GITHUB_APP_ID }}
+          client-id: ${{ secrets.ARC_GITHUB_APP_ID }}
           private-key: ${{ secrets.ARC_GITHUB_APP_PRIVATE_KEY }}
           permission-administration: write
 

--- a/.github/workflows/needs-rebase.yml
+++ b/.github/workflows/needs-rebase.yml
@@ -30,7 +30,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-pull-requests: write
           permission-issues: write

--- a/.github/workflows/ok-to-test-reset.yml
+++ b/.github/workflows/ok-to-test-reset.yml
@@ -22,7 +22,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-pull-requests: write
           permission-issues: write

--- a/.github/workflows/on-main-push.yml
+++ b/.github/workflows/on-main-push.yml
@@ -83,7 +83,7 @@ jobs:
         if: always()
         uses: ./.github/actions/create-bot-token
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
 
       - name: Mark check stale
@@ -166,7 +166,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-pull-requests: write
           permission-issues: write

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -46,7 +46,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
@@ -121,7 +121,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-checks: write
 
@@ -157,7 +157,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-pull-requests: write
           permission-issues: write

--- a/.github/workflows/pr_review_commands_sync.yml
+++ b/.github/workflows/pr_review_commands_sync.yml
@@ -69,7 +69,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.BOT_APP_ID }}
+          client-id: ${{ secrets.BOT_APP_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-issues: write
           permission-pull-requests: write

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -117,10 +117,10 @@ Uses `openshift-install` to create a fully self-managed OpenShift cluster on IBM
 
 ### kubevirt-plugin-bot (required for Prow-replacement merge automation)
 
-| Secret                | Description                             |
-| --------------------- | --------------------------------------- |
-| `BOT_APP_ID`          | GitHub App ID for `kubevirt-plugin-bot` |
-| `BOT_APP_PRIVATE_KEY` | GitHub App private key                  |
+| Secret                | Description                                                                 |
+| --------------------- | --------------------------------------------------------------------------- |
+| `BOT_APP_ID`          | GitHub App Client ID for `kubevirt-plugin-bot` (numeric App ID still works) |
+| `BOT_APP_PRIVATE_KEY` | GitHub App private key                                                      |
 
 Used by `/lgtm`/`/approve`/`/hold`, review sync, `needs-rebase`, auto-merge GraphQL, e2e result labels, and related PR comment/label writes. The App installation must have **Issues: Read & write**, **Pull requests: Read & write**, and **Contents: Read & write** (the last one specifically for `enablePullRequestAutoMerge`/`disablePullRequestAutoMerge` -- see below). Shared helper: [`.github/actions/create-bot-token`](../.github/actions/create-bot-token/action.yml).
 
@@ -306,8 +306,8 @@ To move a repo onto this model (already done for `kubevirt-plugin`):
 1. **Add `Merge Gate` to branch protection's required status checks** on the default branch (alongside `Run Gating Tests`, `build`, `test`, etc.). Native "Allow auto-merge" is **not** required — the script merges directly via the API.
 2. **Install/configure `kubevirt-plugin-bot`** with Contents + Pull requests write; set `BOT_APP_ID` / `BOT_APP_PRIVATE_KEY` secrets. The bot token is **required** for merging — without it the merge gate reports failure.
 3. **Confirm the root `OWNERS` file lists real approvers** -- `/approve` and `/lgtm`'s approve-acting behavior both read it.
-5. **Uninstall/deselect the Prow GitHub App (`openshift-ci`) for this repo**. Removing the `tide:` block from `openshift/release` is optional hygiene afterward.
-6. **Announce the command set** -- `/help` or the table below. Reviews with `/lgtm` in the body now always honor Approve/Request-changes state (no Prow-style silent no-op).
+4. **Uninstall/deselect the Prow GitHub App (`openshift-ci`) for this repo**. Removing the `tide:` block from `openshift/release` is optional hygiene afterward.
+5. **Announce the command set** -- `/help` or the table below. Reviews with `/lgtm` in the body now always honor Approve/Request-changes state (no Prow-style silent no-op).
 
 ### `/lgtm`, `/approve`, `/hold` and their `cancel` variants
 
@@ -471,5 +471,5 @@ Always verify the cluster has been torn down when done testing. The auto-teardow
 - Run `npm install` locally and commit the updated `package-lock.json`
 - Check Node/npm version compatibility (runner image provides Node 22)
 - Verify the runner can reach `registry.npmjs.org`
-  // verify trusted bot fix - 1785662227
+// verify trusted bot fix - 1785662227
 <!-- test: verify Merge Gate commit status -->


### PR DESCRIPTION
## Summary
- Switch `actions/create-github-app-token@v3` from deprecated `app-id` to `client-id` (including the `create-bot-token` composite).
- Existing `BOT_APP_ID` / `ARC_GITHUB_APP_ID` secrets still work (App ID or Client ID as JWT issuer).

## Test plan
- [ ] Confirm bot token generation no longer warns about deprecated `app-id`
- [ ] Smoke: `/lgtm` or auto-merge still mints a bot token successfully


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated automation to support GitHub App Client IDs while retaining compatibility with legacy numeric App IDs.
  - Standardized token-generation configuration across workflows without changing existing secrets or permissions.
  - Improved validation compatibility for current credential configuration.

- **Documentation**
  - Clarified credential setup guidance and improved workflow table formatting.
  - Corrected setup-step numbering and formatting in automation documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->