### PR TITLE
CNV-95746: Fix search-language exclusions when the apiserver proxy is used

### DIFF
--- a/src/utils/hooks/useKubevirtDataPod/types.ts
+++ b/src/utils/hooks/useKubevirtDataPod/types.ts
@@ -1,0 +1,1 @@
+export type KubevirtDataPodFilters = { [key: string]: readonly string[] | string | string[] };

--- a/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPod.ts
+++ b/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPod.ts
@@ -11,13 +11,14 @@ import {
 
 import useDeepCompareMemoize from '../useDeepCompareMemoize/useDeepCompareMemoize';
 
+import { type KubevirtDataPodFilters } from './types';
+import useKubevirtDataPodFilters from './useKubevirtDataPodFilters';
 import {
   compareNameAndNamespace,
   constructURL,
   getResourceVersion,
   registerResourceVersion,
 } from './utils/utils';
-import useKubevirtDataPodFilters, { KubevirtDataPodFilters } from './useKubevirtDataPodFilters';
 
 export type NullableWatchK8sResource = null | WatchK8sResource;
 
@@ -30,7 +31,7 @@ const useKubevirtDataPod = <T extends K8sResourceCommon | K8sResourceCommon[]>(
   const [data, setData] = useState<T>((<unknown>[]) as T);
   const [loaded, setLoaded] = useState<boolean>(false);
   const [error, setError] = useState<Error>(null);
-  const [resourceVersion, setResourceVersion] = useState<string>(null);
+  const [resourceVersion, setResourceVersion] = useState<number | null>(null);
   const query = useKubevirtDataPodFilters(filterOptions);
   const watchOptionsMemoized = useDeepCompareMemoize<NullableWatchK8sResource>(watchOptions, true);
   const url = useMemo(
@@ -46,7 +47,7 @@ const useKubevirtDataPod = <T extends K8sResourceCommon | K8sResourceCommon[]>(
       onOpen: () => kubevirtConsole.log('websocket open kubevirt: ', url),
       queryParams: {
         cluster: 'local-cluster',
-        resourceVersion,
+        ...(resourceVersion != null && { resourceVersion }),
         watch: 'true',
         // fieldSelector: 'metadata.name=?',
       },
@@ -66,7 +67,7 @@ const useKubevirtDataPod = <T extends K8sResourceCommon | K8sResourceCommon[]>(
           watchOptionsMemoized.groupVersionKind.kind,
           jsonData?.metadata?.resourceVersion,
         );
-        setResourceVersion(getResourceVersion(watchOptionsMemoized.groupVersionKind.kind));
+        setResourceVersion(getResourceVersion(watchOptionsMemoized.groupVersionKind.kind) ?? null);
         setData(jsonData?.items ? jsonData.items : jsonData);
         setShouldConnect(true);
         setLoaded(true);

--- a/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPodFilters.ts
+++ b/src/utils/hooks/useKubevirtDataPod/useKubevirtDataPodFilters.ts
@@ -1,45 +1,16 @@
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import useQuery from '@kubevirt-utils/hooks/useQuery';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import useDeepCompareMemoize from '../useDeepCompareMemoize/useDeepCompareMemoize';
+import { type KubevirtDataPodFilters } from './types';
+import { buildProxyFilterQuery } from './utils/buildProxyFilterQuery';
 
-import { YAML_PATH_DELIMITER } from './utils/constants';
-
-export type KubevirtDataPodFilters = { [key: string]: readonly string[] | string | string[] };
-
-const updateQueryString = (setQueryString: Dispatch<SetStateAction<string>>) => (url: string) =>
-  setQueryString((prevQuery) => (prevQuery !== url ? url : prevQuery));
-
-const useKubevirtDataPodFilters = (filters: KubevirtDataPodFilters) => {
-  const [queryString, setQueryString] = useState<string>('');
+const useKubevirtDataPodFilters = (filters: KubevirtDataPodFilters): string => {
   const query = useQuery();
   const filtersMemoized = useDeepCompareMemoize(filters);
 
-  useEffect(() => {
-    const url = new URLSearchParams();
-    for (const [key, value] of query.entries()) {
-      const valueReplaced = value === 'No InstanceType' || value === 'None' ? null : value;
-
-      if (key === 'rowFilter-status' && value === 'Error') {
-        continue;
-      }
-
-      const yamlPath = filtersMemoized?.[key];
-      if (yamlPath) {
-        url.set(
-          Array.isArray(yamlPath) ? yamlPath.join(YAML_PATH_DELIMITER) : (yamlPath as string),
-          valueReplaced,
-        );
-      }
-    }
-    const urlString = url.toString();
-
-    (!isEmpty(urlString) || !isEmpty(queryString)) && updateQueryString(setQueryString)(urlString);
-  }, [filtersMemoized, query, queryString]);
-
-  return queryString;
+  return useMemo(() => buildProxyFilterQuery(query, filtersMemoized), [query, filtersMemoized]);
 };
 
 export default useKubevirtDataPodFilters;

--- a/src/utils/hooks/useKubevirtDataPod/utils/buildProxyFilterQuery.test.ts
+++ b/src/utils/hooks/useKubevirtDataPod/utils/buildProxyFilterQuery.test.ts
@@ -1,0 +1,45 @@
+import { buildProxyFilterQuery } from './buildProxyFilterQuery';
+
+const FILTER_OPTIONS = {
+  labels: 'metadata.labels',
+  name: 'metadata.name',
+  os: ['spec.preference.name', 'spec.template.metadata.annotations.vm\\.kubevirt\\.io/os'],
+  status: 'status.printableStatus',
+};
+
+describe('buildProxyFilterQuery', () => {
+  it('should return empty string when filterOptions is missing', () => {
+    expect(buildProxyFilterQuery(new URLSearchParams('status=Running'))).toBe('');
+  });
+
+  it('should map a single included filter to its yaml path', () => {
+    expect(buildProxyFilterQuery(new URLSearchParams('name=vm-rhel'), FILTER_OPTIONS)).toBe(
+      'metadata.name=vm-rhel',
+    );
+  });
+
+  it('should join array yaml paths into one proxy key', () => {
+    expect(buildProxyFilterQuery(new URLSearchParams('os=rhel'), FILTER_OPTIONS)).toBe(
+      'spec.preference.name%7Cspec.template.metadata.annotations.vm%5C.kubevirt%5C.io%2Fos=rhel',
+    );
+  });
+
+  it('should omit excluded values', () => {
+    expect(buildProxyFilterQuery(new URLSearchParams('name=!vm-rhel'), FILTER_OPTIONS)).toBe('');
+  });
+
+  it('should join repeated keys into one comma-separated proxy value', () => {
+    expect(
+      buildProxyFilterQuery(new URLSearchParams('status=Running&status=Stopped'), FILTER_OPTIONS),
+    ).toBe('status.printableStatus=Running%2CStopped');
+  });
+
+  it('should keep includes and drop excludes when both are repeated keys', () => {
+    expect(
+      buildProxyFilterQuery(
+        new URLSearchParams('status=Running&status=!Stopped&name=!vm-rhel'),
+        FILTER_OPTIONS,
+      ),
+    ).toBe('status.printableStatus=Running');
+  });
+});

--- a/src/utils/hooks/useKubevirtDataPod/utils/buildProxyFilterQuery.ts
+++ b/src/utils/hooks/useKubevirtDataPod/utils/buildProxyFilterQuery.ts
@@ -1,0 +1,51 @@
+import { isExcludedValue } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/utils';
+
+import { type KubevirtDataPodFilters } from '../types';
+
+import { YAML_PATH_DELIMITER } from './constants';
+
+const toYamlPath = (yamlPath: readonly string[] | string | string[]): string =>
+  typeof yamlPath === 'string' ? yamlPath : yamlPath.join(YAML_PATH_DELIMITER);
+
+const addIncludedValue = (
+  pathToValues: Map<string, string[]>,
+  path: string,
+  value: string,
+): void => {
+  const existingValues = pathToValues.get(path) ?? [];
+  if (existingValues.includes(value)) return;
+  pathToValues.set(path, [...existingValues, value]);
+};
+
+/**
+ * Maps UI filter query params to the proxy's yaml-path query string.
+ * Repeated keys (status=Running&status=Stopped) are collected and joined with
+ * commas because the proxy reads a single value per path and splits on comma.
+ * Excluded values (prefixed with !) are omitted so the proxy never treats them as includes.
+ */
+export const buildProxyFilterQuery = (
+  query: URLSearchParams,
+  filterOptions?: KubevirtDataPodFilters,
+): string => {
+  if (!filterOptions) return '';
+
+  const pathToValues = new Map<string, string[]>();
+
+  for (const [key, value] of query.entries()) {
+    const yamlPath = filterOptions[key];
+    if (!yamlPath) continue;
+
+    const path = toYamlPath(yamlPath);
+
+    if (isExcludedValue(value)) continue;
+
+    addIncludedValue(pathToValues, path, value);
+  }
+
+  const url = new URLSearchParams();
+  for (const [path, values] of pathToValues) {
+    url.set(path, values.join(','));
+  }
+
+  return url.toString();
+};

--- a/src/utils/hooks/useKubevirtDataPod/utils/utils.ts
+++ b/src/utils/hooks/useKubevirtDataPod/utils/utils.ts
@@ -1,22 +1,26 @@
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { K8sResourceCommon, WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  type K8sResourceCommon,
+  type WatchK8sResource,
+} from '@openshift-console/dynamic-plugin-sdk';
 
 import { PROXY_KUBEVIRT_URL } from './constants';
 
-const rsMapper = {};
+const rsMapper: Record<string, number> = {};
 
-export const registerResourceVersion = (key: string, rs: string) => {
-  rsMapper[key] = Number(rs < rsMapper?.[key] ? rsMapper?.[key] : rs);
-  return;
+export const registerResourceVersion = (key: string, resourceVersion: string): void => {
+  const resourceVersionNumber = Number(resourceVersion);
+  rsMapper[key] = resourceVersionNumber < rsMapper[key] ? rsMapper[key] : resourceVersionNumber;
 };
-export const getResourceVersion = (key: string) => rsMapper?.[key];
 
-export const constructURL = (watchOptions: WatchK8sResource, query?: string) => {
+export const getResourceVersion = (key: string): number | undefined => rsMapper[key];
+
+export const constructURL = (watchOptions: WatchK8sResource, query?: string): string => {
   const { groupVersionKind, name, namespace } = watchOptions || {};
   const baseUrl = `${PROXY_KUBEVIRT_URL}apis/${groupVersionKind?.group}/${groupVersionKind?.version}/`;
-  const namespaceUrl = `${namespace ? `namespaces/${namespace}/` : ''}`;
-  const nameUrl = `${!name ? 's' : `/${name}`}`;
+  const namespaceUrl = namespace ? `namespaces/${namespace}/` : '';
+  const nameUrl = !name ? 's' : `/${name}`;
   const kindUrl = groupVersionKind?.kind.toLowerCase();
   const appendedQuery = !isEmpty(query) ? `?${query}` : '';
 

--- a/src/utils/hooks/useKubevirtDataViewFilters/utils.test.ts
+++ b/src/utils/hooks/useKubevirtDataViewFilters/utils.test.ts
@@ -1,0 +1,50 @@
+import { hasActiveProxyFilter } from './utils';
+
+const FILTER_OPTIONS = {
+  labels: 'metadata.labels',
+  name: 'metadata.name',
+  os: ['spec.preference.name'],
+  status: 'status.printableStatus',
+};
+
+describe('hasActiveProxyFilter', () => {
+  it('should return false when filterOptions is missing', () => {
+    expect(hasActiveProxyFilter(new URLSearchParams('name=vm-rhel'))).toBe(false);
+  });
+
+  it('should return false when the query has no mapped keys', () => {
+    expect(hasActiveProxyFilter(new URLSearchParams('sortBy=name'), FILTER_OPTIONS)).toBe(false);
+  });
+
+  it('should return false when the only mapped filter is excluded', () => {
+    expect(hasActiveProxyFilter(new URLSearchParams('name=!vm-rhel'), FILTER_OPTIONS)).toBe(false);
+  });
+
+  it('should return true when a mapped filter has an included value', () => {
+    expect(hasActiveProxyFilter(new URLSearchParams('name=vm-rhel'), FILTER_OPTIONS)).toBe(true);
+  });
+
+  it('should return true when an include remains beside an exclude', () => {
+    expect(
+      hasActiveProxyFilter(new URLSearchParams('status=Stopped&name=!vm-rhel'), FILTER_OPTIONS),
+    ).toBe(true);
+  });
+
+  it('should return true for repeated include keys', () => {
+    expect(
+      hasActiveProxyFilter(new URLSearchParams('status=Running&status=Stopped'), FILTER_OPTIONS),
+    ).toBe(true);
+  });
+
+  it('should return true when a repeated key has both include and exclude', () => {
+    expect(
+      hasActiveProxyFilter(new URLSearchParams('status=Running&status=!Stopped'), FILTER_OPTIONS),
+    ).toBe(true);
+  });
+
+  it('should return false when every repeated key value is excluded', () => {
+    expect(
+      hasActiveProxyFilter(new URLSearchParams('status=!Running&status=!Stopped'), FILTER_OPTIONS),
+    ).toBe(false);
+  });
+});

--- a/src/utils/hooks/useKubevirtDataViewFilters/utils.ts
+++ b/src/utils/hooks/useKubevirtDataViewFilters/utils.ts
@@ -40,6 +40,19 @@ export const isExcludedValue = (value: string): boolean => value.startsWith(EXCL
 export const stripExclusionPrefix = (value: string): string =>
   isExcludedValue(value) ? value.slice(EXCLUSION_URL_PREFIX.length) : value;
 
+export const hasActiveProxyFilter = (
+  query: URLSearchParams,
+  filterOptions?: Record<string, unknown>,
+): boolean => {
+  if (!filterOptions) return false;
+
+  for (const [key, value] of query.entries()) {
+    if (Object.hasOwn(filterOptions, key) && !isExcludedValue(value)) return true;
+  }
+
+  return false;
+};
+
 export const matchesWithExclusion = <T extends FilterableObject>(
   filterDef: KubevirtFilter<T>,
   obj: T,

--- a/src/utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource.ts
+++ b/src/utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource.ts
@@ -1,14 +1,18 @@
 import { useMemo } from 'react';
 
-import { K8sResourceCommon, WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
-import { AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
+import {
+  type K8sResourceCommon,
+  type WatchK8sResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { type AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
+
+import useQuery from '../useQuery';
 
 import { KUBEVIRT_APISERVER_PROXY } from '../useFeatures/constants';
 import { useFeatures } from '../useFeatures/useFeatures';
 import useKubevirtDataPodHealth from '../useKubevirtDataPod/hooks/useKubevirtDataPodHealth';
-import { KubevirtDataPodFilters } from '../useKubevirtDataPod/useKubevirtDataPodFilters';
-import useQuery from '../useQuery';
-
+import { type KubevirtDataPodFilters } from '../useKubevirtDataPod/types';
+import { hasActiveProxyFilter } from '../useKubevirtDataViewFilters/utils';
 import useRedirectWatchHooks from './useRedirectWatchHooks';
 
 export type Result<R extends K8sResourceCommon | K8sResourceCommon[]> = [
@@ -25,16 +29,18 @@ const useKubevirtWatchResource = <T extends K8sResourceCommon | K8sResourceCommo
   const isProxyPodAlive = useKubevirtDataPodHealth();
   const { featureEnabled, loading } = useFeatures(KUBEVIRT_APISERVER_PROXY);
   const query = useQuery();
-
-  const hasNoFilter = !filterOptions || query.size === 0;
+  const shouldUseProxyFilter = useMemo(
+    () => hasActiveProxyFilter(query, filterOptions),
+    [query, filterOptions],
+  );
 
   const shouldUseProxyPod = useMemo(() => {
     if (watchOptions?.cluster) return false;
-    if (hasNoFilter) return false;
+    if (!shouldUseProxyFilter) return false;
     if (!featureEnabled && !loading) return false;
     if (featureEnabled && !loading && isProxyPodAlive !== null) return isProxyPodAlive;
     return null;
-  }, [featureEnabled, loading, isProxyPodAlive, watchOptions?.cluster, hasNoFilter]);
+  }, [featureEnabled, loading, isProxyPodAlive, watchOptions?.cluster, shouldUseProxyFilter]);
 
   return useRedirectWatchHooks<T>(watchOptions, filterOptions, searchQueries, shouldUseProxyPod);
 };

--- a/src/utils/hooks/useKubevirtWatchResource/useRedirectWatchHooks.ts
+++ b/src/utils/hooks/useKubevirtWatchResource/useRedirectWatchHooks.ts
@@ -3,19 +3,21 @@ import { useMemo } from 'react';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import useKubevirtSearchPoll from '@multicluster/hooks/useKubevirtSearchPoll';
 import useIsACMPage from '@multicluster/useIsACMPage';
-import { K8sResourceCommon, WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
-import { AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
+import {
+  type K8sResourceCommon,
+  type WatchK8sResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { type AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
 
+import { type KubevirtDataPodFilters } from '../useKubevirtDataPod/types';
 import useKubevirtDataPod from '../useKubevirtDataPod/useKubevirtDataPod';
-import { KubevirtDataPodFilters } from '../useKubevirtDataPod/useKubevirtDataPodFilters';
-
-import { Result } from './useKubevirtWatchResource';
+import { type Result } from './useKubevirtWatchResource';
 
 const useRedirectWatchHooks = <T extends K8sResourceCommon | K8sResourceCommon[]>(
   watchOptions: WatchK8sResource & { cluster?: string },
   filterOptions?: KubevirtDataPodFilters,
   searchQueries?: AdvancedSearchFilter,
-  shouldUseProxyPod?: boolean,
+  shouldUseProxyPod?: boolean | null,
 ): Result<T> => {
   const isACMTreeView = useIsACMPage();
 

--- a/src/views/virtualmachines/list/utils/constants.ts
+++ b/src/views/virtualmachines/list/utils/constants.ts
@@ -1,11 +1,8 @@
 export const VM_FILTER_OPTIONS = {
   labels: 'metadata.labels',
   name: 'metadata.name',
-  'rowFilter-os': [
-    'spec.template.metadata.annotations.vm\\.kubevirt\\.io/os',
-    'spec.preference.name',
-  ],
-  'rowFilter-status': 'status.printableStatus',
+  os: ['spec.template.metadata.annotations.vm\\.kubevirt\\.io/os', 'spec.preference.name'],
+  status: 'status.printableStatus',
 } as const;
 
 export const VMI_FILTER_OPTIONS = {

--- a/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
+++ b/src/views/virtualmachines/search/hooks/useAccessibleResources.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
-import { KubevirtDataPodFilters } from '@kubevirt-utils/hooks/useKubevirtDataPod/useKubevirtDataPodFilters';
+import { type KubevirtDataPodFilters } from '@kubevirt-utils/hooks/useKubevirtDataPod/types';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
 import { isSystemNamespace } from '@kubevirt-utils/resources/namespace/helper';
@@ -9,11 +9,11 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import {
-  K8sGroupVersionKind,
-  Selector,
+  type K8sGroupVersionKind,
+  type Selector,
   useK8sWatchResources,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
+import { type AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
 import { getSearchQueries } from '@virtualmachines/search/utils';
 import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils/constants';
 
@@ -31,7 +31,7 @@ type UseAccessibleResourcesArgs = {
 
 type UseAccessibleResourcesReturn<T> = {
   loaded: boolean;
-  loadError?: any;
+  loadError?: Error;
   resources: T[];
 };
 

--- a/src/views/virtualmachines/search/hooks/useVMSearchQueries.ts
+++ b/src/views/virtualmachines/search/hooks/useVMSearchQueries.ts
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 
+import { isExcludedValue } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/utils';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getRowFilterQueryKey } from '@search/utils/query';
-import { AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
+import { type AdvancedSearchFilter } from '@stolostron/multicluster-sdk';
 import { appendDateCreatedSearchQueries } from '@virtualmachines/search/utils';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
 
@@ -25,14 +26,17 @@ const useVMSearchQueries = (): VMSearchQueries => {
     return value ? value.split(',') : [];
   };
 
-  const vmName = getParam(VirtualMachineRowFilterType.Name);
-  const ipAddress = getParam(VirtualMachineRowFilterType.IP);
+  const vmNames = getMultipleParams(VirtualMachineRowFilterType.Name);
+  const ipAddresses = getMultipleParams(VirtualMachineRowFilterType.IP);
+  const projects = getMultipleParams(VirtualMachineRowFilterType.Project);
+  const clusters = getMultipleParams(VirtualMachineRowFilterType.Cluster);
+
   const dateCreated = getParam(VirtualMachineRowFilterType.DateCreated);
   const createdFrom = getParam(VirtualMachineRowFilterType.DateCreatedFrom);
   const createdTo = getParam(VirtualMachineRowFilterType.DateCreatedTo);
 
-  const projects = getMultipleParams(VirtualMachineRowFilterType.Project);
-  const clusters = getMultipleParams(VirtualMachineRowFilterType.Cluster);
+  const vmName = vmNames.find((name) => !isExcludedValue(name));
+  const ipAddress = ipAddresses.find((ipAddr) => !isExcludedValue(ipAddr));
 
   return useMemo(() => {
     const queries: VMSearchQueries = {


### PR DESCRIPTION




<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fix search-language exclusions when the apiserver proxy is used

The proxy treated `!` as a literal include, so queries like `-name:vm-rhel` never hid matching VMs. Excludes now stay on the client; the proxy only runs when a mapped filter still has an include.

- Omit excluded (`!`) values from the proxy query and join remaining repeated keys as a comma-separated OR
- Use the proxy only when a mapped filter has an include (`hasActiveProxyFilter`); skip it for exclude-only searches
- Map `os` / `status` in `VM_FILTER_OPTIONS` so those filters reach the proxy after the `rowFilter-` URL migration
- Drop the `rowFilter-status=Error` skip; the proxy already expands the Error category
- Drop the obsolete `None` / `No InstanceType` proxy rewrite
- Skip excluded name/IP values in ACM search queries
- Derive the proxy query in render instead of via `useEffect` + debounce leftover

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-95746

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/92076de2-119d-4626-9b7b-79f3edd4870b



After:


https://github.com/user-attachments/assets/3813a1f0-f3d5-48f8-b311-2dfff4b4d9b9




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved filtering for virtual machines and data views, including multi-valued name and IP filters.
  * Added support for mapping filters to Kubernetes YAML paths and handling included or excluded values.
  * Proxy-based resource loading now activates only for applicable active filters.
  * Improved resource-version handling for more reliable watch updates.

* **Bug Fixes**
  * Improved filter detection and query generation for repeated and excluded values.
  * Improved error reporting for resource-loading failures.

* **Tests**
  * Added coverage for filter detection and query construction scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->