### PR TITLE
CNV-92611: [release-4.18] Non-admin users trigger excessive per-namespace watches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ playwright/
 .playwright-mcp
 .cursor/rules/personal-*.mdc
 .cursor/debug-*.log
+.env.local
+local.env

--- a/src/utils/components/DedicatedResourcesModal/DedicatedResourcesModal.tsx
+++ b/src/utils/components/DedicatedResourcesModal/DedicatedResourcesModal.tsx
@@ -2,17 +2,17 @@ import React, { FC, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import produce from 'immer';
 
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import ModalPendingChangesAlert from '@kubevirt-utils/components/PendingChanges/ModalPendingChangesAlert/ModalPendingChangesAlert';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useNodes from '@kubevirt-utils/hooks/useNodes';
 import { modelToGroupVersionKind, NodeModel } from '@kubevirt-utils/models';
 import { getCPU } from '@kubevirt-utils/resources/vm';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { ResourceLink, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Alert,
   AlertVariant,
@@ -46,10 +46,7 @@ const DedicatedResourcesModal: FC<DedicatedResourcesModalProps> = ({
   const { t } = useKubevirtTranslation();
   const [checked, setChecked] = useState<boolean>(!!getCPU(vm)?.dedicatedCpuPlacement);
 
-  const [nodes, loaded, loadError] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
-    groupVersionKind: modelToGroupVersionKind(NodeModel),
-    isList: true,
-  });
+  const [nodes, loaded, loadError] = useNodes();
 
   const { hasNodes, qualifiedNodes } = useMemo(() => {
     const filteredNodes = nodes?.filter(

--- a/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
+++ b/src/utils/components/PendingChanges/hooks/usePendingChanges.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
-import { modelToGroupVersionKind, NodeModel } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import AffinityModal from '@kubevirt-utils/components/AffinityModal/AffinityModal';
 import BootOrderModal from '@kubevirt-utils/components/BootOrderModal/BootOrderModal';
@@ -30,11 +28,12 @@ import {
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
+import useNodes from '@kubevirt-utils/hooks/useNodes';
 import { getCPU, getGPUDevices, getHostDevices } from '@kubevirt-utils/resources/vm';
 import { isInstanceTypeVM } from '@kubevirt-utils/resources/vm/utils/instanceTypes';
 import { DESCHEDULER_EVICT_LABEL } from '@kubevirt-utils/resources/vmi';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { k8sUpdate, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { k8sUpdate } from '@openshift-console/dynamic-plugin-sdk';
 
 import {
   checkBootModeChanged,
@@ -75,10 +74,7 @@ export const usePendingChanges = (
 
   const [hyperConverge, hyperLoaded, hyperLoadingError] = useHyperConvergeConfiguration();
 
-  const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
-    groupVersionKind: modelToGroupVersionKind(NodeModel),
-    isList: true,
-  });
+  const [nodes, nodesLoaded] = useNodes();
 
   const cpuMemoryChanged = checkCPUMemoryChanged(vm, vmi);
   const bootOrderChanged = checkBootOrderChanged(vm, vmi);

--- a/src/utils/hooks/useFeatures/useFeatures.ts
+++ b/src/utils/hooks/useFeatures/useFeatures.ts
@@ -6,6 +6,7 @@ import {
   IoK8sApiRbacV1Role,
   IoK8sApiRbacV1RoleBinding,
 } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { k8sCreate, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
 import { featuresConfigMapInitialState, featuresRole, featuresRoleBinding } from './constants';
@@ -14,6 +15,36 @@ import useFeaturesConfigMap from './useFeaturesConfigMap';
 
 type UseFeatures = (featureName: string) => UseFeaturesValues;
 
+const ensureFeaturesRBAC = async () => {
+  try {
+    await k8sCreate<IoK8sApiRbacV1Role>({
+      data: featuresRole,
+      model: RoleModel,
+    });
+  } catch (roleError) {
+    if (roleError?.code !== 409) {
+      kubevirtConsole.warn('Failed to create kubevirt-ui-features RBAC Role', roleError);
+    }
+  }
+
+  try {
+    await k8sCreate<IoK8sApiRbacV1RoleBinding>({
+      data: featuresRoleBinding,
+      model: RoleBindingModel,
+    });
+  } catch (roleBindingError) {
+    if (roleBindingError?.code !== 409) {
+      kubevirtConsole.warn(
+        'Failed to create kubevirt-ui-features RBAC RoleBinding',
+        roleBindingError,
+      );
+    }
+  }
+};
+
+// Shared so the bootstrap runs once per page load, not once per mounted useFeatures consumer.
+let featuresRBACBootstrap: null | Promise<void> = null;
+
 export const useFeatures: UseFeatures = (featureName) => {
   const { featuresConfigMapData, isAdmin } = useFeaturesConfigMap();
   const [featureConfigMap, loaded, loadError] = featuresConfigMapData;
@@ -21,37 +52,50 @@ export const useFeatures: UseFeatures = (featureName) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error>(null);
 
+  // Ensure the RBAC independently of configmap existence -- HCO may pre-create the configmap
+  // itself, which would otherwise skip this bootstrap and leave non-admins 403ing forever.
   useEffect(() => {
+    if (!isAdmin) {
+      return;
+    }
+
+    if (!featuresRBACBootstrap) {
+      featuresRBACBootstrap = ensureFeaturesRBAC();
+    }
+  }, [isAdmin]);
+
+  useEffect(() => {
+    let ignore = false;
+
     if (loadError?.code === 404) {
       setError(loadError);
 
-      const createResources = async () => {
-        await k8sCreate<IoK8sApiCoreV1ConfigMap>({
-          data: featuresConfigMapInitialState,
-          model: ConfigMapModel,
-        });
+      // Only admins can bootstrap the shared configmap; non-admins simply fall back to defaults.
+      if (isAdmin) {
+        const createConfigMap = async () => {
+          try {
+            await k8sCreate<IoK8sApiCoreV1ConfigMap>({
+              data: featuresConfigMapInitialState,
+              model: ConfigMapModel,
+            });
+          } catch (createError) {
+            // Don't reinstate a stale error once a later run of this effect has moved on.
+            if (!ignore) {
+              setError(createError);
+            }
+          }
+        };
 
-        await k8sCreate<IoK8sApiRbacV1Role>({
-          data: featuresRole,
-          model: RoleModel,
-        });
-
-        await k8sCreate<IoK8sApiRbacV1RoleBinding>({
-          data: featuresRoleBinding,
-          model: RoleBindingModel,
-        });
-      };
-
-      try {
-        createResources();
-        setFeatureEnabled(featuresConfigMapInitialState.data[featureName] === 'true');
-        setLoading(false);
-        setError(null);
-      } catch (createError) {
-        setError(createError);
+        createConfigMap();
       }
 
-      return;
+      setFeatureEnabled(featuresConfigMapInitialState.data[featureName] === 'true');
+      setLoading(false);
+      setError(null);
+
+      return () => {
+        ignore = true;
+      };
     }
 
     if (!loaded && loadError) {
@@ -71,26 +115,30 @@ export const useFeatures: UseFeatures = (featureName) => {
         // In case of features config-map exists but there is a new feature to enter that is missing
         case undefined:
         case null: {
-          const applyMissingFeatures = async () => {
-            await k8sPatch({
-              data: [
-                {
-                  op: 'replace',
-                  path: `/data/${featureName}`,
-                  value: featuresConfigMapInitialState.data[featureName],
-                },
-              ],
-              model: ConfigMapModel,
-              resource: featureConfigMap,
-            });
-          };
+          // Only admins can patch the shared configmap; non-admins simply fall back to defaults.
+          if (isAdmin) {
+            const applyMissingFeatures = async () => {
+              try {
+                await k8sPatch({
+                  data: [
+                    {
+                      op: 'replace',
+                      path: `/data/${featureName}`,
+                      value: featuresConfigMapInitialState.data[featureName],
+                    },
+                  ],
+                  model: ConfigMapModel,
+                  resource: featureConfigMap,
+                });
+              } catch (updateError) {
+                setError(updateError);
+              }
+            };
 
-          try {
             applyMissingFeatures();
-            setFeatureEnabled(featuresConfigMapInitialState.data[featureName] === 'true');
-          } catch (updateError) {
-            setError(updateError);
           }
+
+          setFeatureEnabled(featuresConfigMapInitialState.data[featureName] === 'true');
           break;
         }
         default:
@@ -99,7 +147,8 @@ export const useFeatures: UseFeatures = (featureName) => {
       setLoading(false);
       return;
     }
-  }, [loadError, featureConfigMap, loaded, featureName, featureEnabled]);
+    // featureEnabled is excluded: it's written by this effect, so including it would re-trigger it.
+  }, [loadError, featureConfigMap, loaded, featureName, isAdmin]);
 
   const toggleFeature = useCallback(
     async (value: boolean) => {

--- a/src/utils/hooks/useFeatures/useFeaturesConfigMap.ts
+++ b/src/utils/hooks/useFeatures/useFeaturesConfigMap.ts
@@ -3,6 +3,8 @@ import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
 import {
   getGroupVersionKindForModel,
+  K8sVerb,
+  useAccessReview,
   useK8sWatchResource,
   WatchK8sResult,
 } from '@openshift-console/dynamic-plugin-sdk';
@@ -19,12 +21,34 @@ type UseFeaturesConfigMap = () => {
 const useFeaturesConfigMap: UseFeaturesConfigMap = () => {
   const isAdmin = useIsAdmin();
 
-  const featuresConfigMapData = useK8sWatchResource<IoK8sApiCoreV1ConfigMap>({
-    groupVersionKind: getGroupVersionKindForModel(ConfigMapModel),
-    isList: false,
+  // Non-admins only get `watch` once the RBAC bootstrap in useFeatures.ts has run.
+  const [canGetFeaturesConfigMap, canGetFeaturesConfigMapLoading] = useAccessReview({
+    group: ConfigMapModel.apiGroup,
     name: FEATURES_CONFIG_MAP_NAME,
     namespace: DEFAULT_OPERATOR_NAMESPACE,
+    resource: ConfigMapModel.plural,
+    verb: 'watch' as K8sVerb,
   });
+
+  const canWatch = isAdmin || (!canGetFeaturesConfigMapLoading && canGetFeaturesConfigMap);
+
+  const featuresConfigMapData = useK8sWatchResource<IoK8sApiCoreV1ConfigMap>(
+    canWatch && {
+      groupVersionKind: getGroupVersionKindForModel(ConfigMapModel),
+      isList: false,
+      name: FEATURES_CONFIG_MAP_NAME,
+      namespace: DEFAULT_OPERATOR_NAMESPACE,
+    },
+  );
+
+  if (!isAdmin && canGetFeaturesConfigMapLoading) {
+    return { featuresConfigMapData: [undefined, false, null], isAdmin };
+  }
+
+  if (!canWatch) {
+    return { featuresConfigMapData: [undefined, true, null], isAdmin };
+  }
+
   return { featuresConfigMapData: [...featuresConfigMapData], isAdmin };
 };
 

--- a/src/utils/hooks/useHyperConvergeConfiguration.ts
+++ b/src/utils/hooks/useHyperConvergeConfiguration.ts
@@ -1,10 +1,16 @@
 import { useMemo } from 'react';
 
 import { HyperConvergedModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import HyperConvergedModel from '@kubevirt-ui/kubevirt-api/console/models/HyperConvergedModel';
 import { V1LabelSelector } from '@kubevirt-ui/kubevirt-api/containerized-data-importer/models';
 import { V1MigrationConfiguration } from '@kubevirt-ui/kubevirt-api/kubevirt';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { DEFAULT_OPERATOR_NAMESPACE, isEmpty } from '@kubevirt-utils/utils/utils';
+import {
+  K8sResourceCommon,
+  K8sVerb,
+  useAccessReview,
+  useK8sWatchResource,
+} from '@openshift-console/dynamic-plugin-sdk';
 
 export type HyperConverged = K8sResourceCommon & {
   spec: {
@@ -49,17 +55,38 @@ type UseHyperConvergeConfigurationType = () => [
 ];
 
 const useHyperConvergeConfiguration: UseHyperConvergeConfigurationType = () => {
+  // Scoped to DEFAULT_OPERATOR_NAMESPACE (was cluster-wide) and gated on `watch`, which
+  // non-admins are rarely granted.
+  const [canWatchHyperConverged, canWatchHyperConvergedLoading] = useAccessReview({
+    group: HyperConvergedModelGroupVersionKind.group,
+    namespace: DEFAULT_OPERATOR_NAMESPACE,
+    resource: HyperConvergedModel.plural,
+    verb: 'watch' as K8sVerb,
+  });
+
   const [hyperConvergeData, hyperConvergeDataLoaded, hyperConvergeDataError] = useK8sWatchResource<
     HyperConverged[]
-  >({
-    groupVersionKind: HyperConvergedModelGroupVersionKind,
-    isList: true,
-  });
+  >(
+    canWatchHyperConverged && {
+      groupVersionKind: HyperConvergedModelGroupVersionKind,
+      isList: true,
+      namespace: DEFAULT_OPERATOR_NAMESPACE,
+    },
+  );
 
   const hyperConverge = useMemo(
     () => getHyperConvergedObject(hyperConvergeData),
     [hyperConvergeData],
   );
+
+  if (canWatchHyperConvergedLoading) {
+    return [undefined, false, null];
+  }
+
+  if (!canWatchHyperConverged) {
+    // Non-null so consumers already guarding on it don't treat "denied" as "cluster default".
+    return [undefined, true, new Error('User cannot watch HyperConverged resources')];
+  }
 
   return [hyperConverge, hyperConvergeDataLoaded, hyperConvergeDataError];
 };

--- a/src/utils/hooks/useKubevirtHyperconvergeConfiguration.ts/index.ts
+++ b/src/utils/hooks/useKubevirtHyperconvergeConfiguration.ts/index.ts
@@ -1,6 +1,11 @@
 import { V1KubeVirtConfiguration } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { DEFAULT_OPERATOR_NAMESPACE } from '@kubevirt-utils/utils/utils';
-import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  K8sResourceCommon,
+  K8sVerb,
+  useAccessReview,
+  useK8sWatchResource,
+} from '@openshift-console/dynamic-plugin-sdk';
 
 import { KUBEVIRT_HC_GROUP_VERSION_KIND, KUBEVIRT_HC_NAME } from './constants';
 
@@ -15,13 +20,31 @@ const useKubevirtHyperconvergeConfiguration = (): [
   configLoaded: boolean,
   configError: any,
 ] => {
+  // Non-admins often have `get`/`list` on the KubeVirt CR but not `watch`, which
+  // useK8sWatchResource needs to open a live connection.
+  const [canGetHC, canGetHCLoading] = useAccessReview({
+    group: KUBEVIRT_HC_GROUP_VERSION_KIND.group,
+    name: KUBEVIRT_HC_NAME,
+    namespace: DEFAULT_OPERATOR_NAMESPACE,
+    resource: 'kubevirts',
+    verb: 'watch' as K8sVerb,
+  });
+
   const [kubevirtHCConfig, configLoaded, configError] = useK8sWatchResource<KubevirtHyperconverged>(
-    {
+    canGetHC && {
       groupVersionKind: KUBEVIRT_HC_GROUP_VERSION_KIND,
       name: KUBEVIRT_HC_NAME,
       namespace: DEFAULT_OPERATOR_NAMESPACE,
     },
   );
+
+  if (canGetHCLoading) {
+    return [undefined, false, null];
+  }
+
+  if (!canGetHC) {
+    return [undefined, true, null];
+  }
 
   return [kubevirtHCConfig, configLoaded, configError];
 };

--- a/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings.ts
@@ -1,13 +1,9 @@
 import { useEffect, useState } from 'react';
 
-import {
-  ConfigMapModel,
-  modelToGroupVersionKind,
-  UserModel,
-} from '@kubevirt-ui/kubevirt-api/console';
+import { ConfigMapModel, UserModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { DEFAULT_OPERATOR_NAMESPACE, isEmpty } from '@kubevirt-utils/utils/utils';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { k8sGet } from '@openshift-console/dynamic-plugin-sdk';
 
 import { KUBEVIRT_USER_SETTINGS_CONFIG_MAP_NAME } from './utils/const';
 import { UseKubevirtUserSettings } from './utils/types';
@@ -19,21 +15,60 @@ const useKubevirtUserSettings: UseKubevirtUserSettings = (key) => {
   const [userSettings, setUserSettings] = useState<UserSettingsState>();
   const [loading, setLoading] = useState<boolean>(false);
 
-  const [user, loadedUser, errorUser] = useK8sWatchResource<IoK8sApiCoreV1ConfigMap>({
-    groupVersionKind: modelToGroupVersionKind(UserModel),
-    name: '~',
-  });
+  const [userName, setUserName] = useState<string>();
+  const [loadedUser, setLoadedUser] = useState<boolean>(false);
+  const [errorUser, setErrorUser] = useState<Error>();
 
-  const userName = user?.metadata?.uid || user?.metadata?.name?.replace(/[^-._a-zA-Z0-9]+/g, '-');
+  const [userConfigMap, setUserConfigMap] = useState<IoK8sApiCoreV1ConfigMap>();
+  const [loadedConfigMap, setLoadedConfigMap] = useState<boolean>(false);
+  const [configMapError, setConfigMapError] = useState<Error>();
 
-  const [userConfigMap, loadedConfigMap, configMapError] =
-    useK8sWatchResource<IoK8sApiCoreV1ConfigMap>(
-      userName && {
-        groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
-        name: KUBEVIRT_USER_SETTINGS_CONFIG_MAP_NAME,
-        namespace: DEFAULT_OPERATOR_NAMESPACE,
-      },
-    );
+  // Regular users only have `get` (no `watch`/`list`) here, so fetch once instead of watching.
+  useEffect(() => {
+    let isMounted = true;
+
+    k8sGet({ model: UserModel, name: '~' })
+      .then((user) => {
+        if (!isMounted) return;
+        setUserName(user?.metadata?.uid || user?.metadata?.name?.replace(/[^-._a-zA-Z0-9]+/g, '-'));
+        setLoadedUser(true);
+      })
+      .catch((getUserError) => {
+        if (!isMounted) return;
+        setErrorUser(getUserError);
+        setLoadedUser(true);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!userName) return;
+
+    let isMounted = true;
+
+    k8sGet<IoK8sApiCoreV1ConfigMap>({
+      model: ConfigMapModel,
+      name: KUBEVIRT_USER_SETTINGS_CONFIG_MAP_NAME,
+      ns: DEFAULT_OPERATOR_NAMESPACE,
+    })
+      .then((configMap) => {
+        if (!isMounted) return;
+        setUserConfigMap(configMap);
+        setLoadedConfigMap(true);
+      })
+      .catch((getConfigMapError) => {
+        if (!isMounted) return;
+        setConfigMapError(getConfigMapError);
+        setLoadedConfigMap(true);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [userName]);
 
   useEffect(() => {
     if (!isEmpty(userConfigMap) && userName) {
@@ -47,7 +82,8 @@ const useKubevirtUserSettings: UseKubevirtUserSettings = (key) => {
     setLoading(true);
 
     try {
-      await patchUserConfigMap(userConfigMap, userName, data);
+      const updatedConfigMap = await patchUserConfigMap(userConfigMap, userName, data);
+      setUserConfigMap(updatedConfigMap);
       resolve(key ? data[key] : data);
     } catch (apiError) {
       setError(apiError);
@@ -57,20 +93,19 @@ const useKubevirtUserSettings: UseKubevirtUserSettings = (key) => {
     setLoading(false);
   };
 
+  // Kept out of a setUserSettings updater: updaters must stay pure and can run more than once.
   const updateUserSetting = (val: any) => {
+    const data = key ? { ...userSettings, [key]: val } : val;
+
     return new Promise((resolve, reject) => {
-      setUserSettings((prevUserSettings) => {
-        const data = key ? { ...prevUserSettings, [key]: val } : val;
-
-        pushUserSettingsChanges(data, resolve, reject);
-
-        return data;
-      });
+      setUserSettings(data);
+      pushUserSettingsChanges(data, resolve, reject);
     });
   };
 
-  const loadedCM = loadedConfigMap || !isEmpty(configMapError);
   const loadedUsr = loadedUser || !isEmpty(errorUser);
+  // No userName means the configmap fetch never runs, so there's nothing left to wait for.
+  const loadedCM = loadedConfigMap || !isEmpty(configMapError) || (loadedUsr && !userName);
 
   return [
     key ? userSettings?.[key] : userSettings,

--- a/src/utils/hooks/useKubevirtWatchResource.ts
+++ b/src/utils/hooks/useKubevirtWatchResource.ts
@@ -1,8 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import {
+  AccessReviewResourceAttributes,
   K8sResourceCommon,
+  K8sVerb,
+  useK8sModel,
   useK8sWatchResource,
+  useK8sWatchResources,
   WatchK8sResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -10,6 +14,10 @@ import { KUBEVIRT_APISERVER_PROXY } from './useFeatures/constants';
 import { useFeatures } from './useFeatures/useFeatures';
 import useKubevirtDataPodHealth from './useKubevirtDataPod/hooks/useKubevirtDataPodHealth';
 import useKubevirtDataPod from './useKubevirtDataPod/useKubevirtDataPod';
+import { useIsAdmin } from './useIsAdmin';
+import useMultipleAccessReviews from './useMultipleAccessReviews';
+import useProjects from './useProjects';
+
 type Result<R extends K8sResourceCommon | K8sResourceCommon[]> = [R, boolean, Error];
 
 type UseKubevirtWatchResource = <T extends K8sResourceCommon | K8sResourceCommon[]>(
@@ -27,29 +35,98 @@ const useKubevirtWatchResource: UseKubevirtWatchResource = <T>(watchOptions, fil
     if (featureEnabled && !loading && isProxyPodAlive !== null) return isProxyPodAlive;
     return null;
   }, [featureEnabled, loading, isProxyPodAlive]);
-  const [resourceK8sWatch, loadedK8sWatch, loadErrorK8sWatch] = useK8sWatchResource<T>(
-    shouldUseProxyPod === false && watchOptions,
+
+  const isAdmin = useIsAdmin();
+  // "All projects" (no namespace) would otherwise watch cluster-wide, which non-admins are
+  // rarely granted -- fall back to aggregating per-namespace watches they're allowed to list.
+  const needsNamespaceFiltering = !watchOptions?.namespace && !isAdmin;
+
+  const [model] = useK8sModel(watchOptions?.groupVersionKind);
+  const [projectNames] = useProjects();
+
+  const listAccessReviewAttributes = useMemo<AccessReviewResourceAttributes[]>(
+    () =>
+      needsNamespaceFiltering && model
+        ? (projectNames || []).map((namespace) => ({
+            group: model.apiGroup,
+            namespace,
+            resource: model.plural,
+            verb: 'list' as K8sVerb,
+          }))
+        : [],
+    [needsNamespaceFiltering, model, projectNames],
   );
+  const [listAccessReviews, listAccessReviewsLoading] = useMultipleAccessReviews(
+    listAccessReviewAttributes,
+  );
+
+  const allowedNamespaces = useMemo(
+    () =>
+      (listAccessReviews || [])
+        .filter((review) => review.allowed)
+        .map((review) => review.resourceAttributes?.namespace)
+        .filter(Boolean),
+    [listAccessReviews],
+  );
+
+  const [resourceK8sWatch, loadedK8sWatch, loadErrorK8sWatch] = useK8sWatchResource<T>(
+    shouldUseProxyPod === false && !needsNamespaceFiltering && watchOptions,
+  );
+
+  const perNamespaceResources = useK8sWatchResources<{ [namespace: string]: T }>(
+    Object.fromEntries(
+      shouldUseProxyPod === false && needsNamespaceFiltering
+        ? allowedNamespaces.map((namespace) => [namespace, { ...watchOptions, namespace }])
+        : [],
+    ),
+  );
+
   const [resourceKubevirtDataPod, loadedKubevirtDataPod, loadErrorKubevirtDataPod] =
     useKubevirtDataPod<T>(shouldUseProxyPod ? watchOptions : {}, filterOptions);
 
   useEffect(() => {
-    if (shouldUseProxyPod !== null) {
-      const [resource, loaded, loadError] = shouldUseProxyPod
-        ? [resourceKubevirtDataPod, loadedKubevirtDataPod, loadErrorKubevirtDataPod]
-        : [resourceK8sWatch, loadedK8sWatch, loadErrorK8sWatch];
-      setLoadedData(loaded);
+    if (shouldUseProxyPod === null) {
+      return;
+    }
 
-      if (loadError) {
-        setLoadErrorData(loadError);
-        setLoadedData(true);
-      }
-      if (resource && loaded) {
-        const isList = typeof resource?.[0] === 'string';
-        setData((isList && resource?.[1]) || (<T & { items?: T[] }>resource)?.items || resource);
-        setLoadedData(loaded);
-        setLoadErrorData(null);
-      }
+    let resource;
+    let loaded;
+    let loadError;
+
+    if (shouldUseProxyPod) {
+      [resource, loaded, loadError] = [
+        resourceKubevirtDataPod,
+        loadedKubevirtDataPod,
+        loadErrorKubevirtDataPod,
+      ];
+    } else if (needsNamespaceFiltering) {
+      const perNamespaceResourceList = Object.values(perNamespaceResources);
+
+      resource = perNamespaceResourceList.flatMap(
+        (namespaceResource) => namespaceResource?.data ?? [],
+      );
+      loaded =
+        !listAccessReviewsLoading &&
+        (allowedNamespaces.length === 0 ||
+          perNamespaceResourceList.every((namespaceResource) => namespaceResource?.loaded));
+      loadError = perNamespaceResourceList.find(
+        (namespaceResource) => namespaceResource?.loadError,
+      )?.loadError;
+    } else {
+      [resource, loaded, loadError] = [resourceK8sWatch, loadedK8sWatch, loadErrorK8sWatch];
+    }
+
+    setLoadedData(loaded);
+
+    if (loadError) {
+      // A namespace failure shouldn't be masked by other namespaces' data resolving successfully.
+      setLoadErrorData(loadError);
+      setLoadedData(true);
+    } else if (resource && loaded) {
+      const isList = typeof resource?.[0] === 'string';
+      setData((isList && resource?.[1]) || (<T & { items?: T[] }>resource)?.items || resource);
+      setLoadedData(loaded);
+      setLoadErrorData(null);
     }
   }, [
     resourceKubevirtDataPod,
@@ -60,6 +137,10 @@ const useKubevirtWatchResource: UseKubevirtWatchResource = <T>(watchOptions, fil
     loadErrorK8sWatch,
     isProxyPodAlive,
     shouldUseProxyPod,
+    needsNamespaceFiltering,
+    perNamespaceResources,
+    listAccessReviewsLoading,
+    allowedNamespaces,
   ]);
   return [data, loadedData, loadErrorData];
 };

--- a/src/utils/hooks/useMultipleAccessReviews.ts
+++ b/src/utils/hooks/useMultipleAccessReviews.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { AccessReviewResourceAttributes, checkAccess } from '@openshift-console/dynamic-plugin-sdk';
 import { ImpersonateKind } from '@openshift-console/dynamic-plugin-sdk/lib/app/redux-types';
 
@@ -30,8 +31,7 @@ const useMultipleAccessReviews: UseMultipleAccessReviews = (
         setAllowedResourceAttributes(updatedAllowedArr);
       })
       .catch((e) => {
-        // eslint-disable-next-line no-console
-        console.warn('SelfSubjectAccessReview failed', e);
+        kubevirtConsole.warn('SelfSubjectAccessReview failed', e);
         setLoading(false);
       });
   }, [impersonate, multipleResourceAttributes]);

--- a/src/utils/hooks/useNodes.test.ts
+++ b/src/utils/hooks/useNodes.test.ts
@@ -1,0 +1,67 @@
+import { act } from 'react-dom/test-utils';
+
+import { useAccessReview, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { renderHook } from '@testing-library/react-hooks';
+
+import useNodes from './useNodes';
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  useAccessReview: jest.fn(),
+  useK8sWatchResource: jest.fn(),
+}));
+
+describe('useNodes', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('does not open a Node watch while the access review is loading', () => {
+    (useAccessReview as jest.Mock).mockReturnValue([false, true]);
+    (useK8sWatchResource as jest.Mock).mockReturnValue([[], false, null]);
+
+    const { result } = renderHook(() => useNodes());
+
+    expect(useK8sWatchResource).toHaveBeenCalledWith(false);
+    expect(result.current).toEqual([[], false, null]);
+  });
+
+  it('never opens a Node watch when the user cannot watch nodes', () => {
+    (useAccessReview as jest.Mock).mockReturnValue([false, false]);
+    (useK8sWatchResource as jest.Mock).mockReturnValue([[], false, null]);
+
+    const { result } = renderHook(() => useNodes());
+
+    expect(useK8sWatchResource).toHaveBeenCalledWith(false);
+    expect(result.current).toEqual([[], false, expect.any(Error)]);
+  });
+
+  it('opens the Node watch when the user can watch nodes', () => {
+    const nodes = [{ metadata: { name: 'node-1' } }];
+    (useAccessReview as jest.Mock).mockReturnValue([true, false]);
+    (useK8sWatchResource as jest.Mock).mockReturnValue([nodes, true, null]);
+
+    const { result } = renderHook(() => useNodes());
+
+    expect(useK8sWatchResource).toHaveBeenCalledWith(expect.objectContaining({ isList: true }));
+    expect(result.current).toEqual([nodes, true, null]);
+  });
+
+  it('opens the Node watch as soon as the access review resolves to authorized', () => {
+    const nodes = [{ metadata: { name: 'node-1' } }];
+    (useAccessReview as jest.Mock).mockReturnValue([false, true]);
+    (useK8sWatchResource as jest.Mock).mockReturnValue([[], false, null]);
+
+    const { rerender, result } = renderHook(() => useNodes());
+
+    expect(result.current).toEqual([[], false, null]);
+
+    act(() => {
+      (useAccessReview as jest.Mock).mockReturnValue([true, false]);
+      (useK8sWatchResource as jest.Mock).mockReturnValue([nodes, true, null]);
+      rerender();
+    });
+
+    expect(useK8sWatchResource).toHaveBeenLastCalledWith(expect.objectContaining({ isList: true }));
+    expect(result.current).toEqual([nodes, true, null]);
+  });
+});

--- a/src/utils/hooks/useNodes.ts
+++ b/src/utils/hooks/useNodes.ts
@@ -1,0 +1,38 @@
+import { modelToGroupVersionKind, NodeModel } from '@kubevirt-ui/kubevirt-api/console';
+import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes';
+import {
+  K8sVerb,
+  useAccessReview,
+  useK8sWatchResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+
+type UseNodes = () => [nodes: IoK8sApiCoreV1Node[], loaded: boolean, error: Error | null];
+
+// Nodes are cluster-scoped with no per-namespace fallback, and non-admins are frequently
+// denied `watch` access -- check first and skip the watch entirely if forbidden.
+const useNodes: UseNodes = () => {
+  const [canWatchNodes, canWatchNodesLoading] = useAccessReview({
+    resource: NodeModel.plural,
+    verb: 'watch' as K8sVerb,
+  });
+
+  const [nodes, nodesLoaded, nodesError] = useK8sWatchResource<IoK8sApiCoreV1Node[]>(
+    canWatchNodes && {
+      groupVersionKind: modelToGroupVersionKind(NodeModel),
+      isList: true,
+    },
+  );
+
+  if (canWatchNodesLoading) {
+    return [[], false, null];
+  }
+
+  if (!canWatchNodes) {
+    // Distinct from "successfully loaded, cluster has no Nodes" so consumers can tell them apart.
+    return [[], false, new Error('User cannot watch Node resources')];
+  }
+
+  return [nodes, nodesLoaded, nodesError];
+};
+
+export default useNodes;

--- a/src/utils/resources/udn/hooks/useNamespaceUDN.ts
+++ b/src/utils/resources/udn/hooks/useNamespaceUDN.ts
@@ -1,3 +1,4 @@
+import ClusterUserDefinedNetworkModel from '@kubevirt-ui/kubevirt-api/console/models/ClusterUserDefinedNetworkModel';
 import {
   ClusterUserDefinedNetworkModelGroupVersionKind,
   modelToGroupVersionKind,
@@ -11,7 +12,12 @@ import {
 } from '@kubevirt-utils/resources/udn/types';
 import { matchSelector } from '@kubevirt-utils/utils/matchSelector';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  K8sResourceCommon,
+  K8sVerb,
+  useAccessReview,
+  useK8sWatchResource,
+} from '@openshift-console/dynamic-plugin-sdk';
 
 const useNamespaceUDN = (
   namespace: string,
@@ -30,10 +36,20 @@ const useNamespaceUDN = (
     namespace,
   });
 
-  const [clusterUDNs] = useK8sWatchResource<ClusterUserDefinedNetworkKind[]>({
-    groupVersionKind: ClusterUserDefinedNetworkModelGroupVersionKind,
-    isList: true,
+  // ClusterUserDefinedNetwork is cluster-scoped; non-admins are frequently denied `watch` on it.
+  const [canWatchClusterUDNs, canWatchClusterUDNsLoading] = useAccessReview({
+    group: ClusterUserDefinedNetworkModelGroupVersionKind.group,
+    resource: ClusterUserDefinedNetworkModel.plural,
+    verb: 'watch' as K8sVerb,
   });
+
+  const [clusterUDNs] = useK8sWatchResource<ClusterUserDefinedNetworkKind[]>(
+    !canWatchClusterUDNsLoading &&
+      canWatchClusterUDNs && {
+        groupVersionKind: ClusterUserDefinedNetworkModelGroupVersionKind,
+        isList: true,
+      },
+  );
 
   const primaryUDN = udns?.find(
     (udn) => udn?.spec?.layer2?.role === UserDefinedNetworkRole.Primary,

--- a/src/utils/resources/vmi/hooks/useVirtualMachineInstanceMigration.ts
+++ b/src/utils/resources/vmi/hooks/useVirtualMachineInstanceMigration.ts
@@ -4,17 +4,23 @@ import { MIGRATION_VMI_NAME_LABEL } from '@kubevirt-utils/resources/vmim/constan
 import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 const useVirtualMachineInstanceMigration = (resource: K8sResourceCommon) => {
+  // `resource` starts as `{}` while loading -- both fields are required, or an unscoped watch
+  // (missing namespace) or an undefined selector value (missing name) could slip through.
+  const namespace = resource?.metadata?.namespace;
+  const name = resource?.metadata?.name;
+
   const [vmims] = useK8sWatchResource<V1VirtualMachineInstanceMigration[]>(
-    resource && {
-      groupVersionKind: VirtualMachineInstanceMigrationModelGroupVersionKind,
-      isList: true,
-      namespace: resource?.metadata?.namespace,
-      selector: {
-        matchLabels: {
-          [MIGRATION_VMI_NAME_LABEL]: resource?.metadata?.name,
+    namespace &&
+      name && {
+        groupVersionKind: VirtualMachineInstanceMigrationModelGroupVersionKind,
+        isList: true,
+        namespace,
+        selector: {
+          matchLabels: {
+            [MIGRATION_VMI_NAME_LABEL]: name,
+          },
         },
       },
-    },
   );
 
   // since migration objects are kepts until VMI is deleted

--- a/src/views/catalog/wizard/tabs/scheduling/components/WizardSchedulingGrid.tsx
+++ b/src/views/catalog/wizard/tabs/scheduling/components/WizardSchedulingGrid.tsx
@@ -1,8 +1,6 @@
 import React, { FC } from 'react';
 
 import { UpdateValidatedVM } from '@catalog/utils/WizardVMContext';
-import { modelToGroupVersionKind, NodeModel } from '@kubevirt-ui/kubevirt-api/console';
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import AffinityModal from '@kubevirt-utils/components/AffinityModal/AffinityModal';
 import DedicatedResourcesModal from '@kubevirt-utils/components/DedicatedResourcesModal/DedicatedResourcesModal';
@@ -13,8 +11,8 @@ import NodeSelectorDetailItem from '@kubevirt-utils/components/NodeSelectorDetai
 import NodeSelectorModal from '@kubevirt-utils/components/NodeSelectorModal/NodeSelectorModal';
 import TolerationsModal from '@kubevirt-utils/components/TolerationsModal/TolerationsModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useNodes from '@kubevirt-utils/hooks/useNodes';
 import { getEvictionStrategy } from '@kubevirt-utils/resources/vm';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList, Grid, GridItem } from '@patternfly/react-core';
 
 import { WizardDescriptionItem } from '../../../components/WizardDescriptionItem';
@@ -34,10 +32,7 @@ const WizardSchedulingGrid: FC<WizardSchedulingGridProps> = ({ updateVM, vm }) =
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
 
-  const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
-    groupVersionKind: modelToGroupVersionKind(NodeModel),
-    isList: true,
-  });
+  const [nodes, nodesLoaded] = useNodes();
 
   return (
     <Grid className="wizard-scheduling-tab__grid" hasGutter>

--- a/src/views/cdi-upload-provider/upload-pvc-form/UploadPVC.tsx
+++ b/src/views/cdi-upload-provider/upload-pvc-form/UploadPVC.tsx
@@ -18,6 +18,7 @@ import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { createUploadPVC } from '@kubevirt-utils/hooks/useCDIUpload/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useMultipleAccessReviews from '@kubevirt-utils/hooks/useMultipleAccessReviews';
 import {
   TEMPLATE_TYPE_BASE,
   TEMPLATE_TYPE_LABEL,
@@ -33,7 +34,6 @@ import {
 import { ActionGroup, Alert, Button, ButtonVariant } from '@patternfly/react-core';
 
 import useBaseImages from '../hooks/useBaseImages';
-import useMultipleAccessReviews from '../hooks/useMultipleAccessReviews';
 import { CDI_UPLOAD_OS_URL_PARAM, CDI_UPLOAD_URL_BUILDER, uploadErrorType } from '../utils/consts';
 import { CDIUploadContext } from '../utils/context';
 import { getName, getNamespace, getPVCNamespace } from '../utils/selectors';

--- a/src/views/checkups/network/components/form/CheckupsNetworkFormNodes.tsx
+++ b/src/views/checkups/network/components/form/CheckupsNetworkFormNodes.tsx
@@ -1,12 +1,10 @@
 import React, { Dispatch, SetStateAction, useMemo } from 'react';
 
-import { modelToGroupVersionKind, NodeModel } from '@kubevirt-ui/kubevirt-api/console';
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useNodes from '@kubevirt-utils/hooks/useNodes';
 import { getName } from '@kubevirt-utils/resources/shared';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
   ButtonVariant,
@@ -39,10 +37,7 @@ const CheckupsNetworkFormNodes = ({
 }) => {
   const { t } = useKubevirtTranslation();
 
-  const [nodes] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
-    groupVersionKind: modelToGroupVersionKind(NodeModel),
-    isList: true,
-  });
+  const [nodes] = useNodes();
 
   const options: EnhancedSelectOptionProps[] = useMemo(
     () =>

--- a/src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData.ts
+++ b/src/views/clusteroverview/MigrationsTab/hooks/useMigrationCardData.ts
@@ -7,11 +7,11 @@ import {
   V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource';
 import useMigrationPolicies from '@kubevirt-utils/hooks/useMigrationPolicies';
 import {
   OnFilterChange,
   RowFilter,
-  useK8sWatchResource,
   useListPageFilter,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
@@ -44,7 +44,7 @@ const useMigrationCardDataAndFilters: UseMigrationCardDataAndFilters = (duration
   const [activeNamespace] = useActiveNamespace();
   const namespace = activeNamespace !== ALL_NAMESPACES_SESSION_KEY ? activeNamespace : null;
 
-  const [vmims, vmimsLoaded, vmimsErrors] = useK8sWatchResource<
+  const [vmims, vmimsLoaded, vmimsErrors] = useKubevirtWatchResource<
     V1VirtualMachineInstanceMigration[]
   >({
     groupVersionKind: VirtualMachineInstanceMigrationModelGroupVersionKind,
@@ -52,7 +52,7 @@ const useMigrationCardDataAndFilters: UseMigrationCardDataAndFilters = (duration
     namespace,
   });
 
-  const [vmis, vmisLoaded, vmisErrors] = useK8sWatchResource<V1VirtualMachineInstance[]>({
+  const [vmis, vmisLoaded, vmisErrors] = useKubevirtWatchResource<V1VirtualMachineInstance[]>({
     groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
     isList: true,
     namespace,

--- a/src/views/clusteroverview/OverviewTab/inventory-card/hooks/useWatchedResourcesInventoryCard.test.ts
+++ b/src/views/clusteroverview/OverviewTab/inventory-card/hooks/useWatchedResourcesInventoryCard.test.ts
@@ -1,0 +1,101 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import useMultipleAccessReviews from '@kubevirt-utils/hooks/useMultipleAccessReviews';
+import { AccessReviewResourceAttributes } from '@openshift-console/dynamic-plugin-sdk';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useWatchedResourcesHook } from './useWatchedResourcesInventoryCard';
+
+const projectNames = ['ns-allowed', 'ns-forbidden', 'ns-templates-only'];
+
+// namespaces where each resource's `list` verb should be considered allowed
+const allowedNamespacesByResource: Record<string, string[]> = {
+  'network-attachment-definitions': ['ns-allowed'],
+  templates: ['ns-allowed', 'ns-templates-only'],
+  virtualmachines: ['ns-allowed'],
+};
+
+jest.mock('./useProjectNames', () => ({
+  __esModule: true,
+  useProjectNames: jest.fn(() => projectNames),
+}));
+
+const defaultAccessReviewsImplementation = (attributes: AccessReviewResourceAttributes[]) => [
+  attributes.map((resourceAttributes) => ({
+    allowed: allowedNamespacesByResource[resourceAttributes.resource]?.includes(
+      resourceAttributes.namespace,
+    ),
+    resourceAttributes,
+  })),
+  false,
+];
+
+jest.mock('@kubevirt-utils/hooks/useMultipleAccessReviews', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('useWatchedResourcesHook', () => {
+  beforeEach(() => {
+    (useMultipleAccessReviews as jest.Mock).mockReset();
+    (useMultipleAccessReviews as jest.Mock).mockImplementation(defaultAccessReviewsImplementation);
+  });
+
+  describe('for non-admin users', () => {
+    it('only watches namespaces where the user can list the resource', () => {
+      const { result } = renderHook(() => useWatchedResourcesHook(false)());
+
+      expect(Object.keys(result.current)).toEqual(
+        expect.arrayContaining([
+          'ns-allowed/virtualmachines',
+          'ns-allowed/templates',
+          'ns-templates-only/templates',
+          'ns-allowed/network-attachment-definitions',
+        ]),
+      );
+    });
+
+    it('never opens a watch for a namespace the user is forbidden to list', () => {
+      const { result } = renderHook(() => useWatchedResourcesHook(false)());
+
+      const forbiddenKeys = [
+        'ns-forbidden/virtualmachines',
+        'ns-forbidden/templates',
+        'ns-forbidden/network-attachment-definitions',
+        'ns-templates-only/virtualmachines',
+        'ns-templates-only/network-attachment-definitions',
+      ];
+
+      forbiddenKeys.forEach((key) => {
+        expect(Object.keys(result.current)).not.toContain(key);
+      });
+    });
+
+    it('still includes the cluster-scoped nodes watch', () => {
+      const { result } = renderHook(() => useWatchedResourcesHook(false)());
+
+      expect(result.current.nodes).toEqual(
+        expect.objectContaining({ isList: true, namespaced: false }),
+      );
+    });
+
+    it('opens no per-namespace watches while access reviews are still loading', () => {
+      (useMultipleAccessReviews as jest.Mock).mockImplementation(() => [[], true]);
+
+      const { result } = renderHook(() => useWatchedResourcesHook(false)());
+
+      expect(Object.keys(result.current)).toEqual(['nodes']);
+    });
+  });
+
+  describe('for admin users', () => {
+    it('uses cluster-scoped watches instead of per-namespace ones', () => {
+      const { result } = renderHook(() => useWatchedResourcesHook(true)());
+      const adminResources = result.current as unknown as Record<string, { namespaced?: boolean }>;
+
+      expect(Object.keys(adminResources)).toEqual(
+        expect.arrayContaining(['nads', 'nodes', 'vms', 'vmTemplates']),
+      );
+      expect(adminResources.vms).toEqual(expect.objectContaining({ namespaced: true }));
+    });
+  });
+});

--- a/src/views/clusteroverview/OverviewTab/inventory-card/hooks/useWatchedResourcesInventoryCard.ts
+++ b/src/views/clusteroverview/OverviewTab/inventory-card/hooks/useWatchedResourcesInventoryCard.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import {
   modelToGroupVersionKind,
   NodeModel,
@@ -9,16 +11,76 @@ import NetworkAttachmentDefinitionModel, {
 import VirtualMachineModel, {
   VirtualMachineModelGroupVersionKind,
 } from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
+import useMultipleAccessReviews from '@kubevirt-utils/hooks/useMultipleAccessReviews';
 import { getAllowedResources, getAllowedTemplateResources } from '@kubevirt-utils/resources/shared';
 import { TEMPLATE_TYPE_LABEL } from '@kubevirt-utils/resources/template';
+import {
+  AccessReviewResourceAttributes,
+  K8sModel,
+  K8sVerb,
+} from '@openshift-console/dynamic-plugin-sdk';
 
 import { useProjectNames } from './useProjectNames';
 
+type AccessReviewResult = { allowed: boolean; resourceAttributes: AccessReviewResourceAttributes };
+
+const buildListAccessReviewAttributes = (
+  namespaces: string[],
+  model: K8sModel,
+): AccessReviewResourceAttributes[] =>
+  (namespaces || []).map((namespace) => ({
+    group: model.apiGroup,
+    namespace,
+    resource: model.plural,
+    verb: 'list' as K8sVerb,
+  }));
+
+// Drops namespaces the user can't list the resource in, even if the Project is visible.
+const filterAllowedNamespaces = (accessReviews: AccessReviewResult[]): string[] =>
+  (accessReviews || [])
+    .filter((review) => review.allowed)
+    .map((review) => review.resourceAttributes?.namespace)
+    .filter(Boolean);
+
 const useNonAdminResourcesInventoryCard = () => {
   const projectNames = useProjectNames();
-  const allowedVMResources = getAllowedResources(projectNames, VirtualMachineModel);
-  const allowedNADResources = getAllowedResources(projectNames, NetworkAttachmentDefinitionModel);
-  const allowedTemplateResources = getAllowedTemplateResources(projectNames);
+
+  const vmAccessReviewAttributes = useMemo(
+    () => buildListAccessReviewAttributes(projectNames, VirtualMachineModel),
+    [projectNames],
+  );
+  const templateAccessReviewAttributes = useMemo(
+    () => buildListAccessReviewAttributes(projectNames, TemplateModel),
+    [projectNames],
+  );
+  const nadAccessReviewAttributes = useMemo(
+    () => buildListAccessReviewAttributes(projectNames, NetworkAttachmentDefinitionModel),
+    [projectNames],
+  );
+
+  const [vmAccessReviews] = useMultipleAccessReviews(vmAccessReviewAttributes);
+  const [templateAccessReviews] = useMultipleAccessReviews(templateAccessReviewAttributes);
+  const [nadAccessReviews] = useMultipleAccessReviews(nadAccessReviewAttributes);
+
+  const allowedVMNamespaces = useMemo(
+    () => filterAllowedNamespaces(vmAccessReviews),
+    [vmAccessReviews],
+  );
+  const allowedTemplateNamespaces = useMemo(
+    () => filterAllowedNamespaces(templateAccessReviews),
+    [templateAccessReviews],
+  );
+  const allowedNADNamespaces = useMemo(
+    () => filterAllowedNamespaces(nadAccessReviews),
+    [nadAccessReviews],
+  );
+
+  const allowedVMResources = getAllowedResources(allowedVMNamespaces, VirtualMachineModel);
+  const allowedNADResources = getAllowedResources(
+    allowedNADNamespaces,
+    NetworkAttachmentDefinitionModel,
+  );
+  const allowedTemplateResources = getAllowedTemplateResources(allowedTemplateNamespaces);
 
   const watchedResources = {
     ...allowedVMResources,

--- a/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusesCard.tsx
+++ b/src/views/clusteroverview/OverviewTab/vm-statuses-card/VMStatusesCard.tsx
@@ -4,8 +4,8 @@ import { VirtualMachineModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/c
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource';
 import { VM_STATUS } from '@kubevirt-utils/resources/vm/utils/vmStatus';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Accordion,
@@ -34,7 +34,7 @@ const VMStatusesCard: React.FC = () => {
   );
 
   const { t } = useKubevirtTranslation();
-  const [vms] = useK8sWatchResource<V1VirtualMachine[]>({
+  const [vms] = useKubevirtWatchResource<V1VirtualMachine[]>({
     groupVersionKind: VirtualMachineModelGroupVersionKind,
     isList: true,
     namespace: namespace,

--- a/src/views/clusteroverview/OverviewTab/vms-per-resource-card/hooks/useVMsPerResource.ts
+++ b/src/views/clusteroverview/OverviewTab/vms-per-resource-card/hooks/useVMsPerResource.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { VirtualMachineModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 
 type UseVMsPerResource = () => {
@@ -19,7 +19,7 @@ const useVMsPerResource: UseVMsPerResource = () => {
     [activeNamespace],
   );
 
-  const [vms, loaded, loadedError] = useK8sWatchResource<V1VirtualMachine[]>({
+  const [vms, loaded, loadedError] = useKubevirtWatchResource<V1VirtualMachine[]>({
     groupVersionKind: VirtualMachineModelGroupVersionKind,
     isList: true,
     namespace,

--- a/src/views/templates/details/tabs/scheduling/components/AffinityRulesModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/AffinityRulesModal.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import produce from 'immer';
 import { getAffinity } from 'src/views/templates/utils/selectors';
 
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import AffinityEditModal from '@kubevirt-utils/components/AffinityModal/components/AffinityEditModal/AffinityEditModal';
 import AffinityEmptyState from '@kubevirt-utils/components/AffinityModal/components/AffinityEmptyState';
 import AffinityList from '@kubevirt-utils/components/AffinityModal/components/AffinityList/AffinityList';
@@ -17,10 +16,10 @@ import { AffinityRowData } from '@kubevirt-utils/components/AffinityModal/utils/
 import { isEqualObject } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { modelToGroupVersionKind, NodeModel, V1Template } from '@kubevirt-utils/models';
+import useNodes from '@kubevirt-utils/hooks/useNodes';
+import { V1Template } from '@kubevirt-utils/models';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { ModalVariant } from '@patternfly/react-core';
 
 type AffinityModalProps = {
@@ -43,10 +42,7 @@ const AffinityRulesModal: React.FC<AffinityModalProps> = ({
   const [focusedAffinity, setFocusedAffinity] = React.useState<AffinityRowData>(defaultNewAffinity);
   const [isEditing, setIsEditing] = React.useState(false);
   const [isCreating, setIsCreating] = React.useState(false);
-  const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
-    groupVersionKind: modelToGroupVersionKind(NodeModel),
-    isList: true,
-  });
+  const [nodes, nodesLoaded] = useNodes();
   const [qualifiedRequiredNodes, qualifiedPreferredNodes] = useRequiredAndPrefferedQualifiedNodes(
     nodes,
     nodesLoaded,

--- a/src/views/templates/details/tabs/scheduling/components/DedicatedResourcesModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/DedicatedResourcesModal.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom-v5-compat';
 import produce from 'immer';
 import { isDedicatedCPUPlacement } from 'src/views/templates/utils/utils';
 
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes';
 import {
   cpuManagerLabel,
   cpuManagerLabelKey,
@@ -12,10 +11,11 @@ import {
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useNodes from '@kubevirt-utils/hooks/useNodes';
 import { modelToGroupVersionKind, NodeModel, V1Template } from '@kubevirt-utils/models';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { ensurePath, isEmpty } from '@kubevirt-utils/utils/utils';
-import { ResourceLink, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Alert,
   AlertVariant,
@@ -42,10 +42,7 @@ const DedicatedResourcesModal: FC<DedicatedResourcesModalProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const [checked, setChecked] = useState<boolean>(isDedicatedCPUPlacement(template));
-  const [nodes, nodesLoaded, loadError] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
-    groupVersionKind: modelToGroupVersionKind(NodeModel),
-    isList: true,
-  });
+  const [nodes, nodesLoaded, loadError] = useNodes();
 
   const { hasNodes, qualifiedNodes } = useMemo(() => {
     const filteredNodes = nodes?.filter(

--- a/src/views/templates/details/tabs/scheduling/components/NodeSelectorModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/NodeSelectorModal.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import produce from 'immer';
 import { getNodeSelector } from 'src/views/templates/utils/selectors';
 
-import { modelToGroupVersionKind, NodeModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
+import { NodeModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import LabelsList from '@kubevirt-utils/components/NodeSelectorModal/components/LabelList';
 import LabelRow from '@kubevirt-utils/components/NodeSelectorModal/components/LabelRow';
 import NodeCheckerAlert from '@kubevirt-utils/components/NodeSelectorModal/components/NodeCheckerAlert';
@@ -16,9 +15,9 @@ import {
 import { IDLabel } from '@kubevirt-utils/components/NodeSelectorModal/utils/types';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useNodes from '@kubevirt-utils/hooks/useNodes';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Form } from '@patternfly/react-core';
 
 type NodeSelectorModalProps = {
@@ -42,10 +41,7 @@ const NodeSelectorModal: React.FC<NodeSelectorModalProps> = ({
     onEntityDelete: onLabelDelete,
   } = useIDEntities<IDLabel>(nodeSelectorToIDLabels(getNodeSelector(template)));
 
-  const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
-    groupVersionKind: modelToGroupVersionKind(NodeModel),
-    isList: true,
-  });
+  const [nodes, nodesLoaded] = useNodes();
 
   const qualifiedNodes = useNodeLabelQualifier(nodes, nodesLoaded, selectorLabels);
 

--- a/src/views/templates/details/tabs/scheduling/components/TolerationsModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/TolerationsModal.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import produce from 'immer';
 import { getTolerations } from 'src/views/templates/utils/selectors';
 
-import { modelToGroupVersionKind, NodeModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
+import { NodeModel, V1Template } from '@kubevirt-ui/kubevirt-api/console';
 import {
   K8sIoApiCoreV1Toleration,
   K8sIoApiCoreV1TolerationEffectEnum,
@@ -19,9 +18,9 @@ import TolerationModalDescriptionText from '@kubevirt-utils/components/Toleratio
 import { TolerationLabel } from '@kubevirt-utils/components/TolerationsModal/utils/constants';
 import { getNodeTaintQualifier } from '@kubevirt-utils/components/TolerationsModal/utils/helpers';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useNodes from '@kubevirt-utils/hooks/useNodes';
 import { getTemplateVirtualMachineObject } from '@kubevirt-utils/resources/template';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Form, ModalVariant } from '@patternfly/react-core';
 
 type TolerationsModalProps = {
@@ -47,10 +46,7 @@ const TolerationsModal: React.FC<TolerationsModalProps> = ({
     (getTolerations(template) || []).map((toleration, id) => ({ ...toleration, id })),
   );
   const tolerationLabelsEmpty = tolerationsLabels?.length === 0;
-  const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
-    groupVersionKind: modelToGroupVersionKind(NodeModel),
-    isList: true,
-  });
+  const [nodes, nodesLoaded] = useNodes();
   const qualifiedNodes = getNodeTaintQualifier(nodes, nodesLoaded, tolerationsLabels);
 
   const onSelectorLabelAdd = () =>

--- a/src/views/topology/hooks/usePodsForVM.ts
+++ b/src/views/topology/hooks/usePodsForVM.ts
@@ -34,25 +34,29 @@ const usePodsForVM: UsePodsForVM = (vm) => {
   const vmName = getName(vm);
   const vmNamespace = getNamespace(vm);
 
+  // Skip watching until vmNamespace is known, otherwise it falls back to an unscoped watch.
   const watchedResources = useMemo(
-    () => ({
-      pods: {
-        groupVersionKind: getGroupVersionKindForModel(PodModel),
-        isList: true,
-        vmNamespace,
-      },
-      replicationControllers: {
-        groupVersionKind: getGroupVersionKindForModel(ReplicationControllerModel),
-        isList: true,
-        vmNamespace,
-      },
-      virtualmachineinstances: {
-        groupVersionKind: getGroupVersionKindForModel(VirtualMachineInstanceModel),
-        isList: true,
-        optional: true,
-        vmNamespace,
-      },
-    }),
+    () =>
+      vmNamespace
+        ? {
+            pods: {
+              groupVersionKind: getGroupVersionKindForModel(PodModel),
+              isList: true,
+              namespace: vmNamespace,
+            },
+            replicationControllers: {
+              groupVersionKind: getGroupVersionKindForModel(ReplicationControllerModel),
+              isList: true,
+              namespace: vmNamespace,
+            },
+            virtualmachineinstances: {
+              groupVersionKind: getGroupVersionKindForModel(VirtualMachineInstanceModel),
+              isList: true,
+              namespace: vmNamespace,
+              optional: true,
+            },
+          }
+        : {},
     [vmNamespace],
   );
 

--- a/src/views/virtualmachines/actions/tests/useVirtualMachineActionsProvider.test.tsx
+++ b/src/views/virtualmachines/actions/tests/useVirtualMachineActionsProvider.test.tsx
@@ -8,7 +8,9 @@ import { exampleRunningVirtualMachine } from './mocks';
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   getGroupVersionKindForModel: jest.fn(() => ({})),
+  k8sCreate: jest.fn(() => Promise.resolve({})),
   k8sPatch: jest.fn(() => ({})),
+  useAccessReview: jest.fn(() => [true, false]),
   useFlag: jest.fn(() => true),
   useK8sModel: jest.fn(() => [[], true]),
   useK8sWatchResource: jest.fn(() => [[], true]),

--- a/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPageTitle.tsx
@@ -6,6 +6,7 @@ import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevir
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import SidebarEditorSwitch from '@kubevirt-utils/components/SidebarEditor/SidebarEditorSwitch';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import useVirtualMachineInstanceMigration from '@kubevirt-utils/resources/vmi/hooks/useVirtualMachineInstanceMigration';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
@@ -35,12 +36,20 @@ const VirtualMachineNavPageTitle: FC<VirtualMachineNavPageTitleProps> = ({
   const { t } = useKubevirtTranslation();
   const location = useLocation();
 
-  const [vmi] = useK8sWatchResource<V1VirtualMachineInstance>({
-    groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
-    isList: false,
-    name: vm?.metadata?.name,
-    namespace: vm?.metadata?.namespace,
-  });
+  const vmName = getName(vm);
+  const vmNamespace = getNamespace(vm);
+
+  // `vm` starts as `{}` before the VM watch resolves; without this guard, undefined
+  // name/namespace would fall back to a cluster-wide VMI list.
+  const [vmi] = useK8sWatchResource<V1VirtualMachineInstance>(
+    vmName &&
+      vmNamespace && {
+        groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
+        isList: false,
+        name: vmName,
+        namespace: vmNamespace,
+      },
+  );
   const vmim = useVirtualMachineInstanceMigration(vm);
   const [actions] = useVirtualMachineActionsProvider(vm, vmim);
   const StatusIcon = getVMStatusIcon(vm?.status?.printableStatus);

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSection.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSection.tsx
@@ -1,17 +1,12 @@
 import React, { FC } from 'react';
 
-import { modelToGroupVersionKind, NodeModel } from '@kubevirt-ui/kubevirt-api/console';
 import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useNodes from '@kubevirt-utils/hooks/useNodes';
 import { asAccessReview } from '@kubevirt-utils/resources/shared';
-import {
-  K8sVerb,
-  useAccessReview,
-  useK8sWatchResource,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { K8sVerb, useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 import { Grid, GridItem, Title } from '@patternfly/react-core';
 
 import SchedulingSectionLeftGrid from './SchedulingSectionLeftGrid';
@@ -26,10 +21,7 @@ type SchedulingSectionProps = {
 
 const SchedulingSection: FC<SchedulingSectionProps> = ({ instanceTypeVM, onSubmit, vm, vmi }) => {
   const { t } = useKubevirtTranslation();
-  const [nodes, nodesLoaded] = useK8sWatchResource<IoK8sApiCoreV1Node[]>({
-    groupVersionKind: modelToGroupVersionKind(NodeModel),
-    isList: true,
-  });
+  const [nodes, nodesLoaded] = useNodes();
   const accessReview = asAccessReview(VirtualMachineModel, vm, 'update' as K8sVerb);
   const [canUpdateVM] = useAccessReview(accessReview || {});
 

--- a/src/views/virtualmachines/tree/hooks/useTreeViewData.test.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewData.test.ts
@@ -1,0 +1,155 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import useMultipleAccessReviews from '@kubevirt-utils/hooks/useMultipleAccessReviews';
+import {
+  AccessReviewResourceAttributes,
+  useK8sWatchResources,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { createTreeViewData } from '../utils/utils';
+
+import { useTreeViewData } from './useTreeViewData';
+
+const projectNames = ['ns-allowed', 'ns-forbidden', 'ns-empty'];
+
+// namespaces where `list virtualmachines` should be considered allowed
+const allowedNamespaces = ['ns-allowed'];
+
+jest.mock('@kubevirt-utils/hooks/useIsAdmin', () => ({
+  useIsAdmin: jest.fn(() => false),
+}));
+
+jest.mock('@kubevirt-utils/hooks/useProjects', () => ({
+  __esModule: true,
+  default: jest.fn(() => [projectNames, true, null]),
+}));
+
+jest.mock('@kubevirt-utils/hooks/useFeatures/useFeatures', () => ({
+  useFeatures: jest.fn(() => ({ featureEnabled: false })),
+}));
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  ...jest.requireActual('@openshift-console/dynamic-plugin-sdk'),
+  useK8sWatchResource: jest.fn(() => [[], true]),
+  useK8sWatchResources: jest.fn((resourcesToWatch: Record<string, unknown>) =>
+    Object.fromEntries(
+      Object.keys(resourcesToWatch).map((namespace) => [namespace, { data: [], loaded: true }]),
+    ),
+  ),
+}));
+
+jest.mock('@kubevirt-utils/hooks/useMultipleAccessReviews', () => ({
+  __esModule: true,
+  default: jest.fn((attributes: AccessReviewResourceAttributes[]) => [
+    attributes.map((resourceAttributes) => ({
+      allowed: allowedNamespaces.includes(resourceAttributes.namespace),
+      resourceAttributes,
+    })),
+    false,
+  ]),
+}));
+
+jest.mock('../utils/utils', () => ({
+  __esModule: true,
+  createTreeViewData: jest.fn(() => []),
+  isSystemNamespace: jest.fn(() => false),
+}));
+
+const getWatchedNamespaces = (): string[] =>
+  Object.keys((useK8sWatchResources as jest.Mock).mock.calls.at(-1)?.[0] ?? {});
+
+describe('useTreeViewData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useMultipleAccessReviews as jest.Mock).mockImplementation(
+      (attributes: AccessReviewResourceAttributes[]) => [
+        attributes.map((resourceAttributes) => ({
+          allowed: allowedNamespaces.includes(resourceAttributes.namespace),
+          resourceAttributes,
+        })),
+        false,
+      ],
+    );
+  });
+
+  it('only watches namespaces where the user can list VMs', () => {
+    renderHook(() => useTreeViewData());
+
+    expect(getWatchedNamespaces()).toEqual(['ns-allowed']);
+  });
+
+  it('never opens a watch for a namespace the user is forbidden to list VMs in', () => {
+    renderHook(() => useTreeViewData());
+
+    expect(getWatchedNamespaces()).not.toEqual(expect.arrayContaining(['ns-forbidden']));
+  });
+
+  it('opens no per-namespace watches while access reviews are still loading', () => {
+    (useMultipleAccessReviews as jest.Mock).mockImplementation(() => [[], true]);
+
+    const { result } = renderHook(() => useTreeViewData());
+
+    expect(getWatchedNamespaces()).toEqual([]);
+    expect(result.current.loaded).toBe(false);
+  });
+
+  it('reports loaded once access reviews resolve, even if the user has no allowed namespaces', () => {
+    (useMultipleAccessReviews as jest.Mock).mockImplementation(
+      (attributes: AccessReviewResourceAttributes[]) => [
+        attributes.map((resourceAttributes) => ({ allowed: false, resourceAttributes })),
+        false,
+      ],
+    );
+
+    const { result } = renderHook(() => useTreeViewData());
+
+    expect(getWatchedNamespaces()).toEqual([]);
+    expect(result.current.loaded).toBe(true);
+  });
+
+  it('does not perform per-namespace access reviews for admin users', () => {
+    jest.requireMock('@kubevirt-utils/hooks/useIsAdmin').useIsAdmin.mockReturnValueOnce(true);
+
+    renderHook(() => useTreeViewData());
+
+    expect(useMultipleAccessReviews).toHaveBeenCalledWith([]);
+  });
+
+  it('only passes namespaces the user can list VMs in to createTreeViewData for tree structure', () => {
+    renderHook(() => useTreeViewData());
+
+    expect(createTreeViewData).toHaveBeenCalledWith(
+      allowedNamespaces,
+      expect.anything(),
+      false,
+      expect.anything(),
+      false,
+    );
+  });
+
+  it('never includes a forbidden namespace in the tree structure, even as an empty project', () => {
+    renderHook(() => useTreeViewData());
+
+    expect(createTreeViewData).toHaveBeenCalledWith(
+      expect.not.arrayContaining(['ns-forbidden']),
+      expect.anything(),
+      false,
+      expect.anything(),
+      false,
+    );
+  });
+
+  it('passes all project names to createTreeViewData for admin users', () => {
+    jest.requireMock('@kubevirt-utils/hooks/useIsAdmin').useIsAdmin.mockReturnValueOnce(true);
+
+    renderHook(() => useTreeViewData());
+
+    expect(createTreeViewData).toHaveBeenCalledWith(
+      projectNames,
+      expect.anything(),
+      true,
+      expect.anything(),
+      false,
+    );
+  });
+});

--- a/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
+++ b/src/views/virtualmachines/tree/hooks/useTreeViewData.ts
@@ -2,12 +2,19 @@ import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 
 import { VirtualMachineModelGroupVersionKind } from '@kubevirt-ui/kubevirt-api/console';
+import VirtualMachineModel from '@kubevirt-ui/kubevirt-api/console/models/VirtualMachineModel';
 import { V1VirtualMachine } from '@kubevirt-ui/kubevirt-api/kubevirt';
 import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
+import useMultipleAccessReviews from '@kubevirt-utils/hooks/useMultipleAccessReviews';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
-import { useK8sWatchResource, useK8sWatchResources } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  AccessReviewResourceAttributes,
+  K8sVerb,
+  useK8sWatchResource,
+  useK8sWatchResources,
+} from '@openshift-console/dynamic-plugin-sdk';
 import { TreeViewDataItem } from '@patternfly/react-core';
 import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils';
 
@@ -27,17 +34,45 @@ export const useTreeViewData = (): UseTreeViewData => {
   const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
   const [projectNames, projectNamesLoaded, projectNamesError] = useProjects();
 
-  const [allVMs, allVMsLoaded] = useK8sWatchResource<V1VirtualMachine[]>({
-    groupVersionKind: VirtualMachineModelGroupVersionKind,
-    isList: true,
-    limit: OBJECTS_FETCHING_LIMIT,
-  });
+  // Only admins can list VMs cluster-wide; non-admins rely on the per-namespace watches below.
+  const [allVMs, allVMsLoaded] = useK8sWatchResource<V1VirtualMachine[]>(
+    isAdmin && {
+      groupVersionKind: VirtualMachineModelGroupVersionKind,
+      isList: true,
+      limit: OBJECTS_FETCHING_LIMIT,
+    },
+  );
+
+  const vmAccessReviewAttributes = useMemo<AccessReviewResourceAttributes[]>(
+    () =>
+      !isAdmin
+        ? (projectNames || []).map((namespace) => ({
+            group: VirtualMachineModel.apiGroup,
+            namespace,
+            resource: VirtualMachineModel.plural,
+            verb: 'list' as K8sVerb,
+          }))
+        : [],
+    [isAdmin, projectNames],
+  );
+  const [vmAccessReviews, vmAccessReviewsLoading] =
+    useMultipleAccessReviews(vmAccessReviewAttributes);
+
+  // Drops namespaces the user can't list VMs in, even if the Project is visible.
+  const allowedNamespaces = useMemo(
+    () =>
+      (vmAccessReviews || [])
+        .filter((review) => review.allowed)
+        .map((review) => review.resourceAttributes?.namespace)
+        .filter(Boolean),
+    [vmAccessReviews],
+  );
 
   // user has limited access, so we can only get vms from allowed namespaces
   const allowedResources = useK8sWatchResources<{ [key: string]: V1VirtualMachine[] }>(
     Object.fromEntries(
-      projectNamesLoaded && !isAdmin
-        ? (projectNames || []).map((namespace) => [
+      !isAdmin
+        ? allowedNamespaces.map((namespace) => [
             namespace,
             {
               groupVersionKind: VirtualMachineModelGroupVersionKind,
@@ -50,26 +85,36 @@ export const useTreeViewData = (): UseTreeViewData => {
   );
 
   const memoizedVMs = useMemo(
-    () => (isAdmin ? allVMs : Object.values(allowedResources).flatMap((resource) => resource.data)),
+    () =>
+      isAdmin
+        ? allVMs
+        : Object.values(allowedResources).flatMap((resource) => resource?.data ?? []),
     [allVMs, allowedResources, isAdmin],
   );
 
   const loaded =
     projectNamesLoaded &&
-    (isAdmin ? allVMsLoaded : Object.values(allowedResources).some((resource) => resource.loaded));
+    (isAdmin
+      ? allVMsLoaded
+      : !vmAccessReviewsLoading &&
+        (allowedNamespaces.length === 0 ||
+          Object.values(allowedResources).every((resource) => resource?.loaded)));
+
+  // Otherwise the tree would still render (and link into) namespaces the user can't list VMs in.
+  const treeViewNamespaces = isAdmin ? projectNames : allowedNamespaces;
 
   const treeData = useMemo(
     () =>
       loaded
         ? createTreeViewData(
-            projectNames,
+            treeViewNamespaces,
             memoizedVMs,
             isAdmin,
             location.pathname,
             treeViewFoldersEnabled,
           )
         : [],
-    [projectNames, memoizedVMs, loaded, isAdmin, treeViewFoldersEnabled, location.pathname],
+    [treeViewNamespaces, memoizedVMs, loaded, isAdmin, treeViewFoldersEnabled, location.pathname],
   );
 
   const isSwitchDisabled = useMemo(() => projectNames.every(isSystemNamespace), [projectNames]);

--- a/start-console.sh
+++ b/start-console.sh
@@ -49,8 +49,8 @@ BRIDGE_K8S_MODE="off-cluster"
 BRIDGE_K8S_AUTH="bearer-token"
 BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
 BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(oc whoami --show-server)
-BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}')
-BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')
+BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}' 2>/dev/null || true)
+BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}' 2>/dev/null || true)
 BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
 BRIDGE_USER_SETTINGS_LOCATION="localstorage"
 BRIDGE_I18N_NAMESPACES="plugin__kubevirt-plugin"


### PR DESCRIPTION
## 📝 Description

Non-admin users were seeing a constant flood of 403 Forbidden errors (and slow, sometimes broken pages) because the plugin was opening live `Kubernetes` watches for `VMs`, `Templates`, `Nodes`, `NetworkAttachmentDefinitions`, and a few other resources before checking whether the user was actually allowed to list/watch them - being able to see a Project didn't mean you could list resources inside it, and "All Projects" watches silently fell back to cluster-wide requests that non-admins rarely have access to. 
This PR fixes the root cause everywhere it showed up: every affected hook now runs a `SelfSubjectAccessReview` check first (via `useAccessReview`/`useMultipleAccessReviews`) and only opens a watch for `namespaces`/`resources` the user is actually permitted to access, instead of firing first and discovering the 403 at runtime. 
It also fixes a few related issues found along the way - a VM Tree View that linked into forbidden namespaces, watches that fired on still-loading placeholder objects, and RBAC-write calls that could throw uncaught errors, plus adds unit tests covering the non-admin behavior for the hardened hooks.

## 🔗 Links

Jira ticket: [CNV-92611](https://redhat.atlassian.net/browse/CNV-92611)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/e136da53-1099-4858-97fd-a436965b2da5


After:

https://github.com/user-attachments/assets/c6cc8c4c-37ed-4aaa-8de0-8b253d099a0e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource listings and inventory views now respect access permissions, showing only namespaces and resources available to the current user.
  * Feature settings are managed according to administrator permissions, with sensible defaults when settings are unavailable.
  * Node, virtual machine, migration, and network resource views now use more consistent loading and access handling.

* **Bug Fixes**
  * Prevented unscoped resource requests while names or namespaces are still loading.
  * Improved handling of unavailable monitoring and Alertmanager configuration, avoiding startup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->