### PR TITLE
CNV-94675: allow VM creation without a boot source

### DIFF
--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/types.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/types.ts
@@ -1,53 +1,40 @@
-import { type V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { type BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import { type VMWizardFormValues } from '@virtualmachines/wizard/state/vm-wizard-form/types';
 
-type GenerateVMArgs = {
-  cluster?: string;
-  customDiskSize: string;
-  dvSource: V1beta1DataVolume;
+export type GenerateVMContext = {
   enableMultiArchBootImageImport?: boolean;
-  folder: string;
   isIPv6SingleStack?: boolean;
   isUDNManagedNamespace: boolean;
   populatedCloudInitYAML: string;
-  pvcSource: IoK8sApiCoreV1PersistentVolumeClaim;
-  selectedBootableVolume: BootableVolume;
-  selectedInstanceType: { name: string; namespace: string };
   sshSecretName?: string;
-  targetNamespace: string;
   vmCreationNad?: NetworkAttachmentDefinitionKind;
-  vmDescription?: string;
-  vmName?: string;
+  vmName: string;
+};
+
+export type GenerateVMArgs = {
+  context: GenerateVMContext;
+  instanceTypeData: VMWizardFormValues['instanceTypeData'];
+  vmData: VMWizardFormValues['vmData'];
 };
 
 export type GenerateVMCallback = (props: GenerateVMArgs) => V1VirtualMachine;
 
 export type GenerateVMSpecConfiguration = {
-  customDiskSize: string;
-  dvSource: VMWizardFormValues['instanceTypeData']['dvSource'];
-  enableMultiArchBootImageImport: boolean;
-  isIPv6SingleStack: boolean;
-  isUDNManagedNamespace: boolean;
-  populatedCloudInitYAML: string;
-  pvcSource: VMWizardFormValues['instanceTypeData']['pvcSource'];
-  selectedBootableVolume: BootableVolume;
-  selectedInstanceType: VMWizardFormValues['instanceTypeData']['selectedInstanceType'];
-  vmCreationNad?: NetworkAttachmentDefinitionKind;
-  vmName: string;
+  context: Omit<GenerateVMContext, 'sshSecretName'>;
+  instanceTypeData: VMWizardFormValues['instanceTypeData'];
 };
 
 export type GenerateVMSpecTemplateConfiguration = {
-  enableMultiArchBootImageImport: boolean;
-  isIPv6SingleStack: boolean;
+  enableMultiArchBootImageImport?: boolean;
+  hasBootVolume: boolean;
+  isIPv6SingleStack?: boolean;
   isIso: boolean;
   isUDNManagedNamespace: boolean;
   populatedCloudInitYAML: string;
-  selectedBootableVolume: BootableVolume;
-  selectedPreference: string;
+  selectedBootableVolume: BootableVolume | null;
+  selectedPreference?: string;
   vmCreationNad?: NetworkAttachmentDefinitionKind;
   vmName: string;
   volumeName: string;
@@ -55,9 +42,9 @@ export type GenerateVMSpecTemplateConfiguration = {
 
 export type GenerateVMSpecDataVolumeTemplates = {
   customDiskSize: string | undefined;
-  dvSource: Parameters<GenerateVMCallback>[0]['dvSource'];
+  dvSource: VMWizardFormValues['instanceTypeData']['dvSource'];
   isIso: boolean;
-  pvcSource: Parameters<GenerateVMCallback>[0]['pvcSource'];
+  pvcSource: VMWizardFormValues['instanceTypeData']['pvcSource'];
   selectedBootableVolume: BootableVolume;
   storageClassName: string;
   vmName: string;

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/useGenerateVM.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/useGenerateVM.ts
@@ -2,10 +2,7 @@ import { useMemo } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import {
-  DEFAULT_PREFERENCE_LABEL,
-  KUBEVIRT_OS,
-} from '@kubevirt-utils/constants/instancetypes-and-preferences';
+import { KUBEVIRT_OS } from '@kubevirt-utils/constants/instancetypes-and-preferences';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import useIsIPv6SingleStackCluster from '@kubevirt-utils/hooks/useIPStackType/useIsIPv6SingleStackCluster';
@@ -20,17 +17,13 @@ import { useDriversImage } from '@kubevirt-utils/resources/vm/utils/disk/useDriv
 import { generatePrettyName, getValidNamespace } from '@kubevirt-utils/utils/utils';
 import { AUTOMATIC_UPDATE_FEATURE_NAME } from '@settings/tabs/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/utils/constants';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
-import {
-  CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA,
-  CREATE_VM_FORM_FIELDS_VM_DATA,
-} from '@virtualmachines/wizard/state/vm-wizard-form/consts';
 import { type VMWizardFormValues } from '@virtualmachines/wizard/state/vm-wizard-form/types';
 import {
+  createPopulatedCloudInitYAML,
   generateVM,
   isWindowBootableVolume,
 } from '@virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVM';
-
-import { createPopulatedCloudInitYAML } from './utils/generateVM';
+import { getSelectedPreferenceName } from '@virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/getSelectedPreference';
 
 export type UseGenerateVMResult = {
   generatedVM: V1VirtualMachine;
@@ -39,48 +32,18 @@ export type UseGenerateVMResult = {
 
 const useGenerateVM = (): UseGenerateVMResult => {
   const { control } = useVMWizard();
-  const [
-    cluster,
-    namespace,
-    selectedBootableVolume,
-    vmDescription,
-    folder,
-    vmName,
-    customDiskSize,
-    dvSource,
-    pvcSource,
-    selectedInstanceType,
-  ] = useWatch({
+  const [vmData, instanceTypeData] = useWatch({
     control,
-    name: [
-      CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER,
-      CREATE_VM_FORM_FIELDS_VM_DATA.PROJECT,
-      CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.SELECTED_BOOTABLE_VOLUME,
-      CREATE_VM_FORM_FIELDS_VM_DATA.DESCRIPTION,
-      CREATE_VM_FORM_FIELDS_VM_DATA.FOLDER,
-      CREATE_VM_FORM_FIELDS_VM_DATA.NAME,
-      CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.CUSTOM_DISK_SIZE,
-      CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.DV_SOURCE,
-      CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.PVC_SOURCE,
-      CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.SELECTED_INSTANCE_TYPE,
-    ],
-  }) as [
-    VMWizardFormValues['vmData']['cluster'],
-    VMWizardFormValues['vmData']['project'],
-    VMWizardFormValues['instanceTypeData']['selectedBootableVolume'],
-    VMWizardFormValues['vmData']['description'],
-    VMWizardFormValues['vmData']['folder'],
-    VMWizardFormValues['vmData']['name'],
-    VMWizardFormValues['instanceTypeData']['customDiskSize'],
-    VMWizardFormValues['instanceTypeData']['dvSource'],
-    VMWizardFormValues['instanceTypeData']['pvcSource'],
-    VMWizardFormValues['instanceTypeData']['selectedInstanceType'],
-  ];
-  const { featureEnabled: autoUpdateEnabled } = useFeatures(AUTOMATIC_UPDATE_FEATURE_NAME);
+    name: ['vmData', 'instanceTypeData'],
+  }) as [VMWizardFormValues['vmData'], VMWizardFormValues['instanceTypeData']];
 
+  const { cluster, name, project } = vmData;
+  const { preference, selectedBootableVolume } = instanceTypeData;
+
+  const { featureEnabled: autoUpdateEnabled } = useFeatures(AUTOMATIC_UPDATE_FEATURE_NAME);
   const { subscriptionData } = useRHELAutomaticSubscription();
 
-  const validNamespace = getValidNamespace(namespace);
+  const validNamespace = getValidNamespace(project);
   const [isUDNManagedNamespace] = useNamespaceUDN(validNamespace);
   const { loaded, vmCreationNad } = useProjectDefaultNad({
     cluster,
@@ -91,8 +54,8 @@ const useGenerateVM = (): UseGenerateVMResult => {
   const enableMultiArchBootImageImport =
     hyperConverge?.spec?.featureGates?.enableMultiArchBootImageImport;
 
-  const selectedPreference = getLabel(selectedBootableVolume, DEFAULT_PREFERENCE_LABEL);
-  const osLabel = getLabel(selectedBootableVolume, KUBEVIRT_OS);
+  const selectedPreference = getSelectedPreferenceName(selectedBootableVolume, preference);
+  const osLabel = getLabel(selectedBootableVolume, KUBEVIRT_OS) || preference?.name;
   const populatedCloudInitYAML = useMemo(
     () =>
       createPopulatedCloudInitYAML(
@@ -108,48 +71,38 @@ const useGenerateVM = (): UseGenerateVMResult => {
   const [driversImage] = useDriversImage(cluster);
   const [authorizedSSHKeys] = useKubevirtUserSettings(USER_SETTINGS_KEYS.ssh, cluster);
   const defaultSSHSecretName =
-    typeof authorizedSSHKeys?.[namespace] === 'string'
-      ? (authorizedSSHKeys[namespace] as string)
+    typeof authorizedSSHKeys?.[project] === 'string'
+      ? (authorizedSSHKeys[project] as string)
       : undefined;
 
-  const generatedVM = useMemo(() => {
-    return generateVM({
-      cluster,
-      customDiskSize,
-      dvSource,
+  const generatedVM = useMemo(
+    () =>
+      generateVM({
+        context: {
+          enableMultiArchBootImageImport,
+          isIPv6SingleStack,
+          isUDNManagedNamespace,
+          populatedCloudInitYAML,
+          sshSecretName: defaultSSHSecretName,
+          vmCreationNad,
+          vmName: name ?? generatedVMName,
+        },
+        instanceTypeData,
+        vmData,
+      }),
+    [
+      defaultSSHSecretName,
       enableMultiArchBootImageImport,
-      folder,
+      generatedVMName,
+      instanceTypeData,
       isIPv6SingleStack,
       isUDNManagedNamespace,
+      name,
       populatedCloudInitYAML,
-      pvcSource,
-      selectedBootableVolume,
-      selectedInstanceType,
-      sshSecretName: defaultSSHSecretName,
-      targetNamespace: namespace,
       vmCreationNad,
-      vmDescription,
-      vmName: vmName ?? generatedVMName,
-    });
-  }, [
-    cluster,
-    customDiskSize,
-    defaultSSHSecretName,
-    dvSource,
-    enableMultiArchBootImageImport,
-    folder,
-    generatedVMName,
-    isIPv6SingleStack,
-    isUDNManagedNamespace,
-    populatedCloudInitYAML,
-    vmCreationNad,
-    pvcSource,
-    selectedBootableVolume,
-    selectedInstanceType,
-    namespace,
-    vmDescription,
-    vmName,
-  ]);
+      vmData,
+    ],
+  );
 
   const vmWithDrivers = useMemo(() => {
     const isWindowsOSVolume = isWindowBootableVolume(selectedBootableVolume);

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVM.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVM.ts
@@ -1,83 +1,61 @@
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { DYNAMIC_CREDENTIALS_SUPPORT } from '@kubevirt-utils/components/DynamicSSHKeyInjection/constants/constants';
-import { addSecretToVM } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
-import { DEFAULT_PREFERENCE_LABEL } from '@kubevirt-utils/constants/instancetypes-and-preferences';
-import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
-import { getLabel } from '@kubevirt-utils/resources/shared';
-import { OS_WINDOWS_PREFIX } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
-import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
-
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
   addDNFUpdateToRunCMD,
   addSubscriptionManagerToRunCMD,
-  CloudInitUserData,
+  type CloudInitUserData,
   convertUserDataObjectToYAML,
 } from '@kubevirt-utils/components/CloudinitModal/utils/cloudinit-utils';
-import { RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
+import { DYNAMIC_CREDENTIALS_SUPPORT } from '@kubevirt-utils/components/DynamicSSHKeyInjection/constants/constants';
+import { addSecretToVM } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
+import { DEFAULT_PREFERENCE_LABEL } from '@kubevirt-utils/constants/instancetypes-and-preferences';
+import { type RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
+import { type BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { getLabel } from '@kubevirt-utils/resources/shared';
 import { OS_NAME_TYPES, OS_NAME_TYPES_NOT_SUPPORTED } from '@kubevirt-utils/resources/template';
+import { OS_WINDOWS_PREFIX } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import { getRandomChars, isEmpty } from '@kubevirt-utils/utils/utils';
 import { AutomaticSubscriptionTypeEnum } from '@settings/tabs/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/components/AutomaticSubscriptionType/utils/utils';
-import { GenerateVMCallback } from '../types';
+import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
+
+import { type GenerateVMCallback } from '../types';
+
 import { getSpecConfiguration } from './generateVMSpecConfig';
 
-export const generateVM: GenerateVMCallback = ({
-  cluster,
-  customDiskSize,
-  dvSource,
-  enableMultiArchBootImageImport,
-  folder,
-  isIPv6SingleStack,
-  isUDNManagedNamespace,
-  populatedCloudInitYAML,
-  vmCreationNad,
-  pvcSource,
-  selectedBootableVolume,
-  selectedInstanceType,
-  sshSecretName,
-  targetNamespace,
-  vmDescription,
-  vmName,
-}) => {
+export const generateVM: GenerateVMCallback = ({ context, instanceTypeData, vmData }) => {
+  const { cluster, description, folder, project } = vmData;
+  const { selectedBootableVolume } = instanceTypeData;
+
   const generatedVM: V1VirtualMachine = {
     apiVersion: `${VirtualMachineModel.apiGroup}/${VirtualMachineModel.apiVersion}`,
     kind: VirtualMachineModel.kind,
     ...(cluster && { cluster }),
     metadata: {
-      ...(vmDescription && { annotations: { description: vmDescription } }),
-      name: vmName,
-      namespace: targetNamespace,
+      ...(description && { annotations: { description } }),
+      name: context.vmName,
+      namespace: project,
       ...(folder && { labels: { [VM_FOLDER_LABEL]: folder } }),
     },
     spec: getSpecConfiguration({
-      selectedBootableVolume,
-      dvSource,
-      pvcSource,
-      customDiskSize,
-      vmName,
-      selectedInstanceType,
-      enableMultiArchBootImageImport,
-      isIPv6SingleStack,
-      populatedCloudInitYAML,
-      isUDNManagedNamespace,
-      vmCreationNad,
+      context,
+      instanceTypeData,
     }),
   };
 
-  if (sshSecretName) {
+  if (context.sshSecretName) {
     const isDynamic = getLabel(selectedBootableVolume, DYNAMIC_CREDENTIALS_SUPPORT) === 'true';
-    return addSecretToVM(generatedVM, sshSecretName, isDynamic);
+    return addSecretToVM(generatedVM, context.sshSecretName, isDynamic);
   }
 
   return generatedVM;
 };
 
-export const isWindowBootableVolume = (selectedBootableVolume: BootableVolume | null) => {
+export const isWindowBootableVolume = (selectedBootableVolume: BootableVolume | null): boolean => {
   const defaultPreferenceName = getLabel(selectedBootableVolume, DEFAULT_PREFERENCE_LABEL);
-  return defaultPreferenceName?.startsWith(OS_WINDOWS_PREFIX);
+  return defaultPreferenceName?.startsWith(OS_WINDOWS_PREFIX) ?? false;
 };
 
-export const generateCloudInitPassword = () =>
+export const generateCloudInitPassword = (): string =>
   `${getRandomChars(4)}-${getRandomChars(4)}-${getRandomChars(4)}`;
 
 const getCloudInitUserNameByOS = (selectedPreferenceName: string, osLabel: string): string => {
@@ -93,7 +71,7 @@ export const createPopulatedCloudInitYAML = (
   osLabel: string,
   subscriptionData: RHELAutomaticSubscriptionData,
   autoUpdateEnabled?: boolean,
-) => {
+): string => {
   const { activationKey, organizationID, type } = subscriptionData;
 
   const cloudInitConfig: CloudInitUserData = {

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVMSpecConfig.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVMSpecConfig.ts
@@ -1,132 +1,85 @@
 import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import {
-  DEFAULT_INSTANCETYPE_LABEL,
-  DEFAULT_PREFERENCE_KIND_LABEL,
-  DEFAULT_PREFERENCE_LABEL,
-} from '@kubevirt-utils/constants/instancetypes-and-preferences';
+import { DEFAULT_INSTANCETYPE_LABEL } from '@kubevirt-utils/constants/instancetypes-and-preferences';
 import { VirtualMachineInstancetypeModel } from '@kubevirt-utils/models';
 import { isBootableVolumeISO } from '@kubevirt-utils/resources/bootableresources/helpers';
 import { getPVCStorageClassName } from '@kubevirt-utils/resources/bootableresources/selectors';
-import {
-  buildDefaultNetwork,
-  buildDefaultNetworkInterface,
-} from '@kubevirt-utils/resources/namespace/networkDefault';
-import { getLabel, getLabels } from '@kubevirt-utils/resources/shared';
+import { getLabels } from '@kubevirt-utils/resources/shared';
 import { getDefaultRunningStrategy } from '@kubevirt-utils/resources/vm';
-import { OS_WINDOWS_PREFIX } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
-import { getArchitecture } from '@kubevirt-utils/utils/architecture';
-import {
-  HEADLESS_SERVICE_LABEL,
-  HEADLESS_SERVICE_NAME,
-} from '@kubevirt-utils/utils/headless-service';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
-import {
-  type GenerateVMSpecConfiguration,
-  type GenerateVMSpecTemplateConfiguration,
-} from '../types';
+import { type GenerateVMSpecConfiguration } from '../types';
 
 import { getDataVolumeTemplates } from './generateVMSpecTemplateConfig';
-import { getDomainDisks, getTemplateVolumes } from './templateVolumeAndDisk';
+import { getSelectedPreferenceMatcher } from './getSelectedPreference';
+import { getSpecTemplateConfiguration } from './getSpecTemplateConfiguration';
 
-type VMSpecTemplate = NonNullable<NonNullable<V1VirtualMachine['spec']>['template']>;
 type VMSpec = NonNullable<V1VirtualMachine['spec']>;
 
-const getSpecTemplateConfiguration = ({
-  enableMultiArchBootImageImport,
-  isIPv6SingleStack,
-  isIso,
-  isUDNManagedNamespace,
-  populatedCloudInitYAML,
-  selectedBootableVolume,
-  selectedPreference,
-  vmCreationNad,
-  vmName,
-  volumeName,
-}: GenerateVMSpecTemplateConfiguration): VMSpecTemplate => {
-  const defaultInterface = buildDefaultNetworkInterface({ isUDNManagedNamespace, vmCreationNad });
-  const defaultNetwork = buildDefaultNetwork({ vmCreationNad });
-
-  const isWindowsVM = selectedPreference?.startsWith(OS_WINDOWS_PREFIX);
-
-  const volumeArchitecture = getArchitecture(selectedBootableVolume);
-
-  return {
-    metadata: {
-      labels: {
-        ...(!isUDNManagedNamespace && {
-          [HEADLESS_SERVICE_LABEL]: HEADLESS_SERVICE_NAME,
-        }),
-      },
-    },
-    spec: {
-      ...(!isEmpty(volumeArchitecture) &&
-        enableMultiArchBootImageImport && {
-          architecture: volumeArchitecture,
-        }),
-      domain: {
-        devices: {
-          autoattachPodInterface: false,
-          disks: getDomainDisks(isIso, vmName),
-          interfaces: isIPv6SingleStack ? [] : [defaultInterface],
-        },
-      },
-      networks: isIPv6SingleStack ? [] : [defaultNetwork],
-      subdomain: HEADLESS_SERVICE_NAME,
-      volumes: getTemplateVolumes(volumeName, isIso, vmName, isWindowsVM, populatedCloudInitYAML),
-    },
-  };
-};
-
 export const getSpecConfiguration = ({
-  customDiskSize,
-  dvSource,
-  enableMultiArchBootImageImport,
-  isIPv6SingleStack,
-  isUDNManagedNamespace,
-  populatedCloudInitYAML,
-  pvcSource,
-  selectedBootableVolume,
-  selectedInstanceType,
-  vmCreationNad,
-  vmName,
+  context,
+  instanceTypeData,
 }: GenerateVMSpecConfiguration): VMSpec => {
-  const selectedPreference = getLabel(selectedBootableVolume, DEFAULT_PREFERENCE_LABEL);
-  const selectPreferenceKind = getLabel(
+  const {
+    customDiskSize,
+    dvSource,
+    preference,
+    pvcSource,
     selectedBootableVolume,
-    DEFAULT_PREFERENCE_KIND_LABEL,
-    null,
+    selectedInstanceType,
+    useBootSource,
+  } = instanceTypeData;
+  const {
+    enableMultiArchBootImageImport,
+    isIPv6SingleStack,
+    isUDNManagedNamespace,
+    populatedCloudInitYAML,
+    vmCreationNad,
+    vmName,
+  } = context;
+
+  const { kind: selectPreferenceKind, name: selectedPreference } = getSelectedPreferenceMatcher(
+    selectedBootableVolume,
+    preference,
   );
-  const isIso = isBootableVolumeISO(selectedBootableVolume);
+  const instanceTypeName =
+    selectedInstanceType?.name ?? getLabels(selectedBootableVolume)?.[DEFAULT_INSTANCETYPE_LABEL];
+  const hasBootVolume = useBootSource && !isEmpty(selectedBootableVolume);
+  const isIso = hasBootVolume && isBootableVolumeISO(selectedBootableVolume);
   const storageClassName = getPVCStorageClassName(pvcSource);
   const volumeName = `${vmName}-volume`;
 
   return {
-    dataVolumeTemplates: getDataVolumeTemplates({
-      customDiskSize,
-      dvSource,
-      isIso,
-      pvcSource,
-      selectedBootableVolume,
-      storageClassName,
-      vmName,
-      volumeName,
-    }),
-    instancetype: {
-      ...(selectedInstanceType?.namespace && {
-        kind: VirtualMachineInstancetypeModel.kind,
+    ...(hasBootVolume &&
+      selectedBootableVolume && {
+        dataVolumeTemplates: getDataVolumeTemplates({
+          customDiskSize,
+          dvSource,
+          isIso,
+          pvcSource,
+          selectedBootableVolume,
+          storageClassName,
+          vmName,
+          volumeName,
+        }),
       }),
-      name:
-        selectedInstanceType?.name ??
-        getLabels(selectedBootableVolume)?.[DEFAULT_INSTANCETYPE_LABEL],
-    },
-    preference: {
-      name: selectedPreference,
-      ...(selectPreferenceKind && { kind: selectPreferenceKind }),
-    },
+    ...(instanceTypeName && {
+      instancetype: {
+        ...(selectedInstanceType?.namespace && {
+          kind: VirtualMachineInstancetypeModel.kind,
+        }),
+        name: instanceTypeName,
+      },
+    }),
+    ...(selectedPreference && {
+      preference: {
+        name: selectedPreference,
+        ...(selectPreferenceKind && { kind: selectPreferenceKind }),
+      },
+    }),
     runStrategy: getDefaultRunningStrategy(),
     template: getSpecTemplateConfiguration({
       enableMultiArchBootImageImport,
+      hasBootVolume,
       isIPv6SingleStack,
       isIso,
       isUDNManagedNamespace,

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVMSpecTemplateConfig.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/generateVMSpecTemplateConfig.ts
@@ -1,3 +1,4 @@
+import { type V1DataVolumeTemplateSpec } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { DEFAULT_DISK_SIZE } from '@kubevirt-utils/components/DiskModal/utils/constants';
 import { DataSourceModel } from '@kubevirt-utils/models';
 import { isBootableVolumePVCKind } from '@kubevirt-utils/resources/bootableresources/helpers';
@@ -5,16 +6,26 @@ import {
   getDataVolumeSize,
   getPVCSize,
 } from '@kubevirt-utils/resources/bootableresources/selectors';
-import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { type BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { GenerateVMCallback, GenerateVMSpecDataVolumeTemplates } from '../types';
+
+import { type GenerateVMSpecDataVolumeTemplates } from '../types';
+
+type DataVolumeStorageResources = NonNullable<
+  NonNullable<NonNullable<V1DataVolumeTemplateSpec['spec']>['storage']>['resources']
+>;
+
+type BootVolumeDataVolumeSource = Pick<
+  NonNullable<V1DataVolumeTemplateSpec['spec']>,
+  'source' | 'sourceRef'
+>;
 
 const getMainDataVolumeStorage = (
-  dvSource: Parameters<GenerateVMCallback>[0]['dvSource'],
-  pvcSource: Parameters<GenerateVMCallback>[0]['pvcSource'],
+  dvSource: GenerateVMSpecDataVolumeTemplates['dvSource'],
+  pvcSource: GenerateVMSpecDataVolumeTemplates['pvcSource'],
   customDiskSize?: string,
   isIso?: boolean,
-) => {
+): DataVolumeStorageResources => {
   if (customDiskSize && !isIso) {
     return { requests: { storage: customDiskSize } };
   }
@@ -22,7 +33,7 @@ const getMainDataVolumeStorage = (
   if (dvSource || pvcSource) {
     return {
       requests: {
-        storage: getDataVolumeSize(dvSource) || getPVCSize(pvcSource),
+        storage: getDataVolumeSize(dvSource) ?? getPVCSize(pvcSource),
       },
     };
   }
@@ -35,10 +46,11 @@ const getISODataVolumeTemplates = (
   vmName: string,
   storageClassName: string,
   customDiskSize?: string,
-) => {
+): V1DataVolumeTemplateSpec[] => {
   if (!isIso) return [];
 
-  const storage = customDiskSize || '30Gi';
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string must fall back
+  const storage = customDiskSize || DEFAULT_DISK_SIZE;
 
   return [
     {
@@ -58,7 +70,9 @@ const getISODataVolumeTemplates = (
   ];
 };
 
-const getBootVolumeDataVolumeSource = (selectedBootableVolume: BootableVolume) => {
+const getBootVolumeDataVolumeSource = (
+  selectedBootableVolume: BootableVolume,
+): BootVolumeDataVolumeSource => {
   const name = getName(selectedBootableVolume);
   const namespace = getNamespace(selectedBootableVolume);
 
@@ -82,13 +96,13 @@ const getBootVolumeDataVolumeSource = (selectedBootableVolume: BootableVolume) =
 export const getDataVolumeTemplates = ({
   customDiskSize,
   dvSource,
-  pvcSource,
   isIso,
+  pvcSource,
+  selectedBootableVolume,
   storageClassName,
   vmName,
   volumeName,
-  selectedBootableVolume,
-}: GenerateVMSpecDataVolumeTemplates) => {
+}: GenerateVMSpecDataVolumeTemplates): V1DataVolumeTemplateSpec[] => {
   return [
     {
       metadata: {

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/getSelectedPreference.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/getSelectedPreference.ts
@@ -1,0 +1,34 @@
+import {
+  DEFAULT_PREFERENCE_KIND_LABEL,
+  DEFAULT_PREFERENCE_LABEL,
+} from '@kubevirt-utils/constants/instancetypes-and-preferences';
+import { type BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { getLabel } from '@kubevirt-utils/resources/shared';
+import { type VMWizardFormValues } from '@virtualmachines/wizard/state/vm-wizard-form/types';
+
+type PreferenceFormValue = VMWizardFormValues['instanceTypeData']['preference'];
+
+export const getSelectedPreferenceName = (
+  selectedBootableVolume: BootableVolume | null,
+  preference?: PreferenceFormValue,
+): string | undefined =>
+  getLabel(selectedBootableVolume, DEFAULT_PREFERENCE_LABEL) || preference?.name;
+
+export const getSelectedPreferenceMatcher = (
+  selectedBootableVolume: BootableVolume | null,
+  preference?: PreferenceFormValue,
+): { kind?: string; name?: string } => {
+  const volumePreferenceName = getLabel(selectedBootableVolume, DEFAULT_PREFERENCE_LABEL);
+
+  if (volumePreferenceName) {
+    return {
+      kind: getLabel(selectedBootableVolume, DEFAULT_PREFERENCE_KIND_LABEL, null) ?? undefined,
+      name: volumePreferenceName,
+    };
+  }
+
+  return {
+    kind: preference?.kind,
+    name: preference?.name,
+  };
+};

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/getSpecTemplateConfiguration.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/getSpecTemplateConfiguration.ts
@@ -1,0 +1,69 @@
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  buildDefaultNetwork,
+  buildDefaultNetworkInterface,
+} from '@kubevirt-utils/resources/namespace/networkDefault';
+import { OS_WINDOWS_PREFIX } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
+import { getArchitecture } from '@kubevirt-utils/utils/architecture';
+import {
+  HEADLESS_SERVICE_LABEL,
+  HEADLESS_SERVICE_NAME,
+} from '@kubevirt-utils/utils/headless-service';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+
+import { type GenerateVMSpecTemplateConfiguration } from '../types';
+
+import {
+  getDomainDisks,
+  getNoBootSourceVolumes,
+  getTemplateVolumes,
+} from './templateVolumeAndDisk';
+
+type VMSpecTemplate = NonNullable<NonNullable<V1VirtualMachine['spec']>['template']>;
+
+export const getSpecTemplateConfiguration = ({
+  enableMultiArchBootImageImport,
+  hasBootVolume,
+  isIPv6SingleStack,
+  isIso,
+  isUDNManagedNamespace,
+  populatedCloudInitYAML,
+  selectedBootableVolume,
+  selectedPreference,
+  vmCreationNad,
+  vmName,
+  volumeName,
+}: GenerateVMSpecTemplateConfiguration): VMSpecTemplate => {
+  const defaultInterface = buildDefaultNetworkInterface({ isUDNManagedNamespace, vmCreationNad });
+  const defaultNetwork = buildDefaultNetwork({ vmCreationNad });
+  const isWindowsVM = Boolean(selectedPreference?.startsWith(OS_WINDOWS_PREFIX));
+  const volumeArchitecture = getArchitecture(selectedBootableVolume);
+
+  return {
+    metadata: {
+      labels: {
+        ...(!isUDNManagedNamespace && {
+          [HEADLESS_SERVICE_LABEL]: HEADLESS_SERVICE_NAME,
+        }),
+      },
+    },
+    spec: {
+      ...(!isEmpty(volumeArchitecture) &&
+        enableMultiArchBootImageImport && {
+          architecture: volumeArchitecture,
+        }),
+      domain: {
+        devices: {
+          autoattachPodInterface: false,
+          disks: hasBootVolume ? getDomainDisks(isIso, vmName) : [],
+          interfaces: isIPv6SingleStack ? [] : [defaultInterface],
+        },
+      },
+      networks: isIPv6SingleStack ? [] : [defaultNetwork],
+      subdomain: HEADLESS_SERVICE_NAME,
+      volumes: hasBootVolume
+        ? getTemplateVolumes(volumeName, isIso, vmName, isWindowsVM, populatedCloudInitYAML)
+        : getNoBootSourceVolumes(isWindowsVM, populatedCloudInitYAML),
+    },
+  };
+};

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/templateVolumeAndDisk.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/templateVolumeAndDisk.ts
@@ -1,7 +1,8 @@
+import { type V1Disk, type V1Volume } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { InterfaceTypes } from '@kubevirt-utils/components/DiskModal/utils/types';
 import { CLOUDINITDISK, ROOTDISK } from '@kubevirt-utils/constants/constants';
 
-export const getDomainDisks = (isIso: boolean, vmName: string) => {
+export const getDomainDisks = (isIso: boolean, vmName: string): V1Disk[] => {
   if (isIso) {
     return [
       {
@@ -26,13 +27,13 @@ export const getDomainDisks = (isIso: boolean, vmName: string) => {
   ];
 };
 
-const getRootDiskVolumeName = (isIso: boolean, vmName: string) => {
+const getRootDiskVolumeName = (isIso: boolean, vmName: string): string => {
   if (isIso) return `${vmName}-cdrom-iso`;
 
   return ROOTDISK;
 };
 
-const getISOVolumes = (isIso: boolean, vmName: string) => {
+const getISOVolumes = (isIso: boolean, vmName: string): V1Volume[] => {
   if (!isIso) return [];
 
   return [
@@ -43,28 +44,37 @@ const getISOVolumes = (isIso: boolean, vmName: string) => {
   ];
 };
 
+const getCloudInitVolume = (isWindowsVM: boolean, populatedCloudInitYAML: string): V1Volume[] => {
+  if (isWindowsVM) return [];
+
+  return [
+    {
+      cloudInitNoCloud: {
+        userData: populatedCloudInitYAML,
+      },
+      name: CLOUDINITDISK,
+    },
+  ];
+};
+
 export const getTemplateVolumes = (
   volumeName: string,
   isIso: boolean,
   vmName: string,
   isWindowsVM: boolean,
   populatedCloudInitYAML: string,
-) => {
+): V1Volume[] => {
   return [
     {
       dataVolume: { name: volumeName },
       name: getRootDiskVolumeName(isIso, vmName),
     },
-    ...(!isWindowsVM
-      ? [
-          {
-            cloudInitNoCloud: {
-              userData: populatedCloudInitYAML,
-            },
-            name: CLOUDINITDISK,
-          },
-        ]
-      : []),
+    ...getCloudInitVolume(isWindowsVM, populatedCloudInitYAML),
     ...getISOVolumes(isIso, vmName),
   ];
 };
+
+export const getNoBootSourceVolumes = (
+  isWindowsVM: boolean,
+  populatedCloudInitYAML: string,
+): V1Volume[] => getCloudInitVolume(isWindowsVM, populatedCloudInitYAML);


### PR DESCRIPTION
## 📝 Description

Fixes VM creation from the catalog wizard when the user selects **No boot source**.

Previously, preference (and potentially instance type) matchers were emitted empty because they were only resolved from the boot volume label. The wizard then failed on Review/create.

This change:
- Falls back to the selected Guest OS preference when there is no boot volume
- Omits boot DataVolumes / root disks when `useBootSource` is false
- Only emits `preference` / `instancetype` when a name is resolved
- Passes form slices (`vmData`, `instanceTypeData`) plus a small context object into `generateVM`

## 🔗 Links

- https://issues.redhat.com/browse/CNV-94675

## 🎥 Demo


**BEFORE**

https://github.com/user-attachments/assets/98354e50-b418-420f-9a5d-e95e63deba4d

**AFTER**

The vm gets created 

https://github.com/user-attachments/assets/3172489d-6c6d-4663-8720-352e1250c6fe


## Test plan

- [ ] Create VM from catalog, select Guest OS, choose **No boot source**, complete wizard → VM is created successfully
- [ ] Create VM with a normal boot volume → still works (preference/instancetype from volume labels)
- [ ] Review YAML / generated VM has no empty `spec.preference` / `spec.instancetype` when values are missing
- [ ] No-boot-source VM has no root DataVolume template and no root disk


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual machine creation when no boot source is selected.
  * Preserved cloud-init configuration and appropriate volume handling across supported operating systems.
  * Improved fallback handling for VM names, preferences, and operating system labels.

* **Improvements**
  * Updated VM creation for more consistent wizard configuration.
  * Improved handling of optional boot-image imports, IPv6 settings, boot volumes, and data volumes.
  * Improved generated VM specifications when boot volumes or optional settings are unavailable.
  * Improved preference selection using the most relevant boot-volume information.
  * Improved disk-size fallback behavior for ISO-based virtual machines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->