### PR TITLE
CNV-94249: welcome modal do not show again checkbox

### DIFF
--- a/playwright/tests/tier2/welcome-modal/utils/utils.ts
+++ b/playwright/tests/tier2/welcome-modal/utils/utils.ts
@@ -1,0 +1,138 @@
+import RequestContextClient from '@/clients/request-context-client';
+import NavigationComponent from '@/components/shared/navigation-component';
+import { KubernetesResource } from '@/data-models/kubernetes-types';
+import { EnvVariables } from '@/utils/env-variables';
+import { SECOND, TestTimeouts } from '@/utils/test-config';
+import { expect, Page } from '@playwright/test';
+
+export const SUITE = 'Welcome Modal';
+const WELCOME_MODAL_LOCATOR = '[data-test="welcome-modal"]';
+const WELCOME_MODAL_CHECKBOX_LOCATOR = '[id="welcome-modal-checkbox"]';
+export const CLOSE_BUTTON_LOCATOR = '[aria-label="Welcome modal"] .pf-v6-c-modal-box__close button';
+export const ONBOARDING_POPOVER_LOCATOR = '[data-test="onboarding-popover"]';
+const TOUR_STEP_COUNTER_LOCATOR = '[data-test="tour-step-counter"]';
+const TOUR_HEADER_LOCATOR = '[data-test="tour-popover-header"]';
+const TOUR_NEXT_BUTTON_LOCATOR = '[data-test="tour-next-btn"]';
+const TOUR_STEPS_COUNT = 8;
+
+export const verifyWelcomeModalVisibility = async (
+  page: Page,
+  expectVisible: boolean,
+  timeout = SECOND,
+) => {
+  const modal = page.locator(WELCOME_MODAL_LOCATOR);
+  if (expectVisible) {
+    await modal.waitFor({ state: 'visible', timeout });
+  }
+  const visible = await modal.isVisible();
+  expect(visible, 'Welcome modal should be visible').toBe(expectVisible);
+};
+
+export const resetUserSettings = async (apiClient: RequestContextClient) => {
+  const user: KubernetesResource | null = await apiClient.getResource(
+    'user.openshift.io',
+    'v1',
+    'users',
+    '~',
+  );
+
+  const settingsKey =
+    user?.metadata?.uid || user?.metadata?.name?.replace(/[^-._a-zA-Z0-9]+/g, '-');
+
+  if (!settingsKey) return;
+
+  const userSettingsCm = await apiClient.getKubeVirtUserSettings(EnvVariables.cnvNamespace);
+  const cmData = (userSettingsCm?.data ?? {}) as Record<string, string>;
+
+  if (!(settingsKey in cmData)) return;
+
+  const parsed = JSON.parse(cmData[settingsKey] || '{}');
+  parsed.quickStart = { ...parsed.quickStart, dontShowWelcomeModal: false, tourStepsSeen: [] };
+
+  await apiClient.patchConfigMap('kubevirt-user-settings', EnvVariables.cnvNamespace, [
+    { op: 'replace', path: `/data/${settingsKey}`, value: JSON.stringify(parsed) },
+  ]);
+};
+
+export const getTourTotalSteps = async (page: Page): Promise<number> => {
+  const stepCounter = page.locator(TOUR_STEP_COUNTER_LOCATOR);
+  await stepCounter.waitFor({ state: 'visible', timeout: SECOND });
+  const text = (await stepCounter.textContent()) ?? '';
+  const match = text.match(/\/(\d+)/);
+  return match ? parseInt(match[1], 10) : 0;
+};
+
+export const enterVirtualMachinesPage = async (page: Page, nav: NavigationComponent) => {
+  await nav.clickNavVirtualMachines();
+  await page.waitForLoadState('load');
+  await verifyWelcomeModalVisibility(page, true, TestTimeouts.SHORT_WAIT);
+};
+
+export const checkIfModalIsVisibleAfterCheckboxClick = async (page: Page) => {
+  const patchPromise = page.waitForResponse(
+    (resp) =>
+      resp.url().includes('kubevirt-user-settings') &&
+      (resp.request().method() === 'PATCH' || resp.request().method() === 'PUT') &&
+      resp.status() >= 200 &&
+      resp.status() < 300,
+    { timeout: TestTimeouts.SHORT_WAIT },
+  );
+
+  await page.locator(WELCOME_MODAL_CHECKBOX_LOCATOR).click({ force: true });
+
+  const patchResponse = await patchPromise.catch(() => null);
+  expect(
+    patchResponse,
+    'User settings should be patched with dontShowWelcomeModal: true',
+  ).not.toBeNull();
+
+  await verifyWelcomeModalVisibility(page, true);
+};
+
+export const tourStepsTest = async (page: Page) => {
+  // Wait for the tour popover to appear (Joyride needs target elements to be in DOM)
+  await page
+    .locator('[data-test="tour-popover"]')
+    .waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+
+  const totalSteps = await getTourTotalSteps(page);
+  expect(totalSteps, 'Tour should report step count').toBe(TOUR_STEPS_COUNT);
+
+  const tourHeader = page.locator(TOUR_HEADER_LOCATOR);
+  const nextButton = page.locator(TOUR_NEXT_BUTTON_LOCATOR);
+  const stepTitles: string[] = [];
+
+  for (let i = 0; i < totalSteps; i++) {
+    await tourHeader.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    const title = (await tourHeader.textContent())?.trim() ?? '';
+    stepTitles.push(title);
+
+    const hasNext = await nextButton.isVisible().catch(() => false);
+    if (hasNext) {
+      await nextButton.click();
+      await page.waitForTimeout(SECOND);
+    }
+  }
+
+  expect(stepTitles.length, `Tour should have ${totalSteps} steps`).toBe(totalSteps);
+
+  const okayButton = page.locator('[data-test="tour-next-btn"]:has-text("Okay, got it!")');
+  if (await okayButton.isVisible().catch(() => false)) {
+    await okayButton.click();
+    await page.waitForTimeout(SECOND);
+  }
+};
+
+export const expendSidebarIfCollapsed = async (page: Page) => {
+  const sidebar = page.locator('.pf-v6-c-page__sidebar');
+  const isCollapsed = await sidebar
+    .evaluate((el) => el.classList.contains('pf-m-collapsed'))
+    .catch(() => false);
+  if (isCollapsed) {
+    const navToggle = page.locator(
+      '#nav-toggle, button.pf-v6-c-masthead__toggle, .pf-v6-c-masthead__toggle button',
+    );
+    await navToggle.first().click();
+    await page.waitForTimeout(500);
+  }
+};

