### PR TITLE
CNV-95299: Virtual Machines list: Select page selects the wrong VMs after sorting the table

### DIFF
--- a/src/utils/hooks/useDataViewTableSort/useDataViewTableSort.ts
+++ b/src/utils/hooks/useDataViewTableSort/useDataViewTableSort.ts
@@ -2,12 +2,39 @@ import { useCallback, useMemo } from 'react';
 
 import { universalComparator } from '@kubevirt-utils/utils/utils';
 import { useDataViewSort } from '@patternfly/react-data-view';
-import { DataViewTh } from '@patternfly/react-data-view/dist/esm/DataViewTable';
-import { SortByDirection, ThProps } from '@patternfly/react-table';
+import { type DataViewTh } from '@patternfly/react-data-view/dist/esm/DataViewTable';
+import { type SortByDirection, type ThProps } from '@patternfly/react-table';
 
 import { useResponsiveColumns } from '../useResponsiveColumns/useResponsiveColumns';
+import { type ColumnConfig } from './types';
 
-import { ColumnConfig } from './types';
+export const sortDataViewTableData = <TData, TCallbacks = undefined>(
+  data: TData[],
+  columns: ColumnConfig<TData, TCallbacks>[],
+  sortBy?: string,
+  direction?: string,
+  callbacks?: TCallbacks,
+): TData[] => {
+  const column = columns.find((col) => col.key === sortBy);
+  if (!direction) return data;
+
+  if (column?.sort) {
+    return column.sort([...data], direction as SortByDirection, callbacks);
+  }
+
+  const getValue = column?.getValue;
+  if (!getValue) return data;
+
+  return [...data].sort((a, b) => {
+    const aVal = getValue(a, callbacks);
+    const bVal = getValue(b, callbacks);
+    const cmp =
+      typeof aVal === 'number' && typeof bVal === 'number'
+        ? aVal - bVal
+        : universalComparator(aVal, bVal);
+    return direction === 'asc' ? cmp : -cmp;
+  });
+};
 
 export const useDataViewTableSort = <TData, TCallbacks = undefined>(
   data: TData[],
@@ -56,27 +83,10 @@ export const useDataViewTableSort = <TData, TCallbacks = undefined>(
     [visibleColumns, getSortParams],
   );
 
-  const sortedData = useMemo(() => {
-    const column = columns.find((col) => col.key === sortBy);
-    if (!direction) return data;
-
-    if (column?.sort) {
-      return column.sort([...data], direction as SortByDirection, callbacks);
-    }
-
-    const getValue = column?.getValue;
-    if (!getValue) return data;
-
-    return [...data].sort((a, b) => {
-      const aVal = getValue(a, callbacks);
-      const bVal = getValue(b, callbacks);
-      const cmp =
-        typeof aVal === 'number' && typeof bVal === 'number'
-          ? aVal - bVal
-          : universalComparator(aVal, bVal);
-      return direction === 'asc' ? cmp : -cmp;
-    });
-  }, [data, sortBy, direction, columns, callbacks]);
+  const sortedData = useMemo(
+    () => sortDataViewTableData(data, columns, sortBy, direction, callbacks),
+    [data, sortBy, direction, columns, callbacks],
+  );
 
   return { sortedData, tableColumns, visibleColumns };
 };

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -13,6 +13,7 @@ import { runningTourSignal } from '@kubevirt-utils/components/GuidedTour/utils/g
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
 import { TableToolbarActionsFlex } from '@kubevirt-utils/components/TableToolbarActions/TableToolbarActionsFlex';
 import { PageTitles } from '@kubevirt-utils/constants/page-constants';
+import { sortDataViewTableData } from '@kubevirt-utils/hooks/useDataViewTableSort/useDataViewTableSort';
 import { KUBEVIRT_APISERVER_PROXY } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { type KubevirtFilterState } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
