### PR TITLE
CNV-94189: Fix VM list crash from spread React keys after rspack migration

### DIFF
--- a/src/views/virtualmachines/search/VirtualMachineFilterToolbar.tsx
+++ b/src/views/virtualmachines/search/VirtualMachineFilterToolbar.tsx
@@ -95,15 +95,14 @@ const VirtualMachineFilterToolbar: FC<VirtualMachineFilterToolbarProps> = ({
             filters,
             isToggleVisible:
               filtersShown.includes(filterDef.id as VirtualMachineRowFilterType) || showMoreFilters,
-            key: filterDef.id,
             onSetFilters: handleSetFilters,
             toggleSize: MenuToggleSize.sm,
           };
 
           return filterDef.optionGroups ? (
-            <GroupedCheckboxSelect {...sharedProps} data={vms ?? []} />
+            <GroupedCheckboxSelect key={filterDef.id} {...sharedProps} data={vms ?? []} />
           ) : (
-            <SelectFilterItem {...sharedProps} />
+            <SelectFilterItem key={filterDef.id} {...sharedProps} />
           );
         })}
         <ToolbarItem>


### PR DESCRIPTION
## 📝 Description

After the webpack-to-rspack migration in [#4544](https://github.com/kubevirt-ui/kubevirt-plugin/pull/4544) ([CNV-94185](https://redhat.atlassian.net/browse/CNV-94185)), the VirtualMachines list crashes in development with:

`TypeError: Cannot read properties of undefined (reading 'getStackAddendum')`

Rspack uses the modern JSX transform. A React list `key` inside a props object that is spread onto a child is **not** treated as a list key. React then tries to warn about missing keys, and that warning path blows up.

This change passes `key={filterDef.id}` as a real JSX attribute on `GroupedCheckboxSelect` / `SelectFilterItem`, matching `KubevirtFilterToolbar`.

## 🔗 Links

- Jira: [CNV-94185](https://issues.redhat.com/browse/CNV-94185)
- Regression introduced by: https://github.com/kubevirt-ui/kubevirt-plugin/pull/4544

## 🎥 Demo

<img width="1376" height="489" alt="Screenshot 2026-08-26 at 12 32 40" src="https://github.com/user-attachments/assets/c31b2eca-0bf3-4525-9ca6-742f11dca245" />


## Test plan

- [ ] Open the VirtualMachines list after this change (dev mode) and confirm the `getStackAddendum` overlay is gone
- [ ] Confirm filter chips / select filters still render and can be toggled (show more / show less)
- [ ] Confirm grouped filters (if present) still work


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter rendering stability in the virtual machine search toolbar without changing filter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->