### PR TITLE
CNV-96190: Console crashes when opening the Network dropdown in Add network interface

### DIFF
--- a/src/utils/components/SelectTypeahead/SelectTypeahead.tsx
+++ b/src/utils/components/SelectTypeahead/SelectTypeahead.tsx
@@ -110,7 +110,7 @@ const SelectTypeahead: FC<SelectTypeaheadProps> = ({
     >
       <SelectList id={listboxId}>
         {selectOptions?.map(({ label, optionProps, value }, index) => {
-          const { children, ...otherOptionProps } = optionProps ?? {};
+          const { children, key: _key, ...otherOptionProps } = optionProps ?? {};
           return (
             <SelectOption
               key={value}


### PR DESCRIPTION
## 📝 Description

Console crashes when opening the Network dropdown in Add network interface

## 🔗 Links

Jira ticket: [CNV-96190](https://redhat.atlassian.net/browse/CNV-96190)


## 🎥 Demo

Before:

https://github.com/user-attachments/assets/ff778fe4-f442-41f6-86fa-f7657915449d


After:

https://github.com/user-attachments/assets/f7001c66-52d9-4096-a5aa-1ec88589900f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where internal option keys could be incorrectly passed to selectable options, improving component behavior and preventing unintended prop handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->