### PR TITLE
CNV-95999: fix Delete modal "k8s.getIn is not a function" error

### DIFF
--- a/src/utils/components/DeleteModal/DeleteModal.tsx
+++ b/src/utils/components/DeleteModal/DeleteModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, ReactNode } from 'react';
+import React, { type FC, memo, type ReactNode } from 'react';
 import { useNavigate } from 'react-router';
 
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
@@ -7,9 +7,9 @@ import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
 import { getResourceUrl } from '@kubevirt-utils/resources/shared';
 import {
   getGroupVersionKindForResource,
-  K8sResourceCommon,
+  type K8sResourceCommon,
+  useK8sModel,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/utils/k8s/hooks/useK8sModel';
 import { ButtonVariant } from '@patternfly/react-core';
 
 import ConfirmActionMessage from '../ConfirmActionMessage/ConfirmActionMessage';
@@ -41,18 +41,18 @@ const DeleteModal: FC<DeleteModalProps> = memo(
 
     const [model] = useK8sModel(getGroupVersionKindForResource(obj));
     const namespace = useNamespaceParam();
-    const url = redirectUrl || getResourceUrl({ activeNamespace: namespace, model });
+    const url = redirectUrl ?? getResourceUrl({ activeNamespace: namespace, model });
 
     return (
       <TabModal<K8sResourceCommon>
-        onSubmit={async () => {
-          await onDeleteSubmit();
-          shouldRedirect && navigate(url);
-        }}
-        headerText={headerText || t('Delete resource?')}
+        headerText={headerText ?? t('Delete resource?')}
         isOpen={isOpen}
         obj={obj}
         onClose={onClose}
+        onSubmit={async () => {
+          await onDeleteSubmit();
+          shouldRedirect && void navigate(url);
+        }}
         submitBtnText={t('Delete')}
         submitBtnVariant={ButtonVariant.danger}
         titleIconVariant="warning"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes Delete modal "k8s.getIn is not a function" error

- fixed by changing import path of `useK8sModel` (the rest is linter updates)

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-95999

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/7648ffe3-5ca6-464b-822f-ead1452eb428



After:

https://github.com/user-attachments/assets/e28186e4-fe77-4827-83c8-43b7d67e68fc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delete confirmation behavior by preserving valid empty values in redirect and header settings.
  * Ensured delete navigation proceeds without blocking the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->