### PR TITLE
CNV-90382: husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
+set -e
+
 npm run lint-staged
 
 translation_file_diff=$(git diff --name-only locales/en/plugin__kubevirt-plugin.json)


### PR DESCRIPTION
## 📝 Description

Fix pre-commit hook to block commits when lint error exist. 

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-90382



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the pre-commit checks so they stop immediately when a command fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->