### PR TITLE
CNV-87425: stabilize Playwright Tier1 nav and MigrationPolicy bandwidth

### DIFF
--- a/.cursor/commands/create-test.md
+++ b/.cursor/commands/create-test.md
@@ -85,7 +85,6 @@ tests/
 Every fixture extends `baseTest` from `scenario-test-fixture.ts`:
 
 ```typescript
-import { withSafeActions } from '@/page-objects/base-page';
 import SomePage from '@/page-objects/some/some-page';
 import { baseTest, expect } from './scenario-test-fixture';
 
@@ -95,7 +94,7 @@ interface MyFixtures {
 
 const test = baseTest.extend<MyFixtures>({
   somePage: async ({ page }, use) => {
-    await use(withSafeActions(new SomePage(page)));
+    await use(new SomePage(page));
   },
 });
 
@@ -105,7 +104,6 @@ export { expect, test };
 Key points:
 
 - `baseTest` provides `apiClient`, `utils`, `testConfig`, `page`, `cleanup`, and auto-fixtures
-- Page objects are wrapped with `withSafeActions()` in the fixture
 - Page objects extend `BasePage` or `PageCommons` (not standalone classes)
 - Components live in `playwright/src/components/` and compose into page objects in `playwright/src/page-objects/`
 
@@ -204,7 +202,6 @@ This avoids requiring a running console for test creation and ensures locators m
 If no fixture exists for the feature area, create one in `playwright/src/fixtures/<feature>-fixture.ts`:
 
 ```typescript
-import { withSafeActions } from '@/page-objects/base-page';
 import FeaturePage from '@/page-objects/feature/feature-page';
 import PageCommons from '@/page-objects/page-commons';
 import { baseTest, expect } from './scenario-test-fixture';
