### PR TITLE
CNV-95611: Add create-std-doc Cursor skill for generating Playwright STD docs

### DIFF
--- a/.cursor/commands/create-std-doc.md
+++ b/.cursor/commands/create-std-doc.md
@@ -1,0 +1,40 @@
+# /create-std-doc -- Create STD Doc Command
+
+Read `.cursor/skills/create-std-doc/SKILL.md` — it is the single source of truth for what this command does and how.
+
+## Input
+
+```text
+/create-std-doc <spec-file-path-or-feature-name>
+```
+
+- **Spec file path**: `/create-std-doc playwright/tests/<tier>/<feature>/<name>.spec.ts`
+- **Feature name**: `/create-std-doc <feature description>`
+
+If no path or feature name is given, ask the user which spec to document.
+
+### Feature-name resolution
+
+STD docs are written only for Playwright `.spec.ts` files (as a colocated
+`.spec.md`). Feature-name search must return only `*.spec.ts` candidates —
+never `.spec.md`, helpers, fixtures, or other TypeScript files.
+
+When the input is not a `.spec.ts` path, map the description to `.spec.ts`
+files **before** generating an STD:
+
+1. List files with `rg --files playwright/tests -g '*.spec.ts'` (search only that tree).
+2. Normalize the description to lowercase tokens (split on whitespace and punctuation; drop empty tokens).
+3. A `.spec.ts` file is a candidate when its repo-relative path contains **every** token as a case-insensitive substring, or when its basename without `.spec.ts` equals the full description (case-insensitive).
+4. Print the full list of matching `.spec.ts` repo-relative paths.
+
+Then:
+
+- **Zero matches:** stop and ask the user for a single relative `playwright/tests/...spec.ts` path.
+- **Multiple matches:** stop, list the candidates, and wait for the user to select exactly one.
+- **Exactly one match:** use that path.
+
+Do not generate an STD until exactly one spec is identified. Path validation, reading, and writing then follow the skill.
+
+## Execution
+
+Follow `.cursor/skills/create-std-doc/SKILL.md` end-to-end.

--- a/.cursor/skills/create-std-doc/SKILL.md
+++ b/.cursor/skills/create-std-doc/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: create-std-doc
+description: >-
+  Create or update a Software Test Description (STD) markdown file for a
+  KubeVirt Playwright E2E spec, colocated next to the .spec.ts file and
+  following playwright/docs/STD-TEMPLATE.md.
+disable-model-invocation: true
+---
+
+# Create STD Doc
+
+You are an expert QA Automation Engineer. Your task is to generate or update a colocated Software Test Description (STD) markdown file (`.spec.md`) for a Playwright E2E spec (`.spec.ts`).
+
+## 1. Execution Workflow
+
+1. **Analyze Files:** Read the target `.spec.ts` file, the official template (`playwright/docs/STD-TEMPLATE.md`), and the existing `.spec.md` (if it exists).
+2. **Sanitize:** Redact any credentials, tokens, cookies, or unnecessary PII found in the spec file.
+3. **Plan:** Output a brief, 2-3 sentence summary of the test cases identified and what existing data (Approvals, IDs, Matrix rows) will be preserved.
+4. **Generate:** Write the `.spec.md` file to the exact same directory as the `.spec.ts` file, replacing the `.ts` extension with `.md`.
+5. **Validate:** Output the Validation Checklist at the end.
+
+## 2. Extraction & Mapping Rules
+
+Strictly follow `STD-TEMPLATE.md` for structure and section names.
+
+| Spec Source                    | STD Field / Action                                             |
+| ------------------------------ | -------------------------------------------------------------- |
+| `test.describe(...)`           | Describe / Tags line                                           |
+| `utils.withAllure(...)`        | Allure line (Suite & Feature). Fallback to describe tags.      |
+| `test(...)`                    | Numbered test case. **Preserve existing IDs; never renumber.** |
+| `test.step(...)`               | Step / Expected Result table rows.                             |
+| Setup helpers / hooks          | Test Environment & Prerequisites.                              |
+| `test.skip()` / `test.fixme()` | Document as **Pending** cases (include the block reason).      |
+
+- **Objectives:** Derive the test case `Objective` from what the test _actually asserts_, not just the title string.
+- **Skipped/Deferred Tests:** Do not omit them. If a skip is conditional and evaluates to false, mark it as `Automated`. If unconditional or true, mark it `Pending`.
+
+## 3. Design Conventions & Traceability
+
+- **Versioning:** Use `Latest version` and `Target version` (formatted as `CNV <major>.<minor>`, derived from PR base branch or Jira `fixVersions`). Ensure they match. Default `Document Status` to `Draft`.
+- **Titles & Jira IDs:** Write precise scenario titles. **Do not put Jira IDs in scenario titles.** Place `CNV-[0-9]+` keys in the per-scenario `Jira References` field and the Traceability Matrix.
+- **Scope Definition:**
+  - _In-Scope:_ Derived directly from the file's assertions.
+  - _Out-of-Scope:_ Only note adjacent, untested variants of the _same_ feature/modal covered in this file. (Do not list unrelated features).
+- **Preservation Rule:** If updating an existing `.spec.md`, you **must preserve** manually maintained Approvals, Traceability Matrix rows, and existing Test Case IDs unless explicitly told otherwise.
+
+## 4. Validation Checklist
+
+Print and check off these items at the end of your response:
+
+- [ ] Placed the generated `.spec.md` in the exact same directory as the `.spec.ts` file.
+- [ ] Used exact section headers from `playwright/docs/STD-TEMPLATE.md`.
+- [ ] Documented every test case (including `.skip` and `.fixme`).
+- [ ] Preserved existing Test Case IDs, Approvals, and historical Traceability Matrix rows.
+- [ ] Placed Jira IDs in `Jira References` and the Matrix, NOT in scenario titles.
+- [ ] Redacted all credentials, secrets, and cluster IDs.
+- [ ] Formatted target versions correctly as `CNV <major>.<minor>`.


### PR DESCRIPTION
## 📝 Description

Add `create-std-doc` Cursor skill and custom command (`/create-std-doc`) for generating Playwright STD documentation

## 🔗 Links

Jira ticket: [CNV-95611](https://redhat.atlassian.net/browse/CNV-95611)



## 🎥 Demo

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `/create-std-doc` command to generate or update colocated Software Test Description documents.
  * Supports specification paths and feature names, requesting clarification when no unique specification is identified.
  * Documents test coverage, skipped or deferred tests, traceability, Jira references, release versions, and validation checks.
  * Preserves manually maintained content while applying standardized placement, formatting, and safe handling of sensitive information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->