### PR TITLE
CNV-94654: [release-4.18] Quick Create CNV UI VMs does not retain a selected SSH key for non-admin users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ console-extensions.md
 scripts/ca.crt
 scripts/console-client-secret
 *.json-*
+playwright/
+.playwright-mcp
+.cursor/rules/personal-*.mdc
+.cursor/debug-*.log

--- a/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/useTemplateSecrets.ts
+++ b/src/views/catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/useTemplateSecrets.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useDrawerContext } from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useDrawerContext';
 import { TemplateSSHDetails } from '@catalog/templatescatalog/components/TemplatesCatalogDrawer/hooks/useTemplateSecrets/utils/types';
@@ -34,6 +34,9 @@ type UseTemplateSecrets = (
 
 const useTemplateSecrets: UseTemplateSecrets = (namespaceDefaultSecretName, targetNamespace) => {
   const { setSSHDetails, setVM, sshDetails, template, vm } = useDrawerContext();
+
+  // Prevents the initialization effect from overwriting an explicit user choice.
+  const userHasSetSSH = useRef(false);
 
   const [templateSecretDetails] = useState<TemplateSSHDetails>(getTemplateSSHSecret(template));
   const { templateSecretName, templateSecretNamespace } = templateSecretDetails;
@@ -86,7 +89,16 @@ const useTemplateSecrets: UseTemplateSecrets = (namespaceDefaultSecretName, targ
     [sshDetails, setVM, vm, setSSHDetails],
   );
 
+  const onUserSSHChange = useCallback(
+    (newSSHDetails: SSHSecretDetails) => {
+      userHasSetSSH.current = true;
+      return onSSHChange(newSSHDetails);
+    },
+    [onSSHChange],
+  );
+
   useEffect(() => {
+    if (userHasSetSSH.current) return;
     if (isEmpty(sshDetails) || !secretsData?.secretsLoaded) {
       const initialSSHDetails = getInitialSSHDetails({
         applyKeyToProject: !isEmpty(namespaceDefaultSecretName),
@@ -112,7 +124,7 @@ const useTemplateSecrets: UseTemplateSecrets = (namespaceDefaultSecretName, targ
 
   return {
     copyTemplateSecretToTargetNS,
-    onSSHChange,
+    onSSHChange: onUserSSHChange,
     overwriteTemplateSSHKey: !isEmpty(namespaceDefaultSecretName) && !isEmpty(templateSecretName),
     sshDetails,
   };


### PR DESCRIPTION
## 📝 Description

When a non-admin user creates a VirtualMachine from a template using the Quick Create VirtualMachine workflow, the selected SSH public key is not retained after clicking Save.

## 🔗 Links

Jira ticket: [CNV-94654](https://redhat.atlassian.net/browse/CNV-94654)

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/2249ff83-58e5-488e-9259-a03ba97193fc


After:

https://github.com/user-attachments/assets/e3d8a0f7-fef0-4b21-880b-d6ca38d01262





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added virtual machine topology views with status-aware nodes, resource relationships, and detailed side panels.
  - Added guided storage profile settings for access mode and volume mode recommendations.
  - Added clearer VM details, including labels, annotations, operating system, IP addresses, credentials, hardware, and workload profile.
  - Added dedicated access-denied screens for restricted and unavailable resources.

- **Bug Fixes**
  - Improved CPU, disk capacity, migration, secret, and VM selection handling.
  - Improved chart labeling and utilization calculations.

- **Documentation**
  - Updated development, internationalization, telemetry, and virtualization documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->