### PR TITLE
CNV-94405: Clean up auto pilot code

### DIFF
--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildCapabilityRow.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildCapabilityRow.tsx
@@ -16,15 +16,25 @@ import {
 } from '../../utils/types';
 import ConfigurationStatusCell from '../ConfigurationStatusCell/ConfigurationStatusCell';
 
-export const buildCapabilityRow = (
-  feature: CapabilityFeature,
-  installState: CapabilityInstallState,
-  isInstalling: boolean,
-  actions: ActionDropdownItemType[],
-  t: TFunction,
+type BuildCapabilityRowParams = {
+  actions: ActionDropdownItemType[];
+  configStatus?: ConfigurationStatus;
+  feature: CapabilityFeature;
+  includeConfigCell?: boolean;
+  installState: CapabilityInstallState;
+  isInstalling: boolean;
+  t: TFunction;
+};
+
+export const buildCapabilityRow = ({
+  actions,
+  configStatus,
+  feature,
   includeConfigCell = false,
-  configStatus?: ConfigurationStatus,
-) => {
+  installState,
+  isInstalling,
+  t,
+}: BuildCapabilityRowParams) => {
   const { color, getLabel } = CAPABILITY_INSTALL_STATE_CONFIG[installState];
 
   return [

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildOperatorRow.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildOperatorRow.tsx
@@ -16,16 +16,27 @@ import {
 } from '../../utils/types';
 import ConfigurationStatusCell from '../ConfigurationStatusCell/ConfigurationStatusCell';
 
-export const buildOperatorRow = (
-  operator: CapabilityFeatureOperator,
-  opDetails: RecommendedCapabilityOperatorDetails | undefined,
-  navigate: (path: string) => void,
-  t: TFunction,
-  actions?: ActionDropdownItemType[],
+type BuildOperatorRowParams = {
+  actions?: ActionDropdownItemType[];
+  configStatus?: ConfigurationStatus;
+  includeConfigCell?: boolean;
+  navigate: (path: string) => void;
+  onReviewClick?: () => void;
+  opDetails: RecommendedCapabilityOperatorDetails | undefined;
+  operator: CapabilityFeatureOperator;
+  t: TFunction;
+};
+
+export const buildOperatorRow = ({
+  actions,
+  configStatus,
   includeConfigCell = false,
-  configStatus?: ConfigurationStatus,
-  onReviewClick?: () => void,
-): DataViewTrTree => {
+  navigate,
+  onReviewClick,
+  opDetails,
+  operator,
+  t,
+}: BuildOperatorRowParams): DataViewTrTree => {
   const { color, label } = getOperatorInstallStatusLabel(
     opDetails?.installState,
     opDetails?.isRedHatProvided,

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildTreeRows.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildTreeRows.tsx
@@ -72,26 +72,26 @@ export const buildTreeRows = ({
           opAutopilotStatus?.configStatus,
           opDetails,
         );
-        return buildOperatorRow(
-          op,
-          opDetails,
-          navigate,
-          t,
-          opActions,
+        return buildOperatorRow({
+          actions: opActions,
+          configStatus: effectiveConfigStatus,
           includeConfigCell,
-          effectiveConfigStatus,
-          onOpenReviewModal ? () => onOpenReviewModal(op.packageName) : undefined,
-        );
+          navigate,
+          onReviewClick: onOpenReviewModal ? () => onOpenReviewModal(op.packageName) : undefined,
+          opDetails,
+          operator: op,
+          t,
+        });
       }),
       id: feature.id,
-      row: buildCapabilityRow(
+      row: buildCapabilityRow({
+        actions: capabilityActions,
+        configStatus: capabilityConfigStatus,
         feature,
-        installState,
-        isFeatureInstalling,
-        capabilityActions,
-        t,
         includeConfigCell,
-        capabilityConfigStatus,
-      ),
+        installState,
+        isInstalling: isFeatureInstalling,
+        t,
+      }),
     };
   });

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ReviewRecommendationModal/ReviewRecommendationModal.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ReviewRecommendationModal/ReviewRecommendationModal.tsx
@@ -1,22 +1,10 @@
 import React, { FC, Suspense } from 'react';
 
 import Loading from '@kubevirt-utils/components/Loading/Loading';
+import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { type K8sResourceCommon, YAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
-import {
-  Alert,
-  Button,
-  Content,
-  ContentVariants,
-  Grid,
-  GridItem,
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-  Stack,
-  StackItem,
-} from '@patternfly/react-core';
+import { Content, ContentVariants, Grid, GridItem, ModalVariant } from '@patternfly/react-core';
 
 import { type AutopilotRegistryEntry } from '../../utils/autopilotRegistry';
 
@@ -44,77 +32,40 @@ const ReviewRecommendationModal: FC<ReviewRecommendationModalProps> = ({
   registryEntry,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { currentYAML, handleSubmit, isSubmitting, submitError } = useApplyRecommendation(
-    managedCR,
-    registryEntry,
-    onClose,
-  );
+  const { currentYAML, onSubmit } = useApplyRecommendation(managedCR, registryEntry);
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} variant="large">
-      <ModalHeader title={t('Recommended settings for {{name}}', { name: operatorDisplayName })} />
-      <ModalBody>
-        <Stack hasGutter>
-          <StackItem>
-            <Content
-              className="review-recommendation-modal__description"
-              component={ContentVariants.p}
-            >
-              {t(
-                'Review the recommended settings for this operator. Apply to switch to recommended configuration, or close to keep your manual configuration.',
-              )}
-            </Content>
-          </StackItem>
-          <StackItem>
-            <hr className="review-recommendation-modal__separator" />
-          </StackItem>
-          <StackItem>
-            <Grid hasGutter>
-              <GridItem span={6}>
-                <Content component={ContentVariants.h4}>{t('Current configuration')}</Content>
-                <div className="review-recommendation-modal__editor">
-                  <Suspense fallback={<Loading />}>
-                    <YAMLEditor minHeight="350px" options={EDITOR_OPTIONS} value={currentYAML} />
-                  </Suspense>
-                </div>
-              </GridItem>
-              <GridItem span={6}>
-                <Content component={ContentVariants.h4}>{t('Managed by autopilot')}</Content>
-                <div className="review-recommendation-modal__editor">
-                  <Suspense fallback={<Loading />}>
-                    <YAMLEditor
-                      minHeight="350px"
-                      options={EDITOR_OPTIONS}
-                      value={recommendedYAML}
-                    />
-                  </Suspense>
-                </div>
-              </GridItem>
-            </Grid>
-          </StackItem>
-          {submitError && (
-            <StackItem>
-              <Alert isInline title={submitError.message} variant="danger" />
-            </StackItem>
-          )}
-        </Stack>
-      </ModalBody>
-      <ModalFooter>
-        <div className="review-recommendation-modal__footer">
-          <Button
-            isDisabled={isSubmitting}
-            isLoading={isSubmitting}
-            onClick={handleSubmit}
-            variant="primary"
-          >
-            {t('Apply')}
-          </Button>
-          <Button onClick={onClose} variant="link">
-            {t('Close')}
-          </Button>
-        </div>
-      </ModalFooter>
-    </Modal>
+    <TabModal
+      headerDescription={t(
+        'Review the recommended settings for this operator. Apply to switch to recommended configuration, or close to keep your manual configuration.',
+      )}
+      headerText={t('Recommended settings for {{name}}', { name: operatorDisplayName })}
+      isOpen={isOpen}
+      modalVariant={ModalVariant.large}
+      onClose={onClose}
+      onSubmit={onSubmit}
+      submitBtnText={t('Apply')}
+    >
+      <hr className="review-recommendation-modal__separator" />
+      <Grid hasGutter>
+        <GridItem span={6}>
+          <Content component={ContentVariants.h4}>{t('Current configuration')}</Content>
+          <div className="review-recommendation-modal__editor">
+            <Suspense fallback={<Loading />}>
+              <YAMLEditor minHeight="350px" options={EDITOR_OPTIONS} value={currentYAML} />
+            </Suspense>
+          </div>
+        </GridItem>
+        <GridItem span={6}>
+          <Content component={ContentVariants.h4}>{t('Managed by autopilot')}</Content>
+          <div className="review-recommendation-modal__editor">
+            <Suspense fallback={<Loading />}>
+              <YAMLEditor minHeight="350px" options={EDITOR_OPTIONS} value={recommendedYAML} />
+            </Suspense>
+          </div>
+        </GridItem>
+      </Grid>
+    </TabModal>
   );
 };
 

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ReviewRecommendationModal/review-recommendation-modal.scss
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ReviewRecommendationModal/review-recommendation-modal.scss
@@ -1,13 +1,8 @@
 .review-recommendation-modal {
-  &__description {
-    font-size: var(--pf-t--global--font--size--body--lg);
-    margin-bottom: var(--pf-t--global--spacer--md);
-  }
-
   &__separator {
     border: none;
     border-top: 1px solid var(--pf-t--global--border--color--default);
-    margin: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--lg) 0;
+    margin: 0 var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--md);
   }
 
   &__editor {
@@ -27,10 +22,5 @@
         overflow-y: auto;
       }
     }