--- a/playwright/tests/tier2/welcome-modal/welcome-modal.spec.ts
+++ b/playwright/tests/tier2/welcome-modal/welcome-modal.spec.ts
@@ -1,0 +1,73 @@
+import NavigationComponent from '@/components/shared/navigation-component';
+import { T2, T2_TAG } from '@/data-models/allure-constants';
+import { expect, test } from '@/fixtures/scenario-test-fixture';
+import { TestTimeouts } from '@/utils/test-config';
+import {
+  checkIfModalIsVisibleAfterCheckboxClick,
+  CLOSE_BUTTON_LOCATOR,
+  enterVirtualMachinesPage,
+  expendSidebarIfCollapsed,
+  ONBOARDING_POPOVER_LOCATOR,
+  resetUserSettings,
+  SUITE,
+  tourStepsTest,
+  verifyWelcomeModalVisibility,
+} from './utils/utils';
+
+test.describe('Welcome Modal', { tag: [T2_TAG, '@tier2-welcome-modal'] }, () => {
+  test('WelcomeModal - checkbox dismiss flow', async ({ apiClient, page, utils }) => {
+    await resetUserSettings(apiClient);
+    await utils.withAllure({
+      suite: SUITE,
+      feature: T2,
+      tags: [T2_TAG, '@tier2-welcome-modal'],
+    });
+
+    const nav = new NavigationComponent(page);
+
+    await test.step('Verify welcome modal is visible', async () => {
+      await nav.clickNavVirtualMachines();
+      await page.waitForLoadState('load');
+
+      await verifyWelcomeModalVisibility(page, true, TestTimeouts.SHORT_WAIT);
+    });
+
+    await test.step('Click "Start tour" and verify all steps display in order', async () => {
+      await page.reload({ waitUntil: 'load' });
+      await page.waitForLoadState('load');
+
+      await page.locator('button:has-text("Start tour")').click();
+
+      await tourStepsTest(page);
+
+      // Dismiss onboarding popover if it appeared after tour ended
+      const onboardingDismiss = page.locator('[data-test="onboarding-dismiss-btn"]');
+      if (await onboardingDismiss.isVisible().catch(() => false)) {
+        await onboardingDismiss.click();
+        await page.waitForTimeout(500);
+      }
+
+      await expendSidebarIfCollapsed(page);
+    });
+
+    await test.step('Click "Do not show again" checkbox, verify settings updated and modal stays open', async () => {
+      await enterVirtualMachinesPage(page, nav);
+      await checkIfModalIsVisibleAfterCheckboxClick(page);
+    });
+
+    await test.step('Close modal and verify no modal or onboarding popovers are visible', async () => {
+      await page.locator(CLOSE_BUTTON_LOCATOR).click();
+
+      const popoverVisible = await page.locator(ONBOARDING_POPOVER_LOCATOR).first().isVisible();
+      expect(
+        popoverVisible,
+        'Onboarding popovers should not be displayed after closing modal with checkbox checked',
+      ).toBe(false);
+
+      await page.reload({ waitUntil: 'load' });
+      await page.waitForLoadState('load');
+
+      await verifyWelcomeModalVisibility(page, false, TestTimeouts.RETRY_DELAY);
+    });
+  });
+});

