### PR TITLE
[release-4.21] CNV-95928: Remove CDI dataVolumeTTLSeconds deprecated logic

### DIFF
--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useVolumeOwnedResource.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useVolumeOwnedResource.tsx
@@ -1,14 +1,18 @@
-import { V1beta1CDIConfig } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import { V1VirtualMachine, V1Volume } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { CDIConfigModelGroupVersionKind, modelToGroupVersionKind } from '@kubevirt-utils/models';
-import { buildOwnerReference, compareOwnerReferences } from '@kubevirt-utils/resources/shared';
+import { type V1VirtualMachine, type V1Volume } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type VolumeTypes } from '@kubevirt-utils/components/DiskModal/utils/types';
+import { modelToGroupVersionKind } from '@kubevirt-utils/models';
+import {
+  buildOwnerReference,
+  compareOwnerReferences,
+  getNamespace,
+} from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
-import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk-internal/lib/extensions/console-types';
+import { type K8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk-internal/lib/extensions/console-types';
 
 import { mapVolumeTypeToK8sModel } from './utils/constants';
-import { convertDataVolumeToPVC, getVolumeResourceName, getVolumeType } from './utils/utils';
+import { getVolumeResourceName, getVolumeType } from './utils/utils';
 
 type UseVolumeOwnedResource = (
   vm: V1VirtualMachine,
@@ -17,40 +21,35 @@ type UseVolumeOwnedResource = (
   error: Error;
   loaded: boolean;
   volumeResource: K8sResourceCommon;
-  volumeResourceModel: K8sModel;
+  volumeResourceModel: K8sModel | null;
   volumeResourceName: string;
 };
 
 const useVolumeOwnedResource: UseVolumeOwnedResource = (vm, volume) => {
   const cluster = getCluster(vm);
 
-  const [cdiConfig, isCdiConfigLoaded, isCdiConfigError] = useK8sWatchData<V1beta1CDIConfig>({
-    cluster,
-    groupVersionKind: CDIConfigModelGroupVersionKind,
-    isList: false,
-    namespaced: false,
-  });
+  const volumeType = getVolumeType(volume);
+  const volumeResourceModel = mapVolumeTypeToK8sModel[volumeType as VolumeTypes];
+  const volumeGroupVersionKind = volumeResourceModel
+    ? modelToGroupVersionKind(volumeResourceModel)
+    : null;
 
-  const updatedVolume = volume?.dataVolume ? convertDataVolumeToPVC(volume, cdiConfig) : volume;
-  const volumeType = getVolumeType(updatedVolume);
-  const volumeResourceModel = mapVolumeTypeToK8sModel[volumeType];
-  const volumeGroupVersionKind =
-    volumeResourceModel && modelToGroupVersionKind(volumeResourceModel);
   const volumeResourceName = getVolumeResourceName(volume);
-  const watchVolumeResource = {
-    cluster,
-    groupVersionKind: volumeGroupVersionKind,
-    isList: false,
-    name: volumeResourceName,
-    namespace: vm.metadata.namespace,
-  };
-  const [resource, loaded, error] = useK8sWatchData<K8sResourceCommon>(
-    volumeGroupVersionKind && volumeResourceName && watchVolumeResource,
-  );
+  const watchVolumeResource =
+    volumeGroupVersionKind && volumeResourceName
+      ? {
+          cluster,
+          groupVersionKind: volumeGroupVersionKind,
+          isList: false,
+          name: volumeResourceName,
+          namespace: getNamespace(vm),
+        }
+      : null;
+  const [resource, loaded, error] = useK8sWatchData<K8sResourceCommon>(watchVolumeResource);
 
-  if (!volumeResourceModel || !volumeResourceName) {
+  if (!watchVolumeResource) {
     return {
-      error: error || isCdiConfigError,
+      error: error,
       loaded: true,
       volumeResource: null,
       volumeResourceModel: null,
@@ -62,8 +61,8 @@ const useVolumeOwnedResource: UseVolumeOwnedResource = (vm, volume) => {
     return compareOwnerReferences(ownerRef, vmOwnerRef);
   });
   return {
-    error: error || isCdiConfigError,
-    loaded: loaded && isCdiConfigLoaded,
+    error: error,
+    loaded: loaded,
     volumeResource: volumeResourceReference ? resource : null,
     volumeResourceModel,
     volumeResourceName,

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/utils/constants.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/utils/constants.ts
@@ -1,13 +1,14 @@
 import {
   ConfigMapModel,
+  DataVolumeModel,
   PersistentVolumeClaimModel,
   SecretModel,
   ServiceAccountModel,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { DataVolumeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VolumeTypes } from '@kubevirt-utils/components/DiskModal/utils/types';
+import { type K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
-export const mapVolumeTypeToK8sModel = {
+export const mapVolumeTypeToK8sModel: Partial<Record<VolumeTypes, K8sModel>> = {
   [VolumeTypes.CONFIG_MAP]: ConfigMapModel,
   [VolumeTypes.DATA_VOLUME]: DataVolumeModel,
   [VolumeTypes.PERSISTENT_VOLUME_CLAIM]: PersistentVolumeClaimModel,

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/utils/utils.ts
@@ -1,18 +1,5 @@
-import { V1beta1CDIConfig } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import { V1Volume } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1Volume } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { VolumeTypes } from '@kubevirt-utils/components/DiskModal/utils/types';
-
-export const convertDataVolumeToPVC = (volume: V1Volume, cdiConfig: V1beta1CDIConfig): V1Volume => {
-  const isDataVolumeGarbageCollector = cdiConfig?.spec?.dataVolumeTTLSeconds !== -1;
-  const transformedDataVolumeToPVC: V1Volume = {
-    name: volume.name,
-    [VolumeTypes.PERSISTENT_VOLUME_CLAIM]: {
-      claimName: volume.dataVolume.name,
-      hotpluggable: volume.dataVolume.hotpluggable,
-    },
-  };
-  return isDataVolumeGarbageCollector ? transformedDataVolumeToPVC : volume;
-};
 
 export const getVolumeType = (volume: V1Volume): string => {
   if (!volume) return null;

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
@@ -1,10 +1,6 @@
-import React, { FC, useMemo, useState } from 'react';
+import React, { type FC, useMemo, useState } from 'react';
 
-import {
-  V1VirtualMachine,
-  V1VirtualMachineInstance,
-  V1Volume,
-} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DiskModal from '@kubevirt-utils/components/DiskModal/DiskModal';
 import {
   isDeclarativeHotplugVolumesEnabled,
@@ -16,18 +12,10 @@ import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKube
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { getDataVolumeTemplates, getDisks, getVolumes } from '@kubevirt-utils/resources/vm';
-import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
-import {
-  hasContainerDisk,
-  hasDataVolume,
-  hasPersistentVolumeClaim,
-  isCDROMDisk,
-} from '@kubevirt-utils/resources/vm/utils/disk/selectors';
-import { isEmptyContainerDiskImage } from '@kubevirt-utils/resources/vm/utils/disk/utils';
+import { isCDROMDisk } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
 import { getContentScrollableElement } from '@kubevirt-utils/utils/utils';
 import { ButtonVariant, Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core';
 import { updateDisks } from '@virtualmachines/details/tabs/configuration/details/utils/utils';
-import { isRunning } from '@virtualmachines/utils';
 
 import CreateBootableVolumeModal from '../../modal/CreateBootableVolumeModal';
 import DeleteDiskModal from '../../modal/DeleteDiskModal';
@@ -36,15 +24,9 @@ import EjectCDROMModal from '../../modal/EjectCDROMModal';
 import MakePersistentModal from '../../modal/MakePersistentModal';
 import MountCDROMModal from '../../modal/MountCDROMModal';
 
+import { getDiskVolumeState } from './utils/getDiskVolumeState';
 import { isHotplugVolume, isPVCSource } from './utils/helpers';
-
-type DiskRowActionsProps = {
-  customize?: boolean;
-  obj: DiskRowDataLayout;
-  onDiskUpdate?: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine>;
-  vm: V1VirtualMachine;
-  vmi?: V1VirtualMachineInstance;
-};
+import { type DiskRowActionsProps } from './types';
 
 const DiskRowActions: FC<DiskRowActionsProps> = ({
   customize = false,
@@ -60,7 +42,6 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const { name: diskName, source: diskSource } = obj || {};
 
-  const isVMRunning = isRunning(vm);
   const isHotplug = isHotplugVolume(vm, diskName, vmi);
 
   const vmDisk = getDisks(vm)?.find((disk) => disk.name === diskName);
@@ -70,25 +51,10 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
     [featureGates],
   );
 
-  const { isCDROMMountedState, volume } = useMemo(() => {
-    const vols = isVMRunning && !isCDROM ? vmi?.spec?.volumes : getVolumes(vm);
-    const vol = vols?.find(({ name }) => name === diskName);
-
-    const isMountedVolume = (targetVolume: undefined | V1Volume): boolean => {
-      if (!targetVolume) return false;
-      if (hasContainerDisk(targetVolume)) {
-        return !isEmptyContainerDiskImage(targetVolume);
-      }
-      return hasDataVolume(targetVolume) || hasPersistentVolumeClaim(targetVolume);
-    };
-
-    const mounted = isMountedVolume(vol);
-
-    return {
-      isCDROMMountedState: isCDROM && mounted,
-      volume: vol,
-    };
-  }, [vm, vmi, isVMRunning, diskName, isCDROM]);
+  const { isCDROMMountedState, volume } = useMemo(
+    () => getDiskVolumeState(vm, vmi, diskName, isCDROM),
+    [vm, vmi, diskName, isCDROM],
+  );
 
   const isCDROMOperationsEnabled = isCDROM && isDeclarativeHotplugVolumesFeatureGateEnabled;
 
@@ -96,36 +62,37 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
   const deleteBtnText = t('Detach');
   const removeHotplugBtnText = t('Make persistent');
 
-  const onCustomizeDeleteDisk = () => {
+  const onCustomizeDeleteDisk = (): Promise<V1VirtualMachine> => {
     const newVM = produceVMDisks(vm, (draftVM) => {
-      const volumeToDelete = getVolumes(vm).find((v) => v.name === diskName);
+      const volumeToDelete = getVolumes(draftVM)?.find((vol) => vol.name === diskName);
+      const volumeName = volumeToDelete?.name ?? diskName;
       draftVM.spec.template.spec.domain.devices.disks = getDisks(draftVM)?.filter(
-        (disk) => disk.name !== (volumeToDelete?.name || diskName),
+        (disk) => disk.name !== volumeName,
       );
       draftVM.spec.template.spec.volumes = getVolumes(draftVM)?.filter(
-        (v) => v.name !== (volumeToDelete?.name || diskName),
+        (vol) => vol.name !== volumeName,
       );
       draftVM.spec.dataVolumeTemplates = getDataVolumeTemplates(draftVM)?.filter(
         (dataVolume) => getName(dataVolume) !== volumeToDelete?.dataVolume?.name,
       );
     });
 
-    return onDiskUpdate(newVM);
+    return (onDiskUpdate ?? updateDisks)(newVM);
   };
 
-  const createEditDiskModal = () =>
+  const createEditDiskModal = (): void =>
     createModal(({ isOpen, onClose }) => (
       <DiskModal
         createdPVCName={isPVCSource(obj) ? obj?.source : null}
         editDiskName={diskName}
         isOpen={isOpen}
         onClose={onClose}
-        onSubmit={onDiskUpdate || updateDisks}
+        onSubmit={onDiskUpdate ?? updateDisks}
         vm={vm}
       />
     ));
 
-  const createDeleteDiskModal = () =>
+  const createDeleteDiskModal = (): void =>
     createModal(({ isOpen, onClose }) =>
       customize || isCDROM ? (
         <DetachModal
@@ -149,37 +116,37 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({
       ),
     );
 
-  const createBootableVolume = () => {
+  const createBootableVolume = (): void => {
     createModal(({ isOpen, onClose }) => (
       <CreateBootableVolumeModal diskObj={obj} isOpen={isOpen} onClose={onClose} vm={vm} />
     ));
   };
 
-  const makePersistent = () =>
+  const makePersistent = (): void =>
     createModal(({ isOpen, onClose }) => (
       <MakePersistentModal isOpen={isOpen} onClose={onClose} vm={vm} vmi={vmi} volume={volume} />
     ));
 
-  const createCDROMModal = () => {
+  const createCDROMModal = (): void => {
     const Component = isCDROMMountedState ? EjectCDROMModal : MountCDROMModal;
     return createModal(({ isOpen, onClose }) => (
       <Component
         cdromName={diskName}
         isOpen={isOpen}
         onClose={onClose}
-        onSubmit={onDiskUpdate || updateDisks}
+        onSubmit={onDiskUpdate ?? updateDisks}
         vm={vm}
         {...(isCDROMMountedState && { source: diskSource })}
       />
     ));
   };
 
-  const onModalOpen = (createModalCallback: () => void) => {
+  const onModalOpen = (createModalCallback: () => void): void => {
     createModalCallback();
     setIsDropdownOpen(false);
   };
 
-  const onToggle = () => setIsDropdownOpen((prevIsOpen) => !prevIsOpen);
+  const onToggle = (): void => setIsDropdownOpen((prevIsOpen) => !prevIsOpen);
 
   return (
     <Dropdown

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/types.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/types.ts
@@ -1,0 +1,13 @@
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
+
+export type DiskRowActionsProps = {
+  customize?: boolean;
+  obj: DiskRowDataLayout;
+  onDiskUpdate?: (updatedVM: V1VirtualMachine) => Promise<V1VirtualMachine>;
+  vm: V1VirtualMachine;
+  vmi?: V1VirtualMachineInstance;
+};

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/utils/getDiskVolumeState.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/utils/getDiskVolumeState.ts
@@ -1,0 +1,57 @@
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+  type V1Volume,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getRunningVMMissingVolumesFromVMI } from '@kubevirt-utils/components/DiskModal/utils/helpers';
+import { getVolumes } from '@kubevirt-utils/resources/vm';
+import {
+  hasContainerDisk,
+  hasDataVolume,
+  hasPersistentVolumeClaim,
+} from '@kubevirt-utils/resources/vm/utils/disk/selectors';
+import { isEmptyContainerDiskImage } from '@kubevirt-utils/resources/vm/utils/disk/utils';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+
+type DiskVolumeState = {
+  isCDROMMountedState: boolean;
+  volume: undefined | V1Volume;
+};
+
+const getVMVolumesWithRunningVMIVolumes = (
+  vmVolumes: V1Volume[],
+  vmi: undefined | V1VirtualMachineInstance,
+): V1Volume[] => {
+  if (isEmpty(vmi)) {
+    return vmVolumes;
+  }
+
+  const missingVolumes: V1Volume[] = getRunningVMMissingVolumesFromVMI(vmVolumes, vmi);
+  return [...vmVolumes, ...missingVolumes];
+};
+
+const isMountedVolume = (targetVolume: undefined | V1Volume): boolean => {
+  if (!targetVolume) return false;
+  if (hasContainerDisk(targetVolume)) {
+    return !isEmptyContainerDiskImage(targetVolume);
+  }
+  return hasDataVolume(targetVolume) || hasPersistentVolumeClaim(targetVolume);
+};
+
+export const getDiskVolumeState = (
+  vm: V1VirtualMachine,
+  vmi: undefined | V1VirtualMachineInstance,
+  diskName: string,
+  isCDROM: boolean,
+): DiskVolumeState => {
+  const vmVolumes: V1Volume[] = getVolumes(vm) ?? [];
+  const volumes = isCDROM ? vmVolumes : getVMVolumesWithRunningVMIVolumes(vmVolumes, vmi);
+
+  const volume = volumes.find((vol) => vol.name === diskName);
+  const mounted = isMountedVolume(volume);
+
+  return {
+    isCDROMMountedState: isCDROM && mounted,
+    volume,
+  };
+};


### PR DESCRIPTION
## Cherry-pick to `release-4.21`

**Source PR**: #4585
**Fix version**: CNV v4.21.z

### Jira
- [CNV-95928](https://redhat.atlassian.net/browse/CNV-95928)

Cherry-pick applied with conflict resolution.

### Conflict resolution notes
- Kept the `release-4.21` CD-ROM mount flow (no `onUploadStarted`; that API is not on this branch)
- Applied the DiskRowActions types + `getDiskVolumeState` extraction from #4585
- Kept DataVolume detach matching via `volumeToDelete?.dataVolume?.name` because `getDataVolumeName` is not present on `release-4.21`
- Applied the `useVolumeOwnedResource` simplification that removes CDI `dataVolumeTTLSeconds` DataVolume-to-PVC conversion

## Test plan
- [ ] Open a VM details page → Configuration → Storage tab
- [ ] Verify disk row kebab menu actions: Edit, Detach, Save as bootable volume
- [ ] For a hotplug volume, verify "Make persistent" action appears and opens the correct modal
- [ ] For a CDROM disk, verify Mount/Eject actions
- [ ] Detach a disk backed by a DataVolume and verify the delete-owned-resource checkbox appears when the VM owns the resource
- [ ] Detach a disk backed by a PVC and verify the same owned-resource behavior


Made with [Cursor](https://cursor.com)