### PR TITLE
CNV-95508: Colors are incorrect on the vm migration pie chart

### DIFF
--- a/src/utils/resources/vmim/statuses.ts
+++ b/src/utils/resources/vmim/statuses.ts
@@ -7,6 +7,8 @@ export const vmimStatuses = {
   Scheduled: 'Scheduled',
   Scheduling: 'Scheduling',
   Succeeded: 'Succeeded',
+  Synchronizing: 'Synchronizing',
   TargetReady: 'TargetReady',
   Unset: '',
+  WaitingForSync: 'WaitingForSync',
 };

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationChartLegend.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationChartLegend.tsx
@@ -4,8 +4,7 @@ import { type OnSetFilters } from '@kubevirt-utils/hooks/useKubevirtDataViewFilt
 import { Button, Flex, FlexItem } from '@patternfly/react-core';
 
 import { MIGRATION_STATUS_FILTER_ID } from '../MigrationsTable/utils/constants';
-import { colorScale } from './constants';
-import { type ChartDataItem } from './MigrationsChartDonut';
+import { type ChartDataItem } from './utils';
 
 type MigrationChartLegendProps = {
   legendItems: ChartDataItem[];
@@ -15,14 +14,15 @@ type MigrationChartLegendProps = {
 const MigrationChartLegend: FC<MigrationChartLegendProps> = ({ legendItems, onSetFilters }) => {
   return (
     <Flex gap={{ default: 'gapMd' }}>
-      {legendItems?.map((item, index) => {
-        const { x: status, y: statusCount } = item || {};
+      {legendItems?.map((item) => {
+        const { fill, x: status, y: statusCount } = item || {};
         return (
           <FlexItem key={status} style={{ whiteSpace: 'nowrap' }}>
             <i
               aria-hidden="true"
               className="fas fa-square"
-              style={{ color: colorScale[index % colorScale.length] }}
+              data-test={`migration-legend-swatch-${status}`}
+              style={{ color: fill }}
             />{' '}
             <Button
               isInline

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationsChartDonut.test.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationsChartDonut.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+import { type V1VirtualMachineInstanceMigration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
+import { ChartDonut } from '@patternfly/react-charts/victory';
+import chart_color_green_400 from '@patternfly/react-tokens/dist/esm/chart_color_green_400';
+import chart_color_red_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_red_orange_300';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { MIGRATION_STATUS_FILTER_ID } from '../MigrationsTable/utils/constants';
+import MigrationChartLegend from './MigrationChartLegend';
+import MigrationsChartDonut from './MigrationsChartDonut';
+import { getMigrationChartData } from './utils';
+
+jest.mock('@patternfly/react-charts/victory', () => {
+  const mockReact = require('react');
+
+  return {
+    ChartDonut: jest.fn(() =>
+      mockReact.createElement('div', { 'data-test': 'migrations-chart-donut' }),
+    ),
+    ChartLabel: () => null,
+  };
+});
+
+jest.mock('@kubevirt-utils/hooks/useKubevirtTranslation', () => ({
+  useKubevirtTranslation: () => ({ t: (value: string) => value }),
+}));
+
+jest.mock('../LiveMigrationSettingsPopover/LiveMigrationSettingsPopover', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockChartDonut = ChartDonut as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const vmimWithPhase = (phase: string): V1VirtualMachineInstanceMigration =>
+  ({
+    status: { phase },
+  }) as V1VirtualMachineInstanceMigration;
+
+describe('MigrationChartLegend', () => {
+  it('filters the table by the clicked status', () => {
+    const legendItems = getMigrationChartData([
+      vmimWithPhase(vmimStatuses.Scheduling),
+      vmimWithPhase(vmimStatuses.Failed),
+      vmimWithPhase(vmimStatuses.Succeeded),
+    ]);
+    const onSetFilters = jest.fn();
+
+    render(<MigrationChartLegend legendItems={legendItems} onSetFilters={onSetFilters} />);
+
+    fireEvent.click(screen.getByRole('button', { name: `1 ${vmimStatuses.Failed}` }));
+    expect(onSetFilters).toHaveBeenCalledWith({
+      [MIGRATION_STATUS_FILTER_ID]: [vmimStatuses.Failed],
+    });
+  });
+});
+
+describe('MigrationsChartDonut', () => {
+  it('passes per-status fill to ChartDonut and titles the slice total', () => {
+    const vmims = [
+      vmimWithPhase(vmimStatuses.Scheduling),
+      vmimWithPhase(vmimStatuses.Failed),
+      vmimWithPhase(vmimStatuses.Succeeded),
+      {} as V1VirtualMachineInstanceMigration,
+    ];
+
+    render(<MigrationsChartDonut onSetFilters={jest.fn()} vmims={vmims} />);
+
+    const donutProps = mockChartDonut.mock.calls[0][0];
+    const data = donutProps.data as { fill: string; x: string; y: number }[];
+    const fillFromStyle = donutProps.style.data.fill as (args: {
+      datum: { fill: string };
+    }) => string;
+
+    expect(donutProps.colorScale).toBeUndefined();
+    expect(donutProps.title).toBe('3');
+    expect(data.find((item) => item.x === vmimStatuses.Succeeded)?.fill).toBe(
+      chart_color_green_400.value,
+    );
+    expect(data.find((item) => item.x === vmimStatuses.Failed)?.fill).toBe(
+      chart_color_red_orange_300.value,
+    );
+    expect(fillFromStyle({ datum: { fill: 'token-fill' } })).toBe('token-fill');
+  });
+});

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationsChartDonut.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationsChartDonut.tsx
@@ -1,26 +1,20 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachineInstanceMigration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineInstanceMigration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/SubTitleChartLabel';
 import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
-import { OnSetFilters } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import { type OnSetFilters } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ChartDonut } from '@patternfly/react-charts/victory';
 import { CardFooter, Split, SplitItem } from '@patternfly/react-core';
 
 import LiveMigrationSettingsPopover from '../LiveMigrationSettingsPopover/LiveMigrationSettingsPopover';
-
-import { colorScale } from './constants';
 import MigrationChartLegend from './MigrationChartLegend';
+import { getMigrationChartData, getMigrationChartTotal } from './utils';
 
 type MigrationsChartDonutProps = {
   onSetFilters: OnSetFilters;
   vmims: V1VirtualMachineInstanceMigration[];
-};
-
-export type ChartDataItem = {
-  x: string; // vmim status key
-  y: number; // count of each status
 };
 
 const MigrationsChartDonut: FC<MigrationsChartDonutProps> = ({ onSetFilters, vmims }) => {
@@ -28,39 +22,23 @@ const MigrationsChartDonut: FC<MigrationsChartDonutProps> = ({ onSetFilters, vmi
 
   if (!vmims?.length) return null;
 
-  const vmimsStatusCountMap = vmims?.reduce(
-    (acc, vmim) => {
-      const vmimStatusKey = vmim?.status?.phase;
-
-      acc[vmimStatusKey] = acc?.[vmimStatusKey] + 1 || 1;
-
-      return acc;
-    },
-    {} as { [status: string]: number },
-  );
-
-  const chartData: ChartDataItem[] = Object.entries(vmimsStatusCountMap)?.map(
-    ([status, statusCount]) => ({
-      x: status,
-      y: statusCount,
-    }),
-  );
+  const chartData = getMigrationChartData(vmims);
 
   return (
     <>
       <ChartDonut
         ariaDesc={t('Cluster scope migrations')}
         ariaTitle={t('Migrations')}
-        colorScale={colorScale}
         constrainToVisibleArea
         data={chartData}
         height={220}
-        labels={({ datum }) => `${datum.x}: ${datum.y}`}
+        labels={({ datum }) => t('{{status}}: {{count}}', { count: datum.y, status: datum.x })}
         legendPosition="bottom"
         padding={20}
+        style={{ data: { fill: ({ datum }) => datum.fill } }}
         subTitle={t('Migrations')}
         subTitleComponent={<SubTitleChartLabel />}
-        title={vmims?.length.toString()}
+        title={getMigrationChartTotal(chartData).toString()}
         titleComponent={<TitleChartLabel />}
         width={600}
       />

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/constants.ts
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/constants.ts
@@ -1,1 +1,40 @@
-export const colorScale = ['#2B9AF3', '#3E8635', '#C9190B', '#F0AB00', '#40199A'];
+import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
+import chart_color_black_400 from '@patternfly/react-tokens/dist/esm/chart_color_black_400';
+import chart_color_blue_100 from '@patternfly/react-tokens/dist/esm/chart_color_blue_100';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
+import chart_color_blue_500 from '@patternfly/react-tokens/dist/esm/chart_color_blue_500';
+import chart_color_green_400 from '@patternfly/react-tokens/dist/esm/chart_color_green_400';
+import chart_color_orange_100 from '@patternfly/react-tokens/dist/esm/chart_color_orange_100';
+import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
+import chart_color_orange_400 from '@patternfly/react-tokens/dist/esm/chart_color_orange_400';
+import chart_color_orange_500 from '@patternfly/react-tokens/dist/esm/chart_color_orange_500';
+import chart_color_red_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_red_orange_300';
+import chart_color_teal_300 from '@patternfly/react-tokens/dist/esm/chart_color_teal_300';
+
+export const defaultMigrationStatusColor = chart_color_black_400.value;
+
+export const migrationChartStatusOrder: string[] = [
+  vmimStatuses.Pending,
+  vmimStatuses.WaitingForSync,
+  vmimStatuses.Synchronizing,
+  vmimStatuses.Scheduling,
+  vmimStatuses.Scheduled,
+  vmimStatuses.PreparingTarget,
+  vmimStatuses.TargetReady,
+  vmimStatuses.Running,
+  vmimStatuses.Succeeded,
+  vmimStatuses.Failed,
+];
+
+export const migrationStatusColorMap: { [status: string]: string } = {
+  [vmimStatuses.Failed]: chart_color_red_orange_300.value,
+  [vmimStatuses.Pending]: chart_color_blue_100.value,
+  [vmimStatuses.PreparingTarget]: chart_color_orange_300.value,
+  [vmimStatuses.Running]: chart_color_teal_300.value,
+  [vmimStatuses.Scheduled]: chart_color_blue_500.value,
+  [vmimStatuses.Scheduling]: chart_color_blue_300.value,
+  [vmimStatuses.Succeeded]: chart_color_green_400.value,
+  [vmimStatuses.Synchronizing]: chart_color_orange_400.value,
+  [vmimStatuses.TargetReady]: chart_color_orange_500.value,
+  [vmimStatuses.WaitingForSync]: chart_color_orange_100.value,
+};

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/utils.test.ts
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/utils.test.ts
@@ -1,0 +1,149 @@
+import { type V1VirtualMachineInstanceMigration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
+import chart_color_blue_100 from '@patternfly/react-tokens/dist/esm/chart_color_blue_100';
+import chart_color_blue_300 from '@patternfly/react-tokens/dist/esm/chart_color_blue_300';
+import chart_color_blue_500 from '@patternfly/react-tokens/dist/esm/chart_color_blue_500';
+import chart_color_green_400 from '@patternfly/react-tokens/dist/esm/chart_color_green_400';
+import chart_color_orange_100 from '@patternfly/react-tokens/dist/esm/chart_color_orange_100';
+import chart_color_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_orange_300';
+import chart_color_orange_400 from '@patternfly/react-tokens/dist/esm/chart_color_orange_400';
+import chart_color_red_orange_300 from '@patternfly/react-tokens/dist/esm/chart_color_red_orange_300';
+
+import { defaultMigrationStatusColor } from './constants';
+import { getMigrationChartData, getMigrationChartTotal, getMigrationStatusColor } from './utils';
+
+const vmimWithPhase = (phase: string): V1VirtualMachineInstanceMigration =>
+  ({
+    status: { phase },
+  }) as V1VirtualMachineInstanceMigration;
+
+const findItem = (
+  chartData: ReturnType<typeof getMigrationChartData>,
+  status: string,
+): ReturnType<typeof getMigrationChartData>[number] | undefined =>
+  chartData.find((item) => item.x === status);
+
+describe('getMigrationChartData', () => {
+  it('colors Succeeded green and Failed red regardless of insertion order', () => {
+    const chartData = getMigrationChartData([
+      vmimWithPhase(vmimStatuses.Scheduling),
+      vmimWithPhase(vmimStatuses.Failed),
+      vmimWithPhase(vmimStatuses.Succeeded),
+      vmimWithPhase(vmimStatuses.Pending),
+    ]);
+
+    expect(findItem(chartData, vmimStatuses.Succeeded)).toEqual(
+      expect.objectContaining({ fill: chart_color_green_400.value, y: 1 }),
+    );
+    expect(findItem(chartData, vmimStatuses.Failed)).toEqual(
+      expect.objectContaining({ fill: chart_color_red_orange_300.value, y: 1 }),
+    );
+    expect(findItem(chartData, vmimStatuses.Scheduling)).toEqual(
+      expect.objectContaining({ fill: chart_color_blue_300.value }),
+    );
+    expect(findItem(chartData, vmimStatuses.Pending)).toEqual(
+      expect.objectContaining({ fill: chart_color_blue_100.value }),
+    );
+  });
+
+  it('keeps the same colors when the same statuses appear in a different order', () => {
+    const inOriginalOrder = getMigrationChartData([
+      vmimWithPhase(vmimStatuses.Scheduling),
+      vmimWithPhase(vmimStatuses.Failed),
+      vmimWithPhase(vmimStatuses.Succeeded),
+    ]);
+    const inReverseOrder = getMigrationChartData([
+      vmimWithPhase(vmimStatuses.Succeeded),
+      vmimWithPhase(vmimStatuses.Failed),
+      vmimWithPhase(vmimStatuses.Scheduling),
+    ]);
+
+    expect(findItem(inReverseOrder, vmimStatuses.Succeeded)?.fill).toBe(
+      findItem(inOriginalOrder, vmimStatuses.Succeeded)?.fill,
+    );
+    expect(findItem(inReverseOrder, vmimStatuses.Failed)?.fill).toBe(
+      findItem(inOriginalOrder, vmimStatuses.Failed)?.fill,
+    );
+    expect(findItem(inReverseOrder, vmimStatuses.Scheduling)?.fill).toBe(
+      findItem(inOriginalOrder, vmimStatuses.Scheduling)?.fill,
+    );
+  });
+
+  it('uses distinct colors for related phases', () => {
+    const chartData = getMigrationChartData([
+      vmimWithPhase(vmimStatuses.Scheduling),
+      vmimWithPhase(vmimStatuses.Scheduled),
+      vmimWithPhase(vmimStatuses.PreparingTarget),
+      vmimWithPhase(vmimStatuses.WaitingForSync),
+      vmimWithPhase(vmimStatuses.Synchronizing),
+    ]);
+
+    expect(findItem(chartData, vmimStatuses.Scheduling)?.fill).toBe(chart_color_blue_300.value);
+    expect(findItem(chartData, vmimStatuses.Scheduled)?.fill).toBe(chart_color_blue_500.value);
+    expect(findItem(chartData, vmimStatuses.PreparingTarget)?.fill).toBe(
+      chart_color_orange_300.value,
+    );
+    expect(findItem(chartData, vmimStatuses.WaitingForSync)?.fill).toBe(
+      chart_color_orange_100.value,
+    );
+    expect(findItem(chartData, vmimStatuses.Synchronizing)?.fill).toBe(
+      chart_color_orange_400.value,
+    );
+    expect(findItem(chartData, vmimStatuses.Scheduling)?.fill).not.toBe(
+      findItem(chartData, vmimStatuses.Scheduled)?.fill,
+    );
+  });
+
+  it('orders slices by lifecycle, not insertion order', () => {
+    const chartData = getMigrationChartData([
+      vmimWithPhase(vmimStatuses.Failed),
+      vmimWithPhase(vmimStatuses.Succeeded),
+      vmimWithPhase(vmimStatuses.Pending),
+    ]);
+
+    expect(chartData.map((item) => item.x)).toEqual([
+      vmimStatuses.Pending,
+      vmimStatuses.Succeeded,
+      vmimStatuses.Failed,
+    ]);
+  });
+
+  it('counts migrations per status', () => {
+    const chartData = getMigrationChartData([
+      vmimWithPhase(vmimStatuses.Succeeded),
+      vmimWithPhase(vmimStatuses.Succeeded),
+      vmimWithPhase(vmimStatuses.Failed),
+    ]);
+
+    expect(findItem(chartData, vmimStatuses.Succeeded)?.y).toBe(2);
+    expect(findItem(chartData, vmimStatuses.Failed)?.y).toBe(1);
+    expect(getMigrationChartTotal(chartData)).toBe(3);
+  });
+
+  it('returns an empty array for an empty list', () => {
+    expect(getMigrationChartData([])).toEqual([]);
+  });
+
+  it('skips migrations that have no status phase', () => {
+    const chartData = getMigrationChartData([
+      vmimWithPhase(vmimStatuses.Succeeded),
+      {} as V1VirtualMachineInstanceMigration,
+      { status: {} } as V1VirtualMachineInstanceMigration,
+      vmimWithPhase(vmimStatuses.Unset),
+    ]);
+
+    expect(chartData).toHaveLength(1);
+    expect(findItem(chartData, vmimStatuses.Succeeded)?.y).toBe(1);
+    expect(getMigrationChartTotal(chartData)).toBe(1);
+  });
+});
+
+describe('getMigrationStatusColor', () => {
+  it('returns the mapped color for a known status', () => {
+    expect(getMigrationStatusColor(vmimStatuses.Succeeded)).toBe(chart_color_green_400.value);
+  });
+
+  it('falls back to the default color for an unknown status', () => {
+    expect(getMigrationStatusColor('SomeUnmappedPhase')).toBe(defaultMigrationStatusColor);
+  });
+});

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/utils.ts
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/utils.ts
@@ -1,0 +1,57 @@
+import { type V1VirtualMachineInstanceMigration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getMigrationPhase } from '@kubevirt-utils/resources/vmim/selectors';
+
+import {
+  defaultMigrationStatusColor,
+  migrationChartStatusOrder,
+  migrationStatusColorMap,
+} from './constants';
+
+export type ChartDataItem = {
+  fill: string;
+  x: string;
+  y: number;
+};
+
+const statusOrderIndex = new Map(migrationChartStatusOrder.map((status, index) => [status, index]));
+
+export const getMigrationStatusColor = (status: string): string =>
+  migrationStatusColorMap[status] ?? defaultMigrationStatusColor;
+
+export const getMigrationChartTotal = (chartData: ChartDataItem[]): number =>
+  chartData.reduce((sum, item) => sum + item.y, 0);
+
+const compareChartStatuses = (statusA: string, statusB: string): number => {
+  const indexA = statusOrderIndex.get(statusA) ?? Number.MAX_SAFE_INTEGER;
+  const indexB = statusOrderIndex.get(statusB) ?? Number.MAX_SAFE_INTEGER;
+
+  if (indexA !== indexB) {
+    return indexA - indexB;
+  }
+
+  return statusA.localeCompare(statusB);
+};
+
+export const getMigrationChartData = (
+  vmims: V1VirtualMachineInstanceMigration[],
+): ChartDataItem[] => {
+  const statusCountMap = (vmims || []).reduce<{ [status: string]: number }>((acc, vmim) => {
+    const status = getMigrationPhase(vmim);
+
+    if (!status) {
+      return acc;
+    }
+
+    acc[status] = (acc[status] ?? 0) + 1;
+
+    return acc;
+  }, {});
+
+  return Object.entries(statusCountMap)
+    .sort(([statusA], [statusB]) => compareChartStatuses(statusA, statusB))
+    .map(([status, statusCount]) => ({
+      fill: getMigrationStatusColor(status),
+      x: status,
+      y: statusCount,
+    }));
+};

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/utils/migrationStatusConstants.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/utils/migrationStatusConstants.ts
@@ -13,6 +13,8 @@ export const OTHER_STATUSES = [
   vmimStatuses.PreparingTarget,
   vmimStatuses.Pending,
   vmimStatuses.Paused,
+  vmimStatuses.Synchronizing,
+  vmimStatuses.WaitingForSync,
 ];
 
 export const buildStatusFilterPath = (basePath: string, statuses: string[]): string =>


### PR DESCRIPTION
## 📝 Description

The migration chart donut colors were assigned by array index based on the order distinct migration statuses first appeared in the data, not by the status itself. As a result, the same status (e.g. `Succeeded` or `Failed`) could end up with a different color depending on which statuses were present and in what order, sometimes causing failures to appear green and successes to appear red. 

## 🔗 Links

Jira ticket: [CNV-95508](https://redhat.atlassian.net/browse/CNV-95508)

## 🎥 Demo

Before:
<img width="1579" height="611" alt="Before" src="https://github.com/user-attachments/assets/6c41f625-3320-453b-a962-95233a64d532" />

After:

<img width="1539" height="571" alt="After" src="https://github.com/user-attachments/assets/837fdba4-696a-4a98-a30c-284c417fb44c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for “Synchronizing” and “Waiting for Sync” migration statuses.
  - Updated migration charts with consistent, status-specific colors.
  - Charts now show accurate totals, status counts, and lifecycle ordering.
  - Added fallback handling for unknown statuses and clearer visualization for migrations without standard phases.

- **Bug Fixes**
  - Improved legend and donut slice colors so they remain accurate and consistent regardless of data order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->