### PR TITLE
CNV-87423: Selectable Hot Cluster E2E suites via UI and /test-e2e

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -44,6 +44,12 @@
       "workflow": ".github/workflows/retest-e2e.yml"
     },
     {
+      "command": "/test-e2e <suite> [args…]",
+      "description": "Run a Hot Cluster E2E suite on this PR (tier1, tier2, suite, gating, settings, api, all). Optional Playwright args (spec path or -g name) filter the run. Non-gating suites do not update the required Run Gating Tests check. OWNERS only.",
+      "trust": "owners",
+      "workflow": ".github/workflows/pr-commands.yml"
+    },
+    {
       "command": "/retest-failed",
       "description": "Re-run failed jobs in the latest CI and PR Validation runs for this PR, and dispatch a fresh Hot Cluster E2E run only if 'Run Gating Tests' is not currently passing (missing, cancelled, or otherwise not a success). Does not lift a /hold-e2e hold (only /retest-e2e does) or force a fresh run of anything already passing.",
       "trust": "owners",

--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -45,7 +45,7 @@
     },
     {
       "command": "/test-e2e <suite> [args…]",
-      "description": "Run a Hot Cluster E2E suite on this PR (tier1, tier2, suite, gating, settings, api, all). Optional Playwright args (spec path or -g name) filter the run. Non-gating suites do not update the required Run Gating Tests check. OWNERS only.",
+      "description": "Run a Hot Cluster E2E suite on this PR (Playwright: gating, tier1, tier2, suite, settings, api, all; Cypress release: gating or features). Optional Playwright args (spec path or -g name) filter the run. Non-gating / filtered runs do not update the required Run Gating Tests check. OWNERS only.",
       "trust": "owners",
       "workflow": ".github/workflows/pr-commands.yml"
     },

--- a/.github/scripts/src/commands/command-registry.ts
+++ b/.github/scripts/src/commands/command-registry.ts
@@ -8,6 +8,7 @@ import { executeHelp } from './help';
 import { executeHoldE2E } from './hold-e2e';
 import { executeRetestE2E } from './retest-e2e';
 import { executeRetestFailed } from './retest-failed';
