### PR TITLE
CNV-93274: add Playwright tests for VirtIO drivers alert

### DIFF
--- a/playwright/src/components/overview/overview-settings-component.ts
+++ b/playwright/src/components/overview/overview-settings-component.ts
@@ -25,6 +25,9 @@ export default class OverviewSettingsComponent extends BaseComponent {
   private readonly _divIdAutoUpdateRhelVmsInputpfV6CSwitchInput = this.locator(
     'div[id="auto-update-rhel-vms"] input.pf-v6-c-switch__input',
   );
+  private readonly _downloadIsoButton = this.testId('virtio-drivers-section-download-iso');
+  private readonly _downloadsTab = this.testId('settings-tab-downloads');
+  private readonly _downloadsTabContent = this.testId('downloads');
   private readonly _generalSettingsButton = this.locator('button:has-text("General settings")');
   private readonly _guestManagementButton = this.locator('button:has-text("Guest management")');
   private readonly _guestSystemLog = this.testId('guest-system-log');
@@ -90,6 +93,10 @@ export default class OverviewSettingsComponent extends BaseComponent {
     } catch {
       return false;
     }
+  }
+
+  async clickDownloadsTab(): Promise<void> {
+    await this.navigateToTab(this._downloadsTab);
   }
 
   async clickSearchResultMenuItem(
@@ -602,6 +609,30 @@ export default class OverviewSettingsComponent extends BaseComponent {
   async isAdvancedCdromFeaturesEnabled(): Promise<boolean> {
     try {
       return await this._advancedCdromFeaturesToggle.isChecked().catch(() => false);
+    } catch {
+      return false;
+    }
+  }
+
+  async isDownloadIsoButtonVisible(): Promise<boolean> {
+    try {
+      await this._downloadIsoButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.ELEMENT_WAIT,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async isDownloadsTabContentVisible(): Promise<boolean> {
+    try {
+      await this._downloadsTabContent.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.ELEMENT_WAIT,
+      });
+      return true;
     } catch {
       return false;
     }

--- a/playwright/src/components/vm/vm-list-virtio-alert-component.ts
+++ b/playwright/src/components/vm/vm-list-virtio-alert-component.ts
@@ -1,0 +1,77 @@
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+const VIRTIO_DRIVERS_ALERT_DISMISSED_KEY = 'kubevirt-virtio-drivers-alert-dismissed';
+
+/** VM list VirtIO drivers warning alert (Windows VMs) and its dismiss / Downloads actions. */
+export default class VmListVirtioAlertComponent extends BaseComponent {
+  private readonly _alert = this.testId('virtio-drivers-alert');
+  private readonly _closeButton = this._alert.getByRole('button', { name: /^Close/i });
+  private readonly _dontShowAgain = this.page.getByRole('checkbox', {
+    name: /Don't show this message again/i,
+  });
+  private readonly _expandToggle = this._alert.getByRole('button', { name: /alert details/i });
+  private readonly _goToDownloads = this._alert.getByRole('link', { name: 'Go to Downloads' });
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async checkDontShowAgain(): Promise<void> {
+    await this.expand();
+    if (await this._dontShowAgain.isChecked()) {
+      return;
+    }
+    await this.robustClick(this._dontShowAgain);
+  }
+
+  async getDismissedFromLocalStorage(): Promise<string | null> {
+    return this.page.evaluate(
+      (key) => localStorage.getItem(key),
+      VIRTIO_DRIVERS_ALERT_DISMISSED_KEY,
+    );
+  }
+
+  async clickGoToDownloads(): Promise<void> {
+    await this.expand();
+    await this.robustClick(this._goToDownloads);
+  }
+
+  async close(): Promise<void> {
+    await this._closeButton.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.ELEMENT_WAIT,
+    });
+    await this.robustClick(this._closeButton);
+    await this._alert.waitFor({
+      state: 'hidden',
+      timeout: TestTimeouts.ELEMENT_WAIT,
+    });
+  }
+
+  async expand(): Promise<void> {
+    await this._alert.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.ELEMENT_WAIT,
+    });
+    const expanded = await this._expandToggle.getAttribute('aria-expanded');
+    if (expanded === 'true') {
+      return;
+    }
+    await this.robustClick(this._expandToggle);
+    await this._goToDownloads.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.ELEMENT_WAIT,
+    });
+  }
+
+  async isVisible(timeout = TestTimeouts.ELEMENT_WAIT): Promise<boolean> {
+    try {
+      await this._alert.waitFor({ state: 'visible', timeout });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/playwright/src/page-objects/settings/settings-page.ts
+++ b/playwright/src/page-objects/settings/settings-page.ts
@@ -38,6 +38,12 @@ export default class SettingsPage extends BasePage {
     return this._features.adjustMemoryRequestRatio(...args);
   }
 
+  clickDownloadsTab(
+    ...args: Parameters<OverviewSettingsPage['clickDownloadsTab']>
+  ): ReturnType<OverviewSettingsPage['clickDownloadsTab']> {
+    return this._settings.clickDownloadsTab(...args);
+  }
+
   disableAaq(
     ...args: Parameters<OverviewVirtualizationFeaturesPage['disableAaq']>
   ): ReturnType<OverviewVirtualizationFeaturesPage['disableAaq']> {
@@ -230,6 +236,18 @@ export default class SettingsPage extends BasePage {
     ...args: Parameters<OverviewSettingsPage['isAdvancedCdromFeaturesEnabled']>
   ): ReturnType<OverviewSettingsPage['isAdvancedCdromFeaturesEnabled']> {
     return this._settings.isAdvancedCdromFeaturesEnabled(...args);
+  }
+
+  isDownloadIsoButtonVisible(
+    ...args: Parameters<OverviewSettingsPage['isDownloadIsoButtonVisible']>
+  ): ReturnType<OverviewSettingsPage['isDownloadIsoButtonVisible']> {
+    return this._settings.isDownloadIsoButtonVisible(...args);
+  }
+
+  isDownloadsTabContentVisible(
+    ...args: Parameters<OverviewSettingsPage['isDownloadsTabContentVisible']>
+  ): ReturnType<OverviewSettingsPage['isDownloadsTabContentVisible']> {
+    return this._settings.isDownloadsTabContentVisible(...args);
   }
 
   isAutomaticGrantVirtualizationRolesChecked(

--- a/playwright/src/page-objects/vm/virtual-machines-page.ts
+++ b/playwright/src/page-objects/vm/virtual-machines-page.ts
@@ -11,6 +11,7 @@ import {
   VmListTreeComponent,
 } from '@/components/vm/vm-list-state-migration-components';
 import VmListTemplateCreateComponent from '@/components/vm/vm-list-template-create-component';
+import VmListVirtioAlertComponent from '@/components/vm/vm-list-virtio-alert-component';
 import type { VmMetricEntry } from '@/data-factories/vm-metrics-mock-factory';
 import PageCommons from '@/page-objects/page-commons';
 import { TreeContextMenuMixin } from '@/page-objects/vm/tree-context-menu-mixin';
@@ -31,6 +32,7 @@ export default class VirtualMachinesPage extends TreeContextMenuMixin(PageCommon
   readonly templateCreate: VmListTemplateCreateComponent;
 
   readonly tree: VmListTreeComponent;
+  readonly virtioAlert: VmListVirtioAlertComponent;
 
   /**
    * Creates a new VirtualMachinesPage instance.
@@ -51,6 +53,7 @@ export default class VirtualMachinesPage extends TreeContextMenuMixin(PageCommon
     this.overviewWidgets = new VmListOverviewWidgetsComponent(page, {
       searchTreeView: (t) => this.tree.searchTreeView(t),
     });
+    this.virtioAlert = new VmListVirtioAlertComponent(page);
   }
 
   async areAllCheckboxesChecked(): Promise<boolean> {

--- a/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload-to-registry.spec.md
+++ b/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload-to-registry.spec.md
@@ -4,7 +4,7 @@
 
 - **Project Name:** KubeVirt UI — Playwright E2E Tests
 - **Feature Area:** Tier1 — Bootable volumes
-- **Latest version:** CNV 5.00
+- **Latest version:** CNV 5.0.0
 - **Latest update:** 2026-08-17
 - **Document Status:** Approved
 

--- a/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload.spec.md
+++ b/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload.spec.md
@@ -4,7 +4,7 @@
 
 - **Project Name:** KubeVirt UI — Playwright E2E Tests
 - **Feature Area:** Tier1 — Bootable volumes
-- **Latest version:** CNV 5.00
+- **Latest version:** CNV 5.0.0
 - **Latest update:** 2026-08-17
 - **Document Status:** Approved
 

--- a/playwright/tests/tier1/virtualmachines/vm-list/virtio-drivers-alert.spec.md
+++ b/playwright/tests/tier1/virtualmachines/vm-list/virtio-drivers-alert.spec.md
@@ -1,0 +1,124 @@
+# Software Test Description (STD): VirtIO Drivers Alert
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier1 — VM list
+- **Latest version:** CNV 5.0.0
+- **Latest update:** 2026-08-26
+- **Document Status:** Approved
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify the VM list VirtIO drivers warning alert: it appears only when a Windows VM is in the
+current namespace list, the "Go to Downloads" link opens Settings → Downloads with a Download ISO
+button, and checking "Don't show this message again" before closing persists dismissal in
+localStorage across reload.
+
+### 2.2 Scope
+
+- **In-Scope:** VirtIO drivers alert visibility on the namespaced VM list, expandable alert body
+  actions (Go to Downloads, Don't show this message again, close), Downloads tab Download ISO
+  button visibility, localStorage key `kubevirt-virtio-drivers-alert-dismissed`.
+- **Out-of-Scope:** Session-only close without the checkbox; empty VM list (empty state does not
+  mount the list or alert); the "How to update Windows VMs" external documentation link.
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator installed; Playwright `Tier1` project.
+- **Configuration:** No special feature gates. Halted container-disk VMs are created via
+  `VirtualMachineFactory`; the Windows case sets `os` / `osLabel` to `windows` so
+  `vm.kubevirt.io/os` matches the UI Windows detector. No Windows guest image or boot is required.
+- **Initial Setup:** `beforeAll` creates two namespaces (`setupTestNamespace`) and one halted VM in
+  each (`createHaltedVm`). VMs are deleted in `afterAll` via `cleanupVmFixtures`;
+  namespaces are tracked for cleanup.
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier1/virtualmachines/virtio-drivers-alert.spec.ts`
+**Describe:** `VirtIO drivers alert` — **Tags:** `@tier1`, `@nonpriv`
+**Allure:** suite `VirtIO drivers alert`, feature `Tier 1`
+
+---
+
+### `001`: Alert is shown only when a Windows VM is in the list
+
+- **Objective:** Verify the VirtIO drivers alert is hidden on a Linux-only VM list and visible when
+  a Windows-labeled VM is listed in the namespace.
+- **Target version:** CNV 5.0.0
+- **Jira References:** CNV-93277
+- **Pre-conditions:** Dedicated Linux and Windows namespaces each contain one halted VM; dismiss
+  localStorage key is cleared
+- **Tags:** `@nonpriv`
+
+| Step | Action                                                             | Expected Result                    |
+| :--- | :----------------------------------------------------------------- | :--------------------------------- |
+| 1    | Open the Linux namespace VM list and wait for the Linux VM row     | VM list table shows the Linux VM   |
+| 2    | Check for the VirtIO drivers alert                                 | Alert is not visible               |
+| 3    | Open the Windows namespace VM list and wait for the Windows VM row | VM list table shows the Windows VM |
+| 4    | Check for the VirtIO drivers alert                                 | Alert is visible                   |
+
+---
+
+### `002`: Go to Downloads opens the Downloads tab with the Download ISO button
+
+- **Objective:** Verify that expanding the alert and clicking Go to Downloads navigates to the
+  Settings Downloads tab and shows the Download ISO button.
+- **Target version:** CNV 5.0.0
+- **Jira References:** CNV-93277
+- **Pre-conditions:** Windows namespace VM list shows the alert; dismiss localStorage key is cleared
+- **Tags:** `@nonpriv`
+
+| Step | Action                                                    | Expected Result                                                                     |
+| :--- | :-------------------------------------------------------- | :---------------------------------------------------------------------------------- |
+| 1    | Open the Windows namespace VM list                        | Alert is visible                                                                    |
+| 2    | Expand the alert and click Go to Downloads                | URL contains `virtualization-settings/downloads` and hash `#virtio-drivers-windows` |
+| 3    | Observe Downloads tab content and the Download ISO button | Tab content and Download ISO button are visible                                     |
+
+---
+
+### `003`: Checking Don't show again and closing the alert hides it after reload
+
+- **Objective:** Verify that checking "Don't show this message again" and closing the alert writes
+  localStorage and keeps the alert hidden after reload.
+- **Target version:** CNV 5.0.0
+- **Jira References:** CNV-93277
+- **Pre-conditions:** Windows namespace VM list shows the alert; dismiss localStorage key is cleared
+  at the start of the test
+- **Tags:** `@nonpriv`
+
+| Step | Action                                                              | Expected Result             |
+| :--- | :------------------------------------------------------------------ | :-------------------------- |
+| 1    | Open the Windows namespace VM list                                  | Alert is visible            |
+| 2    | Expand the alert, check Don't show this message again, and close it | Alert is dismissed          |
+| 3    | Read `kubevirt-virtio-drivers-alert-dismissed` from localStorage    | Stored value is JSON `true` |
+| 4    | Reload the VM list and wait for the Windows VM row                  | Alert is not visible        |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+Maps Jira tickets to the test cases that provide coverage. Tickets without a specific test case indicate
+a planned coverage gap (status: Pending).
+
+| Jira Ticket | Test Case ID | Coverage Type    | Status    |
+| ----------- | ------------ | ---------------- | --------- |
+| CNV-93277   | `001`        | Feature coverage | Automated |
+| CNV-93277   | `002`        | Feature coverage | Automated |
+| CNV-93277   | `003`        | Feature coverage | Automated |
+
+**Coverage Type values:**
+
+- `Feature coverage` — test validates a feature delivered by the ticket
+- `Bugfix regression guard` — test asserts the specific bug fixed by the ticket does not regress
+- `Functional smoke` — test validates baseline behavior; no specific Jira ticket drives it
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** Adam Viktora
+- **Approval Signature:** Adam Viktora

--- a/playwright/tests/tier1/virtualmachines/vm-list/virtio-drivers-alert.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-list/virtio-drivers-alert.spec.ts
@@ -1,0 +1,161 @@
+import { NONPRIV_TAG, T1, T1_TAG, VM_LIST_TAG } from '@/data-models/allure-constants';
+import { expect, test } from '@/fixtures/vm-search-fixture';
+import { withSafeActions } from '@/page-objects/base-page';
+import SettingsPage from '@/page-objects/settings/settings-page';
+import type VirtualMachinesPage from '@/page-objects/vm/virtual-machines-page';
+import { TestTimeouts } from '@/utils/test-config';
+import { setupTestNamespace } from '@/utils/test-setup-helpers';
+import { cleanupVmFixtures, createHaltedVm } from '@/utils/vm-search-test-helpers';
+
+const SUITE = 'VirtIO drivers alert';
+
+const openNamespaceVmList = async (
+  vmListPage: VirtualMachinesPage,
+  namespace: string,
+  vmName: string,
+): Promise<void> => {
+  await vmListPage.navigateToNamespaceVirtualMachinesViaUI(namespace);
+  await vmListPage.clickVmListTab();
+  await vmListPage.waitForVmRowVisible(vmName);
+};
+
+test.describe(SUITE, { tag: [T1_TAG, NONPRIV_TAG] }, () => {
+  let linuxNs: string;
+  let windowsNs: string;
+  let linuxVm: string;
+  let windowsVm: string;
+
+  test.beforeAll(async ({ apiClient, utils }) => {
+    linuxNs = await setupTestNamespace(apiClient, 'virtio-linux');
+    windowsNs = await setupTestNamespace(apiClient, 'virtio-win');
+
+    linuxVm = utils.generateRandomVmName('linux');
+    windowsVm = utils.generateRandomVmName('win');
+
+    await createHaltedVm(apiClient, {
+      cpuCores: 1,
+      memory: '256Mi',
+      name: linuxVm,
+      namespace: linuxNs,
+    });
+    await createHaltedVm(apiClient, {
+      cpuCores: 1,
+      memory: '256Mi',
+      name: windowsVm,
+      namespace: windowsNs,
+      os: 'windows',
+      osLabel: 'windows',
+    });
+  });
+
+  test.afterAll(async ({ apiClient }) => {
+    if (linuxNs) {
+      await cleanupVmFixtures(apiClient, linuxNs, [linuxVm]);
+    }
+    if (windowsNs) {
+      await cleanupVmFixtures(apiClient, windowsNs, [windowsVm]);
+    }
+  });
+
+  test('Alert is shown only when a Windows VM is in the list', async ({ vmListPage, utils }) => {
+    await utils.withAllure({
+      suite: SUITE,
+      feature: T1,
+      tags: [T1_TAG, VM_LIST_TAG, NONPRIV_TAG],
+    });
+
+    await test.step('Linux-only namespace does not show the VirtIO drivers alert', async () => {
+      await openNamespaceVmList(vmListPage, linuxNs, linuxVm);
+      const alertVisible = await vmListPage.virtioAlert.isVisible(TestTimeouts.SHORT_WAIT);
+      expect.soft(alertVisible, 'Alert should be hidden when no Windows VM is listed').toBe(false);
+    });
+
+    await test.step('Windows namespace shows the VirtIO drivers alert', async () => {
+      await openNamespaceVmList(vmListPage, windowsNs, windowsVm);
+      const alertVisible = await vmListPage.virtioAlert.isVisible();
+      expect.soft(alertVisible, 'Alert should be visible when a Windows VM is listed').toBe(true);
+    });
+  });
+
+  test('Go to Downloads opens the Downloads tab with the Download ISO button', async ({
+    page,
+    vmListPage,
+    utils,
+  }) => {
+    await utils.withAllure({
+      suite: SUITE,
+      feature: T1,
+      tags: [T1_TAG, VM_LIST_TAG, NONPRIV_TAG],
+    });
+
+    const settingsPage = withSafeActions(new SettingsPage(page));
+
+    await test.step('Open the VM list for the Windows namespace', async () => {
+      await openNamespaceVmList(vmListPage, windowsNs, windowsVm);
+      const alertVisible = await vmListPage.virtioAlert.isVisible();
+      expect(alertVisible, 'Alert should be visible before navigating to Downloads').toBe(true);
+    });
+
+    await test.step('Click Go to Downloads and land on the Downloads tab', async () => {
+      await vmListPage.virtioAlert.clickGoToDownloads();
+      await expect
+        .poll(() => page.url(), {
+          timeout: TestTimeouts.NAVIGATION,
+          message: 'URL should include virtualization-settings/downloads',
+        })
+        .toContain('virtualization-settings/downloads');
+      expect
+        .soft(page.url(), 'URL hash should highlight Windows drivers')
+        .toContain('#virtio-drivers-windows');
+    });
+
+    await test.step('Download ISO button is visible', async () => {
+      const tabVisible = await settingsPage.isDownloadsTabContentVisible();
+      expect.soft(tabVisible, 'Downloads tab content should be visible').toBe(true);
+
+      const isoVisible = await settingsPage.isDownloadIsoButtonVisible();
+      expect.soft(isoVisible, 'Download ISO button should be visible').toBe(true);
+    });
+  });
+
+  test('Checking "Do not show again" and closing the alert hides it after remount', async ({
+    vmListPage,
+    utils,
+  }) => {
+    await utils.withAllure({
+      suite: SUITE,
+      feature: T1,
+      tags: [T1_TAG, VM_LIST_TAG, NONPRIV_TAG],
+    });
+
+    await test.step('Open the VM list and dismiss the alert permanently', async () => {
+      await openNamespaceVmList(vmListPage, windowsNs, windowsVm);
+      const alertVisible = await vmListPage.virtioAlert.isVisible();
+      expect(alertVisible, 'Alert should be visible before dismiss').toBe(true);
+
+      await vmListPage.virtioAlert.checkDontShowAgain();
+      await vmListPage.virtioAlert.close();
+    });
+
+    await test.step('localStorage records the permanent dismiss', async () => {
+      await expect
+        .poll(() => vmListPage.virtioAlert.getDismissedFromLocalStorage(), {
+          timeout: TestTimeouts.ELEMENT_WAIT,
+          message: 'Dismiss key should be JSON true after close',
+        })
+        .toBe('true');
+    });
+
+    await test.step('Navigate away and back to remount the VM list', async () => {
+      await vmListPage.clickOverviewTab();
+      await vmListPage.clickVmListTab();
+      await vmListPage.waitForVmRowVisible(windowsVm);
+
+      const storedAfterRemount = await vmListPage.virtioAlert.getDismissedFromLocalStorage();
+      expect(storedAfterRemount, 'Dismiss key should persist after navigation').toBe('true');
+
+      const alertVisible = await vmListPage.virtioAlert.isVisible(TestTimeouts.SHORT_WAIT);
+      expect.soft(alertVisible, 'Alert should stay hidden after remount').toBe(false);
+    });
+  });
+});

--- a/playwright/tests/tier1/virtualmachines/vm-search/vm-group-filter.spec.md
+++ b/playwright/tests/tier1/virtualmachines/vm-search/vm-group-filter.spec.md
@@ -4,7 +4,7 @@
 
 - **Project Name:** KubeVirt UI — Playwright E2E Tests
 - **Feature Area:** Tier1 — Virtual machines / Search
-- **Latest version:** CNV 5.00
+- **Latest version:** CNV 5.0.0
 - **Latest update:** 2026-08-18
 - **Document Status:** Approved
 

--- a/playwright/tests/tier1/virtualmachines/vm-search/vm-project-filter.spec.md
+++ b/playwright/tests/tier1/virtualmachines/vm-search/vm-project-filter.spec.md
@@ -4,7 +4,7 @@
 
 - **Project Name:** KubeVirt UI — Playwright E2E Tests
 - **Feature Area:** Tier1 — Virtual machines / Search
-- **Latest version:** CNV 5.00
+- **Latest version:** CNV 5.0.0
 - **Latest update:** 2026-08-21
 - **Document Status:** Approved
 
@@ -47,7 +47,7 @@ the list URL from a namespaced path to all-namespaces.
 
 - **Objective:** Verify that clicking a project in the tree sets `project=` in the URL, shows a
   Project chip, and lists only that project's VMs.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-93586
 - **Pre-conditions:** Halted VMs exist in two test namespaces
 - **Tags:** `@adminOnly`
@@ -65,7 +65,7 @@ the list URL from a namespaced path to all-namespaces.
 
 - **Objective:** Verify that the Project toolbar filter is not disabled when a project is selected
   in the tree view.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-93586
 - **Pre-conditions:** Halted VMs exist in two test namespaces
 - **Tags:** `@adminOnly`
@@ -81,7 +81,7 @@ the list URL from a namespaced path to all-namespaces.
 
 - **Objective:** Verify that clicking Local cluster after a project selection removes `project=` from
   the URL and shows VMs from both test projects.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-93586
 - **Pre-conditions:** Halted VMs exist in two test namespaces
 - **Tags:** `@adminOnly`
@@ -99,7 +99,7 @@ the list URL from a namespaced path to all-namespaces.
 
 - **Objective:** Verify that selecting another project in the toolbar while the path is
   `/ns/<project-A>` broadens the path to `/all-namespaces` and keeps both project filters.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-93586
 - **Pre-conditions:** Halted VMs exist in two test namespaces
 - **Tags:** `@adminOnly`

--- a/playwright/tests/tier1/virtualmachines/vm-search/vm-search-language.spec.md
+++ b/playwright/tests/tier1/virtualmachines/vm-search/vm-search-language.spec.md
@@ -4,7 +4,7 @@
 
 - **Project Name:** KubeVirt UI — Playwright E2E Tests
 - **Feature Area:** Tier1 — Virtual machines / Search
-- **Latest version:** CNV 5.00
+- **Latest version:** CNV 5.0.0
 - **Latest update:** 2026-08-18
 - **Document Status:** Approved
 
@@ -51,7 +51,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 
 - **Objective:** Verify that submitting a VM name as plain text creates a name chip and lists only that
   VM.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** Fixture VMs exist in the test namespace
 - **Tags:** `@adminOnly`
@@ -68,7 +68,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 ### `002`: key:value search filters by status
 
 - **Objective:** Verify that `status:Running` produces a Running chip and hides Stopped fixture VMs.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** Fixture VMs exist and are Stopped
 - **Tags:** `@adminOnly`
@@ -85,7 +85,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 
 - **Objective:** Verify that `status:Running,Stopped` produces both chips and lists the Stopped fixture
   VMs.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** Fixture VMs exist and are Stopped
 - **Tags:** `@adminOnly`
@@ -102,7 +102,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 
 - **Objective:** Verify that `status:Stopped os:Fedora` produces both chips and lists only Stopped
   Fedora VMs.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** Fixture VMs exist and are Stopped
 - **Tags:** `@adminOnly`
@@ -118,7 +118,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 ### `005`: Numeric filter with > operator for vCPU
 
 - **Objective:** Verify that `vcpu>4` produces a CPU chip and lists only VMs with more than 4 vCPUs.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** Fixture VMs exist
 - **Tags:** `@adminOnly`
@@ -134,7 +134,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 ### `006`: Numeric filter with >= operator for memory
 
 - **Objective:** Verify that `memory>=8GiB` produces a memory chip and lists only the 8Gi VM.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** Fixture VMs exist
 - **Tags:** `@adminOnly`
@@ -151,7 +151,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 
 - **Objective:** Verify that `-status:Error` produces an Exclude Error chip and does not hide Stopped
   fixture VMs.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** Fixture VMs exist and are Stopped (none are Error)
 - **Tags:** `@adminOnly`
@@ -168,7 +168,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 
 - **Objective:** Verify that `-has:gpu` produces an Exclude gpu chip and hides the VM that has a GPU
   device.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** Fixture VMs exist; the RHEL VM has a dummy GPU
 - **Tags:** `@adminOnly`
@@ -184,7 +184,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 ### `009`: Exclusion prefix -name: hides the named VM
 
 - **Objective:** Verify that `-name:<vm>` produces an Exclude name chip and hides only that VM.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** Fixture VMs exist
 - **Tags:** `@adminOnly`
@@ -201,7 +201,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 
 - **Objective:** Verify that `description:database` produces a description chip and lists only the VM
   whose description contains that text.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** Fixture VMs exist
 - **Tags:** `@adminOnly`
@@ -217,7 +217,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 ### `011`: Clear button empties the search input
 
 - **Objective:** Verify that the clear search control removes typed query text from the input.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** None
 - **Tags:** `@adminOnly`
@@ -232,7 +232,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 ### `012`: Search dropdown shows key suggestions on focus
 
 - **Objective:** Verify that focusing the search input opens the dropdown with expected search keys.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** None
 - **Tags:** `@adminOnly`
@@ -248,7 +248,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 ### `013`: Search dropdown shows value suggestions after typing key:
 
 - **Objective:** Verify that typing `status:` shows value autocomplete including Running and Stopped.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** None
 - **Tags:** `@adminOnly`
@@ -265,7 +265,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 
 - **Objective:** Verify that `status:Stopped vcpu>4 -has:gpu` produces all three chips and lists only
   the Stopped high-CPU VM that does not have a GPU.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** Fixture VMs exist and are Stopped
 - **Tags:** `@adminOnly`
@@ -281,7 +281,7 @@ that submitted queries actually show and hide VirtualMachines in the list.
 ### `015`: Search examples are shown in the dropdown
 
 - **Objective:** Verify that the search dropdown surfaces example query patterns.
-- **Target version:** CNV 5.00
+- **Target version:** CNV 5.0.0
 - **Jira References:** CNV-74174
 - **Pre-conditions:** None
 - **Tags:** `@adminOnly`

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-cdrom-upload.spec.md
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-cdrom-upload.spec.md
@@ -4,7 +4,7 @@
 
 - **Project Name:** KubeVirt UI — Playwright E2E Tests
 - **Feature Area:** Tier1 — VM tabs (CD-ROM)
-- **Latest version:** CNV 5.00
+- **Latest version:** CNV 5.0.0
 - **Latest update:** 2026-08-17
 - **Document Status:** Approved
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Add Playwright Tier1 tests for VirtIO drivers alert

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-93274

## 🎥 Demo

Tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a VirtIO drivers alert for Windows-based virtual machines.
  - Users can expand or dismiss the alert, choose “Don’t show again,” and open the Downloads settings.
  - Added visibility of the Downloads tab and ISO download option when accessed from the alert.

- **Tests**
  - Added coverage for alert visibility, Downloads navigation, and persistent dismissal behavior.
  - Added Linux and Windows virtual machine scenarios.

- **Documentation**
  - Updated documented CNV version references from 5.00 to 5.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->