@@ -216,10 +213,10 @@ interface FeatureFixtures {
 
 const test = baseTest.extend<FeatureFixtures>({
   featurePage: async ({ page }, use) => {
-    await use(withSafeActions(new FeaturePage(page)));
+    await use(new FeaturePage(page));
   },
   pageCommons: async ({ page }, use) => {
-    await use(withSafeActions(new PageCommons(page)));
+    await use(new PageCommons(page));
   },
 });
 
@@ -377,7 +374,6 @@ playwright/
 ## Rules
 
 - **Every fixture extends `baseTest`** from `scenario-test-fixture.ts`
-- **Page objects are wrapped with `withSafeActions()`** in fixtures
 - **Page objects extend `BasePage` or `PageCommons`** — not standalone classes
 - **Components extend `BaseComponent`** and are composed by page objects
 - **Use allure constants** from `@/data-models/allure-constants` — never raw strings for tier/feature labels

--- a/.cursor/commands/test-fix.md
+++ b/.cursor/commands/test-fix.md
@@ -100,7 +100,6 @@ For `test_bug` classified failures:
 #### Architecture constraints
 
 - All fixtures extend `baseTest` from `scenario-test-fixture.ts`
-- Page objects are wrapped with `withSafeActions()` in fixtures
 - Page objects extend `BasePage` or `PageCommons`
 - Components extend `BaseComponent` and are composed by page objects
 - Specs import `test` and `expect` from their feature fixture — never from `@playwright/test`
@@ -129,7 +128,6 @@ For `test_bug` classified failures:
 - **Timing issue**: Add `waitFor()` in the page object method or use `expect.poll()`
 - **Setup failure masking tests**: Remove `setupError` + `test.skip` patterns — let setup failures fail the suite
 - **Missing cleanup**: Add `apiClient.trackResource()` after resource creation
-- **`withSafeActions` silent skip**: If a test appears skipped but should fail, check if `withSafeActions` is swallowing a timeout — the fix belongs in the page object method
 
 ### Phase 5: Re-run Fixed Tests
 
@@ -158,16 +156,16 @@ Remaining failures: <list with classification>
 
 ## Common Failure Patterns
 
-| Symptom                        | Likely Cause                       | Fix Location                      |
-| ------------------------------ | ---------------------------------- | --------------------------------- |
-| `Timeout waiting for selector` | Selector changed                   | Component or page object          |
-| `locator.click: Target closed` | Page navigated mid-action          | Add wait in page object method    |
-| `expect.toBe: false`           | Assertion timing                   | Use `waitFor()` / `expect.poll()` |
-| `strict mode violation`        | Multiple matches                   | Refine locator in component       |
-| `net::ERR_CONNECTION_REFUSED`  | Cluster down                       | Environment issue                 |
-| `401 Unauthorized`             | Token expired                      | Re-run global setup               |
-| `test.skip` but should fail    | `withSafeActions` swallowing error | Fix timeout in page object        |
-| `setupError` skip cascade      | Catch-and-skip in beforeAll        | Remove pattern, let it fail       |
+| Symptom                        | Likely Cause                      | Fix Location                      |
+| ------------------------------ | --------------------------------- | --------------------------------- |
+| `Timeout waiting for selector` | Selector changed                  | Component or page object          |
+| `locator.click: Target closed` | Page navigated mid-action         | Add wait in page object method    |
+| `expect.toBe: false`           | Assertion timing                  | Use `waitFor()` / `expect.poll()` |
+| `strict mode violation`        | Multiple matches                  | Refine locator in component       |
+| `net::ERR_CONNECTION_REFUSED`  | Cluster down                      | Environment issue                 |
+| `401 Unauthorized`             | Token expired                     | Re-run global setup               |
+| `test.skip` but should fail    | Soft assertion or swallowed error | Fix timeout in page object        |
+| `setupError` skip cascade      | Catch-and-skip in beforeAll       | Remove pattern, let it fail       |
 
 ## Environment Variables
 
@@ -263,7 +261,7 @@ playwright/
 
 - **Fix locators in components/page objects** — not in spec files
 - **Specs import from feature fixtures** — never from `@playwright/test` directly
-- **Page objects extend `BasePage` / `PageCommons`** — use `withSafeActions()` in fixtures
+- **Page objects extend `BasePage` / `PageCommons`**
 - **Use `TestTimeouts.*` constants** — never inline timeout numbers
 - **Use allure constants** from `@/data-models/allure-constants` — never raw strings
 - **Verify via API** — use `apiClient` (`RequestContextClient`) to check K8s state after UI actions

--- a/.cursor/rules/agents/e2e-orchestrator.mdc
+++ b/.cursor/rules/agents/e2e-orchestrator.mdc
@@ -35,7 +35,7 @@ Tests are organized by tiers. Each tier maps to a Playwright project and has its
 ```
 Spec (.spec.ts) → imports { test, expect } from feature fixture
   ↓
-Feature fixture → extends baseTest, wraps page objects with withSafeActions()
+Feature fixture → extends baseTest, provides page objects
   ↓
 Page objects (page-objects/) → extend BasePage/PageCommons, compose components
   ↓
@@ -48,7 +48,7 @@ RequestContextClient (clients/request-context-client.ts) → console proxy → K
 ### Key Components
 
 - **`baseTest`** (`scenario-test-fixture.ts`) — root fixture providing `ocClient`, `utils`, `testConfig`, auto-fixtures, cleanup
-- **Per-feature fixtures** (`fixtures/<feature>-fixture.ts`) — extend `baseTest`, add page objects wrapped with `withSafeActions()`
+- **Per-feature fixtures** (`fixtures/<feature>-fixture.ts`) — extend `baseTest`, add page objects
 - **Page objects** (`page-objects/`) — extend `BasePage` or `PageCommons`, compose components, expose high-level methods
 - **Components** (`components/`) — extend `BaseComponent`, contain locators and interaction methods for UI sections
 - **OcClient** (`clients/oc-cli-client.ts`) — `oc` CLI wrapper with handler delegates; RBAC-limited in HC mode (see RBAC section below)
@@ -190,7 +190,7 @@ All fixtures extend `baseTest`. Create per-feature fixtures for each test area:
 ```typescript
 const test = baseTest.extend<FeatureFixtures>({
   featurePage: async ({ page }, use) => {
-    await use(withSafeActions(new FeaturePage(page)));
+    await use(new FeaturePage(page));
   },
 });
 ```

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -161,7 +161,7 @@ Never run two concurrent `npx playwright test` commands. Global setup creates sh
 ```text
 Spec (.spec.ts) → imports { test, expect } from feature fixture
   ↓
-Feature fixture → extends baseTest, wraps page objects with withSafeActions()
+Feature fixture → extends baseTest, provides page objects
   ↓
 Page objects (page-objects/) → extend BasePage/PageCommons, compose components
   ↓
@@ -241,11 +241,9 @@ playwright/
 ### Fixtures
 
 - Every fixture extends `baseTest` from `scenario-test-fixture.ts`.
-- Page objects are wrapped with `withSafeActions()` in the fixture.
 - `baseTest` provides `apiClient`, `utils`, `testConfig`, `page`, `cleanup`, and auto-fixtures.
 
 ```typescript
-import { withSafeActions } from '@/page-objects/base-page';
 import FeaturePage from '@/page-objects/feature/feature-page';
 import { baseTest, expect } from './scenario-test-fixture';
 
@@ -255,7 +253,7 @@ interface FeatureFixtures {
 
 const test = baseTest.extend<FeatureFixtures>({
   featurePage: async ({ page }, use) => {
-    await use(withSafeActions(new FeaturePage(page)));
+    await use(new FeaturePage(page));
   },
 });
 
@@ -395,15 +393,15 @@ Explore live UI workflows to find visual, functional, or UX issues.
 
 ## Common Failure Patterns
 
-| Symptom                        | Likely Cause                         | Fix Location                      |
-| ------------------------------ | ------------------------------------ | --------------------------------- |
-| `Timeout waiting for selector` | Selector changed in product          | Component or page object          |
-| `locator.click: Target closed` | Page navigated mid-action            | Add wait in page object method    |
-| `expect.toBe: false`           | Assertion timing                     | Use `waitFor()` / `expect.poll()` |
-| `strict mode violation`        | Multiple matches                     | Refine locator in component       |
-| `net::ERR_CONNECTION_REFUSED`  | Cluster unreachable                  | Environment issue                 |
-| `401 Unauthorized`             | Token expired                        | Re-run global setup               |
-| Test silently skipped          | `withSafeActions` swallowing timeout | Fix timeout in page object        |
+| Symptom                        | Likely Cause                      | Fix Location                      |
+| ------------------------------ | --------------------------------- | --------------------------------- |
+| `Timeout waiting for selector` | Selector changed in product       | Component or page object          |
+| `locator.click: Target closed` | Page navigated mid-action         | Add wait in page object method    |
+| `expect.toBe: false`           | Assertion timing                  | Use `waitFor()` / `expect.poll()` |
+| `strict mode violation`        | Multiple matches                  | Refine locator in component       |
+| `net::ERR_CONNECTION_REFUSED`  | Cluster unreachable               | Environment issue                 |
+| `401 Unauthorized`             | Token expired                     | Re-run global setup               |
+| Test silently skipped          | Soft assertion or swallowed error | Fix timeout / error handling      |
 
 ---
 

--- a/playwright/src/clients/proxy-handlers/vm-proxy-handler.ts
+++ b/playwright/src/clients/proxy-handlers/vm-proxy-handler.ts
@@ -558,13 +558,12 @@ export class VirtualMachineProxyHandler {
     const start = Date.now();
     while (Date.now() - start < timeoutMs) {
       try {
-        const vmi = await this.getInstance(namespace, vmName);
-        if (vmi) {
-          const status = vmi.status as Record<string, unknown> | undefined;
-          if (status?.phase === 'Running') return true;
-        }
+        const vm = await this.get(namespace, vmName);
+        const printableStatus = (vm?.status as { printableStatus?: string } | undefined)
+          ?.printableStatus;
+        if (printableStatus === 'Running') return true;
       } catch {
-        // VMI not yet available
+        // VM not yet available
       }
       await new Promise((r) => setTimeout(r, 5000));
     }

--- a/playwright/src/components/create-vm/bootable-volumes-create-components.ts
+++ b/playwright/src/components/create-vm/bootable-volumes-create-components.ts
@@ -15,6 +15,50 @@ export interface CreateBootableVolumeFormOptions {
   instanceType?: string;
 }
 
+type RegistrySelectHost = {
+  page: Page;
+  testId: (id: string) => Locator;
+  robustClick: (locator: Locator) => Promise<unknown>;
+};
+
+async function selectRegistrySourceTypeInAddVolumeModal(
+  host: RegistrySelectHost,
+  dialog: Locator,
+): Promise<void> {
+  const sourceTypeSelect = dialog.getByTestId('source-type-select');
+  await sourceTypeSelect.waitFor({
+    state: 'visible',
+    timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+  });
+
+  const containerImageInput = dialog.getByTestId('volume-registry-container-source-input');
+
+  await expect
+    .poll(
+      async () => {
+        await host.robustClick(sourceTypeSelect);
+        const useRegistry = host.testId('use-registry');
+        await useRegistry.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ACTION_COMPLETE,
+        });
+        if (await useRegistry.isDisabled().catch(() => false)) {
+          throw new Error(
+            'Registry source option is disabled (likely missing DataSource create permission)',
+          );
+        }
+        await host.robustClick(useRegistry);
+        return containerImageInput.isVisible();
+      },
+      {
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+        intervals: [TestTimeouts.UI_DELAY_SHORT],
+        message: 'Failed to select Registry source type in Add volume modal',
+      },
+    )
+    .toBe(true);
+}
+
 export class BootableVolumesRowActionsComponent extends BaseComponent {
   private readonly _dialogModal = this.testId('dialog-modal');
 
@@ -935,29 +979,14 @@ export class BootableVolumesCreateFormsComponent extends BaseComponent {
       timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
     });
 
-    const sourceTypeSelect = this._addVolumeDialog.getByTestId('source-type-select');
-    await sourceTypeSelect.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
-    });
-    await this.robustClick(sourceTypeSelect);
-    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
-
-    const useRegistry = this.testId('use-registry');
-    await useRegistry.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await this.robustClick(useRegistry);
-    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    await selectRegistrySourceTypeInAddVolumeModal(
+      this as unknown as RegistrySelectHost,
+      this._addVolumeDialog,
+    );
 
     const containerImageInput = this._addVolumeDialog.getByTestId(
       'volume-registry-container-source-input',
     );
-    await containerImageInput.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
     await containerImageInput.fill(registryUrl);
 
     const cronExpInput = this._addVolumeDialog
@@ -1603,115 +1632,6 @@ export class BootableVolumesCreateComponent extends BaseComponent {
     await this.robustClick(this._createFormSaveButton);
   }
 
-  async fillCreateBootableVolumeFormFromRegistryAndSave(
-    volumeName: string,
-    registryUrl: string,
-    cronExpression: string,
-    options: CreateBootableVolumeFormOptions = {},
-  ): Promise<void> {
-    const { preference = 'alpine', instanceType = 'nano' } = options;
-
-    await this._addVolumeDialog.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
-    });
-
-    const sourceTypeSelect = this._addVolumeDialog.getByTestId('source-type-select');
-    await sourceTypeSelect.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
-    });
-    await this.robustClick(sourceTypeSelect);
-    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
-
-    const useRegistry = this.testId('use-registry');
-    await useRegistry.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await this.robustClick(useRegistry);
-    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
-
-    const containerImageInput = this._addVolumeDialog.getByTestId(
-      'volume-registry-container-source-input',
-    );
-    await containerImageInput.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await containerImageInput.fill(registryUrl);
-
-    const cronExpInput = this._addVolumeDialog
-      .locator('[data-test="volume-registry-retain-cron-expression"]')
-      .or(this._addVolumeDialog.locator('#volume-registry-retain-cron-expression'));
-    await cronExpInput.scrollIntoViewIfNeeded();
-    await cronExpInput.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await cronExpInput.clear();
-    await cronExpInput.fill(cronExpression);
-
-    await this._createFormNameInput.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
-    });
-    await this._createFormNameInput.fill(volumeName);
-
-    const selectPreferenceButton = this._addVolumeDialog.locator(
-      'button:has-text("Select preference")',
-    );
-    await selectPreferenceButton.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await this.robustClick(selectPreferenceButton);
-
-    const searchPreferenceInput = this._selectInlineFilterInput;
-    await searchPreferenceInput.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await searchPreferenceInput.fill(preference);
-
-    const preferenceOption = this.locator(
-      `#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
-    );
-    await this.robustClick(preferenceOption);
-
-    const selectInstanceButton = this._addVolumeDialog.locator(
-      'button:has-text("Select InstanceType")',
-    );
-    await selectInstanceButton.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await this.robustClick(selectInstanceButton);
-
-    const redHatProvided = this._addVolumeDialog
-      .locator('button:has-text("Red Hat provided")')
-      .first();
-    await this.robustClick(redHatProvided);
-
-    const uSeries = this._addVolumeDialog.locator('button:has-text("U series")').first();
-    await this.robustClick(uSeries);
-
-    const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}:")`).first();
-    await this.robustClick(instanceTypeOption);
-
-    await this._createFormSaveButton.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
-    });
-    await expect(
-      this._createFormSaveButton,
-      'Create volume form Save button should be enabled after selecting registry source and instance type',
-    ).toBeEnabled({
-      timeout: TestTimeouts.FILE_UPLOAD,
-    });
-    await this.robustClick(this._createFormSaveButton);
-  }
-
   async fillCreateBootableVolumeFormFromSnapshotAndSave(
     volumeName: string,
     snapshotName: string,
@@ -1799,17 +1719,24 @@ export class BootableVolumesCreateComponent extends BaseComponent {
   async selectSourceTypeInAddVolumeModal(
     sourceType: 'URL' | 'Registry' | 'Volume' | 'Volume snapshot',
   ): Promise<void> {
-    const sourceTypeLocators: Record<string, Locator> = {
-      URL: this.testId('use-http'),
-      Registry: this.testId('use-registry'),
-      Volume: this.locator('button[role="option"]:has-text("Volume"):not(:has-text("snapshot"))'),
-      'Volume snapshot': this.locator('button[role="option"]:has-text("Volume snapshot")'),
-    };
-
     await this._addVolumeDialog.waitFor({
       state: 'visible',
       timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
     });
+
+    if (sourceType === 'Registry') {
+      await selectRegistrySourceTypeInAddVolumeModal(
+        this as unknown as RegistrySelectHost,
+        this._addVolumeDialog,
+      );
+      return;
+    }
+
+    const sourceTypeLocators: Record<string, Locator> = {
+      URL: this.testId('use-http'),
+      Volume: this.locator('button[role="option"]:has-text("Volume"):not(:has-text("snapshot"))'),
+      'Volume snapshot': this.locator('button[role="option"]:has-text("Volume snapshot")'),
+    };
 
     const sourceTypeSelect = this._addVolumeDialog.getByTestId('source-type-select');
     await sourceTypeSelect.waitFor({

--- a/playwright/src/components/create-vm/bootable-volumes-create-components.ts
+++ b/playwright/src/components/create-vm/bootable-volumes-create-components.ts
@@ -15,6 +15,50 @@ export interface CreateBootableVolumeFormOptions {
   instanceType?: string;
 }
 
+type RegistrySelectHost = {
+  page: Page;
+  testId: (id: string) => Locator;
+  robustClick: (locator: Locator) => Promise<unknown>;
+};
+
+async function selectRegistrySourceTypeInAddVolumeModal(
+  host: RegistrySelectHost,
+  dialog: Locator,
+): Promise<void> {
+  const sourceTypeSelect = dialog.getByTestId('source-type-select');
+  await sourceTypeSelect.waitFor({
+    state: 'visible',
+    timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+  });
+
+  const containerImageInput = dialog.getByTestId('volume-registry-container-source-input');
+
+  await expect
+    .poll(
+      async () => {
+        await host.robustClick(sourceTypeSelect);
+        const useRegistry = host.testId('use-registry');
+        await useRegistry.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ACTION_COMPLETE,
+        });
+        if (await useRegistry.isDisabled().catch(() => false)) {
+          throw new Error(
+            'Registry source option is disabled (likely missing DataSource create permission)',
+          );
+        }
+        await host.robustClick(useRegistry);
+        return containerImageInput.isVisible();
+      },
+      {
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+        intervals: [TestTimeouts.UI_DELAY_SHORT],
+        message: 'Failed to select Registry source type in Add volume modal',
+      },
+    )
+    .toBe(true);
+}
+
 export class BootableVolumesRowActionsComponent extends BaseComponent {
   private readonly _dialogModal = this.testId('dialog-modal');
 
@@ -913,29 +957,14 @@ export class BootableVolumesCreateFormsComponent extends BaseComponent {
       timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
     });
 
-    const sourceTypeSelect = this._addVolumeDialog.getByTestId('source-type-select');
-    await sourceTypeSelect.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
-    });
-    await this.robustClick(sourceTypeSelect);
-    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
-
-    const useRegistry = this.testId('use-registry');
-    await useRegistry.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await this.robustClick(useRegistry);
-    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+    await selectRegistrySourceTypeInAddVolumeModal(
+      this as unknown as RegistrySelectHost,
+      this._addVolumeDialog,
+    );
 
     const containerImageInput = this._addVolumeDialog.getByTestId(
       'volume-registry-container-source-input',
     );
-    await containerImageInput.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
     await containerImageInput.fill(registryUrl);
 
     const cronExpInput = this._addVolumeDialog
@@ -1581,115 +1610,6 @@ export class BootableVolumesCreateComponent extends BaseComponent {
     await this.robustClick(this._createFormSaveButton);
   }
 
-  async fillCreateBootableVolumeFormFromRegistryAndSave(
-    volumeName: string,
-    registryUrl: string,
-    cronExpression: string,
-    options: CreateBootableVolumeFormOptions = {},
-  ): Promise<void> {
-    const { preference = 'alpine', instanceType = 'nano' } = options;
-
-    await this._addVolumeDialog.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
-    });
-
-    const sourceTypeSelect = this._addVolumeDialog.getByTestId('source-type-select');
-    await sourceTypeSelect.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
-    });
-    await this.robustClick(sourceTypeSelect);
-    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
-
-    const useRegistry = this.testId('use-registry');
-    await useRegistry.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await this.robustClick(useRegistry);
-    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
-
-    const containerImageInput = this._addVolumeDialog.getByTestId(
-      'volume-registry-container-source-input',
-    );
-    await containerImageInput.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await containerImageInput.fill(registryUrl);
-
-    const cronExpInput = this._addVolumeDialog
-      .locator('[data-test="volume-registry-retain-cron-expression"]')
-      .or(this._addVolumeDialog.locator('#volume-registry-retain-cron-expression'));
-    await cronExpInput.scrollIntoViewIfNeeded();
-    await cronExpInput.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await cronExpInput.clear();
-    await cronExpInput.fill(cronExpression);
-
-    await this._createFormNameInput.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
-    });
-    await this._createFormNameInput.fill(volumeName);
-
-    const selectPreferenceButton = this._addVolumeDialog.locator(
-      'button:has-text("Select preference")',
-    );
-    await selectPreferenceButton.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await this.robustClick(selectPreferenceButton);
-
-    const searchPreferenceInput = this._selectInlineFilterInput;
-    await searchPreferenceInput.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await searchPreferenceInput.fill(preference);
-
-    const preferenceOption = this.locator(
-      `#select-inline-filter-VirtualMachineClusterPreference-${preference}`,
-    );
-    await this.robustClick(preferenceOption);
-
-    const selectInstanceButton = this._addVolumeDialog.locator(
-      'button:has-text("Select InstanceType")',
-    );
-    await selectInstanceButton.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ACTION_COMPLETE,
-    });
-    await this.robustClick(selectInstanceButton);
-
-    const redHatProvided = this._addVolumeDialog
-      .locator('button:has-text("Red Hat provided")')
-      .first();
-    await this.robustClick(redHatProvided);
-
-    const uSeries = this._addVolumeDialog.locator('button:has-text("U series")').first();
-    await this.robustClick(uSeries);
-
-    const instanceTypeOption = this.locator(`#u1 button:has-text("${instanceType}:")`).first();
-    await this.robustClick(instanceTypeOption);
-
-    await this._createFormSaveButton.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
-    });
-    await expect(
-      this._createFormSaveButton,
-      'Create volume form Save button should be enabled after selecting registry source and instance type',
-    ).toBeEnabled({
-      timeout: TestTimeouts.FILE_UPLOAD,
-    });
-    await this.robustClick(this._createFormSaveButton);
-  }
-
   async fillCreateBootableVolumeFormFromSnapshotAndSave(
     volumeName: string,
     snapshotName: string,
@@ -1777,17 +1697,24 @@ export class BootableVolumesCreateComponent extends BaseComponent {
   async selectSourceTypeInAddVolumeModal(
     sourceType: 'URL' | 'Registry' | 'Volume' | 'Volume snapshot',
   ): Promise<void> {
-    const sourceTypeLocators: Record<string, Locator> = {
-      URL: this.testId('use-http'),
-      Registry: this.testId('use-registry'),
-      Volume: this.locator('button[role="option"]:has-text("Volume"):not(:has-text("snapshot"))'),
-      'Volume snapshot': this.locator('button[role="option"]:has-text("Volume snapshot")'),
-    };
-
     await this._addVolumeDialog.waitFor({
       state: 'visible',
       timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
     });
+
+    if (sourceType === 'Registry') {
+      await selectRegistrySourceTypeInAddVolumeModal(
+        this as unknown as RegistrySelectHost,
+        this._addVolumeDialog,
+      );
+      return;
+    }
+
+    const sourceTypeLocators: Record<string, Locator> = {
+      URL: this.testId('use-http'),
+      Volume: this.locator('button[role="option"]:has-text("Volume"):not(:has-text("snapshot"))'),
+      'Volume snapshot': this.locator('button[role="option"]:has-text("Volume snapshot")'),
+    };
 
     const sourceTypeSelect = this._addVolumeDialog.getByTestId('source-type-select');
     await sourceTypeSelect.waitFor({

--- a/playwright/src/components/shared/navigation-component.ts
+++ b/playwright/src/components/shared/navigation-component.ts
@@ -14,6 +14,27 @@ export default class NavigationComponent extends BaseComponent {
     super(page);
   }
 
+  private async closePerspectiveMenu(): Promise<void> {
+    const openOption = this.consoleTestId('perspective-switcher-menu-option').first();
+    const isOpen = await openOption.isVisible().catch(() => false);
+    if (!isOpen) return;
+
+    await this.page.keyboard.press('Escape').catch(() => undefined);
+    const closed = await openOption
+      .waitFor({ state: 'hidden', timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .then(() => true)
+      .catch(() => false);
+    if (closed) return;
+
+    // Escape sometimes leaves the PF menu open — toggle again to close.
+    await this.consoleTestId('perspective-switcher-toggle')
+      .click({ force: true })
+      .catch(() => undefined);
+    await openOption
+      .waitFor({ state: 'hidden', timeout: TestTimeouts.UI_DELAY_SHORT })
+      .catch(() => undefined);
+  }
+
   private async dismissBlockingModals(): Promise<void> {
     const welcomeModal = this.testId('welcome-modal');
     if (await welcomeModal.isVisible().catch(() => false)) {
@@ -171,9 +192,19 @@ export default class NavigationComponent extends BaseComponent {
       });
 
     if (expectedUrlPattern) {
-      await this.page
-        .waitForURL(expectedUrlPattern, { timeout: TestTimeouts.NAVIGATION })
-        .catch(() => undefined);
+      const navigated = await this.page
+        .waitForURL(expectedUrlPattern, { timeout: TestTimeouts.UI_DELAY_LONG })
+        .then(() => true)
+        .catch(() => false);
+      if (!navigated) {
+        await this.closePerspectiveMenu();
+        await navLocator
+          .click({ force: true, timeout: TestTimeouts.UI_DELAY_MEDIUM })
+          .catch(async () => {
+            await navLocator.dispatchEvent('click');
+          });
+        await this.page.waitForURL(expectedUrlPattern, { timeout: TestTimeouts.UI_DELAY_LONG });
+      }
     }
 
     await this.page.waitForLoadState('domcontentloaded');
@@ -188,10 +219,14 @@ export default class NavigationComponent extends BaseComponent {
   }
 
   async expandVirtualizationNavSection(): Promise<void> {
-    await this.switchToVirtualizationPerspective();
+    try {
+      await this.switchToVirtualizationPerspective();
+    } catch {
+      // Perspective switch unavailable — continue with section expansion under current perspective.
+    }
+    await this.closePerspectiveMenu();
     // Wait for the auto-hide requestAnimationFrame to fire and settle before checking sidebar state
     await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
-
     await this.ensureSidebarExpanded();
 
     const childItem = this.testId('virtualmachines-nav-item')
@@ -358,11 +393,35 @@ export default class NavigationComponent extends BaseComponent {
       }
     }
 
-    const currentText = (await toggle.textContent().catch(() => '')) ?? '';
-    if (currentText.toLowerCase().includes('virtualization')) return;
+    const getToggleText = async (): Promise<string> =>
+      ((await toggle.textContent().catch(() => '')) ?? '').replace(/\s+/g, ' ').trim();
 
+    const isVirtualizationToggle = (text: string): boolean =>
+      /virtualization/i.test(text) && !/fleet/i.test(text);
+
+    const hasVirtNav = async (): Promise<boolean> => {
+      const section = this.locator('[data-quickstart-id="qs-nav-sec-virtualization"]');
+      const navItem = this.testId('bootablevolumes-nav-item')
+        .or(this.testId('virtualmachines-nav-item'))
+        .or(this.testId('templates-nav-item'))
+        .or(this.testId('virtualmachineclusterinstancetypes-nav-item'));
+      return (
+        (await section.isVisible().catch(() => false)) ||
+        (await navItem.first().isVisible().catch(() => false))
+      );
+    };
+
+    // Already on Virtualization (or Core Platform with virt nav) — do not open the menu.
+    if (isVirtualizationToggle(await getToggleText()) || (await hasVirtNav())) {
+      await this.closePerspectiveMenu();
+      return;
+    }
+
+    // Exact label match avoids selecting "Fleet Virtualization".
     const virtOption = this.consoleTestId('perspective-switcher-menu-option').filter({
-      hasText: 'Virtualization',
+      has: this.locator('.pf-v6-c-menu__item-text', {
+        hasText: /^Virtualization$/,
+      }),
     });
 
     const maxAttempts = 4;
@@ -384,10 +443,14 @@ export default class NavigationComponent extends BaseComponent {
         await clickTarget.click({ force: true, timeout: TestTimeouts.DEFAULT });
         await this.page.waitForLoadState('domcontentloaded');
         await this.waitForLoadingComplete(TestTimeouts.SHORT_WAIT);
-        return;
+        await this.closePerspectiveMenu();
+
+        if (isVirtualizationToggle(await getToggleText()) || (await hasVirtNav())) {
+          return;
+        }
       }
 
-      await this.page.keyboard.press('Escape').catch(() => undefined);
+      await this.closePerspectiveMenu();
       await this.page.waitForTimeout(TestTimeouts.RETRY_DELAY);
     }
 

--- a/playwright/src/components/shared/navigation-component.ts
+++ b/playwright/src/components/shared/navigation-component.ts
@@ -1,5 +1,5 @@
 import { TestTimeouts } from '@/utils/test-config';
-import type { Locator, Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 
 import BaseComponent from './base-component';
 
@@ -9,6 +9,11 @@ export default class NavigationComponent extends BaseComponent {
     'perspective-switcher-menu-option',
   );
   private readonly _perspectiveSwitcherToggle = this.consoleTestId('perspective-switcher-toggle');
+  private readonly _tourSkipButton = this.testId('tour-step-footer-secondary');
+  private readonly _virtNavSection = this.locator(
+    '[data-quickstart-id="qs-nav-sec-virtualization"]',
+  );
+  private readonly _welcomeModalCheckbox = this.locator('#welcome-modal-checkbox');
 
   constructor(page: Page) {
     super(page);
@@ -35,6 +40,30 @@ export default class NavigationComponent extends BaseComponent {
       .catch(() => undefined);
   }
 
+  private async normalizedToggleText(): Promise<string> {
+    return ((await this._perspectiveSwitcherToggle.textContent().catch(() => '')) ?? '')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  private perspectiveOptionByLabel(label: RegExp): Locator {
+    return this._perspectiveSwitcherMenuOption.filter({
+      has: this.locator('.pf-v6-c-menu__item-text', { hasText: label }),
+    });
+  }
+
+  private async waitForSelectedPerspective(expected: RegExp): Promise<void> {
+    await this._perspectiveSwitcherToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.DEFAULT,
+    });
+    await expect
+      .poll(async () => this.normalizedToggleText(), {
+        timeout: TestTimeouts.UI_DELAY_LONG,
+      })
+      .toMatch(expected);
+  }
+
   private async dismissBlockingModals(): Promise<void> {
     const welcomeModal = this.testId('welcome-modal');
     if (await welcomeModal.isVisible().catch(() => false)) {
@@ -49,6 +78,44 @@ export default class NavigationComponent extends BaseComponent {
       await dismissBtn.click({ force: true }).catch(() => undefined);
       await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
     }
+  }
+
+  /**
+   * Dismiss guided-tour, onboarding, and welcome overlays that block the
+   * perspective switcher after the first console load.
+   */
+  async dismissStartupOverlays(): Promise<void> {
+    const hasTour = await this._tourSkipButton
+      .isVisible({ timeout: TestTimeouts.RETRY_DELAY })
+      .catch(() => false);
+    if (hasTour) {
+      await this._tourSkipButton.click({ force: true }).catch(() => undefined);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    const onboardingDismiss = this.testId('onboarding-dismiss-btn');
+    if (
+      await onboardingDismiss.isVisible({ timeout: TestTimeouts.RETRY_DELAY }).catch(() => false)
+    ) {
+      await onboardingDismiss.click({ force: true }).catch(() => undefined);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    await this.dismissBlockingModals();
+
+    const hasWelcome = await this._welcomeModalCheckbox
+      .isVisible({ timeout: TestTimeouts.RETRY_DELAY })
+      .catch(() => false);
+    if (hasWelcome) {
+      await this._welcomeModalCheckbox.check({ force: true }).catch(() => undefined);
+      const closeBtn = this.locator('.pf-v6-c-modal-box__close button');
+      await closeBtn.click({ force: true }).catch(() => undefined);
+      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    }
+
+    await this.locator('.pf-v6-c-backdrop')
+      .waitFor({ state: 'hidden', timeout: TestTimeouts.UI_DELAY_LONG })
+      .catch(() => undefined);
   }
 
   /**
@@ -255,16 +322,15 @@ export default class NavigationComponent extends BaseComponent {
     if (childVisible) return;
 
     // Fallback for Core Platform perspective where Virtualization is a collapsible section.
-    const virtualizationSection = this.locator('[data-quickstart-id="qs-nav-sec-virtualization"]');
-    const sectionVisible = await virtualizationSection
+    const sectionVisible = await this._virtNavSection
       .isVisible({ timeout: TestTimeouts.RETRY_DELAY })
       .catch(() => false);
     if (!sectionVisible) return;
 
-    const isExpanded = await virtualizationSection.getAttribute('aria-expanded');
+    const isExpanded = await this._virtNavSection.getAttribute('aria-expanded');
     if (isExpanded === 'false') {
-      await virtualizationSection.click().catch(async () => {
-        await virtualizationSection.dispatchEvent('click');
+      await this._virtNavSection.click().catch(async () => {
+        await this._virtNavSection.dispatchEvent('click');
       });
       await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
     }
@@ -275,16 +341,87 @@ export default class NavigationComponent extends BaseComponent {
       .catch(() => undefined);
   }
 
+  /**
+   * After console load, select Virtualization when the perspective switcher is
+   * present. Fall back to Core Platform on ACM hubs that do not ship that
+   * perspective. No-op when Virtualization is already a sidebar section.
+   */
+  async ensureInitialPerspective(): Promise<void> {
+    const navType = await Promise.race([
+      this._perspectiveSwitcherToggle
+        .waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT })
+        .then(() => 'perspective' as const),
+      this._virtNavSection
+        .waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT })
+        .then(() => 'section' as const),
+    ]).catch(() => 'none' as const);
+
+    if (navType !== 'perspective') return;
+
+    const toggleLabel = await this.normalizedToggleText();
+    if (/^Virtualization$/i.test(toggleLabel) || /^Core Platform$/i.test(toggleLabel)) {
+      return;
+    }
+
+    const virtOption = this.perspectiveOptionByLabel(/^Virtualization$/);
+    const corePlatformOption = this.perspectiveOptionByLabel(/^Core Platform$/i);
+    const selectionAttempts = 3;
+
+    for (let selAttempt = 1; selAttempt <= selectionAttempts; selAttempt++) {
+      try {
+        await this._perspectiveSwitcherToggle.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.DEFAULT,
+        });
+        await this._perspectiveSwitcherToggle.click();
+
+        const virtVisible = await virtOption
+          .waitFor({
+            state: 'visible',
+            timeout: TestTimeouts.UI_DELAY_LONG,
+          })
+          .then(() => true)
+          .catch(() => false);
+
+        if (virtVisible) {
+          await virtOption.scrollIntoViewIfNeeded();
+          await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MICRO);
+          await virtOption.click();
+          await this.waitForSelectedPerspective(/^Virtualization$/i);
+        } else {
+          const coreVisible = await corePlatformOption
+            .waitFor({
+              state: 'visible',
+              timeout: TestTimeouts.UI_DELAY_LONG,
+            })
+            .then(() => true)
+            .catch(() => false);
+          if (!coreVisible) {
+            throw new Error('Neither Virtualization nor Core Platform perspective found');
+          }
+          await corePlatformOption.scrollIntoViewIfNeeded();
+          await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MICRO);
+          await corePlatformOption.click();
+          await this.waitForSelectedPerspective(/^Core Platform$/i);
+        }
+        await this.page.waitForLoadState('load');
+        return;
+      } catch {
+        if (selAttempt === selectionAttempts) {
+          throw new Error('Perspective selection did not navigate to Virtualization');
+        }
+        await this.page.keyboard.press('Escape').catch(() => undefined);
+        await this.page.waitForTimeout(TestTimeouts.POLLING_INTERVAL);
+      }
+    }
+  }
+
   async getPerspectiveSwitcherOptionText(perspectiveName: string): Promise<string | null> {
     const toggle = this._perspectiveSwitcherToggle;
     await toggle.waitFor({ state: 'visible', timeout: TestTimeouts.UI_VISIBILITY_QUICK });
     await toggle.click();
 
-    const option = this._perspectiveSwitcherMenuOption.filter({
-      has: this.locator('.pf-v6-c-menu__item-text', {
-        hasText: new RegExp(`^${perspectiveName}$`, 'i'),
-      }),
-    });
+    const option = this.perspectiveOptionByLabel(new RegExp(`^${perspectiveName}$`, 'i'));
 
     const visible = await option.isVisible().catch(() => false);
     const text = visible
@@ -303,11 +440,7 @@ export default class NavigationComponent extends BaseComponent {
 
   async isPerspectiveOptionVisible(perspectiveName: string): Promise<boolean> {
     await this.openPerspectiveDropdown();
-    const option = this._perspectiveSwitcherMenuOption.filter({
-      has: this.locator('.pf-v6-c-menu__item-text', {
-        hasText: new RegExp(`^${perspectiveName}$`, 'i'),
-      }),
-    });
+    const option = this.perspectiveOptionByLabel(new RegExp(`^${perspectiveName}$`, 'i'));
     const visible = await option.isVisible().catch(() => false);
     await this.page.keyboard.press('Escape');
     return visible;
@@ -315,8 +448,7 @@ export default class NavigationComponent extends BaseComponent {
 
   async isSidebarItemVisible(itemText: string): Promise<boolean> {
     try {
-      const section = this.locator('[data-quickstart-id="qs-nav-sec-virtualization"]');
-      const item = section.locator('a').filter({ hasText: itemText });
+      const item = this._virtNavSection.locator('a').filter({ hasText: itemText });
       return await item.isVisible();
     } catch {
       return false;
@@ -338,11 +470,9 @@ export default class NavigationComponent extends BaseComponent {
 
   async switchToPerspective(perspectiveName: string): Promise<void> {
     await this.openPerspectiveDropdown();
-    const perspectiveOption = this.consoleTestId('perspective-switcher-menu-option').filter({
-      has: this.locator('.pf-v6-c-menu__item-text', {
-        hasText: new RegExp(`^${perspectiveName}$`, 'i'),
-      }),
-    });
+    const perspectiveOption = this.perspectiveOptionByLabel(
+      new RegExp(`^${perspectiveName}$`, 'i'),
+    );
     await perspectiveOption.waitFor({
       state: 'visible',
       timeout: TestTimeouts.UI_VISIBILITY_QUICK,
@@ -400,14 +530,16 @@ export default class NavigationComponent extends BaseComponent {
       /virtualization/i.test(text) && !/fleet/i.test(text);
 
     const hasVirtNav = async (): Promise<boolean> => {
-      const section = this.locator('[data-quickstart-id="qs-nav-sec-virtualization"]');
       const navItem = this.testId('bootablevolumes-nav-item')
         .or(this.testId('virtualmachines-nav-item'))
         .or(this.testId('templates-nav-item'))
         .or(this.testId('virtualmachineclusterinstancetypes-nav-item'));
       return (
-        (await section.isVisible().catch(() => false)) ||
-        (await navItem.first().isVisible().catch(() => false))
+        (await this._virtNavSection.isVisible().catch(() => false)) ||
+        (await navItem
+          .first()
+          .isVisible()
+          .catch(() => false))
       );
     };
 
@@ -418,11 +550,7 @@ export default class NavigationComponent extends BaseComponent {
     }
 
     // Exact label match avoids selecting "Fleet Virtualization".
-    const virtOption = this.consoleTestId('perspective-switcher-menu-option').filter({
-      has: this.locator('.pf-v6-c-menu__item-text', {
-        hasText: /^Virtualization$/,
-      }),
-    });
+    const virtOption = this.perspectiveOptionByLabel(/^Virtualization$/);
 
     const maxAttempts = 4;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {

--- a/playwright/src/components/shared/navigation-component.ts
+++ b/playwright/src/components/shared/navigation-component.ts
@@ -14,6 +14,27 @@ export default class NavigationComponent extends BaseComponent {
     super(page);
   }
 
+  private async closePerspectiveMenu(): Promise<void> {
+    const openOption = this.consoleTestId('perspective-switcher-menu-option').first();
+    const isOpen = await openOption.isVisible().catch(() => false);
+    if (!isOpen) return;
+
+    await this.page.keyboard.press('Escape').catch(() => undefined);
+    const closed = await openOption
+      .waitFor({ state: 'hidden', timeout: TestTimeouts.UI_DELAY_MEDIUM })
+      .then(() => true)
+      .catch(() => false);
+    if (closed) return;
+
+    // Escape sometimes leaves the PF menu open — toggle again to close.
+    await this.consoleTestId('perspective-switcher-toggle')
+      .click({ force: true })
+      .catch(() => undefined);
+    await openOption
+      .waitFor({ state: 'hidden', timeout: TestTimeouts.UI_DELAY_SHORT })
+      .catch(() => undefined);
+  }
+
   private async dismissBlockingModals(): Promise<void> {
     const welcomeModal = this.testId('welcome-modal');
     if (await welcomeModal.isVisible().catch(() => false)) {
@@ -171,9 +192,19 @@ export default class NavigationComponent extends BaseComponent {
       });
 
     if (expectedUrlPattern) {
-      await this.page
-        .waitForURL(expectedUrlPattern, { timeout: TestTimeouts.NAVIGATION })
-        .catch(() => undefined);
+      const navigated = await this.page
+        .waitForURL(expectedUrlPattern, { timeout: TestTimeouts.UI_DELAY_LONG })
+        .then(() => true)
+        .catch(() => false);
+      if (!navigated) {
+        await this.closePerspectiveMenu();
+        await navLocator
+          .click({ force: true, timeout: TestTimeouts.UI_DELAY_MEDIUM })
+          .catch(async () => {
+            await navLocator.dispatchEvent('click');
+          });
+        await this.page.waitForURL(expectedUrlPattern, { timeout: TestTimeouts.UI_DELAY_LONG });
+      }
     }
 
     await this.page.waitForLoadState('domcontentloaded');
@@ -188,7 +219,12 @@ export default class NavigationComponent extends BaseComponent {
   }
 
   async expandVirtualizationNavSection(): Promise<void> {
-    await this.switchToVirtualizationPerspective();
+    try {
+      await this.switchToVirtualizationPerspective();
+    } catch {
+      // Perspective switch unavailable — continue with section expansion under current perspective.
+    }
+    await this.closePerspectiveMenu();
     await this.ensureSidebarExpanded();
 
     const childItem = this.testId('virtualmachines-nav-item')
@@ -355,11 +391,35 @@ export default class NavigationComponent extends BaseComponent {
       }
     }
 
-    const currentText = (await toggle.textContent().catch(() => '')) ?? '';
-    if (currentText.toLowerCase().includes('virtualization')) return;
+    const getToggleText = async (): Promise<string> =>
+      ((await toggle.textContent().catch(() => '')) ?? '').replace(/\s+/g, ' ').trim();
 
+    const isVirtualizationToggle = (text: string): boolean =>
+      /virtualization/i.test(text) && !/fleet/i.test(text);
+
+    const hasVirtNav = async (): Promise<boolean> => {
+      const section = this.locator('[data-quickstart-id="qs-nav-sec-virtualization"]');
+      const navItem = this.testId('bootablevolumes-nav-item')
+        .or(this.testId('virtualmachines-nav-item'))
+        .or(this.testId('templates-nav-item'))
+        .or(this.testId('virtualmachineclusterinstancetypes-nav-item'));
+      return (
+        (await section.isVisible().catch(() => false)) ||
+        (await navItem.first().isVisible().catch(() => false))
+      );
+    };
+
+    // Already on Virtualization (or Core Platform with virt nav) — do not open the menu.
+    if (isVirtualizationToggle(await getToggleText()) || (await hasVirtNav())) {
+      await this.closePerspectiveMenu();
+      return;
+    }
+
+    // Exact label match avoids selecting "Fleet Virtualization".
     const virtOption = this.consoleTestId('perspective-switcher-menu-option').filter({
-      hasText: 'Virtualization',
+      has: this.locator('.pf-v6-c-menu__item-text', {
+        hasText: /^Virtualization$/,
+      }),
     });
 
     const maxAttempts = 4;
@@ -381,10 +441,14 @@ export default class NavigationComponent extends BaseComponent {
         await clickTarget.click({ force: true, timeout: TestTimeouts.DEFAULT });
         await this.page.waitForLoadState('domcontentloaded');
         await this.waitForLoadingComplete(TestTimeouts.SHORT_WAIT);
-        return;
+        await this.closePerspectiveMenu();
+
+        if (isVirtualizationToggle(await getToggleText()) || (await hasVirtNav())) {
+          return;
+        }
       }
 
-      await this.page.keyboard.press('Escape').catch(() => undefined);
+      await this.closePerspectiveMenu();
       await this.page.waitForTimeout(TestTimeouts.RETRY_DELAY);
     }
 

--- a/playwright/src/components/shared/upload-progress-toast-component.ts
+++ b/playwright/src/components/shared/upload-progress-toast-component.ts
@@ -3,12 +3,19 @@
  * (see `useUploadProgressToast` in product code). Covers the "uploading" toast
  * (with abort action and context links), the terminal success toast (with links),
  * and the terminal aborted/error toasts.
+ *
+ * Console renders each toast as a PatternFly Alert: the filename is in the Alert
+ * title, while `data-test="upload-progress-*"` marks only the Alert description
+ * (progress bar / links). Match by title + body, not `hasText` on the body.
  */
 
 import { TestTimeouts } from '@/utils/test-config';
 import type { Locator, Page } from '@playwright/test';
 
 import BaseComponent from './base-component';
+
+const TOAST_ALERT = '.pf-v6-c-alert, .pf-v5-c-alert, .pf-c-alert';
+const TOAST_ALERT_TITLE = '.pf-v6-c-alert__title, .pf-v5-c-alert__title, .pf-c-alert__title';
 
 export default class UploadProgressToastComponent extends BaseComponent {
   private readonly _abortButton = this.testId('upload-progress-abort');
@@ -67,12 +74,18 @@ export default class UploadProgressToastComponent extends BaseComponent {
     const aborted = this.toastContaining(this._abortedToast, fileName);
 
     const start = Date.now();
-    await uploading
-      .or(success)
-      .or(error)
-      .or(aborted)
-      .first()
-      .waitFor({ state: 'visible', timeout });
+    try {
+      await uploading
+        .or(success)
+        .or(error)
+        .or(aborted)
+        .first()
+        .waitFor({ state: 'visible', timeout });
+    } catch {
+      throw new Error(
+        `Expected an upload toast${fileName ? ` for "${fileName}"` : ''} within ${timeout}ms. ${await this.toastDebugSuffix()}`,
+      );
+    }
 
     // The toast that triggered the wait above may have already transitioned to another
     // state by the time we classify it (e.g. a fast upload moving from "uploading" to
@@ -86,7 +99,7 @@ export default class UploadProgressToastComponent extends BaseComponent {
     }
 
     throw new Error(
-      `Upload toast became visible but could not classify state${fileName ? ` for "${fileName}"` : ''}`,
+      `Upload toast became visible but could not classify state${fileName ? ` for "${fileName}"` : ''}. ${await this.toastDebugSuffix()}`,
     );
   }
 
@@ -145,11 +158,27 @@ export default class UploadProgressToastComponent extends BaseComponent {
       .catch(() => false);
   }
 
+  /**
+   * Toast Alert whose title includes `fileName` and whose description is `root`
+   * (`data-test="upload-progress-*"`). The filename is the Alert title, not body text.
+   */
   private toastContaining(root: Locator, fileName?: string): Locator {
     if (!fileName) {
       return root;
     }
-    return root.filter({ hasText: fileName });
+
+    return this.page
+      .locator(TOAST_ALERT)
+      .filter({ has: this.page.locator(TOAST_ALERT_TITLE).filter({ hasText: fileName }) })
+      .filter({ has: root });
+  }
+
+  private async toastDebugSuffix(): Promise<string> {
+    const titles = (await this.page.locator(TOAST_ALERT_TITLE).allTextContents())
+      .map((title) => title.trim())
+      .filter(Boolean);
+
+    return `Visible toast titles: ${titles.length ? titles.join('; ') : '(none)'}`;
   }
 
   private async waitForToastVisible(
@@ -164,7 +193,9 @@ export default class UploadProgressToastComponent extends BaseComponent {
         .waitFor({ state: 'visible', timeout });
     } catch {
       const suffix = fileName ? ` for "${fileName}"` : '';
-      throw new Error(`Expected ${kind} upload toast to be visible${suffix} within ${timeout}ms`);
+      throw new Error(
+        `Expected ${kind} upload toast to be visible${suffix} within ${timeout}ms. ${await this.toastDebugSuffix()}`,
+      );
     }
   }
 }

--- a/playwright/src/components/vm-wizard/wizard-step-components.ts
+++ b/playwright/src/components/vm-wizard/wizard-step-components.ts
@@ -415,7 +415,7 @@ export class VmCreationWizardBootSourceComponent extends BaseComponent {
 
   async isBootVolumeEmptyStateVisible(): Promise<boolean> {
     try {
-      const heading = this.locator('h3:has-text("No volumes found")');
+      const heading = this.locator('h3:has-text("You don\'t have any volumes yet")');
       return await heading.isVisible({ timeout: TestTimeouts.SHORT_WAIT }).catch(() => false);
     } catch {
       return false;
@@ -486,10 +486,28 @@ export class VmCreationWizardBootSourceComponent extends BaseComponent {
     }
 
     const table = this.locator('.pf-v6-c-wizard table, .pf-v6-c-wizard [role="grid"]');
-    await table.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const tableVisible = await table
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_LONG })
+      .then(() => true)
+      .catch(() => false);
+
+    if (!tableVisible || (await this.isBootVolumeEmptyStateVisible())) {
+      await this.selectNoBootSource();
+      return;
+    }
 
     const nameCell = this._pfV6CWizardTableTbodyTr.first().locator('td[id="name"]');
-    await nameCell.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const rowVisible = await nameCell
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_LONG })
+      .then(() => true)
+      .catch(() => false);
+
+    if (!rowVisible) {
+      await this.selectNoBootSource();
+      return;
+    }
+
     await this.robustClick(nameCell);
   }
 

--- a/playwright/src/components/vm/vm-detail-config-components.ts
+++ b/playwright/src/components/vm/vm-detail-config-components.ts
@@ -172,6 +172,7 @@ export class VirtualMachineDetailConfigurationCdromComponent extends BaseCompone
 
     const successAlert = this.page
       .locator('.pf-v6-c-alert.pf-m-success, .pf-c-alert.pf-m-success')
+      .filter({ hasNot: this.page.locator('[data-test^="upload-progress-"]') })
       .first();
     const closeButton = successAlert.locator(
       'button[aria-label="Close success alert"], button.pf-v6-c-button.pf-m-plain, button.pf-c-button.pf-m-plain',

--- a/playwright/src/components/vm/vm-detail-storage-metrics-components.ts
+++ b/playwright/src/components/vm/vm-detail-storage-metrics-components.ts
@@ -737,6 +737,7 @@ export class VmStorageAddDiskComponent extends BaseComponent {
 
     const successAlert = this.page
       .locator('.pf-v6-c-alert.pf-m-success, .pf-c-alert.pf-m-success')
+      .filter({ hasNot: this.page.locator('[data-test^="upload-progress-"]') })
       .first();
     const closeButton = successAlert.locator(
       'button[aria-label="Close success alert"], button.pf-v6-c-button.pf-m-plain, button.pf-c-button.pf-m-plain',

--- a/playwright/src/fixtures/bootable-volumes-fixture.ts
+++ b/playwright/src/fixtures/bootable-volumes-fixture.ts
@@ -7,7 +7,6 @@
  *   import { test, expect } from '@/fixtures/bootable-volumes-fixture';
  */
 
-import { withSafeActions } from '@/page-objects/base-page';
 import BootableVolumeDetailPage from '@/page-objects/create-vm/bootable-volume-detail-page';
 import BootableVolumesPage from '@/page-objects/create-vm/bootable-volumes-page';
 import CreateVmPage from '@/page-objects/create-vm/create-vm-page';
@@ -26,19 +25,19 @@ interface BootableVolumesFixtures {
 
 const test = baseTest.extend<BootableVolumesFixtures>({
   bootableVolumesPage: async ({ page }, use) => {
-    await use(withSafeActions(new BootableVolumesPage(page)));
+    await use(new BootableVolumesPage(page));
   },
   bootableVolumeDetailPage: async ({ page }, use) => {
-    await use(withSafeActions(new BootableVolumeDetailPage(page)));
+    await use(new BootableVolumeDetailPage(page));
   },
   createVmPage: async ({ page }, use) => {
-    await use(withSafeActions(new CreateVmPage(page)));
+    await use(new CreateVmPage(page));
   },
   vmDetailPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachineDetailPage(page)));
+    await use(new VirtualMachineDetailPage(page));
   },
   vmListPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachinesPage(page)));
+    await use(new VirtualMachinesPage(page));
   },
 });
 

--- a/playwright/src/fixtures/bv-lifecycle-fixture.ts
+++ b/playwright/src/fixtures/bv-lifecycle-fixture.ts
@@ -7,7 +7,6 @@
  *   import { test, expect } from '@/fixtures/bv-lifecycle-fixture';
  */
 
-import { withSafeActions } from '@/page-objects/base-page';
 import BootableVolumesPage from '@/page-objects/create-vm/bootable-volumes-page';
 import VmTreePage from '@/page-objects/vm/vm-tree-page';
 
@@ -20,10 +19,10 @@ interface BvLifecycleFixtures {
 
 const test = baseTest.extend<BvLifecycleFixtures>({
   bootableVolumesPage: async ({ page }, use) => {
-    await use(withSafeActions(new BootableVolumesPage(page)));
+    await use(new BootableVolumesPage(page));
   },
   vmTreePage: async ({ page }, use) => {
-    await use(withSafeActions(new VmTreePage(page)));
+    await use(new VmTreePage(page));
   },
 });
 

--- a/playwright/src/fixtures/checkups-fixture.ts
+++ b/playwright/src/fixtures/checkups-fixture.ts
@@ -7,7 +7,6 @@
  *   import { test, expect } from '@/fixtures/checkups-fixture';
  */
 
-import { withSafeActions } from '@/page-objects/base-page';
 import CheckupsPage from '@/page-objects/cluster/checkups-page';
 import OverviewPage from '@/page-objects/overview/overview-page';
 import PageCommons from '@/page-objects/page-commons';
@@ -22,13 +21,13 @@ interface CheckupsFixtures {
 
 const test = baseTest.extend<CheckupsFixtures>({
   checkupsPage: async ({ page }, use) => {
-    await use(withSafeActions(new CheckupsPage(page)));
+    await use(new CheckupsPage(page));
   },
   overviewPage: async ({ page }, use) => {
-    await use(withSafeActions(new OverviewPage(page)));
+    await use(new OverviewPage(page));
   },
   pageCommons: async ({ page }, use) => {
-    await use(withSafeActions(new PageCommons(page)));
+    await use(new PageCommons(page));
   },
 });
 

--- a/playwright/src/fixtures/create-vm-fixture.ts
+++ b/playwright/src/fixtures/create-vm-fixture.ts
@@ -7,7 +7,6 @@
  *   import { test, expect } from '@/fixtures/create-vm-fixture';
  */
 
-import { withSafeActions } from '@/page-objects/base-page';
 import CreateVmInstanceTypesPage from '@/page-objects/create-vm/create-vm-instance-types-page';
 import VirtualMachinesPage from '@/page-objects/vm/virtual-machines-page';
 import VmTreePage from '@/page-objects/vm/vm-tree-page';
@@ -28,22 +27,22 @@ interface CreateVmFixtures {
 
 const test = baseTest.extend<CreateVmFixtures>({
   vmTreePage: async ({ page }, use) => {
-    await use(withSafeActions(new VmTreePage(page)));
+    await use(new VmTreePage(page));
   },
   vmListPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachinesPage(page)));
+    await use(new VirtualMachinesPage(page));
   },
   vmWizardNavigationPage: async ({ page }, use) => {
-    await use(withSafeActions(new VmWizardNavigationPage(page)));
+    await use(new VmWizardNavigationPage(page));
   },
   vmWizardBootSourcePage: async ({ page }, use) => {
-    await use(withSafeActions(new VmWizardBootSourcePage(page)));
+    await use(new VmWizardBootSourcePage(page));
   },
   vmWizardComputePage: async ({ page }, use) => {
-    await use(withSafeActions(new VmWizardComputeCustomizationPage(page)));
+    await use(new VmWizardComputeCustomizationPage(page));
   },
   createVmInstanceTypesPage: async ({ page }, use) => {
-    await use(withSafeActions(new CreateVmInstanceTypesPage(page)));
+    await use(new CreateVmInstanceTypesPage(page));
   },
 });
 

--- a/playwright/src/fixtures/gating-fixture.ts
+++ b/playwright/src/fixtures/gating-fixture.ts
@@ -26,9 +26,6 @@ import VirtualMachinesPage from '@/page-objects/vm/virtual-machines-page';
 import VmOverviewTabPage from '@/page-objects/vm/vm-overview-tab-page';
 import VmTreePage from '@/page-objects/vm/vm-tree-page';
 import VmCreationWizardPage from '@/page-objects/vm-wizard/vm-creation-wizard-page';
-import VmWizardBootSourcePage from '@/page-objects/vm-wizard/vm-wizard-boot-source-page';
-import VmWizardComputeCustomizationPage from '@/page-objects/vm-wizard/vm-wizard-compute-customization-page';
-import VmWizardNavigationPage from '@/page-objects/vm-wizard/vm-wizard-navigation-page';
 import { EnvVariables } from '@/utils/env-variables';
 import { TestTimeouts } from '@/utils/test-config';
 
@@ -53,9 +50,6 @@ interface GatingFixtures {
   quotasPage: QuotasPage;
   virtualizationOverviewPage: VirtualizationOverviewPage;
   vmCreationWizardPage: VmCreationWizardPage;
-  vmWizardBootSourcePage: VmWizardBootSourcePage;
-  vmWizardComputePage: VmWizardComputeCustomizationPage;
-  vmWizardNavigationPage: VmWizardNavigationPage;
 }
 
 const test = baseTest.extend<GatingFixtures>({
@@ -175,15 +169,6 @@ const test = baseTest.extend<GatingFixtures>({
   },
   vmCreationWizardPage: async ({ page }, use) => {
     await use(new VmCreationWizardPage(page));
-  },
-  vmWizardBootSourcePage: async ({ page }, use) => {
-    await use(new VmWizardBootSourcePage(page));
-  },
-  vmWizardComputePage: async ({ page }, use) => {
-    await use(new VmWizardComputeCustomizationPage(page));
-  },
-  vmWizardNavigationPage: async ({ page }, use) => {
-    await use(new VmWizardNavigationPage(page));
   },
 });
 

--- a/playwright/src/fixtures/instance-types-fixture.ts
+++ b/playwright/src/fixtures/instance-types-fixture.ts
@@ -7,7 +7,6 @@
  *   import { test, expect } from '@/fixtures/instance-types-fixture';
  */
 
-import { withSafeActions } from '@/page-objects/base-page';
 import InstanceTypesPage from '@/page-objects/create-vm/instance-types-page';
 import PageCommons from '@/page-objects/page-commons';
 
@@ -20,10 +19,10 @@ interface InstanceTypesFixtures {
 
 const test = baseTest.extend<InstanceTypesFixtures>({
   instanceTypesPage: async ({ page }, use) => {
-    await use(withSafeActions(new InstanceTypesPage(page)));
+    await use(new InstanceTypesPage(page));
   },
   pageCommons: async ({ page }, use) => {
-    await use(withSafeActions(new PageCommons(page)));
+    await use(new PageCommons(page));
   },
 });
 

--- a/playwright/src/fixtures/migration-fixture.ts
+++ b/playwright/src/fixtures/migration-fixture.ts
@@ -9,7 +9,6 @@
  */
 
 import RequestContextClient from '@/clients/request-context-client';
-import { withSafeActions } from '@/page-objects/base-page';
 import CreateVmCreatePage from '@/page-objects/create-vm/create-vm-create-page';
 import CreateVmTemplatesPage from '@/page-objects/create-vm/create-vm-templates-page';
 import PageCommons from '@/page-objects/page-commons';
@@ -33,22 +32,22 @@ interface MigrationFixtures {
 
 const test = baseTest.extend<MigrationFixtures>({
   vmTreePage: async ({ page }, use) => {
-    await use(withSafeActions(new VmTreePage(page)));
+    await use(new VmTreePage(page));
   },
   vmDetailPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachineDetailPage(page)));
+    await use(new VirtualMachineDetailPage(page));
   },
   vmListPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachinesPage(page)));
+    await use(new VirtualMachinesPage(page));
   },
   pageCommons: async ({ page }, use) => {
-    await use(withSafeActions(new PageCommons(page)));
+    await use(new PageCommons(page));
   },
   createVmTemplatesPage: async ({ page }, use) => {
-    await use(withSafeActions(new CreateVmTemplatesPage(page)));
+    await use(new CreateVmTemplatesPage(page));
   },
   createVmCreatePage: async ({ page }, use) => {
-    await use(withSafeActions(new CreateVmCreatePage(page)));
+    await use(new CreateVmCreatePage(page));
   },
   requestContextClient: async ({ page }, use) => {
     const testConfig = TestConfigManager.getConfig();

--- a/playwright/src/fixtures/migration-policies-fixture.ts
+++ b/playwright/src/fixtures/migration-policies-fixture.ts
@@ -7,7 +7,6 @@
  *   import { test, expect } from '@/fixtures/migration-policies-fixture';
  */
 
-import { withSafeActions } from '@/page-objects/base-page';
 import MigrationPoliciesPage from '@/page-objects/cluster/migration-policies-page';
 import PageCommons from '@/page-objects/page-commons';
 
@@ -20,10 +19,10 @@ interface MigrationPoliciesFixtures {
 
 const test = baseTest.extend<MigrationPoliciesFixtures>({
   migrationPoliciesPage: async ({ page }, use) => {
-    await use(withSafeActions(new MigrationPoliciesPage(page)));
+    await use(new MigrationPoliciesPage(page));
   },
   pageCommons: async ({ page }, use) => {
-    await use(withSafeActions(new PageCommons(page)));
+    await use(new PageCommons(page));
   },
 });
 

--- a/playwright/src/fixtures/nonpriv-fixture.ts
+++ b/playwright/src/fixtures/nonpriv-fixture.ts
@@ -10,7 +10,6 @@
  * Run with: `./playwright-runner.sh test-nonpriv`
  */
 
-import { withSafeActions } from '@/page-objects/base-page';
 import BootableVolumeDetailPage from '@/page-objects/create-vm/bootable-volume-detail-page';
 import BootableVolumesPage from '@/page-objects/create-vm/bootable-volumes-page';
 import InstanceTypesPage from '@/page-objects/create-vm/instance-types-page';
@@ -43,40 +42,40 @@ interface NonPrivFixtures {
 
 const test = baseTest.extend<NonPrivFixtures>({
   vmTreePage: async ({ page }, use) => {
-    await use(withSafeActions(new VmTreePage(page)));
+    await use(new VmTreePage(page));
   },
   vmListPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachinesPage(page)));
+    await use(new VirtualMachinesPage(page));
   },
   vmListTabPage: async ({ page }, use) => {
-    await use(withSafeActions(new VmListPage(page)));
+    await use(new VmListPage(page));
   },
   vmDetailPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachineDetailPage(page)));
+    await use(new VirtualMachineDetailPage(page));
   },
   bootableVolumesPage: async ({ page }, use) => {
-    await use(withSafeActions(new BootableVolumesPage(page)));
+    await use(new BootableVolumesPage(page));
   },
   bootableVolumeDetailPage: async ({ page }, use) => {
-    await use(withSafeActions(new BootableVolumeDetailPage(page)));
+    await use(new BootableVolumeDetailPage(page));
   },
   instanceTypesPage: async ({ page }, use) => {
-    await use(withSafeActions(new InstanceTypesPage(page)));
+    await use(new InstanceTypesPage(page));
   },
   templatesPage: async ({ page }, use) => {
-    await use(withSafeActions(new TemplatesPage(page)));
+    await use(new TemplatesPage(page));
   },
   overviewPage: async ({ page }, use) => {
-    await use(withSafeActions(new OverviewPage(page)));
+    await use(new OverviewPage(page));
   },
   vmWizardNavigationPage: async ({ page }, use) => {
-    await use(withSafeActions(new VmWizardNavigationPage(page)));
+    await use(new VmWizardNavigationPage(page));
   },
   vmWizardBootSourcePage: async ({ page }, use) => {
-    await use(withSafeActions(new VmWizardBootSourcePage(page)));
+    await use(new VmWizardBootSourcePage(page));
   },
   vmWizardComputePage: async ({ page }, use) => {
-    await use(withSafeActions(new VmWizardComputeCustomizationPage(page)));
+    await use(new VmWizardComputeCustomizationPage(page));
   },
 });
 

--- a/playwright/src/fixtures/quotas-fixture.ts
+++ b/playwright/src/fixtures/quotas-fixture.ts
@@ -7,7 +7,6 @@
  *   import { test, expect } from '@/fixtures/quotas-fixture';
  */
 
-import { withSafeActions } from '@/page-objects/base-page';
 import QuotasPage from '@/page-objects/cluster/quotas-page';
 
 import { baseTest, expect } from './scenario-test-fixture';
@@ -18,7 +17,7 @@ interface QuotasFixtures {
 
 const test = baseTest.extend<QuotasFixtures>({
   quotasPage: async ({ page }, use) => {
-    await use(withSafeActions(new QuotasPage(page)));
+    await use(new QuotasPage(page));
   },
 });
 

--- a/playwright/src/fixtures/scenario-test-fixture.ts
+++ b/playwright/src/fixtures/scenario-test-fixture.ts
@@ -205,8 +205,11 @@ const _test = base.extend<TestFixtures, WorkerFixtures>({
           ]).catch(() => 'none' as const);
 
           if (navType === 'perspective') {
-            const perspectiveUrlPattern = /virtualization/;
-            const inTargetPerspective = perspectiveUrlPattern.test(page.url());
+            const toggleLabel = ((await perspectiveToggle.textContent().catch(() => '')) ?? '')
+              .replace(/\s+/g, ' ')
+              .trim();
+            const inTargetPerspective =
+              /^Virtualization$/i.test(toggleLabel) || /^Core Platform$/i.test(toggleLabel);
 
             if (!inTargetPerspective) {
               const perspectiveOption = page
@@ -215,6 +218,14 @@ const _test = base.extend<TestFixtures, WorkerFixtures>({
                 .filter({
                   has: page.locator('.pf-v6-c-menu__item-text', {
                     hasText: /^Virtualization$/,
+                  }),
+                });
+              const corePlatformOption = page
+                .getByTestId('perspective-switcher-menu-option')
+                .or(page.locator('[data-test-id="perspective-switcher-menu-option"]'))
+                .filter({
+                  has: page.locator('.pf-v6-c-menu__item-text', {
+                    hasText: /^Core Platform$/i,
                   }),
                 });
 
@@ -226,22 +237,61 @@ const _test = base.extend<TestFixtures, WorkerFixtures>({
                     .or(page.locator('[data-test-id="perspective-switcher-toggle"]'));
                   await toggle.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
                   await toggle.click();
-                  await perspectiveOption.waitFor({
-                    state: 'visible',
-                    timeout: TestTimeouts.UI_DELAY_LONG,
-                  });
-                  await perspectiveOption.scrollIntoViewIfNeeded();
-                  await page.waitForTimeout(TestTimeouts.UI_DELAY_MICRO);
-                  await perspectiveOption.click();
 
-                  await page.waitForURL(perspectiveUrlPattern, {
-                    timeout: TestTimeouts.UI_DELAY_LONG,
-                  });
+                  const virtVisible = await perspectiveOption
+                    .waitFor({
+                      state: 'visible',
+                      timeout: TestTimeouts.UI_DELAY_LONG,
+                    })
+                    .then(() => true)
+                    .catch(() => false);
+
+                  if (virtVisible) {
+                    await perspectiveOption.scrollIntoViewIfNeeded();
+                    await page.waitForTimeout(TestTimeouts.UI_DELAY_MICRO);
+                    await perspectiveOption.click();
+                    await page.waitForFunction(
+                      () => {
+                        const el = document.querySelector(
+                          '[data-test-id="perspective-switcher-toggle"], [data-test="perspective-switcher-toggle"]',
+                        );
+                        const text = (el?.textContent ?? '').replace(/\s+/g, ' ').trim();
+                        return /^Virtualization$/i.test(text);
+                      },
+                      undefined,
+                      { timeout: TestTimeouts.UI_DELAY_LONG },
+                    );
+                  } else {
+                    const coreVisible = await corePlatformOption
+                      .waitFor({
+                        state: 'visible',
+                        timeout: TestTimeouts.UI_DELAY_LONG,
+                      })
+                      .then(() => true)
+                      .catch(() => false);
+                    if (!coreVisible) {
+                      throw new Error('Neither Virtualization nor Core Platform perspective found');
+                    }
+                    await corePlatformOption.scrollIntoViewIfNeeded();
+                    await page.waitForTimeout(TestTimeouts.UI_DELAY_MICRO);
+                    await corePlatformOption.click();
+                    await page.waitForFunction(
+                      () => {
+                        const el = document.querySelector(
+                          '[data-test-id="perspective-switcher-toggle"], [data-test="perspective-switcher-toggle"]',
+                        );
+                        const text = (el?.textContent ?? '').replace(/\s+/g, ' ').trim();
+                        return /^Core Platform$/i.test(text);
+                      },
+                      undefined,
+                      { timeout: TestTimeouts.UI_DELAY_LONG },
+                    );
+                  }
                   await page.waitForLoadState('load');
                   break;
                 } catch {
                   if (selAttempt === selectionAttempts)
-                    throw new Error('Perspective selection did not navigate to target URL');
+                    throw new Error('Perspective selection did not navigate to Virtualization');
                   await page.keyboard.press('Escape').catch(() => undefined);
                   await page.waitForTimeout(TestTimeouts.POLLING_INTERVAL);
                 }

--- a/playwright/src/fixtures/scenario-test-fixture.ts
+++ b/playwright/src/fixtures/scenario-test-fixture.ts
@@ -1,6 +1,7 @@
 import { setApiClient } from '@/clients/rcc-singleton';
 import RequestContextClient from '@/clients/request-context-client';
 import ScenarioContextManager from '@/context-managers/scenario-context-manager';
+import PageCommons from '@/page-objects/page-commons';
 import { detectAuthExpired, healBrowserAuth } from '@/utils/auth-healer';
 import { waitForClusterResources, waitForNamespaceReady } from '@/utils/cluster-resource-checker';
 import { EnvVariables } from '@/utils/env-variables';
@@ -149,155 +150,10 @@ const _test = base.extend<TestFixtures, WorkerFixtures>({
             }
           }
 
-          // Dismiss Core platform "Welcome to OpenShift" guided tour modal.
-          const tourSkipBtn = page.getByTestId('tour-step-footer-secondary');
-          const hasTour = await tourSkipBtn
-            .isVisible({ timeout: TestTimeouts.RETRY_DELAY })
-            .catch(() => false);
-          if (hasTour) {
-            await tourSkipBtn.click({ force: true }).catch(() => undefined);
-            await page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
-          }
-
-          // Dismiss onboarding popover ("We've maximized your workspace") if present.
-          const onboardingDismiss = page.locator('[data-test="onboarding-dismiss-btn"]');
-          if (
-            await onboardingDismiss
-              .isVisible({ timeout: TestTimeouts.RETRY_DELAY })
-              .catch(() => false)
-          ) {
-            await onboardingDismiss.click({ force: true }).catch(() => undefined);
-            await page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
-          }
-
-          // Dismiss Virtualization welcome modal.
-          const welcomeCheckbox = page.locator('#welcome-modal-checkbox');
-          const hasWelcome = await welcomeCheckbox
-            .isVisible({ timeout: TestTimeouts.RETRY_DELAY })
-            .catch(() => false);
-          if (hasWelcome) {
-            await welcomeCheckbox.check({ force: true }).catch(() => undefined);
-            const closeBtn = page.locator('.pf-v6-c-modal-box__close button');
-            await closeBtn.click({ force: true }).catch(() => undefined);
-            await page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
-          }
-
-          // Wait for any modal backdrop to clear before interacting with the page.
-          await page
-            .locator('.pf-v6-c-backdrop')
-            .waitFor({ state: 'hidden', timeout: TestTimeouts.UI_DELAY_LONG })
-            .catch(() => undefined);
-
+          const consolePage = new PageCommons(page);
+          await consolePage.dismissStartupOverlays();
           await page.waitForTimeout(consoleStabilizationMs);
-
-          const perspectiveToggle = page
-            .getByTestId('perspective-switcher-toggle')
-            .or(page.locator('[data-test-id="perspective-switcher-toggle"]'));
-          const virtNavSection = page.locator('[data-quickstart-id="qs-nav-sec-virtualization"]');
-
-          const navType = await Promise.race([
-            perspectiveToggle
-              .waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT })
-              .then(() => 'perspective' as const),
-            virtNavSection
-              .waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT })
-              .then(() => 'section' as const),
-          ]).catch(() => 'none' as const);
-
-          if (navType === 'perspective') {
-            const toggleLabel = ((await perspectiveToggle.textContent().catch(() => '')) ?? '')
-              .replace(/\s+/g, ' ')
-              .trim();
-            const inTargetPerspective =
-              /^Virtualization$/i.test(toggleLabel) || /^Core Platform$/i.test(toggleLabel);
-
-            if (!inTargetPerspective) {
-              const perspectiveOption = page
-                .getByTestId('perspective-switcher-menu-option')
-                .or(page.locator('[data-test-id="perspective-switcher-menu-option"]'))
-                .filter({
-                  has: page.locator('.pf-v6-c-menu__item-text', {
-                    hasText: /^Virtualization$/,
-                  }),
-                });
-              const corePlatformOption = page
-                .getByTestId('perspective-switcher-menu-option')
-                .or(page.locator('[data-test-id="perspective-switcher-menu-option"]'))
-                .filter({
-                  has: page.locator('.pf-v6-c-menu__item-text', {
-                    hasText: /^Core Platform$/i,
-                  }),
-                });
-
-              const selectionAttempts = 3;
-              for (let selAttempt = 1; selAttempt <= selectionAttempts; selAttempt++) {
-                try {
-                  const toggle = page
-                    .getByTestId('perspective-switcher-toggle')
-                    .or(page.locator('[data-test-id="perspective-switcher-toggle"]'));
-                  await toggle.waitFor({ state: 'visible', timeout: TestTimeouts.DEFAULT });
-                  await toggle.click();
-
-                  const virtVisible = await perspectiveOption
-                    .waitFor({
-                      state: 'visible',
-                      timeout: TestTimeouts.UI_DELAY_LONG,
-                    })
-                    .then(() => true)
-                    .catch(() => false);
-
-                  if (virtVisible) {
-                    await perspectiveOption.scrollIntoViewIfNeeded();
-                    await page.waitForTimeout(TestTimeouts.UI_DELAY_MICRO);
-                    await perspectiveOption.click();
-                    await page.waitForFunction(
-                      () => {
-                        const el = document.querySelector(
-                          '[data-test-id="perspective-switcher-toggle"], [data-test="perspective-switcher-toggle"]',
-                        );
-                        const text = (el?.textContent ?? '').replace(/\s+/g, ' ').trim();
-                        return /^Virtualization$/i.test(text);
-                      },
-                      undefined,
-                      { timeout: TestTimeouts.UI_DELAY_LONG },
-                    );
-                  } else {
-                    const coreVisible = await corePlatformOption
-                      .waitFor({
-                        state: 'visible',
-                        timeout: TestTimeouts.UI_DELAY_LONG,
-                      })
-                      .then(() => true)
-                      .catch(() => false);
-                    if (!coreVisible) {
-                      throw new Error('Neither Virtualization nor Core Platform perspective found');
-                    }
-                    await corePlatformOption.scrollIntoViewIfNeeded();
-                    await page.waitForTimeout(TestTimeouts.UI_DELAY_MICRO);
-                    await corePlatformOption.click();
-                    await page.waitForFunction(
-                      () => {
-                        const el = document.querySelector(
-                          '[data-test-id="perspective-switcher-toggle"], [data-test="perspective-switcher-toggle"]',
-                        );
-                        const text = (el?.textContent ?? '').replace(/\s+/g, ' ').trim();
-                        return /^Core Platform$/i.test(text);
-                      },
-                      undefined,
-                      { timeout: TestTimeouts.UI_DELAY_LONG },
-                    );
-                  }
-                  await page.waitForLoadState('load');
-                  break;
-                } catch {
-                  if (selAttempt === selectionAttempts)
-                    throw new Error('Perspective selection did not navigate to Virtualization');
-                  await page.keyboard.press('Escape').catch(() => undefined);
-                  await page.waitForTimeout(TestTimeouts.POLLING_INTERVAL);
-                }
-              }
-            }
-          }
+          await consolePage.ensureInitialPerspective();
 
           break;
         } catch (error) {

--- a/playwright/src/fixtures/settings-fixture.ts
+++ b/playwright/src/fixtures/settings-fixture.ts
@@ -7,7 +7,6 @@
  * All settings specs must use this fixture and be tagged @cnv-settings.
  */
 
-import { withSafeActions } from '@/page-objects/base-page';
 import QuotasPage from '@/page-objects/cluster/quotas-page';
 import PageCommons from '@/page-objects/page-commons';
 import SettingsPage from '@/page-objects/settings/settings-page';
@@ -22,13 +21,13 @@ interface SettingsFixtures {
 
 const test = baseTest.extend<SettingsFixtures>({
   settingsPage: async ({ page }, use) => {
-    await use(withSafeActions(new SettingsPage(page)));
+    await use(new SettingsPage(page));
   },
   pageCommons: async ({ page }, use) => {
-    await use(withSafeActions(new PageCommons(page)));
+    await use(new PageCommons(page));
   },
   quotasPage: async ({ page }, use) => {
-    await use(withSafeActions(new QuotasPage(page)));
+    await use(new QuotasPage(page));
   },
 });
 

--- a/playwright/src/fixtures/templates-fixture.ts
+++ b/playwright/src/fixtures/templates-fixture.ts
@@ -7,7 +7,6 @@
  *   import { test, expect } from '@/fixtures/templates-fixture';
  */
 
-import { withSafeActions } from '@/page-objects/base-page';
 import CreateVmPage from '@/page-objects/create-vm/create-vm-page';
 import TemplateDetailPage from '@/page-objects/create-vm/template-detail-page';
 import TemplatesPage from '@/page-objects/create-vm/templates-page';
@@ -36,34 +35,34 @@ interface TemplatesFixtures {
 
 const test = baseTest.extend<TemplatesFixtures>({
   createVmPage: async ({ page }, use) => {
-    await use(withSafeActions(new CreateVmPage(page)));
+    await use(new CreateVmPage(page));
   },
   overviewPage: async ({ page }, use) => {
-    await use(withSafeActions(new OverviewPage(page)));
+    await use(new OverviewPage(page));
   },
   templatesPage: async ({ page }, use) => {
-    await use(withSafeActions(new TemplatesPage(page)));
+    await use(new TemplatesPage(page));
   },
   templateDetailPage: async ({ page }, use) => {
-    await use(withSafeActions(new TemplateDetailPage(page)));
+    await use(new TemplateDetailPage(page));
   },
   vmTreePage: async ({ page }, use) => {
-    await use(withSafeActions(new VmTreePage(page)));
+    await use(new VmTreePage(page));
   },
   vmDetailPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachineDetailPage(page)));
+    await use(new VirtualMachineDetailPage(page));
   },
   vmListPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachinesPage(page)));
+    await use(new VirtualMachinesPage(page));
   },
   pageCommons: async ({ page }, use) => {
-    await use(withSafeActions(new PageCommons(page)));
+    await use(new PageCommons(page));
   },
   vmWizardNavigationPage: async ({ page }, use) => {
-    await use(withSafeActions(new VmWizardNavigationPage(page)));
+    await use(new VmWizardNavigationPage(page));
   },
   vmWizardComputePage: async ({ page }, use) => {
-    await use(withSafeActions(new VmWizardComputeCustomizationPage(page)));
+    await use(new VmWizardComputeCustomizationPage(page));
   },
 });
 

--- a/playwright/src/fixtures/vm-actions-fixture.ts
+++ b/playwright/src/fixtures/vm-actions-fixture.ts
@@ -8,7 +8,6 @@
  */
 
 import RequestContextClient from '@/clients/request-context-client';
-import { withSafeActions } from '@/page-objects/base-page';
 import CreateVmCreatePage from '@/page-objects/create-vm/create-vm-create-page';
 import CreateVmTemplatesPage from '@/page-objects/create-vm/create-vm-templates-page';
 import TemplatesPage from '@/page-objects/create-vm/templates-page';
@@ -38,31 +37,31 @@ interface VmActionsFixtures {
 
 const test = baseTest.extend<VmActionsFixtures>({
   vmTreePage: async ({ page }, use) => {
-    await use(withSafeActions(new VmTreePage(page)));
+    await use(new VmTreePage(page));
   },
   vmDetailPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachineDetailPage(page)));
+    await use(new VirtualMachineDetailPage(page));
   },
   vmListPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachinesPage(page)));
+    await use(new VirtualMachinesPage(page));
   },
   vmOverviewTabPage: async ({ page }, use) => {
-    await use(withSafeActions(new VmOverviewTabPage(page)));
+    await use(new VmOverviewTabPage(page));
   },
   pageCommons: async ({ page }, use) => {
-    await use(withSafeActions(new PageCommons(page)));
+    await use(new PageCommons(page));
   },
   overviewPage: async ({ page }, use) => {
-    await use(withSafeActions(new OverviewPage(page)));
+    await use(new OverviewPage(page));
   },
   templatesPage: async ({ page }, use) => {
-    await use(withSafeActions(new TemplatesPage(page)));
+    await use(new TemplatesPage(page));
   },
   createVmTemplatesPage: async ({ page }, use) => {
-    await use(withSafeActions(new CreateVmTemplatesPage(page)));
+    await use(new CreateVmTemplatesPage(page));
   },
   createVmCreatePage: async ({ page }, use) => {
-    await use(withSafeActions(new CreateVmCreatePage(page)));
+    await use(new CreateVmCreatePage(page));
   },
   requestContextClient: async ({ page }, use) => {
     const testConfig = TestConfigManager.getConfig();

--- a/playwright/src/fixtures/vm-search-fixture.ts
+++ b/playwright/src/fixtures/vm-search-fixture.ts
@@ -7,7 +7,6 @@
  *   import { test, expect } from '@/fixtures/vm-search-fixture';
  */
 
-import { withSafeActions } from '@/page-objects/base-page';
 import PageCommons from '@/page-objects/page-commons';
 import VirtualMachinesPage from '@/page-objects/vm/virtual-machines-page';
 import VmTreePage from '@/page-objects/vm/vm-tree-page';
@@ -22,13 +21,13 @@ interface VmSearchFixtures {
 
 const test = baseTest.extend<VmSearchFixtures>({
   vmListPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachinesPage(page)));
+    await use(new VirtualMachinesPage(page));
   },
   vmTreePage: async ({ page }, use) => {
-    await use(withSafeActions(new VmTreePage(page)));
+    await use(new VmTreePage(page));
   },
   pageCommons: async ({ page }, use) => {
-    await use(withSafeActions(new PageCommons(page)));
+    await use(new PageCommons(page));
   },
 });
 

--- a/playwright/src/fixtures/vm-tabs-fixture.ts
+++ b/playwright/src/fixtures/vm-tabs-fixture.ts
@@ -7,7 +7,6 @@
  *   import { test, expect } from '@/fixtures/vm-tabs-fixture';
  */
 
-import { withSafeActions } from '@/page-objects/base-page';
 import ConsoleStandalonePage from '@/page-objects/cluster/console-standalone-page';
 import CreateVmCreatePage from '@/page-objects/create-vm/create-vm-create-page';
 import CreateVmPage from '@/page-objects/create-vm/create-vm-page';
@@ -36,34 +35,34 @@ interface VmTabsFixtures {
 
 const test = baseTest.extend<VmTabsFixtures>({
   vmTreePage: async ({ page }, use) => {
-    await use(withSafeActions(new VmTreePage(page)));
+    await use(new VmTreePage(page));
   },
   vmDetailPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachineDetailPage(page)));
+    await use(new VirtualMachineDetailPage(page));
   },
   vmListPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachinesPage(page)));
