### PR TITLE
CNV-93915: Enable to edit disk size on create vm

### DIFF
--- a/src/utils/components/DiskModal/components/DiskSizeInput/DiskSizeInput.tsx
+++ b/src/utils/components/DiskModal/components/DiskSizeInput/DiskSizeInput.tsx
@@ -1,18 +1,18 @@
-import React, { FC } from 'react';
+import React, { type FC, useCallback } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { formatQuantityString } from '@kubevirt-utils/utils/units';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import CapacityInput from '../../../CapacityInput/CapacityInput';
-import { V1DiskFormState } from '../../utils/types';
+import { type V1DiskFormState } from '../../utils/types';
 import { DISK_SIZE_FIELD } from '../utils/constants';
-import { getDataVolumeTemplateSize, getPVCClaimName, getSourceRef } from '../utils/selectors';
-
+import { getPVCClaimName, getSourceRef } from '../utils/selectors';
 import ExpandPVC from './ExpandPVC';
 import usePVCSourceSize from './usePVCSourceSize';
+import useSourceMinSize from './useSourceMinSize';
+import { enforceMinDiskSize, formatMinSizeHelperText, getDiskSize, isAtMinSize } from './utils';
 
 type DiskSizeInputProps = {
   isCreated?: boolean;
@@ -33,16 +33,27 @@ const DiskSizeInput: FC<DiskSizeInputProps> = ({ isCreated, isDisabled, namespac
     diskState.cluster,
   );
 
-  if (isCreated) return <ExpandPVC pvc={pvc} />;
+  const sourceMinSize = useSourceMinSize(diskState, namespace);
+
+  const handleSizeChange = useCallback(
+    (quantity: string) => setValue(DISK_SIZE_FIELD, enforceMinDiskSize(quantity, sourceMinSize)),
+    [sourceMinSize, setValue],
+  );
+
+  if (isCreated && pvc) return <ExpandPVC pvc={pvc} />;
 
   if (isEmpty(diskState.dataVolumeTemplate) && isEmpty(pvcSize)) return null;
 
+  const currentSize = getDiskSize(diskState, pvcSize);
+
   return (
     <CapacityInput
+      helperText={formatMinSizeHelperText(sourceMinSize, t)}
       isEditingCreatedDisk={isDisabled}
+      isMinusDisabled={isAtMinSize(currentSize, sourceMinSize)}
       label={t('Disk size')}
-      onChange={(quantity) => setValue(DISK_SIZE_FIELD, quantity)}
-      size={getDataVolumeTemplateSize(diskState) || formatQuantityString(pvcSize)}
+      onChange={handleSizeChange}
+      size={currentSize}
     />
   );
 };

--- a/src/utils/components/DiskModal/components/DiskSizeInput/ExpandPVC.tsx
+++ b/src/utils/components/DiskModal/components/DiskSizeInput/ExpandPVC.tsx
@@ -1,16 +1,17 @@
-import React, { FC } from 'react';
+import React, { type FC, useCallback } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import CapacityInput from '@kubevirt-utils/components/CapacityInput/CapacityInput';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getPVCSize } from '@kubevirt-utils/resources/bootableresources/selectors';
-import { formatQuantityString, quantityToString, toQuantity } from '@kubevirt-utils/utils/units';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
+import { formatQuantityString } from '@kubevirt-utils/utils/units';
 
-import { V1DiskFormState } from '../../utils/types';
+import { type V1DiskFormState } from '../../utils/types';
 import { EXPAND_PVC_SIZE } from '../utils/constants';
-
-import { getMinSizes } from './utils';
+import useSourceMinSize from './useSourceMinSize';
+import { enforceMinDiskSize, formatMinSizeHelperText, isAtMinSize } from './utils';
 
 type ExpandPVCProps = { pvc: IoK8sApiCoreV1PersistentVolumeClaim };
 