+import { executeTestE2E } from './test-e2e';
 import { executeValidationCommand } from './validation-handler';
 
 export type CommandContext = {
@@ -38,6 +39,12 @@ export const COMMANDS: CommandConfig[] = [
     execute: executeRetestE2E,
     name: 'retest-e2e',
     pattern: /(^|\s)\/retest-e2e(\s|$)/,
+    requiresTrust: true,
+  },
+  {
+    execute: executeTestE2E,
+    name: 'test-e2e',
+    pattern: /(^|\s)\/test-e2e(\s|$)/,
     requiresTrust: true,
   },
   {

--- a/.github/scripts/src/commands/test-e2e-helpers.test.ts
+++ b/.github/scripts/src/commands/test-e2e-helpers.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildTestE2EReport, parseTestE2ECommand } from './test-e2e-helpers';
+
+describe('parseTestE2ECommand', () => {
+  it('parses suite-only commands', () => {
+    assert.deepEqual(parseTestE2ECommand('/test-e2e tier1'), {
+      testArgs: '',
+      testProject: 'tier1',
+    });
+    assert.deepEqual(parseTestE2ECommand('/test-e2e Tier2'), {
+      testArgs: '',
+      testProject: 'tier2',
+    });
+    assert.deepEqual(parseTestE2ECommand('/test-e2e suite'), {
+      testArgs: '',
+      testProject: 'suite',
+    });
+  });
+
+  it('parses optional Playwright args', () => {
+    assert.deepEqual(parseTestE2ECommand('/test-e2e tier1 playwright/tests/tier1/foo.spec.ts'), {
+      testArgs: 'playwright/tests/tier1/foo.spec.ts',
+      testProject: 'tier1',
+    });
+    assert.deepEqual(parseTestE2ECommand('/test-e2e gating -g MyTestName'), {
+      testArgs: '-g MyTestName',
+      testProject: 'gating',
+    });
+  });
+
+  it('returns null for missing or unknown suites', () => {
+    assert.equal(parseTestE2ECommand('/test-e2e'), null);
+    assert.equal(parseTestE2ECommand('/test-e2e nope'), null);
+    assert.equal(parseTestE2ECommand('/retest-e2e'), null);
+  });
+
+  it('ignores surrounding comment text when the command is on its own line', () => {
+    assert.deepEqual(parseTestE2ECommand('please run\n/test-e2e tier2\nthanks'), {
+      testArgs: '',
+      testProject: 'tier2',
+    });
+  });
+});
+
+describe('buildTestE2EReport', () => {
+  it('warns that non-gating suites do not update Run Gating Tests', () => {
+    const body = buildTestE2EReport('o', 'r', 'tier1', '');
+    assert.match(body, /does \*\*not\*\* update/);
+    assert.match(body, /tier1/);
+  });
+
+  it('omits the ad-hoc warning for gating', () => {
+    const body = buildTestE2EReport('o', 'r', 'gating', '-g Foo');
+    assert.doesNotMatch(body, /does \*\*not\*\* update/);
+    assert.match(body, /gating/);
+    assert.match(body, /-g Foo/);
+  });
+});

--- a/.github/scripts/src/commands/test-e2e-helpers.test.ts
+++ b/.github/scripts/src/commands/test-e2e-helpers.test.ts
@@ -45,16 +45,9 @@ describe('parseTestE2ECommand', () => {
 });
 
 describe('buildTestE2EReport', () => {
-  it('warns that non-gating suites do not update Run Gating Tests', () => {
-    const body = buildTestE2EReport('o', 'r', 'tier1', '');
-    assert.match(body, /does \*\*not\*\* update/);
-    assert.match(body, /tier1/);
-  });
-
-  it('omits the ad-hoc warning for gating', () => {
-    const body = buildTestE2EReport('o', 'r', 'gating', '-g Foo');
-    assert.doesNotMatch(body, /does \*\*not\*\* update/);
-    assert.match(body, /gating/);
-    assert.match(body, /-g Foo/);
+  it('warns for ad-hoc runs and omits the warning for unfiltered gating', () => {
+    assert.match(buildTestE2EReport('o', 'r', 'tier1', ''), /does \*\*not\*\* update/);
+    assert.match(buildTestE2EReport('o', 'r', 'gating', '-g Foo'), /does \*\*not\*\* update/);
+    assert.doesNotMatch(buildTestE2EReport('o', 'r', 'gating', ''), /does \*\*not\*\* update/);
   });
 });

--- a/.github/scripts/src/commands/test-e2e-helpers.ts
+++ b/.github/scripts/src/commands/test-e2e-helpers.ts
@@ -1,5 +1,6 @@
 import type { Octokit } from '@octokit/rest';
 
+import { isRequiredGatingSuite } from '../shared/is-required-gating-suite';
 import { failStep, setOutput } from '../shared/output';
 
 export const VALID_TEST_E2E_PROJECTS = [
@@ -56,7 +57,7 @@ export const buildTestE2EReport = (
   const suiteLabel = testArgs ? `\`${testProject}\` with \`${testArgs}\`` : `\`${testProject}\``;
   const lines = [`🚀 \`/test-e2e\` dispatched Hot Cluster E2E for ${suiteLabel} on this PR.`, ''];
 
-  if (testProject !== 'gating') {
+  if (!isRequiredGatingSuite(testProject, testArgs)) {
     lines.push(
       '> This is an ad-hoc suite run — it does **not** update the required **Run Gating Tests** check.',
       '',

--- a/.github/scripts/src/commands/test-e2e-helpers.ts
+++ b/.github/scripts/src/commands/test-e2e-helpers.ts
@@ -1,0 +1,98 @@
+import type { Octokit } from '@octokit/rest';
+
+import { failStep, setOutput } from '../shared/output';
+
+export const VALID_TEST_E2E_PROJECTS = [
+  'gating',
+  'tier1',
+  'tier2',
+  'suite',
+  'features',
+  'settings',
+  'api',
+  'all',
+] as const;
+
+export type TestE2EProject = (typeof VALID_TEST_E2E_PROJECTS)[number];
+
+export type ParsedTestE2ECommand = {
+  testArgs: string;
+  testProject: TestE2EProject;
+};
+
+/** Parse `/test-e2e <suite> [args…]` from a PR comment body (first matching line). */
+export const parseTestE2ECommand = (commentBody: string): ParsedTestE2ECommand | null => {
+  const line = commentBody
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith('/test-e2e'));
+  if (!line) {
+    return null;
+  }
+
+  const match = line.match(/^\/test-e2e(?:\s+([a-zA-Z0-9_-]+))?(?:\s+(.+))?$/);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  const testProject = match[1].toLowerCase();
+  if (!(VALID_TEST_E2E_PROJECTS as readonly string[]).includes(testProject)) {
+    return null;
+  }
+
+  return {
+    testArgs: (match[2] ?? '').trim(),
+    testProject: testProject as TestE2EProject,
+  };
+};
+
+/** Build the comment body for a successful /test-e2e dispatch. */
+export const buildTestE2EReport = (
+  owner: string,
+  repo: string,
+  testProject: string,
+  testArgs: string,
+): string => {
+  const suiteLabel = testArgs ? `\`${testProject}\` with \`${testArgs}\`` : `\`${testProject}\``;
+  const lines = [
+    `🚀 \`/test-e2e\` dispatched Hot Cluster E2E for ${suiteLabel} on this PR.`,
+    '',
+  ];
+
+  if (testProject !== 'gating') {
+    lines.push(
+      '> This is an ad-hoc suite run — it does **not** update the required **Run Gating Tests** check.',
+      '',
+    );
+  }
+
+  lines.push(
+    `Track progress in the [Actions tab](https://github.com/${owner}/${repo}/actions/workflows/hot-cluster-e2e.yml).`,
+  );
+  return lines.join('\n');
+};
+
+/** Report an unexpected error for /test-e2e. */
+export const reportTestE2EError = async (
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  message: string,
+): Promise<void> => {
+  setOutput('unexpected_error', 'true');
+  setOutput('error_message', message);
+
+  try {
+    await octokit.issues.createComment({
+      body: `⚠️ \`/test-e2e\` hit an unexpected error:\n\n\`\`\`\n${message}\n\`\`\``,
+      issue_number: prNumber,
+      owner,
+      repo,
+    });
+  } catch {
+    /* best effort */
+  }
+
+  failStep(message);
+};

--- a/.github/scripts/src/commands/test-e2e-helpers.ts
+++ b/.github/scripts/src/commands/test-e2e-helpers.ts
@@ -30,18 +30,18 @@ export const parseTestE2ECommand = (commentBody: string): ParsedTestE2ECommand |
     return null;
   }
 
-  const match = line.match(/^\/test-e2e(?:\s+([a-zA-Z0-9_-]+))?(?:\s+(.+))?$/);
-  if (!match?.[1]) {
+  const [command, suite, ...argParts] = line.split(/\s+/);
+  if (command !== '/test-e2e' || !suite) {
     return null;
   }
 
-  const testProject = match[1].toLowerCase();
+  const testProject = suite.toLowerCase();
   if (!(VALID_TEST_E2E_PROJECTS as readonly string[]).includes(testProject)) {
     return null;
   }
 
   return {
-    testArgs: (match[2] ?? '').trim(),
+    testArgs: argParts.join(' '),
     testProject: testProject as TestE2EProject,
   };
 };

--- a/.github/scripts/src/commands/test-e2e-helpers.ts
+++ b/.github/scripts/src/commands/test-e2e-helpers.ts
@@ -21,7 +21,7 @@ export type ParsedTestE2ECommand = {
 };
 
 /** Parse `/test-e2e <suite> [args…]` from a PR comment body (first matching line). */
-export const parseTestE2ECommand = (commentBody: string): ParsedTestE2ECommand | null => {
+export const parseTestE2ECommand = (commentBody: string): null | ParsedTestE2ECommand => {
   const line = commentBody
     .split(/\r?\n/)
     .map((entry) => entry.trim())
@@ -54,10 +54,7 @@ export const buildTestE2EReport = (
   testArgs: string,
 ): string => {
   const suiteLabel = testArgs ? `\`${testProject}\` with \`${testArgs}\`` : `\`${testProject}\``;
-  const lines = [
-    `🚀 \`/test-e2e\` dispatched Hot Cluster E2E for ${suiteLabel} on this PR.`,
-    '',
-  ];
+  const lines = [`🚀 \`/test-e2e\` dispatched Hot Cluster E2E for ${suiteLabel} on this PR.`, ''];
 
   if (testProject !== 'gating') {
     lines.push(

--- a/.github/scripts/src/commands/test-e2e.ts
+++ b/.github/scripts/src/commands/test-e2e.ts
@@ -26,10 +26,10 @@ import { dispatchWorkflow } from '../shared/dispatch';
 import { failStep } from '../shared/output';
 import type { CommandContext } from './command-registry';
 import {
-  VALID_TEST_E2E_PROJECTS,
   buildTestE2EReport,
   parseTestE2ECommand,
   reportTestE2EError,
+  VALID_TEST_E2E_PROJECTS,
 } from './test-e2e-helpers';
 
 const main = async (): Promise<void> => {
@@ -77,8 +77,9 @@ const main = async (): Promise<void> => {
     const headSha = pullRequest.head.sha;
     const baseRef = pullRequest.base.ref;
 
+    const suiteArgs = parsed.testArgs ? ` ${parsed.testArgs}` : '';
     console.log(
-      `/test-e2e ${parsed.testProject}${parsed.testArgs ? ` ${parsed.testArgs}` : ''} ` +
+      `/test-e2e ${parsed.testProject}${suiteArgs} ` +
         `requested by ${author} on PR #${prNumber} (HEAD: ${headSha}, base: ${baseRef})`,
     );
 

--- a/.github/scripts/src/commands/test-e2e.ts
+++ b/.github/scripts/src/commands/test-e2e.ts
@@ -1,0 +1,126 @@
+/**
+ * /test-e2e command — dispatch Hot Cluster E2E for a chosen suite (and optional
+ * Playwright filter) against this PR. Does not replace /retest-e2e (gating) and
+ * does not publish the required "Run Gating Tests" check for non-gating suites.
+ *
+ * Usage:
+ *   /test-e2e tier1
+ *   /test-e2e tier2
+ *   /test-e2e suite
+ *   /test-e2e tier1 playwright/tests/tier1/foo.spec.ts
+ *   /test-e2e gating -g MyTestName
+ *
+ * Entry point: npx tsx src/commands/test-e2e.ts
+ *
+ * Required env: BOT_TOKEN|GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER,
+ *               COMMENT_ID, COMMENT_AUTHOR, TRUSTED, COMMENT_BODY
+ */
+
+import { Octokit } from '@octokit/rest';
+
+import { requireEnv } from '../utils';
+
+import { getRepoContext } from '../shared/actions-context';
+import { enforceCommentTrust, reactToComment } from '../shared/command-helpers';
+import { dispatchWorkflow } from '../shared/dispatch';
+import { failStep } from '../shared/output';
+import type { CommandContext } from './command-registry';
+import {
+  VALID_TEST_E2E_PROJECTS,
+  buildTestE2EReport,
+  parseTestE2ECommand,
+  reportTestE2EError,
+} from './test-e2e-helpers';
+
+const main = async (): Promise<void> => {
+  const token = process.env.BOT_TOKEN ?? requireEnv('GITHUB_TOKEN');
+  const { owner, repo } = getRepoContext();
+  const prNumber = Number(requireEnv('PR_NUMBER'));
+  const commentId = Number(requireEnv('COMMENT_ID'));
+  const author = requireEnv('COMMENT_AUTHOR');
+  const trusted = process.env.TRUSTED === 'true';
+  const commentBody = requireEnv('COMMENT_BODY');
+  const octokit = new Octokit({ auth: token });
+
+  try {
+    if (
+      !(await enforceCommentTrust(octokit, owner, repo, commentId, author, trusted, '/test-e2e'))
+    ) {
+      return;
+    }
+
+    const parsed = parseTestE2ECommand(commentBody);
+    if (!parsed) {
+      await octokit.issues.createComment({
+        body: [
+          '⚠️ `/test-e2e` needs a suite name.',
+          '',
+          'Usage: `/test-e2e <suite> [playwright-args…]`',
+          '',
+          `Suites: \`${VALID_TEST_E2E_PROJECTS.join('` · `')}\``,
+          '',
+          'Examples:',
+          '- `/test-e2e tier1`',
+          '- `/test-e2e tier2`',
+          '- `/test-e2e suite`',
+          '- `/test-e2e tier1 playwright/tests/tier1/foo.spec.ts`',
+          '- `/test-e2e gating -g MyTestName`',
+        ].join('\n'),
+        issue_number: prNumber,
+        owner,
+        repo,
+      });
+      return;
+    }
+
+    const { data: pullRequest } = await octokit.pulls.get({ owner, pull_number: prNumber, repo });
+    const headSha = pullRequest.head.sha;
+    const baseRef = pullRequest.base.ref;
+
+    console.log(
+      `/test-e2e ${parsed.testProject}${parsed.testArgs ? ` ${parsed.testArgs}` : ''} ` +
+        `requested by ${author} on PR #${prNumber} (HEAD: ${headSha}, base: ${baseRef})`,
+    );
+
+    await reactToComment(octokit, owner, repo, commentId, 'rocket');
+
+    await dispatchWorkflow(octokit, {
+      inputs: {
+        base_ref: baseRef,
+        pr_number: String(prNumber),
+        skip_pool_check: 'true',
+        test_args: parsed.testArgs,
+        test_project: parsed.testProject,
+      },
+      owner,
+      ref: 'main',
+      repo,
+      workflowId: 'hot-cluster-e2e.yml',
+    });
+
+    const body = buildTestE2EReport(owner, repo, parsed.testProject, parsed.testArgs);
+    try {
+      await octokit.issues.createComment({ body, issue_number: prNumber, owner, repo });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`Could not comment: ${msg}`);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    await reportTestE2EError(octokit, owner, repo, prNumber, msg);
+  }
+};
+
+export const executeTestE2E = async (ctx: CommandContext): Promise<void> => {
+  process.env.BOT_TOKEN = process.env.BOT_TOKEN ?? '';
+  process.env.PR_NUMBER = String(ctx.prNumber);
+  process.env.COMMENT_ID = String(ctx.commentId);
+  process.env.COMMENT_AUTHOR = ctx.author;
+  process.env.COMMENT_BODY = ctx.commentBody;
+  process.env.TRUSTED = 'true';
+  await main();
+};
+
+if (require.main === module) {
+  void main().catch((err) => failStep(err instanceof Error ? err.message : String(err)));
+}

--- a/.github/scripts/src/e2e/verify.ts
+++ b/.github/scripts/src/e2e/verify.ts
@@ -67,6 +67,42 @@ const main = async (): Promise<void> => {
     return;
   }
 
+  const testProject = (process.env.TEST_PROJECT ?? 'gating').toLowerCase();
+  const testArgs = (process.env.TEST_ARGS ?? '').trim();
+  const isGatingSuite = testProject === 'gating';
+
+  // Ad-hoc /test-e2e tier1|tier2|suite|filter runs must not overwrite the
+  // required "Run Gating Tests" check or e2e-passed/e2e-failed labels.
+  if (!isGatingSuite) {
+    const suiteLabel = testArgs ? `${testProject} (${testArgs})` : testProject;
+    const passed = reason === 'passed';
+    const emoji = passed ? '✅' : '❌';
+    const body = [
+      `${emoji} Hot Cluster E2E ad-hoc suite \`${suiteLabel}\` ${passed ? 'passed' : 'failed'}.`,
+      '',
+      `[View run](${runUrl})`,
+      testFailureSummary ? `\n${testFailureSummary}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    console.log(
+      `test_project=${testProject} -- skipping Run Gating Tests publish; commenting on PR #${prNumber}.`,
+    );
+    try {
+      await botOctokit.issues.createComment({
+        body,
+        issue_number: Number(prNumber),
+        owner,
+        repo,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`Could not comment ad-hoc suite result: ${msg}`);
+    }
+    return;
+  }
+
   const held = await checkHoldState(octokit, owner, repo, prNumber, E2E_HOLD_LABEL);
 
   const result = mapResultDetails({

--- a/.github/scripts/src/e2e/verify.ts
+++ b/.github/scripts/src/e2e/verify.ts
@@ -22,6 +22,7 @@ import { Octokit } from '@octokit/rest';
 import { requireEnv } from '../utils';
 
 import { getRepoContext, getRunUrl } from '../shared/actions-context';
+import { isRequiredGatingSuite } from '../shared/is-required-gating-suite';
 import { E2E_HOLD_LABEL } from '../shared/merge-pool';
 import { failStep, setOutput } from '../shared/output';
 import { mapResultDetails, type VerifyReason } from './result-mapper';
@@ -69,10 +70,8 @@ const main = async (): Promise<void> => {
 
   const testProject = (process.env.TEST_PROJECT ?? 'gating').toLowerCase();
   const testArgs = (process.env.TEST_ARGS ?? '').trim();
-  const isGatingSuite = testProject === 'gating';
+  const isGatingSuite = isRequiredGatingSuite(testProject, testArgs);
 
-  // Ad-hoc /test-e2e tier1|tier2|suite|filter runs must not overwrite the
-  // required "Run Gating Tests" check or e2e-passed/e2e-failed labels.
   if (!isGatingSuite) {
     const suiteLabel = testArgs ? `${testProject} (${testArgs})` : testProject;
     const passed = reason === 'passed';

--- a/.github/scripts/src/shared/is-required-gating-suite.test.ts
+++ b/.github/scripts/src/shared/is-required-gating-suite.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { isRequiredGatingSuite } from './is-required-gating-suite';
+
+describe('isRequiredGatingSuite', () => {
+  it('is true only for unfiltered gating', () => {
+    assert.equal(isRequiredGatingSuite('gating', ''), true);
+    assert.equal(isRequiredGatingSuite('gating', '-g Foo'), false);
+    assert.equal(isRequiredGatingSuite('tier1', ''), false);
+  });
+});

--- a/.github/scripts/src/shared/is-required-gating-suite.ts
+++ b/.github/scripts/src/shared/is-required-gating-suite.ts
@@ -1,0 +1,4 @@
+export const isRequiredGatingSuite = (testProject: string, testArgs: string): boolean => {
+  const project = testProject.trim().toLowerCase();
+  return (project === 'gating' || project === '') && testArgs.trim() === '';
+};

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,12 +6,12 @@ Index of workflows in this directory. Deep design notes (check-run model, merge 
 
 ## Hot Cluster E2E
 
-| Workflow                              | Trigger                                | Role                                                                                   |
-| ------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------- |
-| `hot-cluster-e2e.yml`                 | `workflow_dispatch` only               | Full E2E graph; publishes required **Run Gating Tests**                                |
-| `hot-cluster-e2e-run.yml`             | `workflow_call`                        | Build plugin image + run Playwright on ARC                                             |
-| `hot-cluster-check.yml`               | `workflow_call` (+ manual health)      | Cluster readiness / health                                                             |
-| `hot-cluster-e2e-pr-gate.yml`         | PR opened / synchronize / reopened     | Thin gate → dispatch `hot-cluster-e2e.yml`                                             |
+| Workflow                              | Trigger                                | Role                                                                                                                         |
+| ------------------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `hot-cluster-e2e.yml`                 | `workflow_dispatch` only               | Full E2E graph; suite via `test_project` (+ optional `test_args`); publishes required **Run Gating Tests** only for `gating` |
+| `hot-cluster-e2e-run.yml`             | `workflow_call` / `workflow_dispatch`  | Build plugin image + run Playwright/Cypress on ARC                                                                           |
+| `hot-cluster-check.yml`               | `workflow_call` (+ manual health)      | Cluster readiness / health                                                                                                   |
+| `hot-cluster-e2e-pr-gate.yml`         | PR opened / synchronize / reopened     | Thin gate → dispatch `hot-cluster-e2e.yml`                                                                                   |
 | `pr-validation.yml`                   | All PR events (push + label)           | Unified PR validation: Jira, path checks, review labels, E2E dispatch, merge-pool sync |
 | `ok-to-test-reset.yml`                | synchronize while `ok-to-test` present | Remove `ok-to-test` when head moves                                                    |
 | `hot-cluster-e2e-cancel-on-close.yml` | PR closed                              | Cancel in-flight when PR closes                                                        |
@@ -22,7 +22,7 @@ Index of workflows in this directory. Deep design notes (check-run model, merge 
 | Workflow                      | Trigger                       | Role                                                                                                                                   |
 | ----------------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `auto-merge.yml`              | label / review / synchronize… | Required **Merge Gate** + enable/disable GitHub auto-merge                                                                             |
-| `pr-commands.yml`             | issue comment                 | Unified dispatcher for all PR commands (`/lgtm`, `/approve`, `/hold`, `/retest-e2e`, etc.)                                             |
+| `pr-commands.yml`             | issue comment                 | Unified dispatcher for all PR commands (`/lgtm`, `/approve`, `/hold`, `/retest-e2e`, `/test-e2e`, etc.)                                 |
 | `pr_review_commands.yml`      | review submitted              | Captures review data only (no secrets -- see below), uploads artifact                                                                  |
 | `pr_review_commands_sync.yml` | `workflow_run` (after above)  | Approve / Request changes ↔ `lgtm` (+ `approved` for root OWNERS); split out since `pull_request_review` withholds secrets on fork PRs |
 | `needs-rebase.yml`            | PR events                     | Sync `needs-rebase` from GitHub `mergeable`                                                                                            |

--- a/.github/workflows/hot-cluster-e2e-cancel-on-close.yml
+++ b/.github/workflows/hot-cluster-e2e-cancel-on-close.yml
@@ -44,24 +44,31 @@ jobs:
   # that job). Gating this on detect's findings would leave a real
   # in-progress job running untouched whenever that lookup misses it (API
   # lag, or the run hasn't reached in_progress/queued yet).
+  # Matrix covers every test_project key used in hot-cluster-e2e.yml.
   cancel-cluster-check:
-    name: Cancel Cluster Check
+    name: Cancel Cluster Check (${{ matrix.suite }})
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    strategy:
+      matrix:
+        suite: [gating, tier1, tier2, suite, features, settings, api, all]
     concurrency:
-      group: hot-cluster-check-${{ github.event.pull_request.number }}
+      group: hot-cluster-check-${{ github.event.pull_request.number }}-${{ matrix.suite }}
       cancel-in-progress: true
     steps:
-      - run: echo "Entered the cluster-check concurrency group for PR ${{ github.event.pull_request.number }} -- cancels any in-progress instance."
+      - run: echo "Entered the cluster-check concurrency group for PR ${{ github.event.pull_request.number }} suite ${{ matrix.suite }}."
 
   # Same as above, for run-e2e-tests -- the job that actually costs real
   # cluster/test time.
   cancel-run-e2e-tests:
-    name: Cancel Run E2E Tests
+    name: Cancel Run E2E Tests (${{ matrix.suite }})
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    strategy:
+      matrix:
+        suite: [gating, tier1, tier2, suite, features, settings, api, all]
     concurrency:
-      group: hot-cluster-run-e2e-${{ github.event.pull_request.number }}
+      group: hot-cluster-run-e2e-${{ github.event.pull_request.number }}-${{ matrix.suite }}
       cancel-in-progress: true
     steps:
-      - run: echo "Entered the run-e2e-tests concurrency group for PR ${{ github.event.pull_request.number }} -- cancels any in-progress instance."
+      - run: echo "Entered the run-e2e-tests concurrency group for PR ${{ github.event.pull_request.number }} suite ${{ matrix.suite }}."

--- a/.github/workflows/hot-cluster-e2e-cancel-on-close.yml
+++ b/.github/workflows/hot-cluster-e2e-cancel-on-close.yml
@@ -44,31 +44,24 @@ jobs:
   # that job). Gating this on detect's findings would leave a real
   # in-progress job running untouched whenever that lookup misses it (API
   # lag, or the run hasn't reached in_progress/queued yet).
-  # Matrix covers every test_project key used in hot-cluster-e2e.yml.
   cancel-cluster-check:
-    name: Cancel Cluster Check (${{ matrix.suite }})
+    name: Cancel Cluster Check
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    strategy:
-      matrix:
-        suite: [gating, tier1, tier2, suite, features, settings, api, all]
     concurrency:
-      group: hot-cluster-check-${{ github.event.pull_request.number }}-${{ matrix.suite }}
+      group: hot-cluster-check-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - run: echo "Entered the cluster-check concurrency group for PR ${{ github.event.pull_request.number }} suite ${{ matrix.suite }}."
+      - run: echo "Entered the cluster-check concurrency group for PR ${{ github.event.pull_request.number }} -- cancels any in-progress instance."
 
   # Same as above, for run-e2e-tests -- the job that actually costs real
   # cluster/test time.
   cancel-run-e2e-tests:
-    name: Cancel Run E2E Tests (${{ matrix.suite }})
+    name: Cancel Run E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 2
-    strategy:
-      matrix:
-        suite: [gating, tier1, tier2, suite, features, settings, api, all]
     concurrency:
-      group: hot-cluster-run-e2e-${{ github.event.pull_request.number }}-${{ matrix.suite }}
+      group: hot-cluster-run-e2e-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - run: echo "Entered the run-e2e-tests concurrency group for PR ${{ github.event.pull_request.number }} suite ${{ matrix.suite }}."
+      - run: echo "Entered the run-e2e-tests concurrency group for PR ${{ github.event.pull_request.number }} -- cancels any in-progress instance."

--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -6,8 +6,9 @@ on:
     inputs:
       test_project:
         description: |
-          Suite to run. Playwright: gating / tier1 / tier2 / suite / settings / api / all.
-          Cypress (release): gating or features (=tier1).
+          Suite to run.
+          Playwright (main): gating / tier1 / tier2 / suite / settings / api / all.
+          Cypress (release only): gating or features (Cypress's Tier1 suite — not a Playwright project).
         required: true
         default: gating
         type: choice
@@ -91,7 +92,9 @@ on:
   workflow_call:
     inputs:
       test_project:
-        description: Suite to run (gating, tier1, tier2, suite, features, settings, api, all)
+        description: |
+          Suite to run. Playwright: gating / tier1 / tier2 / suite / settings / api / all.
+          Cypress (release only): gating or features (Cypress's Tier1 suite — not a Playwright project).
         type: string
         required: false
         default: gating

--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -333,6 +333,8 @@ jobs:
           STATUS_CONTEXT: ${{ inputs.progress_status_context }}
         run: npx tsx src/e2e/progress-running.ts
 
+      # Playwright (main): Gating + Tier1 via playwright-runner-hc-e2e.sh Gating.
+      # Cypress (release): gating.cy.ts, or tier1.cy.ts when test_project=features.
       - name: Run gating tests
         env:
           BRIDGE_BASE_ADDRESS: ${{ steps.ci-env.outputs.bridge-base-address }}

--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -353,9 +353,6 @@ jobs:
           STATUS_CONTEXT: ${{ inputs.progress_status_context }}
         run: npx tsx src/e2e/progress-running.ts
 
-      # Playwright (main): TEST_PROJECT → playwright-runner-hc-e2e.sh project;
-      # TEST_ARGS forwarded as extra Playwright CLI args (paths / -g / …).
-      # Cypress (release): gating.cy.ts, or tier1.cy.ts when test_project=features|tier1.
       - name: Run E2E tests
         env:
           BRIDGE_BASE_ADDRESS: ${{ steps.ci-env.outputs.bridge-base-address }}

--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -5,13 +5,28 @@ on:
   workflow_dispatch:
     inputs:
       test_project:
-        description: Test project/suite to run (gating, or the features/tier1 equivalent)
+        description: |
+          Suite to run. Playwright: gating / tier1 / tier2 / suite / settings / api / all.
+          Cypress (release): gating or features (=tier1).
         required: true
         default: gating
         type: choice
         options:
           - gating
+          - tier1
+          - tier2
+          - suite
           - features
+          - settings
+          - api
+          - all
+      test_args:
+        description: |
+          Optional Playwright filter (space-separated CLI args), e.g. a spec path
+          or -g MyTestName. Leave empty to run the full selected suite.
+        required: false
+        default: ''
+        type: string
       test_engine:
         description: |
           E2E test engine to run against the checked-out code. Defaults to
@@ -76,10 +91,15 @@ on:
   workflow_call:
     inputs:
       test_project:
-        description: Test project/suite to run (gating, or the features/tier1 equivalent)
+        description: Suite to run (gating, tier1, tier2, suite, features, settings, api, all)
         type: string
         required: false
         default: gating
+      test_args:
+        description: Optional Playwright filter CLI args (space-separated)
+        type: string
+        required: false
+        default: ''
       test_engine:
         description: E2E test engine to run (playwright or cypress); see hot-cluster-e2e.yml's prepare job for auto-detection.
         type: string
@@ -333,12 +353,14 @@ jobs:
           STATUS_CONTEXT: ${{ inputs.progress_status_context }}
         run: npx tsx src/e2e/progress-running.ts
 
-      # Playwright (main): Gating + Tier1 via playwright-runner-hc-e2e.sh Gating.
-      # Cypress (release): gating.cy.ts, or tier1.cy.ts when test_project=features.
-      - name: Run gating tests
+      # Playwright (main): TEST_PROJECT → playwright-runner-hc-e2e.sh project;
+      # TEST_ARGS forwarded as extra Playwright CLI args (paths / -g / …).
+      # Cypress (release): gating.cy.ts, or tier1.cy.ts when test_project=features|tier1.
+      - name: Run E2E tests
         env:
           BRIDGE_BASE_ADDRESS: ${{ steps.ci-env.outputs.bridge-base-address }}
           TEST_PROJECT: ${{ inputs.test_project }}
+          TEST_ARGS: ${{ inputs.test_args || '' }}
         working-directory: ci-scripts/hot-cluster/ts
         run: npx tsx src/scripts/run-gating-tests.ts
 

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -12,8 +12,10 @@ on:
     inputs:
       test_project:
         description: |
-          Suite to run. Playwright: gating / tier1 / tier2 / suite / settings / api / all.
-          Cypress (release): gating or features (=tier1). Default gating is the required PR check.
+          Suite to run.
+          Playwright (main): gating / tier1 / tier2 / suite / settings / api / all.
+          Cypress (release only): gating or features (Cypress's Tier1 suite — not a Playwright project).
+          Default gating is the required PR check.
         required: true
         default: gating
         type: choice

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -3,7 +3,7 @@
 # never lands natively on a PR. Composes hot-cluster-check.yml,
 # hot-cluster-e2e-run.yml, and .github/actions/hot-cluster/ via `uses:`.
 name: Hot Cluster E2E
-run-name: "Hot Cluster E2E [${{ inputs.base_ref || inputs.cluster_name || github.base_ref || 'kubevirt-plugin-ci' }}] @ ${{ inputs.pr_number != '' && format('PR#{0} retest', inputs.pr_number) || github.head_ref || github.ref_name }}"
+run-name: "Hot Cluster E2E [${{ inputs.test_project || 'gating' }}] [${{ inputs.base_ref || inputs.cluster_name || github.base_ref || 'kubevirt-plugin-ci' }}] @ ${{ inputs.pr_number != '' && format('PR#{0} retest', inputs.pr_number) || github.head_ref || github.ref_name }}"
 
 # No PR events trigger this directly -- pr-validation.yml and
 # hot-cluster-e2e-pr-gate.yml dispatch it via workflow_dispatch instead.
@@ -11,13 +11,29 @@ on:
   workflow_dispatch:
     inputs:
       test_project:
-        description: Playwright project to run (setup runs automatically as dependency)
+        description: |
+          Suite to run. Playwright: gating / tier1 / tier2 / suite / settings / api / all.
+          Cypress (release): gating or features (=tier1). Default gating is the required PR check.
         required: true
         default: gating
         type: choice
         options:
           - gating
+          - tier1
+          - tier2
+          - suite
           - features
+          - settings
+          - api
+          - all
+      test_args:
+        description: |
+          Optional Playwright filter forwarded as CLI args (space-separated), e.g.
+          a spec path (playwright/tests/tier1/foo.spec.ts) or -g MyTestName.
+          Leave empty to run the full selected suite.
+        required: false
+        default: ''
+        type: string
       cluster_name:
         description: 'Cluster name (max 21 chars — IBM Cloud IPI limit, longer names get silently truncated)'
         required: true
@@ -219,10 +235,13 @@ jobs:
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-checks: write
 
+      # Only the required gating suite owns "Run Gating Tests". Ad-hoc
+      # tier1/tier2/suite/filter runs must not supersede that check.
       - name: Supersede stale "Run Gating Tests" check for this run
         id: supersede-gating-check
         if: |
           always() &&
+          (inputs.test_project == 'gating' || inputs.test_project == '') &&
           steps.resolve-progress.outputs.head-sha != '' &&
           !(github.event_name == 'workflow_dispatch' && inputs.pr_number == '') &&
           steps.resolve-pr-context.outcome != 'failure' &&
@@ -243,9 +262,10 @@ jobs:
   cluster-check:
     needs: [prepare]
     if: always()
-    # Cancels a same-PR push/retest's stale cluster check.
+    # Cancels a same-PR+suite push/retest's stale cluster check. Suite is in
+    # the key so /test-e2e tier1 does not cancel an in-flight gating run.
     concurrency:
-      group: hot-cluster-check-${{ inputs.pr_number || format('{0}-{1}', github.ref, inputs.cluster_name || 'kubevirt-plugin-ci') }}
+      group: hot-cluster-check-${{ inputs.pr_number || format('{0}-{1}', github.ref, inputs.cluster_name || 'kubevirt-plugin-ci') }}-${{ inputs.test_project || 'gating' }}
       cancel-in-progress: true
     uses: ./.github/workflows/hot-cluster-check.yml
     with:
@@ -320,11 +340,12 @@ jobs:
       needs.prepare.outputs.pr_trusted != 'false'
     # Own group, same reasoning as cluster-check's concurrency.
     concurrency:
-      group: hot-cluster-run-e2e-${{ inputs.pr_number || format('{0}-{1}', github.ref, inputs.cluster_name || 'kubevirt-plugin-ci') }}
+      group: hot-cluster-run-e2e-${{ inputs.pr_number || format('{0}-{1}', github.ref, inputs.cluster_name || 'kubevirt-plugin-ci') }}-${{ inputs.test_project || 'gating' }}
       cancel-in-progress: true
     uses: ./.github/workflows/hot-cluster-e2e-run.yml
     with:
       test_project: ${{ inputs.test_project || 'gating' }}
+      test_args: ${{ inputs.test_args || '' }}
       test_engine: ${{ needs.prepare.outputs.test_engine }}
       runner_label: ${{ inputs.runner_label || needs.prepare.outputs.cluster_name }}
       cluster_name: ${{ needs.prepare.outputs.cluster_name }}
@@ -412,6 +433,9 @@ jobs:
           GATING_CHECK_RUN_ID: ${{ needs.prepare.outputs.gating_check_run_id }}
           JOB_STATUS: ${{ job.status }}
           TEST_FAILURE_SUMMARY: ${{ needs.run-e2e-tests.outputs.test_failure_summary }}
+          # Non-gating suites must not publish/overwrite "Run Gating Tests".
+          TEST_PROJECT: ${{ inputs.test_project || 'gating' }}
+          TEST_ARGS: ${{ inputs.test_args || '' }}
         working-directory: .github/scripts
         run: npx tsx src/e2e/verify.ts
 

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -235,13 +235,12 @@ jobs:
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-checks: write
 
-      # Only the required gating suite owns "Run Gating Tests". Ad-hoc
-      # tier1/tier2/suite/filter runs must not supersede that check.
       - name: Supersede stale "Run Gating Tests" check for this run
         id: supersede-gating-check
         if: |
           always() &&
-          (inputs.test_project == 'gating' || inputs.test_project == '') &&
+          (inputs.test_project || 'gating') == 'gating' &&
+          !inputs.test_args &&
           steps.resolve-progress.outputs.head-sha != '' &&
           !(github.event_name == 'workflow_dispatch' && inputs.pr_number == '') &&
           steps.resolve-pr-context.outcome != 'failure' &&
@@ -433,7 +432,6 @@ jobs:
           GATING_CHECK_RUN_ID: ${{ needs.prepare.outputs.gating_check_run_id }}
           JOB_STATUS: ${{ job.status }}
           TEST_FAILURE_SUMMARY: ${{ needs.run-e2e-tests.outputs.test_failure_summary }}
-          # Non-gating suites must not publish/overwrite "Run Gating Tests".
           TEST_PROJECT: ${{ inputs.test_project || 'gating' }}
           TEST_ARGS: ${{ inputs.test_args || '' }}
         working-directory: .github/scripts

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -85,8 +85,10 @@ jobs:
     if: needs.dispatch.outputs.needs_cancel == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 1
+    # Must match hot-cluster-e2e.yml's gating suite concurrency key
+    # (…-${{ pr }}-gating). Ad-hoc /test-e2e tier* runs use a different key.
     concurrency:
-      group: hot-cluster-check-${{ github.event.issue.number }}
+      group: hot-cluster-check-${{ github.event.issue.number }}-gating
       cancel-in-progress: true
     steps:
       - run: echo "Entered cluster-check concurrency group for PR ${{ github.event.issue.number }}"
@@ -98,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     concurrency:
-      group: hot-cluster-run-e2e-${{ github.event.issue.number }}
+      group: hot-cluster-run-e2e-${{ github.event.issue.number }}-gating
       cancel-in-progress: true
     steps:
       - run: echo "Entered run-e2e-tests concurrency group for PR ${{ github.event.issue.number }}"

--- a/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
@@ -28,7 +28,6 @@ const PLAYWRIGHT_PROJECT_BY_TEST_PROJECT: Record<string, string> = {
   tier2: 'Tier2',
 };
 
-/** Split TEST_ARGS on whitespace for safe argv forwarding (no shell). */
 const parseTestArgs = (raw: string): string[] => {
   const trimmed = raw.trim();
   if (!trimmed) {

--- a/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
@@ -1,6 +1,10 @@
 /**
  * Run gating tests: dispatches to the correct test engine (Cypress or Playwright).
  *
+ * Playwright (main): runs Gating + Tier1 via playwright-runner-hc-e2e.sh Gating.
+ * Cypress (release branches): runs tests/gating.cy.ts, or tests/tier1.cy.ts when
+ * TEST_PROJECT=features.
+ *
  * Required env: TEST_ENGINE, BRIDGE_BASE_ADDRESS, TEST_PROJECT
  * Cypress-specific env: TEST_NS, OS_IMAGES_NS, CNV_NS, TEST_SECRET_NAME
  */

--- a/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
@@ -1,11 +1,15 @@
 /**
- * Run gating tests: dispatches to the correct test engine (Cypress or Playwright).
+ * Run E2E tests: dispatches to the correct test engine (Cypress or Playwright).
  *
- * Playwright (main): runs Gating + Tier1 via playwright-runner-hc-e2e.sh Gating.
+ * Playwright (main): maps TEST_PROJECT to a playwright-runner-hc-e2e.sh project
+ * (gating, tier1, tier2, suite, …) and forwards TEST_ARGS as extra CLI args
+ * (file paths, -g patterns, --workers, …).
+ *
  * Cypress (release branches): runs tests/gating.cy.ts, or tests/tier1.cy.ts when
- * TEST_PROJECT=features.
+ * TEST_PROJECT=features (or tier1).
  *
  * Required env: TEST_ENGINE, BRIDGE_BASE_ADDRESS, TEST_PROJECT
+ * Optional env: TEST_ARGS
  * Cypress-specific env: TEST_NS, OS_IMAGES_NS, CNV_NS, TEST_SECRET_NAME
  */
 
@@ -13,9 +17,42 @@ import { execFileSync, execSync } from 'node:child_process';
 
 import { requireEnv } from '../utils';
 
+const PLAYWRIGHT_PROJECT_BY_TEST_PROJECT: Record<string, string> = {
+  all: 'all',
+  api: 'API',
+  features: 'Tier1',
+  gating: 'Gating',
+  settings: 'Settings',
+  suite: 'suite',
+  tier1: 'Tier1',
+  tier2: 'Tier2',
+};
+
+/** Split TEST_ARGS on whitespace for safe argv forwarding (no shell). */
+const parseTestArgs = (raw: string): string[] => {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return [];
+  }
+  return trimmed.split(/\s+/);
+};
+
+const resolvePlaywrightProject = (testProject: string): string => {
+  const key = testProject.toLowerCase();
+  const mapped = PLAYWRIGHT_PROJECT_BY_TEST_PROJECT[key];
+  if (mapped) {
+    return mapped;
+  }
+  throw new Error(
+    `Unsupported TEST_PROJECT '${testProject}' for Playwright. ` +
+      `Expected one of: ${Object.keys(PLAYWRIGHT_PROJECT_BY_TEST_PROJECT).join(', ')}`,
+  );
+};
+
 const main = async (): Promise<void> => {
   const testEngine = requireEnv('TEST_ENGINE');
   const testProject = requireEnv('TEST_PROJECT');
+  const testArgs = parseTestArgs(process.env.TEST_ARGS ?? '');
 
   if (testEngine === 'cypress') {
     const testNs = requireEnv('TEST_NS');
@@ -33,13 +70,25 @@ const main = async (): Promise<void> => {
 
     execSync(`oc project "${testNs}"`, { env, stdio: 'inherit' });
 
-    const spec = testProject === 'features' ? 'tests/tier1.cy.ts' : 'tests/gating.cy.ts';
+    const projectLower = testProject.toLowerCase();
+    const spec =
+      projectLower === 'features' || projectLower === 'tier1'
+        ? 'tests/tier1.cy.ts'
+        : 'tests/gating.cy.ts';
     execSync(`npm run test-cypress-headless -- --spec ${spec}`, { env, stdio: 'inherit' });
   } else {
     const repoRoot =
       process.env.GITHUB_WORKSPACE ??
       execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
-    execSync('./playwright-runner-hc-e2e.sh Gating', { cwd: repoRoot, stdio: 'inherit' });
+    const playwrightProject = resolvePlaywrightProject(testProject);
+    console.log(
+      `Running Playwright project '${playwrightProject}'` +
+        (testArgs.length > 0 ? ` with args: ${testArgs.join(' ')}` : ''),
+    );
+    execFileSync('./playwright-runner-hc-e2e.sh', [playwrightProject, ...testArgs], {
+      cwd: repoRoot,
+      stdio: 'inherit',
+    });
   }
 };
 

--- a/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
@@ -1,13 +1,6 @@
 /**
  * Run E2E tests: dispatches to the correct test engine (Cypress or Playwright).
  *
- * Playwright (main): maps TEST_PROJECT to a playwright-runner-hc-e2e.sh project
- * (gating, tier1, tier2, suite, …) and forwards TEST_ARGS as extra CLI args
- * (file paths, -g patterns, --workers, …).
- *
- * Cypress (release branches): runs tests/gating.cy.ts, or tests/tier1.cy.ts when
- * TEST_PROJECT=features (or tier1).
- *
  * Required env: TEST_ENGINE, BRIDGE_BASE_ADDRESS, TEST_PROJECT
  * Optional env: TEST_ARGS
  * Cypress-specific env: TEST_NS, OS_IMAGES_NS, CNV_NS, TEST_SECRET_NAME
@@ -17,15 +10,21 @@ import { execFileSync, execSync } from 'node:child_process';
 
 import { requireEnv } from '../utils';
 
+/** Playwright (main) TEST_PROJECT → playwright-runner-hc-e2e.sh project name. */
 const PLAYWRIGHT_PROJECT_BY_TEST_PROJECT: Record<string, string> = {
   all: 'all',
   api: 'API',
-  features: 'Tier1',
   gating: 'Gating',
   settings: 'Settings',
   suite: 'suite',
   tier1: 'Tier1',
   tier2: 'Tier2',
+};
+
+/** Cypress (release) TEST_PROJECT → spec file. `features` is Cypress's Tier1 suite. */
+const CYPRESS_TEST_PROJECTS: Record<string, string> = {
+  features: 'tests/tier1.cy.ts',
+  gating: 'tests/gating.cy.ts',
 };
 
 const parseTestArgs = (raw: string): string[] => {
@@ -45,6 +44,18 @@ const resolvePlaywrightProject = (testProject: string): string => {
   throw new Error(
     `Unsupported TEST_PROJECT '${testProject}' for Playwright. ` +
       `Expected one of: ${Object.keys(PLAYWRIGHT_PROJECT_BY_TEST_PROJECT).join(', ')}`,
+  );
+};
+
+const resolveCypressSpec = (testProject: string): string => {
+  const key = testProject.toLowerCase();
+  const spec = CYPRESS_TEST_PROJECTS[key];
+  if (spec) {
+    return spec;
+  }
+  throw new Error(
+    `Unsupported TEST_PROJECT '${testProject}' for Cypress. ` +
+      `Expected one of: ${Object.keys(CYPRESS_TEST_PROJECTS).join(', ')}`,
   );
 };
 
@@ -69,11 +80,7 @@ const main = async (): Promise<void> => {
 
     execSync(`oc project "${testNs}"`, { env, stdio: 'inherit' });
 
-    const projectLower = testProject.toLowerCase();
-    const spec =
-      projectLower === 'features' || projectLower === 'tier1'
-        ? 'tests/tier1.cy.ts'
-        : 'tests/gating.cy.ts';
+    const spec = resolveCypressSpec(testProject);
     execSync(`npm run test-cypress-headless -- --spec ${spec}`, { env, stdio: 'inherit' });
   } else {
     const repoRoot =

--- a/playwright-runner-hc-e2e.sh
+++ b/playwright-runner-hc-e2e.sh
@@ -17,8 +17,9 @@
 #                Sets WEB_CONSOLE_URL=http://localhost:9000 automatically.
 #
 # Examples:
-#   ./playwright-runner-hc-e2e.sh Gating --workers=4
+#   ./playwright-runner-hc-e2e.sh Gating --workers=4   # Gating + Tier1 (PR CI)
 #   IS_LOCAL=1 ./playwright-runner-hc-e2e.sh Gating --headed
+#   ./playwright-runner-hc-e2e.sh Tier1
 #   ./playwright-runner-hc-e2e.sh all
 # ────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
@@ -64,9 +65,9 @@ if [[ -z "${PROJECT}" ]]; then
   echo "Usage: $0 <project> [extra-args...]"
   echo ""
   echo "Available projects:"
-  echo "  Gating                 Gating specs (scenario infrastructure)"
-  echo "  Tier1                  Tier 1 specs (scenario infrastructure)"
-  echo "  Tier2                  Tier 2 specs (scenario infrastructure)"
+  echo "  Gating                 Gating + Tier1 specs (PR Hot Cluster E2E)"
+  echo "  Tier1                  Tier 1 specs only (scenario infrastructure)"
+  echo "  Tier2                  Tier 2 specs only (scenario infrastructure)"
   echo "  Settings               Settings specs (scenario infrastructure)"
   echo "  API                    API contract tests (browserless)"
   echo "  suite                  Run Gating + Tier1 + Tier2 together"
@@ -97,11 +98,11 @@ EXTRA_ARGS=("$@")
 PROJECT_LOWER=$(echo "${PROJECT}" | tr '[:upper:]' '[:lower:]')
 
 if [[ "${PROJECT_LOWER}" == "gating" ]]; then
-  echo "🚀 Running project: Gating (HC E2E mode)..."
-  npx playwright test --project Gating "${EXTRA_ARGS[@]}"
-elif [[ "${PROJECT_LOWER}" == "suite" ]]; then
-  echo "🚀 Running suite: Gating + Tier1 (HC E2E mode)..."
+  echo "🚀 Running Gating + Tier1 (HC E2E mode)..."
   npx playwright test --project Gating --project Tier1 "${EXTRA_ARGS[@]}"
+elif [[ "${PROJECT_LOWER}" == "suite" ]]; then
+  echo "🚀 Running suite: Gating + Tier1 + Tier2 (HC E2E mode)..."
+  npx playwright test --project Gating --project Tier1 --project Tier2 "${EXTRA_ARGS[@]}"
 elif [[ "${PROJECT_LOWER}" == "all" ]]; then
   PROJECTS=(
     Gating

--- a/playwright-runner-hc-e2e.sh
+++ b/playwright-runner-hc-e2e.sh
@@ -6,8 +6,9 @@
 # Differences from playwright-runner.sh:
 #   • Exports HC_E2E=true so global setup uses the in-cluster / SA-token auth
 #     flow and skips browser OAuth login.
-#   • Includes the Gating and Tier1 projects (scenario infrastructure).
+#   • Includes the Gating, Tier1, and Tier2 projects (scenario infrastructure).
 #   • Supports IS_LOCAL=1 for localhost development (localhost:9000).
+#   • Extra args (file paths, -g patterns, --workers, …) are forwarded to Playwright.
 #
 # Usage:
 #   ./playwright-runner-hc-e2e.sh [project] [extra-args...]
@@ -17,9 +18,11 @@
 #                Sets WEB_CONSOLE_URL=http://localhost:9000 automatically.
 #
 # Examples:
-#   ./playwright-runner-hc-e2e.sh Gating --workers=4   # Gating + Tier1 (PR CI)
-#   IS_LOCAL=1 ./playwright-runner-hc-e2e.sh Gating --headed
+#   ./playwright-runner-hc-e2e.sh Gating --workers=4
 #   ./playwright-runner-hc-e2e.sh Tier1
+#   ./playwright-runner-hc-e2e.sh Tier2 playwright/tests/tier2/foo.spec.ts
+#   IS_LOCAL=1 ./playwright-runner-hc-e2e.sh Gating --headed
+#   ./playwright-runner-hc-e2e.sh suite
 #   ./playwright-runner-hc-e2e.sh all
 # ────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
@@ -65,13 +68,15 @@ if [[ -z "${PROJECT}" ]]; then
   echo "Usage: $0 <project> [extra-args...]"
   echo ""
   echo "Available projects:"
-  echo "  Gating                 Gating + Tier1 specs (PR Hot Cluster E2E)"
-  echo "  Tier1                  Tier 1 specs only (scenario infrastructure)"
-  echo "  Tier2                  Tier 2 specs only (scenario infrastructure)"
+  echo "  Gating                 Gating specs (scenario infrastructure)"
+  echo "  Tier1                  Tier 1 specs (scenario infrastructure)"
+  echo "  Tier2                  Tier 2 specs (scenario infrastructure)"
   echo "  Settings               Settings specs (scenario infrastructure)"
   echo "  API                    API contract tests (browserless)"
   echo "  suite                  Run Gating + Tier1 + Tier2 together"
   echo "  all                    Run all projects"
+  echo ""
+  echo "Extra args are forwarded to Playwright (file paths, -g, --workers, …)."
   echo ""
   echo "Environment:"
   echo "  IS_LOCAL=1             Run against localhost:9000 (local console)"
@@ -98,8 +103,14 @@ EXTRA_ARGS=("$@")
 PROJECT_LOWER=$(echo "${PROJECT}" | tr '[:upper:]' '[:lower:]')
 
 if [[ "${PROJECT_LOWER}" == "gating" ]]; then
-  echo "🚀 Running Gating + Tier1 (HC E2E mode)..."
-  npx playwright test --project Gating --project Tier1 "${EXTRA_ARGS[@]}"
+  echo "🚀 Running project: Gating (HC E2E mode)..."
+  npx playwright test --project Gating "${EXTRA_ARGS[@]}"
+elif [[ "${PROJECT_LOWER}" == "tier1" ]]; then
+  echo "🚀 Running project: Tier1 (HC E2E mode)..."
+  npx playwright test --project Tier1 "${EXTRA_ARGS[@]}"
+elif [[ "${PROJECT_LOWER}" == "tier2" ]]; then
+  echo "🚀 Running project: Tier2 (HC E2E mode)..."
+  npx playwright test --project Tier2 "${EXTRA_ARGS[@]}"
 elif [[ "${PROJECT_LOWER}" == "suite" ]]; then
   echo "🚀 Running suite: Gating + Tier1 + Tier2 (HC E2E mode)..."
   npx playwright test --project Gating --project Tier1 --project Tier2 "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
## 📝 Description

Replaces bundling Tier1 into the required Gating run with an explicit suite selector.

- **Required PR check stays Gating-only** (`test_project=gating`)
- Hot Cluster E2E `workflow_dispatch` accepts `test_project` (`gating` / `tier1` / `tier2` / `suite` / …) and optional `test_args` (spec path, `-g`, etc.)
- New PR command `/test-e2e <suite> [args…]` (OWNERS) dispatches the same workflow against the PR
- Non-gating / filtered runs comment results on the PR and **do not** overwrite **Run Gating Tests**

Examples:
```text
/test-e2e tier1
/test-e2e tier2
/test-e2e suite
/test-e2e tier1 playwright/tests/tier1/foo.spec.ts
/test-e2e gating -g MyTestName
```

Also available via Actions → **Hot Cluster E2E** → Run workflow (set `pr_number` to target a PR).

## 🔗 Links

- Jira: https://issues.redhat.com/browse/CNV-87423

## 🎥 Demo

N/A — CI / workflow change.

## Test plan

- [ ] Default PR Hot Cluster E2E still runs Gating only (required check)
- [ ] Actions UI: run Hot Cluster E2E with `test_project=tier1` succeeds and logs Tier1
- [ ] Actions UI: `test_project=tier2` + `test_args` path filters to that spec
- [ ] PR comment `/test-e2e tier1` dispatches a run and does **not** change Run Gating Tests
- [ ] PR comment `/test-e2e suite` runs Gating+Tier1+Tier2
- [ ] `/retest-e2e` / `/cancel-e2e` still target the gating concurrency group
- [ ] Closing a PR cancels in-flight gating and ad-hoc suite runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Expanded Hot Cluster E2E testing to support additional Playwright suites (Tier1, Tier2, Suite, Settings, API, All) alongside existing Cypress gating/features suites.
* Added support for passing custom Playwright CLI arguments when triggering E2E test runs.
* Introduced a new PR command, `/test-e2e <suite> [args…]`, allowing trusted users to trigger specific E2E suites directly from a pull request.
* Ad-hoc (non-gating) E2E suite runs now automatically post pass/fail results as PR comments, including suite name, run link, and failure summary when applicable.

## Documentation
* Updated workflow documentation to reflect new suite options, manual trigger support, and the new `/test-e2e` PR command.

## Tests
* Added test coverage for parsing and validating the new `/test-e2e` command and its reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->