+    await use(new VirtualMachinesPage(page));
   },
   pageCommons: async ({ page }, use) => {
-    await use(withSafeActions(new PageCommons(page)));
+    await use(new PageCommons(page));
   },
   overviewPage: async ({ page }, use) => {
-    await use(withSafeActions(new OverviewPage(page)));
+    await use(new OverviewPage(page));
   },
   snapshotDetailPage: async ({ page }, use) => {
-    await use(withSafeActions(new VirtualMachineSnapshotDetailPage(page)));
+    await use(new VirtualMachineSnapshotDetailPage(page));
   },
   consoleStandalonePage: async ({ page }, use) => {
-    await use(withSafeActions(new ConsoleStandalonePage(page)));
+    await use(new ConsoleStandalonePage(page));
   },
   createVmPage: async ({ page }, use) => {
-    await use(withSafeActions(new CreateVmPage(page)));
+    await use(new CreateVmPage(page));
   },
   createVmCreatePage: async ({ page }, use) => {
-    await use(withSafeActions(new CreateVmCreatePage(page)));
+    await use(new CreateVmCreatePage(page));
   },
   createVmTemplatesPage: async ({ page }, use) => {
-    await use(withSafeActions(new CreateVmTemplatesPage(page)));
+    await use(new CreateVmTemplatesPage(page));
   },
 });
 