-  }
-
-  &__footer {
-    display: flex;
-    gap: var(--pf-t--global--spacer--sm);
   }
 }

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ReviewRecommendationModal/useApplyRecommendation.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ReviewRecommendationModal/useApplyRecommendation.ts
@@ -1,113 +1,94 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { dump } from 'js-yaml';
 
 import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { escapeJsonPointerToken, kubevirtConsole } from '@kubevirt-utils/utils/utils';
+import { getAnnotation } from '@kubevirt-utils/resources/shared';
+import { escapeJsonPointerToken } from '@kubevirt-utils/utils/utils';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
-import { type K8sModel, type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { useSettingsCluster } from '@settings/context/SettingsClusterContext';
 
-import { AUTOPILOT_MODE_ANNOTATION } from '../../utils/autopilotConstants';
+import {
+  AUTOPILOT_MODE_ANNOTATION,
+  HCO_AUTOPILOT_ANNOTATION,
+} from '../../utils/autopilotConstants';
 import { type AutopilotRegistryEntry } from '../../utils/autopilotRegistry';
-import { buildModelFromRegistryEntry } from '../../utils/autopilotUtils';
-
-type PatchAction = {
-  data: Array<{ op: string; path: string; value?: string }>;
-  model: K8sModel;
-  resource: K8sResourceCommon;
-};
-
-const resolvePatchAction = (
-  managedCR: K8sResourceCommon | undefined,
-  registryEntry: AutopilotRegistryEntry,
-  hco: K8sResourceCommon | undefined,
-): PatchAction | null => {
-  if (managedCR?.metadata?.name) {
-    return {
-      data: [
-        {
-          op: 'remove',
-          path: `/metadata/annotations/${escapeJsonPointerToken(AUTOPILOT_MODE_ANNOTATION)}`,
-        },
-      ],
-      model: buildModelFromRegistryEntry(registryEntry),
-      resource: managedCR,
-    };
-  }
-
-  if (registryEntry.enableAnnotation && hco) {
-    return {
-      data: [
-        {
-          op: 'add',
-          path: `/metadata/annotations/${escapeJsonPointerToken(registryEntry.enableAnnotation)}`,
-          value: 'true',
-        },
-      ],
-      model: HyperConvergedModel,
-      resource: hco,
-    };
-  }
-
-  return null;
-};
 
 type UseApplyRecommendationReturn = {
   currentYAML: string;
-  handleSubmit: () => Promise<void>;
-  isSubmitting: boolean;
-  submitError: Error | undefined;
+  onSubmit: () => Promise<void>;
 };
 
 const useApplyRecommendation = (
   managedCR: K8sResourceCommon | undefined,
   registryEntry: AutopilotRegistryEntry,
-  onClose: () => void,
 ): UseApplyRecommendationReturn => {
   const { t } = useKubevirtTranslation();
   const cluster = useSettingsCluster();
   const [hco] = useHyperConvergeConfiguration();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submitError, setSubmitError] = useState<Error>();
 
   const currentYAML = useMemo(() => {
     if (!managedCR) {
-      return `# ${t('{{name}} CR absent – not yet configured', { name: registryEntry.crGVK.kind })}`;
+      return `# ${t('{{name}} CR absent – not yet configured', { name: registryEntry.crModel.kind })}`;
     }
     const { managedFields: _, ...metadataWithoutManaged } = managedCR.metadata || {};
     return dump({ ...managedCR, metadata: metadataWithoutManaged }, { skipInvalid: true });
-  }, [managedCR, registryEntry.crGVK.kind, t]);
+  }, [managedCR, registryEntry.crModel.kind, t]);
 
