### PR TITLE
CNV-94189: stop spreading React keys onto remaining select options

### DIFF
--- a/src/utils/components/CheckboxSelect/CheckboxSelect.tsx
+++ b/src/utils/components/CheckboxSelect/CheckboxSelect.tsx
@@ -65,7 +65,7 @@ const CheckboxSelect: FC<CheckboxSelectProps> = ({
       toggle={toggle}
     >
       <SelectList>
-        {options?.map((option) => (
+        {options?.map(({ key: _key, ...option }) => (
           <SelectOption hasCheckbox key={String(option.value)} {...option} />
         ))}
         {isEmpty(options) && <SelectOption isDisabled>{t('No options found')}</SelectOption>}

--- a/src/utils/components/EnvironmentEditor/hooks/useEnvironmentSelectOptions.tsx
+++ b/src/utils/components/EnvironmentEditor/hooks/useEnvironmentSelectOptions.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useMemo } from 'react';
 
-import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
+import { type EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
-import { EnvironmentKind, EnvironmentVariable, MapKindToAbbr } from '../constants';
+import { EnvironmentKind, type EnvironmentVariable, MapKindToAbbr } from '../constants';
 import { getEnvironmentOptionValue } from '../utils';
 
 import useEnvironmentsResources from './useEnvironmentsResources';
@@ -11,15 +11,11 @@ import useEnvironmentsResources from './useEnvironmentsResources';
 const useEnvironmentSelectOptions = (
   namespace: string,
   environments: EnvironmentVariable[],
-): { loaded: boolean; loadError: any; selectOptions: EnhancedSelectOptionProps[] } => {
+): { loaded: boolean; loadError: unknown; selectOptions: EnhancedSelectOptionProps[] } => {
   const { t } = useKubevirtTranslation();
-  const {
-    configMaps,
-    error: loadError,
-    loaded,
-    secrets,
-    serviceAccounts,
-  } = useEnvironmentsResources(namespace);
+  const environmentResources = useEnvironmentsResources(namespace);
+  const { configMaps, loaded, secrets, serviceAccounts } = environmentResources;
+  const loadError: unknown = environmentResources.error as unknown;
 
   const getEnhancedSelectOptionProps = useCallback(
     (optionName: string, optionKind: EnvironmentKind): EnhancedSelectOptionProps => ({
@@ -33,7 +29,6 @@ const useEnvironmentSelectOptions = (
         </>
       ),
       isDisabled: environments.some((env) => env.name === optionName),
-      key: optionName,
       value: getEnvironmentOptionValue(optionName, optionKind),
       valueForFilter: optionName,
     }),
@@ -41,7 +36,9 @@ const useEnvironmentSelectOptions = (
   );
 
   const selectOptions = useMemo(() => {
-    if (!loaded) return [];
+    if (!loaded) {
+      return [];
+    }
 
     return [
       ...secrets.map((secret) => ({

--- a/src/utils/components/FilterSelect/components/InlineFilterSelectOption.tsx
+++ b/src/utils/components/FilterSelect/components/InlineFilterSelectOption.tsx
@@ -1,9 +1,8 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { SelectOption } from '@patternfly/react-core';
 
-import { EnhancedSelectOptionProps } from '../utils/types';
-
+import { type EnhancedSelectOptionProps } from '../utils/types';
 import InlineFilterSelectOptionContent from './InlineFilterSelectOptionContent';
 
 type InlineFilterSelectOptionProps = {
@@ -11,13 +10,15 @@ type InlineFilterSelectOptionProps = {
   option: EnhancedSelectOptionProps;
 };
 const InlineFilterSelectOption: FC<InlineFilterSelectOptionProps> = ({ isFocused, option }) => {
+  const optionValue = String(option.value);
+  const { key: _key, ...optionWithoutKey } = option;
   return (
     <SelectOption
-      data-test={`select-option-${option.value}`}
-      id={`select-inline-filter-${option.value?.replace(' ', '-')}`}
+      data-test={`select-option-${optionValue}`}
+      id={`select-inline-filter-${optionValue.replace(' ', '-')}`}
       isFocused={isFocused}
-      value={option.value}
-      {...option}
+      value={optionValue}
+      {...optionWithoutKey}
     >
       <InlineFilterSelectOptionContent option={option} />
     </SelectOption>

--- a/src/utils/components/FilterSelect/components/InlineFilterSelectOption.tsx
+++ b/src/utils/components/FilterSelect/components/InlineFilterSelectOption.tsx
@@ -11,14 +11,14 @@ type InlineFilterSelectOptionProps = {
 };
 const InlineFilterSelectOption: FC<InlineFilterSelectOptionProps> = ({ isFocused, option }) => {
   const optionValue = String(option.value);
-  const { key: _key, ...optionWithoutKey } = option;
+  const { key: _key, ...rest } = option;
   return (
     <SelectOption
       data-test={`select-option-${optionValue}`}
       id={`select-inline-filter-${optionValue.replace(' ', '-')}`}
       isFocused={isFocused}
       value={optionValue}
-      {...optionWithoutKey}
+      {...rest}
     >
       <InlineFilterSelectOptionContent option={option} />
     </SelectOption>

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/buildNetworkOptions.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/buildNetworkOptions.tsx
@@ -46,7 +46,6 @@ export const getEditingNetworkOptionIfMissing = ({
           </Label>
         </>
       ),
-      key: selectNetworkName,
     },
     type: interfaceTypesProxy.bridge,
     value: selectNetworkName,
@@ -82,7 +81,6 @@ export const buildNetworkSelectOptions = ({
             </Label>
           </>
         ),
-        key: value,
       },
       type,
       value,
@@ -105,7 +103,6 @@ export const buildNetworkSelectOptions = ({
             </Label>
           </span>
         ),
-        key: POD_NETWORK,
       },
       type: podNetworkType,
       value: POD_NETWORK,


### PR DESCRIPTION
## 📝 Description

Follow-up to #4596 and #4603. After the rspack / automatic JSX transform, a React `key` inside a props object that is spread onto a child is not treated as a list key. React then tries to warn, and that warning path crashes Console with `getStackAddendum`.

This change:
- Removes `key` from network and environment select option objects
- Stops spreading `key` onto `SelectOption` in `InlineFilterSelectOption` and `CheckboxSelect`

`SelectTypeahead` was already fixed in #4603.

## 🔗 Links

- Jira: [CNV-94185](https://issues.redhat.com/browse/CNV-94185)
- Related: [CNV-96190](https://issues.redhat.com/browse/CNV-96190)
- Related PRs: https://github.com/kubevirt-ui/kubevirt-plugin/pull/4596, https://github.com/kubevirt-ui/kubevirt-plugin/pull/4603

## 🎥 Demo

WIP — still need to verify:
- [ ] Add network interface → Network dropdown
- [ ] VM environment editor resource dropdown
- [ ] Checkbox filter selects (no regression)

## Test plan

- [ ] Open Add network interface and expand the Network dropdown (dev mode, no overlay)
- [ ] Open a VM environment editor and expand the resource select
- [ ] Toggle checkbox filters on list pages


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved option handling across environment, network, and filter selectors for more reliable selection behavior.
  * Corrected option identifiers and values used by inline filters, improving consistency for accessibility and automated interactions.
  * Preserved disabled and favorite states while maintaining expected selection behavior.
  * Improved error reporting when environment options fail to load, making loading issues easier to handle.
  * Standardized option values and identifiers to prevent duplicate or conflicting selection metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->