### PR TITLE
CNV-92254: Detect HCO v1 via managed-cluster API discovery

### DIFF
--- a/src/multicluster/helpers/isManagedSpokeCluster.ts
+++ b/src/multicluster/helpers/isManagedSpokeCluster.ts
@@ -1,0 +1,8 @@
+/**
+ * True when `cluster` is a managed spoke (not the ACM hub / local cluster).
+ */
+export const isManagedSpokeCluster = (
+  cluster: string | undefined,
+  hubClusterName: string | undefined,
+  hubClusterLoaded: boolean,
+): boolean => Boolean(cluster) && hubClusterLoaded && cluster !== hubClusterName;

--- a/src/utils/hooks/useVMTemplateFeatureFlag/tests/useHyperConvergedAPIDiscovery.test.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/tests/useHyperConvergedAPIDiscovery.test.ts
@@ -1,0 +1,126 @@
+import { createElement, type FC } from 'react';
+
+import { clearHCOAPIDiscoveryCache } from '@kubevirt-utils/store/hcoAPIDiscovery';
+import useK8sBaseAPIPath from '@multicluster/hooks/useK8sBaseAPIPath';
+import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
+
+import useHyperConvergedAPIDiscovery from '../useHyperConvergedAPIDiscovery';
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  consoleFetchJSON: jest.fn(),
+}));
+
+jest.mock('@multicluster/hooks/useK8sBaseAPIPath', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockUseK8sBaseAPIPath = useK8sBaseAPIPath as jest.Mock;
+const mockConsoleFetchJSON = consoleFetchJSON as unknown as jest.Mock;
+
+const SPOKE = 'spoke-a';
+const SPOKE_API_PATH = `/api/proxy/plugin/mce/console/multicloud/managedclusterproxy/${SPOKE}`;
+
+describe('useHyperConvergedAPIDiscovery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearHCOAPIDiscoveryCache();
+    mockUseK8sBaseAPIPath.mockReturnValue([SPOKE_API_PATH, true]);
+    mockConsoleFetchJSON.mockResolvedValue({ preferredVersion: { version: 'v1' } });
+  });
+
+  it('skips discovery when cluster is undefined', () => {
+    const { result } = renderHook(() => useHyperConvergedAPIDiscovery());
+
+    expect(mockUseK8sBaseAPIPath).toHaveBeenCalledWith(undefined);
+    expect(mockConsoleFetchJSON).not.toHaveBeenCalled();
+    expect(result.current).toEqual({ loading: false, preferredVersion: undefined });
+  });
+
+  it('fetches preferredVersion for a managed cluster', async () => {
+    mockConsoleFetchJSON.mockResolvedValue({
+      preferredVersion: { groupVersion: 'hco.kubevirt.io/v1', version: 'v1' },
+    });
+
+    const { result } = renderHook(() => useHyperConvergedAPIDiscovery(SPOKE));
+
+    await waitFor(() => expect(result.current).toEqual({ loading: false, preferredVersion: 'v1' }));
+
+    expect(mockUseK8sBaseAPIPath).toHaveBeenCalledWith(SPOKE);
+    expect(mockConsoleFetchJSON).toHaveBeenCalledWith(`${SPOKE_API_PATH}/apis/hco.kubevirt.io`);
+  });
+
+  it('returns undefined preferredVersion when discovery fails', async () => {
+    mockConsoleFetchJSON.mockRejectedValue(new Error('Not Found'));
+
+    const { result } = renderHook(() => useHyperConvergedAPIDiscovery(SPOKE));
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ loading: false, preferredVersion: undefined }),
+    );
+  });
+
+  it('waits for the API path before discovering', async () => {
+    mockUseK8sBaseAPIPath.mockReturnValue([undefined, false]);
+
+    const { rerender, result } = renderHook(() => useHyperConvergedAPIDiscovery(SPOKE));
+
+    expect(result.current).toEqual({ loading: true, preferredVersion: undefined });
+    expect(mockConsoleFetchJSON).not.toHaveBeenCalled();
+
+    mockUseK8sBaseAPIPath.mockReturnValue([SPOKE_API_PATH, true]);
+    mockConsoleFetchJSON.mockResolvedValue({ preferredVersion: { version: 'v1beta1' } });
+
+    rerender();
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ loading: false, preferredVersion: 'v1beta1' }),
+    );
+  });
+
+  it('shares a single discovery request across multiple hook instances', async () => {
+    mockConsoleFetchJSON.mockResolvedValue({ preferredVersion: { version: 'v1' } });
+
+    const { result: first } = renderHook(() => useHyperConvergedAPIDiscovery(SPOKE));
+    const { result: second } = renderHook(() => useHyperConvergedAPIDiscovery(SPOKE));
+
+    await waitFor(() => {
+      expect(first.current).toEqual({ loading: false, preferredVersion: 'v1' });
+      expect(second.current).toEqual({ loading: false, preferredVersion: 'v1' });
+    });
+
+    expect(mockConsoleFetchJSON).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares a single discovery request when two consumers mount together', async () => {
+    mockConsoleFetchJSON.mockResolvedValue({ preferredVersion: { version: 'v1' } });
+
+    const DualMount: FC = () => {
+      const first = useHyperConvergedAPIDiscovery(SPOKE);
+      const second = useHyperConvergedAPIDiscovery(SPOKE);
+
+      return createElement(
+        'div',
+        null,
+        createElement('span', { 'data-test-id': 'first' }, JSON.stringify(first)),
+        createElement('span', { 'data-test-id': 'second' }, JSON.stringify(second)),
+      );
+    };
+
+    render(createElement(DualMount));
+
+    await waitFor(() => {
+      expect(JSON.parse(screen.getByTestId('first').textContent ?? '')).toEqual({
+        loading: false,
+        preferredVersion: 'v1',
+      });
+      expect(JSON.parse(screen.getByTestId('second').textContent ?? '')).toEqual({
+        loading: false,
+        preferredVersion: 'v1',
+      });
+    });
+
+    expect(mockConsoleFetchJSON).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/hooks/useVMTemplateFeatureFlag/tests/useIsHyperConvergedV1Available.test.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/tests/useIsHyperConvergedV1Available.test.ts
@@ -1,0 +1,141 @@
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { useHubClusterName } from '@stolostron/multicluster-sdk';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import useHyperConvergedAPIDiscovery from '../useHyperConvergedAPIDiscovery';
+import useIsHyperConvergedV1Available from '../useIsHyperConvergedV1Available';
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  useK8sModel: jest.fn(),
+}));
+
+jest.mock('@stolostron/multicluster-sdk', () => ({
+  useHubClusterName: jest.fn(),
+}));
+
+jest.mock('@multicluster/hooks/useClusterParam', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../useHyperConvergedAPIDiscovery', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockUseK8sModel = useK8sModel as jest.Mock;
+const mockUseHubClusterName = useHubClusterName as jest.Mock;
+const mockUseClusterParam = useClusterParam as jest.Mock;
+const mockUseHyperConvergedAPIDiscovery = useHyperConvergedAPIDiscovery as jest.Mock;
+
+const HUB = 'hub-cluster';
+const SPOKE = 'spoke-a';
+
+describe('useIsHyperConvergedV1Available', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseClusterParam.mockReturnValue(undefined);
+    mockUseHubClusterName.mockReturnValue([HUB, true, undefined]);
+    mockUseK8sModel.mockReturnValue([{ kind: 'HyperConverged' }, false]);
+    mockUseHyperConvergedAPIDiscovery.mockReturnValue({
+      loading: false,
+      preferredVersion: undefined,
+    });
+  });
+
+  it('uses useK8sModel on the hub cluster', () => {
+    mockUseClusterParam.mockReturnValue(HUB);
+
+    const { result } = renderHook(() => useIsHyperConvergedV1Available());
+
+    expect(mockUseHyperConvergedAPIDiscovery).toHaveBeenCalledWith(undefined);
+    expect(result.current).toEqual({ isHCOV1: true, loading: false });
+  });
+
+  it('uses useK8sModel when no cluster is selected', () => {
+    const { result } = renderHook(() => useIsHyperConvergedV1Available());
+
+    expect(mockUseHyperConvergedAPIDiscovery).toHaveBeenCalledWith(undefined);
+    expect(result.current).toEqual({ isHCOV1: true, loading: false });
+  });
+
+  it('uses discovery preferredVersion on a managed cluster', () => {
+    mockUseClusterParam.mockReturnValue(SPOKE);
+    mockUseHyperConvergedAPIDiscovery.mockReturnValue({
+      loading: false,
+      preferredVersion: 'v1',
+    });
+
+    const { result } = renderHook(() => useIsHyperConvergedV1Available());
+
+    expect(mockUseHyperConvergedAPIDiscovery).toHaveBeenCalledWith(SPOKE);
+    expect(result.current).toEqual({ isHCOV1: true, loading: false });
+  });
+
+  it('returns unavailable when managed preferredVersion is v1beta1', () => {
+    mockUseClusterParam.mockReturnValue(SPOKE);
+    mockUseHyperConvergedAPIDiscovery.mockReturnValue({
+      loading: false,
+      preferredVersion: 'v1beta1',
+    });
+
+    const { result } = renderHook(() => useIsHyperConvergedV1Available());
+
+    expect(result.current).toEqual({ isHCOV1: false, loading: false });
+  });
+
+  it('honors clusterOverride for managed discovery', () => {
+    mockUseClusterParam.mockReturnValue(HUB);
+    mockUseHyperConvergedAPIDiscovery.mockReturnValue({
+      loading: false,
+      preferredVersion: 'v1',
+    });
+
+    const { result } = renderHook(() => useIsHyperConvergedV1Available(SPOKE));
+
+    expect(mockUseHyperConvergedAPIDiscovery).toHaveBeenCalledWith(SPOKE);
+    expect(result.current).toEqual({ isHCOV1: true, loading: false });
+  });
+
+  it('stays loading until hub cluster name is resolved when a cluster is set', async () => {
+    mockUseClusterParam.mockReturnValue(SPOKE);
+    mockUseHubClusterName.mockReturnValue([undefined, false, undefined]);
+
+    const { rerender, result } = renderHook(() => useIsHyperConvergedV1Available());
+
+    expect(result.current).toEqual({ isHCOV1: false, loading: true });
+
+    mockUseHubClusterName.mockReturnValue([HUB, true, undefined]);
+    mockUseHyperConvergedAPIDiscovery.mockReturnValue({
+      loading: false,
+      preferredVersion: 'v1',
+    });
+
+    rerender();
+
+    await waitFor(() => expect(result.current).toEqual({ isHCOV1: true, loading: false }));
+  });
+
+  it('falls back to useK8sModel when hub cluster name fails to load', () => {
+    mockUseClusterParam.mockReturnValue(SPOKE);
+    mockUseHubClusterName.mockReturnValue([undefined, false, new Error('hub unavailable')]);
+
+    const { result } = renderHook(() => useIsHyperConvergedV1Available());
+
+    expect(mockUseHyperConvergedAPIDiscovery).toHaveBeenCalledWith(undefined);
+    expect(result.current).toEqual({ isHCOV1: true, loading: false });
+  });
+
+  it('surfaces discovery loading state on managed clusters', () => {
+    mockUseClusterParam.mockReturnValue(SPOKE);
+    mockUseHyperConvergedAPIDiscovery.mockReturnValue({
+      loading: true,
+      preferredVersion: undefined,
+    });
+
+    const { result } = renderHook(() => useIsHyperConvergedV1Available());
+
+    expect(result.current).toEqual({ isHCOV1: false, loading: true });
+  });
+});

