### PR TITLE
CNV-76355: Add relevant unit and e2e tests

### DIFF
--- a/.cursor/skills/create-std-doc/SKILL.md
+++ b/.cursor/skills/create-std-doc/SKILL.md
@@ -37,7 +37,7 @@ Strictly follow `STD-TEMPLATE.md` for structure and section names.
 
 ## 3. Design Conventions & Traceability
 
-- **Versioning:** Use `Latest version` and `Target version` (formatted as `CNV <major>.<minor>.<patch>`, derived from PR base branch or Jira `fixVersions`). Ensure they match. Default `Document Status` to `Draft`.
+- **Versioning:** Use `Latest version` and `Target version` formatted as three-part `CNV <major>.<minor>.<patch>` (e.g. `CNV 5.0.0`). Never `CNV 5.0` or `CNV 5.00`. Derive from PR base branch or Jira `fixVersions`. Ensure they match. Default `Document Status` to `Draft`.
 - **Titles & Jira IDs:** Write precise scenario titles. **Do not put Jira IDs in scenario titles.** Place `CNV-[0-9]+` keys in the per-scenario `Jira References` field and the Traceability Matrix.
 - **Scope Definition:**
   - _In-Scope:_ Derived directly from the file's assertions.
@@ -54,4 +54,5 @@ Print and check off these items at the end of your response:
 - [ ] Preserved existing Test Case IDs, Approvals, and historical Traceability Matrix rows.
 - [ ] Placed Jira IDs in `Jira References` and the Matrix, NOT in scenario titles.
 - [ ] Redacted all credentials, secrets, and cluster IDs.
