### PR TITLE
CNV-94639: [release-4.20] Quick Create CNV UI VMs does not retain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ scripts/ca.crt
 scripts/console-client-secret
 *.json-*
 /playwright
+.playwright-mcp
 .env.local
 local.env
+.cursor/rules/personal-*.mdc
+.cursor/debug-*.log

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/useTemplateSecrets.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/useTemplateSecrets.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useDrawerContext } from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDrawerContext';
 import { TemplateSSHDetails } from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/utils/types';
@@ -39,6 +39,9 @@ const useTemplateSecrets: UseTemplateSecrets = (
   cluster,
 ) => {
   const { setSSHDetails, setVM, sshDetails, template, vm } = useDrawerContext();
+
+  // Prevents the initialization effect from overwriting an explicit user choice.
+  const userHasSetSSH = useRef(false);
 
   const [templateSecretDetails] = useState<TemplateSSHDetails>(getTemplateSSHSecret(template));
   const { templateSecretName, templateSecretNamespace } = templateSecretDetails;
@@ -91,7 +94,16 @@ const useTemplateSecrets: UseTemplateSecrets = (
     [sshDetails, setVM, vm, setSSHDetails],
   );
 
+  const onUserSSHChange = useCallback(
+    (newSSHDetails: SSHSecretDetails) => {
+      userHasSetSSH.current = true;
+      return onSSHChange(newSSHDetails);
+    },
+    [onSSHChange],
+  );
+
   useEffect(() => {
+    if (userHasSetSSH.current) return;
     if (isEmpty(sshDetails) || !secretsData?.secretsLoaded) {
       const initialSSHDetails = getInitialSSHDetails({
         applyKeyToProject: !isEmpty(namespaceDefaultSecretName),
@@ -117,7 +129,7 @@ const useTemplateSecrets: UseTemplateSecrets = (
 
   return {
     copyTemplateSecretToTargetNS,
-    onSSHChange,
+    onSSHChange: onUserSSHChange,
     overwriteTemplateSSHKey: !isEmpty(namespaceDefaultSecretName) && !isEmpty(templateSecretName),
     sshDetails,
   };


### PR DESCRIPTION
## 📝 Description

When a non-admin user creates a VirtualMachine from a template using the Quick Create VirtualMachine workflow, the selected SSH public key is not retained after clicking Save.

## 🔗 Links

Jira ticket: [CNV-94639](https://redhat.atlassian.net/browse/CNV-94639)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/78453831-e3cc-48a9-b91e-521eef47061d

After:

https://github.com/user-attachments/assets/9cbc09c7-dec1-4ec9-ada3-a641c424595e

