### PR TITLE
CNV-90308: Add minimizable to upload toasts, cancel in-progress uploads when clearing upload toasts from notifications 

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,9 @@ allow-git=none
 
 min-release-age-exclude[]=@kubevirt-ui-ext/kubevirt-api
 min-release-age-exclude[]=@forklift-ui/types
+min-release-age-exclude[]=@openshift-console/dynamic-plugin-sdk
+min-release-age-exclude[]=@openshift-console/dynamic-plugin-sdk-webpack
+min-release-age-exclude[]=@openshift-console/dynamic-plugin-sdk-internal
+min-release-age-exclude[]=@openshift/dynamic-plugin-sdk
+min-release-age-exclude[]=@openshift/dynamic-plugin-sdk-webpack
+min-release-age-exclude[]=@openshift/api-types

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "react-hook-form": "^7.31.2",
         "react-i18next": "~16.5.8",
         "react-joyride": "^2.9.3",
-        "react-router": "~7.13.1",
+        "react-router": "~7.18.1",
         "react-tagsinput": "^3.19.0",
         "react-use-websocket": "^4.3.1",
         "typesafe-actions": "5.1.0",
@@ -79,7 +79,7 @@
         "@eslint-react/eslint-plugin": "^5.9.0",
         "@octokit/graphql": "^9.0.3",
         "@octokit/rest": "^21.1.1",
-        "@openshift-console/dynamic-plugin-sdk": "4.23.0-prerelease.4",
+        "@openshift-console/dynamic-plugin-sdk": "4.23.0-prerelease.5",
         "@openshift-console/dynamic-plugin-sdk-internal": "4.23.0-prerelease.4",
         "@openshift-console/dynamic-plugin-sdk-webpack": "4.23.0-prerelease.4",
         "@playwright/test": "^1.59.1",
@@ -5137,13 +5137,13 @@
       }
     },
     "node_modules/@openshift-console/dynamic-plugin-sdk": {
-      "version": "4.23.0-prerelease.4",
-      "resolved": "https://registry.npmjs.org/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-4.23.0-prerelease.4.tgz",
-      "integrity": "sha512-thAjE3HDeitqezDPhBiUnJHv2wtUffG4qVMBnSX99cssvuJrEAcRhc9yVtdHtCpX3eUGWSX0s2vGby55tAoZJg==",
+      "version": "4.23.0-prerelease.5",
+      "resolved": "https://registry.npmjs.org/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-4.23.0-prerelease.5.tgz",
+      "integrity": "sha512-KirTTBWjOsJ6HXZiynilddErX8bnPT8OWUCYah2KZG42oOHF7Yp+Hx+uEbxP5KR4ZrdTXfs60OrDyXzeelaPig==",
       "license": "Apache-2.0",
       "dependencies": {
         "@openshift/api-types": "^1.0.0",
-        "@openshift/dynamic-plugin-sdk": "^8.0.0",
+        "@openshift/dynamic-plugin-sdk": "^9.1.0",
         "immutable": "^3.8.3",
         "lodash": "^4.18.1",
         "reselect": "^5.1.1",
@@ -5154,7 +5154,7 @@
         "react": "^18.3.1",
         "react-i18next": "~16.5.8",
         "react-redux": "~9.2.0",
-        "react-router": "~7.13.1",
+        "react-router": "~7.18.1",
         "redux": "~5.0.1",
         "redux-thunk": "~3.1.0"
       },
@@ -5225,6 +5225,41 @@
         }
       }
     },
+    "node_modules/@openshift-console/dynamic-plugin-sdk/node_modules/@openshift/dynamic-plugin-sdk": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-9.1.0.tgz",
+      "integrity": "sha512-R6nkUuWXGy7GpYUurV94ahahI4/JBMW6DGC3B3vGl+mmc8R23uaDCAGCDGfj3SeCIIxrVSEtIV21ncvziEEpXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.17.23",
+        "semver": "^7.7.3",
+        "zod": "^3.25.67"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@openshift-console/dynamic-plugin-sdk/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@openshift-console/dynamic-plugin-sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@openshift/api-types": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@openshift/api-types/-/api-types-1.0.0.tgz",
@@ -5235,6 +5270,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-8.2.0.tgz",
       "integrity": "sha512-HKt8ILsf4+He+XqhIZI1PU7Xm+orA03WoVSQDYZdfpYByJbc8JxmBmv5u0Z8RZG0bg+EkCzicKvU91manNP2fQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.23",
