### PR TITLE
CNV-94094: add E2E tier1 tests for Group filter

### DIFF
--- a/playwright/src/components/vm/vm-list-search-components.ts
+++ b/playwright/src/components/vm/vm-list-search-components.ts
@@ -373,7 +373,7 @@ export class VmListSearchComponent extends BaseComponent {
       state: 'visible',
       timeout: TestTimeouts.ELEMENT_WAIT,
     });
-    const savedSearchButton = this._savedSearches.locator(`button:has-text("${saveName}")`);
+    const savedSearchButton = this._savedSearches.locator('button', { hasText: saveName });
     await savedSearchButton.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
     await this.robustClick(savedSearchButton);
   }
@@ -656,7 +656,7 @@ export class VmListSearchComponent extends BaseComponent {
     await dateToggle.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
     await this.robustClick(dateToggle);
     await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
-    const dateOption = this.locator(`button:has-text("${date}")`);
+    const dateOption = this.locator('button', { hasText: date });
     await dateOption.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
     await this.robustClick(dateOption);
   }
@@ -675,7 +675,7 @@ export class VmListSearchComponent extends BaseComponent {
       state: 'visible',
       timeout: TestTimeouts.ELEMENT_WAIT,
     });
-    const networkButton = this._advSearchNetwork.locator('button:has-text("Network")');
+    const networkButton = this._advSearchNetwork.locator('button', { hasText: 'Network' });
     await networkButton.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
     await this.robustClick(networkButton);
     await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
@@ -693,7 +693,7 @@ export class VmListSearchComponent extends BaseComponent {
     await labelsInput.clear();
     await labelsInput.fill(labelKey);
     await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
-    const labelButton = this.locator(`button:has-text("${labelKey}=${labelValue}")`);
+    const labelButton = this.locator('button', { hasText: `${labelKey}=${labelValue}` });
     await labelButton.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
     await this.robustClick(labelButton);
   }
@@ -706,7 +706,7 @@ export class VmListSearchComponent extends BaseComponent {
       });
       await this.robustClick(this._advSearchMemOperatorToggle);
       await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
-      const operatorButton = this.locator(`button:has-text("${operator}")`);
+      const operatorButton = this.locator('button', { hasText: operator });
       await operatorButton.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
       await this.robustClick(operatorButton);
     }
@@ -723,7 +723,7 @@ export class VmListSearchComponent extends BaseComponent {
     await nadToggle.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
     await this.robustClick(nadToggle);
     await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
-    const nadOption = this.locator(`button:has-text("${nad}")`);
+    const nadOption = this.locator('button', { hasText: nad });
     await nadOption.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
     await this.robustClick(nadOption);
   }
@@ -737,7 +737,7 @@ export class VmListSearchComponent extends BaseComponent {
     await nodeToggle.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
     await this.robustClick(nodeToggle);
     await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
-    const nodeOption = this.locator(`button:has-text("${node}")`);
+    const nodeOption = this.locator('button', { hasText: node });
     await nodeOption.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
     await this.robustClick(nodeOption);
   }