@@ -30,6 +31,7 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useIsAllClustersPage from '@multicluster/hooks/useIsAllClustersPage';
 import { DocumentTitle, type K8sVerb, ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
 import { Flex, Pagination } from '@patternfly/react-core';
+import { DataViewSortParams } from '@patternfly/react-data-view';
 import { useSignals } from '@preact/signals-react/runtime';
 import SearchBar from '@search/components/SearchBar';
 import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
@@ -81,6 +83,14 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({
   useVMMetrics();
 
   const query = useQuery();
+  const sortBy = query.get(DataViewSortParams.SORT_BY);
+  const sortDirection = query.get(DataViewSortParams.DIRECTION);
+  const selectionResetKey = useMemo(() => {
+    const params = new URLSearchParams(query);
+    params.delete(DataViewSortParams.SORT_BY);
+    params.delete(DataViewSortParams.DIRECTION);
+    return params.toString();
+  }, [query]);
 
   const [namespacedVMs, namespacedVMsLoaded, loadError] = useKubevirtWatchResource<
     V1VirtualMachine[]
@@ -134,12 +144,18 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({
   const [pagination, setPagination] = useState(paginationInitialState);
 
   const resetPagination = useCallback(() => {
-    setPagination((prev) => ({
-      ...prev,
-      endIndex: prev?.perPage,
-      page: 1,
-      startIndex: 0,
-    }));
+    setPagination((prev) => {
+      if (prev.page === 1 && prev.startIndex === 0) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        endIndex: prev?.perPage,
+        page: 1,
+        startIndex: 0,
+      };
+    });
   }, []);
 
   const handleSetFilters = useCallback(
@@ -155,7 +171,11 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({
 
   useEffect(() => {
     deselectAllVMs();
-  }, [namespace, cluster, query]);
+  }, [namespace, cluster, selectionResetKey]);
+
+  useEffect(() => {
+    resetPagination();
+  }, [resetPagination, sortBy, sortDirection]);
 
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -183,6 +203,18 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({
   );
 
   const loaded = vmsLoaded && columnUtilsLoaded && !loadingFeatureProxy && loadedColumns;
+
+  const sortedVMs = useMemo(
+    () =>
+      sortDataViewTableData(
+        filteredVMs ?? [],
+        columns,
+        sortBy ?? VM_COLUMN_KEYS.name,
+        sortDirection ?? 'asc',
+        callbacks,
+      ),
+    [callbacks, columns, filteredVMs, sortBy, sortDirection],
+  );
 
   useVMListTelemetry({ loaded });
 
@@ -241,7 +273,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({
                 vms={vmsToShow}
               />
               <div className="list-managment-group">
-                <VirtualMachineSelection pagination={pagination} vms={filteredVMs} />
+                <VirtualMachineSelection pagination={pagination} vms={sortedVMs} />
                 <Flex className="list-managment-group__flex" flexWrap={{ default: 'nowrap' }}>
                   <VirtualMachineBulkActionButton vmimMapper={vmimMapper} vms={filteredVMs} />
                   <TableToolbarActionsFlex>


### PR DESCRIPTION
## 📝 Description

On the Virtual Machines list, after sorting the table by a column, using bulk select "Select page" selects different virtual machines than the ones currently shown on the page.

## 🔗 Links

Jira ticket: [CNV-95299](https://redhat.atlassian.net/browse/CNV-95299)

## 🎥 Demo

Before: 

https://github.com/user-attachments/assets/4763ca02-11d9-4dee-85bc-49ddbe3b4668

After:

https://github.com/user-attachments/assets/5dd775ed-2e4f-43d8-b74b-b4b969e259f4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added URL-based sorting for the virtual machine list, preserving sort choices across navigation and refreshes.
  - Virtual machine rows now display in the selected ascending or descending order.

- **Bug Fixes**
  - Selection resets appropriately when filters, search criteria, or pagination context changes.
  - Pagination no longer triggers unnecessary updates when already on the first page.
  - Sorting behavior is now consistent across supported column types and custom sorting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->