### PR TITLE
CNV-94565: Require CNV v5.0.0 fix version for PRs targeting main

### DIFF
--- a/.cursor/rules/agents/coverage-analyst.mdc
+++ b/.cursor/rules/agents/coverage-analyst.mdc
@@ -226,7 +226,7 @@ Map commits to routes by path (same path registry as above).
 ```bash
 BASE_JQL='project = CNV AND component = "CNV User Interface"'
 TYPE_FILTER='AND type IN (Story, Epic, "Feature Request")'
-VERSION_FILTER='AND fixVersion IN ("CNV v4.22.0", "CNV v4.23.0")'
+VERSION_FILTER='AND fixVersion IN ("CNV v5.0.0", "CNV v5.0.z")'
 KEYWORD='AND text ~ "<route-jql-keywords>"'
 ```
 

--- a/.github/scripts/src/version-compare.test.ts
+++ b/.github/scripts/src/version-compare.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  computeNextVersion,
+  getExpectedVersionForBranch,
+  MAIN_MIN_FIX_VERSION,
+} from './version-compare';
+
+describe('getExpectedVersionForBranch', () => {
+  it('returns the release version for release branches', () => {
+    assert.equal(getExpectedVersionForBranch('release-4.22', []), '4.22');
+    assert.equal(getExpectedVersionForBranch('release-5.0', ['release-4.22']), '5.0');
+  });
+
+  it('floors main at 5.0 when the highest release branch is still 4.x', () => {
+    assert.equal(MAIN_MIN_FIX_VERSION, '5.0');
+    assert.equal(computeNextVersion('4.22'), '4.23');
+    assert.equal(getExpectedVersionForBranch('main', ['release-4.21', 'release-4.22']), '5.0');
+  });
+
+  it('uses MAIN_MIN_FIX_VERSION when no release branches exist', () => {
+    assert.equal(getExpectedVersionForBranch('main', []), MAIN_MIN_FIX_VERSION);
+  });
+
+  it('uses the computed next version once release branches reach 5.x', () => {
+    assert.equal(getExpectedVersionForBranch('main', ['release-4.22', 'release-5.0']), '5.1');
+  });
+
+  it('returns null for non-main, non-release branches', () => {
+    assert.equal(getExpectedVersionForBranch('feature/foo', ['release-4.22']), null);
+  });
+});

--- a/.github/scripts/src/version-compare.ts
+++ b/.github/scripts/src/version-compare.ts
@@ -4,6 +4,13 @@ import { extractVersionNumber, parseVersionToNumber } from './version-parse';
 const RELEASE_BRANCH_REGEX = /^release-(\d+\.\d+)$/;
 const RELEASE_SUMMARY_PREFIX_REGEX = /^\[release-\d+\.\d+\]\s*/i;
 
+/**
+ * Minimum fix version accepted on `main` (matches Jira "CNV v5.0.0" → "5.0").
+ * Used as a floor when release-branch auto-detection still points at a 4.x next
+ * minor (e.g. highest branch is release-4.22 → computed 4.23) after a major bump.
+ */
+export const MAIN_MIN_FIX_VERSION = '5.0';
+
 /** Extract "4.21" from "release-4.21". Returns null for non-release branches. */
 export const extractVersionFromBranch = (branchName: string): null | string => {
   const match = RELEASE_BRANCH_REGEX.exec(branchName);
@@ -56,8 +63,13 @@ export const getExpectedVersionForBranch = (
 
   if (baseBranch === 'main') {
     const highest = findHighestReleaseBranchVersion(releaseBranches);
-    if (!highest) return null;
-    return computeNextVersion(highest);
+    const computed = highest ? computeNextVersion(highest) : null;
+    if (!computed) {
+      return MAIN_MIN_FIX_VERSION;
+    }
+    return parseVersionToNumber(computed) >= parseVersionToNumber(MAIN_MIN_FIX_VERSION)
+      ? computed
+      : MAIN_MIN_FIX_VERSION;
   }
 
   return null;


### PR DESCRIPTION
## 📝 Description

Floor Jira fix-version validation on `main` at **5.0** (`CNV v5.0.0`).

With the highest release branch still at `release-4.22`, auto-detection was deriving `4.23` for main. After the major bump, PRs to main should require fix version `>= 5.0`. Once a `release-5.0` branch exists, the computed next version (`5.1+`) takes over again.

Also updates the coverage-analyst Jira version filter to `CNV v5.0.0` / `CNV v5.0.z`.

## 🔗 Links

- Jira: https://redhat.atlassian.net/browse/CNV-94565

## Test plan

- [x] Unit tests for `getExpectedVersionForBranch` (`npm test` in `.github/scripts`)
- [ ] Open a PR to `main` with fix version `CNV v4.23.0` → Jira validation fails (below floor)
- [ ] Open a PR to `main` with fix version `CNV v5.0.0` → fix-version check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated enriched Jira reporting to use the current CNV 5.0 fix versions.
  * Ensured main-branch version calculations do not fall below version 5.0.

* **Tests**
  * Added coverage for release branches, minimum-version handling, 5.x version progression, empty release lists, and unrelated branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->