### PR TITLE
CNV-93583: add Playwright tests for VM Project filter from tree view

### DIFF
--- a/playwright/src/components/shared/page-content-component.ts
+++ b/playwright/src/components/shared/page-content-component.ts
@@ -96,10 +96,6 @@ export default class PageContentComponent extends BaseComponent {
     return statusTexts;
   }
 
-  getCurrentUrl(): string {
-    return this.page.url();
-  }
-
   async getMainHeadingH1Text(): Promise<string | null> {
     const raw = await this.page.locator('h1').textContent();
     return raw?.trim() ?? null;

--- a/playwright/src/components/vm/virtual-machine-detail-metrics-snapshots-component.ts
+++ b/playwright/src/components/vm/virtual-machine-detail-metrics-snapshots-component.ts
@@ -151,10 +151,6 @@ export default class VirtualMachineDetailMetricsSnapshotsComponent extends BaseC
     await this.robustClick(confirmButton);
   }
 
-  getCurrentUrl(): string {
-    return this.page.url();
-  }
-
   async getFirstSnapshotNameFromSnapshotsTable(
     timeoutMs: number = TestTimeouts.STATUS_VALIDATION,
   ): Promise<string> {

--- a/playwright/src/components/vm/vm-detail-component.ts
+++ b/playwright/src/components/vm/vm-detail-component.ts
@@ -275,10 +275,6 @@ export default class VmDetailComponent extends PageCommons {
     return (await moreLink.textContent())?.trim() || '';
   }
 
-  override getCurrentUrl(): string {
-    return this.page.url();
-  }
-
   async getStorageUtilizationText(): Promise<string | null> {
     try {
       const storageSummary = this._utilSummaryStorage;

--- a/playwright/src/components/vm/vm-list-component.ts
+++ b/playwright/src/components/vm/vm-list-component.ts
@@ -225,10 +225,6 @@ export default class VmListComponent extends BaseComponent {
     await this._templateVmNameInput.fill(vmName);
   }
 
-  getCurrentUrl(): string {
-    return this.page.url();
-  }
-
   async getTemplateVmName(): Promise<string> {
     return await this._templateVmNameInput.inputValue();
   }

--- a/playwright/src/components/vm/vm-list-overview-widgets-component.ts
+++ b/playwright/src/components/vm/vm-list-overview-widgets-component.ts
@@ -174,15 +174,10 @@ export default class VmListOverviewWidgetsComponent extends BaseComponent {
         .catch(() => false);
     }
 
-    const treeItem = this._treeView
-      .locator('[role="treeitem"]')
-      .filter({
-        has: this.page.locator('button', { hasText: 'Local cluster' }),
-      })
-      .first();
+    const treeItem = this._treeView.locator('[id="#ALL_NS#"]').first();
     await treeItem.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
 
-    const labelButton = treeItem.locator('button', { hasText: 'Local cluster' }).last();
+    const labelButton = treeItem.locator('button', { hasText: 'Local cluster' });
     await labelButton.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
     await this.robustClick(labelButton);
 

--- a/playwright/src/components/vm/vm-list-search-components.ts
+++ b/playwright/src/components/vm/vm-list-search-components.ts
@@ -101,6 +101,14 @@ export class VmListFiltersComponent extends BaseComponent {
     await this.robustClick(statusFilter);
   }
 
+  async isProjectFilterEnabled(): Promise<boolean> {
+    await this._filterToolbarProjectButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    return this._filterToolbarProjectButton.isEnabled();
+  }
+
   async openProjectFilter(): Promise<void> {
     await this._filterToolbarProjectButton.waitFor({
       state: 'visible',
@@ -130,6 +138,7 @@ export class VmListFiltersComponent extends BaseComponent {
   async selectProjectInFilterMenu(projectName: string): Promise<void> {
     const menuitem = this._filterMenuitem.filter({ hasText: projectName }).first();
     await menuitem.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await menuitem.scrollIntoViewIfNeeded();
     await menuitem.click({ force: true });
   }
 

--- a/playwright/src/components/vm/vm-list-state-migration-components.ts
+++ b/playwright/src/components/vm/vm-list-state-migration-components.ts
@@ -245,6 +245,9 @@ export class VmListEmptyStateComponent extends BaseComponent {
 /** VM list tree view: drawer, search, namespace/project nodes, and folder rows. */
 export class VmListTreeComponent extends BaseComponent {
   private readonly _idVmsTreeViewSearchInput = this.locator('[id="vms-tree-view-search-input"]');
+  private readonly _localClusterNodeButton = this.locator('[id="#ALL_NS#"]').locator('button', {
+    hasText: 'Local cluster',
+  });
   private readonly _projectName = this.locator('#project-name');
   private readonly _treeNode = this.locator('.pf-v6-c-tree-view__node');
   private readonly _treeView = this.locator('.pf-v6-c-tree-view');
@@ -266,6 +269,15 @@ export class VmListTreeComponent extends BaseComponent {
     const node = this.locator(`[id="${nodeId}"]`);
     await node.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
     await node.click();
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+  }
+
+  async clickLocalClusterInTree(): Promise<void> {
+    await this._localClusterNodeButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.ELEMENT_WAIT,
+    });
+    await this.robustClick(this._localClusterNodeButton);
     await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
   }
 
@@ -374,9 +386,11 @@ export class VmListTreeComponent extends BaseComponent {
   }
 
   async createProject(projectName: string): Promise<void> {
-    const allProjectsNode = this._treeNode.filter({ hasText: 'All projects' }).first();
-    await allProjectsNode.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
-    await allProjectsNode.click({ button: 'right' });
+    await this._localClusterNodeButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.ELEMENT_WAIT,
+    });
+    await this._localClusterNodeButton.click({ button: 'right' });
     await this.page.waitForTimeout(TestTimeouts.UI_ANIMATION_DELAY);
 
     const createProjectOption = this.locator('button:has-text("Create project")');
@@ -470,9 +484,7 @@ export class VmListTreeComponent extends BaseComponent {
   }
 
   async navigateToAllProjects(): Promise<void> {
-    const allProjectsNode = this.page.getByRole('treeitem', { name: /All projects/ });
-    await allProjectsNode.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
-    await this.robustClick(allProjectsNode);
+    return this.clickLocalClusterInTree();
   }
 
   async searchTreeView(searchText: string): Promise<void> {

--- a/playwright/src/page-objects/cluster/quotas-page.ts
+++ b/playwright/src/page-objects/cluster/quotas-page.ts
@@ -82,10 +82,6 @@ export default class QuotasPage extends BasePage {
     await input.fill(value);
   }
 
-  async getCurrentUrl(): Promise<string> {
-    return this.page.url();
-  }
-
   async getDocumentationLinkHref(): Promise<string | null> {
     try {
       const docLink = this._aHasTextLearnMoreAboutManagingVMQuotasWithAAQ;

--- a/playwright/src/page-objects/page-commons.ts
+++ b/playwright/src/page-objects/page-commons.ts
@@ -399,10 +399,6 @@ export default class PageCommons extends BasePage {
     return this.pageContent.getAllStatusTexts();
   }
 
-  getCurrentUrl(): string {
-    return this.pageContent.getCurrentUrl();
-  }
-
   async getMainHeadingH1Text(): Promise<string | null> {
     return this.pageContent.getMainHeadingH1Text();
   }

--- a/playwright/src/page-objects/vm/virtual-machine-detail-page.ts
+++ b/playwright/src/page-objects/vm/virtual-machine-detail-page.ts
@@ -380,9 +380,6 @@ export default class VirtualMachineDetailPage extends PageCommons {
   async getCloudInitValues(): Promise<{ username: string; password: string } | null> {
     return this.diagnostics.getCloudInitValues();
   }
-  override getCurrentUrl(): string {
-    return this.metricsSnapshots.getCurrentUrl();
-  }
   async getDiagnosticsOverviewCardCounts(): Promise<{
     critical: number;
     warnings: number;

--- a/playwright/src/page-objects/vm/virtual-machines-page.ts
+++ b/playwright/src/page-objects/vm/virtual-machines-page.ts
@@ -189,7 +189,7 @@ export default class VirtualMachinesPage extends TreeContextMenuMixin(PageCommon
   }
 
   async clickLocalClusterInTree(): Promise<void> {
-    return this.overviewWidgets.clickLocalClusterInTree();
+    return this.tree.clickLocalClusterInTree();
   }
 
   async clickMigrateConfirmationButton(): Promise<void> {
@@ -705,6 +705,10 @@ export default class VirtualMachinesPage extends TreeContextMenuMixin(PageCommon
 
   async isOverviewTabSelected(): Promise<boolean> {
     return this.overviewWidgets.isOverviewTabSelected();
+  }
+
+  async isProjectFilterEnabled(): Promise<boolean> {
+    return this.listFilters.isProjectFilterEnabled();
   }
 
   async isProjectHintVisible(timeout: number = TestTimeouts.ELEMENT_WAIT): Promise<boolean> {

--- a/playwright/src/page-objects/vm/vm-tree-page.ts
+++ b/playwright/src/page-objects/vm/vm-tree-page.ts
@@ -108,15 +108,10 @@ export default class VmTreePage extends TreeContextMenuMixin(PageCommons) {
         .catch(() => false);
     }
 
-    const treeItem = this._treeView
-      .locator('[role="treeitem"]')
-      .filter({
-        has: this.page.locator('button', { hasText: 'Local cluster' }),
-      })
-      .first();
+    const treeItem = this._treeView.locator('[id="#ALL_NS#"]').first();
     await treeItem.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
 
-    const labelButton = treeItem.locator('button', { hasText: 'Local cluster' }).last();
+    const labelButton = treeItem.locator('button', { hasText: 'Local cluster' });
     await labelButton.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
     await this.robustClick(labelButton);
 
@@ -242,9 +237,11 @@ export default class VmTreePage extends TreeContextMenuMixin(PageCommons) {
   }
 
   async createProject(projectName: string): Promise<void> {
-    const allProjectsNode = this._treeNode.filter({ hasText: 'All projects' }).first();
-    await allProjectsNode.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
-    await allProjectsNode.click({ button: 'right' });
+    const localClusterNode = this.locator('[id="#ALL_NS#"]').locator('button', {
+      hasText: 'Local cluster',
+    });
+    await localClusterNode.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await localClusterNode.click({ button: 'right' });
     await this.page.waitForTimeout(TestTimeouts.UI_ANIMATION_DELAY);
 
     const createProjectOption = this.locator('button:has-text("Create project")');
@@ -345,9 +342,7 @@ export default class VmTreePage extends TreeContextMenuMixin(PageCommons) {
   }
 
   async navigateToAllProjects(): Promise<void> {
-    const allProjectsNode = this.page.getByRole('treeitem', { name: /All projects/ });
-    await allProjectsNode.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
-    await this.robustClick(allProjectsNode);
+    return this.clickLocalClusterInTree();
   }
 
   async navigateToFleetVirtualizationVmsForClusterNamespace(

--- a/playwright/tests/tier1/virtualmachines/vm-search/vm-project-filter.spec.md
+++ b/playwright/tests/tier1/virtualmachines/vm-search/vm-project-filter.spec.md
@@ -1,0 +1,135 @@
+# Software Test Description (STD): VM Project Filter
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier1 — Virtual machines / Search
+- **Latest version:** CNV 5.00
+- **Latest update:** 2026-08-21
+- **Document Status:** Approved
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify that selecting a project in the VirtualMachines tree view applies a Project toolbar filter
+instead of disabling the filter, and that changing the Project filter from the toolbar can broaden
+the list URL from a namespaced path to all-namespaces.
+
+### 2.2 Scope
+
+- **In-Scope:** Tree-view project and Local cluster clicks, Project toolbar toggle remaining enabled,
+  URL `project=` query parameter updates, Project filter chips, list visibility across two
+  projects, and toolbar multi-select that navigates from `/ns/<project>` to `/all-namespaces`.
+- **Out-of-Scope:** Cluster filter (ACM / Fleet Virtualization only; no ACM Playwright job). Group
+  filter coverage (`vm-group-filter.spec.ts`). Search-language syntax (`vm-search-language.spec.ts`).
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator installed; Playwright `Tier1` project.
+- **Configuration:** No special feature gates required. Tests run on standalone virtualization
+  (not ACM).
+- **Initial Setup:** `beforeAll` creates two namespaces, each with one Halted VM. `afterAll` deletes
+  those VMs. Each test opens the VirtualMachines list tab; individual cases start from Local cluster
+  or a namespaced list as specified.
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier1/virtualmachines/vm-search/vm-project-filter.spec.ts`
+**Describe:** `VM Project Filter` — **Tags:** `@tier1`, `@vm-search`
+**Allure:** suite `VM Project Filter`, feature `Tier 1`
+
+---
+
+### `001`: Clicking a project node applies a Project filter
+
+- **Objective:** Verify that clicking a project in the tree sets `project=` in the URL, shows a
+  Project chip, and lists only that project's VMs.
+- **Target version:** CNV 5.00
+- **Jira References:** CNV-93586
+- **Pre-conditions:** Halted VMs exist in two test namespaces
+- **Tags:** `@adminOnly`
+
+| Step | Action                                                | Expected Result                              |
+| :--- | :---------------------------------------------------- | :------------------------------------------- |
+| 1    | Click Local cluster, then click project A in the tree | Project A is selected                        |
+| 2    | Observe the URL                                       | URL contains `project=<project-A>`           |
+| 3    | Observe filter chips                                  | A Project chip containing project A is shown |
+| 4    | Observe the VM list                                   | VM A is visible; VM B is hidden              |
+
+---
+
+### `002`: Project filter toggle stays enabled after a tree selection
+
+- **Objective:** Verify that the Project toolbar filter is not disabled when a project is selected
+  in the tree view.
+- **Target version:** CNV 5.00
+- **Jira References:** CNV-93586
+- **Pre-conditions:** Halted VMs exist in two test namespaces
+- **Tags:** `@adminOnly`
+
+| Step | Action                                                | Expected Result                      |
+| :--- | :---------------------------------------------------- | :----------------------------------- |
+| 1    | Click Local cluster, then click project A in the tree | Project filter is applied            |
+| 2    | Observe the Project toolbar toggle                    | The Project filter toggle is enabled |
+
+---
+
+### `003`: Clicking Local cluster clears the Project filter
+
+- **Objective:** Verify that clicking Local cluster after a project selection removes `project=` from
+  the URL and shows VMs from both test projects.
+- **Target version:** CNV 5.00
+- **Jira References:** CNV-93586
+- **Pre-conditions:** Halted VMs exist in two test namespaces
+- **Tags:** `@adminOnly`
+
+| Step | Action                                                | Expected Result                 |
+| :--- | :---------------------------------------------------- | :------------------------------ |
+| 1    | Click Local cluster, then click project A in the tree | Project filter is applied       |
+| 2    | Click Local cluster                                   | Local cluster is selected       |
+| 3    | Observe the URL                                       | URL does not contain `project=` |
+| 4    | Observe the VM list                                   | VM A and VM B are visible       |
+
+---
+
+### `004`: Adding a second Project filter from a namespaced URL navigates to all-namespaces
+
+- **Objective:** Verify that selecting another project in the toolbar while the path is
+  `/ns/<project-A>` broadens the path to `/all-namespaces` and keeps both project filters.
+- **Target version:** CNV 5.00
+- **Jira References:** CNV-93586
+- **Pre-conditions:** Halted VMs exist in two test namespaces
+- **Tags:** `@adminOnly`
+
+| Step | Action                                                 | Expected Result                                              |
+| :--- | :----------------------------------------------------- | :----------------------------------------------------------- |
+| 1    | Open the namespaced VirtualMachines list for project A | Path is `/ns/<project-A>` and `project=<project-A>` is set   |
+| 2    | Open the Project filter and select project B           | Project B is added to the filter                             |
+| 3    | Observe the URL                                        | Path is `/all-namespaces`; `project=` includes both projects |
+| 4    | Observe the VM list                                    | VM A and VM B are visible                                    |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+| Jira Ticket | Test Case ID | Coverage Type    | Status    |
+| ----------- | ------------ | ---------------- | --------- |
+| CNV-93586   | `001`        | Feature coverage | Automated |
+| CNV-93586   | `002`        | Feature coverage | Automated |
+| CNV-93586   | `003`        | Feature coverage | Automated |
+| CNV-93586   | `004`        | Feature coverage | Automated |
+
+**Coverage Type values:**
+
+- `Feature coverage` — test validates a feature delivered by the ticket
+- `Bugfix regression guard` — test asserts the specific bug fixed by the ticket does not regress
+- `Functional smoke` — test validates baseline behavior; no specific Jira ticket drives it
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** Adam Viktora
+- **Approval Signature:** Adam Viktora

--- a/playwright/tests/tier1/virtualmachines/vm-search/vm-project-filter.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-search/vm-project-filter.spec.ts
@@ -1,0 +1,231 @@
+import { load as yamlLoad } from 'js-yaml';
+
+import { ADMIN_ONLY_TAG, T1, T1_TAG, VM_SEARCH_TAG } from '@/data-models/allure-constants';
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import { expect, test } from '@/fixtures/vm-search-fixture';
+import { TestTimeouts } from '@/utils/test-config';
+import { setupTestNamespace } from '@/utils/test-setup-helpers';
+
+const SUITE = 'VM Project Filter';
+
+const projectParams = (url: string): string[] => new URL(url).searchParams.getAll('project');
+
+const isAllNamespacesPath = (url: string): boolean =>
+  new URL(url).pathname.includes('/all-namespaces/');
+
+test.describe(SUITE, { tag: [T1_TAG, VM_SEARCH_TAG] }, () => {
+  let projectA: string;
+  let projectB: string;
+  let vmA: string;
+  let vmB: string;
+
+  test.beforeAll(async ({ apiClient, utils }) => {
+    projectA = await setupTestNamespace(apiClient, 'proj-a');
+    projectB = await setupTestNamespace(apiClient, 'proj-b');
+
+    vmA = utils.generateRandomVmName('vm-a');
+    vmB = utils.generateRandomVmName('vm-b');
+
+    const createHaltedVm = async (vmName: string, namespace: string) => {
+      const yaml = utils.VirtualMachineFactory.create({
+        name: vmName,
+        namespace,
+        runStrategy: 'Halted',
+        cpuCores: 1,
+        memory: '256Mi',
+      });
+      const payload = yamlLoad(yaml) as KubernetesResource;
+      await apiClient.createVirtualMachine(namespace, payload);
+      await apiClient.waitForVmExists(vmName, namespace);
+      apiClient.trackResource('VirtualMachine', vmName, namespace);
+    };
+
+    await createHaltedVm(vmA, projectA);
+    await createHaltedVm(vmB, projectB);
+  });
+
+  test.afterAll(async ({ apiClient }) => {
+    const vms: Array<[string, string]> = [
+      [vmA, projectA],
+      [vmB, projectB],
+    ];
+    for (const [vmName, namespace] of vms) {
+      if (vmName && namespace) {
+        await apiClient.deleteVirtualMachine(namespace, vmName).catch(() => undefined);
+        await apiClient.waitForVmDeleted(vmName, namespace).catch(() => undefined);
+      }
+    }
+  });
+
+  test.beforeEach(async ({ vmListPage }) => {
+    await vmListPage.navigateToVirtualMachinesViaUI();
+    await vmListPage.clickVmListTab();
+  });
+
+  test('clicking a project node applies a Project filter', async ({ vmListPage, utils }) => {
+    await utils.withAllure({
+      suite: SUITE,
+      feature: T1,
+      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+    });
+
+    await test.step('Click Local cluster, then click project A in the tree', async () => {
+      await vmListPage.clickLocalClusterInTree();
+      await vmListPage.clickProjectNode(projectA);
+    });
+
+    await test.step('URL contains project parameter for project A', async () => {
+      await expect
+        .poll(() => projectParams(vmListPage.page.url()), {
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        })
+        .toContain(projectA);
+    });
+
+    await test.step('Project filter chip appears with project A', async () => {
+      const chips = await vmListPage.getFilterChipTexts();
+      const hasProjectChip = chips.some((chip) => chip.includes(projectA));
+      expect
+        .soft(hasProjectChip, `Project chip "${projectA}" should appear (got: ${chips.join(', ')})`)
+        .toBe(true);
+    });
+
+    await test.step('Only the VM in project A is listed', async () => {
+      const vmAVisible = await vmListPage.isVmVisibleByDataTest(vmA);
+      const vmBHidden = await vmListPage.isVmNameHidden(vmB, TestTimeouts.SHORT_WAIT);
+
+      expect.soft(vmAVisible, `VM ${vmA} should be visible`).toBe(true);
+      expect.soft(vmBHidden, `VM ${vmB} should be hidden`).toBe(true);
+    });
+  });
+
+  test('Project filter toggle stays enabled after a tree selection', async ({
+    vmListPage,
+    utils,
+  }) => {
+    await utils.withAllure({
+      suite: SUITE,
+      feature: T1,
+      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+    });
+
+    await test.step('Click Local cluster, then click project A in the tree', async () => {
+      await vmListPage.clickLocalClusterInTree();
+      await vmListPage.clickProjectNode(projectA);
+      await expect
+        .poll(() => projectParams(vmListPage.page.url()), {
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        })
+        .toContain(projectA);
+    });
+
+    await test.step('Project toolbar toggle remains enabled', async () => {
+      const enabled = await vmListPage.isProjectFilterEnabled();
+      expect
+        .soft(enabled, 'Project filter toggle should stay enabled after a tree selection')
+        .toBe(true);
+    });
+  });
+
+  test('clicking Local cluster clears the Project filter', async ({ vmListPage, utils }) => {
+    await utils.withAllure({
+      suite: SUITE,
+      feature: T1,
+      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+    });
+
+    await test.step('Click Local cluster, then click project A in the tree', async () => {
+      await vmListPage.clickLocalClusterInTree();
+      await vmListPage.clickProjectNode(projectA);
+      await expect
+        .poll(() => projectParams(vmListPage.page.url()), {
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        })
+        .toContain(projectA);
+    });
+
+    await test.step('Click Local cluster', async () => {
+      await vmListPage.clickLocalClusterInTree();
+    });
+
+    await test.step('URL no longer contains project parameter', async () => {
+      await expect
+        .poll(() => projectParams(vmListPage.page.url()), {
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        })
+        .toEqual([]);
+      expect
+        .soft(
+          isAllNamespacesPath(vmListPage.page.url()),
+          `URL should be all-namespaces (got: ${vmListPage.page.url()})`,
+        )
+        .toBe(true);
+    });
+
+    await test.step('VMs from both projects are visible', async () => {
+      const vmAVisible = await vmListPage.isVmVisibleByDataTest(vmA);
+      const vmBVisible = await vmListPage.isVmVisibleByDataTest(vmB);
+
+      expect
+        .soft(vmAVisible, `VM ${vmA} should be visible after clearing the project filter`)
+        .toBe(true);
+      expect
+        .soft(vmBVisible, `VM ${vmB} should be visible after clearing the project filter`)
+        .toBe(true);
+    });
+  });
+
+  test('adding a second Project filter from a namespaced URL navigates to all-namespaces', async ({
+    vmListPage,
+    utils,
+  }) => {
+    await utils.withAllure({
+      suite: SUITE,
+      feature: T1,
+      tags: [T1_TAG, VM_SEARCH_TAG, ADMIN_ONLY_TAG],
+    });
+
+    await test.step('Open the namespaced VirtualMachines list for project A', async () => {
+      await vmListPage.clickLocalClusterInTree();
+      await vmListPage.clickProjectNode(projectA);
+      await expect
+        .poll(() => new URL(vmListPage.page.url()).pathname, {
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        })
+        .toContain(`/ns/${projectA}/`);
+      await expect
+        .poll(() => projectParams(vmListPage.page.url()), {
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        })
+        .toContain(projectA);
+    });
+
+    await test.step('Open the Project filter and select project B', async () => {
+      const enabled = await vmListPage.isProjectFilterEnabled();
+      expect.soft(enabled, 'Project filter should be enabled on a namespaced list').toBe(true);
+      await vmListPage.openProjectFilter();
+      await vmListPage.selectProjectInFilterMenu(projectB);
+    });
+
+    await test.step('URL path is all-namespaces and both project filters are set', async () => {
+      await expect
+        .poll(() => isAllNamespacesPath(vmListPage.page.url()), {
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        })
+        .toBe(true);
+      await expect
+        .poll(() => projectParams(vmListPage.page.url()), {
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        })
+        .toEqual(expect.arrayContaining([projectA, projectB]));
+    });
+
+    await test.step('VMs from both projects are listed', async () => {
+      const vmAVisible = await vmListPage.isVmVisibleByDataTest(vmA);
+      const vmBVisible = await vmListPage.isVmVisibleByDataTest(vmB);
+
+      expect.soft(vmAVisible, `VM ${vmA} should be visible with both project filters`).toBe(true);
+      expect.soft(vmBVisible, `VM ${vmB} should be visible with both project filters`).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add Playwright Tier1 tests for VM Project filter from tree view

- Add `vm-project-filter` spec and STD file (tree apply/clear, toggle stays enabled, ns → all-namespaces)
- Click Local cluster via `#ALL_NS#` id + "Local cluster" text; drop the All projects tree locators
- Remove unused `getCurrentUrl` wrappers

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-93583

## 🎥 Demo

Tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VM project filtering coverage, including project selection, filter persistence, clearing filters, and multi-project views.
  * Added checks for whether the VM project filter is enabled.
  * Improved navigation to the Local cluster and all-projects views.

* **Bug Fixes**
  * Improved Local cluster and project tree-item targeting for more reliable navigation.

* **Documentation**
  * Added test documentation covering VM project-filtering scenarios and expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->