### PR TITLE
CNV-94182: request workflows write for auto-merge bot token

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,16 +6,16 @@ Index of workflows in this directory. Deep design notes (check-run model, merge 
 
 ## Hot Cluster E2E
 
-| Workflow                              | Trigger                                | Role                                                            |
-| ------------------------------------- | -------------------------------------- | --------------------------------------------------------------- |
-| `hot-cluster-e2e.yml`                 | `workflow_dispatch` only               | Full E2E graph; publishes required **Run Gating Tests**         |
-| `hot-cluster-e2e-run.yml`             | `workflow_call`                        | Build plugin image + run Playwright on ARC                      |
-| `hot-cluster-check.yml`               | `workflow_call` (+ manual health)      | Cluster readiness / health                                      |
-| `hot-cluster-e2e-pr-gate.yml`         | PR opened / synchronize / reopened     | Thin gate → dispatch `hot-cluster-e2e.yml`                      |
+| Workflow                              | Trigger                                | Role                                                                                   |
+| ------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------- |
+| `hot-cluster-e2e.yml`                 | `workflow_dispatch` only               | Full E2E graph; publishes required **Run Gating Tests**                                |
+| `hot-cluster-e2e-run.yml`             | `workflow_call`                        | Build plugin image + run Playwright on ARC                                             |
+| `hot-cluster-check.yml`               | `workflow_call` (+ manual health)      | Cluster readiness / health                                                             |
+| `hot-cluster-e2e-pr-gate.yml`         | PR opened / synchronize / reopened     | Thin gate → dispatch `hot-cluster-e2e.yml`                                             |
 | `pr-validation.yml`                   | All PR events (push + label)           | Unified PR validation: Jira, path checks, review labels, E2E dispatch, merge-pool sync |
-| `ok-to-test-reset.yml`                | synchronize while `ok-to-test` present | Remove `ok-to-test` when head moves                             |
-| `hot-cluster-e2e-cancel-on-close.yml` | PR closed                              | Cancel in-flight when PR closes                                 |
-| `on-main-push.yml`                    | push to `main`                         | Mark checks stale; retest merge-pool PRs; sync needs-rebase     |
+| `ok-to-test-reset.yml`                | synchronize while `ok-to-test` present | Remove `ok-to-test` when head moves                                                    |
+| `hot-cluster-e2e-cancel-on-close.yml` | PR closed                              | Cancel in-flight when PR closes                                                        |
+| `on-main-push.yml`                    | push to `main`                         | Mark checks stale; retest merge-pool PRs; sync needs-rebase                            |
 
 ## Merge automation (Prow / Tide replacements)
 
@@ -34,7 +34,7 @@ Pool eligibility (`isMergePoolPr`): `lgtm` + `approved`, and no blockers (`hold`
 ## PR validation (OWNERS-gated paths)
 
 | Workflow            | Trigger               | Role                                              |
-| ------------------- | --------------------- | -------------------------------------------------- |
+| ------------------- | --------------------- | ------------------------------------------------- |
 | `pr-validation.yml` | `pull_request_target` | Jira + AI-config + CI-scripts validation statuses |
 
 Sensitive-path review uses `/ai-approved` and `/ci-approved` (`.github/OWNERS`), not `/approve`. Review label trust enforcement is handled by the label-gate route in `pr-validation.yml`.
@@ -68,4 +68,4 @@ See [`ci-scripts/manual-console/README.md`](../../ci-scripts/manual-console/READ
 | [`.github/actions/clear-e2e-result-labels`](../actions/clear-e2e-result-labels/action.yml) | Remove `e2e-passed`/`e2e-failed` (shared by PR gate + on-main-push)           |
 | [`.github/scripts/`](../scripts/)                                                          | TypeScript for validation commands, merge-pool verify, Jira/AI/CI checks      |
 
-Bot secrets: `BOT_APP_ID`, `BOT_APP_PRIVATE_KEY` (Issues + Pull requests write on the App). Details: [`ci-scripts/README.md`](../../ci-scripts/README.md#kubevirt-plugin-bot-required-for-prow-replacement-merge-automation).
+Bot secrets: `BOT_APP_ID`, `BOT_APP_PRIVATE_KEY` (Issues + Pull requests + Contents + Workflows write on the App; Workflows is required for auto-merge of PRs that touch `.github/workflows/*`). Details: [`ci-scripts/README.md`](../../ci-scripts/README.md#kubevirt-plugin-bot-required-for-prow-replacement-merge-automation).

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -41,6 +41,7 @@ jobs:
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
           permission-administration: read
 
       - name: Setup scripts

--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -122,7 +122,7 @@ Uses `openshift-install` to create a fully self-managed OpenShift cluster on IBM
 | `BOT_APP_ID`          | GitHub App ID for `kubevirt-plugin-bot` |
 | `BOT_APP_PRIVATE_KEY` | GitHub App private key                  |
 
-Used by `/lgtm`/`/approve`/`/hold`, review sync, `needs-rebase`, auto-merge GraphQL, e2e result labels, and related PR comment/label writes. The App installation must have **Issues: Read & write**, **Pull requests: Read & write**, and **Contents: Read & write** (the last one specifically for `enablePullRequestAutoMerge`/`disablePullRequestAutoMerge` -- see below). Shared helper: [`.github/actions/create-bot-token`](../.github/actions/create-bot-token/action.yml).
+Used by `/lgtm`/`/approve`/`/hold`, review sync, `needs-rebase`, auto-merge (direct merge API), e2e result labels, and related PR comment/label writes. The App installation must have **Issues: Read & write**, **Pull requests: Read & write**, **Contents: Read & write**, and **Workflows: Read & write** (Contents for the merge API; Workflows so merges that touch `.github/workflows/*` don't 403 -- see below). Shared helper: [`.github/actions/create-bot-token`](../.github/actions/create-bot-token/action.yml).
 
 Ghost runner cleanup reuses the ARC Authentication GitHub App credentials above (`ARC_GITHUB_APP_ID` + `ARC_GITHUB_APP_PRIVATE_KEY`) — no separate secret needed, since that app is already scoped to `administration: write`, exactly what deregistering offline runners requires.
 
@@ -304,10 +304,10 @@ Branch protection must require **`Merge Gate`** and **`Run Gating Tests`** (plus
 To move a repo onto this model (already done for `kubevirt-plugin`):
 
 1. **Add `Merge Gate` to branch protection's required status checks** on the default branch (alongside `Run Gating Tests`, `build`, `test`, etc.). Native "Allow auto-merge" is **not** required — the script merges directly via the API.
-2. **Install/configure `kubevirt-plugin-bot`** with Contents + Pull requests write; set `BOT_APP_ID` / `BOT_APP_PRIVATE_KEY` secrets. The bot token is **required** for merging — without it the merge gate reports failure.
+2. **Install/configure `kubevirt-plugin-bot`** with Contents + Pull requests + Workflows write; set `BOT_APP_ID` / `BOT_APP_PRIVATE_KEY` secrets. The bot token is **required** for merging — without it the merge gate reports failure. Workflows write is required specifically so PRs that change `.github/workflows/*` can be merged by the bot.
 3. **Confirm the root `OWNERS` file lists real approvers** -- `/approve` and `/lgtm`'s approve-acting behavior both read it.
-5. **Uninstall/deselect the Prow GitHub App (`openshift-ci`) for this repo**. Removing the `tide:` block from `openshift/release` is optional hygiene afterward.
-6. **Announce the command set** -- `/help` or the table below. Reviews with `/lgtm` in the body now always honor Approve/Request-changes state (no Prow-style silent no-op).
+4. **Uninstall/deselect the Prow GitHub App (`openshift-ci`) for this repo**. Removing the `tide:` block from `openshift/release` is optional hygiene afterward.
+5. **Announce the command set** -- `/help` or the table below. Reviews with `/lgtm` in the body now always honor Approve/Request-changes state (no Prow-style silent no-op).
 
 ### `/lgtm`, `/approve`, `/hold` and their `cancel` variants
 
@@ -376,7 +376,9 @@ Both labels are also cleared on `synchronize`, regardless of `e2e-hold` state --
 
 Confirmed live on PR #4363: even with `Merge Gate` correctly reporting `success`, `auto-merge.yml`'s GraphQL call to `enablePullRequestAutoMerge` failed with `Resource not accessible by integration` -- **regardless of the workflow's `permissions:` block**. `enablePullRequestAutoMerge`/`disablePullRequestAutoMerge` are two of a small set of mutations GitHub blocks for the default Actions bot identity as a platform restriction, not a scope you can widen your way around. Fixed by generating a `kubevirt-plugin-bot` App token (via [`.github/actions/create-bot-token`](../.github/actions/create-bot-token/action.yml) or `actions/create-github-app-token@v3` directly) and passing it as `github-token:` to that GraphQL step -- the eligibility-check step stays on the default token.
 
-**Granting the App "Contents: Read & write" in its installation settings is not enough on its own.** `actions/create-github-app-token@v3`'s `permission-*` inputs narrow the generated token to exactly what's requested, regardless of what the App's own installation permissions allow -- requesting only `permission-pull-requests: write` still 403'd with the same error even after the App was granted Contents access, because the token itself never carried a `contents` scope. The `Generate bot token` step in `auto-merge.yml` requests both `permission-contents: write` and `permission-pull-requests: write` for this reason.
+**Granting the App "Contents: Read & write" in its installation settings is not enough on its own.** `actions/create-github-app-token@v3`'s `permission-*` inputs narrow the generated token to exactly what's requested, regardless of what the App's own installation permissions allow -- requesting only `permission-pull-requests: write` still 403'd with the same error even after the App was granted Contents access, because the token itself never carried a `contents` scope. The `Generate bot token` step in `auto-merge.yml` requests `permission-contents: write`, `permission-pull-requests: write`, and `permission-workflows: write` for this reason.
+
+**Merging a PR that touches `.github/workflows/*` also needs Workflows write on both the App and the minted token.** Confirmed live on PR #4475: with Contents + Pull requests granted (and requested on the token), `PUT /pulls/:number/merge` still returned `Resource not accessible by integration` because the PR changed `ci_checks.yml`. PRs that only touch non-workflow paths (e.g. #4510) merge fine without it. The App installation must have **Workflows: Read & write**, and `auto-merge.yml` must request `permission-workflows: write` — same two-layer rule as Contents above.
 
 ### Known limitations
 
@@ -471,5 +473,5 @@ Always verify the cluster has been torn down when done testing. The auto-teardow
 - Run `npm install` locally and commit the updated `package-lock.json`
 - Check Node/npm version compatibility (runner image provides Node 22)
 - Verify the runner can reach `registry.npmjs.org`
-  // verify trusted bot fix - 1785662227
+// verify trusted bot fix - 1785662227
 <!-- test: verify Merge Gate commit status -->


### PR DESCRIPTION
## Summary
- Request `permission-workflows: write` when minting the `kubevirt-plugin-bot` token in `auto-merge.yml`, so the merge API can land PRs that touch `.github/workflows/*`.
- Document that the App installation needs **Workflows: Read & write** (already granted) in addition to Contents + Pull requests — same two-layer rule as Contents.

Without this, eligible PRs that change workflow files (e.g. #4475) fail merge with `Resource not accessible by integration` even though Contents + Pull requests are granted.

## Test plan
- [ ] Confirm Auto Merge bot-token step requests `permission-workflows: write` and token mint succeeds
- [ ] Re-trigger merge on a workflow-touching pool PR (e.g. #4475 after `/ci-approved` / label nudge) and confirm Merge Gate merges instead of 403
- [ ] Confirm a non-workflow PR still auto-merges as before


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated merge workflows to support changes involving workflow configuration.
  * Expanded the required permissions for automation to include workflow management.

* **Documentation**
  * Clarified setup requirements for bot permissions and access tokens.
  * Improved workflow documentation formatting and provided more complete permission details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->