### PR TITLE
CNV-95837: wait for column settings save before closing management modal

### DIFF
--- a/src/utils/components/ColumnManagementModal/ColumnManagementModal.tsx
+++ b/src/utils/components/ColumnManagementModal/ColumnManagementModal.tsx
@@ -64,12 +64,12 @@ export const ColumnManagementModal: FC<ColumnManagementModalProps> = ({
     setCheckedColumns(updatedCheckedColumns);
   };
 
-  const submit: MouseEventHandler<HTMLButtonElement> = (event) => {
+  const submit: MouseEventHandler<HTMLButtonElement> = async (event) => {
     event.preventDefault();
     const orderedCheckedColumns = new Set<string>();
     for (const ids of checkedColumns) orderedCheckedColumns.add(ids);
 
-    setActiveColumns([...orderedCheckedColumns]);
+    await setActiveColumns([...orderedCheckedColumns]);
     onClose();
   };
 

--- a/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns.ts
+++ b/src/utils/hooks/useKubevirtUserSettings/useKubevirtUserSettingsTableColumns.ts
@@ -1,15 +1,16 @@
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { TableColumnWithOptionalIndex } from '@virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/types';
+import { type TableColumnWithOptionalIndex } from '@virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/types';
 
 import useKubevirtUserSettings from './useKubevirtUserSettings';
 import { USER_SETTINGS_KEYS } from './utils/const';
+import { type UserSettingsState } from './utils/userSettingsInitialState';
 
 type UseKubevirtUserSettingsTableColumnsType = <T>(input: {
   columnManagementID: string;
   columns: TableColumnWithOptionalIndex<T>[];
 }) => [
   activeColumns: TableColumnWithOptionalIndex<T>[],
-  setActiveColumns: (val: any) => void,
+  setActiveColumns: (columnIds: string[]) => Promise<UserSettingsState['columns']> | undefined,
   loaded: boolean,
   error: Error,
 ];
@@ -22,8 +23,10 @@ const useKubevirtUserSettingsTableColumns: UseKubevirtUserSettingsTableColumnsTy
     USER_SETTINGS_KEYS.columns,
   );
 
-  const setActiveColumns = (columnIds: string[]) => {
-    setUserColumns?.({
+  const setActiveColumns = (
+    columnIds: string[],
+  ): Promise<UserSettingsState['columns']> | undefined => {
+    return setUserColumns?.({
       ...userColumns,
       [columnManagementID]: columnIds,
     });


### PR DESCRIPTION
## Summary
- `setActiveColumns` now returns the user-settings update Promise instead of discarding it.
- Column management Save awaits that Promise so the modal is not unmounted before the ConfigMap patch is scheduled.

Jira ID is a placeholder (`TEMP-0`); replace it in the title and commit when you have the ticket.

## Test plan
- [ ] Open a table with column management (e.g. VirtualMachines list) and change visible columns, then Save
- [ ] Confirm a ConfigMap patch for user settings is sent and the table columns update after the modal closes
- [ ] Confirm Save still works if you close/reopen the modal immediately after saving
- [ ] Confirm a failed save keeps the modal open (or at least does not silently drop the request)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved column management so the modal closes only after column updates are successfully applied.
  * Added more reliable handling when saving table column preferences.
  * Improved validation of selected column identifiers to prevent invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->