### PR TITLE
CNV-95191: fix default applied ssh key to not apply without cloudinit

### DIFF
--- a/playwright/src/components/vm-wizard/vm-creation-wizard-component.ts
+++ b/playwright/src/components/vm-wizard/vm-creation-wizard-component.ts
@@ -439,6 +439,10 @@ export default class VmCreationWizardComponent extends BaseComponent {
     return this.location.openEditLocationPanel();
   }
 
+  async selectLocationProject(namespace: string): Promise<void> {
+    return this.location.selectLocationProject(namespace);
+  }
+
   async openWizardFromCreateDropdown(): Promise<void> {
     return this.deployment.openWizardFromCreateDropdown();
   }

--- a/playwright/src/components/vm-wizard/vm-wizard-boot-source-component.ts
+++ b/playwright/src/components/vm-wizard/vm-wizard-boot-source-component.ts
@@ -190,6 +190,19 @@ export default class VmWizardBootSourceComponent extends BaseComponent {
     await this.page.waitForTimeout(500);
   }
 
+  async selectFirstBootVolumeOrNone(): Promise<void> {
+    const paginationCount = await this.getBootVolumeCount();
+    const rowCount = await this._pfV6CWizardTableTbodyTr.count();
+    if (paginationCount === 0 && rowCount === 0) {
+      await this.selectNoBootSource();
+      return;
+    }
+
+    const row = this._pfV6CWizardTableTbodyTr.first();
+    await row.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(row);
+  }
+
   async selectBootVolumeByName(volumeName: string): Promise<void> {
     const table = this.locator('.pf-v6-c-wizard table, .pf-v6-c-wizard [role="grid"]');
     await table.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });

--- a/playwright/src/components/vm-wizard/vm-wizard-compute-customization-component.ts
+++ b/playwright/src/components/vm-wizard/vm-wizard-compute-customization-component.ts
@@ -11,9 +11,9 @@ export default class VmWizardComputeCustomizationComponent extends BaseComponent
   };
   private readonly _inputTypeText = this.locator('input[type="text"]');
   private readonly _pfV6CMenuToggle = this.locator('.pf-v6-c-menu-toggle');
-  private readonly _pfV6CWizardButtonpfV6CButtonpfMPrimary = this.locator(
-    '.pf-v6-c-wizard button.pf-v6-c-button.pf-m-primary',
-  );
+  private readonly _wizardFooterCreateButton = this.page
+    .getByTestId('wizard-create-button')
+    .filter({ hasText: 'Create VirtualMachine' });
   private readonly _pfV6CWizardInputPlaceholderFindSettings = this.locator(
     '.pf-v6-c-wizard input[placeholder="Find settings"]',
   );