--- a/playwright/src/page-objects/base-page.ts
+++ b/playwright/src/page-objects/base-page.ts
@@ -6,10 +6,8 @@
 import BaseComponent from '@/components/shared/base-component';
 import type { ContextKey, ContextValueType } from '@/context-managers/context-keys';
 import ScenarioContextManager from '@/context-managers/scenario-context-manager';
-
 import type { TrackedResourceType } from '@/utils/test-resource-tracker';
-import type { Page, TestInfo } from '@playwright/test';
-import { test as base } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 export default abstract class BasePage extends BaseComponent {
   constructor(page: Page) {
@@ -31,92 +29,4 @@ export default abstract class BasePage extends BaseComponent {
   protected trackResource(type: TrackedResourceType, name: string, namespace?: string): void {
     this.ctx.trackResource(type, name, namespace);
   }
-}
-
-const TIMEOUT_PATTERNS: RegExp[] = [
-  /Timeout \d+ms exceeded/i,
-  /TimeoutError/i,
-  /exceeded while waiting/i,
-  /waiting for locator/i,
-  /locator\.waitFor/i,
-  /page\.waitFor/i,
-  /waiting for selector/i,
-  /Navigation timeout/i,
-  /net::ERR_TIMED_OUT/i,
-  /within \d+ms$/i,
-];
-
-export type TimeoutAwareTestInfo = TestInfo & {
-  _actionTimeouts?: Array<{ method: string; message: string }>;
-  _diagnosisHandled?: boolean;
-};
-
-export function isBrowserClosedError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false;
-  const msg = (error as { message?: string }).message ?? String(error);
-  return /Target page, context or browser has been closed/i.test(msg);
-}
-
-export function isTimeoutError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false;
-  const msg = (error as { message?: string }).message ?? String(error);
-  return TIMEOUT_PATTERNS.some((p) => p.test(msg));
-}
-
-/**
- * Wraps a page object so async method calls capture errors instead of
- * failing the test immediately. Timeout errors are recorded on
- * testInfo._actionTimeouts so the _autoTimeoutGuard fixture can
- * reclassify the test as skipped. Non-timeout errors are logged to
- * stderr so the reporter can surface them.
- */
-export function withSafeActions<T extends object>(instance: T): T {
-  const className = (target: T) =>
-    (target as { constructor?: { name?: string } }).constructor?.name ?? 'UnknownPage';
-
-  return new Proxy(instance, {
-    get(target, prop, receiver) {
-      const value = Reflect.get(target, prop, receiver);
-      if (typeof value === 'function') {
-        return (...args: unknown[]) => {
-          const result = value.apply(target, args);
-          if (result && typeof result === 'object' && typeof result.then === 'function') {
-            return (result as Promise<unknown>).catch(async (error: unknown) => {
-              const msg =
-                error && typeof error === 'object'
-                  ? ((error as { message?: string }).message ?? String(error))
-                  : String(error);
-              const label = `${className(target)}.${String(prop)}`;
-
-              if (isBrowserClosedError(error)) {
-                try {
-                  const info = base.info() as TimeoutAwareTestInfo;
-                  if (!info._actionTimeouts) info._actionTimeouts = [];
-                  info._actionTimeouts.push({
-                    method: String(prop),
-                    message: 'browser context closed',
-                  });
-                } catch {
-                  /* outside test context */
-                }
-              } else if (isTimeoutError(error)) {
-                try {
-                  const info = base.info() as TimeoutAwareTestInfo;
-                  if (!info._actionTimeouts) info._actionTimeouts = [];
-                  info._actionTimeouts.push({ method: String(prop), message: msg });
-                } catch {
-                  /* outside test context */
-                }
-              } else {
-                console.error(`[safeAction] ✖ ERROR in ${label}: ${msg.split('\n')[0]}`);
-              }
-              return undefined;
-            });
-          }
-          return result;
-        };
-      }
-      return value;
-    },
-  });
 }