--- a/src/utils/components/GuidedTour/components/TourPopover/TourPopover.tsx
+++ b/src/utils/components/GuidedTour/components/TourPopover/TourPopover.tsx
@@ -1,5 +1,5 @@
-import React, { FC, MouseEventHandler } from 'react';
-import { TooltipRenderProps } from 'react-joyride';
+import React, { type FC, type MouseEventHandler } from 'react';
+import { type TooltipRenderProps } from 'react-joyride';
 import classNames from 'classnames';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -22,9 +22,13 @@ const TourPopover: FC<TooltipRenderProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   return (
-    <div className={classNames(popoverStyles.popover, 'kv-tour-popover')}>
+    <div className={classNames(popoverStyles.popover, 'kv-tour-popover')} data-test="tour-popover">
       <Split>
-        {step.title && <SplitItem className="kv-tour-popover__header">{step.title}</SplitItem>}
+        {step.title && (
+          <SplitItem className="kv-tour-popover__header" data-test="tour-popover-header">
+            {step.title}
+          </SplitItem>
+        )}
         <SplitItem isFilled />
         <SplitItem>
           <Button
@@ -39,7 +43,7 @@ const TourPopover: FC<TooltipRenderProps> = ({
       </Split>
       <div className={classNames(popoverStyles.popoverContent)}>{step.content}</div>
       <Split className="kv-tour-popover__buttons-footer" hasGutter>
-        <SplitItem className="kv-tour-popover__step-counter">
+        <SplitItem className="kv-tour-popover__step-counter" data-test="tour-step-counter">
           {t('Step {{current}}/{{size}}', { current: index + 1, size })}
         </SplitItem>
         <SplitItem isFilled />
@@ -48,6 +52,7 @@ const TourPopover: FC<TooltipRenderProps> = ({
             <Button
               {...backProps}
               className="kv-tour-popover__next"
+              data-test="tour-back-btn"
               variant={ButtonVariant.secondary}
             >
               {t('Back')}
@@ -58,6 +63,7 @@ const TourPopover: FC<TooltipRenderProps> = ({
           <Button
             {...primaryProps}
             className="kv-tour-popover__previous"
+            data-test="tour-next-btn"
             variant={ButtonVariant.primary}
           >
             {isLastStep ? t('Okay, got it!') : t('Next')}

--- a/src/utils/components/GuidedTour/utils/guidedTourSignals.ts
+++ b/src/utils/components/GuidedTour/utils/guidedTourSignals.ts
@@ -4,7 +4,7 @@ export const runningTourSignal = signal(false);
 export const stepIndexSignal = signal(0);
 export const namespaceSignal = signal<string | undefined>(undefined);
 export const tourContextMenuTriggerSignal = signal<HTMLElement | null>(null);
-export const welcomeModalDismissedSignal = signal(false);
+export const dismissOnboardingPopoverByWelcomeModalSignal = signal(false);
 export const tourStepsSeenSignal = signal<number[]>([]);
 
 export const nextStep = () => {

--- a/src/utils/components/OnboardingPopover/OnboardingPopover.tsx
+++ b/src/utils/components/OnboardingPopover/OnboardingPopover.tsx
@@ -1,17 +1,9 @@
-import React, { FC, ReactNode, useCallback, useEffect } from 'react';
+import React, { FC, ReactNode } from 'react';
 
-import {
-  runningTourSignal,
-  tourStepsSeenSignal,
-  welcomeModalDismissedSignal,
-} from '@kubevirt-utils/components/GuidedTour/utils/guidedTourSignals';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
 import { Button, ButtonVariant, Popover, PopoverPosition } from '@patternfly/react-core';
-import { useSignals } from '@preact/signals-react/runtime';
 
-import { ONBOARDING_POPOVER_CHAIN } from './constants';
-import { dismissedPopoverKeysSignal } from './onboardingSignals';
+import useOnboardingPopover from './hooks/useOnboardingPopover';
 import { OnboardingPopoverKey } from './types';
 
 type OnboardingPopoverProps = {
@@ -31,61 +23,29 @@ const OnboardingPopover: FC<OnboardingPopoverProps> = ({
   popoverKey,
   triggerElement,
 }) => {
-  useSignals();
   const { t } = useKubevirtTranslation();
-  const [userSettings, setUserSettings, userSettingsLoaded] = useKubevirtUserSettings();
-  const onboardingPopoversHidden = userSettings?.onboardingPopoversHidden;
-  const quickStarts = userSettings?.quickStart;
-  const chainIndex = ONBOARDING_POPOVER_CHAIN.indexOf(popoverKey);
-  const predecessorsDismissed =
-    chainIndex === -1 ||
-    ONBOARDING_POPOVER_CHAIN.slice(0, chainIndex).every(
-      (key) => onboardingPopoversHidden?.[key] || dismissedPopoverKeysSignal.value.has(key),
-    );
 
-  const tourStepsSeen = [...(quickStarts?.tourStepsSeen || []), ...tourStepsSeenSignal.value];
-  const coveredByTour = coveredByTourSteps?.some((step) => tourStepsSeen.includes(step)) ?? false;
-
-  const hide = useCallback(() => {
-    dismissedPopoverKeysSignal.value = new Set([...dismissedPopoverKeysSignal.value, popoverKey]);
-    setUserSettings({
-      ...userSettings,
-      onboardingPopoversHidden: { ...onboardingPopoversHidden, [popoverKey]: true },
-    });
-  }, [onboardingPopoversHidden, popoverKey, setUserSettings, userSettings]);
-
-  useEffect(() => {
-    if (coveredByTour && !dismissedPopoverKeysSignal.value.has(popoverKey)) {
-      hide();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [coveredByTour]);
-
-  const welcomeExperienceDone =
-    welcomeModalDismissedSignal.value || !!quickStarts?.dontShowWelcomeModal;
-
-  const isVisible =
-    userSettingsLoaded &&
-    !dismissedPopoverKeysSignal.value.has(popoverKey) &&
-    !onboardingPopoversHidden?.[popoverKey] &&
-    predecessorsDismissed &&
-    !coveredByTour &&
-    !runningTourSignal.value &&
-    welcomeExperienceDone &&
-    !!triggerElement;
+  const { dismiss, isVisible } = useOnboardingPopover({
+    coveredByTourSteps,
+    popoverKey,
+    triggerElement,
+  });
 
   const handleClose = (event: KeyboardEvent | MouseEvent) => {
-    // if user clicks the trigger element, don't hide the popover (unless hideOnTriggerClick is true)
-    if (!hideOnTriggerClick && event instanceof MouseEvent) {
-      if (triggerElement?.contains(event.target as Node)) return;
+    const isMouseClick = event instanceof MouseEvent;
+    const isClickOnTriggerElement = isMouseClick && triggerElement?.contains(event.target as Node);
+    const shouldDismissPopover = hideOnTriggerClick || !isClickOnTriggerElement;
+
+    if (!shouldDismissPopover) {
+      return;
     }
-    hide();
+    dismiss();
   };
 
   return (
     <Popover
       footerContent={
-        <Button data-test="onboarding-dismiss-btn" onClick={hide} variant={ButtonVariant.link}>
+        <Button data-test="onboarding-dismiss-btn" onClick={dismiss} variant={ButtonVariant.link}>
           {t('Got it')}
         </Button>
       }

--- a/src/utils/components/OnboardingPopover/hooks/useOnboardingPopover.ts
+++ b/src/utils/components/OnboardingPopover/hooks/useOnboardingPopover.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+
+import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+
+import { useSignals } from '@preact/signals-react/runtime';
+import { dismissedPopoverKeysSignal } from '../onboardingSignals';
+import { OnboardingPopoverKey } from '../types';
+import { getTourStepsSeen, isCoveredByTourSteps, isPopoverVisible } from '../utils';
+
+type UseOnboardingPopoverArgs = {
+  coveredByTourSteps?: number[];
+  popoverKey: OnboardingPopoverKey;
+  triggerElement: HTMLElement | null;
+};
+
+type UseOnboardingPopoverReturn = {
+  dismiss: () => void;
+  isVisible: boolean;
+};
+
+const useOnboardingPopover = ({
+  coveredByTourSteps,
+  popoverKey,
+  triggerElement,
+}: UseOnboardingPopoverArgs): UseOnboardingPopoverReturn => {
+  useSignals();
+  const [userSettings, setUserSettings, userSettingsLoaded] = useKubevirtUserSettings();
+  const onboardingPopoversHidden = userSettings?.onboardingPopoversHidden;
+
+  const tourStepsSeen = getTourStepsSeen(userSettings?.quickStart);
+  const isCoveredByTour = isCoveredByTourSteps(coveredByTourSteps, tourStepsSeen);
+
+  const isVisible = isPopoverVisible({
+    isCoveredByTour,
+    popoverKey,
+    triggerElement,
+    userSettings,
+    userSettingsLoaded,
+  });
+
+  const dismiss = useCallback(() => {
+    dismissedPopoverKeysSignal.value = new Set([...dismissedPopoverKeysSignal.value, popoverKey]);
+    setUserSettings({
+      ...userSettings,
+      onboardingPopoversHidden: { ...onboardingPopoversHidden, [popoverKey]: true },
+    });
+  }, [onboardingPopoversHidden, popoverKey, setUserSettings, userSettings]);
+
+  return { dismiss, isVisible };
+};
+
+export default useOnboardingPopover;

--- a/src/utils/components/OnboardingPopover/utils.ts
+++ b/src/utils/components/OnboardingPopover/utils.ts
@@ -1,0 +1,76 @@
+import {
+  dismissOnboardingPopoverByWelcomeModalSignal,
+  runningTourSignal,
+  tourStepsSeenSignal,
+} from '@kubevirt-utils/components/GuidedTour/utils/guidedTourSignals';
+import type { UserSettingsState } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/userSettingsInitialState';
+
+import { ONBOARDING_POPOVER_CHAIN } from './constants';
+import { dismissedPopoverKeysSignal } from './onboardingSignals';
+import { OnboardingPopoverKey, OnboardingPopoversHidden } from './types';
+
+export const arePredecessorPopoversDismissed = (
+  popoverKey: OnboardingPopoverKey,
+  onboardingPopoversHidden: OnboardingPopoversHidden | undefined,
+  dismissedKeys: Set<OnboardingPopoverKey>,
+): boolean => {
+  const chainIndex = ONBOARDING_POPOVER_CHAIN.indexOf(popoverKey);
+  const isPopoverNotInChain = chainIndex === -1;
+
+  return (
+    isPopoverNotInChain ||
+    ONBOARDING_POPOVER_CHAIN.slice(0, chainIndex).every(
+      (key) => onboardingPopoversHidden?.[key] || dismissedKeys.has(key),
+    )
+  );
+};
+
+export const isCoveredByTourSteps = (
+  coveredByTourSteps: number[] | undefined,
+  tourStepsSeen: number[],
+): boolean => coveredByTourSteps?.some((step) => tourStepsSeen.includes(step)) ?? false;
+
+export const getTourStepsSeen = (
+  quickStart: { tourStepsSeen?: number[] } | undefined,
+): number[] => [...(quickStart?.tourStepsSeen || []), ...tourStepsSeenSignal.value];
+
+type IsPopoverVisibleArgs = {
+  isCoveredByTour: boolean;
+  popoverKey: OnboardingPopoverKey;
+  triggerElement: HTMLElement | null;
+  userSettings: Partial<UserSettingsState> | undefined;
+  userSettingsLoaded: boolean;
+};
+
+export const isPopoverVisible = ({
+  isCoveredByTour,
+  popoverKey,
+  triggerElement,
+  userSettings,
+  userSettingsLoaded,
+}: IsPopoverVisibleArgs): boolean => {
+  const onboardingPopoversHidden = userSettings?.onboardingPopoversHidden;
+  const quickStart = userSettings?.quickStart;
+
+  const shouldDismissOnboardingByWelcomeModal =
+    dismissOnboardingPopoverByWelcomeModalSignal.value || quickStart?.dontShowWelcomeModal;
+
+  if (!userSettingsLoaded || !triggerElement || shouldDismissOnboardingByWelcomeModal) return false;
+
+  const isAlreadyDismissed =
+    dismissedPopoverKeysSignal.value.has(popoverKey) || !!onboardingPopoversHidden?.[popoverKey];
+
+  const predecessorPopoversDismissed = arePredecessorPopoversDismissed(
+    popoverKey,
+    onboardingPopoversHidden,
+    dismissedPopoverKeysSignal.value,
+  );
+
+  const isVisible =
+    !isAlreadyDismissed &&
+    predecessorPopoversDismissed &&
+    !isCoveredByTour &&
+    !runningTourSignal.value;
+
+  return isVisible;
+};

--- a/src/utils/hooks/useKubevirtUserSettings/utils/userSettingsInitialState.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/utils/userSettingsInitialState.ts
@@ -27,7 +27,7 @@ type ColumnsUserSettings = {
   [tableName: string]: string[];
 };
 
-type QuickStartUserSettings = {
+export type QuickStartUserSettings = {
   dontShowWelcomeModal?: boolean;
   tourStepsSeen?: number[];
 };

--- a/src/views/welcome/WelcomeModal.tsx
+++ b/src/views/welcome/WelcomeModal.tsx
@@ -1,14 +1,8 @@
-import React, { FC, useCallback, useEffect, useState } from 'react';
 import openCulture from 'images/openCulture.svg';
+import React, { FC } from 'react';
 
-import {
-  runningTourSignal,
-  welcomeModalDismissedSignal,
-} from '@kubevirt-utils/components/GuidedTour/utils/guidedTourSignals';
 import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
-import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import {
   Checkbox,
   Content,
@@ -21,31 +15,16 @@ import {
   Stack,
   Title,
 } from '@patternfly/react-core';
-import { useSignals } from '@preact/signals-react/runtime';
 
 import WelcomeButtons from './components/WelcomeButtons';
+import useWelcomeModal from './hooks/useWelcomeModal';
 
 import './WelcomeModal.scss';
 
 const WelcomeModal: FC = () => {
-  useSignals();
   const { t } = useKubevirtTranslation();
-  const [isOpen, setIsOpen] = useState<boolean>(true);
-  const [quickStarts, setQuickStarts, loaded] = useKubevirtUserSettings(
-    USER_SETTINGS_KEYS.quickStart,
-  );
   const isWindowsSupported = useIsWindowsSupportedArchitecture();
-
-  useEffect(() => {
-    welcomeModalDismissedSignal.value = false;
-  }, []);
-
-  const onClose = useCallback(() => {
-    setIsOpen(false);
-    welcomeModalDismissedSignal.value = true;
-  }, []);
-
-  if (runningTourSignal.value || !loaded || quickStarts?.dontShowWelcomeModal) return null;
+  const { isOpen, onClose, quickStarts, onDontShowAgainCheckboxChange } = useWelcomeModal();
 
   return (
     <Modal
@@ -84,9 +63,7 @@ const WelcomeModal: FC = () => {
               <WelcomeButtons onClose={onClose} />
 
               <Checkbox
-                onChange={(_event, value) =>
-                  setQuickStarts({ ...quickStarts, dontShowWelcomeModal: value })
-                }
+                onChange={onDontShowAgainCheckboxChange}
                 className="WelcomeModal__checkbox"
                 id="welcome-modal-checkbox"
                 isChecked={quickStarts?.dontShowWelcomeModal}

--- a/src/views/welcome/hooks/useWelcomeModal.ts
+++ b/src/views/welcome/hooks/useWelcomeModal.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  dismissOnboardingPopoverByWelcomeModalSignal,
+  runningTourSignal,
+} from '@kubevirt-utils/components/GuidedTour/utils/guidedTourSignals';
+import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
+import { QuickStartUserSettings } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/userSettingsInitialState';
+import { useSignals } from '@preact/signals-react/runtime';
+
+type UseWelcomeModalReturn = {
+  isOpen: boolean;
+  onClose: () => void;
+  onDontShowAgainCheckboxChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  quickStarts: QuickStartUserSettings | undefined;
+};
+
+const useWelcomeModal = (): UseWelcomeModalReturn => {
+  useSignals();
+  const [quickStarts, setQuickStarts, loaded] = useKubevirtUserSettings(
+    USER_SETTINGS_KEYS.quickStart,
+  );
+  const [isOpen, setIsOpen] = useState(false);
+  const isModalOpenedRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (!loaded || isModalOpenedRef.current) {
+      return;
+    }
+
+    const shouldOpenModal = !runningTourSignal.value && !quickStarts?.dontShowWelcomeModal;
+
+    isModalOpenedRef.current = shouldOpenModal;
+    dismissOnboardingPopoverByWelcomeModalSignal.value = shouldOpenModal;
+    setIsOpen(shouldOpenModal);
+  }, [loaded, quickStarts?.dontShowWelcomeModal]);
+
+  const onClose = () => {
+    setIsOpen(false);
+    dismissOnboardingPopoverByWelcomeModalSignal.value = Boolean(quickStarts?.dontShowWelcomeModal);
+  };
+
+  const onDontShowAgainCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setQuickStarts({
+      ...quickStarts,
+      dontShowWelcomeModal: event.target.checked,
+    });
+  };
+
+  return {
+    isOpen,
+    onClose,
+    onDontShowAgainCheckboxChange,
+    quickStarts,
+  };
+};
+
+export default useWelcomeModal;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Keep the welcome modal open after checking the "Do not show again" checkbox until the user manually closes it and dismiss onboarding popovers when the user checks "Do not show again"
## 🔗 Links

Jira tickets: 
https://redhat.atlassian.net/browse/CNV-94249
https://redhat.atlassian.net/browse/CNV-94251

## 🎥 Demo

before:

https://github.com/user-attachments/assets/e0260383-cc96-42fd-bef1-d44ae654a66e




after:


https://github.com/user-attachments/assets/781bd20e-f641-4278-821e-ec5debb72f6e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined onboarding and welcome-modal behavior.
  * Onboarding popovers now respect dismissal order, guided-tour progress, active tours, and saved preferences.
  * Welcome-modal settings and opt-out choices are synchronized automatically.

* **Bug Fixes**
  * Prevented onboarding popovers from appearing while settings load or when no longer relevant.
  * Preserved trigger-click behavior when dismissing onboarding popovers.

* **Tests**
  * Added coverage for welcome-modal visibility, dismissal, tour progression, and preference persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->