@@ -186,10 +186,8 @@ export default class VmWizardComputeCustomizationComponent extends BaseComponent
 
   async getCreateButtonText(): Promise<string> {
     try {
-      const createBtn = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
-      return (
-        (await createBtn.first().textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || ''
-      );
+      const createBtn = this._wizardFooterCreateButton;
+      return (await createBtn.textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || '';
     } catch {
       return '';
     }
@@ -321,7 +319,7 @@ export default class VmWizardComputeCustomizationComponent extends BaseComponent
 
   async isCreateButtonDisabled(): Promise<boolean> {
     try {
-      const createBtn = this._pfV6CWizardButtonpfV6CButtonpfMPrimary.first();
+      const createBtn = this._wizardFooterCreateButton;
       await createBtn.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
       return createBtn.isDisabled();
     } catch {
@@ -422,6 +420,28 @@ export default class VmWizardComputeCustomizationComponent extends BaseComponent
   ): Promise<void> {
     const tab = this.locator(`button[role="tab"]:has-text("${tabName}")`);
     await this.robustClick(tab.first());
+  }
+
+  async selectLargestComputeSize(): Promise<void> {
+    const sizeBtn = this._pfV6CMenuToggle.filter({
+      hasText: /CPUs.*Memory/,
+    });
+    await this.robustClick(sizeBtn.first());
+
+    const menu = this.page
+      .locator('[role="menu"], .pf-v6-c-menu')
+      .filter({ hasText: /CPUs/ })
+      .first();
+    await menu.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+    const menuItems = menu.getByRole('menuitem');
+    await this.robustClick(menuItems.last());
+
+    await menu
+      .waitFor({ state: 'hidden', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(async () => {
+        await this.page.keyboard.press('Escape');
+      });
   }
 
   async selectInstanceTypeSeries(series: 'cx' | 'd' | 'u' | 'm' | 'n' | 'o' | 'rt'): Promise<void> {

--- a/playwright/src/components/vm-wizard/vm-wizard-navigation-component.ts
+++ b/playwright/src/components/vm-wizard/vm-wizard-navigation-component.ts
@@ -22,9 +22,12 @@ export default class VmWizardNavigationComponent extends BaseComponent {
 
   private readonly _pfV6CMenuToggle = this.locator('.pf-v6-c-menu-toggle');
 
-  private readonly _pfV6CWizardButtonpfV6CButtonpfMPrimary = this.locator(
-    '.pf-v6-c-wizard button.pf-v6-c-button.pf-m-primary',
-  );
+  private readonly _wizardFooterCreateButton = this.page
+    .getByTestId('wizard-create-button')
+    .filter({ hasText: 'Create VirtualMachine' });
+  private readonly _wizardFooterNextButton = this.page
+    .getByTestId('wizard-next-button')
+    .filter({ hasText: 'Next' });
   private readonly _pfV6CWizardMain = this.locator('.pf-v6-c-wizard__main');
   private readonly _pfV6CWizardTemplatesCatalogTile = this.locator(
     '.pf-v6-c-wizard .templates-catalog-tile',
@@ -98,13 +101,13 @@ export default class VmWizardNavigationComponent extends BaseComponent {
 
   async clickCreateVm(): Promise<void> {
     await this.collapseSidebarIfExpanded();
-    const createBtn = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
-    await createBtn.first().waitFor({
+    const createBtn = this._wizardFooterCreateButton;
+    await createBtn.waitFor({
       state: 'visible',
       timeout: TestTimeouts.SHORT_WAIT,
     });
 
-    if (await createBtn.first().isDisabled()) {
+    if (await createBtn.isDisabled()) {
       const nameInput = this._vmNameInput.first();
       if ((await nameInput.count()) > 0) {
         await nameInput.press('Tab');
@@ -112,18 +115,18 @@ export default class VmWizardNavigationComponent extends BaseComponent {
       }
     }
 
-    await this.robustClick(createBtn.first());
+    await this.robustClick(createBtn);
     await this.page.waitForTimeout(2000);
   }
 
   async clickNext(): Promise<void> {
     await this.collapseSidebarIfExpanded();
-    const nextButton = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
-    await nextButton.first().waitFor({
+    const nextButton = this._wizardFooterNextButton;
+    await nextButton.waitFor({
       state: 'visible',
       timeout: TestTimeouts.SHORT_WAIT,
     });
-    await this.robustClick(nextButton.first());
+    await this.robustClick(nextButton);
     await this.page.waitForTimeout(1000);
   }
 
@@ -316,12 +319,12 @@ export default class VmWizardNavigationComponent extends BaseComponent {
   }
 
   async isNextButtonDisabled(): Promise<boolean> {
-    const nextButton = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
-    await nextButton.first().waitFor({
+    const nextButton = this._wizardFooterNextButton;
+    await nextButton.waitFor({
       state: 'visible',
       timeout: TestTimeouts.SHORT_WAIT,
     });
-    return await nextButton.first().isDisabled();
+    return await nextButton.isDisabled();
   }
 
   async navigateToStepByName(stepName: string): Promise<void> {
@@ -345,6 +348,33 @@ export default class VmWizardNavigationComponent extends BaseComponent {
     const editBtn = this._buttonEditVMCreationLocation;
     await this.robustClick(editBtn);
     await this.page.waitForTimeout(500);
+  }
+
+  async selectLocationProject(namespace: string): Promise<void> {
+    const current = await this.getLocationProject();
+    if (current.includes(namespace)) {
+      return;
+    }
+
+    await this.openEditLocationPanel();
+
+    const toggle = this.locator('.vm-creation-wizard').getByTestId('namespace-dropdown-menu-toggle');
+    await toggle.first().waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(toggle.first());
+
+    const filter = this.page.getByTestId('dropdown-text-filter');
+    await filter.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await filter.clear();
+    await filter.fill(namespace);
+
+    const option = this.page.getByRole('menuitem', { name: namespace, exact: true });
+    await option.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(option);
+
+    await toggle
+      .filter({ hasText: namespace })
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
   }
 
   async openWizardFromCreateDropdown(): Promise<void> {

--- a/playwright/src/components/vm-wizard/wizard-deploy-review-components.ts
+++ b/playwright/src/components/vm-wizard/wizard-deploy-review-components.ts
@@ -5,9 +5,9 @@ import type { Page } from '@playwright/test';
 export class VmCreationWizardReviewComponent extends BaseComponent {
   private readonly _inputTypeText = this.locator('input[type="text"]');
 
-  private readonly _pfV6CWizardButtonpfV6CButtonpfMPrimary = this.locator(
-    '.pf-v6-c-wizard button.pf-v6-c-button.pf-m-primary',
-  );
+  private readonly _wizardFooterCreateButton = this.page
+    .getByTestId('wizard-create-button')
+    .filter({ hasText: 'Create VirtualMachine' });
   private readonly _pfV6CWizardInputTypeText = this.locator('.pf-v6-c-wizard input[type="text"]');
   private readonly _startAfterCreateCheckbox = this.locator('#start-after-create-checkbox');
   private readonly _startThisVirtualMachineAfterCreation = this.locator(
@@ -25,13 +25,13 @@ export class VmCreationWizardReviewComponent extends BaseComponent {
 
   async clickCreateVm(): Promise<void> {
     await this.collapseSidebarIfExpanded();
-    const createBtn = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
-    await createBtn.first().waitFor({
+    const createBtn = this._wizardFooterCreateButton;
+    await createBtn.waitFor({
       state: 'visible',
       timeout: TestTimeouts.SHORT_WAIT,
     });
 
-    if (await createBtn.first().isDisabled()) {
+    if (await createBtn.isDisabled()) {
       const nameInput = this.locator('#vm-name');
       if ((await nameInput.count()) > 0) {
         await nameInput.press('Tab');
@@ -39,7 +39,7 @@ export class VmCreationWizardReviewComponent extends BaseComponent {
       }
     }
 
-    await this.robustClick(createBtn.first());
+    await this.robustClick(createBtn);
     await this.page.waitForTimeout(2000);
   }
 
@@ -58,9 +58,9 @@ export class VmCreationWizardReviewComponent extends BaseComponent {
 
   async getCreateButtonText(): Promise<string> {
     try {
-      const createBtn = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
+      const createBtn = this._wizardFooterCreateButton;
       return (
-        (await createBtn.first().textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || ''
+        (await createBtn.textContent({ timeout: TestTimeouts.SHORT_WAIT }))?.trim() || ''
       );
     } catch {
       return '';
@@ -120,7 +120,7 @@ export class VmCreationWizardReviewComponent extends BaseComponent {
 
   async isCreateButtonDisabled(): Promise<boolean> {
     try {
-      const createBtn = this._pfV6CWizardButtonpfV6CButtonpfMPrimary.first();
+      const createBtn = this._wizardFooterCreateButton;
       await createBtn.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
       return createBtn.isDisabled();
     } catch {

--- a/playwright/src/components/vm-wizard/wizard-navigation-components.ts
+++ b/playwright/src/components/vm-wizard/wizard-navigation-components.ts
@@ -3,10 +3,6 @@ import { TestTimeouts } from '@/utils/test-config';
 import type { Page } from '@playwright/test';
 
 export class VmCreationWizardNavigationComponent extends BaseComponent {
-  private readonly _pfV6CWizardButtonpfV6CButtonpfMPrimary = this.locator(
-    '.pf-v6-c-wizard button.pf-v6-c-button.pf-m-primary',
-  );
-
   constructor(page: Page) {
     super(page);
   }
@@ -25,12 +21,12 @@ export class VmCreationWizardNavigationComponent extends BaseComponent {
 
   async clickNext(): Promise<void> {
     await this.collapseSidebarIfExpanded();
-    const nextButton = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
-    await nextButton.first().waitFor({
+    const nextButton = this.page.getByTestId('wizard-next-button').filter({ hasText: 'Next' });
+    await nextButton.waitFor({
       state: 'visible',
       timeout: TestTimeouts.SHORT_WAIT,
     });
-    await this.robustClick(nextButton.first());
+    await this.robustClick(nextButton);
     await this.page.waitForTimeout(1000);
   }
 
@@ -46,12 +42,12 @@ export class VmCreationWizardNavigationComponent extends BaseComponent {
   }
 
   async isNextButtonDisabled(): Promise<boolean> {
-    const nextButton = this._pfV6CWizardButtonpfV6CButtonpfMPrimary;
-    await nextButton.first().waitFor({
+    const nextButton = this.page.getByTestId('wizard-next-button').filter({ hasText: 'Next' });
+    await nextButton.waitFor({
       state: 'visible',
       timeout: TestTimeouts.SHORT_WAIT,
     });
-    return await nextButton.first().isDisabled();
+    return await nextButton.isDisabled();
   }
 
   async navigateToStepByName(stepName: string): Promise<void> {

--- a/playwright/src/components/vm-wizard/wizard-step-components.ts
+++ b/playwright/src/components/vm-wizard/wizard-step-components.ts
@@ -35,6 +35,33 @@ export class VmCreationWizardLocationComponent extends BaseComponent {
     await this.page.waitForTimeout(500);
   }
 
+  async selectLocationProject(namespace: string): Promise<void> {
+    const current = await this.getLocationProject();
+    if (current.includes(namespace)) {
+      return;
+    }
+
+    await this.openEditLocationPanel();
+
+    const toggle = this.locator('.vm-creation-wizard').getByTestId('namespace-dropdown-menu-toggle');
+    await toggle.first().waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(toggle.first());
+
+    const filter = this.page.getByTestId('dropdown-text-filter');
+    await filter.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await filter.clear();
+    await filter.fill(namespace);
+
+    const option = this.page.getByRole('menuitem', { name: namespace, exact: true });
+    await option.waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await this.robustClick(option);
+
+    await toggle
+      .filter({ hasText: namespace })
+      .first()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+  }
+
   async verifyEditLocationButtonVisible(): Promise<boolean> {
     try {
       const editBtn = this._buttonEditVMCreationLocation;

--- a/playwright/src/utils/test-setup-helpers.ts
+++ b/playwright/src/utils/test-setup-helpers.ts
@@ -4,7 +4,8 @@
  */
 
 import type RequestContextClient from '@/clients/request-context-client';
-import type { JsonPatchOp } from '@/data-models/kubernetes-types';
+import type { JsonPatchOp, KubernetesResource } from '@/data-models/kubernetes-types';
+import { EnvVariables } from '@/utils/env-variables';
 import {
   generateRandomName,
   generateRandomString,
@@ -159,6 +160,90 @@ export async function setupTestNamespace(
   client.trackResource('Namespace', namespace);
   return namespace;
 }
+
+type DefaultSSHKeyArgs = {
+  client: RequestContextClient;
+  cnvNamespace?: string;
+  namespace: string;
+};
+
+type SetupDefaultSSHKeyArgs = DefaultSSHKeyArgs & {
+  secretName: string;
+};
+
+type UserSshSettings = { ssh?: Record<string, string> };
+
+async function resolveUserSettingsKey(client: RequestContextClient): Promise<string> {
+  const user = await client.getResource('user.openshift.io', 'v1', 'users', '~');
+  const settingsKey =
+    user?.metadata?.uid ?? user?.metadata?.name?.replace(/[^-._a-zA-Z0-9]+/g, '-');
+  if (!settingsKey) {
+    throw new Error('Could not resolve kubevirt user-settings key for the current user');
+  }
+  return settingsKey;
+}
+
+async function patchDefaultSshForNamespace({
+  client,
+  cnvNamespace = EnvVariables.cnvNamespace,
+  namespace,
+  secretName,
+}: DefaultSSHKeyArgs & { secretName: string | null }): Promise<void> {
+  const settingsKey = await resolveUserSettingsKey(client);
+  const userSettingsCm = await client.getKubeVirtUserSettings(cnvNamespace);
+  if (!userSettingsCm) {
+    throw new Error(`kubevirt-user-settings ConfigMap not found in ${cnvNamespace}`);
+  }
+  const cmData = (userSettingsCm?.data ?? {}) as Record<string, string>;
+  const parsed = JSON.parse(cmData[settingsKey] || '{}') as UserSshSettings;
+  const ssh = { ...parsed.ssh };
+  if (secretName) {
+    ssh[namespace] = secretName;
+  } else {
+    delete ssh[namespace];
+  }
+  parsed.ssh = ssh;
+
+  const op: JsonPatchOp = cmData[settingsKey]
+    ? { op: 'replace', path: `/data/${settingsKey}`, value: JSON.stringify(parsed) }
+    : { op: 'add', path: `/data/${settingsKey}`, value: JSON.stringify(parsed) };
+
+  await client.patchConfigMap('kubevirt-user-settings', cnvNamespace, [op]);
+}
+
+/**
+ * Creates an SSH public-key Secret and records it as the user's default key
+ * for the given namespace in kubevirt-user-settings.
+ */
+export async function setupDefaultSSHKey({
+  client,
+  cnvNamespace = EnvVariables.cnvNamespace,
+  namespace,
+  secretName,
+}: SetupDefaultSSHKeyArgs): Promise<void> {
+  await client.createSSHKeySecret(namespace, secretName);
+  client.trackResource('Secret', secretName, namespace);
+  await patchDefaultSshForNamespace({ client, cnvNamespace, namespace, secretName });
+}
+
+/**
+ * Removes the default SSH key mapping for a namespace from kubevirt-user-settings.
+ * Used when the test namespace is reused (HC E2E) so leftover defaults do not leak.
+ */
+export async function clearDefaultSSHKey({
+  client,
+  cnvNamespace = EnvVariables.cnvNamespace,
+  namespace,
+}: DefaultSSHKeyArgs): Promise<void> {
+  await patchDefaultSshForNamespace({ client, cnvNamespace, namespace, secretName: null });
+}
+
+export const getVmAccessCredentials = (vm: KubernetesResource | null): unknown[] | undefined => {
+  const spec = vm?.spec as {
+    template?: { spec?: { accessCredentials?: unknown[] } };
+  };
+  return spec?.template?.spec?.accessCredentials;
+};
 
 export type ProjectNetworkSettingsAnnotations = {
   /** Value for kubevirt.io/default-network (NAD name in the project). */

--- a/playwright/tests/tier1/create-vm/create-vm-wizard-default-ssh-windows.spec.md
+++ b/playwright/tests/tier1/create-vm/create-vm-wizard-default-ssh-windows.spec.md
@@ -1,0 +1,92 @@
+# Software Test Description (STD): VM Creation Wizard — Default SSH Key on Windows Guests
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier1 — VM Creation Wizard
+- **Latest version:** CNV 5.1.0
+- **Latest update:** 2026-09-03
+- **Document Status:** Approved
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify that when a project has a default SSH public key, creating a Windows VirtualMachine through
+the Create VirtualMachine wizard does not attach SSH `accessCredentials`. Windows guests have no
+cloud-init (`cloudInitNoCloud`) volume, and KubeVirt rejects `noCloud` SSH propagation without one.
+
+### 2.2 Scope
+
+- **In-Scope:** Custom configuration wizard path for a Windows guest OS; default SSH key present in
+  user settings for the test namespace; create succeeds; created VM spec has no
+  `spec.template.spec.accessCredentials`.
+- **Out-of-Scope:** Linux/RHEL guests that still receive the default key via cloud-init. SSH tab UI,
+  sysprep, and Windows password credentials.
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator installed; Playwright `Tier1` project; kubeadmin (or
+  equivalent cluster-admin) session.
+- **Configuration:** A default SSH key is written into `kubevirt-user-settings` for the current
+  console user in the test namespace (`setupDefaultSSHKey`). No extra feature gates.
+- **Initial Setup:** Uses the job test namespace (`testConfig.testNamespace`) so HC E2E does not
+  depend on an extra `pw-*` project (those are swept cluster-wide on teardown). The default SSH
+  mapping is cleared in `afterEach`. The created VirtualMachine is tracked with
+  `apiClient.trackResource` for cleanup.
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier1/create-vm/create-vm-wizard-default-ssh-windows.spec.ts`
+**Describe:** `VM Creation Wizard — default SSH key is not applied to Windows VMs` — **Tags:** `@tier1`, `@catalog-wizard`, `@adminOnly`
+**Allure:** suite `VM Creation Wizard`, feature `Tier 1`
+
+---
+
+### `001`: Windows guest is created without SSH accessCredentials when a default SSH key is set
+
+- **Objective:** Confirm that a Windows VM created through the wizard does not include SSH
+  `accessCredentials` even when a default SSH key is configured for the project.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-95191
+- **Pre-conditions:** Default SSH secret exists and is set as the user's default key for the test
+  namespace; Windows OS tile is available in the wizard.
+- **Tags:** `@tier1`, `@catalog-wizard`, `@adminOnly`
+
+| Step | Action                                                                                     | Expected Result                                                                       |
+| :--- | :----------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| 1    | Set a default SSH key for the current user in the job test namespace                       | User settings point at the SSH secret in `testConfig.testNamespace`                   |
+| 2    | Open Virtualization, go to the namespaced VM list URL, and start Create VirtualMachine     | Wizard is visible                                                                     |
+| 3    | Step 1 — keep Custom configuration, select the test project, generate a VM name, then Next | Custom configuration card is selected; project is the test namespace; wizard advances |
+| 4    | Step 2 — select Windows, then Next                                                         | OS tiles are visible; Windows is selected                                             |
+| 5    | Step 3 — select the first Windows boot volume, or no boot source if none exist, then Next  | Boot source step is visible; a source (or none) is chosen                             |
+| 6    | Step 4 — select General Purpose (U series) and the largest size, then Next                 | Compute step is visible; size dropdown text contains `CPUs`                           |
+| 7    | Step 5 — leave Customization unchanged, then Next                                          | Customization step is visible                                                         |
+| 8    | Step 6 — review and click Create VirtualMachine                                            | Review step is visible; console redirects to VM details                               |
+| 9    | Read the VM name from the URL and fetch the VirtualMachine from the API                    | VM exists in the test namespace                                                       |
+| 10   | Assert `spec.template.spec.accessCredentials`                                              | Field is undefined (default SSH key was not applied)                                  |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+Maps Jira tickets to the test cases that provide coverage. Tickets without a specific test case indicate
+a planned coverage gap (status: Pending).
+
+| Jira Ticket | Test Case ID | Coverage Type           | Status    |
+| ----------- | ------------ | ----------------------- | --------- |
+| CNV-95191   | `001`        | Bugfix regression guard | Automated |
+
+**Coverage Type values:**
+
+- `Feature coverage` — test validates a feature delivered by the ticket
+- `Bugfix regression guard` — test asserts the specific bug fixed by the ticket does not regress
+- `Functional smoke` — test validates baseline behavior; no specific Jira ticket drives it
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** **\*\*\*\***\_\_**\*\*\*\***
+- **Approval Signature:** **\*\*\*\***\_\_**\*\*\*\***

--- a/playwright/tests/tier1/create-vm/create-vm-wizard-default-ssh-windows.spec.ts
+++ b/playwright/tests/tier1/create-vm/create-vm-wizard-default-ssh-windows.spec.ts
@@ -1,0 +1,130 @@
+import { ADMIN_ONLY_TAG, T1, T1_TAG } from '@/data-models/allure-constants';
+import { expect, test } from '@/fixtures/create-vm-fixture';
+import {
+  clearDefaultSSHKey,
+  getVmAccessCredentials,
+  setupDefaultSSHKey,
+} from '@/utils/test-setup-helpers';
+
+const SUITE = 'VM Creation Wizard';
+
+test.describe(
+  'VM Creation Wizard — default SSH key is not applied to Windows VMs',
+  { tag: [T1_TAG, '@catalog-wizard', ADMIN_ONLY_TAG] },
+  () => {
+    test.afterEach(async ({ apiClient, testConfig }) => {
+      try {
+        await clearDefaultSSHKey({ client: apiClient, namespace: testConfig.testNamespace });
+      } catch {
+        // Best-effort: leftover mapping must not fail the spec after the assertion ran.
+      }
+    });
+
+    test('Windows guest is created without accessCredentials when a default SSH key is set', async ({
+      apiClient,
+      testConfig,
+      vmTreePage,
+      vmWizardNavigationPage,
+      vmWizardBootSourcePage,
+      vmWizardComputePage,
+      utils,
+    }) => {
+      test.setTimeout(utils.TestTimeouts.TEST_VM_CREATION);
+      await utils.withAllure({
+        suite: SUITE,
+        feature: T1,
+        tags: [T1_TAG],
+      });
+
+      const wizardNs = testConfig.testNamespace;
+      const secretName = utils.generateRandomSecretName('ssh-key');
+      await setupDefaultSSHKey({ client: apiClient, namespace: wizardNs, secretName });
+
+      await vmTreePage.switchToVirtualizationPerspective();
+      await vmTreePage.navigateToNamespaceVirtualMachines(wizardNs);
+      await vmTreePage.clickVmListTab();
+      await vmWizardNavigationPage.openWizardFromCreateDropdown();
+
+      const wizardVisible = await vmWizardNavigationPage.verifyWizardVisible();
+      expect(wizardVisible, 'Wizard should open').toBe(true);
+
+      await test.step('Step 1: Deployment details — select Custom configuration and generate name', async () => {
+        const isCustomSelected =
+          await vmWizardNavigationPage.verifyCreationMethodCardSelected('newVm');
+        expect
+          .soft(isCustomSelected, 'Custom configuration should be selected by default')
+          .toBe(true);
+
+        await vmWizardNavigationPage.selectLocationProject(wizardNs);
+        await vmWizardNavigationPage.generateVmName();
+        const wizardProject = await vmWizardNavigationPage.getLocationProject();
+        expect(wizardProject, 'Wizard project should be the test namespace').toContain(wizardNs);
+        await vmWizardNavigationPage.clickNext();
+      });
+
+      await test.step('Step 2: Guest OS — select Windows', async () => {
+        const osTilesVisible = await vmWizardNavigationPage.verifyOsTilesVisible();
+        expect.soft(osTilesVisible, 'OS tiles should be visible').toBe(true);
+
+        await vmWizardNavigationPage.selectOperatingSystem('windows');
+        await vmWizardNavigationPage.clickNext();
+      });
+
+      await test.step('Step 3: Boot source — select a Windows volume or no boot source', async () => {
+        const bootStepVisible = await vmWizardBootSourcePage.verifyBootSourceStepVisible();
+        expect.soft(bootStepVisible, 'Boot source step should be visible').toBe(true);
+
+        await vmWizardBootSourcePage.selectFirstBootVolumeOrNone();
+        await vmWizardNavigationPage.clickNext();
+      });
+
+      await test.step('Step 4: Compute resources — select a size that meets Windows preference memory', async () => {
+        const computeVisible = await vmWizardComputePage.verifyComputeResourcesStepVisible();
+        expect.soft(computeVisible, 'Compute resources step should be visible').toBe(true);
+
+        await vmWizardComputePage.selectInstanceTypeSeries('u');
+        await vmWizardComputePage.selectLargestComputeSize();
+
+        const selectedSize = await vmWizardComputePage.getComputeSizeDropdownText();
+        expect.soft(selectedSize, 'A compute size should be selected').toContain('CPUs');
+
+        await vmWizardNavigationPage.clickNext();
+      });
+
+      await test.step('Step 5: Customization — continue to review', async () => {
+        const custVisible = await vmWizardComputePage.verifyCustomizationStepVisible();
+        expect.soft(custVisible, 'Customization step should be visible').toBe(true);
+
+        await vmWizardNavigationPage.clickNext();
+      });
+
+      await test.step('Step 6: Review and create — create the Windows VM', async () => {
+        const reviewVisible = await vmWizardComputePage.verifyReviewStepVisible();
+        expect(reviewVisible, 'Review step should be visible').toBe(true);
+
+        await vmWizardNavigationPage.clickCreateVm();
+        const redirected = await vmWizardNavigationPage.verifyRedirectedToVmDetails();
+        expect(redirected, 'Should redirect to VM details after creation').toBe(true);
+      });
+
+      await test.step('Verify the VM has no SSH accessCredentials', async () => {
+        const vmName = await vmWizardNavigationPage.getCreatedVmNameFromUrl();
+        const vmNs = await vmWizardNavigationPage.getCreatedVmNamespaceFromUrl();
+        expect(vmName.length, 'VM name should be in the URL').toBeGreaterThan(0);
+        expect(vmNs, 'VM should be created in the test namespace (default SSH key is set there)').toBe(
+          wizardNs,
+        );
+        apiClient.trackResource('VirtualMachine', vmName, vmNs);
+
+        const created = await apiClient.verifyVmCreated(vmName, vmNs);
+        expect(created.exists, `VM '${vmName}' should exist in '${vmNs}'`).toBe(true);
+
+        const vm = await apiClient.getVirtualMachine(vmNs, vmName);
+        expect(
+          getVmAccessCredentials(vm),
+          'Windows VM must not get the default SSH key (no cloud-init volume)',
+        ).toBeUndefined();
+      });
+    });
+  },
+);

--- a/src/utils/components/SSHSecretModal/utils/utils.ts
+++ b/src/utils/components/SSHSecretModal/utils/utils.ts
@@ -115,7 +115,7 @@ export const addSecretToVM = (
   secretName?: string,
   isDynamic?: boolean,
 ): V1VirtualMachine => {
-  if (isWindows(vm?.spec?.template)) return vm;
+  if (isWindows(vm?.spec?.template) || isEmpty(getCloudInitVolume(vm))) return vm;
 
   return produce(vm, (vmDraft) => {
     vmDraft.spec.template.spec.volumes = applyCloudDriveCloudInitVolume(vm, isDynamic);

--- a/src/views/virtualmachines/wizard/components/VMNameConfirmationNextButton.tsx
+++ b/src/views/virtualmachines/wizard/components/VMNameConfirmationNextButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { type FC, type ReactNode } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -13,12 +13,14 @@ import {
 
 type VMNameConfirmationNextButtonProps = {
   children: ReactNode;
+  dataTest?: string;
   isSubmitting?: boolean;
   onClick: () => void;
 };
 
 const VMNameConfirmationNextButton: FC<VMNameConfirmationNextButtonProps> = ({
   children,
+  dataTest = 'wizard-next-button',
   isSubmitting = false,
   onClick,
 }) => {
@@ -35,7 +37,7 @@ const VMNameConfirmationNextButton: FC<VMNameConfirmationNextButtonProps> = ({
   const isVMNameInvalid = shouldCheckVMNameProperly ? !isVMNameValid : !isVMNameAlmostValid;
   const isDisabled = isSubmitting || isVMNameInvalid;
 
-  const handleClick = () => {
+  const handleClick = (): void => {
     if (isVMNameValid) {
       onClick();
       return;
@@ -45,6 +47,7 @@ const VMNameConfirmationNextButton: FC<VMNameConfirmationNextButtonProps> = ({
 
   const nextButton = (
     <Button
+      data-test={dataTest}
       isAriaDisabled={isDisabled}
       isLoading={isSubmitting}
       onClick={isDisabled ? undefined : handleClick}

--- a/src/views/virtualmachines/wizard/steps/DeploymentDetailsStep/components/DeploymentDetailsStepFooter.tsx
+++ b/src/views/virtualmachines/wizard/steps/DeploymentDetailsStep/components/DeploymentDetailsStepFooter.tsx
@@ -1,6 +1,6 @@
-import classnames from 'classnames';
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { useWatch } from 'react-hook-form';
+import classnames from 'classnames';
 
 import { FLAG_LIGHTSPEED_PLUGIN } from '@kubevirt-utils/flags/consts';
 import useWizardFooterProps from '@kubevirt-utils/hooks/useWizardFooterProps';
@@ -15,7 +15,6 @@ import {
 } from '@patternfly/react-core';
 import VMNameConfirmationNextButton from '@virtualmachines/wizard/components/VMNameConfirmationNextButton';
 import useCloseWizard from '@virtualmachines/wizard/hooks/useCloseWizard';
-
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
 import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
 import { isCloneCreationMethod } from '@virtualmachines/wizard/utils/utils';
@@ -34,13 +33,13 @@ const DeploymentDetailsStepFooter: FC = () => {
       <ActionList>
         <ActionListGroup>
           <ActionListItem>
-            <Button isDisabled variant="secondary">
+            <Button data-test="wizard-back-button" isDisabled variant="secondary">
               {backButtonText}
             </Button>
           </ActionListItem>
           <ActionListItem>
             {isCloneMethod ? (
-              <Button onClick={goToNextStep} variant="primary">
+              <Button data-test="wizard-next-button" onClick={goToNextStep} variant="primary">
                 {nextButtonText}
               </Button>
             ) : (
@@ -54,6 +53,7 @@ const DeploymentDetailsStepFooter: FC = () => {
           <ActionListItem>
             <Button
               className={classnames({ 'pf-v6-u-mr-4xl': hasOLSConsole })}
+              data-test="wizard-cancel-button"
               onClick={closeWizard}
               variant="link"
             >

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/RedHatProvidedInstanceTypesSection/components/RedHatInstanceTypeSeriesGallery/components/RedHatSeriesMenuCard/RedHatSeriesMenuCard.tsx
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/RedHatProvidedInstanceTypesSection/components/RedHatInstanceTypeSeriesGallery/components/RedHatSeriesMenuCard/RedHatSeriesMenuCard.tsx
@@ -4,7 +4,7 @@ import React, { FC, useMemo } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import { instanceTypeSeriesNameMapper } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/constants';
-import { RedHatInstanceTypeSeries } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/types';
+import { type RedHatInstanceTypeSeries } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/types';
 import {
   getSeriesLabel,
   getSeriesSymbol,
@@ -12,6 +12,7 @@ import {
   seriesHasHugepagesVariant,
 } from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/InstanceTypeDrilldownSelect/utils/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { type InstanceTypeSeries } from '@kubevirt-utils/resources/instancetype/types';
 import { Card, CardBody, CardHeader, Flex, Tooltip } from '@patternfly/react-core';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
 import { CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
@@ -30,11 +31,12 @@ const RedHatSeriesMenuCard: FC<RedHatSeriesMenuCardProps> = ({ rhSeriesItem }) =
   const selectedSeries = useWatch({
     control,
     name: CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.SELECTED_SERIES,
-  });
+  }) as string;
 
   const { classDisplayNameAnnotation, descriptionAnnotation, seriesName, sizes } = rhSeriesItem;
 
-  const { Icon, seriesLabel } = instanceTypeSeriesNameMapper[seriesName] || {};
+  const seriesConfig = instanceTypeSeriesNameMapper[seriesName as InstanceTypeSeries];
+  const Icon = seriesConfig?.Icon;
 
   const isSelectedSeries = useMemo(
     () => seriesName === selectedSeries,
@@ -43,39 +45,39 @@ const RedHatSeriesMenuCard: FC<RedHatSeriesMenuCardProps> = ({ rhSeriesItem }) =
 
   const defaultSeriesLabel = useMemo(() => getSeriesLabel(seriesName, t), [seriesName, t]);
 
-  const handleSeriesClick = () => {
+  const handleSeriesClick = (): void => {
     if (seriesName === selectedSeries) {
       return;
     }
 
     const standardSizes = seriesHasHugepagesVariant(seriesName)
-      ? sizes?.filter((s) => !is1GiInstanceType(s.sizeLabel))
+      ? sizes?.filter((size) => !is1GiInstanceType(size.sizeLabel))
       : sizes;
     const defaultSize = (standardSizes?.[0] ?? sizes?.[0])?.sizeLabel;
     setValue(CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.SELECTED_SERIES, seriesName);
     setValue(CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.SELECTED_SIZE, defaultSize);
     setValue(CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.SELECTED_INSTANCE_TYPE, {
-      name: seriesName,
+      name: defaultSize ? `${seriesName}.${defaultSize}` : seriesName,
       namespace: null,
     });
   };
 
   const card = (
     <Card
+      aria-pressed={isSelectedSeries}
       className={classNames(
         'instance-type-series-menu-card__toggle-card',
         isSelectedSeries && 'selected',
       )}
+      data-test={`instance-type-series-${seriesName}`}
+      isCompact
+      onClick={handleSeriesClick}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           handleSeriesClick();
         }
       }}
-      aria-pressed={isSelectedSeries}
-      data-test={`instance-type-series-${seriesName}`}
-      isCompact
-      onClick={handleSeriesClick}
       role="button"
       tabIndex={0}
     >
@@ -87,9 +89,7 @@ const RedHatSeriesMenuCard: FC<RedHatSeriesMenuCardProps> = ({ rhSeriesItem }) =
           {classDisplayNameAnnotation}
         </CardHeader>
         <CardBody>
-          <div className="instance-type-series-menu-card__series-label">
-            {seriesLabel || defaultSeriesLabel}
-          </div>
+          <div className="instance-type-series-menu-card__series-label">{defaultSeriesLabel}</div>
         </CardBody>
       </Flex>
     </Card>

--- a/src/views/virtualmachines/wizard/steps/ReviewAndCreateStep/components/ReviewAndCreateStepFooter.tsx
+++ b/src/views/virtualmachines/wizard/steps/ReviewAndCreateStep/components/ReviewAndCreateStepFooter.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
@@ -19,6 +19,7 @@ import useCreateVM from '@virtualmachines/wizard/hooks/useCreateVM';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
 import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
 import { isCloneCreationMethod } from '@virtualmachines/wizard/utils/utils';
+
 import { getCreateButtonText } from '../utils/utils';
 
 const ReviewAndCreateStepFooter: FC = () => {
@@ -40,19 +41,23 @@ const ReviewAndCreateStepFooter: FC = () => {
         <ActionList>
           <ActionListGroup>
             <ActionListItem>
-              <Button onClick={goToPrevStep} variant="secondary">
+              <Button data-test="wizard-back-button" onClick={goToPrevStep} variant="secondary">
                 {backButtonText}
               </Button>
             </ActionListItem>
             <ActionListItem data-test="create-virtual-machine">
-              <VMNameConfirmationNextButton isSubmitting={isSubmitting} onClick={createVM}>
+              <VMNameConfirmationNextButton
+                dataTest="wizard-create-button"
+                isSubmitting={isSubmitting}
+                onClick={createVM}
+              >
                 {createButtonText}
               </VMNameConfirmationNextButton>
             </ActionListItem>
           </ActionListGroup>
           <ActionListGroup>
             <ActionListItem>
-              <Button onClick={closeWizard} variant="link">
+              <Button data-test="wizard-cancel-button" onClick={closeWizard} variant="link">
                 {cancelButtonText}
               </Button>
             </ActionListItem>

--- a/src/views/virtualmachines/wizard/utils/displaySteps.ts
+++ b/src/views/virtualmachines/wizard/utils/displaySteps.ts
@@ -1,7 +1,7 @@
-import { createElement } from 'react';
-import { VMCreationMethod, VMWizardStep } from './constants';
+import { createElement, type ReactElement } from 'react';
+import { type TFunction } from 'i18next';
 
-import { TFunction } from 'i18next';
+import DefaultWizardFooter from '../components/DefaultWizardFooter';
 import CloneSourceStep from '../steps/CloneSourceStep/CloneSourceStep';
 import CustomizationStep from '../steps/CustomizationStep/CustomizationStep';
 import DeploymentDetailsStepFooter from '../steps/DeploymentDetailsStep/components/DeploymentDetailsStepFooter';
@@ -14,12 +14,16 @@ import ReviewAndCreateStepFooter from '../steps/ReviewAndCreateStep/components/R
 import ReviewAndCreateStep from '../steps/ReviewAndCreateStep/ReviewAndCreateStep';
 import TemplateStepFooter from '../steps/TemplateStep/components/TemplateStepFooter';
 import TemplateStep from '../steps/TemplateStep/TemplateStep';
+import { VMCreationMethod, VMWizardStep } from './constants';
 import { getVMGenerationNavItem } from './steps';
 import {
-  GetStepsToDisplayByCreationMethodArgs,
-  VMWizardStepDisplay,
-  WizardStepNavItemConfig,
+  type GetStepsToDisplayByCreationMethodArgs,
+  type VMWizardStepDisplay,
+  type WizardStepNavItemConfig,
 } from './types';
+
+const getDefaultFooter = (isNextDisabled: boolean): ReactElement =>
+  createElement(DefaultWizardFooter, { isNextDisabled });
 
 const getDeploymentDetailsStep = (t: TFunction): VMWizardStepDisplay => ({
   children: createElement(DeploymentDetailsStep),
@@ -37,7 +41,7 @@ const getCustomizationStep = (
 ): VMWizardStepDisplay => ({
   children: createElement(CustomizationStep),
   displayIndex: 6,
-  footer: { isNextDisabled: isNextDisabledForStep(VMWizardStep.CUSTOMIZATION) },
+  footer: getDefaultFooter(isNextDisabledForStep(VMWizardStep.CUSTOMIZATION)),
   id: VMWizardStep.CUSTOMIZATION,
   isDisabled: isStepDisabled(VMWizardStep.CUSTOMIZATION),
   name: t('Customization'),
@@ -79,9 +83,7 @@ export const getStepsToDisplayByCreationMethod = ({
       {
         children: createElement(CloneSourceStep),
         displayIndex: 7,
-        footer: {
-          isNextDisabled: isNextDisabledForStep(VMWizardStep.CLONE),
-        },
+        footer: getDefaultFooter(isNextDisabledForStep(VMWizardStep.CLONE)),
         id: VMWizardStep.CLONE,
         isDisabled: isStepDisabled(VMWizardStep.CLONE),
         name: t('Source'),
@@ -93,9 +95,7 @@ export const getStepsToDisplayByCreationMethod = ({
       {
         children: createElement(GuestOSStep),
         displayIndex: 2,
-        footer: {
-          isNextDisabled: isNextDisabledForStep(VMWizardStep.GUEST_OS),
-        },
+        footer: getDefaultFooter(isNextDisabledForStep(VMWizardStep.GUEST_OS)),
         id: VMWizardStep.GUEST_OS,
         isDisabled: isStepDisabled(VMWizardStep.GUEST_OS),
         name: t('Guest OS'),
@@ -103,9 +103,7 @@ export const getStepsToDisplayByCreationMethod = ({
       {
         children: createElement(BootSourceStep),
         displayIndex: 3,
-        footer: {
-          isNextDisabled: isNextDisabledForStep(VMWizardStep.BOOT_SOURCE),
-        },
+        footer: getDefaultFooter(isNextDisabledForStep(VMWizardStep.BOOT_SOURCE)),
         id: VMWizardStep.BOOT_SOURCE,
         isDisabled: isStepDisabled(VMWizardStep.BOOT_SOURCE),
         name: t('Boot source'),


### PR DESCRIPTION

## 📝 Description

fix default ssh key applied to vms without cloudinit + tests

## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-95191

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/13f4958d-563e-4b59-ba10-281e734308f9


After:

https://github.com/user-attachments/assets/3a703f1b-2db4-4952-85d9-b24b03c61543



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VM creation selects the first available boot volume, or “No boot source” when none are available.
  * Added support for selecting the largest available compute size.
  * Instance type cards display the selected default size.
  * Improved namespace and project selection during VM creation.

* **Bug Fixes**
  * Improved reliability of VM wizard navigation and Create actions.
  * Prevented default SSH keys from being added to Windows VMs.
  * Improved handling for VMs without cloud-init configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->