### PR TITLE
CNV-96213: use React Router Link for Required VM labels settings

### DIFF
--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/RequiredVMLabelsDrawerBody.tsx
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/RequiredVMLabelsDrawerBody.tsx
@@ -1,11 +1,12 @@
-import React, { FC, useCallback, useMemo, useState } from 'react';
+import React, { type FC, useCallback, useMemo, useState } from 'react';
+import { Link } from 'react-router';
 
-import { AutoAppliedLabel } from '@kubevirt-utils/hooks/useAutoAppliedLabels/types';
+import { type AutoAppliedLabel } from '@kubevirt-utils/hooks/useAutoAppliedLabels/types';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
 import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
-import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { patchCustomizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
-import { Button, ButtonVariant, Checkbox, Stack, StackItem } from '@patternfly/react-core';
+import { Checkbox, Stack, StackItem } from '@patternfly/react-core';
 import { USER_SETTINGS_URL } from '@settings/constants';
 import { USER_TAB_IDS } from '@settings/search/constants';
 import DefaultVMLabelRow from '@settings/tabs/UserTab/components/DefaultVMLabelsSection/components/DefaultVMLabelRow';
@@ -48,7 +49,7 @@ const RequiredVMLabelsDrawerBody: FC<RequiredVMLabelsDrawerBodyProps> = ({
           <DefaultVMLabelRow
             label={label}
             onValueChange={handleSave}
-            userValue={vmLabels[label.key] || ''}
+            userValue={vmLabels[label.key] ?? ''}
           />
         </StackItem>
       ))}
@@ -63,14 +64,12 @@ const RequiredVMLabelsDrawerBody: FC<RequiredVMLabelsDrawerBodyProps> = ({
       </StackItem>
 
       <StackItem>
-        <Button
-          component="a"
-          href={`${USER_SETTINGS_URL}#${USER_TAB_IDS.defaultVMLabels}`}
-          isInline
-          variant={ButtonVariant.link}
+        <Link
+          id="manage-in-user-settings-link"
+          to={`${USER_SETTINGS_URL}#${USER_TAB_IDS.defaultVMLabels}`}
         >
           {t('Manage in User settings')}
-        </Button>
+        </Link>
       </StackItem>
     </Stack>
   );


### PR DESCRIPTION
## 📝 Description

Fixes [CNV-96213](https://issues.redhat.com/browse/CNV-96213).

The "Manage in User settings" control in the Required VM labels dialog used a PatternFly `Button` with `component="a"` and `href`. That performs a full document navigation, so Console reloads instead of staying in the SPA.

This replaces it with a `react-router` `Link` so the same destination is reached with in-console navigation.

## 🔗 Links

- Jira: [CNV-96213](https://issues.redhat.com/browse/CNV-96213)

## 🎥 Demo

**BEFORE**


https://github.com/user-attachments/assets/6fc47f1e-40af-47af-a9fd-7fd7a1a05d27


**AFTER**

https://github.com/user-attachments/assets/a42cb960-9505-49c6-924d-85732b99b636

## Test plan

- [ ] Configure cluster labels with empty values so the Required VM labels dialog appears
- [ ] Create a VM → custom configuration → step 5
- [ ] In the Required VM labels dialog, click **Manage in User settings**
- [ ] Confirm User settings (Default VM labels) opens without a full page reload
- [ ] Confirm the URL hash still lands on the Default VM labels section


Made with [Cursor](https://cursor.com)