@@ -747,9 +747,21 @@ export class VmListSearchComponent extends BaseComponent {
     await osToggle.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
     await this.robustClick(osToggle);
     await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
-    const osOption = this.locator(`button:has-text("${os}")`);
+    const osOption = this.locator('button', { hasText: os });
     await osOption.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
     await this.robustClick(osOption);
+  }
+
+  async setAdvancedSearchGroup(groupName: string): Promise<void> {
+    const groupToggle = this.testId('adv-search-vm-group-toggle');
+    const groupInput = groupToggle.locator('input');
+    await groupInput.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await groupInput.clear();
+    await groupInput.fill(groupName);
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+    const option = this.locator('button[role="option"]', { hasText: groupName }).first();
+    await option.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+    await this.robustClick(option);
   }
 
   async setAdvancedSearchProject(projectName: string): Promise<void> {
@@ -758,7 +770,7 @@ export class VmListSearchComponent extends BaseComponent {
     await projectInput.clear();
     await projectInput.fill(projectName);
     await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
-    const option = this.locator(`button[role="option"]:has-text("${projectName}")`).first();
+    const option = this.locator('button[role="option"]', { hasText: projectName }).first();
     await option.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
     await this.robustClick(option);
   }
@@ -778,7 +790,7 @@ export class VmListSearchComponent extends BaseComponent {
     await scToggle.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
     await this.robustClick(scToggle);
     await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
-    const scOption = this.locator(`button:has-text("${storageClass}")`);
+    const scOption = this.locator('button', { hasText: storageClass });
     await scOption.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
     await this.robustClick(scOption);
   }
@@ -812,7 +824,7 @@ export class VmListSearchComponent extends BaseComponent {
 
   async verifySavedSearchNotExists(saveName: string): Promise<boolean> {
     try {
-      const savedSearchButton = this.locator(`button:has-text("${saveName}")`);
+      const savedSearchButton = this.locator('button', { hasText: saveName });
       await savedSearchButton
         .waitFor({ state: 'hidden', timeout: TestTimeouts.SHORT_WAIT })
         .catch(() => {

--- a/playwright/src/page-objects/vm/virtual-machines-page.ts
+++ b/playwright/src/page-objects/vm/virtual-machines-page.ts
@@ -1053,6 +1053,10 @@ export default class VirtualMachinesPage extends TreeContextMenuMixin(PageCommon
     return this.search.setAdvancedSearchDescription(description);
   }
 
+  async setAdvancedSearchGroup(groupName: string): Promise<void> {
+    return this.search.setAdvancedSearchGroup(groupName);
+  }
+
   async setAdvancedSearchIp(ipAddress: string): Promise<void> {
     return this.search.setAdvancedSearchIp(ipAddress);
   }

--- a/playwright/tests/tier1/virtualmachines/vm-search/vm-group-filter.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-search/vm-group-filter.spec.ts
@@ -1,0 +1,342 @@
+import { load as yamlLoad } from 'js-yaml';
+
+import { ADMIN_ONLY_TAG, T1, T1_TAG, VM_SEARCH_TAG } from '@/data-models/allure-constants';
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/vm-search-fixture';
+import { FOLDER_LABEL } from '@/utils/api-builders';
+import { TestTimeouts } from '@/utils/test-config';
+
+const SUITE = 'VM Group Filter';
+
+const GROUP_ALPHA = 'group-alpha';
+const GROUP_BETA = 'group-beta';
+const GROUP_GAMMA = 'group-gamma';
+
+test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
+  let vmAlpha1: string;
+  let vmAlpha2: string;
+  let vmBeta1: string;
+  let vmGamma1: string;
+  let testNamespace: string;
+
+  test.beforeAll(async ({ apiClient, testConfig, utils }) => {
+    testNamespace = testConfig.testNamespace;
+
+    vmAlpha1 = utils.generateRandomVmName('vm-a1');
+    vmAlpha2 = utils.generateRandomVmName('vm-a2');
+    vmBeta1 = utils.generateRandomVmName('vm-b1');
+    vmGamma1 = utils.generateRandomVmName('vm-g1');
+
+    const createVmWithFolder = async (vmName: string, folderName: string) => {
+      const yaml = utils.VirtualMachineFactory.create({
+        name: vmName,
+        namespace: testNamespace,
+        runStrategy: 'Halted',
+        cpuCores: 1,
+        memory: '256Mi',
+      });
+      const payload = yamlLoad(yaml) as KubernetesResource;
+      payload.metadata = {
+        ...(payload.metadata ?? {}),
+        labels: {
+          ...(payload.metadata?.labels ?? {}),
+          [FOLDER_LABEL]: folderName,
+        },
+      };
+      await apiClient.createVirtualMachine(testNamespace, payload);
+      await apiClient.waitForVmExists(vmName, testNamespace);
+    };
+
+    await createVmWithFolder(vmAlpha1, GROUP_ALPHA);
+    await createVmWithFolder(vmAlpha2, GROUP_ALPHA);
+    await createVmWithFolder(vmBeta1, GROUP_BETA);
+    await createVmWithFolder(vmGamma1, GROUP_GAMMA);
+  });
+
+  test.afterAll(async ({ apiClient }) => {
+    for (const vmName of [vmAlpha1, vmAlpha2, vmBeta1, vmGamma1]) {
+      if (vmName) {
+        await apiClient.deleteVirtualMachine(testNamespace, vmName).catch(() => undefined);
+        await apiClient.waitForVmDeleted(vmName, testNamespace).catch(() => undefined);
+      }
+    }
+  });
+
+  test.beforeEach(async ({ vmListPage }) => {
+    await vmListPage.navigateToNamespaceVirtualMachinesViaUI(testNamespace);
+    await vmListPage.clickVmListTab();
+  });
+
+  test.describe('Search language', () => {
+    test('group key visible in search suggestions', async ({ vmListPage, utils }) => {
+      await utils.withAllure({
+        suite: SUITE,
+        feature: T1,
+        tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      });
+
+      await test.step('Focus search input to open dropdown', async () => {
+        await vmListPage.typeInVmSearchInput('');
+        const dropdownVisible = await vmListPage.isSearchDropdownVisible();
+        expect
+          .soft(dropdownVisible, 'Search dropdown should appear when input is focused')
+          .toBe(true);
+      });
+
+      await test.step('Group key is visible in search suggestions', async () => {
+        const groupKeyVisible = await vmListPage.isSearchKeyVisible('group');
+        expect
+          .soft(groupKeyVisible, '"group" key should appear in the Search by section')
+          .toBe(true);
+      });
+
+      await vmListPage.pressKeyInVmSearchInput('Escape');
+    });
+
+    test('group:folderName filters VMs by group', async ({ vmListPage, utils }) => {
+      await utils.withAllure({
+        suite: SUITE,
+        feature: T1,
+        tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      });
+
+      await test.step('Submit group:group-alpha search', async () => {
+        await vmListPage.fillVmSearchInput(`group:${GROUP_ALPHA}`);
+      });
+
+      await test.step('Group filter chip appears with folder name', async () => {
+        const chips = await vmListPage.getFilterChipTexts();
+        const hasGroupChip = chips.some((chip) => chip.includes(GROUP_ALPHA));
+        expect
+          .soft(
+            hasGroupChip,
+            `Group filter chip "${GROUP_ALPHA}" should appear (got: ${chips.join(', ')})`,
+          )
+          .toBe(true);
+      });
+
+      await test.step('Only VMs in group-alpha are visible', async () => {
+        const alpha1Visible = await vmListPage.isVmVisibleByDataTest(vmAlpha1);
+        const alpha2Visible = await vmListPage.isVmVisibleByDataTest(vmAlpha2);
+        const beta1Visible = await vmListPage.isVmNameHidden(vmBeta1, TestTimeouts.SHORT_WAIT);
+
+        expect.soft(alpha1Visible, `VM ${vmAlpha1} should be visible`).toBe(true);
+        expect.soft(alpha2Visible, `VM ${vmAlpha2} should be visible`).toBe(true);
+        expect.soft(beta1Visible, `VM ${vmBeta1} should be hidden`).toBe(true);
+      });
+
+      await vmListPage.clickClearSearchButton();
+    });
+
+    test('comma-separated groups apply OR logic', async ({ vmListPage, utils }) => {
+      await utils.withAllure({
+        suite: SUITE,
+        feature: T1,
+        tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      });
+
+      await test.step('Submit group:group-alpha,group-beta search', async () => {
+        await vmListPage.fillVmSearchInput(`group:${GROUP_ALPHA},${GROUP_BETA}`);
+      });
+
+      await test.step('Both group filter chips appear', async () => {
+        const chips = await vmListPage.getFilterChipTexts();
+        const hasAlpha = chips.some((chip) => chip.includes(GROUP_ALPHA));
+        const hasBeta = chips.some((chip) => chip.includes(GROUP_BETA));
+        expect
+          .soft(hasAlpha, `Chip "${GROUP_ALPHA}" should appear (got: ${chips.join(', ')})`)
+          .toBe(true);
+        expect
+          .soft(hasBeta, `Chip "${GROUP_BETA}" should appear (got: ${chips.join(', ')})`)
+          .toBe(true);
+      });
+
+      await test.step('Alpha and beta VMs are visible, gamma VM is hidden', async () => {
+        const alpha1Visible = await vmListPage.isVmVisibleByDataTest(vmAlpha1);
+        const alpha2Visible = await vmListPage.isVmVisibleByDataTest(vmAlpha2);
+        const beta1Visible = await vmListPage.isVmVisibleByDataTest(vmBeta1);
+        const gamma1Hidden = await vmListPage.isVmNameHidden(vmGamma1, TestTimeouts.SHORT_WAIT);
+
+        expect.soft(alpha1Visible, `VM ${vmAlpha1} should be visible`).toBe(true);
+        expect.soft(alpha2Visible, `VM ${vmAlpha2} should be visible`).toBe(true);
+        expect.soft(beta1Visible, `VM ${vmBeta1} should be visible`).toBe(true);
+        expect.soft(gamma1Hidden, `VM ${vmGamma1} should be hidden`).toBe(true);
+      });
+
+      await vmListPage.clickClearSearchButton();
+    });
+
+    test('clearing group filter restores all VMs', async ({ vmListPage, utils }) => {
+      await utils.withAllure({
+        suite: SUITE,
+        feature: T1,
+        tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      });
+
+      await test.step('Apply group filter', async () => {
+        await vmListPage.fillVmSearchInput(`group:${GROUP_ALPHA}`);
+      });
+
+      await test.step('Clear search', async () => {
+        await vmListPage.clickClearSearchButton();
+      });
+
+      await test.step('All VMs are visible again', async () => {
+        const alpha1Visible = await vmListPage.isVmVisibleByDataTest(vmAlpha1);
+        const beta1Visible = await vmListPage.isVmVisibleByDataTest(vmBeta1);
+        const gamma1Visible = await vmListPage.isVmVisibleByDataTest(vmGamma1);
+
+        expect.soft(alpha1Visible, `VM ${vmAlpha1} should be visible after clear`).toBe(true);
+        expect.soft(beta1Visible, `VM ${vmBeta1} should be visible after clear`).toBe(true);
+        expect.soft(gamma1Visible, `VM ${vmGamma1} should be visible after clear`).toBe(true);
+      });
+    });
+  });
+
+  test.describe('Advanced Search modal', () => {
+    test('selecting group in modal applies filter', async ({ vmListPage, utils }) => {
+      await utils.withAllure({
+        suite: SUITE,
+        feature: T1,
+        tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      });
+
+      await test.step('Open Advanced Search modal', async () => {
+        await vmListPage.clickAdvancedSearchButton();
+      });
+
+      await test.step('Select group-alpha in the Group field', async () => {
+        await vmListPage.setAdvancedSearchGroup(GROUP_ALPHA);
+      });
+
+      await test.step('Submit the search', async () => {
+        await vmListPage.clickFooterSearchButton();
+      });
+
+      await test.step('Group filter chip appears', async () => {
+        const chips = await vmListPage.getFilterChipTexts();
+        const hasGroupChip = chips.some((chip) => chip.includes(GROUP_ALPHA));
+        expect
+          .soft(
+            hasGroupChip,
+            `Group chip "${GROUP_ALPHA}" should appear (got: ${chips.join(', ')})`,
+          )
+          .toBe(true);
+      });
+
+      await test.step('Only group-alpha VMs are listed', async () => {
+        const alpha1Visible = await vmListPage.isVmVisibleByDataTest(vmAlpha1);
+        const alpha2Visible = await vmListPage.isVmVisibleByDataTest(vmAlpha2);
+        const beta1Hidden = await vmListPage.isVmNameHidden(vmBeta1, TestTimeouts.SHORT_WAIT);
+
+        expect.soft(alpha1Visible, `VM ${vmAlpha1} should be visible`).toBe(true);
+        expect.soft(alpha2Visible, `VM ${vmAlpha2} should be visible`).toBe(true);
+        expect.soft(beta1Hidden, `VM ${vmBeta1} should be hidden`).toBe(true);
+      });
+
+      await vmListPage.clickClearSearchButton();
+    });
+
+    test('multi-group selection shows all matching VMs', async ({ vmListPage, utils }) => {
+      await utils.withAllure({
+        suite: SUITE,
+        feature: T1,
+        tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      });
+
+      await test.step('Open Advanced Search modal', async () => {
+        await vmListPage.clickAdvancedSearchButton();
+      });
+
+      await test.step('Select both groups', async () => {
+        await vmListPage.setAdvancedSearchGroup(GROUP_ALPHA);
+        await vmListPage.setAdvancedSearchGroup(GROUP_BETA);
+      });
+
+      await test.step('Submit the search', async () => {
+        await vmListPage.clickFooterSearchButton();
+      });
+
+      await test.step('Alpha and beta VMs are visible, gamma VM is hidden', async () => {
+        const alpha1Visible = await vmListPage.isVmVisibleByDataTest(vmAlpha1);
+        const alpha2Visible = await vmListPage.isVmVisibleByDataTest(vmAlpha2);
+        const beta1Visible = await vmListPage.isVmVisibleByDataTest(vmBeta1);
+        const gamma1Hidden = await vmListPage.isVmNameHidden(vmGamma1, TestTimeouts.SHORT_WAIT);
+
+        expect.soft(alpha1Visible, `VM ${vmAlpha1} should be visible`).toBe(true);
+        expect.soft(alpha2Visible, `VM ${vmAlpha2} should be visible`).toBe(true);
+        expect.soft(beta1Visible, `VM ${vmBeta1} should be visible`).toBe(true);
+        expect.soft(gamma1Hidden, `VM ${vmGamma1} should be hidden`).toBe(true);
+      });
+
+      await vmListPage.clickClearSearchButton();
+    });
+  });
+
+  test.describe('Tree view', () => {
+    test('clicking folder node applies group filter', async ({ vmListPage, utils }) => {
+      await utils.withAllure({
+        suite: SUITE,
+        feature: T1,
+        tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      });
+
+      await test.step('Expand project in tree and click group-alpha folder', async () => {
+        await vmListPage.clickTreeNodeAndEnsureExpanded(testNamespace);
+        await vmListPage.clickFolderNode(GROUP_ALPHA, testNamespace);
+      });
+
+      await test.step('URL contains group parameter', async () => {
+        const url = vmListPage.page.url();
+        const hasGroupParam = url.includes(`group=${GROUP_ALPHA}`);
+        expect
+          .soft(hasGroupParam, `URL should contain group=${GROUP_ALPHA} (got: ${url})`)
+          .toBe(true);
+      });
+
+      await test.step('Only group-alpha VMs are listed', async () => {
+        const alpha1Visible = await vmListPage.isVmVisibleByDataTest(vmAlpha1);
+        const alpha2Visible = await vmListPage.isVmVisibleByDataTest(vmAlpha2);
+        const beta1Hidden = await vmListPage.isVmNameHidden(vmBeta1, TestTimeouts.SHORT_WAIT);
+
+        expect.soft(alpha1Visible, `VM ${vmAlpha1} should be visible`).toBe(true);
+        expect.soft(alpha2Visible, `VM ${vmAlpha2} should be visible`).toBe(true);
+        expect.soft(beta1Hidden, `VM ${vmBeta1} should be hidden`).toBe(true);
+      });
+    });
+
+    test('clicking project node removes group filter', async ({ vmListPage, utils }) => {
+      await utils.withAllure({
+        suite: SUITE,
+        feature: T1,
+        tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+      });
+
+      await test.step('Click folder node to apply group filter', async () => {
+        await vmListPage.clickTreeNodeAndEnsureExpanded(testNamespace);
+        await vmListPage.clickFolderNode(GROUP_ALPHA, testNamespace);
+      });
+
+      await test.step('Click project node to remove group filter', async () => {
+        await vmListPage.clickProjectNode(testNamespace);
+      });
+
+      await test.step('URL no longer contains group parameter', async () => {
+        const url = vmListPage.page.url();
+        const hasGroupParam = url.includes('group=');
+        expect.soft(hasGroupParam, `URL should not contain group= (got: ${url})`).toBe(false);
+      });
+
+      await test.step('All VMs are visible again', async () => {
+        await vmListPage.clickVmListTab();
+        const alpha1Visible = await vmListPage.isVmVisibleByDataTest(vmAlpha1);
+        const beta1Visible = await vmListPage.isVmVisibleByDataTest(vmBeta1);
+        const gamma1Visible = await vmListPage.isVmVisibleByDataTest(vmGamma1);
+
+        expect.soft(alpha1Visible, `VM ${vmAlpha1} should be visible`).toBe(true);
+        expect.soft(beta1Visible, `VM ${vmBeta1} should be visible`).toBe(true);
+        expect.soft(gamma1Visible, `VM ${vmGamma1} should be visible`).toBe(true);
+      });
+    });
+  });
+});

--- a/src/utils/utils/selectDataTest.ts
+++ b/src/utils/utils/selectDataTest.ts
@@ -1,4 +1,4 @@
-import { MenuToggleProps } from '@patternfly/react-core';
+import { type MenuToggleProps } from '@patternfly/react-core';
 
 export const getSelectDataTestProps = (dataTest?: string) => {
   if (!dataTest) {

--- a/src/views/search/components/AdvancedSearchModal/formFields/GroupField.tsx
+++ b/src/views/search/components/AdvancedSearchModal/formFields/GroupField.tsx
@@ -1,6 +1,6 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import MultiSelectTypeahead from '@kubevirt-utils/components/MultiSelectTypeahead/MultiSelectTypeahead';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup } from '@patternfly/react-core';
@@ -23,6 +23,7 @@ const GroupField: FC<GroupFieldProps> = ({ vms }) => {
     <FormGroup label={t('Group')}>
       <MultiSelectTypeahead
         allResourceNames={allGroupNames}
+        data-test="adv-search-vm-group"
         emptyValuePlaceholder={t('All groups')}
         selectedResourceNames={value}
         selectPlaceholder={t('Select group')}


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Adds E2E tier1 tests for Group filter

- tests using "group" in search language
- tests Group select in Advanced search modal
- tests tree view clicking on groups

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-94094

## 🎥 Demo

Locally all the new tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advanced search support for filtering virtual machines by group.
  * Added group filtering across single and multiple groups, including tree-view folder and project filters.
  * Added group selection support in the Advanced Search dialog.

* **Bug Fixes**
  * Improved reliability of virtual machine search controls and filtering interactions.

* **Tests**
  * Added comprehensive end-to-end coverage for group suggestions, filtering, clearing filters, and URL updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->