--- a/playwright/src/page-objects/base-page.ts
+++ b/playwright/src/page-objects/base-page.ts
@@ -6,10 +6,8 @@
 import BaseComponent from '@/components/shared/base-component';
 import type { ContextKey, ContextValueType } from '@/context-managers/context-keys';
 import ScenarioContextManager from '@/context-managers/scenario-context-manager';
-import { EnvVariables } from '@/utils/env-variables';
 import type { TrackedResourceType } from '@/utils/test-resource-tracker';
-import type { Page, TestInfo } from '@playwright/test';
-import { test as base } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 export default abstract class BasePage extends BaseComponent {
   constructor(page: Page) {
@@ -31,91 +29,4 @@ export default abstract class BasePage extends BaseComponent {
   protected trackResource(type: TrackedResourceType, name: string, namespace?: string): void {
     this.ctx.trackResource(type, name, namespace);
   }
-}
-
-const TIMEOUT_PATTERNS: RegExp[] = [
-  /Timeout \d+ms exceeded/i,
-  /TimeoutError/i,
-  /exceeded while waiting/i,
-  /waiting for locator/i,
-  /locator\.waitFor/i,
-  /page\.waitFor/i,
-  /waiting for selector/i,
-  /Navigation timeout/i,
-  /net::ERR_TIMED_OUT/i,
-];
-
-export type TimeoutAwareTestInfo = TestInfo & {
-  _actionTimeouts?: Array<{ method: string; message: string }>;
-  _diagnosisHandled?: boolean;
-};
-
-export function isBrowserClosedError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false;
-  const msg = (error as { message?: string }).message ?? String(error);
-  return /Target page, context or browser has been closed/i.test(msg);
-}
-
-export function isTimeoutError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false;
-  const msg = (error as { message?: string }).message ?? String(error);
-  return TIMEOUT_PATTERNS.some((p) => p.test(msg));
-}
-
-/**
- * Wraps a page object so async method calls capture errors instead of
- * failing the test immediately. Timeout errors are recorded on
- * testInfo._actionTimeouts so the _autoTimeoutGuard fixture can
- * reclassify the test as skipped. Non-timeout errors are logged to
- * stderr so the reporter can surface them.
- */
-export function withSafeActions<T extends object>(instance: T): T {
-  const className = (target: T) =>
-    (target as { constructor?: { name?: string } }).constructor?.name ?? 'UnknownPage';
-
-  return new Proxy(instance, {
-    get(target, prop, receiver) {
-      const value = Reflect.get(target, prop, receiver);
-      if (typeof value === 'function') {
-        return (...args: unknown[]) => {
-          const result = value.apply(target, args);
-          if (result && typeof result === 'object' && typeof result.then === 'function') {
-            return (result as Promise<unknown>).catch(async (error: unknown) => {
-              const msg =
-                error && typeof error === 'object'
-                  ? ((error as { message?: string }).message ?? String(error))
-                  : String(error);
-              const label = `${className(target)}.${String(prop)}`;
-
-              if (isBrowserClosedError(error)) {
-                try {
-                  const info = base.info() as TimeoutAwareTestInfo;
-                  if (!info._actionTimeouts) info._actionTimeouts = [];
-                  info._actionTimeouts.push({
-                    method: String(prop),
-                    message: 'browser context closed',
-                  });
-                } catch {
-                  /* outside test context */
-                }
-              } else if (isTimeoutError(error)) {
-                try {
-                  const info = base.info() as TimeoutAwareTestInfo;
-                  if (!info._actionTimeouts) info._actionTimeouts = [];
-                  info._actionTimeouts.push({ method: String(prop), message: msg });
-                } catch {
-                  /* outside test context */
-                }
-              } else {
-                console.error(`[safeAction] ✖ ERROR in ${label}: ${msg.split('\n')[0]}`);
-              }
-              return undefined;
-            });
-          }
-          return result;
-        };
-      }
-      return value;
-    },
-  });
 }

