### PR TITLE
CNV-96200: Fix Topology VM link navigating to [object Object] URL

### DIFF
--- a/src/views/cdi-upload-provider/utils/resourceUtils.ts
+++ b/src/views/cdi-upload-provider/utils/resourceUtils.ts
@@ -1,11 +1,11 @@
-import { DataVolumeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { DataVolumeModel, modelToRef } from '@kubevirt-ui-ext/kubevirt-api/console';
 import type {
   V1beta1DataVolume,
   V1beta1StorageSpecAccessModesEnum,
   V1beta1StorageSpecVolumeModeEnum,
 } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
-import { getGroupVersionKindForModel, type K8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
 import { LABEL_CDROM_SOURCE } from './consts';
 import { getKubevirtModelAvailableAPIVersion } from './selectors';
@@ -30,7 +30,7 @@ export const resourcePathFromModel = (
   }
 
   if (crd) {
-    url += getGroupVersionKindForModel(model);
+    url += modelToRef(model);
   } else if (plural) {
     url += plural;
   }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Use modelToRef when building CRD resource paths so the Topology VM name links to `kubevirt.io~v1~VirtualMachine` instead of stringifying a GVK object.


## 🔗 Links

https://redhat.atlassian.net/browse/CNV-96200

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/9385c450-f89b-4ba1-8b92-8c6e29777093

After:

https://github.com/user-attachments/assets/cd64553e-76f3-418e-a62e-080ecabe750e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource path generation for custom resources.
  * Preserved existing behavior for standard resources and model-based paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->