### PR TITLE
[release-4.20] CNV-96191: fix Pause and Restart actions greyed out for namespace admins

### DIFF
--- a/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
+++ b/src/views/virtualmachines/actions/VirtualMachineActionFactory.tsx
@@ -246,7 +246,7 @@ export const createVirtualMachineActionFactory = (t: TFunction) => ({
     confirmVMActions: boolean,
   ): ActionDropdownItemType => {
     return {
-      accessReview: asAccessReview(VirtualMachineSubresourcesModel, vm, 'update', 'pause'),
+      accessReview: asAccessReview(VirtualMachineInstanceSubresourcesModel, vm, 'update', 'pause'),
       cta: () =>
         confirmVMActions
           ? createModal(({ isOpen, onClose }) => (
@@ -270,12 +270,7 @@ export const createVirtualMachineActionFactory = (t: TFunction) => ({
     confirmVMActions: boolean,
   ): ActionDropdownItemType => {
     return {
-      accessReview: asAccessReview(
-        VirtualMachineInstanceSubresourcesModel,
-        vm,
-        'update',
-        'restart',
-      ),
+      accessReview: asAccessReview(VirtualMachineSubresourcesModel, vm, 'update', 'restart'),
       cta: () =>
         confirmVMActions
           ? createModal(({ isOpen, onClose }) => (


### PR DESCRIPTION
## 📝 Description

Fixes [CNV-96191](https://redhat.atlassian.net/browse/CNV-96191).

Pause and Restart were greyed out for namespace admins because the access reviews used the wrong KubeVirt subresources (a regression from #3392). Pause is a `virtualmachineinstances` subresource and Restart is a `virtualmachines` subresource, matching the APIs `virtctl` already uses.

## 🎥 Demo

N/A — permission checks only; no UI layout change.

## Test plan

- [ ] Log in as a namespace admin (group bound to the `admin` ClusterRole in the namespace, no cluster-scoped extra bindings)
- [ ] Open a running VM → Actions: **Restart** and **Pause** are enabled
- [ ] Pause the VM from the CLI, then confirm **Unpause** remains enabled in the UI
- [ ] Confirm start/stop still work as before


Made with [Cursor](https://cursor.com)