@@ -19,44 +20,26 @@ const ExpandPVC: FC<ExpandPVCProps> = ({ pvc }) => {
   const { setValue, watch } = useFormContext<V1DiskFormState>();
   const diskState = watch();
 
-  const expandPVCSize = diskState.expandPVCSize;
-  const pvcStorage = formatQuantityString(getPVCSize(pvc));
+  const pvcSize = getPVCSize(pvc);
+  const pvcStorage = pvcSize ? (formatQuantityString(pvcSize) ?? undefined) : undefined;
+  const sourceMinSize = useSourceMinSize(diskState, getNamespace(pvc) ?? '');
+  const size = diskState.expandPVCSize ?? pvcStorage ?? '';
+
+  const handleSizeChange = useCallback(
+    (quantity: string) => setValue(EXPAND_PVC_SIZE, enforceMinDiskSize(quantity, sourceMinSize)),
+    [sourceMinSize, setValue],
+  );
+
   if (!pvcStorage) {
     return null;
   }
 
-  const size = expandPVCSize ?? pvcStorage;
-  const { unit, value } = toQuantity(size) ?? {};
-
-  const minSizes = getMinSizes(pvcStorage);
-
-  const onQuantityChange = (quantityString: string) => {
-    const { unit: newUnit, value: newValue } = toQuantity(quantityString) ?? {};
-
-    // unit has changed -> adjust size to be bigger than minimal size for that unit
-    if (newUnit && newUnit !== unit) {
-      const minSize = minSizes[newUnit];
-
-      if (minSize > newValue) {
-        const newPvcSize = quantityToString({ unit: newUnit, value: Math.ceil(minSize) });
-
-        setValue(EXPAND_PVC_SIZE, newPvcSize);
-        return;
-      }
-    }
-
-    setValue(EXPAND_PVC_SIZE, quantityString);
-  };
-
-  const minSize = minSizes[unit];
-  const isMinusDisabled = Math.ceil(minSize) >= value;
-
   return (
     <CapacityInput
-      isMinusDisabled={isMinusDisabled}
+      helperText={formatMinSizeHelperText(sourceMinSize, t)}
+      isMinusDisabled={isAtMinSize(size, sourceMinSize)}
       label={t('PersistentVolumeClaim size')}
-      minValue={minSize}
-      onChange={onQuantityChange}
+      onChange={handleSizeChange}
       size={size}
     />
   );

--- a/src/utils/components/DiskModal/components/DiskSizeInput/useSourceMinSize.ts
+++ b/src/utils/components/DiskModal/components/DiskSizeInput/useSourceMinSize.ts
@@ -1,0 +1,68 @@
+import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
+import {
+  DataSourceModelGroupVersionKind,
+  modelToGroupVersionKind,
+  PersistentVolumeClaimModel,
+  VolumeSnapshotModel,
+} from '@kubevirt-utils/models';
+import {
+  getPVCSize,
+  getVolumeSnapshotSize,
+} from '@kubevirt-utils/resources/bootableresources/selectors';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+
+import { type V1DiskFormState } from '../../utils/types';
+import { getSourcePVCAndSnapshotIdentifiers } from './utils';
+
+const useSourceMinSize = (diskState: V1DiskFormState, namespace: string): string | undefined => {
+  const clusterFromUrl = useClusterParam();
+  const cluster = diskState?.cluster ?? clusterFromUrl ?? undefined;
+
+  const sourceRef = diskState?.dataVolumeTemplate?.spec?.sourceRef;
+
+  const [dataSource] = useK8sWatchData<V1beta1DataSource>(
+    sourceRef?.name
+      ? {
+          cluster,
+          groupVersionKind: DataSourceModelGroupVersionKind,
+          name: sourceRef.name,
+          namespace: sourceRef.namespace,
+        }
+      : null,
+  );
+
+  const { pvcName, pvcNamespace, snapName, snapNamespace } = getSourcePVCAndSnapshotIdentifiers(
+    diskState,
+    dataSource,
+    namespace,
+  );
+
+  const [pvc] = useK8sWatchData<IoK8sApiCoreV1PersistentVolumeClaim>(
+    pvcName
+      ? {
+          cluster,
+          groupVersionKind: modelToGroupVersionKind(PersistentVolumeClaimModel),
+          name: pvcName,
+          namespace: pvcNamespace,
+        }
+      : null,
+  );
+
+  const [volumeSnapshot] = useK8sWatchData<VolumeSnapshotKind>(
+    snapName
+      ? {
+          cluster,
+          groupVersionKind: modelToGroupVersionKind(VolumeSnapshotModel),
+          name: snapName,
+          namespace: snapNamespace,
+        }
+      : null,
+  );
+
+  return getPVCSize(pvc) ?? getVolumeSnapshotSize(volumeSnapshot);
+};
+
+export default useSourceMinSize;

--- a/src/utils/components/DiskModal/components/DiskSizeInput/utils.ts
+++ b/src/utils/components/DiskModal/components/DiskSizeInput/utils.ts
@@ -1,20 +1,111 @@
-import { convertToBaseValue, humanizeBinaryBytesWithoutB } from '@kubevirt-utils/utils/humanize.js';
-import { binaryUnitsOrdered } from '@kubevirt-utils/utils/unitConstants';
-import { type BinaryUnit } from '@kubevirt-utils/utils/unitConstants';
+import { type TFunction } from 'i18next';
 
-export const getMinSizes = (pvcSize: string): Record<BinaryUnit, number> => {
-  const pvcSizeBytes = convertToBaseValue(pvcSize) as null | number;
-  if (!pvcSizeBytes && pvcSizeBytes !== 0) {
+import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type Quantity } from '@kubevirt-utils/types/quantity';
+import { convertToBaseValue, humanizeBinaryBytesWithoutB } from '@kubevirt-utils/utils/humanize.js';
+import { type BinaryUnit, binaryUnitsOrdered } from '@kubevirt-utils/utils/unitConstants';
+import {
+  addByteSuffix,
+  formatQuantityString,
+  quantityToString,
+  toQuantity,
+} from '@kubevirt-utils/utils/units';
+
+import { type V1DiskFormState } from '../../utils/types';
+import { getDataVolumeTemplateSize } from '../utils/selectors';
+
+export const getMinSizes = (size: string): Record<BinaryUnit, number> => {
+  const sizeInBytes = convertToBaseValue(size) as null | number;
+  if (!sizeInBytes && sizeInBytes !== 0) {
     return {} as Record<BinaryUnit, number>;
   }
 
-  const minSizes: Record<BinaryUnit, number> = {} as Record<BinaryUnit, number>;
+  const result: Record<BinaryUnit, number> = {} as Record<BinaryUnit, number>;
 
   for (const unit of binaryUnitsOrdered) {
-    minSizes[unit] = (
-      humanizeBinaryBytesWithoutB(pvcSizeBytes, null, unit) as { value: number }
+    result[unit] = (
+      humanizeBinaryBytesWithoutB(sizeInBytes, null, unit) as { value: number }
     ).value;
   }
 
-  return minSizes;
+  return result;
+};
+
+export const getDiskSize = (diskState: V1DiskFormState, pvcSize: string): string =>
+  getDataVolumeTemplateSize(diskState) ?? formatQuantityString(pvcSize) ?? '';
+
+const getParsedSourceMinSize = (
+  sourceMinSize: string | undefined,
+): { minSizePerUnit: Record<BinaryUnit, number>; parsedMinSize: Quantity } | undefined => {
+  if (!sourceMinSize) return undefined;
+
+  const formattedMinSize = formatQuantityString(sourceMinSize);
+  if (!formattedMinSize) return undefined;
+
+  const parsedMinSize = toQuantity(formattedMinSize);
+  if (!parsedMinSize) return undefined;
+
+  return { minSizePerUnit: getMinSizes(formattedMinSize), parsedMinSize };
+};
+
+export const enforceMinDiskSize = (quantity: string, sourceMinSize: string | undefined): string => {
+  const minSize = getParsedSourceMinSize(sourceMinSize);
+  const parsedQuantity = toQuantity(quantity);
+
+  if (!minSize || !parsedQuantity) return quantity;
+
+  const minInCurrentUnit = Math.ceil(minSize.minSizePerUnit[parsedQuantity.unit as BinaryUnit]);
+
+  return quantityToString({
+    unit: parsedQuantity.unit,
+    value: Math.max(parsedQuantity.value, minInCurrentUnit),
+  });
+};
+
+export const isAtMinSize = (currentSize: string, sourceMinSize: string | undefined): boolean => {
+  const minSize = getParsedSourceMinSize(sourceMinSize);
+  if (!minSize) return false;
+
+  const parsed = toQuantity(currentSize);
+
+  if (!parsed) return false;
+
+  return Math.ceil(minSize.minSizePerUnit[parsed.unit as BinaryUnit]) >= (parsed.value ?? 0);
+};
+
+export const getSourcePVCAndSnapshotIdentifiers = (
+  diskState: V1DiskFormState,
+  dataSource: undefined | V1beta1DataSource,
+  namespace: string,
+): {
+  pvcName: string | undefined;
+  pvcNamespace: string;
+  snapName: string | undefined;
+  snapNamespace: string;
+} => {
+  const clonePVCSource = diskState?.dataVolumeTemplate?.spec?.source?.pvc;
+  const snapshotSource = diskState?.dataVolumeTemplate?.spec?.source?.snapshot;
+  const pvcClaimName = diskState?.volume?.persistentVolumeClaim?.claimName;
+
+  const dsSource = dataSource?.spec?.source;
+
+  return {
+    pvcName: dsSource?.pvc?.name ?? clonePVCSource?.name ?? pvcClaimName,
+    pvcNamespace: dsSource?.pvc?.namespace ?? clonePVCSource?.namespace ?? namespace,
+    snapName: dsSource?.snapshot?.name ?? snapshotSource?.name,
+    snapNamespace: dsSource?.snapshot?.namespace ?? snapshotSource?.namespace ?? namespace,
+  };
+};
+
+export const formatMinSizeHelperText = (
+  sourceMinSize: string | undefined,
+  t: TFunction,
+): string | undefined => {
+  const minSize = getParsedSourceMinSize(sourceMinSize);
+  if (!minSize) return undefined;
+
+  return t('Minimum disk size for this volume: {{value}} {{unit}}', {
+    unit: addByteSuffix(minSize.parsedMinSize.unit),
+    value: minSize.parsedMinSize.value,
+  });
 };

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
@@ -132,7 +132,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
   const createEditDiskModal = () =>
     createModal(({ isOpen, onClose }) => (
       <DiskModal
-        createdPVCName={isPVCSource(obj) ? obj?.source : null}
+        createdPVCName={isPVCSource(obj) && obj?.hasPVC ? obj?.source : null}
         editDiskName={diskName}
         isOpen={isOpen}
         onClose={onClose}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.


- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fix disk size editing during VM creation and enforce minimum size

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-93915
## 🎥 Demo

before:

https://github.com/user-attachments/assets/351098d8-ca52-4e10-94dd-ff46d43f4cce

after:


https://github.com/user-attachments/assets/1f9c0149-b4e9-4a3d-b7b1-c5ebd5d8ddd6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved disk size handling when creating, cloning, or editing virtual machine disks.
  * Disk size fields now reflect existing PVC, snapshot, or template sizes more accurately.
  * Minimum disk sizes and decrement controls are enforced based on the selected disk source.
  * Minimum-size guidance is displayed directly in disk size fields.
  * Disk expansion controls appear only when expansion is available for an existing PVC-backed disk.
  * Improved handling of disk sources without an existing PVC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->