### PR TITLE
CNV-92844: Fix memory usage percentage for Ki and M guest memory units

### DIFF
--- a/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
@@ -51,8 +51,8 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
   const [updateInProcess, setUpdateInProcess] = useState<boolean>(false);
   const [updateError, setUpdateError] = useState<string>();
 
-  const memoryQuantity = getMemory(vm);
-  const { unit, value } = memoryQuantity ? toQuantity(memoryQuantity) : { unit: undefined, value: undefined };
+  const memoryQuantity = toQuantity(getMemory(vm));
+  const { unit, value } = memoryQuantity ?? {};
   const [memory, setMemory] = useState<number>(value || undefined);
   const [memoryUnit, setMemoryUnit] = useState<string>(unit || undefined);
   const [cpu, setCPU] = useState<V1CPU>(getCPU(vm));

--- a/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
@@ -9,6 +9,7 @@ import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getLabel } from '@kubevirt-utils/resources/shared';
 import { getCPU, getMemory, VM_TEMPLATE_ANNOTATION } from '@kubevirt-utils/resources/vm';
+import { toQuantity } from '@kubevirt-utils/utils/units';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import {
@@ -24,7 +25,6 @@ import {
 } from '@patternfly/react-core';
 
 import useTemplateDefaultCpuMemory from './hooks/useTemplateDefaultCpuMemory';
-import { getMemorySize } from './utils/CpuMemoryUtils';
 
 import './cpu-memory-modal.scss';
 
@@ -51,8 +51,9 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
   const [updateInProcess, setUpdateInProcess] = useState<boolean>(false);
   const [updateError, setUpdateError] = useState<string>();
 
-  const { size, unit } = getMemorySize(getMemory(vm));
-  const [memory, setMemory] = useState<number>(size || undefined);
+  const memoryQuantity = getMemory(vm);
+  const { unit, value } = memoryQuantity ? toQuantity(memoryQuantity) : { unit: undefined, value: undefined };
+  const [memory, setMemory] = useState<number>(value || undefined);
   const [memoryUnit, setMemoryUnit] = useState<string>(unit || undefined);
   const [cpu, setCPU] = useState<V1CPU>(getCPU(vm));
 
@@ -68,7 +69,7 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
   const { defaultCpu, defaultMemory } = templateDefaultsData || {};
 
   const cpuLimits = getCPULimitsFromVM(vm);
-  const { size: defaultMemorySize, unit: defaultMemoryUnit } = defaultMemory || {};
+  const { unit: defaultMemoryUnit, value: defaultMemorySize } = defaultMemory || {};
 
   const templateName = getLabel(vm, VM_TEMPLATE_ANNOTATION);
 

--- a/src/utils/components/CPUMemoryModal/hooks/useTemplateDefaultCpuMemory.ts
+++ b/src/utils/components/CPUMemoryModal/hooks/useTemplateDefaultCpuMemory.ts
@@ -2,9 +2,9 @@ import { TemplateModel, V1Template } from '@kubevirt-ui-ext/kubevirt-api/console
 import { V1CPU } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { getCPU, getMemory } from '@kubevirt-utils/resources/vm';
+import { Quantity } from '@kubevirt-utils/types/quantity';
+import { toQuantity } from '@kubevirt-utils/utils/units';
 import useK8sGetData from '@multicluster/hooks/useK8sGetData';
-
-import { getMemorySize } from '../utils/CpuMemoryUtils';
 
 type UseTemplateDefaultCpuMemory = (
   templateName: string,
@@ -13,7 +13,7 @@ type UseTemplateDefaultCpuMemory = (
 ) => {
   data: {
     defaultCpu: V1CPU;
-    defaultMemory: { size: number; unit: string };
+    defaultMemory: Quantity | undefined;
   };
   error: Error | undefined;
   loaded: boolean;
@@ -32,7 +32,8 @@ const useTemplateDefaultCpuMemory: UseTemplateDefaultCpuMemory = (
   });
 
   const vmObject = getTemplateVirtualMachineObject(template);
-  const defaultMemory = getMemorySize(getMemory(vmObject));
+  const memoryQuantity = getMemory(vmObject);
+  const defaultMemory = memoryQuantity ? toQuantity(memoryQuantity) : undefined;
   const defaultCpu = getCPU(vmObject);
 
   return {

--- a/src/utils/components/CPUMemoryModal/hooks/useTemplateDefaultCpuMemory.ts
+++ b/src/utils/components/CPUMemoryModal/hooks/useTemplateDefaultCpuMemory.ts
@@ -32,8 +32,7 @@ const useTemplateDefaultCpuMemory: UseTemplateDefaultCpuMemory = (
   });
 
   const vmObject = getTemplateVirtualMachineObject(template);
-  const memoryQuantity = getMemory(vmObject);
-  const defaultMemory = memoryQuantity ? toQuantity(memoryQuantity) : undefined;
+  const defaultMemory = toQuantity(getMemory(vmObject));
   const defaultCpu = getCPU(vmObject);
 
   return {

--- a/src/utils/components/CPUMemoryModal/utils/CpuMemoryUtils.ts
+++ b/src/utils/components/CPUMemoryModal/utils/CpuMemoryUtils.ts
@@ -1,30 +1,3 @@
-const GIBIBYTE = 'Gi';
-const MEBIBYTE = 'Mi';
-const TEBIBYTE = 'Ti';
+import { BinaryUnit } from '@kubevirt-utils/utils/unitConstants';
 
-const unitsConvertor = new Proxy<Record<string, string>>(
-  {
-    Gi: GIBIBYTE,
-    Mi: MEBIBYTE,
-    Ti: TEBIBYTE,
-  },
-  {
-    get(target: Record<string, string>, prop: string): string {
-      return target[prop] ?? '';
-    },
-  },
-);
-
-export const getMemorySize = (
-  sourceMemory: { [key: string]: string } | string,
-): { size: number; unit: string } => {
-  if (typeof sourceMemory === 'string') {
-    const parts = sourceMemory?.split?.(/(\d+)/g).filter(Boolean) ?? [];
-    const size = parts[0] ?? '';
-    const unit = parts[1] ?? '';
-    return { size: +size || 0, unit: unitsConvertor[unit] };
-  }
-  return { size: +sourceMemory?.size || 0, unit: unitsConvertor[sourceMemory?.unit ?? ''] };
-};
-
-export const memorySizesTypes = [GIBIBYTE, MEBIBYTE, TEBIBYTE];
+export const memorySizesTypes = [BinaryUnit.Gi, BinaryUnit.Mi, BinaryUnit.Ti];

--- a/src/utils/components/CPUMemoryModal/utils/CpuMemoryUtils.ts
+++ b/src/utils/components/CPUMemoryModal/utils/CpuMemoryUtils.ts
@@ -1,3 +1,3 @@
 import { BinaryUnit } from '@kubevirt-utils/utils/unitConstants';
 
-export const memorySizesTypes = [BinaryUnit.Gi, BinaryUnit.Mi, BinaryUnit.Ti];
+export const memorySizesTypes = [BinaryUnit.Mi, BinaryUnit.Gi, BinaryUnit.Ti];

--- a/src/utils/components/CapacityInput/CapacityInput.tsx
+++ b/src/utils/components/CapacityInput/CapacityInput.tsx
@@ -39,18 +39,24 @@ const CapacityInput: FC<CapacityInputProps> = ({
   const { unit, value } = toQuantity(size) ?? {};
 
   const onValueChange = (newValue: number) => {
+    if (!unit) return;
     onChange(quantityToString({ unit, value: newValue }));
   };
 
-  const onUnitChange = (_, newUnit: BinaryUnit) => {
+  const onUnitChange = (_event: unknown, newUnit: BinaryUnit) => {
+    if (value === undefined) return;
     onChange(quantityToString({ unit: newUnit, value }));
   };
 
-  const onMinus = () => onValueChange(Number.isInteger(value) ? value - 1 : Math.floor(value));
+  const onMinus = () => {
+    if (value === undefined) return;
+    onValueChange(Number.isInteger(value) ? value - 1 : Math.floor(value));
+  };
 
-  const onPlus = () =>
-    value < Number.MAX_SAFE_INTEGER &&
+  const onPlus = () => {
+    if (value === undefined || value >= Number.MAX_SAFE_INTEGER) return;
     onValueChange(Number.isInteger(value) ? value + 1 : Math.ceil(value));
+  };
 
   const unitOptions = useUnitOptions(size);
 

--- a/src/utils/components/CapacityInput/CapacityInput.tsx
+++ b/src/utils/components/CapacityInput/CapacityInput.tsx
@@ -36,7 +36,7 @@ const CapacityInput: FC<CapacityInputProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
 
-  const { unit, value } = toQuantity(size);
+  const { unit, value } = toQuantity(size) ?? {};
 
   const onValueChange = (newValue: number) => {
     onChange(quantityToString({ unit, value: newValue }));

--- a/src/utils/components/CapacityInput/useUnitOptions.ts
+++ b/src/utils/components/CapacityInput/useUnitOptions.ts
@@ -1,14 +1,15 @@
 import { useRef } from 'react';
 
+import { BinaryUnit } from '@kubevirt-utils/utils/unitConstants';
 import { toQuantity } from '@kubevirt-utils/utils/units';
 
 import { getUnitOptions } from './utils';
 
 const useUnitOptions = (size: string) => {
   const initialSizeRef = useRef(size);
-  const { unit: initialUnit } = toQuantity(initialSizeRef.current);
+  const { unit: initialUnit } = toQuantity(initialSizeRef.current) ?? {};
 
-  return getUnitOptions(initialUnit);
+  return getUnitOptions(initialUnit ?? BinaryUnit.Gi);
 };
 
 export default useUnitOptions;

--- a/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
+++ b/src/utils/components/Charts/MemoryUtil/MemoryThresholdChart.tsx
@@ -3,10 +3,10 @@ import { Link } from 'react-router';
 import xbytes from 'xbytes';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
 import useVMQuery from '@kubevirt-utils/hooks/useVMQuery';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getMemory } from '@kubevirt-utils/resources/vm';
+import { convertToBaseValue } from '@kubevirt-utils/utils/humanize.js';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
@@ -48,8 +48,6 @@ const MemoryThresholdChart: FC<MemoryThresholdChartProps> = ({ vmi }) => {
   const { query, queryLink } = useVMQuery(vmi, VMQueries.MEMORY_USAGE);
   const { height, ref, width } = useResponsiveCharts();
 
-  const memory = getMemorySize(getMemory(vmi));
-
   const [data, loaded, error] = useFleetPrometheusPoll({
     cluster: getCluster(vmi),
     endpoint: PrometheusEndpoint?.QUERY_RANGE,
@@ -61,7 +59,7 @@ const MemoryThresholdChart: FC<MemoryThresholdChartProps> = ({ vmi }) => {
 
   const isLoading = !loaded;
   const prometheusMemoryData = data?.data?.result?.[0]?.values;
-  const memoryAvailableBytes = xbytes.parseSize(`${memory?.size} ${memory?.unit}B`);
+  const memoryAvailableBytes = convertToBaseValue(getMemory(vmi));
 
   const chartData = prometheusMemoryData?.map(([x, y]) => {
     return { name: 'Memory used', x: new Date(x * MILLISECONDS_MULTIPLIER), y: Number(y) };

--- a/src/utils/components/DiskModal/components/DiskSizeInput/ExpandPVC.tsx
+++ b/src/utils/components/DiskModal/components/DiskSizeInput/ExpandPVC.tsx
@@ -26,15 +26,15 @@ const ExpandPVC: FC<ExpandPVCProps> = ({ pvc }) => {
   }
 
   const size = expandPVCSize ?? pvcStorage;
-  const { unit, value } = toQuantity(size);
+  const { unit, value } = toQuantity(size) ?? {};
 
   const minSizes = getMinSizes(pvcStorage);
 
   const onQuantityChange = (quantityString: string) => {
-    const { unit: newUnit, value: newValue } = toQuantity(quantityString);
+    const { unit: newUnit, value: newValue } = toQuantity(quantityString) ?? {};
 
     // unit has changed -> adjust size to be bigger than minimal size for that unit
-    if (newUnit !== unit) {
+    if (newUnit && newUnit !== unit) {
       const minSize = minSizes[newUnit];
 
       if (minSize > newValue) {

--- a/src/utils/tests/units.test.ts
+++ b/src/utils/tests/units.test.ts
@@ -56,6 +56,16 @@ describe('Test quantity utilities', () => {
   });
 
   describe('toQuantity', () => {
+    describe('Empty input', () => {
+      it('returns undefined for undefined input', () => {
+        expect(toQuantity()).toBeUndefined();
+      });
+
+      it('returns undefined for empty string', () => {
+        expect(toQuantity('')).toBeUndefined();
+      });
+    });
+
     describe('Binary units', () => {
       it('converts 1Ki to binary unit', () => {
         expect(toQuantity('1Ki')).toStrictEqual({ unit: 'Ki', value: 1 });

--- a/src/utils/utils/units.ts
+++ b/src/utils/utils/units.ts
@@ -117,9 +117,7 @@ const convertExponentialToDecimal = (quantityString: string): Quantity => {
  * @param quantityString - The quantity string to convert, must be in a {@link https://github.com/kubevirt/kubevirt/blob/205d9455db56d5fcd42fb331122cfef358f19a69/vendor/k8s.io/apimachinery/pkg/api/resource/quantity.go#L33 Kubernetes Quantity} format
  * @returns The Quantity object, or undefined when the input is empty.
  */
-export function toQuantity(quantityString: string): Quantity;
-export function toQuantity(quantityString?: string): Quantity | undefined;
-export function toQuantity(quantityString?: string): Quantity | undefined {
+export const toQuantity = (quantityString?: string): Quantity | undefined => {
   if (!quantityString) {
     return undefined;
   }
@@ -142,7 +140,7 @@ export function toQuantity(quantityString?: string): Quantity | undefined {
   const { unit, value } = getHumanizedSize(quantityString, 'withoutB');
 
   return { unit, value };
-}
+};
 
 export const quantityToString = ({ unit, value }: Quantity) =>
   `${value}${unit === 'B' ? '' : unit}`;

--- a/src/utils/utils/units.ts
+++ b/src/utils/utils/units.ts
@@ -115,9 +115,15 @@ const convertExponentialToDecimal = (quantityString: string): Quantity => {
 /**
  * Converts a quantity string to a Quantity object.
  * @param quantityString - The quantity string to convert, must be in a {@link https://github.com/kubevirt/kubevirt/blob/205d9455db56d5fcd42fb331122cfef358f19a69/vendor/k8s.io/apimachinery/pkg/api/resource/quantity.go#L33 Kubernetes Quantity} format
- * @returns The Quantity object.
+ * @returns The Quantity object, or undefined when the input is empty.
  */
-export const toQuantity = (quantityString: string): Quantity => {
+export function toQuantity(quantityString: string): Quantity;
+export function toQuantity(quantityString?: string): Quantity | undefined;
+export function toQuantity(quantityString?: string): Quantity | undefined {
+  if (!quantityString) {
+    return undefined;
+  }
+
   if (isExponentialNotation(quantityString)) {
     return convertExponentialToDecimal(quantityString);
   }
@@ -136,7 +142,7 @@ export const toQuantity = (quantityString: string): Quantity => {
   const { unit, value } = getHumanizedSize(quantityString, 'withoutB');
 
   return { unit, value };
-};
+}
 
 export const quantityToString = ({ unit, value }: Quantity) =>
   `${value}${unit === 'B' ? '' : unit}`;

--- a/src/views/templates/details/tabs/details/components/CPUMemoryModal/CPUMemoryModal.tsx
+++ b/src/views/templates/details/tabs/details/components/CPUMemoryModal/CPUMemoryModal.tsx
@@ -82,10 +82,8 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({ isOpen, onClose, onSubmit, te
 
   useEffect(() => {
     if (vm?.metadata) {
-      const memoryQuantity = getMemory(vm);
-      const { unit: memUnit, value: memSize } = memoryQuantity
-        ? toQuantity(memoryQuantity)
-        : { unit: undefined, value: undefined };
+      const memoryQuantity = toQuantity(getMemory(vm));
+      const { unit: memUnit, value: memSize } = memoryQuantity ?? {};
       setMemoryUnit(memUnit);
       setMemory(memSize);
       setCPU(getCPU(vm));

--- a/src/views/templates/details/tabs/details/components/CPUMemoryModal/CPUMemoryModal.tsx
+++ b/src/views/templates/details/tabs/details/components/CPUMemoryModal/CPUMemoryModal.tsx
@@ -5,10 +5,10 @@ import { V1CPU } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import CPUInput from '@kubevirt-utils/components/CPUMemoryModal/components/CPUInput/CPUInput';
 import { getCPULimitsFromTemplate } from '@kubevirt-utils/components/CPUMemoryModal/components/CPUInput/utils/utils';
 import MemoryInput from '@kubevirt-utils/components/CPUMemoryModal/components/MemoryInput/MemoryInput';
-import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getTemplateVirtualMachineObject, Template } from '@kubevirt-utils/resources/template';
 import { getCPU, getMemory } from '@kubevirt-utils/resources/vm';
+import { toQuantity } from '@kubevirt-utils/utils/units';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 import {
   Alert,
@@ -82,7 +82,10 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({ isOpen, onClose, onSubmit, te
 
   useEffect(() => {
     if (vm?.metadata) {
-      const { size: memSize, unit: memUnit } = getMemorySize(getMemory(vm));
+      const memoryQuantity = getMemory(vm);
+      const { unit: memUnit, value: memSize } = memoryQuantity
+        ? toQuantity(memoryQuantity)
+        : { unit: undefined, value: undefined };
       setMemoryUnit(memUnit);
       setMemory(memSize);
       setCPU(getCPU(vm));

--- a/src/views/templates/details/tabs/details/components/CPUMemoryModal/utils.ts
+++ b/src/views/templates/details/tabs/details/components/CPUMemoryModal/utils.ts
@@ -11,10 +11,8 @@ type CPUMemoryValues = {
 export const getDefaultCPUMemoryValues = (template: Template): CPUMemoryValues => {
   const vmObject = getTemplateVirtualMachineObject(template);
   const defaultCPU = getCPU(vmObject);
-  const memoryQuantity = getMemory(vmObject);
-  const { unit, value } = memoryQuantity
-    ? toQuantity(memoryQuantity)
-    : { unit: undefined, value: undefined };
+  const memoryQuantity = toQuantity(getMemory(vmObject));
+  const { unit, value } = memoryQuantity ?? {};
 
   return {
     defaultCPU,

--- a/src/views/templates/details/tabs/details/components/CPUMemoryModal/utils.ts
+++ b/src/views/templates/details/tabs/details/components/CPUMemoryModal/utils.ts
@@ -1,7 +1,7 @@
 import { V1CPU } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
 import { getTemplateVirtualMachineObject, Template } from '@kubevirt-utils/resources/template';
 import { getCPU, getMemory } from '@kubevirt-utils/resources/vm';
+import { toQuantity } from '@kubevirt-utils/utils/units';
 
 type CPUMemoryValues = {
   defaultCPU: V1CPU;
@@ -11,8 +11,13 @@ type CPUMemoryValues = {
 export const getDefaultCPUMemoryValues = (template: Template): CPUMemoryValues => {
   const vmObject = getTemplateVirtualMachineObject(template);
   const defaultCPU = getCPU(vmObject);
-  const defaultMemory = getMemorySize(getMemory(vmObject));
-  const { size, unit } = defaultMemory;
+  const memoryQuantity = getMemory(vmObject);
+  const { unit, value } = memoryQuantity
+    ? toQuantity(memoryQuantity)
+    : { unit: undefined, value: undefined };
 
-  return { defaultCPU, defaultMemory: { defaultMemorySize: size, defaultMemoryUnit: unit } };
+  return {
+    defaultCPU,
+    defaultMemory: { defaultMemorySize: value, defaultMemoryUnit: unit },
+  };
 };

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
@@ -10,6 +10,7 @@ import useVMQueries from '@kubevirt-utils/hooks/useVMQueries';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getMemory } from '@kubevirt-utils/resources/vm';
 import { convertToBaseValue } from '@kubevirt-utils/utils/humanize.js';
+import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
@@ -51,7 +52,9 @@ const MemoryUtil: FC<MemoryUtilProps> = ({ vmi }) => {
       dataTestId="util-summary-memory"
       title={t('Memory')}
       usageValue={isReady ? xbytes(memoryUsed || 0, { fixed: 0, iec: true }) : ''}
-      usedOfTotalText={isReady ? t('Used of {{ total }}', { total: memory }) : ''}
+      usedOfTotalText={
+        isReady ? t('Used of {{ total }}', { total: readableSizeUnit(memory) }) : ''
+      }
     >
       <ComponentReady error={error} isLoading={isLoading} isReady={isReady}>
         <ChartDonutUtilization

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
@@ -1,15 +1,15 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import xbytes from 'xbytes';
 
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/SubTitleChartLabel';
 import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
 import ComponentReady from '@kubevirt-utils/components/Charts/ComponentReady/ComponentReady';
-import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useVMQueries from '@kubevirt-utils/hooks/useVMQueries';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getMemory } from '@kubevirt-utils/resources/vm';
+import { convertToBaseValue } from '@kubevirt-utils/utils/humanize.js';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
@@ -28,7 +28,7 @@ const MemoryUtil: FC<MemoryUtilProps> = ({ vmi }) => {
   const { currentTime } = useDuration();
 
   const queries = useVMQueries(vmi);
-  const memory = getMemorySize(getMemory(vmi));
+  const memory = getMemory(vmi);
 
   const [data, loaded, error] = useFleetPrometheusPoll({
     cluster: getCluster(vmi),
@@ -40,21 +40,23 @@ const MemoryUtil: FC<MemoryUtilProps> = ({ vmi }) => {
 
   const isLoading = !loaded;
   const memoryUsed = +data?.data?.result?.[0]?.value?.[1];
-  const memoryAvailableBytes = xbytes.parseSize(`${memory?.size} ${memory?.unit}B`);
-  const percentageMemoryUsed = (memoryUsed / memoryAvailableBytes) * 100;
-  const isReady = loaded && !isEmpty(memory) && !Number.isNaN(percentageMemoryUsed);
+  const memoryAvailableBytes = Number(convertToBaseValue(memory));
+  const hasMemoryCapacity = Number.isFinite(memoryAvailableBytes) && memoryAvailableBytes > 0;
+  const percentageMemoryUsed = hasMemoryCapacity ? (memoryUsed / memoryAvailableBytes) * 100 : NaN;
+  const isReady =
+    loaded && !isEmpty(memory) && hasMemoryCapacity && Number.isFinite(percentageMemoryUsed);
 
   return (
     <UtilizationBlock
-      usedOfTotalText={
-        isReady ? t('Used of {{ total }}', { total: `${memory?.size} ${memory?.unit}B` }) : ''
-      }
       dataTestId="util-summary-memory"
       title={t('Memory')}
       usageValue={isReady ? xbytes(memoryUsed || 0, { fixed: 0, iec: true }) : ''}
+      usedOfTotalText={isReady ? t('Used of {{ total }}', { total: memory }) : ''}
     >
       <ComponentReady error={error} isLoading={isLoading} isReady={isReady}>
         <ChartDonutUtilization
+          animate
+          constrainToVisibleArea
           data={{
             x: t('Memory used'),
             y: Number(percentageMemoryUsed?.toFixed(2)),
@@ -62,8 +64,6 @@ const MemoryUtil: FC<MemoryUtilProps> = ({ vmi }) => {
           labels={({ datum }) =>
             datum.x ? `${datum.x}: ${xbytes(memoryUsed || 0, { iec: true })}` : null
           }
-          animate
-          constrainToVisibleArea
           style={{ labels: { fontSize: 20 } }}
           subTitle={t('Used')}
           subTitleComponent={<SubTitleChartLabel y={135} />}

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/MemoryUtil/MemoryUtil.tsx
@@ -52,9 +52,7 @@ const MemoryUtil: FC<MemoryUtilProps> = ({ vmi }) => {
       dataTestId="util-summary-memory"
       title={t('Memory')}
       usageValue={isReady ? xbytes(memoryUsed || 0, { fixed: 0, iec: true }) : ''}
-      usedOfTotalText={
-        isReady ? t('Used of {{ total }}', { total: readableSizeUnit(memory) }) : ''
-      }
+      usedOfTotalText={isReady ? t('Used of {{ total }}', { total: readableSizeUnit(memory) }) : ''}
     >
       <ComponentReady error={error} isLoading={isLoading} isReady={isReady}>
         <ChartDonutUtilization

--- a/src/views/virtualmachines/list/metrics.ts
+++ b/src/views/virtualmachines/list/metrics.ts
@@ -1,11 +1,8 @@
-import xbytes from 'xbytes';
-
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { V1CPU } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
+import { V1CPU, V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
 import { getClusterKey, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getVCPUCount } from '@kubevirt-utils/resources/vm';
+import { convertToBaseValue } from '@kubevirt-utils/utils/humanize.js';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
 import { signal } from '@preact/signals-core';
@@ -86,14 +83,11 @@ export const getMemoryUsagePercentage = (vm: V1VirtualMachine, vmiMemory: string
 
   if (isEmpty(memoryUsage) || isEmpty(vmiMemory)) return;
 
-  const memoryRequested = getMemorySize(vmiMemory);
+  const memoryAvailableBytes = convertToBaseValue(vmiMemory);
 
-  const memoryAvailableBytes = xbytes.parseSize(
-    `${memoryRequested?.size} ${memoryRequested?.unit}B`,
-  );
+  if (!memoryAvailableBytes) return;
 
-  const percentage = (memoryUsage * 100) / memoryAvailableBytes;
-  return percentage;
+  return (memoryUsage * 100) / memoryAvailableBytes;
 };
 
 export const getNetworkUsagePercentage = (vm: V1VirtualMachine) => {

--- a/src/views/virtualmachines/list/tests/metrics.test.ts
+++ b/src/views/virtualmachines/list/tests/metrics.test.ts
@@ -1,6 +1,6 @@
-import { V1CPU, V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1CPU, type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
-import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
+import { type PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
 
 import {
   getCPUUsagePercentage,
@@ -30,7 +30,7 @@ const TWO_GIB_IN_BYTES = 2147483648;
 const ONE_MIB_IN_BYTES = 1048576;
 
 jest.mock('@kubevirt-utils/resources/shared', () => ({
-  getClusterKey: (obj: { cluster?: string }) => obj?.cluster || SINGLE_CLUSTER_KEY,
+  getClusterKey: (obj: { cluster?: string }) => obj?.cluster ?? SINGLE_CLUSTER_KEY,
   getName: (obj: { metadata?: { name?: string } }) => obj?.metadata?.name,
   getNamespace: (obj: { metadata?: { namespace?: string } }) => obj?.metadata?.namespace,
 }));
@@ -38,15 +38,7 @@ jest.mock('@kubevirt-utils/resources/shared', () => ({
 jest.mock('@kubevirt-utils/resources/vm', () => ({
   getVCPUCount: (cpu: V1CPU) => {
     if (!cpu) return 0;
-    return (cpu.sockets || 1) * (cpu.cores || 1) * (cpu.threads || 1);
-  },
-}));
-
-jest.mock('@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils', () => ({
-  getMemorySize: (memory: string) => {
-    if (!memory) return null;
-    const match = memory.match(/^(\d+)(\w+)$/);
-    return match ? { size: parseInt(match[1], 10), unit: match[2].replace('B', '') } : null;
+    return (cpu.sockets ?? 1) * (cpu.cores ?? 1) * (cpu.threads ?? 1);
   },
 }));
 
@@ -238,16 +230,52 @@ describe('VM Metrics', () => {
       );
 
       const vm = createMockVM({ name: 'mem-vm', namespace: 'mem-ns' });
-      expect(getMemoryUsagePercentage(vm, '4GiB')).toBeCloseTo(50, 0);
+      expect(getMemoryUsagePercentage(vm, '4Gi')).toBeCloseTo(50, 0);
+    });
+
+    it('should calculate memory usage percentage for Ki guest memory units', () => {
+      // 1953125Ki = 2000000000 bytes; half usage => 50%
+      setMetricFromResponse(
+        createMockPrometheusResponse([{ name: 'ki-vm', namespace: 'ki-ns', value: 1000000000 }]),
+        Metric.memoryUsage,
+      );
+
+      const vm = createMockVM({ name: 'ki-vm', namespace: 'ki-ns' });
+      expect(getMemoryUsagePercentage(vm, '1953125Ki')).toBeCloseTo(50, 0);
+    });
+
+    it('should calculate memory usage percentage for M guest memory units', () => {
+      // 1024M = 1024000000 bytes; half usage => 50%
+      setMetricFromResponse(
+        createMockPrometheusResponse([{ name: 'm-vm', namespace: 'm-ns', value: 512000000 }]),
+        Metric.memoryUsage,
+      );
+
+      const vm = createMockVM({ name: 'm-vm', namespace: 'm-ns' });
+      expect(getMemoryUsagePercentage(vm, '1024M')).toBeCloseTo(50, 0);
     });
 
     it('should return undefined when no memory data or invalid vmiMemory', () => {
       expect(
         getMemoryUsagePercentage(
           createMockVM({ name: 'no-mem-vm', namespace: 'no-mem-ns' }),
-          '8GiB',
+          '8Gi',
         ),
       ).toBeUndefined();
+    });
+
+    it('should return undefined for invalid or zero guest memory capacity', () => {
+      setMetricFromResponse(
+        createMockPrometheusResponse([
+          { name: 'bad-mem-vm', namespace: 'bad-mem-ns', value: ONE_GIB_IN_BYTES },
+        ]),
+        Metric.memoryUsage,
+      );
+
+      const vm = createMockVM({ name: 'bad-mem-vm', namespace: 'bad-mem-ns' });
+      expect(getMemoryUsagePercentage(vm, 'not-a-quantity')).toBeUndefined();
+      expect(getMemoryUsagePercentage(vm, '0Gi')).toBeUndefined();
+      expect(getMemoryUsagePercentage(vm, '0')).toBeUndefined();
     });
   });
 

--- a/src/views/virtualmachines/list/tests/metrics.test.ts
+++ b/src/views/virtualmachines/list/tests/metrics.test.ts
@@ -1,6 +1,6 @@
 import { type V1CPU, type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
 import { type PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
+import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
 
 import {
   getCPUUsagePercentage,
@@ -255,7 +255,7 @@ describe('VM Metrics', () => {
       expect(getMemoryUsagePercentage(vm, '1024M')).toBeCloseTo(50, 0);
     });
 
-    it('should return undefined when no memory data or invalid vmiMemory', () => {
+    it('should return undefined when no memory data', () => {
       expect(
         getMemoryUsagePercentage(
           createMockVM({ name: 'no-mem-vm', namespace: 'no-mem-ns' }),

--- a/src/views/virtualmachines/list/utils/processVMTotalsMetrics.ts
+++ b/src/views/virtualmachines/list/utils/processVMTotalsMetrics.ts
@@ -1,10 +1,7 @@
-import xbytes from 'xbytes';
-
 import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { getMemorySize } from '@kubevirt-utils/components/CPUMemoryModal/utils/CpuMemoryUtils';
 import { getCPU, getMemory, getVCPUCount } from '@kubevirt-utils/resources/vm';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
-import { humanizeCpuCores } from '@kubevirt-utils/utils/humanize.js';
+import { convertToBaseValue, humanizeCpuCores } from '@kubevirt-utils/utils/humanize.js';
 import { METRICS } from '@overview/OverviewTab/metric-charts-card/utils/constants';
 import {
   findUnit,
@@ -33,10 +30,7 @@ export const getCpuUsageText = (cpuUsage: number) => {
 
 export const getMemoryCapacityText = (vmis: V1VirtualMachineInstance[]) => {
   const bytes = vmis
-    .map((vmi) => {
-      const memorySize = getMemorySize(getMemory(vmi));
-      return xbytes.parseSize(`${memorySize?.size} ${memorySize?.unit}B`);
-    })
+    .map((vmi) => convertToBaseValue(getMemory(vmi)) || 0)
     .reduce((acc, cur) => acc + cur, 0);
 
   return getValueWithUnitText(bytes, METRICS.MEMORY);


### PR DESCRIPTION
## 📝 Description

Fixes inflated memory usage percentages on the Virtual Machines list (and related utilization charts) when guest memory uses Kubernetes units like `Ki` or `M`.

`getMemorySize` only recognized `Gi`/`Mi`/`Ti`, so other units were treated as empty and capacity was parsed as raw bytes. This change:
- Uses `convertToBaseValue` for percentage/capacity calculations
- Replaces `getMemorySize` with existing `toQuantity` in CPU/Memory modals
- Adds unit tests for `Ki` and `M` guest memory

## 🔗 Links

- https://issues.redhat.com/browse/CNV-92844

## 🎥 Demo
 calculation fix; verify on VM list with guest memory set to e.g. `1953125Ki` or `1024M` that Memory usage % is in a realistic 0–100% range.


**BEFORE**

<img width="669" height="452" alt="Screenshot 2026-08-04 at 19 45 21" src="https://github.com/user-attachments/assets/f783fa93-a1b9-48c0-ac69-65ee093025ff" />
<img width="1260" height="183" alt="Screenshot 2026-08-04 at 19 45 47" src="https://github.com/user-attachments/assets/4ff85ca6-37f8-4327-b38c-c4189d582187" />


**AFTER**

<img width="834" height="521" alt="Screenshot 2026-08-04 at 20 02 28" src="https://github.com/user-attachments/assets/55427236-46a2-4531-9e0b-8a106e1267c1" />
<img width="725" height="523" alt="Screenshot 2026-08-04 at 20 02 34" src="https://github.com/user-attachments/assets/0a505843-6eb8-4dde-8a5a-76dbafbdeaac" />
<img width="1273" height="227" alt="Screenshot 2026-08-04 at 20 02 46" src="https://github.com/user-attachments/assets/003a8a11-9a1b-4725-9431-4b2c2c402534" />


## Test plan

- [ ] Create/use a running VM with `memory.guest: 1953125Ki` and confirm list Memory usage % is realistic
- [ ] Create/use a running VM with `memory.guest: 1024M` and confirm list Memory usage % is realistic
- [ ] Confirm `Gi`/`Mi` VMs still show correct percentages
- [ ] Open CPU | Memory modal for a VM with `Ki`/`M` guest memory and confirm size/unit populate correctly
- [ ] `npm test -- --testPathPattern=metrics.test.ts --watchman=false`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory quantity parsing and conversion across VM details, templates, charts, metrics, and CPU/memory dialogs.
  * Improved handling of missing, invalid, or zero-capacity memory values to prevent calculation errors.
  * Updated memory usage percentages and total capacity calculations for supported units, including Ki, Mi, and Gi.
  * Improved consistency when displaying and initializing memory values.
  * Improved capacity and disk size input handling for empty values and maximum limits.

* **Tests**
  * Expanded coverage for supported memory units and invalid input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->