### PR TITLE
 CNV-87886: replace useListPageFilter on Compute migrations + Template details pages

### DIFF
--- a/src/utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar.tsx
+++ b/src/utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useMemo, useState } from 'react';
+import React, { FC, ReactNode, useMemo, useState } from 'react';
 
 import {
   FilterableObject,
@@ -21,11 +21,11 @@ import HiddenFilterChips from './components/HiddenFilterChips';
 import SelectFilterItem from './components/SelectFilterItem';
 import TextSearchFilters from './components/TextSearchFilters';
 
-type KubevirtFilterToolbarProps<T extends FilterableObject = FilterableObject> = {
+type KubevirtFilterToolbarProps = {
   clearAllFilters: () => void;
   columnLayout?: ColumnLayout;
-  data?: T[];
-  filterDefinitions?: KubevirtFilter<T>[];
+  data?: FilterableObject[];
+  filterDefinitions?: KubevirtFilter[];
   filters: KubevirtFilterState;
   hideColumnManagement?: boolean;
   hideLabelFilter?: boolean;
@@ -34,18 +34,18 @@ type KubevirtFilterToolbarProps<T extends FilterableObject = FilterableObject> =
   toolbarEndContent?: ReactNode;
 };
 
-const KubevirtFilterToolbar = <T extends FilterableObject = FilterableObject>({
+const KubevirtFilterToolbar: FC<KubevirtFilterToolbarProps> = ({
   clearAllFilters,
   columnLayout,
   data,
-  filterDefinitions = EMPTY_FILTERS as KubevirtFilter<T>[],
+  filterDefinitions = EMPTY_FILTERS,
   filters,
   hideColumnManagement,
   hideLabelFilter,
   loaded,
   onSetFilters,
   toolbarEndContent,
-}: KubevirtFilterToolbarProps<T>) => {
+}) => {
   const { t } = useKubevirtTranslation();
 
   const groupedFilters = useMemo(

--- a/src/utils/components/KubevirtFilterToolbar/components/GroupedFilterDropdown.tsx
+++ b/src/utils/components/KubevirtFilterToolbar/components/GroupedFilterDropdown.tsx
@@ -20,8 +20,7 @@ import ToolbarFilterMultiChip from './ToolbarFilter/ToolbarFilterMultiChip';
 type GroupedFilterDropdownProps = {
   data?: FilterableObject[];
   filters: KubevirtFilterState;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  groupedFilters: KubevirtFilter<any>[];
+  groupedFilters: KubevirtFilter[];
   onSetFilters: OnSetFilters;
 };
 

--- a/src/utils/components/KubevirtFilterToolbar/components/HiddenFilterChips.tsx
+++ b/src/utils/components/KubevirtFilterToolbar/components/HiddenFilterChips.tsx
@@ -11,8 +11,7 @@ import ToolbarFilterMultiChip from './ToolbarFilter/ToolbarFilterMultiChip';
 
 type HiddenFilterChipsProps = {
   filters: KubevirtFilterState;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  hiddenFilters: KubevirtFilter<any>[];
+  hiddenFilters: KubevirtFilter[];
   onSetFilters: OnSetFilters;
 };
 

--- a/src/utils/components/KubevirtFilterToolbar/components/SelectFilterItem.tsx
+++ b/src/utils/components/KubevirtFilterToolbar/components/SelectFilterItem.tsx
@@ -13,8 +13,7 @@ import { getOnSelect } from '../utils';
 import ToolbarFilterMultiChip from './ToolbarFilter/ToolbarFilterMultiChip';
 
 type SelectFilterItemProps = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  filterDef: KubevirtFilter<any>;
+  filterDef: KubevirtFilter;
   filters: KubevirtFilterState;
   isToggleVisible?: boolean;
   onSetFilters: OnSetFilters;

--- a/src/utils/components/KubevirtFilterToolbar/components/ToolbarFilter/ToolbarFilterMultiChip.tsx
+++ b/src/utils/components/KubevirtFilterToolbar/components/ToolbarFilter/ToolbarFilterMultiChip.tsx
@@ -10,8 +10,7 @@ import { ToolbarFilter, ToolbarLabel } from '@patternfly/react-core';
 import { EXCLUSION_URL_PREFIX } from '@search/searchLanguage/constants';
 
 type ToolbarFilterMultiChipProps = PropsWithChildren<{
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  filterDef: KubevirtFilter<any>;
+  filterDef: KubevirtFilter;
   filters: KubevirtFilterState;
   onSetFilters: OnSetFilters;
 }>;

--- a/src/utils/components/KubevirtFilterToolbar/hooks/useItemCounts.ts
+++ b/src/utils/components/KubevirtFilterToolbar/hooks/useItemCounts.ts
@@ -6,8 +6,7 @@ import {
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 
 const useItemCounts = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  filters: KubevirtFilter<any>[],
+  filters: KubevirtFilter[],
   data?: FilterableObject[],
 ): Record<string, Record<string, number>> =>
   useMemo(() => {

--- a/src/utils/resources/vm/utils/network/constants.ts
+++ b/src/utils/resources/vm/utils/network/constants.ts
@@ -10,6 +10,7 @@ import {
 
 export type NetworkPresentation = {
   iface: V1Interface;
+  metadata?: { name?: string };
   network: V1Network;
 };
 

--- a/src/utils/resources/vmi/utils/selectors.ts
+++ b/src/utils/resources/vmi/utils/selectors.ts
@@ -99,3 +99,9 @@ export const getVMIStatusConditionByType = (
   conditionType: string,
 ): undefined | V1VirtualMachineCondition =>
   getResourceStatusConditionsByType<V1VirtualMachineCondition>(vmi, conditionType);
+
+export const getMigrationSourceNode = (vmi: V1VirtualMachineInstance) =>
+  vmi?.status?.migrationState?.sourceNode;
+
+export const getMigrationTargetNode = (vmi: V1VirtualMachineInstance) =>
+  vmi?.status?.migrationState?.targetNode;

--- a/src/views/clusteroverview/MigrationsTab/MigrationsTab.tsx
+++ b/src/views/clusteroverview/MigrationsTab/MigrationsTab.tsx
@@ -34,7 +34,7 @@ const MigrationsTab: FC<MigrationsTabProps> = ({ duration }) => {
 
   const migrationCardDataAndFilters = useMigrationCardDataAndFilters(duration);
 
-  const { filteredVMIMS, loaded, loadErrors, onFilterChange } = migrationCardDataAndFilters;
+  const { filteredVMIMS, loaded, loadErrors, onSetFilters } = migrationCardDataAndFilters;
 
   return (
     <Overview>
@@ -63,7 +63,7 @@ const MigrationsTab: FC<MigrationsTabProps> = ({ duration }) => {
                     <CardTitle>{t('Migrations')}</CardTitle>
                   </CardHeader>
                   <CardBody className="kv-monitoring-card__body">
-                    <MigrationsChartDonut onFilterChange={onFilterChange} vmims={filteredVMIMS} />
+                    <MigrationsChartDonut onSetFilters={onSetFilters} vmims={filteredVMIMS} />
                   </CardBody>
                 </GridItem>
                 <GridItem className="kv-monitoring-card__resources" span={6}>

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationChartLegend.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationChartLegend.tsx
@@ -1,18 +1,18 @@
-import React, { FC } from 'react';
-import { Link } from 'react-router';
+import React, { type FC } from 'react';
 
-import { OnFilterChange } from '@openshift-console/dynamic-plugin-sdk';
-import { Flex, FlexItem } from '@patternfly/react-core';
+import { type OnSetFilters } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import { Button, Flex, FlexItem } from '@patternfly/react-core';
 
+import { MIGRATION_STATUS_FILTER_ID } from '../MigrationsTable/utils/constants';
 import { colorScale } from './constants';
-import { ChartDataItem } from './MigrationsChartDonut';
+import { type ChartDataItem } from './MigrationsChartDonut';
 
 type MigrationChartLegendProps = {
   legendItems: ChartDataItem[];
-  onFilterChange: OnFilterChange;
+  onSetFilters: OnSetFilters;
 };
 
-const MigrationChartLegend: FC<MigrationChartLegendProps> = ({ legendItems, onFilterChange }) => {
+const MigrationChartLegend: FC<MigrationChartLegendProps> = ({ legendItems, onSetFilters }) => {
   return (
     <Flex gap={{ default: 'gapMd' }}>
       {legendItems?.map((item, index) => {
@@ -24,14 +24,13 @@ const MigrationChartLegend: FC<MigrationChartLegendProps> = ({ legendItems, onFi
               className="fas fa-square"
               style={{ color: colorScale[index % colorScale.length] }}
             />{' '}
-            <Link
-              onClick={() => {
-                onFilterChange('status', { all: [status], selected: [status] });
-              }}
-              to={`?rowFilter-status=${status}`}
+            <Button
+              isInline
+              onClick={() => onSetFilters({ [MIGRATION_STATUS_FILTER_ID]: [status] })}
+              variant="link"
             >
               {statusCount} {status}
-            </Link>
+            </Button>
           </FlexItem>
         );
       })}

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationsChartDonut.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationsChartDonut.tsx
@@ -3,8 +3,8 @@ import React, { FC } from 'react';
 import { V1VirtualMachineInstanceMigration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/SubTitleChartLabel';
 import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
+import { OnSetFilters } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { OnFilterChange } from '@openshift-console/dynamic-plugin-sdk';
 import { ChartDonut } from '@patternfly/react-charts/victory';
 import { CardFooter, Split, SplitItem } from '@patternfly/react-core';
 
@@ -14,7 +14,7 @@ import { colorScale } from './constants';
 import MigrationChartLegend from './MigrationChartLegend';
 
 type MigrationsChartDonutProps = {
-  onFilterChange: OnFilterChange;
+  onSetFilters: OnSetFilters;
   vmims: V1VirtualMachineInstanceMigration[];
 };
 
@@ -23,7 +23,7 @@ export type ChartDataItem = {
   y: number; // count of each status
 };
 
-const MigrationsChartDonut: FC<MigrationsChartDonutProps> = ({ onFilterChange, vmims }) => {
+const MigrationsChartDonut: FC<MigrationsChartDonutProps> = ({ onSetFilters, vmims }) => {
   const { t } = useKubevirtTranslation();
 
   if (!vmims?.length) return null;
@@ -67,7 +67,7 @@ const MigrationsChartDonut: FC<MigrationsChartDonutProps> = ({ onFilterChange, v
       <CardFooter>
         <Split hasGutter>
           <SplitItem isFilled>
-            <MigrationChartLegend legendItems={chartData} onFilterChange={onFilterChange} />
+            <MigrationChartLegend legendItems={chartData} onSetFilters={onSetFilters} />
           </SplitItem>
           <SplitItem>
             <LiveMigrationSettingsPopover />

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/MigrationsTable.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/MigrationsTable.tsx
@@ -1,9 +1,9 @@
 import React, { FC, useMemo } from 'react';
 
 import { NodeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import KubevirtFilterToolbar from '@kubevirt-utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar';
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
 import { buildColumnLayout } from '@kubevirt-utils/components/KubevirtTable/utils';
-import ListPageFilter from '@kubevirt-utils/components/ListPageFilter/ListPageFilter';
 import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtTableColumns from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtTableColumns';
@@ -15,8 +15,8 @@ import { Pagination } from '@patternfly/react-core';
 
 import { UseMigrationCardDataAndFiltersValues } from '../../hooks/useMigrationCardData';
 
-import { COLUMN_MANAGEMENT_ID_MIGRATIONS, MIGRATION_COLUMN_KEYS } from './utils/constants';
 import { getMigrationsTableColumns, getMigrationsTableRowId } from './migrationsTableDefinition';
+import { COLUMN_MANAGEMENT_ID_MIGRATIONS, MIGRATION_COLUMN_KEYS } from './utils/constants';
 
 import '@kubevirt-utils/styles/list-managment-group.scss';
 
@@ -29,12 +29,14 @@ const MigrationTable: FC<MigrationTableProps> = ({ tableData }) => {
   const activeNamespace = useActiveNamespace();
 
   const {
+    clearAllFilters,
+    filterDefinitions,
     filters,
     loaded,
     loadErrors,
     migrationsTableFilteredData,
     migrationsTableUnfilteredData,
-    onFilterChange,
+    onSetFilters,
   } = tableData || {};
 
   const [canGetNode] = useAccessReview({
@@ -54,8 +56,12 @@ const MigrationTable: FC<MigrationTableProps> = ({ tableData }) => {
     columns,
   });
 
-  const { handleFilterChange, handlePerPageSelect, handleSetPage, pagination } =
-    usePaginationWithFilters(migrationsTableFilteredData?.length ?? 0, onFilterChange);
+  const {
+    handleFilterChange: handleSetFilters,
+    handlePerPageSelect,
+    handleSetPage,
+    pagination,
+  } = usePaginationWithFilters(migrationsTableFilteredData?.length ?? 0, onSetFilters);
 
   const columnLayout = useMemo(
     () =>
@@ -73,12 +79,14 @@ const MigrationTable: FC<MigrationTableProps> = ({ tableData }) => {
   return (
     <ListPageBody>
       <div className="list-managment-group">
-        <ListPageFilter
+        <KubevirtFilterToolbar
+          clearAllFilters={clearAllFilters}
           columnLayout={columnLayout}
           data={migrationsTableUnfilteredData}
+          filterDefinitions={filterDefinitions}
+          filters={filters}
           loaded={isLoaded}
-          onFilterChange={handleFilterChange}
-          rowFilters={filters ?? []}
+          onSetFilters={handleSetFilters}
         />
         {!isEmpty(migrationsTableFilteredData) && isLoaded && (
           <Pagination

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/utils/constants.ts
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/utils/constants.ts
@@ -11,3 +11,7 @@ export const MIGRATION_COLUMN_KEYS = {
 } as const;
 
 export const COLUMN_MANAGEMENT_ID_MIGRATIONS = 'migrations-table';
+
+export const MIGRATION_STATUS_FILTER_ID = 'status';
+export const MIGRATION_SOURCE_FILTER_ID = 'source';
+export const MIGRATION_TARGET_FILTER_ID = 'target';

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/utils/filters.ts
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsTable/utils/filters.ts
@@ -1,54 +1,56 @@
 import { TFunction } from 'i18next';
 
 import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
-import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 
-export const getStatusFilter = (t: TFunction): RowFilter[] => [
+import {
+  getMigrationSourceNode,
+  getMigrationTargetNode,
+} from '@kubevirt-utils/resources/vmi/utils/selectors';
+import { getMigrationPhase } from '@kubevirt-utils/resources/vmim/selectors';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import {
+  MIGRATION_SOURCE_FILTER_ID,
+  MIGRATION_STATUS_FILTER_ID,
+  MIGRATION_TARGET_FILTER_ID,
+} from './constants';
+import { MigrationTableDataLayout } from './utils';
+
+export const getStatusFilter = (t: TFunction): KubevirtFilter<MigrationTableDataLayout>[] => [
   {
-    filter: (statuses, obj) => {
-      const status = obj?.vmim?.status?.phase;
-
-      return statuses?.selected?.length === 0 || statuses?.selected?.includes(status);
-    },
-    filterGroupName: t('Status'),
-    items: Object.keys(vmimStatuses).map((status) => ({
-      id: status,
-      title: status,
+    categoryLabel: t('Status'),
+    id: MIGRATION_STATUS_FILTER_ID,
+    match: (obj, selected) => selected.includes(getMigrationPhase(obj?.vmim)),
+    options: Object.keys(vmimStatuses).map((status) => ({
+      label: status,
+      value: status,
     })),
-    reducer: (obj) => obj?.vmim?.status?.phase,
-    type: 'status',
   },
 ];
 
 export const getSourceNodeFilter = (
   t: TFunction,
   vmis: V1VirtualMachineInstance[],
-): RowFilter[] => {
-  if (vmis?.length === 0 || vmis?.every((vmi) => !vmi?.status?.migrationState?.sourceNode)) {
-    return [] as RowFilter[];
+): KubevirtFilter<MigrationTableDataLayout>[] => {
+  if (isEmpty(vmis) || vmis.every((vmi) => !getMigrationSourceNode(vmi))) {
+    return [];
   }
 
-  const nodes = new Set(
-    (vmis || []).map((vmi) => vmi?.status?.migrationState?.sourceNode)?.filter(Boolean),
-  );
+  const nodes = new Set((vmis || []).map((vmi) => getMigrationSourceNode(vmi))?.filter(Boolean));
 
   return [
     {
-      filter: (selectedNodes, obj) => {
-        const nodeName = obj?.vmiObj?.status?.migrationState?.sourceNode;
-        return (
-          selectedNodes?.selected?.length === 0 ||
-          selectedNodes?.selected?.includes(`source-${nodeName}`)
-        );
+      categoryLabel: t('Source Node'),
+      id: MIGRATION_SOURCE_FILTER_ID,
+      match: (obj, selected) => {
+        const nodeName = getMigrationSourceNode(obj?.vmiObj);
+        return selected.includes(`source-${nodeName}`);
       },
-      filterGroupName: t('Source Node'),
-      items: Array.from(nodes).map((nodeName) => ({
-        id: `source-${nodeName}`,
-        title: nodeName,
+      options: Array.from(nodes).map((nodeName) => ({
+        label: nodeName,
+        value: `source-${nodeName}`,
       })),
-      reducer: (obj) => `source-${obj?.vmiObj?.status?.migrationState?.sourceNode}`,
-      type: 'source',
     },
   ];
 };
@@ -56,33 +58,25 @@ export const getSourceNodeFilter = (
 export const getTargetNodeFilter = (
   t: TFunction,
   vmis: V1VirtualMachineInstance[],
-): RowFilter[] => {
-  if (vmis?.length === 0 || vmis?.every((vm) => !vm?.status?.migrationState?.targetNode)) {
-    return [] as RowFilter[];
+): KubevirtFilter<MigrationTableDataLayout>[] => {
+  if (isEmpty(vmis) || vmis.every((vmi) => !getMigrationTargetNode(vmi))) {
+    return [];
   }
 
-  const nodes = new Set(
-    (vmis || []).map((vmi) => vmi?.status?.migrationState?.targetNode)?.filter(Boolean),
-  );
+  const nodes = new Set((vmis || []).map((vmi) => getMigrationTargetNode(vmi))?.filter(Boolean));
 
   return [
     {
-      filter: (selectedNodes, obj) => {
-        const nodeName = obj?.vmiObj?.status?.migrationState?.targetNode;
-        return (
-          selectedNodes?.selected?.length === 0 ||
-          selectedNodes?.selected?.includes(`target-${nodeName}`)
-        );
+      categoryLabel: t('Target Node'),
+      id: MIGRATION_TARGET_FILTER_ID,
+      match: (obj, selected) => {
+        const nodeName = getMigrationTargetNode(obj?.vmiObj);
+        return selected.includes(`target-${nodeName}`);
       },
-      filterGroupName: t('Target Node'),
-      items: Array.from(nodes).map((nodeName) => ({
-        id: `target-${nodeName}`,
-        title: nodeName,
+      options: Array.from(nodes).map((nodeName) => ({
+        label: nodeName,
+        value: `target-${nodeName}`,
       })),
-      reducer: (obj) => {
-        return `target-${obj?.vmiObj?.status?.migrationState?.targetNode}`;
-      },
-      type: 'target',
     },
   ];
 };

--- a/src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData.ts
+++ b/src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData.ts
@@ -11,15 +11,16 @@ import {
 import { ALL_CLUSTERS_KEY, ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
 import { useClusterObservabilityDisabled } from '@kubevirt-utils/hooks/useAlerts/utils/useClusterObservabilityDisabled';
+import {
+  KubevirtFilter,
+  KubevirtFilterState,
+  OnSetFilters,
+} from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import useKubevirtDataViewFilters from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/useKubevirtDataViewFilters';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useMigrationPolicies from '@kubevirt-utils/hooks/useMigrationPolicies';
 import useActiveClusterParam from '@multicluster/hooks/useActiveClusterParam';
-import {
-  OnFilterChange,
-  RowFilter,
-  useListPageFilter,
-} from '@openshift-console/dynamic-plugin-sdk';
 import { AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
 
 import useHyperConvergedMigrations from '../components/LiveMigrationSettingsPopover/hooks/useHyperConvergedMigrations';
@@ -34,13 +35,15 @@ import {
 } from '../components/MigrationsTable/utils/utils';
 
 export type UseMigrationCardDataAndFiltersValues = {
+  clearAllFilters: () => void;
+  filterDefinitions: KubevirtFilter<MigrationTableDataLayout>[];
   filteredVMIMS: V1VirtualMachineInstanceMigration[];
-  filters: RowFilter<MigrationTableDataLayout>[];
+  filters: KubevirtFilterState;
   loaded: boolean;
   loadErrors: Error | unknown;
   migrationsTableFilteredData: MigrationTableDataLayout[];
   migrationsTableUnfilteredData: MigrationTableDataLayout[];
-  onFilterChange: OnFilterChange;
+  onSetFilters: OnSetFilters;
   vmims: V1VirtualMachineInstanceMigration[];
 };
 
@@ -110,23 +113,28 @@ const useMigrationCardDataAndFilters: UseMigrationCardDataAndFilters = (duration
     [vmims, vmis, mps, migrationsDefaultConfigurations, duration],
   );
 
-  const filters = useMemo(
+  const filterDefinitions = useMemo(
     () => [...getStatusFilter(t), ...getSourceNodeFilter(t, vmis), ...getTargetNodeFilter(t, vmis)],
     [t, vmis],
   );
 
-  const [unfilteredData, data, onFilterChange] = useListPageFilter(migrationsData, filters);
+  const { clearAllFilters, filteredData, filters, onSetFilters } = useKubevirtDataViewFilters({
+    data: migrationsData,
+    filterDefinitions,
+  });
 
   const filteredVMIMS = useMemo(() => migrationsData.map((item) => item.vmim), [migrationsData]);
 
   return {
+    clearAllFilters,
+    filterDefinitions,
     filteredVMIMS,
     filters,
     loaded: vmimsLoaded && vmisLoaded && observabilityLoaded,
     loadErrors: observabilityError || vmimsErrors || vmisErrors,
-    migrationsTableFilteredData: data,
-    migrationsTableUnfilteredData: unfilteredData,
-    onFilterChange,
+    migrationsTableFilteredData: filteredData,
+    migrationsTableUnfilteredData: migrationsData,
+    onSetFilters,
     vmims,
   };
 };

--- a/src/views/templates/details/tabs/disks/TemplateDisksPage.tsx
+++ b/src/views/templates/details/tabs/disks/TemplateDisksPage.tsx
@@ -5,12 +5,13 @@ import DiskListTitle from '@kubevirt-utils/components/DiskListTitle/DiskListTitl
 import DiskSourceSelect from '@kubevirt-utils/components/DiskModal/components/DiskSourceSelect/DiskSourceSelect';
 import DiskModal from '@kubevirt-utils/components/DiskModal/DiskModal';
 import { SourceTypes } from '@kubevirt-utils/components/DiskModal/utils/types';
+import KubevirtFilterToolbar from '@kubevirt-utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar';
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SidebarEditor from '@kubevirt-utils/components/SidebarEditor/SidebarEditor';
+import useKubevirtDataViewFilters from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/useKubevirtDataViewFilters';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { replaceTemplateVM, Template, updateTemplate } from '@kubevirt-utils/resources/template';
-import { ListPageFilter, useListPageFilter } from '@openshift-console/dynamic-plugin-sdk';
 import { PageSection, Stack, StackItem } from '@patternfly/react-core';
 
 import useEditTemplateAccessReview from '../../hooks/useIsTemplateEditable';
@@ -32,8 +33,14 @@ const TemplateDisksPage: FC<TemplateDisksPageProps> = ({ obj: template }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const [disks, disksLoaded, loadError] = useTemplateDisksTableData(template);
-  const filters = useDisksFilters();
-  const [data, filteredData, onFilterChange] = useListPageFilter(disks, filters);
+  const filterDefinitions = useDisksFilters();
+
+  const { clearAllFilters, filteredData, filters, onSetFilters } = useKubevirtDataViewFilters({
+    data: disks,
+    filterDefinitions,
+    hideLabelFilter: true,
+  });
+
   const vm = getTemplateVMWithNamespace(template);
   const columns = useMemo(() => getTemplateDiskColumns(t), [t]);
 
@@ -74,12 +81,14 @@ const TemplateDisksPage: FC<TemplateDisksPageProps> = ({ obj: template }) => {
             </StackItem>
           )}
           <StackItem>
-            <ListPageFilter
-              data={data}
+            <KubevirtFilterToolbar
+              clearAllFilters={clearAllFilters}
+              data={disks}
+              filterDefinitions={filterDefinitions}
+              filters={filters}
               hideLabelFilter
               loaded={disksLoaded}
-              onFilterChange={onFilterChange}
-              rowFilters={filters}
+              onSetFilters={onSetFilters}
             />
             <KubevirtTable
               ariaLabel={t('Template disks table')}
@@ -93,7 +102,7 @@ const TemplateDisksPage: FC<TemplateDisksPageProps> = ({ obj: template }) => {
               loaded={disksLoaded}
               loadError={loadError}
               noDataMsg={t('No disks found')}
-              unfilteredData={data}
+              unfilteredData={disks}
             />
           </StackItem>
         </Stack>

--- a/src/views/templates/details/tabs/disks/hooks/useDisksFilters.ts
+++ b/src/views/templates/details/tabs/disks/hooks/useDisksFilters.ts
@@ -1,35 +1,28 @@
 import { useMemo } from 'react';
 
+import { KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { diskTypes } from '@kubevirt-utils/resources/vm/utils/disk/constants';
-import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  DiskRowDataLayout,
+  diskTypesLabels,
+} from '@kubevirt-utils/resources/vm/utils/disk/constants';
 
-const useDisksFilters = (): RowFilter[] => {
+const DISK_TYPE_FILTER_ID = 'disk-type';
+
+const useDisksFilters = (): KubevirtFilter<DiskRowDataLayout>[] => {
   const { t } = useKubevirtTranslation();
-  const filters: RowFilter[] = useMemo(
+
+  return useMemo(
     () => [
       {
-        filter: (drives, obj) => {
-          const drive = obj?.drive;
-          return (
-            drives.selected?.length === 0 ||
-            drives.selected?.includes(drive) ||
-            !drives?.all?.find((item) => item === drive)
-          );
-        },
-        filterGroupName: t('Disk type'),
-        items: Object.keys(diskTypes).map((type) => ({
-          id: diskTypes[type],
-          title: diskTypes[type],
-        })),
-        reducer: (obj) => obj?.drive,
-        type: 'disk-type',
+        categoryLabel: t('Disk type'),
+        id: DISK_TYPE_FILTER_ID,
+        match: (obj, selected) => selected.includes(obj?.drive),
+        options: Object.values(diskTypesLabels).map((value) => ({ label: value, value })),
       },
     ],
     [t],
   );
-
-  return filters;
 };
 
 export default useDisksFilters;

--- a/src/views/templates/details/tabs/network/components/list/NetworkInterfaceList.tsx
+++ b/src/views/templates/details/tabs/network/components/list/NetworkInterfaceList.tsx
@@ -1,11 +1,12 @@
 import React, { FC, useMemo } from 'react';
 
+import KubevirtFilterToolbar from '@kubevirt-utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar';
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
+import useKubevirtDataViewFilters from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/useKubevirtDataViewFilters';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getTemplateVirtualMachineObject, Template } from '@kubevirt-utils/resources/template';
 import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
 import { getNetworkInterfaceRowData } from '@kubevirt-utils/resources/vm/utils/network/rowData';
-import { ListPageFilter, useListPageFilter } from '@openshift-console/dynamic-plugin-sdk';
 
 import useNetworkRowFilters from '../../hooks/useNetworkRowFilters';
 
@@ -24,21 +25,29 @@ const NetworkInterfaceList: FC<NetworkInterfaceListProps> = ({ template }) => {
   const vm = getTemplateVirtualMachineObject(template);
   const networks = getNetworks(vm);
   const interfaces = getInterfaces(vm);
-  const filters = useNetworkRowFilters();
+  const filterDefinitions = useNetworkRowFilters();
 
   const networkInterfacesData = getNetworkInterfaceRowData(networks, interfaces);
-  const [data, filteredData, onFilterChange] = useListPageFilter(networkInterfacesData, filters);
+
+  const { clearAllFilters, filteredData, filters, onSetFilters } = useKubevirtDataViewFilters({
+    data: networkInterfacesData,
+    filterDefinitions,
+    hideLabelFilter: true,
+  });
 
   const columns = useMemo(() => getTemplateNetworkColumns(t), [t]);
   const callbacks: TemplateNetworkCallbacks = useMemo(() => ({ template }), [template]);
 
   return (
     <>
-      <ListPageFilter
-        data={data}
-        loaded={true}
-        onFilterChange={onFilterChange}
-        rowFilters={filters}
+      <KubevirtFilterToolbar
+        clearAllFilters={clearAllFilters}
+        data={networkInterfacesData}
+        filterDefinitions={filterDefinitions}
+        filters={filters}
+        hideLabelFilter
+        loaded
+        onSetFilters={onSetFilters}
       />
       <KubevirtTable
         ariaLabel={t('Template network interfaces table')}
@@ -51,7 +60,7 @@ const NetworkInterfaceList: FC<NetworkInterfaceListProps> = ({ template }) => {
         initialSortKey="name"
         loaded={true}
         noDataMsg={t('No network interfaces found')}
-        unfilteredData={data}
+        unfilteredData={networkInterfacesData}
       />
     </>
   );

--- a/src/views/templates/details/tabs/network/hooks/useNetworkRowFilters.ts
+++ b/src/views/templates/details/tabs/network/hooks/useNetworkRowFilters.ts
@@ -1,36 +1,29 @@
 import { useMemo } from 'react';
 
+import { KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { interfaceTypesProxy } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import {
+  interfaceTypesProxy,
+  NetworkPresentation,
+} from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { getNetworkInterfaceType } from '@kubevirt-utils/resources/vm/utils/network/selectors';
-import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 
-const useNetworkRowFilters = (): RowFilter[] => {
+const INTERFACE_TYPE_FILTER_ID = 'interface-type';
+
+const useNetworkRowFilters = (): KubevirtFilter<NetworkPresentation>[] => {
   const { t } = useKubevirtTranslation();
-  const filters: RowFilter[] = useMemo(
+
+  return useMemo(
     () => [
       {
-        filter: (interfaces, obj) => {
-          const drive = getNetworkInterfaceType(obj?.iface);
-          return (
-            interfaces.selected?.length === 0 ||
-            interfaces.selected?.includes(drive) ||
-            !interfaces?.all?.find((item) => item === drive)
-          );
-        },
-        filterGroupName: t('Interface type'),
-        items: Object.keys(interfaceTypesProxy).map((type) => ({
-          id: type,
-          title: interfaceTypesProxy[type],
-        })),
-        reducer: (obj) => getNetworkInterfaceType(obj?.iface),
-        type: 'interface-type',
+        categoryLabel: t('Interface type'),
+        id: INTERFACE_TYPE_FILTER_ID,
+        match: (obj, selected) => selected.includes(getNetworkInterfaceType(obj?.iface)),
+        options: Object.entries(interfaceTypesProxy).map(([value, label]) => ({ label, value })),
       },
     ],
     [t],
   );
-
-  return filters;
 };
 
 export default useNetworkRowFilters;


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Replace deprecated `useListPageFilter` on Compute migrations + Template details pages

___

Followup TODO: `buildStatusFilterPath` - use the new filter format (it still works though due to backwards compatibility workarounds)

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-87886

## 🎥 Demo

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added filtering to migration, template disk, and network interface views.
- Added migration filters for status, source node, and target node.
- Migration chart legend selections now apply the corresponding status filter.
- Improved filtering controls with clearer filter management and reset options.
- Added migration source- and target-node information for display and filtering.
- Network interface data can now include interface metadata names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->