### PR TITLE
CNV-92901: exclude cloudinit volume snapshot from diagnostics warnings

### DIFF
--- a/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticData.ts
+++ b/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticData.ts
@@ -8,6 +8,7 @@ import {
   V1VirtualMachineCondition,
   V1VolumeSnapshotStatus,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { CLOUDINITDISK } from '@kubevirt-utils/constants/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useKubevirtWatchResources from '@multicluster/hooks/useKubevirtWatchResources';
 import { FleetWatchK8sResults } from '@stolostron/multicluster-sdk';
@@ -59,7 +60,7 @@ const volumeSnapshotStatusesTransformer = (
         type: DiagnosticCategory.Storage,
       },
       reason,
-      severity: getSnapshotSeverity(vss?.enabled),
+      severity: vss?.name === CLOUDINITDISK ? 'healthy' : getSnapshotSeverity(vss?.enabled),
       status: vss?.enabled,
     };
   });


### PR DESCRIPTION

## 📝 Description

exclude cloudinit volume snapshot from diagnostics warnings

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-92901

## 🎥 Demo

Before:
<img width="2728" height="1103" alt="image" src="https://github.com/user-attachments/assets/f5b212e3-d252-4d84-b1ac-9c5fcc9029c5" />
<img width="2125" height="731" alt="image" src="https://github.com/user-attachments/assets/03585629-bf76-4a0f-a17d-e064e099bea4" />


After:
<img width="2743" height="1126" alt="Screenshot at Aug 04 13-46-57" src="https://github.com/user-attachments/assets/0dea4cfe-ab68-48ca-9431-84d67ca6cb40" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud-Init disk snapshots are now consistently displayed as healthy in diagnostic views.
  * Severity calculations for all other volume snapshots remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->