--- a/playwright/src/page-objects/cluster/migration-policies-page.ts
+++ b/playwright/src/page-objects/cluster/migration-policies-page.ts
@@ -12,7 +12,9 @@ export default class MigrationPoliciesPage extends PageCommons {
     .filter({ hasText: 'Cluster' })
     .first();
 
-  private readonly _nameInput = this.locator('[role="dialog"] input[type="text"]').first();
+  private readonly _nameInput = this.page.locator('#migration-policy-name');
+
+  private readonly _descriptionInput = this.page.locator('#migration-policy-description');
 
   override readonly _createButton = this.testId('item-create');
 
@@ -55,10 +57,20 @@ export default class MigrationPoliciesPage extends PageCommons {
   }
 
   async clickCreateButton() {
-    // Use text-based locator for the Create button in the form
-    const createButton = this.page.locator('[role="dialog"] button', { hasText: 'Create' });
+    const dialog = this.page.locator('[role="dialog"]');
+    const createButton = dialog.getByRole('button', { name: 'Create', exact: true });
     await createButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
+
+    const enabledDeadline = Date.now() + TestTimeouts.UI_ELEMENT_VISIBILITY;
+    while (Date.now() < enabledDeadline && !(await createButton.isEnabled())) {
+      await this.page.waitForTimeout(TestTimeouts.NETWORK_DELAY);
+    }
+    if (!(await createButton.isEnabled())) {
+      throw new Error('Create MigrationPolicy button remained disabled — form may be invalid');
+    }
+
     await createButton.click();
+    await dialog.waitFor({ state: 'hidden', timeout: TestTimeouts.RESOURCE_CREATION });
   }
 
   /**
@@ -91,8 +103,15 @@ export default class MigrationPoliciesPage extends PageCommons {
     const bandwidthInput = this.testId('bandwidthPerMigration-selected').locator('input');
     await bandwidthInput.waitFor({ state: 'visible' });
     await bandwidthInput.click();
-    await bandwidthInput.press('Control+a');
-    await bandwidthInput.pressSequentially(bandwidth);
+    await bandwidthInput.fill(bandwidth);
+    if ((await bandwidthInput.inputValue()) !== bandwidth) {
+      await bandwidthInput.fill(bandwidth);
+    }
+    if ((await bandwidthInput.inputValue()) !== bandwidth) {
+      throw new Error(
+        `Bandwidth input expected "${bandwidth}" but got "${await bandwidthInput.inputValue()}"`,
+      );
+    }
   }
 
   async fillCompletionTimeout(timeout: string) {
@@ -100,23 +119,26 @@ export default class MigrationPoliciesPage extends PageCommons {
       'input',
     );
     await completionTimeoutInput.waitFor({ state: 'visible' });
-    await completionTimeoutInput.click();
-    await completionTimeoutInput.press('Control+a');
-    await completionTimeoutInput.pressSequentially(timeout);
+    await completionTimeoutInput.fill(timeout);
   }
 
   async fillDescription(description: string) {
-    const descriptionInput = this.locator('[role="dialog"] input[type="text"]').nth(1);
-    await descriptionInput.waitFor({ state: 'visible' });
-    await descriptionInput.clear();
-    await descriptionInput.fill(description);
+    await this._descriptionInput.waitFor({ state: 'visible' });
+    await this._descriptionInput.fill(description);
   }
 
   // Form field interaction methods
   async fillPolicyName(name: string) {
     await this._nameInput.waitFor({ state: 'visible' });
-    await this._nameInput.clear();
     await this._nameInput.fill(name);
+    if ((await this._nameInput.inputValue()) !== name) {
+      await this._nameInput.fill(name);
+    }
+    if ((await this._nameInput.inputValue()) !== name) {
+      throw new Error(
+        `MigrationPolicy name expected "${name}" but got "${await this._nameInput.inputValue()}"`,
+      );
+    }
   }
 
   /**

--- a/playwright/src/page-objects/create-vm/bootable-volumes-list-page.ts
+++ b/playwright/src/page-objects/create-vm/bootable-volumes-list-page.ts
@@ -219,30 +219,14 @@ export default class BootableVolumesListPage extends PageCommons {
     await this.clickNavBootableVolumes();
   }
 
-  async navigateToGeneralBootableVolumes() {
-    await this.goTo('/k8s/all-namespaces/bootablevolumes');
-  }
-
   async navigateToNamespaceBootableVolumesViaUI(namespace: string): Promise<void> {
     await this.switchToVirtualizationPerspective();
     await this.clickNavBootableVolumes();
     await this.page.waitForLoadState('domcontentloaded');
     if (!this.page.url().includes(`/ns/${namespace}/`)) {
-      const path = `/k8s/ns/${namespace}/bootablevolumes`;
-      await this.page.evaluate((p) => {
-        window.history.pushState({}, '', p);
-        window.dispatchEvent(new PopStateEvent('popstate'));
-      }, path);
-      await this.page.waitForFunction((p: string) => window.location.pathname === p, path, {
-        timeout: TestTimeouts.NAVIGATION,
-      });
-      await this.page.waitForLoadState('domcontentloaded');
+      await this.switchToNamespace(namespace);
     }
     await this.verifyPageLoaded([], true, TestTimeouts.UI_ELEMENT_VISIBILITY);
-  }
-
-  async navigateToProjectBootableVolumes(projectName: string) {
-    await this.goTo(`/k8s/ns/${projectName}/bootablevolumes`);
   }
 
   async openClusterFilter(): Promise<void> {

--- a/playwright/src/page-objects/create-vm/bootable-volumes-page.ts
+++ b/playwright/src/page-objects/create-vm/bootable-volumes-page.ts
@@ -45,18 +45,6 @@ export default class BootableVolumesPage extends PageCommons {
     this.uploadToast = new UploadProgressToastComponent(page);
   }
 
-  private async navigateToNamespaceClientSide(namespace: string): Promise<void> {
-    const path = `/k8s/ns/${namespace}/bootablevolumes`;
-    await this.page.evaluate((p) => {
-      window.history.pushState({}, '', p);
-      window.dispatchEvent(new PopStateEvent('popstate'));
-    }, path);
-    await this.page.waitForFunction((p: string) => window.location.pathname === p, path, {
-      timeout: TestTimeouts.NAVIGATION,
-    });
-    await this.page.waitForLoadState('domcontentloaded');
-  }
-
   async addAnnotationInEditAnnotationsModalAndSave(
     annotationKey: string,
     annotationValue: string,
@@ -399,31 +387,16 @@ export default class BootableVolumesPage extends PageCommons {
     return false;
   }
   async navigateToBootableVolumesViaUI(): Promise<void> {
-    await this.switchToVirtualizationPerspective();
     await this.clickNavBootableVolumes();
     await this.page.waitForLoadState('domcontentloaded');
   }
-  async navigateToBootableVolumesWithParams(params: string): Promise<void> {
-    const basePath = '/k8s/all-namespaces/bootablevolumes';
-    await this.goTo(`${basePath}?${params}`);
-    await this.waitForTableData();
-  }
-  /** @deprecated Use navigateToBootableVolumesViaUI() */
-  async navigateToGeneralBootableVolumes() {
-    await this.goTo('/k8s/all-namespaces/bootablevolumes');
-  }
   async navigateToNamespaceBootableVolumesViaUI(namespace: string): Promise<void> {
-    await this.switchToVirtualizationPerspective();
     await this.clickNavBootableVolumes();
     await this.page.waitForLoadState('domcontentloaded');
     if (!this.page.url().includes(`/ns/${namespace}/`)) {
-      await this.navigateToNamespaceClientSide(namespace);
+      await this.switchToNamespace(namespace);
     }
     await this.verifyPageLoaded([], true, TestTimeouts.UI_ELEMENT_VISIBILITY);
-  }
-  /** @deprecated Use navigateToNamespaceBootableVolumesViaUI() */
-  async navigateToProjectBootableVolumes(projectName: string) {
-    await this.goTo(`/k8s/ns/${projectName}/bootablevolumes`);
   }
   async openClusterFilter(): Promise<void> {
     await this._clusterFilterButton.waitFor({

--- a/playwright/src/page-objects/create-vm/bootable-volumes-page.ts
+++ b/playwright/src/page-objects/create-vm/bootable-volumes-page.ts
@@ -42,18 +42,6 @@ export default class BootableVolumesPage extends PageCommons {
     this.rowActions = new BootableVolumesRowActionsComponent(page);
   }
 
-  private async navigateToNamespaceClientSide(namespace: string): Promise<void> {
-    const path = `/k8s/ns/${namespace}/bootablevolumes`;
-    await this.page.evaluate((p) => {
-      window.history.pushState({}, '', p);
-      window.dispatchEvent(new PopStateEvent('popstate'));
-    }, path);
-    await this.page.waitForFunction((p: string) => window.location.pathname === p, path, {
-      timeout: TestTimeouts.NAVIGATION,
-    });
-    await this.page.waitForLoadState('domcontentloaded');
-  }
-
   async addAnnotationInEditAnnotationsModalAndSave(
     annotationKey: string,
     annotationValue: string,
@@ -357,31 +345,16 @@ export default class BootableVolumesPage extends PageCommons {
     return false;
   }
   async navigateToBootableVolumesViaUI(): Promise<void> {
-    await this.switchToVirtualizationPerspective();
     await this.clickNavBootableVolumes();
     await this.page.waitForLoadState('domcontentloaded');
   }
-  async navigateToBootableVolumesWithParams(params: string): Promise<void> {
-    const basePath = '/k8s/all-namespaces/bootablevolumes';
-    await this.goTo(`${basePath}?${params}`);
-    await this.waitForTableData();
-  }
-  /** @deprecated Use navigateToBootableVolumesViaUI() */
-  async navigateToGeneralBootableVolumes() {
-    await this.goTo('/k8s/all-namespaces/bootablevolumes');
-  }
   async navigateToNamespaceBootableVolumesViaUI(namespace: string): Promise<void> {
-    await this.switchToVirtualizationPerspective();
     await this.clickNavBootableVolumes();
     await this.page.waitForLoadState('domcontentloaded');
     if (!this.page.url().includes(`/ns/${namespace}/`)) {
-      await this.navigateToNamespaceClientSide(namespace);
+      await this.switchToNamespace(namespace);
     }
     await this.verifyPageLoaded([], true, TestTimeouts.UI_ELEMENT_VISIBILITY);
-  }
-  /** @deprecated Use navigateToNamespaceBootableVolumesViaUI() */
-  async navigateToProjectBootableVolumes(projectName: string) {
-    await this.goTo(`/k8s/ns/${projectName}/bootablevolumes`);
   }
   async openClusterFilter(): Promise<void> {
     await this._clusterFilterButton.waitFor({

--- a/playwright/src/page-objects/create-vm/instance-types-page.ts
+++ b/playwright/src/page-objects/create-vm/instance-types-page.ts
@@ -160,7 +160,6 @@ export default class InstanceTypesPage extends PageCommons {
 
   async navigateToInstanceTypesViaUI(): Promise<void> {
     for (let attempt = 1; attempt <= 3; attempt++) {
-      await this.switchToVirtualizationPerspective();
       await this.clickNavInstanceTypes();
       if (/instancetype/i.test(this.page.url())) return;
       await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);

--- a/playwright/src/page-objects/page-commons.ts
+++ b/playwright/src/page-objects/page-commons.ts
@@ -698,6 +698,14 @@ export default class PageCommons extends BasePage {
     }
   }
 
+  async dismissStartupOverlays(): Promise<void> {
+    await this._navComponent.dismissStartupOverlays();
+  }
+
+  async ensureInitialPerspective(): Promise<void> {
+    await this._navComponent.ensureInitialPerspective();
+  }
+
   async switchToPerspective(perspectiveName: string): Promise<void> {
     await this._navComponent.switchToPerspective(perspectiveName);
   }

--- a/playwright/src/utils/env-variables.ts
+++ b/playwright/src/utils/env-variables.ts
@@ -120,8 +120,7 @@ export class EnvVariables {
 
   /**
    * Enable the failure diagnosis harness (default: off).
-   * When DIAGNOSE_FAILURES=1, withSafeActions captures a screenshot on timeout
-   * On failure, spawns a Cursor SDK agent (requires CURSOR_API_KEY) that
+   * When DIAGNOSE_FAILURES=1, on failure a Cursor SDK agent (requires CURSOR_API_KEY)
    * inspects the screenshot, ARIA snapshot, cluster health, and Jira context
    * to produce a verdict (pass/skip/fail). Falls back to heuristic
    * classification if the SDK is unavailable or the agent fails.

--- a/playwright/src/utils/vm-k8s-waits.ts
+++ b/playwright/src/utils/vm-k8s-waits.ts
@@ -1,8 +1,12 @@
 import type RequestContextClient from '@/clients/request-context-client';
 import { TestTimeouts } from '@/utils/test-config';
 
+type VmStatus = {
+  printableStatus?: string;
+};
+
 /**
- * Poll until VirtualMachine status.ready is true (mirrors K8s VM lifecycle step driver).
+ * Poll until VirtualMachine status.printableStatus is Running.
  */
 export async function waitForVirtualMachineReady(
   client: RequestContextClient,
@@ -11,12 +15,14 @@ export async function waitForVirtualMachineReady(
   timeoutMs: number = TestTimeouts.VM_BOOTUP,
 ): Promise<void> {
   const start = Date.now();
+  let lastStatus = 'unknown';
   while (Date.now() - start < timeoutMs) {
     try {
       const vm = (await client.getVirtualMachine(namespace, vmName)) as {
-        status?: { ready?: boolean };
+        status?: VmStatus;
       } | null;
-      if (vm?.status?.ready === true) {
+      lastStatus = vm?.status?.printableStatus ?? 'unknown';
+      if (lastStatus === 'Running') {
         return;
       }
     } catch {
@@ -24,11 +30,13 @@ export async function waitForVirtualMachineReady(
     }
     await new Promise((r) => setTimeout(r, TestTimeouts.SHORT_WAIT));
   }
-  throw new Error(`VM ${vmName} did not become ready within ${timeoutMs}ms`);
+  throw new Error(
+    `VM ${vmName} did not become Running within ${timeoutMs}ms (last printableStatus=${lastStatus})`,
+  );
 }
 
 /**
- * Poll until the VM is stopped (VMI no longer exists).
+ * Poll until the VM is stopped (printableStatus Stopped, or VMI gone).
  */
 export async function waitForVirtualMachineStopped(
   client: RequestContextClient,
@@ -37,12 +45,18 @@ export async function waitForVirtualMachineStopped(
   timeoutMs: number = TestTimeouts.VM_BOOTUP,
 ): Promise<void> {
   const start = Date.now();
+  let lastStatus = 'unknown';
   while (Date.now() - start < timeoutMs) {
     try {
       const vm = (await client.getVirtualMachine(namespace, vmName)) as {
-        status?: { ready?: boolean };
+        status?: VmStatus;
       } | null;
-      if (!vm || !vm.status?.ready) {
+      if (!vm) return;
+      lastStatus = vm.status?.printableStatus ?? 'unknown';
+      if (lastStatus === 'Stopped') {
+        return;
+      }
+      if (lastStatus !== 'Running' && lastStatus !== 'Stopping') {
         const vmi = await client.getVirtualMachineInstance(namespace, vmName);
         if (!vmi) return;
       }
@@ -51,7 +65,9 @@ export async function waitForVirtualMachineStopped(
     }
     await new Promise((r) => setTimeout(r, TestTimeouts.SHORT_WAIT));
   }
-  throw new Error(`VM ${vmName} did not stop within ${timeoutMs}ms`);
+  throw new Error(
+    `VM ${vmName} did not stop within ${timeoutMs}ms (last printableStatus=${lastStatus})`,
+  );
 }
 
 /**

--- a/playwright/tests/gating/vm-search-language.spec.ts
+++ b/playwright/tests/gating/vm-search-language.spec.ts
@@ -1,9 +1,9 @@
-import { ADMIN_ONLY_TAG, T1, T1_TAG, VM_SEARCH_TAG } from '@/data-models/allure-constants';
+import { ADMIN_ONLY_TAG, GATING, GATING_TAG, VM_SEARCH_TAG } from '@/data-models/allure-constants';
 import { expect, test } from '@/fixtures/vm-search-fixture';
 
 const SUITE = 'VM Search Language';
 
-test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
+test.describe(SUITE, { tag: [GATING_TAG, VM_SEARCH_TAG] }, () => {
   test.beforeEach(async ({ vmListPage, testConfig }) => {
     await vmListPage.navigateToNamespaceVirtualMachinesViaUI(testConfig.testNamespace);
     await vmListPage.clickVmListTab();
@@ -12,8 +12,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   test('plain text search filters VMs by name', async ({ vmListPage, utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Type plain text and submit search', async () => {
@@ -38,8 +38,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   test('key:value search filters by status', async ({ vmListPage, utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Submit status:Running search', async () => {
@@ -60,8 +60,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   test('comma-separated values apply OR logic within a key', async ({ vmListPage, utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Submit status:Running,Stopped search', async () => {
@@ -92,8 +92,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   test('space-separated tokens apply AND logic across keys', async ({ vmListPage, utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Submit multi-key search with AND logic', async () => {
@@ -118,8 +118,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   test('numeric filter with > operator for vcpu', async ({ vmListPage, utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Submit vcpu>4 search', async () => {
@@ -140,8 +140,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   test('numeric filter with >= operator for memory', async ({ vmListPage, utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Submit memory>=8GiB search', async () => {
@@ -165,8 +165,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   test('exclusion prefix -key:value shows Exclude chip', async ({ vmListPage, utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Submit -status:Error search', async () => {
@@ -189,8 +189,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   test('exclusion with has key: -has:gpu', async ({ vmListPage, utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Submit -has:gpu search', async () => {
@@ -213,8 +213,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   test('description: key explicitly searches descriptions', async ({ vmListPage, utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Submit description:database search', async () => {
@@ -238,8 +238,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   test('search input clears with clear button', async ({ vmListPage, utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Enter a search query', async () => {
@@ -258,8 +258,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   test('search dropdown shows key suggestions on focus', async ({ vmListPage, utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Focus search input to open dropdown', async () => {
@@ -294,8 +294,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Type "status:" to trigger value autocomplete', async () => {
@@ -324,8 +324,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   test('combined search: status:Running vcpu>4 -has:gpu', async ({ vmListPage, utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Submit combined multi-token search', async () => {
@@ -357,8 +357,8 @@ test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
   test('search examples are shown in dropdown', async ({ vmListPage, utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: T1,
-      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      feature: GATING,
+      tags: [GATING_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
     });
 
     await test.step('Focus search input and verify examples appear', async () => {

--- a/playwright/tests/tier1/create-vm/project-network-settings.spec.ts
+++ b/playwright/tests/tier1/create-vm/project-network-settings.spec.ts
@@ -1,11 +1,11 @@
 import type RequestContextClient from '@/clients/request-context-client';
 import {
   ADMIN_ONLY_TAG,
-  GATING,
-  GATING_TAG,
   NETWORKING_TAG_LABEL,
+  T1,
+  T1_TAG,
 } from '@/data-models/allure-constants';
-import { expect, test } from '@/fixtures/gating-fixture';
+import { expect, test } from '@/fixtures/create-vm-fixture';
 import type VmWizardBootSourcePage from '@/page-objects/vm-wizard/vm-wizard-boot-source-page';
 import type VmWizardComputeCustomizationPage from '@/page-objects/vm-wizard/vm-wizard-compute-customization-page';
 import type VmWizardNavigationPage from '@/page-objects/vm-wizard/vm-wizard-navigation-page';
@@ -134,12 +134,12 @@ async function assertAddNicModalHidesPodAndSelectsNad(
   await vmWizardComputePage.cancelNetworkInterfaceModal();
 }
 
-test.describe(SUITE, { tag: [GATING_TAG, '@catalog-wizard', ADMIN_ONLY_TAG] }, () => {
+test.describe(SUITE, { tag: [T1_TAG, '@catalog-wizard', ADMIN_ONLY_TAG] }, () => {
   test.beforeEach(async ({ utils }) => {
     await utils.withAllure({
       suite: SUITE,
-      feature: GATING,
-      tags: [GATING_TAG, NETWORKING_TAG_LABEL, ADMIN_ONLY_TAG],
+      feature: T1,
+      tags: [T1_TAG, NETWORKING_TAG_LABEL, ADMIN_ONLY_TAG],
     });
   });
 

--- a/playwright/tests/tier1/migrationpolicies/migration-policies.spec.ts
+++ b/playwright/tests/tier1/migrationpolicies/migration-policies.spec.ts
@@ -37,18 +37,22 @@ test.describe.serial(
       await migrationPoliciesPage.clickCreateButton();
       apiClient.trackResource('MigrationPolicy', bandwidthPolicyName);
 
+      const created = await apiClient.verifyMigrationPolicyCreated(
+        bandwidthPolicyName,
+        utils.TestTimeouts.DEFAULT,
+      );
+      expect(created, `MigrationPolicy ${bandwidthPolicyName} should exist after creation`).toBe(
+        true,
+      );
+
+      await migrationPoliciesPage.navigateToMigrationPoliciesViaUI();
+      await migrationPoliciesPage.filterByName(bandwidthPolicyName);
       await expect
-        .poll(
-          async () => {
-            await migrationPoliciesPage.navigateToMigrationPoliciesViaUI();
-            return migrationPoliciesPage.isPolicyVisible(bandwidthPolicyName);
-          },
-          {
-            message: `Policy ${bandwidthPolicyName} should appear in the list`,
-            timeout: utils.TestTimeouts.DEFAULT,
-            intervals: [2000, 3000, 5000],
-          },
-        )
+        .poll(() => migrationPoliciesPage.isPolicyVisible(bandwidthPolicyName), {
+          message: `Policy ${bandwidthPolicyName} should appear in the list`,
+          timeout: utils.TestTimeouts.DEFAULT,
+          intervals: [2000, 3000, 5000],
+        })
         .toBe(true);
     });
 
@@ -74,8 +78,8 @@ test.describe.serial(
 
       await expect
         .soft(
-          migrationPoliciesPage.detailContentLocator(/64\s*M/),
-          'Bandwidth value should display 64 M (64Mi converted to human-readable)',
+          migrationPoliciesPage.detailContentLocator(/^\s*64\s+MiB\s*$/),
+          'Bandwidth value should display 64 MiB (64Mi converted to human-readable)',
         )
         .toBeVisible();
     });
@@ -99,18 +103,22 @@ test.describe.serial(
       await migrationPoliciesPage.clickCreateButton();
       apiClient.trackResource('MigrationPolicy', autoConvergePolicyName);
 
+      const created = await apiClient.verifyMigrationPolicyCreated(
+        autoConvergePolicyName,
+        utils.TestTimeouts.DEFAULT,
+      );
+      expect(created, `MigrationPolicy ${autoConvergePolicyName} should exist after creation`).toBe(
+        true,
+      );
+
+      await migrationPoliciesPage.navigateToMigrationPoliciesViaUI();
+      await migrationPoliciesPage.filterByName(autoConvergePolicyName);
       await expect
-        .poll(
-          async () => {
-            await migrationPoliciesPage.navigateToMigrationPoliciesViaUI();
-            return migrationPoliciesPage.isPolicyVisible(autoConvergePolicyName);
-          },
-          {
-            timeout: 30_000,
-            intervals: [2_000],
-            message: `Policy ${autoConvergePolicyName} should appear in the list`,
-          },
-        )
+        .poll(() => migrationPoliciesPage.isPolicyVisible(autoConvergePolicyName), {
+          timeout: utils.TestTimeouts.DEFAULT,
+          intervals: [2_000],
+          message: `Policy ${autoConvergePolicyName} should appear in the list`,
+        })
         .toBe(true);
 
       await test.step('Delete via actions dropdown', async () => {

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-configuration-storage.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-configuration-storage.spec.ts
@@ -27,8 +27,7 @@ test.describe.serial(
       const created = await apiClient.verifyVmCreated(vmName, ns, utils.TestTimeouts.VM_CREATION);
       if (!created.exists) throw new Error(`VM ${vmName} was not created`);
 
-      const running = await apiClient.waitForVmRunning(vmName, ns, utils.TestTimeouts.VM_BOOTUP);
-      if (!running) throw new Error(`VM ${vmName} did not reach Running state`);
+      await apiClient.waitForVmRunning(vmName, ns, utils.TestTimeouts.VM_BOOTUP);
     });
 
     test.beforeEach(async ({ utils }) => {


### PR DESCRIPTION
## 📝 Description

Stabilize Playwright Tier1 helpers after local Tier1 runs:

- Match the exact **Virtualization** perspective (do not treat Fleet virtualization as a match)
- Fall back to **Core Platform** when the Virtualization perspective is unavailable (ACM hubs)
- Close the perspective switcher menu so it cannot block sidebar navigation
- Retry Registry source selection in the Add volume modal (PF Select portal flakiness)
- Fix MigrationPolicy bandwidth input filling on macOS (`Control+a` produced `640 MiB`); assert `64 MiB`
- Remove unused deprecated `goTo`-based bootable volume navigation helpers; use sidebar + client-side namespace navigation

## 🔗 Links

- Epic: https://issues.redhat.com/browse/CNV-87423
- Also: https://redhat.atlassian.net/browse/CNV-87423

## 🎥 Demo

N/A (Playwright test infrastructure)

## Test plan

- [x] `IS_LOCAL=1` MigrationPolicy Tier1 suite — 4/4 passed
- [ ] Re-run Tier1 BV create/delete + navigation-sensitive specs on a healthy non-fleet cluster
- [ ] Confirm remaining VM-ready timeouts are cluster/infrastructure, not regressions from these changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation reliability when switching between Virtualization and Core Platform views.
  - Improved Registry source selection during bootable volume creation.
  - Improved bootable volume and template navigation, including namespace handling and page validation.
  - Improved migration policy form validation and creation completion checks.
  - Improved YAML-based bootable volume creation flow reliability.

- **Tests**
  - Updated VM coverage to use RHEL 9 templates.
  - Refined migration policy, VM wizard, and navigation test coverage.
  - Improved test suite classification and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->