### PR TITLE
CNV-94644: [release-4.19] Quick Create CNV UI VMs does not retain a selected SSH key for non-admin users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ console-extensions.md
 scripts/ca.crt
 scripts/console-client-secret
 *.json-*
+.cursor/rules/personal-*.mdc
+.cursor/debug-*.log
+/playwright
+.playwright-mcp

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/useTemplateSecrets.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/useTemplateSecrets.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useDrawerContext } from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDrawerContext';
 import { TemplateSSHDetails } from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/utils/types';
@@ -34,6 +34,9 @@ type UseTemplateSecrets = (
 
 const useTemplateSecrets: UseTemplateSecrets = (namespaceDefaultSecretName, targetNamespace) => {
   const { setSSHDetails, setVM, sshDetails, template, vm } = useDrawerContext();
+
+  // Prevents the initialization effect from overwriting an explicit user choice.
+  const userHasSetSSH = useRef(false);
 
   const [templateSecretDetails] = useState<TemplateSSHDetails>(getTemplateSSHSecret(template));
   const { templateSecretName, templateSecretNamespace } = templateSecretDetails;
@@ -86,7 +89,16 @@ const useTemplateSecrets: UseTemplateSecrets = (namespaceDefaultSecretName, targ
     [sshDetails, setVM, vm, setSSHDetails],
   );
 
+  const onUserSSHChange = useCallback(
+    (newSSHDetails: SSHSecretDetails) => {
+      userHasSetSSH.current = true;
+      return onSSHChange(newSSHDetails);
+    },
+    [onSSHChange],
+  );
+
   useEffect(() => {
+    if (userHasSetSSH.current) return;
     if (isEmpty(sshDetails) || !secretsData?.secretsLoaded) {
       const initialSSHDetails = getInitialSSHDetails({
         applyKeyToProject: !isEmpty(namespaceDefaultSecretName),
@@ -112,7 +124,7 @@ const useTemplateSecrets: UseTemplateSecrets = (namespaceDefaultSecretName, targ
 
   return {
     copyTemplateSecretToTargetNS,
-    onSSHChange,
+    onSSHChange: onUserSSHChange,
     overwriteTemplateSSHKey: !isEmpty(namespaceDefaultSecretName) && !isEmpty(templateSecretName),
     sshDetails,
   };


### PR DESCRIPTION
## 📝 Description

When a non-admin user creates a VirtualMachine from a template using the Quick Create VirtualMachine workflow, the selected SSH public key is not retained after clicking Save.

## 🔗 Links

Jira ticket: [CCNV-94644](https://redhat.atlassian.net/browse/CNV-94644)

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/34ddd9bb-45ee-43a0-96e1-92a5e36a5562


After:


https://github.com/user-attachments/assets/54747d7c-a5df-4a95-9969-a725eb8fdc68

