### PR TITLE
CNV-87886: replace useListPageFilter on Storage migration list page

### DIFF
--- a/src/views/storagemigrations/list/StorageMigrationList.tsx
+++ b/src/views/storagemigrations/list/StorageMigrationList.tsx
@@ -1,20 +1,16 @@
 import React, { FC, useMemo } from 'react';
 
+import KubevirtFilterToolbar from '@kubevirt-utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar';
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
 import { buildColumnLayout } from '@kubevirt-utils/components/KubevirtTable/utils';
-import ListPageFilter from '@kubevirt-utils/components/ListPageFilter/ListPageFilter';
+import useKubevirtDataViewFilters from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/useKubevirtDataViewFilters';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtTableColumns from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtTableColumns';
 import usePaginationWithFilters from '@kubevirt-utils/hooks/usePagination/usePaginationWithFilters';
 import { paginationDefaultValues } from '@kubevirt-utils/hooks/usePagination/utils/constants';
 import { EXPORT_TABLE_KEYS, KubevirtTableExport } from '@kubevirt-utils/hooks/useTableExport';
-import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import {
-  ListPageBody,
-  ListPageHeader,
-  useListPageFilter,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { ListPageBody, ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
 import { Pagination } from '@patternfly/react-core';
 
 import useStorageMigrationResources from './hooks/useStorageMigrationResources';
@@ -30,20 +26,24 @@ const StorageMigrationList: FC = () => {
   const { loaded, loadError, storageMigPlans } = useStorageMigrationResources();
 
   const columns = useMemo(() => getStorageMigrationColumns(t), [t]);
-  const statusFilters = useMemo(() => getStorageMigrationStatusFilters(t), [t]);
+  const filterDefinitions = useMemo(() => getStorageMigrationStatusFilters(t), [t]);
 
   const { activeColumnKeys, loaded: loadedColumns } = useKubevirtTableColumns({
     columnManagementID: COLUMN_MANAGEMENT_ID_STORAGE_MIGRATIONS,
     columns,
   });
 
-  const [unfilteredData, data, onFilterChange] = useListPageFilter<
-    MultiNamespaceVirtualMachineStorageMigrationPlan,
-    MultiNamespaceVirtualMachineStorageMigrationPlan
-  >(storageMigPlans, statusFilters);
+  const { clearAllFilters, filteredData, filters, onSetFilters } = useKubevirtDataViewFilters({
+    data: storageMigPlans ?? [],
+    filterDefinitions,
+  });
 
-  const { handleFilterChange, handlePerPageSelect, handleSetPage, pagination } =
-    usePaginationWithFilters(data?.length ?? 0, onFilterChange);
+  const {
+    handlePerPageSelect,
+    handleSetPage,
+    pagination,
+    handleFilterChange: handleSetFilters,
+  } = usePaginationWithFilters(filteredData?.length ?? 0, onSetFilters);
 
   const columnLayout = useMemo(
     () =>
@@ -64,28 +64,29 @@ const StorageMigrationList: FC = () => {
 
       <ListPageBody>
         <div className="list-managment-group">
-          <ListPageFilter
+          <KubevirtFilterToolbar
+            clearAllFilters={clearAllFilters}
+            columnLayout={columnLayout}
+            data={storageMigPlans}
+            filterDefinitions={filterDefinitions}
+            filters={filters}
+            loaded={isLoaded}
+            onSetFilters={handleSetFilters}
             toolbarEndContent={
               <KubevirtTableExport
                 activeColumnKeys={activeColumnKeys}
-                asToolbarItem
                 columns={columns}
-                data={data ?? []}
+                data={filteredData ?? []}
                 exportKey={EXPORT_TABLE_KEYS.STORAGE_MIGRATIONS}
                 loaded={isLoaded}
               />
             }
-            columnLayout={columnLayout}
-            data={unfilteredData}
-            loaded={isLoaded}
-            onFilterChange={handleFilterChange}
-            rowFilters={statusFilters}
           />
-          {!isEmpty(data) && isLoaded && (
+          {!isEmpty(filteredData) && isLoaded && (
             <Pagination
               className="list-managment-group__pagination"
               isLastFullPageShown
-              itemCount={data?.length ?? 0}
+              itemCount={filteredData?.length ?? 0}
               onPerPageSelect={handlePerPageSelect}
               onSetPage={handleSetPage}
               page={pagination?.page}
@@ -98,7 +99,7 @@ const StorageMigrationList: FC = () => {
           activeColumnKeys={activeColumnKeys}
           ariaLabel={t('Storage migrations table')}
           columns={columns}
-          data={data ?? []}
+          data={filteredData ?? []}
           dataTest="storage-migrations-list"
           getRowId={getStorageMigrationRowId}
           loaded={isLoaded}
@@ -106,7 +107,7 @@ const StorageMigrationList: FC = () => {
           noDataMsg={t("You don't have any storage migrations yet")}
           pagination={pagination}
           persistSortInUrl
-          unfilteredData={unfilteredData}
+          unfilteredData={storageMigPlans}
         />
       </ListPageBody>
     </>

--- a/src/views/storagemigrations/list/StorageMigrationListFilters.ts
+++ b/src/views/storagemigrations/list/StorageMigrationListFilters.ts
@@ -1,30 +1,26 @@
 import { TFunction } from 'i18next';
 
+import { KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
 import {
   getStorageMigrationStatus,
   StorageMigrationStatusFilterValue,
 } from '@kubevirt-utils/resources/migrations/storageMigrationLifecycle';
-import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 
 export const STORAGE_MIGRATION_STATUS_FILTER_TYPE = 'storage-migration-status';
 
-export { getStorageMigrationStatus, StorageMigrationStatusFilterValue };
-
 export const getStorageMigrationStatusFilters = (
   t: TFunction,
-): RowFilter<MultiNamespaceVirtualMachineStorageMigrationPlan>[] => [
+): KubevirtFilter<MultiNamespaceVirtualMachineStorageMigrationPlan>[] => [
   {
-    filter: ({ selected }, obj) =>
-      selected?.length === 0 || selected.includes(getStorageMigrationStatus(obj)),
-    filterGroupName: t('Status'),
-    items: [
-      { id: StorageMigrationStatusFilterValue.Running, title: t('Running') },
-      { id: StorageMigrationStatusFilterValue.Pending, title: t('Pending') },
-      { id: StorageMigrationStatusFilterValue.Failed, title: t('Failed') },
-      { id: StorageMigrationStatusFilterValue.Completed, title: t('Completed') },
+    categoryLabel: t('Status'),
+    id: STORAGE_MIGRATION_STATUS_FILTER_TYPE,
+    match: (obj, selected) => selected.includes(getStorageMigrationStatus(obj)),
+    options: [
+      { label: t('Running'), value: StorageMigrationStatusFilterValue.Running },
+      { label: t('Pending'), value: StorageMigrationStatusFilterValue.Pending },
+      { label: t('Failed'), value: StorageMigrationStatusFilterValue.Failed },
+      { label: t('Completed'), value: StorageMigrationStatusFilterValue.Completed },
     ],
-    reducer: (obj) => getStorageMigrationStatus(obj),
-    type: STORAGE_MIGRATION_STATUS_FILTER_TYPE,
   },
 ];

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationNavigation.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationNavigation.ts
@@ -6,22 +6,18 @@ import {
   STORAGE_MIGRATION_API,
 } from '@kubevirt-utils/resources/migrations/constants';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
-import { ROW_FILTERS_PREFIX } from '@kubevirt-utils/utils/constants';
 import useManagedClusterConsoleURLs from '@multicluster/hooks/useManagedClusterConsoleURLs';
 import { buildSpokeConsoleUrl } from '@multicluster/urls';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 import { spokeSupportsCustomMigrationsRoute } from '@virtualmachines/actions/hooks/storageMigrationApi/constants';
 
-import {
-  STORAGE_MIGRATION_STATUS_FILTER_TYPE,
-  StorageMigrationStatusFilterValue,
-} from '../../../../../../storagemigrations/list/StorageMigrationListFilters';
+import { StorageMigrationStatusFilterValue } from '@kubevirt-utils/resources/migrations/storageMigrationLifecycle';
+import { STORAGE_MIGRATION_STATUS_FILTER_TYPE } from '../../../../../../storagemigrations/list/StorageMigrationListFilters';
 
 const ALL_NAMESPACES_STORAGE_MIGRATIONS_LIST = '/k8s/all-namespaces/storagemigrations';
-const STATUS_FILTER_PARAM = `${ROW_FILTERS_PREFIX}${STORAGE_MIGRATION_STATUS_FILTER_TYPE}`;
 
 const withStatusFilter = (base: string, value: StorageMigrationStatusFilterValue): string =>
-  `${base}?${STATUS_FILTER_PARAM}=${value}`;
+  `${base}?${STORAGE_MIGRATION_STATUS_FILTER_TYPE}=${value}`;
 
 /**
  * Resolves the console path for spoke clusters.


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Replace deprecated `useListPageFilter` on Storage migration list page

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-87886

## 🎥 Demo

The only visual change is in URL param: `rowFilter-storage-migration-status` -> `storage-migration-status`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consistent filter toolbar for storage migration plans, making it easier to find migrations by status and other available criteria.
  * Filtering now works seamlessly with pagination, table results, and data export, ensuring actions apply to the currently filtered plans.
  * Storage migration status selections are preserved when navigating from virtual machine views, providing a smoother return to migration results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->