--- a/src/utils/hooks/useVMTemplateFeatureFlag/useHyperConvergedAPIDiscovery.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/useHyperConvergedAPIDiscovery.ts
@@ -1,0 +1,66 @@
+import { useEffect } from 'react';
+
+import { hyperConvergedBaseModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import {
+  getHCOAPIDiscoveryEntry,
+  setHCOAPIDiscoveryEntry,
+} from '@kubevirt-utils/store/hcoAPIDiscovery';
+import useK8sBaseAPIPath from '@multicluster/hooks/useK8sBaseAPIPath';
+import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
+import { useSignals } from '@preact/signals-react/runtime';
+
+type APIGroupDiscovery = {
+  preferredVersion?: { version?: string };
+};
+
+type HyperConvergedAPIDiscovery = {
+  loading: boolean;
+  preferredVersion: string | undefined;
+};
+
+type UseHyperConvergedAPIDiscovery = (cluster?: string) => HyperConvergedAPIDiscovery;
+
+/**
+ * Fetches Kubernetes API discovery for the HCO API group on a managed cluster
+ * (`GET {apiPath}/apis/hco.kubevirt.io`) and returns the preferred version.
+ * Results are cached in a signal keyed by cluster so multiple hook instances
+ * share a single request. Pass undefined cluster to skip the fetch.
+ */
+const useHyperConvergedAPIDiscovery: UseHyperConvergedAPIDiscovery = (cluster) => {
+  useSignals();
+  const [apiPath, apiPathLoaded] = useK8sBaseAPIPath(cluster);
+  const entry = cluster ? getHCOAPIDiscoveryEntry(cluster) : undefined;
+
+  useEffect(() => {
+    // Re-read the cache inside the effect so concurrent mounts in the same
+    // commit do not each start a discovery request.
+    if (!cluster || getHCOAPIDiscoveryEntry(cluster) || !apiPathLoaded || !apiPath) {
+      return undefined;
+    }
+
+    setHCOAPIDiscoveryEntry(cluster, { loading: true, preferredVersion: undefined });
+
+    const discoveryURL = `${apiPath}/apis/${hyperConvergedBaseModel.apiGroup}`;
+
+    consoleFetchJSON(discoveryURL)
+      .then((apiGroup: APIGroupDiscovery) => {
+        setHCOAPIDiscoveryEntry(cluster, {
+          loading: false,
+          preferredVersion: apiGroup?.preferredVersion?.version,
+        });
+      })
+      .catch(() => {
+        setHCOAPIDiscoveryEntry(cluster, { loading: false, preferredVersion: undefined });
+      });
+
+    return undefined;
+  }, [apiPath, apiPathLoaded, cluster, entry]);
+
+  if (!cluster) {
+    return { loading: false, preferredVersion: undefined };
+  }
+
+  return entry ?? { loading: true, preferredVersion: undefined };
+};
+
+export default useHyperConvergedAPIDiscovery;

--- a/src/utils/hooks/useVMTemplateFeatureFlag/useIsHyperConvergedV1Available.ts
+++ b/src/utils/hooks/useVMTemplateFeatureFlag/useIsHyperConvergedV1Available.ts
@@ -1,14 +1,52 @@
 import { HyperConvergedV1ModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { isManagedSpokeCluster } from '@multicluster/helpers/isManagedSpokeCluster';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { useHubClusterName } from '@stolostron/multicluster-sdk';
+
+import useHyperConvergedAPIDiscovery from './useHyperConvergedAPIDiscovery';
+
+type HCOV1Availability = {
+  isHCOV1: boolean;
+  loading: boolean;
+};
+
+type UseIsHyperConvergedV1Available = (clusterOverride?: string) => HCOV1Availability;
 
 /**
  * HCO v1 exposes slice-based featureGates (Template is Beta / first-class).
  * HCO v1beta1 still needs the Preview Features jsonpatch toggle.
- * Detection only — all HCO watch/patch paths use v1beta1.
+ *
+ * Hub / local: useK8sModel for HyperConverged v1.
+ * Managed clusters: API discovery preferredVersion via useHyperConvergedAPIDiscovery.
  */
-const useIsHyperConvergedV1Available = (): { isHCOV1: boolean; loading: boolean } => {
+const useIsHyperConvergedV1Available: UseIsHyperConvergedV1Available = (clusterOverride) => {
+  const clusterParam = useClusterParam();
+  const cluster = clusterOverride ?? clusterParam;
+  const [hubClusterName, hubLoaded, hubError] = useHubClusterName() as [
+    string | undefined,
+    boolean,
+    unknown,
+  ];
+
+  const isManagedCluster = isManagedSpokeCluster(cluster, hubClusterName, hubLoaded);
+
   const [hcoV1Model, inFlight] = useK8sModel(HyperConvergedV1ModelGroupVersionKind);
+  const { loading: discoveryLoading, preferredVersion } = useHyperConvergedAPIDiscovery(
+    isManagedCluster ? cluster : undefined,
+  );
+
+  if (cluster && !hubLoaded && !hubError) {
+    return { isHCOV1: false, loading: true };
+  }
+
+  if (isManagedCluster) {
+    return {
+      isHCOV1: preferredVersion === HyperConvergedV1ModelGroupVersionKind.version,
+      loading: discoveryLoading,
+    };
+  }
 
   return {
     isHCOV1: !inFlight && !isEmpty(hcoV1Model),

--- a/src/utils/store/hcoAPIDiscovery.ts
+++ b/src/utils/store/hcoAPIDiscovery.ts
@@ -1,0 +1,19 @@
+import { signal } from '@preact/signals-react';
+
+export type HCOAPIDiscoveryEntry = {
+  loading: boolean;
+  preferredVersion: string | undefined;
+};
+
+export const hcoAPIDiscoveryCache = signal<ReadonlyMap<string, HCOAPIDiscoveryEntry>>(new Map());
+
+export const getHCOAPIDiscoveryEntry = (cluster: string): HCOAPIDiscoveryEntry | undefined =>
+  hcoAPIDiscoveryCache.value.get(cluster);
+
+export const setHCOAPIDiscoveryEntry = (cluster: string, entry: HCOAPIDiscoveryEntry): void => {
+  hcoAPIDiscoveryCache.value = new Map(hcoAPIDiscoveryCache.value).set(cluster, entry);
+};
+
+export const clearHCOAPIDiscoveryCache = (): void => {
+  hcoAPIDiscoveryCache.value = new Map();
+};

--- a/src/views/settings/tabs/PreviewFeaturesTab/hooks/usePreviewFeaturesData.tsx
+++ b/src/views/settings/tabs/PreviewFeaturesTab/hooks/usePreviewFeaturesData.tsx
@@ -48,9 +48,7 @@ const usePreviewFeaturesData: UsePreviewFeaturesData = (cluster) => {
     CONTROL_DEFAULT_VIRTUALIZATION_PERMISSIONS,
     cluster,
   );
-  // HCO v1: Template is Beta / first-class — hide jsonpatch toggle.
-  // HCO v1beta1 only: keep Preview Features toggle.
-  const { isHCOV1, loading: hcoV1Loading } = useIsHyperConvergedV1Available();
+  const { isHCOV1, loading: hcoV1Loading } = useIsHyperConvergedV1Available(cluster);
 
   const features: Feature[] = [
     {

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationNavigation.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/useStorageMigrationNavigation.ts
@@ -2,16 +2,17 @@ import { useMemo } from 'react';
 
 import { getStorageMigrationBackend } from '@kubevirt-utils/resources/migrations/backends';
 import {
-  type StorageMigrationAPI,
   STORAGE_MIGRATION_API,
+  type StorageMigrationAPI,
 } from '@kubevirt-utils/resources/migrations/constants';
+import { StorageMigrationStatusFilterValue } from '@kubevirt-utils/resources/migrations/storageMigrationLifecycle';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
+import { isManagedSpokeCluster } from '@multicluster/helpers/isManagedSpokeCluster';
 import useManagedClusterConsoleURLs from '@multicluster/hooks/useManagedClusterConsoleURLs';
 import { buildSpokeConsoleUrl } from '@multicluster/urls';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 import { spokeSupportsCustomMigrationsRoute } from '@virtualmachines/actions/hooks/storageMigrationApi/constants';
 
-import { StorageMigrationStatusFilterValue } from '@kubevirt-utils/resources/migrations/storageMigrationLifecycle';
 import { STORAGE_MIGRATION_STATUS_FILTER_TYPE } from '../../../../../../storagemigrations/list/StorageMigrationListFilters';
 
 const ALL_NAMESPACES_STORAGE_MIGRATIONS_LIST = '/k8s/all-namespaces/storagemigrations';
@@ -69,9 +70,8 @@ const useStorageMigrationNavigation = (
       };
     }
 
-    const isManagedSpokeCluster =
-      Boolean(cluster) && hubClusterLoaded && cluster !== hubClusterName;
-    const useSpokeConsoleUrl = Boolean(spokeConsoleURL) && isManagedSpokeCluster;
+    const useSpokeConsoleUrl =
+      Boolean(spokeConsoleURL) && isManagedSpokeCluster(cluster, hubClusterName, hubClusterLoaded);
 
     const consolePath = useSpokeConsoleUrl
       ? getSpokeStorageMigrationListPath(storageMigAPI, spokeCsvVersion)


### PR DESCRIPTION
## 📝 Description

Makes `useIsHyperConvergedV1Available` ACM-aware so Preview Features correctly hide the VM Templates jsonpatch toggle on managed clusters that already prefer HCO v1.

- **Hub / local**: keep using `useK8sModel(HyperConvergedV1ModelGroupVersionKind)`
- **Managed clusters**: fetch Kubernetes API discovery for `hco.kubevirt.io` (`GET {fleetProxy}/{cluster}/apis/hco.kubevirt.io`) and treat HCO v1 as available when `preferredVersion` is `v1`
- Cache discovery results in a per-cluster signal so multiple hook mounts share a single request
- Pass `cluster` from `usePreviewFeaturesData` into the availability hook

## 🔗 Links

- https://redhat.atlassian.net/browse/CNV-92254

## 🎥 Demo

**BEFORE**

local use HCO v1 and the managed cluster is 4.22 and use v1beta1 HCO


https://github.com/user-attachments/assets/1bc31055-bdca-4947-9845-47a25e93f0c7


**AFTER**


local use HCO v1 and the managed cluster is 4.22 and use v1beta1 HCO

https://github.com/user-attachments/assets/afaa5725-5a98-4701-9be9-82df7efe2df3



## Test plan

- [ ] Hub / single-cluster: Preview Features still hides VM Templates toggle when local HCO v1 model is present
- [ ] Managed cluster with HCO preferredVersion `v1`: toggle hidden
- [ ] Managed cluster with preferredVersion `v1beta1`: toggle still shown
- [ ] Multiple consumers of the hook for the same cluster only trigger one discovery request
- [ ] `npm test -- --testPathPattern='useHyperConvergedAPIDiscovery|useIsHyperConvergedV1Available' --watchman=false`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cluster-specific detection for HyperConverged Operator v1 availability.
  * Availability and loading states now reflect the selected cluster, including managed clusters.
  * Added automatic API version discovery to support environments using different HyperConverged API versions.
  * Discovery results are reused to improve efficiency and prevent duplicate requests.

* **Tests**
  * Added coverage for successful, failed, deferred, and concurrent API discovery scenarios.
  * Added coverage for hub, local, managed, and cluster-specific availability behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->