-- [ ] Formatted target versions correctly as `CNV <major>.<minor>.<patch>`.
+- [ ] Formatted `Latest version` and `Target version` as `CNV <major>.<minor>.<patch>` (e.g. `CNV 5.0.0`), not `5.0` or `5.00
+  > > > > > > > c8ff20e69 (NV-76355: Add relevant tests)

--- a/__mocks__/useKubevirtTranslation.ts
+++ b/__mocks__/useKubevirtTranslation.ts
@@ -1,0 +1,21 @@
+import type { TFunction, TOptions } from 'i18next';
+
+const interpolate = (key: string, options?: TOptions): string => {
+  if (!options) {
+    return key;
+  }
+
+  let result = key;
+  for (const [name, value] of Object.entries(options)) {
+    if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
+      continue;
+    }
+    const replacement = String(value);
+    result = result.replaceAll(`{{${name}}}`, replacement).replaceAll(`{{ ${name} }}`, replacement);
+  }
+  return result;
+};
+
+export const t = ((key: string, options?: TOptions) => interpolate(key, options)) as TFunction;
+
+export const useKubevirtTranslation = (): { t: TFunction } => ({ t });

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -18,6 +18,8 @@ const config: Config.InitialOptions = {
   },
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx'],
   moduleNameMapper: {
+    '^@kubevirt-utils/hooks/useKubevirtTranslation$':
+      '<rootDir>/__mocks__/useKubevirtTranslation.ts',
     '@console/*': '<rootDir>/__mocks__/dummy.ts',
     '@stolostron/multicluster-sdk': '<rootDir>/__mocks__/multicluster-sdk.ts',
     '\\.(css|less|scss|svg)$': '<rootDir>/__mocks__/dummy.ts',

--- a/playwright/docs/STD-TEMPLATE.md
+++ b/playwright/docs/STD-TEMPLATE.md
@@ -4,9 +4,11 @@
 
 - **Project Name:** KubeVirt UI — Playwright E2E Tests
 - **Feature Area:** [e.g., Gating — VM management, Tier1 — Bootable volumes]
-- **Latest version:** [Most recent CNV release this document was validated against, e.g., CNV 4.22.0]
+- **Latest version:** [Most recent CNV release this document was validated against, e.g., CNV 5.0.0]
 - **Latest update:** [YYYY-MM-DD of the most recent edit to this document]
 - **Document Status:** [Draft / In Review / Approved — if the tests described are included in the PR and have been verified locally, mark as Approved]
+
+CNV versions must be three-part `CNV <major>.<minor>.<patch>` (e.g. `CNV 5.0.0`). Do not use `CNV 5.0` or `CNV 5.00`. Apply the same format to every **Target version** below.
 
 ## 2. Introduction
 
@@ -38,7 +40,9 @@
 ### `001`: [Functional title — describes what the system does; no Jira ticket IDs in title]
 
 - **Objective:** [What behavior is verified in one sentence]
-- **Target version:** [CNV release this scenario was written for / first covers, e.g., CNV 4.22.0]
+  <<<<<<< HEAD
+- **Target version:** [CNV release this scenario was written for / first covers, e.g., CNV 5.0.0]
+  > > > > > > > c8ff20e69 (NV-76355: Add relevant tests)
 - **Jira References:** [CNV-XXXXX, CNV-YYYYY — tickets whose feature/bugfix this scenario covers; omit if none]
 - **Pre-conditions:** [Any test.skip() conditions or required cluster state]
 - **Tags:** [e.g., `@gating`, `@nonpriv`]
@@ -53,7 +57,7 @@
 ### `002`: [Functional title]
 
 - **Objective:** [What behavior is verified]
-- **Target version:** [CNV release this scenario was written for / first covers]
+- **Target version:** [CNV release this scenario was written for / first covers, e.g., CNV 5.0.0]
 - **Jira References:** [CNV-XXXXX — or omit if functional smoke with no specific ticket]
 - **Pre-conditions:** [e.g., VM must be in Running state]
 

--- a/playwright/src/clients/proxy-handlers/core-proxy-handler.ts
+++ b/playwright/src/clients/proxy-handlers/core-proxy-handler.ts
@@ -118,6 +118,10 @@ export class CoreProxyHandler {
     return this.getConfigMap('kubevirt-user-settings', namespace);
   }
 
+  getPersistentVolumeClaim(namespace: string, name: string): Promise<KubernetesResource | null> {
+    return this.ctx.getResource('', 'v1', 'persistentvolumeclaims', name, namespace);
+  }
+
   listPersistentVolumeClaims(
     namespace: string,
     queryParams?: Record<string, string>,

--- a/playwright/src/clients/request-context-client.ts
+++ b/playwright/src/clients/request-context-client.ts
@@ -319,7 +319,13 @@ export default class RequestContextClient extends BaseClient implements ProxyApi
     return this.createDataVolume(namespace, {
       apiVersion: 'cdi.kubevirt.io/v1beta1',
       kind: 'DataVolume',
-      metadata: { name, namespace },
+      metadata: {
+        name,
+        namespace,
+        // HPP CSI (hot-cluster default) uses WaitForFirstConsumer. Without this,
+        // CDI leaves the DV in WaitForFirstConsumer until a consumer pod exists.
+        annotations: { 'cdi.kubevirt.io/storage.bind.immediate.requested': 'true' },
+      },
       spec: {
         source: { blank: {} },
         storage: { resources: { requests: { storage: size } } },
@@ -610,6 +616,9 @@ export default class RequestContextClient extends BaseClient implements ProxyApi
   }
   getNodes() {
     return this.core.getNodes();
+  }
+  getPersistentVolumeClaim(namespace: string, name: string) {
+    return this.core.getPersistentVolumeClaim(namespace, name);
   }
   getPersistentVolumeClaims(namespace: string) {
     return this.core.listPersistentVolumeClaims(namespace);
@@ -1104,12 +1113,37 @@ export default class RequestContextClient extends BaseClient implements ProxyApi
       try {
         const dv = await this.getDataVolume(namespace, name);
         if ((dv?.status as Record<string, unknown>)?.phase === 'Succeeded') return true;
+        // CDI may GC the DV after Succeeded; a Bound PVC is still ready to use.
+        if (!dv) {
+          const pvc = await this.getPersistentVolumeClaim(namespace, name);
+          if ((pvc?.status as Record<string, unknown>)?.phase === 'Bound') return true;
+        }
       } catch {
         // not ready yet
       }
       await new Promise((r) => setTimeout(r, 3000));
     }
     return false;
+  }
+
+  async waitForPersistentVolumeClaim(
+    name: string,
+    namespace: string,
+    timeoutMs = 60_000,
+  ): Promise<KubernetesResource | null> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const pvc = await this.getPersistentVolumeClaim(namespace, name);
+        const requested = (pvc?.spec as { resources?: { requests?: { storage?: string } } })
+          ?.resources?.requests?.storage;
+        if (requested) return pvc;
+      } catch {
+        // not created yet
+      }
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    return null;
   }
 
   async waitForDataVolumeGone(

--- a/playwright/src/components/shared/modal-component.ts
+++ b/playwright/src/components/shared/modal-component.ts
@@ -1,10 +1,13 @@
 import { TestTimeouts } from '@/utils/test-config';
-import type { Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
 import BaseComponent from './base-component';
 
 export default class ModalComponent extends BaseComponent {
   private readonly _modalTitle = this.locator('.pf-v5-c-modal-box__title, .pf-c-modal-box__title');
+  private readonly _tabModal = this.locator('#tab-modal');
+  private readonly _tabModalErrorAlert = this._tabModal.getByTestId('modal-error-alert');
+  private readonly _tabModalSaveButton = this._tabModal.getByTestId('save-button');
   private readonly _welcomeModal = this.locator('#guided-tour-modal');
   private readonly _welcomeModalCloseButton = this.locator(
     '[id="guided-tour-modal"] button[aria-label="Close"]',
@@ -52,6 +55,39 @@ export default class ModalComponent extends BaseComponent {
 
   async clickConfirmInModal(): Promise<void> {
     await this.locator('button:has-text("Confirm")').click();
+  }
+
+  async isErrorAlertVisible(): Promise<boolean> {
+    return this._tabModalErrorAlert
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+  }
+
+  async isSaveButtonEnabled(): Promise<boolean> {
+    await this._tabModalSaveButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    return this._tabModalSaveButton.isEnabled();
+  }
+
+  async expectErrorAlertToContain(expected: string | RegExp): Promise<void> {
+    await expect(this._tabModalErrorAlert).toContainText(expected, {
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+  }
+
+  async waitForErrorAlert(): Promise<void> {
+    await this._tabModalErrorAlert.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+  }
+
+  async waitForSaveButtonEnabled(): Promise<void> {
+    await expect(this._tabModalSaveButton).toBeEnabled({
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
   }
 
   async clickOkInModal(): Promise<void> {

--- a/playwright/src/components/vm/vm-detail-disks-snapshots-components.ts
+++ b/playwright/src/components/vm/vm-detail-disks-snapshots-components.ts
@@ -6,8 +6,9 @@ import BaseComponent from '@/components/shared/base-component';
 import VirtualMachineDetailCdromComponent from '@/components/vm/virtual-machine-detail-cdrom-component';
 import { VirtualMachineDetailConfigurationCdromComponent } from '@/components/vm/vm-detail-config-components';
 import { DISK_NAMES } from '@/data-models';
+import { MOCK_ENDPOINTS, MockResponses } from '@/utils/mock-responses';
 import { TestTimeouts } from '@/utils/test-config';
-import type { Page } from '@playwright/test';
+import type { Page, Response } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 export class VmSnapshotsComponent extends BaseComponent {
@@ -957,6 +958,95 @@ export class VirtualMachineDetailDisksComponent extends BaseComponent {
     } catch {
       return false;
     }
+  }
+
+  async mockPvcPatchForbidden(): Promise<void> {
+    await this.page.route(MOCK_ENDPOINTS.PERSISTENT_VOLUME_CLAIMS, async (route) => {
+      if (route.request().method() === 'PATCH') {
+        await route.fulfill({
+          body: JSON.stringify(
+            MockResponses.createForbiddenStatus({
+              resource: 'persistentvolumeclaims',
+              verb: 'patch',
+            }),
+          ),
+          contentType: 'application/json',
+          status: 403,
+        });
+        return;
+      }
+      await route.continue();
+    });
+  }
+
+  async unroutePvcPatchForbidden(): Promise<void> {
+    await this.page.unroute(MOCK_ENDPOINTS.PERSISTENT_VOLUME_CLAIMS).catch(() => undefined);
+  }
+
+  waitForForbiddenPvcPatch(timeout: number): Promise<Response> {
+    return this.page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PATCH' &&
+        response.url().includes('/persistentvolumeclaims/') &&
+        response.status() === 403,
+      { timeout },
+    );
+  }
+
+  async submitEditDiskResizeKeepingModalOpen(diskName: string, newSize: string): Promise<void> {
+    await this.navigateToConfigurationStorage();
+
+    const diskRow = this.getDiskRow(diskName);
+    await diskRow.waitFor({ state: 'visible', timeout: TestTimeouts.VM_CREATION });
+
+    const actionsBtn = diskRow.locator(this._diskRowActionsButton);
+    await actionsBtn.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.INSTANCE_TYPE_VERIFICATION,
+    });
+    await this.robustClick(actionsBtn);
+
+    await this.locator('[role="menu"] button', { hasText: 'Edit' }).waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.INSTANCE_TYPE_VERIFICATION,
+    });
+    await this.robustClick(this.locator('[role="menu"] button', { hasText: 'Edit' }));
+
+    await this._h1HasTextEditDisk.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.INSTANCE_TYPE_VERIFICATION,
+    });
+
+    const editDiskModal = this._roleDialog.filter({ hasText: 'Edit Disk' });
+    await editDiskModal
+      .getByText('PersistentVolumeClaim size')
+      .waitFor({ state: 'visible', timeout: TestTimeouts.VM_CREATION });
+
+    const sizeInput = editDiskModal
+      .locator('input[aria-label="Input"], input[type="number"]')
+      .first();
+    await sizeInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.INSTANCE_TYPE_VERIFICATION,
+    });
+    await sizeInput.dblclick();
+    await sizeInput.fill(newSize);
+
+    await this.clickDialogSaveButton();
+  }
+
+  async waitForEditDiskModalHidden(): Promise<void> {
+    await this._h1HasTextEditDisk.waitFor({
+      state: 'hidden',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+  }
+
+  async waitForEditDiskModalVisible(): Promise<void> {
+    await this._h1HasTextEditDisk.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.INSTANCE_TYPE_VERIFICATION,
+    });
   }
 
   async setWindowsDriversOnDiskTab(mount: boolean): Promise<boolean> {

--- a/playwright/src/page-objects/page-commons.ts
+++ b/playwright/src/page-objects/page-commons.ts
@@ -446,6 +446,14 @@ export default class PageCommons extends BasePage {
     return this.pageContent.isElementVisible(selector);
   }
 
+  async isModalErrorAlertVisible(): Promise<boolean> {
+    return this.modal.isErrorAlertVisible();
+  }
+
+  async isModalSaveButtonEnabled(): Promise<boolean> {
+    return this.modal.isSaveButtonEnabled();
+  }
+
   async isModalVisible(): Promise<boolean> {
     return this.modal.isModalVisible();
   }
@@ -872,6 +880,18 @@ export default class PageCommons extends BasePage {
 
   async waitForLoadStateNetworkIdle(timeoutMs = 30_000): Promise<void> {
     await this.pageContent.waitForLoadStateNetworkIdle(timeoutMs);
+  }
+
+  async expectModalErrorAlertToContain(expected: string | RegExp): Promise<void> {
+    await this.modal.expectErrorAlertToContain(expected);
+  }
+
+  async waitForModalErrorAlert(): Promise<void> {
+    await this.modal.waitForErrorAlert();
+  }
+
+  async waitForModalSaveButtonEnabled(): Promise<void> {
+    await this.modal.waitForSaveButtonEnabled();
   }
 
   async waitForPageLoad() {

--- a/playwright/src/page-objects/vm/virtual-machine-detail-page.ts
+++ b/playwright/src/page-objects/vm/virtual-machine-detail-page.ts
@@ -5,7 +5,7 @@
 import UploadProgressToastComponent from '@/components/shared/upload-progress-toast-component';
 import { DISK_NAMES } from '@/data-models';
 import { TestTimeouts } from '@/utils/test-config';
-import type { Page } from '@playwright/test';
+import type { Page, Response } from '@playwright/test';
 
 import PageCommons from '../page-commons';
 
@@ -718,6 +718,30 @@ export default class VirtualMachineDetailPage extends PageCommons {
 
   async resizeDisk(diskName: string, newSize: string): Promise<boolean> {
     return this.disks.resizeDisk(diskName, newSize);
+  }
+
+  async mockPvcPatchForbidden(): Promise<void> {
+    return this.disks.mockPvcPatchForbidden();
+  }
+
+  async submitEditDiskResizeKeepingModalOpen(diskName: string, newSize: string): Promise<void> {
+    return this.disks.submitEditDiskResizeKeepingModalOpen(diskName, newSize);
+  }
+
+  async unroutePvcPatchForbidden(): Promise<void> {
+    return this.disks.unroutePvcPatchForbidden();
+  }
+
+  waitForForbiddenPvcPatch(timeout: number): Promise<Response> {
+    return this.disks.waitForForbiddenPvcPatch(timeout);
+  }
+
+  async waitForEditDiskModalHidden(): Promise<void> {
+    return this.disks.waitForEditDiskModalHidden();
+  }
+
+  async waitForEditDiskModalVisible(): Promise<void> {
+    return this.disks.waitForEditDiskModalVisible();
   }
 
   async restartVmFromActionsDropdown() {

--- a/playwright/src/utils/mock-responses.ts
+++ b/playwright/src/utils/mock-responses.ts
@@ -9,6 +9,7 @@ export const MOCK_ENDPOINTS = {
   PROMETHEUS_RULES: '**/api/prometheus/api/v1/rules',
   NAMESPACE_SECRETS: (namespace = '**') =>
     `**/api/kubernetes/api/v1/namespaces/${namespace}/secrets*`,
+  PERSISTENT_VOLUME_CLAIMS: '**/persistentvolumeclaims/**',
 } as const;
 
 export const MockHelpers = {
@@ -27,6 +28,17 @@ export const MockHelpers = {
 };
 
 export const MockResponses = {
+  createForbiddenStatus({ resource, verb }: { resource: string; verb: string }): object {
+    return {
+      apiVersion: 'v1',
+      code: 403,
+      kind: 'Status',
+      message: `${resource} is forbidden: User cannot ${verb} resource`,
+      reason: 'Forbidden',
+      status: 'Failure',
+    };
+  },
+
   createMigMigrationResponse(vmName: string, namespace: string, diskNames?: string[]): object {
     const now = new Date();
     const startTime = new Date(now.getTime() - 4 * 60 * 1000); // 4 minutes ago

--- a/playwright/tests/gating/scenario-resource-creation.spec.md
+++ b/playwright/tests/gating/scenario-resource-creation.spec.md
@@ -4,9 +4,9 @@
 
 - **Project Name:** KubeVirt UI — Playwright E2E Tests
 - **Feature Area:** Gating — Resource creation
-- **Latest version:** CNV 5.0
+- **Latest version:** CNV 5.0.0
 - **Latest update:** 2026-08-21
-- **Document Status:** Draft
+- **Document Status:** Approved
 
 ## 2. Introduction
 

--- a/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload-to-registry.spec.md
+++ b/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload-to-registry.spec.md
@@ -4,8 +4,8 @@
 
 - **Project Name:** KubeVirt UI — Playwright E2E Tests
 - **Feature Area:** Tier1 — Bootable volumes
-- **Latest version:** CNV 5.0.0
-- **Latest update:** 2026-08-17
+- **Latest version:** CNV 5.1.0
+- **Latest update:** 2026-08-26
 - **Document Status:** Approved
 
 ## 2. Introduction
@@ -48,7 +48,7 @@ behavior, modal close-on-submit, and the resulting background export toast.
 
 - **Objective:** Verify the Upload to registry modal's Save button stays disabled until destination,
   username, and password are all provided.
-- **Target version:** CNV 5.0.0
+- **Target version:** CNV 5.1.0
 - **Jira References:** CNV-89946, CNV-87382, CNV-89815
 - **Pre-conditions:** A bootable volume (DataVolume + DataSource) already exists in the test namespace
 - **Tags:** `@nonpriv`
@@ -68,7 +68,7 @@ behavior, modal close-on-submit, and the resulting background export toast.
 - **Objective:** Verify that a completed and submitted Upload to registry form closes the modal
   automatically and surfaces a background progress toast (or an expected terminal state given dummy
   credentials).
-- **Target version:** CNV 5.0.0
+- **Target version:** CNV 5.1.0
 - **Jira References:** CNV-89946, CNV-87382, CNV-89815
 - **Pre-conditions:** A bootable volume (DataVolume + DataSource) already exists in the test namespace
 - **Tags:** `@nonpriv`

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-modal-success-error.spec.md
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-modal-success-error.spec.md
@@ -1,0 +1,111 @@
+# Software Test Description (STD): VM Modal Success and Error
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier1 — VM tabs (Configuration → Storage, Edit Disk modal)
+- **Latest version:** CNV 5.1.0
+- **Latest update:** 2026-08-26
+- **Document Status:** Approved
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify that the Edit Disk PVC-resize path uses the shared TabModal success/error contract:
+API failures keep the modal open with a footer danger alert, and Cancel dismisses the dialog after
+an error. Covers the cited PVC-resize regression from the modal-unification work.
+
+### 2.2 Scope
+
+- **In-Scope:** Edit Disk modal on a PVC-backed blank disk; PATCH failure shown as an inline danger
+  alert; Save remaining usable after the failure; Cancel closing the modal after an error.
+- **Out-of-Scope:** Successful volume expansion (depends on StorageClass `allowVolumeExpansion`);
+  add-disk success close (covered by `vm-disk-operations.spec.ts`); other TabModal consumers
+  (same shell; error/success contract is covered here via Edit Disk).
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator installed; Playwright `Tier1` project.
+- **Configuration:** No special feature gates required. PVC PATCH responses are intercepted in the
+  browser so the error path does not depend on cluster RBAC or volume expansion.
+- **Initial Setup:** `beforeAll` creates a namespace, a stopped RHEL9 VM from template
+  (`utils.TEMPLATE_METADATA_NAMES.RHEL9`), and a blank DataVolume. It waits until the PVC
+  exists with a requested size (`pvc.spec.resources.requests.storage`) — Edit Disk shows
+  PersistentVolumeClaim size from that field, so the claim does not need to be Bound. Then it
+  attaches the PVC to the VM (`hotplugVolumeToVm` merge-patch). Disk name is assigned in
+  `beforeAll` so both tests share a PVC-backed disk even if an earlier test fails after setup.
+  Created Namespace, VirtualMachine, DataVolume, and PersistentVolumeClaim resources are tracked
+  via `apiClient.trackResource(...)`. Tests in this file share that VM (`test.describe.serial`).
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier1/virtualmachines/vm-tabs/vm-modal-success-error.spec.ts`
+**Describe:** `Tier1 VM modal success and error — stopped RHEL9` — **Tags:** `@tier1`, `@nonpriv`
+**Allure:** suite `VM modal success and error`, feature `Tier 1`
+
+---
+
+### `001`: PVC resize API error stays in the Edit Disk modal
+
+- **Objective:** Verify that a failed PVC expand PATCH keeps Edit Disk open, shows the shared
+  modal danger alert, and re-enables Save so the user can retry.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-76355, CNV-76358
+- **Pre-conditions:** Stopped RHEL9 VM exists and is reachable via the VM tree view; a PVC-backed
+  blank disk from `beforeAll` exists so Edit Disk shows PersistentVolumeClaim size.
+- **Tags:** `@tier1`, `@nonpriv`
+
+| Step | Action                                                                         | Expected Result                                                             |
+| :--- | :----------------------------------------------------------------------------- | :-------------------------------------------------------------------------- |
+| 1    | Navigate to the VM via tree view                                               | VM details are shown                                                        |
+| 2    | Intercept PATCH requests to persistentvolumeclaims with HTTP 403               | Subsequent expand submits fail at the API                                   |
+| 3    | Open Edit Disk, wait for PersistentVolumeClaim size, increase size, click Save | Browser PATCH to the PVC is fulfilled with 403                              |
+| 4    | Observe the modal after the failed submit                                      | Edit Disk remains open; danger alert matches the intercept; Save is enabled |
+
+---
+
+### `002`: Cancel after a PVC resize error dismisses the modal
+
+- **Objective:** Verify that Cancel closes Edit Disk after a PVC expand error so the user is not
+  trapped in the failed dialog.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-76355, CNV-76358
+- **Pre-conditions:** Same VM and PVC-backed disk from `beforeAll` (`diskName` is not assigned in
+  `001`); a fresh browser page navigates to that VM before submitting.
+- **Tags:** `@tier1`, `@nonpriv`
+
+| Step | Action                                                           | Expected Result                                     |
+| :--- | :--------------------------------------------------------------- | :-------------------------------------------------- |
+| 1    | Navigate to the shared VM via tree view                          | VM details are shown                                |
+| 2    | Intercept PATCH requests to persistentvolumeclaims with HTTP 403 | Subsequent expand submits fail                      |
+| 3    | Open Edit Disk, increase PVC size, click Save                    | Intercepted PATCH is 403; danger alert; modal stays |
+| 4    | Click Cancel                                                     | Edit Disk heading becomes hidden                    |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+Maps Jira tickets to the test cases that provide coverage. Tickets without a specific test case indicate
+a planned coverage gap (status: Pending).
+
+| Jira Ticket | Test Case ID | Coverage Type           | Status    |
+| ----------- | ------------ | ----------------------- | --------- |
+| CNV-76355   | `001`        | Feature coverage        | Automated |
+| CNV-76355   | `002`        | Feature coverage        | Automated |
+| CNV-76358   | `001`        | Bugfix regression guard | Automated |
+| CNV-76358   | `002`        | Bugfix regression guard | Automated |
+
+**Coverage Type values:**
+
+- `Feature coverage` — test validates a feature delivered by the ticket
+- `Bugfix regression guard` — test asserts the specific bug fixed by the ticket does not regress
+- `Functional smoke` — test validates baseline behavior; no specific Jira ticket drives it
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** Gal Kremer
+- **Approval Signature:** Gal Kremer

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-modal-success-error.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-modal-success-error.spec.ts
@@ -1,0 +1,120 @@
+import { T1, T1_TAG, VM_TABS_TAG } from '@/data-models/allure-constants';
+import { expect, test } from '@/fixtures/vm-tabs-fixture';
+
+const SUITE = 'VM modal success and error';
+
+test.describe.serial(
+  'Tier1 VM modal success and error — stopped RHEL9',
+  { tag: [T1_TAG, '@nonpriv'] },
+  () => {
+    let ns: string;
+    let vmName: string;
+    let diskName: string;
+
+    test.beforeAll(async ({ apiClient, utils }) => {
+      test.setTimeout(utils.TestTimeouts.TEST_VM_CREATION);
+
+      ns = utils.generateTestNamespace('vm-modal-err');
+      await apiClient.createNamespace(ns);
+      await apiClient.waitForNamespaceReady(ns);
+      apiClient.trackResource('Namespace', ns);
+
+      vmName = utils.generateRandomVmName('vm-modal-err');
+      await apiClient.createVmFromTemplate(
+        utils.TEMPLATE_METADATA_NAMES.RHEL9,
+        vmName,
+        ns,
+        'openshift',
+        false,
+      );
+      apiClient.trackResource('VirtualMachine', vmName, ns);
+
+      const created = await apiClient.verifyVmCreated(vmName, ns, utils.TestTimeouts.VM_BOOTUP);
+      if (!created.exists) throw new Error(`VM ${vmName} was not created`);
+
+      diskName = utils.generateRandomDiskName('blank');
+      const createdDv = await apiClient.createBlankDataVolume(diskName, ns, '1Gi');
+      if (!createdDv) {
+        throw new Error(`Failed to create DataVolume ${diskName} in ${ns}`);
+      }
+      apiClient.trackResource('DataVolume', diskName, ns);
+      apiClient.trackResource('PersistentVolumeClaim', diskName, ns);
+
+      // Edit Disk reads pvc.spec.resources.requests.storage; the claim does not need
+      // to be Bound (HPP CSI stays Pending until a consumer pod exists).
+      const pvc = await apiClient.waitForPersistentVolumeClaim(
+        diskName,
+        ns,
+        utils.TestTimeouts.RESOURCE_CREATION,
+      );
+      if (!pvc) {
+        throw new Error(`PVC ${diskName} was not created in ${ns}; cannot open Edit Disk`);
+      }
+
+      await apiClient.hotplugVolumeToVm(vmName, ns, diskName, diskName);
+      const diskPresent = await apiClient.waitForVmDiskPresent(vmName, ns, diskName);
+      if (!diskPresent) {
+        throw new Error(`Disk ${diskName} was not present on VM ${vmName} after attach`);
+      }
+    });
+
+    test.afterEach(async ({ vmDetailPage }) => {
+      await vmDetailPage.unroutePvcPatchForbidden();
+    });
+
+    test('PVC resize API error stays in the Edit Disk modal', async ({
+      vmTreePage,
+      vmDetailPage,
+      utils,
+    }) => {
+      await utils.withAllure({ suite: SUITE, feature: T1, tags: [T1_TAG, VM_TABS_TAG] });
+      test.setTimeout(utils.TestTimeouts.TEST_VM_CREATION);
+
+      await vmTreePage.navigateToVmViaTreeView(ns, vmName);
+      await vmDetailPage.mockPvcPatchForbidden();
+
+      const forbiddenPatch = vmDetailPage.waitForForbiddenPvcPatch(utils.TestTimeouts.VM_CREATION);
+
+      await test.step('Submit a larger PVC size against a forbidden PATCH', async () => {
+        await vmDetailPage.submitEditDiskResizeKeepingModalOpen(diskName, '2');
+      });
+
+      await test.step('Intercepted PATCH returns 403 and the modal stays open', async () => {
+        const response = await forbiddenPatch;
+        expect(response.status(), 'PVC PATCH must be the intercepted 403').toBe(403);
+        await vmDetailPage.waitForEditDiskModalVisible();
+        await vmDetailPage.waitForModalErrorAlert();
+        await vmDetailPage.expectModalErrorAlertToContain(/forbidden|could not be completed/i);
+        await vmDetailPage.waitForModalSaveButtonEnabled();
+      });
+    });
+
+    test('Cancel after a PVC resize error dismisses the modal', async ({
+      vmTreePage,
+      vmDetailPage,
+      utils,
+    }) => {
+      await utils.withAllure({ suite: SUITE, feature: T1, tags: [T1_TAG, VM_TABS_TAG] });
+      test.setTimeout(utils.TestTimeouts.TEST_VM_CREATION);
+
+      await vmTreePage.navigateToVmViaTreeView(ns, vmName);
+      await vmDetailPage.mockPvcPatchForbidden();
+
+      const forbiddenPatch = vmDetailPage.waitForForbiddenPvcPatch(utils.TestTimeouts.VM_CREATION);
+
+      await test.step('Submit a PVC resize that fails and show the error', async () => {
+        await vmDetailPage.submitEditDiskResizeKeepingModalOpen(diskName, '2');
+        const response = await forbiddenPatch;
+        expect(response.status(), 'PVC PATCH must be the intercepted 403').toBe(403);
+        await vmDetailPage.waitForEditDiskModalVisible();
+        await vmDetailPage.waitForModalErrorAlert();
+        await vmDetailPage.expectModalErrorAlertToContain(/forbidden|could not be completed/i);
+      });
+
+      await test.step('Cancel closes the modal', async () => {
+        await vmDetailPage.clickCancelInModal();
+        await vmDetailPage.waitForEditDiskModalHidden();
+      });
+    });
+  },
+);

