### PR TITLE
CNV-87423: fix /test-e2e spec-path and quoted -g filters

### DIFF
--- a/.github/scripts/src/commands/test-e2e-helpers.test.ts
+++ b/.github/scripts/src/commands/test-e2e-helpers.test.ts
@@ -30,6 +30,26 @@ describe('parseTestE2ECommand', () => {
     });
   });
 
+  it('parses filter-only commands without a suite (auto)', () => {
+    assert.deepEqual(
+      parseTestE2ECommand(
+        '/test-e2e playwright/tests/tier1/bootable-volumes/bootable-volumes.spec.ts',
+      ),
+      {
+        testArgs: 'playwright/tests/tier1/bootable-volumes/bootable-volumes.spec.ts',
+        testProject: 'auto',
+      },
+    );
+    assert.deepEqual(parseTestE2ECommand('/test-e2e -g "creates a bootable volume"'), {
+      testArgs: '-g "creates a bootable volume"',
+      testProject: 'auto',
+    });
+    assert.deepEqual(parseTestE2ECommand('/test-e2e auto -g "creates a bootable volume"'), {
+      testArgs: '-g "creates a bootable volume"',
+      testProject: 'auto',
+    });
+  });
+
   it('strips invisible bidi / zero-width marks from copied spec paths', () => {
     assert.deepEqual(
       parseTestE2ECommand('/test-e2e tier1 playwright/tests/tier1/foo.spec.ts\u200e'),
@@ -40,10 +60,13 @@ describe('parseTestE2ECommand', () => {
     );
   });
 
-  it('returns null for missing or unknown suites', () => {
+  it('returns null when suite/args are missing, and treats unknown first tokens as args', () => {
     assert.equal(parseTestE2ECommand('/test-e2e'), null);
-    assert.equal(parseTestE2ECommand('/test-e2e nope'), null);
     assert.equal(parseTestE2ECommand('/retest-e2e'), null);
+    assert.deepEqual(parseTestE2ECommand('/test-e2e nope'), {
+      testArgs: 'nope',
+      testProject: 'auto',
+    });
   });
 
   it('ignores surrounding comment text when the command is on its own line', () => {
@@ -58,6 +81,7 @@ describe('buildTestE2EReport', () => {
   it('warns for ad-hoc runs and omits the warning for unfiltered gating', () => {
     assert.match(buildTestE2EReport('o', 'r', 'tier1', ''), /does \*\*not\*\* update/);
     assert.match(buildTestE2EReport('o', 'r', 'gating', '-g Foo'), /does \*\*not\*\* update/);
+    assert.match(buildTestE2EReport('o', 'r', 'auto', 'foo.spec.ts'), /does \*\*not\*\* update/);
     assert.doesNotMatch(buildTestE2EReport('o', 'r', 'gating', ''), /does \*\*not\*\* update/);
   });
 });

--- a/.github/scripts/src/commands/test-e2e-helpers.test.ts
+++ b/.github/scripts/src/commands/test-e2e-helpers.test.ts
@@ -30,6 +30,18 @@ describe('parseTestE2ECommand', () => {
     });
   });
 
+  it('strips invisible bidi / zero-width marks from copied spec paths', () => {
+    assert.deepEqual(
+      parseTestE2ECommand(
+        '/test-e2e tier1 playwright/tests/tier1/foo.spec.ts\u200e',
+      ),
+      {
+        testArgs: 'playwright/tests/tier1/foo.spec.ts',
+        testProject: 'tier1',
+      },
+    );
+  });
+
   it('returns null for missing or unknown suites', () => {
     assert.equal(parseTestE2ECommand('/test-e2e'), null);
     assert.equal(parseTestE2ECommand('/test-e2e nope'), null);

--- a/.github/scripts/src/commands/test-e2e-helpers.test.ts
+++ b/.github/scripts/src/commands/test-e2e-helpers.test.ts
@@ -32,9 +32,7 @@ describe('parseTestE2ECommand', () => {
 
   it('strips invisible bidi / zero-width marks from copied spec paths', () => {
     assert.deepEqual(
-      parseTestE2ECommand(
-        '/test-e2e tier1 playwright/tests/tier1/foo.spec.ts\u200e',
-      ),
+      parseTestE2ECommand('/test-e2e tier1 playwright/tests/tier1/foo.spec.ts\u200e'),
       {
         testArgs: 'playwright/tests/tier1/foo.spec.ts',
         testProject: 'tier1',

--- a/.github/scripts/src/commands/test-e2e-helpers.ts
+++ b/.github/scripts/src/commands/test-e2e-helpers.ts
@@ -21,11 +21,15 @@ export type ParsedTestE2ECommand = {
   testProject: TestE2EProject;
 };
 
+/** Strip zero-width / bidi marks that GitHub or editors may inject into copied paths. */
+export const sanitizeTestE2EArg = (value: string): string =>
+  value.replace(/[\u200B-\u200F\u202A-\u202E\u2060\uFEFF]/g, '');
+
 /** Parse `/test-e2e <suite> [args…]` from a PR comment body (first matching line). */
 export const parseTestE2ECommand = (commentBody: string): null | ParsedTestE2ECommand => {
   const line = commentBody
     .split(/\r?\n/)
-    .map((entry) => entry.trim())
+    .map((entry) => sanitizeTestE2EArg(entry).trim())
     .find((entry) => entry.startsWith('/test-e2e'));
   if (!line) {
     return null;

--- a/.github/scripts/src/commands/test-e2e-helpers.ts
+++ b/.github/scripts/src/commands/test-e2e-helpers.ts
@@ -4,6 +4,7 @@ import { isRequiredGatingSuite } from '../shared/is-required-gating-suite';
 import { failStep, setOutput } from '../shared/output';
 
 export const VALID_TEST_E2E_PROJECTS = [
+  'auto',
   'gating',
   'tier1',
   'tier2',
@@ -25,7 +26,7 @@ export type ParsedTestE2ECommand = {
 export const sanitizeTestE2EArg = (value: string): string =>
   value.replace(/[\u200B-\u200F\u202A-\u202E\u2060\uFEFF]/g, '');
 
-/** Parse `/test-e2e <suite> [args…]` from a PR comment body (first matching line). */
+/** Parse `/test-e2e [suite] [args…]` from a PR comment body (first matching line). */
 export const parseTestE2ECommand = (commentBody: string): null | ParsedTestE2ECommand => {
   const line = commentBody
     .split(/\r?\n/)
@@ -35,19 +36,25 @@ export const parseTestE2ECommand = (commentBody: string): null | ParsedTestE2ECo
     return null;
   }
 
-  const [command, suite, ...argParts] = line.split(/\s+/);
-  if (command !== '/test-e2e' || !suite) {
+  const [command, ...tokens] = line.split(/\s+/);
+  if (command !== '/test-e2e' || tokens.length === 0) {
     return null;
   }
 
-  const testProject = suite.toLowerCase();
-  if (!(VALID_TEST_E2E_PROJECTS as readonly string[]).includes(testProject)) {
-    return null;
+  const [first, ...rest] = tokens;
+  const firstLower = first.toLowerCase();
+
+  if ((VALID_TEST_E2E_PROJECTS as readonly string[]).includes(firstLower)) {
+    return {
+      testArgs: rest.join(' '),
+      testProject: firstLower as TestE2EProject,
+    };
   }
 
+  // Suite omitted: treat everything as Playwright args with auto project
   return {
-    testArgs: argParts.join(' '),
-    testProject: testProject as TestE2EProject,
+    testArgs: tokens.join(' '),
+    testProject: 'auto',
   };
 };
 

--- a/.github/scripts/src/commands/test-e2e.ts
+++ b/.github/scripts/src/commands/test-e2e.ts
@@ -9,6 +9,7 @@
  *   /test-e2e suite
  *   /test-e2e tier1 playwright/tests/tier1/foo.spec.ts
  *   /test-e2e gating -g MyTestName
+ *   /test-e2e tier1 -g "VM Search Language"
  *
  * Entry point: npx tsx src/commands/test-e2e.ts
  *
@@ -65,6 +66,7 @@ const main = async (): Promise<void> => {
           '- `/test-e2e suite`',
           '- `/test-e2e tier1 playwright/tests/tier1/foo.spec.ts`',
           '- `/test-e2e gating -g MyTestName`',
+          '- `/test-e2e tier1 -g "VM Search Language"`',
         ].join('\n'),
         issue_number: prNumber,
         owner,

--- a/.github/scripts/src/commands/test-e2e.ts
+++ b/.github/scripts/src/commands/test-e2e.ts
@@ -8,7 +8,9 @@
  *   /test-e2e tier2
  *   /test-e2e suite
  *   /test-e2e tier1 playwright/tests/tier1/foo.spec.ts
+ *   /test-e2e playwright/tests/tier1/foo.spec.ts
  *   /test-e2e gating -g MyTestName
+ *   /test-e2e -g "creates a bootable volume"
  *   /test-e2e tier1 -g "VM Search Language"
  *
  * Entry point: npx tsx src/commands/test-e2e.ts
@@ -51,12 +53,15 @@ const main = async (): Promise<void> => {
     }
 
     const parsed = parseTestE2ECommand(commentBody);
-    if (!parsed) {
+    if (!parsed || (parsed.testProject === 'auto' && !parsed.testArgs.trim())) {
       await octokit.issues.createComment({
         body: [
-          '⚠️ `/test-e2e` needs a suite name.',
+          '⚠️ `/test-e2e` needs a suite name, or a Playwright filter (spec path / `-g`).',
           '',
-          'Usage: `/test-e2e <suite> [playwright-args…]`',
+          'Usage:',
+          '- `/test-e2e <suite> [playwright-args…]`',
+          '- `/test-e2e <spec-path>`',
+          '- `/test-e2e -g "test title"`',
           '',
           `Suites: \`${VALID_TEST_E2E_PROJECTS.join('` · `')}\``,
           '',
@@ -65,7 +70,9 @@ const main = async (): Promise<void> => {
           '- `/test-e2e tier2`',
           '- `/test-e2e suite`',
           '- `/test-e2e tier1 playwright/tests/tier1/foo.spec.ts`',
+          '- `/test-e2e playwright/tests/tier1/bootable-volumes/bootable-volumes.spec.ts`',
           '- `/test-e2e gating -g MyTestName`',
+          '- `/test-e2e -g "creates a bootable volume"`',
           '- `/test-e2e tier1 -g "VM Search Language"`',
         ].join('\n'),
         issue_number: prNumber,

--- a/.github/workflows/hot-cluster-e2e-run.yml
+++ b/.github/workflows/hot-cluster-e2e-run.yml
@@ -7,7 +7,8 @@ on:
       test_project:
         description: |
           Suite to run.
-          Playwright (main): gating / tier1 / tier2 / suite / settings / api / all.
+          Playwright (main): gating / tier1 / tier2 / suite / settings / api / all / auto.
+          auto omits --project and requires test_args (spec path or -g).
           Cypress (release only): gating or features (Cypress's Tier1 suite — not a Playwright project).
         required: true
         default: gating
@@ -21,10 +22,12 @@ on:
           - settings
           - api
           - all
+          - auto
       test_args:
         description: |
           Optional Playwright filter (space-separated CLI args), e.g. a spec path
-          or -g MyTestName. Leave empty to run the full selected suite.
+          or -g MyTestName. Required when test_project is auto.
+          Leave empty to run the full selected suite.
         required: false
         default: ''
         type: string

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -31,7 +31,7 @@ on:
       test_args:
         description: |
           Optional Playwright filter forwarded as CLI args (space-separated), e.g.
-          a spec path (playwright/tests/tier1/foo.spec.ts) or -g MyTestName.
+          a spec path (playwright/tests/tier1/foo.spec.ts) or -g "My Test Name".
           Leave empty to run the full selected suite.
         required: false
         default: ''

--- a/.github/workflows/hot-cluster-e2e.yml
+++ b/.github/workflows/hot-cluster-e2e.yml
@@ -13,7 +13,8 @@ on:
       test_project:
         description: |
           Suite to run.
-          Playwright (main): gating / tier1 / tier2 / suite / settings / api / all.
+          Playwright (main): gating / tier1 / tier2 / suite / settings / api / all / auto.
+          auto omits --project and requires test_args (spec path or -g).
           Cypress (release only): gating or features (Cypress's Tier1 suite — not a Playwright project).
           Default gating is the required PR check.
         required: true
@@ -28,11 +29,12 @@ on:
           - settings
           - api
           - all
+          - auto
       test_args:
         description: |
           Optional Playwright filter forwarded as CLI args (space-separated), e.g.
           a spec path (playwright/tests/tier1/foo.spec.ts) or -g "My Test Name".
-          Leave empty to run the full selected suite.
+          Required when test_project is auto. Leave empty to run the full selected suite.
         required: false
         default: ''
         type: string

--- a/ci-scripts/hot-cluster/ts/src/scripts/parse-test-args.test.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/parse-test-args.test.ts
@@ -22,9 +22,8 @@ describe('parseTestArgs', () => {
   });
 
   it('preserves spec paths and strips invisible bidi marks', () => {
-    assert.deepEqual(
-      parseTestArgs('playwright/tests/tier1/foo.spec.ts\u200e'),
-      ['playwright/tests/tier1/foo.spec.ts'],
-    );
+    assert.deepEqual(parseTestArgs('playwright/tests/tier1/foo.spec.ts\u200e'), [
+      'playwright/tests/tier1/foo.spec.ts',
+    ]);
   });
 });

--- a/ci-scripts/hot-cluster/ts/src/scripts/parse-test-args.test.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/parse-test-args.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { parseTestArgs } from './parse-test-args';
+
+describe('parseTestArgs', () => {
+  it('returns an empty list for blank input', () => {
+    assert.deepEqual(parseTestArgs(''), []);
+    assert.deepEqual(parseTestArgs('   '), []);
+  });
+
+  it('splits unquoted tokens on whitespace', () => {
+    assert.deepEqual(parseTestArgs('-g MyTest --workers=2'), ['-g', 'MyTest', '--workers=2']);
+  });
+
+  it('keeps double-quoted values with spaces as one token', () => {
+    assert.deepEqual(parseTestArgs('-g "search language"'), ['-g', 'search language']);
+  });
+
+  it('keeps single-quoted values with spaces as one token', () => {
+    assert.deepEqual(parseTestArgs("-g 'VM Search Language'"), ['-g', 'VM Search Language']);
+  });
+
+  it('preserves spec paths and strips invisible bidi marks', () => {
+    assert.deepEqual(
+      parseTestArgs('playwright/tests/tier1/foo.spec.ts\u200e'),
+      ['playwright/tests/tier1/foo.spec.ts'],
+    );
+  });
+});

--- a/ci-scripts/hot-cluster/ts/src/scripts/parse-test-args.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/parse-test-args.ts
@@ -1,0 +1,30 @@
+/** Strip zero-width / bidi marks that may ride along in TEST_ARGS from PR comments. */
+export const sanitizeTestArg = (value: string): string =>
+  value.replace(/[\u200B-\u200F\u202A-\u202E\u2060\uFEFF]/g, '');
+
+/**
+ * Split a TEST_ARGS string into argv tokens, respecting single/double quotes.
+ *
+ * Naive whitespace splits break `/test-e2e tier1 -g "search language"` into
+ * `['-g', '"search', 'language"']`, which Playwright then treats as a file filter.
+ */
+export const parseTestArgs = (raw: string): string[] => {
+  const trimmed = sanitizeTestArg(raw).trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  const args: string[] = [];
+  const tokenRe = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|(\S+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = tokenRe.exec(trimmed)) !== null) {
+    const token = match[1] ?? match[2] ?? match[3] ?? '';
+    // Unescape simple \" and \' inside quoted tokens.
+    const unescaped = token.replace(/\\(["'\\])/g, '$1');
+    const sanitized = sanitizeTestArg(unescaped);
+    if (sanitized) {
+      args.push(sanitized);
+    }
+  }
+  return args;
+};

--- a/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
@@ -10,6 +10,8 @@ import { execFileSync, execSync } from 'node:child_process';
 
 import { requireEnv } from '../utils';
 
+import { parseTestArgs } from './parse-test-args';
+
 /** Playwright (main) TEST_PROJECT → playwright-runner-hc-e2e.sh project name. */
 const PLAYWRIGHT_PROJECT_BY_TEST_PROJECT: Record<string, string> = {
   all: 'all',
@@ -25,18 +27,6 @@ const PLAYWRIGHT_PROJECT_BY_TEST_PROJECT: Record<string, string> = {
 const CYPRESS_TEST_PROJECTS: Record<string, string> = {
   features: 'tests/tier1.cy.ts',
   gating: 'tests/gating.cy.ts',
-};
-
-/** Strip zero-width / bidi marks that may ride along in TEST_ARGS from PR comments. */
-const sanitizeTestArg = (value: string): string =>
-  value.replace(/[\u200B-\u200F\u202A-\u202E\u2060\uFEFF]/g, '');
-
-const parseTestArgs = (raw: string): string[] => {
-  const trimmed = sanitizeTestArg(raw).trim();
-  if (!trimmed) {
-    return [];
-  }
-  return trimmed.split(/\s+/).map(sanitizeTestArg).filter(Boolean);
 };
 
 const resolvePlaywrightProject = (testProject: string): string => {

--- a/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
@@ -16,6 +16,7 @@ import { parseTestArgs } from './parse-test-args';
 const PLAYWRIGHT_PROJECT_BY_TEST_PROJECT: Record<string, string> = {
   all: 'all',
   api: 'API',
+  auto: 'auto',
   gating: 'Gating',
   settings: 'Settings',
   suite: 'suite',
@@ -81,9 +82,17 @@ const main = async (): Promise<void> => {
       process.env.GITHUB_WORKSPACE ??
       execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
     const playwrightProject = resolvePlaywrightProject(testProject);
+    if (playwrightProject === 'auto' && testArgs.length === 0) {
+      throw new Error(
+        "TEST_PROJECT 'auto' requires TEST_ARGS (spec path or -g filter). " +
+          'Omit auto and pick a suite to run an entire project.',
+      );
+    }
     console.log(
-      `Running Playwright project '${playwrightProject}'` +
-        (testArgs.length > 0 ? ` with args: ${testArgs.join(' ')}` : ''),
+      playwrightProject === 'auto'
+        ? `Running Playwright without --project filter with args: ${testArgs.join(' ')}`
+        : `Running Playwright project '${playwrightProject}'` +
+            (testArgs.length > 0 ? ` with args: ${testArgs.join(' ')}` : ''),
     );
     execFileSync('./playwright-runner-hc-e2e.sh', [playwrightProject, ...testArgs], {
       cwd: repoRoot,

--- a/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/run-gating-tests.ts
@@ -27,12 +27,16 @@ const CYPRESS_TEST_PROJECTS: Record<string, string> = {
   gating: 'tests/gating.cy.ts',
 };
 
+/** Strip zero-width / bidi marks that may ride along in TEST_ARGS from PR comments. */
+const sanitizeTestArg = (value: string): string =>
+  value.replace(/[\u200B-\u200F\u202A-\u202E\u2060\uFEFF]/g, '');
+
 const parseTestArgs = (raw: string): string[] => {
-  const trimmed = raw.trim();
+  const trimmed = sanitizeTestArg(raw).trim();
   if (!trimmed) {
     return [];
   }
-  return trimmed.split(/\s+/);
+  return trimmed.split(/\s+/).map(sanitizeTestArg).filter(Boolean);
 };
 
 const resolvePlaywrightProject = (testProject: string): string => {

--- a/playwright-runner-hc-e2e.sh
+++ b/playwright-runner-hc-e2e.sh
@@ -21,12 +21,15 @@
 #   ./playwright-runner-hc-e2e.sh Gating --workers=4
 #   ./playwright-runner-hc-e2e.sh Tier1
 #   ./playwright-runner-hc-e2e.sh Tier2 playwright/tests/tier2/foo.spec.ts
+#   ./playwright-runner-hc-e2e.sh auto playwright/tests/tier1/foo.spec.ts
+#   ./playwright-runner-hc-e2e.sh auto -g "creates a bootable volume"
 #   IS_LOCAL=1 ./playwright-runner-hc-e2e.sh Gating --headed
 #   ./playwright-runner-hc-e2e.sh suite
 #   ./playwright-runner-hc-e2e.sh all
 #
 # Note: --project=Name (equals form) is required so Playwright's variadic
 # --project option does not swallow file-path / -g filter args.
+# Use project "auto" to omit --project (filter by path / -g across projects).
 # ────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
@@ -78,6 +81,7 @@ if [[ -z "${PROJECT}" ]]; then
   echo "  API                    API contract tests (browserless)"
   echo "  suite                  Run Gating + Tier1 + Tier2 together"
   echo "  all                    Run all projects"
+  echo "  auto                   No --project filter (requires path / -g args)"
   echo ""
   echo "Extra args are forwarded to Playwright (file paths, -g, --workers, …)."
   echo ""
@@ -105,15 +109,13 @@ EXTRA_ARGS=("$@")
 
 PROJECT_LOWER=$(echo "${PROJECT}" | tr '[:upper:]' '[:lower:]')
 
-if [[ "${PROJECT_LOWER}" == "gating" ]]; then
-  echo "🚀 Running project: Gating (HC E2E mode)..."
-  npx playwright test --project=Gating "${EXTRA_ARGS[@]}"
-elif [[ "${PROJECT_LOWER}" == "tier1" ]]; then
-  echo "🚀 Running project: Tier1 (HC E2E mode)..."
-  npx playwright test --project=Tier1 "${EXTRA_ARGS[@]}"
-elif [[ "${PROJECT_LOWER}" == "tier2" ]]; then
-  echo "🚀 Running project: Tier2 (HC E2E mode)..."
-  npx playwright test --project=Tier2 "${EXTRA_ARGS[@]}"
+if [[ "${PROJECT_LOWER}" == "auto" ]]; then
+  if [[ ${#EXTRA_ARGS[@]} -eq 0 ]]; then
+    echo "❌ Project 'auto' requires Playwright filter args (spec path or -g)."
+    exit 1
+  fi
+  echo "🚀 Running Playwright without --project filter (HC E2E mode)..."
+  npx playwright test "${EXTRA_ARGS[@]}"
 elif [[ "${PROJECT_LOWER}" == "suite" ]]; then
   echo "🚀 Running suite: Gating + Tier1 + Tier2 (HC E2E mode)..."
   npx playwright test --project=Gating --project=Tier1 --project=Tier2 "${EXTRA_ARGS[@]}"

--- a/playwright-runner-hc-e2e.sh
+++ b/playwright-runner-hc-e2e.sh
@@ -24,6 +24,9 @@
 #   IS_LOCAL=1 ./playwright-runner-hc-e2e.sh Gating --headed
 #   ./playwright-runner-hc-e2e.sh suite
 #   ./playwright-runner-hc-e2e.sh all
+#
+# Note: --project=Name (equals form) is required so Playwright's variadic
+# --project option does not swallow file-path / -g filter args.
 # ────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
@@ -104,16 +107,16 @@ PROJECT_LOWER=$(echo "${PROJECT}" | tr '[:upper:]' '[:lower:]')
 
 if [[ "${PROJECT_LOWER}" == "gating" ]]; then
   echo "🚀 Running project: Gating (HC E2E mode)..."
-  npx playwright test --project Gating "${EXTRA_ARGS[@]}"
+  npx playwright test --project=Gating "${EXTRA_ARGS[@]}"
 elif [[ "${PROJECT_LOWER}" == "tier1" ]]; then
   echo "🚀 Running project: Tier1 (HC E2E mode)..."
-  npx playwright test --project Tier1 "${EXTRA_ARGS[@]}"
+  npx playwright test --project=Tier1 "${EXTRA_ARGS[@]}"
 elif [[ "${PROJECT_LOWER}" == "tier2" ]]; then
   echo "🚀 Running project: Tier2 (HC E2E mode)..."
-  npx playwright test --project Tier2 "${EXTRA_ARGS[@]}"
+  npx playwright test --project=Tier2 "${EXTRA_ARGS[@]}"
 elif [[ "${PROJECT_LOWER}" == "suite" ]]; then
   echo "🚀 Running suite: Gating + Tier1 + Tier2 (HC E2E mode)..."
-  npx playwright test --project Gating --project Tier1 --project Tier2 "${EXTRA_ARGS[@]}"
+  npx playwright test --project=Gating --project=Tier1 --project=Tier2 "${EXTRA_ARGS[@]}"
 elif [[ "${PROJECT_LOWER}" == "all" ]]; then
   PROJECTS=(
     Gating
@@ -124,11 +127,11 @@ elif [[ "${PROJECT_LOWER}" == "all" ]]; then
   )
   PROJECT_ARGS=()
   for p in "${PROJECTS[@]}"; do
-    PROJECT_ARGS+=(--project "${p}")
+    PROJECT_ARGS+=(--project="${p}")
   done
   echo "🚀 Running all projects (HC E2E mode)..."
   npx playwright test "${PROJECT_ARGS[@]}" "${EXTRA_ARGS[@]}"
 else
   echo "🚀 Running project: ${PROJECT} (HC E2E mode)..."
-  npx playwright test --project "${PROJECT}" "${EXTRA_ARGS[@]}"
+  npx playwright test --project="${PROJECT}" "${EXTRA_ARGS[@]}"
 fi

--- a/playwright-runner.sh
+++ b/playwright-runner.sh
@@ -8,7 +8,11 @@
 # Examples:
 #   ./playwright-runner.sh Gating
 #   ./playwright-runner.sh suite --workers=4
+#   ./playwright-runner.sh Tier1 playwright/tests/tier1/foo.spec.ts
 #   ./playwright-runner.sh all
+#
+# Note: --project=Name (equals form) is required so Playwright's variadic
+# --project option does not swallow file-path / -g filter args.
 # ────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
@@ -73,7 +77,7 @@ PROJECT_LOWER=$(echo "${PROJECT}" | tr '[:upper:]' '[:lower:]')
 
 if [[ "${PROJECT_LOWER}" == "suite" ]]; then
   echo "🚀 Running suite: Gating + Tier1 + Tier2..."
-  npx playwright test --project Gating --project Tier1 --project Tier2 "${EXTRA_ARGS[@]}"
+  npx playwright test --project=Gating --project=Tier1 --project=Tier2 "${EXTRA_ARGS[@]}"
 elif [[ "${PROJECT_LOWER}" == "all" ]]; then
   PROJECTS=(
     Gating
@@ -84,11 +88,11 @@ elif [[ "${PROJECT_LOWER}" == "all" ]]; then
   )
   PROJECT_ARGS=()
   for p in "${PROJECTS[@]}"; do
-    PROJECT_ARGS+=(--project "${p}")
+    PROJECT_ARGS+=(--project="${p}")
   done
   echo "🚀 Running all projects..."
   npx playwright test "${PROJECT_ARGS[@]}" "${EXTRA_ARGS[@]}"
 else
   echo "🚀 Running project: ${PROJECT}..."
-  npx playwright test --project "${PROJECT}" "${EXTRA_ARGS[@]}"
+  npx playwright test --project="${PROJECT}" "${EXTRA_ARGS[@]}"
 fi


### PR DESCRIPTION
## 📝 Description

Fixes two `/test-e2e` filter bugs that made ad-hoc Hot Cluster E2E runs fail before tests could execute.

### 1. Spec-path filters broken by variadic `--project`

Playwright's `--project` option is variadic (`--project <project-name...>`). Space-separated form like `--project Tier1 <spec>` treated the spec path as another project name:

```text
Error: Project(s) "playwright/tests/.../foo.spec.ts" not found.
```

**Fix:** use `--project=Name` in `playwright-runner-hc-e2e.sh` and `playwright-runner.sh`.

### 2. Quoted `-g` filters broken by whitespace splitting

`TEST_ARGS` was split on whitespace only, so:

```text
/test-e2e tier1 -g "search language"
```

became `['-g', '"search', 'language"']`. Playwright then treated `language"` as a file filter:

```text
Error: No tests found.
Make sure that arguments are regular expressions matching test files.
```

**Fix:** quote-aware `parseTestArgs` (single/double quotes) in the HC E2E runner.

### Also

- Strip invisible bidi/zero-width marks from `/test-e2e` comment args and `TEST_ARGS` (GitHub copy/paste can inject U+200E)

### After merge, these work

```text
/test-e2e tier1 playwright/tests/tier1/virtualmachines/vm-search/vm-search-language.spec.ts
/test-e2e tier1 -g "Search Language"
```

## 🔗 Links

Follow-up fix for #4512 (`/test-e2e` suites).

Failures on #4517:
- Spec path: https://github.com/kubevirt-ui/kubevirt-plugin/actions/runs/30941665650
- Quoted `-g`: https://github.com/kubevirt-ui/kubevirt-plugin/actions/runs/30945717542

## 🎥 Demo

N/A (CI runner / PR command plumbing)

## Test plan

- [x] Helper unit tests pass (`test-e2e-helpers.test.ts`)
- [x] `parseTestArgs` unit tests pass (quoted / unquoted / bidi marks)
- [x] Local CLI: `npx playwright test --project=Tier1 <spec> --list` lists only that file
- [ ] After merge, on a PR:
  - `/test-e2e tier1 playwright/tests/tier1/.../some.spec.ts` runs that file (not "Project(s) ... not found")
  - `/test-e2e tier1 -g "Search Language"` greps by title (not "No tests found" from a broken file filter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic Playwright mode for running filtered tests without specifying a project.
  * Added support for suite-less commands using spec paths or test-name filters.

* **Bug Fixes**
  * Removed invisible Unicode characters from copied paths and arguments.
  * Improved handling of quoted, whitespace-separated, and empty test arguments.
  * Rejected incomplete automatic-mode commands before execution.

* **Documentation**
  * Clarified project argument syntax, automatic-mode requirements, quoting, and filtering examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->