### PR TITLE
CNV-94659: CD-ROM canceled upload toast reactivates and interferes with a subsequent retry

### DIFF
--- a/src/utils/hooks/useUploadProgressToast/components/UploadProgressToastContent.tsx
+++ b/src/utils/hooks/useUploadProgressToast/components/UploadProgressToastContent.tsx
@@ -8,16 +8,23 @@ import UploadProgressErrorToast from './UploadProgressErrorToast';
 import UploadProgressSuccessToast from './UploadProgressSuccessToast';
 import UploadProgressUploadingToast from './UploadProgressUploadingToast';
 
+import { UploadEntry } from '../types';
+
 type UploadProgressToastContentProps = {
   navigate: (path: string) => void;
   uploadKey: string;
+  uploadSnapshot?: UploadEntry;
 };
 
 const UploadProgressToastContent: FC<UploadProgressToastContentProps> = ({
   navigate,
   uploadKey,
+  uploadSnapshot,
 }) => {
-  const upload = useUploadProgressStore((state) => state.uploads[uploadKey]);
+  const storeUpload = useUploadProgressStore((state) =>
+    uploadSnapshot ? undefined : state.uploads[uploadKey],
+  );
+  const upload = uploadSnapshot ?? storeUpload;
 
   if (!upload) {
     return null;

--- a/src/utils/hooks/useUploadProgressToast/types.ts
+++ b/src/utils/hooks/useUploadProgressToast/types.ts
@@ -22,6 +22,7 @@ export type UploadEntry = {
   dvNamespace?: string;
   errorMessage?: string;
   fileName: string;
+  generation?: number;
   onCancelCleanup?: () => Promise<void>;
   progress: number;
   resourceName?: string;
@@ -32,7 +33,7 @@ export type UploadEntry = {
   toastId?: string;
 };
 
-export type StartUploadEntry = Omit<UploadEntry, 'progress' | 'status' | 'toastId'>;
+export type StartUploadEntry = Omit<UploadEntry, 'generation' | 'progress' | 'status' | 'toastId'>;
 
 export type CdiUploadTrackMetadata = Partial<
   Pick<

--- a/src/utils/hooks/useUploadProgressToast/uploadProgressStore.test.ts
+++ b/src/utils/hooks/useUploadProgressToast/uploadProgressStore.test.ts
@@ -58,6 +58,7 @@ describe('useUploadProgressStore', () => {
       expect(upload).toEqual({
         blockNavigation: true,
         fileName: FILE_IMAGE_ISO,
+        generation: 1,
         progress: 0,
         status: UPLOAD_PROGRESS_STATUS.UPLOADING,
       });

--- a/src/utils/hooks/useUploadProgressToast/uploadProgressStore.ts
+++ b/src/utils/hooks/useUploadProgressToast/uploadProgressStore.ts
@@ -86,6 +86,7 @@ export const useUploadProgressStore = create<UploadProgressStoreState>((set, get
         [uploadKey]: {
           blockNavigation: true,
           ...entry,
+          generation: (state.uploads[uploadKey]?.generation ?? 0) + 1,
           progress: 0,
           status: UPLOAD_PROGRESS_STATUS.UPLOADING,
         },

--- a/src/utils/hooks/useUploadProgressToast/uploadToastSync.test.tsx
+++ b/src/utils/hooks/useUploadProgressToast/uploadToastSync.test.tsx
@@ -3,6 +3,7 @@ import { TFunction } from 'i18next';
 
 import { UPLOAD_PROGRESS_STATUS } from './constants';
 import { UploadEntry } from './types';
+import { useUploadProgressStore } from './uploadProgressStore';
 import {
   replaceWithTerminalUploadToast,
   showInProgressUploadToast,
@@ -116,6 +117,10 @@ describe('showInProgressUploadToast', () => {
 });
 
 describe('replaceWithTerminalUploadToast', () => {
+  afterEach(() => {
+    useUploadProgressStore.setState({ uploads: {} });
+  });
+
   it('should skip non-terminal upload statuses', () => {
     const context = createMockContext();
     const upload = createUploadEntry({ status: UPLOAD_PROGRESS_STATUS.UPLOADING });
@@ -192,6 +197,58 @@ describe('replaceWithTerminalUploadToast', () => {
 
     expect(context.removeUpload).toHaveBeenCalledWith(UPLOAD_KEY);
     expect(context.cancelTrackedUpload).not.toHaveBeenCalled();
+  });
+
+  it('should not remove the store entry when a retry reused the key with a new non-terminal upload', () => {
+    const context = createMockContext();
+    const upload = createUploadEntry({ status: UPLOAD_PROGRESS_STATUS.CANCELED });
+
+    replaceWithTerminalUploadToast(UPLOAD_KEY, upload, context);
+
+    const { onClose } = context.addWarningToast.mock.calls[0][0] as MockToastOptions;
+
+    // Simulate a retry: a new upload was started for the same uploadKey,
+    // overwriting the store entry with a fresh, in-progress upload.
+    useUploadProgressStore.getState().startUpload(UPLOAD_KEY, { fileName: 'new.iso' });
+
+    onClose?.();
+
+    expect(context.removeUpload).not.toHaveBeenCalled();
+  });
+
+  it('should still remove the store entry on close when no retry has started', () => {
+    const context = createMockContext();
+    const upload = createUploadEntry({ status: UPLOAD_PROGRESS_STATUS.CANCELED });
+
+    replaceWithTerminalUploadToast(UPLOAD_KEY, upload, context);
+
+    const { onClose } = context.addWarningToast.mock.calls[0][0] as MockToastOptions;
+
+    onClose?.();
+
+    expect(context.removeUpload).toHaveBeenCalledWith(UPLOAD_KEY);
+  });
+
+  it('should not remove the store entry when a retry has started and itself became terminal before the old toast closes', () => {
+    const context = createMockContext();
+
+    // Start the first upload through the store so it gets generation = 1.
+    useUploadProgressStore.getState().startUpload(UPLOAD_KEY, { fileName: 'image.iso' });
+    useUploadProgressStore.getState().markUploadCanceled(UPLOAD_KEY);
+    const canceledUpload = useUploadProgressStore.getState().getUpload(UPLOAD_KEY)!;
+
+    replaceWithTerminalUploadToast(UPLOAD_KEY, canceledUpload, context);
+
+    const { onClose } = context.addWarningToast.mock.calls[0][0] as MockToastOptions;
+
+    // Retry: new upload starts (generation = 2) and quickly reaches a terminal state.
+    useUploadProgressStore.getState().startUpload(UPLOAD_KEY, { fileName: 'image.iso' });
+    useUploadProgressStore.getState().failUpload(UPLOAD_KEY, 'network error');
+
+    // Closing the old canceled toast must NOT evict the retry's store entry.
+    onClose?.();
+
+    expect(context.removeUpload).not.toHaveBeenCalled();
   });
 });
 

--- a/src/utils/hooks/useUploadProgressToast/uploadToastSync.tsx
+++ b/src/utils/hooks/useUploadProgressToast/uploadToastSync.tsx
@@ -7,6 +7,7 @@ import UploadProgressToastContent from './components/UploadProgressToastContent'
 import { UPLOAD_PROGRESS_STATUS } from './constants';
 import { getUploadTitle, isTerminalUploadStatus } from './toast/uploadTitles';
 import { UploadEntry } from './types';
+import { useUploadProgressStore } from './uploadProgressStore';
 
 type ToastActions = ReturnType<typeof useKubevirtToast>;
 
@@ -68,10 +69,27 @@ export const replaceWithTerminalUploadToast = (
     context.removeToast(upload.toastId);
   }
 
+  const capturedGeneration = upload.generation;
+
   const toastOptions = {
-    content: <UploadProgressToastContent navigate={context.navigate} uploadKey={uploadKey} />,
+    content: (
+      <UploadProgressToastContent
+        navigate={context.navigate}
+        uploadKey={uploadKey}
+        uploadSnapshot={upload}
+      />
+    ),
     dismissible: true,
-    onClose: () => context.removeUpload(uploadKey),
+    onClose: () => {
+      const latestUpload = useUploadProgressStore.getState().getUpload(uploadKey);
+      if (latestUpload && latestUpload.generation !== capturedGeneration) {
+        return;
+      }
+      if (latestUpload && !isTerminalUploadStatus(latestUpload.status)) {
+        return;
+      }
+      context.removeUpload(uploadKey);
+    },
     timeout: false,
     title: getUploadTitle(upload, context.t),
   };


### PR DESCRIPTION
## 📝 Description

CD-ROM upload: canceled upload toast reactivates and interferes with a subsequent retries. 

## 🔗 Links

Jira ticket: [CNV-94659](https://redhat.atlassian.net/browse/CNV-94659)


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/c0a6afa9-23e6-42c8-9d71-815c56deae6a

After:

https://github.com/user-attachments/assets/49a30182-c821-45bd-bffb-5e389e9d3ff3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload progress toast handling when uploads are retried or reused.
  * Prevented closing a completed upload notification from removing a newer upload with the same identifier.
  * Ensured active uploads remain tracked while they are still in progress.
  * Correctly removes notifications for completed or missing uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->