@@ -5300,6 +5336,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -22332,6 +22369,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
       "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -22825,9 +22863,9 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
-      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -25276,6 +25314,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
       "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tiny-invariant": {
@@ -25396,6 +25435,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tr46": {
@@ -26061,6 +26101,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -27486,6 +27527,7 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/yup/-/yup-1.7.1.tgz",
       "integrity": "sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "property-expr": "^2.0.5",
@@ -27498,6 +27540,7 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=12.20"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-hook-form": "^7.31.2",
     "react-i18next": "~16.5.8",
     "react-joyride": "^2.9.3",
-    "react-router": "~7.13.1",
+    "react-router": "~7.18.1",
     "react-tagsinput": "^3.19.0",
     "react-use-websocket": "^4.3.1",
     "typesafe-actions": "5.1.0",
@@ -70,7 +70,7 @@
     "@eslint-react/eslint-plugin": "^5.9.0",
     "@octokit/graphql": "^9.0.3",
     "@octokit/rest": "^21.1.1",
-    "@openshift-console/dynamic-plugin-sdk": "4.23.0-prerelease.4",
+    "@openshift-console/dynamic-plugin-sdk": "4.23.0-prerelease.5",
     "@openshift-console/dynamic-plugin-sdk-internal": "4.23.0-prerelease.4",
     "@openshift-console/dynamic-plugin-sdk-webpack": "4.23.0-prerelease.4",
     "@playwright/test": "^1.59.1",
@@ -145,7 +145,7 @@
   "name": "kubevirt-plugin",
   "overrides": {
     "@stolostron/multicluster-sdk": {
-      "@openshift-console/dynamic-plugin-sdk": "4.23.0-prerelease.4",
+      "@openshift-console/dynamic-plugin-sdk": "4.23.0-prerelease.5",
       "react-i18next": "~16.5.8"
     },
     "delaunator": "4.0.1"

--- a/src/utils/components/DiskModal/utils/helpers.test.ts
+++ b/src/utils/components/DiskModal/utils/helpers.test.ts
@@ -117,4 +117,67 @@ describe('createEjectMountedDiskCancelCleanup / createDetachDiskCancelCleanup', 
       expect(patchedVM.spec.template.spec.volumes).toEqual([]);
     });
   });
+
+  describe('cancelling multiple disks on the same VM at once (e.g. "Clear all")', () => {
+    it('serializes the fetch+patch cycles instead of racing on a stale VM read', async () => {
+      const secondCdromName = 'cdrom-2';
+      const vmWithTwoCdroms = (): V1VirtualMachine => ({
+        metadata: { name: 'test-vm', namespace: 'test-ns' },
+        spec: {
+          template: {
+            spec: {
+              domain: {
+                devices: {
+                  disks: [
+                    { cdrom: {}, name: cdromName },
+                    { cdrom: {}, name: secondCdromName },
+                  ],
+                },
+              },
+              volumes: [
+                { dataVolume: { name: 'dv-1' }, name: cdromName },
+                { dataVolume: { name: 'dv-2' }, name: secondCdromName },
+              ],
+            },
+          },
+        },
+      });
+
+      let resolveFirstGet: (vm: V1VirtualMachine) => void = () => undefined;
+      mockKubevirtK8sGet.mockImplementationOnce(
+        () =>
+          new Promise<V1VirtualMachine>((resolve) => {
+            resolveFirstGet = resolve;
+          }),
+      );
+
+      const firstCleanup = createEjectMountedDiskCancelCleanup(vmWithTwoCdroms(), cdromName);
+      const secondCleanup = createEjectMountedDiskCancelCleanup(vmWithTwoCdroms(), secondCdromName);
+
+      const firstDone = firstCleanup();
+      const secondDone = secondCleanup();
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The second cleanup must not fetch the VM until the first has fully patched it,
+      // otherwise it would read stale data and overwrite the first cleanup's changes.
+      expect(mockKubevirtK8sGet).toHaveBeenCalledTimes(1);
+
+      resolveFirstGet(vmWithTwoCdroms());
+      await firstDone;
+
+      mockKubevirtK8sGet.mockResolvedValueOnce(mockUpdateDisks.mock.calls[0][0]);
+      await secondDone;
+
+      expect(mockKubevirtK8sGet).toHaveBeenCalledTimes(2);
+      expect(mockUpdateDisks).toHaveBeenCalledTimes(2);
+
+      const finalPatchedVM = mockUpdateDisks.mock.calls[1][0] as V1VirtualMachine;
+      // Both CD-ROMs must be ejected (volumes removed) in the final patch — the first
+      // cleanup's eject was not clobbered by the second cleanup's stale read.
+      expect(finalPatchedVM.spec.template.spec.volumes).toEqual([]);
+      expect(finalPatchedVM.spec.template.spec.domain.devices.disks).toHaveLength(2);
+    });
+  });
 });

