### PR TITLE
CNV-90652: Tests for VM tree view - show all projects by default when no vms exist

### DIFF
--- a/playwright/src/page-objects/vm/vm-tree-page.ts
+++ b/playwright/src/page-objects/vm/vm-tree-page.ts
@@ -7,6 +7,7 @@ export default class VmTreePage extends TreeContextMenuMixin(PageCommons) {
   private readonly _idVmsTreeViewSearchInput = this.locator('[id="vms-tree-view-search-input"]');
   private readonly _overviewTab = this.locator('button[role="tab"]', { hasText: /^Overview$/ });
   private readonly _projectName = this.locator('#project-name');
+  private readonly _showOnlyVMProjectsSwitch = this.testId('show-only-vm-projects-switch');
   private readonly _treeNode = this.locator('.pf-v6-c-tree-view__node');
   private readonly _treeView = this.locator('.pf-v6-c-tree-view');
   private readonly _vmListTab = this.locator('button[role="tab"]', {
@@ -320,6 +321,18 @@ export default class VmTreePage extends TreeContextMenuMixin(PageCommons) {
     return await folderElement.isVisible();
   }
 
+  async isShowOnlyVMProjectsSwitchChecked(): Promise<boolean> {
+    const input = this._showOnlyVMProjectsSwitch;
+    await input.waitFor({ state: 'attached', timeout: TestTimeouts.ELEMENT_WAIT });
+    return input.isChecked();
+  }
+
+  async isShowOnlyVMProjectsSwitchEnabled(): Promise<boolean> {
+    const input = this._showOnlyVMProjectsSwitch;
+    await input.waitFor({ state: 'attached', timeout: TestTimeouts.ELEMENT_WAIT });
+    return input.isEnabled();
+  }
+
   async isTreeNodeVisible(nodeName: string): Promise<boolean> {
     try {
       const node = this._treeNode.filter({ hasText: nodeName });
@@ -442,7 +455,7 @@ export default class VmTreePage extends TreeContextMenuMixin(PageCommons) {
   }
 
   async toggleEmptyProjectsDisplay(show: boolean): Promise<void> {
-    const checkbox = this.locator('.vms-tree-view__toolbar-switch input[type="checkbox"]');
+    const checkbox = this._showOnlyVMProjectsSwitch;
 
     try {
       await checkbox.waitFor({ state: 'attached', timeout: TestTimeouts.ELEMENT_WAIT });

--- a/playwright/tests/tier1/virtualmachines/vm-tree/vm-tree-filter.spec.md
+++ b/playwright/tests/tier1/virtualmachines/vm-tree/vm-tree-filter.spec.md
@@ -1,0 +1,81 @@
+# Software Test Description (STD): VM Tree View Filter
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier1 — Virtual machines / Tree view
+- **Latest version:** CNV 5.1.0
+- **Latest update:** 2026-08-25
+- **Document Status:** Approved
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify that the VirtualMachines tree-view "Show only projects with VirtualMachines" filter stays
+enabled when the cluster has VirtualMachines, and that toggling it hides and shows an empty
+(non-VM) project.
+
+### 2.2 Scope
+
+- **In-Scope:** Filter switch enabled and checked when VirtualMachines exist; empty-project node
+  hidden with the filter on; empty-project node visible with the filter off; hiding again after
+  turning the filter back on.
+- **Out-of-Scope:** Cluster with zero VirtualMachines (disabled switch and tooltip; covered by Jest
+  unit tests). ACM / multi-cluster tree. System-namespace filtering.
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator installed; Playwright `Tier1` project. The cluster
+  already has at least one VirtualMachine from global setup.
+- **Configuration:** No special feature gates required. Tests run on standalone virtualization
+  (not ACM).
+- **Initial Setup:** `beforeAll` creates an empty test namespace with no VirtualMachine via
+  `setupTestNamespace`. Namespace cleanup is handled by the fixture resource tracker.
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier1/virtualmachines/vm-tree/vm-tree-filter.spec.ts`
+**Describe:** `VM tree view filter` — **Tags:** `@tier1`
+**Allure:** suite `VM tree view filter`, feature `Tier 1`
+
+---
+
+### `001`: Empty project visibility follows the tree filter when VirtualMachines exist
+
+- **Objective:** Verify that the filter switch is enabled and on when VirtualMachines exist, that an
+  empty project is hidden while the filter is on, that turning the filter off shows the empty
+  project, and that turning it on hides the project again.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-90652
+- **Pre-conditions:** Cluster has at least one VirtualMachine; an empty test namespace exists
+- **Tags:** `@adminOnly`
+
+| Step | Action                                                                      | Expected Result                                            |
+| :--- | :-------------------------------------------------------------------------- | :--------------------------------------------------------- |
+| 1    | Navigate to VirtualMachines, turn the filter on, search the empty namespace | Filter is on; tree search is scoped to the empty namespace |
+| 2    | Observe the filter switch and the empty project node                        | Switch is enabled and on; empty project is hidden          |
+| 3    | Turn the filter off                                                         | Empty project node is visible                              |
+| 4    | Turn the filter on again                                                    | Empty project node is hidden                               |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+| Jira Ticket | Test Case ID | Coverage Type    | Status    |
+| ----------- | ------------ | ---------------- | --------- |
+| CNV-90652   | `001`        | Feature coverage | Automated |
+
+**Coverage Type values:**
+
+- `Feature coverage` — test validates a feature delivered by the ticket
+- `Bugfix regression guard` — test asserts the specific bug fixed by the ticket does not regress
+- `Functional smoke` — test validates baseline behavior; no specific Jira ticket drives it
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** Gal Kremer
+- **Approval Signature:** Gal Kremer

--- a/playwright/tests/tier1/virtualmachines/vm-tree/vm-tree-filter.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-tree/vm-tree-filter.spec.ts
@@ -1,0 +1,70 @@
+import { ADMIN_ONLY_TAG, T1, T1_TAG, VM_LIST_TAG } from '@/data-models/allure-constants';
+import { expect, test } from '@/fixtures/vm-search-fixture';
+import { TestTimeouts } from '@/utils/test-config';
+import { setupTestNamespace } from '@/utils/test-setup-helpers';
+
+const SUITE = 'VM tree view filter';
+
+test.describe(SUITE, { tag: [T1_TAG] }, () => {
+  let emptyNamespace: string;
+
+  test.beforeAll(async ({ apiClient }) => {
+    emptyNamespace = await setupTestNamespace(apiClient, 'tree-empty');
+  });
+
+  test('toggles empty project visibility when VirtualMachines exist', async ({
+    vmTreePage,
+    utils,
+  }) => {
+    await utils.withAllure({
+      suite: SUITE,
+      feature: T1,
+      tags: [T1_TAG, VM_LIST_TAG, ADMIN_ONLY_TAG, 'CNV-90652'],
+    });
+
+    await test.step('Navigate to VirtualMachines and turn the filter on', async () => {
+      await vmTreePage.navigateToVirtualMachinesViaUI();
+      await vmTreePage.tryCloseWelcomeModal();
+      await vmTreePage.toggleEmptyProjectsDisplay(false);
+      await vmTreePage.searchTreeView(emptyNamespace);
+    });
+
+    await test.step('Switch is enabled and on, and the empty project is hidden', async () => {
+      expect(
+        await vmTreePage.isShowOnlyVMProjectsSwitchEnabled(),
+        'Filter switch should be enabled when VirtualMachines exist',
+      ).toBe(true);
+      expect(
+        await vmTreePage.isShowOnlyVMProjectsSwitchChecked(),
+        'Filter switch should be on when hiding empty projects',
+      ).toBe(true);
+
+      await expect
+        .poll(() => vmTreePage.isTreeNodeVisible(emptyNamespace), {
+          message: `Empty project ${emptyNamespace} should be hidden when the filter is on`,
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        })
+        .toBe(false);
+    });
+
+    await test.step('Turning the filter off shows the empty project', async () => {
+      await vmTreePage.toggleEmptyProjectsDisplay(true);
+      await expect
+        .poll(() => vmTreePage.isTreeNodeVisible(emptyNamespace), {
+          message: `Empty project ${emptyNamespace} should be visible when the filter is off`,
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        })
+        .toBe(true);
+    });
+
+    await test.step('Turning the filter on hides the empty project again', async () => {
+      await vmTreePage.toggleEmptyProjectsDisplay(false);
+      await expect
+        .poll(() => vmTreePage.isTreeNodeVisible(emptyNamespace), {
+          message: `Empty project ${emptyNamespace} should be hidden when the filter is on`,
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        })
+        .toBe(false);
+    });
+  });
+});

--- a/src/views/virtualmachines/tree/components/ShowOnlyVMProjectsSwitch.tsx
+++ b/src/views/virtualmachines/tree/components/ShowOnlyVMProjectsSwitch.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useLocalStorage from '@kubevirt-utils/hooks/useLocalStorage';
@@ -21,6 +21,7 @@ const ShowOnlyVMProjectsSwitch: FC<ShowOnlyVMProjectsSwitchProps> = ({ hasVMs })
       aria-label={showOnlyVMProjectsLabel}
       checked={isShowOnlyVMProjectsChecked(hasVMs, showEmptyProjects)}
       className="vms-tree-view__toolbar-switch"
+      data-test="show-only-vm-projects-switch"
       isDisabled={!hasVMs}
       isReversed
       onChange={(_, checked) => setShowEmptyProjects(checked ? HIDE : SHOW)}

--- a/src/views/virtualmachines/tree/utils/treeHelpers.test.ts
+++ b/src/views/virtualmachines/tree/utils/treeHelpers.test.ts
@@ -1,0 +1,60 @@
+import { type TreeViewDataItem } from '@patternfly/react-core';
+
+import { HIDE, PROJECT_SELECTOR_PREFIX, SHOW } from './constants';
+import {
+  filterNamespaceItems,
+  getEffectiveShowEmptyProjects,
+  isShowOnlyVMProjectsChecked,
+} from './treeHelpers';
+
+const projectItem = (name: string, children?: TreeViewDataItem[]): TreeViewDataItem => ({
+  children,
+  id: `${PROJECT_SELECTOR_PREFIX}/#single-cluster#/${name}`,
+  name,
+});
+
+describe('getEffectiveShowEmptyProjects', () => {
+  it('should force SHOW when the cluster has no VirtualMachines', () => {
+    expect(getEffectiveShowEmptyProjects(false, HIDE)).toBe(SHOW);
+    expect(getEffectiveShowEmptyProjects(false, SHOW)).toBe(SHOW);
+  });
+
+  it('should use the stored preference when VirtualMachines exist', () => {
+    expect(getEffectiveShowEmptyProjects(true, HIDE)).toBe(HIDE);
+    expect(getEffectiveShowEmptyProjects(true, SHOW)).toBe(SHOW);
+  });
+});
+
+describe('isShowOnlyVMProjectsChecked', () => {
+  it('should be unchecked when the cluster has no VirtualMachines', () => {
+    expect(isShowOnlyVMProjectsChecked(false, HIDE)).toBe(false);
+    expect(isShowOnlyVMProjectsChecked(false, SHOW)).toBe(false);
+  });
+
+  it('should follow the stored preference when VirtualMachines exist', () => {
+    expect(isShowOnlyVMProjectsChecked(true, HIDE)).toBe(true);
+    expect(isShowOnlyVMProjectsChecked(true, SHOW)).toBe(false);
+  });
+});
+
+describe('filterNamespaceItems', () => {
+  it('should always include projects that have VirtualMachines', () => {
+    const item = projectItem('app', [{ id: 'vm-1', name: 'vm-1' }]);
+
+    expect(filterNamespaceItems(item, false)).toBe(true);
+    expect(filterNamespaceItems(item, true)).toBe(true);
+  });
+
+  it('should hide empty non-system projects when showEmptyProjects is false', () => {
+    expect(filterNamespaceItems(projectItem('app', []), false)).toBe(false);
+  });
+
+  it('should show empty non-system projects when showEmptyProjects is true', () => {
+    expect(filterNamespaceItems(projectItem('app', []), true)).toBe(true);
+  });
+
+  it('should hide empty system namespaces even when showEmptyProjects is true', () => {
+    expect(filterNamespaceItems(projectItem('openshift', []), true)).toBe(false);
+    expect(filterNamespaceItems(projectItem('kube-system', []), true)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 📝 Description

Adding tests for VirtualMachines tree view: show all projects by default when no VirtualMachines exist.

## 🔗 Links

Jira ticket: [CNV-90652](https://redhat.atlassian.net/browse/CNV-90652)

## 🎥 Demo

All tests passed locally. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the VM project tree filter when showing or hiding empty projects.
  * Ensured system, populated, and empty projects are filtered correctly.
  * Improved filter state handling when the control is enabled, disabled, or toggled.

* **Tests**
  * Added end-to-end coverage for toggling the VM project filter.
  * Added unit tests covering filter states and project visibility.
  * Documented the filter behavior, prerequisites, and validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->