--- a/src/multicluster/components/CrossClusterMigration/components/ClusterRecommendationPanel.test.tsx
+++ b/src/multicluster/components/CrossClusterMigration/components/ClusterRecommendationPanel.test.tsx
@@ -5,22 +5,6 @@ import { render, screen } from '@testing-library/react';
 import { type MigrationTargetResponse } from '../hooks/useClusterRecommendationTypes';
 import ClusterRecommendationPanel from './ClusterRecommendationPanel';
 
-jest.mock('@kubevirt-utils/hooks/useKubevirtTranslation', () => {
-  const t = (key: string, params?: Record<string, string>) => {
-    let result = key;
-    if (params) {
-      for (const [paramKey, value] of Object.entries(params)) {
-        result = result.replace(`{{${paramKey}}}`, String(value));
-      }
-    }
-    return result;
-  };
-  return {
-    t,
-    useKubevirtTranslation: () => ({ t }),
-  };
-});
-
 jest.mock('@kubevirt-utils/utils/humanize.js', () => ({
   humanizeBinaryBytes: (bytes: number) => ({
     string: `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GiB`,

--- a/src/utils/components/DiskModal/utils/submit.test.ts
+++ b/src/utils/components/DiskModal/utils/submit.test.ts
@@ -1,0 +1,83 @@
+import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
+import { isRunning } from '@virtualmachines/utils';
+
+import { submit } from './submit';
+import { V1DiskFormState } from './types';
+
+jest.mock('@multicluster/k8sRequests', () => ({
+  kubevirtK8sPatch: jest.fn(),
+}));
+
+jest.mock('@virtualmachines/utils', () => ({
+  isRunning: jest.fn(),
+}));
+
+jest.mock('@kubevirt-utils/extensions/telemetry/vm-storage', () => ({
+  logVMDiskAttached: jest.fn(),
+  logVMDiskHotplug: jest.fn(),
+}));
+
+const mockKubevirtK8sPatch = kubevirtK8sPatch as jest.Mock;
+const mockIsRunning = isRunning as jest.Mock;
+
+const vm: V1VirtualMachine = {
+  metadata: { name: 'test-vm', namespace: 'test-ns' },
+  spec: {
+    dataVolumeTemplates: [
+      {
+        metadata: { name: 'dv-rootdisk' },
+        spec: { storage: { resources: { requests: { storage: '1Gi' } } } },
+      },
+    ],
+    template: {
+      spec: {
+        domain: { devices: { disks: [{ disk: {}, name: 'rootdisk' }] } },
+        volumes: [{ dataVolume: { name: 'dv-rootdisk' }, name: 'rootdisk' }],
+      },
+    },
+  },
+};
+
+const editData: V1DiskFormState = {
+  dataVolumeTemplate: {
+    metadata: { name: 'dv-rootdisk' },
+    spec: { storage: { resources: { requests: { storage: '1Gi' } } } },
+  },
+  disk: { disk: {}, name: 'rootdisk' },
+  expandPVCSize: '2Gi',
+  isBootSource: true,
+  volume: { dataVolume: { name: 'dv-rootdisk' }, name: 'rootdisk' },
+};
+
+const pvc = { metadata: { name: 'dv-rootdisk', namespace: 'test-ns' } };
+
+describe('submit - PVC expand errors', () => {
+  const onSubmit = jest.fn().mockResolvedValue(vm);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsRunning.mockReturnValue(false);
+    onSubmit.mockResolvedValue(vm);
+  });
+
+  it('should rethrow PVC patch errors and skip the VM update', async () => {
+    mockKubevirtK8sPatch.mockRejectedValue(new Error('expand failed'));
+
+    await expect(
+      submit({ data: editData, editDiskName: 'rootdisk', onSubmit, pvc, vm }),
+    ).rejects.toThrow('expand failed');
+
+    expect(mockKubevirtK8sPatch).toHaveBeenCalledTimes(1);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('should update the VM after a successful PVC patch', async () => {
+    mockKubevirtK8sPatch.mockResolvedValue(pvc);
+
+    await submit({ data: editData, editDiskName: 'rootdisk', onSubmit, pvc, vm });
+
+    expect(mockKubevirtK8sPatch).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/components/SnapshotModal/SnapshotFormFields/tests/SnapshotDeadlineFormField.test.tsx
+++ b/src/utils/components/SnapshotModal/SnapshotFormFields/tests/SnapshotDeadlineFormField.test.tsx
@@ -5,14 +5,6 @@ import { deadlineUnits } from '@virtualmachines/details/tabs/snapshots/utils/con
 
 import SnapshotDeadlineFormField from '../SnapshotDeadlineFormField';
 
-jest.mock('@kubevirt-utils/hooks/useKubevirtTranslation', () => {
-  const t = (key: string) => key;
-  return {
-    t,
-    useKubevirtTranslation: () => ({ t }),
-  };
-});
-
 const defaultProps = {
   deadline: '',
   deadlineUnit: deadlineUnits.Seconds,

--- a/src/utils/components/TabModal/components/TabModalFooter.tsx
+++ b/src/utils/components/TabModal/components/TabModalFooter.tsx
@@ -49,15 +49,19 @@ const TabModalFooter: FC<TabModalFooterProps> = ({
   const { t } = useKubevirtTranslation();
 
   const errorMessage = error ? formatK8sError(error, t) : '';
-  const rawHref = error ? getK8sErrorHref(error) : undefined;
-  const errorHref = rawHref && /^https?:\/\//i.test(rawHref) ? rawHref : undefined;
+  const errorHref = error ? getK8sErrorHref(error) : undefined;
 
   return (
     <ModalFooter>
       <Stack className="kv-tabmodal-footer" hasGutter>
         {error && (
           <StackItem>
-            <Alert isInline title={t('An error occurred')} variant={AlertVariant.danger}>
+            <Alert
+              data-test="modal-error-alert"
+              isInline
+              title={t('An error occurred')}
+              variant={AlertVariant.danger}
+            >
               <Stack hasGutter>
                 <StackItem>{errorMessage}</StackItem>
                 {errorHref && (

--- a/src/utils/hooks/useKubevirtDataViewFilters/useKubevirtDataViewFilters.test.ts
+++ b/src/utils/hooks/useKubevirtDataViewFilters/useKubevirtDataViewFilters.test.ts
@@ -8,10 +8,6 @@ let mockFiltersState: KubevirtFilterState = { labels: [], name: [] };
 const mockClearAllFilters = jest.fn();
 const mockOnSetFilters = jest.fn();
 
-jest.mock('@kubevirt-utils/hooks/useKubevirtTranslation', () => ({
-  useKubevirtTranslation: () => ({ t: (str: string) => str }),
-}));
-
 jest.mock('@patternfly/react-data-view', () => ({
   useDataViewFilters: jest.fn(() => ({
     clearAllFilters: mockClearAllFilters,

--- a/src/utils/utils/formatK8sError.test.ts
+++ b/src/utils/utils/formatK8sError.test.ts
@@ -1,0 +1,84 @@
+import { TFunction } from 'i18next';
+
+import { formatK8sError, getK8sErrorHref, K8sLikeError } from './formatK8sError';
+
+const t = ((key: string) => key) as TFunction;
+
+beforeAll(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+const errorWithMessage = (message: string, href?: string): K8sLikeError => {
+  const error = new Error(message) as K8sLikeError;
+  if (href) {
+    error.href = href;
+  }
+  return error;
+};
+
+describe('formatK8sError', () => {
+  it('should return an empty string when error is undefined', () => {
+    expect(formatK8sError(undefined, t)).toBe('');
+  });
+
+  it('should return the cron format message for illegal cron schedule errors', () => {
+    expect(formatK8sError(errorWithMessage('not a legal cron schedule'), t)).toBe(
+      'Invalid cron schedule format. Use standard cron syntax (e.g., {{ example }}).',
+    );
+  });
+
+  it('should return the missing-fields message', () => {
+    expect(formatK8sError(errorWithMessage('missing required fields: spec'), t)).toBe(
+      'Missing required fields. Complete all required fields before saving.',
+    );
+  });
+
+  it('should return the invalid-certificate message', () => {
+    expect(formatK8sError(errorWithMessage('invalid certificate for registry'), t)).toBe(
+      'Invalid certificate. Open the link below in a new tab to approve the certificate, then try again.',
+    );
+  });
+
+  it('should return the generic admin message for 4xx/5xx prefixes', () => {
+    expect(formatK8sError(errorWithMessage('403 Forbidden: cannot patch'), t)).toBe(
+      'The operation could not be completed. Please try again or contact your administrator.',
+    );
+  });
+
+  it('should return the generic admin message when status is embedded', () => {
+    expect(formatK8sError(errorWithMessage('request failed status: 500'), t)).toBe(
+      'The operation could not be completed. Please try again or contact your administrator.',
+    );
+  });
+
+  it('should return the original message when it does not match a known pattern', () => {
+    expect(formatK8sError(errorWithMessage('volume expansion is not allowed'), t)).toBe(
+      'volume expansion is not allowed',
+    );
+  });
+});
+
+describe('getK8sErrorHref', () => {
+  it('should return http(s) hrefs', () => {
+    expect(getK8sErrorHref(errorWithMessage('invalid certificate', 'https://example.test'))).toBe(
+      'https://example.test',
+    );
+    expect(getK8sErrorHref(errorWithMessage('invalid certificate', 'http://example.test'))).toBe(
+      'http://example.test',
+    );
+  });
+
+  it('should return undefined when error or href is missing', () => {
+    expect(getK8sErrorHref(undefined)).toBeUndefined();
+    expect(getK8sErrorHref(errorWithMessage('no href'))).toBeUndefined();
+  });
+
+  it('should reject javascript and relative hrefs', () => {
+    expect(getK8sErrorHref(errorWithMessage('x', 'javascript:alert(1)'))).toBeUndefined();
+    expect(getK8sErrorHref(errorWithMessage('x', '/relative/path'))).toBeUndefined();
+  });
+});

--- a/src/utils/utils/formatK8sError.ts
+++ b/src/utils/utils/formatK8sError.ts
@@ -39,4 +39,7 @@ export const formatK8sError = (error: K8sLikeError | undefined, t: TFunction): s
   return message;
 };
 
-export const getK8sErrorHref = (error: K8sLikeError | undefined): string | undefined => error?.href;
+export const getK8sErrorHref = (error: K8sLikeError | undefined): string | undefined => {
+  const href = error?.href;
+  return href && /^https?:\/\//i.test(href) ? href : undefined;
+};

--- a/src/views/bootablevolumes/list/hooks/useBootableVolumesFilters.test.ts
+++ b/src/views/bootablevolumes/list/hooks/useBootableVolumesFilters.test.ts
@@ -4,11 +4,6 @@ import { renderHook } from '@testing-library/react';
 import { BootableVolumesFilterID } from './constants';
 import useBootableVolumesFilters from './useBootableVolumesFilters';
 
-jest.mock('@kubevirt-utils/hooks/useKubevirtTranslation', () => ({
-  t: (str: string) => str,
-  useKubevirtTranslation: () => ({ t: (str: string) => str }),
-}));
-
 jest.mock('@multicluster/useIsACMPage', () => ({
   __esModule: true,
   default: () => false,

--- a/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationsChartDonut.test.tsx
+++ b/src/views/clusteroverview/MigrationsTab/components/MigrationsChartDonut/MigrationsChartDonut.test.tsx
@@ -23,10 +23,6 @@ jest.mock('@patternfly/react-charts/victory', () => {
   };
 });
 
-jest.mock('@kubevirt-utils/hooks/useKubevirtTranslation', () => ({
-  useKubevirtTranslation: () => ({ t: (value: string) => value }),
-}));
-
 jest.mock('../LiveMigrationSettingsPopover/LiveMigrationSettingsPopover', () => ({
   __esModule: true,
   default: () => null,

--- a/src/views/virtualmachines/list/components/ManageVirtualMachinesButton/ManageVirtualMachinesButton.test.tsx
+++ b/src/views/virtualmachines/list/components/ManageVirtualMachinesButton/ManageVirtualMachinesButton.test.tsx
@@ -29,12 +29,6 @@ jest.mock('@kubevirt-utils/resources/vm', () => ({
   getVMListPath: (...args: unknown[]): string => mockGetVMListPath(...args),
 }));
 
-jest.mock('@kubevirt-utils/hooks/useKubevirtTranslation', () => ({
-  useKubevirtTranslation: (): { t: (str: string) => string } => ({
-    t: (str: string): string => str,
-  }),
-}));
-
 describe('ManageVirtualMachinesButton', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/views/virtualmachines/list/filters/tests/getOSFilter.test.ts
+++ b/src/views/virtualmachines/list/filters/tests/getOSFilter.test.ts
@@ -1,16 +1,11 @@
 import { type TFunction } from 'i18next';
 
+import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { OS_NAME_LABELS } from '@kubevirt-utils/resources/template';
 
 import { getOSFilter, getOSName } from '../getOSFilter';
 
 import { createMockVM } from './mockVM';
-
-const t = (str: string) => str;
-jest.mock('@kubevirt-utils/hooks/useKubevirtTranslation', () => ({
-  t: (str: string) => str,
-  useKubevirtTranslation: () => ({ t: (str: string) => str }),
-}));
 
 describe('VM OS Filter', () => {
   const osFilter = getOSFilter(t as TFunction);

--- a/src/views/virtualmachines/list/filters/tests/getStatusFilter.test.ts
+++ b/src/views/virtualmachines/list/filters/tests/getStatusFilter.test.ts
@@ -1,5 +1,6 @@
 import { type TFunction } from 'i18next';
 
+import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ERROR_STATUS } from '@kubevirt-utils/resources/vm';
 import {
   errorPrintableVMStatus,
@@ -9,12 +10,6 @@ import {
 import { getStatusFilter } from '../getStatusFilter';
 
 import { createMockVM } from './mockVM';
-
-const t = (str: string) => str;
-jest.mock('@kubevirt-utils/hooks/useKubevirtTranslation', () => ({
-  t: (str: string) => str,
-  useKubevirtTranslation: () => ({ t: (str: string) => str }),
-}));
 
 describe('VM Status Filter', () => {
   const statusFilter = getStatusFilter(t as TFunction);

--- a/src/views/virtualmachines/node/inventoryitem/NodeInventoryItem.test.tsx
+++ b/src/views/virtualmachines/node/inventoryitem/NodeInventoryItem.test.tsx
@@ -58,24 +58,6 @@ jest.mock('@overview/OverviewTab/vm-statuses-card/utils/utils', () => {
   };
 });
 
-jest.mock('@kubevirt-utils/hooks/useKubevirtTranslation', () => {
-  const t = (key: string, params?: Record<string, string>): string => {
-    let result = key;
-    if (params) {
-      for (const [objKey, value] of Object.entries(params)) {
-        result = result.replace(`{{${objKey}}}`, String(value));
-      }
-    }
-    return result;
-  };
-  return {
-    t,
-    useKubevirtTranslation: (): {
-      t: (key: string, params?: Record<string, string>) => string;
-    } => ({ t }),
-  };
-});
-
 jest.mock('@virtualmachines/search/hooks/useAccessibleResources', () => ({
   useAccessibleResources: (): ReturnType<typeof mockUseAccessibleResources> =>
     mockUseAccessibleResources(),


### PR DESCRIPTION
## 📝 Description

E2E and unit tests for verifying that every modal has the same behavior for success and error events. 

## 🔗 Links

Jira ticket: [CNV-76355](https://redhat.atlassian.net/browse/CNV-76355)

## 🎥 Demo

All relevant tests passed locally. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved disk resize error handling so failures remain visible in the Edit Disk dialog.
  - Save and Cancel actions remain available after an error, allowing users to retry or dismiss the dialog.
  - Restricted error links to safe HTTP(S) destinations.

- **Documentation**
  - Updated testing documentation and release references to use three-part CNV versions.

- **Tests**
  - Added coverage for disk resize failures, error persistence, dialog actions, and Kubernetes error formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->