--- a/src/utils/components/DiskModal/utils/helpers.ts
+++ b/src/utils/components/DiskModal/utils/helpers.ts
@@ -38,6 +38,7 @@ import { updateDisks } from '@virtualmachines/details/tabs/configuration/details
 
 import { HotPlugFeatures } from './constants';
 import { BuildUploadTrackMetadataParams, SourceTypes, V1DiskFormState } from './types';
+import { runExclusiveForVm } from './vmCancelCleanupQueue';
 
 export const getEmptyVMDataVolumeResource = (
   vm: V1VirtualMachine,
@@ -47,7 +48,7 @@ export const getEmptyVMDataVolumeResource = (
   // (has a resourceVersion, which indicates it's been persisted)
   // Setting ownerReference to a non-existent VM causes immediate garbage collection
   const shouldSetOwnerRef =
-    createOwnerReference === true && vm?.metadata?.uid && vm?.metadata?.resourceVersion;
+    createOwnerReference === true && getUID(vm) && vm?.metadata?.resourceVersion;
 
   return {
     apiVersion: `${DataVolumeModel.apiGroup}/${DataVolumeModel.apiVersion}`,
@@ -55,7 +56,7 @@ export const getEmptyVMDataVolumeResource = (
     kind: DataVolumeModel.kind,
     metadata: {
       name: '',
-      namespace: vm?.metadata?.namespace,
+      namespace: getNamespace(vm),
       ...(shouldSetOwnerRef
         ? { ownerReferences: [buildOwnerReference(vm, { blockOwnerDeletion: false })] }
         : {}),
@@ -403,6 +404,15 @@ export const detachDiskFromVM = (vm: V1VirtualMachine, diskName: string): V1Virt
   });
 };
 
+const CUSTOMIZE_WIZARD_DRAFT_QUEUE_KEY = 'customize-wizard-draft';
+
+// All disk cancel-cleanups for the same VM must run one at a time (see runExclusiveForVm),
+// since each one reads the VM, transforms it, and patches it back.
+const getVmCancelCleanupQueueKey = (vm: V1VirtualMachine): string =>
+  getCustomizeWizardVM()
+    ? CUSTOMIZE_WIZARD_DRAFT_QUEUE_KEY
+    : `${getCluster(vm) ?? ''}/${getNamespace(vm) ?? ''}/${getName(vm) ?? ''}`;
+
 // If the VM only exists as an in-memory draft (the creation wizard), the wizard signal is
 // the live source of truth: patch it instead of re-fetching from the cluster, since the
 // draft VM has never been persisted and kubevirtK8sGet would fail.
@@ -412,22 +422,23 @@ const createDiskCancelCleanup =
     diskName: string,
     transform: (vm: V1VirtualMachine, name: string) => V1VirtualMachine,
   ): (() => Promise<void>) =>
-  async () => {
-    const draftVM = getCustomizeWizardVM();
+  () =>
+    runExclusiveForVm(getVmCancelCleanupQueueKey(vm), async () => {
+      const draftVM = getCustomizeWizardVM();
 
-    if (draftVM) {
-      await updateVMCustomizeIT(transform(draftVM, diskName));
-      return;
-    }
+      if (draftVM) {
+        await updateVMCustomizeIT(transform(draftVM, diskName));
+        return;
+      }
 
-    const freshVM = await kubevirtK8sGet<V1VirtualMachine>({
-      cluster: getCluster(vm),
-      model: VirtualMachineModel,
-      name: getName(vm),
-      ns: getNamespace(vm),
+      const freshVM = await kubevirtK8sGet<V1VirtualMachine>({
+        cluster: getCluster(vm),
+        model: VirtualMachineModel,
+        name: getName(vm),
+        ns: getNamespace(vm),
+      });
+      await updateDisks(transform(freshVM, diskName));
     });
-    await updateDisks(transform(freshVM, diskName));
-  };
 
 export const createEjectMountedDiskCancelCleanup = (
   vm: V1VirtualMachine,

--- a/src/utils/components/DiskModal/utils/vmCancelCleanupQueue.test.ts
+++ b/src/utils/components/DiskModal/utils/vmCancelCleanupQueue.test.ts
@@ -1,0 +1,115 @@
+import { runExclusiveForVm } from './vmCancelCleanupQueue';
+
+const flushMicrotasks = () => Promise.resolve();
+
+describe('runExclusiveForVm', () => {
+  it('runs tasks for the same key sequentially, one at a time', async () => {
+    const order: string[] = [];
+    let resolveFirst: () => void = () => undefined;
+
+    const first = runExclusiveForVm('sequential-key', async () => {
+      order.push('first-start');
+      await new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+      });
+      order.push('first-end');
+    });
+
+    const second = runExclusiveForVm('sequential-key', async () => {
+      order.push('second-start');
+    });
+
+    await flushMicrotasks();
+    // The second task must not have started yet: the first is still pending.
+    expect(order).toEqual(['first-start']);
+
+    resolveFirst();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(['first-start', 'first-end', 'second-start']);
+  });
+
+  it('runs tasks for different keys independently', async () => {
+    const order: string[] = [];
+    let resolveA: () => void = () => undefined;
+
+    const taskA = runExclusiveForVm('independent-key-a', async () => {
+      order.push('a-start');
+      await new Promise<void>((resolve) => {
+        resolveA = resolve;
+      });
+      order.push('a-end');
+    });
+
+    const taskB = runExclusiveForVm('independent-key-b', async () => {
+      order.push('b-start');
+    });
+
+    await taskB;
+
+    // taskB (a different key) completed while taskA is still pending.
+    expect(order).toContain('a-start');
+    expect(order).toContain('b-start');
+    expect(order).not.toContain('a-end');
+
+    resolveA();
+    await taskA;
+    expect(order).toContain('a-end');
+  });
+
+  it('continues running queued tasks even if an earlier task rejects', async () => {
+    const order: string[] = [];
+
+    const first = runExclusiveForVm('rejecting-key', async () => {
+      order.push('first');
+      throw new Error('boom');
+    });
+
+    const second = runExclusiveForVm('rejecting-key', async () => {
+      order.push('second');
+    });
+
+    await expect(first).rejects.toThrow('boom');
+    await expect(second).resolves.toBeUndefined();
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('propagates each task result to its own caller', async () => {
+    const succeeded = runExclusiveForVm('propagate-key', async () => undefined);
+    const failed = runExclusiveForVm('propagate-key', async () => {
+      throw new Error('fail');
+    });
+
+    await expect(succeeded).resolves.toBeUndefined();
+    await expect(failed).rejects.toThrow('fail');
+  });
+
+  it('serializes more than two tasks queued on the same key', async () => {
+    const order: string[] = [];
+    let resolveFirst: () => void = () => undefined;
+
+    const first = runExclusiveForVm('three-key', async () => {
+      order.push('1-start');
+      await new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+      });
+      order.push('1-end');
+    });
+
+    const second = runExclusiveForVm('three-key', async () => {
+      order.push('2');
+    });
+
+    const third = runExclusiveForVm('three-key', async () => {
+      order.push('3');
+    });
+
+    await flushMicrotasks();
+    expect(order).toEqual(['1-start']);
+
+    resolveFirst();
+    await Promise.all([first, second, third]);
+
+    expect(order).toEqual(['1-start', '1-end', '2', '3']);
+  });
+});

--- a/src/utils/components/DiskModal/utils/vmCancelCleanupQueue.ts
+++ b/src/utils/components/DiskModal/utils/vmCancelCleanupQueue.ts
@@ -1,0 +1,27 @@
+// Disk cleanups do a read-modify-write on the VM (fetch, transform, patch), so running
+// several concurrently for the same VM (e.g. "Clear all") races and silently drops changes.
+// Chaining them per VM key ensures each one reads the VM only after the previous patch applied.
+const vmCancelCleanupQueues = new Map<string, Promise<void>>();
+
+export const runExclusiveForVm = (vmKey: string, task: () => Promise<void>): Promise<void> => {
+  const previous = vmCancelCleanupQueues.get(vmKey) ?? Promise.resolve();
+  const settled = previous.then(
+    () => task(),
+    () => task(),
+  );
+
+  const chained = settled.then(
+    () => undefined,
+    () => undefined,
+  );
+
+  vmCancelCleanupQueues.set(vmKey, chained);
+
+  chained.then(() => {
+    if (vmCancelCleanupQueues.get(vmKey) === chained) {
+      vmCancelCleanupQueues.delete(vmKey);
+    }
+  });
+
+  return settled;
+};

--- a/src/utils/hooks/useUploadProgressToast/UploadProgressToastListener.tsx
+++ b/src/utils/hooks/useUploadProgressToast/UploadProgressToastListener.tsx
@@ -14,6 +14,7 @@ const UploadProgressToastListener: FC = () => {
   const { addDangerToast, addInfoToast, addSuccessToast, addWarningToast, removeToast } =
     useKubevirtToast();
   const uploads = useUploadProgressStore((state) => state.uploads);
+  const cancelTrackedUpload = useUploadProgressStore((state) => state.cancelTrackedUpload);
   const tryMarkTerminalToastShown = useUploadProgressStore(
     (state) => state.tryMarkTerminalToastShown,
   );
@@ -39,6 +40,7 @@ const UploadProgressToastListener: FC = () => {
         addInfoToast,
         addSuccessToast,
         addWarningToast,
+        cancelTrackedUpload,
         navigate,
         removeToast,
         removeUpload,
@@ -55,6 +57,7 @@ const UploadProgressToastListener: FC = () => {
     addInfoToast,
     addSuccessToast,
     addWarningToast,
+    cancelTrackedUpload,
     navigate,
     removeToast,
     removeUpload,

--- a/src/utils/hooks/useUploadProgressToast/uploadToastSync.test.tsx
+++ b/src/utils/hooks/useUploadProgressToast/uploadToastSync.test.tsx
@@ -20,11 +20,14 @@ jest.mock('./toast/uploadTitles', () => ({
 const UPLOAD_KEY = 'test-upload-key';
 const TOAST_ID = 'toast-123';
 
+type MockToastOptions = { onClose?: () => void } & Record<string, unknown>;
+
 const createMockContext = () => ({
-  addDangerToast: jest.fn(() => 'danger-toast-id'),
-  addInfoToast: jest.fn(() => TOAST_ID),
-  addSuccessToast: jest.fn(() => 'success-toast-id'),
-  addWarningToast: jest.fn(() => 'warning-toast-id'),
+  addDangerToast: jest.fn((_options: MockToastOptions) => 'danger-toast-id'),
+  addInfoToast: jest.fn((_options: MockToastOptions) => TOAST_ID),
+  addSuccessToast: jest.fn((_options: MockToastOptions) => 'success-toast-id'),
+  addWarningToast: jest.fn((_options: MockToastOptions) => 'warning-toast-id'),
+  cancelTrackedUpload: jest.fn(),
   navigate: jest.fn(),
   removeToast: jest.fn(),
   removeUpload: jest.fn(),
@@ -72,6 +75,31 @@ describe('showInProgressUploadToast', () => {
     expect(processedToasts.has(UPLOAD_KEY)).toBe(true);
     expect(context.addInfoToast).toHaveBeenCalledTimes(1);
     expect(context.trySetToastId).toHaveBeenCalledWith(UPLOAD_KEY, TOAST_ID);
+  });
+
+  it('should pass minimizable: true so the toast can be minimized instead of cleared', () => {
+    const context = createMockContext();
+    const processedToasts = new Set<string>();
+    const upload = createUploadEntry();
+
+    showInProgressUploadToast(UPLOAD_KEY, upload, context, processedToasts);
+
+    expect(context.addInfoToast).toHaveBeenCalledWith(
+      expect.objectContaining({ minimizable: true }),
+    );
+  });
+
+  it('should call context.cancelTrackedUpload with the upload key when onClose fires', () => {
+    const context = createMockContext();
+    const processedToasts = new Set<string>();
+    const upload = createUploadEntry();
+
+    showInProgressUploadToast(UPLOAD_KEY, upload, context, processedToasts);
+
+    const { onClose } = context.addInfoToast.mock.calls[0][0];
+    onClose?.();
+
+    expect(context.cancelTrackedUpload).toHaveBeenCalledWith(UPLOAD_KEY);
   });
 
   it('should remove toast and processedToasts entry if trySetToastId fails', () => {
@@ -151,6 +179,19 @@ describe('replaceWithTerminalUploadToast', () => {
     replaceWithTerminalUploadToast(UPLOAD_KEY, upload, context);
 
     expect(context.addWarningToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass onClose that calls removeUpload (not cancelTrackedUpload) for terminal toast', () => {
+    const context = createMockContext();
+    const upload = createUploadEntry({ status: UPLOAD_PROGRESS_STATUS.SUCCESS });
+
+    replaceWithTerminalUploadToast(UPLOAD_KEY, upload, context);
+
+    const { onClose } = context.addSuccessToast.mock.calls[0][0] as MockToastOptions;
+    onClose?.();
+
+    expect(context.removeUpload).toHaveBeenCalledWith(UPLOAD_KEY);
+    expect(context.cancelTrackedUpload).not.toHaveBeenCalled();
   });
 });
 

--- a/src/utils/hooks/useUploadProgressToast/uploadToastSync.tsx
+++ b/src/utils/hooks/useUploadProgressToast/uploadToastSync.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
 import { TFunction } from 'i18next';
+import React from 'react';
 
 import useKubevirtToast from '@kubevirt-utils/hooks/useKubevirtToast';
 
 import UploadProgressToastContent from './components/UploadProgressToastContent';
-import { getUploadTitle, isTerminalUploadStatus } from './toast/uploadTitles';
 import { UPLOAD_PROGRESS_STATUS } from './constants';
+import { getUploadTitle, isTerminalUploadStatus } from './toast/uploadTitles';
 import { UploadEntry } from './types';
 
 type ToastActions = ReturnType<typeof useKubevirtToast>;
@@ -15,6 +15,7 @@ type UploadToastContext = {
   addInfoToast: ToastActions['addInfoToast'];
   addSuccessToast: ToastActions['addSuccessToast'];
   addWarningToast: ToastActions['addWarningToast'];
+  cancelTrackedUpload: (uploadKey: string) => void;
   navigate: (path: string) => void;
   removeToast: ToastActions['removeToast'];
   removeUpload: (uploadKey: string) => void;
@@ -38,6 +39,8 @@ export const showInProgressUploadToast = (
   const toastId = context.addInfoToast({
     content: <UploadProgressToastContent navigate={context.navigate} uploadKey={uploadKey} />,
     dismissible: false,
+    minimizable: true,
+    onClose: () => context.cancelTrackedUpload(uploadKey),
     timeout: false,
     title: getUploadTitle(upload, context.t),
   });


### PR DESCRIPTION
## 📝 Description

- Update `Console` to latest version to include the new `minimizable` feature that enables us to minimize toast messages
- All uploads (CD-ROM and bootable volumes) can now be minimized. 
- When clearing current uploads from the notification drawer, the uploads are canceled. 
- 
## 🔗 Links

Jira ticket: [CNV-90308](https://redhat.atlassian.net/browse/CNV-90308)

## 🎥 Demo

### CD-ROM:

https://github.com/user-attachments/assets/ada870bf-2ffd-41cf-bc32-92fe59b4e046

### Bootable Volumes:


https://github.com/user-attachments/assets/99bf10f1-4e46-4bc8-95e6-81da769f8795



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disk cleanup operations are now safely serialized per virtual machine, preventing concurrent removals from overwriting each other.
  * Closing an in-progress upload notification now cancels the tracked upload, while completed notifications continue to be removed normally.

* **Updates**
  * Updated routing and dynamic plugin SDK package versions.
  * Added selected OpenShift packages to the npm release-age exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->