### PR TITLE
CNV-89946: Add Playwright tests for upload experience improvements

### DIFF
--- a/playwright/docs/STD-TEMPLATE.md
+++ b/playwright/docs/STD-TEMPLATE.md
@@ -1,0 +1,88 @@
+# Software Test Description (STD): [Feature/Component Name]
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** [e.g., Gating — VM management, Tier1 — Bootable volumes]
+- **Latest version:** [Most recent CNV release this document was validated against, e.g., CNV 4.22]
+- **Latest update:** [YYYY-MM-DD of the most recent edit to this document]
+- **Document Status:** [Draft / In Review / Approved — if the tests described are included in the PR and have been verified locally, mark as Approved]
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+[Clearly describe what functionality is being verified. Reference the feature area and test tier.]
+
+### 2.2 Scope
+
+- **In-Scope:** [Components, UI elements, workflows, or APIs being tested]
+- **Out-of-Scope:** [Areas explicitly excluded — reference other STDs where applicable]
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** [Required cluster setup, e.g., OpenShift with CNV operator]
+- **Configuration:** [Specific configurations, feature gates, or env vars needed]
+- **Initial Setup:** [Any beforeAll resource creation; cleanup mechanism used]
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/<tier>/<feature>/<file>.spec.ts`
+**Describe:** `[describe block title]` — **Tags:** `@<tier>`
+**Allure:** suite `[suite constant]`, feature `[tier constant]`
+
+---
+
+### `001`: [Functional title — describes what the system does; no Jira ticket IDs in title]
+
+- **Objective:** [What behavior is verified in one sentence]
+- **Target version:** [CNV release this scenario was written for / first covers, e.g., CNV 4.22]
+- **Jira References:** [CNV-XXXXX, CNV-YYYYY — tickets whose feature/bugfix this scenario covers; omit if none]
+- **Pre-conditions:** [Any test.skip() conditions or required cluster state]
+- **Tags:** [e.g., `@gating`, `@nonpriv`]
+
+| Step | Action                                | Expected Result    |
+| :--- | :------------------------------------ | :----------------- |
+| 1    | [Navigate to / click / fill / assert] | [Expected outcome] |
+| 2    | [Next action]                         | [Expected outcome] |
+
+---
+
+### `002`: [Functional title]
+
+- **Objective:** [What behavior is verified]
+- **Target version:** [CNV release this scenario was written for / first covers]
+- **Jira References:** [CNV-XXXXX — or omit if functional smoke with no specific ticket]
+- **Pre-conditions:** [e.g., VM must be in Running state]
+
+| Step | Action   | Expected Result |
+| :--- | :------- | :-------------- |
+| 1    | [action] | [expected]      |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+Maps Jira tickets to the test cases that provide coverage. Tickets without a specific test case indicate
+a planned coverage gap (status: Pending).
+
+| Jira Ticket | Test Case ID | Coverage Type           | Status    |
+| ----------- | ------------ | ----------------------- | --------- |
+| CNV-XXXXX   | `001`        | Feature coverage        | Automated |
+| CNV-YYYYY   | `001`        | Bugfix regression guard | Automated |
+| CNV-ZZZZZ   | `002`        | Feature coverage        | Draft     |
+| —           | `003`        | Functional smoke        | Automated |
+
+**Coverage Type values:**
+
+- `Feature coverage` — test validates a feature delivered by the ticket
+- `Bugfix regression guard` — test asserts the specific bug fixed by the ticket does not regress
+- `Functional smoke` — test validates baseline behavior; no specific Jira ticket drives it
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** ********\_\_********
+- **Approval Signature:** ********\_\_********

--- a/playwright/src/clients/request-context-client.ts
+++ b/playwright/src/clients/request-context-client.ts
@@ -3,6 +3,7 @@ import type {
   KubernetesListResource,
   KubernetesResource,
 } from '@/data-models/kubernetes-types';
+import { DATA_VOLUME_DELETION_POLLING } from '@/data-models/constants';
 import type { APIRequestContext, APIResponse, Page } from '@playwright/test';
 
 import type { ClusterAuthConfig } from './base-client';
@@ -1093,6 +1094,24 @@ export default class RequestContextClient extends BaseClient implements ProxyApi
         // not ready yet
       }
       await new Promise((r) => setTimeout(r, 3000));
+    }
+    return false;
+  }
+
+  async waitForDataVolumeGone(
+    name: string,
+    namespace: string,
+    timeoutMs = DATA_VOLUME_DELETION_POLLING.TIMEOUT_MS,
+  ): Promise<boolean> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const dv = await this.getDataVolume(namespace, name);
+        if (!dv) return true;
+      } catch {
+        // Non-404 error (auth, proxy, server, etc.) — keep retrying until timeout.
+      }
+      await new Promise((r) => setTimeout(r, DATA_VOLUME_DELETION_POLLING.RETRY_INTERVAL_MS));
     }
     return false;
   }

--- a/playwright/src/components/create-vm/bootable-volumes-create-components.ts
+++ b/playwright/src/components/create-vm/bootable-volumes-create-components.ts
@@ -119,6 +119,17 @@ export class BootableVolumesRowActionsComponent extends BaseComponent {
    * Clicks Cancel in the Manage source modal.
    */
   async cancelManageSourceModal(): Promise<void> {
+    await this.cancelOpenDialogModal();
+  }
+
+  /**
+   * Clicks Cancel in the Upload to registry modal.
+   */
+  async cancelUploadToRegistryModal(): Promise<void> {
+    await this.cancelOpenDialogModal();
+  }
+
+  private async cancelOpenDialogModal(): Promise<void> {
     const cancelButton = this._dialogModal.locator('button', { hasText: 'Cancel' });
     await cancelButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
     await this.robustClick(cancelButton);
@@ -359,19 +370,30 @@ export class BootableVolumesRowActionsComponent extends BaseComponent {
   }
 
   /**
-   * Verifies that the Upload to registry modal shows the Upload steps section
-   * ([aria-label="Upload steps"]). Call after clickRowActionUploadToRegistry(volumeName).
+   * Verifies that the Upload to registry modal has rendered its form fields
+   * (Name, Destination, Username, Password). Call after
+   * clickRowActionUploadToRegistry(volumeName).
    */
-  async verifyUploadStepsVisibleInUploadToRegistryModal(): Promise<boolean> {
-    await this.page.waitForLoadState('load', {
-      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
-    });
-    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_EXTRA);
+  async verifyUploadToRegistryFormFieldsVisible(): Promise<boolean> {
+    const dialog = this._dialogModal;
+    await dialog.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
 
-    const uploadSteps = this.locator('[aria-label="Upload steps"]');
-    return await uploadSteps
-      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
-      .catch(() => false);
+    const requiredFields = [
+      dialog.locator('#registryName'),
+      dialog.locator('#destination'),
+      dialog.locator('#username'),
+      dialog.locator('#password'),
+    ];
+
+    for (const field of requiredFields) {
+      const visible = await field
+        .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+        .then(() => true)
+        .catch(() => false);
+      if (!visible) return false;
+    }
+
+    return true;
   }
 }
 

--- a/playwright/src/components/shared/page-content-component.ts
+++ b/playwright/src/components/shared/page-content-component.ts
@@ -181,6 +181,16 @@ export default class PageContentComponent extends BaseComponent {
     await this.page.waitForLoadState('domcontentloaded');
   }
 
+  async waitForElementHidden(
+    selector: string,
+    timeout: number = TestTimeouts.ELEMENT_WAIT,
+  ): Promise<boolean> {
+    return this.locator(selector)
+      .waitFor({ state: 'hidden', timeout })
+      .then(() => true)
+      .catch(() => false);
+  }
+
   async waitForLoadStateNetworkIdle(timeoutMs = 30_000): Promise<void> {
     await this.page.waitForLoadState('networkidle', { timeout: timeoutMs }).catch(() => undefined);
   }

--- a/playwright/src/components/shared/upload-progress-toast-component.ts
+++ b/playwright/src/components/shared/upload-progress-toast-component.ts
@@ -1,0 +1,170 @@
+/**
+ * Upload progress toast — shared component for the CDI upload-experience toasts
+ * (see `useUploadProgressToast` in product code). Covers the "uploading" toast
+ * (with abort action and context links), the terminal success toast (with links),
+ * and the terminal aborted/error toasts.
+ */
+
+import { TestTimeouts } from '@/utils/test-config';
+import type { Locator, Page } from '@playwright/test';
+
+import BaseComponent from './base-component';
+
+export default class UploadProgressToastComponent extends BaseComponent {
+  private readonly _abortButton = this.testId('upload-progress-abort');
+  private readonly _abortedToast = this.testId('upload-progress-aborted-toast');
+  private readonly _errorToast = this.testId('upload-progress-error-toast');
+  private readonly _successToast = this.testId('upload-progress-success-toast');
+  private readonly _uploadingToast = this.testId('upload-progress-toast');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Clicks the abort ("Cancel upload") button. When `fileName` is provided, scopes
+   * to the uploading toast that contains that file name.
+   */
+  async clickAbortUpload(fileName?: string): Promise<void> {
+    const abortButton = fileName
+      ? this.toastContaining(this._uploadingToast, fileName).getByTestId('upload-progress-abort')
+      : this._abortButton;
+
+    await abortButton.first().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(abortButton.first());
+  }
+
+  /** Waits until the aborted toast is visible (optionally matching `fileName`). */
+  async expectAbortedToastVisible(
+    fileName?: string,
+    timeout = TestTimeouts.UI_ELEMENT_VISIBILITY,
+  ): Promise<void> {
+    await this.waitForToastVisible(this._abortedToast, fileName, timeout, 'aborted');
+  }
+
+  /** Waits until the error toast is visible (optionally matching `fileName`). */
+  async expectErrorToastVisible(
+    fileName?: string,
+    timeout = TestTimeouts.UI_ELEMENT_VISIBILITY,
+  ): Promise<void> {
+    await this.waitForToastVisible(this._errorToast, fileName, timeout, 'error');
+  }
+
+  /**
+   * Waits until either the uploading toast or a terminal (success/error/aborted)
+   * toast is visible. Useful when auth may fail before an abortable upload starts.
+   */
+  async expectUploadingOrTerminalToastVisible(
+    fileName?: string,
+    timeout = TestTimeouts.UI_ELEMENT_VISIBILITY,
+  ): Promise<'uploading' | 'success' | 'error' | 'aborted'> {
+    const uploading = this.toastContaining(this._uploadingToast, fileName);
+    const success = this.toastContaining(this._successToast, fileName);
+    const error = this.toastContaining(this._errorToast, fileName);
+    const aborted = this.toastContaining(this._abortedToast, fileName);
+
+    const start = Date.now();
+    await uploading
+      .or(success)
+      .or(error)
+      .or(aborted)
+      .first()
+      .waitFor({ state: 'visible', timeout });
+
+    // The toast that triggered the wait above may have already transitioned to another
+    // state by the time we classify it (e.g. a fast upload moving from "uploading" to
+    // "success"), so keep polling for the remaining time budget instead of checking once.
+    while (Date.now() - start < timeout) {
+      if (await uploading.first().isVisible().catch(() => false)) return 'uploading';
+      if (await success.first().isVisible().catch(() => false)) return 'success';
+      if (await error.first().isVisible().catch(() => false)) return 'error';
+      if (await aborted.first().isVisible().catch(() => false)) return 'aborted';
+      await this.page.waitForTimeout(100);
+    }
+
+    throw new Error(
+      `Upload toast became visible but could not classify state${fileName ? ` for "${fileName}"` : ''}`,
+    );
+  }
+
+  /**
+   * Waits until the success toast is visible, and (if given) contains a link
+   * with the expected label (e.g. "View volume", "View pod logs").
+   */
+  async expectSuccessToastWithLink(
+    linkLabel?: string,
+    timeout = TestTimeouts.UI_ELEMENT_VISIBILITY,
+  ): Promise<void> {
+    await this._successToast.first().waitFor({ state: 'visible', timeout });
+
+    if (!linkLabel) {
+      return;
+    }
+
+    await this._successToast
+      .locator('[data-test="upload-progress-link"]')
+      .filter({ hasText: linkLabel })
+      .first()
+      .waitFor({ state: 'visible', timeout });
+  }
+
+  /** Waits until the uploading toast for the given file (if provided) is visible. */
+  async expectUploadingToastVisible(
+    fileName?: string,
+    timeout = TestTimeouts.UI_ELEMENT_VISIBILITY,
+  ): Promise<void> {
+    await this.waitForToastVisible(this._uploadingToast, fileName, timeout, 'uploading');
+  }
+
+  /** Whether the abort button is currently visible (optionally scoped to `fileName`). */
+  async isAbortButtonVisible(
+    timeout = TestTimeouts.UI_DELAY_MEDIUM,
+    fileName?: string,
+  ): Promise<boolean> {
+    const abortButton = fileName
+      ? this.toastContaining(this._uploadingToast, fileName).getByTestId('upload-progress-abort')
+      : this._abortButton;
+
+    return abortButton
+      .first()
+      .isVisible({ timeout })
+      .catch(() => false);
+  }
+
+  /** Whether any upload toast (uploading or success) is currently visible. */
+  async isAnyUploadToastVisible(timeout = TestTimeouts.UI_DELAY_MEDIUM): Promise<boolean> {
+    return this._uploadingToast
+      .or(this._successToast)
+      .or(this._abortedToast)
+      .or(this._errorToast)
+      .first()
+      .isVisible({ timeout })
+      .catch(() => false);
+  }
+
+  private toastContaining(root: Locator, fileName?: string): Locator {
+    if (!fileName) {
+      return root;
+    }
+    return root.filter({ hasText: fileName });
+  }
+
+  private async waitForToastVisible(
+    root: Locator,
+    fileName: string | undefined,
+    timeout: number,
+    kind: string,
+  ): Promise<void> {
+    try {
+      await this.toastContaining(root, fileName)
+        .first()
+        .waitFor({ state: 'visible', timeout });
+    } catch {
+      const suffix = fileName ? ` for "${fileName}"` : '';
+      throw new Error(`Expected ${kind} upload toast to be visible${suffix} within ${timeout}ms`);
+    }
+  }
+}

--- a/playwright/src/components/vm/vm-detail-config-components.ts
+++ b/playwright/src/components/vm/vm-detail-config-components.ts
@@ -102,13 +102,19 @@ export class VirtualMachineDetailConfigurationCdromComponent extends BaseCompone
 
       await this._fileInput.setInputFiles(sourceValue);
 
-      await this._tabModal
-        .locator('[role="progressbar"], .pf-v6-c-progress, .pf-c-progress')
-        .first()
-        .waitFor({ state: 'visible', timeout: TestTimeouts.FILE_UPLOAD })
-        .catch(() => undefined);
-
-      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+      const fileBasename = sourceValue.split('/').pop() ?? sourceValue;
+      await this._inputIdSimpleFileFilename.waitFor({
+        state: 'attached',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.page.waitForFunction(
+        ({ selector, name }) => {
+          const input = document.querySelector(selector) as HTMLInputElement | null;
+          return Boolean(input?.value && input.value.includes(name));
+        },
+        { selector: 'input[id="simple-file-filename"]', name: fileBasename },
+        { timeout: TestTimeouts.UI_ACTION_COMPLETE },
+      );
     } else if (cdromSource === 'Use existing ISO' && sourceValue) {
       const mountExistingRadio = this.page.locator(
         'input[id="cdrom-source-existing"], input#cdrom-source-existing',

--- a/playwright/src/data-factories/test-file-factory.ts
+++ b/playwright/src/data-factories/test-file-factory.ts
@@ -3,6 +3,8 @@ import * as http from 'http';
 import * as https from 'https';
 import * as path from 'path';
 
+import { TEST_FILE_SIZES } from '@/data-models/constants';
+
 /**
  * Data factory for creating test files in the .test-data directory.
  *
@@ -26,12 +28,35 @@ export class TestFileFactory {
    * ```
    */
   static createEmptyIsoFile(filename: string): string {
-    const testDataDir = this.ensureTestDataDirectory();
-    const filePath = path.join(testDataDir, filename);
-
-    // Create empty ISO file
+    const filePath = this.resolveSafeFilePath(filename);
     fs.writeFileSync(filePath, '');
+    return filePath;
+  }
 
