### PR TITLE
CNV-95901: use Link instead of <a> for smoother redirect

### DIFF
--- a/src/views/virtualmachines/list/components/VirtIODriversAlert/VirtIODriversAlert.tsx
+++ b/src/views/virtualmachines/list/components/VirtIODriversAlert/VirtIODriversAlert.tsx
@@ -1,7 +1,7 @@
-import React, { FC, useState } from 'react';
-import { useLocation } from 'react-router';
+import React, { type FC, useState } from 'react';
+import { Link, useLocation } from 'react-router';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -11,7 +11,6 @@ import {
   Alert,
   AlertActionCloseButton,
   AlertVariant,
-  Button,
   Checkbox,
   Flex,
 } from '@patternfly/react-core';
@@ -19,6 +18,7 @@ import { DOWNLOADS_TAB_IDS } from '@settings/search/constants';
 import { createSettingsSearchURL } from '@settings/search/search';
 import { SETTINGS_TABS } from '@settings/tabs';
 import { getOSName } from '@virtualmachines/list/filters/getOSFilter';
+
 import { VIRTIO_DRIVERS_ALERT_DISMISSED_KEY } from './constants';
 
 type VirtIODriversAlertProps = {
@@ -47,7 +47,7 @@ const VirtIODriversAlert: FC<VirtIODriversAlertProps> = ({ vms }) => {
     location.pathname,
   );
 
-  const handleClose = () => {
+  const handleClose = (): void => {
     if (dontShowAgain) {
       setPermanentlyDismissed(true);
     }
@@ -70,9 +70,7 @@ const VirtIODriversAlert: FC<VirtIODriversAlertProps> = ({ vms }) => {
         )}
       </p>
       <Flex className="pf-v6-u-mt-sm">
-        <Button component="a" href={settingsURL} isInline variant="link">
-          {t('Go to Downloads')}
-        </Button>
+        <Link to={settingsURL}>{t('Go to Downloads')}</Link>
         <ExternalLink
           href={documentationURL.VIRTIO_WIN_DRIVERS}
           text={t('How to update Windows VMs')}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

`VirtIODriversAlert`: use `Link` instead of `<a>` for smoother redirect

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-95901

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/723025a3-c4e1-49fc-a8bb-4fdfc6efdc30



After:


https://github.com/user-attachments/assets/4be97569-28bd-4013-a150-403bf6face24




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation from the VirtIO drivers alert for more consistent behavior.
  * Preserved alert dismissal behavior while clarifying interaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->