### PR TITLE
CNV-93891: Quick Create CNV UI VMs does not retain a selected SSH key for non-admin users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ ci-scripts/generated/
 
 # Personal Cursor rules (not shared with team)
 .cursor/rules/personal-*.mdc
+.cursor/debug-*.log

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/useTemplateSecrets.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/useTemplateSecrets.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useDrawerContext } from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDrawerContext';
 import { TemplateSSHDetails } from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/utils/types';
@@ -40,6 +40,9 @@ const useTemplateSecrets: UseTemplateSecrets = (
   cluster,
 ) => {
   const { setSSHDetails, setVM, sshDetails, template, vm } = useDrawerContext();
+
+  // Prevents the initialization effect from overwriting an explicit user choice.
+  const userHasSetSSH = useRef(false);
 
   const [templateSecretDetails] = useState<TemplateSSHDetails>(getTemplateSSHSecret(template));
   const { templateSecretName, templateSecretNamespace } = templateSecretDetails;
@@ -92,7 +95,16 @@ const useTemplateSecrets: UseTemplateSecrets = (
     [sshDetails, setVM, vm, setSSHDetails],
   );
 
+  const onUserSSHChange = useCallback(
+    (newSSHDetails: SSHSecretDetails) => {
+      userHasSetSSH.current = true;
+      return onSSHChange(newSSHDetails);
+    },
+    [onSSHChange],
+  );
+
   useEffect(() => {
+    if (userHasSetSSH.current) return;
     if (isEmpty(sshDetails) || !secretsData?.secretsLoaded) {
       const initialSSHDetails = getInitialSSHDetails({
         applyKeyToProject: !isEmpty(namespaceDefaultSecretName),
@@ -119,7 +131,7 @@ const useTemplateSecrets: UseTemplateSecrets = (
   return {
     copyTemplateSecretToTargetNS,
     loaded: secretsData?.secretsLoaded,
-    onSSHChange,
+    onSSHChange: onUserSSHChange,
     overwriteTemplateSSHKey: !isEmpty(namespaceDefaultSecretName) && !isEmpty(templateSecretName),
     sshDetails,
   };


### PR DESCRIPTION
## 📝 Description

When a non-admin user creates a VirtualMachine from a template using the Quick Create VirtualMachine workflow, the selected SSH public key is not retained after clicking Save.

## 🔗 Links

Jira ticket: [CNV-93891](https://redhat.atlassian.net/browse/CNV-93891)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/6dee67df-67ab-4d06-a734-a97f598823b2

After:

https://github.com/user-attachments/assets/168712b5-812d-4506-aad5-6a9878b3ca19