+  /**
+   * Creates a non-empty ISO-like file large enough that CDI uploads stay in
+   * progress long enough for abort/toast assertions (default 5 MiB).
+   */
+  static createSizedIsoFile(
+    filename: string,
+    sizeBytes = TEST_FILE_SIZES.DEFAULT_ISO_SIZE_BYTES,
+  ): string {
+    if (!Number.isSafeInteger(sizeBytes) || sizeBytes <= 0) {
+      throw new Error(`Invalid sizeBytes (must be a positive safe integer): ${sizeBytes}`);
+    }
+    const filePath = this.resolveSafeFilePath(filename);
+    const chunk = Buffer.alloc(TEST_FILE_SIZES.ISO_WRITE_CHUNK_SIZE_BYTES, 0);
+    const fd = fs.openSync(filePath, 'w');
+    try {
+      let written = 0;
+      while (written < sizeBytes) {
+        const toWrite = Math.min(chunk.length, sizeBytes - written);
+        fs.writeSync(fd, chunk, 0, toWrite);
+        written += toWrite;
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
     return filePath;
   }
 
@@ -50,8 +75,7 @@ export class TestFileFactory {
    * ```
    */
   static async downloadCirrosImage(filename: string, url?: string): Promise<string> {
-    const testDataDir = this.ensureTestDataDirectory();
-    const filePath = path.join(testDataDir, filename);
+    const filePath = this.resolveSafeFilePath(filename);
     const cirrosUrl = url || 'https://download.cirros-cloud.net/0.3.0/cirros-0.3.0-x86_64-disk.img';
 
     // If file already exists, return the path (avoid re-downloading)
@@ -132,8 +156,7 @@ export class TestFileFactory {
    * ```
    */
   static async downloadIsoFile(filename: string, url?: string): Promise<string> {
-    const testDataDir = this.ensureTestDataDirectory();
-    const filePath = path.join(testDataDir, filename);
+    const filePath = this.resolveSafeFilePath(filename);
     // Default to CirrOS ISO - a small, commonly used test ISO
     const isoUrl = url || 'https://download.cirros-cloud.net/0.3.0/cirros-0.3.0-x86_64-disk.iso';
 
@@ -221,4 +244,15 @@ export class TestFileFactory {
     const projectRoot = process.cwd();
     return path.join(projectRoot, this.TEST_DATA_DIR);
   }
+
+  /** Resolves a basename-only filename under `.test-data`, rejecting path traversal. */
+  private static resolveSafeFilePath(filename: string): string {
+    const base = path.basename(filename);
+    if (!filename || filename === '.' || base !== filename || filename.includes('..') || path.isAbsolute(filename)) {
+      throw new Error(`Invalid test filename (basename only required): ${filename}`);
+    }
+    const testDataDir = this.ensureTestDataDirectory();
+    return path.join(testDataDir, base);
+  }
 }
+

--- a/playwright/src/data-models/constants.ts
+++ b/playwright/src/data-models/constants.ts
@@ -734,3 +734,24 @@ export const SSH_KEY_PATHS = {
   /** Public SSH key file path */
   PUBLIC_KEY: './fixtures/rsa.pub',
 } as const;
+
+/**
+ * Byte-size constants for generated test files (see TestFileFactory)
+ */
+export const TEST_FILE_SIZES = {
+  /** Default size for a non-empty ISO-like file, large enough to keep a CDI upload
+   * in progress long enough for abort/toast assertions. */
+  DEFAULT_ISO_SIZE_BYTES: 5 * 1024 * 1024,
+  /** Chunk size used when writing a sized test file to disk. */
+  ISO_WRITE_CHUNK_SIZE_BYTES: 64 * 1024,
+} as const;
+
+/**
+ * DataVolume deletion polling constants
+ */
+export const DATA_VOLUME_DELETION_POLLING = {
+  /** Timeout for waiting for DataVolume deletion in milliseconds */
+  TIMEOUT_MS: 60_000,
+  /** Retry interval for polling DataVolume deletion in milliseconds */
+  RETRY_INTERVAL_MS: 2000,
+} as const;

--- a/playwright/src/page-objects/base-page.ts
+++ b/playwright/src/page-objects/base-page.ts
@@ -6,7 +6,7 @@
 import BaseComponent from '@/components/shared/base-component';
 import type { ContextKey, ContextValueType } from '@/context-managers/context-keys';
 import ScenarioContextManager from '@/context-managers/scenario-context-manager';
-import { EnvVariables } from '@/utils/env-variables';
+
 import type { TrackedResourceType } from '@/utils/test-resource-tracker';
 import type { Page, TestInfo } from '@playwright/test';
 import { test as base } from '@playwright/test';
@@ -43,6 +43,7 @@ const TIMEOUT_PATTERNS: RegExp[] = [
   /waiting for selector/i,
   /Navigation timeout/i,
   /net::ERR_TIMED_OUT/i,
+  /within \d+ms$/i,
 ];
 
 export type TimeoutAwareTestInfo = TestInfo & {

--- a/playwright/src/page-objects/create-vm/bootable-volumes-page.ts
+++ b/playwright/src/page-objects/create-vm/bootable-volumes-page.ts
@@ -7,6 +7,7 @@ import {
   BootableVolumesCreateFormsComponent,
   BootableVolumesRowActionsComponent,
 } from '@/components/create-vm/bootable-volumes-create-components';
+import UploadProgressToastComponent from '@/components/shared/upload-progress-toast-component';
 import { TestTimeouts } from '@/utils/test-config';
 import type { Page } from '@playwright/test';
 
@@ -35,11 +36,13 @@ export default class BootableVolumesPage extends PageCommons {
   );
   readonly createForms: BootableVolumesCreateFormsComponent;
   readonly rowActions: BootableVolumesRowActionsComponent;
+  private readonly uploadToast: UploadProgressToastComponent;
 
   constructor(page: Page) {
     super(page);
     this.createForms = new BootableVolumesCreateFormsComponent(page);
     this.rowActions = new BootableVolumesRowActionsComponent(page);
+    this.uploadToast = new UploadProgressToastComponent(page);
   }
 
   private async navigateToNamespaceClientSide(namespace: string): Promise<void> {
@@ -79,12 +82,20 @@ export default class BootableVolumesPage extends PageCommons {
     return this.rowActions.cancelManageSourceModal();
   }
 
+  async cancelUploadToRegistryModal(): Promise<void> {
+    return this.rowActions.cancelUploadToRegistryModal();
+  }
+
   async checkDeletePvcCheckbox(): Promise<void> {
     return this.rowActions.checkDeletePvcCheckbox();
   }
 
   async clearAllFilters(): Promise<void> {
     await this.filterToolbar.clearAllFilters();
+  }
+
+  async clickAbortUpload(fileName?: string): Promise<void> {
+    return this.uploadToast.clickAbortUpload(fileName);
   }
 
   override async clickCreateAndSelectOption(option: 'With form' | 'With YAML') {
@@ -192,6 +203,29 @@ export default class BootableVolumesPage extends PageCommons {
       await this.ensureDataVolumeRowVisibleWithReNav(volumeName, namespace);
       await action();
     }
+  }
+
+  async expectAbortedUploadToastVisible(fileName?: string, timeout?: number): Promise<void> {
+    return this.uploadToast.expectAbortedToastVisible(fileName, timeout);
+  }
+
+  async expectSuccessUploadToastWithLink(linkLabel?: string, timeout?: number): Promise<void> {
+    return this.uploadToast.expectSuccessToastWithLink(linkLabel, timeout);
+  }
+
+  async expectUploadingOrTerminalToastVisible(
+    fileName?: string,
+    timeout?: number,
+  ): Promise<'uploading' | 'success' | 'error' | 'aborted'> {
+    return this.uploadToast.expectUploadingOrTerminalToastVisible(fileName, timeout);
+  }
+
+  async expectUploadingToastVisible(fileName?: string, timeout?: number): Promise<void> {
+    return this.uploadToast.expectUploadingToastVisible(fileName, timeout);
+  }
+
+  async expectErrorUploadToastVisible(fileName?: string, timeout?: number): Promise<void> {
+    return this.uploadToast.expectErrorToastVisible(fileName, timeout);
   }
 
   async fillCreateBootableVolumeFormAndSave(
@@ -318,6 +352,14 @@ export default class BootableVolumesPage extends PageCommons {
   async getVisibleRowCount(): Promise<number> {
     return this._row.count();
   }
+  async isAbortUploadButtonVisible(timeout?: number, fileName?: string): Promise<boolean> {
+    return this.uploadToast.isAbortButtonVisible(timeout, fileName);
+  }
+
+  async isAnyUploadToastVisible(timeout?: number): Promise<boolean> {
+    return this.uploadToast.isAnyUploadToastVisible(timeout);
+  }
+
   async isClusterFilterButtonVisible(
     timeout: number = TestTimeouts.UI_VISIBILITY_QUICK,
   ): Promise<boolean> {
@@ -660,8 +702,8 @@ export default class BootableVolumesPage extends PageCommons {
     }
   }
 
-  async verifyUploadStepsVisibleInUploadToRegistryModal(): Promise<boolean> {
-    return this.rowActions.verifyUploadStepsVisibleInUploadToRegistryModal();
+  async verifyUploadToRegistryFormFieldsVisible(): Promise<boolean> {
+    return this.rowActions.verifyUploadToRegistryFormFieldsVisible();
   }
 
   async waitForClusterFilterApplied(): Promise<void> {

--- a/playwright/src/page-objects/page-commons.ts
+++ b/playwright/src/page-objects/page-commons.ts
@@ -859,6 +859,13 @@ export default class PageCommons extends BasePage {
     await this.pageContent.waitForDomContentLoaded();
   }
 
+  async waitForElementHidden(
+    selector: string,
+    timeout: number = TestTimeouts.ELEMENT_WAIT,
+  ): Promise<boolean> {
+    return this.pageContent.waitForElementHidden(selector, timeout);
+  }
+
   async waitForLoadStateNetworkIdle(timeoutMs = 30_000): Promise<void> {
     await this.pageContent.waitForLoadStateNetworkIdle(timeoutMs);
   }

--- a/playwright/src/page-objects/vm/virtual-machine-detail-page.ts
+++ b/playwright/src/page-objects/vm/virtual-machine-detail-page.ts
@@ -2,6 +2,7 @@
  * Page object for VirtualMachine detail/overview page.
  */
 
+import UploadProgressToastComponent from '@/components/shared/upload-progress-toast-component';
 import { DISK_NAMES } from '@/data-models';
 import { TestTimeouts } from '@/utils/test-config';
 import type { Page } from '@playwright/test';
@@ -42,6 +43,7 @@ export default class VirtualMachineDetailPage extends PageCommons {
   readonly overviewTab: VirtualMachineDetailOverviewTabPage;
   readonly overviewWidgets: VirtualMachineDetailOverviewWidgetsPage;
   readonly scheduling: VirtualMachineDetailSchedulingPage;
+  private readonly uploadToast: UploadProgressToastComponent;
 
   constructor(page: Page) {
     super(page);
@@ -61,6 +63,7 @@ export default class VirtualMachineDetailPage extends PageCommons {
       this.overviewWidgets,
       this.configuration,
     );
+    this.uploadToast = new UploadProgressToastComponent(page);
   }
 
   async addBlankDisk(diskName: string, size = '1', storageClass?: string): Promise<boolean> {
@@ -174,6 +177,10 @@ export default class VirtualMachineDetailPage extends PageCommons {
 
   override async clickActionsDropdown() {
     return this.actions.clickActionsDropdown();
+  }
+
+  async clickAbortUpload(fileName?: string): Promise<void> {
+    return this.uploadToast.clickAbortUpload(fileName);
   }
 
   async clickConfigurationStorageSubTab() {
@@ -333,6 +340,25 @@ export default class VirtualMachineDetailPage extends PageCommons {
 
   async expandWarningSeverityAccordion(): Promise<void> {
     return this.alerts.expandWarningSeverityAccordion();
+  }
+
+  async expectAbortedUploadToastVisible(fileName?: string, timeout?: number): Promise<void> {
+    return this.uploadToast.expectAbortedToastVisible(fileName, timeout);
+  }
+
+  async expectUploadingOrTerminalToastVisible(
+    fileName?: string,
+    timeout?: number,
+  ): Promise<'uploading' | 'success' | 'error' | 'aborted'> {
+    return this.uploadToast.expectUploadingOrTerminalToastVisible(fileName, timeout);
+  }
+
+  async expectUploadingToastVisible(fileName?: string, timeout?: number): Promise<void> {
+    return this.uploadToast.expectUploadingToastVisible(fileName, timeout);
+  }
+
+  async isAbortUploadButtonVisible(timeout?: number, fileName?: string): Promise<boolean> {
+    return this.uploadToast.isAbortButtonVisible(timeout, fileName);
   }
 
   async getAffinityRulesButtonText(): Promise<string> {

--- a/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload-to-registry.spec.md
+++ b/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload-to-registry.spec.md
@@ -1,0 +1,104 @@
+# Software Test Description (STD): Bootable Volumes — Upload to Registry
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier1 — Bootable volumes
+- **Latest version:** CNV 5.00
+- **Latest update:** 2026-08-17
+- **Document Status:** Approved
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify the "Upload to registry" export flow for an existing bootable volume: form validation, save
+behavior, modal close-on-submit, and the resulting background export toast.
+
+### 2.2 Scope
+
+- **In-Scope:** Upload to registry modal field validation (Save enabled/disabled), submit behavior,
+  modal auto-close on submit, background toast state after submit (uploading or terminal
+  error/aborted).
+- **Out-of-Scope:** Successful export against a real container registry, password show/hide toggle, and
+  Stepper "In progress" vs "Completed" state rendering (CNV-89815 UX items not asserted here).
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator installed; Playwright `Tier1` project.
+- **Configuration:** No special feature gates required. Uses a dummy Quay destination
+  (`docker://quay.io/kubevirt-plugin-pw-tests/dummy-export:latest`) with placeholder credentials — no
+  real registry access is required or exercised.
+- **Initial Setup:** Each test creates its own namespace via `setupTestNamespace`, then creates a blank
+  DataVolume and a corresponding DataSource via the API (`createBootableVolumeViaApi`) to have an
+  existing bootable volume to export. Created resources are tracked via `apiClient.trackResource(...)`
+  for automatic cleanup.
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier1/bootable-volumes/bootable-volumes-upload-to-registry.spec.ts`
+**Describe:** `Tier1 Bootable Volumes - Upload to registry` — **Tags:** `@tier1`
+**Allure:** suite `Test Virtualization Bootable volumes page`, feature `Tier 1`
+
+---
+
+### `001`: Save is disabled until all required fields are filled
+
+- **Objective:** Verify the Upload to registry modal's Save button stays disabled until destination,
+  username, and password are all provided.
+- **Target version:** CNV 5.00
+- **Jira References:** CNV-89946, CNV-87382, CNV-89815
+- **Pre-conditions:** A bootable volume (DataVolume + DataSource) already exists in the test namespace
+- **Tags:** `@nonpriv`
+
+| Step | Action                                                           | Expected Result                                               |
+| :--- | :--------------------------------------------------------------- | :------------------------------------------------------------ |
+| 1    | Open the row action "Upload to registry" for the existing volume | Modal opens with all expected form fields visible             |
+| 2    | Check the Save button state with an empty form                   | Save is disabled                                              |
+| 3    | Fill only the registry name and check Save state                 | Save remains disabled (destination/username/password not set) |
+| 4    | Fill destination, username, and password, then check Save state  | Save becomes enabled                                          |
+| 5    | Cancel the modal                                                 | Modal closes without creating an export                       |
+
+---
+
+### `002`: Form submits successfully, closes the modal automatically, and shows an uploading or terminal toast
+
+- **Objective:** Verify that a completed and submitted Upload to registry form closes the modal
+  automatically and surfaces a background progress toast (or an expected terminal state given dummy
+  credentials).
+- **Target version:** CNV 5.00
+- **Jira References:** CNV-89946, CNV-87382, CNV-89815
+- **Pre-conditions:** A bootable volume (DataVolume + DataSource) already exists in the test namespace
+- **Tags:** `@nonpriv`
+
+| Step | Action                                                                             | Expected Result                                                                                                                                                                                     |
+| :--- | :--------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1    | Fill the Upload to registry form with destination/username/password and click Save | Form submits without client-side validation errors                                                                                                                                                  |
+| 2    | Observe the modal                                                                  | Modal (`#tab-modal`) closes automatically while the export continues in the background                                                                                                              |
+| 3    | Observe the resulting toast                                                        | Uploading toast is shown, **or** the export reaches a terminal `error`/`aborted` toast state because the dummy registry credentials are invalid; if still uploading, the test aborts it to clean up |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+| Jira Ticket | Test Case ID | Coverage Type    | Status    |
+| ----------- | ------------ | ---------------- | --------- |
+| CNV-89946   | `001`        | Feature coverage | Automated |
+| CNV-89946   | `002`        | Feature coverage | Automated |
+| CNV-89815   | `001`        | Feature coverage | Automated |
+| CNV-89815   | `002`        | Feature coverage | Automated |
+| CNV-87382   | `002`        | Feature coverage | Automated |
+
+**Coverage Type values:**
+
+- `Feature coverage` — test validates a feature delivered by the ticket
+- `Bugfix regression guard` — test asserts the specific bug fixed by the ticket does not regress
+- `Functional smoke` — test validates baseline behavior; no specific Jira ticket drives it
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** Gal Kremer
+- **Approval Signature:** Gal Kremer

--- a/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload-to-registry.spec.ts
+++ b/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload-to-registry.spec.ts
@@ -1,0 +1,191 @@
+import type RequestContextClient from '@/clients/request-context-client';
+import { T1, T1_TAG } from '@/data-models/allure-constants';
+import { expect, test } from '@/fixtures/bootable-volumes-fixture';
+import type BootableVolumesPage from '@/page-objects/create-vm/bootable-volumes-page';
+import { setupTestNamespace } from '@/utils/test-setup-helpers';
+
+type UploadToastAssertions = Pick<
+  BootableVolumesPage,
+  | 'clickAbortUpload'
+  | 'expectAbortedUploadToastVisible'
+  | 'expectUploadingOrTerminalToastVisible'
+  | 'isAbortUploadButtonVisible'
+>;
+
+const SUITE = 'Test Virtualization Bootable volumes page';
+const TAB_MODAL = '#tab-modal';
+const DUMMY_DESTINATION = 'docker://quay.io/kubevirt-plugin-pw-tests/dummy-export:latest';
+const DUMMY_USERNAME = 'testuser';
+const DUMMY_PASSWORD = 'testpass';
+
+async function createBootableVolumeViaApi(
+  apiClient: RequestContextClient,
+  namespace: string,
+  name: string,
+  timeoutMs: number,
+): Promise<void> {
+  await apiClient.createDataVolume(namespace, {
+    apiVersion: 'cdi.kubevirt.io/v1beta1',
+    kind: 'DataVolume',
+    metadata: {
+      name,
+      namespace,
+      labels: {
+        'instancetype.kubevirt.io/default-instancetype': 'u1.medium',
+        'instancetype.kubevirt.io/default-preference': 'fedora',
+      },
+    },
+    spec: {
+      source: { blank: {} },
+      storage: {
+        resources: { requests: { storage: '1Gi' } },
+      },
+    },
+  });
+  apiClient.trackResource('DataVolume', name, namespace);
+
+  const succeeded = await apiClient.waitForDataVolumeSucceeded(name, namespace, timeoutMs);
+  if (!succeeded) {
+    throw new Error(`Blank DataVolume ${name} did not reach Succeeded in ${namespace}`);
+  }
+
+  await apiClient.createDataSource(namespace, {
+    apiVersion: 'cdi.kubevirt.io/v1beta1',
+    kind: 'DataSource',
+    metadata: {
+      name,
+      namespace,
+      labels: {
+        'instancetype.kubevirt.io/default-instancetype': 'u1.medium',
+        'instancetype.kubevirt.io/default-preference': 'fedora',
+      },
+    },
+    spec: {
+      source: {
+        pvc: {
+          name,
+          namespace,
+        },
+      },
+    },
+  });
+  apiClient.trackResource('DataSource', name, namespace);
+}
+
+/**
+ * Registry export against a dummy Quay destination may show an uploading toast
+ * (abortable) or fail quickly with bad credentials. Accept either path.
+ */
+async function abortOrAcceptTerminalToast(
+  bootableVolumesPage: UploadToastAssertions,
+  timeout: number,
+): Promise<void> {
+  const state = await bootableVolumesPage.expectUploadingOrTerminalToastVisible(undefined, timeout);
+
+  if (state === 'uploading') {
+    const abortVisible = await bootableVolumesPage.isAbortUploadButtonVisible(timeout);
+    expect(abortVisible, 'Abort button should be visible while uploading').toBe(true);
+    await bootableVolumesPage.clickAbortUpload();
+    await bootableVolumesPage.expectAbortedUploadToastVisible(undefined, timeout);
+    return;
+  }
+
+  if (state === 'error' || state === 'aborted') {
+    // Dummy registry credentials often fail auth before abort is possible.
+    return;
+  }
+
+  throw new Error(`Unexpected terminal toast state for registry upload: ${state}`);
+}
+
+test.describe('Tier1 Bootable Volumes - Upload to registry', { tag: [T1_TAG] }, () => {
+  test(
+    'Save is disabled until all required fields are filled',
+    { tag: ['@nonpriv'] },
+    async ({ bootableVolumesPage, apiClient, utils }) => {
+      await utils.withAllure({ suite: SUITE, feature: T1, tags: [T1_TAG] });
+
+      const ns = await setupTestNamespace(apiClient, 'bv-registry-validate');
+      const volumeName = utils.generateRandomDataVolumeName('bv-reg-validate');
+      await createBootableVolumeViaApi(apiClient, ns, volumeName, utils.TestTimeouts.DEFAULT);
+
+      await bootableVolumesPage.navigateToNamespaceBootableVolumesViaUI(ns);
+      await bootableVolumesPage.ensureDataVolumeRowVisibleWithReNav(volumeName, ns);
+
+      await test.step('Open the "Upload to registry" modal', async () => {
+        await bootableVolumesPage.clickRowActionUploadToRegistry(volumeName);
+        const formVisible = await bootableVolumesPage.verifyUploadToRegistryFormFieldsVisible();
+        expect(formVisible, 'Upload to registry form fields should be visible').toBe(true);
+      });
+
+      await test.step('Save is disabled while the form is empty', async () => {
+        const disabled = await bootableVolumesPage.isUploadToRegistryModalButtonDisabled();
+        expect(disabled, 'Save should be disabled with an empty form').toBe(true);
+      });
+
+      await test.step('Save is still disabled with only some required fields filled', async () => {
+        await bootableVolumesPage.fillUploadToRegistryForm('registry-name', '', '', '');
+        const disabled = await bootableVolumesPage.isUploadToRegistryModalButtonDisabled();
+        expect(
+          disabled,
+          'Save should stay disabled until destination/username/password are set',
+        ).toBe(true);
+      });
+
+      await test.step('Save becomes enabled once all required fields are filled', async () => {
+        await bootableVolumesPage.fillUploadToRegistryForm(
+          'registry-name',
+          DUMMY_DESTINATION,
+          DUMMY_USERNAME,
+          DUMMY_PASSWORD,
+        );
+        const disabled = await bootableVolumesPage.isUploadToRegistryModalButtonDisabled();
+        expect(disabled, 'Save should be enabled once the form is complete').toBe(false);
+      });
+
+      await bootableVolumesPage.cancelUploadToRegistryModal();
+    },
+  );
+
+  test(
+    'Submits successfully, closes the modal automatically, and shows an uploading toast',
+    { tag: ['@nonpriv'] },
+    async ({ bootableVolumesPage, apiClient, utils }) => {
+      await utils.withAllure({ suite: SUITE, feature: T1, tags: [T1_TAG] });
+
+      const ns = await setupTestNamespace(apiClient, 'bv-registry-submit');
+      const volumeName = utils.generateRandomDataVolumeName('bv-reg-submit');
+      await createBootableVolumeViaApi(apiClient, ns, volumeName, utils.TestTimeouts.DEFAULT);
+
+      await bootableVolumesPage.navigateToNamespaceBootableVolumesViaUI(ns);
+      await bootableVolumesPage.ensureDataVolumeRowVisibleWithReNav(volumeName, ns);
+
+      await test.step('Fill the form and submit', async () => {
+        await bootableVolumesPage.clickRowActionUploadToRegistry(volumeName);
+        await bootableVolumesPage.fillUploadToRegistryForm(
+          'registry-name',
+          DUMMY_DESTINATION,
+          DUMMY_USERNAME,
+          DUMMY_PASSWORD,
+        );
+        await bootableVolumesPage.clickSaveInUploadToRegistryModal();
+      });
+
+      await test.step('Modal closes automatically while the upload continues in the background', async () => {
+        const modalClosed = await bootableVolumesPage.waitForElementHidden(
+          TAB_MODAL,
+          utils.TestTimeouts.ELEMENT_WAIT,
+        );
+        expect(modalClosed, 'Upload to registry modal should close on submit').toBe(true);
+      });
+
+      await test.step('Uploading toast appears, or export fails with dummy credentials', async () => {
+        await abortOrAcceptTerminalToast(
+          bootableVolumesPage,
+          utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+        );
+      });
+    },
+  );
+
+});

--- a/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload.spec.md
+++ b/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload.spec.md
@@ -1,0 +1,123 @@
+# Software Test Description (STD): Bootable Volumes — Upload Experience
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier1 — Bootable volumes
+- **Latest version:** CNV 5.00
+- **Latest update:** 2026-08-17
+- **Document Status:** Approved
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify the bootable volume "Add volume" upload flow: uploading a local image file, the resulting
+progress toast, background upload behavior when the modal is closed, and the ability to abort an
+in-progress upload from the toast.
+
+### 2.2 Scope
+
+- **In-Scope:** Add volume form (local file upload), upload progress toast, modal close-while-uploading
+  behavior, abort/cancel upload action, DataVolume success/deletion outcomes, bootable volumes list row
+  visibility after upload.
+- **Out-of-Scope:** Warning shown when navigating away while an upload is in progress (CNV-89814).
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator installed; Playwright `Tier1` project.
+- **Configuration:** No special feature gates required; uses a downloaded Cirros image as the upload
+  fixture (`TestFileFactory.downloadCirrosImage`).
+- **Initial Setup:** Each test creates its own namespace via `setupTestNamespace`; created DataVolumes are
+  tracked via `apiClient.trackResource('DataVolume', ...)` for automatic cleanup.
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier1/bootable-volumes/bootable-volumes-upload.spec.ts`
+**Describe:** `Tier1 Bootable Volumes - Upload experience` — **Tags:** `@tier1`
+**Allure:** suite `Test Virtualization Bootable volumes page`, feature `Tier 1`
+
+---
+
+### `001`: Uploads a bootable volume from a local file and completes successfully
+
+- **Objective:** Verify that uploading a local image through the Add volume form results in a
+  successful DataVolume and a visible list row.
+- **Target version:** CNV 5.00
+- **Jira References:** CNV-89946, CNV-87382, CNV-89800
+- **Pre-conditions:** None
+- **Tags:** `@nonpriv`
+
+| Step | Action                                                                      | Expected Result                                                    |
+| :--- | :-------------------------------------------------------------------------- | :----------------------------------------------------------------- |
+| 1    | Open "Add volume" via Create → "With form" and fill/save with a local image | Form submits without error                                         |
+| 2    | Observe the uploading toast                                                 | Uploading toast for the image file is visible                      |
+| 3    | Wait for the DataVolume to reach a terminal phase                           | DataVolume reaches the `Succeeded` phase                           |
+| 4    | Observe the success toast                                                   | Success toast with a "View bootable volume `<name>`" link is shown |
+| 5    | Re-navigate to the namespace's bootable volumes list                        | The uploaded volume's row is visible in the list                   |
+
+---
+
+### `002`: Closing the Add volume modal keeps the upload running in the background
+
+- **Objective:** Verify that closing the Add volume modal after submit does not cancel the upload, and
+  the upload can still be aborted from the toast.
+- **Target version:** CNV 5.00
+- **Jira References:** CNV-89946, CNV-87382, CNV-89800
+- **Pre-conditions:** None
+- **Tags:** `@nonpriv`
+
+| Step | Action                                                             | Expected Result                                                         |
+| :--- | :----------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| 1    | Submit the Add volume form                                         | Modal closes immediately on submit                                      |
+| 2    | Verify the modal is no longer present                              | `#tab-modal` is hidden                                                  |
+| 3    | Observe the uploading toast                                        | Uploading toast for the image file is visible while the modal is closed |
+| 4    | Click "Cancel upload" in the toast, then observe the aborted toast | Aborted toast is shown                                                  |
+| 5    | Wait for the DataVolume to be removed                              | DataVolume no longer exists                                             |
+
+---
+
+### `003`: Aborting an in-progress upload from the toast cancels it
+
+- **Objective:** Verify that the abort action in the uploading toast stops the upload and cleans up the
+  DataVolume, and that the abort control disappears once aborted.
+- **Target version:** CNV 5.00
+- **Jira References:** CNV-89946, CNV-87382, CNV-89800
+- **Pre-conditions:** None
+- **Tags:** `@nonpriv`
+
+| Step | Action                                                                   | Expected Result                                |
+| :--- | :----------------------------------------------------------------------- | :--------------------------------------------- |
+| 1    | Start the upload via the Add volume form and observe the uploading toast | Uploading toast for the image file is visible  |
+| 2    | Check for the "Cancel upload" (abort) button on the toast                | Abort button is visible while uploading        |
+| 3    | Click "Cancel upload"                                                    | Aborted toast is shown for the image file      |
+| 4    | Check for the abort button again                                         | Abort button is no longer visible once aborted |
+| 5    | Wait for the DataVolume to be removed                                    | DataVolume no longer exists                    |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+| Jira Ticket | Test Case ID | Coverage Type    | Status    |
+| ----------- | ------------ | ---------------- | --------- |
+| CNV-89946   | `001`        | Feature coverage | Automated |
+| CNV-89946   | `002`        | Feature coverage | Automated |
+| CNV-89946   | `003`        | Feature coverage | Automated |
+| CNV-89800   | `001`        | Feature coverage | Automated |
+| CNV-89800   | `002`        | Feature coverage | Automated |
+| CNV-89800   | `003`        | Feature coverage | Automated |
+| CNV-87382   | `001`        | Feature coverage | Automated |
+
+**Coverage Type values:**
+
+- `Feature coverage` — test validates a feature delivered by the ticket
+- `Bugfix regression guard` — test asserts the specific bug fixed by the ticket does not regress
+- `Functional smoke` — test validates baseline behavior; no specific Jira ticket drives it
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** Gal Kremer
+- **Approval Signature:** Gal Kremer

--- a/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload.spec.ts
+++ b/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload.spec.ts
@@ -1,0 +1,167 @@
+import { T1, T1_TAG } from '@/data-models/allure-constants';
+import { expect, test } from '@/fixtures/bootable-volumes-fixture';
+import { setupTestNamespace } from '@/utils/test-setup-helpers';
+
+const SUITE = 'Test Virtualization Bootable volumes page';
+const TAB_MODAL = '#tab-modal';
+const UPLOAD_IMAGE_FILENAME = 'bv-upload-cirros.img';
+
+test.describe('Tier1 Bootable Volumes - Upload experience', { tag: [T1_TAG] }, () => {
+  test(
+    'Uploads a bootable volume from a local file and completes successfully',
+    { tag: ['@nonpriv'] },
+    async ({ bootableVolumesPage, apiClient, utils }) => {
+      await utils.withAllure({ suite: SUITE, feature: T1, tags: [T1_TAG] });
+
+      const ns = await setupTestNamespace(apiClient, 'bv-upload-ok');
+      const volumeName = utils.generateRandomDataVolumeName('bv-upload');
+      const imagePath = await utils.TestFileFactory.downloadCirrosImage(UPLOAD_IMAGE_FILENAME);
+      apiClient.trackResource('DataVolume', volumeName, ns);
+
+      await bootableVolumesPage.navigateToNamespaceBootableVolumesViaUI(ns);
+
+      await test.step('Open the "Add volume" form and upload a local image', async () => {
+        await bootableVolumesPage.clickCreateAndSelectOption('With form');
+        await bootableVolumesPage.fillCreateBootableVolumeFormAndSave(volumeName, imagePath);
+      });
+
+      await test.step('Uploading toast appears', async () => {
+        await bootableVolumesPage.expectUploadingToastVisible(
+          UPLOAD_IMAGE_FILENAME,
+          utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+        );
+      });
+
+      await test.step('Upload completes and the DataVolume succeeds', async () => {
+        const succeeded = await apiClient.waitForDataVolumeSucceeded(
+          volumeName,
+          ns,
+          utils.TestTimeouts.FILE_UPLOAD,
+        );
+        expect(succeeded, 'DataVolume should reach the Succeeded phase').toBe(true);
+      });
+
+      await test.step('Success toast with a link to the new volume is shown', async () => {
+        await bootableVolumesPage.expectSuccessUploadToastWithLink(
+          `View bootable volume ${volumeName}`,
+          utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+        );
+      });
+
+      await test.step('Volume row appears in the list', async () => {
+        await bootableVolumesPage.navigateToNamespaceBootableVolumesViaUI(ns);
+        const rowVisible = await bootableVolumesPage.ensureDataVolumeRowVisibleWithReNav(
+          volumeName,
+          ns,
+          utils.TestTimeouts.DEFAULT,
+        );
+        expect(rowVisible, 'Uploaded bootable volume row should be visible in the list').toBe(
+          true,
+        );
+      });
+    },
+  );
+
+  test(
+    'Closing the Add volume modal keeps the upload running in the background',
+    { tag: ['@nonpriv'] },
+    async ({ bootableVolumesPage, apiClient, utils }) => {
+      await utils.withAllure({ suite: SUITE, feature: T1, tags: [T1_TAG] });
+
+      const ns = await setupTestNamespace(apiClient, 'bv-upload-bg');
+      const volumeName = utils.generateRandomDataVolumeName('bv-upload-bg');
+      const imagePath = await utils.TestFileFactory.downloadCirrosImage(UPLOAD_IMAGE_FILENAME);
+      apiClient.trackResource('DataVolume', volumeName, ns);
+
+      await bootableVolumesPage.navigateToNamespaceBootableVolumesViaUI(ns);
+
+      await test.step('Submit the upload form (modal closes immediately on submit)', async () => {
+        await bootableVolumesPage.clickCreateAndSelectOption('With form');
+        await bootableVolumesPage.fillCreateBootableVolumeFormAndSave(volumeName, imagePath);
+      });
+
+      await test.step('Modal is closed while the upload continues in the background', async () => {
+        const modalClosed = await bootableVolumesPage.waitForElementHidden(
+          TAB_MODAL,
+          utils.TestTimeouts.ELEMENT_WAIT,
+        );
+        expect(modalClosed, 'Add volume modal should close on submit').toBe(true);
+
+        await bootableVolumesPage.expectUploadingToastVisible(
+          UPLOAD_IMAGE_FILENAME,
+          utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+        );
+      });
+
+      await test.step('Abort the upload to clean up', async () => {
+        await bootableVolumesPage.clickAbortUpload(UPLOAD_IMAGE_FILENAME);
+        await bootableVolumesPage.expectAbortedUploadToastVisible(
+          UPLOAD_IMAGE_FILENAME,
+          utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+        );
+
+        const dvGone = await apiClient.waitForDataVolumeGone(
+          volumeName,
+          ns,
+          utils.TestTimeouts.ELEMENT_WAIT,
+        );
+        expect(dvGone, 'DataVolume should be deleted after abort').toBe(true);
+      });
+    },
+  );
+
+  test(
+    'Aborting an in-progress upload from the toast cancels it',
+    { tag: ['@nonpriv'] },
+    async ({ bootableVolumesPage, apiClient, utils }) => {
+      await utils.withAllure({ suite: SUITE, feature: T1, tags: [T1_TAG] });
+
+      const ns = await setupTestNamespace(apiClient, 'bv-upload-abort');
+      const volumeName = utils.generateRandomDataVolumeName('bv-upload-abort');
+      const imagePath = await utils.TestFileFactory.downloadCirrosImage(UPLOAD_IMAGE_FILENAME);
+      apiClient.trackResource('DataVolume', volumeName, ns);
+
+      await bootableVolumesPage.navigateToNamespaceBootableVolumesViaUI(ns);
+
+      await test.step('Start the upload', async () => {
+        await bootableVolumesPage.clickCreateAndSelectOption('With form');
+        await bootableVolumesPage.fillCreateBootableVolumeFormAndSave(volumeName, imagePath);
+        await bootableVolumesPage.expectUploadingToastVisible(
+          UPLOAD_IMAGE_FILENAME,
+          utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+        );
+      });
+
+      await test.step('Click "Cancel upload" in the toast', async () => {
+        const abortButtonVisible = await bootableVolumesPage.isAbortUploadButtonVisible(
+          utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+          UPLOAD_IMAGE_FILENAME,
+        );
+        expect(abortButtonVisible, 'Abort button should be visible while uploading').toBe(true);
+        await bootableVolumesPage.clickAbortUpload(UPLOAD_IMAGE_FILENAME);
+      });
+
+      await test.step('Aborted toast is shown and the upload stops', async () => {
+        await bootableVolumesPage.expectAbortedUploadToastVisible(
+          UPLOAD_IMAGE_FILENAME,
+          utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+        );
+
+        const stillAbortable = await bootableVolumesPage.isAbortUploadButtonVisible(
+          utils.TestTimeouts.UI_DELAY_MEDIUM,
+          UPLOAD_IMAGE_FILENAME,
+        );
+        expect(stillAbortable, 'Abort button should no longer be visible once aborted').toBe(
+          false,
+        );
+
+        const dvGone = await apiClient.waitForDataVolumeGone(
+          volumeName,
+          ns,
+          utils.TestTimeouts.ELEMENT_WAIT,
+        );
+        expect(dvGone, 'DataVolume should be deleted after abort').toBe(true);
+      });
+    },
+  );
+});

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-cdrom-upload.spec.md
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-cdrom-upload.spec.md
@@ -1,0 +1,105 @@
+# Software Test Description (STD): VM CD-ROM Upload
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier1 — VM tabs (CD-ROM)
+- **Latest version:** CNV 5.00
+- **Latest update:** 2026-08-17
+- **Document Status:** Approved
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify the "Add CD-ROM" flow with the "Upload new ISO" source on an existing, stopped RHEL9 VM,
+including the resulting background upload toast and the ability to abort an in-progress upload.
+
+### 2.2 Scope
+
+- **In-Scope:** Add CD-ROM disk modal with "Upload new ISO" source, background upload progress toast,
+  abort/cancel upload action, DataVolume deletion after abort.
+- **Out-of-Scope:** Adding a CD-ROM with upload during new VM creation (CNV-90313) — this file covers
+  upload to an already-existing VM only.
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator installed; Playwright `Tier1` project.
+- **Configuration:** No special feature gates required; uses a RHEL9 template
+  (`utils.TEMPLATE_METADATA_NAMES.RHEL9`) to create a stopped VM, and a locally generated sized ISO
+  fixture (`TestFileFactory.createSizedIsoFile`) so the upload stays abortable long enough for toast
+  assertions.
+- **Initial Setup:** Each test creates its own namespace and a stopped RHEL9 VM from template; created
+  Namespace, VirtualMachine, and DataVolume resources are tracked via `apiClient.trackResource(...)` for
+  automatic cleanup.
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier1/virtualmachines/vm-tabs/vm-cdrom-upload.spec.ts`
+**Describe:** `Tier1 VM CD-ROM upload — stopped RHEL9` — **Tags:** `@tier1`, `@nonpriv`
+**Allure:** suite `Tier1 VM CD-ROM upload`, feature `Tier 1`
+
+---
+
+### `001`: Add CD-ROM with upload starts a background upload with a toast
+
+- **Objective:** Verify that adding a CD-ROM disk via "Upload new ISO" on an existing stopped VM starts
+  a background upload and surfaces a progress toast.
+- **Target version:** CNV 5.00
+- **Jira References:** CNV-89946, CNV-87382, CNV-89800
+- **Pre-conditions:** VM must exist and be reachable via the VM tree view (created stopped from the
+  RHEL9 template)
+- **Tags:** `@nonpriv`
+
+| Step | Action                                                              | Expected Result                                                       |
+| :--- | :------------------------------------------------------------------ | :-------------------------------------------------------------------- |
+| 1    | Add a CD-ROM disk using "Upload new ISO" with the sized ISO fixture | CD-ROM disk is added from the UI                                      |
+| 2    | Observe the resulting toast after the modal closes                  | Uploading or success toast is shown for the ISO file                  |
+| 3    | Check for the "Cancel upload" (abort) button                        | If still visible (upload in progress), the test aborts it to clean up |
+| 4    | If aborted, observe the aborted toast                               | Aborted toast is shown for the ISO file                               |
+
+---
+
+### `002`: Aborting an in-progress CD-ROM upload from the toast cancels it
+
+- **Objective:** Verify that the abort action in the uploading toast stops an in-progress CD-ROM upload
+  and removes the underlying DataVolume.
+- **Target version:** CNV 5.00
+- **Jira References:** CNV-89946, CNV-87382, CNV-89800
+- **Pre-conditions:** VM must exist and be reachable via the VM tree view (created stopped from the
+  RHEL9 template)
+- **Tags:** `@nonpriv`
+
+| Step | Action                                                              | Expected Result                                  |
+| :--- | :------------------------------------------------------------------ | :----------------------------------------------- |
+| 1    | Add a CD-ROM disk using "Upload new ISO" with the sized ISO fixture | CD-ROM disk is added; uploading toast is visible |
+| 2    | Check for the "Cancel upload" (abort) button on the toast           | Abort button is visible while uploading          |
+| 3    | Click "Cancel upload"                                               | —                                                |
+| 4    | Observe the resulting toast                                         | Aborted toast is shown for the ISO file          |
+| 5    | Wait for the DataVolume to be removed                               | DataVolume no longer exists                      |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+| Jira Ticket | Test Case ID | Coverage Type    | Status    |
+| ----------- | ------------ | ---------------- | --------- |
+| CNV-89946   | `001`        | Feature coverage | Automated |
+| CNV-89946   | `002`        | Feature coverage | Automated |
+| CNV-89800   | `001`        | Feature coverage | Automated |
+| CNV-89800   | `002`        | Feature coverage | Automated |
+| CNV-87382   | `001`        | Feature coverage | Automated |
+
+**Coverage Type values:**
+
+- `Feature coverage` — test validates a feature delivered by the ticket
+- `Bugfix regression guard` — test asserts the specific bug fixed by the ticket does not regress
+- `Functional smoke` — test validates baseline behavior; no specific Jira ticket drives it
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** Gal Kremer
+- **Approval Signature:** Gal Kremer

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-cdrom-upload.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-cdrom-upload.spec.ts
@@ -1,0 +1,140 @@
+import { T1, T1_TAG, VM_TABS_TAG } from '@/data-models/allure-constants';
+import { expect, test } from '@/fixtures/vm-tabs-fixture';
+
+const SUITE = 'Tier1 VM CD-ROM upload';
+
+test.describe('Tier1 VM CD-ROM upload — stopped RHEL9', { tag: [T1_TAG, '@nonpriv'] }, () => {
+  test('Add CD-ROM with upload starts a background upload with a toast', async ({
+    apiClient,
+    vmTreePage,
+    vmDetailPage,
+    utils,
+  }) => {
+    await utils.withAllure({ suite: SUITE, feature: T1, tags: [T1_TAG, VM_TABS_TAG] });
+    test.setTimeout(utils.TestTimeouts.TEST_VM_CREATION);
+
+    const ns = utils.generateTestNamespace('vm-cdrom-upload');
+    await apiClient.createNamespace(ns);
+    await apiClient.waitForNamespaceReady(ns);
+    apiClient.trackResource('Namespace', ns);
+
+    const vmName = utils.generateRandomVmName('vm-cdrom-upload');
+    await apiClient.createVmFromTemplate(
+      utils.TEMPLATE_METADATA_NAMES.RHEL9,
+      vmName,
+      ns,
+      'openshift',
+      false,
+    );
+    apiClient.trackResource('VirtualMachine', vmName, ns);
+
+    const result = await apiClient.verifyVmCreated(vmName, ns, utils.TestTimeouts.VM_BOOTUP);
+    if (!result.exists) throw new Error(`VM ${vmName} was not created`);
+
+    await vmTreePage.navigateToVmViaTreeView(ns, vmName);
+
+    const isoFileName = 'vm-cdrom-upload-test.iso';
+    // Non-empty fixture so the upload stays abortable long enough for toast assertions.
+    const isoPath = utils.TestFileFactory.createSizedIsoFile(isoFileName);
+    const diskName = utils.generateRandomDiskName('cdrom-upload');
+    apiClient.trackResource('DataVolume', diskName, ns);
+
+    await test.step('Add a CD-ROM with "Upload new ISO"', async () => {
+      const added = await vmDetailPage.addCDROMDisk(diskName, 'Upload new ISO', isoPath);
+      expect(added, `CD-ROM disk ${diskName} should be added from UI`).toBe(true);
+    });
+
+    await test.step('Uploading toast is visible after the modal closes', async () => {
+      const state = await vmDetailPage.expectUploadingOrTerminalToastVisible(
+        isoFileName,
+        utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+      );
+      expect(
+        state === 'uploading' || state === 'success',
+        `Expected uploading or success toast, got ${state}`,
+      ).toBe(true);
+    });
+
+    await test.step('Abort the upload to clean up when still in progress', async () => {
+      const abortVisible = await vmDetailPage.isAbortUploadButtonVisible(
+        utils.TestTimeouts.UI_DELAY_MEDIUM,
+        isoFileName,
+      );
+      if (!abortVisible) {
+        return;
+      }
+      await vmDetailPage.clickAbortUpload(isoFileName);
+      await vmDetailPage.expectAbortedUploadToastVisible(
+        isoFileName,
+        utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+      );
+    });
+  });
+
+  test('Aborting an in-progress CD-ROM upload from the toast cancels it', async ({
+    apiClient,
+    vmTreePage,
+    vmDetailPage,
+    utils,
+  }) => {
+    await utils.withAllure({ suite: SUITE, feature: T1, tags: [T1_TAG, VM_TABS_TAG] });
+    test.setTimeout(utils.TestTimeouts.TEST_VM_CREATION);
+
+    const ns = utils.generateTestNamespace('vm-cdrom-abort');
+    await apiClient.createNamespace(ns);
+    await apiClient.waitForNamespaceReady(ns);
+    apiClient.trackResource('Namespace', ns);
+
+    const vmName = utils.generateRandomVmName('vm-cdrom-abort');
+    await apiClient.createVmFromTemplate(
+      utils.TEMPLATE_METADATA_NAMES.RHEL9,
+      vmName,
+      ns,
+      'openshift',
+      false,
+    );
+    apiClient.trackResource('VirtualMachine', vmName, ns);
+
+    const result = await apiClient.verifyVmCreated(vmName, ns, utils.TestTimeouts.VM_BOOTUP);
+    if (!result.exists) throw new Error(`VM ${vmName} was not created`);
+
+    await vmTreePage.navigateToVmViaTreeView(ns, vmName);
+
+    const isoFileName = 'vm-cdrom-abort-test.iso';
+    const isoPath = utils.TestFileFactory.createSizedIsoFile(isoFileName);
+    const diskName = utils.generateRandomDiskName('cdrom-abort');
+    apiClient.trackResource('DataVolume', diskName, ns);
+
+    await test.step('Start the CD-ROM upload', async () => {
+      const added = await vmDetailPage.addCDROMDisk(diskName, 'Upload new ISO', isoPath);
+      expect(added, `CD-ROM disk ${diskName} should be added from UI`).toBe(true);
+      await vmDetailPage.expectUploadingToastVisible(
+        isoFileName,
+        utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+      );
+    });
+
+    await test.step('Click "Cancel upload" in the toast', async () => {
+      const abortVisible = await vmDetailPage.isAbortUploadButtonVisible(
+        utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+        isoFileName,
+      );
+      expect(abortVisible, 'Abort button should be visible while uploading').toBe(true);
+      await vmDetailPage.clickAbortUpload(isoFileName);
+    });
+
+    await test.step('Aborted toast is shown', async () => {
+      await vmDetailPage.expectAbortedUploadToastVisible(
+        isoFileName,
+        utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+      );
+
+      const dvGone = await apiClient.waitForDataVolumeGone(
+        diskName,
+        ns,
+        utils.TestTimeouts.ELEMENT_WAIT,
+      );
+      expect(dvGone, 'DataVolume should be deleted after abort').toBe(true);
+    });
+  });
+});

--- a/src/utils/hooks/useUploadProgressToast/components/ToastLayout.tsx
+++ b/src/utils/hooks/useUploadProgressToast/components/ToastLayout.tsx
@@ -1,9 +1,14 @@
-import React, { FC, ReactNode } from 'react';
+import React, { type FC, type ReactNode } from 'react';
 
 import { Flex } from '@patternfly/react-core';
 
-const ToastLayout: FC<{ children: ReactNode }> = ({ children }) => (
-  <Flex direction={{ default: 'column' }} rowGap={{ default: 'rowGapXs' }}>
+type ToastLayoutProps = {
+  children: ReactNode;
+  dataTest?: string;
+};
+
+const ToastLayout: FC<ToastLayoutProps> = ({ children, dataTest }) => (
+  <Flex data-test={dataTest} direction={{ default: 'column' }} rowGap={{ default: 'rowGapXs' }}>
     {children}
   </Flex>
 );

--- a/src/utils/hooks/useUploadProgressToast/components/UploadProgressAbortButton.tsx
+++ b/src/utils/hooks/useUploadProgressToast/components/UploadProgressAbortButton.tsx
@@ -20,6 +20,7 @@ const UploadProgressAbortButton: FC<UploadProgressAbortButtonProps> = ({
 
   const button = (
     <Button
+      data-test="upload-progress-abort"
       isDanger
       onClick={() => cancelTrackedUpload(uploadKey)}
       variant={ButtonVariant.secondary}

--- a/src/utils/hooks/useUploadProgressToast/components/UploadProgressCanceledToast.tsx
+++ b/src/utils/hooks/useUploadProgressToast/components/UploadProgressCanceledToast.tsx
@@ -20,7 +20,7 @@ const UploadProgressCanceledToast: FC<UploadProgressCanceledToastProps> = ({
   const { contextLinks, fileName, progress } = upload;
 
   return (
-    <ToastLayout>
+    <ToastLayout dataTest="upload-progress-aborted-toast">
       <UploadProgressBar
         fileName={fileName}
         progress={progress}

--- a/src/utils/hooks/useUploadProgressToast/components/UploadProgressErrorToast.tsx
+++ b/src/utils/hooks/useUploadProgressToast/components/UploadProgressErrorToast.tsx
@@ -18,7 +18,7 @@ const UploadProgressErrorToast: FC<UploadProgressErrorToastProps> = ({ navigate,
   const { t } = useKubevirtTranslation();
 
   return (
-    <ToastLayout>
+    <ToastLayout dataTest="upload-progress-error-toast">
       <FlexItem>{upload.errorMessage ?? t('Upload failed.')}</FlexItem>
       {!isEmpty(upload.contextLinks) && (
         <FlexItem>

--- a/src/utils/hooks/useUploadProgressToast/components/UploadProgressLinks.tsx
+++ b/src/utils/hooks/useUploadProgressToast/components/UploadProgressLinks.tsx
@@ -13,6 +13,7 @@ const UploadProgressLinks: FC<UploadProgressLinksProps> = ({ links = [], navigat
   <>
     {links.map((link, index) => (
       <Button
+        data-test="upload-progress-link"
         isInline
         key={`${link.url}-${index}`}
         onClick={() => navigate(link.url)}

--- a/src/utils/hooks/useUploadProgressToast/components/UploadProgressSuccessToast.tsx
+++ b/src/utils/hooks/useUploadProgressToast/components/UploadProgressSuccessToast.tsx
@@ -19,7 +19,7 @@ const UploadProgressSuccessToast: FC<UploadProgressSuccessToastProps> = ({ navig
     successLinks ?? (resourceUrl ? [{ label: t('View volume'), url: resourceUrl }] : []);
 
   return (
-    <ToastLayout>
+    <ToastLayout dataTest="upload-progress-success-toast">
       <UploadProgressLinks links={links} navigate={navigate} />
     </ToastLayout>
   );

--- a/src/utils/hooks/useUploadProgressToast/components/UploadProgressUploadingToast.tsx
+++ b/src/utils/hooks/useUploadProgressToast/components/UploadProgressUploadingToast.tsx
@@ -5,6 +5,7 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 
 import { UploadEntry } from '../types';
 
+import ToastLayout from './ToastLayout';
 import UploadProgressAbortButton from './UploadProgressAbortButton';
 import UploadProgressBar from './UploadProgressBar';
 import UploadProgressLinks from './UploadProgressLinks';
@@ -25,7 +26,7 @@ const UploadProgressUploadingToast: FC<UploadProgressUploadingToastProps> = ({
   const hasActions = !isEmpty(contextLinks) || showAbort;
 
   return (
-    <Flex direction={{ default: 'column' }}>
+    <ToastLayout dataTest="upload-progress-toast">
       <UploadProgressBar fileName={fileName} progress={progress} showSpinner />
       {hasActions && (
         <Flex alignItems={{ default: 'alignItemsCenter' }} className="pf-v6-u-w-100">
@@ -41,7 +42,7 @@ const UploadProgressUploadingToast: FC<UploadProgressUploadingToastProps> = ({
           )}
         </Flex>
       )}
-    </Flex>
+    </ToastLayout>
   );
 };
 


### PR DESCRIPTION
## 📝 Description

Add Playwright e2e tests for upload experience improvements

## 🔗 Links

Jira ticket: [CNV-89946](https://redhat.atlassian.net/browse/CNV-89946)

## 🎥 Demo

Ran full Playwright suite (Gating + Tier1 + Tier2 + Settings + API, 260 tests) against `localhost:9000`.
New upload specs (bootable-volumes-upload, bootable-volumes-upload-to-registry, vm-cdrom-upload) - all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer upload progress notifications for uploading, successful, canceled, and failed uploads.
  * Added the ability to cancel active uploads directly from progress notifications.
  * Added upload status visibility across bootable volume and virtual machine CD-ROM workflows.
  * Improved registry upload form validation and field visibility checks.
* **Bug Fixes**
  * Improved CD-ROM upload handling by reliably confirming the selected filename.
  * Improved reliability when waiting for completed uploads and removed resources.
* **Tests**
  * Expanded coverage for local uploads, registry uploads, cancellation, cleanup, and upload notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->