-  const handleSubmit = useCallback(async () => {
-    setIsSubmitting(true);
-    setSubmitError(undefined);
+  const onSubmit = async () => {
+    const ensureAutopilotEnabled = async () => {
+      if (getAnnotation(hco, HCO_AUTOPILOT_ANNOTATION) === 'true' || !hco) return;
+      await kubevirtK8sPatch({
+        cluster,
+        data: [
+          {
+            op: 'add',
+            path: `/metadata/annotations/${escapeJsonPointerToken(HCO_AUTOPILOT_ANNOTATION)}`,
+            value: 'true',
+          },
+        ],
+        model: HyperConvergedModel,
+        resource: hco,
+      });
+    };
 
-    try {
-      const action = resolvePatchAction(managedCR, registryEntry, hco);
-
-      if (!action) {
-        kubevirtConsole.warn('[ReviewRecommendationModal] No action taken', {
-          enableAnnotation: registryEntry.enableAnnotation,
-          hasManagedCR: !!managedCR,
-          hcoLoaded: !!hco,
-        });
-        onClose();
-        return;
-      }
-
-      await kubevirtK8sPatch({ cluster, ...action });
-      onClose();
-    } catch (error) {
-      setSubmitError(error as Error);
-      kubevirtConsole.error('[ReviewRecommendationModal] Submit failed', error);
-    } finally {
-      setIsSubmitting(false);
+    if (managedCR?.metadata?.name && getAnnotation(managedCR, AUTOPILOT_MODE_ANNOTATION)) {
+      await kubevirtK8sPatch({
+        cluster,
+        data: [
+          {
+            op: 'remove',
+            path: `/metadata/annotations/${escapeJsonPointerToken(AUTOPILOT_MODE_ANNOTATION)}`,
+          },
+        ],
+        model: registryEntry.crModel,
+        resource: managedCR,
+      });
+      await ensureAutopilotEnabled();
+      return;
     }
-  }, [cluster, hco, managedCR, onClose, registryEntry]);
 
-  return { currentYAML, handleSubmit, isSubmitting, submitError };
+    if (registryEntry.enableAnnotation && hco) {
+      await ensureAutopilotEnabled();
+      await kubevirtK8sPatch({
+        cluster,
+        data: [
+          {
+            op: 'add',
+            path: `/metadata/annotations/${escapeJsonPointerToken(registryEntry.enableAnnotation)}`,
+            value: 'true',
+          },
+        ],
+        model: HyperConvergedModel,
+        resource: hco,
+      });
+      return;
+    }
+  };
+
+  return { currentYAML, onSubmit };
 };
 
 export default useApplyRecommendation;

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotConstants.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotConstants.ts
@@ -1,4 +1,4 @@
-import { type K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
 export const AUTOPILOT_MANAGED_BY_LABEL = 'platform.kubevirt.io/managed-by';
 export const AUTOPILOT_MANAGED_BY_VALUE = 'virt-platform-autopilot';
@@ -9,38 +9,74 @@ export const HCO_AUTOPILOT_ANNOTATION = 'platform.kubevirt.io/autopilot';
 export const DESCHEDULER_OPERATOR_PACKAGE = 'cluster-kube-descheduler-operator';
 export const CLUSTER_OBSERVABILITY_OPERATOR_PACKAGE = 'cluster-observability-operator';
 
-export const KubeDeschedulerGVK: K8sGroupVersionKind = {
-  group: 'operator.openshift.io',
+export const KubeDeschedulerModel: K8sModel = {
+  abbr: 'KD',
+  apiGroup: 'operator.openshift.io',
+  apiVersion: 'v1',
+  crd: true,
   kind: 'KubeDescheduler',
-  version: 'v1',
+  label: 'KubeDescheduler',
+  labelPlural: 'KubeDeschedulers',
+  namespaced: true,
+  plural: 'kubedeschedulers',
 };
 
-export const MetalLBGVK: K8sGroupVersionKind = {
-  group: 'metallb.io',
+export const MetalLBModel: K8sModel = {
+  abbr: 'MLB',
+  apiGroup: 'metallb.io',
+  apiVersion: 'v1beta1',
+  crd: true,
   kind: 'MetalLB',
-  version: 'v1beta1',
+  label: 'MetalLB',
+  labelPlural: 'MetalLBs',
+  namespaced: true,
+  plural: 'metallbs',
 };
 
-export const ForkliftControllerGVK: K8sGroupVersionKind = {
-  group: 'forklift.konveyor.io',
+export const ForkliftControllerModel: K8sModel = {
+  abbr: 'FC',
+  apiGroup: 'forklift.konveyor.io',
+  apiVersion: 'v1beta1',
+  crd: true,
   kind: 'ForkliftController',
-  version: 'v1beta1',
+  label: 'ForkliftController',
+  labelPlural: 'ForkliftControllers',
+  namespaced: true,
+  plural: 'forkliftcontrollers',
 };
 
-export const UIPluginGVK: K8sGroupVersionKind = {
-  group: 'observability.openshift.io',
+export const UIPluginModel: K8sModel = {
+  abbr: 'UIP',
+  apiGroup: 'observability.openshift.io',
+  apiVersion: 'v1alpha1',
+  crd: true,
   kind: 'UIPlugin',
-  version: 'v1alpha1',
+  label: 'UIPlugin',
+  labelPlural: 'UIPlugins',
+  namespaced: false,
+  plural: 'uiplugins',
 };
 
-export const LokiStackGVK: K8sGroupVersionKind = {
-  group: 'loki.grafana.com',
+export const LokiStackModel: K8sModel = {
+  abbr: 'LS',
+  apiGroup: 'loki.grafana.com',
+  apiVersion: 'v1',
+  crd: true,
   kind: 'LokiStack',
-  version: 'v1',
+  label: 'LokiStack',
+  labelPlural: 'LokiStacks',
+  namespaced: true,
+  plural: 'lokistacks',
 };
 
-export const ClusterLogForwarderGVK: K8sGroupVersionKind = {
-  group: 'observability.openshift.io',
+export const ClusterLogForwarderModel: K8sModel = {
+  abbr: 'CLF',
+  apiGroup: 'observability.openshift.io',
+  apiVersion: 'v1',
+  crd: true,
   kind: 'ClusterLogForwarder',
-  version: 'v1',
+  label: 'ClusterLogForwarder',
+  labelPlural: 'ClusterLogForwarders',
+  namespaced: true,
+  plural: 'clusterlogforwarders',
 };

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotRecommendedYaml.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotRecommendedYaml.ts
@@ -54,7 +54,7 @@ spec:
 export const CLUSTER_LOG_FORWARDER_RECOMMENDED_YAML = `apiVersion: observability.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
-  name: collector
+  name: instance
   namespace: openshift-logging
 spec:
   managementState: Managed

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotRegistry.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotRegistry.ts
@@ -1,14 +1,14 @@
-import { type K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
 import {
   CLUSTER_OBSERVABILITY_OPERATOR_PACKAGE,
-  ClusterLogForwarderGVK,
+  ClusterLogForwarderModel,
   DESCHEDULER_OPERATOR_PACKAGE,
-  ForkliftControllerGVK,
-  KubeDeschedulerGVK,
-  LokiStackGVK,
-  MetalLBGVK,
-  UIPluginGVK,
+  ForkliftControllerModel,
+  KubeDeschedulerModel,
+  LokiStackModel,
+  MetalLBModel,
+  UIPluginModel,
 } from './autopilotConstants';
 import {
   CLUSTER_LOG_FORWARDER_RECOMMENDED_YAML,
@@ -26,10 +26,9 @@ import {
 } from './operatorNames';
 
 export type AutopilotRegistryEntry = {
-  crGVK: K8sGroupVersionKind;
+  crModel: K8sModel;
   crName: string;
   crNamespace?: string;
-  crPlural: string;
   enableAnnotation?: string;
   operatorPackageName: string;
   recommendedYAML: string;
@@ -37,52 +36,46 @@ export type AutopilotRegistryEntry = {
 
 export const AUTOPILOT_REGISTRY: AutopilotRegistryEntry[] = [
   {
-    crGVK: KubeDeschedulerGVK,
+    crModel: KubeDeschedulerModel,
     crName: 'cluster',
     crNamespace: 'openshift-kube-descheduler-operator',
-    crPlural: 'kubedeschedulers',
     operatorPackageName: DESCHEDULER_OPERATOR_PACKAGE,
     recommendedYAML: KUBE_DESCHEDULER_RECOMMENDED_YAML,
   },
   {
-    crGVK: MetalLBGVK,
+    crModel: MetalLBModel,
     crName: 'metallb',
     crNamespace: 'metallb-system',
-    crPlural: 'metallbs',
     enableAnnotation: 'platform.kubevirt.io/enable-metallb',
     operatorPackageName: METALLB_OPERATOR_NAME,
     recommendedYAML: METALLB_RECOMMENDED_YAML,
   },
   {
-    crGVK: ForkliftControllerGVK,
+    crModel: ForkliftControllerModel,
     crName: 'forklift-controller',
     crNamespace: 'openshift-mtv',
-    crPlural: 'forkliftcontrollers',
     enableAnnotation: 'platform.kubevirt.io/enable-mtv',
     operatorPackageName: MTV_OPERATOR_NAME,
     recommendedYAML: FORKLIFT_CONTROLLER_RECOMMENDED_YAML,
   },
   {
-    crGVK: UIPluginGVK,
+    crModel: UIPluginModel,
     crName: 'monitoring',
-    crPlural: 'uiplugins',
     operatorPackageName: CLUSTER_OBSERVABILITY_OPERATOR_PACKAGE,
     recommendedYAML: UI_PLUGIN_RECOMMENDED_YAML,
   },
   {
-    crGVK: LokiStackGVK,
+    crModel: LokiStackModel,
     crName: 'logging-loki',
     crNamespace: 'openshift-logging',
-    crPlural: 'lokistacks',
     enableAnnotation: 'platform.kubevirt.io/enable-logging',
     operatorPackageName: LOKI_OPERATOR_NAME,
     recommendedYAML: LOKI_STACK_RECOMMENDED_YAML,
   },
   {
-    crGVK: ClusterLogForwarderGVK,
+    crModel: ClusterLogForwarderModel,
     crName: 'instance',
     crNamespace: 'openshift-logging',
-    crPlural: 'clusterlogforwarders',
     enableAnnotation: 'platform.kubevirt.io/enable-logging',
     operatorPackageName: CLUSTER_LOGGING_OPERATOR_NAME,
     recommendedYAML: CLUSTER_LOG_FORWARDER_RECOMMENDED_YAML,

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotUtils.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/autopilotUtils.ts
@@ -1,7 +1,8 @@
 import { type TFunction } from 'i18next';
 
-import { getAnnotation, getLabel } from '@kubevirt-utils/resources/shared';
-import { type K8sModel, type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { getAnnotation, getLabel, getName } from '@kubevirt-utils/resources/shared';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 import {
   AUTOPILOT_MANAGED_BY_LABEL,
@@ -17,7 +18,7 @@ export const watchAutopilotResources = Object.fromEntries(
   AUTOPILOT_REGISTRY.map((entry) => [
     entry.operatorPackageName,
     {
-      groupVersionKind: entry.crGVK,
+      groupVersionKind: modelToGroupVersionKind(entry.crModel),
       name: entry.crName,
       ...(entry.crNamespace && { namespace: entry.crNamespace }),
     },
@@ -27,7 +28,7 @@ export const watchAutopilotResources = Object.fromEntries(
 export const deriveConfigStatus = (
   resource: K8sResourceCommon | undefined,
 ): ConfigurationStatus | undefined => {
-  if (!resource?.metadata?.name) return undefined;
+  if (!getName(resource)) return undefined;
 
   const managedBy = getLabel(resource, AUTOPILOT_MANAGED_BY_LABEL);
   const mode = getAnnotation(resource, AUTOPILOT_MODE_ANNOTATION);
@@ -43,21 +44,6 @@ export const getRegistryEntryByPackageName = (
   packageName: string,
 ): AutopilotRegistryEntry | undefined =>
   AUTOPILOT_REGISTRY.find((entry) => entry.operatorPackageName === packageName);
-
-export const buildModelFromRegistryEntry = (entry: AutopilotRegistryEntry): K8sModel => {
-  const { group, kind, version } = entry.crGVK;
-  return {
-    abbr: kind.slice(0, 3).toUpperCase(),
-    apiGroup: group,
-    apiVersion: version,
-    crd: true,
-    kind,
-    label: kind,
-    labelPlural: kind,
-    namespaced: !!entry.crNamespace,
-    plural: entry.crPlural,
-  };
-};
 
 const AUTOPILOT_PACKAGE_NAMES = new Set(
   AUTOPILOT_REGISTRY.map((entry) => entry.operatorPackageName),


### PR DESCRIPTION

## 📝 Description

Follow-up to #4473 addressing reviewer feedback:

- Refactor `buildOperatorRow` and `buildCapabilityRow` to use object parameters instead of positional arguments
- Define full `K8sModel` objects for autopilot-managed resources and derive GVK using `modelToGroupVersionKind`, removing the need for separate `crPlural` fields
- Use `getName` selector in `deriveConfigStatus` for consistent resource field access
- Refactor `ReviewRecommendationModal` to use `TabModal` instead of raw PatternFly Modal
- Guard JSON Patch `remove` operation to only fire when the annotation exists
- Auto-enable `platform.kubevirt.io/autopilot` annotation on HCO when applying a recommendation
- Fix `ClusterLogForwarder` recommended YAML name (`collector` → `instance`)

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-94405
Feature JIra ticket: https://redhat.atlassian.net/browse/CNV-85794



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the recommendation review dialog with a more consistent layout and streamlined Apply workflow.
  * Improved recommendation application for autopilot-enabled capabilities.
  * Corrected the default resource name for the cluster logging recommendation.
  * Improved capability and operator selection row handling without changing their displayed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->