### PR TITLE
CNV-94724: Fix help icon position

### DIFF
--- a/src/views/settings/tabs/UserTab/components/DefaultVMLabelsSection/DefaultVMLabelsSection.tsx
+++ b/src/views/settings/tabs/UserTab/components/DefaultVMLabelsSection/DefaultVMLabelsSection.tsx
@@ -1,10 +1,9 @@
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
 import RequiredCountBadge from '@kubevirt-utils/components/badges/RequiredCountBadge/RequiredCountBadge';
 import ExpandSectionWithCustomToggle from '@kubevirt-utils/components/ExpandSectionWithCustomToggle/ExpandSectionWithCustomToggle';
 import useAutoAppliedLabels from '@kubevirt-utils/hooks/useAutoAppliedLabels/useAutoAppliedLabels';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { USER_TAB_IDS } from '@settings/search/constants';
 
 import DefaultVMLabelsTable from './DefaultVMLabelsTable';
@@ -16,9 +15,7 @@ const DefaultVMLabelsSection: FC = () => {
 
   return (
     <ExpandSectionWithCustomToggle
-      customContent={
-        !isEmpty(requiredLabels) && <RequiredCountBadge count={requiredLabels.length} />
-      }
+      customContent={<RequiredCountBadge count={requiredLabels.length} />}
       helpTextContent={t(
         'Shows the label keys configured by your administrator. You can set values for keys the administrator left empty.',
       )}


### PR DESCRIPTION
## 📝 Description

In `ExpandSectionWithCustomToggle`, the toggle row is built with a Split layout containing three SplitItems: the toggle label, the help icon, and the customContent slot. Both the help icon and the customContent SplitItem carry isFilled, so their relative positions depend on which items are actually rendered.

When customContent is passed as a React element that renders null internally (e.g., `<RequiredCountBadge count={0} />` returns null when `count === 0`), the customContent check `{customContent && <SplitItem isFilled>…</SplitItem>}` still evaluates to true - because a React element object is always truthy — and the empty SplitItem is rendered. This causes the help icon to be pushed out of its expected position, leaving an unwanted gap in the toggle row.

## 🔗 Links

Jira ticket: [CNV-94724](https://redhat.atlassian.net/browse/CNV-94724)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/1931c0de-9e7d-4852-ac37-a410677f5404


After:

https://github.com/user-attachments/assets/0b509c6e-1509-4d45-97dc-d7d196c4de84



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The required-label badge is now consistently displayed, including when no required labels are configured.
* **Code Quality**
  * Removed unused code and refined type imports without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->