### PR TITLE
CNV-87886: replace useListPageFilter on VM networks list pages

### DIFF
--- a/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/ConnectedVirtualMachines.tsx
+++ b/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/ConnectedVirtualMachines.tsx
@@ -2,8 +2,11 @@ import React, { FC, useCallback, useMemo, useState } from 'react';
 
 import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ActionsDropdown from '@kubevirt-utils/components/ActionsDropdown/ActionsDropdown';
+import KubevirtFilterToolbar from '@kubevirt-utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar';
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
+import ListEmptyState from '@kubevirt-utils/components/ListEmptyState/ListEmptyState';
 import ListSkeleton from '@kubevirt-utils/components/StateHandler/ListSkeleton';
+import useKubevirtDataViewFilters from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/useKubevirtDataViewFilters';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import usePaginationWithFilters from '@kubevirt-utils/hooks/usePagination/usePaginationWithFilters';
 import { paginationDefaultValues } from '@kubevirt-utils/hooks/usePagination/utils/constants';
@@ -11,15 +14,11 @@ import { VirtualMachineModel } from '@kubevirt-utils/models';
 import { asAccessReview, getName } from '@kubevirt-utils/resources/shared';
 import { ClusterUserDefinedNetworkKind } from '@kubevirt-utils/resources/udn/types';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import {
-  ListPageBody,
-  ListPageFilter,
-  useListPageFilter,
-  useModal,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { ListPageBody, useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { Action } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/actions';
 import { BulkSelect, BulkSelectValue } from '@patternfly/react-component-groups';
 import { Flex, Pagination } from '@patternfly/react-core';
+import { VirtualMachineIcon } from '@patternfly/react-icons';
 
 import useConnectedVMs from '../../../hooks/useConnectedVMs';
 
@@ -42,11 +41,17 @@ const ConnectedVirtualMachines: FC<ConnectedVirtualMachinesProps> = ({ obj: vmNe
   const { t } = useKubevirtTranslation();
   const createModal = useModal();
   const [vms, loadedVMs, error] = useConnectedVMs(vmNetwork);
-  const [unfilteredData, filteredData, onFilterChange] = useListPageFilter(vms);
+  const { clearAllFilters, filteredData, filters, onSetFilters } = useKubevirtDataViewFilters({
+    data: vms ?? [],
+  });
   const [selectedVMs, setSelectedVMs] = useState<V1VirtualMachine[]>([]);
 
-  const { handleFilterChange, handlePerPageSelect, handleSetPage, pagination } =
-    usePaginationWithFilters(filteredData?.length ?? 0, onFilterChange);
+  const {
+    handleFilterChange: handleSetFilters,
+    handlePerPageSelect,
+    handleSetPage,
+    pagination,
+  } = usePaginationWithFilters(filteredData?.length ?? 0, onSetFilters);
 
   const vmNetworkName = getName(vmNetwork);
 
@@ -101,6 +106,18 @@ const ConnectedVirtualMachines: FC<ConnectedVirtualMachinesProps> = ({ obj: vmNe
     );
   }
 
+  if (isEmpty(vms)) {
+    return (
+      <ListPageBody>
+        <ListEmptyState
+          bodyContent={t('Virtual machines connected to this network will appear here.')}
+          icon={VirtualMachineIcon}
+          titleText={t('No connected virtual machines yet')}
+        />
+      </ListPageBody>
+    );
+  }
+
   return (
     <ListPageBody>
       <div className="list-managment-group">
@@ -117,10 +134,12 @@ const ConnectedVirtualMachines: FC<ConnectedVirtualMachinesProps> = ({ obj: vmNe
             selectedCount={selectedVMs.length}
             totalCount={filteredData.length}
           />
-          <ListPageFilter
-            data={unfilteredData}
+          <KubevirtFilterToolbar
+            clearAllFilters={clearAllFilters}
+            data={vms}
+            filters={filters}
             loaded={loadedVMs}
-            onFilterChange={handleFilterChange}
+            onSetFilters={handleSetFilters}
           />
           <ActionsDropdown
             actions={bulkActions}
@@ -152,13 +171,12 @@ const ConnectedVirtualMachines: FC<ConnectedVirtualMachinesProps> = ({ obj: vmNe
         initialSortKey={CONNECTED_VMS_COLUMN_KEYS.name}
         loaded={loadedVMs}
         loadError={error}
-        noDataMsg={t('No connected virtual machines found')}
         noFilteredDataMsg={t('No virtual machines match the filter criteria')}
         onSelect={setSelectedVMs}
         pagination={pagination}
         selectable
         selectedItems={selectedVMs}
-        unfilteredData={unfilteredData}
+        unfilteredData={vms}
       />
     </ListPageBody>
   );

--- a/src/views/vmnetworks/list/VMNetworkOtherTypesList.tsx
+++ b/src/views/vmnetworks/list/VMNetworkOtherTypesList.tsx
@@ -1,14 +1,12 @@
 import React, { FC, useMemo } from 'react';
 
+import KubevirtFilterToolbar from '@kubevirt-utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar';
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
 import StateHandler from '@kubevirt-utils/components/StateHandler/StateHandler';
+import useKubevirtDataViewFilters from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/useKubevirtDataViewFilters';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import {
-  ListPageBody,
-  ListPageFilter,
-  useListPageFilter,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
 import { EmptyState } from '@patternfly/react-core';
 
 import useOtherVMNetworkFilters from './hooks/useOtherVMNetworkFilters';
@@ -21,9 +19,12 @@ import {
 const VMNetworkOtherTypesList: FC = () => {
   const { t } = useKubevirtTranslation();
 
-  const [otherVMNetworks, loaded, error] = useOtherVMNetworks();
-  const filters = useOtherVMNetworkFilters();
-  const [data, filteredData, onFilterChange] = useListPageFilter(otherVMNetworks, filters);
+  const [data, loaded, error] = useOtherVMNetworks();
+  const filterDefinitions = useOtherVMNetworkFilters();
+  const { clearAllFilters, filteredData, filters, onSetFilters } = useKubevirtDataViewFilters({
+    data,
+    filterDefinitions,
+  });
   const columns = useMemo(() => getVMNetworkOtherTypesColumns(t), [t]);
 
   return (
@@ -32,12 +33,13 @@ const VMNetworkOtherTypesList: FC = () => {
         <EmptyState headingLevel="h4" titleText={t('No other virtual machine networks found')} />
       ) : (
         <ListPageBody>
-          <ListPageFilter
+          <KubevirtFilterToolbar
+            clearAllFilters={clearAllFilters}
             data={data}
-            hideLabelFilter
+            filterDefinitions={filterDefinitions}
+            filters={filters}
             loaded={loaded}
-            onFilterChange={onFilterChange}
-            rowFilters={filters}
+            onSetFilters={onSetFilters}
           />
           <KubevirtTable
             ariaLabel={t('Other VM Networks table')}

--- a/src/views/vmnetworks/list/hooks/useOtherVMNetworkFilters.ts
+++ b/src/views/vmnetworks/list/hooks/useOtherVMNetworkFilters.ts
@@ -1,12 +1,12 @@
 import { useMemo } from 'react';
 
+import { KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   ClusterUserDefinedNetworkModel,
   NetworkAttachmentDefinitionModel,
   UserDefinedNetworkModel,
 } from '@kubevirt-utils/models';
-import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 
 import { VALID_OTHER_VM_NETWORK_TYPES } from '../constants';
 import { OtherVMNetworkWithType, VMNetworkType } from '../types';
@@ -18,61 +18,50 @@ enum KindFilterIDs {
   UDN = 'udn',
 }
 
-const getIDFromKind = (kind: string): KindFilterIDs => {
+const getIDFromKind = (kind?: string): KindFilterIDs | undefined => {
   if (kind === ClusterUserDefinedNetworkModel.kind) return KindFilterIDs.CUDN;
   if (kind === UserDefinedNetworkModel.kind) return KindFilterIDs.UDN;
   if (kind === NetworkAttachmentDefinitionModel.kind) return KindFilterIDs.NAD;
   return undefined;
 };
 
-const useOtherVMNetworkFilters = (): RowFilter<OtherVMNetworkWithType>[] => {
+const useOtherVMNetworkFilters = (): KubevirtFilter[] => {
   const { t } = useKubevirtTranslation();
 
   return useMemo(
     () => [
       {
-        filter: ({ selected }, obj) => {
-          if (selected?.length === 0) return true;
-
+        categoryLabel: t('Kind'),
+        id: 'vm-network-kind',
+        match: (obj, selected) => {
           const id = getIDFromKind(obj.kind);
-          if (id && selected.includes(id)) return true;
-
-          return false;
+          return Boolean(id && selected.includes(id));
         },
-        filterGroupName: t('Kind'),
-        items: [
+        options: [
           {
-            id: KindFilterIDs.CUDN,
-            title: t('Cluster-wide UserDefinedNetworks'),
+            label: t('Cluster-wide UserDefinedNetworks'),
+            value: KindFilterIDs.CUDN,
           },
           {
-            id: KindFilterIDs.UDN,
-            title: t('Namespaced UserDefinedNetworks'),
+            label: t('Namespaced UserDefinedNetworks'),
+            value: KindFilterIDs.UDN,
           },
           {
-            id: KindFilterIDs.NAD,
-            title: t('NetworkAttachmentDefinitions'),
+            label: t('NetworkAttachmentDefinitions'),
+            value: KindFilterIDs.NAD,
           },
         ],
-        reducer: (obj) => {
-          return getIDFromKind(obj.kind);
-        },
-        type: 'vm-network-kind',
       },
       {
-        filter: ({ selected }, obj) => {
-          if (selected?.length === 0) return true;
-          return selected.includes(obj.type);
-        },
-        filterGroupName: t('Type'),
-        items: Object.values(VMNetworkType)
+        categoryLabel: t('Type'),
+        id: 'vm-network-type',
+        match: (obj, selected) => selected.includes((obj as OtherVMNetworkWithType).type),
+        options: Object.values(VMNetworkType)
           .filter((type) => VALID_OTHER_VM_NETWORK_TYPES.has(type))
           .map((type) => ({
-            id: type,
-            title: getVMNetworkTypeLabel(type, t),
+            label: getVMNetworkTypeLabel(type, t),
+            value: type,
           })),
-        reducer: (obj) => obj.type,
-        type: 'vm-network-type',
       },
     ],
     [t],


### PR DESCRIPTION



## 📝 Description

Replace deprecated `useListPageFilter` on VM networks list pages
- `Connected virtual machines` table
- `Other VM Network types` table
- adds early return EmptyState

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-87886

## 🎥 Demo

Empty state - Before:
<img width="1432" height="586" alt="Screenshot 2026-08-05 at 11 05 30" src="https://github.com/user-attachments/assets/4fe7bb15-b2b1-4c7a-bf06-de9fac381f18" />



Empty state - After:
<img width="1432" height="586" alt="Screenshot 2026-08-05 at 11 07 27" src="https://github.com/user-attachments/assets/670d9b17-3940-4ea0-9ccb-e0964b760153" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent filtering toolbars for virtual machine network lists and connected virtual machines.
  - Improved filtering for network kind and type.
  - Added a dedicated empty state when no connected virtual machines are available.

- **Bug Fixes**
  - Updated filtering behavior to provide more reliable results while preserving table and loading states.
  - Added clearer filter controls, including options to set and clear active filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->